### PR TITLE
add reverse proxy support

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -32,12 +32,14 @@ OC_Util::obEnd();
 // Backends
 $authBackend = new OC_Connector_Sabre_Auth();
 $lockBackend = new OC_Connector_Sabre_Locks();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Create ownCloud Dir
 $publicDir = new OC_Connector_Sabre_Directory('');
 
 // Fire up server
 $server = new Sabre_DAV_Server($publicDir);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri($baseuri);
 
 // Load plugins

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -38,7 +38,7 @@ OCP\App::setActiveNavigationEntry('files_index');
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 // Redirect if directory does not exist
 if (!OC_Filesystem::is_dir($dir . '/')) {
-    header('Location: ' . $_SERVER['SCRIPT_NAME'] . '');
+    header('Location: ' . OC_Request::scriptName() . '');
     exit();
 }
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -36,6 +36,15 @@ $CONFIG = array(
 /* The automatic protocol detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the protocol detection. For example "https" */
 "overwriteprotocol" => "",
 
+/* Host name of a (intransparent) reverse proxies */
+"reverseproxyhost" => "",
+
+/* Optinal prefix for the SCRIPT_NAME and REQUEST_URI of a (intransparent) reverse proxy*/
+"reverseproxyprefix" => "",
+
+/* Optinal prefix for the SCRIPT_NAME and REQUEST_URI of a (intransparent) reverse SSL proxy */
+"reverseproxyprefixssl" => "",
+
 /* Enhanced auth forces users to enter their password again when performing potential sensitive actions like creating or deleting users */
 "enhancedauth" => true,
 

--- a/lib/app.php
+++ b/lib/app.php
@@ -481,7 +481,7 @@ class OC_App{
 	 * @return string
 	 */
 	public static function getCurrentApp() {
-		$script=substr($_SERVER["SCRIPT_NAME"], strlen(OC::$WEBROOT)+1);
+		$script=substr(OC_Request::scriptName(), strlen(OC::$WEBROOT)+1);
 		$topFolder=substr($script, 0, strpos($script, '/'));
 		if (empty($topFolder)) {
 			$path_info = OC_Request::getPathInfo();

--- a/lib/base.php
+++ b/lib/base.php
@@ -120,7 +120,7 @@ class OC
         // calculate the root directories
         OC::$SERVERROOT = str_replace("\\", '/', substr(__DIR__, 0, -4));
         OC::$SUBURI = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen(OC::$SERVERROOT)));
-        $scriptName = $_SERVER["SCRIPT_NAME"];
+        $scriptName = OC_Request::scriptName();
         if (substr($scriptName, -1) == '/') {
             $scriptName .= 'index.php';
             //make sure suburi follows the same rules as scriptName
@@ -212,7 +212,12 @@ class OC
             header('Strict-Transport-Security: max-age=31536000');
             ini_set("session.cookie_secure", "on");
             if (OC_Request::serverProtocol() <> 'https' and !OC::$CLI) {
-                $url = "https://" . OC_Request::serverHost() . $_SERVER['REQUEST_URI'];
+                if (OC_Config::getValue('reverseproxyhost', '') <> '') {
+                    $host = OC_Config::getValue('reverseproxyhost', '');
+                } else {
+                    $host = OC_Request::serverHost();
+                }
+                $url = "https://". $host . OC_Request::requestUri('https');
                 header("Location: $url");
                 exit();
             }

--- a/lib/connector/sabre/request.php
+++ b/lib/connector/sabre/request.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Stefan Herbrechtsmeier
+ * @copyright 2012 Stefan Herbrechtsmeier <stefan@herbrechtsmeier.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class OC_Connector_Sabre_Request extends Sabre_HTTP_Request {
+	/**
+	 * Returns the requested uri
+	 *
+	 * @return string
+	 */
+	public function getUri() {
+		return OC_Request::requestUri();
+	}
+
+	/**
+	 * Returns a specific item from the _SERVER array.
+	 *
+	 * Do not rely on this feature, it is for internal use only.
+	 *
+	 * @param string $field
+	 * @return string
+	 */
+	public function getRawServerValue($field) {
+		if($field == 'REQUEST_URI'){
+			return $this->getUri();
+		}
+		else{
+			return isset($this->_SERVER[$field])?$this->_SERVER[$field]:null;
+		}
+	}
+}

--- a/lib/ocs.php
+++ b/lib/ocs.php
@@ -439,7 +439,7 @@ class OC_OCS {
 	public static function apiConfig($parameters) {
 		$format = $parameters['format'];
 		$user=OC_OCS::checkpassword(false);
-		$url=substr(OCP\Util::getServerHost().$_SERVER['SCRIPT_NAME'], 0, -11).'';
+		$url=substr(OCP\Util::getServerHost().OCP\Util::getScriptName, 0, -11).'';
 
 		$xml['version']='1.7';
 		$xml['website']='ownCloud';

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -219,6 +219,28 @@ class Util {
 	}
 
 	/**
+	 * @brief Returns the request uri
+	 * @returns the request uri
+	 *
+	 * Returns the request uri, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function getRequestUri() {
+		return(\OC_Request::requestUri());
+	}
+
+	/**
+	 * @brief Returns the script name
+	 * @returns the script name
+	 *
+	 * Returns the script name, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function getScriptName() {
+		return(\OC_Request::scriptName());
+	}
+
+	/**
 	 * @brief Creates path to an image
 	 * @param $app app
 	 * @param $image image name

--- a/lib/request.php
+++ b/lib/request.php
@@ -59,6 +59,60 @@ class OC_Request {
 	}
 
 	/**
+	 * @brief Returns the reverse proxy prefix
+	 * @returns the reverse proxy prefix
+	 *
+	 * Returns the reverse proxy prefix
+	 */
+	private static function reverseProxyPrefix($proto = '') {
+		if($proto=='' and OC_Config::getValue('reverseproxyhost', '')<>'' and OC_Config::getValue('reverseproxyhost', '') == self::serverHost()) {
+			$proto = self::serverProtocol();
+		}
+		if($proto<>'') {
+			if($proto=='https' and OC_Config::getValue('reverseproxyprefixssl', '')<>'') {
+				return OC_Config::getValue('reverseproxyprefixssl', '');
+			} else if(OC_Config::getValue('reverseproxyprefix', '')<>'') {
+				return OC_Config::getValue('reverseproxyprefix', '');
+			}
+		}
+		return '';
+	}
+
+
+	/**
+	 * @brief Returns the request uri
+	 * @returns the request uri
+	 *
+	 * Returns the request uri, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function requestUri($proto = '') {
+		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+		$prefix = self::reverseProxyPrefix($proto);
+		if($prefix<>'') {
+			$uri = $prefix.$uri;
+		}
+		return $uri;
+	}
+
+	/**
+	 * @brief Returns the script name
+	 * @returns the script name
+	 *
+	 * Returns the script name, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function scriptName() {
+		$name = $_SERVER['SCRIPT_NAME'];
+		$prefix = self::reverseProxyPrefix();
+		if($prefix<>'') {
+			$name = $prefix.$name;
+		}
+		return $name;
+	}
+
+
+	/**
 	 * @brief get Path info from request
 	 * @returns string Path info or false when not found
 	 */

--- a/lib/util.php
+++ b/lib/util.php
@@ -333,7 +333,7 @@ class OC_Util {
 	public static function checkLoggedIn() {
 		// Check if we are a user
 		if( !OC_User::isLoggedIn()) {
-			header( 'Location: '.OC_Helper::linkToAbsolute( '', 'index.php', array('redirect_url' => $_SERVER["REQUEST_URI"])));
+			header( 'Location: '.OC_Helper::linkToAbsolute( '', 'index.php', array('redirect_url' => OC_Request::requestUri())));
 			exit();
 		}
 	}

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,7 +23,7 @@
 
 require_once '../lib/base.php';
 
-$url=OCP\Util::getServerProtocol().'://'.substr(OCP\Util::getServerHost().$_SERVER['REQUEST_URI'], 0, -17).'ocs/v1.php/';
+$url=OCP\Util::getServerProtocol().'://'.substr(OCP\Util::getServerHost().OCP\Util::getRequestUri(), 0, -17).'ocs/v1.php/';
 
 echo('
 <providers>


### PR DESCRIPTION
Add support for a reverse proxy that handles multiple domains via host name
as prefix in the request URI (https://ssl-proxy.tld/domain.tld/).

As the reverse proxy is transparent for the web server the REQUEST_URI and
SCRIPT_NAME need manual adjustments. This patch replace the direct use
of this _SERVER variables with function calls and extend this functions
to detect the proxy and to add the needed prefix. Additionally it adds
a Sabre request backend with extends the Sabre_HTTP_Request to use the
same functions.
