### PR TITLE
Fix ldap issues

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -139,6 +139,9 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 		if(!$this->enabled) {
 			return array();
 		}
+		if(!$this->groupExists($gid)) {
+			return false;
+		}
 		$cachekey = 'usersInGroup-'.$gid.'-'.$search.'-'.$limit.'-'.$offset;
 		// check for cache of the exact query
 		$groupUsers = $this->connection->getFromCache($cachekey);
@@ -214,6 +217,12 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 	 * @returns array with display names (value) and user ids(key)
 	 */
 	public function displayNamesInGroup($gid, $search, $limit, $offset) {
+		if(!$this->enabled) {
+			return array();
+		}
+		if(!$this->groupExists($gid)) {
+			return false;
+		}
 		$users = $this->usersInGroup($gid, $search, $limit, $offset);
 		$displayNames = array();
 		foreach($users as $user) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -62,7 +62,10 @@ abstract class Access {
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @ldap_read($cr, $dn, $filter, array($attr));
 		if(!is_resource($rr)) {
-			\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
+			if(!empty($attr)) {
+				//do not throw this message on userExists check, irritates
+				\OCP\Util::writeLog('user_ldap', 'readAttribute failed for DN '.$dn, \OCP\Util::DEBUG);
+			}
 			//in case an error occurs , e.g. object does not exist
 			return false;
 		}

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -212,7 +212,6 @@ class Connection {
 	 */
 	private function readConfiguration($force = false) {
 		if((!$this->configured || $force) && !is_null($this->configID)) {
-			$defaults = $this->getDefaults();
 			$v = 'getValue';
 			$this->config['ldapHost']       = $this->$v('ldap_host');
 			$this->config['ldapBackupHost'] = $this->$v('ldap_backup_host');

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -51,7 +51,8 @@ class Helper {
 		$query = '
 			SELECT DISTINCT `configkey`
 			FROM `*PREFIX*appconfig`
-			WHERE `configkey` LIKE ?
+			WHERE `appid` = \'user_ldap\'
+				AND `configkey` LIKE ?
 		';
 		if($activeConfigurations) {
 			$query .= ' AND `configvalue` = \'1\'';

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -180,6 +180,11 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 	* @return boolean
 	*/
 	public function getHome($uid) {
+		// user Exists check required as it is not done in user proxy!
+		if(!$this->userExists($uid)) {
+			return false;
+		}
+
 		$cacheKey = 'getHome'.$uid;
 		if($this->connection->isCached($cacheKey)) {
 			return $this->connection->getFromCache($cacheKey);

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -222,6 +222,10 @@ class USER_LDAP extends lib\Access implements \OCP\UserInterface {
 	 * @return display name
 	 */
 	public function getDisplayName($uid) {
+		if(!$this->userExists($uid)) {
+			return false;
+		}
+
 		$cacheKey = 'getDisplayName'.$uid;
 		if(!is_null($displayName = $this->connection->getFromCache($cacheKey))) {
 			return $displayName;


### PR DESCRIPTION
Fixes some minor issues that have not been reported yet:
- internal userExists() respecitvely groupExists() checks, avoids strange behaviour on multi-server setups
- avoid debug message were not necessary, avoids confusion
- avoid unnecessary func call, a leftover from a former refactoring
- make sure that settings are fetched from appid = user_ldap only

reviewers please, e.g. @Raydiation @bartv2 @tanghus or others :)
