### PR TITLE
Migration of build files from Jenkins

### DIFF
--- a/build/README.TXT
+++ b/build/README.TXT
@@ -1,0 +1,28 @@
+How to setup build.xml on your local machine?
+
+1.) Install ant
+ e.g. apt-get install ant
+
+2.) Install jslint
+ Get the latest distribution from http://code.google.com/p/jslint4java/ and 
+ place jslint4java-*.jar in your home under .ant/lib/
+
+3.) Install PHP qa tools
+ Run as root:
+  pear config-set auto_discover 1
+  pear install pear.phpqatools.org/phpqatools pear.netpirates.net/phpDox
+
+ Alternative:
+  pear install pear.phpunit.de/phploc
+  pear install pear.phpunit.de/phpcpd
+  pear install pear.phpmd.org/PHP_PMD
+  pear install pear.pdepend.org/PHP_Depend
+  pear install pear.php.org/PHP_CodeSniffer
+  pear install PHP_CodeSniffer
+  pear install pear.phpqatools.org/PHP_CodeBrowser
+
+
+How to call this ant script?
+ ant -f  build/build.xml -Dbasedir=. 
+
+

--- a/build/build.xml
+++ b/build/build.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="ownCloud" default="build" xmlns:jsl="antlib:com.googlecode.jslint4java">
+
+ <!-- the target 'build' can be used by developers for command line builds -->
+ <target name="build" depends="prepare,lint,jslint,phploc,pdepend,phpmd,phpcs,phpcpd,phpdoc,phpunit"/>
+
+ <!-- the target 'build-ci' is used within our Jenkins CI-server http://ci.tmit.eu -->
+ <target name="build-ci" depends="prepare,lint,jslint-ci,phploc,pdepend,phpmd-ci,phpcs-ci,phpcpd-ci,phpdoc,phpunit,phpcb-ci"/>
+
+ <!-- the target 'build-pullrequests' is used within our Jenkins CI-server for pull request analysis -->
+ <target name="build-pullrequests" depends="prepare,lint,jslint-ci"/>
+
+ <target name="clean" description="Cleanup build artifacts">
+  <delete dir="${basedir}/build/api"/>
+  <delete dir="${basedir}/build/code-browser"/>
+  <delete dir="${basedir}/build/coverage"/>
+  <delete dir="${basedir}/build/logs"/>
+  <delete dir="${basedir}/build/pdepend"/>
+ </target>
+
+ <target name="prepare" depends="clean"
+         description="Prepare for build">
+  <mkdir dir="${basedir}/build/api"/>
+  <mkdir dir="${basedir}/build/code-browser"/>
+  <mkdir dir="${basedir}/build/coverage"/>
+  <mkdir dir="${basedir}/build/logs"/>
+  <mkdir dir="${basedir}/build/pdepend"/>
+ </target>
+
+ <!-- php syntax analysis -->
+ <target name="lint">
+  <apply executable="php" failonerror="true">
+   <arg value="-l" />
+
+   <fileset dir="${basedir}">
+    <include name="**/*.php" />
+    <exclude name="**/3rdparty/**" />
+    <exclude name="**/l10n/**" />
+    <!-- modified / -->
+   </fileset>
+
+  </apply>
+ </target>
+
+ <!-- javascript lint -->
+ <target name="jslint-ci" description="Run the JSLint tool on JS files">
+  <jsl:jslint options="white,sloppy,vars,bitwise,eqeq,browser" haltOnFailure="false">
+   <jsl:predef>
+jQuery,$$,OC,$,oc_webroot,oc_appswebroots,oc_current_user,t,Files,FileList,FileActions,localStorage,OCCategories,EventSource,OCdialog,SVGSupport,dragOptions,dragOptions,folderDropOptions,formatDate,humanFileSize,procesSelection,relative_modified_date,scanFiles,simpleFileSize,simpleSize
+</jsl:predef>
+   <!-- jsl:formatter type="plain" / -->
+   <jsl:formatter type="xml" destfile="build/logs/jslint.xml" />
+   <fileset dir="${basedir}" includes="**/*.js" excludes="**/*.min.js,**/3rdparty/**" />
+  </jsl:jslint>
+ </target>
+
+ <target name="jslint" description="Run the JSLint tool on JS files">
+  <jsl:jslint options="white,sloppy,vars,bitwise,eqeq,browser" haltOnFailure="false">
+   <jsl:predef>
+jQuery,$$,OC,$,oc_webroot,oc_appswebroots,oc_current_user,t,Files,FileList,FileActions,localStorage,OCCategories,EventSource,OCdialog,SVGSupport,dragOptions,dragOptions,folderDropOptions,formatDate,humanFileSize,procesSelection,relative_modified_date,scanFiles,simpleFileSize,simpleSize
+</jsl:predef>
+   <jsl:formatter type="plain" />
+   <fileset dir="${basedir}" includes="**/*.js" excludes="**/*.min.js,**/3rdparty/**" />
+  </jsl:jslint>
+ </target>
+
+ <target name="phploc" description="Measure project size using PHPLOC">
+  <exec executable="phploc">
+   <arg value="--log-csv" />
+   <arg value="${basedir}/build/logs/phploc.csv" />
+   <arg path="${basedir}" />
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+  </exec>
+ </target>
+
+ <target name="pdepend"
+         description="Calculate software metrics using PHP_Depend">
+  <exec executable="pdepend">
+   <arg value="--jdepend-xml=${basedir}/build/logs/jdepend.xml" />
+   <arg value="--jdepend-chart=${basedir}/build/pdepend/dependencies.svg" />
+   <arg value="--overview-pyramid=${basedir}/build/pdepend/overview-pyramid.svg" />
+   <arg value="--ignore=${basedir}/3rdparty/"/>
+   <arg path="${basedir}" />
+  </exec>
+ </target>
+
+ <target name="phpmd-ci"
+         description="Perform project mess detection using PHPMD creating a log file for the continuous integration server">
+  <exec executable="phpmd">
+   <arg path="${basedir}" />
+   <arg value="xml" />
+   <arg value="${basedir}/build/phpmd.xml" />
+   <arg value="--reportfile" />
+   <arg value="${basedir}/build/logs/pmd.xml" />
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+  </exec>
+ </target>
+
+ <target name="phpmd"
+         description="Perform project mess detection using PHPMD creating a log file for the continuous integration server">
+  <exec executable="phpmd">
+   <arg path="${basedir}" />
+   <arg value="xml" />
+   <arg value="${basedir}/build/phpmd.xml" />
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+  </exec>
+ </target>
+
+ <target name="phpcs-ci"
+         description="Find coding standard violations using PHP_CodeSniffer creating a log file for the continuous integration server">
+  <exec executable="phpcs" >
+   <arg value="-p" />
+   <arg value="-v" />
+   <arg value="--tab-width=4" />
+   <arg value="--report=checkstyle" />
+   <arg value="--report-file=${basedir}/build/logs/checkstyle.xml" />
+   <arg value="--standard=${basedir}/build/phpcs.xml" />
+   <arg path="${basedir}" />
+  </exec>
+ </target>
+
+ <target name="phpcs"
+         description="Find coding standard violations using PHP_CodeSniffer creating a log file for the continuous integration server">
+  <exec executable="phpcs" >
+   <arg value="-p" />
+   <arg value="-v" />
+   <arg value="--tab-width=4" />
+   <arg value="--standard=${basedir}/build/phpcs.xml" />
+   <arg path="${basedir}" />
+  </exec>
+ </target>
+
+ <target name="phpcpd" description="Find duplicate code using PHPCPD">
+  <exec executable="phpcpd">
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+   <arg path="${basedir}" />
+  </exec>
+ </target>
+
+ <target name="phpcpd-ci" description="Find duplicate code using PHPCPD">
+  <exec executable="phpcpd">
+   <arg value="--log-pmd" />
+   <arg value="${basedir}/build/logs/pmd-cpd.xml" />
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+   <arg path="${basedir}" />
+  </exec>
+ </target>
+
+ <!-- No idea if we need this within this build file. This is part of the release which is not contained within this script. -->
+ <target name="phpdoc"
+         description="Generate API documentation using PHPDocumentor">
+  <!-- exec executable="phpdox"/ -->
+ </target>
+
+ <!-- currently we use autotest.sh for executing the unit tests against 3 different database setups -->
+ <target name="phpunit" description="Run unit tests with PHPUnit">
+  <echo message="TODO: phpunit goes here"/>
+  <!-- exec executable="phpunit" failonerror="true"/ -->
+ </target>
+
+ <target name="phpcb-ci"
+         description="Aggregate tool output with PHP_CodeBrowser">
+  <exec executable="phpcb">
+   <arg value="--log" />
+   <arg path="${basedir}/build/logs" />
+   <arg value="--source" />
+   <arg path="${basedir}" />
+   <arg value="--output" />
+   <arg path="${basedir}/build/code-browser" />
+   <arg value="--exclude" />
+   <arg value="${basedir}/3rdparty/" />
+  </exec>
+ </target>
+</project>

