### PR TITLE
Mapper: use md5 hashes for database indexes

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -109,6 +109,14 @@
 			</field>
 
 			<field>
+				<name>logic_path_hash</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>32</length>
+			</field>
+
+			<field>
 				<name>physic_path</name>
 				<type>text</type>
 				<default></default>
@@ -116,11 +124,19 @@
 				<length>512</length>
 			</field>
 
+			<field>
+				<name>physic_path_hash</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>32</length>
+			</field>
+
 			<index>
 				<name>file_map_lp_index</name>
 				<unique>true</unique>
 				<field>
-					<name>logic_path</name>
+					<name>logic_path_hash</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>
@@ -129,7 +145,7 @@
 				<name>file_map_pp_index</name>
 				<unique>true</unique>
 				<field>
-					<name>physic_path</name>
+					<name>physic_path_hash</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/files/mapper.php
+++ b/lib/files/mapper.php
@@ -114,8 +114,8 @@ class Mapper
 
 	private function resolveLogicPath($logicPath) {
 		$logicPath = $this->stripLast($logicPath);
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*file_map` WHERE `logic_path` = ?');
-		$result = $query->execute(array($logicPath));
+		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*file_map` WHERE `logic_path_hash` = ?');
+		$result = $query->execute(array(md5($logicPath)));
 		$result = $result->fetchRow();
 
 		return $result['physic_path'];
@@ -123,8 +123,8 @@ class Mapper
 
 	private function resolvePhysicalPath($physicalPath) {
 		$physicalPath = $this->stripLast($physicalPath);
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*file_map` WHERE `physic_path` = ?');
-		$result = $query->execute(array($physicalPath));
+		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*file_map` WHERE `physic_path_hash` = ?');
+		$result = $query->execute(array(md5($physicalPath)));
 		$result = $result->fetchRow();
 
 		return $result['logic_path'];
@@ -151,8 +151,8 @@ class Mapper
 	}
 
 	private function insert($logicPath, $physicalPath) {
-		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*file_map`(`logic_path`,`physic_path`) VALUES(?,?)');
-		$query->execute(array($logicPath, $physicalPath));
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*file_map`(`logic_path`, `physic_path`, `logic_path_hash`, `physic_path_hash`) VALUES(?, ?, ?, ?)');
+		$query->execute(array($logicPath, $physicalPath, md5($logicPath), md5($physicalPath)));
 	}
 
 	private function slugifyPath($path, $index=null) {


### PR DESCRIPTION
indexing the full path exeeds the maximum index length for MySQL

@DeepDiver1975 
