### PR TITLE
always connect file cache updater hooks first

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -12,3 +12,10 @@ OCP\App::addNavigationEntry( array( "id" => "files_index",
 									"name" => $l->t("Files") ));
 
 OC_Search::registerProvider('OC_Search_Provider_File');
+
+// cache hooks must be connected before all other apps.
+// since 'files' is always loaded first the hooks need to be connected here
+\OC_Hook::connect('OC_Filesystem', 'post_write', '\OC\Files\Cache\Updater', 'writeHook');
+\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
+\OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
+\OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -665,9 +665,4 @@ class Filesystem {
 	}
 }
 
-\OC_Hook::connect('OC_Filesystem', 'post_write', '\OC\Files\Cache\Updater', 'writeHook');
-\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
-\OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
-\OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');
-
 \OC_Util::setupFS();


### PR DESCRIPTION
Debugging issue #2170 I saw that the signals for post rename would first go to the files_sharing updater and then to the files_cache updater. As it turns out `self::$registered[$signalclass][$signalname]` in OC_Hook obviously shows the updaters in the wrong order.

Since the files app is hardcoded to always be the first app, this PR causes the cache updater to be connected before the files_sharing updater. This definitely fixes #2866 and should also fix #2170 

@icewind1991 I think moving the hook connects to the app.php is the right way to force the file cache to always be updated first. Please correct me if I am wrong.

@MTGap please try this PR to see if it fixes the rename issues.

@Raydiation @schiesbn does this help with your trashbin problems?
