### PR TITLE
Converting styling of all internal apps, Settings and core ownCloud from em to px. 

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -3,30 +3,30 @@
  See the COPYING-README file. */
 
 /* FILE MENU */
-.actions { padding:.3em; height:2em; width: 100%; }
+.actions { padding:4px; height:24px; width: 100%; }
 .actions input, .actions button, .actions .button { margin:0; float:left; }
 
 #new {
-	height:17px;  margin:0 0 0 1em; z-index:1010; float:left;
+	height:17px;  margin:0 0 0 12px; z-index:1010; float:left;
 }
 #new.active { border-bottom-left-radius:0; border-bottom-right-radius:0; border-bottom:none; }
-#new>a { padding:.5em 1.2em .3em; }
+#new>a { padding:6px 14px 4px; }
 #new>ul {
-	display:none; position:fixed; min-width:7em; z-index:10;
-	padding:.5em; padding-bottom:0; margin-top:.075em; margin-left:-.5em;
+	display:none; position:fixed; min-width:84px; z-index:10;
+	padding:6px; padding-bottom:0; margin-top:1px; margin-left:-6px;
 	text-align:left;
 	background:#f8f8f8; border:1px solid #ddd; border-radius:10px; border-top-left-radius:0;
 	box-shadow:0 2px 7px rgba(170,170,170,.4);
 }
-#new>ul>li { height:20px; margin:.3em; padding-left:2em; padding-bottom:0.1em;
+#new>ul>li { height:20px; margin:4px; padding-left:24px; padding-bottom:1px;
 		background-repeat:no-repeat; cursor:pointer; }
 #new>ul>li>p { cursor:pointer; }
-#new>ul>li>form>input { padding:0.3em; margin:-0.3em; }
+#new>ul>li>form>input { padding:4px; margin:-4px; }
 
-#trash { height:17px; margin: 0 1em; z-index:1010; float: right; }
+#trash { height:17px; margin: 0 12px; z-index:1010; float: right; }
 
 #upload {
-	height:27px; padding:0; margin-left:0.2em; overflow:hidden;
+	height:27px; padding:0; margin-left:2px; overflow:hidden;
 }
 #upload a {
 	position:relative; display:block; width:100%; height:27px;
@@ -39,24 +39,24 @@
 .file_upload_form { display:inline; float:left; margin:0; padding:0; cursor:pointer; overflow:visible; }
 #file_upload_start {
 	left:0; top:0; width:28px; height:27px; padding:0;
-	font-size:1em;
+	font-size:12px;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; filter:alpha(opacity=0); opacity:0;
 	z-index:20; position:relative; cursor:pointer; overflow:hidden;
 }
 
 #uploadprogresswrapper { float: right; position: relative; }
-#uploadprogresswrapper #uploadprogressbar { position:relative; display:inline-block; width:10em; height:1.5em; top:.4em; }
+#uploadprogresswrapper #uploadprogressbar { position:relative; display:inline-block; width:120px; height:18px; top:5px; }
 
 /* FILE TABLE */
 
 #emptyfolder {
 	position:absolute;
-	margin:10em 0 0 10em;
-	font-size:1.5em; font-weight:bold;
+	margin:120px 0 0 120px;
+	font-size:18px; font-weight:bold;
 	color:#888; text-shadow:#fff 0 1px 0;
 }
 #filestable { position: relative; top:37px; width:100%; }
