### PR TITLE
OCP\Share::shareItem does mistakenly refuse sharing items with an existing user.

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -162,7 +162,11 @@ abstract class Access {
 		if($dn) {
 			return $dn;
 		}
-
+		//There is no cached entry for the user; search the LDAP server
+		$dn = $this->getUserDn($name);
+		if($dn) {
+			return $dn;
+		}
 		return false;
 	}
 
@@ -185,6 +189,25 @@ abstract class Access {
 
 		$record = $query->execute(array($name))->fetchOne();
 		return $record;
+	}
+
+	/**
+	 * @brief returns the LDAP DN corresponding to the giver user identifier
+	 * @param $uid the searched user's identifier
+	 * @returns the LDAP DN on success, otherwise false
+	 * 
+	 * search the LDAP directory server for the entry corresponding to the given
+	 * user identifier
+	 */
+	public function getUserDN($uid) {
+		//find out dn of the user name
+		$filter = \OCP\Util::mb_str_replace('%uid', $uid, $this->connection->ldapLoginFilter, 'UTF-8');
+		$ldap_users = $this->fetchListOfUsers($filter, 'dn');
+		if(count($ldap_users) == 1) {
+			$dn = $ldap_users[0];
+			return $dn;
+		}
+		return false;
 	}
 
 	/**

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -69,13 +69,12 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword($uid, $password) {
-		//find out dn of the user name
-		$filter = \OCP\Util::mb_str_replace('%uid', $uid, $this->connection->ldapLoginFilter, 'UTF-8');
-		$ldap_users = $this->fetchListOfUsers($filter, 'dn');
-		if(count($ldap_users) < 1) {
+		$dn = $this->getUserDN($uid);
+
+		//Does an entry for this user exist on the LDAP server?
+		if(!$dn) {
 			return false;
 		}
-		$dn = $ldap_users[0];
 
 		//are the credentials OK?
 		if(!$this->areCredentialsValid($dn, $password)) {


### PR DESCRIPTION
This does happen for users who didn't login before the item's owner tried to share the item.
