### PR TITLE
Add security section to admin settings to enable the HTTPS enforcement

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -33,6 +33,16 @@ $tmpl->assign('internetconnectionworking', OC_Util::isinternetconnectionworking(
 $tmpl->assign('islocaleworking', OC_Util::issetlocaleworking());
 $tmpl->assign('backgroundjobs_mode', OC_Appconfig::getValue('core', 'backgroundjobs_mode', 'ajax'));
 $tmpl->assign('shareAPIEnabled', OC_Appconfig::getValue('core', 'shareapi_enabled', 'yes'));
+
+// Check if connected using HTTPS
+if (OC_Request::serverProtocol() == 'https') {
+	$connectedHTTPS = true; 
+} else {
+	$connectedHTTPS = false;
+} 
+$tmpl->assign('isConnectedViaHTTPS', $connectedHTTPS);
+$tmpl->assign('enforceHTTPSEnabled', OC_Config::getValue( "forcessl", false)); 
+
 $tmpl->assign('allowLinks', OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
 $tmpl->assign('allowResharing', OC_Appconfig::getValue('core', 'shareapi_allow_resharing', 'yes'));
 $tmpl->assign('sharePolicy', OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global'));

--- a/settings/ajax/setsecurity.php
+++ b/settings/ajax/setsecurity.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright (c) 2013, Lukas Reschke <lukas@statuscode.ch>
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+
+OC_Util::checkAdminUser();
+OCP\JSON::callCheck();
+
+OC_Config::setValue( 'forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
+
+echo 'true';

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -30,4 +30,8 @@ $(document).ready(function(){
 		}
 		OC.AppConfig.setValue('core', $(this).attr('name'), value);
 	});
+
+	$('#security').change(function(){
+		$.post(OC.filePath('settings','ajax','setsecurity.php'), { enforceHTTPS: $('#enforceHTTPSEnabled').val() },function(){} );
+	});
 });

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -58,6 +58,8 @@ $this->create('settings_ajax_getlog', '/settings/ajax/getlog.php')
 	->actionInclude('settings/ajax/getlog.php');
 $this->create('settings_ajax_setloglevel', '/settings/ajax/setloglevel.php')
 	->actionInclude('settings/ajax/setloglevel.php');
+$this->create('settings_ajax_setsecurity', '/settings/ajax/setsecurity.php')
+	->actionInclude('settings/ajax/setsecurity.php');
 
 // apps/user_openid
 $this->create('settings_ajax_openid', '/settings/ajax/openid.php')

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -153,7 +153,7 @@ if (!$_['internetconnectionworking']) {
                     echo $l->t('Please connect to this ownCloud instance via HTTPS to enable or disable the SSL enforcement.'); 
                     echo "</em>"; 
                 } 
-                ?></em>
+                ?>
             </td>
         </tr>
     </table>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -132,6 +132,33 @@ if (!$_['internetconnectionworking']) {
     </table>
 </fieldset>
 
+<fieldset class="personalblock" id="security">
+    <legend><strong><?php echo $l->t('Security');?></strong></legend>
+    <table class="nostyle">
+        <tr>
+            <td id="enable">
+                <input type="checkbox" name="forcessl"  id="enforceHTTPSEnabled"
+                    <?php if ($_['enforceHTTPSEnabled']) {
+                        echo 'checked="checked" ';
+                        echo 'value="false"';
+                    }  else {
+                        echo 'value="true"';
+                    }
+                    ?> 
+                    <?php if (!$_['isConnectedViaHTTPS']) echo 'disabled'; ?> />
+                <label for="forcessl"><?php echo $l->t('Enforce HTTPS');?></label><br/>
+                <em><?php echo $l->t('Enforces the clients to connect to ownCloud via an encrypted connection.'); ?></em>
+                <?php if (!$_['isConnectedViaHTTPS']) {
+                    echo "<br/><em>"; 
+                    echo $l->t('Please connect to this ownCloud instance via HTTPS to enable or disable the SSL enforcement.'); 
+                    echo "</em>"; 
+                } 
+                ?></em>
+            </td>
+        </tr>
+    </table>
+</fieldset>
+
 <fieldset class="personalblock">
     <legend><strong><?php echo $l->t('Log');?></strong></legend>
     <?php echo $l->t('Log level');?> <select name='loglevel' id='loglevel'>


### PR DESCRIPTION
Currently it only allows the admin to enable or disable the HTTPS
enforcement, but in the future it could be expanded to further options.

The HTTPS enforcement only allows the admin to enforce it, if he is
connected via HTTPS. (To prevent admins to enable it without a proper
SSL setup, which would lead to a bad user experience, as he wouldn't be
able to connect to oC anymore without changing the config.php)

Users usually don't read our provided example config.php, so we should
include some options in the admin settings. 

\cc @danimo
