### PR TITLE
In cases where smb4php returns false of an empty array stat/( has to ret...

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -57,12 +57,22 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 
 	public function stat($path) {
 		if ( ! $path and $this->root=='/') {//mtime doesn't work for shares
-			$mtime=$this->shareMTime();
 			$stat=stat($this->constructUrl($path));
+			if (empty($stat)) {
+				return false;
+			}
+			$mtime=$this->shareMTime();
 			$stat['mtime']=$mtime;
 			return $stat;
 		} else {
-			return stat($this->constructUrl($path));
+			$stat = stat($this->constructUrl($path));
+
+			// smb4php can return an empty array if the connection could not be established
+			if (empty($stat)) {
+				return false;
+			}
+
+			return $stat;
 		}
 	}
 


### PR DESCRIPTION
...urn false.

Fixes #3466 because the test method of external filesystems uses stat() to detect if the given parameters are okay.

Changes to 3rdparty are necessary as well:
https://github.com/owncloud/3rdparty/pull/33

@icewind1991 @MTGap THX
