### PR TITLE
Return 401 headers when trying to access a restricted api call

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -94,6 +94,8 @@ class OC_API {
 				$response = new OC_OCS_Result(null, 998, 'Api method not found');
 			} 
 		} else {
+			 header('WWW-Authenticate: Basic realm="Authorisation Required"');
+			 header('HTTP/1.0 401 Unauthorized');
 			$response = new OC_OCS_Result(null, 997, 'Unauthorised');
 		}
 		// Send the response

--- a/lib/api.php
+++ b/lib/api.php
@@ -94,7 +94,7 @@ class OC_API {
 				$response = new OC_OCS_Result(null, 998, 'Api method not found');
 			} 
 		} else {
-			header('WWW-Authenticate: Basic realm="Authorisation Required"');
+			header('WWW-Authenticate: Basic realm="Authorization Required"');
 			header('HTTP/1.0 401 Unauthorized');
 			$response = new OC_OCS_Result(null, 997, 'Unauthorised');
 		}

--- a/lib/api.php
+++ b/lib/api.php
@@ -94,8 +94,8 @@ class OC_API {
 				$response = new OC_OCS_Result(null, 998, 'Api method not found');
 			} 
 		} else {
-			 header('WWW-Authenticate: Basic realm="Authorisation Required"');
-			 header('HTTP/1.0 401 Unauthorized');
+			header('WWW-Authenticate: Basic realm="Authorisation Required"');
+			header('HTTP/1.0 401 Unauthorized');
 			$response = new OC_OCS_Result(null, 997, 'Unauthorised');
 		}
 		// Send the response


### PR DESCRIPTION
Return a 401 header to the browser / client when they try to access a restricted without the correct auth headers. Makes it easier to test the api in a browser, and properly informs the client of the result of the call.
