### PR TITLE
Correct quoting error with Sabre connector. Fix critical pg pbms

### DIFF
--- a/lib/connector/sabre/node.php
+++ b/lib/connector/sabre/node.php
@@ -278,7 +278,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		
 		//remove etag for all Shared folders
 		$query = OC_DB::prepare( 'DELETE FROM `*PREFIX*properties`'
-				.' WHERE `propertypath` = "/Shared"'
+				.' WHERE `propertypath` = \'/Shared\' '
 		);
 		$query->execute(array());
 		


### PR DESCRIPTION
A nasty quoting problem occurs in the file app  and give an ugly FATAL ERROR when using postgresql

this fix the problem 
