### PR TITLE
Fix inField Labels not returning in rare situations.

### DIFF
--- a/core/js/jquery.infieldlabel.js
+++ b/core/js/jquery.infieldlabel.js
@@ -62,6 +62,9 @@
           if(base.$field.val() != ""){
                base.$label.hide();
                base.showing = false;
+          } else {
+               base.$label.fadeIn();
+               base.showing = true;
         };
       },100);
     };


### PR DESCRIPTION
Fixes an issue where if auto-fill data was entered into a number of
fields, changing/removing the auto-fill data removes data from linked
fields but doesn't return labels.

Attn: @jancborchardt
