### PR TITLE
quick fixing this require_once.

### DIFF
--- a/lib/archive/tar.php
+++ b/lib/archive/tar.php
@@ -6,7 +6,7 @@
  * See the COPYING-README file.
  */
 
-require_once 'Archive/Tar.php';
+require_once OC::$THIRDPARTYROOT . '/3rdparty/Archive/Tar.php';
 
 class OC_Archive_TAR extends OC_Archive{
 	const PLAIN=0;


### PR DESCRIPTION
On windows the wrong file will be required: lib/archive/tar.php and not Archive/Tar.php.

Best would be to rename the lib/archive/tar.php or put it into a different folder

Has anybody a better idea? @bartv2 @icewind1991 @blizzz @butonic THX
