### PR TITLE
Remove leading and trailing backslashes in classname. Ref #2310

### DIFF
--- a/core/setup.php
+++ b/core/setup.php
@@ -18,6 +18,10 @@ $hasPostgreSQL = is_callable('pg_connect');
 $hasOracle = is_callable('oci_connect');
 $hasMSSQL = is_callable('sqlsrv_connect');
 $datadir = OC_Config::getValue('datadirectory', OC::$SERVERROOT.'/data');
+$vulnerableToNullByte = false;
+if(file_exists(__FILE__."\0Nullbyte")) { // Check if the used PHP version is vulnerable to the NULL Byte attack (CVE-2006-7243)
+	$vulnerableToNullByte = true;
+} 
 
 // Protect data directory here, so we can test if the protection is working
 OC_Setup::protectDataDirectory();
@@ -31,6 +35,7 @@ $opts = array(
 	'directory' => $datadir,
 	'secureRNG' => OC_Util::secureRNG_available(),
 	'htaccessWorking' => OC_Util::ishtaccessworking(),
+	'vulnerableToNullByte' => $vulnerableToNullByte,
 	'errors' => array(),
 );
 

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -19,6 +19,13 @@
 		<?php endforeach; ?>
 	</ul>
 	<?php endif; ?>
+	<?php if($_['vulnerableToNullByte']): ?>
+	<fieldset class="warning">
+		<legend><strong><?php p($l->t('Security Warning'));?></strong></legend>
+		<p><?php p($l->t('Your PHP version is vulnerable to the NULL Byte attack (CVE-2006-7243)'));?><br/>
+		<?php p($l->t('Please update your PHP installation to use ownCloud securely.'));?></p>
+	</fieldset>
+	<?php endif; ?>
 	<?php if(!$_['secureRNG']): ?>
 	<fieldset class="warning">
 		<legend><strong><?php p($l->t('Security Warning'));?></strong></legend>

--- a/lib/base.php
+++ b/lib/base.php
@@ -78,6 +78,8 @@ class OC {
 	 * SPL autoload
 	 */
 	public static function autoload($className) {
+		$className = trim ($className, '\\');
+		
 		if (array_key_exists($className, OC::$CLASSPATH)) {
 			$path = OC::$CLASSPATH[$className];
 			/** @TODO: Remove this when necessary

--- a/lib/base.php
+++ b/lib/base.php
@@ -78,7 +78,7 @@ class OC {
 	 * SPL autoload
 	 */
 	public static function autoload($className) {
-		$className = trim ($className, '\\');
+		$className = trim($className, '\\');
 		
 		if (array_key_exists($className, OC::$CLASSPATH)) {
 			$path = OC::$CLASSPATH[$className];

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Müller <thomas.mueller@tmit.eu>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+class Test_AutoLoader extends PHPUnit_Framework_TestCase {
+
+	public function testLeadingSlashOnClassName(){
+		$this->assertTrue(class_exists('\OC\Files\Storage\Local'));
+	}
+
+	public function testNoLeadingSlashOnClassName(){
+		$this->assertTrue(class_exists('OC\Files\Storage\Local'));
+	}
+
+}


### PR DESCRIPTION
As discussed here https://github.com/owncloud/core/pull/2409
PHP 5.3.2 fails to load classes with leading '\'  character e.g. '\OC\Files\Storage\Local'
