### PR TITLE
create new version if the same file is uploaded again over the web interface

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -156,11 +156,18 @@ class Storage {
 	/**
 	 * rename versions of a file
 	 */
-	public static function rename($oldpath, $newpath) {
-		list($uid, $oldpath) = self::getUidAndFilename($oldpath);
-		list($uidn, $newpath) = self::getUidAndFilename($newpath);
+	public static function rename($old_path, $new_path) {
+		list($uid, $oldpath) = self::getUidAndFilename($old_path);
+		list($uidn, $newpath) = self::getUidAndFilename($new_path);
 		$versions_view = new \OC\Files\View('/'.$uid .'/files_versions');
 		$files_view = new \OC\Files\View('/'.$uid .'/files');
+		
+		// if the file already exists than it was a upload of a existing file
+		// over the web interface -> store() is the right function we need here
+		if ($files_view->file_exists($newpath)) {
+			return self::store($newpath);
+		}
+		
 		$abs_newpath = $versions_view->getLocalFile($newpath);
 
 		if ( $files_view->is_dir($oldpath) && $versions_view->is_dir($oldpath) ) {

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -164,7 +164,7 @@ class Storage {
 		
 		// if the file already exists than it was a upload of a existing file
 		// over the web interface -> store() is the right function we need here
-		if ($files_view->file_exists($newpath)) {
+		if ($files_view->file_exists($new_path)) {
 			return self::store($newpath);
 		}
 		

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -164,8 +164,8 @@ class Storage {
 		
 		// if the file already exists than it was a upload of a existing file
 		// over the web interface -> store() is the right function we need here
-		if ($files_view->file_exists($new_path)) {
-			return self::store($newpath);
+		if ($files_view->file_exists($newpath)) {
+			return self::store($new_path);
 		}
 		
 		$abs_newpath = $versions_view->getLocalFile($newpath);


### PR DESCRIPTION
If a existing file is uploaded over the web interface again it will stored with a unique name first. Only after the user decided to replace the existing file it gets renamed from the unique name to the name of the existing file. This means that the rename hook needs to handle this situation. Also discussed in #2205 
