### PR TITLE
suppress log messages like `include path for class ... starts with "apps/"`

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -1,12 +1,12 @@
 <?php
 
-OC::$CLASSPATH['OCA\Encryption\Crypt'] = 'apps/files_encryption/lib/crypt.php';
-OC::$CLASSPATH['OCA\Encryption\Hooks'] = 'apps/files_encryption/hooks/hooks.php';
-OC::$CLASSPATH['OCA\Encryption\Util'] = 'apps/files_encryption/lib/util.php';
-OC::$CLASSPATH['OCA\Encryption\Keymanager'] = 'apps/files_encryption/lib/keymanager.php';
-OC::$CLASSPATH['OCA\Encryption\Stream'] = 'apps/files_encryption/lib/stream.php';
-OC::$CLASSPATH['OCA\Encryption\Proxy'] = 'apps/files_encryption/lib/proxy.php';
-OC::$CLASSPATH['OCA\Encryption\Session'] = 'apps/files_encryption/lib/session.php';
+OC::$CLASSPATH['OCA\Encryption\Crypt'] = 'files_encryption/lib/crypt.php';
+OC::$CLASSPATH['OCA\Encryption\Hooks'] = 'files_encryption/hooks/hooks.php';
+OC::$CLASSPATH['OCA\Encryption\Util'] = 'files_encryption/lib/util.php';
+OC::$CLASSPATH['OCA\Encryption\Keymanager'] = 'files_encryption/lib/keymanager.php';
+OC::$CLASSPATH['OCA\Encryption\Stream'] = 'files_encryption/lib/stream.php';
+OC::$CLASSPATH['OCA\Encryption\Proxy'] = 'files_encryption/lib/proxy.php';
+OC::$CLASSPATH['OCA\Encryption\Session'] = 'files_encryption/lib/session.php';
 
 OC_FileProxy::register( new OCA\Encryption\Proxy() );
 

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -6,16 +6,16 @@
  * See the COPYING-README file.
  */
 
