### PR TITLE
Remove echo from lost password page

### DIFF
--- a/core/lostpassword/controller.php
+++ b/core/lostpassword/controller.php
@@ -45,8 +45,6 @@ class OC_Core_LostPassword_Controller {
 				$l = OC_L10N::get('core');
 				$from = OCP\Util::getDefaultEmailAddress('lostpassword-noreply');
 				OC_Mail::send($email, $_POST['user'], $l->t('ownCloud password reset'), $msg, $from, 'ownCloud');
-				echo('Mailsent');
-
 				self::displayLostPasswordPage(false, true);
 			} else {
 				self::displayLostPasswordPage(true, false);


### PR DESCRIPTION
Fix for #1075 

There are echos in both master and stable45 at different locations
