### PR TITLE
fix npe when createStorage() returns null

### DIFF
--- a/lib/files/mount.php
+++ b/lib/files/mount.php
@@ -90,7 +90,11 @@ class Mount {
 	public function getStorageId() {
 		if (!$this->storageId) {
 			if (is_null($this->storage)) {
-				$this->storage = $this->createStorage();
+				$storage = $this->createStorage(); //FIXME: start using exceptions
+				if (is_null($storage)) {
+					return null;
+				}
+				$this->storage = $storage;
 			}
 			$this->storageId = $this->storage->getId();
 			if (strlen($this->storageId) > 64) {


### PR DESCRIPTION
this at least returns null instead of dying with an error in the log. Maybe we should start using exceptions for this? @icewind1991 @DeepDiver1975 @bartv2 @schiesbn comments?
