### PR TITLE
add .disabled class so it can be used for simple a buttons as well

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -98,7 +98,8 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 /* disabled input fields and buttons */
 input:disabled, input:disabled:hover, input:disabled:focus,
 button:disabled, button:disabled:hover, button:disabled:focus,
-.button:disabled, .button:disabled:hover, .button:disabled:focus {
+.button:disabled, .button:disabled:hover, .button:disabled:focus,
+a.disabled, a.disabled:hover, a.disabled:focus {
 	background: rgba(230,230,230,.9);
 	color: #999;
 	cursor: default;


### PR DESCRIPTION
ref #2576 
@DeepDiver1975 this will make the new and upload buttons work with disabled styles, you just need to give them class="disabled" – can you update that part with https://github.com/owncloud/core/pull/2576#issuecomment-16064656 ? We also need to backport both this and that then.

Review please @Raydiation.
