### PR TITLE
Uncomment hours entries in relative date functions

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -641,7 +641,7 @@ if (!Array.prototype.map){
 
 /**
  * Filter Jquery selector by attribute value
- **/
+ */
 $.fn.filterAttr = function(attr_name, attr_value) {
 	return this.filter(function() { return $(this).attr(attr_name) === attr_value; });
 };
@@ -675,7 +675,8 @@ function formatDate(date){
 	return $.datepicker.formatDate(datepickerFormatDate, date)+' '+date.getHours()+':'+((date.getMinutes()<10)?'0':'')+date.getMinutes();
 }
 
-/* takes an absolute timestamp and return a string with a human-friendly relative date
+/**
+ * takes an absolute timestamp and return a string with a human-friendly relative date
  * @param int a Unix timestamp
  */
 function relative_modified_date(timestamp) {
@@ -687,14 +688,14 @@ function relative_modified_date(timestamp) {
 	if(timediff < 60) { return t('core','seconds ago'); }
 	else if(timediff < 120) { return t('core','1 minute ago'); }
 	else if(timediff < 3600) { return t('core','{minutes} minutes ago',{minutes: diffminutes}); }
-	//else if($timediff < 7200) { return '1 hour ago'; }
-	//else if($timediff < 86400) { return $diffhours.' hours ago'; }
+	else if($timediff < 7200) { return '1 hour ago'; }
+	else if($timediff < 86400) { return $diffhours.' hours ago'; }
 	else if(timediff < 86400) { return t('core','today'); }
 	else if(timediff < 172800) { return t('core','yesterday'); }
 	else if(timediff < 2678400) { return t('core','{days} days ago',{days: diffdays}); }
 	else if(timediff < 5184000) { return t('core','last month'); }
-	//else if($timediff < 31556926) { return $diffmonths.' months ago'; }
-	else if(timediff < 31556926) { return t('core','months ago'); }
+	else if($timediff < 31556926) { return $diffmonths.' months ago'; }
+	//else if(timediff < 31556926) { return t('core','months ago'); }
 	else if(timediff < 63113852) { return t('core','last year'); }
 	else { return t('core','years ago'); }
 }

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -688,13 +688,13 @@ function relative_modified_date(timestamp) {
 	if(timediff < 60) { return t('core','seconds ago'); }
 	else if(timediff < 120) { return t('core','1 minute ago'); }
 	else if(timediff < 3600) { return t('core','{minutes} minutes ago',{minutes: diffminutes}); }
-	else if($timediff < 7200) { return '1 hour ago'; }
-	else if($timediff < 86400) { return $diffhours.' hours ago'; }
+	else if(timediff < 7200) { return t('core','1 hour ago'); }
+	else if(timediff < 86400) { return t('core','{hours} hours ago',{hours: diffhours}); }
 	else if(timediff < 86400) { return t('core','today'); }
 	else if(timediff < 172800) { return t('core','yesterday'); }
 	else if(timediff < 2678400) { return t('core','{days} days ago',{days: diffdays}); }
 	else if(timediff < 5184000) { return t('core','last month'); }
-	else if($timediff < 31556926) { return $diffmonths.' months ago'; }
+	else if(timediff < 31556926) { return t('core','{months} months ago',{months: diffmonths}); }
 	//else if(timediff < 31556926) { return t('core','months ago'); }
 	else if(timediff < 63113852) { return t('core','last year'); }
 	else { return t('core','years ago'); }

--- a/lib/template.php
+++ b/lib/template.php
@@ -103,8 +103,8 @@ function relative_modified_date($timestamp) {
 	if($timediff < 60) { return $l->t('seconds ago'); }
 	else if($timediff < 120) { return $l->t('1 minute ago'); }
 	else if($timediff < 3600) { return $l->t('%d minutes ago', $diffminutes); }
-	//else if($timediff < 7200) { return '1 hour ago'; }
-	//else if($timediff < 86400) { return $diffhours.' hours ago'; }
+	else if($timediff < 7200) { return '1 hour ago'; }
+	else if($timediff < 86400) { return $diffhours.' hours ago'; }
 	else if((date('G')-$diffhours) > 0) { return $l->t('today'); }
 	else if((date('G')-$diffhours) > -24) { return $l->t('yesterday'); }
 	else if($timediff < 2678400) { return $l->t('%d days ago', $diffdays); }

--- a/lib/template.php
+++ b/lib/template.php
@@ -103,13 +103,13 @@ function relative_modified_date($timestamp) {
 	if($timediff < 60) { return $l->t('seconds ago'); }
 	else if($timediff < 120) { return $l->t('1 minute ago'); }
 	else if($timediff < 3600) { return $l->t('%d minutes ago', $diffminutes); }
-	else if($timediff < 7200) { return '1 hour ago'; }
-	else if($timediff < 86400) { return $diffhours.' hours ago'; }
+	else if($timediff < 7200) { return $l->t('1 hour ago'); }
+	else if($timediff < 86400) { return $l->t('%d hours ago', $diffhours); }
 	else if((date('G')-$diffhours) > 0) { return $l->t('today'); }
 	else if((date('G')-$diffhours) > -24) { return $l->t('yesterday'); }
 	else if($timediff < 2678400) { return $l->t('%d days ago', $diffdays); }
 	else if($timediff < 5184000) { return $l->t('last month'); }
-	else if((date('n')-$diffmonths) > 0) { return $l->t('months ago'); }
+	else if((date('n')-$diffmonths) > 0) { return $l->t('%d months ago', $diffmonths); }
 	else if($timediff < 63113852) { return $l->t('last year'); }
 	else { return $l->t('years ago'); }
 }


### PR DESCRIPTION
Jan and I agreed (on IRC) that '2 hours ago' or '20 hours ago' is not the same (without commit, it would be 'today' in both cases)
Please review @DeepDiver1975, @jancborchardt 
