### PR TITLE
Implement X-Sendfile support (resubmit)

### DIFF
--- a/lib/filesystemview.php
+++ b/lib/filesystemview.php
@@ -198,6 +198,7 @@ class OC_FilesystemView {
 		return $this->basicOperation('filesize', $path);
 	}
 	public function readfile($path) {
+		$this->addSendfileHeaders($path);
 		@ob_end_clean();
 		$handle=$this->fopen($path, 'rb');
 		if ($handle) {
@@ -210,6 +211,19 @@ class OC_FilesystemView {
 			return $size;
 		}
 		return false;
+	}
+	/* This adds the proper header to let the web server handle
+	* the file transfer, if it's configured through the right
+	* environment variable
+	*/
+	private function addSendfileHeaders($path) {
+		$storage = $this->getStorage($path);
+		if ($storage instanceof OC_Filestorage_Local) {
+			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED']))
+				header("X-Accel-Redirect: " . $this->getLocalFile($path));
+			if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']))
+				header("X-Sendfile: " . $this->getLocalFile($path));
+		}
 	}
 	/**
 	* @deprecated Replaced by isReadable() as part of CRUDS


### PR DESCRIPTION
I fixed the commit history rebasing everything into this single commit. I hope this time is OK, i'm quite new to git.

This closes Enhancement oc-1835.

The solution I implemented to provide support for X-Sendfile / X-Accel-Redirect adds the header to the request only if the web server advertise its support for them and only for a local filestorage.

This means that it is necessary, if X-Sendfile support is wanted, to specify:
- nginx: fastcgi_param MOD_X_ACCEL_REDIRECT_ENABLED on
- Apache: SetEnv MOD_X_SENDFILE_ENABLED 1
  and by properly configuring the paths accessible by the web-server.

The same should be achievable in lighttpd (I haven't tested it).

The use of environment variables prevents the headers from being set if not explicitly wanted.
This way admins that don't want to dig into this configuration will still benefit from the classic file transfer provided by the readfile function.

This also makes possible to set only the correct header for the used web server, preventing both headers from being set (which would make the absolute path to the requested resource visible to the user since only the used header is stripped while the other would be left untouched).
