### PR TITLE
Sharing folder sync stable45

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -3,6 +3,7 @@
 OC::$CLASSPATH['OC_Share_Backend_File'] = "apps/files_sharing/lib/share/file.php";
 OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'apps/files_sharing/lib/share/folder.php';
 OC::$CLASSPATH['OC_Filestorage_Shared'] = "apps/files_sharing/lib/sharedstorage.php";
+OC::$CLASSPATH['OC_Files_Sharing_Util'] = "apps/files_sharing/lib/util.php";
 OCP\Util::connectHook('OC_Filesystem', 'setup', 'OC_Filestorage_Shared', 'setup');
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -112,8 +112,14 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 		if ($path == '' || $path == '/' || !$this->isCreatable(dirname($path))) {
 			return false;
 		} else if ($source = $this->getSourcePath($path)) {
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$intPath = '/'.$parts[3];
 			$storage = OC_Filesystem::getStorage($source);
-			return $storage->mkdir($this->getInternalPath($source));
+			if( ($storage->mkdir($this->getInternalPath($source))) ) {
+				OC_FileCache::put($intPath ,array('user'=>$user), '/'.$user.'/files');
+				return true;
+			}
 		}
 		return false;
 	}
@@ -297,9 +303,14 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 					'source' => $source,
 				);
 			OCP\Util::emitHook('OC_Filestorage_Shared', 'file_put_contents', $info);
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$intPath = '/'.$parts[3];
 			$storage = OC_Filesystem::getStorage($source);
-			$result = $storage->file_put_contents($this->getInternalPath($source), $data);
-			return $result;
+			if( ( $result = $storage->file_put_contents($this->getInternalPath($source), $data) ) ) {
+				OC_FileCache::put($intPath ,array('user'=>$user), '/'.$user.'/files');
+				return $result;
+			}	
 		}
 		return false;
 	}
@@ -368,17 +379,18 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 
 	public function fopen($path, $mode) {
 		if ($source = $this->getSourcePath($path)) {
+			$write = false;
 			switch ($mode) {
+				case 'w':
+				case 'wb':
+				case 'w+':
+				case 'wb+': $write = true;
 				case 'r+':
 				case 'rb+':
-				case 'w+':
-				case 'wb+':
 				case 'x+':
 				case 'xb+':
 				case 'a+':
 				case 'ab+':
-				case 'w':
-				case 'wb':
 				case 'x':
 				case 'xb':
 				case 'a':
@@ -394,7 +406,15 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 			);
 			OCP\Util::emitHook('OC_Filestorage_Shared', 'fopen', $info);
 			$storage = OC_Filesystem::getStorage($source);
-			return $storage->fopen($this->getInternalPath($source), $mode);
+			
+			$parts = explode('/', $source, 4);
+			$user =  $parts[1];
+			$intPath = '/'.$parts[3];
+
+			if ( $write && $storage->touch($this->getInternalPath($source)) ) {
+				OC_FileCache::put($intPath ,array('user'=>$user), '/'.$user.'/files');
+				return $storage->fopen($this->getInternalPath($source), $mode);
+			}			
 		}
 		return false;
 	}

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -413,8 +413,8 @@ class OC_Filestorage_Shared extends OC_Filestorage_Common {
 
 			if ( $write && $storage->touch($this->getInternalPath($source)) ) {
 				OC_FileCache::put($intPath ,array('user'=>$user), '/'.$user.'/files');
-				return $storage->fopen($this->getInternalPath($source), $mode);
-			}			
+			}
+			return $storage->fopen($this->getInternalPath($source), $mode);
 		}
 		return false;
 	}

