### PR TITLE
allow default click behaviour

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -87,8 +87,8 @@ $(document).ready(function() {
 
 	// Sets the file link behaviour :
 	$('td.filename a').live('click',function(event) {
-		event.preventDefault();
 		if (event.ctrlKey || event.shiftKey) {
+			event.preventDefault();
 			if (event.shiftKey) {
 				var last = $(lastChecked).parent().parent().prevAll().length;
 				var first = $(this).parent().parent().prevAll().length;
@@ -130,6 +130,7 @@ $(document).ready(function() {
 				var permissions = $(this).parent().parent().data('permissions');
 				var action=FileActions.getDefault(mime,type, permissions);
 				if(action){
+					event.preventDefault();
 					action(filename);
 				}
 			}


### PR DESCRIPTION
currently clicking on a file in the filelist will always stop the click event from bubbling up. This prevents the default file download behaviour.

this pr stops the event from bubbling up only if a file action has been specified
