### PR TITLE
use post to delete files, get has a limit and fails with many files

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -7,15 +7,15 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
 // Get data
-$dir = stripslashes($_GET["dir"]);
-$files = isset($_GET["file"]) ? stripslashes($_GET["file"]) : stripslashes($_GET["files"]);
+$dir = stripslashes($_POST["dir"]);
+$files = isset($_POST["file"]) ? stripslashes($_POST["file"]) : stripslashes($_POST["files"]);
 
 $files = explode(';', $files);
 $filesWithError = '';
 $success = true;
 //Now delete
 foreach($files as $file) {
-    if( !OC_Files::delete( $dir, $file )) {
+	if( !OC_Files::delete( $dir, $file )) {
 		$filesWithError .= $file . "\n";
 		$success = false;
 	}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -276,6 +276,7 @@ var FileList={
 			$.ajax({
 				url: OC.filePath('files', 'ajax', 'delete.php'),
 				async:!sync,
+				type:'post',
 				data: {dir:$('#dir').val(),files:fileNames},
 				complete: function(data){
 					boolOperationFinished(data, function(){


### PR DESCRIPTION
If you select many files and then delete them, get request can be cut. Using post it won't happen, and it's more correct, get shouldn't be used to do changes.
