### PR TITLE
Storage wording

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -39,7 +39,7 @@ div.quota-select-wrapper { position: relative; }
 select.quota { position:absolute; left:0; top:0; width:10em; }
 select.quota-user { position:relative; left:0; top:0; width:10em; }
 input.quota-other { display:none; position:absolute; left:0.1em; top:0.1em; width:7em; border:none; box-shadow:none; }
-div.quota>span { position:absolute; right:0em; white-space:nowrap; top: 0.7em }
+div.quota>span { position:absolute; right:0; white-space:nowrap; top:.7em; color:#888; text-shadow:0 1px 0 #fff; }
 select.quota.active { background: #fff; }
 
 /* APPS */

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -50,7 +50,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 				</option>
 				<?php endif;?>
 				<?php endforeach;?>
-				<?php if(array_search($_['default_quota'], $_['quota_preset'])===false && array_search($_['default_quota'], array('none', 'default'))===false):?>
+				<?php if($_['defaultQuotaIsUserDefined']):?>
 				<option selected="selected"
 					value='<?php echo $_['default_quota'];?>'>
 					<?php echo $_['default_quota'];?>
@@ -144,7 +144,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 							<?php echo $preset;?>
 						</option>
 						<?php endforeach;?>
-						<?php if(array_search($user['quota'], $_['quota_preset'])===false && array_search($user['quota'], array('none', 'default'))===false):?>
+						<?php if($user['isQuotaUserDefined']):?>
 						<option selected="selected" value='<?php echo $user['quota'];?>'>
 							<?php echo $user['quota'];?>
 						</option>

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -36,6 +36,11 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 		<div class="quota-select-wrapper">
 			<?php if((bool) $_['isadmin']): ?>
 			<select class='quota'>
+                <option
+                    <?php if($_['default_quota']=='none') echo 'selected="selected"';?>
+                        value='none'>
+                    <?php echo $l->t('Unlimited');?>
+                </option>
 				<?php foreach($_['quota_preset'] as $preset):?>
 				<?php if($preset!='default'):?>
 				<option
@@ -45,7 +50,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 				</option>
 				<?php endif;?>
 				<?php endforeach;?>
-				<?php if(array_search($_['default_quota'], $_['quota_preset'])===false):?>
+				<?php if(array_search($_['default_quota'], $_['quota_preset'])===false && array_search($_['default_quota'], array('none', 'default'))===false):?>
 				<option selected="selected"
 					value='<?php echo $_['default_quota'];?>'>
 					<?php echo $_['default_quota'];?>
@@ -55,7 +60,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 					<?php echo $l->t('Other');?>
 					...
 				</option>
-			</select> <input class='quota-other'></input>
+			</select> <input class='quota-other'/>
 			<?php endif; ?>
 			<?php if((bool) !$_['isadmin']): ?>
 				<select class='quota' disabled="disabled">
@@ -122,6 +127,16 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 			<td class="quota">
 				<div class="quota-select-wrapper">
 					<select class='quota-user'>
+                        <option
+                            <?php if($user['quota']=='default') echo 'selected="selected"';?>
+                                value='default'>
+                            <?php echo $l->t('Default');?>
+                        </option>
+                        <option
+                        <?php if($user['quota']=='none') echo 'selected="selected"';?>
+                                value='none'>
+                            <?php echo $l->t('Unlimited');?>
+                        </option>
 						<?php foreach($_['quota_preset'] as $preset):?>
 						<option
 						<?php if($user['quota']==$preset) echo 'selected="selected"';?>
@@ -129,7 +144,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 							<?php echo $preset;?>
 						</option>
 						<?php endforeach;?>
-						<?php if(array_search($user['quota'], $_['quota_preset'])===false):?>
+						<?php if(array_search($user['quota'], $_['quota_preset'])===false && array_search($user['quota'], array('none', 'default'))===false):?>
 						<option selected="selected" value='<?php echo $user['quota'];?>'>
 							<?php echo $user['quota'];?>
 						</option>
@@ -138,7 +153,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 							<?php echo $l->t('Other');?>
 							...
 						</option>
-					</select> <input class='quota-other'></input>
+					</select> <input class='quota-other'/>
 				</div>
 			</td>
 			<td class="remove">

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -32,7 +32,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 		</select> <input type="submit" value="<?php echo $l->t('Create')?>" />
 	</form>
 	<div class="quota">
-		<span><?php echo $l->t('Default Quota');?>:</span>
+		<span><?php echo $l->t('Default Storage');?></span>
 		<div class="quota-select-wrapper">
 			<?php if((bool) $_['isadmin']): ?>
 			<select class='quota'>
@@ -79,7 +79,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 			<?php if(is_array($_['subadmins']) || $_['subadmins']): ?>
 			<th id="headerSubAdmins"><?php echo $l->t('Group Admin'); ?></th>
 			<?php endif;?>
-			<th id="headerQuota"><?php echo $l->t( 'Quota' ); ?></th>
+			<th id="headerQuota"><?php echo $l->t('Storage'); ?></th>
 			<th id="headerRemove">&nbsp;</th>
 		</tr>
 	</thead>

--- a/settings/users.php
+++ b/settings/users.php
@@ -29,11 +29,27 @@ if($isadmin) {
 	$subadmins = false;
 }
 
+// load preset quotas
+$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
+$quotaPreset=explode(',', $quotaPreset);
+foreach($quotaPreset as &$preset) {
+    $preset=trim($preset);
+}
+$quotaPreset=array_diff($quotaPreset, array('default', 'none'));
+
+$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
+$defaultQuotaIsUserDefined=array_search($default_quota, $quotaPreset)===false && array_search($default_quota, array('none', 'default'))===false;
+
+// load users and quota
 foreach($accessibleusers as $i) {
+    $quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
+    $isQuotaUserDefined=array_search($quota, $quotaPreset)===false && array_search($quota, array('none', 'default'))===false;
+
 	$users[] = array(
 		"name" => $i,
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($i)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
-		'quota'=>OC_Preferences::getValue($i, 'files', 'quota', 'default'),
+        'quota'=>$quota,
+        'isQuotaUserDefined'=>$isQuotaUserDefined,
 		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($i)));
 }
 
@@ -41,21 +57,14 @@ foreach( $accessiblegroups as $i ) {
 	// Do some more work here soon
 	$groups[] = array( "name" => $i );
 }
-$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
-$quotaPreset=explode(',', $quotaPreset);
-foreach($quotaPreset as &$preset) {
-	$preset=trim($preset);
-}
-$quotaPreset=array_diff($quotaPreset, array('default', 'none'));
-
-$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
 
 $tmpl = new OC_Template( "settings", "users", "user" );
-$tmpl->assign( "users", $users );
-$tmpl->assign( "groups", $groups );
+$tmpl->assign( 'users', $users );
+$tmpl->assign( 'groups', $groups );
 $tmpl->assign( 'isadmin', (int) $isadmin);
 $tmpl->assign( 'subadmins', $subadmins);
 $tmpl->assign( 'numofgroups', count($accessiblegroups));
 $tmpl->assign( 'quota_preset', $quotaPreset);
 $tmpl->assign( 'default_quota', $defaultQuota);
+$tmpl->assign( 'defaultQuotaIsUserDefined', $defaultQuotaIsUserDefined);
 $tmpl->printPage();

--- a/settings/users.php
+++ b/settings/users.php
@@ -33,7 +33,7 @@ foreach($accessibleusers as $i) {
 	$users[] = array(
 		"name" => $i,
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($i)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
-		'quota'=>OC_Preferences::getValue($i, 'files', 'quota', 'default'),
+		'quota'=>OC_Preferences::getValue($i, 'files', 'quota', 'Default'),
 		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($i)));
 }
 
