### PR TITLE
svg replacement for breadcrumb home icon, fix #1620

### DIFF
--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,7 +1,7 @@
 <?php if(count($_["breadcrumb"])):?>
 	<div class="crumb">
 		<a href="<?php echo $_['baseURL']; ?>">
-			<img src="<?php echo OCP\image_path('core','places/home.svg');?>" />
+			<img src="<?php echo OCP\image_path('core','places/home.svg');?>" class="svg" />
 		</a>
 	</div>
 <?php endif;?>


### PR DESCRIPTION
Yes it was the svg class missing again. Check @DeepDiver1975 @icewind1991 
