### PR TITLE
Improve installation and login

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -79,7 +79,25 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 #login form { width:22em; margin:2em auto 2em; padding:0; }
 #login form fieldset { background:0; border:0; margin-bottom:2em; padding:0; }
 #login form fieldset legend { font-weight:bold; }
+
+/* Nicely grouping input field sets */
+.grouptop input {
+	margin-bottom:0;
+	border-bottom:0; border-bottom-left-radius:0; border-bottom-right-radius:0;
+}
+.groupmiddle input {
+	margin-top:0; margin-bottom:0;
+	border-top:0; border-radius:0;
+	box-shadow:0 1px 1px #fff,0 1px 0 #ddd inset;
+}
+.groupbottom input {
+	margin-top:0;
+	border-top:0; border-top-right-radius:0; border-top-left-radius:0;
+	box-shadow:0 1px 1px #fff,0 1px 0 #ddd inset;
+}
+
 #login form label { margin:.95em 0 0 .85em; color:#666; }
+#login .groupmiddle label, #login .groupbottom label { margin-top:13px; }
 /* NEEDED FOR INFIELD LABELS */
 p.infield { position: relative; }
 label.infield { cursor: text !important; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -56,6 +56,7 @@ input[type="submit"], input[type="button"], button, .button, #quota, div.jp-prog
 input[type="submit"]:hover, input[type="submit"]:focus, input[type="button"]:hover, select:hover, select:focus, select:active, input[type="button"]:focus, .button:hover { background:#fff; color:#333; }
 input[type="submit"] img, input[type="button"] img, button img, .button img { cursor:pointer; }
 input[type="checkbox"] { width:auto; }
+input[type="checkbox"]:hover+label, input[type="checkbox"]:focus+label { color:#111 !important; }
 #quota { cursor:default; }
 
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -77,8 +77,14 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 
 #login { min-height:30em; margin:2em auto 0; border-bottom:1px solid #f8f8f8; background:#eee; }
 #login form { width:22em; margin:2em auto 2em; padding:0; }
-#login form fieldset { background:0; border:0; margin-bottom:2em; padding:0; }
-#login form fieldset legend { font-weight:bold; }
+#login form fieldset { background:0; border:0; margin-bottom:20px; padding:0; }
+#login form #adminaccount { margin-bottom:5px; }
+#login form fieldset legend {
+	width:100%; text-align:center;
+	font-weight:bold; color:#999; text-shadow:0 1px 0 white;
+}
+#login form fieldset legend a { color:#999; }
+#login form #datadirField legend { margin-bottom:15px; }
 
 /* Nicely grouping input field sets */
 .grouptop input {
@@ -107,8 +113,12 @@ label.infield { cursor: text !important; }
 #login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 2em; padding:1em; }
 
 #login form #selectDbType { text-align:center; }
-#login form #selectDbType label { position:static; font-size:1em; margin:0 -.3em 1em; cursor:pointer; padding:.4em; border:1px solid #ddd; font-weight:bold; background:#f8f8f8; color:#555; text-shadow:#eee 0 1px 0; -moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; }
-#login form #selectDbType label span { cursor:pointer; font-size:0.9em; }
+#login form #selectDbType label {
+	position:static; margin:0 -3px 5px; padding:.4em;
+	font-size:12px; font-weight:bold; background:#f8f8f8; color:#555; cursor:pointer;
+	border:1px solid #ddd; text-shadow:#eee 0 1px 0;
+	-moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset;
+}
 #login form #selectDbType label.ui-state-hover, #login form #selectDbType label.ui-state-active { color:#000; background-color:#e8e8e8; }
 
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -58,6 +58,26 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 input[type="checkbox"] { width:auto; }
 #quota { cursor:default; }
 
+
+/* PRIMARY ACTION BUTTON, use sparingly */
+.primary, input[type="submit"].primary, input[type="button"].primary, button.primary, .button.primary {
+	border:1px solid #1d2d44;
+	background:#35537a; color:#ddd; text-shadow:#000 0 -1px 0;
+	-moz-box-shadow:0 0 1px #000,0 1px 1px #6d7d94 inset; -webkit-box-shadow:0 0 1px #000,0 1px 1px #6d7d94 inset; box-shadow:0 0 1px #000,0 1px 1px #6d7d94 inset;
+}
+	.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,
+	.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {
+		border:1px solid #1d2d44;
+		background:#2d3d54; color:#fff; text-shadow:#000 0 -1px 0;
+		-moz-box-shadow:0 0 1px #000,0 1px 1px #5d6d84 inset; -webkit-box-shadow:0 0 1px #000,0 1px 1px #5d6d84 inset; box-shadow:0 0 1px #000,0 1px 1px #5d6d84 inset;
+	}
+	.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {
+		border:1px solid #1d2d44;
+		background:#1d2d42; color:#bbb; text-shadow:#000 0 -1px 0;
+		-moz-box-shadow:0 1px 1px #fff,0 1px 1px 0 rgba(0,0,0,.2) inset; -webkit-box-shadow:0 1px 1px #fff,0 1px 1px 0 rgba(0,0,0,.2) inset; box-shadow:0 1px 1px #fff,0 1px 1px 0 rgba(0,0,0,.2) inset;
+	}
+
+
 #body-login input { font-size:1.5em; }
 #body-login input[type="text"], #body-login input[type="password"] { width: 13em; }
 #body-login input.login { width: auto; float: right; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -34,7 +34,12 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#35537a', end
 
 /* INPUTS */
 input[type="text"], input[type="password"] { cursor:text; }
-input, textarea, select, button, .button, #quota, div.jp-progress, .pager li a { font-size:1em; font-family:Arial, Verdana, sans-serif; width:10em; margin:.3em; padding:.6em .5em .4em; background:#fff; color:#333; border:1px solid #ddd; -moz-box-shadow:0 1px 1px #fff, 0 2px 0 #bbb inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; -moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em; outline:none; }
+input, textarea, select, button, .button, #quota, div.jp-progress, .pager li a {
+	font-size:1em; font-family:Arial, Verdana, sans-serif; width:10em; margin:.3em; padding:.6em .5em .4em;
+	background:#fff; color:#333; border:1px solid #ddd; outline:none;
+	-moz-box-shadow:0 1px 1px #fff, 0 2px 0 #bbb inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset;
+	-moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em;
+}
 input[type="text"], input[type="password"], input[type="search"], textarea { background:#f8f8f8; color:#555; cursor:text; }
 input[type="text"], input[type="password"], input[type="search"] { -webkit-appearance:textfield; -moz-appearance:textfield; -webkit-box-sizing:content-box; -moz-box-sizing:content-box; box-sizing:content-box; }
 input[type="text"]:hover, input[type="text"]:focus, input[type="text"]:active,
@@ -42,7 +47,12 @@ input[type="password"]:hover, input[type="password"]:focus, input[type="password
 .searchbox input[type="search"]:hover, .searchbox input[type="search"]:focus, .searchbox input[type="search"]:active,
 textarea:hover, textarea:focus, textarea:active { background-color:#fff; color:#333; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter:alpha(opacity=100); opacity:1; }
 
-input[type="submit"], input[type="button"], button, .button, #quota, div.jp-progress, select, .pager li a { width:auto; padding:.4em; border:1px solid #ddd; font-weight:bold; cursor:pointer; background:#f8f8f8; color:#555; text-shadow:#fff 0 1px 0; -moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em; }
+input[type="submit"], input[type="button"], button, .button, #quota, div.jp-progress, select, .pager li a {
+	width:auto; padding:.4em;
+	background:#f8f8f8; font-weight:bold; color:#555; text-shadow:#fff 0 1px 0; border:1px solid #ddd; cursor:pointer;
+	-moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset;
+	-moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em;
+}
 input[type="submit"]:hover, input[type="submit"]:focus, input[type="button"]:hover, select:hover, select:focus, select:active, input[type="button"]:focus, .button:hover { background:#fff; color:#333; }
 input[type="submit"] img, input[type="button"] img, button img, .button img { cursor:pointer; }
 input[type="checkbox"] { width:auto; }
@@ -77,13 +87,14 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 
 #login { min-height:30em; margin:2em auto 0; border-bottom:1px solid #f8f8f8; background:#eee; }
 #login form { width:22em; margin:2em auto 2em; padding:0; }
-#login form fieldset { background:0; border:0; margin-bottom:20px; padding:0; }
+#login form fieldset { margin-bottom:20px; }
 #login form #adminaccount { margin-bottom:5px; }
-#login form fieldset legend {
+#login form fieldset legend, #datadirContent label {
 	width:100%; text-align:center;
 	font-weight:bold; color:#999; text-shadow:0 1px 0 white;
 }
 #login form fieldset legend a { color:#999; }
+#login #datadirContent label { color:#999; display:block; }
 #login form #datadirField legend { margin-bottom:15px; }
 
 /* Nicely grouping input field sets */
@@ -115,11 +126,18 @@ label.infield { cursor: text !important; }
 #login form #selectDbType { text-align:center; }
 #login form #selectDbType label {
 	position:static; margin:0 -3px 5px; padding:.4em;
-	font-size:12px; font-weight:bold; background:#f8f8f8; color:#555; cursor:pointer;
+	font-size:12px; font-weight:bold; background:#f8f8f8; color:#888; cursor:pointer;
 	border:1px solid #ddd; text-shadow:#eee 0 1px 0;
 	-moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset;
 }
 #login form #selectDbType label.ui-state-hover, #login form #selectDbType label.ui-state-active { color:#000; background-color:#e8e8e8; }
+
+fieldset.warning {
+	padding:8px;
+	color:#b94a48; background-color:#f2dede; border:1px solid #eed3d7;
+	border-radius:5px;
+}
+fieldset.warning legend { color:#b94a48 !important; }
 
 
 /* NAVIGATION ------------------------------------------------------------- */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -140,7 +140,6 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 p.infield { position: relative; }
 label.infield { cursor: text !important; }
 #login form label.infield { position:absolute; font-size:19px; color:#aaa; white-space:nowrap; }
-#login #dbhostlabel, #login #directorylabel { display:block; margin:.95em 0 .8em -8em; }
 #login form input[type="checkbox"]+label { position:relative; margin:0; font-size:1em; text-shadow:#fff 0 1px 0; }
 #login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 2em; padding:1em; }
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -101,7 +101,7 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 /* NEEDED FOR INFIELD LABELS */
 p.infield { position: relative; }
 label.infield { cursor: text !important; }
-#login form label.infield { position:absolute; font-size:1.5em; color:#AAA; }
+#login form label.infield { position:absolute; font-size:19px; color:#aaa; white-space:nowrap; }
 #login #dbhostlabel, #login #directorylabel { display:block; margin:.95em 0 .8em -8em; }
 #login form input[type="checkbox"]+label { position:relative; margin:0; font-size:1em; text-shadow:#fff 0 1px 0; }
 #login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 2em; padding:1em; }
@@ -109,8 +109,7 @@ label.infield { cursor: text !important; }
 #login form #selectDbType { text-align:center; }
 #login form #selectDbType label { position:static; font-size:1em; margin:0 -.3em 1em; cursor:pointer; padding:.4em; border:1px solid #ddd; font-weight:bold; background:#f8f8f8; color:#555; text-shadow:#eee 0 1px 0; -moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; }
 #login form #selectDbType label span { cursor:pointer; font-size:0.9em; }
-#login form #selectDbType label.ui-state-hover span, #login form #selectDbType label.ui-state-active span { color:#000; }
-#login form #selectDbType label.ui-state-hover, #login form #selectDbType label.ui-state-active { color: #333; background-color: #ccc; }
+#login form #selectDbType label.ui-state-hover, #login form #selectDbType label.ui-state-active { color:#000; background-color:#e8e8e8; }
 
 
 /* NAVIGATION ------------------------------------------------------------- */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -115,7 +115,7 @@ input[type="submit"].highlight{ background:#ffc100; border:1px solid #db0; text-
 	font-weight:bold; color:#999; text-shadow:0 1px 0 white;
 }
 #login form fieldset legend a { color:#999; }
-#login #datadirContent label { color:#999; display:block; }
+#login #datadirContent label { display:block; margin:0; color:#999;  }
 #login form #datadirField legend { margin-bottom:15px; }
 
 /* Nicely grouping input field sets */

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -32,7 +32,7 @@
 		<span><?php echo $l->t('Your data directory and your files are probably accessible from the internet. The .htaccess file that ownCloud provides is not working. We strongly suggest that you configure your webserver in a way that the data directory is no longer accessible or you move the data directory outside the webserver document root.');?></span>		
 	</fieldset>
 	<?php endif; ?>
-	<fieldset>
+	<fieldset id="adminaccount">
 		<legend><?php echo $l->t( 'Create an <strong>admin account</strong>' ); ?></legend>
 		<p class="infield grouptop">
 			<label for="adminlogin" class="infield"><?php echo $l->t( 'Username' ); ?></label>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -47,7 +47,7 @@
 	<fieldset id="datadirField">
 		<legend><a id="showAdvanced"><?php echo $l->t( 'Advanced' ); ?> ▾</a></legend>
 		<div id="datadirContent">
-			<label for="directory"><?php echo $l->t( 'Data folder' ); ?>:</label><br/>
+			<label for="directory"><?php echo $l->t( 'Data folder' ); ?></label><br/>
 			<input type="text" name="directory" id="directory" value="<?php print OC_Helper::init_var('directory', $_['directory']); ?>" />
 		</div>
 	</fieldset>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -124,7 +124,7 @@
 		</div>
 		<?php endif; ?>
 		<p class="infield groupbottom">
-			<label for="dbhost" class="infield"><?php echo $l->t( 'Database host' ); ?></label>
+			<label for="dbhost" class="infield" id="dbhostlabel"><?php echo $l->t( 'Database host' ); ?></label>
 			<input type="text" name="dbhost" id="dbhost" value="<?php print OC_Helper::init_var('dbhost', 'localhost'); ?>" />
 		</p>
 	</fieldset>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -129,5 +129,5 @@
 		</p>
 	</fieldset>
 
-	<div class="buttons"><input type="submit" value="<?php echo $l->t( 'Finish setup' ); ?>" /></div>
+	<div class="buttons"><input type="submit" class="primary" value="<?php echo $l->t( 'Finish setup' ); ?>" /></div>
 </form>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -34,11 +34,11 @@
 	<?php endif; ?>
 	<fieldset>
 		<legend><?php echo $l->t( 'Create an <strong>admin account</strong>' ); ?></legend>
-		<p class="infield">
+		<p class="infield grouptop">
 			<label for="adminlogin" class="infield"><?php echo $l->t( 'Username' ); ?></label>
 			<input type="text" name="adminlogin" id="adminlogin" value="<?php print OC_Helper::init_var('adminlogin'); ?>" autocomplete="off" autofocus required />
 		</p>
-		<p class="infield">
+		<p class="infield groupbottom">
 			<label for="adminpass" class="infield"><?php echo $l->t( 'Password' ); ?></label>
 			<input type="password" name="adminpass" id="adminpass" value="<?php print OC_Helper::init_var('adminpass'); ?>" required />
 		</p>
@@ -101,15 +101,15 @@
 
 		<?php if($hasOtherDB): ?>
 		<div id="use_other_db">
-			<p class="infield">
+			<p class="infield grouptop">
 				<label for="dbuser" class="infield"><?php echo $l->t( 'Database user' ); ?></label>
 				<input type="text" name="dbuser" id="dbuser" value="<?php print OC_Helper::init_var('dbuser'); ?>" autocomplete="off" />
 			</p>
-			<p class="infield">
+			<p class="infield groupmiddle">
 				<label for="dbpass" class="infield"><?php echo $l->t( 'Database password' ); ?></label>
 				<input type="password" name="dbpass" id="dbpass" value="<?php print OC_Helper::init_var('dbpass'); ?>" />
 			</p>
-			<p class="infield">
+			<p class="infield groupmiddle">
 				<label for="dbname" class="infield"><?php echo $l->t( 'Database name' ); ?></label>
 				<input type="text" name="dbname" id="dbname" value="<?php print OC_Helper::init_var('dbname'); ?>" autocomplete="off" pattern="[0-9a-zA-Z$_]+" />
 			</p>
@@ -117,13 +117,13 @@
 		<?php endif; ?>
 		<?php if($_['hasOracle']): ?>
 		<div id="use_oracle_db">
-			<p class="infield">
+			<p class="infield groupmiddle">
 				<label for="dbtablespace" class="infield"><?php echo $l->t( 'Database tablespace' ); ?></label>
 				<input type="text" name="dbtablespace" id="dbtablespace" value="<?php print OC_Helper::init_var('dbtablespace'); ?>" autocomplete="off" />
 			</p>
 		</div>
 		<?php endif; ?>
-		<p class="infield">
+		<p class="infield groupbottom">
 			<label for="dbhost" class="infield"><?php echo $l->t( 'Database host' ); ?></label>
 			<input type="text" name="dbhost" id="dbhost" value="<?php print OC_Helper::init_var('dbhost', 'localhost'); ?>" />
 		</p>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -19,7 +19,7 @@
 	</ul>
 	<?php endif; ?>
 	<?php if(!$_['secureRNG']): ?>
-	<fieldset style="color: #B94A48; background-color: #F2DEDE; border-color: #EED3D7; border-style:solid; border-radius: 5px; border-width:1px; padding:0.5em;">
+	<fieldset class="warning">
 		<legend><strong><?php echo $l->t('Security Warning');?></strong></legend>
 		<span><?php echo $l->t('No secure random number generator is available, please enable the PHP OpenSSL extension.');?></span>		
 		<br/>
@@ -27,7 +27,7 @@
 	</fieldset>
 	<?php endif; ?>
 	<?php if(!$_['htaccessWorking']): ?>
-	<fieldset style="color: #B94A48; background-color: #F2DEDE; border-color: #EED3D7; border-style:solid; border-radius: 5px; border-width:1px; padding:0.5em;">
+	<fieldset class="warning">
 		<legend><strong><?php echo $l->t('Security Warning');?></strong></legend>
 		<span><?php echo $l->t('Your data directory and your files are probably accessible from the internet. The .htaccess file that ownCloud provides is not working. We strongly suggest that you configure your webserver in a way that the data directory is no longer accessible or you move the data directory outside the webserver document root.');?></span>		
 	</fieldset>
@@ -47,7 +47,7 @@
 	<fieldset id="datadirField">
 		<legend><a id="showAdvanced"><?php echo $l->t( 'Advanced' ); ?> ▾</a></legend>
 		<div id="datadirContent">
-			<label for="directory"><?php echo $l->t( 'Data folder' ); ?></label><br/>
+			<label for="directory"><?php echo $l->t( 'Data folder' ); ?></label>
 			<input type="text" name="directory" id="directory" value="<?php print OC_Helper::init_var('directory', $_['directory']); ?>" />
 		</div>
 	</fieldset>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -35,7 +35,7 @@
 	<body id="body-login">
 		<div id="login">
 			<header><div id="header">
-				<img src="<?php echo image_path('', 'logo.png'); ?>" alt="ownCloud" />
+				<img src="<?php echo image_path('', 'logo.svg'); ?>" class="svg" alt="ownCloud" />
 			</div></header>
 			<?php echo $_['content']; ?>
 		</div>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -16,11 +16,11 @@
 			</li></a>
 		<?php endif; ?>
 		</ul>
-		<p class="infield">
+		<p class="infield grouptop">
 			<label for="user" class="infield"><?php echo $l->t( 'Username' ); ?></label>
 			<input type="text" name="user" id="user" value="<?php echo $_['username']; ?>"<?php echo $_['user_autofocus']?' autofocus':''; ?> autocomplete="on" required />
 		</p>
-		<p class="infield">
+		<p class="infield groupbottom">
 			<label for="password" class="infield"><?php echo $l->t( 'Password' ); ?></label>
 			<input type="password" name="password" id="password" value="" required<?php echo $_['user_autofocus']?'':' autofocus'; ?> />
 		</p>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -25,6 +25,6 @@
 			<input type="password" name="password" id="password" value="" required<?php echo $_['user_autofocus']?'':' autofocus'; ?> />
 		</p>
 		<input type="checkbox" name="remember_login" value="1" id="remember_login" /><label for="remember_login"><?php echo $l->t('remember'); ?></label>
-		<input type="submit" id="submit" class="login" value="<?php echo $l->t( 'Log in' ); ?>" />
+		<input type="submit" id="submit" class="login primary" value="<?php echo $l->t( 'Log in' ); ?>" />
 	</fieldset>
 </form>


### PR DESCRIPTION
Lots of improvements to installation and log in feel.

Related input fields are visually grouped, that is username+password, and all the database-related fields.
The legend texts are subdued a bit because they caught too much attention.
Inline CSS from the warnings is assigned a class and moved properly into the CSS.
Aaaand we have a proper primary action button because the simple white-grey button is not enough of a call to action for Installation and log in.

Please review, @Raydiation @karlitschek and if anyone wants to have a look.
