### PR TITLE
 Duplicate DB entries in filecache table when renaming folder in WebUI

### DIFF
--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -324,8 +324,8 @@ class Cache {
 
 		if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 			//find all child entries
-			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `path` LIKE ?');
-			$result = $query->execute(array($source . '/%'));
+			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? `path` LIKE ?');
+			$result = $query->execute(array($this->numericId, $source . '/%'));
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($source);
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ? WHERE `fileid` = ?');

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -325,7 +325,7 @@ class Cache {
 		if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 			//find all child entries
 			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?');
-			$result = $query->execute(array($this->numericId, $source . '/%'));
+			$result = $query->execute(array($this->storageId, $source . '/%'));
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($source);
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ? WHERE `fileid` = ?');

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -324,7 +324,7 @@ class Cache {
 
 		if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 			//find all child entries
-			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? `path` LIKE ?');
+			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?');
 			$result = $query->execute(array($this->numericId, $source . '/%'));
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($source);


### PR DESCRIPTION
We noticed several duplicated entries in the webinterfaces for a lot of our users while there was only one folder in the filesystem. I investigated the filecache table and noticed, that there where a lot of entries with a false path.

Here an example: The first row is the correct entry and the second has a wrong path component FOO which does not exist in this users storage path.

```
*************************** 1. row ***************************
  fileid: 8098951
  storage: 75
  path: files/clientsync/test/test.txt
  path_hash: 4c0c2d21adb3e3cd929adf2eac0cff80
  parent: 8096041
  name: test.txt
  mimetype: 22
  mimepart: 14
  size: 28636
  mtime: 1368025446
  encrypted: 0
  etag: 5190ab7b19a2c

*************************** 2. row ***************************
   fileid: 1892546
   storage: 75
   path: files/FOO/test/test.txt
   path_hash: db5194196cd61b1c0b9d20e192c9c8e7
   parent: 1892541
   name: test.txt
   mimetype: 22
   mimepart: 14
   size: 28636
   mtime: 1368025446
   encrypted: 0
   etag: 518a6969a9434 
```

Eventually I could reproduce the duplicates when renaming a folder via the Webinterface and found the BUG in the code. The failure was obviously the missing storage id. To reproduce the BUG you need two users having the same folder structure. The folders must contain at least one file. Now rename one folder and all filecache entries with the same path will be updated with the new folder name ... regardless of the storage id.
