### PR TITLE
fixes #239: query the database in chunks of 200

### DIFF
--- a/lib/connector/sabre/directory.php
+++ b/lib/connector/sabre/directory.php
@@ -123,6 +123,10 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 		}
 		$properties = array_fill_keys($paths, array());
 		if(count($paths)>0) {
+			//
+			// the number of arguments within IN conditions are limited in most databases
+			// we chunk $paths into arrays of 200 items each to meet this criteria
+			//
 			$chunks = array_chunk($paths, 200, false);
 			foreach ($chunks as $pack) {
 				$placeholders = join(',', array_fill(0, count($pack), '?'));


### PR DESCRIPTION
Currently the sql query will fail as soon as a certain number of items in the IN condition has been reached.
(1000 for Oracle and sqlite - no idea about the others)
The proposed solution will cut the array into tiny little pieces and execute the statement multiple times.

Fixes #239

My setup: apache + sqlite + all on localhost:

current implementation: 0.1331 sec.
proposal within #329: 0.5020 sec
chunked in packs of 999: 0.3075 sec
chunked in packs of 200: 0.2089 sec

chunk size of 200 gave the best results with my setup

A LIKE based query will not work due to the special case of 'Shared' - afaik
