### PR TITLE
Remove MDB2_PORTABILITY_EMPTY_TO_NULL from MDB2 options; fixes issue #2371

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -270,6 +270,7 @@ class OC_DB {
 						'hostspec' => $host,
 						'database' => $name
 					);
+					$options['portability'] = $options['portability'] - MDB2_PORTABILITY_EMPTY_TO_NULL;
 					break;
 				case 'oci':
 					$dsn = array(


### PR DESCRIPTION
Remove MDB2_PORTABILITY_EMPTY_TO_NULL from MDB2 options; fixes issue #2371
