### PR TITLE
replace \MDB with \OC_DB

### DIFF
--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -204,7 +204,7 @@ class Cache {
 			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*filecache`(' . implode(', ', $queryParts) . ')'
 				. ' VALUES(' . implode(', ', $valuesPlaceholder) . ')');
 			$result = $query->execute($params);
-			if (\MDB2::isError($result)) {
+			if (\OC_DB::isError($result)) {
 				\OCP\Util::writeLog('cache', 'Insert to cache failed: '.$result, \OCP\Util::ERROR);
 			}
 


### PR DESCRIPTION
There was a class not found error for MDB2. It should be OC_DB as it will handle errors for PDO and MDB2 ... and Doctrine in the future.

@icewind1991 @DeepDiver1975 @bartv2 nothing big here but still needs :+1: 
