### PR TITLE
do not depend on session to render error templates

### DIFF
--- a/lib/template.php
+++ b/lib/template.php
@@ -181,7 +181,11 @@ class OC_Template{
 		$this->renderas = $renderas;
 		$this->application = $app;
 		$this->vars = array();
-		$this->vars['requesttoken'] = OC_Util::callRegister();
+		if (is_object(\OC::$session)) {
+			$this->vars['requesttoken'] = OC_Util::callRegister();
+		} else {
+			$this->vars['requesttoken'] = null;
+		}
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$this->l10n = OC_L10N::get($parts[0]);
 
@@ -246,14 +250,23 @@ class OC_Template{
 		// if the formfactor is not yet autodetected do the
 		// autodetection now. For possible formfactors check the
 		// detectFormfactor documentation
-		if (!\OC::$session->exists('formfactor')) {
-			\OC::$session->set('formfactor', self::detectFormfactor());
+		if (is_object(OC::$session)) {
+			if (!\OC::$session->exists('formfactor')) {
+				\OC::$session->set('formfactor', self::detectFormfactor());
+			}
+			// allow manual override via GET parameter
+			if(isset($_GET['formfactor'])) {
+				\OC::$session->set('formfactor', $_GET['formfactor']);
+			}
+			$formfactor = \OC::$session->get('formfactor');
+		} else {
+			//no session available, allow manual override via GET parameter
+			if(isset($_GET['formfactor'])) {
+				$formfactor = $_GET['formfactor'];
+			} else {
+				$formfactor = self::detectFormfactor();
+			}
 		}
-		// allow manual override via GET parameter
-		if(isset($_GET['formfactor'])) {
-			\OC::$session->set('formfactor', $_GET['formfactor']);
-		}
-		$formfactor = \OC::$session->get('formfactor');
 		if($formfactor=='default') {
 			$fext='';
 		}elseif($formfactor=='mobile') {

--- a/lib/user.php
+++ b/lib/user.php
@@ -264,7 +264,9 @@ class OC_User {
 	 * @brief Sets user id for session and triggers emit
 	 */
 	public static function setUserId($uid) {
-		\OC::$session->set('user_id', $uid);
+		if( is_object(\OC::$session) ) {
+			\OC::$session->set('user_id', $uid);
+		}
 	}
 
 	/**

--- a/lib/user.php
+++ b/lib/user.php
@@ -356,7 +356,7 @@ class OC_User {
 	 * @return string uid or false
 	 */
 	public static function getUser() {
-		if( \OC::$session->get('user_id') ) {
+		if( is_object(\OC::$session) && \OC::$session->get('user_id') ) {
 			return \OC::$session->get('user_id');
 		}
 		else{


### PR DESCRIPTION
this removes the dependency on a session to render templates. fixes rendering error pages when config.php is not writeable. see https://github.com/owncloud/core/pull/3560
