### PR TITLE
Load Classpaths of apps before appinfo/routes.php

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -322,15 +322,15 @@ class OC
 	}
 
 
-        public static function loadAppClassPaths()
-        {
-                foreach(OC_APP::getEnabledApps() as $app) {
-                        $file = OC_App::getAppPath($app).'/appinfo/classpath.php';
-                        if(file_exists($file)) {
-                                require_once $file;
-                        }
-                }
-        }
+	public static function loadAppClassPaths()
+	{	
+		foreach(OC_APP::getEnabledApps() as $app) {
+			$file = OC_App::getAppPath($app).'/appinfo/classpath.php';
+			if(file_exists($file)) {
+				require_once $file;
+			}
+		}
+	}
 
 
 	public static function init()
@@ -550,9 +550,9 @@ class OC
 			return;
 		}
 
-                // load all the classpaths from the enabled apps so they are available
-                // in the routing files of each app
-                OC::loadAppClassPaths();
+		// load all the classpaths from the enabled apps so they are available
+		// in the routing files of each app
+		OC::loadAppClassPaths();
 
 		try {
 			OC::getRouter()->match(OC_Request::getPathInfo());

--- a/lib/base.php
+++ b/lib/base.php
@@ -321,6 +321,18 @@ class OC
 		return OC::$router;
 	}
 
+
+        public static function loadAppClassPaths()
+        {
+                foreach(OC_APP::getEnabledApps() as $app) {
+                        $file = OC_App::getAppPath($app).'/appinfo/classpath.php';
+                        if(file_exists($file)) {
+                                require_once $file;
+                        }
+                }
+        }
+
+
 	public static function init()
 	{
 		// register autoloader
@@ -537,6 +549,11 @@ class OC
 			header('location: ' . OC_Helper::linkToRemote('webdav'));
 			return;
 		}
+
+                // load all the classpaths from the enabled apps so they are available
+                // in the routing files of each app
+                OC::loadAppClassPaths();
+
 		try {
 			OC::getRouter()->match(OC_Request::getPathInfo());
 			return;


### PR DESCRIPTION
To be able to use the appframework in routing (you need to call the App::main method for handling the request) the classes of the appframework need to be available.

This patch loads all classpath definitions in appinfo/classpath.php before the appinfo/routes.php.
