### PR TITLE
A suggestion for simple, yet efficient variable interpolation in js translations

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -5,7 +5,7 @@
  * @return string
  */
 
-function t(app,text){
+function t(app,text, vars){
 	if( !( t.cache[app] )){
 		$.ajax(OC.filePath('core','ajax','translations.php'),{
 			async:false,//todo a proper sollution for this without sync ajax calls
@@ -21,11 +21,27 @@ function t(app,text){
 			t.cache[app] = [];
 		}
 	}
+	var _build = function(text, vars) {
+		return text.replace(/{([^{}]*)}/g,
+			function (a, b) {
+				var r = vars[b];
+				return typeof r === 'string' || typeof r === 'number' ? r : a;
+			}
+		);
+	}
 	if( typeof( t.cache[app][text] ) !== 'undefined' ){
-		return t.cache[app][text];
+		if(typeof vars === 'object') {
+			return _build(t.cache[app][text], vars);
+		} else {
+			return t.cache[app][text];
+		}
 	}
 	else{
-		return text;
+		if(typeof vars === 'object') {
+			return _build(text, vars);
+		} else {
+			return text;
+		}
 	}
 }
 t.cache={};


### PR DESCRIPTION
Which requires no extra libraries. This is of course for post-4.5, just wanted to get it out of the door while I remembered.

Usage is imo very intuitive:

```
t('app', 'Bake, uncovered, until the {greasystuff} is melted and the {pasta} is heated through, about {min} minutes.',
    {greasystuff: 'cheese', pasta: 'macaroni', min: 10});
```

Not that I want to stir up a discussion of whether macaroni is pasta or not, but my mind was totally blank when I should find an example :-P

btw, I can't take credit for it http://stackoverflow.com/questions/1408289/best-way-to-do-variable-interpolation-in-javascript#answer-1408373
