### PR TITLE
Improve detection of installations errors

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -75,7 +75,13 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					element.data('active',true);
 					element.val(t('settings','Disable'));
 				}
-			},'json');
+			},'json')
+			.fail(function() { 
+				OC.dialogs.alert('Error while enabling app','Error');
+				element.data('active',false);
+				OC.Settings.Apps.removeNavigation(appid);
+				element.val(t('settings','Enable'));
+			});
 			$('#leftcontent li[data-id="'+appid+'"]').addClass('active');
 		}
 	},


### PR DESCRIPTION
When you install an app,
and smth fail because of a syntax error or smth,
owncloud does not provide feedback or message...

i've added a .fail to the ajax and i set back the button to active

may be up-ported to master
