### PR TITLE
Fix inexisting trashbin's sub-folders

### DIFF
--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -52,9 +52,6 @@ class Trashbin {
 		if (!$view->is_dir('files_trashbin/share-keys')) {
 			$view->mkdir('files_trashbin/share-keys');
 		}
-		if (!$view->is_dir('files_trashbin/files')) {
-			$view->mkdir('files_trashbin/files');
-		}
 		$path_parts = pathinfo($file_path);
 
 		$filename = $path_parts['basename'];

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -39,12 +39,22 @@ class Trashbin {
 		$view = new \OC\Files\View('/'. $user);
 		if (!$view->is_dir('files_trashbin')) {
 			$view->mkdir('files_trashbin');
-			$view->mkdir('files_trashbin/files');
-			$view->mkdir('files_trashbin/versions');
-			$view->mkdir('files_trashbin/keyfiles');
-            $view->mkdir('files_trashbin/share-keys');
 		}
-
+		if (!$view->is_dir('files_trashbin/files')) {
+			$view->mkdir('files_trashbin/files');
+		}
+		if (!$view->is_dir('files_trashbin/versions')) {
+			$view->mkdir('files_trashbin/versions');
+		}
+		if (!$view->is_dir('files_trashbin/keyfiles')) {
+			$view->mkdir('files_trashbin/keyfiles');
+		}
+		if (!$view->is_dir('files_trashbin/share-keys')) {
+			$view->mkdir('files_trashbin/share-keys');
+		}
+		if (!$view->is_dir('files_trashbin/files')) {
+			$view->mkdir('files_trashbin/files');
+		}
 		$path_parts = pathinfo($file_path);
 
 		$filename = $path_parts['basename'];


### PR DESCRIPTION
In some cases, only _/files_trashbin_ is created and files cannot been moved to _/files/trashbin/files/_ for example.
This fix checks all required subfolders and create theme if needed.
