### PR TITLE
Remove setContentTypeHeader()

### DIFF
--- a/settings/ajax/disableapp.php
+++ b/settings/ajax/disableapp.php
@@ -1,7 +1,6 @@
 <?php
 OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
-OC_JSON::setContentTypeHeader();
 
 OC_App::disable($_POST['appid']);
 

--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -2,7 +2,6 @@
 
 OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
-OC_JSON::setContentTypeHeader();
 
 $appid = OC_App::enable($_POST['appid']);
 if($appid !== false) {


### PR DESCRIPTION
`OC_JSON::success` and `OC_JSON::error` are calling
`OC_JSON::encodedPrint`, which already sets these headers. So this two
calls are uneeded duplicates.
