### PR TITLE
use the recoveryPassword var instead of accessing the POST array

### DIFF
--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -146,7 +146,7 @@ class Helper
 
 		} else { // get recovery key and check the password
 			$util = new \OCA\Encryption\Util( new \OC_FilesystemView( '/' ), \OCP\User::getUser() );
-			$return = $util->checkRecoveryPassword( $_POST['recoveryPassword'] );
+			$return = $util->checkRecoveryPassword( $recoveryPassword );
 			if ( $return ) {
 				\OC_Appconfig::setValue( 'files_encryption', 'recoveryAdminEnabled', 1 );
 			}


### PR DESCRIPTION
We shouldn't access $_POST[] here... issue #3480 
