### PR TITLE
use to_char to allow comparing string to CLOB cloumns in oracle

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -174,7 +174,8 @@ class OC_App{
 		$apps=array('files');
 		$sql = 'SELECT `appid` FROM `*PREFIX*appconfig`'
 			.' WHERE `configkey` = \'enabled\' AND `configvalue`=\'yes\'';
-		if (OC_Config::getValue( 'dbtype', 'sqlite' ) === 'oci') { //FIXME oracle hack
+		if (OC_Config::getValue( 'dbtype', 'sqlite' ) === 'oci') {
+			//FIXME oracle hack: need to explicitly cast CLOB to CHAR for comparison
 			$sql = 'SELECT `appid` FROM `*PREFIX*appconfig`'
 			.' WHERE `configkey` = \'enabled\' AND to_char(`configvalue`)=\'yes\'';
 		}


### PR DESCRIPTION
I have no better idea than using to_char to compare strings to CLOB columns. Better ideas welcome. Until then give me a :+1: 

@karlitschek @DeepDiver1975 @bartv2 

Originally part of https://github.com/owncloud/core/pull/3583 but fixes two other occurences and does not use time() as a parameter because a comment says it will break sqlite ...
