### PR TITLE
Ldap existence check

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -36,6 +36,15 @@ abstract class Access {
 		return ($this->connection instanceof Connection);
 	}
 
+	/**
+	 * @brief reads a directory record identified by a DN
+	 * @param $dn the record in question
+	 * @param $attr the attribute that shall be retrieved
+	 * @returns the values in an array on success or true if $attr is empty,
+	 * false otherwise
+	 *
+	 * Reads an LDAP entry
+	 */
 	private function entryReader($dn, $attr, $filter = 'objectClass=*'){
 		if(!$this->checkConnection()) {
 			\OCP\Util::writeLog('user_ldap', 'No LDAP Connector assigned, access impossible for entryExists.', \OCP\Util::WARN);
@@ -68,10 +77,16 @@ abstract class Access {
                 return $result;
 	}
 
-        public function entryExists($dn) {
-            
-            return $this->entryReader($dn, array(), 'objectClass=*');
-        }
+	/**
+	 * @brief checks if a directory object identified by a DN really exists
+	 * @param $dn the record in question
+	 * @returns true on success, false otherwise
+	 *
+	 * Checks if an LDAP entry exists
+	 */
+	public function entryExists($dn) {
+		return $this->entryReader($dn, array(), 'objectClass=*');
+	}
 	
 	/**
 	 * @brief reads a given attribute for an LDAP record identified by a DN

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -36,6 +36,27 @@ abstract class Access {
 		return ($this->connection instanceof Connection);
 	}
 
+	public function entryExists($dn){
+		if(!$this->checkConnection()) {
+			\OCP\Util::writeLog('user_ldap', 'No LDAP Connector assigned, access impossible for entryExists.', \OCP\Util::WARN);
+			return false;
+		}
+		$cr = $this->connection->getConnectionResource();
+		if(!is_resource($cr)) {
+			//LDAP not available
+			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
+			return false;
+		}
+		$rr = @ldap_read($cr, $dn, 'objectClass=*');
+		if(!is_resource($rr)) {
+			\OCP\Util::writeLog('user_ldap', 'entryExists failed for DN '.$dn, \OCP\Util::DEBUG);
+			//in case an error occurs , e.g. object does not exist
+			return false;
+		}
+		\OCP\Util::writeLog('user_ldap', 'entryExists: '.$dn.' found', \OCP\Util::DEBUG);
+		return true;	
+	}
+	
 	/**
 	 * @brief reads a given attribute for an LDAP record identified by a DN
 	 * @param $dn the record in question

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -149,7 +149,7 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 			return false;
 		}
 
-		// check if user really still exists
+		//check if user really still exists
 		if(!$this->entryExists($dn) ) {
 			$this->connection->writeToCache('userExists'.$uid, false);
 			return false;

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -149,9 +149,8 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 			return false;
 		}
 
-		//if user really still exists, we will be able to read his objectclass
-		$objcs = $this->readAttribute($dn, 'objectclass');
-		if(!$objcs || empty($objcs)) {
+		// check if user really still exists
+		if(!$this->entryExists($dn) ) {
 			$this->connection->writeToCache('userExists'.$uid, false);
 			return false;
 		}


### PR DESCRIPTION
This is an update for the closed https://github.com/owncloud/core/pull/139.

The common code is now shared by both callers.

The rationale for adding another method is that of API clarity in keeping
existence check separate from attribute reading.
