### PR TITLE
Fix textfield label overlapping value.

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -162,7 +162,7 @@
 		<p class="infield groupbottom">
 			<label for="dbhost" class="infield" id="dbhostlabel"><?php p($l->t( 'Database host' )); ?></label>
 			<input type="text" name="dbhost" id="dbhost" placeholder=""
-				value="<?php p(OC_Helper::init_var('dbhost', 'localhost')); ?>" />
+				value="<?php p(OC_Helper::init_var('dbhost')); ?>" />
 		</p>
 	</fieldset>
 

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -61,7 +61,7 @@ class OC_Setup {
 				$error[] = $l->t("%s you may not use dots in the database name", array($dbprettyname));
 			}
 			if($dbtype != 'oci' && empty($options['dbhost'])) {
-				$error[] = $l->t("%s set the database host.", array($dbprettyname));
+				$options['dbhost'] = 'localhost';
 			}
 		}
 


### PR DESCRIPTION
Fix this:
![Screenshot345](https://f.cloud.github.com/assets/1410802/376496/5e1f5750-a439-11e2-93eb-bf039d55598b.png)

Not the best way, but certainly a way. Other text-values do this as well …

cc @jancborchardt @raghunayyar @Raydiation
