### PR TITLE
check if the parent folder is updatable instead of the file

### DIFF
--- a/lib/files/storage/local.php
+++ b/lib/files/storage/local.php
@@ -95,7 +95,7 @@ class Local extends \OC\Files\Storage\Common{
 		// sets the modification time of the file to the given value.
 		// If mtime is nil the current time is set.
 		// note that the access time of the file always changes to the current time.
-		if(!$this->isUpdatable($path)) {
+		if ( !$this->isUpdatable(dirname($path)) ) {
 			return false;
 		}
 		if(!is_null($mtime)) {


### PR DESCRIPTION
check if the parent folder is updatable instead of the file because touch() is also used to create new empty files.

Fix broken "create new file" operation.

cc @DeepDiver1975 This works for new files creation and should still solve issue #2792 
