### PR TITLE
convert LIMIT to parameter

### DIFF
--- a/lib/files/cache/legacy.php
+++ b/lib/files/cache/legacy.php
@@ -45,7 +45,7 @@ class Legacy {
 			return $this->cacheHasItems;
 		}
 		try {
-			$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*fscache` WHERE `user` = ? LIMIT 1');
+			$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*fscache` WHERE `user` = ?',1);
 		} catch (\Exception $e) {
 			$this->cacheHasItems = false;
 			return false;


### PR DESCRIPTION
LIMIT and OFFSET are not supported by all database platforms. We therefore added them as parameters to `OC_DB::prepare( $query , $limit=null, $offset=null )`

@karlitschek @DeepDiver1975 @icewind1991 

Originally part of https://github.com/owncloud/core/pull/3583

Sidenote: I will submit a PR with a new `OC_DB::executeAudited (...)` call that will do some sanity and error checks that will log the wrong usage of SQL and throw a `DatabasException` to make all developers aware of issues with their SQL. 
