### PR TITLE
Add CSP header and allow only local loading of JS

### DIFF
--- a/lib/template.php
+++ b/lib/template.php
@@ -189,8 +189,8 @@ class OC_Template{
 		header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
 		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
 		header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-		header('Content-Security-Policy: script-src \'self\' \'unsafe-inline\'; object-src \'self\''); // Disallow external JS/Flash + eval()
-		
+		header('Content-Security-Policy: default-src \'self\'; script-src \'self\' \'unsafe-inline\'; style-src \'self\' \'unsafe-inline\''); // Disallow external ressources + eval()
+
 		$this->findTemplate($name);
 	}
 

--- a/lib/template.php
+++ b/lib/template.php
@@ -186,10 +186,11 @@ class OC_Template{
 		$this->l10n = OC_L10N::get($parts[0]);
 
 		// Some headers to enhance security
-		header('X-Frame-Options: Sameorigin');
-		header('X-XSS-Protection: 1; mode=block');
-		header('X-Content-Type-Options: nosniff');
-
+		header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
+		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
+		header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
+		header('Content-Security-Policy: script-src \'self\' \'unsafe-inline\'; object-src \'self\''); // Disallow external JS/Flash + eval()
+		
 		$this->findTemplate($name);
 	}
 


### PR DESCRIPTION
This CSP header will only allow the loading of ressources from the same domain and disallows the usage of `eval()` in JS.

The unprefixed version works currently only in Chrome 25, but other browsers will support this soon, so I don't saw a reason to add several prefixed versions. To test it with Chrome < 25 use the prefixed version: 

``` php
header('X-WebKit-CSP: default-src \'self\'; script-src \'self\' \'unsafe-inline\'; style-src \'self\' \'unsafe-inline\'');
```
