### PR TITLE
Show error message to prevent adding a shared folder in the root dir fix...

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -495,6 +495,10 @@ $(document).ready(function() {
 				$('#notification').text(t('files','Invalid name, \'/\' is not allowed.'));
 				$('#notification').fadeIn();
 				return;
+			} else if( type == 'folder' && $('#dir').val() == '/' && $(this).val() == 'Shared') {
+				$('#notification').text(t('files','Invalid folder name. Usage of "Shared" is reserved by Owncloud'));
+				$('#notification').fadeIn();
+				return;
 			}
 			var name = getUniqueName($(this).val());
 			if (name != $(this).val()) {


### PR DESCRIPTION
When you try to add a "Shared" folder, OC prevent the user to adding it.
But OC failed to inform the user about what's going on...

see #468

here is my attempt to fix it
