### PR TITLE
bugfix for syncing the Shared-folder

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -3,6 +3,7 @@
 OC::$CLASSPATH['OC_Share_Backend_File'] = "apps/files_sharing/lib/share/file.php";
 OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'apps/files_sharing/lib/share/folder.php';
 OC::$CLASSPATH['OC_Filestorage_Shared'] = "apps/files_sharing/lib/sharedstorage.php";
+OC::$CLASSPATH['OC_Files_Sharing_Util'] = "apps/files_sharing/lib/util.php";
 OCP\Util::connectHook('OC_Filesystem', 'setup', 'OC_Filestorage_Shared', 'setup');
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');

--- a/apps/files_sharing/lib/util.php
+++ b/apps/files_sharing/lib/util.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Bjoern Schiessle
+ * @copyright 2012 Bjoern Schiessle schiessle@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+class OC_Files_Sharing_Util {
+
+	private static $files = array();
+
+	/**
+	 * @brief Get the source file path and the permissions granted for a shared file
+	 * @param string Shared target file path
+	 * @return Returns array with the keys path and permissions or false if not found
+	 */
+	private function getFile($target) {
+		$target = '/'.$target;
+		$target = rtrim($target, '/');
+		if (isset(self::$files[$target])) {
+			return self::$files[$target];
+		} else {
+			$pos = strpos($target, '/', 1);
+			// Get shared folder name
+			if ($pos !== false) {
+				$folder = substr($target, 0, $pos);
+				if (isset(self::$files[$folder])) {
+					$file = self::$files[$folder];
+				} else {
+					$file = OCP\Share::getItemSharedWith('folder', $folder, OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+				}
+				if ($file) {
+					self::$files[$target]['path'] = $file['path'].substr($target, strlen($folder));
+					self::$files[$target]['permissions'] = $file['permissions'];
+					return self::$files[$target];
+				}
+			} else {
+				$file = OCP\Share::getItemSharedWith('file', $target, OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+				if ($file) {
+					self::$files[$target] = $file;
+					return self::$files[$target];
+				}
+			}
+			OCP\Util::writeLog('files_sharing', 'File source not found for: '.$target, OCP\Util::ERROR);
+			return false;
+		}
+	}
+
+	/**
+	 * @brief Get the source file path for a shared file
+	 * @param string Shared target file path
+	 * @return Returns source file path or false if not found
+	 */
+	public static function getSourcePath($target) {
+		$file = self::getFile($target);
+		if (isset($file['path'])) {
+			$uid = substr($file['path'], 1, strpos($file['path'], '/', 1) - 1);
+			OC_Filesystem::mount('OC_Filestorage_Local', array('datadir' => OC_User::getHome($uid)), $uid);
+			return $file['path'];
+		}
+		return false;
+	}
+}

--- a/lib/connector/sabre/directory.php
+++ b/lib/connector/sabre/directory.php
@@ -117,16 +117,20 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 	 */
 	public function getChildren() {
 
+		$source = $this->getFileSource($this->path);
+		$path = $source['path'];
+		$user = $source['user'];
+		
 		$folder_content = OC_Files::getDirectoryContent($this->path);
 		$paths = array();
 		foreach($folder_content as $info) {
-			$paths[] = $this->path.'/'.$info['name'];
+			$paths[] = $path.'/'.$info['name'];
 		}
 		$properties = array_fill_keys($paths, array());
 		if(count($paths)>0) {
 			$placeholders = join(',', array_fill(0, count($paths), '?'));
 			$query = OC_DB::prepare( 'SELECT * FROM `*PREFIX*properties` WHERE `userid` = ?' . ' AND `propertypath` IN ('.$placeholders.')' );
-			array_unshift($paths, OC_User::getUser()); // prepend userid
+			array_unshift($paths, $user); // prepend userid
 			$result = $query->execute( $paths );
 			while($row = $result->fetchRow()) {
 				$propertypath = $row['propertypath'];
@@ -139,7 +143,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 		$nodes = array();
 		foreach($folder_content as $info) {
 			$node = $this->getChild($info['name'], $info);
-			$node->setPropertyCache($properties[$this->path.'/'.$info['name']]);
+			$node->setPropertyCache($properties[$path.'/'.$info['name']]);
 			$nodes[] = $node;
 		}
 		return $nodes;

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -141,25 +141,38 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 * @return bool|array
 	 */
 	public function updateProperties($properties) {
+		// get source path of shared files
+		if (!strncmp($this->path, '/Shared/', 8)) {
+			$source = OC_Filestorage_Shared::getSourcePath(str_replace('/Shared/', '', $this->path));
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$path = '/'.$parts[3];
+		} else {
+			$user = OC_User::getUser();
+			$path = $this->path;
+		}
+		
 		$existing = $this->getProperties(array());
 		foreach($properties as $propertyName => $propertyValue) {
 			// If it was null, we need to delete the property
 			if (is_null($propertyValue)) {
 				if(array_key_exists( $propertyName, $existing )) {
 					$query = OC_DB::prepare( 'DELETE FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ? AND `propertyname` = ?' );
-					$query->execute( array( OC_User::getUser(), $this->path, $propertyName ));
+					$query->execute( array( $user, $path, $propertyName ));
 				}
 			}
 			else {
 				if( strcmp( $propertyName, self::LASTMODIFIED_PROPERTYNAME) === 0 ) {
+					error_log("propertyName: " . $propertyName);
 					$this->touch($propertyValue);
 				} else {
+					error_log("update/insert property: user: $user; path: $path");
 					if(!array_key_exists( $propertyName, $existing )) {
 						$query = OC_DB::prepare( 'INSERT INTO `*PREFIX*properties` (`userid`,`propertypath`,`propertyname`,`propertyvalue`) VALUES(?,?,?,?)' );
-						$query->execute( array( OC_User::getUser(), $this->path, $propertyName, $propertyValue ));
+						$query->execute( array( $user, $path, $propertyName, $propertyValue ));
 					} else {
 						$query = OC_DB::prepare( 'UPDATE `*PREFIX*properties` SET `propertyvalue` = ? WHERE `userid` = ? AND `propertypath` = ? AND `propertyname` = ?' );
-						$query->execute( array( $propertyValue, OC_User::getUser(), $this->path, $propertyName ));
+						$query->execute( array( $propertyValue, $user, $path, $propertyName ));
 					}
 				}
 			}
@@ -181,6 +194,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 * @return void
 	 */
 	public function getProperties($properties) {
+		//TODO: Shared files?!?
 		if (is_null($this->property_cache)) {
 			$query = OC_DB::prepare( 'SELECT * FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ?' );
 			$result = $query->execute( array( OC_User::getUser(), $this->path ));
@@ -222,9 +236,19 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		if (empty($tag)) {
 			return null;
 		}
+		
+		if (!strncmp($path, '/Shared/', 8)) {
+			$source = OC_Filestorage_Shared::getSourcePath(str_replace('/Shared/', '', $path));
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$path = '/'.$parts[3];
+		} else {
+			$user = OC_User::getUser();
+		}
+		
 		$etag = '"'.$tag.'"';
 		$query = OC_DB::prepare( 'INSERT INTO `*PREFIX*properties` (`userid`,`propertypath`,`propertyname`,`propertyvalue`) VALUES(?,?,?,?)' );
-		$query->execute( array( OC_User::getUser(), $path, self::GETETAG_PROPERTYNAME, $etag ));
+		$query->execute( array( $user, $path, self::GETETAG_PROPERTYNAME, $etag ));
 		return $etag;
 	}
 
@@ -234,6 +258,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 */
 	static public function removeETagPropertyForPath($path) {
 		// remove tags from this and parent paths
+		//TODO Shared Files?!?
 		$paths = array();
 		while ($path != '/' && $path != '.' && $path != '' && $path != '\\') {
 			$paths[] = $path;

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -263,6 +263,13 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 			);
 		$vals = array( $source['user'], self::GETETAG_PROPERTYNAME );
 		$query->execute(array_merge( $vals, $paths ));
+		
+		//remove etag for all Shared folders
+		$query = OC_DB::prepare( 'DELETE FROM `*PREFIX*properties`'
+				.' WHERE `propertypath` = "/Shared"'
+		);
+		$query->execute(array());
+		
 	}
 	
 	protected function getFileSource($path) {

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -184,17 +184,19 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 * @return void
 	 */
 	public function getProperties($properties) {
-		//TODO: Shared files?!?
-		if (is_null($this->property_cache)) {
+		
+		$source = self::getFileSource($this->path);
+		
+		if (is_null($this->property_cache) || empty($this->property_cache)) {
 			$query = OC_DB::prepare( 'SELECT * FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ?' );
-			$result = $query->execute( array( OC_User::getUser(), $this->path ));
+			$result = $query->execute( array( $source['user'], $source['path'] ));
 
 			$this->property_cache = array();
 			while( $row = $result->fetchRow()) {
 				$this->property_cache[$row['propertyname']] = $row['propertyvalue'];
 			}
 		}
-
+		
 		// if the array was empty, we need to return everything
 		if(count($properties) == 0) {
 			return $this->property_cache;
@@ -241,7 +243,6 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 */
 	static public function removeETagPropertyForPath($path) {
 		// remove tags from this and parent paths
-		
 		$source = self::getFileSource($path);
 		$path = $source['path'];
 		
@@ -264,7 +265,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		$query->execute(array_merge( $vals, $paths ));
 	}
 	
-	private function getFileSource($path) {
+	protected function getFileSource($path) {
 		if ( OC_App::isEnabled('files_sharing') &&  !strncmp($path, '/Shared/', 8)) {
 			$source = OC_Files_Sharing_Util::getSourcePath(str_replace('/Shared/', '', $path));
 			$parts = explode('/', $source, 4);

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -246,9 +246,6 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		$source = self::getFileSource($path);
 		$path = $source['path'];
 		
-		// get all user to which the file is shared
-		//OCP\Share::getItemShared($itemType, $itemSource)
-		
 		$paths = array();
 		while ($path != '/' && $path != '.' && $path != '' && $path != '\\') {
 			$paths[] = $path;

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -142,37 +142,27 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 */
 	public function updateProperties($properties) {
 		// get source path of shared files
-		if (!strncmp($this->path, '/Shared/', 8)) {
-			$source = OC_Filestorage_Shared::getSourcePath(str_replace('/Shared/', '', $this->path));
-			$parts = explode('/', $source, 4);
-			$user =  $parts[1];
-			$path = '/'.$parts[3];
-		} else {
-			$user = OC_User::getUser();
-			$path = $this->path;
-		}
-		
+		$source = self::getFileSource($this->path);
+
 		$existing = $this->getProperties(array());
 		foreach($properties as $propertyName => $propertyValue) {
 			// If it was null, we need to delete the property
 			if (is_null($propertyValue)) {
 				if(array_key_exists( $propertyName, $existing )) {
 					$query = OC_DB::prepare( 'DELETE FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ? AND `propertyname` = ?' );
-					$query->execute( array( $user, $path, $propertyName ));
+					$query->execute( array( $source['user'], $source['path'], $propertyName ));
 				}
 			}
 			else {
 				if( strcmp( $propertyName, self::LASTMODIFIED_PROPERTYNAME) === 0 ) {
-					error_log("propertyName: " . $propertyName);
 					$this->touch($propertyValue);
 				} else {
-					error_log("update/insert property: user: $user; path: $path");
 					if(!array_key_exists( $propertyName, $existing )) {
 						$query = OC_DB::prepare( 'INSERT INTO `*PREFIX*properties` (`userid`,`propertypath`,`propertyname`,`propertyvalue`) VALUES(?,?,?,?)' );
-						$query->execute( array( $user, $path, $propertyName, $propertyValue ));
+						$query->execute( array( $source['user'], $source['path'], $propertyName, $propertyValue ));
 					} else {
 						$query = OC_DB::prepare( 'UPDATE `*PREFIX*properties` SET `propertyvalue` = ? WHERE `userid` = ? AND `propertypath` = ? AND `propertyname` = ?' );
-						$query->execute( array( $propertyValue, $user, $path, $propertyName ));
+						$query->execute( array( $propertyValue, $source['user'], $source['path'], $propertyName ));
 					}
 				}
 			}
@@ -237,18 +227,11 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 			return null;
 		}
 		
-		if (!strncmp($path, '/Shared/', 8)) {
-			$source = OC_Filestorage_Shared::getSourcePath(str_replace('/Shared/', '', $path));
-			$parts = explode('/', $source, 4);
-			$user =  $parts[1];
-			$path = '/'.$parts[3];
-		} else {
-			$user = OC_User::getUser();
-		}
-		
+		$source = self::getFileSource($path);
+			
 		$etag = '"'.$tag.'"';
 		$query = OC_DB::prepare( 'INSERT INTO `*PREFIX*properties` (`userid`,`propertypath`,`propertyname`,`propertyvalue`) VALUES(?,?,?,?)' );
-		$query->execute( array( $user, $path, self::GETETAG_PROPERTYNAME, $etag ));
+		$query->execute( array( $source['user'], $source['path'], self::GETETAG_PROPERTYNAME, $etag ));
 		return $etag;
 	}
 
@@ -258,7 +241,10 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 */
 	static public function removeETagPropertyForPath($path) {
 		// remove tags from this and parent paths
-		//TODO Shared Files?!?
+		
+		$source = self::getFileSource($path);
+		$path = $source['path'];
+		
 		$paths = array();
 		while ($path != '/' && $path != '.' && $path != '' && $path != '\\') {
 			$paths[] = $path;
@@ -274,7 +260,19 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 			.' AND `propertyname` = ?'
 			.' AND `propertypath` IN ('.$path_placeholders.')'
 			);
-		$vals = array( OC_User::getUser(), self::GETETAG_PROPERTYNAME );
+		$vals = array( $source['user'], self::GETETAG_PROPERTYNAME );
 		$query->execute(array_merge( $vals, $paths ));
+	}
+	
+	private function getFileSource($path) {
+		if ( OC_App::isEnabled('files_sharing') &&  !strncmp($path, '/Shared/', 8)) {
+			$source = OC_Files_Sharing_Util::getSourcePath(str_replace('/Shared/', '', $path));
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$path = '/'.$parts[3];
+		} else {
+			$user = OC_User::getUser();
+		}
+		return(array('user' => $user, 'path' => $path));
 	}
 }

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -246,6 +246,9 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		$source = self::getFileSource($path);
 		$path = $source['path'];
 		
+		// get all user to which the file is shared
+		//OCP\Share::getItemShared($itemType, $itemSource)
+		
 		$paths = array();
 		while ($path != '/' && $path != '.' && $path != '' && $path != '\\') {
 			$paths[] = $path;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -98,7 +98,31 @@ class Share {
 		}
 		return false;
 	}
+	
+	
+	/**
+	 * @brief Get the item of item type shared with the current user by source
+	 * @param string Item type
+	 * @param string Item source
+	 * @param string uid of item owner
+	 * @param int Format (optional) Format type must be defined by the backend
+	 * @return Return depends on format
+	 */
+	public static function getRecipientOfItemBySource($itemType, $itemSource, $itemOwner, $format = self::FORMAT_NONE, $parameters = null, $includeCollections = false) {
+		return self::getItems($itemType, $itemSource, self::$shareTypeUserAndGroups, null, $itemOwner, $format, $parameters, 1, $includeCollections, true);
+	}
 
+	/**
+	 * @brief Get the items of item type shared with the current user
+	 * @param string Item type
+	 * @param int Format (optional) Format type must be defined by the backend
+	 * @param int Number of items to return (optional) Returns all by default
+	 * @return Return depends on format
+	 */
+	public static function getRecipientsOfItem($itemType, $itemSource, $format = self::FORMAT_NONE, $parameters = null, $limit = -1, $includeCollections = false) {
+		return self::getItems($itemType, null, self::$shareTypeUserAndGroups, \OC_User::getUser(), null, $format, $parameters, $limit, $includeCollections);
+	}
+	
 	/**
 	* @brief Get the items of item type shared with the current user
 	* @param string Item type

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -98,31 +98,7 @@ class Share {
 		}
 		return false;
 	}
-	
-	
-	/**
-	 * @brief Get the item of item type shared with the current user by source
-	 * @param string Item type
-	 * @param string Item source
-	 * @param string uid of item owner
-	 * @param int Format (optional) Format type must be defined by the backend
-	 * @return Return depends on format
-	 */
-	public static function getRecipientOfItemBySource($itemType, $itemSource, $itemOwner, $format = self::FORMAT_NONE, $parameters = null, $includeCollections = false) {
-		return self::getItems($itemType, $itemSource, self::$shareTypeUserAndGroups, null, $itemOwner, $format, $parameters, 1, $includeCollections, true);
-	}
 
-	/**
-	 * @brief Get the items of item type shared with the current user
-	 * @param string Item type
-	 * @param int Format (optional) Format type must be defined by the backend
-	 * @param int Number of items to return (optional) Returns all by default
-	 * @return Return depends on format
-	 */
-	public static function getRecipientsOfItem($itemType, $itemSource, $format = self::FORMAT_NONE, $parameters = null, $limit = -1, $includeCollections = false) {
-		return self::getItems($itemType, null, self::$shareTypeUserAndGroups, \OC_User::getUser(), null, $format, $parameters, $limit, $includeCollections);
-	}
-	
 	/**
 	* @brief Get the items of item type shared with the current user
 	* @param string Item type


### PR DESCRIPTION
This fixes the problem we had while syncing the Shared folder (issue #260).
- The main problem was that the etags where stored for each virtual "Shared-folder-path" but not for the real physical path. To detect changes from every user with access to the file I now store only the real path in the properties table.
- Since I need to get the origin file source of a shared folder/file I created a new class  OC_Files_Sharing_Util which provides public access to the necessary code originally implemented in OC_Filestorage_Shared. For now I just copied the necessary functions over to the new class to avoid unwanted side effects. @MTGap please have a look at both classes if it is safe to always point to the function in apps/files_sharing/lib/util.php.
- Since it is quite hard and expensive to find all users which have access to a particular file I decided to always modify the etag for the Shared folder.  This means that for every check the sync client will look in the root sync dir and the root of the shared folder for changes.

@dragotin and @danimo please also have a look at it and test it with the desktop client.
