### PR TITLE
better reverse proxy support

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -30,6 +30,12 @@ $CONFIG = array(
 /* Force use of HTTPS connection (true = use HTTPS) */
 "forcessl" => false,
 
+/* The automatic hostname detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the automatic detection. You can also add a port. For example "www.example.com:88" */
+"overwritehost" => "",
+
+/* The automatic protocol detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the protocol detection. For example "https" */
+"overwriteprotocol" => "",
+
 /* Enhanced auth forces users to enter their password again when performing potential sensitive actions like creating or deleting users */
 "enhancedauth" => true,
 

--- a/lib/request.php
+++ b/lib/request.php
@@ -18,6 +18,9 @@ class OC_Request {
 		if(OC::$CLI) {
 			return 'localhost';
 		}
+		if(OC_Config::getValue('overwritehost', '')<>''){
+			return OC_Config::getValue('overwritehost'); 
+		}
 		if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
 			if (strpos($_SERVER['HTTP_X_FORWARDED_HOST'], ",") !== false) {
 				$host = trim(array_pop(explode(",", $_SERVER['HTTP_X_FORWARDED_HOST'])));
@@ -40,6 +43,9 @@ class OC_Request {
 	* Returns the server protocol. It respects reverse proxy servers and load balancers
 	*/
 	public static function serverProtocol() {
+		if(OC_Config::getValue('overwriteprotocol', '')<>''){
+			return OC_Config::getValue('overwriteprotocol'); 
+		}
 		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
 			$proto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
 		}else{

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,7 +23,7 @@
 
 require_once '../lib/base.php';
 
-$url='http://'.substr(OCP\Util::getServerHost().$_SERVER['REQUEST_URI'], 0, -17).'ocs/v1.php/';
+$url=OCP\Util::getServerProtocol().'://'.substr(OCP\Util::getServerHost().$_SERVER['REQUEST_URI'], 0, -17).'ocs/v1.php/';
 
 echo('
 <providers>


### PR DESCRIPTION
make it possible to manually override the hostname and protocol if the automatic detection from ownCloud fails. This can happen in reverse proxy situations or with loadbalancers setups. Please review: @schiesbn @blizzz @bartv2 @DeepDiver1975 
