### PR TITLE
Indicate password strength

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -63,3 +63,9 @@
 .ie8 #nojavascript {
 	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#4c320000', endColorstr='#4c320000'); /* IE */
 }
+
+/* IE8 doesn't have rounded corners, so the strengthify bar should be wider */
+.lte8 #body-login .strengthify-wrapper {
+	width: 271px;
+	left: 6px;
+}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -341,7 +341,7 @@ input[type="submit"].enabled {
 	margin-bottom: 20px;
 	text-align: left;
 }
-#body-login form #adminaccount { margin-bottom:5px; }
+#body-login form #adminaccount { margin-bottom:15px; }
 #body-login form fieldset legend, #datadirContent label {
 	width: 100%;
 	font-weight: bold;
@@ -359,6 +359,21 @@ input[type="submit"].enabled {
 #body-login #showAdvanced img {
 	vertical-align: bottom; /* adjust position of Advanced dropdown arrow */
 	margin-left: -4px;
+}
+
+/* strengthify wrapper */
+#body-login .strengthify-wrapper {
+	display: inline-block;
+	position: relative;
+	left: 15px;
+	top: -21px;
+	width: 252px;
+}
+
+/* tipsy for the strengthify wrapper looks better with following font settings */
+#body-login .tipsy-inner {
+	font-weight: bold;
+	color: #ccc;
 }
 
 /* Icons for username and password fields to better recognize them */

--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -7,9 +7,9 @@ $(document).ready(function() {
 		oracle:!!$('#hasOracle').val(),
 		mssql:!!$('#hasMSSQL').val()
 	};
-	
+
 	$('#selectDbType').buttonset();
-	
+
 	if($('#hasSQLite').val()){
 		$('#use_other_db').hide();
 		$('#use_oracle_db').hide();
@@ -63,17 +63,27 @@ $(document).ready(function() {
 		form.submit();
 		return false;
 	});
-	
+
 	// Expand latest db settings if page was reloaded on error
 	var currentDbType = $('input[type="radio"]:checked').val();
-	
+
 	if (currentDbType === undefined){
 		$('input[type="radio"]').first().click();
 	}
-	
+
 	if (currentDbType === 'sqlite' || (dbtypes.sqlite && currentDbType === undefined)){
 		$('#datadirContent').hide(250);
 		$('#databaseField').hide(250);
 	}
-	
+
+	$('#adminpass').strengthify({
+		zxcvbn: OC.linkTo('3rdparty','zxcvbn/js/zxcvbn.js'),
+		titles: [
+			t('core', 'Very weak password'),
+			t('core', 'Weak password'),
+			t('core', 'So-so password'),
+			t('core', 'Good password'),
+			t('core', 'Strong password')
+		]
+	});
 });

--- a/core/setup.php
+++ b/core/setup.php
@@ -20,6 +20,8 @@ if ($dbIsSet AND $directoryIsSet AND $adminAccountIsSet) {
 	}
 }
 
+OC_Util::addScript( '3rdparty', 'strengthify/jquery.strengthify' );
+OC_Util::addStyle( '3rdparty', 'strengthify/strengthify' );
 OC_Util::addScript('setup');
 
 $hasSQLite = class_exists('SQLite3');

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -59,6 +59,7 @@
 			<img class="svg" id="adminpass-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt="" />
 			<input type="checkbox" id="show" name="show" />
 			<label for="show"></label>
+			<div class="strengthify-wrapper"></div>
 		</p>
 	</fieldset>
 

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -147,3 +147,16 @@ table.shareAPI td { padding-bottom: 0.8em; }
 /* HELP */
 .pressed {background-color:#DDD;}
 
+/* PASSWORD */
+.strengthify-wrapper {
+	position: absolute;
+	left: 189px;
+	width: 131px;
+	margin-top: -7px;
+}
+
+/* OPERA hack for strengthify*/
+doesnotexist:-o-prefocus, .strengthify-wrapper {
+	left: 185px;
+	width: 129px;
+}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2011, Robin Appelman <icewind1991@gmail.com>
+ *               2013, Morris Jobke <morris.jobke@gmail.com>
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  */
@@ -242,6 +243,17 @@ $(document).ready(function(){
 
 	$('#sendcropperbutton').click(function(){
 		sendCropData();
+	});
+
+	$('#pass2').strengthify({
+		zxcvbn: OC.linkTo('3rdparty','zxcvbn/js/zxcvbn.js'),
+		titles: [
+			t('core', 'Very weak password'),
+			t('core', 'Weak password'),
+			t('core', 'So-so password'),
+			t('core', 'Good password'),
+			t('core', 'Strong password')
+		]
 	});
 } );
 

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -13,6 +13,8 @@ $defaults = new OC_Defaults(); // initialize themable default strings and urls
 // Highlight navigation entry
 OC_Util::addScript( 'settings', 'personal' );
 OC_Util::addStyle( 'settings', 'settings' );
+OC_Util::addScript( '3rdparty', 'strengthify/jquery.strengthify' );
+OC_Util::addStyle( '3rdparty', 'strengthify/strengthify' );
 OC_Util::addScript( '3rdparty', 'chosen/chosen.jquery.min' );
 OC_Util::addStyle( '3rdparty', 'chosen' );
 \OC_Util::addScript('files', 'jquery.fileupload');
@@ -20,6 +22,8 @@ if (\OC_Config::getValue('enable_avatars', true) === true) {
 	\OC_Util::addScript('3rdparty/Jcrop', 'jquery.Jcrop.min');
 	\OC_Util::addStyle('3rdparty/Jcrop', 'jquery.Jcrop.min');
 }
+
+// Highlight navigation entry
 OC_App::setActiveNavigationEntry( 'personal' );
 
 $storageInfo=OC_Helper::getStorageInfo('/');

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -44,6 +44,8 @@ if($_['passwordChangeSupported']) {
 			placeholder="<?php echo $l->t('New password');?>" data-typetoggle="#personal-show" />
 		<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
 		<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password');?>" />
+		<br/>
+		<div class="strengthify-wrapper"></div>
 	</fieldset>
 </form>
 <?php


### PR DESCRIPTION
This is a new pull request for #2048.

The commit from #2268 is cherry-picked, because it was based on an too old master branch (2 months ago).

Requires owncloud/3rdparty#20

Task list from #2268
- [x] Load the script asynchronous (how can I get the path of the 3rdparty folder in JS?)
- [x] Make the UI nicer - I'd like [such a cool bar (scoll-down)](https://tech.dropbox.com/2012/04/zxcvbn-realistic-password-strength-estimation/) and when clicking on the (i) there should more info displayed (time to crack, entropy etc...) 
- [x] Clean up the JS / HTML (maybe even make it a jQuery plugin so it's reusable) - is here any jQuery guru who wants to do this?
- [x] tipsy
- [x] delay show

Current appearance:
![password-strength](https://f.cloud.github.com/assets/245432/462363/379efe06-b4a5-11e2-8be2-221e4260c517.png)

A textual rating is in the title attribute, so a hover will show it.

Tested with FF20 and Chromium 26. Can anybody test it with IE?

cc @Raydiation @raghunayyar @jancborchardt @Kondou-ger 
