### PR TITLE
remove (comment out) old code to fix replacing of files

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -216,9 +216,9 @@ var FileList={
 	},
 	replace:function(oldName, newName, isNewFile) {
 		// Finish any existing actions
-		if (FileList.lastAction || !FileList.useUndo) {
+		/*if (FileList.lastAction || !FileList.useUndo) {
 			FileList.lastAction();
-		}
+		}*/
 		$('tr').filterAttr('data-file', oldName).hide();
 		$('tr').filterAttr('data-file', newName).hide();
 		var tr = $('tr').filterAttr('data-file', oldName).clone();


### PR DESCRIPTION
There is a issue when uploading a file with a name that already exists.

Expected behavior: file should be replaced after selecting replace
Actual behavior: the file is not shown after uploading, but after a reload the file is shown as filename (2) in the list, even tough I wanted to replace the file.

Fix replacing files by removing old code

please review @DeepDiver1975 @butonic  
