### PR TITLE
Set required owncloud version to 4.93

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>File Management</description>
 	<licence>AGPL</licence>
 	<author>Robin Appelman</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<standalone/>
 	<default_enable/>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Mount external storage sources</description>
 	<licence>AGPL</licence>
 	<author>Robin Appelman, Michael Gapczynski</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<types>
 		<filesystem/>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>File sharing between users</description>
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<default_enable/>
 	<types>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Versions</name>
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<description>Versioning of files</description>
 	<types>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -7,7 +7,7 @@
 	This app is not compatible to the WebDAV user backend.</description>
 	<licence>AGPL</licence>
 	<author>Dominik Schmidt and Arthur Schiwon</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<types>
 		<authentication/>

--- a/apps/user_webdavauth/appinfo/info.xml
+++ b/apps/user_webdavauth/appinfo/info.xml
@@ -7,7 +7,7 @@
 	This app is not compatible to the LDAP user and group backend.</description>
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek</author>
-	<require>4.91</require>
+	<require>4.93</require>
 	<shipped>true</shipped>
 	<types>
 		<authentication/>


### PR DESCRIPTION
This prevents the upgrade process from disabling all apps

@karlitschek @DeepDiver1975 

@karlitschek could you change make this change before you release a new version/beta for the next time (also in the apps repo)

(also see https://github.com/owncloud/apps/commit/ef8521e6cad958909c8a35927939f746bc76affa)
