### PR TITLE
Cache prepared statements in OC_DB

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -123,6 +123,7 @@ class OC_DB {
 				return true;
 			}
 		}
+		self::$preparedQueries = array();
 		// The global data we need
 		$name = OC_Config::getValue( "dbname", "owncloud" );
 		$host = OC_Config::getValue( "dbhost", "" );
@@ -203,6 +204,7 @@ class OC_DB {
 				return true;
 			}
 		}
+		self::$preparedQueries = array();
 		// The global data we need
 		$name = OC_Config::getValue( "dbname", "owncloud" );
 		$host = OC_Config::getValue( "dbhost", "" );
@@ -598,7 +600,7 @@ class OC_DB {
 				error_log('DB error: '.$entry);
 				OC_Template::printErrorPage( $entry );
 			}
-			
+
 			if($result->numRows() == 0) {
 				$query = 'INSERT INTO "' . $table . '" ("'
 					. implode('","', array_keys($input)) . '") VALUES("'
@@ -633,7 +635,7 @@ class OC_DB {
 
 		return $result->execute();
 	}
-	
+
 	/**
 	 * @brief does minor changes to query
 	 * @param string $query Query string

--- a/lib/db.php
+++ b/lib/db.php
@@ -41,6 +41,8 @@ class OC_DB {
 	const BACKEND_PDO=0;
 	const BACKEND_MDB2=1;
 
+	static private $preparedQueries = array();
+
 	/**
 	 * @var MDB2_Driver_Common
 	 */
@@ -321,7 +323,12 @@ class OC_DB {
 					$query.=$limitsql;
 				}
 			}
+		} else {
+			if (isset(self::$preparedQueries[$query])) {
+				return self::$preparedQueries[$query];
+			}
 		}
+		$rawQuery = $query;
 
 		// Optimize the query
 		$query = self::processQuery( $query );
@@ -342,6 +349,9 @@ class OC_DB {
 				throw new DatabaseException($e->getMessage(), $query);
 			}
 			$result=new PDOStatementWrapper($result);
+		}
+		if (is_null($limit) || $limit == -1) {
+			self::$preparedQueries[$rawQuery] = $result;
 		}
 		return $result;
 	}


### PR DESCRIPTION
Cache prepared statements not involving $limit or $offset

Gives a significant performance increase for database intensive tasks such as filecache scanning and upgrading
