### PR TITLE
Fixes update of shared files with mirall because it dose not update all ...

### DIFF
--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -137,11 +137,13 @@ class OC_FileCache{
 		}
 		$arguments[]=$id;
 
-		$sql = 'UPDATE `*PREFIX*fscache` SET '.implode(' , ', $queryParts).' WHERE `id`=?';
-		$query=OC_DB::prepare($sql);
-		$result=$query->execute($arguments);
-		if(OC_DB::isError($result)) {
-			OC_Log::write('files', 'error while updating file('.$id.') in cache', OC_Log::ERROR);
+		if(!empty($queryParts)) {
+			$sql = 'UPDATE `*PREFIX*fscache` SET '.implode(' , ', $queryParts).' WHERE `id`=?';
+			$query=OC_DB::prepare($sql);
+			$result=$query->execute($arguments);
+			if(OC_DB::isError($result)) {
+				OC_Log::write('files', 'error while updating file('.$id.') in cache', OC_Log::ERROR);
+			}
 		}
 	}
 


### PR DESCRIPTION
...methadata for a file.

This fixes issue #537

The update methode created an invalid SQL string if no attribute is in data.
The data after a mirall update was: array('user' => 'admin')
So the methode update created the SQL string:
UPDATE `*PREFIX*fscache` SET WHERE `id`=?

an simple if(!empty($queryParts)) prevents this
