### PR TITLE
Allow 'unsafe-inline' js

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -146,7 +146,7 @@ $CONFIG = array(
 "remember_login_cookie_lifetime" => 60*60*24*15,
 
 /* Custom CSP policy, changing this will overwrite the standard policy */
-"custom_csp_policy" => "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src *; font-src 'self' data:; media-src *",
+"custom_csp_policy" => "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src *; img-src *; font-src 'self' data:; media-src *",
 
 /* Enable/disable X-Frame-Restriction */
 /* HIGH SECURITY RISK IF DISABLED*/

--- a/lib/template.php
+++ b/lib/template.php
@@ -199,7 +199,7 @@ class OC_Template{
 		// If you change the standard policy, please also change it in config.sample.php
 		$policy = OC_Config::getValue('custom_csp_policy',
 			'default-src \'self\'; '
-			.'script-src \'self\' \'unsafe-eval\'; '
+			.'script-src \'self\' \'unsafe-eval\' \'unsafe-inline\'; '
 			.'style-src \'self\' \'unsafe-inline\'; '
 			.'frame-src *; '
 			.'img-src *; '


### PR DESCRIPTION
The LastPass Chrome plugin exposes a problem with OC_Template's default CSP. If 'unsafe-eval' is allowed, there is no reason 'unsafe-inline' should not be allowed as well. 

There have been other reports of this (https://github.com/owncloud/core/issues/2307, https://github.com/owncloud/core/issues/2479) blaming LastPass, when in actuality it is OC_Template setting too strict CSP.
