### PR TITLE
Update/Bugfix lib/files/cache/legacy.php during database upgrade

### DIFF
--- a/lib/files/cache/legacy.php
+++ b/lib/files/cache/legacy.php
@@ -51,6 +51,12 @@ class Legacy {
 			$this->cacheHasItems = false;
 			return false;
 		}
+		
+		if ($result === false || property_exists($result, 'error_message_prefix')) {
+			$this->cacheHasItems = false;
+			return false;
+		}		
+		
 		$this->cacheHasItems = (bool)$result->fetchRow();
 		return $this->cacheHasItems;
 	}


### PR DESCRIPTION
Fixing a bug that occurs when trying to update a non-existent 'fscache' table in the database - if unfixed upgrading does not succeed.

Unfortunately I could not get a call to PEAR::isError working. That is why I check for the existence of a property present in class MDB2_Error.
