### PR TITLE
Cache: only look for child entires when doing a move operation when moving a folder

### DIFF
--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -162,10 +162,11 @@ class Cache extends \PHPUnit_Framework_TestCase {
 		$file4 = 'folder/foo/1';
 		$file5 = 'folder/foo/2';
 		$data = array('size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar');
+		$folderData = array('size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory');
 
-		$this->cache->put($file1, $data);
-		$this->cache->put($file2, $data);
-		$this->cache->put($file3, $data);
+		$this->cache->put($file1, $folderData);
+		$this->cache->put($file2, $folderData);
+		$this->cache->put($file3, $folderData);
 		$this->cache->put($file4, $data);
 		$this->cache->put($file5, $data);
 


### PR DESCRIPTION
This should speed up the moving operation for files when there are a lot of files in the filecache

cc @DeepDiver1975 @MTGap @butonic 
