### PR TITLE
Introduce more robust SQL execution and exception handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,15 @@
 
 $RUNTIME_NOAPPS = true; //no apps, yet
 
-require_once 'lib/base.php';
+try {
+	
+	require_once 'lib/base.php';
 
-OC::handleRequest();
+	OC::handleRequest();
+
+} catch (Exception $ex) {
+	//show the user a detailed error page
+	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	OC_Template::printExceptionErrorPage($ex);
+}

--- a/lib/db.php
+++ b/lib/db.php
@@ -408,7 +408,6 @@ class OC_DB {
 				// TODO try to convert LIMIT OFFSET notation to parameters, see fixLimitClauseForMSSQL
 				$message = 'LIMIT and OFFSET are forbidden for portability reasons,'
 						 . ' pass an array with \'limit\' and \'offset\' instead';
-				\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
 				throw new DatabaseException($message);
 			}
 			$stmt = array('sql' => $stmt, 'limit' => null, 'offset' => null);
@@ -417,7 +416,6 @@ class OC_DB {
 			// convert to prepared statement
 			if ( ! array_key_exists('sql', $stmt) ) {
 				$message = 'statement array must at least contain key \'sql\'';
-				\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
 				throw new DatabaseException($message);
 			}
 			if ( ! array_key_exists('limit', $stmt) ) {
@@ -438,7 +436,6 @@ class OC_DB {
 			} else {
 				$message = 'Expected a prepared statement or array got ' . gettype($stmt);
 			}
-			\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
 			throw new DatabaseException($message);
 		}
 		return $result;
@@ -937,7 +934,6 @@ class OC_DB {
 			} else {
 				$message .= ', Root cause:' . self::getErrorMessage($result);
 			}
-			OC_Log::write('db', $message, OC_Log::FATAL);
 			throw new DatabaseException($message, getErrorCode($result));
 		}
 	}

