### PR TITLE
remove z-index from app labels which caused overlap with top bar

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -55,8 +55,8 @@ small.recommendedapp.list { float: right; }
 span.version { margin-left:1em; margin-right:1em; color:#555; }
 
 .app { position: relative; display: inline-block; padding: 0.2em 0 0.2em 0 !important; text-overflow: hidden; overflow: hidden; white-space: nowrap; /*transition: .2s max-width linear; -o-transition: .2s max-width linear; -moz-transition: .2s max-width linear; -webkit-transition: .2s max-width linear; -ms-transition: .2s max-width linear;*/ }
-.app.externalapp { max-width: 12.5em; z-index: 100; }
-.app.recommendedapp { max-width: 12.5em; z-index: 100; }
+.app.externalapp { max-width: 12.5em; }
+.app.recommendedapp { max-width: 12.5em; }
 /* Transition to complete width! */
 .app:hover, .app:active { max-width: inherit; }
 


### PR DESCRIPTION
The z-index caused the text to overlap over the top bar (only in Firefox weirdly enough). @tanghus apparently you put it there, what was that supposed to do? Can’t see anything obviously wrong with it being gone.

@Raydiation can you also check it out? Thanks!
