### PR TITLE
Users page: username instead of login name as col header to avoid confus...

### DIFF
--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -79,7 +79,7 @@ $_['subadmingroups'] = array_flip($items);
 <table class="hascontrols" data-groups="<?php p(implode(', ', $allGroups));?>">
 	<thead>
 		<tr>
-			<th id='headerName'><?php p($l->t('Login Name'))?></th>
+			<th id='headerName'><?php p($l->t('Username'))?></th>
 			<th id="headerDisplayName"><?php p($l->t( 'Display Name' )); ?></th>
 			<th id="headerPassword"><?php p($l->t( 'Password' )); ?></th>
 			<th id="headerGroups"><?php p($l->t( 'Groups' )); ?></th>


### PR DESCRIPTION
...ion with other backends

It causes confusion like in #3592 and may be applied to other backends. "Username" is more general and thus hopefully a better designator.

What do you think @jancborchardt @karlitschek @icewind1991 (and others) ?

(LDAP explanation: In LDAP, there is not THE login name. It is what you specify in settings, it can be many – like username and email – and configuration may be changed by Admin. Therefore LDAP backend has a fixed username that is used internally.)
