### PR TITLE
Files External: show display names instead of internal user names in Set...

### DIFF
--- a/apps/files_external/settings.php
+++ b/apps/files_external/settings.php
@@ -32,6 +32,7 @@ $tmpl->assign('mounts', OC_Mount_Config::getSystemMountPoints());
 $tmpl->assign('backends', OC_Mount_Config::getBackends());
 $tmpl->assign('groups', OC_Group::getGroups());
 $tmpl->assign('users', OCP\User::getUsers());
+$tmpl->assign('userDisplayNames', OC_User::getDisplayNames());
 $tmpl->assign('dependencies', OC_Mount_Config::checkDependencies());
 $tmpl->assign('allowUserMounting', OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes'));
 return $tmpl->fetchPage();

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -102,7 +102,7 @@
 									<option value="<?php p($user); ?>"
 									<?php if (isset($mount['applicable']['users']) && in_array($user, $mount['applicable']['users'])): ?>
 											selected="selected"
-									<?php endif; ?>><?php p($user); ?></option>
+									<?php endif; ?>><?php p($_['userDisplayNames'][$user]); ?></option>
 								<?php endforeach; ?>
 								</optgroup>
 							</select>


### PR DESCRIPTION
...tings UI

Before: for LDAP Users only UUID was shown and searchable – not usable.
Now the Display Names are shown, internal names used internally of course.

Please review @icewind1991 @MTGap or others
