### PR TITLE
extend logon page to display multiple error messages

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -2,9 +2,20 @@
 <form method="post">
 	<fieldset>
 		<?php if(!empty($_['redirect'])) { echo '<input type="hidden" name="redirect_url" value="'.$_['redirect'].'" />'; } ?>
-		<?php if($_['display_lostpassword']): ?>
-			<a href="./core/lostpassword/"><?php echo $l->t('Lost your password?'); ?></a>
+		<ul>
+		<?php if($_['invalidcookie']): ?>
+			<li class="errors">
+				<?php echo $l->t('Automatic logon rejected!'); ?><br>
+				<small><?php echo $l->t('If you did not change your password recently, your account may be compromised!'); ?></small><br>
+				<small><?php echo $l->t('Please change your password to secure your account again.'); ?></small>
+			</li>
 		<?php endif; ?>
+		<?php if($_['invalidpassword']): ?>
+			<a href="./core/lostpassword/"><li class="errors">
+				<?php echo $l->t('Lost your password?'); ?>
+			</li></a>
+		<?php endif; ?>
+		</ul>
 		<p class="infield">
 			<label for="user" class="infield"><?php echo $l->t( 'Username' ); ?></label>
 			<input type="text" name="user" id="user" value="<?php echo $_['username']; ?>"<?php echo $_['user_autofocus']?' autofocus':''; ?> autocomplete="on" required />

--- a/lib/base.php
+++ b/lib/base.php
@@ -494,20 +494,20 @@ class OC{
 
 	protected static function handleLogin() {
 		OC_App::loadApps(array('prelogin'));
-		$error = false;
+		$error = array();
 		// remember was checked after last login
 		if (OC::tryRememberLogin()) {
-			// nothing more to do
+			$error[] = 'invalidcookie';
 
 		// Someone wants to log in :
 		} elseif (OC::tryFormLogin()) {
-			$error = true;
+			$error[] = 'invalidpassword';
 
 		// The user is already authenticated using Apaches AuthType Basic... very usable in combination with LDAP
 		} elseif (OC::tryBasicAuthLogin()) {
-			$error = true;
+			$error[] = 'invalidpassword';
 		}
-		OC_Util::displayLoginPage($error);
+		OC_Util::displayLoginPage(array_unique($error));
 	}
 
 	protected static function tryRememberLogin() {

--- a/lib/util.php
+++ b/lib/util.php
@@ -308,9 +308,11 @@ class OC_Util {
 		return $errors;
 	}
 
-	public static function displayLoginPage($display_lostpassword) {
+	public static function displayLoginPage($errors = array()) {
 		$parameters = array();
-		$parameters['display_lostpassword'] = $display_lostpassword;
+		foreach( $errors as $key => $value ) {
+			$parameters[$value] = true;
+		}
 		if (!empty($_POST['user'])) {
 			$parameters["username"] =
 				OC_Util::sanitizeHTML($_POST['user']).'"';


### PR DESCRIPTION
This is one of the outcomes of the persistent cookie discussion.
- There should be a warning message when a cookie is rejected.

So I've extended the logon page code for that.
