### PR TITLE
more translations for stable45

### DIFF
--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -15,5 +15,6 @@ $target = stripslashes(urldecode($_GET["target"]));
 if(OC_Files::move($dir, $file, $target, $file)) {
 	OCP\JSON::success(array("data" => array( "dir" => $dir, "files" => $file )));
 } else {
-	OCP\JSON::error(array("data" => array( "message" => "Could not move $file" )));
+	$l=OC_L10N::get('files');
+	OCP\JSON::error(array("data" => array( "message" => $l->t("Could not move %s", array($file)) )));
 }

--- a/apps/files/ajax/rename.php
+++ b/apps/files/ajax/rename.php
@@ -14,7 +14,7 @@ $newname = stripslashes($_GET["newname"]);
 // Delete
 if( $newname !== '.' and OC_Files::move( $dir, $file, $dir, $newname )) {
 	OCP\JSON::success(array("data" => array( "dir" => $dir, "file" => $file, "newname" => $newname )));
-}
-else{
-	OCP\JSON::error(array("data" => array( "message" => "Unable to rename file" )));
+} else {
+	$l=OC_L10N::get('files');
+	OCP\JSON::error(array("data" => array( "message" => $l->t("Unable to rename file"))));
 }

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -8,24 +8,26 @@ OCP\JSON::setContentTypeHeader('text/plain');
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
+$l=OC_L10N::get('files');
 
 if (!isset($_FILES['files'])) {
-	OCP\JSON::error(array("data" => array( "message" => "No file was uploaded. Unknown error" )));
+	OCP\JSON::error(array('data' => array( 'message' => $l->t( 'No file was uploaded. Unknown error' ))));
 	exit();
 }
 foreach ($_FILES['files']['error'] as $error) {
 	if ($error != 0) {
-		$l=OC_L10N::get('files');
 		$errors = array(
-			UPLOAD_ERR_OK=>$l->t("There is no error, the file uploaded with success"),
-			UPLOAD_ERR_INI_SIZE=>$l->t("The uploaded file exceeds the upload_max_filesize directive in php.ini").ini_get('upload_max_filesize'),
-			UPLOAD_ERR_FORM_SIZE=>$l->t("The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form"),
-			UPLOAD_ERR_PARTIAL=>$l->t("The uploaded file was only partially uploaded"),
-			UPLOAD_ERR_NO_FILE=>$l->t("No file was uploaded"),
-			UPLOAD_ERR_NO_TMP_DIR=>$l->t("Missing a temporary folder"),
+			UPLOAD_ERR_OK=>$l->t('There is no error, the file uploaded with success'),
+			UPLOAD_ERR_INI_SIZE=>$l->t('The uploaded file exceeds the upload_max_filesize directive in php.ini: ')
+										.ini_get('upload_max_filesize'),
+			UPLOAD_ERR_FORM_SIZE=>$l->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified'
+										.' in the HTML form'),
+			UPLOAD_ERR_PARTIAL=>$l->t('The uploaded file was only partially uploaded'),
+			UPLOAD_ERR_NO_FILE=>$l->t('No file was uploaded'),
+			UPLOAD_ERR_NO_TMP_DIR=>$l->t('Missing a temporary folder'),
 			UPLOAD_ERR_CANT_WRITE=>$l->t('Failed to write to disk'),
 		);
-		OCP\JSON::error(array("data" => array( "message" => $errors[$error] )));
+		OCP\JSON::error(array('data' => array( 'message' => $errors[$error] )));
 		exit();
 	}
 }
@@ -39,7 +41,7 @@ foreach($files['size'] as $size) {
 	$totalSize+=$size;
 }
 if($totalSize>OC_Filesystem::free_space('/')) {
-	OCP\JSON::error(array("data" => array( "message" => "Not enough space available" )));
+	OCP\JSON::error(array('data' => array( 'message' => $l->t( 'Not enough space available' ))));
 	exit();
 }
 
