### PR TITLE
Set the SQLite database lock timeout to 60 seconds which is the default ...

### DIFF
--- a/lib/MDB2/Driver/sqlite3.php
+++ b/lib/MDB2/Driver/sqlite3.php
@@ -387,7 +387,7 @@ class MDB2_Driver_sqlite3 extends MDB2_Driver_Common
         $php_errormsg = '';
 		$this->connection = new SQLite3($database_file);
 		if(is_callable(array($this->connection, 'busyTimeout'))) {//busy timout is only available in php>=5.3
-			$this->connection->busyTimeout(100);
+			$this->connection->busyTimeout(60000);
 		}
         $this->_lasterror = $this->connection->lastErrorMsg();
         if (!$this->connection) {


### PR DESCRIPTION
...in PHP anyways. I don't know why the MDB2 driver has this hardcoded to 0.1 seconds. This potentially fixes a lot of SQLite database lock problems and stuck in maintainance mode during upgrade issues.

@dragotin @schiesbn @bartv2 @Raydiation 
