### PR TITLE
Make the ZIP download information friendlier

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -184,7 +184,7 @@ $(document).ready(function() {
 	$('.download').click('click',function(event) {
 		var files=getSelectedFiles('name').join(';');
 		var dir=$('#dir').val()||'/';
-		$('#notification').text(t('files','generating ZIP-file, it may take some time.'));
+		$('#notification').text(t('files','Your download is being prepared. Thanks for your patience.'));
 		$('#notification').fadeIn();
 		// use special download URL if provided, e.g. for public shared files
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -184,7 +184,7 @@ $(document).ready(function() {
 	$('.download').click('click',function(event) {
 		var files=getSelectedFiles('name').join(';');
 		var dir=$('#dir').val()||'/';
-		$('#notification').text(t('files','Your download is being prepared. Thanks for your patience.'));
+		$('#notification').text(t('files','Your download is being prepared. This might take some time if the files are big.'));
 		$('#notification').fadeIn();
 		// use special download URL if provided, e.g. for public shared files
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {


### PR DESCRIPTION
1. Old version started with a typo (lower case "g")
2. I think this sounds a little bit friendlier

(But that's maybe just my strange English, so feel free to -1 it ;-) )
