### PR TITLE
Enhanced multiSelect

### DIFF
--- a/core/css/multiselect.css
+++ b/core/css/multiselect.css
@@ -9,6 +9,8 @@
  	box-shadow:0 1px 1px #ddd;
  	padding-top:.5em;
  	position:absolute;
+	max-height: 20em;
+	overflow-y: auto;
  	z-index:49;
  }
 

--- a/core/css/multiselect.css
+++ b/core/css/multiselect.css
@@ -5,13 +5,21 @@
  ul.multiselectoptions {
  	background-color:#fff;
  	border:1px solid #ddd;
- 	border-bottom-left-radius:.5em;
- 	border-bottom-right-radius:.5em;
  	border-top:none;
  	box-shadow:0 1px 1px #ddd;
  	padding-top:.5em;
  	position:absolute;
  	z-index:49;
+ }
+
+ ul.multiselectoptions.down {
+ 	border-bottom-left-radius:.5em;
+ 	border-bottom-right-radius:.5em;
+ }
+
+ ul.multiselectoptions.up {
+ 	border-top-left-radius:.5em;
+ 	border-top-right-radius:.5em;
  }
 
  ul.multiselectoptions>li {
@@ -30,11 +38,20 @@
 
  div.multiselect.active {
  	background-color:#fff;
+ 	position:relative;
+ 	z-index:50;
+ }
+
+ div.multiselect.up {
+ 	border-top:0 none;
+ 	border-top-left-radius:0;
+ 	border-top-right-radius:0;
+ }
+
+ div.multiselect.down {
  	border-bottom:none;
  	border-bottom-left-radius:0;
  	border-bottom-right-radius:0;
- 	position:relative;
- 	z-index:50;
  }
 
  div.multiselect>span:first-child {

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -18,6 +18,8 @@
 			'createCallback':false,
 			'createText':false,
 			'singleSelect':false,
+			'selectedFirst':false,
+			'sort':true,
 			'title':this.attr('title'),
 			'checked':[],
 			'labels':[],
@@ -133,6 +135,7 @@
 						}
 						settings.checked.push(value);
 						settings.labels.push(label);
+						$(this).parent().addClass('checked');
 					} else {
 						var index=settings.checked.indexOf(value);
 						element.attr('selected',null);
@@ -142,6 +145,7 @@
 								return;
 							}
 						}
+						$(this).parent().removeClass('checked');
 						settings.checked.splice(index,1);
 						settings.labels.splice(index,1);
 					}
@@ -162,6 +166,9 @@
 				});
 				var li=$('<li></li>');
 				li.append(input).append(label);
+				if(input.is(':checked')) {
+					li.addClass('checked');
+				}
 				return li;
 			}
 			$.each(options,function(index,item){
@@ -169,7 +176,7 @@
 			});
 			button.parent().data('preventHide',false);
 			if(settings.createText){
-				var li=$('<li>+ <em>'+settings.createText+'<em></li>');
+				var li=$('<li class="creator">+ <em>'+settings.createText+'<em></li>');
 				li.click(function(event){
 					li.empty();
 					var input=$('<input class="new">');
@@ -237,20 +244,48 @@
 				});
 				list.append(li);
 			}
+			
+			var doSort = function(list, selector) {
+				var rows = list.find('li'+selector).get();
+
+				if(settings.sort) {
+					rows.sort(function(a, b) {
+						return $(a).text().toUpperCase().localeCompare($(b).text().toUpperCase());
+					});
+				}
+
+				$.each(rows, function(index, row) {
+					list.append(row);
+				});
+			};
+			if(settings.sort && settings.selectedFirst) {
+				doSort(list, '.checked');
+				doSort(list, ':not(.checked)');
+			} else if(settings.sort && !settings.selectedFirst) {
+				doSort(list, '');
+			}
+			list.append(list.find('li.creator'));
 			var pos=button.position();
 			if($(document).height() > (button.offset().top+button.outerHeight() + list.children().length * button.height())
 				|| $(document).height()/2 > pos.top
 			) {
-				list.css('top',pos.top+button.outerHeight()-5);
-				list.css('left',pos.left+3);
-				list.css('width',(button.outerWidth()-2)+'px');
+				list.css({
+					top:pos.top+button.outerHeight()-5,
+					left:pos.left+3,
+					width:(button.outerWidth()-2)+'px',
+					'max-height':($(document).height()-(button.offset().top+button.outerHeight()+10))+'px'
+				});
 				list.addClass('down');
 				button.addClass('down');
 				list.slideDown();
 			} else {
-				list.css('top', pos.top - list.height());
-				list.css('left', pos.left+3);
-				list.css('width',(button.outerWidth()-2)+'px');
+				list.css('max-height', $(document).height()-($(document).height()-(pos.top)+50)+'px');
+				list.css({
+					top:pos.top - list.height(),
+					left:pos.left+3,
+					width:(button.outerWidth()-2)+'px'
+					
+				});
 				list.detach().insertBefore($(this));
 				list.addClass('up');
 				button.addClass('up');

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -238,7 +238,9 @@
 				list.append(li);
 			}
 			var pos=button.position();
