### PR TITLE
fix fetchRow checks to also work with MDB2

### DIFF
--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -96,7 +96,7 @@ class Cache {
 	 * get the stored metadata of a file or folder
 	 *
 	 * @param string/int $file
-	 * @return array
+	 * @return array | false
 	 */
 	public function get($file) {
 		if (is_string($file) or $file == '') {
@@ -114,6 +114,12 @@ class Cache {
 			 FROM `*PREFIX*filecache` ' . $where);
 		$result = $query->execute($params);
 		$data = $result->fetchRow();
+
+		//FIXME hide this HACK in the next database layer, or just use doctrine and get rid of MDB2 and PDO
+		//PDO returns false, MDB2 returns null, oracle always uses MDB2, so convert null to false
+		if ($data === null) {
+			$data = false;
+		}
 
 		//merge partial data
 		if (!$data and  is_string($file)) {

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -37,7 +37,7 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$result = $query->execute(array('uri_1'));
 		$this->assertTrue((bool)$result);
 		$row = $result->fetchRow();
-		$this->assertFalse($row);
+		$this->assertFalse((bool)$row); //PDO returns false, MDB2 returns null
 		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (?,?)');
 		$result = $query->execute(array('fullname test', 'uri_1'));
 		$this->assertTrue((bool)$result);
@@ -48,7 +48,7 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('fullname', $row);
 		$this->assertEquals($row['fullname'], 'fullname test');
 		$row = $result->fetchRow();
-		$this->assertFalse($row);
+		$this->assertFalse((bool)$row); //PDO returns false, MDB2 returns null
 	}
 
 	public function testNOW() {


### PR DESCRIPTION
MDB2 returns null when no further rows are available, PDO and doctrine return false. Various places that use `OC\Files\Cache\Cache $cache->get($file)` check for false with `===`. Some of the tests user assertFalse() which also fails. These HACKS will go away when moving to doctrine, but for now. We need to check for null and false. The underlying problem is that using PDO for oracle is not recommended and ownCloud has to fall back to MDB2.

The widespread (IMHO bad) usage of `while ($row = $result->fetchRow()) {` is not affected.

@karlitschek @DeepDiver1975 @icewind1991 @MTGap @bartv2 

Originally part of https://github.com/owncloud/core/pull/3583
