### PR TITLE
Quick Fix a dirty function preventing showing errors

### DIFF
--- a/lib/template.php
+++ b/lib/template.php
@@ -497,18 +497,14 @@ class OC_Template{
 		return $content->printPage();
 	}
 
-        /**
-         * @brief Print a fatal error page and terminates the script
-         * @param string $error The error message to show
-         * @param string $hint An option hint message
-         */
-        public static function printErrorPage( $error, $hint = '' ) {
-                $error['error']=$error;
-                $error['hint']=$hint;
-                $errors[]=$error;
-                OC_Template::printGuestPage("", "error", array("errors" => $errors));
-                die();
-        }
-
-
+	/**
+		* @brief Print a fatal error page and terminates the script
+		* @param string $error The error message to show
+		* @param string $hint An option hint message
+		*/
+	public static function printErrorPage( $error_msg, $hint = '' ) {
+		$errors = array(array('error' => $error_msg, 'hint' => $hint));
+		OC_Template::printGuestPage("", "error", array("errors" => $errors));
+		die();
+	}
 }


### PR DESCRIPTION
Today while a was debuging install i tripped on a case where the DB returned an error..
the error template was displayed but with no error in it...

i digged a little deeper and i saw and corrected this :)

hope this won't stay any longer :p 

We also want to backport this to stable45 :)