--- a/build/phpcs.xml
+++ b/build/phpcs.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+ <description>The coding standard for PHP_CodeSniffer itself.</description>
+ <exclude-pattern>*/Tests/*</exclude-pattern>
+ <exclude-pattern>*/lib/MDB2/*</exclude-pattern>
+ <exclude-pattern>*/3rdparty/*</exclude-pattern>
+ <exclude-pattern>*.min.*</exclude-pattern>
+ <exclude-pattern>*/l10n/*</exclude-pattern>
+ <exclude-pattern>*/files_texteditor/js/aceeditor/*</exclude-pattern>
+ <exclude-pattern>*/files_pdfviewer/js/pdfjs/*</exclude-pattern>
+ <exclude-pattern>*/files_odfviewer/src/*</exclude-pattern>
+ <exclude-pattern>*/files_svgedit/svg-edit/*</exclude-pattern>
+ <exclude-pattern>*jquery-ui-1.8.16.custom.css</exclude-pattern>
+ <extensions>php</extensions>
+
+ <!-- Include the whole PEAR standard -->
+ <rule ref="PEAR">
+  <exclude name="PEAR.Commenting.FileComment.InvalidAuthors" />
+  <exclude name="PEAR.Commenting.FileComment.TagIndent" />
+  <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
+  <exclude name="PEAR.Commenting.FileComment.MissingTag" />
+  <exclude name="PEAR.Commenting.ClassComment.TagIndent" />
+  <!-- exclude name="PEAR.WhiteSpace.ScopeIndent.Incorrect" /-->
+  <exclude name="PEAR.Commenting.ClassComment.WrongTagOrder" />
+  <exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed" />
+  <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
+  <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+  <exclude name="Generic.ControlStructures.InlineControlStructure.Discouraged" />
+  <exclude name="PEAR.Commenting.FunctionComment.ParameterCommentsNotAligned" />
+  <exclude name="PEAR.Commenting.FunctionComment.MissingParamTag" />
+  <exclude name="PEAR.ControlStructures.ControlSignature" />
+
+  <!-- ident and alignment stuff  -->
+  <!-- exclude name="PEAR.ControlStructures.MultiLineCondition.Alignment" />
+  <exclude name="PEAR.WhiteSpace.ScopeClosingBrace.BreakIdent" / -->
+
+  <!-- allow curly on classes and functions -->
+  <exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine" />
+  <exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine" />
+
+  <exclude name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore" />
+  <exclude name="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
+  <exclude name="PEAR.WhiteSpace.ScopeIndent"/>
+ </rule>
+
+ <rule ref="Zend.Files.ClosingTag" />
+
+ <rule ref="Generic.WhiteSpace.ScopeIndent">
+   <properties>
+     <property name="indent" value="4"/>
+   </properties>
+ </rule>
+
+ <rule ref="Generic.Files.LineLength">
+  <properties>
+   <property name="lineLimit" value="120"/>
+   <property name="absoluteLineLimit" value="160"/>
+  </properties>
+ </rule>
+
+ <!-- Include most of the Squiz standard -->
+ <!-- rule ref="Squiz">
+  <exclude name="Squiz.Classes.ClassFileName"/>
+  <exclude name="Squiz.Classes.ValidClassName"/>
+  <exclude name="Squiz.Commenting.ClassComment"/>
+  <exclude name="Squiz.Commenting.FileComment"/>
+  <exclude name="Squiz.Commenting.FunctionComment"/>
+  <exclude name="Squiz.Commenting.VariableComment"/>
+  <exclude name="Squiz.ControlStructures.SwitchDeclaration"/>
+  <exclude name="Squiz.Files.FileExtension"/>
+  <exclude name="Squiz.NamingConventions.ConstantCase"/>
+  <exclude name="Squiz.Operators.ComparisonOperatorUsage"/>
+</rule -->
+
+ <!-- We allow variables to be used inside double quoted strings -->
+ <!-- rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+  <severity>0</severity>
+ </rule -->
+
+</ruleset>

--- a/build/phpmd.xml
+++ b/build/phpmd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+ <ruleset name="My first PHPMD rule set" xmlns="http://pmd.sf.net/ruleset/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd" xsi:noNamespaceSchemaLocation=" http://pmd.sf.net/ruleset_xml_schema.xsd">
+ <description> My custom rule set that checks my code... </description>
+ <!-- Import the entire unused code rule set -->
+ <rule ref="rulesets/unusedcode.xml" />
+
+ <!-- Import the entire cyclomatic complexity rule -->
+ <rule ref="rulesets/codesize.xml/CyclomaticComplexity" /> 
+</ruleset>


### PR DESCRIPTION
Until now the necessary build files for Jenkins have been maintained on the ci server locally.
I'd like to put them into the repo to get all the stuff together in one place and grant everybody access to these files.

Within the next days I'll migrate the jobs on Jenkins to use these files.

@karlitschek Maybe we shall drop the folder build within your release script - I see no need of these files within a productive installation.

@bartv2 @butonic Can you review this please? THX
