### PR TITLE
recover encryption keys if ownCloud can't change the log-in password

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -142,6 +142,15 @@ class Hooks {
 	}
 
 	/**
+	 * @brief If the password can't be changed within ownCloud, than update the key password in advance.
+	 */
+	public static function preSetPassphrase($params) {
+		if ( ! \OC_User::canUserChangePassword($params['uid']) ) {
+			self::setPassphrase($params);
+		}
+	}
+
+	/**
 	 * @brief Change a user's encryption passphrase
 	 * @param array $params keys: uid, password
 	 */

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -48,6 +48,7 @@ class Helper {
 
 		\OCP\Util::connectHook('OC_User', 'post_login', 'OCA\Encryption\Hooks', 'login');
 		\OCP\Util::connectHook('OC_User', 'post_setPassword', 'OCA\Encryption\Hooks', 'setPassphrase');
+		\OCP\Util::connectHook('OC_User', 'pre_setPassword', 'OCA\Encryption\Hooks', 'preSetPassphrase');
 		\OCP\Util::connectHook('OC_User', 'post_createUser', 'OCA\Encryption\Hooks', 'postCreateUser');
 		\OCP\Util::connectHook('OC_User', 'post_deleteUser', 'OCA\Encryption\Hooks', 'postDeleteUser');
 	}

--- a/lib/user/user.php
+++ b/lib/user/user.php
@@ -131,10 +131,10 @@ class User {
 	 * @return bool
 	 */
 	public function setPassword($password, $recoveryPassword) {
+		if ($this->emitter) {
+			$this->emitter->emit('\OC\User', 'preSetPassword', array($this, $password, $recoveryPassword));
+		}
 		if ($this->backend->implementsActions(\OC_USER_BACKEND_SET_PASSWORD)) {
-			if ($this->emitter) {
-				$this->emitter->emit('\OC\User', 'preSetPassword', array($this, $password, $recoveryPassword));
-			}
 			$result = $this->backend->setPassword($this->uid, $password);
 			if ($this->emitter) {
 				$this->emitter->emit('\OC\User', 'postSetPassword', array($this, $password, $recoveryPassword));

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -31,7 +31,11 @@ $_['subadmingroups'] = array_flip($items);
 	</form>
 	<?php if((bool)$_['recoveryAdminEnabled']): ?>
 	<div class="recoveryPassword">
-	<input id="recoveryPassword" type="password" placeholder="<?php p($l->t('Admin Recovery Password'))?>" />
+	<input id="recoveryPassword"
+		   type="password"
+		   placeholder="<?php p($l->t('Admin Recovery Password'))?>"
+		   title="<?php p($l->t('Enter the recovery password in order to recover the users files during password change'))?>"
+		   alt="<?php p($l->t('Enter the recovery password in order to recover the users files during password change'))?>"/>
 	</div>
 	<?php endif; ?>
 	<div class="quota">


### PR DESCRIPTION
This patch enables the admin to recover the users files even if it is not possible to update the users password through ownCloud.

In this case two steps are necessary (it doesn't matter in which order you perform both steps):
- change the log-in password at the back-end (e.g. LDAP)
- go to ownClouds user management. Insert the recovery password to the appropriated filed (I added a tool-tip for a better understanding of the input field) and change the password from the relevant user. -> you will get a message that the back-end doesn't support password change from within ownCloud but that the encryption key was updated successfully)

@FlorinPeter please review the code
@blizzz would be great if you could give it a try with a real LDAP back-end
