### PR TITLE
Warn when we do an upgrade

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -278,7 +278,7 @@ class OC {
 					OC_Config::setValue('maintenance', true);
 					OC_Log::write('core',
 						'starting upgrade from ' . $installedVersion . ' to ' . $currentVersion,
-						OC_Log::DEBUG);
+						OC_Log::WARN);
 					$minimizerCSS = new OC_Minimizer_CSS();
 					$minimizerCSS->clearCache();
 					$minimizerJS = new OC_Minimizer_JS();


### PR DESCRIPTION
Currently we only put a log as debug to tell that we do an upgrade...

i think it's clearly an event admin want to see in logs  by default... so let's raise the level to the default OC level (warn) 

:)
