### PR TITLE
Add span tag while enabling or disbling apps as well.

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -142,7 +142,9 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						li.attr('data-id', entry.id);
 						var img= $('<img class="icon"/>').attr({ src: entry.icon});
 						var a=$('<a></a>').attr('href', entry.href);
-						a.text(entry.name);
+						var filename=$('<span></span>')
+						filename.text(entry.name);
+						a.prepend(filename);
 						a.prepend(img);
 						li.append(a);
 						container.append(li);


### PR DESCRIPTION
I had made a PR : https://github.com/owncloud/core/pull/2853 which added a span element inside the a tag. This PR adds the same span element while the app is being enabled to prevent style errors. Please check : @Raydiation @tanghus @jancborchardt. 

Also, we need to backport this as the commits of my previous PR were also back-ported.

Thanks
