### PR TITLE
Additional index for properties table

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -650,6 +650,18 @@
 				<notnull>true</notnull>
 				<length>255</length>
 			</field>
+            
+            <index>
+				<name>user_propertypath_index</name>
+				<field>
+					<name>userid</name>
+					<sorting>ascending</sorting>
+				</field>
+				<field>
+					<name>propertypath</name>
+					<sorting>ascending</sorting>
+				</field>
+            </index>
 
 		</declaration>
 


### PR DESCRIPTION
I take a look on my MYSQL Server and it seems that there is no index on
the oc_poperties table!

owncloud use the following command:

SELECT \* FROM 'oc_properties' WHERE 'userid' = '<USERID>' AND
'propertypath' = '<PATH>'

it takes up to 2 seconds to execute this command!

after I add:

CREATE INDEX USER_PATH ON owncloudusr.oc_properties (userid,
propertypath)

it takes 0.2 seconds!

Best Regards

Patrick Heller