-tbody tr { background-color:#fff; height:2.5em; }
+tbody tr { background-color:#fff; height:30px; }
 tbody tr:hover, tbody tr:active, tbody tr.selected { background-color:#f8f8f8; }
 tbody tr.selected { background-color:#eee; }
 tbody a { color:#000; }
@@ -64,29 +64,29 @@ span.extension, span.uploading, td.date { color:#999; }
 span.extension { text-transform:lowercase; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)"; filter:alpha(opacity=70); opacity:.7; -webkit-transition:opacity 300ms; -moz-transition:opacity 300ms; -o-transition:opacity 300ms; transition:opacity 300ms; }
 tr:hover span.extension { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter:alpha(opacity=100); opacity:1; color:#777; }
 table tr.mouseOver td { background-color:#eee; }
-table th { height:2em; padding:0 .5em; color:#999; }
-table th .name { float:left; margin-left:.5em; }
+table th { height:24px; padding:0 6px; color:#999; }
+table th .name { float:left; margin-left:6px; }
 table th, table td { border-bottom:1px solid #ddd; text-align:left; font-weight:normal; }
-table td { border-bottom:1px solid #eee; font-style:normal; background-position:1em .5em; background-repeat:no-repeat; }
-table th#headerName { width:100em; /* not really sure why this works better than 100% … table styling */ }
-table th#headerSize, table td.filesize { min-width:3em; padding:0 1em; text-align:right; }
-table th#headerDate, table td.date { min-width:11em; padding:0 .1em 0 1em; text-align:left; }
+table td { border-bottom:1px solid #eee; font-style:normal; background-position:12px 6px; background-repeat:no-repeat; }
+table th#headerName { width:1200px; /* not really sure why this works better than 100% … table styling */ }
+table th#headerSize, table td.filesize { min-width:36px; padding:0 12px; text-align:right; }
+table th#headerDate, table td.date { min-width:132px; padding:0 2px 0 12px; text-align:left; }
 
 /* Multiselect bar */
 #filestable.multiselect { top:63px; }
 table.multiselect thead { position:fixed; top:82px; z-index:1; -moz-box-sizing: border-box; box-sizing: border-box; left: 0; padding-left: 64px; width:100%; }
 table.multiselect thead th { background:rgba(230,230,230,.8); color:#000; font-weight:bold; border-bottom:0; }
 table.multiselect #headerName { width: 100%; }
-table td.selection, table th.selection, table td.fileaction { width:2em; text-align:center; }
-table td.filename a.name { display:block; height:1.5em; vertical-align:middle; margin-left:3em; }
+table td.selection, table th.selection, table td.fileaction { width:24px; text-align:center; }
+table td.filename a.name { display:block; height:18px; vertical-align:middle; margin-left:36px; }
 table tr[data-type="dir"] td.filename a.name span.nametext {font-weight:bold; }
 table td.filename input.filename { width:100%; cursor:text; }
-table td.filename a, table td.login, table td.logout, table td.download, table td.upload, table td.create, table td.delete { padding:.2em .5em .5em 0; }
-table td.filename .nametext, .uploadtext, .modified { float:left; padding:.3em 0; }
+table td.filename a, table td.login, table td.logout, table td.download, table td.upload, table td.create, table td.delete { padding:2px 6px 6px 0; }
+table td.filename .nametext, .uploadtext, .modified { float:left; padding:4px 0; }
 /* TODO fix usability bug (accidental file/folder selection) */
 table td.filename .nametext { overflow:hidden; text-overflow:ellipsis; }
-table td.filename .uploadtext { font-weight:normal; margin-left:.5em; }
-table td.filename form { font-size:.85em; margin-left:3em; margin-right:3em; }
+table td.filename .uploadtext { font-weight:normal; margin-left:6px; }
+table td.filename form { font-size:10px; margin-left:36px; margin-right:36px; }
 
 /* File checkboxes */
 #fileList tr td.filename>input[type="checkbox"]:first-child { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; filter:alpha(opacity=0); opacity:0; float:left; margin:.7em 0 0 1em; /* bigger clickable area doesn’t work in FF width:2.8em; height:2.4em;*/ -webkit-transition:opacity 200ms; -moz-transition:opacity 200ms; -o-transition:opacity 200ms; transition:opacity 200ms; }
@@ -99,13 +99,13 @@ table td.filename form { font-size:.85em; margin-left:3em; margin-right:3em; }
 	position:relative; width:100%;
 	-webkit-transition:background-image 500ms; -moz-transition:background-image 500ms; -o-transition:background-image 500ms; transition:background-image 500ms;
 }
-#select_all { float:left; margin:.3em 0.6em 0 .5em; }
+#select_all { float:left; margin:4px 7px 0 6px; }
 #uploadsize-message,#delete-confirm { display:none; }
 
 /* File actions */
 .fileactions {
-	position:absolute; top:.6em; right:0;
-	font-size:.8em;
+	position:absolute; top:7px; right:0;
+	font-size:10px;
 }
 #fileList .name { position:relative; /* Firefox needs to explicitly have this default set … */ }
 #fileList tr:hover .fileactions { /* background to distinguish when overlaying with file names */
@@ -114,14 +114,14 @@ table td.filename form { font-size:.85em; margin-left:3em; margin-right:3em; }
 #fileList tr.selected:hover .fileactions, #fileList tr.mouseOver .fileactions { /* slightly darker color for selected rows */
 	background:rgba(238,238,238,.9); box-shadow:-5px 0 7px rgba(238,238,238,.9);
 }
-#fileList .fileactions a.action img { position:relative; top:.2em; }
-#fileList a.action { display:inline; margin:-.5em 0; padding:1em .5em 1em .5em !important; }
-#fileList img.move2trash { display:inline; margin:-.5em 0; padding:1em .5em 1em .5em !important; float:right; }
+#fileList .fileactions a.action img { position:relative; top:2px; }
+#fileList a.action { display:inline; margin:-6px 0; padding:12px 6px 12px 6px !important; }
+#fileList img.move2trash { display:inline; margin:6px 0; padding:12px 6px 12px 6px !important; float:right; }
 a.action.delete { float:right; }
 a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 .selectedActions { display:none; float:right; }
-.selectedActions a { display:inline; margin:-.5em 0; padding:.5em !important; }
-.selectedActions a img { position:relative; top:.3em; }
+.selectedActions a { display:inline; margin:-6px 0; padding:6px !important; }
+.selectedActions a img { position:relative; top:4px; }
 
 #fileList a.action {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
@@ -144,7 +144,7 @@ a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 
 #scanning-message{ top:40%; left:40%; position:absolute; display:none; }
 
-div.crumb a{ padding:0.9em 0 0.7em 0; }
+div.crumb a{ padding:9px 0 8px 0; }
 
 table.dragshadow {
 	width:auto;

--- a/apps/files_external/css/settings.css
+++ b/apps/files_external/css/settings.css
@@ -2,8 +2,8 @@ td.status>span { display:inline-block; height:16px; width:16px; }
 span.success { background-image: url('../img/success.png'); background-repeat:no-repeat; }
 span.error { background-image: url('../img/error.png'); background-repeat:no-repeat; }
 span.waiting { background-image: url('../img/waiting.png'); background-repeat:no-repeat; }
-td.mountPoint, td.backend { width:10em; }
-td.remove>img { visibility:hidden; padding-top:0.8em; }
+td.mountPoint, td.backend { width:120px; }
+td.remove>img { visibility:hidden; padding-top:10px; }
 tr:hover>td.remove>img { visibility:visible; cursor:pointer; }
 #addMountPoint>td { border:none; }
 #addMountPoint>td.applicable { visibility:hidden; }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -5,14 +5,14 @@ body {
 #header {
 	background:#1d2d44;
 	box-shadow:0 0 10px rgba(0,0,0,.5), inset 0 -2px 10px #222;
-	height:2.5em;
+	height:30px;
 	left:0;
-	line-height:2.5em;
+	line-height:30px;
 	position:fixed;
 	right:0;
 	top:0;
 	z-index:100;
-	padding:.5em;
+	padding:6px;
 }
 
 #details {
@@ -21,34 +21,34 @@ body {
 
 #header #download {
 	font-weight:700;
-	margin-left:2em;
+	margin-left:24px;
 }
 
 #header #download img {
-	padding-left:.1em;
-	padding-right:.3em;
+	padding-left:1px;
+	padding-right:4px;
 	vertical-align:text-bottom;
 }
 
 #preview {
 	background:#eee;
 	border-bottom:1px solid #f8f8f8;
-	min-height:30em;
+	min-height:360px;
 	text-align:center;
 	margin:45px auto;
 }
 
 #noPreview {
 	display:none;
-	padding-top:5em;
+	padding-top:60px;
 }
 
 p.info {
 	color:#777;
 	text-align:center;
 	text-shadow:#fff 0 1px 0;
-	width:22em;
-	margin:2em auto;
+	width:264px;
+	margin:24px auto;
 }
 
 p.info a {
@@ -58,8 +58,8 @@ p.info a {
 
 #imgframe {
 	height:75%;
-	padding-bottom:2em;
-	padding-top:2em;
+	padding-bottom:24px;
+	padding-top:24px;
 	width:80%;
 	margin:0 auto;
 }

--- a/apps/files_versions/css/versions.css
+++ b/apps/files_versions/css/versions.css
@@ -1,9 +1,9 @@
 #history {
-	margin: 2em 2em 0;
+	margin: 24px 24px 0;
 }
 
 #feedback-messages h3 {
-	font-size: 1.3em;
+	font-size: 16px;
 	font-style: italic;
 }
 

--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -12,6 +12,6 @@
 }
 
 .ldapwarning {
-	margin-left: 1.4em;
+	margin-left: 17px;
 	color: #FF3B3B;
 }

--- a/core/css/auth.css
+++ b/core/css/auth.css
@@ -1,7 +1,7 @@
 h2 {
-	font-size:2em;
+	font-size:24px;
 	font-weight:700;
-	margin-bottom:1em;
+	margin-bottom:12px;
 	white-space:nowrap;
 }
 
@@ -18,8 +18,8 @@ h2 img {
 }
 
 #oauth {
-	width:20em;
-	margin:4em auto 2em;
+	width:240px;
+	margin:48px auto 24px;
 }
 
 #allow-auth {
@@ -33,7 +33,7 @@ h2 img {
 	background:none;
 	border:0;
 	box-shadow:0 0 0 #fff, 0 0 0 #fff inset;
-	font-size:1.2em;
-	margin:.7em;
+	font-size:14px;
+	margin:8px;
 	padding:0;
 }

--- a/core/css/jquery.multiselect.css
+++ b/core/css/jquery.multiselect.css
@@ -4,7 +4,7 @@
 .ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important }
 
 .ui-multiselect-header { margin-bottom:3px; padding:3px 0 3px 4px }
-.ui-multiselect-header ul { font-size:0.9em }
+.ui-multiselect-header ul { font-size:11px }
 .ui-multiselect-header ul li { float:left; padding:0 10px 0 0 }
 .ui-multiselect-header a { text-decoration:none }
 .ui-multiselect-header a:hover { text-decoration:underline }
@@ -15,7 +15,7 @@
 .ui-multiselect-checkboxes { position:relative /* fixes bug in IE6/7 */; overflow-y:scroll }
 .ui-multiselect-checkboxes label { cursor:default; display:block; border:1px solid transparent; padding:3px 1px }
 .ui-multiselect-checkboxes label input { position:relative; top:1px }
-.ui-multiselect-checkboxes li { clear:both; font-size:0.9em; padding-right:3px }
+.ui-multiselect-checkboxes li { clear:both; font-size:11px; padding-right:3px }
 .ui-multiselect-checkboxes li.ui-multiselect-optgroup-label { text-align:center; font-weight:bold; border-bottom:1px solid }
 .ui-multiselect-checkboxes li.ui-multiselect-optgroup-label a { display:block; padding:3px; margin:1px 0; text-decoration:none }
 

--- a/core/css/multiselect.css
+++ b/core/css/multiselect.css
@@ -7,21 +7,21 @@
  	border:1px solid #ddd;
  	border-top:none;
  	box-shadow:0 1px 1px #ddd;
- 	padding-top:.5em;
+ 	padding-top:6px;
  	position:absolute;
-	max-height: 20em;
+	max-height: 240px;
 	overflow-y: auto;
  	z-index:49;
  }
 
  ul.multiselectoptions.down {
- 	border-bottom-left-radius:.5em;
- 	border-bottom-right-radius:.5em;
+ 	border-bottom-left-radius:6px;
+ 	border-bottom-right-radius:6px;
  }
 
  ul.multiselectoptions.up {
- 	border-top-left-radius:.5em;
- 	border-top-right-radius:.5em;
+ 	border-top-left-radius:6px;
+ 	border-top-right-radius:6px;
  }
 
  ul.multiselectoptions>li {
@@ -33,7 +33,7 @@
  	display:inline-block;
  	max-width:400px;
  	min-width:100px;
- 	padding-right:.6em;
+ 	padding-right:7px;
  	position:relative;
  	vertical-align:bottom;
  }
@@ -58,7 +58,7 @@
 
  div.multiselect>span:first-child {
  	float:left;
- 	margin-right:2em;
+ 	margin-right:24px;
  	overflow:hidden;
  	text-overflow:ellipsis;
  	width:90%;
@@ -66,13 +66,13 @@
 
  div.multiselect>span:last-child {
  	position:absolute;
- 	right:.8em;
+ 	right:10px;
  }
 
  ul.multiselectoptions input.new {
  	border-top-left-radius:0;
  	border-top-right-radius:0;
- 	padding-bottom:.2em;
- 	padding-top:.2em;
+ 	padding-bottom:2px;
+ 	padding-top:2px;
  	margin:0;
  }

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -11,7 +11,7 @@
  	margin-right:84px;
  	position:absolute;
  	right:0;
- 	width:108em;
+ 	width:250px;
  	z-index:500;
  	padding:12px;
  }

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -4,25 +4,25 @@
 
  #dropdown {
  	background:#eee;
- 	border-bottom-left-radius:1em;
- 	border-bottom-right-radius:1em;
+ 	border-bottom-left-radius:12px;
+ 	border-bottom-right-radius:12px;
  	box-shadow:0 1px 1px #777;
  	display:block;
- 	margin-right:7em;
+ 	margin-right:84px;
  	position:absolute;
  	right:0;
- 	width:19em;
+ 	width:108em;
  	z-index:500;
- 	padding:1em;
+ 	padding:12px;
  }
 
  #shareWithList {
  	list-style-type:none;
- 	padding:.5em;
+ 	padding:6px;
  }
 
  #shareWithList li {
- 	padding-top:.1em;
+ 	padding-top:1px;
  }
  
  #shareWithList li:first-child {
@@ -42,7 +42,7 @@
  }
 
  #dropdown input[type="checkbox"] {
