### PR TITLE
Fixing files external in stable45 - fixes #290

### DIFF
--- a/3rdparty/smb4php/smb.php
+++ b/3rdparty/smb4php/smb.php
@@ -112,6 +112,10 @@ class smb {
 		}
 		$port = ($purl['port'] <> 139 ? ' -p ' . escapeshellarg ($purl['port']) : '');
 		$options = '-O ' . escapeshellarg(SMB4PHP_SMBOPTIONS);
+
+		// this put env is necessary to read the output of smbclient correctly
+		$old_locale = getenv('LC_ALL');
+		putenv('LC_ALL=en_US.UTF-8');
 		$output = popen (SMB4PHP_SMBCLIENT." -N {$auth} {$options} {$port} {$options} {$params} 2>/dev/null", 'r');
 		$info = array ();
 		$info['info']= array ();
@@ -180,6 +184,14 @@ class smb {
 			}
 		}
 		pclose($output);
+
+		// restore previous locale
+		if ($old_locale===false) {
+			putenv('LC_ALL');
+		} else {
+			putenv('LC_ALL='.$old_locale);
+		}
+		
 		return $info;
 	}
 

--- a/apps/files_external/ajax/removeMountPoint.php
+++ b/apps/files_external/ajax/removeMountPoint.php
@@ -3,6 +3,15 @@
 OCP\JSON::checkAppEnabled('files_external');
 OCP\JSON::callCheck();
 
+if (!isset($_POST['isPersonal']))
+	return;
+if (!isset($_POST['mountPoint']))
+	return;
+if (!isset($_POST['mountType']))
+	return;
+if (!isset($_POST['applicable']))
+	return;
+
 if ($_POST['isPersonal'] == 'true') {
 	OCP\JSON::checkLoggedIn();
 	$isPersonal = true;
@@ -10,4 +19,5 @@ if ($_POST['isPersonal'] == 'true') {
 	OCP\JSON::checkAdminUser();
 	$isPersonal = false;
 }
+
 OC_Mount_Config::removeMountPoint($_POST['mountPoint'], $_POST['mountType'], $_POST['applicable'], $isPersonal);

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -58,12 +58,6 @@ class OC_FileStorage_SMB extends OC_FileStorage_StreamWrapper{
 		}
 	}
 
-	public function filetype($path) {
-		// filetype uses stat of the stream wrapper implementation to determine the file type
-		// see: http://php.net/manual/de/streamwrapper.url-stat.php
-		return filetype($this->constructUrl($path));
-	}
-
 	/**
 	 * check if a file or folder has been updated since $time
 	 * @param int $time

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -59,7 +59,9 @@ class OC_FileStorage_SMB extends OC_FileStorage_StreamWrapper{
 	}
 
 	public function filetype($path) {
-		return (bool)@$this->opendir($path) ? 'dir' : 'file';//using opendir causes the same amount of requests and caches the content of the folder in one go
+		// filetype uses stat of the stream wrapper implementation to determine the file type
+		// see: http://php.net/manual/de/streamwrapper.url-stat.php
+		return filetype($this->constructUrl($path));
 	}
 
 	/**

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -60,7 +60,7 @@
 					<?php if ($_['isAdminPage']): ?>
 					<td class="applicable" align="right" data-applicable-groups='<?php if (isset($mount['applicable']['groups'])) echo json_encode($mount['applicable']['groups']); ?>' data-applicable-users='<?php if (isset($mount['applicable']['users'])) echo json_encode($mount['applicable']['users']); ?>'>
 							<select class="chzn-select" multiple style="width:20em;" data-placeholder="<?php echo $l->t('None set'); ?>">
-								<option value="all"><?php echo $l->t('All Users'); ?></option>
+								<option value="all" <?php if (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users'])) echo 'selected="selected"';?> ><?php echo $l->t('All Users'); ?></option>
 								<optgroup label="<?php echo $l->t('Groups'); ?>">
 									<?php foreach ($_['groups'] as $group): ?>
 										<option value="<?php echo $group; ?>(group)" <?php if (isset($mount['applicable']['groups']) && in_array($group, $mount['applicable']['groups'])) echo 'selected="selected"'; ?>><?php echo $group; ?></option>

--- a/lib/filesystem.php
+++ b/lib/filesystem.php
@@ -233,7 +233,7 @@ class OC_Filesystem{
 		
 			if(isset($mountConfig['user'])) {
 				foreach($mountConfig['user'] as $mountUser=>$mounts) {
-					if($user==='all' or strtolower($mountUser)===strtolower($user)) {
+					if($mountUser==='all' or strtolower($mountUser)===strtolower($user)) {
 						foreach($mounts as $mountPoint=>$options) {
 							$mountPoint=self::setUserVars($mountPoint, $user);
 							foreach($options as &$option) {


### PR DESCRIPTION
This pull request mainly fixes the status 500 error described in #290
## Background:

the previous opendir call on a file is implemented as a smbclient call:

```
smbclient -N -U 'user%******' -d 0 //server/testsmb -c 'dir "folder/file.txt/*"
```

A Samba server will return NT_STATUS_OBJECT_PATH_NOT_FOUND which returns false on the stream wrapper implementation.
A Windows Server/Workstation will return  NT_STATUS_INVALID_PARAMETER which will result in an call to trigger_error() and death :-(
## Fix:

According to the stream wrapper documentation a call to filetype() will call stat() on the stream wrapper and interpret the the result correctly.
This has been tested with Windows 7 and Samba 3.4.3