--- a/lib/db.php
+++ b/lib/db.php
@@ -23,7 +23,8 @@
 class DatabaseException extends Exception{
 	private $query;
 
-	public function __construct($message, $query){
+	//FIXME getQuery seems to be unused, maybe use parent constructor with $message, $code and $previous
+	public function __construct($message, $query = null){
 		parent::__construct($message);
 		$this->query = $query;
 	}
@@ -392,9 +393,62 @@ class OC_DB {
 	}
 
 	/**
+	 * @brief execute a prepared statement, on error write log and throw exception
+	 * @param mixed $stmt PDOStatementWrapper | MDB2_Statement_Common ,
+	 *					  an array with 'sql' and optionally 'limit' and 'offset' keys
+	 *					.. or a simple sql query string
+	 * @param array $parameters
+	 * @return result
+	 * @throws DatabaseException
+	 */
+	static public function executeAudited( $stmt, array $parameters = null) {
+		if (is_string($stmt)) {
+			// convert to an array with 'sql'
+			if (stripos($stmt,'LIMIT') !== false) { //OFFSET requires LIMIT, se we only neet to check for LIMIT
+				// TODO try to convert LIMIT OFFSET notation to parameters, see fixLimitClauseForMSSQL
+				$message = 'LIMIT and OFFSET are forbidden for portability reasons,'
+						 . ' pass an array with \'limit\' and \'offset\' instead';
+				\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
+				throw new DatabaseException($message);
+			}
+			$stmt = array('sql' => $stmt, 'limit' => null, 'offset' => null);
+		}
+		if (is_array($stmt)){
+			// convert to prepared statement
+			if ( ! array_key_exists('sql', $stmt) ) {
+				$message = 'statement array must at least contain key \'sql\'';
+				\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
+				throw new DatabaseException($message);
+			}
+			if ( ! array_key_exists('limit', $stmt) ) {
+				$stmt['limit'] = null;
+			}
+			if ( ! array_key_exists('limit', $stmt) ) {
+				$stmt['offset'] = null;
+			}
+			$stmt = self::prepare($stmt['sql'], $stmt['limit'], $stmt['offset']);
+		}
+		self::raiseExceptionOnError($stmt, 'Could not prepare statement');
+		if ($stmt instanceof PDOStatementWrapper || $stmt instanceof MDB2_Statement_Common) {
+			$result = $stmt->execute($parameters);
+			self::raiseExceptionOnError($result, 'Could not execute statement');
+		} else {
+			if (is_object($stmt)) {
+				$message = 'Expected a prepared statement or array got ' . get_class($stmt);
+			} else {
+				$message = 'Expected a prepared statement or array got ' . gettype($stmt);
+			}
+			\OCP\Util::writeLog('db', $message, \OCP\Util::FATAL);
+			throw new DatabaseException($message);
+		}
+		return $result;
+	}
+
+	/**
 	 * @brief gets last value of autoincrement
 	 * @param string $table The optional table name (will replace *PREFIX*) and add sequence suffix
 	 * @return int id
+	 * @throws DatabaseException
 	 *
 	 * MDB2 lastInsertID()
 	 *
@@ -404,25 +458,27 @@ class OC_DB {
 	public static function insertid($table=null) {
 		self::connect();
 		$type = OC_Config::getValue( "dbtype", "sqlite" );
-		if( $type == 'pgsql' ) {
-			$query = self::prepare('SELECT lastval() AS id');
-			$row = $query->execute()->fetchRow();
+		if( $type === 'pgsql' ) {
+			$result = self::executeAudited('SELECT lastval() AS id');
+			$row = $result->fetchRow();
+			self::raiseExceptionOnError($row, 'fetching row for insertid failed');
 			return $row['id'];
-		}
-		if( $type == 'mssql' ) {
+		} else if( $type === 'mssql') {
 			if($table !== null) {
 				$prefix = OC_Config::getValue( "dbtableprefix", "oc_" );
 				$table = str_replace( '*PREFIX*', $prefix, $table );
 			}
-			return self::$connection->lastInsertId($table);
-		}else{
+			$result = self::$connection->lastInsertId($table);
+		} else {
 			if($table !== null) {
 				$prefix = OC_Config::getValue( "dbtableprefix", "oc_" );
 				$suffix = OC_Config::getValue( "dbsequencesuffix", "_id_seq" );
 				$table = str_replace( '*PREFIX*', $prefix, $table ).$suffix;
 			}
-			return self::$connection->lastInsertId($table);
+			$result = self::$connection->lastInsertId($table);
 		}
+		self::raiseExceptionOnError($result, 'insertid failed');
+		return $result;
 	}
 
 	/**
@@ -512,6 +568,8 @@ class OC_DB {
 
 		//clean up memory
 		unlink( $file2 );
+		
+		self::raiseExceptionOnError($definition,'Failed to parse the database definition');
 
 		// Die in case something went wrong
 		if( $definition instanceof MDB2_Schema_Error ) {
@@ -528,11 +586,7 @@ class OC_DB {
 
 		$ret=self::$schema->createDatabase( $definition );
 
-		// Die in case something went wrong
-		if( $ret instanceof MDB2_Error ) {
-			OC_Template::printErrorPage( self::$MDB2->getDebugOutput().' '.$ret->getMessage() . ': '
-				. $ret->getUserInfo() );
-		}
+		self::raiseExceptionOnError($ret,'Failed to create the database structure');
 
 		return true;
 	}
@@ -552,13 +606,7 @@ class OC_DB {
 		$content = file_get_contents( $file );
 
 		$previousSchema = self::$schema->getDefinitionFromDatabase();
-		if (PEAR::isError($previousSchema)) {
-			$error = $previousSchema->getMessage();
-			$detail = $previousSchema->getDebugInfo();
-			$message = 'Failed to get existing database structure for updating ('.$error.', '.$detail.')';
-			OC_Log::write('core', $message, OC_Log::FATAL);
-			throw new Exception($message);
-		}
+		self::raiseExceptionOnError($previousSchema,'Failed to get existing database structure for updating');
 
 		// Make changes and save them to an in-memory file
 		$file2 = 'static://db_scheme';
@@ -582,13 +630,7 @@ class OC_DB {
 		//clean up memory
 		unlink( $file2 );
 
-		if (PEAR::isError($op)) {
-			$error = $op->getMessage();
-			$detail = $op->getDebugInfo();
-			$message = 'Failed to update database structure ('.$error.', '.$detail.')';
-			OC_Log::write('core', $message, OC_Log::FATAL);
-			throw new Exception($message);
-		}
+		self::raiseExceptionOnError($op,'Failed to update database structure');
 		return true;
 	}
 
@@ -641,15 +683,9 @@ class OC_DB {
 			}
 			$query = substr($query, 0, strlen($query) - 5);
 			try {
-				$stmt = self::prepare($query);
-				$result = $stmt->execute($inserts);
-
-			} catch(PDOException $e) {
-				$entry = 'DB Error: "'.$e->getMessage() . '"<br />';
-				$entry .= 'Offending command was: ' . $query . '<br />';
-				OC_Log::write('core', $entry, OC_Log::FATAL);
-				error_log('DB error: '.$entry);
-				OC_Template::printErrorPage( $entry );
+				$result = self::executeAudited($query, $inserts);
+			} catch(DatabaseException $e) {
+				OC_Template::printExceptionErrorPage( $e );
 			}
 
 			if((int)$result->numRows() === 0) {
@@ -674,16 +710,12 @@ class OC_DB {
 		}
 
 		try {
-			$result = self::prepare($query);
+			$result = self::executeAudited($query, $inserts);
 		} catch(PDOException $e) {
-			$entry = 'DB Error: "'.$e->getMessage() . '"<br />';
-			$entry .= 'Offending command was: ' . $query.'<br />';
-			OC_Log::write('core', $entry, OC_Log::FATAL);
-			error_log('DB error: ' . $entry);
-			OC_Template::printErrorPage( $entry );
+			OC_Template::printExceptionErrorPage( $e );
 		}
 
-		return $result->execute($inserts);
+		return $result;
 	}
 
 	/**
@@ -891,7 +923,33 @@ class OC_DB {
 			return false;
 		}
 	}
+	/**
+	 * check if a result is an error, writes a log entry and throws an exception, works with MDB2 and PDOException
+	 * @param mixed $result
+	 * @param string message
+	 * @return void
+	 * @throws DatabaseException
+	 */
+	public static function raiseExceptionOnError($result, $message = null) {
+		if(self::isError($result)) {
+			if ($message === null) {
+				$message = self::getErrorMessage($result);
+			} else {
+				$message .= ', Root cause:' . self::getErrorMessage($result);
+			}
+			OC_Log::write('db', $message, OC_Log::FATAL);
+			throw new DatabaseException($message, getErrorCode($result));
+		}
+	}
 
+	public static function getErrorCode($error) {
+		if ( self::$backend==self::BACKEND_MDB2 and PEAR::isError($error) ) {
+			$code = $error->getCode();
+		} elseif ( self::$backend==self::BACKEND_PDO and self::$PDO ) {
+			$code = self::$PDO->errorCode();
+		}
+		return $code;
+	}
 	/**
 	 * returns the error code and message as a string for logging
 	 * works with MDB2 and PDOException
@@ -901,9 +959,7 @@ class OC_DB {
 	public static function getErrorMessage($error) {
 		if ( self::$backend==self::BACKEND_MDB2 and PEAR::isError($error) ) {
 			$msg = $error->getCode() . ': ' . $error->getMessage();
-			if (defined('DEBUG') && DEBUG) {
-				$msg .= '(' . $error->getDebugInfo() . ')';
-			}
+			$msg .= ' (' . $error->getDebugInfo() . ')';
 		} elseif (self::$backend==self::BACKEND_PDO and self::$PDO) {
 			$msg = self::$PDO->errorCode() . ': ';
 			$errorInfo = self::$PDO->errorInfo();

--- a/lib/response.php
+++ b/lib/response.php
@@ -11,6 +11,7 @@ class OC_Response {
 	const STATUS_NOT_MODIFIED = 304;
 	const STATUS_TEMPORARY_REDIRECT = 307;
 	const STATUS_NOT_FOUND = 404;
+	const STATUS_INTERNAL_SERVER_ERROR = 500;
 
 	/**
 	* @brief Enable response caching by sending correct HTTP headers
@@ -69,6 +70,9 @@ class OC_Response {
 				break;
 			case self::STATUS_NOT_FOUND;
 				$status = $status . ' Not Found';
+				break;
+			case self::STATUS_INTERNAL_SERVER_ERROR;
+				$status = $status . ' Internal Server Error';
 				break;
 		}
 		header($protocol.' '.$status);

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -106,12 +106,6 @@ class OC_Setup {
 						'hint' => $e->getHint()
 					);
 					return($error);
-				} catch (Exception $e) {
-					$error[] = array(
-						'error' => $e->getMessage(),
-						'hint' => ''
-					);
-					return($error);
 				}
 			}
 			elseif($dbtype == 'pgsql') {
@@ -127,7 +121,7 @@ class OC_Setup {
 
 				try {
 					self::setupPostgreSQLDatabase($dbhost, $dbuser, $dbpass, $dbname, $dbtableprefix, $username);
-				} catch (Exception $e) {
+				} catch (DatabaseSetupException $e) {
 					$error[] = array(
 						'error' => $l->t('PostgreSQL username and/or password not valid'),
 						'hint' => $l->t('You need to enter either an existing account or the administrator.')
@@ -150,7 +144,7 @@ class OC_Setup {
 
 				try {
 					self::setupOCIDatabase($dbhost, $dbuser, $dbpass, $dbname, $dbtableprefix, $dbtablespace, $username);
-				} catch (Exception $e) {
+				} catch (DatabaseSetupException $e) {
 					$error[] = array(
 						'error' => $l->t('Oracle connection could not be established'),
 						'hint' => $e->getMessage().' Check environment: ORACLE_HOME='.getenv('ORACLE_HOME')
@@ -177,7 +171,7 @@ class OC_Setup {
 
 				try {
 					self::setupMSSQLDatabase($dbhost, $dbuser, $dbpass, $dbname, $dbtableprefix);
-				} catch (Exception $e) {
+				} catch (DatabaseSetupException $e) {
 					$error[] = array(
 						'error' => 'MS SQL username and/or password not valid',
 						'hint' => 'You need to enter either an existing account or the administrator.'
@@ -326,7 +320,7 @@ class OC_Setup {
 		$connection_string = "host='$e_host' dbname=postgres user='$e_user' password='$e_password'";
 		$connection = @pg_connect($connection_string);
 		if(!$connection) {
-			throw new Exception($l->t('PostgreSQL username and/or password not valid'));
+			throw new DatabaseSetupException($l->t('PostgreSQL username and/or password not valid'));
 		}
 		$e_user = pg_escape_string($dbuser);
 		//check for roles creation rights in postgresql
@@ -371,7 +365,7 @@ class OC_Setup {
 		$connection_string = "host='$e_host' dbname='$e_dbname' user='$e_user' password='$e_password'";
 		$connection = @pg_connect($connection_string);
 		if(!$connection) {
-			throw new Exception($l->t('PostgreSQL username and/or password not valid'));
+			throw new DatabaseSetupException($l->t('PostgreSQL username and/or password not valid'));
 		}
 		$query = "select count(*) FROM pg_class WHERE relname='{$dbtableprefix}users' limit 1";
 		$result = pg_query($connection, $query);
@@ -461,9 +455,9 @@ class OC_Setup {
 		if(!$connection) {
 			$e = oci_error();
 			if (is_array ($e) && isset ($e['message'])) {
-				throw new Exception($e['message']);
+				throw new DatabaseSetupException($e['message']);
 			}
-			throw new Exception($l->t('Oracle username and/or password not valid'));
+			throw new DatabaseSetupException($l->t('Oracle username and/or password not valid'));
 		}
 		//check for roles creation rights in oracle
 
@@ -530,7 +524,7 @@ class OC_Setup {
 		}
 		$connection = @oci_connect($dbuser, $dbpass, $easy_connect_string);
 		if(!$connection) {
-			throw new Exception($l->t('Oracle username and/or password not valid'));
+			throw new DatabaseSetupException($l->t('Oracle username and/or password not valid'));
 		}
 		$query = "SELECT count(*) FROM user_tables WHERE table_name = :un";
 		$stmt = oci_parse($connection, $query);
@@ -641,7 +635,7 @@ class OC_Setup {
 			} else {
 				$entry = '';
 			}
-			throw new Exception($l->t('MS SQL username and/or password not valid: %s', array($entry)));
+			throw new DatabaseSetupException($l->t('MS SQL username and/or password not valid: %s', array($entry)));
 		}
 
 		OC_Config::setValue('dbuser', $dbuser);

--- a/lib/template.php
+++ b/lib/template.php
@@ -535,4 +535,25 @@ class OC_Template{
 		$content->printPage();
 		die();
 	}
+	
+	/**
+	 * print error page using Exception details
+	 * @param Exception $exception
+	 */
+	
+	public static function printExceptionErrorPage(Exception $exception) {
+		$error_msg = $exception->getMessage();
+		if ($exception->getCode()) {
+			$error_msg = '['.$exception->getCode().'] '.$error_msg;
+		}
+		$hint = $exception->getTraceAsString();
+		while ($exception = $exception->previous()) {
+			$error_msg .= '<br/>Caused by: ';
+			if ($exception->getCode()) {
+				$error_msg .= '['.$exception->getCode().'] ';
+			}
+			$error_msg .= $exception->getMessage();
+		};
+		self::printErrorPage($error_msg, $hint);
+	}
 }

--- a/public.php
+++ b/public.php
@@ -1,21 +1,31 @@
 <?php
 $RUNTIME_NOAPPS = true;
-require_once 'lib/base.php';
-OC::checkMaintenanceMode();
-if (!isset($_GET['service'])) {
-	header('HTTP/1.0 404 Not Found');
-	exit;
+
+try {
+
+	require_once 'lib/base.php';
+	OC::checkMaintenanceMode();
+	if (!isset($_GET['service'])) {
+		header('HTTP/1.0 404 Not Found');
+		exit;
+	}
+	$file = OCP\CONFIG::getAppValue('core', 'public_' . strip_tags($_GET['service']));
+	if(is_null($file)) {
+		header('HTTP/1.0 404 Not Found');
+		exit;
+	}
+
+	$parts=explode('/', $file, 2);
+	$app=$parts[0];
+
+	OC_Util::checkAppEnabled($app);
+	OC_App::loadApp($app);
+
+	require_once OC_App::getAppPath($app) .'/'. $parts[1];
+
+} catch (Exception $ex) {
+	//show the user a detailed error page
+	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	OC_Template::printExceptionErrorPage($ex);
 }
-$file = OCP\CONFIG::getAppValue('core', 'public_' . strip_tags($_GET['service']));
-if(is_null($file)) {
-	header('HTTP/1.0 404 Not Found');
-	exit;
-}
-
-$parts=explode('/', $file, 2);
-$app=$parts[0];
-
-OC_Util::checkAppEnabled($app);
-OC_App::loadApp($app);
-
-require_once OC_App::getAppPath($app) .'/'. $parts[1];

--- a/remote.php
+++ b/remote.php
@@ -1,40 +1,49 @@
 <?php
 $RUNTIME_NOAPPS = true;
-require_once 'lib/base.php';
-$path_info = OC_Request::getPathInfo();
-if ($path_info === false || $path_info === '') {
-	OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);
-	exit;
-}
-if (!$pos = strpos($path_info, '/', 1)) {
-	$pos = strlen($path_info);
-}
-$service=substr($path_info, 1, $pos-1);
 
-$file = OC_AppConfig::getValue('core', 'remote_' . $service);
+try {
 
-if(is_null($file)) {
-	OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);
-	exit;
+	require_once 'lib/base.php';
+	$path_info = OC_Request::getPathInfo();
+	if ($path_info === false || $path_info === '') {
+		OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);
+		exit;
+	}
+	if (!$pos = strpos($path_info, '/', 1)) {
+		$pos = strlen($path_info);
+	}
+	$service=substr($path_info, 1, $pos-1);
+
+	$file = OC_AppConfig::getValue('core', 'remote_' . $service);
+
+	if(is_null($file)) {
+		OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);
+		exit;
+	}
+
+	$file=ltrim($file, '/');
+
+	$parts=explode('/', $file, 2);
+	$app=$parts[0];
+	switch ($app) {
+		case 'core':
+			$file =  OC::$SERVERROOT .'/'. $file;
+			break;
+		default:
+			OC_Util::checkAppEnabled($app);
+			OC_App::loadApp($app);
+			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+				$file = OC_App::getAppPath($app) .'/'. $parts[1];
+			}else{
+				$file = '/' . OC_App::getAppPath($app) .'/'. $parts[1];
+			}
+			break;
+	}
+	$baseuri = OC::$WEBROOT . '/remote.php/'.$service.'/';
+	require_once $file;
+
+} catch (Exception $ex) {
+	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	OC_Template::printExceptionErrorPage($ex);
 }
