### PR TITLE
Disable caching for the browser

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -281,6 +281,7 @@ class OC {
 					$minimizerCSS->clearCache();
 					$minimizerJS = new OC_Minimizer_JS();
 					$minimizerJS->clearCache();
+					OC_Response::disableCaching();
 					OC_Util::addscript('update');
 					$tmpl = new OC_Template('', 'update', 'guest');
 					$tmpl->assign('version', OC_Util::getVersionString());


### PR DESCRIPTION
Another attempt to fix #1520 

@bartv2 Is this right? 

This method doesn't make sense: https://github.com/owncloud/core/blob/master/lib/minimizer.php#L49 It is inherited by both the CSS and JS minimizer and clears both of them?

@Raydiation @MTRichards 
