### PR TITLE
introduction of display names

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -207,6 +207,7 @@ if ($linkItem) {
 		OCP\Util::addScript('files', 'fileactions');
 		$tmpl = new OCP\Template('files_sharing', 'public', 'base');
 		$tmpl->assign('uidOwner', $shareOwner);
+		$tmpl->assign('displayName', \OCP\User::getDisplayName($shareOwner));
 		$tmpl->assign('dir', $dir);
 		$tmpl->assign('filename', $file);
 		$tmpl->assign('mimetype', OC_Filesystem::getMimeType($path));

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -14,9 +14,9 @@
 	<a href="<?php echo link_to('', 'index.php'); ?>" title="" id="owncloud"><img class="svg" src="<?php echo image_path('', 'logo-wide.svg'); ?>" alt="ownCloud" /></a>
 	<div class="header-right">
 	<?php if (isset($_['folder'])): ?>
-		<span id="details"><?php echo $l->t('%s shared the folder %s with you', array($_['uidOwner'], $_['filename'])) ?></span>
+		<span id="details"><?php echo $l->t('%s shared the folder %s with you', array($_['displayName'], $_['filename'])) ?></span>
 	<?php else: ?>
-		<span id="details"><?php echo $l->t('%s shared the file %s with you', array($_['uidOwner'], $_['filename'])) ?></span>
+		<span id="details"><?php echo $l->t('%s shared the file %s with you', array($_['displayName'], $_['filename'])) ?></span>
 	<?php endif; ?>
 		<?php if (!isset($_['folder']) || $_['allowZipDownload']): ?>
 			<a href="<?php echo $_['downloadURL']; ?>" class="button" id="download"><img class="svg" alt="Download" src="<?php echo OCP\image_path("core", "actions/download.svg"); ?>" /><?php echo $l->t('Download')?></a>

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -208,6 +208,50 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 		return false;
 	}
 
