### PR TITLE
add post_moveToTrash and post_restore signals to the trash bin

### DIFF
--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -71,7 +71,9 @@ class Trashbin {
 				\OC_Log::write('files_trashbin', 'trash bin database couldn\'t be updated', \OC_log::ERROR);
 				return;
 			}
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', array('path' => \OC\Files\Filesystem::normalizePath($file_path)));
+			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash',
+					array('filePath' => \OC\Files\Filesystem::normalizePath($file_path),
+							'trashPath' => \OC\Files\Filesystem::normalizePath($deleted.'.d'.$timestamp)));
 			
 			// Take care of file versions
 			if ( \OCP\App::isEnabled('files_versions') ) {
@@ -174,7 +176,9 @@ class Trashbin {
 		$mtime = $view->filemtime($source);
 		if( $view->rename($source, $target.$ext) ) {
 			$view->touch($target.$ext, $mtime);
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', array('path' => \OC\Files\Filesystem::normalizePath('/'.$location.'/'.$filename.$ext)));
+			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', 
+					array('filePath' => \OC\Files\Filesystem::normalizePath('/'.$location.'/'.$filename.$ext),
+							'trashPath' => \OC\Files\Filesystem::normalizePath($file)));
 			if ($view->is_dir($target.$ext)) {
 				$trashbinSize -= self::calculateSize(new \OC\Files\View('/'.$user.'/'.$target.$ext));
 			} else {

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -71,6 +71,7 @@ class Trashbin {
 				\OC_Log::write('files_trashbin', 'trash bin database couldn\'t be updated', \OC_log::ERROR);
 				return;
 			}
+			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', array('path' => \OC\Files\Filesystem::normalizePath($file_path)));
 			
 			// Take care of file versions
 			if ( \OCP\App::isEnabled('files_versions') ) {
@@ -173,6 +174,7 @@ class Trashbin {
 		$mtime = $view->filemtime($source);
 		if( $view->rename($source, $target.$ext) ) {
 			$view->touch($target.$ext, $mtime);
+			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', array('path' => \OC\Files\Filesystem::normalizePath('/'.$location.'/'.$filename.$ext)));
 			if ($view->is_dir($target.$ext)) {
 				$trashbinSize -= self::calculateSize(new \OC\Files\View('/'.$user.'/'.$target.$ext));
 			} else {


### PR DESCRIPTION
This patch added a post_restore and post_moveToTrash signal to the trash bin app.

This enables other apps to react on it and perform its own  actions  to preserve and restore informations.

The signal class is '\OCA\Files_Trashbin\Trashbin'
The signals are 'post_moveToTrash' and 'post_restore'
Both signals contain the parameters filePath (path relative to data/user/file) and trashPath (path relative to data/user/files_trashbin/files) for the moved/restored file.

This should provided everything which is needed in #1431 
