### PR TITLE
[OC6] Allow to load splited config files

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -130,14 +130,24 @@ class OC_Config{
 			return true;
 		}
 
-		if( !file_exists( OC::$SERVERROOT."/config/config.php" )) {
-			return false;
-		}
+		// read all file in config dir ending by config.php
+		$config_files = glob( OC::$SERVERROOT."/config/*.config.php");
 
-		// Include the file, save the data from $CONFIG
-		include OC::$SERVERROOT."/config/config.php";
-		if( isset( $CONFIG ) && is_array( $CONFIG )) {
-			self::$cache = $CONFIG;
+		//Sort array naturally :
+		natsort($config_files);
+
+		//Filter only regular files
+		$config_files = array_filter($config_files, 'is_file');
+
+		// Add default config
+		array_unshift($config_files,OC::$SERVERROOT."/config/config.php");
+
+		//Include file and merge config
+		foreach($config_files as $file){
+			include $file;
+			if( isset( $CONFIG ) && is_array( $CONFIG )) {
+				self::$cache = array_merge(self::$cache, $CONFIG);
+			}
 		}
 
 		// We cached everything

--- a/lib/config.php
+++ b/lib/config.php
@@ -133,11 +133,11 @@ class OC_Config{
 		// read all file in config dir ending by config.php
 		$config_files = glob( OC::$SERVERROOT."/config/*.config.php");
 
-		//Sort array naturally :
-		natsort($config_files);
-
 		//Filter only regular files
 		$config_files = array_filter($config_files, 'is_file');
+
+		//Sort array naturally :
+		natsort($config_files);
 
 		// Add default config
 		array_unshift($config_files,OC::$SERVERROOT."/config/config.php");


### PR DESCRIPTION
**ONLY FOR OC6**

if you tried to manage a clean commented OC file, you probably want to read more :p 

So... when you have a config file, you write things in there like comments or special config values , everything get lost as soon as you have an upgrade of OC.

This PR let you have multiple config files : 
every file that end with ".config.php" will be loaded and we will try to access the $CONFIG var...
so you can have like puppet.config.php or what you want...

It will always load first the config.php file and merge the configs  with later files (ordered naturally)

so it doesn't matter if OC only write in the config.php file (as before) because our config fille will override this (only if the key is defined).

This new behavior should not have effect on either developers or users... only those who are willing to have multiple files

Example : 

``` php
//config.php
<?php
$CONFIG = array (
 'instanceid' => '5506f9e999fe9',
  'passwordsalt' => 'c2536fd54ee820ceb4799400dc932f',
  'loglevel' => '0',
//....
);
```

AND 

``` php
//puppet.config.php
<?php
$CONFIG = array (
  'loglevel' => '12',
);
```

The result will be a loaded like 

``` php
<?php
$CONFIG = array (
 'instanceid' => '5506f9e999fe9',
  'passwordsalt' => 'c2536fd54ee820ceb4799400dc932f',
  'loglevel' => '12',
//....
);
```

 ref #946

_sorry to open another OC6 bug now ... but this thing bother me too much, i had to do smth!_

edit (bartv2):
start with "config.php" -> end with ".config.php"
