### PR TITLE
Update lib/filecache.php

### DIFF
--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -355,7 +355,7 @@ class OC_FileCache{
 		if($sizeDiff==0) return;
 		$item = OC_FileCache_Cached::get($path);
 		//stop walking up the filetree if we hit a non-folder or reached to root folder
-		if($path == '/' || $path=='' || $item['mimetype'] !== 'httpd/unix-directory') {
+		if($path == '\\' || $path == '/' || $path=='' || $item['mimetype'] !== 'httpd/unix-directory') {
 			return;
 		}
 		$id = $item['id'];

--- a/lib/filecache.php
+++ b/lib/filecache.php
@@ -355,18 +355,19 @@ class OC_FileCache{
 		if($sizeDiff==0) return;
 		$item = OC_FileCache_Cached::get($path);
 		//stop walking up the filetree if we hit a non-folder or reached to root folder
-		if($path == '\\' || $path == '/' || $path=='' || $item['mimetype'] !== 'httpd/unix-directory') {
+                $normalizedPath = OC_Filesystem::normalizePath($path);
+                if($normalizedPath == '/' || $item['mimetype'] !== 'httpd/unix-directory') {
 			return;
 		}
 		$id = $item['id'];
 		while($id!=-1) {//walk up the filetree increasing the size of all parent folders
 			$query=OC_DB::prepare('UPDATE `*PREFIX*fscache` SET `size`=`size`+? WHERE `id`=?');
 			$query->execute(array($sizeDiff, $id));
-			$path=dirname($path);
-			if($path == '' or $path =='/') {
+			$normalizedPath=dirname($normalizedPath);
+			if($normalizedPath == '' or $normalizedPath =='/') {
 				return;
 			}
-			$parent = OC_FileCache_Cached::get($path);
+			$parent = OC_FileCache_Cached::get($normalizedPath);
 			$id = $parent['id'];
 			//stop walking up the filetree if we hit a non-folder
 			if($parent['mimetype'] !== 'httpd/unix-directory') {


### PR DESCRIPTION
increaseSize needs to check for Windows file system root (i.e. '\' backslash)
Fixes upload spinner spinning forever (at least on IIS, owncloud 4.5.4).
Maybe there is an easier/better solution to this?
