### PR TITLE
don't use the number of written bytes as indicator if streamCopy() was successful

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -314,7 +314,8 @@ class Shared extends \OC\Files\Storage\Common {
 		if ($this->isCreatable(dirname($path2))) {
 			$source = $this->fopen($path1, 'r');
 			$target = $this->fopen($path2, 'w');
-			return \OC_Helper::streamCopy($source, $target);
+			list ($count, $result) = \OC_Helper::streamCopy($source, $target);
+			return $result;
 		}
 		return false;
 	}

--- a/lib/files/storage/common.php
+++ b/lib/files/storage/common.php
@@ -97,8 +97,8 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	public function copy($path1, $path2) {
 		$source=$this->fopen($path1, 'r');
 		$target=$this->fopen($path2, 'w');
-		$count=\OC_Helper::streamCopy($source, $target);
-		return $count>0;
+		list($count, $result) = \OC_Helper::streamCopy($source, $target);
+		return $result;
 	}
 
 	/**

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -285,7 +285,7 @@ class View {
 				}
 				$target = $this->fopen($path, 'w');
 				if ($target) {
-					$count = \OC_Helper::streamCopy($data, $target);
+					list ($count, $result) = \OC_Helper::streamCopy($data, $target);
 					fclose($target);
 					fclose($data);
 					if ($this->fakeRoot == Filesystem::getRoot()) {
@@ -303,7 +303,7 @@ class View {
 						);
 					}
 					\OC_FileProxy::runPostProxies('file_put_contents', $absolutePath, $count);
-					return $count > 0;
+					return $result;
 				} else {
 					return false;
 				}
@@ -361,7 +361,7 @@ class View {
 				} else {
 					$source = $this->fopen($path1 . $postFix1, 'r');
 					$target = $this->fopen($path2 . $postFix2, 'w');
-					$result = \OC_Helper::streamCopy($source, $target);
+					list($count, $result) = \OC_Helper::streamCopy($source, $target);
 					list($storage1, $internalPath1) = Filesystem::resolvePath($absolutePath1 . $postFix1);
 					$storage1->unlink($internalPath1);
 				}
@@ -443,7 +443,7 @@ class View {
 				} else {
 					$source = $this->fopen($path1 . $postFix1, 'r');
 					$target = $this->fopen($path2 . $postFix2, 'w');
-					$result = \OC_Helper::streamCopy($source, $target);
+					list($count, $result) = \OC_Helper::streamCopy($source, $target);
 				}
 				if ($this->fakeRoot == Filesystem::getRoot()) {
 					\OC_Hook::emit(

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -361,10 +361,9 @@ class View {
 				} else {
 					$source = $this->fopen($path1 . $postFix1, 'r');
 					$target = $this->fopen($path2 . $postFix2, 'w');
-					$count = \OC_Helper::streamCopy($source, $target);
+					$result = \OC_Helper::streamCopy($source, $target);
 					list($storage1, $internalPath1) = Filesystem::resolvePath($absolutePath1 . $postFix1);
 					$storage1->unlink($internalPath1);
-					$result = $count > 0;
 				}
 				if ($this->fakeRoot == Filesystem::getRoot()) {
 					\OC_Hook::emit(

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -513,13 +513,16 @@ class OC_Helper {
 		if(!$source or !$target) {
 			return false;
 		}
-		$result=true;
+		$result = true;
+		$count = 0;
 		while(!feof($source)) {
-			if (fwrite($target, fread($source, 8192)) === false) {
+			if ($c = fwrite($target, fread($source, 8192)) === false) {
 				$result = false;
+			} else {
+				$count += $c;
 			}
 		}
-		return $result;
+		return array($count, $result);
 	}
 
 	/**

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -513,11 +513,13 @@ class OC_Helper {
 		if(!$source or !$target) {
 			return false;
 		}
-		$count=0;
+		$result=true;
 		while(!feof($source)) {
-			$count+=fwrite($target, fread($source, 8192));
+			if (fwrite($target, fread($source, 8192)) === false) {
+				$result = false;
+			}
 		}
-		return $count;
+		return $result;
 	}
 
 	/**

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -516,7 +516,7 @@ class OC_Helper {
 		$result = true;
 		$count = 0;
 		while(!feof($source)) {
-			if ($c = fwrite($target, fread($source, 8192)) === false) {
+			if ( ( $c = fwrite($target, fread($source, 8192)) ) === false) {
 				$result = false;
 			} else {
 				$count += $c;

--- a/lib/public/files.php
+++ b/lib/public/files.php
@@ -62,7 +62,8 @@ class Files {
 	 * @return int the number of bytes copied
 	 */
 	public static function streamCopy( $source, $target ) {
-		return(\OC_Helper::streamCopy( $source, $target ));
+		list($count, $result) = \OC_Helper::streamCopy( $source, $target );
+		return $count;
 	}
 
 	/**


### PR DESCRIPTION
Don't use the number of written bytes as indicator if streamCopy() was successful. Instead check if fwrite() returns the number of bytes or false.

This fixes issue #1851 and other potential errors if we streamCopy empty files.
