### PR TITLE
Fix instanceid format to prevent session loop

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -418,7 +418,8 @@ class OC_Util {
     public static function getInstanceId() {
         $id = OC_Config::getValue('instanceid', null);
         if(is_null($id)) {
-            $id = uniqid();
+            // We need to guarantee at least one letter in instanceid so it can be used as the session_name
+            $id = 'oc' . uniqid();
             OC_Config::setValue('instanceid', $id);
         }
         return $id;

--- a/lib/util.php
+++ b/lib/util.php
@@ -411,18 +411,18 @@ class OC_Util {
 		exit();
 	}
 
-	/**
-	 * get an id unqiue for this instance
-	 * @return string
-	 */
-	public static function getInstanceId() {
-		$id=OC_Config::getValue('instanceid', null);
-		if(is_null($id)) {
-			$id=uniqid();
-			OC_Config::setValue('instanceid', $id);
-		}
-		return $id;
-	}
+    /**
+     * get an id unique for this instance
+     * @return string
+     */
+    public static function getInstanceId() {
+        $id = OC_Config::getValue('instanceid', null);
+        if(is_null($id)) {
+            $id = uniqid();
+            OC_Config::setValue('instanceid', $id);
+        }
+        return $id;
+    }
 
 	/**
 	 * @brief Static lifespan (in seconds) when a request token expires.

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -54,4 +54,9 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('no-reply@example.com', $email);
 		OC_Config::deleteKey('mail_domain');
 	}
+
+  function testGetInstanceIdGeneratesValidId() {
+    OC_Config::deleteKey('instanceid');
+    $this->assertStringStartsWith('oc', OC_Util::getInstanceId());
+  }
 }


### PR DESCRIPTION
instanceid is generated by uniqid() and then used as the session_name. Because session_name requires at least one letter and uniqid() does not guarantee to provide that, in the case that uniqid() generates a string of only digits every request will generate a new PHP session. This will result in either:
a) the user never being able to log in
b) if the user checks "remember me," an infinite redirection loop

I ran into this on my first trial of ownCloud today, and it had me scratching my head for quite a while.
