### PR TITLE
hide upload progress bar and cancel action in IE < 10

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -434,6 +434,10 @@ $(document).ready(function() {
 				$('#uploadprogressbar').progressbar('value',progress);
 			},
 			start: function(e, data) {
+				//IE < 10 does not fire the necessary events for the progress bar.
+				if($.browser.msie && parseInt($.browser.version) < 10) {
+					return;
+				}
 				$('#uploadprogressbar').progressbar({value:0});
 				$('#uploadprogressbar').fadeIn();
 				if(data.dataType != 'iframe ') {


### PR DESCRIPTION
I know im using the deprecated $.browser ... but oh well ... moving to jQuery 2 is worth another PR

@DeepDiver1975 @tanghus please test and then :+1: 
