### PR TITLE
Fix file sharing via public link for one particular file.

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -50,7 +50,7 @@ class OC_Files {
 			$xsendfile = true;
 		}
 
-		if (count($files) == 1) {
+		if (is_array($files) && count($files) == 1) {
 			$files = $files[0];
 		}
 


### PR DESCRIPTION
Fix OC_Files::get() to not return the first character of the filename
if only one file is requested.