- 	margin:0 .2em 0 .5em;
+ 	margin:0 2px 0 6px;
  }
 
  a.showCruds {
@@ -54,13 +54,13 @@
  	display:inline;
  	float:right;
  	opacity:.5;
- 	padding:.3em 0 0 .3em !important;
+ 	padding:4px 0 0 4px !important;
 	margin-top:-5px;
  }
 
  #link {
  	border-top:1px solid #ddd;
- 	padding-top:.5em;
+ 	padding-top:6px;
  }
 
 #dropdown input[type="text"],#dropdown input[type="password"] {
@@ -78,12 +78,12 @@
  }
 
  #link #showPassword img {
- 	padding-left:.3em;
+ 	padding-left:4px;
  	width:12px;
  }
 
  .reshare,#link label,#expiration label {
- 	padding-left:.5em;
+ 	padding-left:6px;
  }
 
  a.showCruds:hover,a.unshare:hover {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -39,7 +39,7 @@ filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#35537a', endC
 input[type="text"], input[type="password"], input[type="number"] { cursor:text; }
 input[type="text"], input[type="password"], input[type="search"], input[type="number"],
 textarea, select, button, .button, #quota, div.jp-progress, .pager li a {
-	width:120px; margin:4px; padding:11px 6px 6px;
+	width:120px; margin:4px; padding:8px 6px 6px 8px;
 	font-size:12px; font-family:Arial, Verdana, sans-serif;
 	background:#fff; color:#333; border:1px solid #ddd; outline:none;
 	-moz-box-shadow:0 1px 1px #fff, 0 2px 0 #bbb inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset;
@@ -154,14 +154,14 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 #login form #datadirField legend { margin-bottom:15px; }
 
 /* Icons for username and password fields to better recognize them */
-#adminlogin, #adminpass, #user, #password { width:225px!important; padding-left:30px; }
+#adminlogin, #adminpass, #user, #password { width:225px!important; padding:11px 5px 9px 30px; }
 #adminlogin+label+img, #adminpass-icon, #user+label+img, #password-icon {
 	position:absolute; left:15px; top:20px;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3;
 }
 #adminpass-icon, #password-icon { top:13px; }
