### PR TITLE
Dont resize content div with javascript but use css box-sizing to do it

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -94,7 +94,8 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 /* CONTENT ------------------------------------------------------------------ */
 #controls { padding:0 0.5em; width:100%; top:3.5em; height:2.8em; margin:0; background:#f7f7f7; border-bottom:1px solid #eee; position:fixed; z-index:50; -moz-box-shadow:0 -3px 7px #000; -webkit-box-shadow:0 -3px 7px #000; box-shadow:0 -3px 7px #000; }
 #controls .button { display:inline-block; }
-#content { top:3.5em; left:12.5em; position:absolute; }
+#content { height: 100%; width: 100%; position: absolute; }
+#content-wrapper { height: 100%; width: 100%; padding-top: 3.5em; padding-left: 12.5em; box-sizing: border-box; -moz-box-sizing: border-box; position: absolute;}
 #leftcontent, .leftcontent { position:fixed; overflow:auto; top:6.4em; width:20em; background:#f8f8f8; border-right:1px solid #ddd; }
 #leftcontent li, .leftcontent li { background:#f8f8f8; padding:.5em .8em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 200ms; -moz-transition:background-color 200ms; -o-transition:background-color 200ms; transition:background-color 200ms; }
 #leftcontent li:hover, #leftcontent li:active, #leftcontent li.active, .leftcontent li:hover, .leftcontent li:active, .leftcontent li.active { background:#eee; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -94,7 +94,7 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 /* CONTENT ------------------------------------------------------------------ */
 #controls { padding:0 0.5em; width:100%; top:3.5em; height:2.8em; margin:0; background:#f7f7f7; border-bottom:1px solid #eee; position:fixed; z-index:50; -moz-box-shadow:0 -3px 7px #000; -webkit-box-shadow:0 -3px 7px #000; box-shadow:0 -3px 7px #000; }
 #controls .button { display:inline-block; }
-#content { height: 100%; width: 100%; position: absolute; }
+#content { height: 100%; width: 100%; position: relative; }
 #content-wrapper { height: 100%; width: 100%; padding-top: 3.5em; padding-left: 12.5em; box-sizing: border-box; -moz-box-sizing: border-box; position: absolute;}
 #leftcontent, .leftcontent { position:fixed; overflow:auto; top:6.4em; width:20em; background:#f8f8f8; border-right:1px solid #ddd; }
 #leftcontent li, .leftcontent li { background:#f8f8f8; padding:.5em .8em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 200ms; -moz-transition:background-color 200ms; -o-transition:background-color 200ms; transition:background-color 200ms; }

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -504,6 +504,7 @@ function fillHeight(selector) {
 	if(selector.outerHeight() > selector.height()){
 		selector.css('height', height-(selector.outerHeight()-selector.height()) + 'px');
 	}
+	console.warn("This function is deprecated! Use CSS instead");
 }
 
 /**
@@ -519,16 +520,10 @@ function fillWindow(selector) {
 	if(selector.outerWidth() > selector.width()){
 		selector.css('width', width-(selector.outerWidth()-selector.width()) + 'px');
 	}
+	console.warn("This function is deprecated! Use CSS instead");
 }
 
 $(document).ready(function(){
-
-	$(window).resize(function () {
-		fillHeight($('#leftcontent'));
-		fillWindow($('#content'));
-		fillWindow($('#rightcontent'));
-	});
-	$(window).trigger('resize');
 
 	if(!SVGSupport()){ //replace all svg images with png images for browser that dont support svg
 		replaceSVG();

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -67,8 +67,10 @@
 			</ul>
 		</div></nav>
 
-		<div id="content">
-			<?php echo $_['content']; ?>
+		<div id="content-wrapper">
+			<div id="content">
+				<?php echo $_['content']; ?>
+			</div>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
I've ported this fix from the navigation branch since that branch seems dead and it still bugs me.

Basically what it does is that it adjusts the content width always to 100% with css instead of JS.

The JS solution produced display bugs and crashed certain browsers on resize, like opera.
