### PR TITLE
Fix #2693

### DIFF
--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -218,8 +218,8 @@ var UserList = {
 							group: group
 						},
 						function (response) {
-							if(response.status === 'success' && response.data.action === 'add') {
-								if(UserList.availableGroups.indexOf(response.data.gropname) === -1) {
+							if(response.status === 'success') {
+								if(UserList.availableGroups.indexOf(response.data.gropname) === -1 && response.data.action === 'add') {
 									UserList.availableGroups.push(response.data.gropname);
 								}
 							} else {

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -219,8 +219,8 @@ var UserList = {
 						},
 						function (response) {
 							if(response.status === 'success') {
-								if(UserList.availableGroups.indexOf(response.data.gropname) === -1 && response.data.action === 'add') {
-									UserList.availableGroups.push(response.data.gropname);
+								if(UserList.availableGroups.indexOf(response.data.groupname) === -1 && response.data.action === 'add') {
+									UserList.availableGroups.push(response.data.groupname);
 								}
 							} else {
 								OC.Notification.show(response.data.message);


### PR DESCRIPTION
When removing a group response.data.action becomes 'remove', thus the if
shows an empty notification.

I also like the following line:

```
UserList.availableGroups.push(response.data.gropname);
```

Guess that should be groupname?

Released under MIT-License
