### PR TITLE
listen to touch hook to update the mtime after sync

### DIFF
--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -115,6 +115,13 @@ class Updater {
 	/**
 	 * @param array $params
 	 */
+	static public function touchHook($params) {
+		self::writeUpdate($params['path']);
+	}
+
+	/**
+	 * @param array $params
+	 */
 	static public function renameHook($params) {
 		self::renameUpdate($params['oldpath'], $params['newpath']);
 	}

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -660,6 +660,7 @@ class Filesystem {
 }
 
 \OC_Hook::connect('OC_Filesystem', 'post_write', '\OC\Files\Cache\Updater', 'writeHook');
+\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
 \OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
 \OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');
 


### PR DESCRIPTION
If the file already exists the touch operation only emits a "touch" signal but no "write" signal. Therefore the file cache must listen to the touch signal in order to update the mtime set by the sync client.

cc @dragotin @icewind1991 
