### PR TITLE
Extend .gitignore for better compatability with phpStorm/IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ nbproject
 
 # phpStorm
 .idea
+*.iml
 
 # geany
 *.geany


### PR DESCRIPTION
Both phpStorm and IntelliJ create project files with the '*.iml' extension.  Would like to have git ignore such files.
