### PR TITLE
fix for tearDownFS, after filesystem::tearDown() in Util

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -67,6 +67,7 @@ class OC_Util {
 	public static function tearDownFS() {
 		\OC\Files\Filesystem::tearDown();
 		self::$fsSetup=false;
+        self::$rootMounted=false;
 	}
 
 	/**


### PR DESCRIPTION
All mountpoints are removed in filesystem::tearDown().
We should set it to rootMounted to false in Util
