### PR TITLE
fixes #2743 - use public OC_User::getDisplayName instead of OC_User::det...

### DIFF
--- a/settings/ajax/userlist.php
+++ b/settings/ajax/userlist.php
@@ -44,7 +44,7 @@ if (OC_User::isAdminUser(OC_User::getUser())) {
 	foreach ($batch as $user) {
 		$users[] = array(
 			'name' => $user,
-			'displayname' => OC_User::determineDisplayName($user),
+			'displayname' => OC_User::getDisplayName($user),
 			'groups' => join(', ', OC_Group::getUserGroups($user)),
 			'quota' => OC_Preferences::getValue($user, 'files', 'quota', 'default'));
 	}


### PR DESCRIPTION
fixes #2743 - use public OC_User::getDisplayName instead of OC_User::determineDisplayName

@schiesbn @blizzz @Raydiation @icewind1991 @karlitschek THX
