### PR TITLE
Add PublicEmitter class

### DIFF
--- a/lib/hooks/publicemitter.php
+++ b/lib/hooks/publicemitter.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Hooks;
+
+class PublicEmitter extends BasicEmitter {
+	/**
+	 * @param string $scope
+	 * @param string $method
+	 * @param array $arguments optional
+	 */
+	public function emit($scope, $method, $arguments = array()) {
+		parent::emit($scope, $method, $arguments);
+	}
+}


### PR DESCRIPTION
BasicEmitter for encapsulation where extending the Emitter isn't an option

cc @Raydiation @karlitschek @MTGap @bartv2 
