### PR TITLE
Don't display shared links if disabled

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -3,6 +3,13 @@ $RUNTIME_NOSETUPFS = true;
 // Load other apps for file previews
 OC_App::loadApps();
 
+if (\OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
+	header('HTTP/1.0 404 Not Found');
+	$tmpl = new OCP\Template('', '404', 'guest');
+	$tmpl->printPage();
+	exit();
+}
+
 function fileCmp($a, $b) {
 	if ($a['type'] == 'dir' and $b['type'] != 'dir') {
 		return -1;


### PR DESCRIPTION
Displays a 404 page instead of the link contents. I thought about deleting all links, but this seems like a better option in case it was an accidental click.

More pull requests coming soon to improve behavior in the sharing dropdown when links are disabled.

@rperezb @jancborchardt @icewind1991 
