### PR TITLE
fix the delete all function

### DIFF
--- a/lib/filestorage/common.php
+++ b/lib/filestorage/common.php
@@ -134,17 +134,17 @@ abstract class OC_Filestorage_Common extends OC_Filestorage {
 
 		}
 
-		if ( !$this->file_exists( \OCP\USER::getUser() . '/' . $directory ) || !$this->is_dir( \OCP\USER::getUser() . '/' . $directory ) ) {
+		if ( !$this->file_exists( $directory ) || !$this->is_dir( $directory ) ) {
 
 			return false;
 
-		} elseif( !$this->is_readable( \OCP\USER::getUser() . '/' . $directory ) ) {
+		} elseif( !$this->isReadable( $directory ) ) {
 
 			return false;
 
 		} else {
 
-			$directoryHandle = $this->opendir( \OCP\USER::getUser() . '/' . $directory );
+			$directoryHandle = $this->opendir( $directory );
 
 			while ( $contents = readdir( $directoryHandle ) ) {
 
@@ -154,11 +154,11 @@ abstract class OC_Filestorage_Common extends OC_Filestorage {
 
 					if ( $this->is_dir( $path ) ) {
 
-						deleteAll( $path );
+						$this->deleteAll( $path );
 
 					} else {
 
-						$this->unlink( \OCP\USER::getUser() .'/' . $path ); // TODO: make unlink use same system path as is_dir
+						$this->unlink( $path ); // TODO: make unlink use same system path as is_dir
 
 					}
 				}


### PR DESCRIPTION
This patch fixes issue https://github.com/owncloud/core/issues/754 for the stable45 branch.
(Master will get a new file version handling which will make this function obsolete. )

I fixed some broken function calls and removed the user-id from some paths. I don't know why the previous version added the user-id in front of the given directory? The view already has the correct root directory and the directory given to the function should always be relative to it.

If I didn't miss anything the only app which calls this function is the files_versions app, which work with this patch. Still it would be good if someone with a deep oc_filestorage understanding can have a look at it, maybe @icewind1991,  @blizzz or @MTGap as the author of this class?
