### PR TITLE
Get the old etag from the properties table during filecache upgrade

### DIFF
--- a/lib/files/cache/legacy.php
+++ b/lib/files/cache/legacy.php
@@ -90,7 +90,7 @@ class Legacy {
 			$relativePath = '';
 		}
 		$query = \OC_DB::prepare('SELECT `propertyvalue` FROM `*PREFIX*properties` WHERE `userid` = ? AND propertypath = ? AND propertyname = "{DAV:}getetag"');
-		$result = $query->execute(array($user, $relativePath));
+		$result = $query->execute(array($user, '/' . $relativePath));
 		if ($row = $result->fetchRow()) {
 			return trim($row['propertyvalue'], '"');
 		} else {

--- a/lib/files/cache/upgrade.php
+++ b/lib/files/cache/upgrade.php
@@ -74,12 +74,12 @@ class Upgrade {
 	function insert($data) {
 		if (!$this->inCache($data['storage'], $data['path_hash'], $data['id'])) {
 			$insertQuery = \OC_DB::prepare('INSERT INTO `*PREFIX*filecache`
-					( `fileid`, `storage`, `path`, `path_hash`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted` )
-					VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+					( `fileid`, `storage`, `path`, `path_hash`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `etag` )
+					VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
 
 			$insertQuery->execute(array($data['id'], $data['storage'],
 				$data['path'], $data['path_hash'], $data['parent'], $data['name'],
-				$data['mimetype'], $data['mimepart'], $data['size'], $data['mtime'], $data['encrypted']));
+				$data['mimetype'], $data['mimepart'], $data['size'], $data['mtime'], $data['encrypted'], $data['etag']));
 		}
 	}
 
@@ -111,6 +111,7 @@ class Upgrade {
 		 */
 		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($data['path']);
 		if ($storage) {
+			$newData['etag'] = $data['etag'];
 			$newData['path_hash'] = md5($internalPath);
 			$newData['path'] = $internalPath;
 			$newData['storage'] = $this->getNumericId($storage);


### PR DESCRIPTION
This should fix the issue of creating a lot of conflict files after upgrading to 5.x

cc @karlitschek @dragotin @MTGap 
