### PR TITLE
API: Treat array keys starting with '@' as XML attributes

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -188,18 +188,25 @@ class OC_API {
 	}
 
 	private static function toXML($array, $writer) {
+		
 		foreach($array as $k => $v) {
-			if (is_numeric($k)) {
+			if (substr($k, 0, 1) === '@') {
+				$writer->writeAttribute(substr($k, 1), $v);
+				continue;
+			} else if (is_numeric($k)) {
 				$k = 'element';
 			}
-			if (is_array($v)) {
+			
+			if(is_array($v)) {
 				$writer->startElement($k);
 				self::toXML($v, $writer);
 				$writer->endElement();
 			} else {
 				$writer->writeElement($k, $v);
 			}
+						
 		}
+		
 	}
 	
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -188,7 +188,6 @@ class OC_API {
 	}
 
 	private static function toXML($array, $writer) {
-		
 		foreach($array as $k => $v) {
 			if (substr($k, 0, 1) === '@') {
 				$writer->writeAttribute(substr($k, 1), $v);
@@ -196,7 +195,6 @@ class OC_API {
 			} else if (is_numeric($k)) {
 				$k = 'element';
 			}
-			
 			if(is_array($v)) {
 				$writer->startElement($k);
 				self::toXML($v, $writer);
@@ -204,9 +202,7 @@ class OC_API {
 			} else {
 				$writer->writeElement($k, $v);
 			}
-						
 		}
-		
 	}
 	
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -189,7 +189,7 @@ class OC_API {
 
 	private static function toXML($array, $writer) {
 		foreach($array as $k => $v) {
-			if (substr($k, 0, 1) === '@') {
+			if ($k[0] === '@') {
 				$writer->writeAttribute(substr($k, 1), $v);
 				continue;
 			} else if (is_numeric($k)) {


### PR DESCRIPTION
Try and test by creating an api method with the following data array:

``` php
        $array = array(
            'array' => array(
                '@version' => '3.0',
                'key' => array(
                    '@attr' => 'attrvalue',
                    'key' => 'value',
                    ),
                'key' => 'value',
                ),
            );
```

Should produce the following result:

``` xml
            <array version="3.0">
                <key attr="attrvalue">
                    <key>value</key>
                </key>
                <anotherkey>value</anotherkey>
            </array>
```
