### PR TITLE
Implement X-Sendfile support

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -56,6 +56,9 @@ if( !OC_Config::getValue( 'installed', false )) {
 // Handle unexpected errors
 register_shutdown_function('handleUnexpectedShutdown');
 
+// Delete temp folder
+OC_Helper::cleanTmpNoClean();
+
 // Exit if background jobs are disabled!
 $appmode = OC_BackgroundJob::getExecutionType();
 if( $appmode == 'none' ) {

--- a/lib/filesystemview.php
+++ b/lib/filesystemview.php
@@ -195,7 +195,6 @@ class OC_FilesystemView {
 		return $this->basicOperation('filesize', $path);
 	}
 	public function readfile($path) {
-		$this->addSendfileHeaders($path);
 		@ob_end_clean();
 		$handle=$this->fopen($path, 'rb');
 		if ($handle) {
@@ -208,19 +207,6 @@ class OC_FilesystemView {
 			return $size;
 		}
 		return false;
-	}
-	/* This adds the proper header to let the web server handle
-	* the file transfer, if it's configured through the right
-	* environment variable
-	*/
-	private function addSendfileHeaders($path) {
-		$storage = $this->getStorage($path);
-		if ($storage instanceof OC_Filestorage_Local) {
-			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED']))
-				header("X-Accel-Redirect: " . $this->getLocalFile($path));
-			if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']))
-				header("X-Sendfile: " . $this->getLocalFile($path));
-		}
 	}
 	/**
 	* @deprecated Replaced by isReadable() as part of CRUDS

--- a/lib/filesystemview.php
+++ b/lib/filesystemview.php
@@ -195,6 +195,7 @@ class OC_FilesystemView {
 		return $this->basicOperation('filesize', $path);
 	}
 	public function readfile($path) {
+		$this->addSendfileHeaders($path);
 		@ob_end_clean();
 		$handle=$this->fopen($path, 'rb');
 		if ($handle) {
@@ -207,6 +208,19 @@ class OC_FilesystemView {
 			return $size;
 		}
 		return false;
+	}
+	/* This adds the proper header to let the web server handle
+	* the file transfer, if it's configured through the right
+	* environment variable
+	*/
+	private function addSendfileHeaders($path) {
+		$storage = $this->getStorage($path);
+		if ($storage instanceof OC_Filestorage_Local) {
+			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED']))
+				header("X-Accel-Redirect: " . $this->getLocalFile($path));
+			if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']))
+				header("X-Sendfile: " . $this->getLocalFile($path));
+		}
 	}
 	/**
 	* @deprecated Replaced by isReadable() as part of CRUDS

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -534,8 +534,9 @@ class OC_Helper {
 	public static function tmpFileNoClean($postfix='') {
 		$tmpDirNoClean=get_temp_dir().'/oc-noclean/';
 		if (!file_exists($tmpDirNoClean) || !is_dir($tmpDirNoClean)) {
-			if (file_exists($tmpDirNoClean))
+			if (file_exists($tmpDirNoClean)) {
 				unlink($tmpDirNoClean);
+			}
 			mkdir($tmpDirNoClean);
 		}
 		$file=$tmpDirNoClean.md5(time().rand()).$postfix;

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -525,6 +525,26 @@ class OC_Helper {
 	}
 
 	/**
+	 * create a temporary file with an unique filename. It will not be deleted
+	 * automatically
+	 * @param string $postfix
+	 * @return string
+	 *
+	 */
+	public static function tmpFileNoClean($postfix='') {
+		$tmpDirNoClean=get_temp_dir().'/oc-noclean/';
+		if (!file_exists($tmpDirNoClean) || !is_dir($tmpDirNoClean)) {
+			if (file_exists($tmpDirNoClean))
+				unlink($tmpDirNoClean);
+			mkdir($tmpDirNoClean);
+		}
+		$file=$tmpDirNoClean.md5(time().rand()).$postfix;
+		$fh=fopen($file,'w');
+		fclose($fh);
+		return $file;
+	}
+	
+	/**
 	 * create a temporary folder with an unique filename
 	 * @return string
 	 *
@@ -556,6 +576,16 @@ class OC_Helper {
 					file_put_contents($leftoversFile, $file."\n", FILE_APPEND);
 				}
 			}
+		}
+	}
+
+	/**
+	 * remove all files created by self::tmpFileNoClean
+	 */
+	public static function cleanTmpNoClean() {
+		$tmpDirNoCleanFile=get_temp_dir().'/oc-noclean/';
+		if(file_exists($tmpDirNoCleanFile)) {
+			self::rmdirr($tmpDirNoCleanFile);
 		}
 	}
 


### PR DESCRIPTION
Well I'm sorry for this third pull reqest but, as I mentioned, I'm not really used to git. This time I created a branch for the feature so that it will be possible to add new commits if it's needed.

This closes Enhancement oc-1835.

The solution I implemented to provide support for X-Sendfile / X-Accel-Redirect adds the header to the request only if the web server advertise its support for them and only for a local filestorage.

This means that it is necessary, if X-Sendfile support is wanted, to specify:
- nginx: fastcgi_param MOD_X_ACCEL_REDIRECT_ENABLED on
- Apache: SetEnv MOD_X_SENDFILE_ENABLED 1 and by properly configuring the paths accessible by the web-server.

The same should be achievable in lighttpd (I haven't tested it).

The use of environment variables prevents the headers from being set if not explicitly wanted.
This way admins that don't want to dig into this configuration will still benefit from the classic file transfer provided by the readfile function.

This also makes possible to set only the correct header for the used web server, preventing both headers from being set (which would make the absolute path to the requested resource visible to the user since only the used header is stripped while the other would be left untouched).
