### PR TITLE
load all enabled apps to make sure that all hooks are triggered (issue #151)

### DIFF
--- a/settings/ajax/removeuser.php
+++ b/settings/ajax/removeuser.php
@@ -2,6 +2,7 @@
 
 OC_JSON::checkSubAdminUser();
 OCP\JSON::callCheck();
+OC_App::loadApps();
 
 $username = $_POST["username"];
 


### PR DESCRIPTION
All enabled apps need to be loaded before performing the delete action to make sure that all necessary hooks are triggered. (fixes issue #151)
