### PR TITLE
add ie css switch to layout templates

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html class="ng-csp">
+<!--[if lt IE 7]><html class="ng-csp ie ie6 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 7]><html class="ng-csp ie ie7 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 8]><html class="ng-csp ie ie8 lte9 lte8"><![endif]-->
+<!--[if IE 9]><html class="ng-csp ie ie9 lte9"><![endif]-->
+<!--[if gt IE 9]><html class="ng-csp ie"><![endif]-->
+<!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 	<head>
 		<title>ownCloud</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html class="ng-csp">
+<!--[if lt IE 7]><html class="ng-csp ie ie6 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 7]><html class="ng-csp ie ie7 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 8]><html class="ng-csp ie ie8 lte9 lte8"><![endif]-->
+<!--[if IE 9]><html class="ng-csp ie ie9 lte9"><![endif]-->
+<!--[if gt IE 9]><html class="ng-csp ie"><![endif]-->
+<!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 	<head>
 		<title>ownCloud</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
-<html class="ng-csp">
+<!--[if lt IE 7]><html class="ng-csp ie ie6 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 7]><html class="ng-csp ie ie7 lte9 lte8 lte7"><![endif]-->
+<!--[if IE 8]><html class="ng-csp ie ie8 lte9 lte8"><![endif]-->
+<!--[if IE 9]><html class="ng-csp ie ie9 lte9"><![endif]-->
+<!--[if gt IE 9]><html class="ng-csp ie"><![endif]-->
+<!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 	<head>
 		<title><?php p(!empty($_['application'])?$_['application'].' | ':'') ?>ownCloud
 			<?php p(trim($_['user_displayname']) != '' ?' ('.$_['user_displayname'].') ':'') ?></title>


### PR DESCRIPTION
This PR adds various ie css tags to the html tag based on the css browser switch mentioned in https://github.com/owncloud/core/issues/308#issuecomment-13583610

It lays the foundation to clean up the css in future pull requests.

It will then be possible to cleanly separate ie CSS magic from HTML5 by prepending rules with .ie, .ie7 or .lte9

Instead of using a browser switch to include a special ie CSS file in the header this allows us to keep related css in one place / file. This hopefully prevents regressions for CSS issues like in #1779 

@karlitschek @Raydiation @jancborchardt @tanghus @bartv2 @DeepDiver1975 please vote
