### PR TITLE
check for database error in userExists

### DIFF
--- a/lib/user/database.php
+++ b/lib/user/database.php
@@ -172,7 +172,10 @@ class OC_User_Database extends OC_User_Backend {
 	public function userExists($uid) {
 		$query = OC_DB::prepare( 'SELECT * FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)' );
 		$result = $query->execute( array( $uid ));
-
+		if (OC_DB::isError($result)) {
+			OC_Log::write('core', OC_DB::getErrorMessage($result), OC_Log::ERROR);
+			return false;
+		}
 		return $result->numRows() > 0;
 	}
 


### PR DESCRIPTION
Not checking for errors will result in a php error:

Call to undefined method MDB2_Error::numRows() in /home/xxx/www/owncloud/lib/user/database.php on line 176

The attached patch logs the error and correctly returns false in that case.
