### PR TITLE
use correct path for property cache

### DIFF
--- a/lib/connector/sabre/directory.php
+++ b/lib/connector/sabre/directory.php
@@ -146,7 +146,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 		$nodes = array();
 		foreach($folder_content as $info) {
 			$node = $this->getChild($info['name'], $info);
-			$node->setPropertyCache($properties[$this->path.'/'.$info['name']]);
+			$node->setPropertyCache($properties[$path.'/'.$info['name']]);
 			$nodes[] = $node;
 		}
 		return $nodes;


### PR DESCRIPTION
use the real path of the file and not the virtual path in the shared folder

This fixes a bug introduced by https://github.com/owncloud/core/commit/8724fe4b11b75ba2cd5c176a3bc14451105d50c7#commitcomment-2179925