--- a/apps/files_sharing/lib/util.php
+++ b/apps/files_sharing/lib/util.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Bjoern Schiessle
+ * @copyright 2012 Bjoern Schiessle schiessle@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+class OC_Files_Sharing_Util {
+
+	private static $files = array();
+
+	/**
+	 * @brief Get the source file path and the permissions granted for a shared file
+	 * @param string Shared target file path
+	 * @return Returns array with the keys path and permissions or false if not found
+	 */
+	private function getFile($target) {
+		$target = '/'.$target;
+		$target = rtrim($target, '/');
+		if (isset(self::$files[$target])) {
+			return self::$files[$target];
+		} else {
+			$pos = strpos($target, '/', 1);
+			// Get shared folder name
+			if ($pos !== false) {
+				$folder = substr($target, 0, $pos);
+				if (isset(self::$files[$folder])) {
+					$file = self::$files[$folder];
+				} else {
+					$file = OCP\Share::getItemSharedWith('folder', $folder, OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+				}
+				if ($file) {
+					self::$files[$target]['path'] = $file['path'].substr($target, strlen($folder));
+					self::$files[$target]['permissions'] = $file['permissions'];
+					return self::$files[$target];
+				}
+			} else {
+				$file = OCP\Share::getItemSharedWith('file', $target, OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+				if ($file) {
+					self::$files[$target] = $file;
+					return self::$files[$target];
+				}
+			}
+			OCP\Util::writeLog('files_sharing', 'File source not found for: '.$target, OCP\Util::ERROR);
+			return false;
+		}
+	}
+
+	/**
+	 * @brief Get the source file path for a shared file
+	 * @param string Shared target file path
+	 * @return Returns source file path or false if not found
+	 */
+	public static function getSourcePath($target) {
+		$file = self::getFile($target);
+		if (isset($file['path'])) {
+			$uid = substr($file['path'], 1, strpos($file['path'], '/', 1) - 1);
+			OC_Filesystem::mount('OC_Filestorage_Local', array('datadir' => OC_User::getHome($uid)), $uid);
+			return $file['path'];
+		}
+		return false;
+	}
+}

--- a/apps/files_sharing/lib/util.php
+++ b/apps/files_sharing/lib/util.php
@@ -30,7 +30,7 @@ class OC_Files_Sharing_Util {
 	 * @param string Shared target file path
 	 * @return Returns array with the keys path and permissions or false if not found
 	 */
-	private function getFile($target) {
+	private static function getFile($target) {
 		$target = '/'.$target;
 		$target = rtrim($target, '/');
 		if (isset(self::$files[$target])) {

--- a/lib/connector/sabre/directory.php
+++ b/lib/connector/sabre/directory.php
@@ -117,16 +117,20 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 	 */
 	public function getChildren() {
 
+		$source = $this->getFileSource($this->path);
+		$path = $source['path'];
+		$user = $source['user'];
+		
 		$folder_content = OC_Files::getDirectoryContent($this->path);
 		$paths = array();
 		foreach($folder_content as $info) {
-			$paths[] = $this->path.'/'.$info['name'];
+			$paths[] = $path.'/'.$info['name'];
 		}
 		$properties = array_fill_keys($paths, array());
 		if(count($paths)>0) {
 			$placeholders = join(',', array_fill(0, count($paths), '?'));
 			$query = OC_DB::prepare( 'SELECT * FROM `*PREFIX*properties` WHERE `userid` = ?' . ' AND `propertypath` IN ('.$placeholders.')' );
-			array_unshift($paths, OC_User::getUser()); // prepend userid
+			array_unshift($paths, $user); // prepend userid
 			$result = $query->execute( $paths );
 			while($row = $result->fetchRow()) {
 				$propertypath = $row['propertypath'];
@@ -139,7 +143,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 		$nodes = array();
 		foreach($folder_content as $info) {
 			$node = $this->getChild($info['name'], $info);
-			$node->setPropertyCache($properties[$this->path.'/'.$info['name']]);
+			$node->setPropertyCache($properties[$path.'/'.$info['name']]);
 			$nodes[] = $node;
 		}
 		return $nodes;

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -284,7 +284,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		
 	}
 	
-	protected function getFileSource($path) {
+	protected static function getFileSource($path) {
 		if ( OC_App::isEnabled('files_sharing') &&  !strncmp($path, '/Shared/', 8)) {
 			$source = OC_Files_Sharing_Util::getSourcePath(str_replace('/Shared/', '', $path));
 			$parts = explode('/', $source, 4);

--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -275,6 +275,13 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 			);
 		$vals = array( $source['user'], self::GETETAG_PROPERTYNAME );
 		$query->execute(array_merge( $vals, $paths ));
+		
+		//remove etag for all Shared folders
+		$query = OC_DB::prepare( 'DELETE FROM `*PREFIX*properties`'
+				.' WHERE `propertypath` = "/Shared"'
+		);
+		$query->execute(array());
+		
 	}
 	
 	protected function getFileSource($path) {

--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -79,8 +79,8 @@ class OC_FileCache{
 
 		// add parent directory to the file cache if it does not exist yet.
 		if ($parent == -1 && $fullpath != $root) {
-			$parentDir = dirname($path);
-			self::scanFile($parentDir);
+			$parentDir = dirname(OC_Filesystem::normalizePath($path));
+			self::scanFile($parentDir, $root);
 			$parent = self::getParentId($fullpath);
 		}
 
@@ -94,15 +94,19 @@ class OC_FileCache{
 		if(!isset($data['versioned'])) {
 			$data['versioned']=false;
 		}
+		if(!isset($data['user'])) {
+			$data['user']=OC_User::getUser();
+		}
+		
+		
 		$mimePart=dirname($data['mimetype']);
 		$data['size']=(int)$data['size'];
 		$data['ctime']=(int)$data['mtime'];
 		$data['writable']=(int)$data['writable'];
 		$data['encrypted']=(int)$data['encrypted'];
 		$data['versioned']=(int)$data['versioned'];
-		$user=OC_User::getUser();
 		$query=OC_DB::prepare('INSERT INTO `*PREFIX*fscache`(`parent`, `name`, `path`, `path_hash`, `size`, `mtime`, `ctime`, `mimetype`, `mimepart`,`user`,`writable`,`encrypted`,`versioned`) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)');
-		$result=$query->execute(array($parent,basename($fullpath),$fullpath,md5($fullpath),$data['size'],$data['mtime'],$data['ctime'],$data['mimetype'],$mimePart,$user,$data['writable'],$data['encrypted'],$data['versioned']));
+		$result=$query->execute(array($parent,basename($fullpath),$fullpath,md5($fullpath),$data['size'],$data['mtime'],$data['ctime'],$data['mimetype'],$mimePart,$data['user'],$data['writable'],$data['encrypted'],$data['versioned']));
 		if(OC_DB::isError($result)) {
 			OC_Log::write('files','error while writing file('.$fullpath.') to cache',OC_Log::ERROR);
 		}


### PR DESCRIPTION
This fixes the problem we had while syncing the Shared folder (issue #260) for stable45. For master we will wait until the new file cache is in place.
- The main problem was that the etags where stored for each virtual "Shared-folder-path" but not for the real physical path. To detect changes from every user with access to the file I now store only the real path in the properties table.
- Since I need to get the origin file source of a shared folder/file I created a new class  OC_Files_Sharing_Util which provides public access to the necessary code originally implemented in OC_Filestorage_Shared. For now I just copied the necessary functions over to the new class to avoid unwanted side effects.
- Since it is quite hard and expensive to find all users which have access to a particular file I decided to always modify the etag for the Shared folder.  This means that for every check the sync client will look in the root sync dir and the root of the shared folder for changes.

@dragotin and @danimo please also have a look at it and test it with the desktop client.
