### PR TITLE
add timeouts 3/30/90 to phpunit tests

### DIFF
--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -103,6 +103,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		\OC_User::deleteUser(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGenerateKey() {
 
 		# TODO: use more accurate (larger) string length for test confirmation
@@ -114,6 +117,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @large
 	 * @return String
 	 */
 	function testGenerateIv() {
@@ -127,6 +131,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @large
 	 * @depends testGenerateIv
 	 */
 	function testConcatIv($iv) {
@@ -159,6 +164,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @depends testConcatIv
 	 */
 	function testSplitIv($testConcatIv) {
@@ -175,6 +181,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @return string padded
 	 */
 	function testAddPadding() {
@@ -190,6 +197,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @depends testAddPadding
 	 */
 	function testRemovePadding($padded) {
@@ -200,6 +208,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testEncrypt() {
 
 		$random = openssl_random_pseudo_bytes(13);
@@ -212,6 +223,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testDecrypt() {
 
 		$random = openssl_random_pseudo_bytes(13);
@@ -226,6 +240,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSymmetricEncryptFileContent() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
@@ -241,6 +258,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSymmetricStreamEncryptShortFileContent() {
 
 		$filename = 'tmp-' . time() . '.test';
@@ -291,6 +311,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief Test that data that is written by the crypto stream wrapper
 	 * @note Encrypted data is manually prepared and decrypted here to avoid dependency on success of stream_read
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
@@ -377,6 +398,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief Test that data that is read by the crypto stream wrapper
 	 */
 	function testSymmetricStreamDecryptShortFileContent() {
@@ -406,6 +428,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSymmetricStreamDecryptLongFileContent() {
 
 		$filename = 'tmp-' . time();
@@ -425,6 +450,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSymmetricEncryptFileContentKeyfile() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
@@ -440,6 +468,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testIsEncryptedContent() {
 
 		$this->assertFalse(Encryption\Crypt::isCatfileContent($this->dataUrl));
@@ -452,6 +483,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @large
+	 */
 	function testMultiKeyEncrypt() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
@@ -476,6 +510,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testKeyEncrypt() {
 
 		// Generate keypair
@@ -494,6 +531,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test encryption using legacy blowfish method
 	 */
 	function testLegacyEncryptShort() {
@@ -510,6 +548,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test decryption using legacy blowfish method
 	 * @depends testLegacyEncryptShort
 	 */
@@ -522,6 +561,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test encryption using legacy blowfish method
 	 */
 	function testLegacyEncryptLong() {
@@ -538,6 +578,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test decryption using legacy blowfish method
 	 * @depends testLegacyEncryptLong
 	 */
@@ -551,6 +592,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test generation of legacy encryption key
 	 * @depends testLegacyDecryptShort
 	 */
@@ -570,6 +612,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test decryption using legacy blowfish method
 	 * @depends testLegacyEncryptLong
 	 */
@@ -586,6 +629,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testRenameFile() {
 
 		$filename = 'tmp-' . time();
@@ -614,6 +660,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($newFilename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testMoveFileIntoFolder() {
 
 		$filename = 'tmp-' . time();
@@ -644,6 +693,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($newFolder);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testMoveFolder() {
 
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
@@ -679,6 +731,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink('/newfolder');
 	}
 
+	/**
+	 * @medium
+	 */
 	function testChangePassphrase() {
 		$filename = 'tmp-' . time();
 
@@ -713,6 +768,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testViewFilePutAndGetContents() {
 
 		$filename = '/tmp-' . time();
@@ -744,6 +802,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($filename);
 	}
 
+	/**
+	 * @large
+	 */
 	function testTouchExistingFile() {
 		$filename = '/tmp-' . time();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
@@ -765,6 +826,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testTouchFile() {
 		$filename = '/tmp-' . time();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
@@ -786,6 +850,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view->unlink($filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testFopenFile() {
 		$filename = '/tmp-' . time();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -103,6 +103,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::$enabled = true;
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGetPrivateKey() {
 
 		$key = Encryption\Keymanager::getPrivateKey($this->view, $this->userId);
@@ -119,6 +122,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGetPublicKey() {
 
 		$publiceKey = Encryption\Keymanager::getPublicKey($this->view, $this->userId);
@@ -132,6 +138,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('key', $sslInfo);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSetFileKey() {
 
 		# NOTE: This cannot be tested until we are able to break out 
@@ -165,6 +174,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGetUserKeys() {
 
 		$keys = Encryption\Keymanager::getUserKeys($this->view, $this->userId);
@@ -188,6 +200,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('key', $sslInfoPrivate);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testFixPartialFilePath() {
 
 		$partFilename = 'testfile.txt.part';
@@ -202,6 +217,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('testfile.txt', Encryption\Keymanager::fixPartialFilePath($filename));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testRecursiveDelShareKeys() {
 
 		// generate filename

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -129,6 +129,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @param bool $withTeardown
 	 */
 	function testShareFile($withTeardown = true) {
@@ -205,6 +206,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @param bool $withTeardown
 	 */
 	function testReShareFile($withTeardown = true) {
@@ -275,6 +277,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @param bool $withTeardown
 	 * @return array
 	 */
@@ -363,6 +366,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @param bool $withTeardown
 	 */
 	function testReShareFolder($withTeardown = true) {
@@ -564,6 +568,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '.shareKey'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testShareFileWithGroup() {
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -639,6 +646,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @large
+	 */
 	function testRecoveryFile() {
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -741,6 +751,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(0, \OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled'));
 	}
 
+	/**
+	 * @large
+	 */
 	function testRecoveryForUser() {
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -837,6 +850,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(0, \OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testFailShareFile() {
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -140,6 +140,9 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$view->unlink($filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testStreamSetTimeout() {
 		$filename = '/tmp-' . time();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -184,6 +184,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test restore file
 	 *
 	 * @depends testDeleteFile
@@ -215,6 +216,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test delete file forever
 	 */
 	function testPermanentDeleteFile() {

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -113,6 +113,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test delete file
 	 */
 	function testDeleteFile() {

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -118,6 +118,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test that paths set during User construction are correct
 	 */
 	function testKeyPaths() {
@@ -132,6 +133,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test setup of encryption directories
 	 */
 	function testSetupServerSide() {
@@ -139,6 +141,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @medium
 	 * @brief test checking whether account is ready for encryption,
 	 */
 	function testUserIsReady() {
@@ -159,6 +162,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 //	}
 
 	/**
+	 * @medium
 	 * @brief test checking whether account is not ready for encryption,
 	 */
 	function testIsLegacyUser() {
@@ -186,6 +190,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->legacyKey, \OC::$session->get('legacyKey'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testRecoveryEnabledForUser() {
 
 		$util = new Encryption\Util($this->view, $this->userId);
@@ -206,6 +213,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGetUidAndFilename() {
 
 		\OC_User::setUserId(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
@@ -232,6 +242,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testIsSharedPath() {
 		$sharedPath = '/user1/files/Shared/test';
 		$path = '/user1/files/test';
@@ -241,6 +254,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->util->isSharedPath($path));
 	}
 
+	/**
+	 * @large
+	 */
 	function testEncryptLegacyFiles() {
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
 

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -51,6 +51,9 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($row);
 	}
 
+	/**
+	 * @medium
+	 */
 	public function testNOW() {
 		$query = OC_DB::prepare('INSERT INTO *PREFIX*'.$this->table2.' (`fullname`,`uri`) VALUES (NOW(),?)');
 		$result = $query->execute(array('uri_2'));

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -36,6 +36,9 @@ class Test_DBSchema extends PHPUnit_Framework_TestCase {
 	}
 
 	// everything in one test, they depend on each other
+	/**
+	 * @medium
+	 */
 	public function testSchema() {
 		$this->doTestSchemaCreating();
 		$this->doTestSchemaChanging();

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -63,6 +63,9 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($cache->inCache('folder/bar2.txt'));
 	}
 
+	/**
+	 * @medium
+	 */
 	public function testFileToFolder() {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -29,6 +29,9 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	/**
+	 * @medium
+	 */
 	function testWatcher() {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -33,6 +33,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	/**
+	 * @medium
+	 */
 	public function testCacheAPI() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -104,6 +107,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), $rootView->getDirectoryContent('/non/existing'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testGetPath() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -127,6 +133,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertNull($folderView->getPath($id1));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testMountPointOverwrite() {
 		$storage1 = $this->getTestStorage(false);
 		$storage2 = $this->getTestStorage();
@@ -170,6 +179,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($textSize, $folderData[0]['size']);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testSearch() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -217,6 +229,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(3, count($folderView->searchByMime('text')));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testWatcher() {
 		$storage1 = $this->getTestStorage();
 		\OC\Files\Filesystem::mount($storage1, array(), '/');
@@ -234,6 +249,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(3, $cachedData['size']);
 	}
 
+	/**
+	 * @medium
+	 */
 	function testCopyBetweenStorages() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -255,6 +273,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($rootView->file_exists('/substorage/folder/bar.txt'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testMoveBetweenStorages() {
 		$storage1 = $this->getTestStorage();
 		$storage2 = $this->getTestStorage();
@@ -271,6 +292,9 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($rootView->file_exists('anotherfolder/bar.txt'));
 	}
 
+	/**
+	 * @medium
+	 */
 	function testTouch() {
 		$storage = $this->getTestStorage(true, '\Test\Files\TemporaryNoTouch');
 

--- a/tests/lib/geo.php
+++ b/tests/lib/geo.php
@@ -7,6 +7,10 @@
  */
 
 class Test_Geo extends PHPUnit_Framework_TestCase {
+	
+	/**
+	 * @medium
+	 */
 	function testTimezone() {
 		$result = OC_Geo::timezone(3, 3);
 		$expected = 'Africa/Porto-Novo';

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="bootstrap.php">
+<phpunit bootstrap="bootstrap.php"
+		 strict="true"
+		 timeoutForSmallTests="3"
+		 timeoutForMediumTests="30"
+		 timeoutForLargeTests="90"
+>
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>
 		<file>apps.php</file>


### PR DESCRIPTION
This allows the testsuite to complete when there is a runaway test, that would otherwise block the rest of the execution and requires manual intervention. Part of https://github.com/owncloud/core/pull/3583

@DeepDiver1975 @karlitschek @schiesbn should be an easy review.
