### PR TITLE
don't include collections while check if a new share is a reshare or not

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -888,7 +888,7 @@ class Share {
 	private static function put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, $parentFolder = null, $token = null) {
 		$backend = self::getBackend($itemType);
 		// Check if this is a reshare
-		if ($checkReshare = self::getItemSharedWithBySource($itemType, $itemSource, self::FORMAT_NONE, null, true)) {
+		if ($checkReshare = self::getItemSharedWithBySource($itemType, $itemSource, self::FORMAT_NONE, null, false)) {
 			// Check if attempting to share back to owner
 			if ($checkReshare['uid_owner'] == $shareWith && $shareType == self::SHARE_TYPE_USER) {
 				$message = 'Sharing '.$itemSource.' failed, because the user '.$shareWith.' is the original sharer';


### PR DESCRIPTION
Don't include collections while check if a new share is a reshare or not. Otherwise the db query will look for the file_source _or_ item_type which can lead to false positives.

@MTGap please also have a look at it.
