### PR TITLE
fixed max possible upload size for files app in admin screen

### DIFF
--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -30,8 +30,11 @@ OCP\User::checkAdminUser();
 $htaccessWorking=(getenv('htaccessWorking')=='true');
 
 $upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize'));
+$upload_max_filesize_possible = OCP\Util::computerFileSize(get_cfg_var('upload_max_filesize'));
 $post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
+$post_max_size_possible = OCP\Util::computerFileSize(get_cfg_var('post_max_size'));
 $maxUploadFilesize = OCP\Util::humanFileSize(min($upload_max_filesize, $post_max_size));
+$maxUploadFilesizePossible = OCP\Util::humanFileSize(min($upload_max_filesize_possible, $post_max_size_possible));
 if($_POST) {
 	if(isset($_POST['maxUploadSize'])) {
 		if(($setMaxSize = OC_Files::setUploadLimit(OCP\Util::computerFileSize($_POST['maxUploadSize']))) !== false) {
@@ -56,7 +59,8 @@ $htaccessWritable=is_writable(OC::$SERVERROOT.'/.htaccess');
 $tmpl = new OCP\Template( 'files', 'admin' );
 $tmpl->assign( 'uploadChangable', $htaccessWorking and $htaccessWritable );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
-$tmpl->assign( 'maxPossibleUploadSize', OCP\Util::humanFileSize(PHP_INT_MAX));
+$tmpl->assign( 'maxPossibleUploadSize', $maxUploadFilesizePossible);
 $tmpl->assign( 'allowZipDownload', $allowZipDownload);
 $tmpl->assign( 'maxZipInputSize', $maxZipInputSize);
 return $tmpl->fetchPage();
+


### PR DESCRIPTION
Could not find some thing in the git log about why we used PHP_INT_MAX here.
I suggest to use get_cfg_var() to get the real limit from php.ini instead of .ht_access and show this value on the admin page.
