### PR TITLE
make sure that only one process can enter the migration mode

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -67,10 +67,10 @@ class Hooks {
 		$session->setPrivateKey($privateKey, $params['uid']);
 
 		// Check if first-run file migration has already been performed
-		$migrationCompleted = $util->getMigrationStatus();
+		$ready = $util->beginMigration();
 
 		// If migration not yet done
-		if (!$migrationCompleted) {
+		if ($ready) {
 
 			$userView = new \OC_FilesystemView('/' . $params['uid']);
 
@@ -102,7 +102,7 @@ class Hooks {
 			}
 
 			// Register successful migration in DB
-			$util->setMigrationStatus(1);
+			$util->finishMigration();
 
 		}
 

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -67,7 +67,10 @@ class Hooks {
 		$session->setPrivateKey($privateKey, $params['uid']);
 
 		// Check if first-run file migration has already been performed
-		$ready = $util->beginMigration();
+		$ready = false;
+		if ($util->getMigrationStatus() === Util::MIGRATION_OPEN) {
+			$ready = $util->beginMigration();
+		}
 
 		// If migration not yet done
 		if ($ready) {

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1095,7 +1095,7 @@ class Util {
 		$manipulatedRows = $result->numRows();
 
 		if ($manipulatedRows === 1) {
-			$result = true;
+			$return = true;
 			\OCP\Util::writeLog('Encryption library', "Finish migration successfully for " . $this->userId, \OCP\Util::INFO);
 		} else {
 			\OCP\Util::writeLog('Encryption library', "Could not deactivate migration mode for " . $this->userId, \OCP\Util::WARN);

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -178,8 +178,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$params['uid'] = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER;
 		$params['password'] = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER;
 
-		$util = new Encryption\Util($this->view, \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
-		$util->setMigrationStatus(0);
+		$this->setMigrationStatus(0, \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
 
 		$this->assertTrue(OCA\Encryption\Hooks::login($params));
 
@@ -269,7 +268,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$params['password'] = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER;
 
 		$util = new Encryption\Util($this->view, \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
-		$util->setMigrationStatus(0);
+		$this->setMigrationStatus(0, \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
 
 		$this->assertTrue(OCA\Encryption\Hooks::login($params));
 
@@ -314,4 +313,20 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$params['password'] = $password;
 		OCA\Encryption\Hooks::login($params);
 	}
+
+	private function setMigrationStatus($status, $user) {
+		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ?';
+		$args = array(
+			$status,
+			$user
+		);
+
+		$query = \OCP\DB::prepare($sql);
+		if ($query->execute($args)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 }

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -314,6 +314,14 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		OCA\Encryption\Hooks::login($params);
 	}
 
+	/**
+	 * helper function to set migration status to the right value
+	 * to be able to test the migration path
+	 * 
+	 * @param $status needed migration status for test
+	 * @param $user for which user the status should be set
+	 * @return boolean
+	 */
 	private function setMigrationStatus($status, $user) {
 		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ?';
 		$args = array(


### PR DESCRIPTION
This patch prohibit that multiple processes enter the migration mode which could lead to multiple encrypted files.

cc @FlorinPeter would be great if you could have a look at it!
