### PR TITLE
Modified how the #lostpassword or #email fields save email addresses on ...

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -8,12 +8,10 @@
  * Post the email address change to the server.
  */
 function changeEmailAddress(){
-    emailInfo = $('#lostpassword #email');
-    console.log("Timout done.");
+    emailInfo = $('#email');
     if (emailInfo.val() === emailInfo.defaultValue){
         return;
     }
-    //event.preventDefault();
     emailInfo.defaultValue = emailInfo.val();
     OC.msg.startSaving('#lostpassword .msg');
     var post = $( "#lostpassword" ).serialize();
@@ -80,7 +78,7 @@ $(document).ready(function(){
 
 	});
 
-    $('#lostpassword #email').keyup(function(){
+    $('#email').keyup(function(){
         if(typeof timeout !== 'undefined'){
             clearTimeout(timeout);
         }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -4,6 +4,24 @@
  * See the COPYING-README file.
  */
 
+/**
+ * Post the email address change to the server.
+ */
+function changeEmailAddress(){
+    emailInfo = $('#lostpassword #email');
+    console.log("Timout done.");
+    if (emailInfo.val() === emailInfo.defaultValue){
+        return;
+    }
+    //event.preventDefault();
+    emailInfo.defaultValue = emailInfo.val();
+    OC.msg.startSaving('#lostpassword .msg');
+    var post = $( "#lostpassword" ).serialize();
+    $.post( 'ajax/lostpassword.php', post, function(data){
+        OC.msg.finishedSaving('#lostpassword .msg', data);
+    });
+}
+
 $(document).ready(function(){
 	$("#passwordbutton").click( function(){
 		if ($('#pass1').val() != '' && $('#pass2').val() != '') {
@@ -62,18 +80,12 @@ $(document).ready(function(){
 
 	});
 
-	$('#lostpassword #email').blur(function(event){
-		if ($(this).val() == this.defaultValue){
-			return;
-		}
-		event.preventDefault();
-		this.defaultValue = $(this).val();
-		OC.msg.startSaving('#lostpassword .msg');
-		var post = $( "#lostpassword" ).serialize();
-		$.post( 'ajax/lostpassword.php', post, function(data){
-			OC.msg.finishedSaving('#lostpassword .msg', data);
-		});
-	});
+    $('#lostpassword #email').keyup(function(){
+        if(typeof timeout !== 'undefined'){
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout('changeEmailAddress()',1000);
+    });
 
 	$("#languageinput").chosen();
 


### PR DESCRIPTION
...the Personal settings page. It now saves one second after the last keyup event, instead of after a blur event.

Apologies for the mess up on the last pull request. I'm new to issuing them. 

@jancborchardt, @raghunayyar, @Raydiation

Per #1599 here are the changes I made to make the email field, on the personal settings page, save 1 second after the last keyup event.
