### PR TITLE
Expand Logwriter for additional logfiles used, managed as parameter from the caller

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -137,7 +137,12 @@ $CONFIG = array(
 
 /* Append All database query and parameters to the log file.
  (whatch out, this option can increase the size of your log file)*/
-"log_query" => false,
+"log_sql_query" => false,
+
+/* Filename only. If set, Owncloud database queries will be written to this filename and 
+  not to the standard log. The file will be written to the datadirectory or the path part
+  of "logfile" if it exists. No writing to Syslog. */
+"log_sql_file" => "",
 
 /* Lifetime of the remember login cookie, default is 15 days */
 "remember_login_cookie_lifetime" => 60*60*24*15,

--- a/lib/db.php
+++ b/lib/db.php
@@ -367,8 +367,9 @@ class OC_DB {
 
 		// Optimize the query
 		$query = self::processQuery( $query );
-		if(OC_Config::getValue( "log_query", false)) {
-			OC_Log::write('core', 'DB prepare : '.$query, OC_Log::DEBUG);
+		if(OC_Config::getValue( "log_sql_query", false)) {
+			// handover the key ("log_sql_file") parameter set in config.php or NULL
+			OC_Log::write('core', 'DB prepare : '.$query, OC_Log::DEBUG, OC_Config::getValue("log_sql_file"));
 		}
 		self::connect();
 		// return the result
@@ -954,9 +955,10 @@ class PDOStatementWrapper{
 	 * make execute return the result instead of a bool
 	 */
 	public function execute($input=array()) {
-		if(OC_Config::getValue( "log_query", false)) {
+		if(OC_Config::getValue( "log_sql_query", false)) {
 			$params_str = str_replace("\n"," ",var_export($input,true));
-			OC_Log::write('core', 'DB execute with arguments : '.$params_str, OC_Log::DEBUG);
+			// handover the key ("log_sql_file") parameter set in config.php or NULL
+			OC_Log::write('core', 'DB execute with arguments : '.$params_str, OC_Log::DEBUG, OC_Config::getValue("log_sql_file"));
 		}
 		$this->lastArguments = $input;
 		if (count($input) > 0) {

--- a/lib/log.php
+++ b/lib/log.php
@@ -27,16 +27,20 @@ class OC_Log {
 	 * write a message in the log
 	 * @param string $app
 	 * @param string $message
-	 * @param int level
+	 * @param int $level
+	 * @param string $special_log_file
+	 *   $special_log_file contains the variable set in config.php writing the log message to. 
+	 *   If null (not present), it will be rerouted to standard write.
+	 *   eg: OC_Config::getValue("log_sql_file") returns either null or the filename used as parameter
 	 */
-	public static function write($app, $message, $level) {
+	public static function write($app, $message, $level, $special_log_file = null) {
 		if (self::$enabled) {
 			if (!self::$class) {
 				self::$class = 'OC_Log_'.ucfirst(OC_Config::getValue('log_type', 'owncloud'));
 				call_user_func(array(self::$class, 'init'));
 			}
 			$log_class=self::$class;
-			$log_class::write($app, $message, $level);
+			$log_class::write($app, $message, $level, $special_log_file);
 		}
 	}
 

--- a/lib/log/owncloud.php
+++ b/lib/log/owncloud.php
@@ -27,30 +27,73 @@
  */
 
 class OC_Log_Owncloud {
-	static protected $logFile;
+	static protected $oC_logFile;
+	static protected $defaultLogPath;
 
 	/**
-	 * Init class data
+	 * Init class data for standard owncloud logging
 	 */
 	public static function init() {
-		$defaultLogFile = OC_Config::getValue("datadirectory", OC::$SERVERROOT.'/data').'/owncloud.log';
-		self::$logFile = OC_Config::getValue("logfile", $defaultLogFile);
-		if (!file_exists(self::$logFile)) {
-			self::$logFile = $defaultLogFile;
+		// set default log path
+		$defaultLogPath = OC_Config::getValue("datadirectory", OC::$SERVERROOT.'/data');
+
+		// try to get file and path from logfile parameter in config.php and separate it
+		$set_logfile = OC_Config::getValue("logfile");
+		if (!is_null($set_logfile)) {
+			$path_parts = pathinfo($set_logfile);
+			$log_path = $path_parts['dirname'];
+			$log_file = $path_parts['basename'];
 		}
+                // check if path exists in logfile parameter and use default if not
+                // was there no path set, php returns a dot, but it is filled
+                if(strlen($log_path) == 1) {
+                        // no path set, use default
+                        self::$defaultLogPath = $defaultLogPath;
+                  }
+                  elseif(!is_writable($log_path)) {
+                        // path set but not write accessible, use default
+                        $error_handler = 1;
+                        self::$defaultLogPath = $defaultLogPath;
+                  }
+                  else {
+                        // path set and accessible, use path set
+                        self::$defaultLogPath = $log_path;
+                }
+                if (strlen($log_file) == 0) {
+                        // no non-standard logfile set, use standard
+                        self::$oC_logFile = '/owncloud.log';
+                  }
+                  else {
+                        // no non-standard logfile set and accessible, use it
+                        self::$oC_logFile = '/'.$log_file;
+                }
+
+                // try to log write attempt of special log path set in config.php
+                if ($error_handler == 1) {
+                        self::write('core', 'Cannot write to log path (' . $log_path . ') using default (' . self::$defaultLogPath . ')', OC_Log::WARN);
+                }
 	}
 
 	/**
 	 * write a message in the log
 	 * @param string $app
 	 * @param string $message
-	 * @param int level
+	 * @param int $level
+	 * @param String $special_log_file
+	 *  special_log_file can either be a real filename as parameter or NULL.
+	 *  the complete path.file is generated on the parameter given
 	 */
-	public static function write($app, $message, $level) {
+	public static function write($app, $message, $level, $special_log_file = NULL) {
 		$minLevel=min(OC_Config::getValue( "loglevel", OC_Log::WARN ), OC_Log::ERROR);
-		if($level>=$minLevel) {
+        // either you reach the minimum log level needed or the special_log_file has a value
+        if($level>=$minLevel or !is_null($special_log_file)) {
 			$entry=array('app'=>$app, 'message'=>$message, 'level'=>$level, 'time'=>time());
-			$handle = @fopen(self::$logFile, 'a');
+			if (is_null($special_log_file)) {
+				$handle = @fopen(self::$defaultLogPath.self::$oC_logFile, 'a');
+			}
+			else {
+				$handle = @fopen(self::$defaultLogPath.'/'.$special_log_file, 'a');
+			}			
 			if ($handle) {
 				fwrite($handle, json_encode($entry)."\n");
 				fclose($handle);
@@ -68,7 +111,7 @@ class OC_Log_Owncloud {
 		self::init();
 		$minLevel=OC_Config::getValue( "loglevel", OC_Log::WARN );
 		$entries = array();
-		$handle = @fopen(self::$logFile, 'rb');
+		$handle = @fopen(self::$defaultLogPath.self::$oC_logFile, 'rb');
 		if ($handle) {
 			fseek($handle, 0, SEEK_END);
 			$pos = ftell($handle);

--- a/lib/log/owncloud.php
+++ b/lib/log/owncloud.php
@@ -44,34 +44,34 @@ class OC_Log_Owncloud {
 			$log_path = $path_parts['dirname'];
 			$log_file = $path_parts['basename'];
 		}
-                // check if path exists in logfile parameter and use default if not
-                // was there no path set, php returns a dot, but it is filled
-                if(strlen($log_path) == 1) {
-                        // no path set, use default
-                        self::$defaultLogPath = $defaultLogPath;
-                  }
-                  elseif(!is_writable($log_path)) {
-                        // path set but not write accessible, use default
-                        $error_handler = 1;
-                        self::$defaultLogPath = $defaultLogPath;
-                  }
-                  else {
-                        // path set and accessible, use path set
-                        self::$defaultLogPath = $log_path;
-                }
-                if (strlen($log_file) == 0) {
-                        // no non-standard logfile set, use standard
-                        self::$oC_logFile = '/owncloud.log';
-                  }
-                  else {
-                        // no non-standard logfile set and accessible, use it
-                        self::$oC_logFile = '/'.$log_file;
-                }
+				// check if path exists in logfile parameter and use default if not
+				// was there no path set, php returns a dot, but it is filled
+				if(strlen($log_path) === 1) {
+						// no path set, use default
+						self::$defaultLogPath = $defaultLogPath;
+					}
+					elseif(!is_writable($log_path)) {
+						// path set but not write accessible, use default
+						$error_handler = 1;
+						self::$defaultLogPath = $defaultLogPath;
+					}
+					else {
+						// path set and accessible, use path set
+						self::$defaultLogPath = $log_path;
+				}
+				if (strlen($log_file) === 0) {
+						// no non-standard logfile set, use standard
+						self::$oC_logFile = '/owncloud.log';
+					}
+					else {
+						// no non-standard logfile set and accessible, use it
+						self::$oC_logFile = '/'.$log_file;
+				}
 
-                // try to log write attempt of special log path set in config.php
-                if ($error_handler == 1) {
-                        self::write('core', 'Cannot write to log path (' . $log_path . ') using default (' . self::$defaultLogPath . ')', OC_Log::WARN);
-                }
+				// try to log write attempt of special log path set in config.php
+				if ($error_handler === 1) {
+						self::write('core', 'Cannot write to log path (' . $log_path . ') using default (' . self::$defaultLogPath . ')', OC_Log::WARN);
+				}
 	}
 
 	/**
@@ -85,8 +85,8 @@ class OC_Log_Owncloud {
 	 */
 	public static function write($app, $message, $level, $special_log_file = NULL) {
 		$minLevel=min(OC_Config::getValue( "loglevel", OC_Log::WARN ), OC_Log::ERROR);
-        // either you reach the minimum log level needed or the special_log_file has a value
-        if($level>=$minLevel or !is_null($special_log_file)) {
+		// either you reach the minimum log level needed or the special_log_file has a value
+		if($level>=$minLevel or !is_null($special_log_file)) {
 			$entry=array('app'=>$app, 'message'=>$message, 'level'=>$level, 'time'=>time());
 			if (is_null($special_log_file)) {
 				$handle = @fopen(self::$defaultLogPath.self::$oC_logFile, 'a');


### PR DESCRIPTION
This is a extension of merger # 2620 (Log DB Queries) from eMerzh.

The basic idea behind is, that someone wants to write additional log information, but not into the main log. Thanks to @tanghus who encouraged me writing this code. I apologise in advance if I made something wrong.

What has been changed:

1.) you can create in config.php additional parameters, as best in pairs, so that coding could hook on. The first parameter is used to check if a special log needs to be written (true/false), the second parameter is used to define the log file name. Therefore I have renamed the original first parameter name defined by eMerzh from log_query to log_sql_query to be specific. The second parameter is new and called in this case log_sql_file. You can see the description in config\config.sample.php. Creating new parameter sets is logical and easy and I could think about log_music_query and log_music_file, but this is just an idea...

2.) I enhanced the calls from eMerzh in lib\db.php with a parameter, eg:
OC_Log::write('core', 'DB prepare : '.$query, OC_Log::DEBUG, OC_Config::getValue("log_sql_file"));
where the last parameter is optional and is in case it is used the log filename the logger writes to.
On the example given you can see, that it is not breaking existing calls, but you can now make calls where you can decide if the log entry is written to a separate logfile not filling up the main oC log.

3.) of course lib\log.php needed a upgrade to manage existing calls and a new call style with the additional logfile name as parameter.

4.) most critical was lib\log\owncloud.php because we need to manage different cases. What I have done there is, that I separated the log path from the log filename. This because, we always write to the log path but maybe to a different log file. Of course we have to manage various szenarios where paths are valid and writable. If not, I write a warning message to the default log path/name. BTW I have seen, that in the original code the config parameter "logfile" was at least not clear to me (but I may be wrong with my view), because I interpreted it as path+file because of the code (if (!file_exists(self::$logFile)) which needs a path to have a proper result. I have here set following definition on config.logfile. If a path is present, use it as alternative logging path, if only a filename is set use the default path and the filename given.

There is one restriction, we do not write into syslog, owncloud log only.

We can now use standard logging and enhanced (special) logging. The call format for special logging is:
    standard:   OC_Log::write($app, $message, $level);
    special:    OC_Log::write($app, $message, $level, OC_Config::getValue("config-parameter"));
where config-parameter is the config name used for the <filename> definition

I have tested this in all combinations and it works well, but I please you to do additional checking and review.

Best Regards
Martin

BTW: the idea some weeks ago posted to have split config files is getting more and more attractive...
