### PR TITLE
Add .user.ini file for php5-fpm apache system

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,0 +1,3 @@
+upload_max_filesize = 513M
+post_max_size = 513M
+memory_limit = 512M


### PR DESCRIPTION
Apache with php5-fpm will not execute php_flag and php_value in .htaccess file, because apache didn't call php using mod_php.
Php5-fpm will read and apply settings in .user.ini file instead.

Ref #1289
