### PR TITLE
Improved free space calculation for trash and versions

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -378,12 +378,14 @@ class Storage {
 			$versions_fileview = new \OC\Files\View('/'.$uid.'/files_versions');
 
 			// get available disk space for user
+			$softQuota = true;
 			$quota = \OC_Preferences::getValue($uid, 'files', 'quota');
 			if ( $quota === null || $quota === 'default') {
 				$quota = \OC_Appconfig::getValue('files', 'default_quota');
 			}
 			if ( $quota === null || $quota === 'none' ) {
-				$quota = \OC\Files\Filesystem::free_space('/') / count(\OCP\User::getUsers());
+				$quota = \OC\Files\Filesystem::free_space('/');
+				$softQuota = false;
 			} else {
 				$quota = \OCP\Util::computerFileSize($quota);
 			}
@@ -397,14 +399,20 @@ class Storage {
 			}
 
 			// calculate available space for version history
-			$files_view = new \OC\Files\View('/'.$uid.'/files');
-			$rootInfo = $files_view->getFileInfo('/');
-			$free = $quota-$rootInfo['size']; // remaining free space for user
-			if ( $free > 0 ) {
-				$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
+			// subtract size of files and current versions size from quota
+			if ($softQuota) {
+				$files_view = new \OC\Files\View('/'.$uid.'/files');
+				$rootInfo = $files_view->getFileInfo('/');
+				$free = $quota-$rootInfo['size']; // remaining free space for user
+				if ( $free > 0 ) {
+					$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
+				} else {
+					$availableSpace = $free-$versionsSize;
+				}
 			} else {
-				$availableSpace = $free-$versionsSize;
+				$availableSpace = $quota;
 			}
+
 
 			// after every 1000s run reduce the number of all versions not only for the current file
 			$random = rand(0, 1000);


### PR DESCRIPTION
This was discussed in #2936. Please also see this issue for detailed explanation.

Basically if no quota is set we call free_space() whichalready takes all used disk space into account. No need to subtract it again. Further, don't divide the free space by the number of users. If no quota is set every user is free to use as much space as he wants.
