### PR TITLE
fix quota off by one error

### DIFF
--- a/lib/fileproxy/quota.php
+++ b/lib/fileproxy/quota.php
@@ -43,7 +43,7 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 			$userQuota=OC_AppConfig::getValue('files', 'default_quota', 'none');
 		}
 		if($userQuota=='none') {
-			$this->userQuota[$user]=0;
+			$this->userQuota[$user]=-1;
 		}else{
 			$this->userQuota[$user]=OC_Helper::computerFileSize($userQuota);
 		}
@@ -61,8 +61,8 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 		$owner=$storage->getOwner($path);
 
 		$totalSpace=$this->getQuota($owner);
-		if($totalSpace==0) {
-			return 0;
+		if($totalSpace==-1) {
+			return -1;
 		}
 
 		$rootInfo=OC_FileCache::get('', "/".$owner."/files");
@@ -79,7 +79,7 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 	
 	public function postFree_space($path, $space) {
 		$free=$this->getFreeSpace($path);
-		if($free==0) {
+		if($free==-1) {
 			return $space;
 		}
 		return min($free, $space);
@@ -89,21 +89,21 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 		if (is_resource($data)) {
 			$data = '';//TODO: find a way to get the length of the stream without emptying it
 		}
-		return (strlen($data)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
+		return (strlen($data)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==-1);
 	}
 
 	public function preCopy($path1, $path2) {
 		if(!self::$rootView) {
 			self::$rootView = new OC_FilesystemView('');
 		}
-		return (self::$rootView->filesize($path1)<$this->getFreeSpace($path2) or $this->getFreeSpace($path2)==0);
+		return (self::$rootView->filesize($path1)<$this->getFreeSpace($path2) or $this->getFreeSpace($path2)==-1);
 	}
 
 	public function preFromTmpFile($tmpfile, $path) {
-		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
+		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==-1);
 	}
 
 	public function preFromUploadedFile($tmpfile, $path) {
-		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==0);
+		return (filesize($tmpfile)<$this->getFreeSpace($path) or $this->getFreeSpace($path)==-1);
 	}
 }


### PR DESCRIPTION
It seems it is currently possible to remove the quota: fill up the space to last byte and OC_FileProxy_Quota->getFreeSpace(...) will return 0, which is interpreted as quota='none'

This pull request uses -1 to represent no quota and thus fix the issue.
