### PR TITLE
The "lost password" field in the personal setting depends on OC_USER_BACKEND_SET_PASSWORD

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -63,6 +63,9 @@ if($_['displayNameChangeSupported']) {
 }
 ?>
 
+<?php
+if($_['passwordChangeSupported']) {
+?>
 <form id="lostpassword">
 	<fieldset class="personalblock">
 		<legend><strong><?php p($l->t('Email'));?></strong></legend>
@@ -71,6 +74,9 @@ if($_['displayNameChangeSupported']) {
 		<em><?php p($l->t('Fill in an email address to enable password recovery'));?></em>
 	</fieldset>
 </form>
+<?php
+}
+?>
 
 <form>
 	<fieldset class="personalblock">


### PR DESCRIPTION
so it should only be visible for users with a supporting backend.
