### PR TITLE
LDAP: fix typo in config value handling.

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -89,7 +89,7 @@ class Connection {
 			\OCP\Util::writeLog('user_ldap', 'Set config ldapUuidAttribute to  '.$value, \OCP\Util::DEBUG);
 			$this->config[$name] = $value;
 			if(!empty($this->configID)) {
-				\OCP\Config::getAppValue($this->configID, 'ldap_uuid_attribute', $value);
+				\OCP\Config::setAppValue($this->configID, 'ldap_uuid_attribute', $value);
 			}
 			$changed = true;
 		}


### PR DESCRIPTION
It's in a setter function...
