### PR TITLE
LDAP: append port when URL is passed in LDAP Host configuration, fixes #...

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -621,6 +621,10 @@ class Connection {
 		if(empty($host)) {
 			return false;
 		}
+		if(strpos($host, '://') !== false) {
+			//ldap_connect ignores port paramater when URLs are passed
+			$host .= ':' . $port;
+		}
 		$this->ldapConnectionRes = ldap_connect($host, $port);
 		if(ldap_set_option($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			if(ldap_set_option($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {


### PR DESCRIPTION
fixes #2600 

because otherweise it is ignored in ldap_connect.

Please test/review @k4k @FlorinPeter @karlitschek 
