### PR TITLE
use lastval() to get the insert id in postgesql

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -355,12 +355,19 @@ class OC_DB {
 	 */
 	public static function insertid($table=null) {
 		self::connect();
-		if($table !== null) {
-			$prefix = OC_Config::getValue( "dbtableprefix", "oc_" );
-			$suffix = OC_Config::getValue( "dbsequencesuffix", "_id_seq" );
-			$table = str_replace( '*PREFIX*', $prefix, $table ).$suffix;
+		$type = OC_Config::getValue( "dbtype", "sqlite" );
+		if( $type == 'pgsql' ) {
+			$query = self::prepare('SELECT lastval() AS id');
+			$row = $query->execute()->fetchRow();
+			return $row['id'];
+		}else{
+			if($table !== null) {
+				$prefix = OC_Config::getValue( "dbtableprefix", "oc_" );
+				$suffix = OC_Config::getValue( "dbsequencesuffix", "_id_seq" );
+				$table = str_replace( '*PREFIX*', $prefix, $table ).$suffix;
+			}
+			return self::$connection->lastInsertId($table);
 		}
-		return self::$connection->lastInsertId($table);
 	}
 
 	/**


### PR DESCRIPTION
This solves the issue with getting the last insert id for me in the filesystem branch.

The old way relied on getting the value from the primary key sequence for the table but this has several problems.
- This fails when the primary key is not an autoincrease integer
- We need to be able to guess the sequence name, which doesn't seem consistent across installations, the current guess is tablename_id_seq', which seems to work for most people but on my current test setup the correct name seems to be tablename.primaryKeyName

Using lastval() removes the need to know the sequence name and should work for all installations
