### PR TITLE
On the Personal Settings page, made the display name save like the email address saves

### DIFF
--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -28,7 +28,7 @@ if(is_null($userstatus)) {
 
 // Return Success story
 if( OC_User::setDisplayName( $username, $displayName )) {
-	OC_JSON::success(array("data" => array( "message" => $l->t('Your display name was changed'), "username" => $username, 'displayName' => $displayName )));
+	OC_JSON::success(array("data" => array( "message" => $l->t('Your display name has been changed.'), "username" => $username, 'displayName' => $displayName )));
 }
 else{
 	OC_JSON::error(array("data" => array( "message" => $l->t("Unable to change display name"), 'displayName' => OC_User::getDisplayName($username) )));

--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -4,6 +4,8 @@
 OCP\JSON::callCheck();
 OC_JSON::checkLoggedIn();
 
+$l=OC_L10N::get('core');
+
 $username = isset($_POST["username"]) ? $_POST["username"] : OC_User::getUser();
 $displayName = $_POST["displayName"];
 
@@ -26,7 +28,7 @@ if(is_null($userstatus)) {
 
 // Return Success story
 if( OC_User::setDisplayName( $username, $displayName )) {
-	OC_JSON::success(array("data" => array( "username" => $username, 'displayName' => $displayName )));
+	OC_JSON::success(array("data" => array( "message" => $l->t('Your display name was changed'), "username" => $username, 'displayName' => $displayName )));
 }
 else{
 	OC_JSON::error(array("data" => array( "message" => $l->t("Unable to change display name"), 'displayName' => OC_User::getDisplayName($username) )));

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -20,16 +20,40 @@ function changeEmailAddress(){
     });
 }
 
+/**
+ * Post the email address change to the server.
+ */
+function changeDisplayName(){
+    if ($('#displayName').val() !== '' ) {
+        OC.msg.startSaving('#displaynameform .msg');
+        // Serialize the data
+        var post = $( "#displaynameform" ).serialize();
+        // Ajax foo
+        $.post( 'ajax/changedisplayname.php', post, function(data){
+            if( data.status === "success" ){
+                $('#oldDisplayName').text($('#displayName').val());
+                // update displayName on the top right expand button
+                $('#expandDisplayName').text($('#displayName').val());
+            }
+            else{
+                $('#newdisplayname').val(data.data.displayName);
+            }
+            OC.msg.finishedSaving('#displaynameform .msg', data);
+        });
+        return false;
+    }
+}
+
 $(document).ready(function(){
 	$("#passwordbutton").click( function(){
-		if ($('#pass1').val() != '' && $('#pass2').val() != '') {
+		if ($('#pass1').val() !== '' && $('#pass2').val() !== '') {
 			// Serialize the data
 			var post = $( "#passwordform" ).serialize();
 			$('#passwordchanged').hide();
 			$('#passworderror').hide();
 			// Ajax foo
 			$.post( 'ajax/changepassword.php', post, function(data){
-				if( data.status == "success" ){
+				if( data.status === "success" ){
 					$('#pass1').val('');
 					$('#pass2').val('');
 					$('#passwordchanged').show();
@@ -48,41 +72,23 @@ $(document).ready(function(){
 
 	});
 
-	$("#displaynamebutton").click( function(){
-		if ($('#displayName').val() != '' ) {
-			// Serialize the data
-			var post = $( "#displaynameform" ).serialize();
-			$('#displaynamechanged').hide();
-			$('#displaynemerror').hide();
-			// Ajax foo
-			$.post( 'ajax/changedisplayname.php', post, function(data){
-				if( data.status == "success" ){
-					$('#displaynamechanged').show();
-					$('#oldDisplayName').text($('#displayName').val());
-					// update displayName on the top right expand button
-					$('#expandDisplayName').text($('#displayName').val());
-				}
-				else{
-					$('#newdisplayname').val(data.data.displayName)
-					$('#displaynameerror').html( data.data.message );
-					$('#displaynameerror').show();
-				}
-			});
-			return false;
-		} else {
-			$('#displayName').val($('#oldDisplayName').val());
-			$('#displaynamechanged').hide();
-			$('#displaynameerror').show();
-			return false;
-		}
+    $('#displayName').keyup(function(){
+        if ($('#displayName').val() !== '' ){
+            if(typeof timeout !== 'undefined'){
+                clearTimeout(timeout);
+            }
+            timeout = setTimeout('changeDisplayName()',1000);
+        }
+    });
 
-	});
 
     $('#email').keyup(function(){
-        if(typeof timeout !== 'undefined'){
-            clearTimeout(timeout);
+        if ($('#email').val() !== '' ){
+            if(typeof timeout !== 'undefined'){
+                clearTimeout(timeout);
+            }
+            timeout = setTimeout('changeEmailAddress()',1000);
         }
-        timeout = setTimeout('changeEmailAddress()',1000);
     });
 
 	$("#languageinput").chosen();
@@ -92,7 +98,7 @@ $(document).ready(function(){
 		var post = $( "#languageinput" ).serialize();
 		// Ajax foo
 		$.post( 'ajax/setlanguage.php', post, function(data){
-			if( data.status == "success" ){
+			if( data.status === "success" ){
 				location.reload();
 			}
 			else{
@@ -113,12 +119,12 @@ OC.msg={
 			.show();
 	},
 	finishedSaving:function(selector, data){
-		if( data.status == "success" ){
+		if( data.status === "success" ){
 			 $(selector).html( data.data.message )
 				.addClass('success')
 				.stop(true, true)
 				.delay(3000)
-				.fadeOut(600);
+				.fadeOut(900);
 		}else{
 			$(selector).html( data.data.message ).addClass('error');
 		}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -21,7 +21,7 @@ function changeEmailAddress(){
 }
 
 /**
- * Post the email address change to the server.
+ * Post the display name change to the server.
  */
 function changeDisplayName(){
     if ($('#displayName').val() !== '' ) {

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -54,11 +54,9 @@ if($_['displayNameChangeSupported']) {
 <form id="displaynameform">
 	<fieldset class="personalblock">
 		<legend><strong><?php echo $l->t('Display Name');?></strong></legend>
-		<div id="displaynamechanged"><?php p($l->t('Your display name was changed'));?></div>
-		<div id="displaynameerror"><?php p($l->t('Unable to change your display name'));?></div>
 		<input type="text" id="displayName" name="displayName" value="<?php p($_['displayName'])?>" />
+        <span class="msg"></span>
 		<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
-		<input id="displaynamebutton" type="submit" value="<?php p($l->t('Change display name'));?>" />
 	</fieldset>
 </form>
 <?php


### PR DESCRIPTION
Made saving the display name work the same way as the email address. Fixed a few comparison operators. Increased the fadeOut time for the success and error messages.

See: https://github.com/owncloud/core/issues/1599
