### PR TITLE
throwing InsufficientStorage in case the quota is reached

### DIFF
--- a/lib/connector/sabre/quotaplugin.php
+++ b/lib/connector/sabre/quotaplugin.php
@@ -51,7 +51,7 @@ class OC_Connector_Sabre_QuotaPlugin extends Sabre_DAV_ServerPlugin {
 			}
 			list($parentUri, $newName) = Sabre_DAV_URLUtil::splitPath($uri);
 			if ($length > OC_Filesystem::free_space($parentUri)) {
-				throw new Sabre_DAV_Exception('Quota exceeded. File is too big.');
+				throw new Sabre_DAV_Exception_InsufficientStorage();
 			}
 		}
 		return true;


### PR DESCRIPTION
As discussed with @evert in #784 - we should throw Sabre_DAV_Exception_InsufficientStorage in case the quota is reached.

@karlitschek @bartv2 @tanghus Please review! THX
