### PR TITLE
Update mapper.php

### DIFF
--- a/lib/files/mapper.php
+++ b/lib/files/mapper.php
@@ -168,6 +168,9 @@ class Mapper
 	}
 
 	public function slugifyPath($path, $index=null) {
+		
+		$path = str_replace('\', '/', $path);
+		
 		$path = $this->stripRootFolder($path, $this->unchangedPhysicalRoot);
 
 		$pathElements = explode('/', $path);


### PR DESCRIPTION
explode('/', $path) doesn't work correctly on windows when slashes and backslashes are mixed i path.
