### PR TITLE
Fix part file ignoring

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -62,7 +62,7 @@ class Scanner {
 	 * @return array with metadata of the scanned file
 	 */
 	public function scanFile($file, $checkExisting = false) {
-		if (!$this->isIgnoredFile($file)) {
+		if (!self::isIgnoredFile($file)) {
 			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
 			$data = $this->getData($file);
 			if ($data) {
@@ -90,7 +90,6 @@ class Scanner {
 			}
 			return $data;
 		}
-		\OCP\Util::writeLog('scanner', 'Ignoring '.$file.' and not triggering scan_file hook.', \OCP\Util::DEBUG);
 		return null;
 	}
 
@@ -155,9 +154,7 @@ class Scanner {
 	 * @return boolean
 	 */
 	private function isIgnoredDir($dir) {
-		if ($dir === '.' || $dir === '..'
-			|| \OC\Files\Filesystem::isFileBlacklisted($file)
-		) {
+		if ($dir === '.' || $dir === '..') {
 			return true;
 		}
 		return false;
@@ -169,7 +166,7 @@ class Scanner {
 	 * @param String $file
 	 * @return boolean
 	 */
-	private function isIgnoredFile($file) {
+	public static function isIgnoredFile($file) {
 		if (pathinfo($file, PATHINFO_EXTENSION) === 'part'
 			|| \OC\Files\Filesystem::isFileBlacklisted($file)
 		) {

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -267,7 +267,7 @@ class View {
 				$path = $this->getRelativePath($absolutePath);
 				$exists = $this->file_exists($path);
 				$run = true;
-				if ($this->fakeRoot == Filesystem::getRoot()) {
+				if ($this->fakeRoot == Filesystem::getRoot() && ! Cache\Scanner::isIgnoredFile($path) ) {
 					if (!$exists) {
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
@@ -295,7 +295,7 @@ class View {
 					list ($count, $result) = \OC_Helper::streamCopy($data, $target);
 					fclose($target);
 					fclose($data);
-					if ($this->fakeRoot == Filesystem::getRoot()) {
+					if ($this->fakeRoot == Filesystem::getRoot() && ! Cache\Scanner::isIgnoredFile($path) ) {
 						if (!$exists) {
 							\OC_Hook::emit(
 								Filesystem::CLASSNAME,
@@ -627,7 +627,7 @@ class View {
 	private function runHooks($hooks, $path, $post = false) {
 		$prefix = ($post) ? 'post_' : '';
 		$run = true;
-		if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot()) {
+		if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot() && ! Cache\Scanner::isIgnoredFile($path) ) {
 			foreach ($hooks as $hook) {
 				if ($hook != 'read') {
 					\OC_Hook::emit(


### PR DESCRIPTION
This solves https://github.com/owncloud/mirall/issues/465 and in addition supresses post write hooks for ignored files (currently *.part and .htaccess by default)

.part files are completely ignored and never make it into the cache, as @dragotin suggested in https://github.com/owncloud/core/pull/2528 

@schiesbn please test, the PHP notice should no longer occur
@karlitschek @icewind1991 @MTGap please review.

I'll backport this to OC5 now
