### PR TITLE
fix for disappearing root mount point on lib/files/filesystem.php

### DIFF
--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -222,7 +222,10 @@ class Filesystem {
 			return false;
 		}
 		self::$defaultInstance = new View($root);
-		self::$mounts = new Mount\Manager();
+
+		if(!self::$mounts) {
+			self::$mounts = new Mount\Manager();
+		}
 
 		//load custom mount config
 		self::initMountPoints($user);


### PR DESCRIPTION
On Util::setupFS() the root is mounted and then Fileystem::init is called.
At this point the "private static $mounts" on Filesystem is overridden and the previous mounted root mount point is gone.

The PR fix this behavior.
