### PR TITLE
Very simple wrapper for js console.

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -266,6 +266,18 @@ var OC={
 		}
 	}
 };
+
+OCConsole = function() {
+}
+
+OCConsole.prototype.log = (oc_debug === true && window.console) ? console.log : function() {};
+OCConsole.prototype.info = (oc_debug === true && window.console && window.console.info) ? console.info : function() {};
+OCConsole.prototype.warn = (oc_debug === true && window.console && window.console.warn) ? console.warn : function() {};
+OCConsole.prototype.error = (oc_debug === true && window.console && window.console.error) ? console.error : function() {};
+OCConsole.prototype.assert = (oc_debug === true && window.console && window.console.assert) ? console.assert : function() {};
+
+OC.console = new OCConsole();
+
 OC.search.customResults={};
 OC.search.currentResult=-1;
 OC.search.lastQuery='';

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -8,6 +8,7 @@
 			<link rel="stylesheet" href="<?php echo $cssfile; ?>" type="text/css" media="screen" />
 		<?php endforeach; ?>
 		<script type="text/javascript">
+			var oc_debug = <?php echo (defined('DEBUG') && DEBUG) ? 'true' : 'false'; ?>;
 			var oc_webroot = '<?php echo OC::$WEBROOT; ?>';
 			var oc_appswebroots = <?php echo $_['apps_paths'] ?>;
 			var oc_current_user = '<?php echo OC_User::getUser() ?>';


### PR DESCRIPTION
Suggestion for simple solution to stray console.log statements.

Simple usage:

``` javascript
OC.console.log('Hello, world');
OC.console.assert(1== 2, 'This guy sucks at math');
```

If DEBUG hasn't been defines as true nothing will happen, otherwise the built-in function will be used.

https://github.com/owncloud/core/issues/343
