### PR TITLE
OC5 beta 2 - prevent multiple slashes in a row when building URLs.

### DIFF
--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -28,9 +28,9 @@
 			>
 		<?php if(!isset($_['readonly']) || !$_['readonly']): ?><input type="checkbox" /><?php endif; ?>
 		<?php if($file['type'] == 'dir'): ?>
-			<a class="name" href="<?php echo $_['baseURL'].$directory.'/'.$name; ?>" title="">
+			<a class="name" href="<?php echo rtrim($_['baseURL'],'/').'/'.trim($directory,'/').'/'.$name; ?>" title="">
 		<?php else: ?>
-			<a class="name" href="<?php echo $_['downloadURL'].$directory.'/'.$name; ?>" title="">
+			<a class="name" href="<?php echo rtrim($_['downloadURL'],'/').'/'.trim($directory,'/').'/'.$name; ?>" title="">
 		<?php endif; ?>
 			<span class="nametext">
 				<?php if($file['type'] == 'dir'):?>


### PR DESCRIPTION
When you hover over e.g. a file name with your cursor you can see that the generated URL contains multiple slashes in a row:

![20130227_owncloud_three_slashes_in_a_row](https://f.cloud.github.com/assets/2572764/202167/49a6decc-8109-11e2-9694-8d9040791024.png)
