### PR TITLE
Fix deleting multiple user w-o reloading V2

### DIFF
--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -16,7 +16,10 @@ var UserList={
 	 * finishDelete() completes the process. This allows for 'undo'.
 	 */
 	do_delete:function( uid ) {
-		
+		if (typeof UserList.deleteUid !== 'undefined') {
+			//Already a user in the undo queue
+			UserList.finishDelete(null);
+		}
 		UserList.deleteUid = uid;
 		
 		// Set undo flag


### PR DESCRIPTION
From PR #296

> When you delete a user,
> as in file, oc put you an undo message. (nice btw)
> and it do the task only when we leave the page.
> 
> so , when you delete 2+ users in row, oc will only delete the last one.
> 
> my patch empty the queue when we want to delete another user.
> so there is always 1 user top in the delete queue as it was meant to be.

**We may want to apply this in master as well.**
