### PR TITLE
Close DB connection as it is no longer required. Fix #638

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -153,10 +153,10 @@ class OC_Setup {
 					if($result) {
 						$row=mysql_fetch_row($result);
 					}
+					mysql_close($connection);
 					if(!$result or $row[0]==0) {
 						OC_DB::createDbFromStructure('db_structure.xml');
 					}
-					mysql_close($connection);
 				}
 			}
 			elseif($dbtype == 'pgsql') {


### PR DESCRIPTION
OC_DB::createDbFromStructure creates a new DB connection. Existing is no longer required.
