### PR TITLE
Minor cleanup in OC_OCSClient::getKnownledgebaseEntries. Fix for #487

### DIFF
--- a/lib/ocsclient.php
+++ b/lib/ocsclient.php
@@ -214,39 +214,34 @@ class OC_OCSClient{
 	 * This function returns a list of all the knowledgebase entries from the OCS server
 	 */
 	public static function getKnownledgebaseEntries($page, $pagesize, $search='') {
-		if(OC_Config::getValue('knowledgebaseenabled', true)==false) {
-			$kbe=array();
-			$kbe['totalitems']=0;
-			return $kbe;
+		$kbe = array('totalitems' => 0);
+		if(OC_Config::getValue('knowledgebaseenabled', true)) {
+			$p = (int) $page;
+			$s = (int) $pagesize;
+			$searchcmd = '';
+			if ($search) {
+				$searchcmd = '&search='.urlencode($search);
+			}
+			$url = OC_OCSClient::getKBURL().'/knowledgebase/data?type=150&page='. $p .'&pagesize='. $s . $searchcmd;
+			$xml = OC_OCSClient::getOCSresponse($url);
+			$data = @simplexml_load_string($xml);
+			if($data===false) {
+				OC_Log::write('core', 'Unable to parse knowledgebase content', OC_Log::FATAL);
+				return null;
+			}
+			$tmp = $data->data->content;
+			for($i = 0; $i < count($tmp); $i++) {
+				$kbe[] = array(
+					'id' => $tmp[$i]->id,
+					'name' => $tmp[$i]->name,
+					'description' => $tmp[$i]->description,
+					'answer' => $tmp[$i]->answer,
+					'preview1' => $tmp[$i]->smallpreviewpic1,
+					'detailpage' => $tmp[$i]->detailpage
+				);
+			}
+			$kbe['totalitems'] = $data->meta->totalitems;
 		}
-
-		$p= (int) $page;
-		$s= (int) $pagesize;
-		if($search<>'') $searchcmd='&search='.urlencode($search); else $searchcmd='';
-		$url=OC_OCSClient::getKBURL().'/knowledgebase/data?type=150&page='.$p.'&pagesize='.$s.$searchcmd;
-
-		$kbe=array();
-		$xml=OC_OCSClient::getOCSresponse($url);
-
-		if($xml==false) {
-			OC_Log::write('core', 'Unable to parse knowledgebase content', OC_Log::FATAL);
-			return null;
-		}
-		$data=simplexml_load_string($xml);
-
-		$tmp=$data->data->content;
-		for($i = 0; $i < count($tmp); $i++) {
-			$kb=array();
-			$kb['id']=$tmp[$i]->id;
-			$kb['name']=$tmp[$i]->name;
-			$kb['description']=$tmp[$i]->description;
-			$kb['answer']=$tmp[$i]->answer;
-			$kb['preview1']=$tmp[$i]->smallpreviewpic1;
-			$kb['detailpage']=$tmp[$i]->detailpage;
-			$kbe[]=$kb;
-		}
-		$total=$data->meta->totalitems;
-		$kbe['totalitems']=$total;
                 return $kbe;
 	}
 

--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -17,7 +17,7 @@
 		}
 	?>
 </diV>
-<?php if(is_null($_["kbe"])):?>
+<?php if(!is_array($_["kbe"]) || !count($_["kbe"])):?>
 	<div class="helpblock">
 		<p><?php echo $l->t('Problems connecting to help database.');?></p>
 		<p><a href="http://apps.owncloud.com/kb"><?php echo $l->t('Go there manually.');?></a></p>


### PR DESCRIPTION
Problem originates in OC_Template::assign. It transforms NULL into empty string.
https://github.com/owncloud/core/issues/487#issuecomment-10933619

There is no need in printing entries from anything but array anyway.
OC_OCSClient::getKnownledgebaseEntries is cleaned for better readability and to comply with style rules.
