### PR TITLE
Sharing: fix condition that didn't make sense.

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -599,7 +599,7 @@ class Share {
 			}
 		}
 		// TODO Add option for collections to be collection of themselves, only 'folder' does it now...
-		if (!self::getBackend($itemType) instanceof Share_Backend_Collection || $itemType != 'folder') {
+		if (!self::getBackend($itemType) instanceof Share_Backend_Collection) {
 			unset($collectionTypes[0]);
 		}
 		// Return array if collections were found or the item type is a


### PR DESCRIPTION
In my hunt for getting instances of `Share_Backend_Collection` to work as collections, I came across this gem as the first stop gap. 
For collections which are not folders it boiled down to: `if(!true||true)`. A condition it's had to argue against ;) Besides that folder types already implements  `Share_Backend_Collection` 
