### PR TITLE
Update hint by the internal version number.

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -73,8 +73,8 @@ class OC_Util {
 	 * @return array
 	 */
 	public static function getVersion() {
-		// hint: We only can count up. So the internal version number
-		// of ownCloud 4.5 will be 4.90.0. This is not visible to the user
+		// hint: We only can count up. Reset minor/patchlevel when
+		// updating major/minor version number.
 		return array(4, 93, 10);
 	}
 


### PR DESCRIPTION
So we don't repeat the 4.5 <=> 4.90 mixup.

@karlitschek 
