### PR TITLE
Init language object before using it

### DIFF
--- a/settings/ajax/removeuser.php
+++ b/settings/ajax/removeuser.php
@@ -21,5 +21,6 @@ if( OC_User::deleteUser( $username )) {
 	OC_JSON::success(array("data" => array( "username" => $username )));
 }
 else{
+	$l = OC_L10N::get('core');
 	OC_JSON::error(array("data" => array( "message" => $l->t("Unable to delete user") )));
 }


### PR DESCRIPTION
If deleting user fails, ownCloud returns a localized string, but this triggers a PHP Fatal error, because the language object ($l) was not initialized yet.
This patch creates an language object before returning the localized string.

please review @DeepDiver1975 @karlitschek @icewind1991 
