### PR TITLE
Decode the password with ISO-8859-1 when using Basic Authentication

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -674,6 +674,13 @@ class OC{
 			$_REQUEST['redirect_url'] = (isset($_SERVER['REQUEST_URI'])?$_SERVER['REQUEST_URI']:'');
 			OC_Util::redirectToDefaultPage();
 		}
+		
+		// Decode ISO-8859-1 which is the encoding sent by some clients
+		if(OC_User::login($_SERVER["PHP_AUTH_USER"], iconv("ISO-8859-1", "UTF-8", $_SERVER["PHP_AUTH_PW"]))) {
+			OC_User::unsetMagicInCookie();
+			$_REQUEST['redirect_url'] = (isset($_SERVER['REQUEST_URI'])?$_SERVER['REQUEST_URI']:'');
+			OC_Util::redirectToDefaultPage();
+		}
 		return true;
 	}
 

--- a/lib/connector/sabre/auth.php
+++ b/lib/connector/sabre/auth.php
@@ -36,13 +36,17 @@ class OC_Connector_Sabre_Auth extends Sabre_DAV_Auth_Backend_AbstractBasic {
 			return true;
 		} else {
 			OC_Util::setUpFS();//login hooks may need early access to the filesystem
+
 			if(OC_User::login($username, $password)) {
 				OC_Util::setUpFS(OC_User::getUser());
 				return true;
 			}
-			else{
-				return false;
+			// Decode ISO-8859-1 which is the encoding sent by some clients
+			if(OC_User::login($username, iconv("ISO-8859-1", "UTF-8", $password))) {
+				OC_Util::setUpFS(OC_User::getUser());
+				return true;
 			}
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
Several browsers/clients encodes the login in different encodings when using Basic Auth, so that the password won't match when using special characters like `ñ` in it.

@MTRichards Does this also solve your issue?
(Related bug #70)
