### PR TITLE
Close the session for writing in webdav

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -28,6 +28,7 @@ $RUNTIME_APPTYPES=array('filesystem', 'authentication', 'logging');
 OC_App::loadApps($RUNTIME_APPTYPES);
 
 OC_Util::obEnd();
+session_write_close();
 
 // Backends
 $authBackend = new OC_Connector_Sabre_Auth();


### PR DESCRIPTION
prevents WebDAV requests from blocking other requests.

@dragotin not having sessions shouldn't have any impact on the sync client right?

cc: @karlitschek @DeepDiver1975 
