### PR TITLE
Urlencode json parameters for ajax calls

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -7,8 +7,8 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
 // Get data
-$dir = stripslashes($_POST["dir"]);
-$files = isset($_POST["file"]) ? stripslashes($_POST["file"]) : stripslashes($_POST["files"]);
+$dir = stripslashes(urldecode($_POST["dir"]));
+$files = isset($_POST["file"]) ? stripslashes(urldecode($_POST["file"])) : stripslashes(urldecode($_POST["files"]));
 
 $files = json_decode($files);
 $filesWithError = '';

--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -30,8 +30,8 @@ $RUNTIME_APPTYPES=array('filesystem');
 // Check if we are a user
 OCP\User::checkLoggedIn();
 
-$files = $_GET["files"];
-$dir = $_GET["dir"];
+$files = urldecode($_GET["files"]);
+$dir = urldecode($_GET["dir"]);
 
 $files_list = json_decode($files);
 // in case we get only a single file

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -330,7 +330,7 @@ var FileList={
 
 		var fileNames = JSON.stringify(files);
 		$.post(OC.filePath('files', 'ajax', 'delete.php'),
-				{dir:$('#dir').val(),files:fileNames},
+				{dir:encodeURIComponent($('#dir').val()),files:encodeURIComponent(fileNames)},
 				function(result){
 					if (result.status == 'success') {
 						$.each(files,function(index,file){

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -228,7 +228,7 @@ $(document).ready(function() {
 		if ( (downloadURL = document.getElementById("downloadURL")) ) {
 			window.location=downloadURL.value+"&download&files="+files;
 		} else {
-			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
+			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: encodeURIComponent(dir), files: encodeURIComponent(fileslist) });
 		}
 		return false;
 	});

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -3,8 +3,8 @@
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
-$files = $_POST['files'];
-$dirlisting = $_POST['dirlisting'];
+$files = urldecode($_POST['files']);
+$dirlisting = urldecode($_POST['dirlisting']);
 $list = json_decode($files);
 
 $error = array();

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -3,8 +3,8 @@
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
-$files = $_POST['files'];
-$dirlisting = $_POST['dirlisting'];
+$files = urldecode($_POST['files']);
+$dirlisting = urldecode($_POST['dirlisting']);
 $list = json_decode($files);
 
 $error = array();

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 			var files = tr.attr('data-file');
 			undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
 			$.post(OC.filePath('files_trashbin','ajax','undelete.php'),
-				{files:JSON.stringify([files]), dirlisting:tr.attr('data-dirlisting') },
+				{files:encodeURIComponent(JSON.stringify([files])), dirlisting:encodeURIComponent((tr.attr('data-dirlisting')) },
 				function(result){
 					for (var i = 0; i < result.data.success.length; i++) {
 						var row = document.getElementById(result.data.success[i].filename);
@@ -36,7 +36,7 @@ $(document).ready(function() {
 			deleteAction[0].outerHTML = newHTML;
 
 			$.post(OC.filePath('files_trashbin','ajax','delete.php'),
-				{files:JSON.stringify([files]), dirlisting:tr.attr('data-dirlisting') },
+				{files:encodeURIComponent(JSON.stringify([files])), dirlisting:encodeURIComponent(tr.attr('data-dirlisting')) },
 				function(result){
 					for (var i = 0; i < result.data.success.length; i++) {
 						var row = document.getElementById(result.data.success[i].filename);
@@ -104,7 +104,7 @@ $(document).ready(function() {
 			}
 
 			$.post(OC.filePath('files_trashbin','ajax','undelete.php'),
-					{files:fileslist, dirlisting:dirlisting},
+					{files:encodeURIComponent(fileslist), dirlisting:encodeURIComponent(dirlisting)},
 					function(result){
 						for (var i = 0; i < result.data.success.length; i++) {
 							var row = document.getElementById(result.data.success[i].filename);
@@ -129,7 +129,7 @@ $(document).ready(function() {
 			}
 
 			$.post(OC.filePath('files_trashbin','ajax','delete.php'),
-					{files:fileslist, dirlisting:dirlisting},
+					{files:encodeURIComponent(fileslist), dirlisting:encodeURIComponent(dirlisting)},
 					function(result){
 						for (var i = 0; i < result.data.success.length; i++) {
 							var row = document.getElementById(result.data.success[i].filename);

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 			var files = tr.attr('data-file');
 			undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
 			$.post(OC.filePath('files_trashbin','ajax','undelete.php'),
-				{files:encodeURIComponent(JSON.stringify([files])), dirlisting:encodeURIComponent((tr.attr('data-dirlisting')) },
+				{files:encodeURIComponent(JSON.stringify([files])), dirlisting:encodeURIComponent(tr.attr('data-dirlisting')) },
 				function(result){
 					for (var i = 0; i < result.data.success.length; i++) {
 						var row = document.getElementById(result.data.success[i].filename);


### PR DESCRIPTION
The json encoded files list needs to be urlencoded/decode otherwise it can happen that the list is broken after the ajax call. I could never reproduce this on my system but thanks to  @mbiebl I could reproduce it on his server and also test the patch there.

More information about the issue: #2290 

cc @icewind1991 please have a look to my changes in the files app to make sure that I didn't miss anything.
