### PR TITLE
This fixes a problem that prevented app routes from being loaded after ocs_api merge

### DIFF
--- a/lib/router.php
+++ b/lib/router.php
@@ -58,23 +58,6 @@ class OC_Router {
 	 * loads the api routes
 	 */
 	public function loadRoutes() {
-
-		// TODO cache
-		$this->root = $this->getCollection('root');
-		foreach(OC_APP::getEnabledApps() as $app){
-			$file = OC_App::getAppPath($app).'/appinfo/routes.php';
-			if(file_exists($file)){
-				$this->useCollection($app);
-				require_once($file);
-				$collection = $this->getCollection($app);
-				$this->root->addCollection($collection, '/apps/'.$app);
-			}
-		}
-		// include ocs routes
-		require_once(OC::$SERVERROOT.'/ocs/routes.php');
-		$collection = $this->getCollection('ocs');
-		$this->root->addCollection($collection, '/ocs');
-
 		foreach($this->getRoutingFiles() as $app => $file) {
 			$this->useCollection($app);
 			require_once $file;

--- a/lib/router.php
+++ b/lib/router.php
@@ -49,6 +49,7 @@ class OC_Router {
 			$files = $this->getRoutingFiles();
 			$files[] = 'settings/routes.php';
 			$files[] = 'core/routes.php';
+			$files[] = 'ocs/routes.php';
 			$this->cache_key = OC_Cache::generateCacheKeyFromFiles($files);
 		}
 		return $this->cache_key;
@@ -58,11 +59,6 @@ class OC_Router {
 	 * loads the api routes
 	 */
 	public function loadRoutes() {
-		// include ocs routes
-		require_once(OC::$SERVERROOT.'/ocs/routes.php');
-		$collection = $this->getCollection('ocs');
-		$this->root->addCollection($collection, '/ocs');
-
 		foreach($this->getRoutingFiles() as $app => $file) {
 			$this->useCollection($app);
 			require_once $file;
@@ -73,6 +69,10 @@ class OC_Router {
 		require_once 'settings/routes.php';
 		require_once 'core/routes.php';
 
+		// include ocs routes
+		require_once 'ocs/routes.php';
+		$collection = $this->getCollection('ocs');
+		$this->root->addCollection($collection, '/ocs');
 	}
 
 	protected function getCollection($name) {

--- a/lib/router.php
+++ b/lib/router.php
@@ -58,6 +58,11 @@ class OC_Router {
 	 * loads the api routes
 	 */
 	public function loadRoutes() {
+		// include ocs routes
+		require_once(OC::$SERVERROOT.'/ocs/routes.php');
+		$collection = $this->getCollection('ocs');
+		$this->root->addCollection($collection, '/ocs');
+
 		foreach($this->getRoutingFiles() as $app => $file) {
 			$this->useCollection($app);
 			require_once $file;


### PR DESCRIPTION
Some old code was reintroduced by the merge of ocs_api. With the help of bartv I was able to fix the error by removing the added lines in the lib/router.php

The bug produced this error message: 
{"app":"PHP","message":"Route \"apptemplate_advanced_index\" does not exist. at \/srv\/http\/3rdparty\/symfony\/routing\/Symfony\/Component\/Routing\/Generator\/UrlGenerator.php#92","level":4,"time":1357568583}
