### PR TITLE
fix multiselect bar offset on shared page, close #1339 finally

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -71,4 +71,5 @@ p.info a {
 
 thead{
 	background-color: white;
+	padding-left:0 !important; /* fixes multiselect bar offset on shared page */
 }


### PR DESCRIPTION
The multiselect bar had an offset on the shared page, because of the positioning and width of the navigation bar in the Files app. Fixed.

Check it @DeepDiver1975 @MTGap 