-input[name="password-clone"] { padding-left:30px; width:225px !important; }
-input[name="adminpass-clone"] { padding-left:30px; width:225px !important; }
+input[name="password-clone"] { padding:11px 5px 9px 30px; width:225px !important; }
+input[name="adminpass-clone"] { padding:11px 5px 9px 30px; width:225px !important; }
 
 /* Nicely grouping input field sets */
 .grouptop input {
@@ -203,7 +203,7 @@ label.infield { cursor:text !important; top:12px; left:10px; }
 	background-image:url("../img/actions/toggle.png"); background-repeat:no-repeat;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3;
 }
-#pass2, input[name="personal-password-clone"] { padding:7px 30px 5px 5px; width:96px;}
+#pass2, input[name="personal-password-clone"] { padding:8px 6px 6px 8px; width:120px;}
 #personal-show + label { margin-top:12px; margin-left:-36px; }
 #passwordbutton { margin-left:6px; }
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -12,16 +12,16 @@ table, td, th { vertical-align:middle; }
 a { border:0; color:#000; text-decoration:none;}
 a, a *, input, input *, select, .button span, li, label { cursor:pointer; }
 ul { list-style:none; }
-body { background:#fefefe; font:normal .8em/1.6em "Lucida Grande", Arial, Verdana, sans-serif; color:#000; }
+body { background:#fefefe; font:normal 12px/19px "Lucida Grande", Arial, Verdana, sans-serif; color:#000; }
 
 
 /* HEADERS */
 #body-user #header, #body-settings #header {
-	position:fixed; top:0; left:0; right:0; z-index:100; height:45px; line-height:2.5em;
+	position:fixed; top:0; left:0; right:0; z-index:100; height:45px; line-height:30px;
 	background:#1d2d44 url('../img/noise.png') repeat;
 	-moz-box-shadow:0 0 10px rgba(0, 0, 0, .5), inset 0 -2px 10px #222; -webkit-box-shadow:0 0 10px rgba(0, 0, 0, .5), inset 0 -2px 10px #222; box-shadow:0 0 10px rgba(0, 0, 0, .5), inset 0 -2px 10px #222; }
-#body-login #header { margin: -2em auto 0; text-align:center; height:10em; padding:1em 0 .5em;
- -moz-box-shadow:0 0 1em rgba(0, 0, 0, .5); -webkit-box-shadow:0 0 1em rgba(0, 0, 0, .5); box-shadow:0 0 1em rgba(0, 0, 0, .5);
+#body-login #header { margin: -24px auto 0; text-align:center; height:120px; padding:12px 0 6px;
+ -moz-box-shadow:0 0 12px rgba(0, 0, 0, .5); -webkit-box-shadow:0 0 12px rgba(0, 0, 0, .5); box-shadow:0 0 12px rgba(0, 0, 0, .5);
 background:#1d2d44; /* Old browsers */
 background:-moz-linear-gradient(top, #35537a 0%, #1d2d42 100%); /* FF3.6+ */
 background:-webkit-gradient(linear, left top, left bottom, color-stop(0%,#35537a), color-stop(100%,#1d2d42)); /* Chrome,Safari4+ */
@@ -32,18 +32,18 @@ background:linear-gradient(top, #35537a 0%,#1d2d42 100%); /* W3C */
 filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#35537a', endColorstr='#1d2d42',GradientType=0 ); /* IE6-9 */ }
 
 #owncloud { position:absolute; top:0; left:0; padding:6px; padding-bottom:0; }
-.header-right { float:right; vertical-align:middle; padding:0 0.5em; }
+.header-right { float:right; vertical-align:middle; padding:0 6px; }
 .header-right > * { vertical-align:middle; }
 
 /* INPUTS */
 input[type="text"], input[type="password"], input[type="number"] { cursor:text; }
 input[type="text"], input[type="password"], input[type="search"], input[type="number"],
 textarea, select, button, .button, #quota, div.jp-progress, .pager li a {
-	width:10em; margin:.3em; padding:.6em .5em .4em;
-	font-size:1em; font-family:Arial, Verdana, sans-serif;
+	width:120px; margin:4px; padding:7px 6px 5px;
+	font-size:12px; font-family:Arial, Verdana, sans-serif;
 	background:#fff; color:#333; border:1px solid #ddd; outline:none;
 	-moz-box-shadow:0 1px 1px #fff, 0 2px 0 #bbb inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset;
-	-moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em;
+	-moz-border-radius:6px; -webkit-border-radius:6px; border-radius:6px;
 }
 input[type="hidden"] { height:0; width:0; }
 input[type="text"], input[type="password"], input[type="search"], input[type="number"], textarea { background:#f8f8f8; color:#555; cursor:text; }
@@ -66,10 +66,10 @@ input[type="checkbox"]:hover+label, input[type="checkbox"]:focus+label { color:#
 
 /* BUTTONS */
 input[type="submit"], input[type="button"], button, .button, #quota, div.jp-progress, select, .pager li a {
-	width:auto; padding:.4em;
+	width:auto; padding:5px;
 	background-color:rgba(240,240,240,.9); font-weight:bold; color:#555; text-shadow:rgba(255,255,255,.9) 0 1px 0; border:1px solid rgba(190,190,190,.9); cursor:pointer;
 	-moz-box-shadow:0 1px 1px rgba(255,255,255,.9), 0 1px 1px rgba(255,255,255,.9) inset; -webkit-box-shadow:0 1px 1px rgba(255,255,255,.9), 0 1px 1px rgba(255,255,255,.9) inset; box-shadow:0 1px 1px rgba(255,255,255,.9), 0 1px 1px rgba(255,255,255,.9) inset;
-	-moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em;
+	-moz-border-radius:6px; -webkit-border-radius:6px; border-radius:6px;
 }
 input[type="submit"]:hover, input[type="submit"]:focus, input[type="button"]:hover, select:hover, select:focus, select:active, input[type="button"]:focus, .button:hover {
 	background:rgba(250,250,250,.9); color:#333;
@@ -96,19 +96,19 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 	}
 
 
-#body-login input { font-size:1.5em; }
-#body-login input[type="text"], #body-login input[type="password"] { width:13em; }
+#body-login input { font-size:18px; }
+#body-login input[type="text"], #body-login input[type="password"] { width:132px; }
 #body-login input.login { width:auto; float:right; padding:7px 9px 6px; }
-#remember_login { margin:.8em .2em 0 1em; vertical-align:text-bottom; }
-.searchbox input[type="search"] { font-size:1.2em; padding:.2em .5em .2em 1.5em; background:#fff url('../img/actions/search.svg') no-repeat .5em center; border:0; -moz-border-radius:1em; -webkit-border-radius:1em; border-radius:1em; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)"; filter:alpha(opacity=70);opacity:.7; -webkit-transition:opacity 300ms; -moz-transition:opacity 300ms; -o-transition:opacity 300ms; transition:opacity 300ms; margin-top:10px; float:right; }
+#remember_login { margin:10px 2px 0 12px; vertical-align:text-bottom; }
+.searchbox input[type="search"] { font-size:14px; padding:2px 6px 2px 18px; background:#fff url('../img/actions/search.svg') no-repeat 6px center; border:0; -moz-border-radius:12px; -webkit-border-radius:12px; border-radius:12px; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)"; filter:alpha(opacity=70);opacity:.7; -webkit-transition:opacity 300ms; -moz-transition:opacity 300ms; -o-transition:opacity 300ms; transition:opacity 300ms; margin-top:10px; float:right; }
 input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-box-shadow:0 1px 1px #f8f8f8, 0 1px 1px #cfc inset; -webkit-box-shadow:0 1px 1px #f8f8f8, 0 1px 1px #cfc inset; box-shadow:0 1px 1px #f8f8f8, 0 1px 1px #cfc inset; }
-#select_all{ margin-top:.4em !important;}
+#select_all{ margin-top:5px !important;}
 
 /* CONTENT ------------------------------------------------------------------ */
 #controls {
 	position:fixed;
-	height:2.8em; width:100%;
-	padding:0 70px 0 0.5em; margin:0;
+	height:34px; width:100%;
+	padding:0 70px 0 6px; margin:0;
 	-moz-box-sizing:border-box; box-sizing:border-box;
 	-moz-box-shadow:0 -3px 7px #000; -webkit-box-shadow:0 -3px 7px #000; box-shadow:0 -3px 7px #000;
 	background:#f7f7f7; border-bottom:1px solid #eee;  z-index:50;
@@ -116,33 +116,33 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 #controls .button { display:inline-block; }
 
 #content { position:relative; height:100%; width:100%; }
-#content .hascontrols { position: relative; top: 2.9em; }
+#content .hascontrols { position: relative; top: 35px; }
 #content-wrapper {
-	position:absolute; height:100%; width:100%; padding-top:3.5em; padding-left:64px;
+	position:absolute; height:100%; width:100%; padding-top:42px; padding-left:64px;
 	-moz-box-sizing:border-box; box-sizing:border-box;
 }
 #leftcontent, .leftcontent {
-	position:relative; overflow:auto; width:20em; height:100%;
+	position:relative; overflow:auto; width:240px; height:100%;
 	background:#f8f8f8; border-right:1px solid #ddd;
 	-moz-box-sizing:border-box; box-sizing:border-box;
 }
-#leftcontent li, .leftcontent li { background:#f8f8f8; padding:.5em .8em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 200ms; -moz-transition:background-color 200ms; -o-transition:background-color 200ms; transition:background-color 200ms; }
+#leftcontent li, .leftcontent li { background:#f8f8f8; padding:6px 10px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 200ms; -moz-transition:background-color 200ms; -o-transition:background-color 200ms; transition:background-color 200ms; }
 #leftcontent li:hover, #leftcontent li:active, #leftcontent li.active, .leftcontent li:hover, .leftcontent li:active, .leftcontent li.active { background:#eee; }
 #leftcontent li.active, .leftcontent li.active { font-weight:bold; }
 #leftcontent li:hover, .leftcontent li:hover { color:#333; background:#ddd; }
-#leftcontent a { height:100%; display:block; margin:0; padding:0 1em 0 0; float:left; }
-#rightcontent, .rightcontent { position:fixed; top:6.4em; left:24.5em; overflow:auto }
+#leftcontent a { height:100%; display:block; margin:0; padding:0 12px 0 0; float:left; }
+#rightcontent, .rightcontent { position:fixed; top:77px; left:294px; overflow:auto }
 
 
 /* LOG IN & INSTALLATION ------------------------------------------------------------ */
 #body-login { background:#ddd; }
 #body-login div.buttons { text-align:center; }
-#body-login p.info { width:22em; text-align:center; margin:2em auto; color:#777; text-shadow:#fff 0 1px 0; }
+#body-login p.info { width:264px; text-align:center; margin:24px auto; color:#777; text-shadow:#fff 0 1px 0; }
 #body-login p.info a { font-weight:bold; color:#777; }
 #body-login #submit.login { margin-right:7px; } /* quick fix for log in button not being aligned with input fields, should be properly fixed by input field width later */
 
-#login { min-height:30em; margin:2em auto 0; border-bottom:1px solid #f8f8f8; background:#eee; }
-#login form { width:22em; margin:2em auto 2em; padding:0; }
+#login { min-height:360px; margin:24px auto 0; border-bottom:1px solid #f8f8f8; background:#eee; }
+#login form { width:264px; margin:24px auto 24px; padding:0; }
 #login form fieldset { margin-bottom:20px; }
 #login form #adminaccount { margin-bottom:5px; }
 #login form fieldset legend, #datadirContent label {
@@ -154,14 +154,14 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 #login form #datadirField legend { margin-bottom:15px; }
 
 /* Icons for username and password fields to better recognize them */
-#adminlogin, #adminpass, #user, #password { width:11.7em!important; padding-left:1.8em; }
+#adminlogin, #adminpass, #user, #password { width:140px!important; padding-left:22px; }
 #adminlogin+label+img, #adminpass-icon, #user+label+img, #password-icon {
-	position:absolute; left:1.25em; top:1.65em;
+	position:absolute; left:15px; top:20px;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3;
 }
-#adminpass-icon, #password-icon { top:1.1em; }
-input[name="password-clone"] { padding-left:1.8em; width:11.7em !important; }
-input[name="adminpass-clone"] { padding-left:1.8em; width:11.7em !important; }
+#adminpass-icon, #password-icon { top:13px; }
+input[name="password-clone"] { padding-left:22px; width:140px !important; }
+input[name="adminpass-clone"] { padding-left:22px; width:140px !important; }
 
 /* Nicely grouping input field sets */
 .grouptop input {
@@ -181,36 +181,36 @@ input[name="adminpass-clone"] { padding-left:1.8em; width:11.7em !important; }
 
 /* In field labels. No, HTML placeholder does not work as well. */
 #login form label { color:#666; }
-#login .groupmiddle label, #login .groupbottom label { top:.65em; }
+#login .groupmiddle label, #login .groupbottom label { top:8px; }
 p.infield { position:relative; }
-label.infield { cursor:text !important; top:1.05em; left:.85em; }
+label.infield { cursor:text !important; top:12px; left:10px; }
 #login form label.infield { /* labels are ellipsized when too long, keep them short */
-	position:absolute; width:90%; padding-left:1.4em;
+	position:absolute; width:90%; padding-left:17px;
 	font-size:19px; color:#aaa;
 	white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
 }
 #login #databaseField .infield { padding-left:0; }
-#login form input[type="checkbox"]+label { position:relative; margin:0; font-size:1em; text-shadow:#fff 0 1px 0; }
-#login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 2em; padding:1em; }
+#login form input[type="checkbox"]+label { position:relative; margin:0; font-size:12px; text-shadow:#fff 0 1px 0; }
+#login form .errors { background:#fed7d7; border:1px solid #f00; list-style-indent:inside; margin:0 0 24px; padding:12px; }
 
 /* Show password toggle */
-#show { position:absolute; right:1em; top:.8em; float:right; }
+#show { position:absolute; right:12px; top:10px; float:right; }
 #show, #personal-show { display:none; }
-#show + label { right:1em; top:1.25em!important; }
+#show + label { right:12px; top:15px!important; }
 #show:checked + label, #personal-show:checked + label { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=80)"; filter:alpha(opacity=80); opacity:.8; }
 #show + label, #personal-show + label {
 	position:absolute!important; height:14px; width:24px;
 	background-image:url("../img/actions/toggle.png"); background-repeat:no-repeat;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3;
 }
-#pass2, input[name="personal-password-clone"] { padding:0.6em 2.5em 0.4em 0.4em; width:8em;}
-#personal-show + label { margin-top:1em; margin-left:-3em; }
-#passwordbutton { margin-left:0.5em; }
+#pass2, input[name="personal-password-clone"] { padding:7px 30px 5px 5px; width:96px;}
+#personal-show + label { margin-top:12px; margin-left:-36px; }
+#passwordbutton { margin-left:6px; }
 
 /* Database selector */
 #login form #selectDbType { text-align:center; }
 #login form #selectDbType label {
-	position:static; margin:0 -3px 5px; padding:.4em;
+	position:static; margin:0 -3px 5px; padding:5px;
 	font-size:12px; font-weight:bold; background:#f8f8f8; color:#888; cursor:pointer;
 	border:1px solid #ddd; text-shadow:#eee 0 1px 0;
 	-moz-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 1px #fff inset;
@@ -233,7 +233,7 @@ fieldset.warning a { color:#b94a48 !important; font-weight:bold; }
 
 /* NAVIGATION ------------------------------------------------------------- */
 #navigation {
-	position:fixed; top:3.5em; float:left; width:64px; padding:0; z-index:75; height:100%;
+	position:fixed; top:42px; float:left; width:64px; padding:0; z-index:75; height:100%;
 	background:#383c43 url('../img/noise.png') repeat; border-right:1px #333 solid;
 	-moz-box-shadow:0 0 7px #000; -webkit-box-shadow:0 0 7px #000; box-shadow:0 0 7px #000;
 	overflow:hidden;
@@ -278,8 +278,8 @@ fieldset.warning a { color:#b94a48 !important; font-weight:bold; }
 .center { text-align:center; }
 
 #notification-container { position: fixed; top: 0px; width: 100%; text-align: center; z-index: 101; line-height: 1.2;}
-#notification { z-index:101; background-color:#fc4; border:0; padding:0 .7em .3em; display:none; position: relative; top:0; -moz-border-radius-bottomleft:1em; -webkit-border-bottom-left-radius:1em; border-bottom-left-radius:1em; -moz-border-radius-bottomright:1em; -webkit-border-bottom-right-radius:1em; border-bottom-right-radius:1em; }
-#notification span { cursor:pointer; font-weight:bold; margin-left:1em; }
+#notification { z-index:101; background-color:#fc4; border:0; padding:0 8px 6px; display:none; position: relative; top:0; -moz-border-radius-bottomleft:12px; -webkit-border-bottom-left-radius:12px; border-bottom-left-radius:12px; -moz-border-radius-bottomright:12px; -webkit-border-bottom-right-radius:12px; border-bottom-right-radius:12px; }
+#notification span { cursor:pointer; font-weight:bold; margin-left:12px; }
 
 tr .action:not(.permanent), .selectedActions a { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; filter:alpha(opacity=0); opacity:0; }
 tr:hover .action, tr .action.permanent, .selectedActions a { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter:alpha(opacity=50); opacity:.5; }
@@ -288,24 +288,24 @@ tr .action { width:16px; height:16px; }
 tr:hover .action:hover, .selectedActions a:hover, .header-action:hover { -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter:alpha(opacity=100); opacity:1; }
 tbody tr:hover, tr:active { background-color:#f8f8f8; }
 
-#body-settings .personalblock, #body-settings .helpblock { padding:.5em 1em; margin:1em; background:#f8f8f8; color:#555; text-shadow:#fff 0 1px 0; -moz-border-radius:.5em; -webkit-border-radius:.5em; border-radius:.5em; }
+#body-settings .personalblock, #body-settings .helpblock { padding:6px 12px; margin:12px; background:#f8f8f8; color:#555; text-shadow:#fff 0 1px 0; -moz-border-radius:6px; -webkit-border-radius:6px; border-radius:6px; }
 #body-settings .personalblock#quota { position:relative; padding:0; }
-#body-settings #controls+.helpblock { position:relative; margin-top:3em; }
-.personalblock > legend { margin-top:2em; }
+#body-settings #controls+.helpblock { position:relative; margin-top:34px; }
+.personalblock > legend { margin-top:24px; }
 .personalblock > legend, th, dt, label { font-weight:bold; }
 code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", monospace; }
 
-#quota div, div.jp-play-bar, div.jp-seek-bar { padding:0; background:#e6e6e6; font-weight:normal; white-space:nowrap; -moz-border-radius-bottomleft:.4em; -webkit-border-bottom-left-radius:.4em; border-bottom-left-radius:.4em; -moz-border-radius-topleft:.4em; -webkit-border-top-left-radius:.4em; border-top-left-radius:.4em; }
-#quotatext {padding:.6em 1em;}
+#quota div, div.jp-play-bar, div.jp-seek-bar { padding:0; background:#e6e6e6; font-weight:normal; white-space:nowrap; -moz-border-radius-bottomleft:5px; -webkit-border-bottom-left-radius:5px; border-bottom-left-radius:5px; -moz-border-radius-topleft:5px; -webkit-border-top-left-radius:5px; border-top-left-radius:5px; }
+#quotatext {padding:7px 12px;}
 div.jp-play-bar, div.jp-seek-bar { padding:0; }
 
-.pager { list-style:none; float:right; display:inline; margin:.7em 13em 0 0; }
+.pager { list-style:none; float:right; display:inline; margin:8px 156px 0 0; }
 .pager li { display:inline-block; }
 
-li.update, li.error { width:640px; margin:4em auto; padding:1em 1em 1em 4em; background:#ffe .8em .8em no-repeat;  border:1px solid #ccc; -moz-border-radius:10px; -webkit-border-radius:10px; border-radius:10px; cursor:default; }
+li.update, li.error { width:640px; margin:48px auto; padding:12px 12px 12px 48px; background:#ffe 10px 10px no-repeat;  border:1px solid #ccc; -moz-border-radius:10px; -webkit-border-radius:10px; border-radius:10px; cursor:default; }
 .error { color:#FF3B3B; }
 .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default { overflow:hidden; text-overflow:ellipsis; }
-.hint { background-image:url('../img/actions/info.png'); background-repeat:no-repeat; color:#777777; padding-left:25px; background-position:0 0.3em;}
+.hint { background-image:url('../img/actions/info.png'); background-repeat:no-repeat; color:#777777; padding-left:25px; background-position:0 4px;}
 .separator { display:inline; border-left:1px solid #d3d3d3; border-right:1px solid #fff; height:10px; width:0px; margin:4px; }
 
 a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;padding-top:0px;padding-bottom:2px; text-decoration:none; margin-top:5px }
@@ -329,25 +329,25 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 #categoryform .bottombuttons { position:absolute; bottom:10px;}
 #categoryform .bottombuttons * { float:left;}
 /*#categorylist { border:1px solid #ddd;}*/
-#categorylist li { background:#f8f8f8; padding:.3em .8em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 500ms; -moz-transition:background-color 500ms; -o-transition:background-color 500ms; transition:background-color 500ms; }
+#categorylist li { background:#f8f8f8; padding:4px 9px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; -webkit-transition:background-color 500ms; -moz-transition:background-color 500ms; -o-transition:background-color 500ms; transition:background-color 500ms; }
 #categorylist li:hover, #categorylist li:active { background:#eee; }
-#category_addinput { width:10em; }
+#category_addinput { width:120px; }
 
 /* ---- APP SETTINGS ---- */
 .popup { background-color:white; border-radius:10px 10px 10px 10px; box-shadow:0 0 20px #888888; color:#333333; padding:10px; position:fixed !important; z-index:200; }
-.popup.topright { top:7em; right:1em; }
-.popup.bottomleft { bottom:1em; left:33em; }
-.popup .close { position:absolute; top:0.2em; right:0.2em; height:20px; width:20px; background:url('../img/actions/delete.svg') no-repeat center; }
-.popup h2 { font-weight:bold; font-size:1.2em; }
+.popup.topright { top:84px; right:12px; }
+.popup.bottomleft { bottom:12px; left:396px; }
+.popup .close { position:absolute; top:2px; right:2px; height:20px; width:20px; background:url('../img/actions/delete.svg') no-repeat center; }
+.popup h2 { font-weight:bold; font-size:14px; }
 .arrow { border-bottom:10px solid white; border-left:10px solid transparent; border-right:10px solid transparent; display:block; height:0; position:absolute; width:0; z-index:201; }
-.arrow.left { left:-13px; bottom:1.2em; -webkit-transform:rotate(270deg); -moz-transform:rotate(270deg); -o-transform:rotate(270deg); -ms-transform:rotate(270deg); transform:rotate(270deg); }
-.arrow.up { top:-8px; right:2em; }
+.arrow.left { left:-13px; bottom:14px; -webkit-transform:rotate(270deg); -moz-transform:rotate(270deg); -o-transform:rotate(270deg); -ms-transform:rotate(270deg); transform:rotate(270deg); }
+.arrow.up { top:-8px; right:24px; }
 .arrow.down { -webkit-transform:rotate(180deg); -moz-transform:rotate(180deg); -o-transform:rotate(180deg); -ms-transform:rotate(180deg); transform:rotate(180deg); }
-.help-includes {overflow: hidden; width: 100%; height: 100%; -moz-box-sizing: border-box;	box-sizing: border-box;	padding-top: 2.8em; }
+.help-includes {overflow: hidden; width: 100%; height: 100%; -moz-box-sizing: border-box;	box-sizing: border-box;	padding-top: 34px; }
 .help-iframe {width: 100%; height: 100%; margin: 0;padding: 0; border: 0; overflow: auto;}
 
 /* ---- BREADCRUMB ---- */
-div.crumb { float:left; display:block; background:url('../img/breadcrumb.svg') no-repeat right 0; padding:.75em 1.5em 0 1em; height:2.9em;  -moz-box-sizing:border-box; box-sizing:border-box; }
+div.crumb { float:left; display:block; background:url('../img/breadcrumb.svg') no-repeat right 0; padding:9px 18px 0 12px; height:34px;  -moz-box-sizing:border-box; box-sizing:border-box; }
 div.crumb:first-child { padding:10px 20px 10px 5px; }
 div.crumb.last { font-weight:bold; background:none; padding-right:10px; }
-div.crumb a{ padding: 0.9em 0 0.7em 0; }
+div.crumb a{ padding: 12px 0 8px 0; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -39,7 +39,7 @@ filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#35537a', endC
 input[type="text"], input[type="password"], input[type="number"] { cursor:text; }
 input[type="text"], input[type="password"], input[type="search"], input[type="number"],
 textarea, select, button, .button, #quota, div.jp-progress, .pager li a {
-	width:120px; margin:4px; padding:7px 6px 5px;
+	width:120px; margin:4px; padding:11px 6px 6px;
 	font-size:12px; font-family:Arial, Verdana, sans-serif;
 	background:#fff; color:#333; border:1px solid #ddd; outline:none;
 	-moz-box-shadow:0 1px 1px #fff, 0 2px 0 #bbb inset; -webkit-box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset; box-shadow:0 1px 1px #fff, 0 1px 0 #bbb inset;
@@ -154,14 +154,14 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 #login form #datadirField legend { margin-bottom:15px; }
 
 /* Icons for username and password fields to better recognize them */
-#adminlogin, #adminpass, #user, #password { width:140px!important; padding-left:22px; }
+#adminlogin, #adminpass, #user, #password { width:225px!important; padding-left:30px; }
 #adminlogin+label+img, #adminpass-icon, #user+label+img, #password-icon {
 	position:absolute; left:15px; top:20px;
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3;
 }
 #adminpass-icon, #password-icon { top:13px; }
-input[name="password-clone"] { padding-left:22px; width:140px !important; }
-input[name="adminpass-clone"] { padding-left:22px; width:140px !important; }
+input[name="password-clone"] { padding-left:30px; width:225px !important; }
+input[name="adminpass-clone"] { padding-left:30px; width:225px !important; }
 
 /* Nicely grouping input field sets */
 .grouptop input {

--- a/settings/css/oauth.css
+++ b/settings/css/oauth.css
@@ -1,4 +1,4 @@
-.guest-container{ width:35%; margin: 2em auto 0 auto; }
+.guest-container{ width:35%; margin: 24px auto 0 auto; }
 #oauth-request a.button{ float: right; }
 #oauth-request ul li{ list-style: disc; }
-#oauth-request ul { margin-left: 2em; margin-top: 1em; }
+#oauth-request ul { margin-left: 12px; margin-top: 12px; }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -2,8 +2,8 @@
  This file is licensed under the Affero General Public License version 3 or later.
  See the COPYING-README file. */
 
-select#languageinput, select#timezone { width:15em; }
-input#openid, input#webdav { width:20em; }
+select#languageinput, select#timezone { width:180px; }
+input#openid, input#webdav { width:240px; }
 
 
 /* PERSONAL */
@@ -18,36 +18,36 @@ input#openid, input#webdav { width:20em; }
 #passwordchanged { display:none; }
 #displaynameerror { display:none; }
 #displaynamechanged { display:none; }
-input#identity { width:20em; }
-#email { width: 17em; }
+input#identity { width:240px; }
+#email { width: 204px; }
 
 .msg.success{ color:#fff; background-color:#0f0; padding:3px; text-shadow:1px 1px #000; }
 .msg.error{ color:#fff; background-color:#f00; padding:3px; text-shadow:1px 1px #000; }
 
-table.nostyle label { margin-right: 2em; }
-table.nostyle td { padding: 0.2em 0; }
+table.nostyle label { margin-right: 24px; }
+table.nostyle td { padding: 2px 0; }
 
 /* USERS */
 form { display:inline; }
-table:not(.nostyle) th { height:2em; color:#999; }
-table:not(.nostyle) th, table:not(.nostyle) td { border-bottom:1px solid #ddd; padding:0 .5em; padding-left:.8em; text-align:left; font-weight:normal; }
-td.name, td.password { padding-left:.8em; }
+table:not(.nostyle) th { height:24px; color:#999; }
+table:not(.nostyle) th, table:not(.nostyle) td { border-bottom:1px solid #ddd; padding:0 6px; padding-left:9px; text-align:left; font-weight:normal; }
+td.name, td.password { padding-left:9px; }
 td.password>img,td.displayName>img, td.remove>a, td.quota>img { visibility:hidden; }
-td.password, td.quota, td.displayName { width:12em; cursor:pointer; }
-td.password>span, td.quota>span, rd.displayName>span { margin-right: 1.2em; color: #C7C7C7; }
+td.password, td.quota, td.displayName { width:144px; cursor:pointer; }
+td.password>span, td.quota>span, rd.displayName>span { margin-right: 14px; color: #C7C7C7; }
 
-td.remove { width:1em; padding-right:1em; }
+td.remove { width:12px; padding-right:12px; }
 tr:hover>td.password>span, tr:hover>td.displayName>span { margin:0; cursor:pointer; }
 tr:hover>td.remove>a, tr:hover>td.password>img,tr:hover>td.displayName>img, tr:hover>td.quota>img { visibility:visible; cursor:pointer; }
 tr:hover>td.remove>a { float:right; }
 li.selected { background-color:#ddd; }
 table:not(.nostyle) { width:100%; }
-#rightcontent { padding-left: 1em; }
-div.quota { float:right; display:block; position:absolute; right:25em; top:-1px; }
+#rightcontent { padding-left: 12px; }
+div.quota { float:right; display:block; position:absolute; right:300px; top:-1px; }
 div.quota-select-wrapper { position: relative; }
-select.quota { position:absolute; left:0; top:0; width:10em; }
-select.quota-user { position:relative; left:0; top:0; width:10em; }
-div.quota>span { position:absolute; right:0; white-space:nowrap; top:.7em; color:#888; text-shadow:0 1px 0 #fff; }
+select.quota { position:absolute; left:0; top:0; width:120px; }
+select.quota-user { position:relative; left:0; top:0; width:120px; }
+div.quota>span { position:absolute; right:0; white-space:nowrap; top:7px; color:#888; text-shadow:0 1px 0 #fff; }
 select.quota.active { background: #fff; }
 
 /* positioning fixes */
@@ -57,25 +57,25 @@ select.quota.active { background: #fff; }
 
 
 /* APPS */
-.appinfo { margin: 1em; }
-h3 { font-size: 1.4em; font-weight: bold; }
-ul.applist li { height: 2.2em; padding: 0.2em 0.2em 0.2em 0.8em !important; }
+.appinfo { margin: 12px; }
+h3 { font-size: 17px; font-weight: bold; }
+ul.applist li { height: 26px; padding: 2px 2px 2px 9px !important; }
 li { color:#888; }
 li.active { color:#000; }
-small.externalapp { color:#FFF; background-color:#BBB; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 4px;}
+small.externalapp { color:#FFF; background-color:#BBB; font-weight:bold; font-size: 7px; margin: 0; padding: 1px 2px; border-radius: 4px;}
 small.externalapp.list { float: right; }
-small.recommendedapp { color:#FFF; background-color:#888; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 4px;}
+small.recommendedapp { color:#FFF; background-color:#888; font-weight:bold; font-size: 7px; margin: 0; padding: 1px 2px; border-radius: 4px;}
 small.recommendedapp.list { float: right; }
-span.version { margin-left:1em; margin-right:1em; color:#555; }
+span.version { margin-left:12px; margin-right:12px; color:#555; }
 
-.app { position: relative; display: inline-block; padding: 0.2em 0 0.2em 0 !important; text-overflow: hidden; overflow: hidden; white-space: nowrap; /*transition: .2s max-width linear; -o-transition: .2s max-width linear; -moz-transition: .2s max-width linear; -webkit-transition: .2s max-width linear; -ms-transition: .2s max-width linear;*/ }
-.app.externalapp { max-width: 12.5em; }
-.app.recommendedapp { max-width: 12.5em; }
+.app { position: relative; display: inline-block; padding: 2px 0 2px 0 !important; text-overflow: hidden; overflow: hidden; white-space: nowrap; /*transition: .2s max-width linear; -o-transition: .2s max-width linear; -moz-transition: .2s max-width linear; -webkit-transition: .2s max-width linear; -ms-transition: .2s max-width linear;*/ }
+.app.externalapp { max-width: 150px; }
+.app.recommendedapp { max-width: 150px; }
 /* Transition to complete width! */
 .app:hover, .app:active { max-width: inherit; }
 
 .appslink { text-decoration: underline; }
-.score { color:#666; font-weight:bold; font-size:0.8em; }
+.score { color:#666; font-weight:bold; font-size:9px; }
 
 /* LOG */
 #log { white-space:normal; }
@@ -83,8 +83,8 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 /* ADMIN */
 span.securitywarning {color:#C33; font-weight:bold; }
 span.connectionwarning {color:#933; font-weight:bold; }
-input[type=radio] { width:1em; }
-table.shareAPI td { padding-bottom: 0.8em; }
+input[type=radio] { width:12px; }
+table.shareAPI td { padding-bottom: 9px; }
 
 /* HELP */
 .pressed {background-color:#DDD;}


### PR DESCRIPTION
The styling written in "em" that was causing various issues like https://github.com/owncloud/core/issues/801 and https://github.com/owncloud/core/issues/1747 to users who used different sizes in the browsers has been converted to the more convenient "px". I have tried to cover almost the entire CSS of the core repository. I gave it a test and the layout seemed fine. I hope I haven't missed out something. So, someone can give this a hard test as a lot of styling is affected by this. 
cc // @jancborchardt @Raydiation  @eMerzh
