### PR TITLE
attach handlers to document instead of filelist

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -185,10 +185,10 @@ OC.Share={
 				html += '<input id="linkPassText" type="password" placeholder="'+t('core', 'Password')+'" />';
 				html += '</div>';
 				html += '</div>';
-                html += '<form id="emailPrivateLink" >';
-                html += '<input id="email" style="display:none; width:65%;" value="" placeholder="'+t('core', 'Email link to person')+'" type="text" />';
-                html += '<input id="emailButton" style="display:none; float:right;" type="submit" value="'+t('core', 'Send')+'" />';
-                html += '</form>';
+				html += '<form id="emailPrivateLink" >';
+				html += '<input id="email" style="display:none; width:65%;" value="" placeholder="'+t('core', 'Email link to person')+'" type="text" />';
+				html += '<input id="emailButton" style="display:none; float:right;" type="submit" value="'+t('core', 'Send')+'" />';
+				html += '</form>';
 			}
 			html += '<div id="expiration">';
 			html += '<input type="checkbox" name="expirationCheckbox" id="expirationCheckbox" value="1" /><label for="expirationCheckbox">'+t('core', 'Set expiration date')+'</label>';
@@ -373,18 +373,18 @@ OC.Share={
 			$('#linkPassText').attr('placeholder', t('core', 'Password protected'));
 		}
 		$('#expiration').show();
