### PR TITLE
Add (two) missing backticks.

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -37,8 +37,8 @@ if (OC::checkUpgrade(false)) {
  */
 function __doFileCacheUpgrade($watcher) {
 	$query = \OC_DB::prepare('
-		SELECT DISTINCT user
-		FROM`*PREFIX*fscache`
+		SELECT DISTINCT `user`
+		FROM `*PREFIX*fscache`
 	');
 	$result = $query->execute();
 	$users = $result->fetchAll();


### PR DESCRIPTION
Especially at user without "" PostgreSQL likes to fail sometimes …

Copyrightwise this is under MIT.
