### PR TITLE
Cache: allow file sizes >2GB

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -266,7 +266,7 @@
 				<type>integer</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>4</length>
+				<length>8</length>
 			</field>
 
 			<field>

--- a/lib/util.php
+++ b/lib/util.php
@@ -74,7 +74,7 @@ class OC_Util {
 	 */
 	public static function getVersion() {
 		// hint: We only can count up. So the internal version number of ownCloud 4.5 will be 4.90.0. This is not visible to the user
-		return array(4, 91, 9);
+		return array(4, 91, 10);
 	}
 
 	/**


### PR DESCRIPTION
use 64bit integers in the filecache

@DeepDiver1975 @butonic @karlitschek 
