### PR TITLE
initialize the session earlier

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -441,14 +441,14 @@ class OC {
 		stream_wrapper_register('oc', 'OC\Files\Stream\OC');
 
 		self::initTemplateEngine();
-		self::checkConfig();
-		self::checkInstalled();
-		self::checkSSL();
 		if ( !self::$CLI ) {
 			self::initSession();
 		} else {
 			self::$session = new \OC\Session\Memory('');
 		}
+		self::checkConfig();
+		self::checkInstalled();
+		self::checkSSL();
 
 		$errors = OC_Util::checkServer();
 		if (count($errors) > 0) {


### PR DESCRIPTION
If checkConfig fails the session object is needed for displaying the error template

cc @MTGap @karlitschek @DeepDiver1975 
