### PR TITLE
Accept Language Header check is case sensitive ... 

### DIFF
--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -270,7 +270,7 @@ class OC_L10N{
 		}
 
 		if(isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-			$accepted_languages = preg_split('/,\s*/', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
+			$accepted_languages = preg_split('/,\s*/', strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']));
 			if(is_array($app)) {
 				$available = $app;
 			}


### PR DESCRIPTION
It seems that 

`curl -H "Accept-Language:DE"  "http://localhost/"` 
give the page in "EN"  and  
`curl -H "Accept-Language:de"  "http://localhost/"` give it correctly in DE ....

This fix the #1328
