### PR TITLE
Remove unnecessary ob_end_clean() from template tests

### DIFF
--- a/tests/lib/template.php
+++ b/tests/lib/template.php
@@ -30,7 +30,6 @@ class Test_TemplateFunctions extends UnitTestCase {
 		ob_start();
 		p($htmlString);
 		$result = ob_get_clean();
-		ob_end_clean();
 
 		$this->assertEqual("&lt;script&gt;alert(&#039;xss&#039;);&lt;/script&gt;", $result);
 	}
@@ -40,7 +39,6 @@ class Test_TemplateFunctions extends UnitTestCase {
 		ob_start();
 		p($normalString);
 		$result = ob_get_clean();
-		ob_end_clean();
 
 		$this->assertEqual("This is a good string!", $result);
 	}
@@ -52,7 +50,6 @@ class Test_TemplateFunctions extends UnitTestCase {
 		ob_start();
 		print_unescaped($htmlString);
 		$result = ob_get_clean();
-		ob_end_clean();
 
 		$this->assertEqual($htmlString, $result);
 	}
@@ -62,7 +59,6 @@ class Test_TemplateFunctions extends UnitTestCase {
 		ob_start();
 		print_unescaped($normalString);
 		$result = ob_get_clean();
-		ob_end_clean();
 
 		$this->assertEqual("This is a good string!", $result);
 	}


### PR DESCRIPTION
Another pull request to get [VisualPHPUnit](https://github.com/NSinopoli/VisualPHPUnit) working. Thanks to @NSinopoli for this one: 

https://github.com/NSinopoli/VisualPHPUnit/issues/84#issuecomment-12464116

> ob_get_clean() essentially executes both ob_get_contents() and ob_end_clean().
> I'm not sure why those tests are calling ob_end_clean() immediately after ob_get_clean(). As a result, VPU's output buffer is getting clobbered.

If anyone's interested in running VisualPHPUnit locally let me know and I can help with the configuration. 
