### PR TITLE
Fix variable for mounting for all users, fix #357

### DIFF
--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -249,7 +249,7 @@ class Filesystem {
 			}
 			if (isset($mountConfig['user'])) {
 				foreach ($mountConfig['user'] as $mountUser => $mounts) {
-					if ($user === 'all' or strtolower($mountUser) === strtolower($user)) {
+					if ($mountUser === 'all' or strtolower($mountUser) === strtolower($user)) {
 						foreach ($mounts as $mountPoint => $options) {
 							$mountPoint = self::setUserVars($user, $mountPoint);
 							foreach ($options as &$option) {


### PR DESCRIPTION
Sorry this took so long... for something so simple.

@icewind1991 @karlitschek @riso @4bendo @bourgeoa

@icewind1991 Since we're moving the mount configuration to the data directory I'm guessing we're forcing admins to use the external storage UI. Do you have any objections to changing the mount config in the future so we don't have 'all' represented as a user?
