### PR TITLE
Fix Bad link for download in files (showstopper)

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -24,7 +24,7 @@
 // Check if we are a user
 OCP\User::checkLoggedIn();
 
-$filename = $_GET["file"];
+$filename = $_GET["file_path"];
 
 if(!\OC\Files\Filesystem::file_exists($filename)) {
 	header("HTTP/1.0 404 Not Found");

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -92,7 +92,7 @@ foreach (explode('/', $dir) as $i) {
 $list = new OCP\Template('files', 'part.list', '');
 $list->assign('files', $files, false);
 $list->assign('baseURL', OCP\Util::linkTo('files', 'index.php') . '?dir=', false);
-$list->assign('downloadURL', OCP\Util::linkTo('files', 'download.php') . '?file=', false);
+$list->assign('downloadURL', OCP\Util::linkTo('files', 'download.php') . '?file_path=', false);
 $list->assign('disableSharing', false);
 $breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '');
 $breadcrumbNav->assign('breadcrumb', $breadcrumb, false);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -15,7 +15,7 @@ var FileList={
 			extension=false;
 		}
 		html+='<td class="filename" style="background-image:url('+img+')"><input type="checkbox" />';
-		html+='<a class="name" href="download.php?file='+$('#dir').val().replace(/</, '&lt;').replace(/>/, '&gt;')+'/'+escapeHTML(name)+'"><span class="nametext">'+escapeHTML(basename);
+		html+='<a class="name" href="' +OC.filePath('files', '', 'download.php') + '?'+ $.param({ file_path: $('#dir').val()+'/'+name }) +'"><span class="nametext">'+escapeHTML(basename);
 		if(extension){
 			html+='<span class="extension">'+escapeHTML(extension)+'</span>';
 		}


### PR DESCRIPTION
In oc5, 

when you click on the name of the file you go to .../files/download.php?file=XX  and when you click on the action download, you go to  ../files/ajax/download.php?files=XX 

the pbm is that the 1st one does not work because the "file" param of $_GET seems to be already used... so he try to download the file ".php" instead of "XX"

I tried to correct this without touching too much :)
