### PR TITLE
use routing for file downloads and folder browsing

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -6,6 +6,10 @@
  * See the COPYING-README file.
  */
 
-$this->create('download', 'download{file}')
-	->requirements(array('file' => '.*'))
-	->actionInclude('files/download.php');
+$this->create('download', 'download')
+	->requirements(array('dir' => '.*','files' => '.*'))
+	->actionInclude('files/ajax/download.php');
+
+$this->create('files_browse', 'browse')
+	->requirements(array('dir' => '.*'))
+	->actionInclude('files/index.php');

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -38,36 +38,40 @@ OCP\App::setActiveNavigationEntry('files_index');
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 // Redirect if directory does not exist
 if (!OC_Filesystem::is_dir($dir . '/')) {
-    header('Location: ' . $_SERVER['SCRIPT_NAME'] . '');
-    exit();
+	header('Location: ' . $_SERVER['SCRIPT_NAME'] . '');
+	exit();
 }
-
 $files = array();
-foreach (OC_Files::getdirectorycontent($dir) as $i) {
-    $i['date'] = OCP\Util::formatDate($i['mtime']);
-    if ($i['type'] == 'file') {
-        $fileinfo = pathinfo($i['name']);
-        $i['basename'] = $fileinfo['filename'];
-        if (!empty($fileinfo['extension'])) {
-            $i['extension'] = '.' . $fileinfo['extension'];
-        } else {
-            $i['extension'] = '';
-        }
-    }
-    if ($i['directory'] == '/') {
-        $i['directory'] = '';
-    }
-    $files[] = $i;
+foreach( OC_Files::getdirectorycontent( $dir ) as $i ) {
+	$i['date'] = OCP\Util::formatDate($i['mtime'] );
+	if ($i['type'] == 'file') {
+		$fileinfo = pathinfo($i['name']);
+		$i['basename'] = $fileinfo['filename'];
+		if (!empty($fileinfo['extension'])) {
+			$i['extension'] = '.' . $fileinfo['extension'];
+		} else {
+			$i['extension'] = '';
+		}
+		$i['route'] = OC::getRouter()->generate('download', array('dir'=>$i['directory'], 'files' => $i['name']));
+	} else {
+		$i['route'] = OC::getRouter()->generate('files_browse', array('dir'=>$i['directory'] . $i['name']));
+	}
+	if ($i['directory'] == '/') {
+		$i['directory'] = '';
+	}
+	
+	$files[] = $i;
 }
 
 // Make breadcrumb
 $breadcrumb = array();
 $pathtohere = '';
 foreach (explode('/', $dir) as $i) {
-    if ($i != '') {
-        $pathtohere .= '/' . $i;
-        $breadcrumb[] = array('dir' => $pathtohere, 'name' => $i);
-    }
+	if ( $i != '' ) {
+		$pathtohere .= '/'.$i;
+		$route = OC::getRouter()->generate('files_browse', array('dir'=>$pathtohere));
+		$breadcrumb[] = array( 'dir' => $pathtohere, 'name' => $i, 'route' => $route );
+	}
 }
 
 // make breadcrumb und filelist markup

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -54,7 +54,7 @@ foreach( OC_Files::getdirectorycontent( $dir ) as $i ) {
 		}
 		$i['route'] = OC::getRouter()->generate('download', array('dir'=>$i['directory'], 'files' => $i['name']));
 	} else {
-		$i['route'] = OC::getRouter()->generate('files_browse', array('dir'=>$i['directory'] . $i['name']));
+		$i['route'] = OC::getRouter()->generate('files_browse', array('dir'=>$i['directory'] . '/' . $i['name']));
 	}
 	if ($i['directory'] == '/') {
 		$i['directory'] = '';

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -150,7 +150,7 @@ $(document).ready(function () {
 	FileActions.register(downloadScope, 'Download', OC.PERMISSION_READ, function () {
 		return OC.imagePath('core', 'actions/download');
 	}, function (filename) {
-		window.location = OC.filePath('files', 'ajax', 'download.php') + '?files=' + encodeURIComponent(filename) + '&dir=' + encodeURIComponent($('#dir').val());
+		window.location = OC.Router.generate('download', {files: filename, dir: $('#dir').val()} );
 	});
 
 	$('#fileList tr').each(function(){
@@ -186,7 +186,7 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 });
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent($('#dir').val()).replace(/%2F/g, '/') + '/' + encodeURIComponent(filename);
+	window.location = OC.Router.generate('files_browse', {dir: $('#dir').val() + '/' + filename});
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -188,6 +188,9 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
 	var dir=$('#dir').val()||'/';
+	if (dir.lastIndexOf('/')!==dir.length-1) {
+		dir += '/';
+	}
 	window.location = OC.Router.generate('files_browse', {dir: dir + filename});
 });
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -150,7 +150,8 @@ $(document).ready(function () {
 	FileActions.register(downloadScope, 'Download', OC.PERMISSION_READ, function () {
 		return OC.imagePath('core', 'actions/download');
 	}, function (filename) {
-		window.location = OC.Router.generate('download', {files: filename, dir: $('#dir').val()} );
+		var dir=$('#dir').val()||'/';
+		window.location = OC.Router.generate('download', {files: filename, dir: dir} );
 	});
 
 	$('#fileList tr').each(function(){
@@ -186,7 +187,8 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 });
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	window.location = OC.Router.generate('files_browse', {dir: $('#dir').val() + '/' + filename});
+	var dir=$('#dir').val()||'/';
+	window.location = OC.Router.generate('files_browse', {dir: dir + filename});
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -15,7 +15,6 @@ var FileList={
 			extension=false;
 		}
 		html+='<td class="filename" style="background-image:url('+img+')"><input type="checkbox" />';
-		//html+='<a class="name" href="download.php?file='+$('#dir').val().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
 		html+='<a class="name" href="'+OC.Router.generate('download', {files: name, dir: $('#dir').val() })+'"><span class="nametext">'+escapeHTML(basename);
 		if(extension){
 			html+='<span class="extension">'+escapeHTML(extension)+'</span>';

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -15,7 +15,8 @@ var FileList={
 			extension=false;
 		}
 		html+='<td class="filename" style="background-image:url('+img+')"><input type="checkbox" />';
-		html+='<a class="name" href="download.php?file='+$('#dir').val().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
+		//html+='<a class="name" href="download.php?file='+$('#dir').val().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
+		html+='<a class="name" href="'+OC.Router.generate('download', {files: name, dir: $('#dir').val() })+'"><span class="nametext">'+escapeHTML(basename);
 		if(extension){
 			html+='<span class="extension">'+escapeHTML(extension)+'</span>';
 		}
@@ -169,6 +170,7 @@ var FileList={
 			tr.attr('data-file', newname);
 			var path = td.children('a.name').attr('href');
 			td.children('a.name').attr('href', path.replace(encodeURIComponent(name), encodeURIComponent(newname)));
+			//TODO use route
 			if (newname.indexOf('.') > 0 && tr.data('type') != 'dir') {
 				var basename=newname.substr(0,newname.lastIndexOf('.'));
 			} else {
@@ -223,6 +225,7 @@ var FileList={
 		td.children('a.name .span').text(newName);
 		var path = td.children('a.name').attr('href');
 		td.children('a.name').attr('href', path.replace(encodeURIComponent(oldName), encodeURIComponent(newName)));
+		//TODO use route
 		if (newName.indexOf('.') > 0) {
 			var basename = newName.substr(0, newName.lastIndexOf('.'));
 		} else {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -41,6 +41,7 @@ Files={
 };
 $(document).ready(function() {
 	Files.bindKeyboardShortcuts(document, jQuery); 
+
 	$('#fileList tr').each(function(){
 		//little hack to set unescape filenames in attribute
 		$(this).attr('data-file',decodeURIComponent($(this).attr('data-file')));
@@ -177,7 +178,7 @@ $(document).ready(function() {
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {
 			window.location=downloadURL.value+"&download&files="+files;
 		} else {
-			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: files });
+			window.location = OC.Router.generate('download', {files: files, dir: dir} );
 		}
 		return false;
 	});
@@ -234,12 +235,12 @@ $(document).ready(function() {
 						}
 					});
 				}else{
-                    var dropTarget = $(e.originalEvent.target).closest('tr');
-                    if(dropTarget && dropTarget.attr('data-type') === 'dir') { // drag&drop upload to folder
-                        var dirName = dropTarget.attr('data-file')
-                    }
+					var dropTarget = $(e.originalEvent.target).closest('tr');
+					if(dropTarget && dropTarget.attr('data-type') === 'dir') { // drag&drop upload to folder
+						var dirName = dropTarget.attr('data-file')
+					}
 
-                    var date=new Date();
+					var date = new Date();
 					if(files){
 						for(var i=0;i<files.length;i++){
 							if(files[i].size>0){
@@ -292,9 +293,9 @@ $(document).ready(function() {
 								var jqXHR =  $('#file_upload_start').fileupload('send', {files: files[i],
 										formData: function(form) {
 											var formArray = form.serializeArray();
-                                            // array index 0 contains the max files size
-                                            // array index 1 contains the request token
-                                            // array index 2 contains the directory
+											// array index 0 contains the max files size
+											// array index 1 contains the request token
+											// array index 2 contains the directory
 											formArray[2]['value'] = dirName;
 											return formArray;
 										}}).success(function(result, textStatus, jqXHR) {
@@ -305,13 +306,13 @@ $(document).ready(function() {
 												$('#notification').fadeIn();
 											}
 											var file=response[0];
-                                            // TODO: this doesn't work if the file name has been changed server side
+											// TODO: this doesn't work if the file name has been changed server side
 											delete uploadingFiles[dirName][file.name];
-                                            if ($.assocArraySize(uploadingFiles[dirName]) == 0) {
-                                                delete uploadingFiles[dirName];
-                                            }
+											if ($.assocArraySize(uploadingFiles[dirName]) == 0) {
+												delete uploadingFiles[dirName];
+											}
 
-                                            var uploadtext = $('tr').filterAttr('data-type', 'dir').filterAttr('data-file', dirName).find('.uploadtext')
+											var uploadtext = $('tr').filterAttr('data-type', 'dir').filterAttr('data-file', dirName).find('.uploadtext')
 											var currentUploads = parseInt(uploadtext.attr('currentUploads'));
 											currentUploads -= 1;
 											uploadtext.attr('currentUploads', currentUploads);

--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,10 +1,13 @@
 	<?php for($i=0; $i<count($_["breadcrumb"]); $i++):
 		$crumb = $_["breadcrumb"][$i];
-		$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
-		$dir = str_replace('%2F', '/', $dir); ?>
-		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg"
-			 data-dir='<?php echo $dir;?>'
+		if (!isset($crumb["route"])) {
+			$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
+			$dir = str_replace('%2F', '/', $dir);
+			$crumb["route"] = $_['baseURL'].$dir;
+		} ?>
+		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg" 
+			 data-dir='<?php echo urlencode($crumb["dir"]);?>'
 			 style='background-image:url("<?php echo OCP\image_path('core', 'breadcrumb.png');?>")'>
-		<a href="<?php echo $_['baseURL'].$dir; ?>"><?php echo OCP\Util::sanitizeHTML($crumb["name"]); ?></a>
+		<a href="<?php echo$crumb["route"]; ?>"><?php echo OCP\Util::sanitizeHTML($crumb["name"]); ?></a>
 		</div>
 	<?php endfor;

--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,12 +1,12 @@
 	<?php for($i=0; $i<count($_["breadcrumb"]); $i++):
 		$crumb = $_["breadcrumb"][$i];
+		$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
+		$dir = str_replace('%2F', '/', $dir);
 		if (!isset($crumb["route"])) {
-			$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
-			$dir = str_replace('%2F', '/', $dir);
 			$crumb["route"] = $_['baseURL'].$dir;
 		} ?>
 		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg" 
-			 data-dir='<?php echo urlencode($crumb["dir"]);?>'
+			 data-dir='<?php echo $dir; ?>'
 			 style='background-image:url("<?php echo OCP\image_path('core', 'breadcrumb.png');?>")'>
 		<a href="<?php echo$crumb["route"]; ?>"><?php echo OCP\Util::sanitizeHTML($crumb["name"]); ?></a>
 		</div>

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -20,21 +20,18 @@
 			$directory = str_replace('+', '%20', urlencode($file['directory']));
 			$directory = str_replace('%2F', '/', $directory); ?>
 			<tr data-id="<?php echo $file['id']; ?>"
-				data-file="<?php echo $name;?>"
+				data-file="<?php echo $file['name']?>"
 				data-type="<?php echo ($file['type'] == 'dir')?'dir':'file'?>"
 				data-mime="<?php echo $file['mimetype']?>"
 				data-size='<?php echo $file['size'];?>'
 				data-permissions='<?php echo $file['permissions']; ?>'>
 				<td class="filename svg"
-				<?php if($file['type'] == 'dir'): ?>
-					style="background-image:url(<?php echo OCP\mimetype_icon('dir'); ?>)"
-				<?php else: ?>
-					style="background-image:url(<?php echo OCP\mimetype_icon($file['mimetype']); ?>)"
-				<?php endif; ?>
-					>
+					style="background-image:url(<?php echo OCP\mimetype_icon($file['mimetype']); ?>)" >
 				<?php if(!isset($_['readonly']) || !$_['readonly']): ?><input type="checkbox" /><?php endif; ?>
-				<?php if($file['type'] == 'dir'): ?>
-					<a class="name" href="<?php $_['baseURL'].$directory.'/'.$name; ?>)" title="">
+				<?php if( isset($file['route'])): ?>
+					<a class="name" href="<?php echo $file['route'] ?>" title="">
+				<?php elseif($file['type'] == 'dir'): ?>
+					<a class="name" href="<?php $_['baseURL'].$directory.'/'.$name; ?>" title="">
 				<?php else: ?>
 					<a class="name" href="<?php echo $_['downloadURL'].$directory.'/'.$name; ?>" title="">
 				<?php endif; ?>

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -73,12 +73,12 @@ function escapeHTML(s) {
 
 /**
 * Get the path to download a file
-* @param file The filename
+* @param files The filename(s)
 * @param dir The directory the file is in - e.g. $('#dir').val()
 * @return string
 */
-function fileDownloadPath(dir, file) {
-	return OC.filePath('files', 'ajax', 'download.php')+'?files='+encodeURIComponent(file)+'&dir='+encodeURIComponent(dir);
+function fileDownloadPath(dir, files) {
+		window.location = OC.Router.generate('download', {files: files, dir: dir} );
 }
 
 var OC={

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -78,7 +78,7 @@ function escapeHTML(s) {
 * @return string
 */
 function fileDownloadPath(dir, files) {
-		window.location = OC.Router.generate('download', {files: files, dir: dir} );
+		return OC.Router.generate('download', {files: files, dir: dir});
 }
 
 var OC={

--- a/core/js/router.js
+++ b/core/js/router.js
@@ -1,11 +1,11 @@
-OC.router_base_url = OC.webroot + '/index.php/',
+OC.router_base_url = OC.webroot + '/index.php';
 OC.Router = {
 	// register your ajax requests to load after the loading of the routes
 	// has finished. otherwise you face problems with race conditions
 	registerLoadedCallback: function(callback){
 		this.routes_request.done(callback);
 	},
-	routes_request: $.ajax(OC.router_base_url + 'core/routes.json', {
+	routes_request: $.ajax(OC.router_base_url + '/core/routes.json', {
 		dataType: 'json',
 		success: function(jsondata) {
 			if (jsondata.status === 'success') {

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -186,7 +186,11 @@ class OC_Helper {
 	 * Returns the path to the image of this file type.
 	 */
 	public static function mimetypeIcon( $mimetype ) {
-		$alias=array('application/xml'=>'code/xml');
+		$alias=array(
+			'application/xml'=>'code/xml',
+			'httpd/unix-directory'=>'dir',
+			'inode/directory'=>'dir'
+			);
 		if(isset($alias[$mimetype])) {
 			$mimetype=$alias[$mimetype];
 		}


### PR DESCRIPTION
I started replacing the file download and file browsing links with router generated urls.
@bartv2 please check the download route. I am now always using the files/ajax/download urls which requires a $files parameter and $dir instead of $file

The templates for part.list and part.breadcrumb use the route if it is present for the file but fallback to the old link construction when browsing shared files as a guest.

At the moment I cannot use routing for /core/public.php/, can I? Can we introduce a parameter to the constructor of OC_Route, or how do we do this?

@eMerzh Do you agree that this pull request supersedes #462? If so please comment and close that pull request :)
