### PR TITLE
Use js templates in OC.dialogs etc.

### DIFF
--- a/apps/files/ajax/rawlist.php
+++ b/apps/files/ajax/rawlist.php
@@ -15,6 +15,14 @@ $mimetype = isset($_GET['mimetype']) ? $_GET['mimetype'] : '';
 
 // make filelist
 $files = array();
+// If a type other than directory is requested first load them.
+if($mimetype && strpos($mimetype, 'httpd/unix-directory') === false) {
+	foreach( \OC\Files\Filesystem::getDirectoryContent( $dir, 'httpd/unix-directory' ) as $i ) {
+		$i["date"] = OCP\Util::formatDate($i["mtime"] );
+		$i['mimetype_icon'] = $i['type'] == 'dir' ? \mimetype_icon('dir'): \mimetype_icon($i['mimetype']);
+		$files[] = $i;
+	}
+}
 foreach( \OC\Files\Filesystem::getDirectoryContent( $dir, $mimetype ) as $i ) {
 	$i["date"] = OCP\Util::formatDate($i["mtime"] );
 	$i['mimetype_icon'] = $i['type'] == 'dir' ? \mimetype_icon('dir'): \mimetype_icon($i['mimetype']);

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -382,13 +382,14 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 .ui-datepicker-prev,.ui-datepicker-next{ border:1px solid #ddd; background:#fff; }
 
 /* ---- DIALOGS ---- */
-#dirup {width:4%;}
-#dirtree {width:92%;}
-#filelist {height:270px; overflow-y:auto; background-color:white; width:100%;}
-#filelist img { margin: 2px 1em 0 4px; }
-#filelist .date { float:right;margin-right:1em; }
-.filepicker_element_selected { background-color:lightblue;}
-.filepicker_loader {height:170px; width:100%; background-color:#333; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3; visibility:visible; position:absolute; top:0; left:0; text-align:center; padding-top:150px;}
+#oc-dialog-filepicker-content .dirup {width:4%; font-weight: bold;}
+#oc-dialog-filepicker-content .dirtree {width:92%; overflow:hidden; font-weight: bold; }
+#oc-dialog-filepicker-content .dirtree span { cursor: pointer; }
+#oc-dialog-filepicker-content .dirtree span:not(last-child)::after { content: '>'; padding: 3px;}
+#oc-dialog-filepicker-content .filelist {height:270px; overflow-y:auto; background-color:white; width:100%;}
+#oc-dialog-filepicker-content .filelist img { margin: 2px 1em 0 4px; }
+#oc-dialog-filepicker-content .filelist .date { float:right;margin-right:1em; }
+#oc-dialog-filepicker-content .filepicker_element_selected { background-color:lightblue;}
 .ui-dialog {position:fixed !important;}
 span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .loading { background: url('../img/loading.gif') no-repeat center; cursor: wait; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -382,7 +382,6 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 .ui-datepicker-prev,.ui-datepicker-next{ border:1px solid #ddd; background:#fff; }
 
 /* ---- DIALOGS ---- */
-#oc-dialog-filepicker-content .dirup {width:4%; font-weight: bold;}
 #oc-dialog-filepicker-content .dirtree {width:92%; overflow:hidden; }
 #oc-dialog-filepicker-content .dirtree span:not(:last-child) { cursor: pointer; }
 #oc-dialog-filepicker-content .dirtree span:last-child { font-weight: bold; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -383,9 +383,10 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 
 /* ---- DIALOGS ---- */
 #oc-dialog-filepicker-content .dirup {width:4%; font-weight: bold;}
-#oc-dialog-filepicker-content .dirtree {width:92%; overflow:hidden; font-weight: bold; }
-#oc-dialog-filepicker-content .dirtree span { cursor: pointer; }
-#oc-dialog-filepicker-content .dirtree span:not(last-child)::after { content: '>'; padding: 3px;}
+#oc-dialog-filepicker-content .dirtree {width:92%; overflow:hidden; }
+#oc-dialog-filepicker-content .dirtree span:not(:last-child) { cursor: pointer; }
+#oc-dialog-filepicker-content .dirtree span:last-child { font-weight: bold; }
+#oc-dialog-filepicker-content .dirtree span:not(:last-child)::after { content: '>'; padding: 3px;}
 #oc-dialog-filepicker-content .filelist {height:270px; overflow-y:auto; background-color:white; width:100%;}
 #oc-dialog-filepicker-content .filelist img { margin: 2px 1em 0 4px; }
 #oc-dialog-filepicker-content .filelist .date { float:right;margin-right:1em; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -385,10 +385,13 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 #dirup {width:4%;}
 #dirtree {width:92%;}
 #filelist {height:270px; overflow-y:auto; background-color:white; width:100%;}
+#filelist img { margin: 2px 1em 0 4px; }
+#filelist .date { float:right;margin-right:1em; }
 .filepicker_element_selected { background-color:lightblue;}
 .filepicker_loader {height:170px; width:100%; background-color:#333; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"; filter:alpha(opacity=30); opacity:.3; visibility:visible; position:absolute; top:0; left:0; text-align:center; padding-top:150px;}
 .ui-dialog {position:fixed !important;}
 span.ui-icon {float: left; margin: 3px 7px 30px 0;}
+.loading { background: url('../img/loading.gif') no-repeat center; cursor: wait; }
 
 /* ---- CATEGORIES ---- */
 #categoryform .scrollarea { position:absolute; left:10px; top:10px; right:10px; bottom:50px; overflow:auto; border:1px solid #ddd; background:#f8f8f8; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -383,6 +383,11 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 
 /* ---- DIALOGS ---- */
 #oc-dialog-filepicker-content .dirtree {width:92%; overflow:hidden; }
+#oc-dialog-filepicker-content .dirtree .home {
+	background-image:url('../img/places/home.svg');
+	background-repeat:no-repeat;
+	background-position: left center;
+}
 #oc-dialog-filepicker-content .dirtree span:not(:last-child) { cursor: pointer; }
 #oc-dialog-filepicker-content .dirtree span:last-child { font-weight: bold; }
 #oc-dialog-filepicker-content .dirtree span:not(:last-child)::after { content: '>'; padding: 3px;}

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -198,7 +198,7 @@ var OCdialogs = {
 				self.$filelist = self.$filePicker.find('.filelist');
 				self.$dirUp = self.$filePicker.find('.dirup');
 				self.$dirTree = self.$filePicker.find('.dirtree');
-				self.$dirTree.on('click', 'span', self, self.handleTreeListSelect);
+				self.$dirTree.on('click', 'span:not(:last-child)', self, self.handleTreeListSelect);
 				self.$dirUp.click(self, self.filepickerDirUp);
 				self.$filelist.on('click', 'li', function(event) {
 					self.handlePickerClick(event, $(this));
@@ -393,7 +393,7 @@ var OCdialogs = {
 		}
 		var $template = $('<span data-dir="{dir}">{name}</span>');
 		var paths = path.split('/');
-		paths.pop();
+		//paths.pop();
 		$.each(paths, function(index, dir) {
 			var dir = paths.pop();
 			if(dir === '') {

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -283,10 +283,10 @@ var OCdialogs = {
 				$li = self.$listTmpl.octemplate({
 					type: entry.type,
 					dir: dir,
-					imgsrc: entry.mimetype_icon,
 					filename: entry.name,
 					date: OC.mtime2date(entry.mtime)
 				});
+				$li.find('img').attr('src', entry.mimetype_icon);
 				self.$filelist.append($li);
 			});
 

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -314,10 +314,10 @@ var OCdialogs = {
 				}));
 			});
 		}
-		this.$dirTree.prepend($template.octemplate({
+		$template.octemplate({
 			dir: '',
-			name: '/'
-		}));
+			name: '&nbsp;&nbsp;&nbsp;&nbsp;' // Ugly but works ;)
+		}, {escapeFunction: null}).addClass('home svg').prependTo(this.$dirTree);
 	},
 	/**
 	 * handle selection made in the tree list

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -173,22 +173,10 @@ var OCdialogs = {
 					}];
 				break;
 				case OCdialogs.OK_BUTTON:
-					var functionToCall;
-					switch(dialog_type) {
-						case 'prompt':
-							buttonlist[1] = {
-								text: t('core', 'Cancel'),
-								click: function() { $(dialog_id).dialog('close'); }
-							};
-							functionToCall = function() { OCdialogs._promptOkHandler(callback, dialog_id); };
-						break;
-						default:
-							functionToCall = function() {
-								$(dialog_id).dialog('close');
-								if(callback !== undefined) { callback() };
-							};
-						break;
-					}
+					var functionToCall = function() {
+						$(dialog_id).dialog('close');
+						if(callback !== undefined) { callback() };
+					};
 					buttonlist[0] = {
 						text: t('core', 'Ok'),
 						click: functionToCall
@@ -254,10 +242,6 @@ var OCdialogs = {
 		}
 	},
 
-	_promptOkHandler: function(callback, dialog_id) {
-		$(dialog_id).dialog('close');
-		if (callback !== undefined) { callback($(dialog_id + ' input#oc-dialog-prompt-input').val()) };
-	},
 	/**
 	 * fills the filepicker with files
 	*/

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -196,10 +196,8 @@ var OCdialogs = {
 
 			self.$filePicker.ready(function() {
 				self.$filelist = self.$filePicker.find('.filelist');
-				self.$dirUp = self.$filePicker.find('.dirup');
 				self.$dirTree = self.$filePicker.find('.dirtree');
 				self.$dirTree.on('click', 'span:not(:last-child)', self, self.handleTreeListSelect);
-				self.$dirUp.click(self, self.filepickerDirUp);
 				self.$filelist.on('click', 'li', function(event) {
 					self.handlePickerClick(event, $(this));
 				});
@@ -416,18 +414,6 @@ var OCdialogs = {
 		var self = event.data;
 		var dir = $(event.target).data('dir');
 		self.fillFilePicker(dir);
-	},
-	/**
-	 * go one directory up
-	*/
-	filepickerDirUp:function(event) {
-		var self = event.data;
-		var old_path = self.$filePicker.data('path');
-		if (old_path !== '') {
-			var splitted_path = old_path.split('/');
-			splitted_path.pop();
-			self.fillFilePicker(splitted_path.join('/'));
-		}
 	},
 	/**
 	 * handle clicks made in the filepicker

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -1,7 +1,7 @@
 /**
  * ownCloud
  *
- * @author Bartek Przybylski,Christopher Schäpers, Thomas Tanghus
+ * @author Bartek Przybylski, Christopher Schäpers, Thomas Tanghus
  * @copyright 2012 Bartek Przybylski bartek@alefzero.eu
  *
  * This library is free software; you can redistribute it and/or
@@ -396,7 +396,8 @@ var OCdialogs = {
 	 * handle selection made in the tree list
 	*/
 	handleTreeListSelect:function(event) {
-		if ($('option:selected', this).html().indexOf('/') !== -1) { // if there's a slash in the selected path, don't append it
+		// if there's a slash in the selected path, don't append it
+		if ($('option:selected', this).html().indexOf('/') !== -1) {
 			$(event.data.dcid).data('path', $('option:selected', this).html());
 		} else {
 			$(event.data.dcid).data('path', $(event.data.dcid).data('path') + $('option:selected', this).html() + '/');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -58,45 +58,6 @@ var OCdialogs = {
 	confirm:function(text, title, callback, modal) {
 		this.message(text, title, 'notice', OCdialogs.YES_NO_BUTTONS, callback, modal);
 	},
-	_getFilePickerTemplate: function() {
-		var defer = $.Deferred();
-		if(!this.$filePickerTemplate) {
-			var self = this;
-			$.get(OC.filePath('core', 'templates', 'filepicker.html'), function(tmpl) {
-				self.$filePickerTemplate = $(tmpl);
-				self.$listTmpl = self.$filePickerTemplate.find('.filelist li:first-child').detach();
-				defer.resolve(self.$filePickerTemplate);
-			})
-			.fail(function() {
-				defer.reject();
-			});
-		} else {
-			defer.resolve(this.$filePickerTemplate);
-		}
-		return defer.promise();
-	},
-	_getMessageTemplate: function() {
-		var defer = $.Deferred();
-		if(!this.$messageTemplate) {
-			var self = this;
-			$.get(OC.filePath('core', 'templates', 'message.html'), function(tmpl) {
-				self.$messageTemplate = $(tmpl);
-				defer.resolve(self.$messageTemplate);
-			})
-			.fail(function() {
-				defer.reject();
-			});
-		} else {
-			defer.resolve(this.$messageTemplate);
-		}
-		return defer.promise();
-	},
-	_getFileList: function(dir, mimeType) {
-		return $.getJSON(
-			OC.filePath('files', 'ajax', 'rawlist.php'),
-			{dir: dir, mimetype: mimeType}
-		);
-	},
 	/**
 	 * show a file picker to pick a file from
 	 * @param title dialog title
@@ -128,11 +89,11 @@ var OCdialogs = {
 			self.$filePicker.ready(function() {
 				self.$filelist = self.$filePicker.find('.filelist');
 				self.$dirTree = self.$filePicker.find('.dirtree');
-				self.$dirTree.on('click', 'span:not(:last-child)', self, self.handleTreeListSelect);
+				self.$dirTree.on('click', 'span:not(:last-child)', self, self._handleTreeListSelect);
 				self.$filelist.on('click', 'li', function(event) {
-					self.handlePickerClick(event, $(this));
+					self._handlePickerClick(event, $(this));
 				});
-				self.fillFilePicker('');
+				self._fillFilePicker('');
 			}).data('multiselect', multiselect).data('mimetype',mimetype_filter);
 
 			// build buttons
@@ -219,7 +180,7 @@ var OCdialogs = {
 								text: t('core', 'Cancel'),
 								click: function() { $(dialog_id).dialog('close'); }
 							};
-							functionToCall = function() { OCdialogs.prompt_ok_handler(callback, dialog_id); };
+							functionToCall = function() { OCdialogs._promptOkHandler(callback, dialog_id); };
 						break;
 						default:
 							functionToCall = function() {
@@ -246,7 +207,46 @@ var OCdialogs = {
 			alert(t('core', 'Error loading file picker template'));
 		});
 	},
-	determineValue: function(element) {
+	_getFilePickerTemplate: function() {
+		var defer = $.Deferred();
+		if(!this.$filePickerTemplate) {
+			var self = this;
+			$.get(OC.filePath('core', 'templates', 'filepicker.html'), function(tmpl) {
+				self.$filePickerTemplate = $(tmpl);
+				self.$listTmpl = self.$filePickerTemplate.find('.filelist li:first-child').detach();
+				defer.resolve(self.$filePickerTemplate);
+			})
+			.fail(function() {
+				defer.reject();
+			});
+		} else {
+			defer.resolve(this.$filePickerTemplate);
+		}
+		return defer.promise();
+	},
+	_getMessageTemplate: function() {
+		var defer = $.Deferred();
+		if(!this.$messageTemplate) {
+			var self = this;
+			$.get(OC.filePath('core', 'templates', 'message.html'), function(tmpl) {
+				self.$messageTemplate = $(tmpl);
+				defer.resolve(self.$messageTemplate);
+			})
+			.fail(function() {
+				defer.reject();
+			});
+		} else {
+			defer.resolve(this.$messageTemplate);
+		}
+		return defer.promise();
+	},
+	_getFileList: function(dir, mimeType) {
+		return $.getJSON(
+			OC.filePath('files', 'ajax', 'rawlist.php'),
+			{dir: dir, mimetype: mimeType}
+		);
+	},
+	_determineValue: function(element) {
 		if ( $(element).attr('type') === 'checkbox' ) {
 			return element.checked;
 		} else {
@@ -254,27 +254,14 @@ var OCdialogs = {
 		}
 	},
 
-	prompt_ok_handler: function(callback, dialog_id) {
+	_promptOkHandler: function(callback, dialog_id) {
 		$(dialog_id).dialog('close');
 		if (callback !== undefined) { callback($(dialog_id + ' input#oc-dialog-prompt-input').val()) };
-	},
-
-	form_ok_handler: function(callback, dialog_id) {
-		if (callback !== undefined) {
-			var valuelist = [];
-			$(dialog_id + ' input, ' + dialog_id + ' select').each(function(index, element) {
-				valuelist[index] = { name: $(element).attr('name'), value: OCdialogs.determineValue(element) };
-			});
-			$(dialog_id).dialog('close');
-			callback(valuelist);
-		} else {
-			$(dialog_id).dialog('close');
-		}
 	},
 	/**
 	 * fills the filepicker with files
 	*/
-	fillFilePicker:function(dir) {
+	_fillFilePicker:function(dir) {
 		var dirs = [];
 		var others = [];
 		var self = this;
@@ -289,7 +276,7 @@ var OCdialogs = {
 				}
 			});
 
-			self.fillSlug();
+			self._fillSlug();
 			var sorted = dirs.concat(others);
 
 			$.each(sorted, function(idx, entry) {
@@ -309,7 +296,7 @@ var OCdialogs = {
 	/**
 	 * fills the tree list with directories
 	*/
-	fillSlug: function() {
+	_fillSlug: function() {
 		this.$dirTree.empty();
 		var self = this
 		var path = this.$filePicker.data('path');
@@ -335,15 +322,15 @@ var OCdialogs = {
 	/**
 	 * handle selection made in the tree list
 	*/
-	handleTreeListSelect:function(event) {
+	_handleTreeListSelect:function(event) {
 		var self = event.data;
 		var dir = $(event.target).data('dir');
-		self.fillFilePicker(dir);
+		self._fillFilePicker(dir);
 	},
 	/**
 	 * handle clicks made in the filepicker
 	*/
-	handlePickerClick:function(event, $element) {
+	_handlePickerClick:function(event, $element) {
 		if ($element.data('type') === 'file') {
 			if (this.$filePicker.data('multiselect') !== true || !event.ctrlKey) {
 				this.$filelist.find('.filepicker_element_selected').removeClass('filepicker_element_selected');
@@ -351,7 +338,7 @@ var OCdialogs = {
 			$element.toggleClass('filepicker_element_selected');
 			return;
 		} else if ( $element.data('type') === 'dir' ) {
-			this.fillFilePicker(this.$filePicker.data('path') + '/' + $element.data('entryname'))
+			this._fillFilePicker(this.$filePicker.data('path') + '/' + $element.data('entryname'))
 		}
 	}
 };

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,0 +1,11 @@
+<div id="{dialog_name}" title="{title}">
+	<button id="dirup">↑</button>
+	<select id="dirtree"></select>
+	<ul id="filelist">
+		<li data-entryname="{filename}" data-type="{type}" data-dcid="{dcid}">
+			<img src="{imgsrc}" />
+			<span class="filename">{filename}</span>
+			<span class="date">{date}</span>
+		</li>
+	</ul>
+</div>

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,5 +1,4 @@
 <div id="{dialog_name}" title="{title}">
-	<button class="dirup">↑</button>
 	<span class="dirtree"></span>
 	<ul class="filelist">
 		<li data-entryname="{filename}" data-type="{type}">

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -2,7 +2,7 @@
 	<span class="dirtree"></span>
 	<ul class="filelist">
 		<li data-entryname="{filename}" data-type="{type}">
-			<img src="{imgsrc}" />
+			<img />
 			<span class="filename">{filename}</span>
 			<span class="date">{date}</span>
 		</li>

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -1,8 +1,8 @@
 <div id="{dialog_name}" title="{title}">
-	<button id="dirup">↑</button>
-	<select id="dirtree"></select>
-	<ul id="filelist">
-		<li data-entryname="{filename}" data-type="{type}" data-dcid="{dcid}">
+	<button class="dirup">↑</button>
+	<span class="dirtree"></span>
+	<ul class="filelist">
+		<li data-entryname="{filename}" data-type="{type}">
 			<img src="{imgsrc}" />
 			<span class="filename">{filename}</span>
 			<span class="date">{date}</span>

--- a/core/templates/message.html
+++ b/core/templates/message.html
@@ -1,0 +1,3 @@
+<div id="{dialog_name}" title="{title}">
+	<p><span class="ui-icon ui-icon-{type}"></span>{message}</p>
+</div>

--- a/lib/base.php
+++ b/lib/base.php
@@ -260,6 +260,7 @@ class OC {
 		OC_Util::addScript("jquery-tipsy");
 		OC_Util::addScript("compatibility");
 		OC_Util::addScript("oc-dialogs");
+		OC_Util::addScript("octemplate");
 		OC_Util::addScript("js");
 		OC_Util::addScript("eventsource");
 		OC_Util::addScript("config");


### PR DESCRIPTION
Other changes:
- It only uses one request to get files and dirs.
- Replaced the select/dropdown with a slug-like path. More intuitive imo.
- There can only be one filepicker at at time. If one is open it will be destroyed.
- The dialog now cleans up the DOM after closing.
- Removed methods prompt() and form().
- General cleanup.

@Kondou-ger @raghunayyar
