### PR TITLE
append .part to put files

### DIFF
--- a/lib/connector/sabre/file.php
+++ b/lib/connector/sabre/file.php
@@ -45,7 +45,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 	 */
 	public function put($data) {
 
-		\OC\Files\Filesystem::file_put_contents($this->path,$data);
+		// mark file as partial while uploading (ignored by the scanner)
+		$partpath = $this->path . '.part';
+		
+		\OC\Files\Filesystem::file_put_contents($partpath, $data);
+		
+		// rename to correct path
+		\OC\Files\Filesystem::rename($partpath, $this->path);
 
 		return OC_Connector_Sabre_Node::getETagPropertyForPath($this->path);
 	}

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -97,7 +97,7 @@ class Scanner {
 		if ($this->storage->is_dir($path) && ($dh = $this->storage->opendir($path))) {
 			\OC_DB::beginTransaction();
 			while ($file = readdir($dh)) {
-				if ($file !== '.' and $file !== '..') {
+				if (!$this->isIgnoredFile($file)) {
 					$child = ($path) ? $path . '/' . $file : $file;
 					$data = $this->scanFile($child);
 					if ($data) {
@@ -132,6 +132,22 @@ class Scanner {
 			}
 		}
 		return $size;
+	}
+	
+	/**
+	 * @brief check if the file should be ignored when scanning
+	 * NOTE: files with a '.part' extension are ignored as well!
+	 *       prevents unfinished put requests to be scanned
+	 * @param String $file
+	 * @return boolean
+	 */
+	private function isIgnoredFile($file) {
+		if ($file === '.' || $file === '..'
+		 || pathinfo($file,PATHINFO_EXTENSION) === 'part')
+		{
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This is an attempt to hande canceled file uploads that use PUT.

First, we store them, appended with '.part' (like chrome does while downloading files)
after we got the content we will rename the file to the original name

Second, to prevent synchronization duplicates of these .part files we ignore them when scanning files.

Third, @dragotin you should probably add "*.part" to the list of excluded files.

I could not reproduce the issue with GVFS. @dragotin @danimo maybe you could test this PR. @icewind1991 please review.
