### PR TITLE
Use curl to get remote file content

### DIFF
--- a/lib/ocsclient.php
+++ b/lib/ocsclient.php
@@ -55,19 +55,29 @@ class OC_OCSClient{
 	 * This function calls an OCS server and returns the response. It also sets a sane timeout
 	*/
 	private static function getOCSresponse($url) {
-		// set a sensible timeout of 10 sec to stay responsive even if the server is down.
-		$ctx = stream_context_create(
-			array(
-				'http' => array(
-					'timeout' => 10
-				)
-			)
-		);
-		$data=@file_get_contents($url, 0, $ctx);
+		$data = self::fileGetContentCurl($url);
 		return($data);
 	}
 
-
+        /**
+         * @Brief Get file content via curl.
+         * @return string of the response
+         * This function get the content of a page via curl.
+         */
+        
+        private static function fileGetContentCurl($url){
+            $curl = curl_init();
+            
+            curl_setopt($curl, CURLOPT_HEADER, 0);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($curl, CURLOPT_URL, $url);
+            
+            $data = curl_exec($curl);
+            curl_close($data);
+            
+            return $data;
+        }
+        
 	/**
 	 * @brief Get all the categories from the OCS server
 	 * @returns array with category ids

--- a/lib/ocsclient.php
+++ b/lib/ocsclient.php
@@ -70,6 +70,7 @@ class OC_OCSClient{
             
             curl_setopt($curl, CURLOPT_HEADER, 0);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
             curl_setopt($curl, CURLOPT_URL, $url);
             
             $data = curl_exec($curl);

--- a/lib/ocsclient.php
+++ b/lib/ocsclient.php
@@ -55,31 +55,11 @@ class OC_OCSClient{
 	 * This function calls an OCS server and returns the response. It also sets a sane timeout
 	*/
 	private static function getOCSresponse($url) {
-		$data = self::fileGetContentCurl($url);
+		$data = \OC_Util::getUrlContent($url);
 		return($data);
 	}
 
         /**
-         * @Brief Get file content via curl.
-         * @return string of the response
-         * This function get the content of a page via curl.
-         */
-        
-        private static function fileGetContentCurl($url){
-            $curl = curl_init();
-            
-            curl_setopt($curl, CURLOPT_HEADER, 0);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
-            curl_setopt($curl, CURLOPT_URL, $url);
-            
-            $data = curl_exec($curl);
-            curl_close($data);
-            
-            return $data;
-        }
-        
-	/**
 	 * @brief Get all the categories from the OCS server
 	 * @returns array with category ids
 	 * @note returns NULL if config value appstoreenabled is set to false

--- a/lib/util.php
+++ b/lib/util.php
@@ -642,4 +642,43 @@ class OC_Util {
 
 		return false;
 	}
+        
+        /**
+         * @Brief Get file content via curl.
+         * @param string $url Url to get content
+         * @return string of the response
+         * This function get the content of a page via curl, if curl is enabled.
+         * If not, file_get_element is used.
+         */
+        
+        public static function getUrlContent($url){
+            
+            if  (function_exists('curl_init')) {
+                
+                $curl = curl_init();
+
+                curl_setopt($curl, CURLOPT_HEADER, 0);
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
+                curl_setopt($curl, CURLOPT_URL, $url);
+
+                $data = curl_exec($curl);
+                curl_close($data);
+
+            } else {
+                
+                $ctx = stream_context_create(
+                    array(
+                        'http' => array(
+                            'timeout' => 10
+                        )
+                    )
+                );
+                $data=@file_get_contents($url, 0, $ctx);
+                
+            }
+            
+            return($data);
+        }
+        
 }

--- a/lib/util.php
+++ b/lib/util.php
@@ -646,7 +646,7 @@ class OC_Util {
         /**
          * @Brief Get file content via curl.
          * @param string $url Url to get content
-         * @return string of the response
+         * @return string of the response or false on error
          * This function get the content of a page via curl, if curl is enabled.
          * If not, file_get_element is used.
          */
@@ -663,7 +663,7 @@ class OC_Util {
                 curl_setopt($curl, CURLOPT_URL, $url);
 
                 $data = curl_exec($curl);
-                curl_close($data);
+                curl_close($curl);
 
             } else {
                 
@@ -678,7 +678,7 @@ class OC_Util {
                 
             }
             
-            return($data);
+            return $data;
         }
         
 }


### PR DESCRIPTION
We had some trouble when using file_get_content.

Using curl is faster. And (Maybe) safer because we dont have to enable fsockopen option in server side.
