### PR TITLE
Files: set the proper mimetype when creating a new text file

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -85,7 +85,7 @@ if($source) {
 	}elseif(\OC\Files\Filesystem::touch($dir . '/' . $filename)) {
 		$meta = \OC\Files\Filesystem::getFileInfo($dir.'/'.$filename);
 		$id = $meta['fileid'];
-		OCP\JSON::success(array("data" => array('content'=>$content, 'id' => $id)));
+		OCP\JSON::success(array("data" => array('content'=>$content, 'id' => $id, 'mime' => $meta['mimetype'])));
 		exit();
 	}
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -511,9 +511,9 @@ $(document).ready(function() {
 								var date=new Date();
 								FileList.addFile(name,0,date,false,hidden);
 								var tr=$('tr').filterAttr('data-file',name);
-								tr.attr('data-mime','text/plain');
+								tr.attr('data-mime',result.data.mime);
 								tr.attr('data-id', result.data.id);
-								getMimeIcon('text/plain',function(path){
+								getMimeIcon(result.data.mime,function(path){
 									tr.find('td.filename').attr('style','background-image:url('+path+')');
 								});
 							} else {


### PR DESCRIPTION
this fixes newly created text files not always having the correct mimetype untill the interface is reloaded.

cc @karlitschek @MTGap @DeepDiver1975 