-
-$file=ltrim($file, '/');
-
-$parts=explode('/', $file, 2);
-$app=$parts[0];
-switch ($app) {
-	case 'core':
-		$file =  OC::$SERVERROOT .'/'. $file;
-		break;
-	default:
-		OC_Util::checkAppEnabled($app);
-		OC_App::loadApp($app);
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-			$file = OC_App::getAppPath($app) .'/'. $parts[1];
-		}else{
-			$file = '/' . OC_App::getAppPath($app) .'/'. $parts[1];
-		}
-		break;
-}
-$baseuri = OC::$WEBROOT . '/remote.php/'.$service.'/';
-require_once $file;

--- a/status.php
+++ b/status.php
@@ -23,13 +23,20 @@
 
 $RUNTIME_NOAPPS = true; //no apps, yet
 
-require_once 'lib/base.php';
+try {
 
-if(OC_Config::getValue('installed')==1) $installed='true'; else $installed='false';
-$values=array(
-	'installed'=>$installed,
-	'version'=>implode('.', OC_Util::getVersion()),
-	'versionstring'=>OC_Util::getVersionString(),
-	'edition'=>OC_Util::getEditionString());
+	require_once 'lib/base.php';
 
-echo(json_encode($values));
+	if(OC_Config::getValue('installed')==1) $installed='true'; else $installed='false';
+	$values=array(
+		'installed'=>$installed,
+		'version'=>implode('.', OC_Util::getVersion()),
+		'versionstring'=>OC_Util::getVersionString(),
+		'edition'=>OC_Util::getEditionString());
+
+	echo(json_encode($values));
+
+} catch (Exception $ex) {
+	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+}


### PR DESCRIPTION
Ok, it's starting to get more meaty. This PR introduces the OC_DB::executeAudited() method that handles execution of plain SQL, an array or a prepared statement. It automagically checks the sql for forbidden usage of LIMIT, converts plain sql or an array to a prepared statement, executes the prepared statement, and throws a DatabaseException when an error occurs.

Based on that I cleaned up the use of the DatabaseSetupException used during installation.

I added the internal server error status to OC_Response and made sure any exceptions get caught in index.php, remote.php, public.php and cron.php, get logged and return 500.

Basically this will allow exceptions to bubble up in the phpunit tests on CI. Currently most queries do not even check the error status and if they do immediately render an error page, which prevents phpunit from showing the actual error.

@karlitschek @DeepDiver1975 @icewind1991 @MTGap @bartv2 please review

Originally part of https://github.com/owncloud/core/pull/3583
