### PR TITLE
collapse user menu when inside one of the settings sections

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -234,7 +234,10 @@ fieldset.warning legend { color:#b94a48 !important; }
 #expand:hover, #expand:focus, #expand:active { color:#fff; }
 #expand img { opacity:.7; margin-bottom:-2px; }
 #expand:hover img, #expand:focus img, #expand:active img { opacity:1; }
-#expanddiv { position:absolute; right:0; top:45px; background-color:#444; border-bottom-left-radius:7px; box-shadow: 0 0 20px rgb(29,45,68); z-index:76; }
+#expanddiv {
+	position:absolute; right:0; top:45px; z-index:76; display:none;
+	background-color:#444; border-bottom-left-radius:7px; box-shadow: 0 0 20px rgb(29,45,68);
+}
 	#expanddiv a { display:block; color:#fff; text-shadow:0 -1px 0 #000; padding:0 8px; opacity:.7; }
 	#expanddiv a img { margin-bottom:-3px; }
 	#expanddiv a:hover, #expanddiv a:focus, #expanddiv a:active { opacity:1; }

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -35,7 +35,7 @@
 					<?php echo OCP\User::getDisplayName($user=null)?OCP\User::getDisplayName($user=null):(OC_User::getUser()?OC_User::getUser():'') ?>
 					<img class="svg" src="<?php echo image_path('', 'actions/caret.svg'); ?>" />
 				</span>
-				<div id="expanddiv" <?php if($_['bodyid'] == 'body-user') echo 'style="display:none;"'; ?>>
+				<div id="expanddiv">
 				<?php foreach($_['settingsnavigation'] as $entry):?>
 					<li>
 						<a href="<?php echo $entry['href']; ?>" title="" <?php if( $entry["active"] ): ?> class="active"<?php endif; ?>>


### PR DESCRIPTION
Previously the user menu stayed open when you went to »Apps« or »Users« or any of the entries in the user menu. This partly obscured content. Also, it was just legacy from when the settings navigation was integrated into the app navigation.

Check it out @schiesbn @DeepDiver1975 @tanghus 
