### PR TITLE
Remove php_value from .htaccess causing 500 errors, fixes #2176

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,4 @@
 <IfModule mod_fcgid.c>
-php_value cgi.fix_pathinfo 1
 <IfModule mod_setenvif.c>
 <IfModule mod_headers.c>
 SetEnvIfNoCase ^Authorization$ "(.+)" XAUTHORIZATION=$1


### PR DESCRIPTION
php_value can only be used with mod_php, using it with FCGI will cause 500 Internal Server errors.  You can not specify php settings in htaccess when using fcgi, this needs to be set in php.ini manually or set using ini_set().
