### PR TITLE
delete fscache on deleting user

### DIFF
--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -203,7 +203,7 @@ class OC_FileCache{
 
 		OC_Cache::remove('fileid/'.$root.$path);
 	}
-
+	
 	/**
 	 * return array of filenames matching the querty
 	 * @param string $query
@@ -509,3 +509,4 @@ class OC_FileCache{
 OC_Hook::connect('OC_Filesystem','post_write','OC_FileCache_Update','fileSystemWatcherWrite');
 OC_Hook::connect('OC_Filesystem','post_delete','OC_FileCache_Update','fileSystemWatcherDelete');
 OC_Hook::connect('OC_Filesystem','post_rename','OC_FileCache_Update','fileSystemWatcherRename');
+OC_Hook::connect('OC_User','post_deleteUser','OC_FileCache_Update','deleteFromUser');

--- a/lib/filecache/update.php
+++ b/lib/filecache/update.php
@@ -216,4 +216,12 @@ class OC_FileCache_Update{
 		OC_FileCache::increaseSize(dirname($newPath), $oldSize, $root);
 		OC_FileCache::move($oldPath, $newPath);
 	}
+
+	/**
+	 * delete files owned by user from the cache
+	 * @param string $parameters$parameters["uid"])
+	 */
+	public static function deleteFromUser($parameters) {
+		OC_FileCache::clear($parameters["uid"]);
+	}
 }


### PR DESCRIPTION
When a user is deleted, share table is cleaned deleting files or folders shared with that user or shared by that user, but fscache is not cleaned.

Maybe files should be deleted too, but I'm not sure. Although if you create a new user with same name, it will get files from previous user, and that isn't good.
