### PR TITLE
Read configuratons for external filesystem test from a private place.

### DIFF
--- a/apps/files_external/tests/config.php
+++ b/apps/files_external/tests/config.php
@@ -1,4 +1,13 @@
 <?php
+
+// in case there are private configurations in the users home -> use them
+$privateConfigFile = $_SERVER['HOME'] . '/owncloud-extfs-test-config.php';
+if (file_exists($privateConfigFile)) {
+	$config = include($privateConfigFile);
+	return $config;
+}
+
+// this is now more a template now for your private configurations
 return array(
 	'ftp'=>array(
 		'run'=>false,


### PR DESCRIPTION
This will help not to accidentially push private data and enable testing on our ci server.

@icewind1991 @MTGap @butonic @schiesbn @karlitschek THX
