### PR TITLE
json encode download list [stable45]

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -33,9 +33,10 @@ OCP\User::checkLoggedIn();
 $files = $_GET["files"];
 $dir = $_GET["dir"];
 
-if ($files == "Shared" and $dir == "/") {
-	$files = '';
-	$dir = "/Shared";
+$files_list = json_decode($files);
+// in case we get only a single file
+if ($files_list === NULL ) {
+	$files_list = array($files);
 }
 
-OC_Files::get($dir, $files, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+OC_Files::get($dir, $files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -198,7 +198,8 @@ $(document).ready(function() {
 	});
 
 	$('.download').click('click',function(event) {
-		var files=getSelectedFiles('name').join(';');
+		var files=getSelectedFiles('name');
+		var fileslist = JSON.stringify(files);
 		var dir=$('#dir').val()||'/';
 		$('#notification').text(t('files','generating ZIP-file, it may take some time.'));
 		$('#notification').fadeIn();
@@ -206,7 +207,7 @@ $(document).ready(function() {
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {
 			window.location=downloadURL.value+"&download&files="+files;
 		} else {
-			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: files });
+			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
 		}
 		return false;
 	});

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -205,7 +205,7 @@ $(document).ready(function() {
 		$('#notification').fadeIn();
 		// use special download URL if provided, e.g. for public shared files
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {
-			window.location=downloadURL.value+"&download&files="+files;
+			window.location=downloadURL.value+"&download&files="+encodeURIComponent(fileslist);
 		} else {
 			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
 		}

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -178,7 +178,13 @@ if ($linkItem) {
 	if (isset($_GET['download'])) {
 		if (isset($_GET['path']) && $_GET['path'] !== '' ) {
 			if ( isset($_GET['files']) ) { // download selected files
-				OC_Files::get($path, $_GET['files'], $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
+				$files = urldecode($_GET['files']);
+				$files_list = json_decode($files);
+				// in case we get only a single file
+				if ($files_list === NULL ) {
+					$files_list = array($files);
+				}
+				OC_Files::get($path, files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
 			} else if (isset($_GET['path']) && $_GET['path'] != '' ) { // download a file from a shared directory
 				OC_Files::get($dir, $file, $_SERVER['REQUEST_METHOD'] == 'HEAD' ? true : false);
 			} else { // download the whole shared directory

--- a/lib/files.php
+++ b/lib/files.php
@@ -140,7 +140,7 @@ class OC_Files {
 	* @param boolean $only_header ; boolean to only send header of the request
 	*/
 	public static function get($dir,$files, $only_header = false) {
-		if (count($files) == 1) {
+		if (is_array($files) && count($files) == 1) {
 			$files = $files[0];
 		}
 		

--- a/lib/files.php
+++ b/lib/files.php
@@ -136,14 +136,14 @@ class OC_Files {
 	* return the content of a file or return a zip file containning multiply files
 	*
 	* @param dir  $dir
-	* @param file $file ; seperated list of files to download
+	* @param file $file array of files
 	* @param boolean $only_header ; boolean to only send header of the request
 	*/
 	public static function get($dir,$files, $only_header = false) {
-		if(strpos($files,';')) {
-			$files=explode(';',$files);
+		if (count($files) == 1) {
+			$files = $files[0];
 		}
-
+		
 		if(is_array($files)) {
 			self::validateZipDownload($dir,$files);
 			$executionTime = intval(ini_get('max_execution_time'));

--- a/lib/filestorage/local.php
+++ b/lib/filestorage/local.php
@@ -20,7 +20,7 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 		return opendir($this->datadir.$path);
 	}
 	public function is_dir($path) {
-		//work arround to detect /Shared as folder, only needed for OC4.5
+		//workaround to detect /Shared as folder, only needed for OC4.5
 		if($path == "files/Shared") {
 			return true;
 		}

--- a/lib/filestorage/local.php
+++ b/lib/filestorage/local.php
@@ -20,6 +20,10 @@ class OC_Filestorage_Local extends OC_Filestorage_Common{
 		return opendir($this->datadir.$path);
 	}
 	public function is_dir($path) {
+		//work arround to detect /Shared as folder, only needed for OC4.5
+		if($path == "files/Shared") {
+			return true;
+		}
 		if(substr($path,-1)=='/') {
 			$path=substr($path,0,-1);
 		}


### PR DESCRIPTION
fix for #2150 in stable45. The same fix was already merged into master.

Only difference: In OC4.5 we need a workaround to detect /Shared as a folder to download it correctly. I moved this workaround from download.php to filestorage/local.php

@icewind1991 @MTGap would be good if you could have a look at this patch, especially at the part with the workaround for the Shared folder.
