### PR TITLE
shorten table identifiers in tests

### DIFF
--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -9,7 +9,7 @@
 
  <table>
 
-  <name>*dbprefix*contacts_addressbooks</name>
+  <name>*dbprefix*cntcts_addrsbks</name>
 
   <declaration>
 
@@ -77,7 +77,7 @@
 
  <table>
 
-  <name>*dbprefix*contacts_cards</name>
+  <name>*dbprefix*cntcts_cards</name>
 
   <declaration>
 

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -9,7 +9,7 @@
 
  <table>
 
-  <name>*dbprefix*contacts_addressbooks</name>
+  <name>*dbprefix*cntcts_addrsbks</name>
 
   <declaration>
 

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -22,8 +22,8 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		OC_DB::createDbFromStructure(self::$schema_file);
 
 		$this->test_prefix = $r;
-		$this->table1 = $this->test_prefix.'contacts_addressbooks';
-		$this->table2 = $this->test_prefix.'contacts_cards';
+		$this->table1 = $this->test_prefix.'cntcts_addrsbks';
+		$this->table2 = $this->test_prefix.'cntcts_cards';
 		$this->table3 = $this->test_prefix.'vcategory';
 	}
 

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -26,8 +26,8 @@ class Test_DBSchema extends PHPUnit_Framework_TestCase {
 		file_put_contents( self::$schema_file2, $content );
 
 		$this->test_prefix = $r;
-		$this->table1 = $this->test_prefix.'contacts_addressbooks';
-		$this->table2 = $this->test_prefix.'contacts_cards';
+		$this->table1 = $this->test_prefix.'cntcts_addrsbks';
+		$this->table2 = $this->test_prefix.'cntcts_cards';
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
oracle can only handle identifiers <= 30 chars. This PR will allow the tests to complete under this constraint.

@karlitschek @DeepDiver1975 @Raydiation @bartv2 @icewind1991 

Originally part of https://github.com/owncloud/core/pull/3583
