### PR TITLE
Sanitize html

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -18,7 +18,7 @@
 			<?php foreach ($_['mounts'] as $mountPoint => $mount): ?>
 				<tr <?php echo ($mountPoint != '') ? 'class="'.$mount['class'].'"' : 'id="addMountPoint"'; ?>>
 					<td class="mountPoint"><input type="text" name="mountPoint"
-												  value="<?php echo $mountPoint; ?>"
+												  value="<?php p($mountPoint); ?>"
 												  placeholder="<?php echo $l->t('Mount point'); ?>" /></td>
 					<?php if ($mountPoint == ''): ?>
 						<td class="backend">

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -182,7 +182,7 @@ var UserList = {
 			var addGroup = function (select, group) {
 				$('select[multiple]').each(function (index, element) {
 					if ($(element).find('option[value="' + group + '"]').length === 0 && select.data('msid') !== $(element).data('msid')) {
-						$(element).append('<option value="' + group + '">' + group + '</option>');
+						$(element).append('<option value="' + escapeHTML(group) + '">' + escapeHTML(group) + '</option>');
 					}
 				})
 			};


### PR DESCRIPTION
@karlitschek This needs a backport to stable45 and stable4, I'm behind a proxy ATM that's why I can't cherry-pick it myself. Could you please do that? `p()` has been introduced with oC 5.0, so you have to use `OC_Util::sanitizeHTML` instead on stable45 and stable4.

\cc @karlitschek @DeepDiver1975 THX
