### PR TITLE
Allow subclassing of OC_OCS_Result class by changing properties from 'private' to 'protected'

### DIFF
--- a/lib/ocs/result.php
+++ b/lib/ocs/result.php
@@ -22,7 +22,7 @@
 
 class OC_OCS_Result{
 
-	private $data, $message, $statusCode, $items, $perPage;
+	protected $data, $message, $statusCode, $items, $perPage;
 
 	/**
 	 * create the OCS_Result object


### PR DESCRIPTION
See https://github.com/owncloud/core/issues/3091
