### PR TITLE
add SSL proxy support

### DIFF
--- a/3rdparty/openid/phpmyid.php
+++ b/3rdparty/openid/phpmyid.php
@@ -1626,7 +1626,7 @@ $profile['req_url'] = sprintf("%s://%s%s",
 		      $proto,
 		      OCP\Util::getServerHost(),
 // 		      $port,//host  already includes the path
-		      $_SERVER["REQUEST_URI"]);
+		      OCP\Util::getRequestUri());
 
 
 // Set the default allowance for testing

--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -29,12 +29,14 @@ OC_App::loadApps($RUNTIME_APPTYPES);
 // Backends
 $authBackend = new OC_Connector_Sabre_Auth();
 $lockBackend = new OC_Connector_Sabre_Locks();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Create ownCloud Dir
 $publicDir = new OC_Connector_Sabre_Directory('');
 
 // Fire up server
 $server = new Sabre_DAV_Server($publicDir);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri($baseuri);
 
 // Load plugins

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -39,7 +39,7 @@ OCP\App::setActiveNavigationEntry( 'files_index' );
 $dir = isset( $_GET['dir'] ) ? stripslashes($_GET['dir']) : '';
 // Redirect if directory does not exist
 if(!OC_Filesystem::is_dir($dir.'/')) {
-	header('Location: '.$_SERVER['SCRIPT_NAME'].'');
+	header('Location: '.OC_Request::scriptName().'');
 	exit();
 }
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -30,6 +30,12 @@ $CONFIG = array(
 /* Force use of HTTPS connection (true = use HTTPS) */
 "forcessl" => false,
 
+/* Host of the SSL proxy */
+"sslproxyhost" => "",
+
+/* URL for SSL proxy, as seen by the browser */
+"sslproxyprefix" => "",
+
 /* Theme to use for OwnCloud */
 "theme" => "",
 

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -1,5 +1,5 @@
 <!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
-<form action="index.php" method="post">
+<form action="<?php echo OC::$WEBROOT; ?>/index.php" method="post">
 	<fieldset>
 		<?php if(!empty($_['redirect'])) { echo '<input type="hidden" name="redirect_url" value="'.$_['redirect'].'" />'; } ?>
 		<?php if($_['display_lostpassword']): ?>

--- a/files/webdav.php
+++ b/files/webdav.php
@@ -30,12 +30,14 @@ require_once '../lib/base.php';
 // Backends
 $authBackend = new OC_Connector_Sabre_Auth();
 $lockBackend = new OC_Connector_Sabre_Locks();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Create ownCloud Dir
 $publicDir = new OC_Connector_Sabre_Directory('');
 
 // Fire up server
 $server = new Sabre_DAV_Server($publicDir);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri(OC::$WEBROOT. '/files/webdav.php');
 
 // Load plugins

--- a/lib/app.php
+++ b/lib/app.php
@@ -466,7 +466,7 @@ class OC_App{
 	 * @return string
 	 */
 	public static function getCurrentApp() {
-		$script=substr($_SERVER["SCRIPT_NAME"], strlen(OC::$WEBROOT)+1);
+		$script=substr(OC_Request::scriptName(), strlen(OC::$WEBROOT)+1);
 		$topFolder=substr($script, 0, strpos($script, '/'));
 		if($topFolder=='apps') {
 			$length=strlen($topFolder);

--- a/lib/base.php
+++ b/lib/base.php
@@ -106,7 +106,7 @@ class OC{
 		// calculate the root directories
 		OC::$SERVERROOT=str_replace("\\", '/', substr(__FILE__, 0, -13));
 		OC::$SUBURI= str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen(OC::$SERVERROOT)));
-		$scriptName=$_SERVER["SCRIPT_NAME"];
+		$scriptName=OC_Request::scriptName();
 		if(substr($scriptName, -1)=='/') {
 			$scriptName.='index.php';
 			//make sure suburi follows the same rules as scriptName
@@ -195,7 +195,16 @@ class OC{
 		if( OC_Config::getValue( "forcessl", false )) {
 			ini_set("session.cookie_secure", "on");
 			if(OC_Request::serverProtocol()<>'https' and !OC::$CLI) {
-				$url = "https://". OC_Request::serverHost() . $_SERVER['REQUEST_URI'];
+				$uri = OC_Request::requestUri();
+				if(OC_Config::getValue('sslproxyhost', '')<>''){
+					$host = OC_Config::getValue('sslproxyhost', '');
+					if(OC_Config::getValue('sslproxyprefix', '')<>''){
+						$uri = '/'.OC_Config::getValue('sslproxyprefix', '').$uri;
+					}
+				}else{
+					$host = OC_Request::serverHost();
+				}
+				$url = "https://". $host . $uri;
 				header("Location: $url");
 				exit();
 			}
@@ -563,7 +572,7 @@ class OC{
 		if (OC_User::login($_SERVER["PHP_AUTH_USER"], $_SERVER["PHP_AUTH_PW"])) {
 			//OC_Log::write('core',"Logged in with HTTP Authentication",OC_Log::DEBUG);
 			OC_User::unsetMagicInCookie();
-			$_REQUEST['redirect_url'] = (isset($_SERVER['REQUEST_URI'])?$_SERVER['REQUEST_URI']:'');
+			$_REQUEST['redirect_url'] = OC_Request::requestUri();
 			OC_Util::redirectToDefaultPage();
 		}
 		return true;

--- a/lib/connector/sabre/request.php
+++ b/lib/connector/sabre/request.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Stefan Herbrechtsmeier
+ * @copyright 2012 Stefan Herbrechtsmeier <stefan@herbrechtsmeier.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class OC_Connector_Sabre_Request extends Sabre_HTTP_Request {
+	/**
+	 * Returns the requested uri
+	 *
+	 * @return string
+	 */
+	public function getUri() {
+		return OC_Request::requestUri();
+	}
+
+	/**
+	 * Returns a specific item from the _SERVER array.
+	 *
+	 * Do not rely on this feature, it is for internal use only.
+	 *
+	 * @param string $field
+	 * @return string
+	 */
+	public function getRawServerValue($field) {
+		if($field == 'REQUEST_URI'){
+			return $this->getUri();
+		}
+		else{
+			return isset($this->_SERVER[$field])?$this->_SERVER[$field]:null;
+		}
+	}
+}

--- a/lib/ocs.php
+++ b/lib/ocs.php
@@ -93,7 +93,7 @@ class OC_OCS {
 		}
 
 		// preprocess url
-		$url = strtolower($_SERVER['REQUEST_URI']);
+		$url = strtolower(OCP\Util::getRequestUri());
 		if(substr($url,(strlen($url)-1))<>'/') $url.='/';
 		$ex=explode('/',$url);
 		$paracount=count($ex);
@@ -383,7 +383,7 @@ class OC_OCS {
 	*/
 	private static function apiConfig($format) {
 		$user=OC_OCS::checkpassword(false);
-		$url=substr(OCP\Util::getServerHost().$_SERVER['SCRIPT_NAME'],0,-11).'';
+		$url=substr(OCP\Util::getServerHost().OCP\Util::getScriptName,0,-11).'';
 
 		$xml['version']='1.7';
 		$xml['website']='ownCloud';

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -181,6 +181,28 @@ class Util {
 	}
 
 	/**
+	 * @brief Returns the request uri
+	 * @returns the request uri
+	 *
+	 * Returns the request uri, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function getRequestUri() {
+		return(\OC_Request::requestUri());
+	}
+
+	/**
+	 * @brief Returns the script name
+	 * @returns the script name
+	 *
+	 * Returns the script name, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function getScriptName() {
+		return(\OC_Request::scriptName());
+	}
+
+	/**
 	 * @brief Creates path to an image
 	 * @param $app app
 	 * @param $image image name

--- a/lib/request.php
+++ b/lib/request.php
@@ -42,6 +42,8 @@ class OC_Request {
 	public static function serverProtocol() {
 		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
 			$proto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
+		}elseif(self::serverHost() == OC_Config::getValue('sslproxyhost', '')) {
+			$proto = 'https';
 		}else{
 			if(isset($_SERVER['HTTPS']) and !empty($_SERVER['HTTPS']) and ($_SERVER['HTTPS']!='off')) {
 				$proto = 'https';
@@ -51,6 +53,39 @@ class OC_Request {
 		}
 		return $proto;
 	}
+
+	/**
+	 * @brief Returns the request uri
+	 * @returns the request uri
+	 *
+	 * Returns the request uri, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function requestUri() {
+		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+		if(self::serverProtocol()=='https' and self::serverHost() == OC_Config::getValue('sslproxyhost', '') 
+		   and OC_Config::getValue('sslproxyprefix', '')<>''){
+			$uri = '/'.OC_Config::getValue('sslproxyprefix', '').$uri;
+		}
+		return $uri;
+	}
+
+	/**
+	 * @brief Returns the script name
+	 * @returns the script name
+	 *
+	 * Returns the script name, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function scriptName() {
+		$name = $_SERVER['SCRIPT_NAME'];
+		if(self::serverProtocol()=='https' and self::serverHost() == OC_Config::getValue('sslproxyhost', '') 
+		   and OC_Config::getValue('sslproxyprefix', '')<>''){
+			$name = '/'.OC_Config::getValue('sslproxyprefix', '').$name;
+		}
+		return $name;
+	}
+
 
 	/**
 	 * @brief get Path info from request

--- a/lib/util.php
+++ b/lib/util.php
@@ -306,7 +306,7 @@ class OC_Util {
 		if (isset($_REQUEST['redirect_url'])) {
 			$redirect_url = OC_Util::sanitizeHTML($_REQUEST['redirect_url']);
 		} else {
-			$redirect_url = $_SERVER['REQUEST_URI'];
+			$redirect_url = OC_Request::requestUri();
 		}
 		$parameters['redirect_url'] = $redirect_url;
 		OC_Template::printGuestPage("", "login", $parameters);
@@ -330,7 +330,7 @@ class OC_Util {
 	public static function checkLoggedIn() {
 		// Check if we are a user
 		if( !OC_User::isLoggedIn()) {
-			header( 'Location: '.OC_Helper::linkToAbsolute( '', 'index.php', array('redirect_url' => urlencode($_SERVER["REQUEST_URI"]))));
+			header( 'Location: '.OC_Helper::linkToAbsolute( '', 'index.php', array('redirect_url' => urlencode(OC_Request::requestUri()))));
 			exit();
 		}
 	}

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,7 +23,7 @@
 
 require_once '../lib/base.php';
 
-$url='http://'.substr(OCP\Util::getServerHost().$_SERVER['REQUEST_URI'], 0, -17).'ocs/v1.php/';
+$url='http://'.substr(OCP\Util::getServerHost().OCP\Util::getRequestUri(), 0, -17).'ocs/v1.php/';
 
 echo('
 <providers>


### PR DESCRIPTION
Add support for a SSL proxy that handles multiple domains via host name
as prefix in the request URI (https://ssl-proxy.tld/domain.tld/).

As the SSL proxy is transparent for the web server the REQUEST_URI and
SCRIPT_NAME need manual adjustments. This patch replace the direct use
of this _SERVER variables with function calls and extend this functions
to detect the proxy and to add the needed prefix. Additionally it adds
a Sabre request backend with extends the Sabre_HTTP_Request to use the
same functions.

http://bugs.owncloud.org/thebuggenie/owncloud/issues/oc-890
