### PR TITLE
Move loading of all the apps to setting the active navigation entry.

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -253,6 +253,8 @@ class OC_App{
 	 * highlighting the current position of the user.
 	 */
 	public static function setActiveNavigationEntry( $id ) {
+		// load all the apps, to make sure we have all the navigation entries
+		self::loadApps();
 		self::$activeapp = $id;
 		return true;
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -512,7 +512,6 @@ class OC{
 			return;
 		}
 		try {
-			OC_App::loadApps();
 			OC::getRouter()->match(OC_Request::getPathInfo());
 			return;
 		} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {


### PR DESCRIPTION
We can't do the loading before matching the route, because some routes
need to do the loading after matching of the route. For example the
navigation detection of the app settings page.
@Raydiation please check if this still works for you
