### PR TITLE
remove deprecated call

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -398,8 +398,8 @@ class OC {
 		ini_set('arg_separator.output', '&amp;');
 
 		// try to switch magic quotes off.
-		if (get_magic_quotes_gpc()) {
-			@set_magic_quotes_runtime(false);
+		if (get_magic_quotes_gpc()==1) {
+			ini_set('magic_quotes_runtime', 0);
 		}
 
 		//try to configure php to enable big file uploads.


### PR DESCRIPTION
Remove deprecated call set_magic_quotes_runtime. ini_set should do the same if someone still has magic quotes turned on.
Should fix:
https://github.com/owncloud/core/issues/2064 and https://github.com/owncloud/core/issues/2273
@VicDeo @Raydiation @tanghus @schiesbn 
