### PR TITLE
Move autoloader to it's own class

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+class Autoloader {
+	public function load($class) {
+		$class = trim($class, '\\');
+
+		if (array_key_exists($class, \OC::$CLASSPATH)) {
+			$path = \OC::$CLASSPATH[$class];
+			/** @TODO: Remove this when necessary
+			Remove "apps/" from inclusion path for smooth migration to mutli app dir
+			 */
+			if (strpos($path, 'apps/') === 0) {
+				\OC_Log::write('core', 'include path for class "' . $class . '" starts with "apps/"', \OC_Log::DEBUG);
+				$path = str_replace('apps/', '', $path);
+			}
+		} elseif (strpos($class, 'OC_') === 0) {
+			$path = strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
+		} elseif (strpos($class, 'OC\\') === 0) {
+			$path = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+		} elseif (strpos($class, 'OCP\\') === 0) {
+			$path = 'public/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+		} elseif (strpos($class, 'OCA\\') === 0) {
+			foreach (\OC::$APPSROOTS as $appDir) {
+				$path = strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
+				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $path);
+				if (file_exists($fullPath)) {
+					require_once $fullPath;
+					return false;
+				}
+				// If not found in the root of the app directory, insert '/lib' after app id and try again.
+				$libpath = substr($path, 0, strpos($path, '/')) . '/lib' . substr($path, strpos($path, '/'));
+				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $libpath);
+				if (file_exists($fullPath)) {
+					require_once $fullPath;
+					return false;
+				}
+			}
+		} elseif (strpos($class, 'Sabre_') === 0) {
+			$path = str_replace('_', '/', $class) . '.php';
+		} elseif (strpos($class, 'Symfony\\Component\\Routing\\') === 0) {
+			$path = 'symfony/routing/' . str_replace('\\', '/', $class) . '.php';
+		} elseif (strpos($class, 'Sabre\\VObject') === 0) {
+			$path = str_replace('\\', '/', $class) . '.php';
+		} elseif (strpos($class, 'Test_') === 0) {
+			$path = 'tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
+		} elseif (strpos($class, 'Test\\') === 0) {
+			$path = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
+		} else {
+			return false;
+		}
+
+		if ($fullPath = stream_resolve_include_path($path)) {
+			require_once $fullPath;
+		}
+		return false;
+	}
+}

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -78,14 +78,15 @@ class Autoloader {
 		} elseif (strpos($class, 'OC\\') === 0) {
 			$paths[] = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OCP\\') === 0) {
-			$paths[] = 'public/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+			$paths[] = 'public/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 		} elseif (strpos($class, 'OCA\\') === 0) {
+			list(, $app, $rest) = explode('\\', $class, 3);
+			$app = strtolower($app);
 			foreach (\OC::$APPSROOTS as $appDir) {
-				list(, $app,) = explode('\\', $class);
-				if (stream_resolve_include_path($appDir['path'] . '/' . strtolower($app))) {
-					$paths[] = $appDir['path'] . '/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
+				if (stream_resolve_include_path($appDir['path'] . '/' . $app)) {
+					$paths[] = $appDir['path'] . '/' . $app . '/' . strtolower(str_replace('\\', '/', $rest) . '.php');
 					// If not found in the root of the app directory, insert '/lib' after app id and try again.
-					$paths[] = $appDir['path'] . '/lib/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
+					$paths[] = $appDir['path'] . '/' . $app . '/lib/' . strtolower(str_replace('\\', '/', $rest) . '.php');
 				}
 			}
 		} elseif (strpos($class, 'Test_') === 0) {

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -9,6 +9,8 @@
 namespace OC;
 
 class Autoloader {
+	private $useGlobalClassPath = true;
+
 	private $classPaths = array();
 
 	/**
@@ -19,6 +21,20 @@ class Autoloader {
 	 */
 	public function registerClass($class, $path) {
 		$this->classPaths[$class] = $path;
+	}
+
+	/**
+	 * disable the usage of the global classpath \OC::$CLASSPATH
+	 */
+	public function disableGlobalClassPath() {
+		$this->useGlobalClassPath = false;
+	}
+
+	/**
+	 * enable the usage of the global classpath \OC::$CLASSPATH
+	 */
+	public function enableGlobalClassPath() {
+		$this->useGlobalClassPath = true;
 	}
 
 	/**
@@ -33,15 +49,15 @@ class Autoloader {
 		$paths = array();
 		if (array_key_exists($class, $this->classPaths)) {
 			$paths[] = $this->classPaths[$class];
-		} else if (array_key_exists($class, \OC::$CLASSPATH)) {
+		} else if ($this->useGlobalClassPath and array_key_exists($class, \OC::$CLASSPATH)) {
 			$paths[] = \OC::$CLASSPATH[$class];
 			/**
 			 * @TODO: Remove this when necessary
 			 * Remove "apps/" from inclusion path for smooth migration to mutli app dir
 			 */
-			if (strpos($path, 'apps/') === 0) {
+			if (strpos(\OC::$CLASSPATH[$class], 'apps/') === 0) {
 				\OC_Log::write('core', 'include path for class "' . $class . '" starts with "apps/"', \OC_Log::DEBUG);
-				$path = str_replace('apps/', '', $path);
+				$path = str_replace('apps/', '', \OC::$CLASSPATH[$class]);
 			}
 		} elseif (strpos($class, 'OC_') === 0) {
 			$paths[] = strtolower(str_replace('_', '/', substr($class, 3)) . '.php');

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -30,10 +30,11 @@ class Autoloader {
 	public function load($class) {
 		$class = trim($class, '\\');
 
+		$paths = array();
 		if (array_key_exists($class, $this->classPaths)) {
-			$path = $this->classPaths[$class];
+			$paths[] = $this->classPaths[$class];
 		} else if (array_key_exists($class, \OC::$CLASSPATH)) {
-			$path = \OC::$CLASSPATH[$class];
+			$paths[] = \OC::$CLASSPATH[$class];
 			/**
 			 * @TODO: Remove this when necessary
 			 * Remove "apps/" from inclusion path for smooth migration to mutli app dir
@@ -43,43 +44,35 @@ class Autoloader {
 				$path = str_replace('apps/', '', $path);
 			}
 		} elseif (strpos($class, 'OC_') === 0) {
-			$path = strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
+			$paths[] = strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OC\\') === 0) {
-			$path = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+			$paths[] = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OCP\\') === 0) {
-			$path = 'public/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+			$paths[] = 'public/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OCA\\') === 0) {
 			foreach (\OC::$APPSROOTS as $appDir) {
-				$path = strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
-				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $path);
-				if (file_exists($fullPath)) {
-					require_once $fullPath;
-					return false;
-				}
+				$paths[] = $appDir['path'] . '/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 				// If not found in the root of the app directory, insert '/lib' after app id and try again.
-				$libpath = substr($path, 0, strpos($path, '/')) . '/lib' . substr($path, strpos($path, '/'));
-				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $libpath);
-				if (file_exists($fullPath)) {
-					require_once $fullPath;
-					return false;
-				}
+				$paths[] = $appDir['path'] . '/lib/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 			}
 		} elseif (strpos($class, 'Sabre_') === 0) {
-			$path = str_replace('_', '/', $class) . '.php';
+			$paths[] = str_replace('_', '/', $class) . '.php';
 		} elseif (strpos($class, 'Symfony\\Component\\Routing\\') === 0) {
-			$path = 'symfony/routing/' . str_replace('\\', '/', $class) . '.php';
+			$paths[] = 'symfony/routing/' . str_replace('\\', '/', $class) . '.php';
 		} elseif (strpos($class, 'Sabre\\VObject') === 0) {
-			$path = str_replace('\\', '/', $class) . '.php';
+			$paths[] = str_replace('\\', '/', $class) . '.php';
 		} elseif (strpos($class, 'Test_') === 0) {
-			$path = 'tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
+			$paths[] = 'tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
 		} elseif (strpos($class, 'Test\\') === 0) {
-			$path = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
+			$paths[] = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
 		} else {
 			return false;
 		}
 
-		if ($fullPath = stream_resolve_include_path($path)) {
-			require_once $fullPath;
+		foreach ($paths as $path) {
+			if ($fullPath = stream_resolve_include_path($path)) {
+				require_once $fullPath;
+			}
 		}
 		return false;
 	}

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -9,13 +9,34 @@
 namespace OC;
 
 class Autoloader {
+	private $classPaths = array();
+
+	/**
+	 * Add a custom classpath to the autoloader
+	 *
+	 * @param string $class
+	 * @param string $path
+	 */
+	public function registerClass($class, $path) {
+		$this->classPaths[$class] = $path;
+	}
+
+	/**
+	 * Load the specified class
+	 *
+	 * @param string $class
+	 * @return bool
+	 */
 	public function load($class) {
 		$class = trim($class, '\\');
 
-		if (array_key_exists($class, \OC::$CLASSPATH)) {
+		if (array_key_exists($class, $this->classPaths)) {
+			$path = $this->classPaths[$class];
+		} else if (array_key_exists($class, \OC::$CLASSPATH)) {
 			$path = \OC::$CLASSPATH[$class];
-			/** @TODO: Remove this when necessary
-			Remove "apps/" from inclusion path for smooth migration to mutli app dir
+			/**
+			 * @TODO: Remove this when necessary
+			 * Remove "apps/" from inclusion path for smooth migration to mutli app dir
 			 */
 			if (strpos($path, 'apps/') === 0) {
 				\OC_Log::write('core', 'include path for class "' . $class . '" starts with "apps/"', \OC_Log::DEBUG);

--- a/lib/base.php
+++ b/lib/base.php
@@ -344,10 +344,14 @@ class OC {
 
 	public static function init() {
 		// register autoloader
-		require_once 'autoloader.php';
+		require_once __DIR__ . '/autoloader.php';
 		self::$loader=new \OC\Autoloader();
+		self::$loader->registerPrefix('Doctrine\\Common', 'doctrine/common/lib');
+		self::$loader->registerPrefix('Doctrine\\DBAL', 'doctrine/dbal/lib');
+		self::$loader->registerPrefix('Symfony\\Component\\Routing', 'symfony/routing');
+		self::$loader->registerPrefix('Sabre\\VObject', '3rdparty');
+		self::$loader->registerPrefix('Sabre_', '3rdparty');
 		spl_autoload_register(array(self::$loader, 'load'));
-		OC_Util::issetlocaleworking();
 
 		// set some stuff
 		//ob_start();
@@ -404,6 +408,7 @@ class OC {
 		}
 
 		self::initPaths();
+		OC_Util::issetlocaleworking();
 
 		// set debug mode if an xdebug session is active
 		if (!defined('DEBUG') || !DEBUG) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -75,61 +75,9 @@ class OC {
 	protected static $router = null;
 
 	/**
-	 * SPL autoload
+	 * @var \OC\Autoloader $loader
 	 */
-	public static function autoload($className) {
-		$className = trim($className, '\\');
-		
-		if (array_key_exists($className, OC::$CLASSPATH)) {
-			$path = OC::$CLASSPATH[$className];
-			/** @TODO: Remove this when necessary
-			Remove "apps/" from inclusion path for smooth migration to mutli app dir
-			 */
-			if (strpos($path, 'apps/') === 0) {
-				OC_Log::write('core', 'include path for class "' . $className . '" starts with "apps/"', OC_Log::DEBUG);
-				$path = str_replace('apps/', '', $path);
-			}
-		} elseif (strpos($className, 'OC_') === 0) {
-			$path = strtolower(str_replace('_', '/', substr($className, 3)) . '.php');
-		} elseif (strpos($className, 'OC\\') === 0) {
-			$path = strtolower(str_replace('\\', '/', substr($className, 3)) . '.php');
-		} elseif (strpos($className, 'OCP\\') === 0) {
-			$path = 'public/' . strtolower(str_replace('\\', '/', substr($className, 3)) . '.php');
-		} elseif (strpos($className, 'OCA\\') === 0) {
-			foreach (self::$APPSROOTS as $appDir) {
-				$path = strtolower(str_replace('\\', '/', substr($className, 4)) . '.php');
-				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $path);
-				if (file_exists($fullPath)) {
-					require_once $fullPath;
-					return false;
-				}
-				// If not found in the root of the app directory, insert '/lib' after app id and try again.
-				$libpath = substr($path, 0, strpos($path, '/')) . '/lib' . substr($path, strpos($path, '/'));
-				$fullPath = stream_resolve_include_path($appDir['path'] . '/' . $libpath);
-				if (file_exists($fullPath)) {
-					require_once $fullPath;
-					return false;
-				}
-			}
-		} elseif (strpos($className, 'Sabre_') === 0) {
-			$path = str_replace('_', '/', $className) . '.php';
-		} elseif (strpos($className, 'Symfony\\Component\\Routing\\') === 0) {
-			$path = 'symfony/routing/' . str_replace('\\', '/', $className) . '.php';
-		} elseif (strpos($className, 'Sabre\\VObject') === 0) {
-			$path = str_replace('\\', '/', $className) . '.php';
-		} elseif (strpos($className, 'Test_') === 0) {
-			$path = 'tests/lib/' . strtolower(str_replace('_', '/', substr($className, 5)) . '.php');
-		} elseif (strpos($className, 'Test\\') === 0) {
-			$path = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($className, 5)) . '.php');
-		} else {
-			return false;
-		}
-
-		if ($fullPath = stream_resolve_include_path($path)) {
-			require_once $fullPath;
-		}
-		return false;
-	}
+	public static $loader = null;
 
 	public static function initPaths() {
 		// calculate the root directories
@@ -396,7 +344,9 @@ class OC {
 
 	public static function init() {
 		// register autoloader
-		spl_autoload_register(array('OC', 'autoload'));
+		require_once 'autoloader.php';
+		self::$loader=new \OC\Autoloader();
+		spl_autoload_register(array(self::$loader, 'load'));
 		OC_Util::issetlocaleworking();
 
 		// set some stuff
@@ -643,7 +593,7 @@ class OC {
 			
 			// Deny the redirect if the URL contains a @
 			// This prevents unvalidated redirects like ?redirect_url=:user@domain.com
-			if (strpos($location, '@') === FALSE) {
+			if (strpos($location, '@') === false) {
 				header('Location: ' . $location);
 				return;
 			}

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -45,23 +45,30 @@ class AutoLoader extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo/Foo/Bar.php'), $this->loader->findClass('Foo_Bar'));
 	}
 
-	public function loadTestNamespace() {
-		$this->assertEquals(array('test/foo/bar.php'), $this->loader->findClass('Test\Foo\Bar'));
+	public function testLoadTestNamespace() {
+		$this->assertEquals(array('tests/lib/foo/bar.php'), $this->loader->findClass('Test\Foo\Bar'));
 	}
 
-	public function loadTest() {
-		$this->assertEquals(array('test/foo/bar.php'), $this->loader->findClass('Test_Foo_Bar'));
+	public function testLoadTest() {
+		$this->assertEquals(array('tests/lib/foo/bar.php'), $this->loader->findClass('Test_Foo_Bar'));
 	}
 
-	public function loadCoreNamespace() {
-		$this->assertEquals(array('lib/foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
+	public function testLoadCoreNamespace() {
+		$this->assertEquals(array('foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
 	}
 
-	public function loadCore() {
-		$this->assertEquals(array('lib/legacy/foo/bar.php', 'lib/foo/bar.php'), $this->loader->findClass('OC_Foo_Bar'));
+	public function testLoadCore() {
+		$this->assertEquals(array('legacy/foo/bar.php', 'foo/bar.php'), $this->loader->findClass('OC_Foo_Bar'));
 	}
 
-	public function loadPublicNamespace() {
-		$this->assertEquals(array('lib/public/foo/bar.php'), $this->loader->findClass('OCP\Foo\Bar'));
+	public function testLoadPublicNamespace() {
+		$this->assertEquals(array('public/foo/bar.php'), $this->loader->findClass('OCP\Foo\Bar'));
+	}
+
+	public function testLoadAppNamespace() {
+		$result = $this->loader->findClass('OCA\Files\Foobar');
+		$this->assertEquals(2, count($result));
+		$this->assertStringEndsWith('apps/files/foobar.php', $result[0]);
+		$this->assertStringEndsWith('apps/files/lib/foobar.php', $result[1]);
 	}
 }

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -6,14 +6,62 @@
  * See the COPYING-README file.
  */
 
-class Test_AutoLoader extends PHPUnit_Framework_TestCase {
+namespace Test;
 
-	public function testLeadingSlashOnClassName(){
-		$this->assertTrue(class_exists('\OC\Files\Storage\Local'));
+class AutoLoader extends \PHPUnit_Framework_TestCase {
+	/**
+	 * @var \OC\Autoloader $loader
+	 */
+	private $loader;
+
+	public function setUp() {
+		$this->loader = new \OC\AutoLoader();
 	}
 
-	public function testNoLeadingSlashOnClassName(){
-		$this->assertTrue(class_exists('OC\Files\Storage\Local'));
+	public function testLeadingSlashOnClassName() {
+		$this->assertEquals(array('files/storage/local.php'), $this->loader->findClass('\OC\Files\Storage\Local'));
 	}
 
+	public function testNoLeadingSlashOnClassName() {
+		$this->assertEquals(array('files/storage/local.php'), $this->loader->findClass('OC\Files\Storage\Local'));
+	}
+
+	public function testLegacyPath() {
+		$this->assertEquals(array('legacy/files.php', 'files.php'), $this->loader->findClass('OC_Files'));
+	}
+
+	public function testClassPath() {
+		$this->loader->registerClass('Foo\Bar', 'foobar.php');
+		$this->assertEquals(array('foobar.php'), $this->loader->findClass('Foo\Bar'));
+	}
+
+	public function testPrefixNamespace() {
+		$this->loader->registerPrefix('Foo', 'foo');
+		$this->assertEquals(array('foo/Foo/Bar.php'), $this->loader->findClass('Foo\Bar'));
+	}
+
+	public function testPrefix() {
+		$this->loader->registerPrefix('Foo_', 'foo');
+		$this->assertEquals(array('foo/Foo/Bar.php'), $this->loader->findClass('Foo_Bar'));
+	}
+
+	public function loadTestNamespace() {
+		$this->assertEquals(array('test/foo/bar.php'), $this->loader->findClass('Test\Foo\Bar'));
+	}
+
+	public function loadTest() {
+		$this->assertEquals(array('test/foo/bar.php'), $this->loader->findClass('Test_Foo_Bar'));
+	}
+
+	public function loadCoreNamespace() {
+		$this->assertEquals(array('lib/foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
+	}
+
+	public function loadCore() {
+		$this->assertEquals(array('lib/legacy/foo/bar.php', 'lib/foo/bar.php'), $this->loader->findClass('OC_Foo_Bar'));
+	}
+
+	public function loadPublicNamespace() {
+		$this->assertEquals(array('lib/public/foo/bar.php'), $this->loader->findClass('OCP\Foo\Bar'));
+	}
 }


### PR DESCRIPTION
Also adds support for loading legacy classes from `lib/legacy`, whenever a class is loaded using underscores instead of namespaces (i.e. `OC_Filesystem`) the autoloader will first look into `lib/legacy` before looking into `lib`. This allows us to move the legacy classes to their own folder and cleanup `lib` a bit.

cc @karlitschek @DeepDiver1975 @bartv2 @Raydiation 
