### PR TITLE
Sort after display name + LDAP server side sorting

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -624,7 +624,8 @@ abstract class Access {
 	 * @brief executes an LDAP search
 	 * @param $filter the LDAP filter for the search
 	 * @param $base an array containing the LDAP subtree(s) that shall be searched
-	 * @param $attr optional, when a certain attribute shall be filtered out
+	 * @param $attr optional, array, one or more attributes that shall be
+	 * retrieved. Results will according to the order in the array.
 	 * @returns array with the search result
 	 *
 	 * Executes an LDAP search
@@ -656,6 +657,14 @@ abstract class Access {
 			\OCP\Util::writeLog('user_ldap', 'Attempt for Paging?  '.print_r($pagedSearchOK, true), \OCP\Util::ERROR);
 			return array();
 		}
+
+		// Do the server-side sorting
+		foreach(array_reverse($attr) as $sortAttr){
+			foreach($sr as $searchResource) {
+				ldap_sort($link_resource, $searchResource, $sortAttr);
+			}
+		}
+
 		$findings = array();
 		foreach($sr as $key => $res) {
 		    $findings = array_merge($findings, ldap_get_entries($link_resource, $res ));

--- a/lib/user.php
+++ b/lib/user.php
@@ -530,7 +530,7 @@ class OC_User {
 				$displayNames = array_merge($displayNames, $backendDisplayNames);
 			}
 		}
-		ksort($displayNames);
+		asort($displayNames);
 		return $displayNames;
 	}
 

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -116,9 +116,9 @@ var UserList = {
 		}
 		var added = false;
 		if (sort) {
-			username = username.toLowerCase();
+			displayname = displayname.toLowerCase();
 			$('tbody tr').each(function () {
-				if (username < $(this).attr('data-uid').toLowerCase()) {
+				if (displayname < $(this).attr('data-uid').toLowerCase()) {
 					$(tr).insertBefore($(this));
 					added = true;
 					return false;


### PR DESCRIPTION
LDAP server side sorting added. To take real effect, this PR changes the sorting on the Users page to sort according to the display name instead of the internal/login name. The internal name from LDAP users will be unreadable UUID like AF926DEA-E6B4-49C6-9A14-D2E918C2F9B2 so it does not make sense to sort it after this.

Hope that is okay. Adresses an issue stated in https://github.com/owncloud/core/issues/1609 It does not do natural sort, however.

What do you think @jancborchardt @tanghus @schiesbn @karlitschek others?
