### PR TITLE
Improve generation of interal user names resp. group display names

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -4,7 +4,7 @@
  * ownCloud – LDAP Access
  *
  * @author Arthur Schiwon
- * @copyright 2012 Arthur Schiwon blizzz@owncloud.com
+ * @copyright 2012, 2013 Arthur Schiwon blizzz@owncloud.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE


### PR DESCRIPTION
Improves limitations from old way. Uses UUIDs for users and for groups (still used as display name) sequential numbers if name already exists.
Old entries are not affected.
