### PR TITLE
extract the right file name for drag&drop. 

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -722,7 +722,7 @@ var folderDropOptions={
 }
 var crumbDropOptions={
 	drop: function( event, ui ) {
-		var file=ui.draggable.text().trim();
+		var file=ui.draggable.parent().data('file');
 		var target=$(this).data('dir');
 		var dir=$('#dir').val();
 		while(dir.substr(0,1)=='/'){//remove extra leading /'s


### PR DESCRIPTION
This was necessary after the switch to css to show/hide file actions, otherwise the actions where part of the extracted file name.

@icewind1991 please have a look at it since this fix was most likely necessary because of your changes: https://github.com/owncloud/core/commit/fe6b987b3d48a5fc9bab8f4bfdccb99e9605f07a#apps/files/js/files.js
