### PR TITLE
Fix install app version check

### DIFF
--- a/lib/installer.php
+++ b/lib/installer.php
@@ -134,8 +134,10 @@ class OC_Installer{
 		}
 
 		// check if the app is compatible with this version of ownCloud
-		$version=OC_Util::getVersion();
-		if(!isset($info['require']) or ($version[0]>$info['require'])) {
+		if(
+            !isset($info['require'])
+            or !OC_App::isAppVersionCompatible(OC_Util::getVersion(), $info['require'])
+        ) {
 			OC_Log::write('core',
 				'App can\'t be installed because it is not compatible with this version of ownCloud',
 				OC_Log::ERROR);


### PR DESCRIPTION
The app/plugin installer (OC_Installer::installApp()) does incorrect version checking. It should be updated to use the new version check method.

```
It looks like this: https://github.com/owncloud/core/blob/master/lib/installer.php#L138
It should look like this: https://github.com/owncloud/core/blob/master/lib/app.php#L226

Someone mentioned this issue recently on the forums: http://forum.owncloud.org/viewtopic.php?t=9512&p=23701#p23701
```
