### PR TITLE
write a info message to the log if a file gets removed from the trash bin automatically

### DIFF
--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -2,7 +2,20 @@
 <info>
 	<id>files_trashbin</id>
 	<name>Deleted files</name>
-	<description>Keep a copy of deleted files so that they can be restored if needed</description>
+	<description>
+	ownCloud keeps a copy of your deleted files in case you need them again. 
+	To make sure that the user doesn't run out of memory the deleted files app
+	manages the size of the deleted files for the user. By default deleted files
+	stay in the trash bin for 180 days. ownCloud checks the age of the files
+	every time a new files gets moved to the deleted files and remove all files
+	older than 180 days. The user can adjust this value in the config.php by
+	setting the "trashbin_retention_obligation" value.
+
+	Beside that the delted files app take care to never use more that 50% of
+	your currently available free space. If your deleted files exceed this limit
+	ownCloud deletes the oldest versions until it meets the memory usage limit
+	again.
+	</description>
 	<licence>AGPL</licence>
 	<author>Bjoern Schiessle</author>
 	<shipped>true</shipped>

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -375,6 +375,7 @@ class Trashbin {
 			$filename = $r['id'];
 			if ( $r['timestamp'] < $limit ) {
 				$size += self::delete($filename, $timestamp);
+				\OC_Log::write('files_trashbin', 'remove "'.$filename.'" fom trash bin because it is older than '.$retention_obligation, \OC_log::INFO);
 			}
 		}
 		$availableSpace = $availableSpace + $size;
@@ -387,6 +388,7 @@ class Trashbin {
 			$i = 0;
 			while ( $i < $length &&   $availableSpace < 0 ) {
 				$tmp = self::delete($result[$i]['id'], $result[$i]['timestamp']);
+				\OC_Log::write('files_trashbin', 'remove "'.$result[$i]['id'].'" ('.$tmp.'B) to meet the limit of trash bin size (50% of available quota)', \OC_log::INFO);
 				$availableSpace += $tmp;
 				$size += $tmp;
 				$i++;

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -6,7 +6,25 @@
 	<author>Frank Karlitschek</author>
 	<require>4.93</require>
 	<shipped>true</shipped>
-	<description>Versioning of files</description>
+	<description>
+	ownCloud supports simple version control for files.	The versioning app
+	expires old versions automatically to make sure that
+	the user doesn't run out of space. Following pattern is used to delete
+	old versions:
+	For the first 10 seconds ownCloud keeps one version every 2 seconds;
+	For the first hour ownCloud keeps one version every minute;
+	For the first 24 hours ownCloud keeps one version every hour;
+	For the first 30 days ownCloud keeps one version every day;
+	After the first 30 days ownCloud keeps one version every week.
+
+	The versions are adjusted along this pattern every time a new version gets
+	created.
+
+	Beside that the version app takes care to never use more that 50% of the users
+	currently available free space. If the stored versions exceed this limit
+	ownCloud deletes the oldest versions until it meets the memory usage limit
+	again.
+	</description>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
From time to time we get complains that a file doesn't end up in the trash bin. Often this happens because the file is to large for the users quota (the trash bin doesn't use more than 50% of the currently available free space). In this case the expire() function removes the file from the trash bin again.

To make this more transparent for the user this patch writes a Info to the log file every time a file gets expired. Additionally it adds a short explanation of the expire function to the app description of the deleted files app and the versioning app. 
