### PR TITLE
Translations for themes

### DIFF
--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -122,18 +122,19 @@ class OC_L10N{
 				)
 				&& file_exists($i18ndir.$lang.'.php')) {
 				// Include the file, save the data from $CONFIG
-				include strip_tags($i18ndir).strip_tags($lang).'.php';
+				$transFile = strip_tags($i18ndir).strip_tags($lang).'.php';
+				include $transFile;
 				if(isset($TRANSLATIONS) && is_array($TRANSLATIONS)) {
 					$this->translations = $TRANSLATIONS;
 					//merge with translations from theme
-                                        $theme = OC_Config::getValue( "theme" );
-                                        if (!is_null($theme)) {
-                                                $transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
-                                                if (file_exists($transFile)) {
-                                                        include $transFile;
-                                                        $this->translations = array_merge($this->translations, $TRANSLATIONS);
-                                                }
-                                        }
+					$theme = OC_Config::getValue( "theme" );
+					if (!is_null($theme)) {
+						$transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
+						if (file_exists($transFile)) {
+							include $transFile;
+							$this->translations = array_merge($this->translations, $TRANSLATIONS);
+						}
+					}
 				}
 			}
 

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -125,6 +125,15 @@ class OC_L10N{
 				include strip_tags($i18ndir).strip_tags($lang).'.php';
 				if(isset($TRANSLATIONS) && is_array($TRANSLATIONS)) {
 					$this->translations = $TRANSLATIONS;
+					//merge with translations from theme
+                                        $theme = OC_Config::getValue( "theme" );
+                                        if (!is_null($theme)) {
+                                                $transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
+                                                if (file_exists($transFile)) {
+                                                        include $transFile;
+                                                        $this->translations = array_merge($this->translations, $TRANSLATIONS);
+                                                }
+                                        }
 				}
 			}
 

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -132,7 +132,9 @@ class OC_L10N{
 						$transFile = OC::$SERVERROOT.'/themes/'.$theme.substr($transFile, strlen(OC::$SERVERROOT));
 						if (file_exists($transFile)) {
 							include $transFile;
-							$this->translations = array_merge($this->translations, $TRANSLATIONS);
+							if (isset($TRANSLATIONS) && is_array($TRANSLATIONS)) {
+								$this->translations = array_merge($this->translations, $TRANSLATIONS);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
I have augmented translation file handling to include files from the configured theme. For each translation file that is retrieved from the core or from an app, I am checking if there is a respective translation file in the theme's folder. If there are additional translation entries, they are merged with the existing set.

Without this feature, the displayed text in customized templates cannot be translated. At least not without adding the translation entries to the core translation files, where they will not survive the next ownCloud upgrade.