-OC::$CLASSPATH['OC\Files\Storage\StreamWrapper']='apps/files_external/lib/streamwrapper.php';
-OC::$CLASSPATH['OC\Files\Storage\FTP']='apps/files_external/lib/ftp.php';
-OC::$CLASSPATH['OC\Files\Storage\DAV']='apps/files_external/lib/webdav.php';
-OC::$CLASSPATH['OC\Files\Storage\Google']='apps/files_external/lib/google.php';
-OC::$CLASSPATH['OC\Files\Storage\SWIFT']='apps/files_external/lib/swift.php';
-OC::$CLASSPATH['OC\Files\Storage\SMB']='apps/files_external/lib/smb.php';
-OC::$CLASSPATH['OC\Files\Storage\AmazonS3']='apps/files_external/lib/amazons3.php';
-OC::$CLASSPATH['OC\Files\Storage\Dropbox']='apps/files_external/lib/dropbox.php';
-OC::$CLASSPATH['OC\Files\Storage\SFTP']='apps/files_external/lib/sftp.php';
-OC::$CLASSPATH['OC_Mount_Config']='apps/files_external/lib/config.php';
+OC::$CLASSPATH['OC\Files\Storage\StreamWrapper'] = 'files_external/lib/streamwrapper.php';
+OC::$CLASSPATH['OC\Files\Storage\FTP'] = 'files_external/lib/ftp.php';
+OC::$CLASSPATH['OC\Files\Storage\DAV'] = 'files_external/lib/webdav.php';
+OC::$CLASSPATH['OC\Files\Storage\Google'] = 'files_external/lib/google.php';
+OC::$CLASSPATH['OC\Files\Storage\SWIFT'] = 'files_external/lib/swift.php';
+OC::$CLASSPATH['OC\Files\Storage\SMB'] = 'files_external/lib/smb.php';
+OC::$CLASSPATH['OC\Files\Storage\AmazonS3'] = 'files_external/lib/amazons3.php';
+OC::$CLASSPATH['OC\Files\Storage\Dropbox'] = 'files_external/lib/dropbox.php';
+OC::$CLASSPATH['OC\Files\Storage\SFTP'] = 'files_external/lib/sftp.php';
+OC::$CLASSPATH['OC_Mount_Config'] = 'files_external/lib/config.php';
 
 OCP\App::registerAdmin('files_external', 'settings');
 if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == 'yes') {

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -1,11 +1,11 @@
 <?php
 
-OC::$CLASSPATH['OC_Share_Backend_File'] = "apps/files_sharing/lib/share/file.php";
-OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'apps/files_sharing/lib/share/folder.php';
-OC::$CLASSPATH['OC\Files\Storage\Shared'] = "apps/files_sharing/lib/sharedstorage.php";
-OC::$CLASSPATH['OC\Files\Cache\Shared_Cache'] = 'apps/files_sharing/lib/cache.php';
-OC::$CLASSPATH['OC\Files\Cache\Shared_Permissions'] = 'apps/files_sharing/lib/permissions.php';
-OC::$CLASSPATH['OC\Files\Cache\Shared_Watcher'] = 'apps/files_sharing/lib/watcher.php';
+OC::$CLASSPATH['OC_Share_Backend_File'] = 'files_sharing/lib/share/file.php';
+OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'files_sharing/lib/share/folder.php';
+OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
+OC::$CLASSPATH['OC\Files\Cache\Shared_Cache'] = 'files_sharing/lib/cache.php';
+OC::$CLASSPATH['OC\Files\Cache\Shared_Permissions'] = 'files_sharing/lib/permissions.php';
+OC::$CLASSPATH['OC\Files\Cache\Shared_Watcher'] = 'files_sharing/lib/watcher.php';
 OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');

--- a/apps/files_trashbin/appinfo/app.php
+++ b/apps/files_trashbin/appinfo/app.php
@@ -1,7 +1,7 @@
 <?php
 
-OC::$CLASSPATH['OCA\Files_Trashbin\Hooks'] = 'apps/files_trashbin/lib/hooks.php';
-OC::$CLASSPATH['OCA\Files_Trashbin\Trashbin'] = 'apps/files_trashbin/lib/trash.php';
+OC::$CLASSPATH['OCA\Files_Trashbin\Hooks'] = 'files_trashbin/lib/hooks.php';
+OC::$CLASSPATH['OCA\Files_Trashbin\Trashbin'] = 'files_trashbin/lib/trash.php';
 
 
 OCP\Util::connectHook('OC_Filesystem', 'delete', "OCA\Files_Trashbin\Hooks", "remove_hook");

--- a/apps/files_versions/appinfo/app.php
+++ b/apps/files_versions/appinfo/app.php
@@ -1,8 +1,8 @@
 <?php
 
 //require_once 'files_versions/versions.php';
-OC::$CLASSPATH['OCA\Files_Versions\Storage'] = 'apps/files_versions/lib/versions.php';
-OC::$CLASSPATH['OCA\Files_Versions\Hooks'] = 'apps/files_versions/lib/hooks.php';
+OC::$CLASSPATH['OCA\Files_Versions\Storage'] = 'files_versions/lib/versions.php';
+OC::$CLASSPATH['OCA\Files_Versions\Hooks'] = 'files_versions/lib/hooks.php';
 
 OCP\Util::addscript('files_versions', 'versions');
 

--- a/apps/user_webdavauth/appinfo/app.php
+++ b/apps/user_webdavauth/appinfo/app.php
@@ -21,7 +21,7 @@
 *
 */
 
-require_once 'apps/user_webdavauth/user_webdavauth.php';
+require_once OC_App::getAppPath('user_webdavauth').'/user_webdavauth.php';
 
 OC_APP::registerAdmin('user_webdavauth', 'settings');
 


### PR DESCRIPTION
removed "apps/" from class pathes and made use of OC_App::getAppPath function to support multiple apps pathes.
