### PR TITLE
Ability for the action handler to get more info on the current file

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -162,9 +162,10 @@ $(document).ready(function() {
 			var tr=$('tr').filterAttr('data-file',filename);
 			var renaming=tr.data('renaming');
 			if(!renaming && !FileList.isLoading(filename)){
-				var mime=$(this).parent().parent().data('mime');
-				var type=$(this).parent().parent().data('type');
-				var permissions = $(this).parent().parent().data('permissions');
+				FileActions.currentFile = $(this).parent();
+				var mime=FileActions.getCurrentMimeType();
+				var type=FileActions.getCurrentType();
+				var permissions = FileActions.getCurrentPermissions();
 				var action=FileActions.getDefault(mime,type, permissions);
 				if(action){
 					event.preventDefault();


### PR DESCRIPTION
This is required to fix video viewer app.  It needs file mime-type in addition to the filename to create video element properly.
Stable45 allows to get mime-type for the current file while processing the action with 

```
 FileActions.getCurrentMimeType();
```

while master implementation always returns mime-type for the last file in the files list instead.

This pull request reverts FileActions to the previous behavior.
