### PR TITLE
Fixes keyboard accessibility of expandable settings

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -38,7 +38,7 @@
 				src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="ownCloud" /></a>
 
 			<ul id="settings" class="svg">
-				<span id="expand">
+				<span id="expand" tabindex="0" role="link">
 					<span id="expandDisplayName"><?php  p(trim($_['user_displayname']) != '' ? $_['user_displayname'] : $_['user_uid']) ?></span>
 					<img class="svg" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" />
 				</span>


### PR DESCRIPTION
Tabindex="0" makes the element focussable with the keyboard and
role="link" tells assistive technologies such as screen readers that this clickable span
element is supposed to be presented as a hyperlink.
