### PR TITLE
up limit of share dropdown from 4 to 15, scrollbar after 4 1/2 entries, fix #135

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -185,8 +185,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$users = array();
 				$limit = 0;
 				$offset = 0;
-				while ($count < 4 && count($users) == $limit) {
-					$limit = 4 - $count;
+				while ($count < 15 && count($users) == $limit) {
+					$limit = 15 - $count;
 					if ($sharePolicy == 'groups_only') {
 						$users = OC_Group::DisplayNamesInGroups($groups, $_GET['search'], $limit, $offset);
 					} else {
@@ -209,7 +209,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				}
 				$count = 0;
 				foreach ($groups as $group) {
-					if ($count < 4) {
+					if ($count < 15) {
 						if (stripos($group, $_GET['search']) !== false
 							&& (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -91,3 +91,9 @@
  }
 
 .reshare { white-space:normal; } /* fix shared by text going out of box */
+
+.ui-autocomplete { /* limit dropdown height to 4 1/2 entries */
+	max-height:103px;
+	overflow-y:auto;
+	overflow-x:hidden;
+}


### PR DESCRIPTION
Finally. Check it out @Raydiation @MTGap @tanghus @DeepDiver1975 

The cut at 4 1/2 is to visibly hint that there are more entries below. I upped the limit of the pulled users from 4 to 15 – maybe that can even be fully removed but I don’t know.

CHECK AND LET’S PULL THIS IN!
