### PR TITLE
Remove duplicate / for first folder in root

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -190,7 +190,11 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent($('#dir').val()).replace(/%2F/g, '/') + '/' + encodeURIComponent(filename);
+	var dir = encodeURIComponent($('#dir').val()).replace(/%2F/g, '/');
+	if (dir != '/') {
+		dir = dir + '/';
+	}
+	window.location = OC.linkTo('files', 'index.php') + '?dir=' + dir + encodeURIComponent(filename);
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -190,11 +190,11 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	var dir = encodeURIComponent($('#dir').val()).replace(/%2F/g, '/');
+	var dir = $('#dir').val()
 	if (dir != '/') {
 		dir = dir + '/';
 	}
-	window.location = OC.linkTo('files', 'index.php') + '?dir=' + dir + encodeURIComponent(filename);
+	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent(dir + filename);
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -191,7 +191,7 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
 	var dir = $('#dir').val()
-	if (dir != '/') {
+	if (dir !== '/') {
 		dir = dir + '/';
 	}
 	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent(dir + filename);


### PR DESCRIPTION
The URLs used to look like: /core/index.php/apps/files?dir=//Test 
After you went further into folders that extra slash would disappear. It came about due to #dir in the template, which is now '/' instead of ' ' because of the normalizePath function. I figured this is the best way to fix this without messing up anything else. 
