### PR TITLE
Remove not null constraint. Fix #2976

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -910,7 +910,6 @@
 				<name>displayname</name>
 				<type>text</type>
 				<default></default>
-				<notnull>true</notnull>
 				<length>64</length>
 			</field>
 

--- a/lib/util.php
+++ b/lib/util.php
@@ -75,7 +75,7 @@ class OC_Util {
 	public static function getVersion() {
 		// hint: We only can count up. Reset minor/patchlevel when
 		// updating major/minor version number.
-		return array(5, 80, 01);
+		return array(5, 80, 02);
 	}
 
 	/**


### PR DESCRIPTION
oc_user.displayname had a not null constraint which prevented user creation with PostgreSQL.
Tested by creating user with PostgreSQL db backend before and after patch.
