### PR TITLE
Add a Build Url function in OC to avoid quirck url constructions

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -91,6 +91,26 @@ var OC={
 	appswebroots:oc_appswebroots,
 	currentUser:(typeof oc_current_user!=='undefined')?oc_current_user:false,
 	coreApps:['', 'admin','log','search','settings','core','3rdparty'],
+
+	/**
+	 * Get a constructed url with a reference to a file in an app
+	 * and add eventualy some datas in parameters
+	 * @see filePath
+	 *
+	 * @param app the id of the app
+	 * @param type the type of the file to link to (e.g. css,img,ajax.template)
+	 * @param file the filename
+	 */
+	buildUrl:function(app,type,file,data){
+		var fileUrl = OC.filePath(app,type,file);
+		var separator = '&';
+
+		if(fileUrl.indexOf('?') === -1) {
+			separator = '?';
+		}
+		return fileUrl + separator + jQuery.param(data);
+	},
+	
 	/**
 	 * get an absolute url to a file in an appen
 	 * @param app the id of the app the file belongs to


### PR DESCRIPTION
In owncloud JS, 
we have a lot of quircky constructed url...
having to encode every param is boring an fault prone...
sometimes you forget to do it, sometimes you do it twice....
let's add a util function that use the current filePath option and add a data paramter...

the function also test for the ? or & to concatenate the data:

just use it as 

``` js

window.location = OC.buildUrl('files', 'ajax', 'download.php', {file: filename, dir: $('#dir').val()} );

OC.buildUrl('core', 'ajax', 'vcategories/edit.php', {type: type });
```

instead of 

``` js
window.location = OC.filePath('files', 'ajax', 'download.php') + '?files=' + encodeURIComponent(filename) + '&dir=' + encodeURIComponent($('#dir').val());

//unescape 
OC.filePath('core', 'ajax', 'vcategories/edit.php') + '?type=' + type
```

What do you guys think about this...?
