### PR TITLE
improved handling of xsendfile zip generation race condition

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -59,11 +59,7 @@ class OC_Files {
 			$executionTime = intval(ini_get('max_execution_time'));
 			set_time_limit(0);
 			$zip = new ZipArchive();
-			if ($xsendfile) {
-				$filename = OC_Helper::tmpFileNoClean('.zip');
-			}else{
-				$filename = OC_Helper::tmpFile('.zip');
-			}
+			$filename = OC_Helper::tmpFile('.zip');
 			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
 				exit("cannot open <$filename>\n");
 			}
@@ -78,6 +74,9 @@ class OC_Files {
 				}
 			}
 			$zip->close();
+			if ($xsendfile) {
+				$filename = OC_Helper::moveToNoClean($filename);
+			}
 			$basename = basename($dir);
 			if ($basename) {
 				$name = $basename . '.zip';
@@ -91,17 +90,16 @@ class OC_Files {
 			$executionTime = intval(ini_get('max_execution_time'));
 			set_time_limit(0);
 			$zip = new ZipArchive();
-			if ($xsendfile) {
-				$filename = OC_Helper::tmpFileNoClean('.zip');
-			}else{
-				$filename = OC_Helper::tmpFile('.zip');
-			}
+			$filename = OC_Helper::tmpFile('.zip');
 			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
 				exit("cannot open <$filename>\n");
 			}
 			$file = $dir . '/' . $files;
 			self::zipAddDir($file, $zip);
 			$zip->close();
+			if ($xsendfile) {
+				$filename = OC_Helper::moveToNoClean($filename);
+			}
 			$name = $files . '.zip';
 			set_time_limit($executionTime);
 		} else {

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -541,13 +541,15 @@ class OC_Helper {
 	}
 
 	/**
-	 * create a temporary file with an unique filename. It will not be deleted
-	 * automatically
-	 * @param string $postfix
-	 * @return string
+	 * move a file to oc-noclean temp dir
+	 * @param string $filename
+	 * @return mixed
 	 *
 	 */
-	public static function tmpFileNoClean($postfix='') {
+	public static function moveToNoClean($filename='') {
+		if ($filename == '') {
+			return false;
+		}
 		$tmpDirNoClean=get_temp_dir().'/oc-noclean/';
 		if (!file_exists($tmpDirNoClean) || !is_dir($tmpDirNoClean)) {
 			if (file_exists($tmpDirNoClean)) {
@@ -555,10 +557,12 @@ class OC_Helper {
 			}
 			mkdir($tmpDirNoClean);
 		}
-		$file=$tmpDirNoClean.md5(time().rand()).$postfix;
-		$fh=fopen($file, 'w');
-		fclose($fh);
-		return $file;
+		$newname=$tmpDirNoClean.basename($filename);
+		if (rename($filename, $newname)) {
+			return $newname;
+		} else {
+			return false;
+		}
 	}
 
 	/**
@@ -597,7 +601,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * remove all files created by self::tmpFileNoClean
+	 * remove all files in PHP /oc-noclean temp dir 
 	 */
 	public static function cleanTmpNoClean() {
 		$tmpDirNoCleanFile=get_temp_dir().'/oc-noclean/';


### PR DESCRIPTION
With the current X-Sendfile implementation the following behavior might happen:
1. Download of zip file **A** from web interface is started
2. Before that zip generation is completed cron is run

This causes the deletion of **A** and therefore an error to the client (notice that this cannot happen during file download because the webserver keeps the file open and denies the removal).

This PR helps avoiding this behavior by moving the file to the _oc-noclean_ directory only when generation is completed. 

Note that this is not a final fix for the issue (the race condition is mitigated but not removed) since it might happen that cron is run right after zip creation but before that the response is actually sent by PHP. 

As of writing though I don't have a final fix since that would require some sort of callback on a completed download in order to perform the deletion of the temporary file only at that time (and avoid using cron altogether), but I don't think that this is possible due to the fact that the download is entirely managed by the webserver.
