### PR TITLE
Fix mkdir and opendir warnings when path does not exist

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -285,7 +285,12 @@ class OC_Mount_Config {
 	public static function getCertificates() {
 		$view = \OCP\Files::getStorage('files_external');
 		$path=\OCP\Config::getSystemValue('datadirectory').$view->getAbsolutePath("").'uploads/';
-		if (!is_dir($path)) mkdir($path);
+		\OCP\Util::writeLog('files_external', 'checking path '.$path, \OCP\Util::INFO);
+		if(!is_dir($path)) {
+			//path might not exist (e.g. non-standard OC_User::getHome() value)
+			//in this case create full path using 3rd (recursive=true) parameter.
+			mkdir($path, 0777, true);
+		}
 		$result = array();
 		$handle = opendir($path);
 		if (!$handle) {


### PR DESCRIPTION
When the user backend`s implementation of getHome() returns a non-standard path (i.e. not $datadirectory/$username) two PHP warnings are triggered

{"app":"PHP","message":"mkdir(): No such file or directory at ...\/master\/apps\/files_external\/lib\/config.php#289","level":2,"time":1352146879}
{"app":"PHP","message":"opendir(...\/master\/data\/alicccce\/files_external\/uploads\/): failed to open dir: No such file or directory at ...\/master\/apps\/files_external\/lib\/config.php#291","level":2,"time":1352146879}

The commit fixes it by creating the whole path. According to Georg getHome() is not meant to be the place for meta data, so it does not need to be considered.

Btw, the 0777 mode is the default value.

Please review, e.g. (but not limited to) @georgehrke  @icewind1991 @bartv2 
