### PR TITLE
Simplify the isSubDirectory() function

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -625,7 +625,7 @@ class OC_Helper {
 		return $newpath;
 	}
 
-	/*
+	/**
 	 * @brief Checks if $sub is a subdirectory of $parent
 	 *
 	 * @param string $sub

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -626,7 +626,7 @@ class OC_Helper {
 	}
 
 	/*
-	 * checks if $sub is a subdirectory of $parent
+	 * @brief Checks if $sub is a subdirectory of $parent
 	 *
 	 * @param string $sub
 	 * @param string $parent

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -633,29 +633,9 @@ class OC_Helper {
 	 * @return bool
 	 */
 	public static function issubdirectory($sub, $parent) {
-		if($sub == null || $sub == '' || $parent == null || $parent == '') {
-			return false;
+		if (strpos(realpath($sub), realpath($parent)) !== false) {
+			return true;
 		}
-		$realpath_sub = realpath($sub);
-		$realpath_parent = realpath($parent);
-		if(($realpath_sub == false && substr_count($realpath_sub, './') != 0) || ($realpath_parent == false && substr_count($realpath_parent, './') != 0)) { //it checks for  both ./ and ../
-			return false;
-		}
-		if($realpath_sub && $realpath_sub != '' && $realpath_parent && $realpath_parent != '') {
-			if(substr($realpath_sub, 0, strlen($realpath_parent)) == $realpath_parent) {
-				return true;
-			}
-		}else{
-			if(substr($sub, 0, strlen($parent)) == $parent) {
-				return true;
-			}
-		}
-		/*echo 'SUB: ' . $sub . "\n";
-		echo 'PAR: ' . $parent . "\n";
-		echo 'REALSUB: ' . $realpath_sub . "\n";
-		echo 'REALPAR: ' . $realpath_parent . "\n";
-		echo substr($realpath_sub, 0, strlen($realpath_parent));
-		exit;*/
 		return false;
 	}
 

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -633,7 +633,7 @@ class OC_Helper {
 	 * @return bool
 	 */
 	public static function issubdirectory($sub, $parent) {
-		if (strpos(realpath($sub), realpath($parent)) !== false) {
+		if (strpos(realpath($sub), realpath($parent)) === 0) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
isSubDirectory() checks if a specified $sub is a subdirectory of the
$parent, this is needed to prevent file inclusions.

Actually, the current code is more kind of a "hack" which I always
struggle over if browsing through source. So this should be a much
better implementation.

The implementation is really straightforward:
- [realpath()](http://php.net/manual/function.realpath.php) expands all
  symbolic links and resolves references to '/./', '/../' and extra '/'
  characters in the input path and return the canonicalized absolute
  pathname.
- [strpos()](http://php.net/manual/function.strpos.php) returns FALSE if the
  substring wasn't found.

**Since this is an absolutely critical piece of code, I'd like to ensure
that this is absolutely safe!** - Any comment appreciated!!!

@georgehrke I know that you implemented the existing method. What's 
your thought on this?
