### PR TITLE
Add OC\VObject\StringProperty. Partial fix for owncloud/apps#762

### DIFF
--- a/lib/vobject/stringproperty.php
+++ b/lib/vobject/stringproperty.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * ownCloud - VObject String Property
+ *
+ * This class adds escaping of simple string properties.
+ *
+ * @author Thomas Tanghus
+ * @author Evert Pot (http://www.rooftopsolutions.nl/)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\VObject;
+
+/**
+ * This class overrides \Sabre\VObject\Property::serialize() properly
+ * escape commas and semi-colons in string properties.
+*/
+class StringProperty extends \Sabre\VObject\Property {
+
+	/**
+	* Turns the object back into a serialized blob.
+	*
+	* @return string
+	*/
+	public function serialize() {
+
+		$str = $this->name;
+		if ($this->group) {
+			$str = $this->group . '.' . $this->name;
+		}
+
+		foreach($this->parameters as $param) {
+			$str.=';' . $param->serialize();
+		}
+
+		$src = array(
+			'\\',
+			"\n",
+			';',
+			',',
+		);
+		$out = array(
+			'\\\\',
+			'\n',
+			'\;',
+			'\,',
+		);
+		$value = strtr($this->value, array('\,' => ',', '\;' => ';', '\\\\' => '\\'));
+		$str.=':' . str_replace($src, $out, $value);
+
+		$out = '';
+		while(strlen($str) > 0) {
+			if (strlen($str) > 75) {
+				$out .= mb_strcut($str, 0, 75, 'utf-8') . "\r\n";
+				$str = ' ' . mb_strcut($str, 75, strlen($str), 'utf-8');
+			} else {
+				$out .= $str . "\r\n";
+				$str = '';
+				break;
+			}
+		}
+
+		return $out;
+
+	}
+
+}

--- a/tests/lib/vobject.php
+++ b/tests/lib/vobject.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Tanghus (thomas@tanghus.net)
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+class Test_VObject extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+		Sabre\VObject\Property::$classMap['SUMMARY'] = 'OC\VObject\StringProperty';
+	}
+
+	function testStringProperty() {
+		$property = Sabre\VObject\Property::create('SUMMARY', 'Escape;this,please');
+		$this->assertEquals("SUMMARY:Escape\;this\,please\r\n", $property->serialize());
+	}
+}


### PR DESCRIPTION
This fixes a flaw in Sabre\VObject\Property where you couldn't escape commas and semi-colons in properties as required by the rfc, because the serializer would then double escape it.
As VObject doesn't (yet) have a deserialize() method, it is up to the implementer to to unescape using somthing like `$value = strtr($property->value, array('\,' => ',', '\;' => ';', '\\\\' => '\\'));`

Edit: Or we could patch OC_VObject::getAsString() to do this.

To enable this for an app, add the properties you want to use this class to Sabre\VObject\Property::$classMap in appinfo/app.php e.g.:

```
Sabre\VObject\Property::$classMap['SUMMARY'] = 'OC\VObject\StringProperty';
Sabre\VObject\Property::$classMap['DESCRIPTION'] = 'OC\VObject\StringProperty';
```

@bartv2 @georgehrke 

Refs owncloud/apps#762
