### PR TITLE
fix js success callback on safari when uploading files

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -361,7 +361,8 @@ $(document).ready(function() {
 						}
 					}else{
 						data.submit().success(function(data, status) {
-							response = jQuery.parseJSON(data[0].body.innerText);
+							// in safari data is a string
+							response = jQuery.parseJSON(typeof data === 'string' ? data : data[0].body.innerText);
 							if(response[0] != undefined && response[0].status == 'success') {
 								var file=response[0];
 								delete uploadingFiles[file.name];


### PR DESCRIPTION
When I upload a file wiht safari, both with choose file dialog and drag and drop, icon keeps spinning, becuase of an ajax callback error.

I have tested this fix in chrome, firefox and IE and it still works
