### PR TITLE
Fix 1465

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -524,7 +524,7 @@ $(document).ready(function() {
 		crumb.text(text);
 	}
 
-	$(window).click(function(){
+	$(document).click(function(){
 		$('#new>ul').hide();
 		$('#new').removeClass('active');
 		$('#new li').each(function(i,element){

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -669,7 +669,7 @@ $(document).ready(function(){
 	$('#settings #expanddiv').click(function(event){
 		event.stopPropagation();
 	});
-	$(window).click(function(){//hide the settings menu when clicking outside it
+	$(document).click(function(){//hide the settings menu when clicking outside it
 		$('#settings #expanddiv').slideUp(200);
 	});
 

--- a/search/js/result.js
+++ b/search/js/result.js
@@ -28,7 +28,7 @@ OC.search.showResults=function(results){
 				OC.search.hide();
 				event.stopPropagation();
 			});
-			$(window).click(function(event){
+			$(document).click(function(event){
 				OC.search.hide();
 			});
 			OC.search.lastResults=results;


### PR DESCRIPTION
IE8 does not support window.onclick. I changed all occurences to document. unfortunately there is the multiselect.js in core and contacts which still uses window. not sure if its a problem though.

this also fixes the settings menu not closing in ie8 as well as search results not closing in ie8.
