### PR TITLE
Add create permission, fixes #780

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -83,6 +83,9 @@ $breadcrumbNav->assign('baseURL', OCP\Util::linkTo('files', 'index.php') . '?dir
 $maxUploadFilesize=OCP\Util::maxUploadFilesize($dir);
 
 $permissions = OCP\PERMISSION_READ;
+if (OC_Filesystem::isCreatable($dir . '/')) {
+	$permissions |= OCP\PERMISSION_CREATE;
+}
 if (OC_Filesystem::isUpdatable($dir . '/')) {
 	$permissions |= OCP\PERMISSION_UPDATE;
 }


### PR DESCRIPTION
I finally realized that it was only for a **new** folder that create permission didn't appear. I discovered this thanks to issue #1329.
