### PR TITLE
Feature share link with token

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -19,6 +19,24 @@ if (isset($_GET['token'])) {
 		\OCP\Util::writeLog('files_sharing', 'You have files that are shared by link originating from ownCloud 4.0. Redistribute the new links, because backwards compatibility will be removed in ownCloud 5.', \OCP\Util::WARN);
 	}
 }
+
+function getID($path) {
+	// use the share table from the db to find the item source if the file was reshared because shared files
+	//are not stored in the file cache.
+	if (substr(OC_Filesystem::getMountPoint($path), -7, 6) == "Shared") {
+		$path_parts = explode('/', $path, 5);
+		$user = $path_parts[1];
+		$intPath = '/'.$path_parts[4];
+		$query = \OC_DB::prepare('SELECT `item_source` FROM `*PREFIX*share` WHERE `uid_owner` = ? AND `file_target` = ? ');
+		$result = $query->execute(array($user, $intPath));
+		$row = $result->fetchRow();
+		$fileSource = $row['item_source'];
+	} else {
+		$fileSource = OC_Filecache::getId($path, '');
+	}
+
+	return $fileSource;
+}
 // Enf of backward compatibility
 
 /**
@@ -33,6 +51,7 @@ function getPathAndUser($id) {
 	$row = $result->fetchRow();
 	return $row;
 }
+
 
 if (isset($_GET['t'])) {
 	$token = $_GET['t'];
@@ -59,166 +78,201 @@ if (isset($_GET['t'])) {
 			
 			//mount filesystem of file owner
 			OC_Util::setupFS($fileOwner);
-			if (!isset($linkItem['item_type'])) {
-				OCP\Util::writeLog('share', 'No item type set for share id: '.$linkItem['id'], \OCP\Util::ERROR);
-				header('HTTP/1.0 404 Not Found');
-				$tmpl = new OCP\Template('', '404', 'guest');
-				$tmpl->printPage();
-				exit();
-			}
-			if (isset($linkItem['share_with'])) {
-				// Authenticate share_with
-				$url = OCP\Util::linkToPublic('files').'&t='.$token;
-				if (isset($_GET['file'])) {
-					$url .= '&file='.urlencode($_GET['file']);
-				} else if (isset($_GET['dir'])) {
-					$url .= '&dir='.urlencode($_GET['dir']);
-				}
-				if (isset($_POST['password'])) {
-					$password = $_POST['password'];
-					if ($linkItem['share_type'] == OCP\Share::SHARE_TYPE_LINK) {
-						// Check Password
-						$forcePortable = (CRYPT_BLOWFISH != 1);
-						$hasher = new PasswordHash(8, $forcePortable);
-						if (!($hasher->CheckPassword($password.OC_Config::getValue('passwordsalt', ''), $linkItem['share_with']))) {
-							$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
-							$tmpl->assign('URL', $url);
-							$tmpl->assign('error', true);
-							$tmpl->printPage();
-							exit();
-						} else {
-							// Save item id in session for future requests
-							$_SESSION['public_link_authenticated'] = $linkItem['id'];
-						}
-					} else {
-						OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type'].' for share id '.$linkItem['id'], \OCP\Util::ERROR);
-						header('HTTP/1.0 404 Not Found');
-						$tmpl = new OCP\Template('', '404', 'guest');
-						$tmpl->printPage();
-						exit();
-					}
-				// Check if item id is set in session
-				} else if (!isset($_SESSION['public_link_authenticated']) || $_SESSION['public_link_authenticated'] !== $linkItem['id']) {
-					// Prompt for password
+		}
+	}
+} else if (isset($_GET['file']) || isset($_GET['dir'])) {
+	OCP\Util::writeLog('share', 'Missing token, trying fallback file/dir links', \OCP\Util::DEBUG);
+	if (isset($_GET['dir'])) {
+		$type = 'folder';
+		$path = $_GET['dir'];
+		if(strlen($path)>1 and substr($path, -1, 1)==='/') {
+			$path=substr($path, 0, -1);
+		}
+		$baseDir = $path;
+		$dir = $baseDir;
+	} else {
+		$type = 'file';
+		$path = $_GET['file'];
+		if(strlen($path)>1 and substr($path, -1, 1)==='/') {
+			$path=substr($path, 0, -1);
+		}
+	}
+	$shareOwner = substr($path, 1, strpos($path, '/', 1) - 1);
+	
+	if (OCP\User::userExists($shareOwner)) {
+		OC_Util::setupFS($shareOwner);
+		$fileSource = getId($path);
+		if ($fileSource != -1 ) {
+			$linkItem = OCP\Share::getItemSharedWithByLink($type, $fileSource, $shareOwner);
+			$pathAndUser['path'] = $path;
+			$path_parts = explode('/', $path, 5);
+			$pathAndUser['user'] = $path_parts[1];
+			$fileOwner = $path_parts[1];
+		}
+	}
+}
+
+if ($linkItem) {
+	if (!isset($linkItem['item_type'])) {
+		OCP\Util::writeLog('share', 'No item type set for share id: '.$linkItem['id'], \OCP\Util::ERROR);
+		header('HTTP/1.0 404 Not Found');
+		$tmpl = new OCP\Template('', '404', 'guest');
+		$tmpl->printPage();
+		exit();
+	}
+	if (isset($linkItem['share_with'])) {
+		// Authenticate share_with
+		$url = OCP\Util::linkToPublic('files').'&t='.$token;
+		if (isset($_GET['file'])) {
+			$url .= '&file='.urlencode($_GET['file']);
+		} else if (isset($_GET['dir'])) {
+			$url .= '&dir='.urlencode($_GET['dir']);
+		}
+		if (isset($_POST['password'])) {
+			$password = $_POST['password'];
+			if ($linkItem['share_type'] == OCP\Share::SHARE_TYPE_LINK) {
+				// Check Password
+				$forcePortable = (CRYPT_BLOWFISH != 1);
+				$hasher = new PasswordHash(8, $forcePortable);
+				if (!($hasher->CheckPassword($password.OC_Config::getValue('passwordsalt', ''), $linkItem['share_with']))) {
 					$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
 					$tmpl->assign('URL', $url);
+					$tmpl->assign('error', true);
 					$tmpl->printPage();
 					exit();
+				} else {
+					// Save item id in session for future requests
+					$_SESSION['public_link_authenticated'] = $linkItem['id'];
 				}
-			}
-			$basePath = substr($pathAndUser['path'] , strlen('/'.$fileOwner.'/files'));
-			$path = $basePath;
-			if (isset($_GET['path'])) {
-				$path .= $_GET['path'];
-			}
-			if (!$path || !OC_Filesystem::isValidPath($path) || !OC_Filesystem::file_exists($path)) {
-				OCP\Util::writeLog('share', 'Invalid path '.$path.' for share id '.$linkItem['id'], \OCP\Util::ERROR);
+			} else {
+				OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type'].' for share id '.$linkItem['id'], \OCP\Util::ERROR);
 				header('HTTP/1.0 404 Not Found');
 				$tmpl = new OCP\Template('', '404', 'guest');
 				$tmpl->printPage();
 				exit();
 			}
-			$dir = dirname($path);
-			$file = basename($path);
-			// Download the file
-			if (isset($_GET['download'])) {
-				if (isset($_GET['path']) && $_GET['path'] !== '' ) {
-					if ( isset($_GET['files']) ) { // download selected files
-						OC_Files::get($path, $_GET['files'], $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
-					} else if (isset($_GET['path']) && $_GET['path'] != '' ) { // download a file from a shared directory
-						OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
-					} else { // download the whole shared directory
-						OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
-					}
-				} else { // download a single shared file
-					OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
-				}
-
-			} else {
-				OCP\Util::addStyle('files_sharing', 'public');
-				OCP\Util::addScript('files_sharing', 'public');
-				OCP\Util::addScript('files', 'fileactions');
-				$tmpl = new OCP\Template('files_sharing', 'public', 'base');
-				$tmpl->assign('uidOwner', $shareOwner);
-				$tmpl->assign('dir', $dir);
-				$tmpl->assign('filename', $file);
-				$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));
-				if (isset($_GET['path'])) {
-					$getPath = $_GET['path'];
-				} else {
-					$getPath = '';
-				}
-				// Show file list
-				if (OC_Filesystem::is_dir($path)) {
-					OCP\Util::addStyle('files', 'files');
-					OCP\Util::addScript('files', 'files');
-					OCP\Util::addScript('files', 'filelist');
-					$files = array();
-					$rootLength = strlen($basePath) + 1;
-					foreach (OC_Files::getDirectoryContent($path) as $i) {
-						$i['date'] = OCP\Util::formatDate($i['mtime']);
-						if ($i['type'] == 'file') {
-							$fileinfo = pathinfo($i['name']);
-							$i['basename'] = $fileinfo['filename'];
-							$i['extension'] = isset($fileinfo['extension']) ? ('.'.$fileinfo['extension']) : '';
-						}
-						$i['directory'] = '/'.substr($i['directory'], $rootLength);
-						if ($i['directory'] == '/') {
-							$i['directory'] = '';
-						}
-						$i['permissions'] = OCP\PERMISSION_READ;
-						$files[] = $i;
-					}
-					// Make breadcrumb
-					$breadcrumb = array();
-					$pathtohere = '';
-					
-					//add base breadcrumb
-					$breadcrumb[] = array('dir' => '/', 'name' => basename($basePath));
-					
-					//add subdir breadcrumbs
-					foreach (explode('/', urldecode($_GET['path'])) as $i) {
-						if ($i != '') {
-							$pathtohere .= '/'.$i;
-							$breadcrumb[] = array('dir' => $pathtohere, 'name' => $i);
-						}
-					}
-					
-					$list = new OCP\Template('files', 'part.list', '');
-					$list->assign('files', $files, false);
-					$list->assign('publicListView', true);
-					$list->assign('baseURL', OCP\Util::linkToPublic('files').'&t='.$token.'&path=', false);
-					$list->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path=', false);
-					$breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '' );
-					$breadcrumbNav->assign('breadcrumb', $breadcrumb, false);
-					$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files').'&t='.$token.'&path=', false);
-					$folder = new OCP\Template('files', 'index', '');
-					$folder->assign('fileList', $list->fetchPage(), false);
-					$folder->assign('breadcrumb', $breadcrumbNav->fetchPage(), false);
-					$folder->assign('isCreatable', false);
-					$folder->assign('permissions', 0);
-					$folder->assign('files', $files);
-					$folder->assign('uploadMaxFilesize', 0);
-					$folder->assign('uploadMaxHumanFilesize', 0);
-					$folder->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
-					$tmpl->assign('folder', $folder->fetchPage(), false);
-					$tmpl->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
-					$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path='.urlencode($getPath));
-				} else {
-					// Show file preview if viewer is available
-					if ($type == 'file') {
-						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download');
-					} else {
-						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path='.urlencode($getPath));
-					}
-				}
-				$tmpl->printPage();
-			}
+		// Check if item id is set in session
+		} else if (!isset($_SESSION['public_link_authenticated']) || $_SESSION['public_link_authenticated'] !== $linkItem['id']) {
+			// Prompt for password
+			$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
+			$tmpl->assign('URL', $url);
+			$tmpl->printPage();
 			exit();
 		}
 	}
+	$basePath = substr($pathAndUser['path'] , strlen('/'.$fileOwner.'/files'));
+	$path = $basePath;
+	if (isset($_GET['path'])) {
+		$path .= $_GET['path'];
+	}
+	if (!$path || !OC_Filesystem::isValidPath($path) || !OC_Filesystem::file_exists($path)) {
+		OCP\Util::writeLog('share', 'Invalid path '.$path.' for share id '.$linkItem['id'], \OCP\Util::ERROR);
+		header('HTTP/1.0 404 Not Found');
+		$tmpl = new OCP\Template('', '404', 'guest');
+		$tmpl->printPage();
+		exit();
+	}
+	$dir = dirname($path);
+	$file = basename($path);
+	// Download the file
+	if (isset($_GET['download'])) {
+		if (isset($_GET['path']) && $_GET['path'] !== '' ) {
+			if ( isset($_GET['files']) ) { // download selected files
+				OC_Files::get($path, $_GET['files'], $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+			} else if (isset($_GET['path']) && $_GET['path'] != '' ) { // download a file from a shared directory
+				OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+			} else { // download the whole shared directory
+				OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+			}
+		} else { // download a single shared file
+			OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+		}
+
+	} else {
+		OCP\Util::addStyle('files_sharing', 'public');
+		OCP\Util::addScript('files_sharing', 'public');
+		OCP\Util::addScript('files', 'fileactions');
+		$tmpl = new OCP\Template('files_sharing', 'public', 'base');
+		$tmpl->assign('uidOwner', $shareOwner);
+		$tmpl->assign('dir', $dir);
+		$tmpl->assign('filename', $file);
+		$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));
+		if (isset($_GET['path'])) {
+			$getPath = $_GET['path'];
+		} else {
+			$getPath = '';
+		}
+		//
+		$urlLinkIdentifiers= (isset($token)?'&t='.$token:'').(isset($_GET['dir'])?'&dir='.$_GET['dir']:'').(isset($_GET['file'])?'&file='.$_GET['file']:'');
+		// Show file list
+		if (OC_Filesystem::is_dir($path)) {
+			OCP\Util::addStyle('files', 'files');
+			OCP\Util::addScript('files', 'files');
+			OCP\Util::addScript('files', 'filelist');
+			$files = array();
+			$rootLength = strlen($basePath) + 1;
+			foreach (OC_Files::getDirectoryContent($path) as $i) {
+				$i['date'] = OCP\Util::formatDate($i['mtime']);
+				if ($i['type'] == 'file') {
+					$fileinfo = pathinfo($i['name']);
+					$i['basename'] = $fileinfo['filename'];
+					$i['extension'] = isset($fileinfo['extension']) ? ('.'.$fileinfo['extension']) : '';
+				}
+				$i['directory'] = '/'.substr($i['directory'], $rootLength);
+				if ($i['directory'] == '/') {
+					$i['directory'] = '';
+				}
+				$i['permissions'] = OCP\PERMISSION_READ;
+				$files[] = $i;
+			}
+			// Make breadcrumb
+			$breadcrumb = array();
+			$pathtohere = '';
+
+			//add base breadcrumb
+			$breadcrumb[] = array('dir' => '/', 'name' => basename($basePath));
+
+			//add subdir breadcrumbs
+			foreach (explode('/', urldecode($_GET['path'])) as $i) {
+				if ($i != '') {
+					$pathtohere .= '/'.$i;
+					$breadcrumb[] = array('dir' => $pathtohere, 'name' => $i);
+				}
+			}
+
+			$list = new OCP\Template('files', 'part.list', '');
+			$list->assign('files', $files, false);
+			$list->assign('publicListView', true);
+			$list->assign('baseURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&path=', false);
+			$list->assign('downloadURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&download&path=', false);
+			$breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '' );
+			$breadcrumbNav->assign('breadcrumb', $breadcrumb, false);
+			$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&path=', false);
+			$folder = new OCP\Template('files', 'index', '');
+			$folder->assign('fileList', $list->fetchPage(), false);
+			$folder->assign('breadcrumb', $breadcrumbNav->fetchPage(), false);
+			$folder->assign('isCreatable', false);
+			$folder->assign('permissions', 0);
+			$folder->assign('files', $files);
+			$folder->assign('uploadMaxFilesize', 0);
+			$folder->assign('uploadMaxHumanFilesize', 0);
+			$folder->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
+			$tmpl->assign('folder', $folder->fetchPage(), false);
+			$tmpl->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
+			$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&download&path='.urlencode($getPath));
+		} else {
+			// Show file preview if viewer is available
+			if ($type == 'file') {
+				$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&download');
+			} else {
+				$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').$urlLinkIdentifiers.'&download&path='.urlencode($getPath));
+			}
+		}
+		$tmpl->printPage();
+	}
+	exit();
 } else {
-	OCP\Util::writeLog('share', 'Missing token', \OCP\Util::DEBUG);
+	OCP\Util::writeLog('share', 'could not resolve linkItem', \OCP\Util::DEBUG);
 }
 header('HTTP/1.0 404 Not Found');
 $tmpl = new OCP\Template('', '404', 'guest');

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -21,73 +21,81 @@ if (isset($_GET['token'])) {
 }
 // Enf of backward compatibility
 
-function getID($path) {
-	// use the share table from the db to find the item source if the file was reshared because shared files
-	//are not stored in the file cache.
-	if (substr(OC_Filesystem::getMountPoint($path), -7, 6) == "Shared") {
-		$path_parts = explode('/', $path, 5);
-		$user = $path_parts[1];
-		$intPath = '/'.$path_parts[4];
-		$query = \OC_DB::prepare('SELECT item_source FROM *PREFIX*share WHERE uid_owner = ? AND file_target = ? ');
-		$result = $query->execute(array($user, $intPath));
-		$row = $result->fetchRow();
-		$fileSource = $row['item_source'];
-	} else {
-		$fileSource = OC_Filecache::getId($path, '');
-	}
-
-	return $fileSource;
+/**
+ * lookup file path and owner by fetching it from the fscache
+ * needed becaus OC_FileCache::getPath($id, $user) already requires the user
+ * @param int $id
+ * @return array
+ */
+function getPathAndUser($id) {
+	$query = \OC_DB::prepare('SELECT `user`, `path` FROM `*PREFIX*fscache` WHERE `id` = ?');
+	$result = $query->execute(array($id));
+	$row = $result->fetchRow();
+	return $row;
 }
 
