### PR TITLE
Files without defined actions did not trigger a download on click

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -75,8 +75,11 @@ $(document).ready(function() {
 
 	// Sets the file link behaviour :
 	$('td.filename a').live('click',function(event) {
-		event.preventDefault();
+		
 		if (event.ctrlKey || event.shiftKey) {
+			
+			event.preventDefault();
+			
 			if (event.shiftKey) {
 				var last = $(lastChecked).parent().parent().prevAll().length;
 				var first = $(this).parent().parent().prevAll().length;
@@ -118,6 +121,7 @@ $(document).ready(function() {
 				var permissions = $(this).parent().parent().data('permissions');
 				var action=FileActions.getDefault(mime,type, permissions);
 				if(action){
+					event.preventDefault();
 					action(filename);
 				}
 			}


### PR DESCRIPTION
Files without defined app/actions did not trigger a normal file download, but left the link dead.

The culprit was the event.preventDefault() which killed the normal link action even though no action was found for the clicked file.

The shuffled code now suppresses the default link action only when the library has better things planned for the file.
