### PR TITLE
Improve behaviour when max upload size is unknown

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -47,7 +47,7 @@ $totalSize = 0;
 foreach ($files['size'] as $size) {
 	$totalSize += $size;
 }
-if ($totalSize > $maxUploadFilesize) {
+if ($maxUploadFilesize >= 0 and $totalSize > $maxUploadFilesize) {
 	OCP\JSON::error(array('data' => array('message' => $l->t('Not enough storage available'),
 		'uploadMaxFilesize' => $maxUploadFilesize,
 		'maxHumanFilesize' => $maxHumanFilesize)));

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -23,8 +23,10 @@
 					  method="post"
 					  enctype="multipart/form-data"
 					  target="file_upload_target_1">
+					<?php if($_['uploadMaxFilesize'] >= 0):?>
 					<input type="hidden" name="MAX_FILE_SIZE" id="max_upload"
 						   value="<?php p($_['uploadMaxFilesize']) ?>">
+					<?php endif;?>
 					<!-- Send the requesttoken, this is needed for older IE versions
 						 because they don't send the CSRF token via HTTP header in this case -->
 					<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" id="requesttoken">

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -30,6 +30,7 @@
 namespace OC\Files;
 
 const FREE_SPACE_UNKNOWN = -2;
+const FREE_SPACE_UNLIMITED = -3;
 
 class Filesystem {
 	public static $loaded = false;

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -764,7 +764,8 @@ class OC_Helper {
 	public static function maxUploadFilesize($dir) {
 		$upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize'));
 		$post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
-		if ($upload_max_filesize === 0 and $post_max_size === 0) {
+		$freeSpace = \OC\Files\Filesystem::free_space($dir);
+		if ($upload_max_filesize == 0 and $post_max_size == 0) {
 			$maxUploadFilesize = \OC\Files\FREE_SPACE_UNLIMITED;
 		} elseif ($upload_max_filesize === 0 or $post_max_size === 0) {
 			$maxUploadFilesize = max($upload_max_filesize, $post_max_size); //only the non 0 value counts
@@ -772,7 +773,6 @@ class OC_Helper {
 			$maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 		}
 
-		$freeSpace = \OC\Files\Filesystem::free_space($dir);
 		if($freeSpace !== \OC\Files\FREE_SPACE_UNKNOWN){
 			$freeSpace = max($freeSpace, 0);
 

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -764,7 +764,13 @@ class OC_Helper {
 	public static function maxUploadFilesize($dir) {
 		$upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize'));
 		$post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
-		$maxUploadFilesize = min($upload_max_filesize, $post_max_size);
+		if ($upload_max_filesize === 0 and $post_max_size === 0) {
+			$maxUploadFilesize = \OC\Files\FREE_SPACE_UNLIMITED;
+		} elseif ($upload_max_filesize === 0 or $post_max_size === 0) {
+			$maxUploadFilesize = max($upload_max_filesize, $post_max_size); //only the non 0 value counts
+		} else {
+			$maxUploadFilesize = min($upload_max_filesize, $post_max_size);
+		}
 
 		$freeSpace = \OC\Files\Filesystem::free_space($dir);
 		if($freeSpace !== \OC\Files\FREE_SPACE_UNKNOWN){

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -812,11 +812,19 @@ class OC_Helper {
 			$used = 0;
 		}
 		$free = \OC\Files\Filesystem::free_space();
-		$total = $free + $used;
+		if ($free >= 0){
+			$total = $free + $used;
+		} else {
+			$total = $free; //either unknown or unlimited
+		}
 		if ($total == 0) {
 			$total = 1; // prevent division by zero
 		}
-		$relative = round(($used / $total) * 10000) / 100;
+		if ($total >= 0){
+			$relative = round(($used / $total) * 10000) / 100;
+		} else {
+			$relative = 0;
+		}
 
 		return array('free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative);
 	}


### PR DESCRIPTION
- Don't block uploads if max upload size is unknown or unlimited
- Don't show storage full warning if free space is unknown or unlimited.

@karlitschek @DeepDiver1975 

Fixes #2345 might fix #2199
