### PR TITLE
Add listener for VisualPHPUnit

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -11,4 +11,7 @@
 			<directory suffix=".php">../3rdparty</directory>
 		</exclude>
 	</whitelist>
+	<listeners>
+		<listener class="PHPUnit_Util_Log_JSON"></listener>
+	</listeners>
 </phpunit>


### PR DESCRIPTION
I'm using [VisualPHPUnit](https://github.com/NSinopoli/VisualPHPUnit) to run the ownCloud tests locally and it requires this JSON listener. It shouldn't have any other effect on running the tests.
