### PR TITLE
Ldap stable45

### DIFF
--- a/apps/user_ldap/settings.php
+++ b/apps/user_ldap/settings.php
@@ -50,7 +50,7 @@ if ($_POST) {
 			OCP\Config::setAppValue('user_ldap', $param, 0);
 		}
 	}
-	if($clearCache){
+	if($clearCache) {
 		$ldap = new \OCA\user_ldap\lib\Connection('user_ldap');
 		$ldap->clearCache();
 	}

--- a/apps/user_ldap/settings.php
+++ b/apps/user_ldap/settings.php
@@ -26,16 +26,12 @@ OCP\Util::addscript('user_ldap', 'settings');
 OCP\Util::addstyle('user_ldap', 'settings');
 
 if ($_POST) {
+	$clearCache = false;
 	foreach($params as $param) {
 		if(isset($_POST[$param])) {
+			$clearCache = true;
 			if('ldap_agent_password' == $param) {
 				OCP\Config::setAppValue('user_ldap', $param, base64_encode($_POST[$param]));
-			} elseif('ldap_cache_ttl' == $param) {
-				if(OCP\Config::getAppValue('user_ldap', $param,'') != $_POST[$param]) {
-					$ldap = new \OCA\user_ldap\lib\Connection('user_ldap');
-					$ldap->clearCache();
-					OCP\Config::setAppValue('user_ldap', $param, $_POST[$param]);
-				}
 			} elseif('home_folder_naming_rule' == $param) {
 				$value = empty($_POST[$param]) ? 'opt:username' : 'attr:'.$_POST[$param];
 				OCP\Config::setAppValue('user_ldap', $param, $value);
@@ -53,6 +49,10 @@ if ($_POST) {
 		elseif('ldap_turn_off_cert_check' == $param) {
 			OCP\Config::setAppValue('user_ldap', $param, 0);
 		}
+	}
+	if($clearCache){
+		$ldap = new \OCA\user_ldap\lib\Connection('user_ldap');
+		$ldap->clearCache();
 	}
 }
 


### PR DESCRIPTION
Backport fix for #194 (LDAP: clear the cache not only when TTL changes, but with every settings update) to stable45
