### PR TITLE
Prettier alternative login buttons

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -237,8 +237,8 @@ fieldset.warning a { color:#b94a48 !important; font-weight:bold; }
 
 /* Alternative Logins */
 #alternative-logins legend { margin-bottom:10px; }
-#alternative-logins li { height:40px; display:inline-block; white-space:nowrap; }
-
+#alternative-logins li { height:40px; display:block; white-space:nowrap; }
+#alternative-logins a.button { display:block; left:0; right:0; text-align:center; }
 
 /* NAVIGATION ------------------------------------------------------------- */
 #navigation {


### PR DESCRIPTION
I have made some small css changes that increase the width of the alternative login buttons to 100% (minus margins) and centres the button text.

before:
![before](https://f.cloud.github.com/assets/1328243/333553/f20dc6c8-9c59-11e2-9a89-6a2ce4d77f5e.png)

after:
![after](https://f.cloud.github.com/assets/1328243/333554/f69dd1ba-9c59-11e2-8ddb-faf6afef3fbd.png)

I have tested this only with Firefox 19.0.2 and Chrome 26.0 on Ubuntu 12.04, but it should work with all browser versions that aren't completely outdated.

Do I really have to sign the contributor agreement, before you pull these changes?
