### PR TITLE
Remove support of sqlite2

### DIFF
--- a/core/setup.php
+++ b/core/setup.php
@@ -12,7 +12,7 @@ if( file_exists( $autosetup_file )) {
 
 OC_Util::addScript('setup');
 
-$hasSQLite = (is_callable('sqlite_open') or class_exists('SQLite3'));
+$hasSQLite = (is_callable('sqlite_open') and class_exists('SQLite3'));
 $hasMySQL = is_callable('mysql_connect');
 $hasPostgreSQL = is_callable('pg_connect');
 $hasOracle = is_callable('oci_connect');

--- a/core/setup.php
+++ b/core/setup.php
@@ -12,7 +12,7 @@ if( file_exists( $autosetup_file )) {
 
 OC_Util::addScript('setup');
 
-$hasSQLite = (is_callable('sqlite_open') and class_exists('SQLite3'));
+$hasSQLite = class_exists('SQLite3');
 $hasMySQL = is_callable('mysql_connect');
 $hasPostgreSQL = is_callable('pg_connect');
 $hasOracle = is_callable('oci_connect');


### PR DESCRIPTION
Hi, 

This PR disable the ability to install OC with sqlite2.
Sqlite3 is still supported of course. 
Sqlite2 support in OC was really unmaintained and buggy...and it has been unsupported for a long time upstream ... it's just a logicial path :)

see #116

This commit only remove the ability to install.. is does not clear sqlite2 references all over the place...
