### PR TITLE
Dont task external storages with creating their own root

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -45,7 +45,6 @@ class Dropbox extends \OC\Files\Storage\Common {
 			$oauth = new \Dropbox_OAuth_Curl($params['app_key'], $params['app_secret']);
 			$oauth->setToken($params['token'], $params['token_secret']);
 			$this->dropbox = new \Dropbox_API($oauth, 'dropbox');
-			$this->mkdir('');
 		} else {
 			throw new \Exception('Creating \OC\Files\Storage\Dropbox storage failed');
 		}

--- a/apps/files_external/lib/ftp.php
+++ b/apps/files_external/lib/ftp.php
@@ -35,10 +35,6 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 			if ( ! $this->root || $this->root[0]!='/') {
 				$this->root='/'.$this->root;
 			}
-			//create the root folder if necessary
-			if ( ! $this->is_dir('')) {
-				$this->mkdir('');
-			}
 		} else {
 			throw new \Exception();
 		}
@@ -63,7 +59,6 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 		return $url;
 	}
 	public function fopen($path,$mode) {
-		$this->init();
 		switch($mode) {
 			case 'r':
 			case 'rb':
@@ -100,7 +95,6 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 	}
 
 	public function writeBack($tmpFile) {
-		$this->init();
 		if (isset(self::$tempFiles[$tmpFile])) {
 			$this->uploadFile($tmpFile, self::$tempFiles[$tmpFile]);
 			unlink($tmpFile);

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -50,10 +50,6 @@ class SFTP extends \OC\Files\Storage\Common {
 			$host_keys[$this->host] = $current_host_key;
 			$this->write_host_keys($host_keys);
 		}
-
-		if(!$this->file_exists('')){
-			$this->mkdir('');
-		}
 	}
 
 	public function test() {

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -73,7 +73,6 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 	 * @return bool
 	 */
 	public function hasUpdated($path,$time) {
-		$this->init();
 		if(!$path and $this->root=='/') {
 			// mtime doesn't work for shares, but giving the nature of the backend,
 			// doing a full update is still just fast enough

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -8,46 +8,28 @@
 
 namespace OC\Files\Storage;
 
-abstract class StreamWrapper extends \OC\Files\Storage\Common{
-	private $ready = false;
-
-	protected function init(){
-		if($this->ready) {
-			return;
-		}
-		$this->ready = true;
-
-		//create the root folder if necesary
-		if(!$this->is_dir('')) {
-			$this->mkdir('');
-		}
-	}
-
+abstract class StreamWrapper extends Common{
 	abstract public function constructUrl($path);
 
 	public function mkdir($path) {
-		$this->init();
 		return mkdir($this->constructUrl($path));
 	}
 
 	public function rmdir($path) {
-		$this->init();
 		if($this->file_exists($path)) {
-			$succes = rmdir($this->constructUrl($path));
+			$success = rmdir($this->constructUrl($path));
 			clearstatcache();
-			return $succes;
+			return $success;
 		} else {
 			return false;
 		}
 	}
 
 	public function opendir($path) {
-		$this->init();
 		return opendir($this->constructUrl($path));
 	}
 
 	public function filetype($path) {
-		$this->init();
 		return filetype($this->constructUrl($path));
 	}
 
@@ -60,24 +42,20 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common{
 	}
 
 	public function file_exists($path) {
-		$this->init();
 		return file_exists($this->constructUrl($path));
 	}
 
 	public function unlink($path) {
-		$this->init();
-		$succes = unlink($this->constructUrl($path));
+		$success = unlink($this->constructUrl($path));
 		clearstatcache();
-		return $succes;
+		return $success;
 	}
 
 	public function fopen($path, $mode) {
-		$this->init();
 		return fopen($this->constructUrl($path), $mode);
 	}
 
 	public function touch($path, $mtime=null) {
-		$this->init();
 		if(is_null($mtime)) {
 			$fh = $this->fopen($path, 'a');
 			fwrite($fh, '');
@@ -88,22 +66,18 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common{
 	}
 
 	public function getFile($path, $target) {
-		$this->init();
 		return copy($this->constructUrl($path), $target);
 	}
 
 	public function uploadFile($path, $target) {
-		$this->init();
 		return copy($path, $this->constructUrl($target));
 	}
 
 	public function rename($path1, $path2) {
-		$this->init();
 		return rename($this->constructUrl($path1), $this->constructUrl($path2));
 	}
 
 	public function stat($path) {
-		$this->init();
 		return stat($this->constructUrl($path));
 	}
 

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -73,8 +73,6 @@ class DAV extends \OC\Files\Storage\Common{
 				$this->client->addTrustedCertificates($certPath);
 			}
 		}
-		//create the root folder if necessary
-		$this->mkdir('');
 	}
 
 	public function getId(){

--- a/apps/files_external/tests/ftp.php
+++ b/apps/files_external/tests/ftp.php
@@ -19,6 +19,7 @@ class FTP extends Storage {
 		}
 		$this->config['ftp']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new \OC\Files\Storage\FTP($this->config['ftp']);
+		$this->instance->mkdir('/');
 	}
 
 	public function tearDown() {

--- a/apps/files_external/tests/sftp.php
+++ b/apps/files_external/tests/sftp.php
@@ -33,6 +33,7 @@ class SFTP extends Storage {
 		}
 		$this->config['sftp']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new \OC\Files\Storage\SFTP($this->config['sftp']);
+		$this->instance->mkdir('/');
 	}
 
 	public function tearDown() {

--- a/apps/files_external/tests/smb.php
+++ b/apps/files_external/tests/smb.php
@@ -20,6 +20,7 @@ class SMB extends Storage {
 		}
 		$this->config['smb']['root'] .= $id; //make sure we have an new empty folder to work in
 		$this->instance = new \OC\Files\Storage\SMB($this->config['smb']);
+		$this->instance->mkdir('/');
 	}
 
 	public function tearDown() {

--- a/apps/files_external/tests/webdav.php
+++ b/apps/files_external/tests/webdav.php
@@ -20,6 +20,7 @@ class DAV extends Storage {
 		}
 		$this->config['webdav']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new \OC\Files\Storage\DAV($this->config['webdav']);
+		$this->instance->mkdir('/');
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
This "feature" was only used by test cases anyway, this decreases the number of calls to the external sever resulting in an increase in performance when using an external storage.

No idea why I ever though that was a good idea :/

cc @MTGap @DeepDiver1975 
