### PR TITLE
Group name does't need to be sanitized before storing it in the database

### DIFF
--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -5,7 +5,7 @@ OCP\JSON::callCheck();
 
 $success = true;
 $username = $_POST["username"];
-$group = OC_Util::sanitizeHTML($_POST["group"]);
+$group = $_POST["group"];
 
 if(!OC_Group::inGroup(OC_User::getUser(), 'admin') && (!OC_SubAdmin::isUserAccessible(OC_User::getUser(), $username) || !OC_SubAdmin::isGroupAccessible(OC_User::getUser(), $group))) {
 	$l = OC_L10N::get('core');

--- a/settings/ajax/togglesubadmins.php
+++ b/settings/ajax/togglesubadmins.php
@@ -4,7 +4,7 @@ OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
 
 $username = $_POST["username"];
-$group = OC_Util::sanitizeHTML($_POST["group"]);
+$group = $_POST["group"];
 
 // Toggle group
 if(OC_SubAdmin::isSubAdminofGroup($username, $group)) {


### PR DESCRIPTION
It should only be sanitized before display

see also #552
