### PR TITLE
add missing backticks all over the place

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -289,7 +289,7 @@ class Util {
 	 */
 	public function recoveryEnabledForUser() {
 
-		$sql = 'SELECT `recovery_enabled` FROM `*PREFIX*encryption` WHERE  uid = ?';
+		$sql = 'SELECT `recovery_enabled` FROM `*PREFIX*encryption` WHERE `uid` = ?';
 
 		$args = array($this->userId);
 
@@ -347,7 +347,7 @@ class Util {
 			// Create a new record instead
 		} else {
 
-			$sql = 'UPDATE `*PREFIX*encryption` SET recovery_enabled = ? WHERE uid = ?';
+			$sql = 'UPDATE `*PREFIX*encryption` SET `recovery_enabled` = ? WHERE `uid` = ?';
 
 			$args = array(
 				$enabled,
@@ -1060,7 +1060,7 @@ class Util {
 	 */
 	public function setMigrationStatus($status) {
 
-		$sql = 'UPDATE `*PREFIX*encryption` SET migration_status = ? WHERE uid = ?';
+		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ?';
 
 		$args = array(
 			$status,
@@ -1089,7 +1089,7 @@ class Util {
 	 */
 	public function getMigrationStatus() {
 
-		$sql = 'SELECT `migration_status` FROM `*PREFIX*encryption`  WHERE uid = ?';
+		$sql = 'SELECT `migration_status` FROM `*PREFIX*encryption` WHERE `uid` = ?';
 
 		$args = array($this->userId);
 

--- a/lib/files/cache/backgroundwatcher.php
+++ b/lib/files/cache/backgroundwatcher.php
@@ -59,9 +59,9 @@ class BackgroundWatcher {
 	 */
 	static private function getNextFileId($previous, $folder) {
 		if ($folder) {
-			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND mimetype = ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
+			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` = ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
 		} else {
-			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND mimetype != ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
+			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` != ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
 		}
 		$result = $query->execute(array($previous));
 		if ($row = $result->fetchRow()) {

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -241,7 +241,7 @@ class Cache {
 		$params[] = $id;
 
 		$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=?'
-			. ' WHERE fileid = ?');
+			. ' WHERE `fileid` = ?');
 		$query->execute($params);
 	}
 
@@ -385,10 +385,10 @@ class Cache {
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear() {
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*filecache` WHERE storage = ?');
+		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?');
 		$query->execute(array($this->getNumericStorageId()));
 
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*storages` WHERE id = ?');
+		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*storages` WHERE `id` = ?');
 		$query->execute(array($this->storageId));
 	}
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -152,11 +152,11 @@ class Share {
 
 			// Fetch all shares of this file path from DB
 			$query = \OC_DB::prepare(
-				'SELECT share_with
+				'SELECT `share_with`
 				FROM
 				`*PREFIX*share`
 				WHERE
-				item_source = ? AND share_type = ?'
+				`item_source` = ? AND `share_type` = ?'
 			);
 
 			$result = $query->execute(array($source, self::SHARE_TYPE_USER));
@@ -171,11 +171,11 @@ class Share {
 			// We also need to take group shares into account
 
 			$query = \OC_DB::prepare(
-				'SELECT share_with
+				'SELECT `share_with`
 				FROM
 				`*PREFIX*share`
 				WHERE
-				item_source = ? AND share_type = ?'
+				`item_source` = ? AND `share_type` = ?'
 			);
 
 			$result = $query->execute(array($source, self::SHARE_TYPE_GROUP));
@@ -192,11 +192,11 @@ class Share {
 			//check for public link shares
 			if (!$publicShare) {
 				$query = \OC_DB::prepare(
-					'SELECT share_with
+					'SELECT `share_with`
 					FROM
 					`*PREFIX*share`
 					WHERE
-					item_source = ? AND share_type = ?'
+					`item_source` = ? AND `share_type` = ?'
 				);
 
 				$result = $query->execute(array($source, self::SHARE_TYPE_LINK));

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -33,15 +33,15 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testQuotes() {
-		$query = OC_DB::prepare('SELECT `fullname` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array('uri_1'));
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();
 		$this->assertFalse($row);
-		$query = OC_DB::prepare('INSERT INTO *PREFIX*'.$this->table2.' (`fullname`,`uri`) VALUES (?,?)');
+		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (?,?)');
 		$result = $query->execute(array('fullname test', 'uri_1'));
 		$this->assertTrue((bool)$result);
-		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array('uri_1'));
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();
@@ -52,19 +52,19 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testNOW() {
-		$query = OC_DB::prepare('INSERT INTO *PREFIX*'.$this->table2.' (`fullname`,`uri`) VALUES (NOW(),?)');
+		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (NOW(),?)');
 		$result = $query->execute(array('uri_2'));
 		$this->assertTrue((bool)$result);
-		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array('uri_2'));
 		$this->assertTrue((bool)$result);
 	}
 
 	public function testUNIX_TIMESTAMP() {
-		$query = OC_DB::prepare('INSERT INTO *PREFIX*'.$this->table2.' (`fullname`,`uri`) VALUES (UNIX_TIMESTAMP(),?)');
+		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (UNIX_TIMESTAMP(),?)');
 		$result = $query->execute(array('uri_3'));
 		$this->assertTrue((bool)$result);
-		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname`,`uri` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array('uri_3'));
 		$this->assertTrue((bool)$result);
 	}
@@ -88,7 +88,7 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 			$this->assertTrue((bool)$result);
 		}
 
-		$query = OC_DB::prepare('SELECT * FROM *PREFIX*'.$this->table3);
+		$query = OC_DB::prepare('SELECT * FROM `*PREFIX*'.$this->table3.'`');
 		$result = $query->execute();
 		$this->assertTrue((bool)$result);
 		$this->assertEquals('4', $result->numRows());
@@ -100,10 +100,10 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$carddata = 'This is a vCard';
 
 		// Normal test to have same known data inserted.
-		$query = OC_DB::prepare('INSERT INTO *PREFIX*'.$this->table2.' (`fullname`, `uri`, `carddata`) VALUES (?, ?, ?)');
+		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`, `uri`, `carddata`) VALUES (?, ?, ?)');
 		$result = $query->execute(array($fullname, $uri, $carddata));
 		$this->assertTrue((bool)$result);
-		$query = OC_DB::prepare('SELECT `fullname`, `uri`, `carddata` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname`, `uri`, `carddata` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array($uri));
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();
@@ -119,7 +119,7 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 			));
 		$this->assertTrue((bool)$result);
 
-		$query = OC_DB::prepare('SELECT `fullname`, `uri`, `carddata` FROM *PREFIX*'.$this->table2.' WHERE `uri` = ?');
+		$query = OC_DB::prepare('SELECT `fullname`, `uri`, `carddata` FROM `*PREFIX*'.$this->table2.'` WHERE `uri` = ?');
 		$result = $query->execute(array($uri));
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();


### PR DESCRIPTION
I know backticks are ugly and actually bad practice. Nevertheless, we currently need to use them for portability reasons. Please check that you add them whenever writing SQL. There are exceptions in installation and migration code, but for now the general rule is to always quote identifiers. Unquoted backticks are HARD to debug.

@icewind1991 @MTGap @karlitschek @DeepDiver1975 

Originally part of https://github.com/owncloud/core/pull/3583
