### PR TITLE
Fixing 1659 master

### DIFF
--- a/lib/files/storage/mappedlocal.php
+++ b/lib/files/storage/mappedlocal.php
@@ -20,7 +20,7 @@ class MappedLocal extends \OC\Files\Storage\Common{
 			$this->datadir.='/';
 		}
 
-		$this->mapper= new \OC\Files\Mapper();
+		$this->mapper= new \OC\Files\Mapper($this->datadir);
 	}
 	public function __destruct() {
 		if (defined('PHPUNIT_RUN')) {
@@ -274,7 +274,7 @@ class MappedLocal extends \OC\Files\Storage\Common{
 		return $this->buildPath($path);
 	}
 
-	protected function searchInDir($query, $dir='', $isLogicPath=true) {
+	protected function searchInDir($query, $dir='') {
 		$files=array();
 		$physicalDir = $this->buildPath($dir);
 		foreach (scandir($physicalDir) as $item) {
@@ -287,7 +287,7 @@ class MappedLocal extends \OC\Files\Storage\Common{
 				$files[]=$dir.'/'.$item;
 			}
 			if(is_dir($physicalItem)) {
-				$files=array_merge($files, $this->searchInDir($query, $physicalItem, false));
+				$files=array_merge($files, $this->searchInDir($query, $dir.'/'.$item));
 			}
 		}
 		return $files;

--- a/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
+++ b/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
@@ -27,8 +27,10 @@ class MappedLocalWithDottedDataDir extends Storage {
 	 * @var string tmpDir
 	 */
 	private $tmpDir;
+
 	public function setUp() {
 		$this->tmpDir = \OC_Helper::tmpFolder().'dir.123'.DIRECTORY_SEPARATOR;
+		mkdir($this->tmpDir);
 		$this->instance=new \OC\Files\Storage\MappedLocal(array('datadir'=>$this->tmpDir));
 	}
 

--- a/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
+++ b/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
@@ -1,0 +1,40 @@
+<?php
+/**
+* ownCloud
+*
+* @author Robin Appelman
+* @copyright 2012 Robin Appelman icewind@owncloud.com
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+namespace Test\Files\Storage;
+
+class MappedLocalWithDottedDataDir extends Storage {
+	/**
+	 * @var string tmpDir
+	 */
+	private $tmpDir;
+	public function setUp() {
+		$this->tmpDir = \OC_Helper::tmpFolder().'dir.123'.DIRECTORY_SEPARATOR;
+		$this->instance=new \OC\Files\Storage\MappedLocal(array('datadir'=>$this->tmpDir));
+	}
+
+	public function tearDown() {
+		\OC_Helper::rmdirr($this->tmpDir);
+		unset($this->instance);
+	}
+}
+

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -223,6 +223,22 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertContains('/logo-wide.png', $result);
 	}
 
+	public function testSearchInSubFolder() {
+		$this->instance->mkdir('sub')
+		;
+		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
+		$this->instance->file_put_contents('/sub/lorem.txt', file_get_contents($textFile, 'r'));
+		$pngFile = \OC::$SERVERROOT . '/tests/data/logo-wide.png';
+		$this->instance->file_put_contents('/sub/logo-wide.png', file_get_contents($pngFile, 'r'));
+		$svgFile = \OC::$SERVERROOT . '/tests/data/logo-wide.svg';
+		$this->instance->file_put_contents('/sub/logo-wide.svg', file_get_contents($svgFile, 'r'));
+
+		$result = $this->instance->search('logo');
+		$this->assertEquals(2, count($result));
+		$this->assertContains('/sub/logo-wide.svg', $result);
+		$this->assertContains('/sub/logo-wide.png', $result);
+	}
+
 	public function testFOpen() {
 		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
 


### PR DESCRIPTION
fixes #1659 

In cases where the data dir already contained characters like . the generated physical file names were all wrong.

The class Mapper now respects an unchanged root directory which is excluded from slugifying.

@karlitschek @icewind1991 @bartv2 @butonic THX
