### PR TITLE
improved persistent cookies

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -404,6 +404,14 @@
 				<notnull>false</notnull>
 			</field>
 
+			<field>
+				<name>created</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<length>8</length>
+			</field>
+
 			<index>
 				<name>pref_userid_appid_key_index</name>
 				<field>

--- a/lib/base.php
+++ b/lib/base.php
@@ -503,21 +503,31 @@ class OC{
 	}
 
 	protected static function tryRememberLogin() {
-		if(!isset($_COOKIE["oc_remember_login"])
-			|| !isset($_COOKIE["oc_token"])
-			|| !isset($_COOKIE["oc_username"])
-			|| !$_COOKIE["oc_remember_login"])
+		if(!isset($_COOKIE['oc_remember_login'])
+		  || !isset($_COOKIE['oc_token'])
+		  || !isset($_COOKIE['oc_username'])
+		  || !$_COOKIE['oc_remember_login'])
 		{
 			return false;
 		}
 		OC_App::loadApps(array('authentication'));
-		if(defined("DEBUG") && DEBUG) {
+		if(defined('DEBUG') && DEBUG) {
 			OC_Log::write('core', 'Trying to login from cookie', OC_Log::DEBUG);
 		}
+		// delete tokens older than 90 days
+                OC_Preferences::deleteValues($_COOKIE['oc_username'], 'login', 'token', time() - 7776000 );
 		// confirm credentials in cookie
 		if(isset($_COOKIE['oc_token']) && OC_User::userExists($_COOKIE['oc_username']) &&
-			OC_Preferences::getValue($_COOKIE['oc_username'], "login", "token") === $_COOKIE['oc_token'])
+			OC_Preferences::valueExists($_COOKIE['oc_username'], 'login', 'token', $_COOKIE['oc_token']))
 		{
+			// generate new cookie
+			if(defined('DEBUG') && DEBUG) {
+				OC_Log::write('core','Refresh token in persistent login cookie',OC_Log::DEBUG);
+			}
+			$newtoken = md5($_COOKIE['oc_username'].mt_rand(1000000, 9999999).$_COOKIE['oc_token']);
+			OC_Preferences::setMultiValue($_COOKIE['oc_username'], 'login', 'token', $_COOKIE['oc_token'], $newtoken);
+			OC_User::setMagicInCookie($_COOKIE['oc_username'], $newtoken);
+			// login
 			OC_User::setUserId($_COOKIE['oc_username']);
 			OC_Util::redirectToDefaultPage();
 		}
@@ -528,7 +538,7 @@ class OC{
 	}
 
 	protected static function tryFormLogin() {
-		if(!isset($_POST["user"]) || !isset($_POST['password'])) {
+		if(!isset($_POST['user']) || !isset($_POST['password'])) {
 			return false;
 		}
 
@@ -536,15 +546,15 @@ class OC{
 
 		//setup extra user backends
 		OC_User::setupBackends();
-
-		if(OC_User::login($_POST["user"], $_POST["password"])) {
-			if(!empty($_POST["remember_login"])) {
-				if(defined("DEBUG") && DEBUG) {
+		
+		if(OC_User::login($_POST['user'], $_POST['password'])) {
+			if(!empty($_POST['remember_login'])) {
+				if(defined('DEBUG') && DEBUG) {
 					OC_Log::write('core', 'Setting remember login to cookie', OC_Log::DEBUG);
 				}
-				$token = md5($_POST["user"].time().$_POST['password']);
-				OC_Preferences::setValue($_POST['user'], 'login', 'token', $token);
-				OC_User::setMagicInCookie($_POST["user"], $token);
+				$token = md5($_POST['user'].mt_rand(1000000, 9999999).$_POST['password']);
+				OC_Preferences::setMultiValue($_POST['user'], 'login', 'token', 'not defined', $token);
+				OC_User::setMagicInCookie($_POST['user'], $token);
 			}
 			else {
 				OC_User::unsetMagicInCookie();

--- a/lib/base.php
+++ b/lib/base.php
@@ -524,7 +524,7 @@ class OC{
 			if(defined('DEBUG') && DEBUG) {
 				OC_Log::write('core','Refresh token in persistent login cookie',OC_Log::DEBUG);
 			}
-			$newtoken = md5($_COOKIE['oc_username'].mt_rand(1000000, 9999999).$_COOKIE['oc_token']);
+			$newtoken = md5($_COOKIE['oc_username'].OC_Util::generate_random_bytes(10).$_COOKIE['oc_token']);
 			OC_Preferences::setMultiValue($_COOKIE['oc_username'], 'login', 'token', $_COOKIE['oc_token'], $newtoken);
 			OC_User::setMagicInCookie($_COOKIE['oc_username'], $newtoken);
 			// login
@@ -552,7 +552,7 @@ class OC{
 				if(defined('DEBUG') && DEBUG) {
 					OC_Log::write('core', 'Setting remember login to cookie', OC_Log::DEBUG);
 				}
-				$token = md5($_POST['user'].mt_rand(1000000, 9999999).$_POST['password']);
+				$token = md5($_POST['user'].OC_Util::generate_random_bytes(10).$_POST['password']);
 				OC_Preferences::setMultiValue($_POST['user'], 'login', 'token', 'not defined', $token);
 				OC_User::setMagicInCookie($_POST['user'], $token);
 			}

--- a/lib/util.php
+++ b/lib/util.php
@@ -80,8 +80,8 @@ class OC_Util {
 	 * @return array
 	 */
 	public static function getVersion() {
-		// hint: We only can count up. So the internal version number of ownCloud 4.5 will be 4.9.0. This is not visible to the user
-		return array(4,87,12);
+		// hint: We only can count up. So the internal version number of ownCloud 4.5 will be 4,9,0. This is not visible to the user
+		return array(4,87,13);
 	}
 
 	/**


### PR DESCRIPTION
Each user can have more than one persistent login token which enables persistent sessions in multiple browsers.

Tokens and cookies are regenerated on each login.

Tokens will be deleted if they aren't used for 90 days.

I've modified token generation from time to random number to make it more secure.

Regards,
Michael
