### PR TITLE
Allow admins to disable "from URL" via admin panel

### DIFF
--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -63,7 +63,7 @@ $tmpl = new OCP\Template( 'files', 'admin' );
 $tmpl->assign( 'uploadChangable', $htaccessWorking and $htaccessWritable );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign( 'maxPossibleUploadSize', $maxUploadFilesizePossible);
-$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true'));
+$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', true));
 $tmpl->assign( 'allowZipDownload', $allowZipDownload);
 $tmpl->assign( 'maxZipInputSize', $maxZipInputSize);
 return $tmpl->fetchPage();

--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -35,7 +35,7 @@ $post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
 $post_max_size_possible = OCP\Util::computerFileSize(get_cfg_var('post_max_size'));
 $maxUploadFilesize = OCP\Util::humanFileSize(min($upload_max_filesize, $post_max_size));
 $maxUploadFilesizePossible = OCP\Util::humanFileSize(min($upload_max_filesize_possible, $post_max_size_possible));
-if($_POST && OC_Util::isCallRegistered) {
+if($_POST && OC_Util::isCallRegistered()) {
 	if(isset($_POST['maxUploadSize'])) {
 		if(($setMaxSize = OC_Files::setUploadLimit(OCP\Util::computerFileSize($_POST['maxUploadSize']))) !== false) {
 			$maxUploadFilesize = OCP\Util::humanFileSize($setMaxSize);

--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -48,6 +48,9 @@ if($_POST && OC_Util::isCallRegistered()) {
 	if(isset($_POST['submitFilesAdminSettings'])) {
 		OCP\Config::setSystemValue('allowZipDownload', isset($_POST['allowZipDownload']));
 	}
+	if(isset($_POST['submitFilesAdminSettings'])) {
+		OC_Appconfig::setValue('files', 'allowHTTPDownload', isset($_POST['allowHTTPDownload']));
+	}
 }
 $maxZipInputSize = OCP\Util::humanFileSize(OCP\Config::getSystemValue('maxZipInputSize', OCP\Util::computerFileSize('800 MB')));
 $allowZipDownload = intval(OCP\Config::getSystemValue('allowZipDownload', true));
@@ -60,6 +63,7 @@ $tmpl = new OCP\Template( 'files', 'admin' );
 $tmpl->assign( 'uploadChangable', $htaccessWorking and $htaccessWritable );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign( 'maxPossibleUploadSize', $maxUploadFilesizePossible);
+$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true'));
 $tmpl->assign( 'allowZipDownload', $allowZipDownload);
 $tmpl->assign( 'maxZipInputSize', $maxZipInputSize);
 return $tmpl->fetchPage();

--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -35,7 +35,7 @@ $post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
 $post_max_size_possible = OCP\Util::computerFileSize(get_cfg_var('post_max_size'));
 $maxUploadFilesize = OCP\Util::humanFileSize(min($upload_max_filesize, $post_max_size));
 $maxUploadFilesizePossible = OCP\Util::humanFileSize(min($upload_max_filesize_possible, $post_max_size_possible));
-if($_POST) {
+if($_POST && OC_Util::isCallRegistered) {
 	if(isset($_POST['maxUploadSize'])) {
 		if(($setMaxSize = OC_Files::setUploadLimit(OCP\Util::computerFileSize($_POST['maxUploadSize']))) !== false) {
 			$maxUploadFilesize = OCP\Util::humanFileSize($setMaxSize);

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -55,7 +55,7 @@ function progress($notification_code, $severity, $message, $message_code, $bytes
 }
 
 if($source) {
-	if(OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true') == true) {
+	if(OC_Appconfig::getValue('files', 'allowHTTPDownload', true) == true) {
 		if(substr($source, 0, 8)!='https://' and substr($source, 0, 7)!='http://') {
 			OCP\JSON::error(array("data" => array( "message" => "Not a valid source" )));
 			exit();

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -55,7 +55,7 @@ function progress($notification_code, $severity, $message, $message_code, $bytes
 }
 
 if($source) {
-	if(OC_Config::getValue('allowHTTPDownload', true) === true) {
+	if(OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true') == true) {
 		if(substr($source, 0, 8)!='https://' and substr($source, 0, 7)!='http://') {
 			OCP\JSON::error(array("data" => array( "message" => "Not a valid source" )));
 			exit();

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -110,5 +110,5 @@ $tmpl->assign( 'files', $files );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign( 'uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 $tmpl->assign( 'allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
-$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true'));
+$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', true));
 $tmpl->printPage();

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -110,5 +110,5 @@ $tmpl->assign( 'files', $files );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign( 'uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 $tmpl->assign( 'allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
-$tmpl->assign( 'allowHTTPDownload', OC_Config::getValue('allowHTTPDownload', true));
+$tmpl->assign( 'allowHTTPDownload', OC_Appconfig::getValue('files', 'allowHTTPDownload', 'true'));
 $tmpl->printPage();

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -110,4 +110,5 @@ $tmpl->assign( 'files', $files );
 $tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign( 'uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 $tmpl->assign( 'allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
+$tmpl->assign( 'allowHTTPDownload', OC_Config::getValue('allowHTTPDownload', true));
 $tmpl->printPage();

--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -11,6 +11,7 @@
 			<input name="maxZipInputSize" id="maxZipInputSize" style="width:180px;" value='<?php echo $_['maxZipInputSize'] ?>' title="<?php echo $l->t( '0 is unlimited' ); ?>"<?php if (!$_['allowZipDownload']) echo ' disabled="disabled"'; ?> />
 			<label for="maxZipInputSize"><?php echo $l->t( 'Maximum input size for ZIP files' ); ?> </label><br />
 
+		<input type="hidden" value="<?php echo $_['requesttoken']; ?>" name="requesttoken" />
 		<input type="submit" name="submitFilesAdminSettings" id="submitFilesAdminSettings" value="<?php echo $l->t( 'Save' ); ?>"/>
 	</fieldset>
 </form>

--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -10,7 +10,8 @@
 
 			<input name="maxZipInputSize" id="maxZipInputSize" style="width:180px;" value='<?php echo $_['maxZipInputSize'] ?>' title="<?php echo $l->t( '0 is unlimited' ); ?>"<?php if (!$_['allowZipDownload']) echo ' disabled="disabled"'; ?> />
 			<label for="maxZipInputSize"><?php echo $l->t( 'Maximum input size for ZIP files' ); ?> </label><br />
-
+		
+		<input type="checkbox" name="allowHTTPDownload" id="allowHTTPDownload" value="1" title="<?php echo $l->t( 'This functions could allow your users to DoS the server with downloading multiple large files at the same time.' ); ?>"<?php if ($_['allowHTTPDownload']) echo ' checked="checked"'; ?> /> <label for="allowHTTPDownload"><?php echo $l->t( 'Allow users to download files from websites' ); ?></label> <br/>
 		<input type="hidden" value="<?php echo $_['requesttoken']; ?>" name="requesttoken" />
 		<input type="submit" name="submitFilesAdminSettings" id="submitFilesAdminSettings" value="<?php echo $l->t( 'Save' ); ?>"/>
 	</fieldset>

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -8,7 +8,9 @@
 				<ul class="popup popupTop">
 					<li style="background-image:url('<?php echo OCP\mimetype_icon('text/plain') ?>')" data-type='file'><p><?php echo $l->t('Text file');?></p></li>
 					<li style="background-image:url('<?php echo OCP\mimetype_icon('dir') ?>')" data-type='folder'><p><?php echo $l->t('Folder');?></p></li>
-					<li style="background-image:url('<?php echo OCP\image_path('core','actions/public.png') ?>')" data-type='web'><p><?php echo $l->t('From link');?></p></li>
+					<?php if($_['allowHTTPDownload']):?>
+						<li style="background-image:url('<?php echo OCP\image_path('core','actions/public.png') ?>')" data-type='web'><p><?php echo $l->t('From link');?></p></li>
+					<?php endif; ?>
 				</ul>
 			</div>
 			<div class="file_upload_wrapper svg">

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -36,9 +36,6 @@ $CONFIG = array(
 /* Time in seconds how long an user is authenticated without entering his password again before performing sensitive actions like creating or deleting users etc...*/
 "enhancedauthtime" => 15 * 60,
 
-/* Define wheter the "from link" function is available to users in the new files popup  (false = disable "from link") */
-'allowHTTPDownload' => false,
-
 /* Theme to use for ownCloud */
 "theme" => "",
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -36,6 +36,9 @@ $CONFIG = array(
 /* Time in seconds how long an user is authenticated without entering his password again before performing sensitive actions like creating or deleting users etc...*/
 "enhancedauthtime" => 15 * 60,
 
+/* Define wheter the "from link" function is available to users in the new files popup  (false = disable "from link") */
+'allowHTTPDownload' => false,
+
 /* Theme to use for ownCloud */
 "theme" => "",
 


### PR DESCRIPTION
It is possible to DoS a server via multiple really large downloads with the "from URL" function, so it should be at least configurable for the admin to disable this function.
