### PR TITLE
Cache: reuse known folder sizes when doing a shallow scan - rebase

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -101,18 +101,16 @@ class Scanner {
 					$child = ($path) ? $path . '/' . $file : $file;
 					$data = $this->scanFile($child);
 					if ($data) {
-						if ($data['mimetype'] === 'httpd/unix-directory') {
+						if ($data['size'] === -1) {
 							if ($recursive === self::SCAN_RECURSIVE) {
 								$childQueue[] = $child;
 								$data['size'] = 0;
 							} else {
-								$data['size'] = -1;
+								$size = -1;
 							}
-						} else {
 						}
-						if ($data['size'] === -1) {
-							$size = -1;
-						} elseif ($size !== -1) {
+
+						if ($size !== -1) {
 							$size += $data['size'];
 						}
 					}
@@ -133,7 +131,7 @@ class Scanner {
 		}
 		return $size;
 	}
-	
+
 	/**
 	 * @brief check if the file should be ignored when scanning
 	 * NOTE: files with a '.part' extension are ignored as well!
@@ -143,8 +141,8 @@ class Scanner {
 	 */
 	private function isIgnoredFile($file) {
 		if ($file === '.' || $file === '..'
-		 || pathinfo($file,PATHINFO_EXTENSION) === 'part')
-		{
+			|| pathinfo($file, PATHINFO_EXTENSION) === 'part'
+		) {
 			return true;
 		}
 		return false;

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -74,7 +74,7 @@ class Scanner {
 					$this->scanFile($parent);
 				}
 			}
-			if ($data['size'] === -1 and $cacheData = $this->cache->get($file)) {
+			if ($checkExisting and $data['size'] === -1 and $cacheData = $this->cache->get($file)) {
 				$data['size'] = $cacheData['size'];
 			}
 			$this->cache->put($file, $data);

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -76,6 +76,9 @@ class Scanner {
 			}
 			if ($checkExisting and $data['size'] === -1 and $cacheData = $this->cache->get($file)) {
 				$data['size'] = $cacheData['size'];
+				if ($data['mtime'] === $cacheData['mtime']) {
+					$data['etag'] = $cacheData['etag'];
+				}
 			}
 			$this->cache->put($file, $data);
 		}

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -75,7 +75,7 @@ class Scanner {
 				}
 			}
 			if ($checkExisting) {
-				$cacheData = $this->cache->get($file)
+				$cacheData = $this->cache->get($file);
 				if ($data['size'] === -1) {
 					$data['size'] = $cacheData['size'];
 				}

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -74,8 +74,11 @@ class Scanner {
 					$this->scanFile($parent);
 				}
 			}
-			if ($checkExisting and $data['size'] === -1 and $cacheData = $this->cache->get($file)) {
-				$data['size'] = $cacheData['size'];
+			if ($checkExisting) {
+				$cacheData = $this->cache->get($file)
+				if ($data['size'] === -1) {
+					$data['size'] = $cacheData['size'];
+				}
 				if ($data['mtime'] === $cacheData['mtime']) {
 					$data['etag'] = $cacheData['etag'];
 				}

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -74,8 +74,7 @@ class Scanner {
 					$this->scanFile($parent);
 				}
 			}
-			if ($checkExisting) {
-				$cacheData = $this->cache->get($file);
+			if ($checkExisting and $cacheData = $this->cache->get($file)) {
 				if ($data['size'] === -1) {
 					$data['size'] = $cacheData['size'];
 				}

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -76,7 +76,6 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$updater->checkUpdate('');
 
 		$entry = $cache->get('foo.txt');
-		$this->assertEquals(-1, $entry['size']);
 		$this->assertEquals('httpd/unix-directory', $entry['mimetype']);
 		$this->assertFalse($cache->inCache('folder'));
 		$this->assertFalse($cache->inCache('folder/bar.txt'));


### PR DESCRIPTION
This fixes having to do a full recursive rescan of a folder when the content of the folder changes.

Also fixes being generating new etags to often.

@butonic @DeepDiver1975 @MTGap @karlitschek @LukasReschke 
