### PR TITLE
recursive mkdir

### DIFF
--- a/lib/filestorage/local.php
+++ b/lib/filestorage/local.php
@@ -11,7 +11,7 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 		}
 	}
 	public function mkdir($path) {
-		return @mkdir($this->datadir.$path, 0770);
+		return @mkdir($this->datadir.$path, 0770, true);
 	}
 	public function rmdir($path) {
 		return @rmdir($this->datadir.$path);

--- a/lib/filestorage/local.php
+++ b/lib/filestorage/local.php
@@ -11,7 +11,7 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 		}
 	}
 	public function mkdir($path) {
-		return @mkdir($this->datadir.$path);
+		return @mkdir($this->datadir.$path, 0770);
 	}
 	public function rmdir($path) {
 		return @rmdir($this->datadir.$path);
@@ -105,6 +105,9 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 			}
 			$source=substr($path1, strrpos($path1, '/')+1);
 			$path2.=$source;
+		} else if ( !$this->file_exists($path2) ) {
+			$this->mkdir($path2);
+			
 		}
 		return copy($this->datadir.$path1, $this->datadir.$path2);
 	}

--- a/lib/filestorage/local.php
+++ b/lib/filestorage/local.php
@@ -105,8 +105,8 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 			}
 			$source=substr($path1, strrpos($path1, '/')+1);
 			$path2.=$source;
-		} else if ( !$this->file_exists($path2) ) {
-			$this->mkdir($path2);
+		} else if ( !$this->file_exists(dirname($path2)) ) {
+			$this->mkdir(dirname($path2));
 			
 		}
 		return copy($this->datadir.$path1, $this->datadir.$path2);


### PR DESCRIPTION
mkdir: also create the parent directories if they don't exist.
copy: call mkdir before copy a file to make sure that the directory exists

This patch makes sure that always the complete directory structure exists if we copy a file/directory or create new ones.

@icewind1991, @karlitschek, @blizz or anybody else, please have a look at it. Thanks!
