### PR TITLE
add index for properties ( userid, propertypath )

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -702,6 +702,18 @@
 				</field>
 			</index>
 
+			<index>
+				<name>user_property_index</name>
+				<field>
+					<name>userid</name>
+					<sorting>ascending</sorting>
+				</field>
+				<field>
+					<name>propertypath</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
 		</declaration>
 
 	</table>

--- a/lib/util.php
+++ b/lib/util.php
@@ -75,7 +75,7 @@ class OC_Util {
 	public static function getVersion() {
 		// hint: We only can count up. Reset minor/patchlevel when
 		// updating major/minor version number.
-		return array(5, 80, 02);
+		return array(5, 80, 03);
 	}
 
 	/**


### PR DESCRIPTION
I enabled mysqls `log-slow-queries` with `log-queries-not-using-indexes` and used nautilus as well as the sync client to upload files to owncloud. The only query that seemed suspicious was the property resolving queries:

``` sql
# Query_time: 0.003756  Lock_time: 0.000024 Rows_sent: 0  Rows_examined: 16197
SET timestamp=1366367355;
SELECT * FROM `oc_properties` WHERE `userid` = 'myuser' AND `propertypath` = '/clientsync/rahhhhhh.html';
```

there is also

``` sql
# Query_time: 0.007433  Lock_time: 0.000020 Rows_sent: 0  Rows_examined: 22217
SET timestamp=1366367355;
SELECT `path`, `fileid` FROM `oc_filecache` WHERE `path` LIKE 'files/clientsync/rahhhhhh.html.part/%';
```

But I'll look into that in another PR. So, this is yet another small drop on performance for https://github.com/owncloud/mirall/issues/58 and https://github.com/owncloud/mirall/issues/331

@dragotin @danimo @bartv2 @icewind1991 @MTGap @DeepDiver1975 
