### PR TITLE
Add Redirect to getUrlContent fix #1065

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -639,6 +639,9 @@ class OC_Util {
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 10);
 			curl_setopt($curl, CURLOPT_URL, $url);
+			curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+			curl_setopt($curl, CURLOPT_MAXREDIRS, 10);
+
 			curl_setopt($curl, CURLOPT_USERAGENT, "ownCloud Server Crawler");
 			if(OC_Config::getValue('proxy','')<>'') {
 				curl_setopt($curl, CURLOPT_PROXY, OC_Config::getValue('proxy'));


### PR DESCRIPTION
Hi, 
this small PR  add the behavior of following redirections  for Util::getUrlContent .

The function is used at some places like bookmarks,... this PR fix a regression for redirected urls
