### PR TITLE
Generate .htaccess when upgrading from old versions

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -221,6 +221,12 @@ class OC{
 			$installedVersion=OC_Config::getValue('version', '0.0.0');
 			$currentVersion=implode('.', OC_Util::getVersion());
 			if (version_compare($currentVersion, $installedVersion, '>')) {
+				// Check if the .htaccess is existing - this is needed for upgrades from really old ownCloud versions
+				if (isset($_SERVER['SERVER_SOFTWARE']) && strstr($_SERVER['SERVER_SOFTWARE'], 'Apache')) {
+					if(!OC_Util::ishtaccessworking()) {
+						OC_Setup::createHtaccess();
+					}
+				}		
 				OC_Log::write('core', 'starting upgrade from '.$installedVersion.' to '.$currentVersion, OC_Log::DEBUG);
 				$result=OC_DB::updateDbFromStructure(OC::$SERVERROOT.'/db_structure.xml');
 				if(!$result) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -224,7 +224,11 @@ class OC{
 				// Check if the .htaccess is existing - this is needed for upgrades from really old ownCloud versions
 				if (isset($_SERVER['SERVER_SOFTWARE']) && strstr($_SERVER['SERVER_SOFTWARE'], 'Apache')) {
 					if(!OC_Util::ishtaccessworking()) {
-						OC_Setup::createHtaccess();
+						if(!file_exists(OC::$SERVERROOT.'/data/.htaccess')) {
+							$content = "deny from all\n";
+							$content.= "IndexIgnore *";
+							file_put_contents(OC_Config::getValue('datadirectory', OC::$SERVERROOT.'/data').'/.htaccess', $content);
+						}
 					}
 				}		
 				OC_Log::write('core', 'starting upgrade from '.$installedVersion.' to '.$currentVersion, OC_Log::DEBUG);


### PR DESCRIPTION
When upgrading from old ownCloud versions like 2.x the .htaccess is not generated - which exposes the data to the internet. This fix will generate a .htaccess when upgrading.
Fixes #127

Please review this change.
