### PR TITLE
Prevent backgroundScan() from looping

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -179,9 +179,11 @@ class Scanner {
 	 * walk over any folders that are not fully scanned yet and scan them
 	 */
 	public function backgroundScan() {
-		while (($path = $this->cache->getIncomplete()) !== false) {
+		$lastPath = null;
+		while (($path = $this->cache->getIncomplete()) !== false && $path !== $lastPath) {
 			$this->scan($path);
 			$this->cache->correctFolderSize($path);
+			$lastPath = $path;
 		}
 	}
 }


### PR DESCRIPTION
The Dropbox storage library was returning an unexpected result for empty directories which resulted in opendir() returning false. The backgroundScan() kept trying to scan this folder because the folder was always returned by getIncomplete(). Now it should only try once for failing scans. I'll correct the Dropbox storage, but I wanted to add this in case there are other actual occurrences of opendir() failing.

@icewind1991 
