### PR TITLE
Fix for #3049

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,5 +32,8 @@ RewriteRule ^remote/(.*) remote.php [QSA,L]
 AddType image/svg+xml svg svgz
 AddEncoding gzip svgz
 </IfModule>
+<IfModule dir_module>
+DirectoryIndex index.php index.html
+</IfModule>
 AddDefaultCharset utf-8
 Options -Indexes

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<script type="text/javascript"> window.location.href="index.php"; </script>
 	<meta http-equiv="refresh" content="0; URL=index.php">
 </head>
 </html>

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -828,6 +828,10 @@ class OC_Setup {
 		$content.= "AddType image/svg+xml svg svgz\n";
 		$content.= "AddEncoding gzip svgz\n";
 		$content.= "</IfModule>\n";
+		$content.= "<IfModule dir_module>\n";
+		$content.= "DirectoryIndex index.php index.html\n";
+		$content.= "</IfModule>\n";
+		$content.= "AddDefaultCharset utf-8\n";
 		$content.= "Options -Indexes\n";
 		@file_put_contents(OC::$SERVERROOT.'/.htaccess', $content); //supress errors in case we don't have permissions for it
 


### PR DESCRIPTION
This is using inline JS, as this seems to be allowed by the current security policies. But in the first place, it tries to convince Apache to prefer `index.php` over `index.html`, as a remedy for #3049.

I did not find a place where this could cause harm (e.g. where an `index.html` is located as a safety net to ensure a certain directory cannot be listed, and this directory allows user-writeable content. Please double-check.

@DeepDiver1975 @LukasReschke 
