### PR TITLE
in case of maintenance the error page returns http status 503.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -231,6 +231,12 @@ class OC
 	public static function checkMaintenanceMode() {
 		// Allow ajax update script to execute without being stopped
 		if (OC_Config::getValue('maintenance', false) && OC::$SUBURI != '/core/ajax/update.php') {
+			// send http status 503
+			header('HTTP/1.1 503 Service Temporarily Unavailable');
+			header('Status: 503 Service Temporarily Unavailable');
+			header('Retry-After: 120');
+
+			// render error page
 			$tmpl = new OC_Template('', 'error', 'guest');
 			$tmpl->assign('errors', array(1 => array('error' => 'ownCloud is in maintenance mode')));
 			$tmpl->printPage();


### PR DESCRIPTION
This is necessary to enable the desktop sync client to react properly.
Currently the SabreDAV plugin OC_Connector_Sabre_MaintenancePlugin is not executed because this error page is returned before the SabreDAV code is executed

@dragotin can you please test this in conjunction with the desktop client? THX