-			if($(document).height() > button.offset().top+button.outerHeight() + list.children().length * button.height()) {
+			if($(document).height() > (button.offset().top+button.outerHeight() + list.children().length * button.height())
+				|| $(document).height()/2 > pos.top
+			) {
 				list.css('top',pos.top+button.outerHeight()-5);
 				list.css('left',pos.left+3);
 				list.css('width',(button.outerWidth()-2)+'px');

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -68,12 +68,12 @@
 				if(self.menuDirection === 'down') {
 					button.parent().children('ul').slideUp(400,function() {
 						button.parent().children('ul').remove();
-						button.removeClass('active');
+						button.removeClass('active down');
 					});
 				} else {
 					button.parent().children('ul').fadeOut(400,function() {
 						button.parent().children('ul').remove();
-						button.removeClass('active').removeClass('up');
+						button.removeClass('active up');
 					});
 				}
 				return;
@@ -267,12 +267,12 @@
 				if(self.menuDirection === 'down') {
 					button.parent().children('ul').slideUp(400,function() {
 						button.parent().children('ul').remove();
-						button.removeClass('active').removeClass('down');
+						button.removeClass('active down');
 					});
 				} else {
 					button.parent().children('ul').fadeOut(400,function() {
 						button.parent().children('ul').remove();
-						button.removeClass('active').removeClass('up');
+						button.removeClass('active up');
 					});
 				}
 			}

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -10,7 +10,7 @@
  */
 (function( $ ){
 	var multiSelectId=-1;
-	$.fn.multiSelect=function(options){
+	$.fn.multiSelect=function(options) {
 		multiSelectId++;
 		var settings = {
 			'createCallback':false,
@@ -24,14 +24,14 @@
 			'minWidth': 'default;',
 		};
 		$.extend(settings,options);
-		$.each(this.children(),function(i,option){
+		$.each(this.children(),function(i,option) {
 			// If the option is selected, but not in the checked array, add it.
-			if($(option).attr('selected') && settings.checked.indexOf($(option).val()) == -1){
+			if($(option).attr('selected') && settings.checked.indexOf($(option).val()) === -1) {
 				settings.checked.push($(option).val());
 				settings.labels.push($(option).text().trim());
 			}
 			// If the option is in the checked array but not selected, select it.
-			else if(settings.checked.indexOf($(option).val()) !== -1 && !$(option).attr('selected')){
+			else if(settings.checked.indexOf($(option).val()) !== -1 && !$(option).attr('selected')) {
 				$(option).attr('selected', 'selected');
 				settings.labels.push($(option).text().trim());
 			}
@@ -43,15 +43,14 @@
 		button.selectedItems=[];
 		this.hide();
 		this.before(span);
-		if(settings.minWidth=='default'){
+		if(settings.minWidth=='default') {
 			settings.minWidth=button.width();
 		}
 		button.css('min-width',settings.minWidth);
 		settings.minOuterWidth=button.outerWidth()-2;
 		button.data('settings',settings);
 
-		if(!settings.singleSelect && settings.checked.length>0){
-			//button.children('span').first().text(settings.checked.join(', '));
+		if(!settings.singleSelect && settings.checked.length>0) {
 			button.children('span').first().text(settings.labels.join(', '));
 		} else if(settings.singleSelect) {
 			button.children('span').first().text(this.find(':selected').text());
@@ -62,14 +61,14 @@
 		button.click(function(event){
 			
 			var button=$(this);
-			if(button.parent().children('ul').length>0){
+			if(button.parent().children('ul').length>0) {
 				if(self.menuDirection === 'down') {
-					button.parent().children('ul').slideUp(400,function(){
+					button.parent().children('ul').slideUp(400,function() {
 						button.parent().children('ul').remove();
 						button.removeClass('active');
 					});
 				} else {
-					button.parent().children('ul').fadeOut(400,function(){
+					button.parent().children('ul').fadeOut(400,function() {
 						button.parent().children('ul').remove();
 						button.removeClass('active').removeClass('up');
 					});
@@ -87,7 +86,7 @@
 			var options=$(this).parent().next().children();
 			var list=$('<ul class="multiselectoptions"/>').hide().appendTo($(this).parent());
 			var inputType = settings.singleSelect ? 'radio' : 'checkbox';
-			function createItem(element,checked){
+			function createItem(element, checked){
 				element=$(element);
 				var item=element.val();
 				var id='ms'+multiSelectId+'-option-'+item;
@@ -99,16 +98,22 @@
 				var label=$('<label/>');
 				label.attr('for',id);
 				label.text(element.text() || item);
-				if(settings.checked.indexOf(item)!=-1 || checked){
-					input.attr('checked',true);
+				if(settings.checked.indexOf(item)!=-1 || checked) {
+					input.attr('checked', true);
 				}
 				if(checked){
-					settings.checked.push(item);
+					if(settings.singleSelect) {
+						settings.checked = [item];
+						settings.labels = [item];
+					} else {
+						settings.checked.push(item);
+						settings.labels.push(item);
+					}
 				}
 				input.change(function(){
 					var value = $(this).attr('id').substring(String('ms'+multiSelectId+'-option').length+1);
 					var label = $(this).next().text().trim();
-					if($(this).is(':checked')){
+					if($(this).is(':checked')) {
 						if(settings.singleSelect) {
 							settings.checked = [];
 							settings.labels = [];
@@ -117,19 +122,19 @@
 							});
 						}
 						element.attr('selected','selected');
-						if(typeof settings.oncheck === 'function'){
-							if(settings.oncheck(value)===false){
+						if(typeof settings.oncheck === 'function') {
+							if(settings.oncheck(value)===false) {
 								$(this).attr('checked', false);
 								return;
 							}
 						}
 						settings.checked.push(value);
 						settings.labels.push(label);
-					}else{
+					} else {
 						var index=settings.checked.indexOf(value);
 						element.attr('selected',null);
-						if(typeof settings.onuncheck === 'function'){
-							if(settings.onuncheck(value)===false){
+						if(typeof settings.onuncheck === 'function') {
+							if(settings.onuncheck(value)===false) {
 								$(this).attr('checked',true);
 								return;
 							}
@@ -184,26 +189,34 @@
 							if (exists) {
 								return false;
 							}
+							if(settings.singleSelect) {
+								$.each(select.find('option:selected'), function() {
+									$(this).removeAttr('selected');
+								});
+							}
 							var li=$(this).parent();
 							$(this).remove();
 							li.text('+ '+settings.createText);
-							li.before(createItem(this, true));
+							li.before(createItem(this));
 							if(self.menuDirection === 'up') {
-							var list = li.parent();
+								var list = li.parent();
 								list.css('top', list.position().top-li.outerHeight());
 							}
 							var select=button.parent().next();
 							var option=$('<option selected="selected"/>');
 							select.append(option);
-							option.text($(this).val());
-							li.prev().children('input').trigger('click');
+							option.text($(this).val()).val($(this).val()).attr('selected', 'selected');
+							li.prev().children('input').prop('checked', true).trigger('change');
 							button.parent().data('preventHide',false);
-							if(typeof settings.createCallback === 'function'){
+							button.children('span').first().text(settings.labels.length > 0 
+								? settings.labels.join(', ')
+								: settings.title);
+							if(typeof settings.createCallback === 'function') {
 								settings.createCallback($(this).val());
 							}
 						}
 					});
-					input.blur(function(){
+					input.blur(function() {
 						event.preventDefault();
 						event.stopPropagation();
 						$(this).remove();
@@ -233,20 +246,20 @@
 				list.fadeIn();
 				self.menuDirection = 'up';
 			}
-			list.click(function(event){
+			list.click(function(event) {
 				event.stopPropagation();
 			});
 		});
-		$(window).click(function(){
-			if(!button.parent().data('preventHide')){
+		$(window).click(function() {
+			if(!button.parent().data('preventHide')) {
 				// How can I save the effect in a var?
 				if(self.menuDirection === 'down') {
-					button.parent().children('ul').slideUp(400,function(){
+					button.parent().children('ul').slideUp(400,function() {
 						button.parent().children('ul').remove();
 						button.removeClass('active').removeClass('down');
 					});
 				} else {
-					button.parent().children('ul').fadeOut(400,function(){
+					button.parent().children('ul').fadeOut(400,function() {
 						button.parent().children('ul').remove();
 						button.removeClass('active').removeClass('up');
 					});

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -117,7 +117,7 @@
 							});
 						}
 						element.attr('selected','selected');
-						if(settings.oncheck){
+						if(typeof settings.oncheck === 'function'){
 							if(settings.oncheck(value)===false){
 								$(this).attr('checked', false);
 								return;
@@ -128,7 +128,7 @@
 					}else{
 						var index=settings.checked.indexOf(value);
 						element.attr('selected',null);
-						if(settings.onuncheck){
+						if(typeof settings.onuncheck === 'function'){
 							if(settings.onuncheck(value)===false){
 								$(this).attr('checked',true);
 								return;

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -1,5 +1,7 @@
 /**
- * @param 'createCallback' A function to be called when a new entry is created. Only argument to the function is the value of the option.
+ * @param 'createCallback' A function to be called when a new entry is created. Two arguments are supplied to this function:
+ *	The select element used and the value of the option. If the function returns false addition will be cancelled. If it returns
+ * 	anything else it will be used as the value of the newly added option.
  * @param 'createText' The placeholder text for the create action.
  * @param 'title' The title to show if no options are selected.
  * @param 'checked' An array containing values for options that should be checked. Any options which are already selected will be added to this array.
@@ -23,6 +25,7 @@
 			'onuncheck':false,
 			'minWidth': 'default;',
 		};
+		$(this).attr('data-msid', multiSelectId);
 		$.extend(settings,options);
 		$.each(this.children(),function(i,option) {
 			// If the option is selected, but not in the checked array, add it.
@@ -189,30 +192,36 @@
 							if (exists) {
 								return false;
 							}
+							var li=$(this).parent();
+							var val = $(this).val()
+							var select=button.parent().next();
+							if(typeof settings.createCallback === 'function') {
+								var response = settings.createCallback(select, val);
+								if(response === false) {
+									return false;
+								} else if(typeof response !== 'undefined') {
+									val = response;
+								}
+							}
 							if(settings.singleSelect) {
 								$.each(select.find('option:selected'), function() {
 									$(this).removeAttr('selected');
 								});
 							}
-							var li=$(this).parent();
 							$(this).remove();
 							li.text('+ '+settings.createText);
 							li.before(createItem(this));
-							if(self.menuDirection === 'up') {
-								var list = li.parent();
-								list.css('top', list.position().top-li.outerHeight());
-							}
-							var select=button.parent().next();
 							var option=$('<option selected="selected"/>');
+							option.text($(this).val()).val(val).attr('selected', 'selected');
 							select.append(option);
-							option.text($(this).val()).val($(this).val()).attr('selected', 'selected');
 							li.prev().children('input').prop('checked', true).trigger('change');
 							button.parent().data('preventHide',false);
 							button.children('span').first().text(settings.labels.length > 0 
 								? settings.labels.join(', ')
 								: settings.title);
-							if(typeof settings.createCallback === 'function') {
-								settings.createCallback($(this).val());
+							if(self.menuDirection === 'up') {
+								var list = li.parent();
+								list.css('top', list.position().top-li.outerHeight());
 							}
 						}
 					});

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -178,9 +178,9 @@ var UserList={
 			}else{
 				checkHandeler=false;
 			}
-			var addGroup = function(group) {
+			var addGroup = function(select, group) {
 				$('select[multiple]').each(function(index, element) {
-					if ($(element).find('option[value="'+group +'"]').length == 0) {
+					if ($(element).find('option[value="'+group +'"]').length === 0 && select.data('msid') !== $(element).data('msid')) {
 						$(element).append('<option value="'+group+'">'+group+'</option>');
 					}
 				})

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -193,6 +193,7 @@ var UserList = {
             element.multiSelect({
                 createCallback:addGroup,
                 createText:label,
+                selectedFirst:true,
                 checked:checked,
                 oncheck:checkHandeler,
                 onuncheck:checkHandeler,

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -177,9 +177,9 @@ var UserList = {
             } else {
                 checkHandeler = false;
             }
-            var addGroup = function (group) {
+            var addGroup = function (select, group) {
                 $('select[multiple]').each(function (index, element) {
-                    if ($(element).find('option[value="' + group + '"]').length == 0) {
+                    if ($(element).find('option[value="' + group + '"]').length === 0 && select.data('msid') !== $(element).data('msid')) {
                         $(element).append('<option value="' + group + '">' + group + '</option>');
                     }
                 })


### PR DESCRIPTION
I couldn't rebase #693 so here's the updated version

Some enhancements to the multiSelect jquery widget as used in settings/users. Refs owncloud/apps#244 and #971

Changes from original:
- Previously only used the underlying options values, not the text.
- Can now be used as singleSelect like Eric Hynds jquery.multiselect
- If there's not enough room in the viewport the widget will pop up instead of drop down.
- Uses both items in the checked array argument and sets those as selected, and adds items to the checked array that are selected.

And in this version:
- Added sort and having selected items first options.
- Made max-height dynamic instead of hardcoded to 20em.
- Don't try to show the dropdown above button if there's less space than below.

/cc @jancborchardt @icewind1991
