### PR TITLE
Change post_write hook to write for files_versions app

### DIFF
--- a/apps/files_versions/appinfo/app.php
+++ b/apps/files_versions/appinfo/app.php
@@ -10,7 +10,7 @@ OCP\App::registerPersonal('files_versions', 'settings-personal');
 OCP\Util::addscript('files_versions', 'versions');
 
 // Listen to write signals
-OCP\Util::connectHook('OC_Filesystem', 'post_write', "OCA_Versions\Hooks", "write_hook");
+OCP\Util::connectHook('OC_Filesystem', 'write', "OCA_Versions\Hooks", "write_hook");
 // Listen to delete and rename signals
 OCP\Util::connectHook('OC_Filesystem', 'delete', "OCA_Versions\Hooks", "remove_hook");
 OCP\Util::connectHook('OC_Filesystem', 'rename', "OCA_Versions\Hooks", "rename_hook");


### PR DESCRIPTION
Listening to the post_write hook causes the files_versions app to store a copy of a newly uploaded file. Changing it to write will make the files_versions app only store the copy of a file right before it is changed. So, there won't be any duplicates.

This should also fix some performance problems with files_versions and external storage. The file cache in master is emitting post_write as it scans files, which means that all the files in external storage are being copied and stored as versions. 
