### PR TITLE
fix wrong shared icon description

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -113,6 +113,7 @@ var FileActions = {
 			}
 		});
 		if(actions.Share && !($('#dir').val() === '/' && file === 'Shared')){
+			// t('files', 'Share')
 			addAction('Share', actions.Share);
 		}
 


### PR DESCRIPTION
fix #2928

translation of string "Shared" has to be marked as located in "files" for the translation extractor

see #3105
