### PR TITLE
fix wrong shared icon description

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -96,7 +96,12 @@ var FileActions = {
 				if (img) {
 					html += '<img class ="svg" src="' + img + '" /> ';
 				}
-				html += t('files', name) + '</a>';
+				// translation of "Share" is located in 'core' and not 'files'
+				if(name === 'Share')
+					html += t('core', name);
+				else
+					html += t('files', name);
+				html += '</a>';
 
 				var element = $(html);
 				element.data('action', name);


### PR DESCRIPTION
fix #2928

translation of string "Shared" is located in "core" and not in "files"
