### PR TITLE
Use global oc_requesttoken for Event Source

### DIFF
--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -40,7 +40,7 @@ OC.EventSource=function(src,data){
 			dataStr+=name+'='+encodeURIComponent(data[name])+'&';
 		}
 	}
-	dataStr+='requesttoken='+OC.EventSource.requesttoken;
+	dataStr+='requesttoken='+oc_requesttoken;
 	if(!this.useFallBack && typeof EventSource !='undefined'){
 		var joinChar = '&';
 		if(src.indexOf('?') == -1) {

--- a/core/templates/update.php
+++ b/core/templates/update.php
@@ -5,7 +5,6 @@
 </ul>
 <script>
 	$(document).ready(function () {
-		OC.EventSource.requesttoken = oc_requesttoken;
 		var updateEventSource = new OC.EventSource(OC.webroot+'/core/ajax/update.php');
 		updateEventSource.listen('success', function(message) {
 			$('<span>').append(message).append('<br />').appendTo($('.update'));


### PR DESCRIPTION
The OC.EventSource.requesttoken variable is undefined and I've been manually setting it. If it is undefined it causes ajax requests to spawn every 10 seconds or so. I'm not sure how to fix that problem. I've replaced OC.EventSource.requesttoken with oc_requesttoken. 

@icewind1991 
