### PR TITLE
Don't throw insufficient storage exception if free space is unknown

### DIFF
--- a/lib/connector/sabre/quotaplugin.php
+++ b/lib/connector/sabre/quotaplugin.php
@@ -51,7 +51,7 @@ class OC_Connector_Sabre_QuotaPlugin extends Sabre_DAV_ServerPlugin {
 			}
 			list($parentUri, $newName) = Sabre_DAV_URLUtil::splitPath($uri);
 			$freeSpace = \OC\Files\Filesystem::free_space($parentUri);
-			if ($freeSpace !== \OC\Files\FREE_SPACE_UNKNOWN && $length > \OC\Files\Filesystem::free_space($parentUri)) {
+			if ($freeSpace !== \OC\Files\FREE_SPACE_UNKNOWN && $length > $freeSpace) {
 				throw new Sabre_DAV_Exception_InsufficientStorage();
 			}
 		}

--- a/lib/connector/sabre/quotaplugin.php
+++ b/lib/connector/sabre/quotaplugin.php
@@ -50,7 +50,8 @@ class OC_Connector_Sabre_QuotaPlugin extends Sabre_DAV_ServerPlugin {
 				$uri='/'.$uri;
 			}
 			list($parentUri, $newName) = Sabre_DAV_URLUtil::splitPath($uri);
-			if ($length > \OC\Files\Filesystem::free_space($parentUri)) {
+			$freeSpace = \OC\Files\Filesystem::free_space($parentUri);
+			if ($freeSpace !== \OC\Files\FREE_SPACE_UNKNOWN && $length > \OC\Files\Filesystem::free_space($parentUri)) {
 				throw new Sabre_DAV_Exception_InsufficientStorage();
 			}
 		}


### PR DESCRIPTION
The WebDAV connector shouldn't throw an exception when the free space is unknown. This prevents upload.

@icewind1991 @schiesbn 
