### PR TITLE
fix regression in file versioning for shared files

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -10,7 +10,9 @@ OCP\Util::connectHook('OC_User', 'post_login', 'OC_Crypt', 'loginListener');
 
 stream_wrapper_register('crypt', 'OC_CryptStream');
 
-if(!isset($_SESSION['enckey']) and OCP\User::isLoggedIn()) {//force the user to re-loggin if the encryption key isn't unlocked (happens when a user is logged in before the encryption app is enabled)
+// force the user to re-loggin if the encryption key isn't unlocked
+// (happens when a user is logged in before the encryption app is enabled)
+if ( ! isset($_SESSION['enckey']) and OCP\User::isLoggedIn()) {
 	OCP\User::logout();
 	header("Location: ".OC::$WEBROOT.'/');
 	exit();

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -27,7 +27,8 @@
 //  - Setting if crypto should be on by default
 //  - Add a setting "Don´t encrypt files larger than xx because of performance reasons"
 //  - Transparent decrypt/encrypt in filesystem.php. Autodetect if a file is encrypted (.encrypted extension)
-//  - Don't use a password directly as encryption key. but a key which is stored on the server and encrypted with the user password. -> password change faster
+//  - Don't use a password directly as encryption key, but a key which is stored on the server and encrypted with the
+//    user password. -> password change faster
 //  - IMPORTANT! Check if the block lenght of the encrypted data stays the same
 
 
@@ -45,12 +46,12 @@ class OC_Crypt {
 
 	public static function init($login, $password) {
 		$view=new OC_FilesystemView('/');
-		if(!$view->file_exists('/'.$login)) {
+		if ( ! $view->file_exists('/'.$login)) {
 			$view->mkdir('/'.$login);
 		}
 
 		OC_FileProxy::$enabled=false;
-		if(!$view->file_exists('/'.$login.'/encryption.key')) {// does key exist?
+		if ( ! $view->file_exists('/'.$login.'/encryption.key')) {// does key exist?
 			OC_Crypt::createkey($login, $password);
 		}
 		$key=$view->file_get_contents('/'.$login.'/encryption.key');
@@ -67,13 +68,13 @@ class OC_Crypt {
 	 * if the key is left out, the default handeler will be used
 	 */
 	public static function getBlowfish($key='') {
-		if($key) {
+		if ($key) {
 			return new Crypt_Blowfish($key);
-		}else{
-			if(!isset($_SESSION['enckey'])) {
+		} else {
+			if ( ! isset($_SESSION['enckey'])) {
 				return false;
 			}
-			if(!self::$bf) {
+			if ( ! self::$bf) {
 				self::$bf=new Crypt_Blowfish($_SESSION['enckey']);
 			}
 			return self::$bf;
@@ -96,7 +97,7 @@ class OC_Crypt {
 	}
 
 	public static function changekeypasscode($oldPassword, $newPassword) {
-		if(OCP\User::isLoggedIn()) {
+		if (OCP\User::isLoggedIn()) {
 			$username=OCP\USER::getUser();
 			$view=new OC_FilesystemView('/'.$username);
 
@@ -151,7 +152,7 @@ class OC_Crypt {
 	*/
 	public static function encryptFile( $source, $target, $key='') {
 		$handleread  = fopen($source, "rb");
-		if($handleread!=false) {
+		if ($handleread!=false) {
 			$handlewrite = fopen($target, "wb");
 			while (!feof($handleread)) {
 				$content = fread($handleread, 8192);
@@ -174,12 +175,12 @@ class OC_Crypt {
 		*/
 	public static function decryptFile( $source, $target, $key='') {
 		$handleread  = fopen($source, "rb");
-		if($handleread!=false) {
+		if ($handleread!=false) {
 			$handlewrite = fopen($target, "wb");
 			while (!feof($handleread)) {
 				$content = fread($handleread, 8192);
 				$enccontent=OC_CRYPT::decrypt( $content, $key);
-				if(feof($handleread)) {
+				if (feof($handleread)) {
 					$enccontent=rtrim($enccontent, "\0");
 				}
 				fwrite($handlewrite, $enccontent);
@@ -194,7 +195,7 @@ class OC_Crypt {
 	 */
 	public static function blockEncrypt($data, $key='') {
 		$result='';
-		while(strlen($data)) {
+		while (strlen($data)) {
 			$result.=self::encrypt(substr($data, 0, 8192), $key);
 			$data=substr($data, 8192);
 		}
@@ -206,13 +207,13 @@ class OC_Crypt {
 	 */
 	public static function blockDecrypt($data, $key='', $maxLength=0) {
 		$result='';
-		while(strlen($data)) {
+		while (strlen($data)) {
 			$result.=self::decrypt(substr($data, 0, 8192), $key);
 			$data=substr($data, 8192);
 		}
-		if($maxLength>0) {
+		if ($maxLength>0) {
 			return substr($result, 0, $maxLength);
-		}else{
+		} else {
 			return rtrim($result, "\0");
 		}
 	}

--- a/apps/files_encryption/settings.php
+++ b/apps/files_encryption/settings.php
@@ -7,7 +7,9 @@
  */
 
 $tmpl = new OCP\Template( 'files_encryption', 'settings');
-$blackList=explode(',', OCP\Config::getAppValue('files_encryption', 'type_blacklist', 'jpg,png,jpeg,avi,mpg,mpeg,mkv,mp3,oga,ogv,ogg'));
+$blackList=explode(',', OCP\Config::getAppValue('files_encryption',
+												'type_blacklist',
+												'jpg,png,jpeg,avi,mpg,mpeg,mkv,mp3,oga,ogv,ogg'));
 $enabled=(OCP\Config::getAppValue('files_encryption', 'enable_encryption', 'true')=='true');
 $tmpl->assign('blacklist', $blackList);
 $tmpl->assign('encryption_enabled', $enabled);

--- a/apps/files_encryption/templates/settings.php
+++ b/apps/files_encryption/templates/settings.php
@@ -1,12 +1,14 @@
 <form id="calendar">
 	<fieldset class="personalblock">
 	<strong><?php echo $l->t('Encryption'); ?></strong>
-		<?php echo $l->t("Exclude the following file types from encryption"); ?>
+		<?php echo $l->t('Exclude the following file types from encryption'); ?>
 		<select id='encryption_blacklist' title="<?php echo $l->t('None')?>" multiple="multiple">
-			<?php foreach($_["blacklist"] as $type): ?>
+			<?php foreach ($_['blacklist'] as $type): ?>
 				<option selected="selected" value="<?php echo $type;?>"><?php echo $type;?></option>
 			<?php endforeach;?>
 		</select>
-		<input type='checkbox' id='enable_encryption' <?php if($_['encryption_enabled']) {echo 'checked="checked"';} ?>></input><label for='enable_encryption'><?php echo $l->t('Enable Encryption')?></label>
+		<input type='checkbox'<?php if ($_['encryption_enabled']): ?> checked="checked"<?php endif; ?>
+			   id='enable_encryption' ></input>
+		<label for='enable_encryption'><?php echo $l->t('Enable Encryption')?></label>
 	</fieldset>
 </form>

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -42,7 +42,7 @@ class Test_CryptProxy extends UnitTestCase {
 
 	public function tearDown() {
 		OCP\Config::setAppValue('files_encryption', 'enable_encryption', $this->oldConfig);
-		if(!is_null($this->oldKey)) {
+		if ( ! is_null($this->oldKey)) {
 			$_SESSION['enckey']=$this->oldKey;
 		}
 	}

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -41,13 +41,13 @@ class Test_CryptStream extends UnitTestCase {
 	 * @return resource
 	 */
 	function getStream($id, $mode, $size) {
-		if($id==='') {
+		if ($id==='') {
 			$id=uniqid();
 		}
-		if(!isset($this->tmpFiles[$id])) {
+		if ( ! isset($this->tmpFiles[$id])) {
 			$file=OCP\Files::tmpFile();
 			$this->tmpFiles[$id]=$file;
-		}else{
+		} else {
 			$file=$this->tmpFiles[$id];
 		}
 		$stream=fopen($file, $mode);

--- a/apps/files_external/ajax/addMountPoint.php
+++ b/apps/files_external/ajax/addMountPoint.php
@@ -10,4 +10,9 @@ if ($_POST['isPersonal'] == 'true') {
 	OCP\JSON::checkAdminUser();
 	$isPersonal = false;
 }
-OC_Mount_Config::addMountPoint($_POST['mountPoint'], $_POST['class'], $_POST['classOptions'], $_POST['mountType'], $_POST['applicable'], $isPersonal);
+OC_Mount_Config::addMountPoint($_POST['mountPoint'],
+							   $_POST['class'],
+							   $_POST['classOptions'],
+							   $_POST['mountType'],
+							   $_POST['applicable'],
+							   $isPersonal);

--- a/apps/files_external/ajax/addRootCertificate.php
+++ b/apps/files_external/ajax/addRootCertificate.php
@@ -2,7 +2,7 @@
 
 OCP\JSON::checkAppEnabled('files_external');
 
-if ( !($filename = $_FILES['rootcert_import']['name']) ) {
+if ( ! ($filename = $_FILES['rootcert_import']['name']) ) {
 	header("Location: settings/personal.php");
 	exit;
 }
@@ -13,7 +13,7 @@ fclose($fh);
 $filename = $_FILES['rootcert_import']['name'];
 
 $view = new \OC_FilesystemView('/'.\OCP\User::getUser().'/files_external/uploads');
-if (!$view->file_exists('')) $view->mkdir('');
+if ( ! $view->file_exists('')) $view->mkdir('');
 
 $isValid = openssl_pkey_get_public($data);
 
@@ -29,8 +29,10 @@ if ( $isValid ) {
 	$view->file_put_contents($filename, $data);
 	OC_Mount_Config::createCertificateBundle();
 } else {
-	OCP\Util::writeLog("files_external", "Couldn't import SSL root certificate ($filename), allowed formats: PEM and DER", OCP\Util::WARN);
+	OCP\Util::writeLog('files_external',
+			'Couldn\'t import SSL root certificate ('.$filename.'), allowed formats: PEM and DER',
+			OCP\Util::WARN);
 }
 
-header("Location: settings/personal.php");
+header('Location: settings/personal.php');
 exit;

--- a/apps/files_external/ajax/dropbox.php
+++ b/apps/files_external/ajax/dropbox.php
@@ -16,9 +16,13 @@ if (isset($_POST['app_key']) && isset($_POST['app_secret'])) {
 						$callback = null;
 					}
 					$token = $oauth->getRequestToken();
-					OCP\JSON::success(array('data' => array('url' => $oauth->getAuthorizeUrl($callback), 'request_token' => $token['token'], 'request_token_secret' => $token['token_secret'])));
+					OCP\JSON::success(array('data' => array('url' => $oauth->getAuthorizeUrl($callback),
+															'request_token' => $token['token'],
+															'request_token_secret' => $token['token_secret'])));
 				} catch (Exception $exception) {
-					OCP\JSON::error(array('data' => array('message' => 'Fetching request tokens failed. Verify that your Dropbox app key and secret are correct.')));
+					OCP\JSON::error(array('data' => array('message' =>
+						'Fetching request tokens failed. Verify that your Dropbox app key and secret are correct.')
+						));
 				}
 				break;
 			case 2:
@@ -26,9 +30,12 @@ if (isset($_POST['app_key']) && isset($_POST['app_secret'])) {
 					try {
 						$oauth->setToken($_POST['request_token'], $_POST['request_token_secret']);
 						$token = $oauth->getAccessToken();
-						OCP\JSON::success(array('access_token' => $token['token'], 'access_token_secret' => $token['token_secret']));
+						OCP\JSON::success(array('access_token' => $token['token'],
+												'access_token_secret' => $token['token_secret']));
 					} catch (Exception $exception) {
-						OCP\JSON::error(array('data' => array('message' => 'Fetching access tokens failed. Verify that your Dropbox app key and secret are correct.')));
+						OCP\JSON::error(array('data' => array('message' =>
+							'Fetching access tokens failed. Verify that your Dropbox app key and secret are correct.')
+							));
 					}
 				}
 				break;

--- a/apps/files_external/ajax/google.php
+++ b/apps/files_external/ajax/google.php
@@ -14,7 +14,9 @@ if (isset($_POST['step'])) {
 			} else {
 				$callback = null;
 			}
-			$scope = 'https://docs.google.com/feeds/ https://docs.googleusercontent.com/ https://spreadsheets.google.com/feeds/';
+			$scope = 'https://docs.google.com/feeds/'
+					.' https://docs.googleusercontent.com/'
+					.' https://spreadsheets.google.com/feeds/';
 			$url = 'https://www.google.com/accounts/OAuthGetRequestToken?scope='.urlencode($scope);
 			$params = array('scope' => $scope, 'oauth_callback' => $callback);
 			$request = OAuthRequest::from_consumer_and_token($consumer, null, 'GET', $url, $params);
@@ -24,24 +26,35 @@ if (isset($_POST['step'])) {
 			parse_str($response, $token);
 			if (isset($token['oauth_token']) && isset($token['oauth_token_secret'])) {
 				$authUrl = 'https://www.google.com/accounts/OAuthAuthorizeToken?oauth_token='.$token['oauth_token'];
-				OCP\JSON::success(array('data' => array('url' => $authUrl, 'request_token' => $token['oauth_token'], 'request_token_secret' => $token['oauth_token_secret'])));
+				OCP\JSON::success(array('data' => array('url' => $authUrl,
+														'request_token' => $token['oauth_token'],
+														'request_token_secret' => $token['oauth_token_secret'])));
 			} else {
-				OCP\JSON::error(array('data' => array('message' => 'Fetching request tokens failed. Error: '.$response)));
+				OCP\JSON::error(array('data' => array(
+					'message' => 'Fetching request tokens failed. Error: '.$response
+					)));
 			}
 			break;
 		case 2:
-			if (isset($_POST['oauth_verifier']) && isset($_POST['request_token']) && isset($_POST['request_token_secret'])) {
+			if (isset($_POST['oauth_verifier'])
+				&& isset($_POST['request_token'])
+				&& isset($_POST['request_token_secret'])
+			) {
 				$token = new OAuthToken($_POST['request_token'], $_POST['request_token_secret']);
 				$url = 'https://www.google.com/accounts/OAuthGetAccessToken';
-				$request = OAuthRequest::from_consumer_and_token($consumer, $token, 'GET', $url, array('oauth_verifier' => $_POST['oauth_verifier']));
+				$request = OAuthRequest::from_consumer_and_token($consumer, $token, 'GET', $url,
+																 array('oauth_verifier' => $_POST['oauth_verifier']));
 				$request->sign_request($sigMethod, $consumer, $token);
 				$response = send_signed_request('GET', $url, array($request->to_header()), null, false);
 				$token = array();
 				parse_str($response, $token);
 				if (isset($token['oauth_token']) && isset($token['oauth_token_secret'])) {
-					OCP\JSON::success(array('access_token' => $token['oauth_token'], 'access_token_secret' => $token['oauth_token_secret']));
+					OCP\JSON::success(array('access_token' => $token['oauth_token'],
+											'access_token_secret' => $token['oauth_token_secret']));
 				} else {
-					OCP\JSON::error(array('data' => array('message' => 'Fetching access tokens failed. Error: '.$response)));
+					OCP\JSON::error(array('data' => array(
+						'message' => 'Fetching access tokens failed. Error: '.$response
+						)));
 				}
 			}
 			break;

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -142,7 +142,7 @@ $(document).ready(function() {
 	$('td.remove>img').live('click', function() {
 		var tr = $(this).parent().parent();
 		var mountPoint = $(tr).find('.mountPoint input').val();
-		if (!mountPoint) {
+		if ( ! mountPoint) {
 			var row=this.parentNode.parentNode;
 			$.post(OC.filePath('files_external', 'ajax', 'removeRootCertificate.php'), { cert: row.id  });
 			$(tr).remove();

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -39,14 +39,64 @@ class OC_Mount_Config {
 	*/
 	public static function getBackends() {
 		return array(
-			'OC_Filestorage_Local' => array('backend' => 'Local', 'configuration' => array('datadir' => 'Location')),
-			'OC_Filestorage_AmazonS3' => array('backend' => 'Amazon S3', 'configuration' => array('key' => 'Key', 'secret' => '*Secret', 'bucket' => 'Bucket')),
-			'OC_Filestorage_Dropbox' => array('backend' => 'Dropbox', 'configuration' => array('configured' => '#configured','app_key' => 'App key', 'app_secret' => 'App secret', 'token' => '#token', 'token_secret' => '#token_secret'), 'custom' => 'dropbox'),
-			'OC_Filestorage_FTP' => array('backend' => 'FTP', 'configuration' => array('host' => 'URL', 'user' => 'Username', 'password' => '*Password', 'root' => '&Root', 'secure' => '!Secure ftps://')),
-			'OC_Filestorage_Google' => array('backend' => 'Google Drive', 'configuration' => array('configured' => '#configured', 'token' => '#token', 'token_secret' => '#token secret'), 'custom' => 'google'),
-			'OC_Filestorage_SWIFT' => array('backend' => 'OpenStack Swift', 'configuration' => array('host' => 'URL', 'user' => 'Username', 'token' => '*Token', 'root' => '&Root', 'secure' => '!Secure ftps://')),
-			'OC_Filestorage_SMB' => array('backend' => 'SMB', 'configuration' => array('host' => 'URL', 'user' => 'Username', 'password' => '*Password', 'share' => 'Share', 'root' => '&Root')),
-			'OC_Filestorage_DAV' => array('backend' => 'WebDAV', 'configuration' => array('host' => 'URL', 'user' => 'Username', 'password' => '*Password', 'root' => '&Root', 'secure' => '!Secure https://'))
+			'OC_Filestorage_Local' => array(
+				'backend' => 'Local',
+				'configuration' => array(
+					'datadir' => 'Location')),
+			'OC_Filestorage_AmazonS3' => array(
+				'backend' => 'Amazon S3',
+				'configuration' => array(
+					'key' => 'Key',
+					'secret' => '*Secret',
+					'bucket' => 'Bucket')),
+			'OC_Filestorage_Dropbox' => array(
+				'backend' => 'Dropbox',
+				'configuration' => array(
+					'configured' => '#configured',
+					'app_key' => 'App key',
+					'app_secret' => 'App secret',
+					'token' => '#token',
+					'token_secret' => '#token_secret'),
+				'custom' => 'dropbox'),
+			'OC_Filestorage_FTP' => array(
+				'backend' => 'FTP',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'password' => '*Password',
+					'root' => '&Root',
+					'secure' => '!Secure ftps://')),
+			'OC_Filestorage_Google' => array(
+				'backend' => 'Google Drive',
+				'configuration' => array(
+					'configured' => '#configured',
+					'token' => '#token',
+					'token_secret' => '#token secret'),
+				'custom' => 'google'),
+			'OC_Filestorage_SWIFT' => array(
+				'backend' => 'OpenStack Swift',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'token' => '*Token',
+					'root' => '&Root',
+					'secure' => '!Secure ftps://')),
+			'OC_Filestorage_SMB' => array(
+				'backend' => 'SMB',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'password' => '*Password',
+					'share' => 'Share',
+					'root' => '&Root')),
+			'OC_Filestorage_DAV' => array(
+				'backend' => 'WebDAV',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'password' => '*Password',
+					'root' => '&Root',
+					'secure' => '!Secure https://'))
 		);
 	}
 
@@ -66,9 +116,14 @@ class OC_Mount_Config {
 					$mountPoint = substr($mountPoint, 13);
 					// Merge the mount point into the current mount points
 					if (isset($system[$mountPoint]) && $system[$mountPoint]['configuration'] == $mount['options']) {
-						$system[$mountPoint]['applicable']['groups'] = array_merge($system[$mountPoint]['applicable']['groups'], array($group));
+						$system[$mountPoint]['applicable']['groups']
+							= array_merge($system[$mountPoint]['applicable']['groups'], array($group));
 					} else {
-						$system[$mountPoint] = array('class' => $mount['class'], 'backend' => $backends[$mount['class']]['backend'], 'configuration' => $mount['options'], 'applicable' => array('groups' => array($group), 'users' => array()));
+						$system[$mountPoint] = array(
+							'class' => $mount['class'],
+							'backend' => $backends[$mount['class']]['backend'],
+							'configuration' => $mount['options'],
+							'applicable' => array('groups' => array($group), 'users' => array()));
 					}
 				}
 			}
@@ -80,9 +135,13 @@ class OC_Mount_Config {
 					$mountPoint = substr($mountPoint, 13);
 					// Merge the mount point into the current mount points
 					if (isset($system[$mountPoint]) && $system[$mountPoint]['configuration'] == $mount['options']) {
-						$system[$mountPoint]['applicable']['users'] = array_merge($system[$mountPoint]['applicable']['users'], array($user));
+						$system[$mountPoint]['applicable']['users']
+							= array_merge($system[$mountPoint]['applicable']['users'], array($user));
 					} else {
-						$system[$mountPoint] = array('class' => $mount['class'], 'backend' => $backends[$mount['class']]['backend'], 'configuration' => $mount['options'], 'applicable' => array('groups' => array(), 'users' => array($user)));
+						$system[$mountPoint] = array('class' => $mount['class'],
+							'backend' => $backends[$mount['class']]['backend'],
+							'configuration' => $mount['options'],
+							'applicable' => array('groups' => array(), 'users' => array($user)));
 					}
 				}
 			}
@@ -103,7 +162,9 @@ class OC_Mount_Config {
 		if (isset($mountPoints[self::MOUNT_TYPE_USER][$uid])) {
 			foreach ($mountPoints[self::MOUNT_TYPE_USER][$uid] as $mountPoint => $mount) {
 				// Remove '/uid/files/' from mount point
-				$personal[substr($mountPoint, strlen($uid) + 8)] = array('class' => $mount['class'], 'backend' => $backends[$mount['class']]['backend'], 'configuration' => $mount['options']);
+				$personal[substr($mountPoint, strlen($uid) + 8)] = array('class' => $mount['class'],
+																'backend' => $backends[$mount['class']]['backend'],
+																'configuration' => $mount['options']);
 			}
 		}
 		return $personal;
@@ -135,7 +196,12 @@ class OC_Mount_Config {
 	* @param bool Personal or system mount point i.e. is this being called from the personal or admin page
 	* @return bool
 	*/
-	public static function addMountPoint($mountPoint, $class, $classOptions, $mountType, $applicable, $isPersonal = false) {
+	public static function addMountPoint($mountPoint,
+										 $class,
+										 $classOptions,
+										 $mountType,
+										 $applicable,
+										 $isPersonal = false) {
 		if ($isPersonal) {
 			// Verify that the mount point applies for the current user
 			// Prevent non-admin users from mounting local storage
@@ -176,7 +242,8 @@ class OC_Mount_Config {
 		// Merge the new mount point into the current mount points
 		if (isset($mountPoints[$mountType])) {
 			if (isset($mountPoints[$mountType][$applicable])) {
-				$mountPoints[$mountType][$applicable] = array_merge($mountPoints[$mountType][$applicable], $mount[$applicable]);
+				$mountPoints[$mountType][$applicable]
+					= array_merge($mountPoints[$mountType][$applicable], $mount[$applicable]);
 			} else {
 				$mountPoints[$mountType] = array_merge($mountPoints[$mountType], $mount);
 			}
@@ -286,18 +353,18 @@ class OC_Mount_Config {
 		$view = \OCP\Files::getStorage('files_external');
 		$path=\OCP\Config::getSystemValue('datadirectory').$view->getAbsolutePath("").'uploads/';
 		\OCP\Util::writeLog('files_external', 'checking path '.$path, \OCP\Util::INFO);
-		if(!is_dir($path)) {
+		if ( ! is_dir($path)) {
 			//path might not exist (e.g. non-standard OC_User::getHome() value)
 			//in this case create full path using 3rd (recursive=true) parameter.
 			mkdir($path, 0777, true);
 		}
 		$result = array();
 		$handle = opendir($path);
-		if (!$handle) {
+		if ( ! $handle) {
 			return array();
 		}
 		while (false !== ($file = readdir($handle))) {
-			if($file != '.' && $file != '..') $result[] = $file;
+			if ($file != '.' && $file != '..') $result[] = $file;
 		}
 		return $result;
 	}

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -31,7 +31,12 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 	private static $tempFiles = array();
 
 	public function __construct($params) {
-		if (isset($params['configured']) && $params['configured'] == 'true' && isset($params['app_key']) && isset($params['app_secret']) && isset($params['token']) && isset($params['token_secret'])) {
+		if (isset($params['configured']) && $params['configured'] == 'true'
+			&& isset($params['app_key'])
+			&& isset($params['app_secret'])
+			&& isset($params['token'])
+			&& isset($params['token_secret'])
+		) {
 			$this->root=isset($params['root'])?$params['root']:'';
 			$oauth = new Dropbox_OAuth_Curl($params['app_key'], $params['app_secret']);
 			$oauth->setToken($params['token'], $params['token_secret']);
@@ -44,7 +49,7 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 
 	private function getMetaData($path, $list = false) {
 		$path = $this->root.$path;
-		if (!$list && isset($this->metaData[$path])) {
+		if ( ! $list && isset($this->metaData[$path])) {
 			return $this->metaData[$path];
 		} else {
 			if ($list) {
@@ -95,7 +100,8 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 	}
 
 	public function opendir($path) {
-		if ($contents = $this->getMetaData($path, true)) {
+		$contents = $this->getMetaData($path, true);
+		if ($contents) {
 			$files = array();
 			foreach ($contents as $file) {
 				$files[] = basename($file['path']);
@@ -107,7 +113,8 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 	}
 
 	public function stat($path) {
-		if ($metaData = $this->getMetaData($path)) {
+		$metaData = $this->getMetaData($path);
+		if ($metaData) {
 			$stat['size'] = $metaData['bytes'];
 			$stat['atime'] = time();
 			$stat['mtime'] = (isset($metaData['modified'])) ? strtotime($metaData['modified']) : time();
@@ -120,11 +127,14 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 	public function filetype($path) {
 		if ($path == '' || $path == '/') {
 			return 'dir';
-		} else if ($metaData = $this->getMetaData($path)) {
-			if ($metaData['is_dir'] == 'true') {
-				return 'dir';
-			} else {
-				return 'file';
+		} else {
+			$metaData = $this->getMetaData($path);
+			if ($metaData) {
+				if ($metaData['is_dir'] == 'true') {
+					return 'dir';
+				} else {
+					return 'file';
+				}
 			}
 		}
 		return false;
@@ -241,8 +251,11 @@ class OC_Filestorage_Dropbox extends OC_Filestorage_Common {
 	public function getMimeType($path) {
 		if ($this->filetype($path) == 'dir') {
 			return 'httpd/unix-directory';
-		} else if ($metaData = $this->getMetaData($path)) {
-			return $metaData['mime_type'];
+		} else {
+			$metaData = $this->getMetaData($path);
+			if ($metaData) {
+				return $metaData['mime_type'];
+			}
 		}
 		return false;
 	}

--- a/apps/files_external/lib/ftp.php
+++ b/apps/files_external/lib/ftp.php
@@ -19,21 +19,21 @@ class OC_FileStorage_FTP extends OC_FileStorage_StreamWrapper{
 		$this->host=$params['host'];
 		$this->user=$params['user'];
 		$this->password=$params['password'];
-		if(isset($params['secure'])) {
-			if(is_string($params['secure'])) {
+		if (isset($params['secure'])) {
+			if (is_string($params['secure'])) {
 				$this->secure = ($params['secure'] === 'true');
-			}else{
+			} else {
 				$this->secure = (bool)$params['secure'];
 			}
-		}else{
+		} else {
 			$this->secure = false;
 		}
 		$this->root=isset($params['root'])?$params['root']:'/';
-		if(!$this->root || $this->root[0]!='/') {
+		if ( ! $this->root || $this->root[0]!='/') {
 			$this->root='/'.$this->root;
 		}
 		//create the root folder if necesary
-		if (!$this->is_dir('')) {
+		if ( ! $this->is_dir('')) {
 			$this->mkdir('');
 		}
 	}
@@ -45,7 +45,7 @@ class OC_FileStorage_FTP extends OC_FileStorage_StreamWrapper{
 	 */
 	public function constructUrl($path) {
 		$url='ftp';
-		if($this->secure) {
+		if ($this->secure) {
 			$url.='s';
 		}
 		$url.='://'.$this->user.':'.$this->password.'@'.$this->host.$this->root.$path;
@@ -71,14 +71,14 @@ class OC_FileStorage_FTP extends OC_FileStorage_StreamWrapper{
 			case 'c':
 			case 'c+':
 				//emulate these
-				if(strrpos($path, '.')!==false) {
+				if (strrpos($path, '.')!==false) {
 					$ext=substr($path, strrpos($path, '.'));
-				}else{
+				} else {
 					$ext='';
 				}
 				$tmpFile=OCP\Files::tmpFile($ext);
 				OC_CloseStreamWrapper::$callBacks[$tmpFile]=array($this, 'writeBack');
-				if($this->file_exists($path)) {
+				if ($this->file_exists($path)) {
 					$this->getFile($path, $tmpFile);
 				}
 				self::$tempFiles[$tmpFile]=$path;
@@ -87,7 +87,7 @@ class OC_FileStorage_FTP extends OC_FileStorage_StreamWrapper{
 	}
 
 	public function writeBack($tmpFile) {
-		if(isset(self::$tempFiles[$tmpFile])) {
+		if (isset(self::$tempFiles[$tmpFile])) {
 			$this->uploadFile($tmpFile, self::$tempFiles[$tmpFile]);
 			unlink($tmpFile);
 		}

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -21,45 +21,46 @@ class OC_FileStorage_SMB extends OC_FileStorage_StreamWrapper{
 		$this->password=$params['password'];
 		$this->share=$params['share'];
 		$this->root=isset($params['root'])?$params['root']:'/';
-		if(!$this->root || $this->root[0]!='/') {
+		if ( ! $this->root || $this->root[0]!='/') {
 			$this->root='/'.$this->root;
 		}
-		if(substr($this->root, -1, 1)!='/') {
+		if (substr($this->root, -1, 1)!='/') {
 			$this->root.='/';
 		}
-		if(!$this->share || $this->share[0]!='/') {
+		if ( ! $this->share || $this->share[0]!='/') {
 			$this->share='/'.$this->share;
 		}
-		if(substr($this->share, -1, 1)=='/') {
+		if (substr($this->share, -1, 1)=='/') {
 			$this->share=substr($this->share, 0, -1);
 		}
 
 		//create the root folder if necesary
-		if(!$this->is_dir('')) {
+		if ( ! $this->is_dir('')) {
 			$this->mkdir('');
 		}
 	}
 
 	public function constructUrl($path) {
-		if(substr($path, -1)=='/') {
+		if (substr($path, -1)=='/') {
 			$path=substr($path, 0, -1);
 		}
 		return 'smb://'.$this->user.':'.$this->password.'@'.$this->host.$this->share.$this->root.$path;
 	}
 
 	public function stat($path) {
-		if(!$path and $this->root=='/') {//mtime doesn't work for shares
+		if ( ! $path and $this->root=='/') {//mtime doesn't work for shares
 			$mtime=$this->shareMTime();
 			$stat=stat($this->constructUrl($path));
 			$stat['mtime']=$mtime;
 			return $stat;
-		}else{
+		} else {
 			return stat($this->constructUrl($path));
 		}
 	}
 
 	public function filetype($path) {
-		return (bool)@$this->opendir($path) ? 'dir' : 'file';//using opendir causes the same amount of requests and caches the content of the folder in one go
+		// using opendir causes the same amount of requests and caches the content of the folder in one go
+		return (bool)@$this->opendir($path) ? 'dir' : 'file';
 	}
 
 	/**
@@ -68,10 +69,11 @@ class OC_FileStorage_SMB extends OC_FileStorage_StreamWrapper{
 	 * @return bool
 	 */
 	public function hasUpdated($path, $time) {
-		if(!$path and $this->root=='/') {
-			//mtime doesn't work for shares, but giving the nature of the backend, doing a full update is still just fast enough
+		if ( ! $path and $this->root=='/') {
+			// mtime doesn't work for shares, but giving the nature of the backend,
+			// doing a full update is still just fast enough
 			return true;
-		}else{
+		} else {
 			$actualTime=$this->filemtime($path);
 			return $actualTime>$time;
 		}
@@ -84,9 +86,9 @@ class OC_FileStorage_SMB extends OC_FileStorage_StreamWrapper{
 		$dh=$this->opendir('');
 		$lastCtime=0;
 		while($file=readdir($dh)) {
-			if($file!='.' and $file!='..') {
+			if ($file!='.' and $file!='..') {
 				$ctime=$this->filemtime($file);
-				if($ctime>$lastCtime) {
+				if ($ctime>$lastCtime) {
 					$lastCtime=$ctime;
 				}
 			}

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -15,11 +15,11 @@ abstract class OC_FileStorage_StreamWrapper extends OC_Filestorage_Common{
 	}
 
 	public function rmdir($path) {
-		if($this->file_exists($path)) {
-			$succes=rmdir($this->constructUrl($path));
+		if ($this->file_exists($path)) {
+			$succes = rmdir($this->constructUrl($path));
 			clearstatcache();
 			return $succes;
-		}else{
+		} else {
 			return false;
 		}
 	}
@@ -45,7 +45,7 @@ abstract class OC_FileStorage_StreamWrapper extends OC_Filestorage_Common{
 	}
 
 	public function unlink($path) {
-		$succes=unlink($this->constructUrl($path));
+		$succes = unlink($this->constructUrl($path));
 		clearstatcache();
 		return $succes;
 	}
@@ -58,12 +58,12 @@ abstract class OC_FileStorage_StreamWrapper extends OC_Filestorage_Common{
 		return 0;
 	}
 
-	public function touch($path, $mtime=null) {
-		if(is_null($mtime)) {
-			$fh=$this->fopen($path, 'a');
+	public function touch($path, $mtime = null) {
+		if (is_null($mtime)) {
+			$fh = $this->fopen($path, 'a');
 			fwrite($fh, '');
 			fclose($fh);
-		}else{
+		} else {
 			return false;//not supported
 		}
 	}
@@ -83,7 +83,5 @@ abstract class OC_FileStorage_StreamWrapper extends OC_Filestorage_Common{
 	public function stat($path) {
 		return stat($this->constructUrl($path));
 	}
-
-
 
 }

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -49,17 +49,17 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return CF_Container
 	 */
 	private function getContainer($path) {
-		if($path=='' or $path=='/') {
+		if ($path=='' or $path=='/') {
 			return $this->rootContainer;
 		}
-		if(isset($this->containers[$path])) {
+		if (isset($this->containers[$path])) {
 			return $this->containers[$path];
 		}
-		try{
+		try {
 			$container=$this->conn->get_container($this->getContainerName($path));
 			$this->containers[$path]=$container;
 			return $container;
-		}catch(NoSuchContainerException $e) {
+		} catch(NoSuchContainerException $e) {
 			return null;
 		}
 	}
@@ -70,16 +70,16 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return CF_Container
 	 */
 	private function createContainer($path) {
-		if($path=='' or $path=='/' or $path=='.') {
+		if ($path=='' or $path=='/' or $path=='.') {
 			return $this->conn->create_container($this->getContainerName($path));
 		}
 		$parent=dirname($path);
-		if($parent=='' or $parent=='/' or $parent=='.') {
+		if ($parent=='' or $parent=='/' or $parent=='.') {
 			$parentContainer=$this->rootContainer;
-		}else{
-			if(!$this->containerExists($parent)) {
+		} else {
+			if ( ! $this->containerExists($parent)) {
 				$parentContainer=$this->createContainer($parent);
-			}else{
+			} else {
 				$parentContainer=$this->getContainer($parent);
 			}
 		}
@@ -93,21 +93,21 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return CF_Object
 	 */
 	private function getObject($path) {
-		if(isset($this->objects[$path])) {
+		if (isset($this->objects[$path])) {
 			return $this->objects[$path];
 		}
 		$container=$this->getContainer(dirname($path));
-		if(is_null($container)) {
+		if (is_null($container)) {
 			return null;
-		}else{
+		} else {
 			if ($path=="/" or $path=='') {
 				return null;
 			}
-			try{
+			try {
 				$obj=$container->get_object(basename($path));
 				$this->objects[$path]=$obj;
 				return $obj;
-			}catch(NoSuchObjectException $e) {
+			} catch(NoSuchObjectException $e) {
 				return null;
 			}
 		}
@@ -119,11 +119,11 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return array
 	 */
 	private function getObjects($container) {
-		if(is_null($container)) {
+		if (is_null($container)) {
 			return array();
-		}else{
+		} else {
 			$files=$container->get_objects();
-			foreach($files as &$file) {
+			foreach ($files as &$file) {
 				$file=$file->name;
 			}
 			return $files;
@@ -137,7 +137,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 */
 	private function createObject($path) {
 		$container=$this->getContainer(dirname($path));
-		if(!is_null($container)) {
+		if ( ! is_null($container)) {
 			$container=$this->createContainer(dirname($path));
 		}
 		return $container->create_object(basename($path));
@@ -169,15 +169,15 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	private function getSubContainers($container) {
 		$tmpFile=OCP\Files::tmpFile();
 		$obj=$this->getSubContainerFile($container);
-		try{
+		try {
 			$obj->save_to_filename($tmpFile);
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return array();
 		}
 		$obj->save_to_filename($tmpFile);
 		$containers=file($tmpFile);
 		unlink($tmpFile);
-		foreach($containers as &$sub) {
+		foreach ($containers as &$sub) {
 			$sub=trim($sub);
 		}
 		return $containers;
@@ -190,25 +190,25 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return bool
 	 */
 	private function addSubContainer($container, $name) {
-		if(!$name) {
+		if ( ! $name) {
 			return false;
 		}
 		$tmpFile=OCP\Files::tmpFile();
 		$obj=$this->getSubContainerFile($container);
-		try{
+		try {
 			$obj->save_to_filename($tmpFile);
 			$containers=file($tmpFile);
-			foreach($containers as &$sub) {
+			foreach ($containers as &$sub) {
 				$sub=trim($sub);
 			}
-			if(array_search($name, $containers)!==false) {
+			if (array_search($name, $containers)!==false) {
 				unlink($tmpFile);
 				return false;
-			}else{
+			} else {
 				$fh=fopen($tmpFile, 'a');
 				fwrite($fh, $name."\n");
 			}
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			$containers=array();
 			file_put_contents($tmpFile, $name."\n");
 		}
@@ -225,25 +225,25 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return bool
 	 */
 	private function removeSubContainer($container, $name) {
-		if(!$name) {
+		if ( ! $name) {
 			return false;
 		}
 		$tmpFile=OCP\Files::tmpFile();
 		$obj=$this->getSubContainerFile($container);
-		try{
+		try {
 			$obj->save_to_filename($tmpFile);
 			$containers=file($tmpFile);
-		}catch(Exception $e) {
+		} catch (Exception $e) {
 			return false;
 		}
-		foreach($containers as &$sub) {
+		foreach ($containers as &$sub) {
 			$sub=trim($sub);
 		}
 		$i=array_search($name, $containers);
-		if($i===false) {
+		if ($i===false) {
 			unlink($tmpFile);
 			return false;
-		}else{
+		} else {
 			unset($containers[$i]);
 			file_put_contents($tmpFile, implode("\n", $containers)."\n");
 		}
@@ -259,9 +259,9 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @return CF_Object
 	 */
 	private function getSubContainerFile($container) {
-		try{
+		try {
 			return $container->get_object(self::SUBCONTAINER_FILE);
-		}catch(NoSuchObjectException $e) {
+		} catch(NoSuchObjectException $e) {
 			return $container->create_object(self::SUBCONTAINER_FILE);
 		}
 	}
@@ -271,16 +271,16 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 		$this->host=$params['host'];
 		$this->user=$params['user'];
 		$this->root=isset($params['root'])?$params['root']:'/';
-		if(isset($params['secure'])) {
-			if(is_string($params['secure'])) {
+		if (isset($params['secure'])) {
+			if (is_string($params['secure'])) {
 				$this->secure = ($params['secure'] === 'true');
-			}else{
+			} else {
 				$this->secure = (bool)$params['secure'];
 			}
-		}else{
+		} else {
 			$this->secure = false;
 		}
-		if(!$this->root || $this->root[0]!='/') {
+		if ( ! $this->root || $this->root[0]!='/') {
 			$this->root='/'.$this->root;
 		}
 		$this->auth = new CF_Authentication($this->user, $this->token, null, $this->host);
@@ -288,29 +288,29 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 		$this->conn = new CF_Connection($this->auth);
 
-		if(!$this->containerExists('/')) {
+		if ( ! $this->containerExists('/')) {
 			$this->rootContainer=$this->createContainer('/');
-		}else{
+		} else {
 			$this->rootContainer=$this->getContainer('/');
 		}
 	}
 
 
 	public function mkdir($path) {
-		if($this->containerExists($path)) {
+		if ($this->containerExists($path)) {
 			return false;
-		}else{
+		} else {
 			$this->createContainer($path);
 			return true;
 		}
 	}
 
 	public function rmdir($path) {
-		if(!$this->containerExists($path)) {
+		if ( ! $this->containerExists($path)) {
 			return false;
-		}else{
+		} else {
 			$this->emptyContainer($path);
-			if($path!='' and $path!='/') {
+			if ($path!='' and $path!='/') {
 				$parentContainer=$this->getContainer(dirname($path));
 				$this->removeSubContainer($parentContainer, basename($path));
 			}
@@ -323,12 +323,12 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 	private function emptyContainer($path) {
 		$container=$this->getContainer($path);
-		if(is_null($container)) {
+		if (is_null($container)) {
 			return;
 		}
 		$subContainers=$this->getSubContainers($container);
-		foreach($subContainers as $sub) {
-			if($sub) {
+		foreach ($subContainers as $sub) {
+			if ($sub) {
 				$this->emptyContainer($path.'/'.$sub);
 				$this->conn->delete_container($this->getContainerName($path.'/'.$sub));
 				unset($this->containers[$path.'/'.$sub]);
@@ -336,7 +336,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 		}
 
 		$objects=$this->getObjects($container);
-		foreach($objects as $object) {
+		foreach ($objects as $object) {
 			$container->delete_object($object);
 			unset($this->objects[$path.'/'.$object]);
 		}
@@ -346,7 +346,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 		$container=$this->getContainer($path);
 		$files=$this->getObjects($container);
 		$i=array_search(self::SUBCONTAINER_FILE, $files);
-		if($i!==false) {
+		if ($i!==false) {
 			unset($files[$i]);
 		}
 		$subContainers=$this->getSubContainers($container);
@@ -357,9 +357,9 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	}
 
 	public function filetype($path) {
-		if($this->containerExists($path)) {
+		if ($this->containerExists($path)) {
 			return 'dir';
-		}else{
+		} else {
 			return 'file';
 		}
 	}
@@ -373,16 +373,16 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	}
 
 	public function file_exists($path) {
-		if($this->is_dir($path)) {
+		if ($this->is_dir($path)) {
 			return true;
-		}else{
+		} else {
 			return $this->objectExists($path);
 		}
 	}
 
 	public function file_get_contents($path) {
 		$obj=$this->getObject($path);
-		if(is_null($obj)) {
+		if (is_null($obj)) {
 			return false;
 		}
 		return $obj->read();
@@ -390,9 +390,9 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 	public function file_put_contents($path, $content) {
 		$obj=$this->getObject($path);
-		if(is_null($obj)) {
+		if (is_null($obj)) {
 			$container=$this->getContainer(dirname($path));
-			if(is_null($container)) {
+			if (is_null($container)) {
 				return false;
 			}
 			$obj=$container->create_object(basename($path));
@@ -402,14 +402,14 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	}
 
 	public function unlink($path) {
-		if($this->containerExists($path)) {
+		if ($this->containerExists($path)) {
 			return $this->rmdir($path);
 		}
-		if($this->objectExists($path)) {
+		if ($this->objectExists($path)) {
 			$container=$this->getContainer(dirname($path));
 			$container->delete_object(basename($path));
 			unset($this->objects[$path]);
-		}else{
+		} else {
 			return false;
 		}
 	}
@@ -447,7 +447,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	}
 
 	public function writeBack($tmpFile) {
-		if(isset(self::$tempFiles[$tmpFile])) {
+		if (isset(self::$tempFiles[$tmpFile])) {
 			$this->fromTmpFile($tmpFile, self::$tempFiles[$tmpFile]);
 			unlink($tmpFile);
 		}
@@ -459,10 +459,10 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 	public function touch($path, $mtime=null) {
 		$obj=$this->getObject($path);
-		if(is_null($obj)) {
+		if (is_null($obj)) {
 			return false;
 		}
-		if(is_null($mtime)) {
+		if (is_null($mtime)) {
 			$mtime=time();
 		}
 
@@ -476,7 +476,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 		$targetContainer=$this->getContainer(dirname($path2));
 		$result=$sourceContainer->move_object_to(basename($path1), $targetContainer, basename($path2));
 		unset($this->objects[$path1]);
-		if($result) {
+		if ($result) {
 			$targetObj=$this->getObject($path2);
 			$this->resetMTime($targetObj);
 		}
@@ -487,7 +487,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 		$sourceContainer=$this->getContainer(dirname($path1));
 		$targetContainer=$this->getContainer(dirname($path2));
 		$result=$sourceContainer->copy_object_to(basename($path1), $targetContainer, basename($path2));
-		if($result) {
+		if ($result) {
 			$targetObj=$this->getObject($path2);
 			$this->resetMTime($targetObj);
 		}
@@ -496,7 +496,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 	public function stat($path) {
 		$container=$this->getContainer($path);
-		if (!is_null($container)) {
+		if ( ! is_null($container)) {
 			return array(
 				'mtime'=>-1,
 				'size'=>$container->bytes_used,
@@ -506,13 +506,13 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 		$obj=$this->getObject($path);
 
-		if(is_null($obj)) {
+		if (is_null($obj)) {
 			return false;
 		}
 
-		if(isset($obj->metadata['Mtime']) and $obj->metadata['Mtime']>-1) {
+		if (isset($obj->metadata['Mtime']) and $obj->metadata['Mtime']>-1) {
 			$mtime=$obj->metadata['Mtime'];
-		}else{
+		} else {
 			$mtime=strtotime($obj->last_modified);
 		}
 		return array(
@@ -524,18 +524,18 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 
 	private function getTmpFile($path) {
 		$obj=$this->getObject($path);
-		if(!is_null($obj)) {
+		if ( ! is_null($obj)) {
 			$tmpFile=OCP\Files::tmpFile();
 			$obj->save_to_filename($tmpFile);
 			return $tmpFile;
-		}else{
+		} else {
 			return OCP\Files::tmpFile();
 		}
 	}
 
 	private function fromTmpFile($tmpFile, $path) {
 		$obj=$this->getObject($path);
-		if(is_null($obj)) {
+		if (is_null($obj)) {
 			$obj=$this->createObject($path);
 		}
 		$obj->load_from_filename($tmpFile);
@@ -547,7 +547,7 @@ class OC_FileStorage_SWIFT extends OC_Filestorage_Common{
 	 * @param CF_Object obj
 	 */
 	private function resetMTime($obj) {
-		if(isset($obj->metadata['Mtime'])) {
+		if (isset($obj->metadata['Mtime'])) {
 			$obj->metadata['Mtime']=-1;
 			$obj->sync_metadata();
 		}

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -27,20 +27,20 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 		$this->host=$host;
 		$this->user=$params['user'];
 		$this->password=$params['password'];
-		if(isset($params['secure'])) {
-			if(is_string($params['secure'])) {
+		if (isset($params['secure'])) {
+			if (is_string($params['secure'])) {
 				$this->secure = ($params['secure'] === 'true');
-			}else{
+			} else {
 				$this->secure = (bool)$params['secure'];
 			}
-		}else{
+		} else {
 			$this->secure = false;
 		}
 		$this->root=isset($params['root'])?$params['root']:'/';
-		if(!$this->root || $this->root[0]!='/') {
+		if ( ! $this->root || $this->root[0]!='/') {
 			$this->root='/'.$this->root;
 		}
-		if(substr($this->root, -1, 1)!='/') {
+		if (substr($this->root, -1, 1)!='/') {
 			$this->root.='/';
 		}
 
@@ -52,7 +52,8 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 		$this->client = new OC_Connector_Sabre_Client($settings);
 
-		if($caview = \OCP\Files::getStorage('files_external')) {
+		$caview = \OCP\Files::getStorage('files_external');
+		if ($caview) {
 			$certPath=\OCP\Config::getSystemValue('datadirectory').$caview->getAbsolutePath("").'rootcerts.crt';
 			if (file_exists($certPath)) {
 				$this->client->addTrustedCertificates($certPath);
@@ -64,7 +65,7 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 	private function createBaseUri() {
 		$baseUri='http';
-		if($this->secure) {
+		if ($this->secure) {
 			$baseUri.='s';
 		}
 		$baseUri.='://'.$this->host.$this->root;
@@ -83,29 +84,29 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 	public function opendir($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->propfind($path, array(), 1);
 			$id=md5('webdav'.$this->root.$path);
 			OC_FakeDirStream::$dirs[$id]=array();
 			$files=array_keys($response);
 			array_shift($files);//the first entry is the current directory
-			foreach($files as $file) {
+			foreach ($files as $file) {
 				$file = urldecode(basename($file));
 				OC_FakeDirStream::$dirs[$id][]=$file;
 			}
 			return opendir('fakedir://'.$id);
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return false;
 		}
 	}
 
 	public function filetype($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->propfind($path, array('{DAV:}resourcetype'));
 			$responseType=$response["{DAV:}resourcetype"]->resourceType;
 			return (count($responseType)>0 and $responseType[0]=="{DAV:}collection")?'dir':'file';
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			error_log($e->getMessage());
 			\OCP\Util::writeLog("webdav client", \OCP\Util::sanitizeHTML($e->getMessage()), \OCP\Util::ERROR);
 			return false;
@@ -122,10 +123,10 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 	public function file_exists($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$this->client->propfind($path, array('{DAV:}resourcetype'));
 			return true;//no 404 exception
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return false;
 		}
 	}
@@ -139,7 +140,7 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 		switch($mode) {
 			case 'r':
 			case 'rb':
-				if(!$this->file_exists($path)) {
+				if ( ! $this->file_exists($path)) {
 					return false;
 				}
 				//straight up curl instead of sabredav here, sabredav put's the entire get result in memory
@@ -166,14 +167,14 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 			case 'c':
 			case 'c+':
 				//emulate these
-				if(strrpos($path, '.')!==false) {
+				if (strrpos($path, '.')!==false) {
 					$ext=substr($path, strrpos($path, '.'));
-				}else{
+				} else {
 					$ext='';
 				}
 				$tmpFile=OCP\Files::tmpFile($ext);
 				OC_CloseStreamWrapper::$callBacks[$tmpFile]=array($this, 'writeBack');
-				if($this->file_exists($path)) {
+				if ($this->file_exists($path)) {
 					$this->getFile($path, $tmpFile);
 				}
 				self::$tempFiles[$tmpFile]=$path;
@@ -182,7 +183,7 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 	}
 
 	public function writeBack($tmpFile) {
-		if(isset(self::$tempFiles[$tmpFile])) {
+		if (isset(self::$tempFiles[$tmpFile])) {
 			$this->uploadFile($tmpFile, self::$tempFiles[$tmpFile]);
 			unlink($tmpFile);
 		}
@@ -190,20 +191,20 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 	public function free_space($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->propfind($path, array('{DAV:}quota-available-bytes'));
-			if(isset($response['{DAV:}quota-available-bytes'])) {
+			if (isset($response['{DAV:}quota-available-bytes'])) {
 				return (int)$response['{DAV:}quota-available-bytes'];
-			}else{
+			} else {
 				return 0;
 			}
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return 0;
 		}
 	}
 
 	public function touch($path, $mtime=null) {
-		if(is_null($mtime)) {
+		if (is_null($mtime)) {
 			$mtime=time();
 		}
 		$path=$this->cleanPath($path);
@@ -232,10 +233,10 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 	public function rename($path1, $path2) {
 		$path1=$this->cleanPath($path1);
 		$path2=$this->root.$this->cleanPath($path2);
-		try{
+		try {
 			$response=$this->client->request('MOVE', $path1, null, array('Destination'=>$path2));
 			return true;
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			echo $e;
 			echo 'fail';
 			var_dump($response);
@@ -246,10 +247,10 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 	public function copy($path1, $path2) {
 		$path1=$this->cleanPath($path1);
 		$path2=$this->root.$this->cleanPath($path2);
-		try{
+		try {
 			$response=$this->client->request('COPY', $path1, null, array('Destination'=>$path2));
 			return true;
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			echo $e;
 			echo 'fail';
 			var_dump($response);
@@ -259,50 +260,50 @@ class OC_FileStorage_DAV extends OC_Filestorage_Common{
 
 	public function stat($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->propfind($path, array('{DAV:}getlastmodified', '{DAV:}getcontentlength'));
 			return array(
 				'mtime'=>strtotime($response['{DAV:}getlastmodified']),
 				'size'=>(int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 				'ctime'=>-1,
 			);
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return array();
 		}
 	}
 
 	public function getMimeType($path) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->propfind($path, array('{DAV:}getcontenttype', '{DAV:}resourcetype'));
 			$responseType=$response["{DAV:}resourcetype"]->resourceType;
 			$type=(count($responseType)>0 and $responseType[0]=="{DAV:}collection")?'dir':'file';
-			if($type=='dir') {
+			if ($type=='dir') {
 				return 'httpd/unix-directory';
-			}elseif(isset($response['{DAV:}getcontenttype'])) {
+			} elseif (isset($response['{DAV:}getcontenttype'])) {
 				return $response['{DAV:}getcontenttype'];
-			}else{
+			} else {
 				return false;
 			}
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return false;
 		}
 	}
 
 	private function cleanPath($path) {
-		if(!$path || $path[0]=='/') {
+		if ( ! $path || $path[0]=='/') {
 			return substr($path, 1);
-		}else{
+		} else {
 			return $path;
 		}
 	}
 
 	private function simpleResponse($method, $path, $body, $expected) {
 		$path=$this->cleanPath($path);
-		try{
+		try {
 			$response=$this->client->request($method, $path, $body);
 			return $response['statusCode']==$expected;
-		}catch(Exception $e) {
+		} catch(Exception $e) {
 			return false;
 		}
 	}

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -16,18 +16,22 @@
 			<?php $_['mounts'] = array_merge($_['mounts'], array('' => array())); ?>
 			<?php foreach ($_['mounts'] as $mountPoint => $mount): ?>
 				<tr <?php echo ($mountPoint != '') ? 'class="'.$mount['class'].'"' : 'id="addMountPoint"'; ?>>
-					<td class="mountPoint"><input type="text" name="mountPoint" value="<?php echo $mountPoint; ?>" placeholder="<?php echo $l->t('Mount point'); ?>" /></td>
+					<td class="mountPoint"><input type="text" name="mountPoint"
+												  value="<?php echo $mountPoint; ?>"
+												  placeholder="<?php echo $l->t('Mount point'); ?>" /></td>
 					<?php if ($mountPoint == ''): ?>
 						<td class="backend">
 							<select id="selectBackend" data-configurations='<?php echo json_encode($_['backends']); ?>'>
-								<option value="" disabled selected style="display:none;"><?php echo $l->t('Add mount point'); ?></option>
+								<option value="" disabled selected
+										style="display:none;"><?php echo $l->t('Add mount point'); ?></option>
 								<?php foreach ($_['backends'] as $class => $backend): ?>
 									<option value="<?php echo $class; ?>"><?php echo $backend['backend']; ?></option>
 								<?php endforeach; ?>
 							</select>
 						</td>
 					<?php else: ?>
-						<td class="backend" data-class="<?php echo $mount['class']; ?>"><?php echo $mount['backend']; ?></td>
+						<td class="backend"
+							data-class="<?php echo $mount['class']; ?>"><?php echo $mount['backend']; ?></td>
 					<?php endif; ?>
 					<td class ="configuration" width="100%">
 						<?php if (isset($mount['configuration'])): ?>
@@ -35,46 +39,75 @@
 								<?php if (isset($_['backends'][$mount['class']]['configuration'][$parameter])): ?>
 									<?php $placeholder = $_['backends'][$mount['class']]['configuration'][$parameter]; ?>
 									<?php if (strpos($placeholder, '*') !== false): ?>
-										<input type="password" data-parameter="<?php echo $parameter; ?>" value="<?php echo $value; ?>" placeholder="<?php echo substr($placeholder, 1); ?>" />
-									<?php elseif(strpos($placeholder, '!') !== false): ?>
-										<label><input type="checkbox" data-parameter="<?php echo $parameter; ?>" <?php if ($value == 'true') echo ' checked="checked"'; ?>  /><?php echo substr($placeholder, 1); ?></label>
+										<input type="password"
+											   data-parameter="<?php echo $parameter; ?>"
+											   value="<?php echo $value; ?>"
+											   placeholder="<?php echo substr($placeholder, 1); ?>" />
+									<?php elseif (strpos($placeholder, '!') !== false): ?>
+										<label><input type="checkbox"
+													  data-parameter="<?php echo $parameter; ?>"
+													  <?php if ($value == 'true'): ?> checked="checked"<?php endif; ?> 
+													  /><?php echo substr($placeholder, 1); ?></label>
 									<?php elseif (strpos($placeholder, '&') !== false): ?>
-										<input type="text" class="optional" data-parameter="<?php echo $parameter; ?>" value="<?php echo $value; ?>" placeholder="<?php echo substr($placeholder, 5); ?>" />
+										<input type="text"
+											   class="optional"
+											   data-parameter="<?php echo $parameter; ?>"
+											   value="<?php echo $value; ?>"
+											   placeholder="<?php echo substr($placeholder, 5); ?>" />
 									<?php elseif (strpos($placeholder, '#') !== false): ?>
-										<input type="hidden" data-parameter="<?php echo $parameter; ?>" value="<?php echo $value; ?>" />
+										<input type="hidden"
+											   data-parameter="<?php echo $parameter; ?>"
+											   value="<?php echo $value; ?>" />
 									<?php else: ?>
-										<input type="text" data-parameter="<?php echo $parameter; ?>" value="<?php echo $value; ?>" placeholder="<?php echo $placeholder; ?>" />
+										<input type="text"
+											   data-parameter="<?php echo $parameter; ?>"
+											   value="<?php echo $value; ?>"
+											   placeholder="<?php echo $placeholder; ?>" />
 									<?php endif; ?>
 								<?php endif; ?>
 							<?php endforeach; ?>
-							<?php if (isset($_['backends'][$mount['class']]['custom'])) OCP\Util::addScript('files_external', $_['backends'][$mount['class']]['custom']); ?>
+							<?php if (isset($_['backends'][$mount['class']]['custom'])): ?>
+								<?php OCP\Util::addScript('files_external',
+														  $_['backends'][$mount['class']]['custom']); ?>
+							<?php endif; ?>
 						<?php endif; ?>
 					</td>
-					<!--<td class="options">
-						<select class="selectOptions" title="<?php echo $l->t('None set')?>" multiple="multiple" disabled>
-							<?php if (OCP\App::isEnabled('files_encryption')) echo '<option value="Encrypt">Encrypt</option>'; ?>
-							<?php if (OCP\App::isEnabled('files_versions')) echo '<option value="Version control">Version control</option>'; ?>
-							<?php if (OCP\App::isEnabled('files_sharing')) echo '<option value="Allow sharing">Allow sharing</option>'; ?>
-						</select>
-					</td>-->
 					<?php if ($_['isAdminPage']): ?>
-					<td class="applicable" align="right" data-applicable-groups='<?php if (isset($mount['applicable']['groups'])) echo json_encode($mount['applicable']['groups']); ?>' data-applicable-users='<?php if (isset($mount['applicable']['users'])) echo json_encode($mount['applicable']['users']); ?>'>
-							<select class="chzn-select" multiple style="width:20em;" data-placeholder="<?php echo $l->t('None set'); ?>">
+					<td class="applicable"
+						align="right"
+						data-applicable-groups='<?php if (isset($mount['applicable']['groups']))
+														echo json_encode($mount['applicable']['groups']); ?>'
+						data-applicable-users='<?php if (isset($mount['applicable']['users']))
+														echo json_encode($mount['applicable']['users']); ?>'>
+							<select class="chzn-select"
+									multiple style="width:20em;"
+									data-placeholder="<?php echo $l->t('None set'); ?>">
 								<option value="all"><?php echo $l->t('All Users'); ?></option>
 								<optgroup label="<?php echo $l->t('Groups'); ?>">
-									<?php foreach ($_['groups'] as $group): ?>
-										<option value="<?php echo $group; ?>(group)" <?php if (isset($mount['applicable']['groups']) && in_array($group, $mount['applicable']['groups'])) echo 'selected="selected"'; ?>><?php echo $group; ?></option>
-									<?php endforeach; ?>
+								<?php foreach ($_['groups'] as $group): ?>
+									<option value="<?php echo $group; ?>(group)"
+									<?php if (isset($mount['applicable']['groups']) && in_array($group, $mount['applicable']['groups'])): ?>
+											selected="selected"
+									<?php endif; ?>><?php echo $group; ?></option>
+								<?php endforeach; ?>
 								</optgroup>
 								<optgroup label="<?php echo $l->t('Users'); ?>">
-									<?php foreach ($_['users'] as $user): ?>
-										<option value="<?php echo $user; ?>" <?php if (isset($mount['applicable']['users']) && in_array($user, $mount['applicable']['users'])) echo 'selected="selected"'; ?>"><?php echo $user; ?></option>
-									<?php endforeach; ?>
+								<?php foreach ($_['users'] as $user): ?>
+									<option value="<?php echo $user; ?>"
+									<?php if (isset($mount['applicable']['users']) && in_array($user, $mount['applicable']['users'])): ?>
+											selected="selected"
+									<?php endif; ?>><?php echo $user; ?></option>
+								<?php endforeach; ?>
 								</optgroup>
 							</select>
 						</td>
 					<?php endif; ?>
-					<td <?php echo ($mountPoint != '') ? 'class="remove"' : 'style="visibility:hidden;"'; ?>><img alt="<?php echo $l->t('Delete'); ?>" title="<?php echo $l->t('Delete'); ?>" class="svg action" src="<?php echo image_path('core', 'actions/delete.svg'); ?>" /></td>
+					<td <?php if ($mountPoint != ''): ?>class="remove"
+						<?php else: ?>style="visibility:hidden;"
+						<?php endif ?>><img alt="<?php echo $l->t('Delete'); ?>" 
+											title="<?php echo $l->t('Delete'); ?>"
+											class="svg action"
+											src="<?php echo image_path('core', 'actions/delete.svg'); ?>" /></td>
 				</tr>
 			<?php endforeach; ?>
 			</tbody>
@@ -83,16 +116,22 @@
 
 		<?php if ($_['isAdminPage']): ?>
 			<br />
-			<input type="checkbox" name="allowUserMounting" id="allowUserMounting" value="1" <?php if ($_['allowUserMounting'] == 'yes') echo ' checked="checked"'; ?> />
+			<input type="checkbox"
+				   name="allowUserMounting"
+				   id="allowUserMounting"
+				   value="1" <?php if ($_['allowUserMounting'] == 'yes') echo ' checked="checked"'; ?> />
 			<label for="allowUserMounting"><?php echo $l->t('Enable User External Storage'); ?></label><br/>
 			<em><?php echo $l->t('Allow users to mount their own external storage'); ?></em>
 		<?php endif; ?>
 	</fieldset>
 </form>
 
-<form id="files_external" method="post" enctype="multipart/form-data" action="<?php echo OCP\Util::linkTo('files_external', 'ajax/addRootCertificate.php'); ?>">
+<form id="files_external"
+	  method="post"
+	  enctype="multipart/form-data"
+	  action="<?php echo OCP\Util::linkTo('files_external', 'ajax/addRootCertificate.php'); ?>">
 <fieldset class="personalblock">
-<?php if (!$_['isAdminPage']):  ?>
+<?php if ( ! $_['isAdminPage']):  ?>
 		<table id="sslCertificate" data-admin='<?php echo json_encode($_['isAdminPage']); ?>'>
 			<thead>
 				<tr>
@@ -104,13 +143,18 @@
 			<?php foreach ($_['certs'] as $rootCert): ?>
 			<tr id="<?php echo $rootCert ?>">
 			<td class="rootCert"><?php echo $rootCert ?></td>
-			<td <?php echo ($rootCert != '') ? 'class="remove"' : 'style="visibility:hidden;"'; ?>><img alt="<?php echo $l->t('Delete'); ?>" title="<?php echo $l->t('Delete'); ?>" class="svg action" src="<?php echo image_path('core', 'actions/delete.svg'); ?>" /></td>
+			<td <?php if ($rootCert != ''): ?>class="remove"
+				<?php else: ?>style="visibility:hidden;"
+				<?php endif; ?>><img alt="<?php echo $l->t('Delete'); ?>"
+									 title="<?php echo $l->t('Delete'); ?>"
+									 class="svg action"
+									 src="<?php echo image_path('core', 'actions/delete.svg'); ?>" /></td>
 			</tr>
 			<?php endforeach; ?>
 			</tbody>
 		</table>
-        <input type="file" id="rootcert_import" name="rootcert_import" style="width:230px;">
-        <input type="submit" name="cert_import" value="<?php echo $l->t('Import Root Certificate'); ?>" />
+		<input type="file" id="rootcert_import" name="rootcert_import" style="width:230px;">
+		<input type="submit" name="cert_import" value="<?php echo $l->t('Import Root Certificate'); ?>" />
 		<?php endif; ?>
 </fieldset>
 </form>

--- a/apps/files_external/tests/amazons3.php
+++ b/apps/files_external/tests/amazons3.php
@@ -28,7 +28,7 @@ class Test_Filestorage_AmazonS3 extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['amazons3']) or !$this->config['amazons3']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['amazons3']) or ! $this->config['amazons3']['run']) {
 			$this->markTestSkipped('AmazonS3 backend not configured');
 		}
 		$this->config['amazons3']['bucket'] = $id; // Make sure we have a new empty bucket to work in
@@ -37,7 +37,8 @@ class Test_Filestorage_AmazonS3 extends Test_FileStorage {
 
 	public function tearDown() {
 		if ($this->instance) {
-			$s3 = new AmazonS3(array('key' => $this->config['amazons3']['key'], 'secret' => $this->config['amazons3']['secret']));
+			$s3 = new AmazonS3(array('key' => $this->config['amazons3']['key'],
+									 'secret' => $this->config['amazons3']['secret']));
 			if ($s3->delete_all_objects($this->id)) {
 				$s3->delete_bucket($this->id);
 			}

--- a/apps/files_external/tests/dropbox.php
+++ b/apps/files_external/tests/dropbox.php
@@ -12,7 +12,7 @@ class Test_Filestorage_Dropbox extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['dropbox']) or !$this->config['dropbox']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['dropbox']) or ! $this->config['dropbox']['run']) {
 			$this->markTestSkipped('Dropbox backend not configured');
 		}
 		$this->config['dropbox']['root'] .= '/' . $id; //make sure we have an new empty folder to work in

--- a/apps/files_external/tests/ftp.php
+++ b/apps/files_external/tests/ftp.php
@@ -12,7 +12,7 @@ class Test_Filestorage_FTP extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['ftp']) or !$this->config['ftp']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['ftp']) or ! $this->config['ftp']['run']) {
 			$this->markTestSkipped('FTP backend not configured');
 		}
 		$this->config['ftp']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
@@ -26,7 +26,11 @@ class Test_Filestorage_FTP extends Test_FileStorage {
 	}
 
 	public function testConstructUrl(){
-		$config = array ( 'host' => 'localhost', 'user' => 'ftp', 'password' => 'ftp', 'root' => '/', 'secure' => false );
+		$config = array ( 'host' => 'localhost',
+						  'user' => 'ftp',
+						  'password' => 'ftp',
+						  'root' => '/',
+						  'secure' => false );
 		$instance = new OC_Filestorage_FTP($config);
 		$this->assertEqual('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 

--- a/apps/files_external/tests/google.php
+++ b/apps/files_external/tests/google.php
@@ -27,7 +27,7 @@ class Test_Filestorage_Google extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['google']) or !$this->config['google']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['google']) or ! $this->config['google']['run']) {
 			$this->markTestSkipped('Google backend not configured');
 		}
 		$this->config['google']['root'] .= '/' . $id; //make sure we have an new empty folder to work in

--- a/apps/files_external/tests/smb.php
+++ b/apps/files_external/tests/smb.php
@@ -12,7 +12,7 @@ class Test_Filestorage_SMB extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['smb']) or !$this->config['smb']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['smb']) or ! $this->config['smb']['run']) {
 			$this->markTestSkipped('Samba backend not configured');
 		}
 		$this->config['smb']['root'] .= $id; //make sure we have an new empty folder to work in

--- a/apps/files_external/tests/swift.php
+++ b/apps/files_external/tests/swift.php
@@ -12,7 +12,7 @@ class Test_Filestorage_SWIFT extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['swift']) or !$this->config['swift']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['swift']) or ! $this->config['swift']['run']) {
 			$this->markTestSkipped('OpenStack SWIFT backend not configured');
 		}
 		$this->config['swift']['root'] .= '/' . $id; //make sure we have an new empty folder to work in

--- a/apps/files_external/tests/webdav.php
+++ b/apps/files_external/tests/webdav.php
@@ -12,7 +12,7 @@ class Test_Filestorage_DAV extends Test_FileStorage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['webdav']) or !$this->config['webdav']['run']) {
+		if ( ! is_array($this->config) or ! isset($this->config['webdav']) or ! $this->config['webdav']['run']) {
 			$this->markTestSkipped('WebDAV backend not configured');
 		}
 		$this->config['webdav']['root'] .= '/' . $id; //make sure we have an new empty folder to work in

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -94,7 +94,7 @@ class Storage {
 
 			// check mininterval if the file is being modified by the owner (all shared files should be versioned despite mininterval)
 			if ($uid == \OCP\User::getUser()) {
-				$versions_fileview = new \OC_FilesystemView('/'.uid.'/files_versions');
+				$versions_fileview = new \OC_FilesystemView('/'.$uid.'/files_versions');
 				$versionsName=\OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath($filename);
 				$versionsFolderName=\OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath('');
 				$matches=glob($versionsName.'.v*');

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -58,8 +58,8 @@ class Storage {
 	public function store($filename) {
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			list($uid, $filename) = self::getUidAndFilename($filename);
-			$files_view = new \OC_FilesystemView('/'.\OCP\User::getUser() .'/files');
-			$users_view = new \OC_FilesystemView('/'.\OCP\User::getUser());
+			$files_view = new \OC_FilesystemView('/'.$uid .'/files');
+			$users_view = new \OC_FilesystemView('/'.$uid);
 
 			//check if source file already exist as version to avoid recursions.
 			// todo does this check work?
@@ -94,7 +94,7 @@ class Storage {
 
 			// check mininterval if the file is being modified by the owner (all shared files should be versioned despite mininterval)
 			if ($uid == \OCP\User::getUser()) {
-				$versions_fileview = new \OC_FilesystemView('/'.\OCP\User::getUser().'/files_versions');
+				$versions_fileview = new \OC_FilesystemView('/'.uid.'/files_versions');
 				$versionsName=\OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath($filename);
 				$versionsFolderName=\OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath('');
 				$matches=glob($versionsName.'.v*');
@@ -128,7 +128,7 @@ class Storage {
 
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			list($uid, $filename) = self::getUidAndFilename($filename);
-			$users_view = new \OC_FilesystemView('/'.\OCP\User::getUser());
+			$users_view = new \OC_FilesystemView('/'.$uid);
 
 			// rollback
 			if( @$users_view->copy('files_versions'.$filename.'.v'.$revision, 'files'.$filename) ) {
@@ -151,7 +151,7 @@ class Storage {
 	public static function isversioned($filename) {
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			list($uid, $filename) = self::getUidAndFilename($filename);
-			$versions_fileview = new \OC_FilesystemView('/'.\OCP\User::getUser().'/files_versions');
+			$versions_fileview = new \OC_FilesystemView('/'.$uid.'/files_versions');
 
 			$versionsName=\OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath($filename);
 
@@ -178,7 +178,7 @@ class Storage {
 	public static function getVersions( $filename, $count = 0 ) {
 		if( \OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true' ) {
 			list($uid, $filename) = self::getUidAndFilename($filename);
-			$versions_fileview = new \OC_FilesystemView('/'.\OCP\User::getUser().'/files_versions');
+			$versions_fileview = new \OC_FilesystemView('/'.$uid.'/files_versions');
 
 			$versionsName = \OCP\Config::getSystemValue('datadirectory').$versions_fileview->getAbsolutePath($filename);
 			$versions = array();


### PR DESCRIPTION
fix some obvious regressions in master with respect to versioning of shared files.

Even with this fix versioning of shared files does not work completely in master. The function used to get the source of a shared file only works for files directly shared but not for files in a shared folder because such files are not stored in the oc_share database.

@MTGap we really need to find a solution here. We have various places where we need to find the file source of files somewhere in a shared folder. This does not work with the database queries provided by OCP\Share::get*. Will this work with the new file cache and the adapted sharing? Otherwise I would really like to get apps/files_sharing/lib/util.php from stable45 into master. There are more and more issues which are resolved in stable45 but can't be fixed in master because such a function is missed.

Nevertheless I would like to get this patch into master because it fixes some obvious regressions.
