### PR TITLE
Files: fix the order fileactions are computed for a file

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -22,18 +22,18 @@ var FileActions = {
 		if (FileActions.actions.all) {
 			actions = $.extend(actions, FileActions.actions.all);
 		}
-		if (mime) {
-			if (FileActions.actions[mime]) {
-				actions = $.extend(actions, FileActions.actions[mime]);
+		if (type) {//type is 'dir' or 'file'
+			if (FileActions.actions[type]) {
+				actions = $.extend(actions, FileActions.actions[type]);
 			}
+		}
+		if (mime) {
 			var mimePart = mime.substr(0, mime.indexOf('/'));
 			if (FileActions.actions[mimePart]) {
 				actions = $.extend(actions, FileActions.actions[mimePart]);
 			}
-		}
-		if (type) {//type is 'dir' or 'file'
-			if (FileActions.actions[type]) {
-				actions = $.extend(actions, FileActions.actions[type]);
+			if (FileActions.actions[mime]) {
+				actions = $.extend(actions, FileActions.actions[mime]);
 			}
 		}
 		var filteredActions = {};


### PR DESCRIPTION
Without this, an action registered for 'text' will overwrite an action registered for 'text/foo'

cc @DeepDiver1975 @karlitschek 
