### PR TITLE
Use displayName in the From field of outbound email about new shares.

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -110,7 +110,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 
 			// send it out now
 			try {
-				OCP\Util::sendMail($to_address, $to_address, $subject, $text, $from_address, $user);
+				OCP\Util::sendMail($to_address, $to_address, $subject, $text, $from_address, $displayName);
 				OCP\JSON::success();
 			} catch (Exception $exception) {
 				OCP\JSON::error(array('data' => array('message' => OC_Util::sanitizeHTML($exception->getMessage()))));


### PR DESCRIPTION
This is important in the Active Directory case where users are
currently getting a GUID in the From field, making emails look quite a
lot like spam.

This patch released under the MIT license as requested.
