### PR TITLE
Fix #2657

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -182,7 +182,7 @@ class Shared_Cache extends Cache {
 	 */
 	public function move($source, $target) {
 		if ($cache = $this->getSourceCache($source)) {
-			$targetPath = \OC_Share_Backend_File::getSourcePath(dirname($target));
+			$targetPath = \OC_Share_Backend_File::getSource(dirname($target));
 			if ($targetPath) {
 				$targetPath .= '/' . basename($target);
 				$cache->move($this->files[$source], $targetPath);


### PR DESCRIPTION
Should fix #2657

Testing would be noice~

Also getSourcePath($path) is scattered all over apps/files_sharing/lib/sharedstorage.php which will probably complain as well about missing functions, should I fix these too?

Released under MIT-License
