### PR TITLE
prevent to fire delete ajax a second time.

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -233,7 +233,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('.delete').click(function(event) {
+	$('.delete-selected').click(function(event) {
 		var files=getSelectedFiles('name');
 		event.preventDefault();
 		FileList.do_delete(files);

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -84,13 +84,13 @@
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>
 <!-- 					NOTE: Temporary fix to allow unsharing of files in root of Shared folder -->
 					<?php if ($_['dir'] == '/Shared'): ?>
-						<span class="selectedActions"><a href="" class="delete">
+						<span class="selectedActions"><a href="" class="delete-selected">
 							<?php p($l->t('Unshare'))?>
 							<img class="svg" alt="<?php p($l->t('Unshare'))?>"
 								 src="<?php print_unescaped(OCP\image_path("core", "actions/delete.svg")); ?>" />
 						</a></span>
 					<?php else: ?>
-						<span class="selectedActions"><a href="" class="delete">
+						<span class="selectedActions"><a href="" class="delete-selected">
 							<?php p($l->t('Delete'))?>
 							<img class="svg" alt="<?php p($l->t('Delete'))?>"
 								 src="<?php print_unescaped(OCP\image_path("core", "actions/delete.svg")); ?>" />


### PR DESCRIPTION
Before the click on a single file delete icon fired two different handlers - one of them is for multiple deletion only

@schiesbn @Raydiation @butonic @karlitschek THX
