### PR TITLE
Add $fileData to search result and 'data-dir' to each file item

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -1,192 +1,203 @@
 var FileActions = {
-	actions: {},
-	defaults: {},
-	icons: {},
-	currentFile: null,
-	register: function (mime, name, permissions, icon, action) {
-		if (!FileActions.actions[mime]) {
-			FileActions.actions[mime] = {};
-		}
-		if (!FileActions.actions[mime][name]) {
-			FileActions.actions[mime][name] = {};
-		}
-		FileActions.actions[mime][name]['action'] = action;
-		FileActions.actions[mime][name]['permissions'] = permissions;
-		FileActions.icons[name] = icon;
-	},
-	setDefault: function (mime, name) {
-		FileActions.defaults[mime] = name;
-	},
-	get: function (mime, type, permissions) {
-		var actions = {};
-		if (FileActions.actions.all) {
-			actions = $.extend(actions, FileActions.actions.all);
-		}
-		if (mime) {
-			if (FileActions.actions[mime]) {
-				actions = $.extend(actions, FileActions.actions[mime]);
-			}
-			var mimePart = mime.substr(0, mime.indexOf('/'));
-			if (FileActions.actions[mimePart]) {
-				actions = $.extend(actions, FileActions.actions[mimePart]);
-			}
-		}
-		if (type) {//type is 'dir' or 'file'
-			if (FileActions.actions[type]) {
-				actions = $.extend(actions, FileActions.actions[type]);
-			}
-		}
-		var filteredActions = {};
-		$.each(actions, function (name, action) {
-			if (action.permissions & permissions) {
-				filteredActions[name] = action.action;
-			}
-		});
-		return filteredActions;
-	},
-	getDefault: function (mime, type, permissions) {
-		if (mime) {
-			var mimePart = mime.substr(0, mime.indexOf('/'));
-		}
-		var name = false;
-		if (mime && FileActions.defaults[mime]) {
-			name = FileActions.defaults[mime];
-		} else if (mime && FileActions.defaults[mimePart]) {
-			name = FileActions.defaults[mimePart];
-		} else if (type && FileActions.defaults[type]) {
-			name = FileActions.defaults[type];
-		} else {
-			name = FileActions.defaults.all;
-		}
-		var actions = this.get(mime, type, permissions);
-		return actions[name];
-	},
-	display: function (parent) {
-		FileActions.currentFile = parent;
-		var actions = FileActions.get(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
-		var file = FileActions.getCurrentFile();
-		if ($('tr').filterAttr('data-file', file).data('renaming')) {
-			return;
-		}
-		parent.children('a.name').append('<span class="fileactions" />');
-		var defaultAction = FileActions.getDefault(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
+    actions: {},
+    defaults: {},
+    icons: {},
+    currentFile: null,
+    register: function (mime, name, permissions, icon, action) {
+        if (!FileActions.actions[mime]) {
+            FileActions.actions[mime] = {};
+        }
+        if (!FileActions.actions[mime][name]) {
+            FileActions.actions[mime][name] = {};
+        }
+        FileActions.actions[mime][name]['action'] = action;
+        FileActions.actions[mime][name]['permissions'] = permissions;
+        FileActions.icons[name] = icon;
+    },
+    setDefault: function (mime, name) {
+        FileActions.defaults[mime] = name;
+    },
+    get: function (mime, type, permissions) {
+        var actions = {};
+        if (FileActions.actions.all) {
+            actions = $.extend(actions, FileActions.actions.all);
+        }
+        if (mime) {
+            if (FileActions.actions[mime]) {
+                actions = $.extend(actions, FileActions.actions[mime]);
+            }
+            var mimePart = mime.substr(0, mime.indexOf('/'));
+            if (FileActions.actions[mimePart]) {
+                actions = $.extend(actions, FileActions.actions[mimePart]);
+            }
+        }
+        if (type) {//type is 'dir' or 'file'
+            if (FileActions.actions[type]) {
+                actions = $.extend(actions, FileActions.actions[type]);
+            }
+        }
+        var filteredActions = {};
+        $.each(actions, function (name, action) {
+            if (action.permissions & permissions) {
+                filteredActions[name] = action.action;
+            }
+        });
+        return filteredActions;
+    },
+    getDefault: function (mime, type, permissions) {
+        if (mime) {
+            var mimePart = mime.substr(0, mime.indexOf('/'));
+        }
+        var name = false;
+        if (mime && FileActions.defaults[mime]) {
+            name = FileActions.defaults[mime];
+        } else if (mime && FileActions.defaults[mimePart]) {
+            name = FileActions.defaults[mimePart];
+        } else if (type && FileActions.defaults[type]) {
+            name = FileActions.defaults[type];
+        } else {
+            name = FileActions.defaults.all;
+        }
+        var actions = this.get(mime, type, permissions);
+        return actions[name];
+    },
+    display: function (parent) {
+        FileActions.currentFile = parent;
+        var actions = FileActions.get(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
+        var file = FileActions.getCurrentFile();
+        if ($('tr').filterAttr('data-file', file).data('renaming')) {
+            return;
+        }
+        parent.children('a.name').append('<span class="fileactions" />');
+        var defaultAction = FileActions.getDefault(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
 		
-		var actionHandler = function (event) {
-			event.stopPropagation();
-			event.preventDefault();
+        var actionHandler = function (event) {
+            event.stopPropagation();
+            event.preventDefault();
 
-			FileActions.currentFile = event.data.elem;
-			var file = FileActions.getCurrentFile();
+            FileActions.currentFile = event.data.elem;
+            var file = FileActions.getCurrentFile();
 			
-			event.data.actionFunc(file);
-		};
+            event.data.actionFunc(file);
+        };
 		
-		$.each(actions, function (name, action) {
-			// NOTE: Temporary fix to prevent rename action in root of Shared directory
-			if (name === 'Rename' && $('#dir').val() === '/Shared') {
-				return true;
-			}
+        $.each(actions, function (name, action) {
+            // NOTE: Temporary fix to prevent rename action in root of Shared directory
+            if (name === 'Rename' && FileActions.getCurrentDir() === '/Shared') {
+                return true;
+            }
 			
-			if ((name === 'Download' || action !== defaultAction) && name !== 'Delete') {
-				var img = FileActions.icons[name];
-				if (img.call) {
-					img = img(file);
-				}
-				var html = '<a href="#" class="action" data-action="'+name+'">';
-				if (img) {
-					html += '<img class ="svg" src="' + img + '" /> ';
-				}
-				html += t('files', name) + '</a>';
+            if ((name === 'Download' || action !== defaultAction) && name !== 'Delete') {
+                var img = FileActions.icons[name];
+                if (img.call) {
+                    img = img(file);
+                }
+                var html = '<a href="#" class="action" data-action="'+name+'">';
+                if (img) {
+                    html += '<img class ="svg" src="' + img + '" /> ';
+                }
+                html += t('files', name) + '</a>';
 				
-				var element = $(html);
-				element.data('action', name);
-				//alert(element);
-				element.on('click',{a:null, elem:parent, actionFunc:actions[name]},actionHandler);
-				parent.find('a.name>span.fileactions').append(element);
-			}
+                var element = $(html);
+                element.data('action', name);
+                //alert(element);
+                element.on('click',{
+                    a:null, 
+                    elem:parent, 
+                    actionFunc:actions[name]
+                    },actionHandler);
+                parent.find('a.name>span.fileactions').append(element);
+            }
 			
-		});
+        });
 		
-		if (actions['Delete']) {
-			var img = FileActions.icons['Delete'];
-			if (img.call) {
-				img = img(file);
-			}
-			// NOTE: Temporary fix to allow unsharing of files in root of Shared folder
-			if ($('#dir').val() == '/Shared') {
-				var html = '<a href="#" original-title="' + t('files', 'Unshare') + '" class="action delete" />';
-			} else {
-				var html = '<a href="#" original-title="' + t('files', 'Delete') + '" class="action delete" />';
-			}
-			var element = $(html);
-			if (img) {
-				element.append($('<img class ="svg" src="' + img + '"/>'));
-			}
-			element.data('action', actions['Delete']);
-			element.on('click',{a:null, elem:parent, actionFunc:actions['Delete']},actionHandler);
-			parent.parent().children().last().append(element);
-		}
-	},
-	getCurrentFile: function () {
-		return FileActions.currentFile.parent().attr('data-file');
-	},
-	getCurrentMimeType: function () {
-		return FileActions.currentFile.parent().attr('data-mime');
-	},
-	getCurrentType: function () {
-		return FileActions.currentFile.parent().attr('data-type');
-	},
-	getCurrentPermissions: function () {
-		return FileActions.currentFile.parent().data('permissions');
-	}
+        if (actions['Delete']) {
+            var img = FileActions.icons['Delete'];
+            if (img.call) {
+                img = img(file);
+            }
+            // NOTE: Temporary fix to allow unsharing of files in root of Shared folder
+            if (FileActions.getCurrentDir() == '/Shared') {
+                var html = '<a href="#" original-title="' + t('files', 'Unshare') + '" class="action delete" />';
+            } else {
+                var html = '<a href="#" original-title="' + t('files', 'Delete') + '" class="action delete" />';
+            }
+            var element = $(html);
+            if (img) {
+                element.append($('<img class ="svg" src="' + img + '"/>'));
+            }
+            element.data('action', actions['Delete']);
+            element.on('click',{
+                a:null, 
+                elem:parent, 
+                actionFunc:actions['Delete']
+                },actionHandler);
+            parent.parent().children().last().append(element);
+        }
+    },
+    getCurrentFile: function () {
+        return FileActions.currentFile.parent().attr('data-file');
+    },
+    getCurrentMimeType: function () {
+        return FileActions.currentFile.parent().attr('data-mime');
+    },
+    getCurrentType: function () {
+        return FileActions.currentFile.parent().attr('data-type');
+    },
+    getCurrentPermissions: function () {
+        return FileActions.currentFile.parent().data('permissions');
+    },
+    getCurrentDir: function() {
+        return FileActions.currentFile.parent().attr('data-dir');
+    }
 };
 
 $(document).ready(function () {
-	if ($('#allowZipDownload').val() == 1) {
-		var downloadScope = 'all';
-	} else {
-		var downloadScope = 'file';
-	}
-	FileActions.register(downloadScope, 'Download', OC.PERMISSION_READ, function () {
-		return OC.imagePath('core', 'actions/download');
-	}, function (filename) {
-		window.location = OC.filePath('files', 'ajax', 'download.php') + '?files=' + encodeURIComponent(filename) + '&dir=' + encodeURIComponent($('#dir').val());
-	});
+    if ($('#allowZipDownload').val() == 1) {
+        var downloadScope = 'all';
+    } else {
+        var downloadScope = 'file';
+    }
+    FileActions.register(downloadScope, 'Download', OC.PERMISSION_READ, function () {
+        return OC.imagePath('core', 'actions/download');
+    }, function (filename) {
+        window.location = OC.filePath('files', 'ajax', 'download.php') + '?files=' + encodeURIComponent(filename) + '&dir=' + encodeURIComponent(FileActions.getCurrentDir());
+    });
 
-	$('#fileList tr').each(function(){
-		FileActions.display($(this).children('td.filename'));
-	});
+    $('#fileList tr').each(function(){
+        FileActions.display($(this).children('td.filename'));
+    });
 });
 
 FileActions.register('all', 'Delete', OC.PERMISSION_DELETE, function () {
-	return OC.imagePath('core', 'actions/delete');
+    return OC.imagePath('core', 'actions/delete');
 }, function (filename) {
-	if (Files.cancelUpload(filename)) {
-		if (filename.substr) {
-			filename = [filename];
-		}
-		$.each(filename, function (index, file) {
-			var filename = $('tr').filterAttr('data-file', file);
-			filename.hide();
-			filename.find('input[type="checkbox"]').removeAttr('checked');
-			filename.removeClass('selected');
-		});
-		procesSelection();
-	} else {
-		FileList.do_delete(filename);
-	}
-	$('.tipsy').remove();
+    if (Files.cancelUpload(filename)) {
+        if (filename.substr) {
+            filename = [filename];
+        }
+        $.each(filename, function (index, file) {
+            var filename = $('tr').filterAttr('data-file', file);
+            filename.hide();
+            filename.find('input[type="checkbox"]').removeAttr('checked');
+            filename.removeClass('selected');
+        });
+        procesSelection();
+    } else {
+        FileList.do_delete(filename);
+    }
+    $('.tipsy').remove();
 });
 
 // t('files', 'Rename')
 FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
-	return OC.imagePath('core', 'actions/rename');
+    return OC.imagePath('core', 'actions/rename');
 }, function (filename) {
-	FileList.rename(filename);
+    FileList.rename(filename);
 });
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent($('#dir').val()).replace(/%2F/g, '/') + '/' + encodeURIComponent(filename);
+    window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent(FileActions.getCurrentDir()).replace(/%2F/g, '/') + '/' + encodeURIComponent(filename);
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -15,7 +15,7 @@ var FileList={
 			extension=false;
 		}
 		html+='<td class="filename" style="background-image:url('+img+')"><input type="checkbox" />';
-		html+='<a class="name" href="download.php?file='+$('#dir').val().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
+		html+='<a class="name" href="download.php?file='+FileActions.getCurrentDir().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
 		if(extension){
 			html+='<span class="extension">'+escapeHTML(extension)+'</span>';
 		}
@@ -48,7 +48,7 @@ var FileList={
 		html = $('<tr></tr>').attr({ "data-type": "dir", "data-size": size, "data-file": name, "data-permissions": $('#permissions').val()});
 		td = $('<td></td>').attr({"class": "filename", "style": 'background-image:url('+OC.imagePath('core', 'filetypes/folder.png')+')' });
 		td.append('<input type="checkbox" />');
-		link_elem = $('<a></a>').attr({ "class": "name", "href": OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent($('#dir').val()+'/'+name).replace(/%2F/g, '/') });
+		link_elem = $('<a></a>').attr({ "class": "name", "href": OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent(FileActions.getCurrentDir()+'/'+name).replace(/%2F/g, '/') });
 		link_elem.append($('<span></span>').addClass('nametext').text(name));
 		link_elem.append($('<span></span>').attr({'class': 'uploadtext', 'currentUploads': 0}));
 		td.append(link_elem);
@@ -156,7 +156,7 @@ var FileList={
 				if (FileList.checkName(name, newname, false)) {
 					newname = name;
 				} else {
-					$.get(OC.filePath('files','ajax','rename.php'), { dir : $('#dir').val(), newname: newname, file: name },function(result) {
+					$.get(OC.filePath('files','ajax','rename.php'), { dir : FileActions.getCurrentDir(), newname: newname, file: name },function(result) {
 						if (!result || result.status == 'error') {
 							OC.dialogs.alert(result.data.message, 'Error moving file');
 							newname = name;
@@ -253,7 +253,7 @@ var FileList={
 	},
 	finishReplace:function() {
 		if (!FileList.replaceCanceled && FileList.replaceOldName && FileList.replaceNewName) {
-			$.ajax({url: OC.filePath('files', 'ajax', 'rename.php'), async: false, data: { dir: $('#dir').val(), newname: FileList.replaceNewName, file: FileList.replaceOldName }, success: function(result) {
+			$.ajax({url: OC.filePath('files', 'ajax', 'rename.php'), async: false, data: { dir: FileActions.getCurrentDir(), newname: FileList.replaceNewName, file: FileList.replaceOldName }, success: function(result) {
 				if (result && result.status == 'success') {
 					$('tr').filterAttr('data-replace', 'true').removeAttr('data-replace');
 				} else {
@@ -278,7 +278,7 @@ var FileList={
 			FileList.lastAction();
 		} else {
 			// NOTE: Temporary fix to change the text to unshared for files in root of Shared folder
-			if ($('#dir').val() == '/Shared') {
+			if (FileActions.getCurrentDir() == '/Shared') {
 				$('#notification').html(t('files', 'unshared {files}', {'files': escapeHTML(files)})+'<span class="undo">'+t('files', 'undo')+'</span>');
 			} else {
 				$('#notification').html(t('files', 'deleted {files}', {'files': escapeHTML(files)})+'<span class="undo">'+t('files', 'undo')+'</span>');
@@ -293,7 +293,7 @@ var FileList={
 				url: OC.filePath('files', 'ajax', 'delete.php'),
 				async:!sync,
 				type:'post',
-				data: {dir:$('#dir').val(),files:fileNames},
+				data: {dir:FileActions.getCurrentDir(),files:fileNames},
 				complete: function(data){
 					boolOperationFinished(data, function(){
 						$('#notification').fadeOut('400');

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -170,7 +170,7 @@ $(document).ready(function() {
 
 	$('.download').click('click',function(event) {
 		var files=getSelectedFiles('name').join(';');
-		var dir=$('#dir').val()||'/';
+		var dir=FileActions.getCurrentDir()||'/';
 		$('#notification').text(t('files','generating ZIP-file, it may take some time.'));
 		$('#notification').fadeIn();
 		// use special download URL if provided, e.g. for public shared files
@@ -511,7 +511,7 @@ $(document).ready(function() {
 		input.change(function(){
 			if (type != 'web' && Files.containsInvalidCharacters($(this).val())) {
 				return;
-			} else if( type == 'folder' && $('#dir').val() == '/' && $(this).val() == 'Shared') {
+			} else if( type == 'folder' && FileActions.getCurrentDir() == '/' && $(this).val() == 'Shared') {
 				$('#notification').text(t('files','Invalid folder name. Usage of "Shared" is reserved by Owncloud'));
 				$('#notification').fadeIn();
 				return;
@@ -530,7 +530,7 @@ $(document).ready(function() {
 				case 'file':
 					$.post(
 						OC.filePath('files','ajax','newfile.php'),
-						{dir:$('#dir').val(),filename:name},
+						{dir:FileActions.getCurrentDir(),filename:name},
 						function(result){
 							if (result.status == 'success') {
 								var date=new Date();
@@ -550,7 +550,7 @@ $(document).ready(function() {
 				case 'folder':
 					$.post(
 						OC.filePath('files','ajax','newfolder.php'),
-						{dir:$('#dir').val(),foldername:name},
+						{dir:FileActions.getCurrentDir(),foldername:name},
 						function(result){
 							if (result.status == 'success') {
 								var date=new Date();
@@ -580,7 +580,7 @@ $(document).ready(function() {
 					$('#uploadprogressbar').progressbar({value:0});
 					$('#uploadprogressbar').fadeIn();
 
-					var eventSource=new OC.EventSource(OC.filePath('files','ajax','newfile.php'),{dir:$('#dir').val(),source:name,filename:localName});
+					var eventSource=new OC.EventSource(OC.filePath('files','ajax','newfile.php'),{dir:FileActions.getCurrentDir(),source:name,filename:localName});
 					eventSource.listen('progress',function(progress){
 						$('#uploadprogressbar').progressbar('value',progress);
 					});
@@ -734,7 +734,7 @@ var folderDropOptions={
 	drop: function( event, ui ) {
 		var file=ui.draggable.parent().data('file');
 		var target=$(this).find('.nametext').text().trim();
-		var dir=$('#dir').val();
+		var dir=FileActions.getCurrentDir();
 		$.ajax({
 			url: OC.filePath('files', 'ajax', 'move.php'),
 			data: "dir="+encodeURIComponent(dir)+"&file="+encodeURIComponent(file)+'&target='+encodeURIComponent(dir)+'/'+encodeURIComponent(target),
@@ -750,7 +750,7 @@ var crumbDropOptions={
 	drop: function( event, ui ) {
 		var file=ui.draggable.parent().data('file');
 		var target=$(this).data('dir');
-		var dir=$('#dir').val();
+		var dir=FileActions.getCurrentDir();
 		while(dir.substr(0,1)=='/'){//remove extra leading /'s
 				dir=dir.substr(1);
 		}

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -29,7 +29,7 @@
 					<input type="hidden" name="requesttoken" value="<?php echo $_['requesttoken'] ?>" id="requesttoken">
 					<input type="hidden" class="max_human_file_size"
 						   value="(max <?php echo $_['uploadMaxHumanFilesize']; ?>)">
-					<input type="hidden" name="dir" value="<?php echo $_['dir'] ?>" id="dir">
+					<input type="hidden" name="dir" value="<?php echo $_['dir'] ?>" id="dir"> <!-- use of $('#dir').val() should be deprecated; use FileActions.getCurrentDir() instead. -->
 					<input type="file" id="file_upload_start" name='files[]'/>
 					<a href="#" class="svg" onclick="return false;"
 					   title="<?php echo $l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize'] ?>"></a>

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -21,6 +21,7 @@
 			$directory = str_replace('%2F', '/', $directory); ?>
 			<tr data-id="<?php echo $file['id']; ?>"
 				data-file="<?php echo $name;?>"
+                                data-dir="<?php echo $directory;?>"
 				data-type="<?php echo ($file['type'] == 'dir')?'dir':'file'?>"
 				data-mime="<?php echo $file['mimetype']?>"
 				data-size='<?php echo $file['size'];?>'

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -3,10 +3,10 @@ $(document).ready(function() {
 	if (typeof OC.Share !== 'undefined' && typeof FileActions !== 'undefined'  && !publicListView) {
 		
 		FileActions.register('all', 'Share', OC.PERMISSION_READ, OC.imagePath('core', 'actions/share'), function(filename) {
-			if ($('#dir').val() == '/') {
-				var item = $('#dir').val() + filename;
+			if (FileActions.getCurrentDir() == '/') {
+				var item = FileActions.getCurrentDir() + filename;
 			} else {
-				var item = $('#dir').val() + '/' + filename;
+				var item = FileActions.getCurrentDir() + '/' + filename;
 			}
 			var tr = $('tr').filterAttr('data-file', filename);
 			if ($(tr).data('type') == 'dir') {

--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -23,7 +23,7 @@ $(document).ready(function(){
 				// Action to perform when clicked
 				if (scanFiles.scanning){return;}//workaround to prevent additional http request block scanning feedback
 
-				var file = $('#dir').val()+'/'+filename;
+				var file = FileActions.getCurrentDir()+'/'+filename;
 				// Check if drop down is already visible for a different file
 				if (($('#dropdown').length > 0) && $('#dropdown').hasClass('drop-versions') ) {
 					if (file != $('#dropdown').data('file')) {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -74,7 +74,7 @@ function escapeHTML(s) {
 /**
 * Get the path to download a file
 * @param file The filename
-* @param dir The directory the file is in - e.g. $('#dir').val()
+* @param dir The directory the file is in - e.g. FileActions.getCurrentDir()
 * @return string
 */
 function fileDownloadPath(dir, file) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -25,7 +25,7 @@ OC.Share={
 						if (file.length > 0) {
 							$(file).find('.fileactions .action').filterAttr('data-action', 'Share').find('img').attr('src', image);
 						}
-						var dir = $('#dir').val();
+						var dir = FileActions.getCurrentDir();
 						if (dir.length > 1) {
 							var last = '';
 							var path = dir;
@@ -49,10 +49,10 @@ OC.Share={
 	updateIcon:function(itemType, itemSource) {
 		if (itemType == 'file' || itemType == 'folder') {
 			var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
-			if ($('#dir').val() == '/') {
-				itemSource = $('#dir').val() + filename;
+			if (FileActions.getCurrentDir() == '/') {
+				itemSource = FileActions.getCurrentDir() + filename;
 			} else {
-				itemSource = $('#dir').val() + '/' + filename;
+				itemSource = FileActions.getCurrentDir() + '/' + filename;
 			}
 		}
 		var shares = false;
@@ -88,10 +88,10 @@ OC.Share={
 		// Switch file sources to path to check if status is set
 		if (itemType == 'file' || itemType == 'folder') {
 			var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
-			if ($('#dir').val() == '/') {
-				var item = $('#dir').val() + filename;
+			if (FileActions.getCurrentDir() == '/') {
+				var item = FileActions.getCurrentDir() + filename;
 			} else {
-				var item = $('#dir').val() + '/' + filename;
+				var item = FileActions.getCurrentDir() + '/' + filename;
 			}
 			if (item.substring(0, 8) != '/Shared/') {
 				checkReshare = false;
@@ -334,10 +334,10 @@ OC.Share={
 			//fallback to pre token link
 			var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
 			var type = $('tr').filterAttr('data-id', String(itemSource)).data('type');
-			if ($('#dir').val() == '/') {
-				var file = $('#dir').val() + filename;
+			if (FileActions.getCurrentDir() == '/') {
+				var file = FileActions.getCurrentDir() + filename;
 			} else {
-				var file = $('#dir').val() + '/' + filename;
+				var file = FileActions.getCurrentDir() + '/' + filename;
 			}
 			file = '/'+OC.currentUser+'/files'+file;
 			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&'+type+'='+encodeURIComponent(file);

--- a/lib/search/provider.php
+++ b/lib/search/provider.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * provides search functionalty
+ * Provides search functionalty.
  */
 abstract class OC_Search_Provider {
 	private $options;
-
+        
+        /**
+         * Constructor
+         * @param array $options currently unused
+         */
 	public function __construct($options) {
 		$this->options=$options;
 	}
 
 	/**
-	 * search for $query
+	 * Search for $query
 	 * @param string $query
 	 * @return array An array of OC_Search_Result's
 	 */

--- a/lib/search/provider/file.php
+++ b/lib/search/provider/file.php
@@ -1,6 +1,16 @@
 <?php
-
+/**
+ * A search provider that queries only file names.
+ */
 class OC_Search_Provider_File extends OC_Search_Provider{
+    
+        /**
+         * Search through the database and return files with names that match
+         * the query; additionally, classify the results by type (e.g. image,
+         * text, etc.)
+         * @param string $query
+         * @return OC_Search_Result
+         */
 	function search($query) {
 		$files=OC_FileCache::search($query, true);
 		$results=array();
@@ -8,7 +18,6 @@ class OC_Search_Provider_File extends OC_Search_Provider{
 		foreach($files as $fileData) {
 			$path = $fileData['path'];
 			$mime = $fileData['mimetype'];
-
 			$name = basename($path);
 			$text = '';
 			$skip = false;
@@ -37,7 +46,7 @@ class OC_Search_Provider_File extends OC_Search_Provider{
 				}
 			}
 			if(!$skip) {
-				$results[] = new OC_Search_Result($name, $text, $link, $type);
+				$results[] = new OC_Search_Result($name, $text, $link, $type, $fileData);
 			}
 		}
 		return $results;

--- a/lib/search/result.php
+++ b/lib/search/result.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * a result of a search
+ * A result of a search.
  */
 class OC_Search_Result{
 	public $name;
@@ -9,16 +9,18 @@ class OC_Search_Result{
 	public $type;
 
 	/**
-	 * create a new search result
+	 * Create a new search result
 	 * @param string $name short name for the result
 	 * @param string $text some more information about the result
 	 * @param string $link link for the result
 	 * @param string $type the type of result as human readable string ('File', 'Music', etc)
+         * @param array $fileData detailed properties of the file in question (e.g. path, ctime, mtime, etc.)
 	 */
-	public function __construct($name, $text, $link, $type) {
+	public function __construct($name, $text, $link, $type, $fileData=null) {
 		$this->name=$name;
 		$this->text=$text;
 		$this->link=$link;
 		$this->type=$type;
+                $this->fileData=$fileData;
 	}
 }


### PR DESCRIPTION
These improvments/changes are needed to allow an application like Advanced Search to work. The second commit will be a bit more controversial because it would break a hidde input tag used to determine the directory in a file list; I think the change is good because it abstracts this away with a FileActions function and gives each file item its own 'data-dir' attribute. My main concern is that this would affect other apps.
