### PR TITLE
fixing issues with UTF8 characters in translatable strings

### DIFF
--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -104,7 +104,7 @@ if( $task eq 'read' ){
 			my $language = ( $file =~ /\.js$/ ? 'Python' : 'PHP');
 			my $joinexisting = ( -e $output ? '--join-existing' : '');
 			print "    Reading $file\n";
-			`xgettext --output="$output" $joinexisting --keyword=$keyword --language=$language "$file"`;
+			`xgettext --output="$output" $joinexisting --keyword=$keyword --language=$language "$file" --from-code=UTF-8 --package-version="5.0.0" --package-name="ownCloud Core" --msgid-bugs-address="translations\@owncloud.org"`;
 		}
 		chdir( $whereami );
 	}


### PR DESCRIPTION
Currently the l10n script to extract translatable string assumed ASCII as character set and failed e.g. in firstrunwizard:

```
    Reading ./lib/firstrunwizard.php
    Reading ./templates/wizard.php
xgettext: Non-ASCII string at ./templates/wizard.php:34.
          Please specify the source encoding through --from-code.
    Reading ./wizard.php
```

In order to fix this the character set is set to utf8 on the xgettext call.

Patch has already been applied to the apps repo.

@karlitschek @jakobsack @blizzz THX
