### PR TITLE
also set 'renaming' to false if renaming was aborted, this fixes issue #442

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -156,11 +156,11 @@ var FileList={
 							OC.dialogs.alert(result.data.message, 'Error moving file');
 							newname = name;
 						}
-						tr.data('renaming',false);
 					});
 					
 				}
 			}
+			tr.data('renaming',false);
 			tr.attr('data-file', newname);
 			var path = td.children('a.name').attr('href');
 			td.children('a.name').attr('href', path.replace(encodeURIComponent(name), encodeURIComponent(newname)));


### PR DESCRIPTION
This fixes issue #442.
Always set "renaming" to false, also if renaming was aborted, to finalize the operation and show the file actions again.
