### PR TITLE
Fix ldap sqlite n js

### DIFF
--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -14,7 +14,7 @@ var LdapConfiguration = {
 
 						//deal with Checkboxes
 						if($(elementID).is('input[type=checkbox]')) {
-							if(configvalue === 1) {
+							if(parseInt(configvalue) === 1) {
 								$(elementID).attr('checked', 'checked');
 							} else {
 								$(elementID).removeAttr('checked');

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -118,7 +118,13 @@ class Helper {
 			return false;
 		}
 
-		$query = \OCP\DB::prepare('TRUNCATE '.$table);
+		if(strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !== false) {
+			$query = \OCP\DB::prepare('DELETE FROM '.$table);
+		} else {
+			$query = \OCP\DB::prepare('TRUNCATE '.$table);
+		}
+
+
 		$res = $query->execute();
 
 		if(\OCP\DB::isError($res)) {


### PR DESCRIPTION
Fixes two things:

1) sqlite compatibility with clearing the mappings (→ emptying a table). sqlite does not understand TRUNCATE.

2) fixes a regression in master when applying values to configuration UI. The "Configuration Active" checkbox was not set correctly because of failing string-int clash in the comparison.
