### PR TITLE
OC_FSV->copy now only caches files which are copied from data/user/files

### DIFF
--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -28,6 +28,7 @@
  * It will try to keep the data up to date but changes from outside ownCloud can invalidate the cache
  */
 class OC_FileCache{
+
 	/**
 	 * get the filesystem info from the cache
 	 * @param string path
@@ -58,8 +59,8 @@ class OC_FileCache{
 	 * @param string $path
 	 * @param array data
 	 * @param string root (optional)
-	 *
-	 * $data is an assiciative array in the same format as returned by get
+	 * @note $data is an associative array in the same format as returned 
+	 * by get
 	 */
 	public static function put($path, $data, $root=false) {
 		if($root===false) {

--- a/lib/filesystemview.php
+++ b/lib/filesystemview.php
@@ -430,7 +430,10 @@ class OC_FilesystemView {
 					$target = $this->fopen($path2.$postFix2, 'w');
 					$result = OC_Helper::streamCopy($source, $target);
 				}
-				if( $this->fakeRoot==OC_Filesystem::getRoot() ) {
+				if( $this->fakeRoot==OC_Filesystem::getRoot() ) { 
+				// If the file to be copied originates within 
+				// the user's data directory
+				
 					OC_Hook::emit(
 						OC_Filesystem::CLASSNAME,
 						OC_Filesystem::signal_post_copy,
@@ -451,11 +454,33 @@ class OC_FilesystemView {
 						OC_Filesystem::signal_post_write,
 						array( OC_Filesystem::signal_param_path => $path2)
 					);
-				} else { // no real copy, file comes from somewhere else, e.g. version rollback -> just update the file cache and the webdav properties without all the other post_write actions
-					OC_FileCache_Update::update($path2, $this->fakeRoot);
+					
+				} else { 
+				// If this is not a normal file copy operation 
+				// and the file originates somewhere else 
+				// (e.g. a version rollback operation), do not 
+				// perform all the other post_write actions
+					
+					// Update webdav properties
 					OC_Filesystem::removeETagHook(array("path" => $path2), $this->fakeRoot);
+					
+					$splitPath2 = explode( '/', $path2 );
+					
+					// Only cache information about files 
+					// that are being copied from within 
+					// the user files directory. Caching 
+					// other files, like VCS backup files,
+					// serves no purpose
+					if ( $splitPath2[1] == 'files' ) {
+						
+						OC_FileCache_Update::update($path2, $this->fakeRoot);
+						
+					}
+				
 				}
+				
 				return $result;
+			
 			}
 		}
 	}


### PR DESCRIPTION
Fix for issue: https://github.com/owncloud/core/issues/327

To prevent VCS backup files being unnecessarily tracked in the file cache, I added a check that allows only files copied from data/user/files to be cached by ->copy. AFAIK there are no other uses of ->copy that would need caching to be used outside of the above scenario. Also added some contextual comments.

Please review @schiesbn, @blizzz
