### PR TITLE
properly implement displayNamesInGroup in Core and LDAP, fixes #1689

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -210,6 +210,19 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 	}
 
 	/**
+	 * @brief get a list of all display names in a group
+	 * @returns array with display names (value) and user ids(key)
+	 */
+	public function displayNamesInGroup($gid, $search, $limit, $offset) {
+		$users = $this->usersInGroup($gid, $search, $limit, $offset);
+		$displayNames = array();
+		foreach($users as $user) {
+			$displayNames[$user] = \OC_User::getDisplayName($user);
+		}
+		return $displayNames;
+	}
+
+	/**
 	 * @brief get a list of all groups
 	 * @returns array with group names
 	 *
@@ -287,8 +300,6 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 	* compared with OC_USER_BACKEND_CREATE_USER etc.
 	*/
 	public function implementsActions($actions) {
-		//always returns false, because possible actions are modifying
-		// actions. We do not write to LDAP, at least for now.
-		return false;
+		return (bool)(OC_GROUP_BACKEND_GET_DISPLAYNAME	& $actions);
 	}
 }

--- a/apps/user_ldap/group_proxy.php
+++ b/apps/user_ldap/group_proxy.php
@@ -143,7 +143,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 		$displayNames = array();
 
 		foreach($this->backends as $backend) {
-		    $backendUsers = $backend->displayNamesInGroup($gid, $search, $limit, $offset);
+			$backendUsers = $backend->displayNamesInGroup($gid, $search, $limit, $offset);
 			if (is_array($backendUsers)) {
 				$displayNames = array_merge($displayNames, $backendUsers);
 			}

--- a/apps/user_ldap/group_proxy.php
+++ b/apps/user_ldap/group_proxy.php
@@ -136,6 +136,22 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
+	 * @brief get a list of all display names in a group
+	 * @returns array with display names (value) and user ids(key)
+	 */
+	public function displayNamesInGroup($gid, $search, $limit, $offset) {
+		$displayNames = array();
+
+		foreach($this->backends as $backend) {
+		    $backendUsers = $backend->displayNamesInGroup($gid, $search, $limit, $offset);
+			if (is_array($backendUsers)) {
+				$displayNames = array_merge($displayNames, $backendUsers);
+			}
+		}
+		return $displayNames;
+	}
+
+	/**
 	 * @brief get a list of all groups
 	 * @returns array with group names
 	 *

--- a/lib/group.php
+++ b/lib/group.php
@@ -294,7 +294,13 @@ class OC_Group {
 	public static function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$displayNames=array();
 		foreach(self::$_usedBackends as $backend) {
-			$displayNames = array_merge($backend->displayNamesInGroup($gid, $search, $limit, $offset), $displayNames);
+			if($backend->implementsActions(OC_GROUP_BACKEND_GET_DISPLAYNAME)) {
+				$displayNames = array_merge($backend->displayNamesInGroup($gid, $search, $limit, $offset), $displayNames);
+			} else {
+				$users = $backend->usersInGroup($gid, $search, $limit, $offset);
+				$names = array_combine($users, $users);
+				$displayNames = array_merge($names, $displayNames);
+			}
 		}
 		return $displayNames;
 	}

--- a/lib/group/backend.php
+++ b/lib/group/backend.php
@@ -33,6 +33,7 @@ define('OC_GROUP_BACKEND_CREATE_GROUP',      0x00000001);
 define('OC_GROUP_BACKEND_DELETE_GROUP',      0x00000010);
 define('OC_GROUP_BACKEND_ADD_TO_GROUP',      0x00000100);
 define('OC_GROUP_BACKEND_REMOVE_FROM_GOUP',  0x00001000);
+define('OC_GROUP_BACKEND_GET_DISPLAYNAME',   0x00010000);
 
 /**
  * Abstract base class for user management
@@ -43,6 +44,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 		OC_GROUP_BACKEND_DELETE_GROUP => 'deleteGroup',
 		OC_GROUP_BACKEND_ADD_TO_GROUP => 'addToGroup',
 		OC_GROUP_BACKEND_REMOVE_FROM_GOUP => 'removeFromGroup',
+		OC_GROUP_BACKEND_GET_DISPLAYNAME => 'displayNamesInGroup',
 	);
 
 	/**


### PR DESCRIPTION
what happens here: displayNamesInGroup was not declared necessary in OC_Group_Interface (though has a good implemtation in OC_Group_Backend). Because of this and not to break other apps that may implement the Interface at this point of time, i marked it optional using implementsAction(). The fallback behaviour in OC_Group is use internal name as display name, like OC_Group_Backend does.

To work well, properly and expected the functionality was added for the LDAP backend, too.

Reviewers please, especially but not only @schiesbn
