### PR TITLE
Close sessions when doing background jobs

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -48,6 +48,8 @@ function handleUnexpectedShutdown() {
 $RUNTIME_NOSETUPFS = true;
 require_once 'lib/base.php';
 
+session_write_close();
+
 // Don't do anything if ownCloud has not been installed
 if( !OC_Config::getValue( 'installed', false )) {
 	exit( 0 );


### PR DESCRIPTION
nothing in cron.php should rely on sessions anyway since it won't have a session if it's called from system cron

@DeepDiver1975 @karlitschek
