### PR TITLE
fix utf8 filenames in ie download response header according to rfc5987, ...

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -40,7 +40,12 @@ if(!OC_Filesystem::file_exists($filename)) {
 $ftype=OC_Filesystem::getMimeType( $filename );
 
 header('Content-Type:'.$ftype);
-header('Content-Disposition: attachment; filename="'.basename($filename).'"');
+if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
+	header( 'Content-Disposition: attachment; filename="' . rawurlencode( basename($filename) ) . '"' );
+} else {
+	header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode( basename($filename) )
+										 . '; filename="' . rawurlencode( basename($filename) ) . '"' );
+}
 OCP\Response::disableCaching();
 header('Content-Length: '.OC_Filesystem::filesize($filename));
 

--- a/lib/files.php
+++ b/lib/files.php
@@ -184,7 +184,12 @@ class OC_Files {
 		}
 		@ob_end_clean();
 		if($zip or OC_Filesystem::is_readable($filename)) {
-			header('Content-Disposition: attachment; filename="'.basename($filename).'"');
+			if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
+				header( 'Content-Disposition: attachment; filename="' . rawurlencode( basename($filename) ) . '"' );
+			} else {
+				header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode( basename($filename) )
+													 . '; filename="' . rawurlencode( basename($filename) ) . '"' );
+			}
 			header('Content-Transfer-Encoding: binary');
 			OC_Response::disableCaching();
 			if($zip) {


### PR DESCRIPTION
...see http://stackoverflow.com/questions/93551/how-to-encode-the-filename-parameter-of-content-disposition-header-in-http

Backport of #929 to stable45
