### PR TITLE
Add the option to use $displayName in mount configurations

### DIFF
--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -290,6 +290,8 @@ class Filesystem {
 	 * @return string
 	 */
 	private static function setUserVars($user, $input) {
+		$displayName = \OC_User::getDisplayName($user);
+		$input = str_replace('$displayName', $displayName, $input);
 		return str_replace('$user', $user, $input);
 	}
 


### PR DESCRIPTION
@blizzz this is mainly for ldap users, could you test it in a situation where the username and displayname are different.

cc @MTGap 
