### PR TITLE
Fixing default email sender address

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -89,12 +89,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			if ($type === 'dir')
 				$text = (string)$l->t('User %s shared the folder "%s" with you. It is available for download here: %s', array($user, $file, $link));
 
-			// handle localhost installations
-			$server_host = OCP\Util::getServerHost();
-			if ($server_host === 'localhost')
-				$server_host = "example.com";
 
-			$default_from = 'sharing-noreply@' . $server_host;
+			$default_from = OCP\Util::getDefaultEmailAddress('sharing-noreply');
 			$from_address = OCP\Config::getUserValue($user, 'settings', 'email', $default_from );
 
 			// send it out now

--- a/core/lostpassword/controller.php
+++ b/core/lostpassword/controller.php
@@ -43,7 +43,7 @@ class OC_Core_LostPassword_Controller {
 				$tmpl->assign('link', $link, false);
 				$msg = $tmpl->fetchPage();
 				$l = OC_L10N::get('core');
-				$from = 'lostpassword-noreply@' . OCP\Util::getServerHost();
+				$from = OCP\Util::getDefaultEmailAddress('lostpassword-noreply');
 				OC_Mail::send($email, $_POST['user'], $l->t('ownCloud password reset'), $msg, $from, 'ownCloud');
 				echo('Mailsent');
 

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -173,6 +173,42 @@ class Util {
 	}
 
 	/**
+	 * @brief returns the server hostname
+	 * @returns the server hostname
+	 *
+	 * Returns the server host name without an eventual port number
+	 */
+	public static function getServerHostName() {
+		$host_name = self::getServerHost();
+		// strip away port number (if existing)
+		$colon_pos = strpos($host_name, ':');
+		if ($colon_pos != FALSE) {
+			$host_name = substr($host_name, 0, $colon_pos);
+		}
+		return $host_name;
+	}
+
+	/**
+	 * @brief Returns the default email address
+	 * @param $user_part the user part of the address
+	 * @returns the default email address 
+	 *
+	 * Assembles a default email address (using the server hostname
+	 * and the given user part, and returns it
+	 * Example: when given lostpassword-noreply as $user_part param,
+	 *     and is currently accessed via http(s)://example.com/,
+	 *     it would return 'lostpassword-noreply@example.com'
+	 */
+	public static function getDefaultEmailAddress($user_part) {
+		$host_name = self::getServerHostName();
+		// handle localhost installations
+		if ($server_host === 'localhost') {
+			$server_host = "example.com";
+		}
+		return $user_part.'@'.$host_name;
+	}
+
+	/**
 	 * @brief Returns the server protocol
 	 * @returns the server protocol
 	 *


### PR DESCRIPTION
Should fix https://github.com/owncloud/core/issues/927; takes care of both the default addresses used in the share and the lostpassword implementation.
Are there any other places where such a default email address is used?
