### PR TITLE
gitignore all apps except core ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,17 @@ config/mount.php
 apps/inc.php
 3rdparty
 
+# ignore all apps except core ones
+apps/*
+!apps/files
+!apps/files_encryption
+!apps/files_external
+!apps/files_sharing
+!apps/files_trashbin
+!apps/files_versions
+!apps/user_ldap
+!apps/user_webdavauth
+
 # just sane ignores
 .*.sw[po]
 *.bak


### PR DESCRIPTION
This makes git status painless (and useful) again when you have a bunch of apps symlinked from the apps repo.

Please review @icewind1991 @DeepDiver1975 