@@ -41,13 +41,13 @@ foreach( $accessiblegroups as $i ) {
 	// Do some more work here soon
 	$groups[] = array( "name" => $i );
 }
-$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', 'default,none,1 GB, 5 GB, 10 GB');
+$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', 'Default, Unlimited, 1 GB, 5 GB, 10 GB');
 $quotaPreset=explode(',', $quotaPreset);
 foreach($quotaPreset as &$preset) {
 	$preset=trim($preset);
 }
 
-$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
+$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'Unlimited');
 
 $tmpl = new OC_Template( "settings", "users", "user" );
 $tmpl->assign( "users", $users );

--- a/settings/users.php
+++ b/settings/users.php
@@ -38,7 +38,7 @@ foreach($quotaPreset as &$preset) {
 $quotaPreset=array_diff($quotaPreset, array('default', 'none'));
 
 $defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
-$defaultQuotaIsUserDefined=array_search($default_quota, $quotaPreset)===false && array_search($default_quota, array('none', 'default'))===false;
+$defaultQuotaIsUserDefined=array_search($defaultQuota, $quotaPreset)===false && array_search($defaultQuota, array('none', 'default'))===false;
 
 // load users and quota
 foreach($accessibleusers as $i) {

--- a/settings/users.php
+++ b/settings/users.php
@@ -30,10 +30,15 @@ if($isadmin) {
 }
 
 foreach($accessibleusers as $i) {
+    $quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
+    // translation of old value 'none' to 'unlimited'
+    if ($quota=='none')
+        $quota='unlimited';
+
 	$users[] = array(
 		"name" => $i,
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($i)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
-		'quota'=>OC_Preferences::getValue($i, 'files', 'quota', 'Default'),
+		'quota'=>OC_Preferences::getValue($i, 'files', 'quota', 'default'),
 		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($i)));
 }
 
@@ -41,13 +46,14 @@ foreach( $accessiblegroups as $i ) {
 	// Do some more work here soon
 	$groups[] = array( "name" => $i );
 }
-$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', 'Default, Unlimited, 1 GB, 5 GB, 10 GB');
+$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
 $quotaPreset=explode(',', $quotaPreset);
 foreach($quotaPreset as &$preset) {
 	$preset=trim($preset);
 }
+$quotaPreset=array_diff($quotaPreset, array('default', 'none'));
 
-$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'Unlimited');
+$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
 
 $tmpl = new OC_Template( "settings", "users", "user" );
 $tmpl->assign( "users", $users );

--- a/settings/users.php
+++ b/settings/users.php
@@ -30,11 +30,6 @@ if($isadmin) {
 }
 
 foreach($accessibleusers as $i) {
-    $quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
-    // translation of old value 'none' to 'unlimited'
-    if ($quota=='none')
-        $quota='unlimited';
-
 	$users[] = array(
 		"name" => $i,
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($i)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),


### PR DESCRIPTION
3 seemingly simple changes to the storage part in Users management:
- dim the label a bit so it’s not so aggressive
- change technical expression »Quota« to more common »Storage«
- change ambiguous »none« to correct »Unlimited« (also captalize »Default«) (cc @MTRichards)

:warning: Now here’s the problem about the 3rd change: interface strings and database values don’t seem to be separated in the current code. So the pull request as it is now is probably going to fuck stuff up. Also, the strings »Default« and »Unlimited« aren’t even translatable.

Can someone help me and separate these values? @icewind1991 @DeepDiver1975 
