### PR TITLE
Fix token expire IE updated

### DIFF
--- a/apps/files/ajax/iframerequest.php
+++ b/apps/files/ajax/iframerequest.php
@@ -1,0 +1,7 @@
+<?php 
+
+OCP\JSON::checkLoggedIn();
+$_SESSION['IFRAME_REQUESTTOKEN']=OC_Util::callRegister();
+//OC_Log::write('core', 'register Call done', OC_Log::DEBUG);
+
+?>

--- a/apps/files/js/jquery.iframe-transport.js
+++ b/apps/files/js/jquery.iframe-transport.js
@@ -47,7 +47,7 @@
                     // elements that have already been added to the DOM,
                     // so we set the name along with the iframe HTML markup:
                     iframe = $(
-                        '<iframe src="javascript:false;" name="iframe-transport-' +
+                        '<iframe src="'+OC.filePath('files', 'ajax', 'iframerequest.php')+'" name="iframe-transport-' +
                             (counter += 1) + '"></iframe>'
                     ).bind('load', function () {
                         var fileInputClones;
@@ -77,7 +77,7 @@
                                 );
                                 // Fix for IE endless progress bar activity bug
                                 // (happens on form submits to iframe targets):
-                                $('<iframe src="javascript:false;"></iframe>')
+                                $('<iframe src="'+OC.filePath('files', 'ajax', 'iframerequest.php')+'"></iframe>')
                                     .appendTo(form);
                                 form.remove();
                             });

--- a/lib/util.php
+++ b/lib/util.php
@@ -528,6 +528,9 @@ class OC_Util {
 			$token=$_POST['requesttoken'];
 		}elseif(isset($_SERVER['HTTP_REQUESTTOKEN'])) {
 			$token=$_SERVER['HTTP_REQUESTTOKEN'];
+		}elseif(isset($_SESSION['IFRAME_REQUESTTOKEN'])) {
+			$token=$_SESSION['IFRAME_REQUESTTOKEN'];
+			unset($_SESSION['IFRAME_REQUESTTOKEN']);			
 		}else{
 			//no token found.
 			return false;


### PR DESCRIPTION
This fix is safer against CSRF-attacks. Now we use the callregister method from owncloud!

<!---
@huboard:{"order":44.125}
-->
