### PR TITLE
fix versioning for the sync client - distinguish between touch and write operation

### DIFF
--- a/apps/files_versions/lib/hooks.php
+++ b/apps/files_versions/lib/hooks.php
@@ -21,6 +21,12 @@ class Hooks {
 
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			$path = $params[\OC\Files\Filesystem::signal_param_path];
+			$pos = strrpos($path, '.part');
+			if ($pos) {
+				error_log("old path: $path");
+				$path = substr($path, 0, $pos);
+				error_log("new path: $path");
+			}
 			if($path<>'') {
 				Storage::store($path);
 			}

--- a/apps/files_versions/lib/hooks.php
+++ b/apps/files_versions/lib/hooks.php
@@ -21,12 +21,6 @@ class Hooks {
 
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			$path = $params[\OC\Files\Filesystem::signal_param_path];
-			$pos = strrpos($path, '.part');
-			if ($pos) {
-				error_log("old path: $path");
-				$path = substr($path, 0, $pos);
-				error_log("new path: $path");
-			}
 			if($path<>'') {
 				Storage::store($path);
 			}

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -107,6 +107,7 @@ class Storage {
 
 			// store a new version of a file
 			$users_view->copy('files'.$filename, 'files_versions'.$filename.'.v'.$users_view->filemtime('files'.$filename));
+			error_log("version created!");
 			$versionsSize = self::getVersionsSize($uid);
 			if (  $versionsSize === false || $versionsSize < 0 ) {
 				$versionsSize = self::calculateSize($uid);

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -61,7 +61,7 @@ class Storage {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * write to the database how much space is in use for versions
 	 * 
@@ -107,7 +107,6 @@ class Storage {
 
 			// store a new version of a file
 			$users_view->copy('files'.$filename, 'files_versions'.$filename.'.v'.$users_view->filemtime('files'.$filename));
-			error_log("version created!");
 			$versionsSize = self::getVersionsSize($uid);
 			if (  $versionsSize === false || $versionsSize < 0 ) {
 				$versionsSize = self::calculateSize($uid);

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -82,6 +82,14 @@ class Storage {
 	 */
 	public static function store($filename) {
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
+			
+			// if the file gets streamed we need to remove the .part extension
+			// to get the right target
+			$ext = pathinfo($filename, PATHINFO_EXTENSION);
+			if ($ext === 'part') {
+				$filename = substr($filename, 0, strlen($filename)-5);
+			}
+			
 			list($uid, $filename) = self::getUidAndFilename($filename);
 
 			$files_view = new \OC\Files\View('/'.$uid .'/files');

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -245,7 +245,14 @@ class View {
 		if (!is_null($mtime) and !is_numeric($mtime)) {
 			$mtime = strtotime($mtime);
 		}
-		return $this->basicOperation('touch', $path, array('write'), $mtime);
+		
+		$hooks = array('touch');
+		
+		if (!$this->file_exists($path)) {
+			$hooks[] = 'write';
+		}
+		
+		return $this->basicOperation('touch', $path, $hooks, $mtime);
 	}
 
 	public function file_get_contents($path) {
@@ -596,6 +603,7 @@ class View {
 			if ($path == null) {
 				return false;
 			}
+			foreach ($hooks as $h) if ($h == "write") error_log("write triggered by $operation for $path");
 			$run = $this->runHooks($hooks, $path);
 			list($storage, $internalPath) = Filesystem::resolvePath($absolutePath . $postFix);
 			if ($run and $storage) {

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -603,7 +603,7 @@ class View {
 			if ($path == null) {
 				return false;
 			}
-			foreach ($hooks as $h) if ($h == "write") error_log("write triggered by $operation for $path");
+
 			$run = $this->runHooks($hooks, $path);
 			list($storage, $internalPath) = Filesystem::resolvePath($absolutePath . $postFix);
 			if ($run and $storage) {


### PR DESCRIPTION
Fix for issue #2111 
The sync client always performs two operations if he updates a file. First he writes the file to the server and than he triggers a touch() to correct the timestamp.

The problem: writing the file and touch() both triggers a "write" hook which makes it impossible for apps like the file versioning to distinguish between the two operation which leads to version duplicates.

Solution: I updated the touch operation to send a 'touch' signal by default in case if someone always needs to listen to the touch operation and add the "write' signal only when the touch operation creates a new file.

I looked at the code where we use touch(). It is used in the trash bin and versioning app, for both this changes are OK. Our sabre connector uses it to set the timestamp, that's why I introduced the changes so it should be safe too. The files app uses it to create a new file but than the write hook will be added, so it should be also safe.

Please review it, especially @icewind1991 
