### PR TITLE
Add the quota to the external API for use with the mobile and desktop clients

### DIFF
--- a/lib/ocs/cloud.php
+++ b/lib/ocs/cloud.php
@@ -47,9 +47,9 @@ class OC_OCS_Cloud {
 	/**
 	 * gets user info
 	 */
-	public static function getUser($parameters){
+	public static function getUser($parameters) {
 		// Check if they are viewing information on themselves
-		if($parameters['userid'] === OC_User::getUser()){
+		if($parameters['userid'] === OC_User::getUser()) {
 			// Self lookup
 			$quota = array();
 			$storage = OC_Helper::getStorageInfo();

--- a/lib/ocs/cloud.php
+++ b/lib/ocs/cloud.php
@@ -35,12 +35,35 @@ class OC_OCS_Cloud {
 			'edition' => OC_Util::getEditionString(),
 			);
 			
-			$result['capabilities'] = array(
-				'core' => array(
-					'pollinterval' => OC_Config::getValue('pollinterval', 60),
-					),
-				);
+		$result['capabilities'] = array(
+			'core' => array(
+				'pollinterval' => OC_Config::getValue('pollinterval', 60),
+				),
+			);
+			
 		return new OC_OCS_Result($result);
+	}
+	
+	/**
+	 * gets user info
+	 */
+	public static function getUser($parameters){
+		// Check if they are viewing information on themselves
+		if($parameters['userid'] === OC_User::getUser()){
+			// Self lookup
+			$quota = array();
+			$storage = OC_Helper::getStorageInfo();
+			$quota = array(
+				'free' =>  $storage['free'],
+				'used' =>  $storage['used'],
+				'total' =>  $storage['total'],
+				'relative' => $storage['relative'],
+				);
+			return new OC_OCS_Result(array('quota' => $quota));
+		} else {
+			// No permission to view this user data
+			return new OC_OCS_Result(null, 997);
+		}
 	}
 
 	public static function getUserPublickey($parameters) {

--- a/lib/ocs/cloud.php
+++ b/lib/ocs/cloud.php
@@ -46,6 +46,19 @@ class OC_OCS_Cloud {
 	
 	/**
 	 * gets user info
+	 *
+	 * exposes the quota of an user:
+	 * <data>
+	 *   <quota>
+	 *      <free>1234</free>
+	 *      <used>4321</used>
+	 *      <total>5555</total>
+	 *      <ralative>0.78</ralative>
+	 *   </quota>
+	 * </data>
+	 *
+	 * @param $parameters object should contain parameter 'userid' which identifies
+	 *                           the user from whom the information will be returned
 	 */
 	public static function getUser($parameters) {
 		// Check if they are viewing information on themselves

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -28,7 +28,7 @@ OC_API::register(
 	array('OC_OCS_Activity', 'activityGet'),
 	'core',
 	OC_API::USER_AUTH
-	); 
+	);
 // Privatedata
 OC_API::register(
 	'get',
@@ -72,6 +72,13 @@ OC_API::register(
 	'get',
 	'/cloud/capabilities',
 	array('OC_OCS_Cloud', 'getCapabilities'),
+	'core',
+	OC_API::USER_AUTH
+	);
+OC_API::register(
+	'get',
+	'/cloud/users/{userid}',
+	array('OC_OCS_Cloud', 'getUser'),
 	'core',
 	OC_API::USER_AUTH
 	);


### PR DESCRIPTION
GET /ocs/v1.php/cloud/users/$user 

``` xml
<?xml version="1.0"?>
<ocs>
    <meta>
        <status>ok</status>
        <statuscode>100</statuscode>
        <message/>
    </meta>
    <data>
        <quota>
            <free>3677700096</free>
            <used>22849805</used>
            <total>3700549901</total>
            <relative>0.62</relative>
        </quota>
    </data>
</ocs>
```
