### PR TITLE
Add a background job to watch for external filesystem changes

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -19,3 +19,5 @@ OC_Search::registerProvider('OC_Search_Provider_File');
 \OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
 \OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
 \OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');
+
+\OC_BackgroundJob_RegularTask::register('\OC\Files\Cache\BackgroundWatcher', 'checkNext');

--- a/lib/files/cache/backgroundwatcher.php
+++ b/lib/files/cache/backgroundwatcher.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Cache;
+
+use \OC\Files\Mount;
+use \OC\Files\Filesystem;
+
+class BackgroundWatcher {
+	static private function checkUpdate($id) {
+		$cacheItem = Cache::getById($id);
+		if (is_null($cacheItem)) {
+			return;
+		}
+		list($storageId, $internalPath) = $cacheItem;
+		$mounts = Mount::findByStorageId($storageId);
+
+		if (count($mounts) === 0) {
+			//if the storage we need isn't mounted on default, try to find a user that has access to the storage
+			$permissionsCache = new Permissions($storageId);
+			$users = $permissionsCache->getUsers($id);
+			if (count($users) === 0) {
+				return;
+			}
+			Filesystem::initMountPoints($users[0]);
+			$mounts = Mount::findByStorageId($storageId);
+			if (count($mounts) === 0) {
+				return;
+			}
+		}
+		$storage = $mounts[0]->getStorage();
+		$watcher = new Watcher($storage);
+		$watcher->checkUpdate($internalPath);
+	}
+
+	/**
+	 * get the next fileid in the cache
+	 *
+	 * @param int $previous
+	 * @return int
+	 */
+	static private function getNextFileId($previous) {
+		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? ORDER BY `fileid` ASC', 1);
+		$result = $query->execute(array($previous));
+		if ($row = $result->fetchRow()) {
+			return $row['fileid'];
+		} else {
+			return 0;
+		}
+	}
+
+	static public function checkNext() {
+		$previous = \OC_Appconfig::getValue('files', 'backgroundwatcher_previous', 0);
+		$next = self::getNextFileId($previous);
+		error_log($next);
+		\OC_Appconfig::setValue('files', 'backgroundwatcher_previous', $next);
+		self::checkUpdate($next);
+	}
+
+	static public function checkAll() {
+		$previous = 0;
+		$next = 1;
+		while ($next != 0) {
+			$next = self::getNextFileId($previous);
+			self::checkUpdate($next);
+		}
+	}
+}

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -517,6 +517,7 @@ class Cache {
 	/**
 	 * get the storage id of the storage for a file and the internal path of the file
 	 *
+	 * @param int $id
 	 * @return array, first element holding the storage id, second the path
 	 */
 	static public function getById($id) {

--- a/lib/files/cache/permissions.php
+++ b/lib/files/cache/permissions.php
@@ -107,4 +107,19 @@ class Permissions {
 			$query->execute(array($fileId, $user));
 		}
 	}
+
+	/**
+	 * get the list of users which have permissions stored for a file
+	 *
+	 * @param int $fileId
+	 */
+	public function getUsers($fileId) {
+		$query = \OC_DB::prepare('SELECT `user` FROM `*PREFIX*permissions` WHERE `fileid` = ?');
+		$result = $query->execute(array($fileId));
+		$users = array();
+		while ($row = $result->fetchRow()) {
+			$users[] = $row['user'];
+		}
+		return $users;
+	}
 }

--- a/tests/lib/files/cache/permissions.php
+++ b/tests/lib/files/cache/permissions.php
@@ -14,8 +14,8 @@ class Permissions extends \PHPUnit_Framework_TestCase {
 	 */
 	private $permissionsCache;
 
-	function setUp(){
-		$this->permissionsCache=new \OC\Files\Cache\Permissions('dummy');
+	function setUp() {
+		$this->permissionsCache = new \OC\Files\Cache\Permissions('dummy');
 	}
 
 	function testSimple() {
@@ -23,8 +23,10 @@ class Permissions extends \PHPUnit_Framework_TestCase {
 		$user = uniqid();
 
 		$this->assertEquals(-1, $this->permissionsCache->get(1, $user));
+		$this->assertNotContains($user, $this->permissionsCache->getUsers(1));
 		$this->permissionsCache->set(1, $user, 1);
 		$this->assertEquals(1, $this->permissionsCache->get(1, $user));
+		$this->assertContains($user, $this->permissionsCache->getUsers(1));
 		$this->assertEquals(-1, $this->permissionsCache->get(2, $user));
 		$this->assertEquals(-1, $this->permissionsCache->get(1, $user . '2'));
 


### PR DESCRIPTION
The background job iterates over all items in the filecache, each iteration one folder and one file are checked for external changes.

By iterating over files and folders separably, we decrease the number of times the background job needs to be run before it has checked all folders (because there are usually less folders than files). This increases the speed new files or folders are detected.

While this solved the issue where external filesystem changes are not synced to the desktop client, it can still take a while before the external change is detected if there are a large number of items in the filesystem cache due to the nature of background jobs.

cc: @karlitschek @MTGap @DeepDiver1975 
