### PR TITLE
fix bug while changing string from "Share" to "Shared"

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -26,7 +26,7 @@ OC.Share={
 							var action = $(file).find('.fileactions .action').filterAttr('data-action', 'Share');
 							action.find('img').attr('src', image);
 							action.addClass('permanent');
-							action.html(action.html().replace(t('core', 'Share'), t('core', 'Shared')));
+							action.html(t('core', 'Shared'));
 						}
 						var dir = $('#dir').val();
 						if (dir.length > 1) {
@@ -40,7 +40,7 @@ OC.Share={
 									if (img.attr('src') != OC.imagePath('core', 'actions/public')) {
 										img.attr('src', image);
 										action.addClass('permanent');
-										action.html(action.html().replace(t('core', 'Share'), t('core', 'Shared')));
+										action.html(t('core', 'Shared'));
 									}
 								}
 								last = path;
@@ -87,10 +87,10 @@ OC.Share={
 			action.find('img').attr('src', image);
 			if (shares) {
 				action.addClass('permanent');
-				action.html(action.html().replace(t('core', 'Share'), t('core', 'Shared')));
+				action.html(t('core', 'Shared'));
 			} else {
 				action.removeClass('permanent');
-				action.html(action.html().replace(t('core', 'Shared'), t('core', 'Share')));
+				action.html(t('core', 'Share'));
 			}
 		}
 		if (shares) {


### PR DESCRIPTION
if you add/remove more than one user from the share dialog replacing 'Share' with 'Shared' will lead to a string with more and more trailing 'd's
