### PR TITLE
Fix retrieval of users with multiple backends

### DIFF
--- a/settings/ajax/userlist.php
+++ b/settings/ajax/userlist.php
@@ -27,9 +27,14 @@ if (isset($_GET['offset'])) {
 } else {
 	$offset = 0;
 }
+if (isset($_GET['limit'])) {
+	$limit = $_GET['limit'];
+} else {
+	$limit = 10;
+}
 $users = array();
 if (OC_User::isAdminUser(OC_User::getUser())) {
-	$batch = OC_User::getDisplayNames('', 10, $offset);
+	$batch = OC_User::getDisplayNames('', $limit, $offset);
 	foreach ($batch as $user => $displayname) {
 		$users[] = array(
 			'name' => $user,
@@ -40,7 +45,7 @@ if (OC_User::isAdminUser(OC_User::getUser())) {
 	}
 } else {
 	$groups = OC_SubAdmin::getSubAdminsGroups(OC_User::getUser());
-	$batch = OC_Group::usersInGroups($groups, '', 10, $offset);
+	$batch = OC_Group::usersInGroups($groups, '', $limit, $offset);
 	foreach ($batch as $user) {
 		$users[] = array(
 			'name' => $user,


### PR DESCRIPTION
getUsers passes the Offset and Limit to each backend (not possible in a reliable way otherwise). So, when opening a users page all active backends are asked to send 30 users, offset 0 (not via Ajax, only subsequent getUsers are triggered by Ajax).
For example, when you have 6 local users and 120 LDAP users, you will see 35 users in the beginning. Scrolling down will trigger the load of the next 10 users.

Behaviour before:
The sum of users in the list was used as offset. Although it is OK with only one user backend it makes no sense with multiple ones. In our example, on scrolling down all backends were asked so send 10 users, offset 35. Local backend will return nothing, LDAP will skip 5 users.

Now:
Offset starts hardcodedly with 30. It is not a problem when there are less users, the backends will simply return nothing. After a successful request, the limit (here JS variable usersToLoad) will be added. In our example, the next 10 users will be loaded with offset of 30, then offset 40 and so on.

Was found while digging in #2545 (but not the whole solution for the bug).

Please review @tanghus @karlitschek @icewind1991 
