### PR TITLE
reduce number of queries on the db

### DIFF
--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -176,7 +176,8 @@ class OC_FileCache{
 		$query=OC_DB::prepare('SELECT `path` FROM `*PREFIX*fscache` WHERE `path` LIKE ?');
 		$oldLength=strlen($oldPath);
 		$updateQuery=OC_DB::prepare('UPDATE `*PREFIX*fscache` SET `path`=?, `path_hash`=? WHERE `path_hash`=?');
-		while($row= $query->execute(array($oldPath.'/%'))->fetchRow()) {
+		$result =  $query->execute(array($oldPath.'/%'));
+		while($row= $result->fetchRow()) {
 			$old=$row['path'];
 			$new=$newPath.substr($old, $oldLength);
 			$updateQuery->execute(array($new, md5($new), md5($old)));


### PR DESCRIPTION
execute  $query->execute(array($oldPath.'/%')) only once and iterate through the results
instead of executing it until it doesn't return any more results.
