### PR TITLE
Filter display of blacklisted files

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -151,6 +151,7 @@ class Scanner {
 	private function isIgnoredFile($file) {
 		if ($file === '.' || $file === '..'
 			|| pathinfo($file, PATHINFO_EXTENSION) === 'part'
+			|| \OC\Files\Filesystem::isFileBlacklisted($file)
 		) {
 			return true;
 		}


### PR DESCRIPTION
Blacklisted files like ".htaccess" and ".git" should not only be
blacklisted for upload and rename, but they should also not be displayed
in the directory listings.

I needed this personally to hide ".git" folders in shared folders. Its
also a simple implementation of feature requests like
http://forum.owncloud.org/viewtopic.php?f=4&t=3279 and
http://forum.owncloud.org/viewtopic.php?f=3&t=5708
