### PR TITLE
Check that external api methods return instances of OC_OCS_Result

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -90,6 +90,9 @@ class OC_API {
 		if(self::isAuthorised(self::$actions[$name])) {
 			if(is_callable(self::$actions[$name]['action'])) {
 				$response = call_user_func(self::$actions[$name]['action'], $parameters);
+				if(!($response instanceof OC_OCS_Result)){
+					$response = new OC_OCS_Result(null, 996, 'Internal Server Error');
+				}
 			} else {
 				$response = new OC_OCS_Result(null, 998, 'Api method not found');
 			} 

--- a/lib/api.php
+++ b/lib/api.php
@@ -90,7 +90,7 @@ class OC_API {
 		if(self::isAuthorised(self::$actions[$name])) {
 			if(is_callable(self::$actions[$name]['action'])) {
 				$response = call_user_func(self::$actions[$name]['action'], $parameters);
-				if(!($response instanceof OC_OCS_Result)){
+				if(!($response instanceof OC_OCS_Result)) {
 					$response = new OC_OCS_Result(null, 996, 'Internal Server Error');
 				}
 			} else {


### PR DESCRIPTION
Catch an error if the api method doesn't return and OC_OCS_Result instance.
