### PR TITLE
LDAP: do not reset UUID attribute setting when guid is detected

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -427,7 +427,9 @@ class Connection {
 				'No group filter is specified, LDAP group feature will not be used.',
 				\OCP\Util::INFO);
 		}
-		if(!in_array($this->config['ldapUuidAttribute'], array('auto', 'entryuuid', 'nsuniqueid', 'objectguid'))
+		$uuidAttributes = array(
+			'auto', 'entryuuid', 'nsuniqueid', 'objectguid', 'guid');
+		if(!in_array($this->config['ldapUuidAttribute'], $uuidAttributes)
 			&& (!is_null($this->configID))) {
 			\OCP\Config::setAppValue($this->configID, $this->configPrefix.'ldap_uuid_attribute', 'auto');
 			\OCP\Util::writeLog('user_ldap',


### PR DESCRIPTION
Easy to review: just adds an item to the array while the array is now initialized into a var for better readability. The array contains a set of valid UUID attributes, plus "auto".

Please review @schiesbn @karlitschek @Raydiation or others, thx!
