### PR TITLE
Ldap webdavauth conflict

### DIFF
--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -42,3 +42,6 @@ $entry = array(
 );
 
 OCP\Backgroundjob::addRegularTask('OCA\user_ldap\lib\Jobs', 'updateGroups');
+if(OCP\App::isEnabled('user_webdavauth')) {
+	OCP\Util::writeLog('user_ldap', 'user_ldap and user_webdavauth are incompatible. You may experience unexpected behaviour', OCP\Util::WARN);
+}

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -2,7 +2,9 @@
 <info>
 	<id>user_ldap</id>
 	<name>LDAP user and group backend</name>
-	<description>Authenticate Users by LDAP</description>
+	<description>Authenticate users and groups by LDAP resp. Active Directoy.
+
+	This app is not compatible to the WebDAV user backend.</description>
 	<licence>AGPL</licence>
 	<author>Dominik Schmidt and Arthur Schiwon</author>
 	<require>4.9</require>

--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -8,3 +8,8 @@
 	width: 70%;
 	display: inline-block;
 }
+
+.ldapwarning {
+	margin-left: 1.4em;
+	color: #FF3B3B;
+}

--- a/apps/user_ldap/templates/settings.php
+++ b/apps/user_ldap/templates/settings.php
@@ -4,6 +4,10 @@
 		<li><a href="#ldapSettings-1">LDAP Basic</a></li>
 		<li><a href="#ldapSettings-2">Advanced</a></li>
 	</ul>
+		<?php if(OCP\App::isEnabled('user_webdavauth')) {
+			echo '<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behaviour. Please ask your system administrator to disable one of them.').'</p>';
+		}
+		?>
 	<fieldset id="ldapSettings-1">
 		<p><label for="ldap_host"><?php echo $l->t('Host');?></label><input type="text" id="ldap_host" name="ldap_host" value="<?php echo $_['ldap_host']; ?>" title="<?php echo $l->t('You can omit the protocol, except you require SSL. Then start with ldaps://');?>"></p>
 		<p><label for="ldap_base"><?php echo $l->t('Base DN');?></label><input type="text" id="ldap_base" name="ldap_base" value="<?php echo $_['ldap_base']; ?>" title="<?php echo $l->t('You can specify Base DN for users and groups in the Advanced tab');?>" /></p>

--- a/apps/user_ldap/templates/settings.php
+++ b/apps/user_ldap/templates/settings.php
@@ -7,6 +7,9 @@
 		<?php if(OCP\App::isEnabled('user_webdavauth')) {
 			echo '<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behaviour. Please ask your system administrator to disable one of them.').'</p>';
 		}
+		if(!function_exists('ldap_connect')) {
+			echo '<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module needs is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>';
+		}
 		?>
 	<fieldset id="ldapSettings-1">
 		<p><label for="ldap_host"><?php echo $l->t('Host');?></label><input type="text" id="ldap_host" name="ldap_host" value="<?php echo $_['ldap_host']; ?>" title="<?php echo $l->t('You can omit the protocol, except you require SSL. Then start with ldaps://');?>"></p>

--- a/apps/user_webdavauth/appinfo/info.xml
+++ b/apps/user_webdavauth/appinfo/info.xml
@@ -2,7 +2,9 @@
 <info>
 	<id>user_webdavauth</id>
 	<name>WebDAV user backend</name>
-	<description>Authenticate users by a WebDAV call. You can use any WebDAV server, ownCloud server or other webserver to authenticate. It should return http 200 for right credentials and http 401 for wrong ones.</description>
+	<description>Authenticate users by a WebDAV call. You can use any WebDAV server, ownCloud server or other webserver to authenticate. It should return http 200 for right credentials and http 401 for wrong ones.
+
+	This app is not compatible to the LDAP user and group backend.</description>
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek</author>
 	<require>4.9</require>


### PR DESCRIPTION
Since user_webdavauth returns always true on userExists(), the ldap backend cannot assign usernames to new users. This can be tricky to debug, so we give a warning about possible incompatibilities. 

@karlitschek @DeepDiver1975 others to review?
