### PR TITLE
Handle empty datafolder better.

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -63,6 +63,7 @@
 		<div id="datadirContent">
 			<label for="directory"><?php p($l->t( 'Data folder' )); ?></label>
 			<input type="text" name="directory" id="directory"
+				placeholder="<?php p(OC_Helper::init_var('directory', $_['directory'])); ?>"
 				value="<?php p(OC_Helper::init_var('directory', $_['directory'])); ?>" />
 		</div>
 	</fieldset>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -63,7 +63,7 @@
 		<div id="datadirContent">
 			<label for="directory"><?php p($l->t( 'Data folder' )); ?></label>
 			<input type="text" name="directory" id="directory"
-				placeholder="<?php p(OC_Helper::init_var('directory', $_['directory'])); ?>"
+				placeholder="<?php p(OC::$SERVERROOT."/data"); ?>"
 				value="<?php p(OC_Helper::init_var('directory', $_['directory'])); ?>" />
 		</div>
 	</fieldset>

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -37,7 +37,7 @@ class OC_Setup {
 			$error[] = $l->t('Set an admin password.');
 		}
 		if(empty($options['directory'])) {
-			$error[] = $l->t('Specify a data folder.');
+			$options['directory'] = OC::$SERVERROOT."/data";
 		}
 
 		if($dbtype == 'mysql' or $dbtype == 'pgsql' or $dbtype == 'oci' or $dbtype == 'mssql') { //mysql and postgresql needs more config options


### PR DESCRIPTION
If datafolder is erased, the default value will be shown as a placeholder.

If installation is submitted without a datafolder the default value will be used.
#852

@jancborchardt
