### PR TITLE
Fix ugly error style on install

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -467,11 +467,11 @@ class OC {
 		stream_wrapper_register('close', 'OC\Files\Stream\Close');
 		stream_wrapper_register('oc', 'OC\Files\Stream\OC');
 
+		self::initTemplateEngine();
 		self::checkConfig();
 		self::checkInstalled();
 		self::checkSSL();
 		self::initSession();
-		self::initTemplateEngine();
 
 		$errors = OC_Util::checkServer();
 		if (count($errors) > 0) {


### PR DESCRIPTION
By initializing the template engine first we can show the
'Can't write into config directory 'config'' error in a nice way instead
of plain unstyled HTML.
