### PR TITLE
Fix etag update

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -184,11 +184,12 @@ class Storage {
 	/**
 	 * rollback to an old version of a file.
 	 */
-	public static function rollback($filename, $revision) {
+	public static function rollback($file, $revision) {
 
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
-			list($uid, $filename) = self::getUidAndFilename($filename);
+			list($uid, $filename) = self::getUidAndFilename($file);
 			$users_view = new \OC\Files\View('/'.$uid);
+			$files_view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
 			$versionCreated = false;
 
 			//first create a new version
@@ -200,8 +201,8 @@ class Storage {
 
 			// rollback
 			if( @$users_view->copy('files_versions'.$filename.'.v'.$revision, 'files'.$filename) ) {
-				$users_view->touch('files'.$filename, $revision);
-				Storage::expire($filename);
+				$files_view->touch($file, $revision);
+				Storage::expire($file);
 				return true;
 
 			}else if ( $versionCreated ) {

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -200,7 +200,7 @@ class Storage {
 			}
 
 			// rollback
-			if( @$users_view->copy('files_versions'.$filename.'.v'.$revision, 'files'.$filename) ) {
+			if( @$users_view->rename('files_versions'.$filename.'.v'.$revision, 'files'.$filename) ) {
 				$files_view->touch($file, $revision);
 				Storage::expire($file);
 				return true;

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -122,7 +122,6 @@ class Updater {
 		$id = $cache->getId($internalPath);
 		if ($id !== -1) {
 			$cache->update($id, array('etag' => $storage->getETag($internalPath)));
-			self::correctFolder($parent, $time);
 		}
 		self::writeUpdate($path);
 	}

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -116,7 +116,15 @@ class Updater {
 	 * @param array $params
 	 */
 	static public function touchHook($params) {
-		self::writeUpdate($params['path']);
+		$path = $params['path'];
+		list($storage, $internalPath) = self::resolvePath($path);
+		$cache = $storage->getCache();
+		$id = $cache->getId($internalPath);
+		if ($id !== -1) {
+			$cache->update($id, array('etag' => $storage->getETag($internalPath)));
+			self::correctFolder($parent, $time);
+		}
+		self::writeUpdate($path);
 	}
 
 	/**


### PR DESCRIPTION
Make sure that not only the etags from the parent directories gets updated but also the etag of the actual file after it was touched. This should fix issue #3280 

Further change the copy operation to a rename operation if a versions gets restored to make sure to not end up with only one version which is exactly the same as the actual file.
