### PR TITLE
skip update if the recipient is the same user as the owner

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -38,12 +38,12 @@ class Shared_Updater {
 			while (!empty($users)) {
 				$reshareUsers = array();
 				foreach ($users as $user) {
-                                    if ( $user !== $uidOwner ) {
-                                        $etag = \OC\Files\Filesystem::getETag('');
-					\OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
-					// Look for reshares
-					$reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $info['fileid'], $user, true));
-                                    }
+					if ( $user !== $uidOwner ) {
+						$etag = \OC\Files\Filesystem::getETag('');
+						\OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
+						// Look for reshares
+						$reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $info['fileid'], $user, true));
+					}
 				}
 				$users = $reshareUsers;
 			}
@@ -90,12 +90,12 @@ class Shared_Updater {
 				while (!empty($users)) {
 					$reshareUsers = array();
 					foreach ($users as $user) {
-                                            if ($user !== $uidOwner) {
-                                                $etag = \OC\Files\Filesystem::getETag('');
-                                                \OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
-                                                // Look for reshares
-                                                $reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $params['fileSource'], $user, true));
-                                            }
+						if ($user !== $uidOwner) {
+							$etag = \OC\Files\Filesystem::getETag('');
+							\OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
+							// Look for reshares
+							$reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $params['fileSource'], $user, true));
+						}
 					}
 					$users = $reshareUsers;
 				}

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -38,10 +38,12 @@ class Shared_Updater {
 			while (!empty($users)) {
 				$reshareUsers = array();
 				foreach ($users as $user) {
-					$etag = \OC\Files\Filesystem::getETag('');
+                                    if ( $user !== $uidOwner ) {
+                                        $etag = \OC\Files\Filesystem::getETag('');
 					\OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
 					// Look for reshares
 					$reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $info['fileid'], $user, true));
+                                    }
 				}
 				$users = $reshareUsers;
 			}
@@ -88,10 +90,12 @@ class Shared_Updater {
 				while (!empty($users)) {
 					$reshareUsers = array();
 					foreach ($users as $user) {
-						$etag = \OC\Files\Filesystem::getETag('');
-						\OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
-						// Look for reshares
-						$reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $params['fileSource'], $user, true));
+                                            if ($user !== $uidOwner) {
+                                                $etag = \OC\Files\Filesystem::getETag('');
+                                                \OCP\Config::setUserValue($user, 'files_sharing', 'etag', $etag);
+                                                // Look for reshares
+                                                $reshareUsers = array_merge($reshareUsers, \OCP\Share::getUsersItemShared('file', $params['fileSource'], $user, true));
+                                            }
 					}
 					$users = $reshareUsers;
 				}

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -140,7 +140,7 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 			return array();
 		}
 		if(!$this->groupExists($gid)) {
-			return false;
+			return array();
 		}
 		$cachekey = 'usersInGroup-'.$gid.'-'.$search.'-'.$limit.'-'.$offset;
 		// check for cache of the exact query
@@ -221,7 +221,7 @@ class GROUP_LDAP extends lib\Access implements \OCP\GroupInterface {
 			return array();
 		}
 		if(!$this->groupExists($gid)) {
-			return false;
+			return array();
 		}
 		$users = $this->usersInGroup($gid, $search, $limit, $offset);
 		$displayNames = array();


### PR DESCRIPTION
skip update if the recipient is the same user as the owner, otherwise we run in a infinite loop for group shares.

I'm not sure if this is only a quick fix or the only possible solution (see discussion in #2299) but for now it fixes issue #2299 

@MTGap @blizzz please review.
