### PR TITLE
Installation label overflow, fix #871

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -177,7 +177,11 @@ input[name="password-clone"] { padding-left:1.8em; width:11.7em !important; }
 #login .groupmiddle label, #login .groupbottom label { top:.65em; }
 p.infield { position:relative; }
 label.infield { cursor:text !important; top:1.05em; left:.85em; }
-#login form label.infield { position:absolute; font-size:19px; color:#aaa; white-space:nowrap; padding-left:1.4em; }
+#login form label.infield { /* labels are ellipsized when too long, keep them short */
+	position:absolute; width:90%; padding-left:1.4em;
+	font-size:19px; color:#aaa;
+	white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
 #login #databaseField .infield { padding-left:0; }
 #login form input[type="checkbox"]+label { position:relative; margin:0; font-size:1em; text-shadow:#fff 0 1px 0; }
 #login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 2em; padding:1em; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -163,7 +163,7 @@ input[name="password-clone"] { padding-left:1.8em; width:11.7em !important; }
 }
 .groupmiddle input {
 	margin-top:0; margin-bottom:0;
-	border-top:0; border-radius:0;
+	border-top:0; border-bottom:0; border-radius:0;
 	box-shadow:0 1px 1px #fff,0 1px 0 #ddd inset;
 }
 .groupbottom input {


### PR DESCRIPTION
My overzealous and stupid 2 month younger self said:
»Yeah, the text size of overflowing labels should automatically be decreased in these cases so the label fits the input field. Probably doable via JS, maybe there’s even a library for that.«

Of course! Well, December 2012 Jan, instead of attempting wizardry or pulling in yet. another. JS. library, I just fixed the damn problem, which is the labels overflowing, which didn’t look good.

Now granted, this also cuts it off for languages such as French (as in the original issue) and Spanish (as I use myself), but that is the less important part (»database«) which gets cut off. And I’d say since there is a header called »Configure the database«, or »Configurar la base de datos« respectively, probably the labels in there should also just be translated as »Username« and »Password« in those languages where it overflows.

If there’s any objections to that, I would recommend thumbs downing this pull request, and opine that a little overflow of the labels in languages where these two expressions are long in a way which leads to aforementioned overflow, isn’t that bad. But an attempt to fix it anywhere else than in the translations will be either a hack, have edge-cases or just be damn hard to maintain because it probably requires a library which might already have been dropped by its creator long ago.

As a bonus, I fixed a small style issue which made that group of database input fields have 2 thicker dividers, which looked ugly.

Hold your votes @eMerzh @karlitschek @DeepDiver1975 
