### PR TITLE
Fix problem with apache2+fcgid install, e.g. on Debian Squeeze

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,11 @@
+<IfModule mod_fcgid.c>
+<IfModule mod_setenvif.c>
+<IfModule mod_headers.c>
+SetEnvIfNoCase ^Authorization$ "(.+)" XAUTHORIZATION=$1
+RequestHeader set XAuthorization %{XAUTHORIZATION}e env=XAUTHORIZATION
+</IfModule>
+</IfModule>
+</IfModule>
 ErrorDocument 403 /core/templates/403.php
 ErrorDocument 404 /core/templates/404.php
 <IfModule mod_php5.c>

--- a/lib/base.php
+++ b/lib/base.php
@@ -356,6 +356,10 @@ class OC{
 		//try to set the session lifetime to 60min
 		@ini_set('gc_maxlifetime', '3600');
 
+		//copy http auth headers for apache+php-fcgid work around
+		if (isset($_SERVER['HTTP_XAUTHORIZATION']) && !isset($_SERVER['HTTP_AUTHORIZATION'])) {
+			$_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['HTTP_XAUTHORIZATION'];
+		}
 
 		//set http auth headers for apache+php-cgi work around
 		if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -573,7 +573,15 @@ class OC_Setup {
 	 * create .htaccess files for apache hosts
 	 */
 	private static function createHtaccess() {
-		$content = "ErrorDocument 403 ".OC::$WEBROOT."/core/templates/403.php\n";//custom 403 error page
+		$content = "<IfModule mod_fcgid.c>\n";
+		$content.= "<IfModule mod_setenvif.c>\n";
+		$content.= "<IfModule mod_headers.c>\n";
+		$content.= "SetEnvIfNoCase ^Authorization$ \"(.+)\" XAUTHORIZATION=$1\n";
+		$content.= "RequestHeader set XAuthorization %{XAUTHORIZATION}e env=XAUTHORIZATION\n";
+		$content.= "</IfModule>\n";
+		$content.= "</IfModule>\n";
+		$content.= "</IfModule>\n";
+		$content.= "ErrorDocument 403 ".OC::$WEBROOT."/core/templates/403.php\n";//custom 403 error page
 		$content.= "ErrorDocument 404 ".OC::$WEBROOT."/core/templates/404.php\n";//custom 404 error page
 		$content.= "<IfModule mod_php5.c>\n";
 		$content.= "php_value upload_max_filesize 512M\n";//upload limit


### PR DESCRIPTION
On my Debian squeeze install, ownCloud wouldn't let the authorize for WebDAV and the Android sync client.  Somehow, the "Authorization" header is not passed to CGI script, probably as a security measure. This is the workaround. See also http://forum.owncloud.org/viewtopic.php?f=3&t=2625
