### PR TITLE
Replace %2F with / in breadcrumbs

### DIFF
--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,6 +1,7 @@
 	<?php for($i=0; $i<count($_["breadcrumb"]); $i++):
-	$crumb = $_["breadcrumb"][$i];
-	$dir = str_replace('+', '%20', urlencode($crumb["dir"])); ?>
+		$crumb = $_["breadcrumb"][$i];
+		$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
+		$dir = str_replace('%2F', '/', $dir); ?>
 		<div class="crumb <?php if($i == count($_["breadcrumb"])-1) echo 'last';?> svg"
 			 data-dir='<?php echo $dir;?>'
 			 style='background-image:url("<?php echo OCP\image_path('core', 'breadcrumb.png');?>")'>


### PR DESCRIPTION
Fixes the indentation and replaces the ugly %2F with / in the breadcrumb URL
