### PR TITLE
Preserve Debug flag accross config writes

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -155,7 +155,11 @@ class OC_Config{
 	 */
 	public static function writeData() {
 		// Create a php file ...
-		$content = "<?php\n\$CONFIG = ";
+		$content = "<?php\n ";
+		if (defined('DEBUG') && DEBUG) {
+			$content .= "define('DEBUG',true);\n";
+		}
+		$content .= "\$CONFIG = ";
 		$content .= var_export(self::$cache, true);
 		$content .= ";\n";
 


### PR DESCRIPTION
When you set the debug flag to true in your config file, 
and you have an upgrade (even a minor) your config file gets overwritten ...
which lead to unset your debug flag ...

This is a fewliner but as we are close to release it might be delayed to OC6 ...

what do you think? 
