### PR TITLE
fix for SQLite3Result::fetchArray() on setup

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -542,10 +542,12 @@ class OC {
 	 * register hooks for sharing
 	 */
 	public static function registerShareHooks() {
-		OC_Hook::connect('OC_User', 'post_deleteUser', 'OCP\Share', 'post_deleteUser');
-		OC_Hook::connect('OC_User', 'post_addToGroup', 'OCP\Share', 'post_addToGroup');
-		OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OCP\Share', 'post_removeFromGroup');
-		OC_Hook::connect('OC_User', 'post_deleteGroup', 'OCP\Share', 'post_deleteGroup');
+		if(\OC_Config::getValue('installed')) {
+			OC_Hook::connect('OC_User', 'post_deleteUser', 'OCP\Share', 'post_deleteUser');
+			OC_Hook::connect('OC_User', 'post_addToGroup', 'OCP\Share', 'post_addToGroup');
+			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OCP\Share', 'post_removeFromGroup');
+			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OCP\Share', 'post_deleteGroup');
+		}
 	}
 
 	/**

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1401,34 +1401,31 @@ class Share {
 	}
 
 	public static function post_addToGroup($arguments) {
-		
-		if(\OC_Config::getValue('installed')) {
-			// Find the group shares and check if the user needs a unique target
-			$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `share_type` = ? AND `share_with` = ?');
-			$result = $query->execute(array(self::SHARE_TYPE_GROUP, $arguments['gid']));
-			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`,'
-				.' `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`,'
-				.' `stime`, `file_source`, `file_target`) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
-			while ($item = $result->fetchRow()) {
-				if ($item['item_type'] == 'file' || $item['item_type'] == 'file') {
-					$itemTarget = null;
-				} else {
-					$itemTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
-						$arguments['uid'], $item['uid_owner'], $item['item_target'], $item['id']);
-				}
-				if (isset($item['file_source'])) {
-					$fileTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
-						$arguments['uid'], $item['uid_owner'], $item['file_target'], $item['id']);
-				} else {
-					$fileTarget = null;
-				}
-				// Insert an extra row for the group share if the item or file target is unique for this user
-				if ($itemTarget != $item['item_target'] || $fileTarget != $item['file_target']) {
-					$query->execute(array($item['item_type'], $item['item_source'], $itemTarget, $item['id'],
-						self::$shareTypeGroupUserUnique, $arguments['uid'], $item['uid_owner'], $item['permissions'],
-						$item['stime'], $item['file_source'], $fileTarget));
-					\OC_DB::insertid('*PREFIX*share');
-				}
+		// Find the group shares and check if the user needs a unique target
+		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `share_type` = ? AND `share_with` = ?');
+		$result = $query->execute(array(self::SHARE_TYPE_GROUP, $arguments['gid']));
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`,'
+			.' `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`,'
+			.' `stime`, `file_source`, `file_target`) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+		while ($item = $result->fetchRow()) {
+			if ($item['item_type'] == 'file' || $item['item_type'] == 'file') {
+				$itemTarget = null;
+			} else {
+				$itemTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
+					$arguments['uid'], $item['uid_owner'], $item['item_target'], $item['id']);
+			}
+			if (isset($item['file_source'])) {
+				$fileTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
+					$arguments['uid'], $item['uid_owner'], $item['file_target'], $item['id']);
+			} else {
+				$fileTarget = null;
+			}
+			// Insert an extra row for the group share if the item or file target is unique for this user
+			if ($itemTarget != $item['item_target'] || $fileTarget != $item['file_target']) {
+				$query->execute(array($item['item_type'], $item['item_source'], $itemTarget, $item['id'],
+					self::$shareTypeGroupUserUnique, $arguments['uid'], $item['uid_owner'], $item['permissions'],
+					$item['stime'], $item['file_source'], $fileTarget));
+				\OC_DB::insertid('*PREFIX*share');
 			}
 		}
 	}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1401,31 +1401,34 @@ class Share {
 	}
 
 	public static function post_addToGroup($arguments) {
-		// Find the group shares and check if the user needs a unique target
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `share_type` = ? AND `share_with` = ?');
-		$result = $query->execute(array(self::SHARE_TYPE_GROUP, $arguments['gid']));
-		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`,'
-			.' `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`,'
-			.' `stime`, `file_source`, `file_target`) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
-		while ($item = $result->fetchRow()) {
-			if ($item['item_type'] == 'file' || $item['item_type'] == 'file') {
-				$itemTarget = null;
-			} else {
-				$itemTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
-					$arguments['uid'], $item['uid_owner'], $item['item_target'], $item['id']);
-			}
-			if (isset($item['file_source'])) {
-				$fileTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
-					$arguments['uid'], $item['uid_owner'], $item['file_target'], $item['id']);
-			} else {
-				$fileTarget = null;
-			}
-			// Insert an extra row for the group share if the item or file target is unique for this user
-			if ($itemTarget != $item['item_target'] || $fileTarget != $item['file_target']) {
-				$query->execute(array($item['item_type'], $item['item_source'], $itemTarget, $item['id'],
-					self::$shareTypeGroupUserUnique, $arguments['uid'], $item['uid_owner'], $item['permissions'],
-					$item['stime'], $item['file_source'], $fileTarget));
-				\OC_DB::insertid('*PREFIX*share');
+		
+		if(\OC_Config::getValue('installed')) {
+			// Find the group shares and check if the user needs a unique target
+			$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `share_type` = ? AND `share_with` = ?');
+			$result = $query->execute(array(self::SHARE_TYPE_GROUP, $arguments['gid']));
+			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`,'
+				.' `item_target`, `parent`, `share_type`, `share_with`, `uid_owner`, `permissions`,'
+				.' `stime`, `file_source`, `file_target`) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+			while ($item = $result->fetchRow()) {
+				if ($item['item_type'] == 'file' || $item['item_type'] == 'file') {
+					$itemTarget = null;
+				} else {
+					$itemTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
+						$arguments['uid'], $item['uid_owner'], $item['item_target'], $item['id']);
+				}
+				if (isset($item['file_source'])) {
+					$fileTarget = self::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER,
+						$arguments['uid'], $item['uid_owner'], $item['file_target'], $item['id']);
+				} else {
+					$fileTarget = null;
+				}
+				// Insert an extra row for the group share if the item or file target is unique for this user
+				if ($itemTarget != $item['item_target'] || $fileTarget != $item['file_target']) {
+					$query->execute(array($item['item_type'], $item['item_source'], $itemTarget, $item['id'],
+						self::$shareTypeGroupUserUnique, $arguments['uid'], $item['uid_owner'], $item['permissions'],
+						$item['stime'], $item['file_source'], $fileTarget));
+					\OC_DB::insertid('*PREFIX*share');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fix the "The SQLite3Result object has not been correctly initialised" on the setup.
When the given user at the setup is added to the admin group, this also trigger the hook "post_addToGroup" on lib/public/share.php.
The query runs into an exception like this log entry:
{"app":"PHP","message":"SQLite3Result::fetchArray(): The SQLite3Result object has not been correctly initialised at \/Users\/fp\/PhpstormProjects\/ownCloud\/files_encryption\/lib\/MDB2\/Driver\/sqlite3.php#942"......
