### PR TITLE
LDAP: compatibility with Novell eDirectory UUID

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -84,7 +84,7 @@ abstract class Access {
 			for($i=0;$i<$result[$attr]['count'];$i++) {
 				if($this->resemblesDN($attr)) {
 					$values[] = $this->sanitizeDN($result[$attr][$i]);
-				} elseif(strtolower($attr) == 'objectguid') {
+				} elseif(strtolower($attr) == 'objectguid' || strtolower($attr) == 'guid') {
 					$values[] = $this->convertObjectGUID2Str($result[$attr][$i]);
 				} else {
 					$values[] = $result[$attr][$i];
@@ -895,7 +895,7 @@ abstract class Access {
 		}
 
 		//for now, supported (known) attributes are entryUUID, nsuniqueid, objectGUID
-		$testAttributes = array('entryuuid', 'nsuniqueid', 'objectguid');
+		$testAttributes = array('entryuuid', 'nsuniqueid', 'objectguid', 'guid');
 
 		foreach($testAttributes as $attribute) {
 			\OCP\Util::writeLog('user_ldap', 'Testing '.$attribute.' as UUID attr', \OCP\Util::DEBUG);


### PR DESCRIPTION
fixes #1968 

OK to be merged after 5.0 release (for the first maintenance release) to not delay it.
