### PR TITLE
Add Default Robot Disallow

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Add a robots.txt. Often there are older versions of web applications sitting on servers and if that site is publically accessible, there are obvious security implications. This change would stop people from being able to easily find Owncloud installations and make mass exploits harder.
