### PR TITLE
Speed up octemplate rendering.

### DIFF
--- a/core/js/octemplate.js
+++ b/core/js/octemplate.js
@@ -61,7 +61,9 @@
 
 			if(typeof this.options.escapeFunction === 'function') {
 				for (var key = 0; key < this.vars.length; key++) {
-					this.vars[key] = self.options.escapeFunction(this.vars[key]);
+					if(typeof this.vars[key] === 'string') {
+						this.vars[key] = self.options.escapeFunction(this.vars[key]);
+					}
 				}
 			}
 

--- a/core/js/octemplate.js
+++ b/core/js/octemplate.js
@@ -60,11 +60,9 @@
 			var self = this;
 
 			if(typeof this.options.escapeFunction === 'function') {
-				$.each(this.vars, function(key, val) {
-					if(typeof val === 'string') {
-						self.vars[key] = self.options.escapeFunction(val);
-					}
-				});
+				for (var key = 0; key < this.vars.length; key++) {
+					this.vars[key] = self.options.escapeFunction(this.vars[key]);
+				}
 			}
 
 			var _html = this._build(this.vars);


### PR DESCRIPTION
This cuts ~40% of the rendering time for Firefox. Chromium shows little difference as it's considerately faster than FF, IE 8 seems faster, but doesn't have console.time()/timeEnd().

Tested with Firefox 21, Chromium 25 and IE 8.
