### PR TITLE
disable mbstring.func_overload

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,6 +12,7 @@ ErrorDocument 404 /core/templates/404.php
 php_value upload_max_filesize 513M
 php_value post_max_size 513M
 php_value memory_limit 512M
+php_value mbstring.func_overload 0
 <IfModule env_module>
   SetEnv htaccessWorking true
 </IfModule>


### PR DESCRIPTION
PHP has the option to overload common string functions like strlen, to use the multibyte versions instead. http://php.net/manual/en/mbstring.overload.php
This could potentially break responses for apps using appframework, where a Content-Length header is sent with the response.

@Raydiation @DeepDiver1975 
