### PR TITLE
add additional mail_smtp.. parameters to fix possible SMTP connection problems.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -67,7 +67,7 @@ $CONFIG = array(
 "appstoreurl" => "http://api.apps.owncloud.com/v1",
 
 /* Enable SMTP class debugging */
-"mail_smtpdebug" => false;
+"mail_smtpdebug" => false,
 
 /* Mode to use for sending mail, can be sendmail, smtp, qmail or php, see PHPMailer docs */
 "mail_smtpmode" => "sendmail",

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -66,6 +66,9 @@ $CONFIG = array(
 /* URL of the appstore to use, server should understand OCS */
 "appstoreurl" => "http://api.apps.owncloud.com/v1",
 
+/* Enable SMTP class debugging */
+"mail_smtpdebug" => false;
+
 /* Mode to use for sending mail, can be sendmail, smtp, qmail or php, see PHPMailer docs */
 "mail_smtpmode" => "sendmail",
 
@@ -74,6 +77,13 @@ $CONFIG = array(
 
 /* Port to use for sending mail, depends on mail_smtpmode if this is used */
 "mail_smtpport" => 25,
+
+/* SMTP server timeout in seconds for sending mail, depends on mail_smtpmode if this is used */
+"mail_smtptimeout" => 10;
+
+/* SMTP connection prefix or sending mail, depends on mail_smtpmode if this is used.
+   Can be '', ssl or tls */
+"mail_smtpsecure" => '',
 
 /* authentication needed to send mail, depends on mail_smtpmode if this is used
  * (false = disable authentication)

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -79,11 +79,11 @@ $CONFIG = array(
 "mail_smtpport" => 25,
 
 /* SMTP server timeout in seconds for sending mail, depends on mail_smtpmode if this is used */
-"mail_smtptimeout" => 10;
+"mail_smtptimeout" => 10,
 
 /* SMTP connection prefix or sending mail, depends on mail_smtpmode if this is used.
    Can be '', ssl or tls */
-"mail_smtpsecure" => '',
+"mail_smtpsecure" => "",
 
 /* authentication needed to send mail, depends on mail_smtpmode if this is used
  * (false = disable authentication)

--- a/lib/mail.php
+++ b/lib/mail.php
@@ -40,6 +40,9 @@ class OC_Mail {
 		$SMTPAUTH = OC_Config::getValue( 'mail_smtpauth', false );
 		$SMTPUSERNAME = OC_Config::getValue( 'mail_smtpname', '' );
 		$SMTPPASSWORD = OC_Config::getValue( 'mail_smtppassword', '' );
+		$SMTPDEBUG    = OC_Config::getValue( 'mail_smtpdebug', false );
+		$SMTPTIMEOUT  = OC_Config::getValue( 'mail_smtptimeout', 10 );
+		$SMTPSECURE   = OC_Config::getValue( 'mail_smtpsecure', '' );
 
 
 		$mailo = new PHPMailer(true);
@@ -57,12 +60,15 @@ class OC_Mail {
 		$mailo->Host = $SMTPHOST;
 		$mailo->Port = $SMTPPORT;
 		$mailo->SMTPAuth = $SMTPAUTH;
+		$mailo->SMTPDebug = $SMTPDEBUG;
+		$mailo->SMTPSecure = $SMTPSECURE;
 		$mailo->Username = $SMTPUSERNAME;
 		$mailo->Password = $SMTPPASSWORD;
+		$mailo->Timeout  = $SMTPTIMEOUT;
 
-		$mailo->From =$fromaddress;
+		$mailo->From = $fromaddress;
 		$mailo->FromName = $fromname;;
-		$mailo->Sender =$fromaddress;
+		$mailo->Sender = $fromaddress;
 		$a=explode(' ', $toaddress);
 		try {
 			foreach($a as $ad) {


### PR DESCRIPTION
Added three additional mail_smtp.. parameters.
- mail_smtpdebug - enable debug messages to analyse SMTP problems.
- mail_smtptimeout - set SMTP timeout which is set to 10s by
  default and this is sometimes to short especially if a malware/
  spam scanner is used.
- mail_smtpsecure - force secure SMTP connections.
