### PR TITLE
fix files table CSS specificity issue causing multiselect bar overlap

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -73,7 +73,7 @@ table th#headerSize, table td.filesize { min-width:3em; padding:0 1em; text-alig
 table th#headerDate, table td.date { min-width:11em; padding:0 .1em 0 1em; text-align:left; }
 
 /* Multiselect bar */
-table.multiselect { top:63px; }
+#filestable.multiselect { top:63px; }
 table.multiselect thead { position:fixed; top:82px; z-index:1; -moz-box-sizing: border-box; box-sizing: border-box; left: 0; padding-left: 64px; width:100%; }
 table.multiselect thead th { background:rgba(230,230,230,.8); color:#000; font-weight:bold; border-bottom:0; }
 table.multiselect #headerName { width: 100%; }

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -9,7 +9,7 @@
 	<div id="emptyfolder"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 <?php endif; ?>
 
-<table>
+<table id="filestable">
 	<thead>
 		<tr>
 			<th id='headerName'>


### PR DESCRIPTION
Fix #2075

Check it out @schiesbn @raghunayyar @Raydiation 

@raghunayyar if you introduce a new ID (#filestable) and CSS rule, make sure that you’re not overriding other rules. ;)
