### PR TITLE
load logging apps for webdav connections

### DIFF
--- a/apps/files/appinfo/filesync.php
+++ b/apps/files/appinfo/filesync.php
@@ -21,7 +21,7 @@
  */
 
 // only need filesystem apps
-$RUNTIME_APPTYPES=array('filesystem','authentication');
+$RUNTIME_APPTYPES=array('filesystem','authentication','logging');
 OC_App::loadApps($RUNTIME_APPTYPES);
 if(!OC_User::isLoggedIn()) {
         if(!isset($_SERVER['PHP_AUTH_USER'])) {

--- a/apps/files/appinfo/filesync.php
+++ b/apps/files/appinfo/filesync.php
@@ -20,7 +20,7 @@
  * The final URL will look like http://.../remote.php/filesync/oc_chunked/path/to/file
  */
 
-// only need filesystem apps
+// load needed apps
 $RUNTIME_APPTYPES=array('filesystem','authentication','logging');
 OC_App::loadApps($RUNTIME_APPTYPES);
 if(!OC_User::isLoggedIn()) {

--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -22,7 +22,7 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-// only need filesystem apps
+// load needed apps
 $RUNTIME_APPTYPES=array('filesystem','authentication','logging');
 OC_App::loadApps($RUNTIME_APPTYPES);
 

--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -23,7 +23,7 @@
  *
  */
 // only need filesystem apps
-$RUNTIME_APPTYPES=array('filesystem','authentication');
+$RUNTIME_APPTYPES=array('filesystem','authentication','logging');
 OC_App::loadApps($RUNTIME_APPTYPES);
 
 // Backends


### PR DESCRIPTION
Until now we only loaded "filesystem" and "authentication" apps if the user connects to owncloud over webdav. This patch takes care that also logging apps are loaded to enable logging of webdav activities.
