### PR TITLE
Fix delete link when new user is added

### DIFF
--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -93,7 +93,8 @@ var UserList={
 			UserList.applyMultiplySelect(subadminSelect);
 		}
 		if (tr.find('td.remove img').length == 0 && OC.currentUser != username) {
-			tr.find('td.remove').append($('<img alt="Delete" title="'+t('settings','Delete')+'" class="svg action" src="'+OC.imagePath('core','actions/delete')+'"/>'));
+			tr.find('td.remove').append($('<a class="action delete" href="#"><img alt="Delete" title="'+t('settings','Delete') +
+				'" class="svg action" src="'+OC.imagePath('core','actions/delete')+'"/></a>'));
 		} else if (OC.currentUser == username) {
 			tr.find('td.remove a').remove();
 		}


### PR DESCRIPTION
When you add a user, 
OC directly add the user to the table while ajaxing to the backend.

The newly created row has a "delete" icon that does not work.
In fact we attach a live event on td.remove>a but we only create a td.remove>img

if you refresh the page, then you have the ability to remove the user.

This patch fix that
