### PR TITLE
Fix public links

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -1,5 +1,4 @@
 <?php
-$RUNTIME_NOSETUPFS = true;
 // Load other apps for file previews
 OC_App::loadApps();
 
@@ -46,6 +45,7 @@ if (isset($_GET['t'])) {
 			$fileOwner = $shareOwner;
 		}
 		if (isset($fileOwner)) {
+			OC_Util::tearDownFS();
 			OC_Util::setupFS($fileOwner);
 			$path = \OC\Files\Filesystem::getPath($linkItem['file_source']);
 		}

--- a/cron.php
+++ b/cron.php
@@ -45,7 +45,6 @@ function handleUnexpectedShutdown() {
 	}
 }
 
-$RUNTIME_NOSETUPFS = true;
 require_once 'lib/base.php';
 
 session_write_close();


### PR DESCRIPTION
Fixes #2973 RUNTIME_NOSETUPFS doesn't exist anymore and was doing nothing. Using tearDownFS() instead.

Backported: https://github.com/owncloud/core/commit/412f0962e75e64becb9fcf5ece3e877159537b69 to fix the issue in stable5.

@icewind1991 @schiesbn @Contex @Happyfeet01 @hepaly @gdsjerry
