### PR TITLE
LDAP: reset user/group-config association only after exists-check, may p...

### DIFF
--- a/apps/user_ldap/group_proxy.php
+++ b/apps/user_ldap/group_proxy.php
@@ -76,8 +76,15 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 			if(isset($this->backends[$prefix])) {
 				$result = call_user_func_array(array($this->backends[$prefix], $method), $parameters);
 				if(!$result) {
-					//not found here, reset cache to null
-					$this->writeToCache($cacheKey, null);
+					//not found here, reset cache to null if group vanished
+					//because sometimes methods return false with a reason
+					$groupExists = call_user_func_array(
+						array($this->backends[$prefix], 'groupExists'),
+						array($gid)
+					);
+					if(!$groupExists) {
+						$this->writeToCache($cacheKey, null);
+					}
 				}
 				return $result;
 			}

--- a/apps/user_ldap/user_proxy.php
+++ b/apps/user_ldap/user_proxy.php
@@ -76,8 +76,15 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 			if(isset($this->backends[$prefix])) {
 				$result = call_user_func_array(array($this->backends[$prefix], $method), $parameters);
 				if(!$result) {
-					//not found here, reset cache to null
-					$this->writeToCache($cacheKey, null);
+					//not found here, reset cache to null if user vanished
+					//because sometimes methods return false with a reason
+					$userExists = call_user_func_array(
+						array($this->backends[$prefix], 'userExists'),
+						array($uid)
+					);
+					if(!$userExists) {
+						$this->writeToCache($cacheKey, null);
+					}
 				}
 				return $result;
 			}


### PR DESCRIPTION
...erformance in some cases

Explanation: because we support multiple LDAP servers, we have a proxy that delegates a method call to the correct backend. To avoid roundtrips, we cache to which LDAP server a user belongs. Sometimes we reset this on a per-user basis. Until now when the method returned false. However, "false" can be a very valid return value. So we check whether the user (or the group) still exists on the LDAP server before resolving the association.

In some cases it improves performance noticeable.

@karlitschek @bartv2 @MTGap or others, thanks.
