### PR TITLE
Backport: Do the url encoding once, only in breadcrumbs template

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -25,7 +25,7 @@ if($doBreadcrumb) {
 	}
 
 	$breadcrumbNav = new OCP\Template( "files", "part.breadcrumb", "" );
-	$breadcrumbNav->assign( "breadcrumb", $breadcrumb );
+	$breadcrumbNav->assign( "breadcrumb", $breadcrumb, false );
 
 	$data['breadcrumb'] = $breadcrumbNav->fetchPage();
 }

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -36,7 +36,7 @@ if(!isset($_SESSION['timezone'])) {
 }
 OCP\App::setActiveNavigationEntry( 'files_index' );
 // Load the files
-$dir = isset( $_GET['dir'] ) ? urldecode(stripslashes($_GET['dir'])) : '';
+$dir = isset( $_GET['dir'] ) ? stripslashes($_GET['dir']) : '';
 // Redirect if directory does not exist
 if(!OC_Filesystem::is_dir($dir.'/')) {
 	header('Location: '.$_SERVER['SCRIPT_NAME'].'');
@@ -67,7 +67,7 @@ $breadcrumb = array();
 $pathtohere = '';
 foreach( explode( '/', $dir ) as $i ) {
 	if( $i != '' ) {
-		$pathtohere .= '/'.str_replace('+','%20', urlencode($i));
+		$pathtohere .= '/'.$i;
 		$breadcrumb[] = array( 'dir' => $pathtohere, 'name' => $i );
 	}
 }

--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,6 +1,7 @@
 	<?php for($i=0; $i<count($_["breadcrumb"]); $i++):
-        $crumb = $_["breadcrumb"][$i]; ?>
-		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg" data-dir='<?php echo urlencode($crumb["dir"]);?>' style='background-image:url("<?php echo OCP\image_path('core','breadcrumb.png');?>")'>
-		<a href="<?php echo $_['baseURL'].urlencode($crumb["dir"]); ?>"><?php echo OCP\Util::sanitizeHTML($crumb["name"]); ?></a>
+	$crumb = $_["breadcrumb"][$i];
+	$dir = str_replace('+','%20', urlencode($crumb["dir"])); ?>
+		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg" data-dir='<?php echo $dir;?>' style='background-image:url("<?php echo OCP\image_path('core', 'breadcrumb.png');?>")'>
+		<a href="<?php echo $_['baseURL'].$dir; ?>"><?php echo OCP\Util::sanitizeHTML($crumb["name"]); ?></a>
 		</div>
 	<?php endfor;?>


### PR DESCRIPTION
fixes issue #438

Conflicts:
    apps/files/index.php
    apps/files/templates/part.breadcrumb.php