-        $('#emailPrivateLink #email').show();
-        $('#emailPrivateLink #emailButton').show();
+		$('#emailPrivateLink #email').show();
+		$('#emailPrivateLink #emailButton').show();
 	},
 	hideLink:function() {
 		$('#linkText').hide('blind');
 		$('#showPassword').hide();
 		$('#showPassword+label').hide();
 		$('#linkPass').hide();
-        $('#emailPrivateLink #email').hide();
-        $('#emailPrivateLink #emailButton').hide();
-    },
- 	dirname:function(path) {
+		$('#emailPrivateLink #email').hide();
+		$('#emailPrivateLink #emailButton').hide();
+	},
+	dirname:function(path) {
 		return path.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');
 	},
 	showExpirationDate:function(date) {
@@ -401,16 +401,16 @@ OC.Share={
 $(document).ready(function() {
 	
 	if(typeof monthNames != 'undefined'){
-	$.datepicker.setDefaults({
-		monthNames: monthNames,
-		monthNamesShort: $.map(monthNames, function(v) { return v.slice(0,3)+'.'; }),
-		dayNames: dayNames,
-		dayNamesMin: $.map(dayNames, function(v) { return v.slice(0,2); }),
-		dayNamesShort: $.map(dayNames, function(v) { return v.slice(0,3)+'.'; }),
-		firstDay: firstDay
-	});
-  }
-	$('#fileList').on('click', 'a.share', function(event) {
+		$.datepicker.setDefaults({
+			monthNames: monthNames,
+			monthNamesShort: $.map(monthNames, function(v) { return v.slice(0,3)+'.'; }),
+			dayNames: dayNames,
+			dayNamesMin: $.map(dayNames, function(v) { return v.slice(0,2); }),
+			dayNamesShort: $.map(dayNames, function(v) { return v.slice(0,3)+'.'; }),
+			firstDay: firstDay
+		});
+	}
+	$(document).on('click', 'a.share', function(event) {
 		event.stopPropagation();
 		if ($(this).data('item-type') !== undefined && $(this).data('item') !== undefined) {
 			var itemType = $(this).data('item-type');
@@ -444,12 +444,12 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#fileList').on('mouseenter', '#dropdown #shareWithList li', function(event) {
+	$(document).on('mouseenter', '#dropdown #shareWithList li', function(event) {
 		// Show permissions and unshare button
 		$(':hidden', this).filter(':not(.cruds)').show();
 	});
 
-	$('#fileList').on('mouseleave', '#dropdown #shareWithList li', function(event) {
+	$(document).on('mouseleave', '#dropdown #shareWithList li', function(event) {
 		// Hide permissions and unshare button
 		if (!$('.cruds', this).is(':visible')) {
 			$('a', this).hide();
@@ -462,11 +462,11 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#fileList').on('click', '#dropdown .showCruds', function() {
+	$(document).on('click', '#dropdown .showCruds', function() {
 		$(this).parent().find('.cruds').toggle();
 	});
 
-	$('#fileList').on('click', '#dropdown .unshare', function() {
+	$(document).on('click', '#dropdown .unshare', function() {
 		var li = $(this).parent();
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
@@ -483,7 +483,7 @@ $(document).ready(function() {
 		});
 	});
 
-	$('#fileList').on('change', '#dropdown .permissions', function() {
+	$(document).on('change', '#dropdown .permissions', function() {
 		if ($(this).attr('name') == 'edit') {
 			var li = $(this).parent().parent()
 			var checkboxes = $('.permissions', li);
@@ -496,10 +496,17 @@ $(document).ready(function() {
 			var li = $(this).parent().parent().parent();
 			var checkboxes = $('.permissions', li);
 			// Uncheck Edit if Create, Update, and Delete are not checked
-			if (!$(this).is(':checked') && !$(checkboxes).filter('input[name="create"]').is(':checked') && !$(checkboxes).filter('input[name="update"]').is(':checked') && !$(checkboxes).filter('input[name="delete"]').is(':checked')) {
+			if (!$(this).is(':checked')
+				&& !$(checkboxes).filter('input[name="create"]').is(':checked')
+				&& !$(checkboxes).filter('input[name="update"]').is(':checked')
+				&& !$(checkboxes).filter('input[name="delete"]').is(':checked'))
+			{
 				$(checkboxes).filter('input[name="edit"]').attr('checked', false);
 			// Check Edit if Create, Update, or Delete is checked
-			} else if (($(this).attr('name') == 'create' || $(this).attr('name') == 'update' || $(this).attr('name') == 'delete')) {
+			} else if (($(this).attr('name') == 'create'
+					 || $(this).attr('name') == 'update'
+					 || $(this).attr('name') == 'delete'))
+			{
 				$(checkboxes).filter('input[name="edit"]').attr('checked', true);
 			}
 		}
@@ -507,10 +514,14 @@ $(document).ready(function() {
 		$(checkboxes).filter(':not(input[name="edit"])').filter(':checked').each(function(index, checkbox) {
 			permissions |= $(checkbox).data('permissions');
 		});
-		OC.Share.setPermissions($('#dropdown').data('item-type'), $('#dropdown').data('item-source'), $(li).data('share-type'), $(li).data('share-with'), permissions);
+		OC.Share.setPermissions($('#dropdown').data('item-type'),
+			$('#dropdown').data('item-source'),
+			$(li).data('share-type'),
+			$(li).data('share-with'),
+			permissions);
 	});
 
-	$('#fileList').on('change', '#dropdown #linkCheckbox', function() {
+	$(document).on('change', '#dropdown #linkCheckbox', function() {
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
 		if (this.checked) {
@@ -532,12 +543,12 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#fileList').on('click', '#dropdown #linkText', function() {
+	$(document).on('click', '#dropdown #linkText', function() {
 		$(this).focus();
 		$(this).select();
 	});
 
-	$('#fileList').on('click', '#dropdown #showPassword', function() {
+	$(document).on('click', '#dropdown #showPassword', function() {
 		$('#linkPass').toggle('blind');
 		if (!$('#showPassword').is(':checked') ) {
 			var itemType = $('#dropdown').data('item-type');
@@ -548,7 +559,7 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#fileList').on('focusout keyup', '#dropdown #linkPassText', function(event) {
+	$(document).on('focusout keyup', '#dropdown #linkPassText', function(event) {
 		if ( $('#linkPassText').val() != '' && (event.type == 'focusout' || event.keyCode == 13) ) {
 			var itemType = $('#dropdown').data('item-type');
 			var itemSource = $('#dropdown').data('item-source');
@@ -560,7 +571,7 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#fileList').on('click', '#dropdown #expirationCheckbox', function() {
+	$(document).on('click', '#dropdown #expirationCheckbox', function() {
 		if (this.checked) {
 			OC.Share.showExpirationDate('');
 		} else {
@@ -575,7 +586,7 @@ $(document).ready(function() {
 		}
 	});
 	
-	$('#fileList').on('change', '#dropdown #expirationDate', function() {
+	$(document).on('change', '#dropdown #expirationDate', function() {
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
 		$.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'setExpirationDate', itemType: itemType, itemSource: itemSource, date: $(this).val() }, function(result) {
@@ -586,33 +597,33 @@ $(document).ready(function() {
 	});
 
 
-    $('#fileList').on('submit', '#dropdown #emailPrivateLink', function(event) {
-        event.preventDefault();
-        var link = $('#linkText').val();
-        var itemType = $('#dropdown').data('item-type');
-        var itemSource = $('#dropdown').data('item-source');
-        var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
-        var email = $('#email').val();
-        if (email != '') {
-            $('#email').attr('disabled', "disabled");
-            $('#email').val(t('core', 'Sending ...'));
-            $('#emailButton').attr('disabled', "disabled");
+	$(document).on('submit', '#dropdown #emailPrivateLink', function(event) {
+		event.preventDefault();
+		var link = $('#linkText').val();
+		var itemType = $('#dropdown').data('item-type');
+		var itemSource = $('#dropdown').data('item-source');
+		var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
+		var email = $('#email').val();
+		if (email != '') {
+			$('#email').attr('disabled', "disabled");
+			$('#email').val(t('core', 'Sending ...'));
+			$('#emailButton').attr('disabled', "disabled");
 
-            $.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'email', toaddress: email, link: link, itemType: itemType, itemSource: itemSource, file: file},
-                function(result) {
-                    $('#email').attr('disabled', "false");
-                    $('#emailButton').attr('disabled', "false");
-                if (result && result.status == 'success') {
-                    $('#email').css('font-weight', 'bold');
-                    $('#email').animate({ fontWeight: 'normal' }, 2000, function() {
-                        $(this).val('');
-                    }).val(t('core','Email sent'));
-                } else {
-                    OC.dialogs.alert(result.data.message, t('core', 'Error while sharing'));
-                }
-            });
-        }
-    });
+			$.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'email', toaddress: email, link: link, itemType: itemType, itemSource: itemSource, file: file},
+				function(result) {
+					$('#email').attr('disabled', "false");
+					$('#emailButton').attr('disabled', "false");
+				if (result && result.status == 'success') {
+					$('#email').css('font-weight', 'bold');
+					$('#email').animate({ fontWeight: 'normal' }, 2000, function() {
+						$(this).val('');
+					}).val(t('core','Email sent'));
+				} else {
+					OC.dialogs.alert(result.data.message, t('core', 'Error while sharing'));
+				}
+			});
+		}
+	});
 
 
 });


### PR DESCRIPTION
@georgehrke This fixes all places where a #dropdown element is used. The calendar though performs differently: you have to click the submit button, to save changes, which is not what users might expect compared to the default sharing dropdown.

@jancborchardt maybe you have a mockup for how sharing in the calendar could use the same dropdown as files and gallery sharing?

also contains minor whitespace cleanups: don't for get to indent using tabs!
