### PR TITLE
fix error message, add appid to the output to know which app caused the error

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -725,7 +725,7 @@ class OC_App{
 				}
 				return new OC_FilesystemView('/'.OC_User::getUser().'/'.$appid);
 			}else{
-				OC_Log::write('core', 'Can\'t get app storage, app, user not logged in', OC_Log::ERROR);
+				OC_Log::write('core', 'Can\'t get app storage, app '.$appid.', user not logged in', OC_Log::ERROR);
 				return false;
 			}
 		}else{


### PR DESCRIPTION
add appid to the output to know which app caused the error if OC_App::getStorage() fails.
