### PR TITLE
gitignore apps2 folder as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ config/mount.php
 apps/inc.php
 
 # ignore all apps except core ones
-apps/*
+apps*
 !apps/files
 !apps/files_encryption
 !apps/files_external


### PR DESCRIPTION
Simple. Since we have a suggestion for the apps2 folder in the docs and I suppose some of us use the folder, we should gitignore it. Please review @DeepDiver1975 @icewind1991 
