### PR TITLE
bug fix for issue 1739

### DIFF
--- a/lib/group.php
+++ b/lib/group.php
@@ -311,12 +311,13 @@ class OC_Group {
 		$displayNames = array();
 		foreach ($gids as $gid) {
 			// TODO Need to apply limits to groups as total
-			$displayNames = array_merge(
-				array_diff(
-					self::displayNamesInGroup($gid, $search, $limit, $offset),
-					$displayNames
-				),
-				$displayNames);
+			$diff = array_diff(
+				self::displayNamesInGroup($gid, $search, $limit, $offset),
+				$displayNames
+			);
+			if ($diff) {
+				$displayNames = array_merge($diff, $displayNames);
+			}
 		}
 		return $displayNames;
 	}

--- a/lib/group/database.php
+++ b/lib/group/database.php
@@ -225,7 +225,7 @@ class OC_Group_Database extends OC_Group_Backend {
 		$stmt = OC_DB::prepare('SELECT `*PREFIX*users`.`uid`, `*PREFIX*users`.`displayname`'
 			.' FROM `*PREFIX*users`'
 			.' INNER JOIN `*PREFIX*group_user` ON `*PREFIX*group_user`.`uid` = `*PREFIX*users`.`uid`'
-			.' WHERE `gid` = ? AND `*PREFIX*group_user.uid` LIKE ?',
+			.' WHERE `gid` = ? AND `*PREFIX*group_user`.`uid` LIKE ?',
 			$limit,
 			$offset);
 		$result = $stmt->execute(array($gid, $search.'%'));


### PR DESCRIPTION
Two changes included:
- fix typo in OC_Group_Database::DisplayNamesInGroup's SQL clause
- check `array_diff` return value in OC_Group::displayNamesInGroups,
  when there is no difference between two arrays, it will return
  NULL, so we have to take care of it.

This PR fixes #1739

//cc @karlitschek 
