### PR TITLE
Minor cleanup in OC_OCSClient::getKnownledgebaseEntries. Fix for #487

### DIFF
--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -18,7 +18,7 @@
 		}
 	?>
 </diV>
-<?php if(is_null($_["kbe"])):?>
+<?php if(!is_array($_["kbe"]) || !count($_["kbe"])):?>
 	<div class="helpblock">
 		<p><?php echo $l->t('Problems connecting to help database.');?></p>
 		<p><a href="http://apps.owncloud.com/kb"><?php echo $l->t('Go there manually.');?></a></p>


### PR DESCRIPTION
Backport  of https://github.com/owncloud/core/pull/682
Fixes PHP warning on the Help page if there is no connection to KB
