### PR TITLE
refactored/cleaned up lib/files.php and switched get() to ZipStreamer

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -21,19 +21,45 @@
  *
  */
 
+require_once realpath( dirname(__FILE__).'/../3rdparty/ZipStreamer/ZipStreamer.php' );
+
+class GET_TYPE {
+	const FILE = 1;
+	const ZIP_FILES = 2;
+	const ZIP_DIR = 3;
+}
+
 /**
  * Class for fileserver access
  *
  */
 class OC_Files {
-	static $tmpFiles = array();
-
 	static public function getFileInfo($path){
 		return \OC\Files\Filesystem::getFileInfo($path);
 	}
 
 	static public function getDirectoryContent($path){
 		return \OC\Files\Filesystem::getDirectoryContent($path);
+	}
+
+	private static function sendHeaders($filename, $name, $zip = false) {
+		if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
+			header( 'Content-Disposition: attachment; filename="' . rawurlencode($name) . '"' );
+		} else {
+			header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($name)
+			. '; filename="' . rawurlencode($name) . '"' );
+		}
+		header('Content-Transfer-Encoding: binary');
+		OC_Response::disableCaching();
+		if ($zip) {
+			header('Content-Type: application/zip');
+		} else {
+			$filesize = \OC\Files\Filesystem::filesize($filename);
+			header('Content-Type: '.\OC\Files\Filesystem::getMimeType($filename));
+			if ($filesize > -1) {
+				header("Content-Length: ".$filesize);
+			}
+		}
 	}
 
 	/**
@@ -56,87 +82,39 @@ class OC_Files {
 		}
 
 		if (is_array($files)) {
-			self::validateZipDownload($dir, $files);
-			$executionTime = intval(ini_get('max_execution_time'));
-			set_time_limit(0);
-			$zip = new ZipArchive();
-			$filename = OC_Helper::tmpFile('.zip');
-			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
-				$l = OC_L10N::get('lib');
-				throw new Exception($l->t('cannot open "%s"', array($filename)));
-			}
-			foreach ($files as $file) {
-				$file = $dir . '/' . $file;
-				if (\OC\Files\Filesystem::is_file($file)) {
-					$tmpFile = \OC\Files\Filesystem::toTmpFile($file);
-					self::$tmpFiles[] = $tmpFile;
-					$zip->addFile($tmpFile, basename($file));
-				} elseif (\OC\Files\Filesystem::is_dir($file)) {
-					self::zipAddDir($file, $zip);
-				}
-			}
-			$zip->close();
-			if ($xsendfile) {
-				$filename = OC_Helper::moveToNoClean($filename);
-			}
-			$basename = basename($dir);
-			if ($basename) {
-				$name = $basename . '.zip';
-			} else {
-				$name = 'owncloud.zip';
-			}
-			
-			set_time_limit($executionTime);
-		} elseif (\OC\Files\Filesystem::is_dir($dir . '/' . $files)) {
-			self::validateZipDownload($dir, $files);
-			$executionTime = intval(ini_get('max_execution_time'));
-			set_time_limit(0);
-			$zip = new ZipArchive();
-			$filename = OC_Helper::tmpFile('.zip');
-			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
-				$l = OC_L10N::get('lib');
-				throw new Exception($l->t('cannot open "%s"', array($filename)));
-			}
-			$file = $dir . '/' . $files;
-			self::zipAddDir($file, $zip);
-			$zip->close();
-			if ($xsendfile) {
-				$filename = OC_Helper::moveToNoClean($filename);
-			}
-			$name = $files . '.zip';
-			set_time_limit($executionTime);
+			$get_type = GET_TYPE::ZIP_FILES;
 		} else {
-			$zip = false;
 			$filename = $dir . '/' . $files;
+			if (\OC\Files\Filesystem::is_dir($dir . '/' . $files)) {
+				$get_type = GET_TYPE::ZIP_DIR;
+			} else {
+				$get_type = GET_TYPE::FILE;
+			}
+		}
+
+		if ($get_type == GET_TYPE::ZIP_FILES || $get_type == GET_TYPE::ZIP_DIR) {
+			self::validateZipDownload($dir, $files);
+			if ($get_type == GET_TYPE::ZIP_FILES) {
+				$basename = basename($dir);
+				if ($basename) {
+					$name = $basename . '.zip';
+				} else {
+					$name = 'owncloud.zip';
+				}
+			} else {
+				$name = $files . '.zip';
+			}
+			$zip = new ZipStreamer(false);
+		} else {
 			$name = $files;
+			$zip = false;
 		}
 		OC_Util::obEnd();
+
 		if ($zip or \OC\Files\Filesystem::isReadable($filename)) {
-			if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
-				header( 'Content-Disposition: attachment; filename="' . rawurlencode($name) . '"' );
-			} else {
-				header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($name)
-													 . '; filename="' . rawurlencode($name) . '"' );
-			}
-			header('Content-Transfer-Encoding: binary');
-			OC_Response::disableCaching();
-			if ($zip) {
-				ini_set('zlib.output_compression', 'off');
-				header('Content-Type: application/zip');
-				header('Content-Length: ' . filesize($filename));
-				self::addSendfileHeader($filename);
-			}else{
-				$filesize = \OC\Files\Filesystem::filesize($filename);
-				header('Content-Type: '.\OC\Files\Filesystem::getMimeType($filename));
-				if ($filesize > -1) {
-					header("Content-Length: ".$filesize);
-				}
-				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
-				if ($storage instanceof \OC\Files\Storage\Local) {
-					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
-				}
-			}
-		} elseif ($zip or !\OC\Files\Filesystem::file_exists($filename)) {
+			ini_set('zlib.output_compression', 'off');
+			self::sendHeaders($filename, $name, $zip);
+		} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
 			header("HTTP/1.0 404 Not Found");
 			$tmpl = new OC_Template('', '404', 'guest');
 			$tmpl->assign('file', $name);
@@ -145,27 +123,39 @@ class OC_Files {
 			header("HTTP/1.0 403 Forbidden");
 			die('403 Forbidden');
 		}
+
 		if($only_header) {
 			return ;
 		}
+
 		if ($zip) {
-			$handle = fopen($filename, 'r');
-			if ($handle) {
-				$chunkSize = 8 * 1024; // 1 MB chunks
-				while (!feof($handle)) {
-					echo fread($handle, $chunkSize);
-					flush();
+			$executionTime = intval(ini_get('max_execution_time'));
+			set_time_limit(0);
+			if ($get_type == GET_TYPE::ZIP_FILES) {
+				foreach ($files as $file) {
+					$file = $dir . '/' . $file;
+					if (\OC\Files\Filesystem::is_file($file)) {
+						$fh = \OC\Files\Filesystem::fopen($file, 'r');
+						$zip->addFileFromStream($fh, basename($file));
+						fclose($fh);
+					} elseif (\OC\Files\Filesystem::is_dir($file)) {
+						self::zipAddDir($file, $zip);
+					}
 				}
+			} elseif ($get_type == GET_TYPE::ZIP_DIR) {
+				$file = $dir . '/' . $files;
+				self::zipAddDir($file, $zip);
 			}
-			if (!$xsendfile) {
-				unlink($filename);
-			}
-		}else{
-			\OC\Files\Filesystem::readfile($filename);
-		}
-		foreach (self::$tmpFiles as $tmpFile) {
-			if (file_exists($tmpFile) and is_file($tmpFile)) {
-				unlink($tmpFile);
+			$zip->finalize();
+			set_time_limit($executionTime);
+		} else {
+			if ($xsendfile) {
+				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
+				if ($storage instanceof \OC\Files\Storage\Local) {
+					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
+				}
+			} else {
+				\OC\Files\Filesystem::readfile($filename);
 			}
 		}
 	}
@@ -173,9 +163,9 @@ class OC_Files {
 	private static function addSendfileHeader($filename) {
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
 			header("X-Sendfile: " . $filename);
- 		}
+		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
-			if (isset($_SERVER['HTTP_RANGE']) && 
+			if (isset($_SERVER['HTTP_RANGE']) &&
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
  				if ($range[2] == "") {
@@ -188,7 +178,6 @@ class OC_Files {
  				header("X-Sendfile: " . $filename);
  			}
 		}
-		
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			header("X-Accel-Redirect: " . $filename);
 		}
@@ -203,9 +192,9 @@ class OC_Files {
 			$filename=$file['name'];
 			$file=$dir.'/'.$filename;
 			if(\OC\Files\Filesystem::is_file($file)) {
-				$tmpFile=\OC\Files\Filesystem::toTmpFile($file);
-				OC_Files::$tmpFiles[]=$tmpFile;
-				$zip->addFile($tmpFile, $internalDir.$filename);
+				$fh = \OC\Files\Filesystem::fopen($file, 'r');
+				$zip->addFileFromStream($fh, $internalDir.$filename);
+				fclose($fh);
 			}elseif(\OC\Files\Filesystem::is_dir($file)) {
 				self::zipAddDir($file, $zip, $internalDir);
 			}

--- a/lib/files.php
+++ b/lib/files.php
@@ -77,7 +77,7 @@ class OC_Files {
 			$xsendfile = true;
 		}
 
-		if (is_array($files) && count($files) == 1) {
+		if (is_array($files) && count($files) === 1) {
 			$files = $files[0];
 		}
 
@@ -92,9 +92,9 @@ class OC_Files {
 			}
 		}
 
-		if ($get_type == GET_TYPE::ZIP_FILES || $get_type == GET_TYPE::ZIP_DIR) {
+		if ($get_type === GET_TYPE::ZIP_FILES || $get_type === GET_TYPE::ZIP_DIR) {
 			self::validateZipDownload($dir, $files);
-			if ($get_type == GET_TYPE::ZIP_FILES) {
+			if ($get_type === GET_TYPE::ZIP_FILES) {
 				$basename = basename($dir);
 				if ($basename) {
 					$name = $basename . '.zip';
@@ -131,7 +131,7 @@ class OC_Files {
 		if ($zip) {
 			$executionTime = intval(ini_get('max_execution_time'));
 			set_time_limit(0);
-			if ($get_type == GET_TYPE::ZIP_FILES) {
+			if ($get_type === GET_TYPE::ZIP_FILES) {
 				foreach ($files as $file) {
 					$file = $dir . '/' . $file;
 					if (\OC\Files\Filesystem::is_file($file)) {
@@ -142,7 +142,7 @@ class OC_Files {
 						self::zipAddDir($file, $zip);
 					}
 				}
-			} elseif ($get_type == GET_TYPE::ZIP_DIR) {
+			} elseif ($get_type === GET_TYPE::ZIP_DIR) {
 				$file = $dir . '/' . $files;
 				self::zipAddDir($file, $zip);
 			}
@@ -269,7 +269,7 @@ class OC_Files {
 		}
 
 		//don't allow user to break his config -- broken or malicious size input
-		if (intval($size) == 0) {
+		if (intval($size) === 0) {
 			return false;
 		}
 
@@ -291,7 +291,7 @@ class OC_Files {
 			if ($content !== null) {
 				$htaccess = $content;
 			}
-			if ($hasReplaced == 0) {
+			if ($hasReplaced === 0) {
 				$htaccess .= "\n" . $setting;
 			}
 		}

--- a/lib/files.php
+++ b/lib/files.php
@@ -73,7 +73,7 @@ class OC_Files {
 			$xsendfile = true;
 		}
 
-		if (is_array($files) && count($files) == 1) {
+		if (is_array($files) && count($files) === 1) {
 			$files = $files[0];
 		}
 
@@ -88,9 +88,9 @@ class OC_Files {
 			}
 		}
 
-		if ($get_type == GET_TYPE::ZIP_FILES || $get_type == GET_TYPE::ZIP_DIR) {
+		if ($get_type === GET_TYPE::ZIP_FILES || $get_type === GET_TYPE::ZIP_DIR) {
 			self::validateZipDownload($dir, $files);
-			if ($get_type == GET_TYPE::ZIP_FILES) {
+			if ($get_type === GET_TYPE::ZIP_FILES) {
 				$basename = basename($dir);
 				if ($basename) {
 					$name = $basename . '.zip';
@@ -127,7 +127,7 @@ class OC_Files {
 		if ($zip) {
 			$executionTime = intval(ini_get('max_execution_time'));
 			set_time_limit(0);
-			if ($get_type == GET_TYPE::ZIP_FILES) {
+			if ($get_type === GET_TYPE::ZIP_FILES) {
 				foreach ($files as $file) {
 					$file = $dir . '/' . $file;
 					if (\OC\Files\Filesystem::is_file($file)) {
@@ -138,7 +138,7 @@ class OC_Files {
 						self::zipAddDir($file, $zip);
 					}
 				}
-			} elseif ($get_type == GET_TYPE::ZIP_DIR) {
+			} elseif ($get_type === GET_TYPE::ZIP_DIR) {
 				$file = $dir . '/' . $files;
 				self::zipAddDir($file, $zip);
 			}
@@ -261,7 +261,7 @@ class OC_Files {
 		}
 
 		//don't allow user to break his config -- broken or malicious size input
-		if (intval($size) == 0) {
+		if (intval($size) === 0) {
 			return false;
 		}
 
@@ -283,7 +283,7 @@ class OC_Files {
 			if ($content !== null) {
 				$htaccess = $content;
 			}
-			if ($hasReplaced == 0) {
+			if ($hasReplaced === 0) {
 				$htaccess .= "\n" . $setting;
 			}
 		}

--- a/lib/files.php
+++ b/lib/files.php
@@ -21,19 +21,42 @@
  *
  */
 
