### PR TITLE
Clear the CSS and JS cache earlier to make sure update goes smoothly

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -17,10 +17,6 @@ if (OC::checkUpgrade(false)) {
 	} catch (Exception $exception) {
 		$watcher->failure($exception->getMessage());
 	}
-	$minimizerCSS = new OC_Minimizer_CSS();
-	$minimizerCSS->clearCache();
-	$minimizerJS = new OC_Minimizer_JS();
-	$minimizerJS->clearCache();
 	OC_Config::setValue('version', implode('.', OC_Util::getVersion()));
 	OC_App::checkAppsRequirements();
 	// load all apps to also upgrade enabled apps

--- a/lib/base.php
+++ b/lib/base.php
@@ -277,6 +277,10 @@ class OC {
 					OC_Log::write('core',
 						'starting upgrade from ' . $installedVersion . ' to ' . $currentVersion,
 						OC_Log::DEBUG);
+					$minimizerCSS = new OC_Minimizer_CSS();
+					$minimizerCSS->clearCache();
+					$minimizerJS = new OC_Minimizer_JS();
+					$minimizerJS->clearCache();
 					OC_Util::addscript('update');
 					$tmpl = new OC_Template('', 'update', 'guest');
 					$tmpl->assign('version', OC_Util::getVersionString());


### PR DESCRIPTION
I moved the clearing of CSS and JS caches from ajax/update.php to lib/base.php

There was an issue with the Event Source js failing because the browser was using an old cached version of the eventsource.js file. This prevented the update from occurring until a refresh.

Maybe fix for #1520 

@karlitschek @schiesbn @MTRichards 