-if (isset($_GET['file']) || isset($_GET['dir'])) {
-	if (isset($_GET['dir'])) {
-		$type = 'folder';
-		$path = $_GET['dir'];
-		if(strlen($path)>1 and substr($path, -1, 1)==='/') {
-			$path=substr($path, 0, -1);
-		}
-		$baseDir = $path;
-		$dir = $baseDir;
-	} else {
-		$type = 'file';
-		$path = $_GET['file'];
-		if(strlen($path)>1 and substr($path, -1, 1)==='/') {
-			$path=substr($path, 0, -1);
-		}
-	}
-	$uidOwner = substr($path, 1, strpos($path, '/', 1) - 1);
-	if (OCP\User::userExists($uidOwner)) {
-		OC_Util::setupFS($uidOwner);
-		$fileSource = getId($path);
-		if ($fileSource != -1 && ($linkItem = OCP\Share::getItemSharedWithByLink($type, $fileSource, $uidOwner))) {
-			// TODO Fix in the getItems
-			if (!isset($linkItem['item_type']) || $linkItem['item_type'] != $type) {
+if (isset($_GET['t'])) {
+	$token = $_GET['t'];
+	$linkItem = OCP\Share::getShareByToken($token);
+	if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
+		// seems to be a valid share
+		$type = $linkItem['item_type'];
+		$fileSource = $linkItem['file_source'];
+		$shareOwner = $linkItem['uid_owner'];
+		
+		if (OCP\User::userExists($shareOwner) && $fileSource != -1 ) {
+			
+			$pathAndUser = getPathAndUser($linkItem['file_source']);
+			$fileOwner = $pathAndUser['user'];
+			
+			//if this is a reshare check the file owner also exists
+			if ($shareOwner != $fileOwner && ! OCP\User::userExists($fileOwner)) {
+					OCP\Util::writeLog('share', 'original file owner '.$fileOwner.' does not exist for share '.$linkItem['id'], \OCP\Util::ERROR);
+					header('HTTP/1.0 404 Not Found');
+					$tmpl = new OCP\Template('', '404', 'guest');
+					$tmpl->printPage();
+					exit();
+			}
+			
+			//mount filesystem of file owner
+			OC_Util::setupFS($fileOwner);
+			if (!isset($linkItem['item_type'])) {
+				OCP\Util::writeLog('share', 'No item type set for share id: '.$linkItem['id'], \OCP\Util::ERROR);
 				header('HTTP/1.0 404 Not Found');
 				$tmpl = new OCP\Template('', '404', 'guest');
 				$tmpl->printPage();
 				exit();
 			}
 			if (isset($linkItem['share_with'])) {
-				// Check password
+				// Authenticate share_with
+				$url = OCP\Util::linkToPublic('files').'&t='.$token;
 				if (isset($_GET['file'])) {
-					$url = OCP\Util::linkToPublic('files').'&file='.urlencode($_GET['file']);
-				} else {
-					$url = OCP\Util::linkToPublic('files').'&dir='.urlencode($_GET['dir']);
+					$url .= '&file='.urlencode($_GET['file']);
+				} else if (isset($_GET['dir'])) {
+					$url .= '&dir='.urlencode($_GET['dir']);
 				}
 				if (isset($_POST['password'])) {
 					$password = $_POST['password'];
-					$storedHash = $linkItem['share_with'];
-					$forcePortable = (CRYPT_BLOWFISH != 1);
-					$hasher = new PasswordHash(8, $forcePortable);
-					if (!($hasher->CheckPassword($password.OC_Config::getValue('passwordsalt', ''), $storedHash))) {
-						$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
-						$tmpl->assign('URL', $url);
-						$tmpl->assign('error', true);
+					if ($linkItem['share_type'] == OCP\Share::SHARE_TYPE_LINK) {
+						// Check Password
+						$forcePortable = (CRYPT_BLOWFISH != 1);
+						$hasher = new PasswordHash(8, $forcePortable);
+						if (!($hasher->CheckPassword($password.OC_Config::getValue('passwordsalt', ''), $linkItem['share_with']))) {
+							$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
+							$tmpl->assign('URL', $url);
+							$tmpl->assign('error', true);
+							$tmpl->printPage();
+							exit();
+						} else {
+							// Save item id in session for future requests
+							$_SESSION['public_link_authenticated'] = $linkItem['id'];
+						}
+					} else {
+						OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type'].' for share id '.$linkItem['id'], \OCP\Util::ERROR);
+						header('HTTP/1.0 404 Not Found');
+						$tmpl = new OCP\Template('', '404', 'guest');
 						$tmpl->printPage();
 						exit();
-					} else {
-						// Save item id in session for future requests
-						$_SESSION['public_link_authenticated'] = $linkItem['id'];
 					}
 				// Check if item id is set in session
 				} else if (!isset($_SESSION['public_link_authenticated']) || $_SESSION['public_link_authenticated'] !== $linkItem['id']) {
@@ -98,29 +106,32 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 					exit();
 				}
 			}
-			$path = $linkItem['path'];
+			$basePath = substr($pathAndUser['path'] , strlen('/'.$fileOwner.'/files'));
+			$path = $basePath;
 			if (isset($_GET['path'])) {
 				$path .= $_GET['path'];
-				$dir .= $_GET['path'];
-				if (!OC_Filesystem::file_exists($path)) {
-					header('HTTP/1.0 404 Not Found');
-					$tmpl = new OCP\Template('', '404', 'guest');
-					$tmpl->printPage();
-					exit();
-				}
 			}
+			if (!$path || !OC_Filesystem::isValidPath($path) || !OC_Filesystem::file_exists($path)) {
+				OCP\Util::writeLog('share', 'Invalid path '.$path.' for share id '.$linkItem['id'], \OCP\Util::ERROR);
+				header('HTTP/1.0 404 Not Found');
+				$tmpl = new OCP\Template('', '404', 'guest');
+				$tmpl->printPage();
+				exit();
+			}
+			$dir = dirname($path);
+			$file = basename($path);
 			// Download the file
 			if (isset($_GET['download'])) {
-				if (isset($_GET['dir'])) {
+				if (isset($_GET['path']) && $_GET['path'] !== '' ) {
 					if ( isset($_GET['files']) ) { // download selected files
 						OC_Files::get($path, $_GET['files'], $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
-					} else 	if (isset($_GET['path']) &&  $_GET['path'] != '' ) { // download a file from a shared directory
-						OC_Files::get('', $path, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+					} else if (isset($_GET['path']) && $_GET['path'] != '' ) { // download a file from a shared directory
+						OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
 					} else { // download the whole shared directory
-						OC_Files::get($path, '', $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+						OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
 					}
 				} else { // download a single shared file
-					OC_Files::get("", $path, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+					OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
 				}
 
 			} else {
@@ -128,14 +139,22 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 				OCP\Util::addScript('files_sharing', 'public');
 				OCP\Util::addScript('files', 'fileactions');
 				$tmpl = new OCP\Template('files_sharing', 'public', 'base');
-				$tmpl->assign('owner', $uidOwner);
+				$tmpl->assign('uidOwner', $shareOwner);
+				$tmpl->assign('dir', $dir);
+				$tmpl->assign('filename', $file);
+				$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));
+				if (isset($_GET['path'])) {
+					$getPath = $_GET['path'];
+				} else {
+					$getPath = '';
+				}
 				// Show file list
 				if (OC_Filesystem::is_dir($path)) {
 					OCP\Util::addStyle('files', 'files');
 					OCP\Util::addScript('files', 'files');
 					OCP\Util::addScript('files', 'filelist');
 					$files = array();
-					$rootLength = strlen($baseDir) + 1;
+					$rootLength = strlen($basePath) + 1;
 					foreach (OC_Files::getDirectoryContent($path) as $i) {
 						$i['date'] = OCP\Util::formatDate($i['mtime']);
 						if ($i['type'] == 'file') {
@@ -143,7 +162,7 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 							$i['basename'] = $fileinfo['filename'];
 							$i['extension'] = isset($fileinfo['extension']) ? ('.'.$fileinfo['extension']) : '';
 						}
-						$i['directory'] = '/'.substr('/'.$uidOwner.'/files'.$i['directory'], $rootLength);
+						$i['directory'] = '/'.substr($i['directory'], $rootLength);
 						if ($i['directory'] == '/') {
 							$i['directory'] = '';
 						}
@@ -153,30 +172,29 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 					// Make breadcrumb
 					$breadcrumb = array();
 					$pathtohere = '';
-					$count = 1;
-					foreach (explode('/', $dir) as $i) {
+					
+					//add base breadcrumb
+					$breadcrumb[] = array('dir' => '/', 'name' => basename($basePath));
+					
+					//add subdir breadcrumbs
+					foreach (explode('/', urldecode($_GET['path'])) as $i) {
 						if ($i != '') {
-							if ($i != $baseDir) {
-								$pathtohere .= '/'.$i;
-							}
-							if ( strlen($pathtohere) <  strlen($_GET['dir'])) {
-								continue;
-							}
-							$breadcrumb[] = array('dir' => str_replace($_GET['dir'], "", $pathtohere, $count), 'name' => $i);
+							$pathtohere .= '/'.$i;
+							$breadcrumb[] = array('dir' => $pathtohere, 'name' => $i);
 						}
 					}
+					
 					$list = new OCP\Template('files', 'part.list', '');
 					$list->assign('files', $files, false);
 					$list->assign('publicListView', true);
-					$list->assign('baseURL', OCP\Util::linkToPublic('files').'&dir='.urlencode($_GET['dir']).'&path=', false);
-					$list->assign('downloadURL', OCP\Util::linkToPublic('files').'&download&dir='.urlencode($_GET['dir']).'&path=', false);
+					$list->assign('baseURL', OCP\Util::linkToPublic('files').'&t='.$token.'&path=', false);
+					$list->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path=', false);
 					$breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '' );
 					$breadcrumbNav->assign('breadcrumb', $breadcrumb, false);
-					$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files').'&dir='.urlencode($_GET['dir']).'&path=', false);
+					$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files').'&t='.$token.'&path=', false);
 					$folder = new OCP\Template('files', 'index', '');
 					$folder->assign('fileList', $list->fetchPage(), false);
 					$folder->assign('breadcrumb', $breadcrumbNav->fetchPage(), false);
-					$folder->assign('dir', basename($dir));
 					$folder->assign('isCreatable', false);
 					$folder->assign('permissions', 0);
 					$folder->assign('files', $files);
@@ -184,32 +202,14 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 					$folder->assign('uploadMaxHumanFilesize', 0);
 					$folder->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
 					$tmpl->assign('folder', $folder->fetchPage(), false);
-					$tmpl->assign('uidOwner', $uidOwner);
-					$tmpl->assign('dir', basename($dir));
-					$tmpl->assign('filename', basename($path));
-					$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));
 					$tmpl->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
-					if (isset($_GET['path'])) {
-						$getPath = $_GET['path'];
-					} else {
-						$getPath = '';
-					}
-					$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&download&dir='.urlencode($_GET['dir']).'&path='.urlencode($getPath), false);
+					$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path='.urlencode($getPath));
 				} else {
 					// Show file preview if viewer is available
-					$tmpl->assign('uidOwner', $uidOwner);
-					$tmpl->assign('dir', dirname($path));
-					$tmpl->assign('filename', basename($path));
-					$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));
 					if ($type == 'file') {
-						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&file='.urlencode($_GET['file']).'&download', false);
+						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download');
 					} else {
-						if (isset($_GET['path'])) {
-							$getPath = $_GET['path'];
-						} else {
-							$getPath = '';
-						}
-						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&download&dir='.urlencode($_GET['dir']).'&path='.urlencode($getPath), false);
+						$tmpl->assign('downloadURL', OCP\Util::linkToPublic('files').'&t='.$token.'&download&path='.urlencode($getPath));
 					}
 				}
 				$tmpl->printPage();
@@ -217,6 +217,8 @@ if (isset($_GET['file']) || isset($_GET['dir'])) {
 			exit();
 		}
 	}
+} else {
+	OCP\Util::writeLog('share', 'Missing token', \OCP\Util::DEBUG);
 }
 header('HTTP/1.0 404 Not Found');
 $tmpl = new OCP\Template('', '404', 'guest');

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -28,13 +28,19 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 		case 'share':
 			if (isset($_POST['shareType']) && isset($_POST['shareWith']) && isset($_POST['permissions'])) {
 				try {
-					if ((int)$_POST['shareType'] === OCP\Share::SHARE_TYPE_LINK && $_POST['shareWith'] == '') {
+					$shareType = (int)$_POST['shareType'];
+					$shareWith = $_POST['shareWith'];
+					if ($shareType === OCP\Share::SHARE_TYPE_LINK && $shareWith == '') {
 						$shareWith = null;
-					} else {
-						$shareWith = $_POST['shareWith'];
 					}
-					OCP\Share::shareItem($_POST['itemType'], $_POST['itemSource'], (int)$_POST['shareType'], $shareWith, $_POST['permissions']);
-					OC_JSON::success();
+					
+					$token = OCP\Share::shareItem($_POST['itemType'], $_POST['itemSource'], $shareType, $shareWith, $_POST['permissions']);
+					
+					if (is_string($token)) {
+						OC_JSON::success(array('data' => array('token' => $token)));
+					} else {
+						OC_JSON::success();
+					}
 				} catch (Exception $exception) {
 					OC_JSON::error(array('data' => array('message' => $exception->getMessage())));
 				}

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -179,7 +179,7 @@ OC.Share={
 			if (data.shares) {
 				$.each(data.shares, function(index, share) {
 					if (share.share_type == OC.Share.SHARE_TYPE_LINK) {
-						OC.Share.showLink(share.token, share.share_with);
+						OC.Share.showLink(share.token, share.share_with, itemSource);
 					} else {
 						if (share.collection) {
 							OC.Share.addShareWith(share.share_type, share.share_with, share.permissions, possiblePermissions, share.collection);
@@ -323,10 +323,24 @@ OC.Share={
 			$('#expiration').show();
 		}
 	},
-	showLink:function(token, password) {
+	showLink:function(token, password, itemSource) {
 		OC.Share.itemShares[OC.Share.SHARE_TYPE_LINK] = true;
 		$('#linkCheckbox').attr('checked', true);
-		var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
+		if (! token) {
+			//fallback to pre token link
+			var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
+			var type = $('tr').filterAttr('data-id', String(itemSource)).data('type');
+			if ($('#dir').val() == '/') {
+				var file = $('#dir').val() + filename;
+			} else {
+				var file = $('#dir').val() + '/' + filename;
+			}
+			file = '/'+OC.currentUser+'/files'+file;
+			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&'+type+'='+encodeURIComponent(file);
+		} else {
+			//TODO add path param when showing a link to file in a subfolder of a public link share
+			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
+		}
 		$('#linkText').val(link);
 		$('#linkText').show('blind');
 		$('#showPassword').show();
@@ -473,7 +487,7 @@ $(document).ready(function() {
 		if (this.checked) {
 			// Create a link
 			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', OC.PERMISSION_READ, function(data) {
-				OC.Share.showLink(data.token);
+				OC.Share.showLink(data.token, null, itemSource);
 				OC.Share.updateIcon(itemType, itemSource);
 			});
 		} else {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -179,7 +179,7 @@ OC.Share={
 			if (data.shares) {
 				$.each(data.shares, function(index, share) {
 					if (share.share_type == OC.Share.SHARE_TYPE_LINK) {
-						OC.Share.showLink(itemSource, share.share_with);
+						OC.Share.showLink(share.token, share.share_with);
 					} else {
 						if (share.collection) {
 							OC.Share.addShareWith(share.share_type, share.share_with, share.permissions, possiblePermissions, share.collection);
@@ -323,18 +323,10 @@ OC.Share={
 			$('#expiration').show();
 		}
 	},
-	showLink:function(itemSource, password) {
+	showLink:function(token, password) {
 		OC.Share.itemShares[OC.Share.SHARE_TYPE_LINK] = true;
 		$('#linkCheckbox').attr('checked', true);
-		var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
-		var type = $('tr').filterAttr('data-id', String(itemSource)).data('type');
-		if ($('#dir').val() == '/') {
-			var file = $('#dir').val() + filename;
-		} else {
-			var file = $('#dir').val() + '/' + filename;
-		}
-		file = '/'+OC.currentUser+'/files'+file;
-		var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&'+type+'='+encodeURIComponent(file);
+		var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
 		$('#linkText').val(link);
 		$('#linkText').show('blind');
 		$('#showPassword').show();
@@ -480,8 +472,8 @@ $(document).ready(function() {
 		var itemSource = $('#dropdown').data('item-source');
 		if (this.checked) {
 			// Create a link
-			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', OC.PERMISSION_READ, function() {
-				OC.Share.showLink(itemSource);
+			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', OC.PERMISSION_READ, function(data) {
+				OC.Share.showLink(data.token);
 				OC.Share.updateIcon(itemType, itemSource);
 			});
 		} else {

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -581,6 +581,21 @@
 				<notnull>false</notnull>
 			</field>
 
+			<field>
+				<name>token</name>
+				<type>text</type>
+				<default></default>
+				<notnull>false</notnull>
+				<length>32</length>
+			</field>
+
+			<index>
+				<name>token_index</name>
+				<field>
+					<name>token</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
 		</declaration>
 
 	</table>

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -758,5 +758,4 @@ class OC_Helper {
 		}
 		return $str;
 	}
-
 }

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -53,6 +53,8 @@ class Share {
 	const FORMAT_STATUSES = -2;
 	const FORMAT_SOURCES = -3;
 
+	const TOKEN_LENGTH = 32; // see db_structure.xml
+
 	private static $shareTypeUserAndGroups = -1;
 	private static $shareTypeGroupUserUnique = 2;
 	private static $backends = array();
@@ -140,6 +142,20 @@ class Share {
 	}
 
 	/**
+	 * @brief Get the item shared by a token
+	 * @param string token
+	 * @return Item
+	 */
+	public static function getShareByToken($token) {
+		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `token` = ?',1);
+		$result = $query->execute(array($token));
+		if (\OC_DB::isError($result)) {
+			\OC_Log::write('OCP\Share', \OC_DB::getErrorMessage($result) . ', token=' . $token, \OC_Log::ERROR);
+		}
+		return $result->fetchRow();
+	}
+
+	/**
 	* @brief Get the shared items of item type owned by the current user
 	* @param string Item type
 	* @param int Format (optional) Format type must be defined by the backend
@@ -168,7 +184,7 @@ class Share {
 	* @param int SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
 	* @param string User or group the item is being shared with
 	* @param int CRUDS permissions
-	* @return bool Returns true on success or false on failure
+	* @return bool|string Returns true on success or false on failure, Returns token on success for links
 	*/
 	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions) {
 		$uidOwner = \OC_User::getUser();
@@ -230,23 +246,33 @@ class Share {
 			$shareWith['users'] = array_diff(\OC_Group::usersInGroup($group), array($uidOwner));
 		} else if ($shareType === self::SHARE_TYPE_LINK) {
 			if (\OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes') == 'yes') {
+				// when updating a link share
 				if ($checkExists = self::getItems($itemType, $itemSource, self::SHARE_TYPE_LINK, null, $uidOwner, self::FORMAT_NONE, null, 1)) {
-					// If password is set delete the old link
-					if (isset($shareWith)) {
-						self::delete($checkExists['id']);
-					} else {
-						$message = 'Sharing '.$itemSource.' failed, because this item is already shared with a link';
-						\OC_Log::write('OCP\Share', $message, \OC_Log::ERROR);
-						throw new \Exception($message);
-					}
+					// remember old token
+					$oldToken = $checkExists['token'];
+					//delete the old share
+					self::delete($checkExists['id']);
 				}
+				
 				// Generate hash of password - same method as user passwords
 				if (isset($shareWith)) {
 					$forcePortable = (CRYPT_BLOWFISH != 1);
 					$hasher = new \PasswordHash(8, $forcePortable);
 					$shareWith = $hasher->HashPassword($shareWith.\OC_Config::getValue('passwordsalt', ''));
 				}
-				return self::put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions);
+				
+				// Generate token
+				if (isset($oldToken)) {
+					$token = $oldToken;
+				} else {
+					$token = \OC_Util::generate_random_bytes(self::TOKEN_LENGTH);
+				}
+				$result = self::put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, null, $token);
+				if ($result) {
+					return $token;
+				} else {
+					return false;
+				}
 			}
 			$message = 'Sharing '.$itemSource.' failed, because sharing with links is not allowed';
 			\OC_Log::write('OCP\Share', $message, \OC_Log::ERROR);
@@ -654,9 +680,9 @@ class Share {
 		} else {
 			if (isset($uidOwner)) {
 				if ($itemType == 'file' || $itemType == 'folder') {
-					$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `file_source`, `path`, `permissions`, `stime`, `expiration`';
+					$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `file_source`, `path`, `permissions`, `stime`, `expiration`, `token`';
 				} else {
-					$select = '`id`, `item_type`, `item_source`, `parent`, `share_type`, `share_with`, `permissions`, `stime`, `file_source`, `expiration`';
+					$select = '`id`, `item_type`, `item_source`, `parent`, `share_type`, `share_with`, `permissions`, `stime`, `file_source`, `expiration`, `token`';
 				}
 			} else {
 				if ($fileDependent) {
@@ -835,7 +861,7 @@ class Share {
 	* @param bool|array Parent folder target (optional)
 	* @return bool Returns true on success or false on failure
 	*/
-	private static function put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, $parentFolder = null) {
+	private static function put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, $parentFolder = null, $token = null) {
 		$backend = self::getBackend($itemType);
 		// Check if this is a reshare
 		if ($checkReshare = self::getItemSharedWithBySource($itemType, $itemSource, self::FORMAT_NONE, null, true)) {
@@ -892,7 +918,7 @@ class Share {
 				$fileSource = null;
 			}
 		}
-		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`, `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`, `file_target`) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`, `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`, `file_target`, `token`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
 		// Share with a group
 		if ($shareType == self::SHARE_TYPE_GROUP) {
 			$groupItemTarget = self::generateTarget($itemType, $itemSource, $shareType, $shareWith['group'], $uidOwner, $suggestedItemTarget);
@@ -913,7 +939,7 @@ class Share {
 			} else {
 				$groupFileTarget = null;
 			}
-			$query->execute(array($itemType, $itemSource, $groupItemTarget, $parent, $shareType, $shareWith['group'], $uidOwner, $permissions, time(), $fileSource, $groupFileTarget));
+			$query->execute(array($itemType, $itemSource, $groupItemTarget, $parent, $shareType, $shareWith['group'], $uidOwner, $permissions, time(), $fileSource, $groupFileTarget, $token));
 			// Save this id, any extra rows for this group share will need to reference it
 			$parent = \OC_DB::insertid('*PREFIX*share');
 			// Loop through all users of this group in case we need to add an extra row
@@ -947,11 +973,12 @@ class Share {
 					'permissions' => $permissions,
 					'fileSource' => $fileSource,
 					'fileTarget' => $fileTarget,
-					'id' => $parent
+					'id' => $parent,
+					'token' => $token
 				));
 				// Insert an extra row for the group share if the item or file target is unique for this user
 				if ($itemTarget != $groupItemTarget || (isset($fileSource) && $fileTarget != $groupFileTarget)) {
-					$query->execute(array($itemType, $itemSource, $itemTarget, $parent, self::$shareTypeGroupUserUnique, $uid, $uidOwner, $permissions, time(), $fileSource, $fileTarget));
+					$query->execute(array($itemType, $itemSource, $itemTarget, $parent, self::$shareTypeGroupUserUnique, $uid, $uidOwner, $permissions, time(), $fileSource, $fileTarget, $token));
 					$id = \OC_DB::insertid('*PREFIX*share');
 				}
 			}
@@ -976,7 +1003,7 @@ class Share {
 			} else {
 				$fileTarget = null;
 			}
-			$query->execute(array($itemType, $itemSource, $itemTarget, $parent, $shareType, $shareWith, $uidOwner, $permissions, time(), $fileSource, $fileTarget));
+			$query->execute(array($itemType, $itemSource, $itemTarget, $parent, $shareType, $shareWith, $uidOwner, $permissions, time(), $fileSource, $fileTarget, $token));
 			$id = \OC_DB::insertid('*PREFIX*share');
 			\OC_Hook::emit('OCP\Share', 'post_shared', array(
 				'itemType' => $itemType,
@@ -989,7 +1016,8 @@ class Share {
 				'permissions' => $permissions,
 				'fileSource' => $fileSource,
 				'fileTarget' => $fileTarget,
-				'id' => $id
+				'id' => $id,
+				'token' => $token
 			));
 			if ($parentFolder === true) {
 				$parentFolders['id'] = $id;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -689,7 +689,7 @@ class Share {
 					if (($itemType == 'file' || $itemType == 'folder') && $format == \OC_Share_Backend_File::FORMAT_FILE_APP || $format == \OC_Share_Backend_File::FORMAT_FILE_APP_ROOT) {
 						$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `uid_owner`, `share_type`, `share_with`, `file_source`, `path`, `file_target`, `permissions`, `expiration`, `name`, `ctime`, `mtime`, `mimetype`, `size`, `encrypted`, `versioned`, `writable`';
 					} else {
-						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `item_target`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `uid_owner`, `file_source`, `path`, `file_target`, `permissions`, `stime`, `expiration`';
+						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `item_target`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `uid_owner`, `file_source`, `path`, `file_target`, `permissions`, `stime`, `expiration`, `token`';
 					}
 				} else {
 					$select = '*';

--- a/lib/util.php
+++ b/lib/util.php
@@ -95,7 +95,7 @@ class OC_Util {
 	 */
 	public static function getVersion() {
 		// hint: We only can count up. So the internal version number of ownCloud 4.5 will be 4.90.0. This is not visible to the user
-		return array(4, 91, 01);
+		return array(4, 91, 02);
 	}
 
 	/**


### PR DESCRIPTION
To make reviewing easier I separated the changes into smaller commits with a - hopefully - meaningful commit message.

I plan to refactor some of the sharing code and add authorization mechanisms for shares by contacts and email. But let's first get this into core :)

@mtgap Please have a look at  OCP\Share::getShareByToken($token) which I added to retrieve the share item. I admit that I bypass any magic in getItem(...) and cannot see whether that is a problem for other use cases like sharing a contact or an event ...

related to #105