+require_once realpath( dirname(__FILE__).'/../3rdparty/ZipStreamer/ZipStreamer.php' );
+
+class GET_TYPE {
+	const FILE = 1;
+	const ZIP_FILES = 2;
+	const ZIP_DIR = 3;
+}
+
 /**
  * Class for fileserver access
  *
  */
 class OC_Files {
-	static $tmpFiles = array();
-
 	static public function getFileInfo($path){
 		return \OC\Files\Filesystem::getFileInfo($path);
 	}
 
 	static public function getDirectoryContent($path){
 		return \OC\Files\Filesystem::getDirectoryContent($path);
+	}
+
+	private static function sendHeaders($filename, $name, $zip = false) {
+		if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
+			header( 'Content-Disposition: attachment; filename="' . rawurlencode($name) . '"' );
+		} else {
+			header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($name)
+			. '; filename="' . rawurlencode($name) . '"' );
+		}
+		header('Content-Transfer-Encoding: binary');
+		OC_Response::disableCaching();
+		if ($zip) {
+			header('Content-Type: application/zip');
+		} else {
+			header('Content-Type: '.\OC\Files\Filesystem::getMimeType($filename));
+			header("Content-Length: ".\OC\Files\Filesystem::filesize($filename));
+		}
 	}
 
 	/**
@@ -55,82 +78,39 @@ class OC_Files {
 		}
 
 		if (is_array($files)) {
-			self::validateZipDownload($dir, $files);
-			$executionTime = intval(ini_get('max_execution_time'));
-			set_time_limit(0);
-			$zip = new ZipArchive();
-			$filename = OC_Helper::tmpFile('.zip');
-			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
-				exit("cannot open <$filename>\n");
-			}
-			foreach ($files as $file) {
-				$file = $dir . '/' . $file;
-				if (\OC\Files\Filesystem::is_file($file)) {
-					$tmpFile = \OC\Files\Filesystem::toTmpFile($file);
-					self::$tmpFiles[] = $tmpFile;
-					$zip->addFile($tmpFile, basename($file));
-				} elseif (\OC\Files\Filesystem::is_dir($file)) {
-					self::zipAddDir($file, $zip);
-				}
-			}
-			$zip->close();
-			if ($xsendfile) {
-				$filename = OC_Helper::moveToNoClean($filename);
-			}
-			$basename = basename($dir);
-			if ($basename) {
-				$name = $basename . '.zip';
-			} else {
-				$name = 'owncloud.zip';
-			}
-			
-			set_time_limit($executionTime);
-		} elseif (\OC\Files\Filesystem::is_dir($dir . '/' . $files)) {
-			self::validateZipDownload($dir, $files);
-			$executionTime = intval(ini_get('max_execution_time'));
-			set_time_limit(0);
-			$zip = new ZipArchive();
-			$filename = OC_Helper::tmpFile('.zip');
-			if ($zip->open($filename, ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE)!==true) {
-				exit("cannot open <$filename>\n");
-			}
-			$file = $dir . '/' . $files;
-			self::zipAddDir($file, $zip);
-			$zip->close();
-			if ($xsendfile) {
-				$filename = OC_Helper::moveToNoClean($filename);
-			}
-			$name = $files . '.zip';
-			set_time_limit($executionTime);
+			$get_type = GET_TYPE::ZIP_FILES;
 		} else {
-			$zip = false;
 			$filename = $dir . '/' . $files;
+			if (\OC\Files\Filesystem::is_dir($dir . '/' . $files)) {
+				$get_type = GET_TYPE::ZIP_DIR;
+			} else {
+				$get_type = GET_TYPE::FILE;
+			}
+		}
+
+		if ($get_type == GET_TYPE::ZIP_FILES || $get_type == GET_TYPE::ZIP_DIR) {
+			self::validateZipDownload($dir, $files);
+			if ($get_type == GET_TYPE::ZIP_FILES) {
+				$basename = basename($dir);
+				if ($basename) {
+					$name = $basename . '.zip';
+				} else {
+					$name = 'owncloud.zip';
+				}
+			} else {
+				$name = $files . '.zip';
+			}
+			$zip = new ZipStreamer(false);
+		} else {
 			$name = $files;
+			$zip = false;
 		}
 		OC_Util::obEnd();
+
 		if ($zip or \OC\Files\Filesystem::isReadable($filename)) {
-			if ( preg_match( "/MSIE/", $_SERVER["HTTP_USER_AGENT"] ) ) {
-				header( 'Content-Disposition: attachment; filename="' . rawurlencode($name) . '"' );
-			} else {
-				header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($name)
-													 . '; filename="' . rawurlencode($name) . '"' );
-			}
-			header('Content-Transfer-Encoding: binary');
-			OC_Response::disableCaching();
-			if ($zip) {
-				ini_set('zlib.output_compression', 'off');
-				header('Content-Type: application/zip');
-				header('Content-Length: ' . filesize($filename));
-				self::addSendfileHeader($filename);
-			}else{
-				header('Content-Type: '.\OC\Files\Filesystem::getMimeType($filename));
-				header("Content-Length: ".\OC\Files\Filesystem::filesize($filename));
-				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
-				if ($storage instanceof \OC\Files\Storage\Local) {
-					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
-				}
-			}
-		} elseif ($zip or !\OC\Files\Filesystem::file_exists($filename)) {
+			ini_set('zlib.output_compression', 'off');
+			self::sendHeaders($filename, $name, $zip);
+		} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
 			header("HTTP/1.0 404 Not Found");
 			$tmpl = new OC_Template('', '404', 'guest');
 			$tmpl->assign('file', $name);
@@ -139,27 +119,39 @@ class OC_Files {
 			header("HTTP/1.0 403 Forbidden");
 			die('403 Forbidden');
 		}
+
 		if($only_header) {
 			return ;
 		}
+
 		if ($zip) {
-			$handle = fopen($filename, 'r');
-			if ($handle) {
-				$chunkSize = 8 * 1024; // 1 MB chunks
-				while (!feof($handle)) {
-					echo fread($handle, $chunkSize);
-					flush();
+			$executionTime = intval(ini_get('max_execution_time'));
+			set_time_limit(0);
+			if ($get_type == GET_TYPE::ZIP_FILES) {
+				foreach ($files as $file) {
+					$file = $dir . '/' . $file;
+					if (\OC\Files\Filesystem::is_file($file)) {
+						$fh = \OC\Files\Filesystem::fopen($file, 'r');
+						$zip->addFileFromStream($fh, basename($file));
+						fclose($fh);
+					} elseif (\OC\Files\Filesystem::is_dir($file)) {
+						self::zipAddDir($file, $zip);
+					}
 				}
+			} elseif ($get_type == GET_TYPE::ZIP_DIR) {
+				$file = $dir . '/' . $files;
+				self::zipAddDir($file, $zip);
 			}
-			if (!$xsendfile) {
-				unlink($filename);
-			}
-		}else{
-			\OC\Files\Filesystem::readfile($filename);
-		}
-		foreach (self::$tmpFiles as $tmpFile) {
-			if (file_exists($tmpFile) and is_file($tmpFile)) {
-				unlink($tmpFile);
+			$zip->finalize();
+			set_time_limit($executionTime);
+		} else {
+			if ($xsendfile) {
+				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
+				if ($storage instanceof \OC\Files\Storage\Local) {
+					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
+				}
+			} else {
+				\OC\Files\Filesystem::readfile($filename);
 			}
 		}
 	}
@@ -182,9 +174,9 @@ class OC_Files {
 			$filename=$file['name'];
 			$file=$dir.'/'.$filename;
 			if(\OC\Files\Filesystem::is_file($file)) {
-				$tmpFile=\OC\Files\Filesystem::toTmpFile($file);
-				OC_Files::$tmpFiles[]=$tmpFile;
-				$zip->addFile($tmpFile, $internalDir.$filename);
+				$fh = \OC\Files\Filesystem::fopen($file, 'r');
+				$zip->addFileFromStream($fh, $internalDir.$filename);
+				fclose($fh);
 			}elseif(\OC\Files\Filesystem::is_dir($file)) {
 				self::zipAddDir($file, $zip, $internalDir);
 			}


### PR DESCRIPTION
This commit mainly adds the ability for owncloud to use ZipStreamer instead of the builtin ZipArchive. This reduces disk i/o greatly, as the current implementation creates one temp file for each file to be added to the zip, and then again a temp file of the complete zip, before starting to send the temp zip to the client.
The ZipStreamer creates the zip file on the fly in memory and directly sends the data to the client, no temp file needed at all. The ZipStreamer class was added in a second pull request to 3rdparty.
