### PR TITLE
Log DB Queries

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -135,6 +135,10 @@ $CONFIG = array(
 /* Loglevel to start logging at. 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (default is WARN) */
 "loglevel" => "",
 
+/* Append All database query and parameters to the log file.
+ (whatch out, this option can increase the size of your log file)*/
+"log_query" => false,
+
 /* Lifetime of the remember login cookie, default is 15 days */
 "remember_login_cookie_lifetime" => 60*60*24*15,
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -159,6 +159,9 @@ class OC_Config{
 		if (defined('DEBUG') && DEBUG) {
 			$content .= "define('DEBUG',true);\n";
 		}
+		if (defined('LOG_QUERIES') && LOG_QUERIES) {
+			$content .= "define('LOG_QUERIES',true);\n";
+		}
 		$content .= "\$CONFIG = ";
 		$content .= var_export(self::$cache, true);
 		$content .= ";\n";

--- a/lib/config.php
+++ b/lib/config.php
@@ -159,9 +159,6 @@ class OC_Config{
 		if (defined('DEBUG') && DEBUG) {
 			$content .= "define('DEBUG',true);\n";
 		}
-		if (defined('LOG_QUERIES') && LOG_QUERIES) {
-			$content .= "define('LOG_QUERIES',true);\n";
-		}
 		$content .= "\$CONFIG = ";
 		$content .= var_export(self::$cache, true);
 		$content .= ";\n";

--- a/lib/db.php
+++ b/lib/db.php
@@ -367,7 +367,7 @@ class OC_DB {
 
 		// Optimize the query
 		$query = self::processQuery( $query );
-		if(defined('LOG_QUERIES') && LOG_QUERIES === true) {
+		if(OC_Config::getValue( "log_query", false)) {
 			OC_Log::write('core', 'DB prepare : '.$query, OC_Log::DEBUG);
 		}
 		self::connect();
@@ -954,7 +954,7 @@ class PDOStatementWrapper{
 	 * make execute return the result instead of a bool
 	 */
 	public function execute($input=array()) {
-		if(defined('LOG_QUERIES') && LOG_QUERIES === true) {
+		if(OC_Config::getValue( "log_query", false)) {
 			$params_str = str_replace("\n"," ",var_export($input,true));
 			OC_Log::write('core', 'DB execute with arguments : '.$params_str, OC_Log::DEBUG);
 		}

--- a/lib/db.php
+++ b/lib/db.php
@@ -367,7 +367,9 @@ class OC_DB {
 
 		// Optimize the query
 		$query = self::processQuery( $query );
-
+		if(defined('LOG_QUERIES') && LOG_QUERIES === true) {
+			OC_Log::write('core', 'DB prepare : '.$query, OC_Log::DEBUG);
+		}
 		self::connect();
 		// return the result
 		if(self::$backend==self::BACKEND_MDB2) {
@@ -952,6 +954,10 @@ class PDOStatementWrapper{
 	 * make execute return the result instead of a bool
 	 */
 	public function execute($input=array()) {
+		if(defined('LOG_QUERIES') && LOG_QUERIES === true) {
+			$params_str = str_replace("\n"," ",var_export($input,true));
+			OC_Log::write('core', 'DB execute with arguments : '.$params_str, OC_Log::DEBUG);
+		}
 		$this->lastArguments = $input;
 		if (count($input) > 0) {
 


### PR DESCRIPTION
Hi everybody :)

This PR add query logging for OC .

 Why doing Query logging?
Sometime it's hard to discover why a problem happend. In OC, we log some things but often not enough to discover the problem.
In sqlite for example it's hard to tell what was executed
or in a mutulized host, you often don't have access to db logs (as i have on my host).
So for an easy debug i add query and param logging :)

The idea is not to have this always enable as it can be really verbose and can make bigger problem harder to see.

I used a flag as suggested by @tanghus as we don't want to have that enable by default in a production environment ...

What do you guys think?
