### PR TITLE
No Text Overflows the Sharing Dropdown. 

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -24,6 +24,10 @@
  #shareWithList li {
  	padding-top:.1em;
  }
+ 
+ #shareWithList li:first-child {
+	 white-space:normal;
+ }
 
  #dropdown label {
  	font-weight:400;


### PR DESCRIPTION
A fix for https://github.com/owncloud/core/issues/895. I don't know the logic behind how it worked, but it did and without changing the width of the dropdown. Please check.
