### PR TITLE
urlencode file/dir to allow special characters in filename/path (issue #95)

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -70,9 +70,9 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 			if (isset($linkItem['share_with'])) {
 				// Check password
 				if (isset($_GET['file'])) {
-					$url = OCP\Util::linkToPublic('files').'&file='.$_GET['file'];
+					$url = OCP\Util::linkToPublic('files').'&file='.urlencode($_GET['file']);
 				} else {
-					$url = OCP\Util::linkToPublic('files').'&dir='.$_GET['dir'];
+					$url = OCP\Util::linkToPublic('files').'&dir='.urlencode($_GET['dir']);
 				}
 				if (isset($_POST['password'])) {
 					$password = $_POST['password'];


### PR DESCRIPTION
Fix for issue #95. Urlencode files/dir before assigning them to the authenticate template to allow special characters in filename/path

<!---
@huboard:{"order":189.0}
-->
