### PR TITLE
don't add share action to the Shared folder

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -112,7 +112,7 @@ var FileActions = {
 				addAction(name, action);
 			}
 		});
-		if(actions.Share){
+		if(actions.Share && file !== 'Shared'){
 			addAction('Share', actions.Share);
 		}
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -112,7 +112,7 @@ var FileActions = {
 				addAction(name, action);
 			}
 		});
-		if(actions.Share && file !== 'Shared'){
+		if(actions.Share && !($('#dir').val() === '/' && file === 'Shared')){
 			addAction('Share', actions.Share);
 		}
 


### PR DESCRIPTION
Don't display the share action for the Shared folder, see issue #898 