+	/**
+	 * @brief get display name of the user
+	 * @param $uid user ID of the user
+	 * @return display name
+	 */
+	public function getDisplayName($uid) {
+		$cacheKey = 'getDisplayName'.$uid;
+		if(!is_null($displayName = $this->connection->getFromCache($cacheKey))) {
+			return $displayName;
+		}
+
+		$displayName = $this->readAttribute(
+			$this->username2dn($uid),
+			$this->connection->ldapUserDisplayName);
+
+		if($displayName && (count($displayName) > 0)) {
+			$this->connection->writeToCache($cacheKey, $displayName);
+			return $displayName[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @brief Get a list of all display names
+	 * @returns array with  all displayNames (value) and the correspondig uids (key)
+	 *
+	 * Get a list of all display names and user ids.
+	 */
+	public function getDisplayNames($search = '', $limit = null, $offset = null) {
+		$cacheKey = 'getDisplayNames-'.$search.'-'.$limit.'-'.$offset;
+		if(!is_null($displayNames = $this->connection->getFromCache($cacheKey))) {
+			return $displayNames;
+		}
+
+		$displayNames = array();
+		$users = $this->getUsers($search, $limit, $offset);
+		foreach ($users as $user) {
+			$displayNames[$user] = $this->getDisplayName($user);
+		}
+		$this->connection->writeToCache($cacheKey, $displayNames);
+		return $displayNames;
+	}
+
 		/**
 	* @brief Check if backend implements actions
 	* @param $actions bitwise-or'ed actions

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -164,7 +164,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);
 					}
 					$offset += $limit;
-					foreach ($users as $displayName => $uid) {
+					foreach ($users as $uid => $displayName) {
 						if ((!isset($_GET['itemShares']) || !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) || !in_array($uid, $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])) && $uid != OC_User::getUser()) {
 							$shareWith[] = array('label' => $displayName, 'value' => array('shareType' => OCP\Share::SHARE_TYPE_USER, 'shareWith' => $uid));
 							$count++;

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -72,6 +72,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 		case 'email':
 			// read post variables
 			$user = OCP\USER::getUser();
+			$displayName = OCP\User::getDisplayName();
 			$type = $_POST['itemType'];
 			$link = $_POST['link'];
 			$file = $_POST['file'];
@@ -81,13 +82,13 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$l = OC_L10N::get('core');
 
 			// setup the email
-			$subject = (string)$l->t('User %s shared a file with you', $user);
+			$subject = (string)$l->t('User %s shared a file with you', $displayName);
 			if ($type === 'dir')
-				$subject = (string)$l->t('User %s shared a folder with you', $user);
+				$subject = (string)$l->t('User %s shared a folder with you', $displayName);
 
-			$text = (string)$l->t('User %s shared the file "%s" with you. It is available for download here: %s', array($user, $file, $link));
+			$text = (string)$l->t('User %s shared the file "%s" with you. It is available for download here: %s', array($displayName, $file, $link));
 			if ($type === 'dir')
-				$text = (string)$l->t('User %s shared the folder "%s" with you. It is available for download here: %s', array($user, $file, $link));
+				$text = (string)$l->t('User %s shared the folder "%s" with you. It is available for download here: %s', array($displayName, $file, $link));
 
 
 			$default_from = OCP\Util::getDefaultEmailAddress('sharing-noreply');
@@ -158,14 +159,14 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				while ($count < 4 && count($users) == $limit) {
 					$limit = 4 - $count;
 					if ($sharePolicy == 'groups_only') {
-						$users = OC_Group::usersInGroups($groups, $_GET['search'], $limit, $offset);
+						$users = OC_Group::DisplayNamesInGroups($groups, $_GET['search'], $limit, $offset);
 					} else {
-						$users = OC_User::getUsers($_GET['search'], $limit, $offset);
+						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);
 					}
 					$offset += $limit;
-					foreach ($users as $user) {
-						if ((!isset($_GET['itemShares']) || !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) || !in_array($user, $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])) && $user != OC_User::getUser()) {
-							$shareWith[] = array('label' => $user, 'value' => array('shareType' => OCP\Share::SHARE_TYPE_USER, 'shareWith' => $user));
+					foreach ($users as $displayName => $uid) {
+						if ((!isset($_GET['itemShares']) || !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) || !in_array($uid, $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])) && $uid != OC_User::getUser()) {
+							$shareWith[] = array('label' => $displayName, 'value' => array('shareType' => OCP\Share::SHARE_TYPE_USER, 'shareWith' => $uid));
 							$count++;
 						}
 					}

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -148,9 +148,9 @@ OC.Share={
 		var html = '<div id="dropdown" class="drop" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
 		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
 			if (data.reshare.share_type == OC.Share.SHARE_TYPE_GROUP) {
-				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.uid_owner})+'</span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.displayname_owner})+'</span>';
 			} else {
-				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.uid_owner})+'</span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner})+'</span>';
 			}
 			html += '<br />';
 		}
@@ -186,9 +186,9 @@ OC.Share={
 						OC.Share.showLink(share.token, share.share_with, itemSource);
 					} else {
 						if (share.collection) {
-							OC.Share.addShareWith(share.share_type, share.share_with, share.permissions, possiblePermissions, share.collection);
+							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.collection);
 						} else {
-							OC.Share.addShareWith(share.share_type, share.share_with, share.permissions, possiblePermissions, false);
+							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname,  share.permissions, possiblePermissions, false);
 						}
 					}
 					if (share.expiration != null) {
@@ -228,7 +228,7 @@ OC.Share={
 				// Default permissions are Read and Share
 				var permissions = OC.PERMISSION_READ | OC.PERMISSION_SHARE;
 				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, function() {
-					OC.Share.addShareWith(shareType, shareWith, permissions, possiblePermissions);
+					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, possiblePermissions);
 					$('#shareWith').val('');
 					OC.Share.updateIcon(itemType, itemSource);
 				});
@@ -257,7 +257,7 @@ OC.Share={
 			}
 		});
 	},
-	addShareWith:function(shareType, shareWith, permissions, possiblePermissions, collection) {
+	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, collection) {
 		if (!OC.Share.itemShares[shareType]) {
 			OC.Share.itemShares[shareType] = [];
 		}
@@ -272,7 +272,7 @@ OC.Share={
 			if (collectionList.length > 0) {
 				$(collectionList).append(', '+shareWith);
 			} else {
-				var html = '<li style="clear: both;" data-collection="'+item+'">'+t('core', 'Shared in {item} with {user}', {'item': item, user: shareWith})+'</li>';
+				var html = '<li style="clear: both;" data-collection="'+item+'">'+t('core', 'Shared in {item} with {user}', {'item': item, user: shareWithDisplayName})+'</li>';
 				$('#shareWithList').prepend(html);
 			}
 		} else {
@@ -295,9 +295,9 @@ OC.Share={
 			var html = '<li style="clear: both;" data-share-type="'+shareType+'" data-share-with="'+shareWith+'" title="' + shareWith + '">';
 			html += '<a href="#" class="unshare" style="display:none;"><img class="svg" alt="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
 			if(shareWith.length > 14){
-				html += shareWith.substr(0,11) + '...';
+				html += shareWithDisplayName.substr(0,11) + '...';
 			}else{
-				html += shareWith;
+				html += shareWithDisplayName;
 			}
 			if (possiblePermissions & OC.PERMISSION_CREATE || possiblePermissions & OC.PERMISSION_UPDATE || possiblePermissions & OC.PERMISSION_DELETE) {
 				if (editChecked == '') {

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title><?php echo isset($_['application']) && !empty($_['application'])?$_['application'].' | ':'' ?>ownCloud <?php echo OC_User::getUser()?' ('.OC_User::getUser().') ':'' ?></title>
+		<title><?php echo isset($_['application']) && !empty($_['application'])?$_['application'].' | ':'' ?>ownCloud <?php echo OC_User::getDisplayName()?' ('.OC_User::getDisplayName().') ':'' ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="shortcut icon" href="<?php echo image_path('', 'favicon.png'); ?>" /><link rel="apple-touch-icon-precomposed" href="<?php echo image_path('', 'favicon-touch.png'); ?>" />
 		<?php foreach($_['cssfiles'] as $cssfile): ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title><?php echo isset($_['application']) && !empty($_['application'])?$_['application'].' | ':'' ?>ownCloud <?php echo OC_User::getDisplayName()?' ('.OC_User::getDisplayName().') ':'' ?></title>
+		<title><?php echo isset($_['application']) && !empty($_['application'])?$_['application'].' | ':'' ?>ownCloud <?php echo OC_User::getDisplayName()?' ('.OC_Util::sanitizeHTML(OC_User::getDisplayName()).') ':'' ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="shortcut icon" href="<?php echo image_path('', 'favicon.png'); ?>" /><link rel="apple-touch-icon-precomposed" href="<?php echo image_path('', 'favicon-touch.png'); ?>" />
 		<?php foreach($_['cssfiles'] as $cssfile): ?>

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -680,6 +680,14 @@
 			</field>
 
 			<field>
+				<name>displayname</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
 				<name>password</name>
 				<type>text</type>
 				<default></default>

--- a/lib/group.php
+++ b/lib/group.php
@@ -286,4 +286,33 @@ class OC_Group {
 		}
 		return $users;
 	}
+	
+	/**
+	 * @brief get a list of all display names in a group
+	 * @returns array with display names (key) and user ids(value)
+	 */
+	public static function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$displayNames=array();
+		foreach(self::$_usedBackends as $backend) {
+			$displayNames = array_merge($backend->displayNamesInGroup($gid, $search, $limit, $offset), $displayNames);
+		}
+		return $displayNames;
+	}
+	
+	/**
+	 * @brief get a list of all display names in several groups
+	 * @param array $gids
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array with display names (Key) user ids (value)
+	 */
+	public static function displayNamesInGroups($gids, $search = '', $limit = -1, $offset = 0) {
+		$displayNames = array();
+		foreach ($gids as $gid) {
+			// TODO Need to apply limits to groups as total
+			$displayNames = array_merge(array_diff(self::displayNamesInGroup($gid, $search, $limit, $offset), $displayNames), $displayNames);
+		}
+		return $displayNames;
+	}
 }

--- a/lib/group.php
+++ b/lib/group.php
@@ -289,7 +289,7 @@ class OC_Group {
 	
 	/**
 	 * @brief get a list of all display names in a group
-	 * @returns array with display names (key) and user ids(value)
+	 * @returns array with display names (value) and user ids(key)
 	 */
 	public static function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$displayNames=array();

--- a/lib/group/backend.php
+++ b/lib/group/backend.php
@@ -133,5 +133,23 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		return array();
 	}
+	
+	/**
+	 * @brief get a list of all display names in a group
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array with display names (key) and user ids (value)
+	 */
+	public function DisplayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$displayNames = '';
+		$users = $this->usersInGroup($gid, $search, $limit, $offset);
+		foreach ( $users as $user ) {
+			$DisplayNames[$user] = $user;
+		}
+			
+		return $DisplayNames;
+	}
 
 }

