### PR TITLE
cleanPath needs to be public

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -313,7 +313,7 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 	}
 
-	private function cleanPath($path) {
+	public function cleanPath($path) {
 		if ( ! $path || $path[0]=='/') {
 			return substr($path, 1);
 		} else {


### PR DESCRIPTION
function cleanPath() needs to be public. Otherwise webdav mounts will fail.
