### PR TITLE
Avoid to display empty DisplayNames for menu and title

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -2,7 +2,7 @@
 <html class="ng-csp">
 	<head>
 		<title><?php p(!empty($_['application'])?$_['application'].' | ':'') ?>ownCloud
-			<?php p(!empty($_['user_displayname'])?' ('.$_['user_displayname'].') ':'') ?></title>
+			<?php p(trim($_['user_displayname']) != '' ?' ('.$_['user_displayname'].') ':'') ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="apple-itunes-app" content="app-id=543672169">
 		<link rel="shortcut icon" href="<?php print_unescaped(image_path('', 'favicon.png')); ?>" />
@@ -34,7 +34,7 @@
 
 			<ul id="settings" class="svg">
 				<span id="expand">
-					<span id="expandDisplayName"><?php p($_['user_displayname']) ?></span>
+					<span id="expandDisplayName"><?php  p(trim($_['user_displayname']) != '' ? $_['user_displayname'] : $_['user_uid']) ?></span>
 					<img class="svg" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" />
 				</span>
 				<div id="expanddiv">

--- a/lib/templatelayout.php
+++ b/lib/templatelayout.php
@@ -31,6 +31,7 @@ class OC_TemplateLayout extends OC_Template {
 			}
 			$user_displayname = OC_User::getDisplayName();
 			$this->assign( 'user_displayname', $user_displayname );
+			$this->assign( 'user_uid', OC_User::getUser() );
 		} else if ($renderas == 'guest' || $renderas == 'error') {
 			parent::__construct('core', 'layout.guest');
 		} else {


### PR DESCRIPTION
When the Display name for a user is empty or emptied ( set to spaces or ...)
the title  of the page is weird and the menu display only the small arrow.

see the screenshot :

![oc_layout3](https://f.cloud.github.com/assets/177003/213018/c5de1764-834b-11e2-9ed2-cb7b4441e52e.jpg)

so i've choose to display the uid instead of the display name for the menu if it is empty
