### PR TITLE
allow autotest to run 10x times longer

### DIFF
--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
 		 strict="true"
-		 timeoutForSmallTests="3"
-		 timeoutForMediumTests="30"
-		 timeoutForLargeTests="90"
+		 timeoutForSmallTests="30"
+		 timeoutForMediumTests="300"
+		 timeoutForLargeTests="900"
 >
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>


### PR DESCRIPTION
CI runs on a VM with sporadic lags. That causes the `@small` and `@medium` tests to sporadically fail. We'll give him 10x more time with this.

@DeepDiver1975 @Raydiation @kabum @icewind1991 @MTGap 

@karlitschek what's the status of the new hardware?
