### PR TITLE
Ldap fix reatrieval of objectguid (AD), more error checking

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -73,7 +73,13 @@ abstract class Access {
 		if(isset($result[$attr]) && $result[$attr]['count'] > 0) {
 			$values = array();
 			for($i=0;$i<$result[$attr]['count'];$i++) {
-				$values[] = $this->resemblesDN($attr) ? $this->sanitizeDN($result[$attr][$i]) : $result[$attr][$i];
+				if($this->resemblesDN($attr)) {
+					$values[] = $this->sanitizeDN($result[$attr][$i]);
+				} elseif(strtolower($attr) == 'objectguid') {
+					$values[] = $this->convertObjectGUID2Str($result[$attr][$i]);
+				} else {
+					$values[] = $result[$attr][$i];
+				}
 			}
 			return $values;
 		}
@@ -685,5 +691,33 @@ abstract class Access {
 			$uuid = false;
 		}
 		return $uuid;
+	}
+
+	/**
+	 * @brief converts a binary ObjectGUID into a string representation
+	 * @param $oguid the ObjectGUID in it's binary form as retrieved from AD
+	 * @returns String
+	 *
+	 * converts a binary ObjectGUID into a string representation
+	 * http://www.php.net/manual/en/function.ldap-get-values-len.php#73198
+	 */
+	private function convertObjectGUID2Str($oguid) {
+		$hex_guid = bin2hex($oguid);
+		$hex_guid_to_guid_str = '';
+		for($k = 1; $k <= 4; ++$k) {
+			$hex_guid_to_guid_str .= substr($hex_guid, 8 - 2 * $k, 2);
+		}
+		$hex_guid_to_guid_str .= '-';
+		for($k = 1; $k <= 2; ++$k) {
+			$hex_guid_to_guid_str .= substr($hex_guid, 12 - 2 * $k, 2);
+		}
+		$hex_guid_to_guid_str .= '-';
+		for($k = 1; $k <= 2; ++$k) {
+			$hex_guid_to_guid_str .= substr($hex_guid, 16 - 2 * $k, 2);
+		}
+		$hex_guid_to_guid_str .= '-' . substr($hex_guid, 16, 4);
+		$hex_guid_to_guid_str .= '-' . substr($hex_guid, 20);
+
+		return strtoupper($hex_guid_to_guid_str);
 	}
 }

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -516,6 +516,12 @@ abstract class Access {
 		$link_resource = $this->connection->getConnectionResource();
 		if(is_resource($link_resource)) {
 			$sr = ldap_search($link_resource, $base, $filter, $attr);
+			if(!is_resource($sr)) {
+				$errmsg  = '('.ldap_errno($link_resource).') ' . ldap_error($link_resource);
+				$errmsg .= ', search filter: ' . $filter;
+				\OCP\Util::writeLog('user_ldap', 'Search: no result resource, LDAP error message: ' . $errmsg, \OCP\Util::ERROR);
+				return array();
+			}
 			$findings = ldap_get_entries($link_resource, $sr );
 
 			// if we're here, probably no connection resource is returned.


### PR DESCRIPTION
First commit fixes #211: AD stores and returns their UUID attribute in a binary way, this needs to be handled accordingly. This was successfully tested by @techjordan (who filed the bug report).

Second commit checks whether the search query was OK, otherwise a log entry is created and we continue with giving back an empty array. This avoids a PHP warning.
