### PR TITLE
Indicate password strength using zxcvbn

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -89,3 +89,16 @@ table.shareAPI td { padding-bottom: 0.8em; }
 /* HELP */
 .pressed {background-color:#DDD;}
 
+/* PASSWORD */
+#password-strength {
+	display: inline-block;
+	margin-left: 13em;
+}
+.password-bad {
+	color:#C33; 
+	font-weight:bold;
+}
+.password-good {
+	 color :#33CC33;
+	 font-weight: bold;
+}

--- a/settings/js/password-strength.js
+++ b/settings/js/password-strength.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2013, Lukas Reschke <lukas@statuscode.ch>
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+
+ $(function() {
+ 	$('#pass2').keyup(function() {
+ 		var result = zxcvbn($(this).val());
+ 		$('#password-strength').text(t('core', 'Crack time:') + " " + readableTime(result.crack_time));
+
+ 		if(result.score < 3) {
+ 			$("#password-strength").attr('class', 'password-bad');
+ 		} else {
+ 			$("#password-strength").attr('class', 'password-good');
+ 		}
+ 	});
+
+ 	function readableTime(seconds)
+ 	{
+ 		var minute = 60;
+ 		var hour = minute * 60;
+ 		var day = hour * 24;
+ 		var month = day * 31;
+ 		var year = month * 12;
+ 		var century = year * 100;
+
+ 		if(seconds < minute) {
+ 			return t('core', 'instant');
+ 		}
+ 		if(seconds < hour) {
+ 			return Math.ceil(seconds / minute) + " " + t('core', 'minutes');
+ 		}
+ 		if(seconds < day) {
+ 			return Math.ceil(seconds / hour) + " " + t('core', 'hours');
+ 		}
+ 		if(seconds < month) {
+ 			return Math.ceil(seconds / day) + " " + t('core', 'days');
+ 		}
+ 		if(seconds < year) {
+ 			return Math.ceil(seconds / month) + " " + t('core', 'months');
+ 		}
+ 		if(seconds < century) {
+ 			return Math.ceil(seconds / year) + " " + t('core', 'years');
+ 		}
+ 		return t('core', 'centuries');
+ 	}
+ });

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -8,11 +8,14 @@
 OC_Util::checkLoggedIn();
 OC_App::loadApps();
 
-// Highlight navigation entry
 OC_Util::addScript( 'settings', 'personal' );
 OC_Util::addStyle( 'settings', 'settings' );
+OC_Util::addScript( '3rdparty/zxcvbn', 'zxcvbn' );
+OC_Util::addScript( 'settings', 'password-strength' );
 OC_Util::addScript( '3rdparty', 'chosen/chosen.jquery.min' );
 OC_Util::addStyle( '3rdparty', 'chosen' );
+
+// Highlight navigation entry
 OC_App::setActiveNavigationEntry( 'personal' );
 
 $storageInfo=OC_Helper::getStorageInfo();

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -42,6 +42,7 @@ if($_['passwordChangeSupported']) {
 			placeholder="<?php echo $l->t('New password');?>" data-typetoggle="#personal-show" />
 		<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
 		<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password');?>" />
+		<br/><span id="password-strength"></span>
 	</fieldset>
 </form>
 <?php


### PR DESCRIPTION
There are still a few problems:
- [ ] Load the script asynchronous (how can I get the path of the 3rdparty folder in JS?)
- [ ] Make the UI nicer - I'd like [such a cool bar (scoll-down)](https://tech.dropbox.com/2012/04/zxcvbn-realistic-password-strength-estimation/) and when clicking on the (i) there should more info displayed (time to crack, entropy etc...) @jancborchardt Interessted?

![u8jh6nhwnjpa](https://f.cloud.github.com/assets/878997/253174/b8144cb0-8bc6-11e2-9fc6-93b13f2fde1e.png)
- [ ] Clean up the JS / HTML (maybe even make it a jQuery plugin so it's reusable) - is here any jQuery guru who wants to do this? @Raydiation @raghunayyar? _hides_ ;-)

Requires https://github.com/owncloud/3rdparty/pull/20

Ref #2048
