### PR TITLE
Let autoloader resolve paths under apps lib directory.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -103,6 +103,7 @@ class OC {
 					require_once $fullPath;
 					return false;
 				}
+				// If not found in the root of the app directory, insert '/lib' after app id and try again.
 				$libpath = substr($path, 0, strpos($path, '/')) . '/lib' . substr($path, strpos($path, '/'));
 				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $libpath);
 				if (file_exists($fullPath)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -97,8 +97,14 @@ class OC {
 			$path = 'public/' . strtolower(str_replace('\\', '/', substr($className, 3)) . '.php');
 		} elseif (strpos($className, 'OCA\\') === 0) {
 			foreach (self::$APPSROOTS as $appDir) {
-				$path = $appDir['path'] . '/' . strtolower(str_replace('\\', '/', substr($className, 3)) . '.php');
-				$fullPath = stream_resolve_include_path($path);
+				$path = strtolower(str_replace('\\', '/', substr($className, 4)) . '.php');
+				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $path);
+				if (file_exists($fullPath)) {
+					require_once $fullPath;
+					return false;
+				}
+				$libpath = substr($path, 0, strpos($path, '/')) . '/lib' . substr($path, strpos($path, '/'));
+				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $libpath);
 				if (file_exists($fullPath)) {
 					require_once $fullPath;
 					return false;


### PR DESCRIPTION
The autoloader only resolved paths to classes where the path was from the appwebroot.

I find it cleaner to have all classes under lib/.

With this patch it can resolve e.g. `OCA\Contacts\AddressBook` to `/var/www/owncloud/apps/contacts/lib/addressbook.php`.

Both variations are still supported.

@bartv2 @VicDeo @icewind1991 @DeepDiver1975 
