### PR TITLE
gitignore Cloud9IDE system folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ nbproject
 
 # Cloud9IDE
 .settings.xml
+.c9revisions
 
 # vim ex mode
 .vimrc


### PR DESCRIPTION
Just gitignore another folder Cloud9IDE uses. Btw it’s really nice, it’s open source and you can run it locally: https://github.com/ajaxorg/cloud9
