### PR TITLE
Don't start the session when in cli mode

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -478,7 +478,9 @@ class OC {
 		self::checkConfig();
 		self::checkInstalled();
 		self::checkSSL();
-		self::initSession();
+		if ( !self::$CLI ) {
+			self::initSession();
+		}
 
 		$errors = OC_Util::checkServer();
 		if (count($errors) > 0) {


### PR DESCRIPTION
Make sure cli requests don't block other requests by starting a session.

sessions don't work in cli anyway.

cc: @karlitschek @DeepDiver1975 @schiesbn 
