### PR TITLE
do not check WebDAV and htaccess if we do not have an internet connection

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -682,6 +682,12 @@ class OC_Util {
 	 * file in the data directory and trying to access via http
 	 */
 	public static function isHtAccessWorking() {
+
+		// in case there is no internet connection there is no need to display a warning
+		if (self::isInternetConnectionEnabled() === false) {
+			return true;
+		}
+
 		// testdata
 		$fileName = '/htaccesstest.txt';
 		$testContent = 'testcontent';
@@ -727,6 +733,12 @@ class OC_Util {
 	 *
 	 */
 	public static function isWebDAVWorking() {
+
+		// in case there is no internet connection there is no need to display a warning
+		if (self::isInternetConnectionEnabled() === false) {
+			return true;
+		}
+
 		if (!function_exists('curl_init')) {
 			return true;
 		}


### PR DESCRIPTION
Checking WebDAV and htaccess will result in timeouts and warnings if we do not have an internet connection but access ownCloud via the internet, like it is the case when ownCloud is behind a reverse proxy or NAT.

This was discussed in
 https://github.com/owncloud/core/issues/2495#issuecomment-15257787
 https://github.com/owncloud/core/issues/2495#issuecomment-15294265
 https://github.com/owncloud/core/issues/2511

There is a different version of this patch at https://github.com/evgeni/owncloud_core/tree/no-remote-checks-v2 -- take the one you like most (I prefer this one :))
