### PR TITLE
fix shared updated for rename action

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -66,8 +66,8 @@ class Shared_Updater {
 	 * @param array $params
 	 */
 	static public function renameHook($params) {
-		self::correctFolders($params['oldpath']);
 		self::correctFolders($params['newpath']);
+		self::correctFolders(pathinfo($params['oldpath'], PATHINFO_DIRNAME));
 	}
 
 	/**


### PR DESCRIPTION
the old path no longer exists after rename, update the parent folder instead.

cc @MTGap 
