### PR TITLE
External Storage: Check for curl in PHP

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -70,7 +70,7 @@ class OC_Mount_Config {
 				'root' => '&Root',
 				'secure' => '!Secure ftps://'));
 
-		$backends['\OC\Files\Storage\Google']=array(
+		if(OC_Mount_Config::checkcurl()) $backends['\OC\Files\Storage\Google']=array(
 			'backend' => 'Google Drive',
 			'configuration' => array(
 				'configured' => '#configured',
@@ -96,7 +96,7 @@ class OC_Mount_Config {
 				'share' => 'Share',
 				'root' => '&Root'));
 
-		$backends['\OC\Files\Storage\DAV']=array(
+		if(OC_Mount_Config::checkcurl()) $backends['\OC\Files\Storage\DAV']=array(
 			'backend' => 'ownCloud / WebDAV',
 			'configuration' => array(
 				'host' => 'URL',
@@ -415,6 +415,13 @@ class OC_Mount_Config {
 	}
 
 	/**
+	 * check if curl is installed
+	 */
+	public static function checkcurl() {
+		return (function_exists('curl_init'));
+	}
+
+	/**
 	 * check dependencies
 	 */
 	public static function checkDependencies() {
@@ -425,6 +432,9 @@ class OC_Mount_Config {
 		}
 		if(!OC_Mount_Config::checkphpftp()) {
 			$txt.=$l->t('<b>Warning:</b> The FTP support in PHP is not enabled or installed. Mounting of FTP shares is not possible. Please ask your system administrator to install it.').'<br />';
+		}
+		if(!OC_Mount_Config::checkcurl()) {
+			$txt.=$l->t('<b>Warning:</b> The Curl support in PHP is not enabled or installed. Mounting of ownCloud / WebDAV or GoogleDrive is not possible. Please ask your system administrator to install it.').'<br />';
 		}
 
 		return($txt);


### PR DESCRIPTION
If no curl is found, disable the storage that needs it.
