### PR TITLE
if rename of file fails, the rename is undone in the view - fix 2820

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -208,13 +208,44 @@ var FileList={
 				if (FileList.checkName(name, newname, false)) {
 					newname = name;
 				} else {
-					$.get(OC.filePath('files','ajax','rename.php'), { dir : $('#dir').val(), newname: newname, file: name },function(result) {
-						if (!result || result.status == 'error') {
-							OC.dialogs.alert(result.data.message, 'Error moving file');
-							newname = name;
+					// save background image, because it's replaced by a spinner while async request
+					var oldBackgroundImage = td.css('background-image');
+					// mark as loading
+					td.css('background-image', 'url('+ OC.imagePath('core', 'loading.gif') + ')');
+					$.ajax({
+						url: OC.filePath('files','ajax','rename.php'),
+						data: {
+							dir : $('#dir').val(),
+							newname: newname,
+							file: name
+						},
+						success: function(result) {
+							if (!result || result.status === 'error') {
+								OC.Notification.show(result.data.message);
+								newname = name;
+								// revert changes
+								tr.attr('data-file', newname);
+								var path = td.children('a.name').attr('href');
+								td.children('a.name').attr('href', path.replace(encodeURIComponent(name), encodeURIComponent(newname)));
+								if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
+									var basename=newname.substr(0,newname.lastIndexOf('.'));
+								} else {
+									var basename=newname;
+								}
+								td.find('a.name span.nametext').text(basename);
+								if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
+									if (td.find('a.name span.extension').length === 0 ) {
+										td.find('a.name span.nametext').append('<span class="extension"></span>');
+									}
+									td.find('a.name span.extension').text(newname.substr(newname.lastIndexOf('.')));
+								}
+								tr.find('.fileactions').effect('highlight', {}, 5000);
+								tr.effect('highlight', {}, 5000);
+							}
+							// remove loading mark and recover old image
+							td.css('background-image', oldBackgroundImage);
 						}
 					});
-
 				}
 			}
 			tr.data('renaming',false);

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -70,7 +70,7 @@ class App {
 		} else {
 			// rename failed
 			$result['data'] = array(
-				'message'	=> $this->l10n->t('Unable to rename file')
+				'message'	=> $this->l10n->t('%s could not be renamed', array($oldname))
 			);
 		}
 		return $result;

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -50,7 +50,7 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 		$result = $this->files->rename($dir, $oldname, $newname);
 		$expected = array(
 			'success'	=> false,
-			'data'		=> array('message' => 'Unable to rename file')
+			'data'		=> array('message' => '%s could not be renamed')
 		);
 
 		$this->assertEquals($expected, $result);

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -349,10 +349,10 @@ OC.Notification={
 	},
 	show: function(text) {
 		if(($('#notification').filter('span.undo').length == 1) || OC.Notification.isHidden()){
-			$('#notification').html(text);
+			$('#notification').text(text);
 			$('#notification').fadeIn().css("display","inline");
 		}else{
-			OC.Notification.queuedNotifications.push($(text).html());
+			OC.Notification.queuedNotifications.push($('<div/>').text(text).html());
 		}
 	},
 	isHidden: function() {


### PR DESCRIPTION
I've just reformat the ajax call and add the async option.

fix 2820

@Kondou-ger @tanghus Something weird happens: If the error dialog shows up, the "Ok" button doesn't work anymore. 

```
Uncaught Error: cannot call methods on dialog prior to initialization; attempted to call method 'close' jquery-1.7.2.min.js:2
e.extend.error jquery-1.7.2.min.js:2
(anonymous function) jquery-ui-1.10.0.custom.js:491
e.extend.each jquery-1.7.2.min.js:2
e.fn.e.each jquery-1.7.2.min.js:2
$.widget.bridge.$.fn.(anonymous function) jquery-ui-1.10.0.custom.js:487
functionToCall oc-dialogs.js:234
$.widget._createButtons.$.each.props.click jquery-ui-1.10.0.custom.js:9194
f.event.dispatch jquery-1.7.2.min.js:3
f.event.add.h.handle.i jquery-1.7.2.min.js:3
```

The "Close" button works as expected.
