### PR TITLE
add multselect dnd

### DIFF
--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -7,9 +7,9 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
 // Get data
-$dir = stripslashes($_GET["dir"]);
-$file = stripslashes($_GET["file"]);
-$target = stripslashes(rawurldecode($_GET["target"]));
+$dir = stripslashes($_POST["dir"]);
+$file = stripslashes($_POST["file"]);
+$target = stripslashes(rawurldecode($_POST["target"]));
 
 $l=OC_L10N::get('files');
 

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -122,3 +122,14 @@ a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 #scanning-message{ top:40%; left:40%; position:absolute; display:none; }
 
 div.crumb a{ padding:0.9em 0 0.7em 0; }
+
+table.dragshadow {
+	width:auto;
+}
+table.dragshadow td.filename {
+	padding-left:36px;
+	padding-right:16px;
+}
+table.dragshadow td.size {
+	padding-right:8px;
+}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -874,7 +874,7 @@ var folderDropOptions={
 			return false;
 		}
 		
-		var target=$(this).find('.nametext').text().trim();
+		var target=$.trim($(this).find('.nametext').text());
 		
 		var files = ui.helper.find('tr');
 		$(files).each(function(i,row){
@@ -1045,7 +1045,7 @@ function getUniqueName(name){
 			num=parseInt(numMatch[numMatch.length-1])+1;
 			base=base.split('(')
 			base.pop();
-			base=base.join('(').trim();
+			base=$.trim(base.join('('));
 		}
 		name=base+' ('+num+')';
 		if (extension) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -815,9 +815,18 @@ function updateBreadcrumb(breadcrumbHtml) {
 
 var createDragShadow = function(event){
 	//select dragged file
-	$(event.target).parents('tr').find('td input:first').prop('checked', true);
+	var isDragSelected = $(event.target).parents('tr').find('td input:first').prop('checked');
+	if (!isDragSelected) {
+		//select dragged file
+		$(event.target).parents('tr').find('td input:first').prop('checked',true);
+	}
 	
 	var selectedFiles = getSelectedFiles();
+	
+	if (!isDragSelected && selectedFiles.length == 1) {
+		//revert the selection
+		$(event.target).parents('tr').find('td input:first').prop('checked',false);
+	}
 	
 	//also update class when we dragged more than one file
 	if (selectedFiles.length > 1) {
@@ -832,8 +841,7 @@ var createDragShadow = function(event){
 	var dir=$('#dir').val();
 	
 	$(selectedFiles).each(function(i,elem){
-		var selected= $(event.target).parents('tr').hasClass('selected');
-		var newtr = $('<tr data-dir="'+dir+'" data-filename="'+elem.name+'" data-selected="'+selected+'">'
+		var newtr = $('<tr data-dir="'+dir+'" data-filename="'+elem.name+'">'
 						+'<td class="filename">'+elem.name+'</td><td class="size">'+humanFileSize(elem.size)+'</td>'
 					 +'</tr>');
 		tbody.append(newtr);
@@ -851,16 +859,11 @@ var createDragShadow = function(event){
 
 //options for file drag/drop
 var dragOptions={
-	revert: 'invalid', opacity: 0.7, zIndex: 100, appendTo: 'body', cursorAt: { left: -5, top: -5 },
+	revert: 'invalid', revertDuration: 300,
+	opacity: 0.7, zIndex: 100, appendTo: 'body', cursorAt: { left: -5, top: -5 },
 	helper: createDragShadow, cursor: 'move',
 	stop: function(event, ui) {
 		$('#fileList tr td.filename').addClass('ui-draggable');
-		//reset selection
-		$(ui.helper.find('tr')).each(function(i,row){
-			var file = $(row).data('filename');
-			var selected = $(row).data('selected');
-			$('#fileList tr').filterAttr('data-file',file).find('td input:first').prop('checked',selected);
-		});
 	}
 }
 
@@ -899,10 +902,6 @@ var folderDropOptions={
 				}
 			});
 		});
-		//reset checkbox if we dragged a single file
-		if (files.length == 1) {
-			$(event.target).parents('tr').find('td input:first').prop('checked', $(event.target).parents('tr').hasClass('selected'));
-		}
 	},
 	tolerance: 'pointer'
 }
@@ -941,10 +940,6 @@ var crumbDropOptions={
 				}
 			});
 		});
-		//reset checkbox if we dragged a single file
-		if (files.length == 1) {
-			$(event.target).parents('tr').find('td input:first').prop('checked', $(event.target).parents('tr').hasClass('selected'));
-		}
 	},
 	tolerance: 'pointer'
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -877,7 +877,7 @@ var folderDropOptions={
 		$(files).each(function(i,row){
 			var dir = $(row).data('dir');
 			var file = $(row).data('filename');
-			$.get(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: dir+'/'+target }, function(result) {
+			$.post(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: dir+'/'+target }, function(result) {
 				if (result) {
 					if (result.status === 'success') {
 						//recalculate folder size
@@ -925,7 +925,7 @@ var crumbDropOptions={
 		$(files).each(function(i,row){
 			var dir = $(row).data('dir');
 			var file = $(row).data('filename');
-			$.get(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: target }, function(result) {
+			$.post(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: target }, function(result) {
 				if (result) {
 					if (result.status === 'success') {
 						FileList.remove(file);


### PR DESCRIPTION
this pr adds dnd moving of more than one file if selected:
- it adds the createDragShadow helper that collects the selected files
- the dragshadow is a css styled table containing a row for each file with filename and size
- the code also handles dnd for singlefiles and restores the correct selected class / checkbox if dragging is stopped

I also moved from $.ajax to $.get and handle the result myself instead of using boolOperationFinished. mainly because I then don't have to construct the url parameters with encodeURIComponent. I know @DeepDiver1975 uses that method to update the max file upload size in another PR. I'll add that depending on what gets merged first ;)

@jancborchardt @DeepDiver1975 @MTGap @icewind1991 @tanghus @schiesbn If you want multi select dnd give me your :+1: after testing
