### PR TITLE
LDAP: cachekey in set method needs to match with that one from get

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1031,7 +1031,7 @@ abstract class Access {
 	 */
 	private function setPagedResultCookie($base, $filter, $limit, $offset, $cookie) {
 		if(!empty($cookie)) {
-			$cachekey = 'lc' . dechex(crc32($base)) . '-' . dechex(crc32($filter)) . '-' .$limit . '-' . $offset;
+			$cachekey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' .$limit . '-' . $offset;
 			$cookie = $this->connection->writeToCache($cachekey, $cookie);
 		}
 	}


### PR DESCRIPTION
$cacheky in https://github.com/owncloud/core/blob/master/apps/user_ldap/lib/access.php#L1015 needs to match with that in https://github.com/owncloud/core/blob/master/apps/user_ldap/lib/access.php#L1034, it won't ever work like it is now.

another low-hanging review, @bartv2 @karlitschek, @Raydiation or others please.
