### PR TITLE
Fix the api response when a shipped and third party app both fail.

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -155,11 +155,11 @@ class OC_API {
 			// They may have failed for different reasons (different status codes)
 			// Which reponse code should we return?
 			// Maybe any that are not OC_API::RESPOND_SERVER_ERROR
-			$response = $shipped['failed'][0];
+			$response = reset($shipped['failed']);
 			return $response;
 		} else {
 			// Return the third party failure result
-			$response = $thirdparty['failed'][0];
+			$response = reset($thirdparty['failed']);
 			return $response;
 		}
 		// Merge the successful responses


### PR DESCRIPTION
@karlitschek @butonic This should now return the correct response even if both / just the third party app's api function fails. 