--- a/lib/group/backend.php
+++ b/lib/group/backend.php
@@ -140,7 +140,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return array with display names (key) and user ids (value)
+	 * @return array with display names (value) and user ids (key)
 	 */
 	public function DisplayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$displayNames = '';

--- a/lib/group/database.php
+++ b/lib/group/database.php
@@ -208,4 +208,32 @@ class OC_Group_Database extends OC_Group_Backend {
 		}
 		return $users;
 	}
+	
+	/**
+	 * @brief get a list of all display names in a group
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array with display names (value) and user ids (key)
+	 */
+	public function DisplayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
+		$displayNames = '';
+		/*
+		
+		SELECT Persons.LastName, Persons.FirstName, Orders.OrderNo
+		FROM Persons
+		INNER JOIN Orders
+		ON Persons.P_Id=Orders.P_Id
+		ORDER BY Persons.LastName
+		*/
+		$stmt = OC_DB::prepare('SELECT `*PREFIX*users`.`uid`, `*PREFIX*users`.`displayname` FROM `*PREFIX*users` INNER JOIN `*PREFIX*group_user` ON `*PREFIX*group_user`.`uid` = `*PREFIX*users`.`uid`  WHERE `gid` = ? AND `*PREFIX*group_user.uid` LIKE ?', $limit, $offset);
+		$result = $stmt->execute(array($gid, $search.'%'));
+		$users = array();
+		while ($row = $result->fetchRow()) {
+			$displayName = trim($row['displayname'], ' ');
+			$displayNames[$row['uid']] = empty($displayName) ? $row['uid'] : $displayName;
+		}
+		return $displayNames;
+	}
 }

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -946,6 +946,15 @@ class Share {
 					continue;
 				}
 			}
