### PR TITLE
db structure, allow null in columns for '' values

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -70,7 +70,7 @@
 				<name>id</name>
 				<type>text</type>
 				<default></default>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 				<length>64</length>
 			</field>
 
@@ -220,7 +220,7 @@
 				<name>path</name>
 				<type>text</type>
 				<default></default>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 				<length>512</length>
 			</field>
 
@@ -244,7 +244,7 @@
 				<name>name</name>
 				<type>text</type>
 				<default></default>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 				<length>250</length>
 			</field>
 


### PR DESCRIPTION
originally from https://github.com/owncloud/core/pull/3583

fixes https://github.com/owncloud/core/issues/2371 and https://github.com/owncloud/core/issues/3298 without hiding portability issues (PR https://github.com/owncloud/core/pull/2389 can be closed when this is merged)

@karlitschek @DeepDiver1975 @icewind1991 @MTGap @bartv2 empty string is considered null so we have to allow null in db columns of type text when we need to store the empty string.
