### PR TITLE
Add two specific mimetype extensions (ebooks): for epub and mobi files

### DIFF
--- a/lib/mimetypes.list.php
+++ b/lib/mimetypes.list.php
@@ -95,4 +95,7 @@ return array(
 	'cdr' => 'application/coreldraw',
 	'impress' => 'text/impress',
 	'ai' => 'application/illustrator',
+	'epub' => 'application/epub+zip',
+	'mobi' => 'application/x-mobipocket-ebook',
+
 );

--- a/lib/mimetypes.list.php
+++ b/lib/mimetypes.list.php
@@ -97,5 +97,4 @@ return array(
 	'ai' => 'application/illustrator',
 	'epub' => 'application/epub+zip',
 	'mobi' => 'application/x-mobipocket-ebook',
-
 );


### PR DESCRIPTION
Add  two specific mimetype extensions (ebooks): for epub and mobi files.
(used for my "library" application).

The proposed changes are under the MIT license.