@@ -47,19 +49,19 @@ $result=array();
 if(strpos($dir, '..') === false) {
 	$fileCount=count($files['name']);
 	for($i=0;$i<$fileCount;$i++) {
-        $target = OCP\Files::buildNotExistingFileName(stripslashes($dir), $files['name'][$i]);
+		$target = OCP\Files::buildNotExistingFileName(stripslashes($dir), $files['name'][$i]);
 		// $path needs to be normalized - this failed within drag'n'drop upload to a sub-folder
 		$target = OC_Filesystem::normalizePath($target);
 		if(is_uploaded_file($files['tmp_name'][$i]) and OC_Filesystem::fromTmpFile($files['tmp_name'][$i], $target)) {
 			$meta = OC_FileCache::get($target);
 			$id = OC_FileCache::getId($target);
-			$result[]=array( "status" => "success", 'mime'=>$meta['mimetype'], 'size'=>$meta['size'], 'id'=>$id, 'name'=>basename($target));
+			$result[]=array( 'status' => 'success', 'mime'=>$meta['mimetype'], 'size'=>$meta['size'], 'id'=>$id, 'name'=>basename($target));
 		}
 	}
 	OCP\JSON::encodedPrint($result);
 	exit();
 } else {
-	$error='invalid dir';
+	$error=$l->t( 'Invalid directory.' );
 }
 
-OCP\JSON::error(array('data' => array('error' => $error, "file" => $fileName)));
+OCP\JSON::error(array('data' => array('message' => $error )));

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -891,21 +891,20 @@ function relative_modified_date(timestamp) {
 	var diffminutes = Math.round(timediff/60);
 	var diffhours = Math.round(diffminutes/60);
 	var diffdays = Math.round(diffhours/24);
-	var diffmonths = Math.round(diffdays/31);
-	var diffyears = Math.round(diffdays/365);
-	if(timediff < 60) { return t('files','seconds ago'); }
-	else if(timediff < 120) { return '1 '+t('files','minute ago'); }
-	else if(timediff < 3600) { return diffminutes+' '+t('files','minutes ago'); }
+	//var diffmonths = Math.round(diffdays/31);
+	//var diffyears = Math.round(diffdays/365);
+	if(timediff < 60) { return t('lib','seconds ago'); }
+	else if(timediff < 120) { return t('lib','1 minute ago'); }
+	else if(timediff < 3600) { return t('lib','%d minutes ago',diffminutes); }
 	//else if($timediff < 7200) { return '1 hour ago'; }
 	//else if($timediff < 86400) { return $diffhours.' hours ago'; }
-	else if(timediff < 86400) { return t('files','today'); }
-	else if(timediff < 172800) { return t('files','yesterday'); }
-	else if(timediff < 2678400) { return diffdays+' '+t('files','days ago'); }
-	else if(timediff < 5184000) { return t('files','last month'); }
-	//else if($timediff < 31556926) { return $diffmonths.' months ago'; }
-	else if(timediff < 31556926) { return t('files','months ago'); }
-	else if(timediff < 63113852) { return t('files','last year'); }
-	else { return diffyears+' '+t('files','years ago'); }
+	else if(timediff < 86400) { return t('lib','today'); }
+	else if(timediff < 172800) { return t('lib','yesterday'); }
+	else if(timediff < 2678400) { return t('lib','%d days ago',diffdays); }
+	else if(timediff < 5184000) { return t('lib','last month'); }
+	else if(timediff < 31556926) { return t('lib','months ago'); }
+	else if(timediff < 63113852) { return t('lib','last year'); }
+	else { return t('lib','years ago'); }
 }
 
 function getMimeIcon(mime, ready){


### PR DESCRIPTION
translated the error messages in move, rename and upload ajax calls.
furthermore the relative modified date is now taken from 'lib' instead of 'files'. No need to duplicate the translations here.
@DeepDiver1975 will the translated strings automatically be cleared from 'files'?
