### PR TITLE
upload_max_filesize = 0 not possible if post_max_size is not 0

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -787,9 +787,9 @@ class OC_Helper {
 		$upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize'));
 		$post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
 		$freeSpace = \OC\Files\Filesystem::free_space($dir);
-		if ($upload_max_filesize == 0 and $post_max_size == 0) {
+		if ((int)$upload_max_filesize === 0 and (int)$post_max_size === 0) {
 			$maxUploadFilesize = \OC\Files\FREE_SPACE_UNLIMITED;
-		} elseif ($upload_max_filesize === 0 or $post_max_size === 0) {
+		} elseif ((int)$upload_max_filesize === 0 or (int)$post_max_size === 0) {
 			$maxUploadFilesize = max($upload_max_filesize, $post_max_size); //only the non 0 value counts
 		} else {
 			$maxUploadFilesize = min($upload_max_filesize, $post_max_size);


### PR DESCRIPTION
When trying to upload files bigger than 2GB we need to set upload_max_filesize to 0 because PHP will fail with values greater than 2GB. But if you set a value for post_max_size the if clause did not match the type safe comparator "===". So I just changed them to "=="
