### PR TITLE
disable mbstring.func_overload in setup v.3

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -811,6 +811,7 @@ class OC_Setup {
 		$content.= "php_value upload_max_filesize 512M\n";//upload limit
 		$content.= "php_value post_max_size 512M\n";
 		$content.= "php_value memory_limit 512M\n";
+		$content.= "php_value mbstring.func_overload 0\n";
 		$content.= "<IfModule env_module>\n";
 		$content.= "  SetEnv htaccessWorking true\n";
 		$content.= "</IfModule>\n";


### PR DESCRIPTION
Same as https://github.com/owncloud/core/pull/3308 but due to borked master and a stupidly named branch name I had to make a new one.
Lesson learned: Don't prefix branch names with a `-`

@kabum @DeepDiver1975 @icewind1991 
