### PR TITLE
Ldap existence check no refactor

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -40,9 +40,10 @@ abstract class Access {
 	 * @brief reads a given attribute for an LDAP record identified by a DN
 	 * @param $dn the record in question
 	 * @param $attr the attribute that shall be retrieved
-	 * @returns the values in an array on success, false otherwise
+	 *        if empty, just check the record's existence
+	 * @returns true or the values in an array on success, false otherwise
 	 *
-	 * Reads an attribute from an LDAP entry
+	 * Reads an attribute from an LDAP entry or check if entry exists
 	 */
 	public function readAttribute($dn, $attr, $filter = 'objectClass=*') {
 		if(!$this->checkConnection()) {
@@ -57,9 +58,13 @@ abstract class Access {
 		}
 		$rr = @ldap_read($cr, $dn, $filter, array($attr));
 		if(!is_resource($rr)) {
-			\OCP\Util::writeLog('user_ldap', 'readAttribute '.$attr.' failed for DN '.$dn, \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
 			//in case an error occurs , e.g. object does not exist
 			return false;
+		}
+		if (empty($attr)) {
+			\OCP\Util::writeLog('user_ldap', 'readAttribute: '.$dn.' found', \OCP\Util::DEBUG);
+			return true;
 		}
 		$er = ldap_first_entry($cr, $rr);
 		if(!is_resource($er)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -41,7 +41,8 @@ abstract class Access {
 	 * @param $dn the record in question
 	 * @param $attr the attribute that shall be retrieved
 	 *        if empty, just check the record's existence
-	 * @returns true or the values in an array on success, false otherwise
+	 * @returns an array of values on success or an empty
+	 *          array if $attr is empty, false otherwise
 	 *
 	 * Reads an attribute from an LDAP entry or check if entry exists
 	 */
@@ -64,7 +65,7 @@ abstract class Access {
 		}
 		if (empty($attr)) {
 			\OCP\Util::writeLog('user_ldap', 'readAttribute: '.$dn.' found', \OCP\Util::DEBUG);
-			return true;
+			return array();
 		}
 		$er = ldap_first_entry($cr, $rr);
 		if(!is_resource($er)) {

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -150,7 +150,7 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 		}
 
 		//check if user really still exists by reading its entry
-		if(!$this->readAttribute($dn, '') ) {
+		if(!is_array($this->readAttribute($dn, ''))) {
 			$this->connection->writeToCache('userExists'.$uid, false);
 			return false;
 		}

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -149,9 +149,8 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 			return false;
 		}
 
-		//if user really still exists, we will be able to read his objectclass
-		$objcs = $this->readAttribute($dn, 'objectclass');
-		if(!$objcs || empty($objcs)) {
+		//check if user really still exists by reading its entry
+		if(!$this->readAttribute($dn, '') ) {
 			$this->connection->writeToCache('userExists'.$uid, false);
 			return false;
 		}


### PR DESCRIPTION
Since some sites configure the directory not to allow direct reading of the entry's objectClass attribute, there is a need to enable a direct entry existence check.

This version of the changes is meant to be more akin to with blizzz tastes than the replaced https://github.com/owncloud/core/pull/230.

Thank you
