### PR TITLE
Store the global mount configuration file in the datadir

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -307,8 +307,9 @@ class OC_Mount_Config {
 			$phpFile = OC_User::getHome(OCP\User::getUser()).'/mount.php';
 			$jsonFile = OC_User::getHome(OCP\User::getUser()).'/mount.json';
 		} else {
+			$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 			$phpFile = OC::$SERVERROOT.'/config/mount.php';
-			$jsonFile = OC::$SERVERROOT.'/config/mount.json';
+			$jsonFile = $datadir . '/mount.json';
 		}
 		if (is_file($jsonFile)) {
 			$mountPoints = json_decode(file_get_contents($jsonFile), true);
@@ -333,7 +334,8 @@ class OC_Mount_Config {
 		if ($isPersonal) {
 			$file = OC_User::getHome(OCP\User::getUser()).'/mount.json';
 		} else {
-			$file = OC::$SERVERROOT.'/config/mount.json';
+			$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
+			$file = $datadir . '/mount.json';
 		}
 		$content = json_encode($data);
 		@file_put_contents($file, $content);

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -221,11 +221,16 @@ class Filesystem {
 
 		$root = \OC_User::getHome($user);
 		self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
+		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 
+		//move config file to it's new position
+		if (is_file(\OC::$SERVERROOT . '/config/mount.json')) {
+			rename(\OC::$SERVERROOT . '/config/mount.json', $datadir . '/mount.json');
+		}
 		// Load system mount points
-		if (is_file(\OC::$SERVERROOT . '/config/mount.php') or is_file(\OC::$SERVERROOT . '/config/mount.json')) {
-			if (is_file(\OC::$SERVERROOT . '/config/mount.json')) {
-				$mountConfig = json_decode(file_get_contents(\OC::$SERVERROOT . '/config/mount.json'), true);
+		if (is_file(\OC::$SERVERROOT . '/config/mount.php') or is_file($datadir . '/mount.json')) {
+			if (is_file($datadir . '/mount.json')) {
+				$mountConfig = json_decode(file_get_contents($datadir . '/mount.json'), true);
 			} elseif (is_file(\OC::$SERVERROOT . '/config/mount.php')) {
 				$mountConfig = $parser->parsePHP(file_get_contents(\OC::$SERVERROOT . '/config/mount.php'));
 			}


### PR DESCRIPTION
This prevents people from reading the config file

@karlitschek @MTGap @LukasReschke 
