### PR TITLE
sharing, unset the right item to avoid false positives during the check if resharing is allowed

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -847,7 +847,7 @@ class Share {
 					}
 					// Remove collection item
 					$toRemove = $row['id'];
-					if (array_key_exists($row['id'], $switchedItems)) {
+					if (array_key_exists($toRemove, $switchedItems)) {
 						$toRemove = $switchedItems[$toRemove];
 					}
 					unset($items[$toRemove]);

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -724,6 +724,7 @@ class Share {
 		}
 		$items = array();
 		$targets = array();
+		$switchedItems = array();
 		while ($row = $result->fetchRow()) {
 			// Filter out duplicate group shares for users with unique targets
 			if ($row['share_type'] == self::$shareTypeGroupUserUnique && isset($items[$row['parent']])) {
@@ -748,6 +749,7 @@ class Share {
 						// Switch ids if sharing permission is granted on only one share to ensure correct parent is used if resharing
 						if (~(int)$items[$id]['permissions'] & self::PERMISSION_SHARE && (int)$row['permissions'] & self::PERMISSION_SHARE) {
 							$items[$row['id']] = $items[$id];
+							$switchedItems[$id] = $row['id'];
 							unset($items[$id]);
 							$id = $row['id'];
 						}
@@ -844,7 +846,11 @@ class Share {
 						}
 					}
 					// Remove collection item
-					unset($items[$row['id']]);
+					$toRemove = $row['id'];
+					if (array_key_exists($row['id'], $switchedItems)) {
+						$toRemove = $switchedItems[$toRemove];
+					}
+					unset($items[$toRemove]);
 				}
 			}
 			if (!empty($collectionItems)) {


### PR DESCRIPTION
In some cases it can happen that a user can no longer share any file/folder because every share will be detected as a forbidden re-share.

You can try this out by following this steps:
- You need to have two users (userA, userB), both in the same group (groupA).
- Login as userA
- userA shares a folder with userB with all permissions (create, update, delete, share)
- userA shares the same folder with groupA, permissions: create, update
- Login as userB
- Try to share a random folder from him with userA, you will get a message that resharing is not allowed.

The problem:

Because of the same share with different permissions the ID will be switched here:
https://github.com/owncloud/core/blob/stable45/lib/public/share.php#L748

Later during the test if this is a collection of the requested item_type it want to remove the item again:
https://github.com/owncloud/core/blob/stable45/lib/public/share.php#L847

This will fail because of the switch above which will result in different ids in items[] than the actual ID of the row.

The solution:

I added a array to track the ID switches so that they can be later mapped