+
+			// Add display names to result
+			if ( isset($row['share_with']) && $row['share_with'] != '') {
+				$row['share_with_displayname'] = \OCP\User::getDisplayName($row['share_with']);
+			}
+			if ( isset($row['uid_owner']) && $row['uid_owner'] != '') {
+				$row['displayname_owner'] = \OCP\User::getDisplayName($row['uid_owner']);
+			}
+			
 			$items[$row['id']] = $row;
 		}
 		if (!empty($items)) {

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -62,7 +62,7 @@ class User {
 	
 	/**
 	 * @brief Get a list of all display names
-	 * @returns array with all display names (key) and the correspondig uids (value)
+	 * @returns array with all display names (value) and the correspondig uids (key)
 	 *
 	 * Get a list of all display names and user ids.
 	 */

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -51,7 +51,15 @@ class User {
 	public static function getUsers($search = '', $limit = null, $offset = null) {
 		return \OC_USER::getUsers();
 	}
-
+	
+	/**
+	 * @brief get the user display name of the user currently logged in.
+	 * @return string display name
+	 */
+	public static function getDisplayName() {
+		return \OC_USER::getDisplayName();
+	}
+	
 	/**
 	 * @brief Check if the user is logged in
 	 * @returns true/false

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -56,8 +56,8 @@ class User {
 	 * @brief get the user display name of the user currently logged in.
 	 * @return string display name
 	 */
-	public static function getDisplayName() {
-		return \OC_USER::getDisplayName();
+	public static function getDisplayName($user=null) {
+		return \OC_USER::getDisplayName($user);
 	}
 	
 	/**

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -62,9 +62,9 @@ class User {
 	
 	/**
 	 * @brief Get a list of all display names
-	 * @returns array with all display names and the correspondig uids
+	 * @returns array with all display names (key) and the correspondig uids (value)
 	 *
-	 * Get a list of all display names.
+	 * Get a list of all display names and user ids.
 	 */
 	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
 		return \OC_USER::getDisplayNames($search, $limit, $offset);

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -61,6 +61,16 @@ class User {
 	}
 	
 	/**
+	 * @brief Get a list of all display names
+	 * @returns array with all display names and the correspondig uids
+	 *
+	 * Get a list of all display names.
+	 */
+	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
+		return \OC_USER::getDisplayNames($search, $limit, $offset);
+	}
+	
+	/**
 	 * @brief Check if the user is logged in
 	 * @returns true/false
 	 *

--- a/lib/user.php
+++ b/lib/user.php
@@ -265,7 +265,7 @@ class OC_User {
 	public static function setUserId($uid) {
 		$_SESSION['user_id'] = $uid;
 	}
-	
+
 	/**
 	 * @brief Sets user display name for session
 	 */
@@ -284,10 +284,10 @@ class OC_User {
 			$result = true;
 		}
 		$_SESSION['display_name'] = $displayName;
-		return result;
+		return $result;
 	}
-	
-	
+
+
 	/**
 	 * @brief get display name
 	 * @param $uid The username
@@ -360,7 +360,7 @@ class OC_User {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * @brief get the display name of the user currently logged in.
 	 * @return string uid or false
@@ -375,7 +375,7 @@ class OC_User {
 			return false;
 		}
 	}
-	
+
 	/**
 	 * @brief Autogenerate a password
 	 * @returns string
@@ -474,7 +474,7 @@ class OC_User {
 		asort($users);
 		return $users;
 	}
-	
+
 	/**
 	 * @brief Get a list of all users display name
 	 * @returns associative array with all display names (value) and corresponding uids (key)

--- a/lib/user.php
+++ b/lib/user.php
@@ -269,9 +269,24 @@ class OC_User {
 	/**
 	 * @brief Sets user display name for session
 	 */
-	private static function setDisplayName($uid) {
-		$_SESSION['display_name'] = self::determineDisplayName($uid);
+	public static function setDisplayName($uid, $displayName = null) {
+		$result = false;
+		if ($displayName ) {
+			foreach(self::$_usedBackends as $backend) {
+				if($backend->implementsActions(OC_USER_BACKEND_SET_DISPLAYNAME)) {
+					if($backend->userExists($uid)) {
+						$success |= $backend->setDisplayName($uid, $displayName);
+					}
+				}
+			}
+		} else {
+			$displayName = self::determineDisplayName($uid);
+			$result = true;
+		}
+		$_SESSION['display_name'] = $displayName;
+		return result;
 	}
+	
 	
 	/**
 	 * @brief get display name

--- a/lib/user.php
+++ b/lib/user.php
@@ -351,7 +351,7 @@ class OC_User {
 	 * @return string uid or false
 	 */
 	public static function getDisplayName() {
-		if( isset($_SESSION['user_id']) AND $_SESSION['user_id'] ) {
+		if( isset($_SESSION['display_name']) AND $_SESSION['display_name'] ) {
 			return $_SESSION['display_name'];
 		}
 		else{

--- a/lib/user.php
+++ b/lib/user.php
@@ -350,8 +350,10 @@ class OC_User {
 	 * @brief get the display name of the user currently logged in.
 	 * @return string uid or false
 	 */
-	public static function getDisplayName() {
-		if( isset($_SESSION['display_name']) AND $_SESSION['display_name'] ) {
+	public static function getDisplayName($user=null) {
+		if ( $user ) {
+			return self::determineDisplayName($user);
+		} else if( isset($_SESSION['display_name']) AND $_SESSION['display_name'] ) {
 			return $_SESSION['display_name'];
 		}
 		else{

--- a/lib/user.php
+++ b/lib/user.php
@@ -251,6 +251,7 @@ class OC_User {
 			if($uid && $enabled) {
 				session_regenerate_id(true);
 				self::setUserId($uid);
+				self::setDisplayName($uid);
 				OC_Hook::emit( "OC_User", "post_login", array( "uid" => $uid, 'password'=>$password ));
 				return true;
 			}
@@ -263,6 +264,31 @@ class OC_User {
 	 */
 	public static function setUserId($uid) {
 		$_SESSION['user_id'] = $uid;
+	}
+	
+	/**
+	 * @brief Sets user display name for session
+	 */
+	private static function setDisplayName($uid) {
+		$_SESSION['display_name'] = self::determineDisplayName($uid);
+	}
+	
+	/**
+	 * @brief get display name
+	 * @param $uid The username
+	 * @returns string display name or uid if no display name is defined
+	 *
+	 */
+	private static function determineDisplayName( $uid ) {
+		foreach(self::$_usedBackends as $backend) {
+			if($backend->implementsActions(OC_USER_BACKEND_GET_DISPLAYNAME)) {
+				$result=$backend->getDisplayName( $uid );
+				if($result) {
+					return $result;
+				}
+			}
+		}
+		return $uid;
 	}
 
 	/**
@@ -319,7 +345,20 @@ class OC_User {
 			return false;
 		}
 	}
-
+	
+	/**
+	 * @brief get the display name of the user currently logged in.
+	 * @return string uid or false
+	 */
+	public static function getDisplayName() {
+		if( isset($_SESSION['user_id']) AND $_SESSION['user_id'] ) {
+			return $_SESSION['display_name'];
+		}
+		else{
+			return false;
+		}
+	}
+	
 	/**
 	 * @brief Autogenerate a password
 	 * @returns string

--- a/lib/user.php
+++ b/lib/user.php
@@ -283,7 +283,9 @@ class OC_User {
 			$displayName = self::determineDisplayName($uid);
 			$result = true;
 		}
-		$_SESSION['display_name'] = $displayName;
+		if (OC_User::getUser() === $uid) {
+			$_SESSION['display_name'] = $displayName;
+		}
 		return $result;
 	}
 

--- a/lib/user.php
+++ b/lib/user.php
@@ -460,9 +460,9 @@ class OC_User {
 	
 	/**
 	 * @brief Get a list of all users display name
-	 * @returns associative array with all display names and corresponding uids
+	 * @returns associative array with all display names (key) and corresponding uids (value)
 	 *
-	 * Get a list of all users.
+	 * Get a list of all display names and user ids.
 	 */
 	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = array();

--- a/lib/user.php
+++ b/lib/user.php
@@ -477,7 +477,7 @@ class OC_User {
 	
 	/**
 	 * @brief Get a list of all users display name
-	 * @returns associative array with all display names (key) and corresponding uids (value)
+	 * @returns associative array with all display names (value) and corresponding uids (key)
 	 *
 	 * Get a list of all display names and user ids.
 	 */

--- a/lib/user.php
+++ b/lib/user.php
@@ -457,6 +457,24 @@ class OC_User {
 		asort($users);
 		return $users;
 	}
+	
+	/**
+	 * @brief Get a list of all users display name
+	 * @returns associative array with all display names and corresponding uids
+	 *
+	 * Get a list of all users.
+	 */
+	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
+		$displayNames = array();
+		foreach (self::$_usedBackends as $backend) {
+			$backendDisplayNames = $backend->getDisplayNames($search, $limit, $offset);
+			if (is_array($backendDisplayNames)) {
+				$displayNames = array_merge($displayNames, $backendDisplayNames);
+			}
+		}
+		ksort($displayNames);
+		return $displayNames;
+	}
 
 	/**
 	 * @brief check if a user exists

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -134,7 +134,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	
 	/**
 	 * @brief Get a list of all display names
-	 * @returns array with  all displayNames (key) and the correspondig uids (value)
+	 * @returns array with  all displayNames (value) and the correspondig uids (key)
 	 *
 	 * Get a list of all display names and user ids.
 	 */
@@ -142,7 +142,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 		$displayNames = array();
 		$users = $this->getUsers($search, $limit, $offset);
 		foreach ( $users as $user) {
-			$displayNames[$user] = $user;
+			$displayNames[$user] = "foo";
 		}
 		return $displayNames;
 	}

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -36,6 +36,7 @@ define('OC_USER_BACKEND_SET_PASSWORD',      0x000010);
 define('OC_USER_BACKEND_CHECK_PASSWORD',    0x000100);
 define('OC_USER_BACKEND_GET_HOME',			0x001000);
 define('OC_USER_BACKEND_GET_DISPLAYNAME',	0x010000);
+define('OC_USER_BACKEND_SET_DISPLAYNAME',	0x010000);
 
 
 /**
@@ -52,6 +53,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 		OC_USER_BACKEND_CHECK_PASSWORD => 'checkPassword',
 		OC_USER_BACKEND_GET_HOME => 'getHome',
 		OC_USER_BACKEND_GET_DISPLAYNAME => 'getDisplayName',
+		OC_USER_BACKEND_SET_DISPLAYNAME => 'setDisplayName',
 	);
 
 	/**

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -131,4 +131,19 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	public function getDisplayName($uid) {
 		return $uid;
 	}
+	
+	/**
+	 * @brief Get a list of all display names
+	 * @returns array with  all displayNames and the correspondig uids
+	 *
+	 * Get a list of all display names.
+	 */
+	public function getDisplayNames($search = '', $limit = null, $offset = null) {
+		$displayNames = array();
+		$users = $this->getUsers($search, $limit, $offset);
+		foreach ( $users as $user) {
+			$displayNames[$user] = $user;
+		}
+		return $displayNames;
+	}
 }

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -134,9 +134,9 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	
 	/**
 	 * @brief Get a list of all display names
-	 * @returns array with  all displayNames and the correspondig uids
+	 * @returns array with  all displayNames (key) and the correspondig uids (value)
 	 *
-	 * Get a list of all display names.
+	 * Get a list of all display names and user ids.
 	 */
 	public function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = array();

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -35,6 +35,7 @@ define('OC_USER_BACKEND_CREATE_USER',       0x000001);
 define('OC_USER_BACKEND_SET_PASSWORD',      0x000010);
 define('OC_USER_BACKEND_CHECK_PASSWORD',    0x000100);
 define('OC_USER_BACKEND_GET_HOME',			0x001000);
+define('OC_USER_BACKEND_GET_DISPLAYNAME',	0x010000);
 
 
 /**
@@ -50,6 +51,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 		OC_USER_BACKEND_SET_PASSWORD => 'setPassword',
 		OC_USER_BACKEND_CHECK_PASSWORD => 'checkPassword',
 		OC_USER_BACKEND_GET_HOME => 'getHome',
+		OC_USER_BACKEND_GET_DISPLAYNAME => 'getDisplayName',
 	);
 
 	/**
@@ -119,5 +121,14 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	*/
 	public function getHome($uid) {
 		return false;
+	}
+	
+	/**
+	 * @brief get display name of the user
+	 * @param $uid user ID of the user
+	 * @return display name
+	 */
+	public function getDisplayName($uid) {
+		return $uid;
 	}
 }

--- a/lib/user/backend.php
+++ b/lib/user/backend.php
@@ -144,7 +144,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 		$displayNames = array();
 		$users = $this->getUsers($search, $limit, $offset);
 		foreach ( $users as $user) {
-			$displayNames[$user] = "foo";
+			$displayNames[$user] = $user;
 		}
 		return $displayNames;
 	}

--- a/lib/user/database.php
+++ b/lib/user/database.php
@@ -110,6 +110,24 @@ class OC_User_Database extends OC_User_Backend {
 			return false;
 		}
 	}
+	
+	/**
+	 * @brief Set display name
+	 * @param $uid The username
+	 * @param $displayName The new display name
+	 * @returns true/false
+	 *
+	 * Change the display name of a user
+	 */
+	public function setDisplayName( $uid, $displayName ) {
+		if( $this->userExists($uid) ) {
+			$query = OC_DB::prepare( 'UPDATE `*PREFIX*users` SET `displayname` = ? WHERE `uid` = ?' );
+			$query->execute( array( $displayName, $uid ));
+			return true;
+		}else{
+			return false;
+		}
+	}
 
 	/**
 	 * @brief Check if the password is correct

--- a/lib/user/database.php
+++ b/lib/user/database.php
@@ -155,7 +155,7 @@ class OC_User_Database extends OC_User_Backend {
 	 */
 	public function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = array();
-		$query = OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) LIKE LOWER(?)', $limit, $offset);
+		$query = OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`displayname`) LIKE LOWER(?)', $limit, $offset);
 		$result = $query->execute(array($search.'%'));
 		$users = array();
 		while ($row = $result->fetchRow()) {

--- a/lib/user/database.php
+++ b/lib/user/database.php
@@ -130,6 +130,40 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
+	 * @brief get display name of the user
+	 * @param $uid user ID of the user
+	 * @return display name
+	 */
+	public function getDisplayName($uid) {
+		if( $this->userExists($uid) ) {
+			$query = OC_DB::prepare( 'SELECT displayname FROM `*PREFIX*users` WHERE `uid` = ?' );
+			$result = $query->execute( array( $uid ))->fetchAll();
+			if (!empty($result[0]['displayname'])) {
+				return $result[0]['displayname'];
+			} else {
+				return $uid;
+			}
+		}
+	}
+	
+	/**
+	 * @brief Get a list of all display names
+	 * @returns array with  all displayNames (value) and the correspondig uids (key)
+	 *
+	 * Get a list of all display names and user ids.
+	 */
+	public function getDisplayNames($search = '', $limit = null, $offset = null) {
+		$displayNames = array();
+		$query = OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) LIKE LOWER(?)', $limit, $offset);
+		$result = $query->execute(array($search.'%'));
+		$users = array();
+		while ($row = $result->fetchRow()) {
+			$displayNames[$row['uid']] = $row['displayname'];
+		}
+		return $displayNames;
+	}
+	
+	/**
 	 * @brief Check if the password is correct
 	 * @param $uid The username
 	 * @param $password The password

--- a/lib/user/database.php
+++ b/lib/user/database.php
@@ -138,8 +138,9 @@ class OC_User_Database extends OC_User_Backend {
 		if( $this->userExists($uid) ) {
 			$query = OC_DB::prepare( 'SELECT displayname FROM `*PREFIX*users` WHERE `uid` = ?' );
 			$result = $query->execute( array( $uid ))->fetchAll();
-			if (!empty($result[0]['displayname'])) {
-				return $result[0]['displayname'];
+			$displayName = trim($result[0]['displayname'], ' ');
+			if ( !empty($displayName) ) {
+				return $displayName;
 			} else {
 				return $uid;
 			}
@@ -158,7 +159,8 @@ class OC_User_Database extends OC_User_Backend {
 		$result = $query->execute(array($search.'%'));
 		$users = array();
 		while ($row = $result->fetchRow()) {
-			$displayNames[$row['uid']] = $row['displayname'];
+			$displayName =  trim($row['displayname'], ' ');
+			$displayNames[$row['uid']] = empty($displayName) ? $row['uid'] : $displayName;
 		}
 		return $displayNames;
 	}

--- a/lib/user/interface.php
+++ b/lib/user/interface.php
@@ -57,4 +57,19 @@ interface OC_User_Interface {
 	*/
 	public function userExists($uid);
 
+	/**
+	 * @brief get display name of the user
+	 * @param $uid user ID of the user
+	 * @return display name
+	 */
+	public function getDisplayName($uid);
+
+	/**
+	 * @brief Get a list of all display names
+	 * @returns array with  all displayNames (value) and the correspondig uids (key)
+	 *
+	 * Get a list of all display names and user ids.
+	 */
+	public function getDisplayNames($search = '', $limit = null, $offset = null);
+
 }

--- a/lib/util.php
+++ b/lib/util.php
@@ -95,7 +95,7 @@ class OC_Util {
 	 */
 	public static function getVersion() {
 		// hint: We only can count up. So the internal version number of ownCloud 4.5 will be 4.90.0. This is not visible to the user
-		return array(4, 91, 02);
+		return array(4, 91, 03);
 	}
 
 	/**

--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -1,0 +1,15 @@
+<?php
+// Check if we are a user
+OCP\JSON::callCheck();
+OC_JSON::checkLoggedIn();
+
+$username = isset($_POST["username"]) ? $_POST["username"] : OC_User::getUser();
+$displayName = $_POST["displayName"];
+
+// Return Success story
+if( OC_User::setDisplayName( $username, $displayName )) {
+	OC_JSON::success(array("data" => array( "username" => $username )));
+}
+else{
+	OC_JSON::error(array("data" => array( "message" => "Unable to change display name" )));
+}

--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -6,6 +6,19 @@ OC_JSON::checkLoggedIn();
 $username = isset($_POST["username"]) ? $_POST["username"] : OC_User::getUser();
 $displayName = $_POST["displayName"];
 
+$userstatus = null;
+if(OC_User::isAdminUser(OC_User::getUser())) {
+	$userstatus = 'admin';
+}
+if(OC_SubAdmin::isUserAccessible(OC_User::getUser(), $username)) {
+	$userstatus = 'subadmin';
+}
+
+if(is_null($userstatus)) {
+	OC_JSON::error( array( "data" => array( "message" => "Authentication error" )));
+	exit();
+}
+
 // Return Success story
 if( OC_User::setDisplayName( $username, $displayName )) {
 	OC_JSON::success(array("data" => array( "username" => $username )));

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -320,7 +320,6 @@ $(document).ready(function () {
                         OC.filePath('settings', 'ajax', 'changedisplayname.php'),
                         {username:uid, displayName:$(this).val()},
                         function (result) {
-                        	console.log("come back!");
                         }
                     );
                     input.blur();

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -70,7 +70,9 @@ var UserList = {
     add:function (username, groups, subadmin, quota, sort) {
         var tr = $('tbody tr').first().clone();
         tr.attr('data-uid', username);
+        tr.attr('data-displayName', username);
         tr.find('td.name').text(username);
+        tr.find('td.displayName').text(username);
         var groupsSelect = $('<select multiple="multiple" class="groupsselect" data-placehoder="Groups" title="' + t('settings', 'Groups') + '"></select>').attr('data-username', username).attr('data-user-groups', groups);
         tr.find('td.groups').empty();
         if (tr.find('td.subadmins').length > 0) {

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -311,11 +311,8 @@ $(document).ready(function () {
         img.parent().children('span').replaceWith(input);
         input.focus();
         input.keypress(function (event) {
-        	console.log("event!");
             if (event.keyCode == 13) {
-            	console.log("13");
                 if ($(this).val().length > 0) {
-                	console.log("post");
                     $.post(
                         OC.filePath('settings', 'ajax', 'changedisplayname.php'),
                         {username:uid, displayName:$(this).val()},

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -305,7 +305,8 @@ $(document).ready(function () {
         event.stopPropagation();
         var img = $(this);
         var uid = img.parent().parent().attr('data-uid');
-        var input = $('<input type="text">');
+        var displayName = img.parent().parent().attr('data-displayName');
+        var input = $('<input type="text" value="'+displayName+'">');
         img.css('display', 'none');
         img.parent().children('span').replaceWith(input);
         input.focus();

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -300,6 +300,43 @@ $(document).ready(function () {
     $('td.password').live('click', function (event) {
         $(this).children('img').click();
     });
+    
+    $('td.displayName>img').live('click', function (event) {
+        event.stopPropagation();
+        var img = $(this);
+        var uid = img.parent().parent().attr('data-uid');
+        var input = $('<input type="text">');
+        img.css('display', 'none');
+        img.parent().children('span').replaceWith(input);
+        input.focus();
+        input.keypress(function (event) {
+        	console.log("event!");
+            if (event.keyCode == 13) {
+            	console.log("13");
+                if ($(this).val().length > 0) {
+                	console.log("post");
+                    $.post(
+                        OC.filePath('settings', 'ajax', 'changedisplayname.php'),
+                        {username:uid, displayName:$(this).val()},
+                        function (result) {
+                        	console.log("come back!");
+                        }
+                    );
+                    input.blur();
+                } else {
+                    input.blur();
+                }
+            }
+        });
+        input.blur(function () {
+            $(this).replaceWith($(this).val());
+            img.css('display', '');
+        });
+    });
+    $('td.displayName').live('click', function (event) {
+        $(this).children('img').click();
+    });
+    
 
     $('select.quota, select.quota-user').live('change', function () {
         var select = $(this);

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -39,6 +39,8 @@ $this->create('settings_ajax_removegroup', '/settings/ajax/removegroup.php')
 	->actionInclude('settings/ajax/removegroup.php');
 $this->create('settings_ajax_changepassword', '/settings/ajax/changepassword.php')
 	->actionInclude('settings/ajax/changepassword.php');
+$this->create('settings_ajax_changedisplayname', '/settings/ajax/changedisplayname.php')
+->actionInclude('settings/ajax/changedisplayname.php');
 // personel
 $this->create('settings_ajax_lostpassword', '/settings/ajax/lostpassword.php')
 	->actionInclude('settings/ajax/lostpassword.php');

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -91,7 +91,8 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 	</thead>
 	<tbody>
 		<?php foreach($_["users"] as $user): ?>
-		<tr data-uid="<?php echo $user["name"] ?>">
+		<tr data-uid="<?php echo $user["name"] ?>"
+			data-displayName="<?php echo $user["displayName"] ?>">
 			<td class="name"><?php echo $user["name"]; ?></td>
 			<td class="displayName"><span><?php echo $user["displayName"]; ?></span> <img class="svg action"
 				src="<?php echo image_path('core', 'actions/rename.svg')?>"

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -79,6 +79,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 	<thead>
 		<tr>
 			<th id='headerName'><?php echo $l->t('Name')?></th>
+			<th id="headerDisplayName"><?php echo $l->t( 'Display Name' ); ?></th>
 			<th id="headerPassword"><?php echo $l->t( 'Password' ); ?></th>
 			<th id="headerGroups"><?php echo $l->t( 'Groups' ); ?></th>
 			<?php if(is_array($_['subadmins']) || $_['subadmins']): ?>
@@ -92,6 +93,10 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 		<?php foreach($_["users"] as $user): ?>
 		<tr data-uid="<?php echo $user["name"] ?>">
 			<td class="name"><?php echo $user["name"]; ?></td>
+			<td class="displayName"><?php echo $user["displayName"]; ?> <img class="svg action"
+				src="<?php echo image_path('core', 'actions/rename.svg')?>"
+				alt="change display name" title="change display name"/>
+			</td>
 			<td class="password"><span>●●●●●●●</span> <img class="svg action"
 				src="<?php echo image_path('core', 'actions/rename.svg')?>"
 				alt="set new password" title="set new password"/>
@@ -157,7 +162,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 				</div>
 			</td>
 			<td class="remove">
-				<?php if($user['uid']!=OC_User::getUser()):?>
+				<?php if($user['name']!=OC_User::getUser()):?>
 					<a href="#" class="action delete" original-title="<?php echo $l->t('Delete')?>">
 						<img src="<?php echo image_path('core', 'actions/delete.svg') ?>" />
 					</a>

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -157,7 +157,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 				</div>
 			</td>
 			<td class="remove">
-				<?php if($user['name']!=OC_User::getUser()):?>
+				<?php if($user['uid']!=OC_User::getUser()):?>
 					<a href="#" class="action delete" original-title="<?php echo $l->t('Delete')?>">
 						<img src="<?php echo image_path('core', 'actions/delete.svg') ?>" />
 					</a>

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -93,7 +93,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 		<?php foreach($_["users"] as $user): ?>
 		<tr data-uid="<?php echo $user["name"] ?>">
 			<td class="name"><?php echo $user["name"]; ?></td>
-			<td class="displayName"><?php echo $user["displayName"]; ?> <img class="svg action"
+			<td class="displayName"><span><?php echo $user["displayName"]; ?></span> <img class="svg action"
 				src="<?php echo image_path('core', 'actions/rename.svg')?>"
 				alt="change display name" title="change display name"/>
 			</td>

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -18,7 +18,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 </script>
 <div id="controls">
 	<form id="newuser" autocomplete="off">
-		<input id="newusername" type="text" placeholder="<?php echo $l->t('Name')?>" /> <input
+		<input id="newusername" type="text" placeholder="<?php echo $l->t('Login Name')?>" /> <input
 			type="password" id="newuserpassword"
 			placeholder="<?php echo $l->t('Password')?>" /> <select
 			class="groupsselect"
@@ -78,7 +78,7 @@ var isadmin = <?php echo $_['isadmin']?'true':'false'; ?>;
 <table data-groups="<?php echo implode(', ', $allGroups);?>">
 	<thead>
 		<tr>
-			<th id='headerName'><?php echo $l->t('Name')?></th>
+			<th id='headerName'><?php echo $l->t('Login Name')?></th>
 			<th id="headerDisplayName"><?php echo $l->t( 'Display Name' ); ?></th>
 			<th id="headerPassword"><?php echo $l->t( 'Password' ); ?></th>
 			<th id="headerGroups"><?php echo $l->t( 'Groups' ); ?></th>

--- a/settings/users.php
+++ b/settings/users.php
@@ -53,6 +53,7 @@ foreach($accessibleusers as $displayName => $uid) {
 	
 	$users[] = array(
 		"name" => $name,
+		"uid" => $uid,
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($uid)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
 		'quota'=>$quota,
 		'isQuotaUserDefined'=>$isQuotaUserDefined,

--- a/settings/users.php
+++ b/settings/users.php
@@ -26,7 +26,7 @@ if($isadmin) {
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
 	$accessiblegroups = OC_SubAdmin::getSubAdminsGroups(OC_User::getUser());
-	$accessibleusers = OC_Group::usersInGroups($accessiblegroups, '', 30);
+	$accessibleusers = OC_Group::displayNamesInGroups($accessiblegroups, '', 30);
 	$subadmins = false;
 }
 

--- a/settings/users.php
+++ b/settings/users.php
@@ -57,7 +57,7 @@ foreach($accessibleusers as $displayName => $uid) {
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($uid)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
 		'quota'=>$quota,
 		'isQuotaUserDefined'=>$isQuotaUserDefined,
-		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($iuid)));
+		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($uid)));
 }
 
 foreach( $accessiblegroups as $i ) {

--- a/settings/users.php
+++ b/settings/users.php
@@ -22,7 +22,7 @@ $isadmin = OC_User::isAdminUser(OC_User::getUser());
 
 if($isadmin) {
 	$accessiblegroups = OC_Group::getGroups();
-	$accessibleusers = OC_User::getUsers('', 30);
+	$accessibleusers = OC_User::getDisplayNames('', 30);
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
 	$accessiblegroups = OC_SubAdmin::getSubAdminsGroups(OC_User::getUser());
@@ -42,16 +42,21 @@ $defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
 $defaultQuotaIsUserDefined=array_search($defaultQuota, $quotaPreset)===false && array_search($defaultQuota, array('none', 'default'))===false;
 
 // load users and quota
-foreach($accessibleusers as $i) {
+foreach($accessibleusers as $displayName => $uid) {
 	$quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
 	$isQuotaUserDefined=array_search($quota, $quotaPreset)===false && array_search($quota, array('none', 'default'))===false;
 
+	$name = $displayName;
+	if ( $displayName != $uid ) {
+		$name = $name . ' ('.$uid.')';
+	} 
+	
 	$users[] = array(
-		"name" => $i,
-		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($i)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
+		"name" => $name,
+		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($uid)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
 		'quota'=>$quota,
 		'isQuotaUserDefined'=>$isQuotaUserDefined,
-		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($i)));
+		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($iuid)));
 }
 
 foreach( $accessiblegroups as $i ) {

--- a/settings/users.php
+++ b/settings/users.php
@@ -42,7 +42,7 @@ $defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
 $defaultQuotaIsUserDefined=array_search($defaultQuota, $quotaPreset)===false && array_search($defaultQuota, array('none', 'default'))===false;
 
 // load users and quota
-foreach($accessibleusers as $displayName => $uid) {
+foreach($accessibleusers as $uid => $displayName) {
 	$quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
 	$isQuotaUserDefined=array_search($quota, $quotaPreset)===false && array_search($quota, array('none', 'default'))===false;
 
@@ -52,8 +52,8 @@ foreach($accessibleusers as $displayName => $uid) {
 	} 
 	
 	$users[] = array(
-		"name" => $name,
-		"uid" => $uid,
+		"name" => $uid,
+		"displayName" => $displayName, 
 		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($uid)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
 		'quota'=>$quota,
 		'isQuotaUserDefined'=>$isQuotaUserDefined,

--- a/settings/users.php
+++ b/settings/users.php
@@ -43,7 +43,7 @@ $defaultQuotaIsUserDefined=array_search($defaultQuota, $quotaPreset)===false && 
 
 // load users and quota
 foreach($accessibleusers as $uid => $displayName) {
-	$quota=OC_Preferences::getValue($i, 'files', 'quota', 'default');
+	$quota=OC_Preferences::getValue($uid, 'files', 'quota', 'default');
 	$isQuotaUserDefined=array_search($quota, $quotaPreset)===false && array_search($quota, array('none', 'default'))===false;
 
 	$name = $displayName;


### PR DESCRIPTION
This pull request introduce display names. If the user back-end supports display names you can define random names, different to the login names, as display names. Currently the LDAP-Back-End and our database back-end supports display names. Both implementations are part of this pull request.

If you are the author of a user back-end which also knows the concept of display names feel free to add it to your ownCloud implementation.

The display name will be used in various places as your primary name, e.g automatically generated mail, sharing dialog, etc. It is only used to represent the user in the various interfaces. For internal reference we continue to use the login name.

This means that if you use the name of the user only for internal purpose, e.g in the database, to access the data folder, etc nothing has to be changed. If your App also displays the name in the UI, in mails, etc than you should change your App to retrieve the display name instead of the login name. Therefore we introduced some new functions:

OCP\User:: getDisplayName($user=null)
-> returns either the display name of the current user or of the user
(login name) given as parameter

OCP\User::getDisplayNames($search = '', $limit = null, $offset = null)
-> lets you search for a specific display name and returns an array with
the login name as key and the display name as value

Both function behave the same as OCP\User:: getUsers() and OCP\User::getUserNames();

In most cases it should be enough to just replace the function names in your code when you want to get the display name instead of the login name.

I already made the necessary changes to ownCloud core which are also part of this pull request. Feel free to double check you Core-App to make sure that I didn't miss something.
