### PR TITLE
use distance option to delay dragging in sane browsers

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -863,6 +863,10 @@ var dragOptions={
 		$('#fileList tr td.filename').addClass('ui-draggable');
 	}
 }
+// sane browsers support using the distance option
+if ( ! $.browser.msie) {
+	dragOptions['distance'] = 20;
+} 
 
 var folderDropOptions={
 	drop: function( event, ui ) {


### PR DESCRIPTION
this adds the distance option for browsers other than ie to delay the drag option in the files app. improves usability with regard to #720 
@jancborchardt @DeepDiver1975 @karlitschek @tanghus please test and :+1: 
