### PR TITLE
check free space using folder's owner

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -38,7 +38,7 @@ $totalSize=0;
 foreach($files['size'] as $size) {
 	$totalSize+=$size;
 }
-if($totalSize>OC_Filesystem::free_space('/')) {
+if($totalSize>OC_Filesystem::free_space($dir)){
 	OCP\JSON::error(array("data" => array( "message" => "Not enough space available" )));
 	exit();
 }

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -85,7 +85,7 @@ $upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize')
 $post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
 $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 
-$freeSpace=OC_Filesystem::free_space('/');
+$freeSpace=OC_Filesystem::free_space($dir);
 $freeSpace=max($freeSpace,0);
 $maxUploadFilesize = min($maxUploadFilesize ,$freeSpace);
 

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -108,6 +108,14 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 		return $internalPath;
 	}
 
+	public function getOwner($target) {
+		$shared_item = OCP\Share::getItemSharedWith('folder', $target, OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+		if ($shared_item) {
+			return $shared_item[0]["uid_owner"];
+		}
+		return null;
+	}
+
 	public function mkdir($path) {
 		if ($path == '' || $path == '/' || !$this->isCreatable(dirname($path))) {
 			return false;

--- a/lib/fileproxy/quota.php
+++ b/lib/fileproxy/quota.php
@@ -27,52 +27,58 @@
 
 class OC_FileProxy_Quota extends OC_FileProxy{
 	static $rootView;
-	private $userQuota=-1;
+	private $userQuota=array();
 
 	/**
-	 * get the quota for the current user
+	 * get the quota for the user
+	 * @param user
 	 * @return int
 	 */
-	private function getQuota() {
-		if($this->userQuota!=-1) {
-			return $this->userQuota;
+	private function getQuota($user) {
+		if(in_array($user, $this->userQuota)) {
+			return $this->userQuota[$user];
 		}
-		$userQuota=OC_Preferences::getValue(OC_User::getUser(),'files','quota','default');
+		$userQuota=OC_Preferences::getValue($user,'files','quota','default');
 		if($userQuota=='default') {
 			$userQuota=OC_AppConfig::getValue('files','default_quota','none');
 		}
 		if($userQuota=='none') {
-			$this->userQuota=0;
+			$this->userQuota[$user]=0;
 		}else{
-			$this->userQuota=OC_Helper::computerFileSize($userQuota);
+			$this->userQuota[$user]=OC_Helper::computerFileSize($userQuota);
 		}
-		return $this->userQuota;
+		return $this->userQuota[$user];
 
 	}
 
 	/**
-	 * get the free space in the users home folder
+	 * get the free space in the path's owner home folder
+	 * @param path
 	 * @return int
 	 */
-	private function getFreeSpace() {
-		$rootInfo=OC_FileCache_Cached::get('');
+	private function getFreeSpace($path) {
+		$storage=OC_Filesystem::getStorage($path);
+		$owner=$storage->getOwner($path);
+
+		$totalSpace=$this->getQuota($owner);
+		if($totalSpace==0) {
+			return 0;
+		}
+
+		$rootInfo=OC_FileCache::get('', "/".$owner."/files");
 		// TODO Remove after merge of share_api
-		if (OC_FileCache::inCache('/Shared')) {
-			$sharedInfo=OC_FileCache_Cached::get('/Shared');
+		if (OC_FileCache::inCache('/Shared', "/".$owner."/files")) {
+			$sharedInfo=OC_FileCache::get('/Shared', "/".$owner."/files");
 		} else {
 			$sharedInfo = null;
 		}
 		$usedSpace=isset($rootInfo['size'])?$rootInfo['size']:0;
 		$usedSpace=isset($sharedInfo['size'])?$usedSpace-$sharedInfo['size']:$usedSpace;
-		$totalSpace=$this->getQuota();
-		if($totalSpace==0) {
-			return 0;
-		}
 		return $totalSpace-$usedSpace;
 	}
-
+	
 	public function postFree_space($path,$space) {
-		$free=$this->getFreeSpace();
+		$free=$this->getFreeSpace($path);
 		if($free==0) {
 			return $space;
 		}
@@ -83,21 +89,21 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 		if (is_resource($data)) {
 			$data = '';//TODO: find a way to get the length of the stream without emptying it
 		}
-		return (strlen($data)<$this->getFreeSpace() or $this->getFreeSpace()==0);
+		return (strlen($data)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
 	}
 
 	public function preCopy($path1,$path2) {
 		if(!self::$rootView){
 			self::$rootView = new OC_FilesystemView('');
 		}
-		return (self::$rootView->filesize($path1)<$this->getFreeSpace() or $this->getFreeSpace()==0);
+		return (self::$rootView->filesize($path1)<$this->getFreeSpace($path2) or $this->getFreeSpace($path2)==0);
 	}
 
 	public function preFromTmpFile($tmpfile,$path) {
-		return (filesize($tmpfile)<$this->getFreeSpace() or $this->getFreeSpace()==0);
+		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
 	}
 
 	public function preFromUploadedFile($tmpfile,$path) {
-		return (filesize($tmpfile)<$this->getFreeSpace() or $this->getFreeSpace()==0);
+		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
 	}
 }

--- a/lib/filestorage.php
+++ b/lib/filestorage.php
@@ -63,4 +63,5 @@ abstract class OC_Filestorage{
 	 * returning true for other changes in the folder is optional
 	 */
 	abstract public function hasUpdated($path,$time);
+	abstract public function getOwner($path);
 }

--- a/lib/filestorage/common.php
+++ b/lib/filestorage/common.php
@@ -279,4 +279,13 @@ abstract class OC_Filestorage_Common extends OC_Filestorage {
 	public function hasUpdated($path,$time) {
 		return $this->filemtime($path)>$time;
 	}
+
+	/**
+	 * get the owner of a path
+	 * @param $path The path to get the owner
+	 * @return string uid or false
+	 */
+	public function getOwner($path) {
+		return OC_User::getUser();
+	}
 }


### PR DESCRIPTION
When you upload a file in a shared folder, it won't be accounted for your used space, but anyway you won't be allowed to upload a file if your quota is full.

I think quota of shared folder's owner should be used, because uploading a file will affect to that user.

With this change you can create users with 1B quota, so they only can upload to folders shared with them
