### PR TITLE
Revoke DB rights on install only if the db is newly created

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -319,9 +319,11 @@ class OC_Setup {
 				$entry.='Offending command was: '.$query.'<br />';
 				echo($entry);
 			}
+			else {
+				$query = "REVOKE ALL PRIVILEGES ON DATABASE \"$e_name\" FROM PUBLIC";
+				$result = pg_query($connection, $query);
+			}
 		}
-		$query = "REVOKE ALL PRIVILEGES ON DATABASE \"$e_name\" FROM PUBLIC";
-		$result = pg_query($connection, $query);
 	}
 
 	private static function pg_createDBUser($name, $password, $connection) {


### PR DESCRIPTION
When we install OC on pg, 
the installer try to create a new DB and if the DB already exists it use the existing one.

No matter what, OC remove all rights except those of the OC user.

this PR is about revoking the DB rights only if the installer had to create the DB.

it address the issue #560 

may be eventually backported to 4.5.X
