### PR TITLE
Fix fetching source path of shared files

### DIFF
--- a/lib/files/mount.php
+++ b/lib/files/mount.php
@@ -176,10 +176,12 @@ class Mount {
 	}
 
 	/**
+	 * Find mounts by storage id
+	 *
 	 * @param string $id
-	 * @return \OC\Files\Storage\Storage[]
+	 * @return Mount[]
 	 */
-	public static function findById($id) {
+	public static function findByStorageId($id) {
 		if (strlen($id) > 64) {
 			$id = md5($id);
 		}
@@ -190,5 +192,25 @@ class Mount {
 			}
 		}
 		return $result;
+	}
+
+	/**
+	 * Find mounts by numeric storage id
+	 *
+	 * @param string $id
+	 * @return Mount
+	 */
+	public static function findByNumericId($id) {
+		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*storages` WHERE `numeric_id` = ?');
+		$result = $query->execute(array($id))->fetchOne();
+		if ($result) {
+			$id = $result;
+			foreach (self::$mounts as $mount) {
+				if ($mount->getStorageId() === $id) {
+					return $mount;
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -960,7 +960,7 @@ class View {
 	 */
 	public function getPath($id) {
 		list($storage, $internalPath) = Cache\Cache::getById($id);
-		$mounts = Mount::findById($storage);
+		$mounts = Mount::findByStorageId($storage);
 		foreach ($mounts as $mount) {
 			/**
 			 * @var \OC\Files\Mount $mount

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -786,7 +786,7 @@ class Share {
 					} else {
 						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `item_target`,
 							`*PREFIX*share`.`parent`, `share_type`, `share_with`, `uid_owner`,
-							`file_source`, `path`, `file_target`, `permissions`, `stime`, `expiration`, `token`';
+							`file_source`, `path`, `file_target`, `permissions`, `stime`, `expiration`, `token`, `storage`';
 					}
 				} else {
 					$select = '*';

--- a/tests/lib/files/mount.php
+++ b/tests/lib/files/mount.php
@@ -39,7 +39,7 @@ class Mount extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, count(\OC\Files\Mount::findIn('/')));
 
 		$id = $mount->getStorageId();
-		$this->assertEquals(array($mount), \OC\Files\Mount::findById($id));
+		$this->assertEquals(array($mount), \OC\Files\Mount::findByStorageId($id));
 
 		$mount2 = new \OC\Files\Mount($storage, '/foo/bar');
 		$this->assertEquals(array($mount, $mount2), \OC\Files\Mount::findByStorageId($id));

--- a/tests/lib/files/mount.php
+++ b/tests/lib/files/mount.php
@@ -42,7 +42,7 @@ class Mount extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array($mount), \OC\Files\Mount::findById($id));
 
 		$mount2 = new \OC\Files\Mount($storage, '/foo/bar');
-		$this->assertEquals(array($mount, $mount2), \OC\Files\Mount::findById($id));
+		$this->assertEquals(array($mount, $mount2), \OC\Files\Mount::findByStorageId($id));
 	}
 
 	public function testLong() {
@@ -51,8 +51,8 @@ class Mount extends \PHPUnit_Framework_TestCase {
 
 		$id = $mount->getStorageId();
 		$storageId = $storage->getId();
-		$this->assertEquals(array($mount), \OC\Files\Mount::findById($id));
-		$this->assertEquals(array($mount), \OC\Files\Mount::findById($storageId));
-		$this->assertEquals(array($mount), \OC\Files\Mount::findById(md5($storageId)));
+		$this->assertEquals(array($mount), \OC\Files\Mount::findByStorageId($id));
+		$this->assertEquals(array($mount), \OC\Files\Mount::findByStorageId($storageId));
+		$this->assertEquals(array($mount), \OC\Files\Mount::findByStorageId(md5($storageId)));
 	}
 }


### PR DESCRIPTION
Fixes #2141 and #2160 

I thought I already fixed the resharing problem, the code was taken directly from apps/files_sharing/public.php I'll be working to consolidate sharing code after OC5.

@icewind1991 I changed lib/files/mount.php because I couldn't find an alternative. Let me know if there is a simpler way to do this. Would I be better off creating a new view for the file owner each time?

Still need to fix the paths returned for the shared status icons. Don't merge yet, just review current code please. 

@schiesbn @karlitschek @MTRichards 
