### PR TITLE
Fix undefined index for share mount point retrieval

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -877,7 +877,7 @@ class Share {
 					if (!isset($mounts[$row['storage']])) {
 						$mountPoints = \OC\Files\Filesystem::getMountByNumericId($row['storage']);
 						if (is_array($mountPoints)) {
-							$mounts[$row['storage']] = $mountPoints[key($mountPoints)];
+							$mounts[$row['storage']] = current($mountPoints);
 						}
 					}
 					if ($mounts[$row['storage']]) {


### PR DESCRIPTION
Not sure why I was doing it the way I did before, but that didn't work. Only affects master.

@icewind1991 @DeepDiver1975 @bartv2 
