### PR TITLE
use executeAudited in files cache

### DIFF
--- a/lib/files/cache/backgroundwatcher.php
+++ b/lib/files/cache/backgroundwatcher.php
@@ -18,8 +18,8 @@ class BackgroundWatcher {
 		if (!is_null(self::$folderMimetype)) {
 			return self::$folderMimetype;
 		}
-		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?');
-		$result = $query->execute(array('httpd/unix-directory'));
+		$sql = 'SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?';
+		$result = \OC_DB::executeAudited($sql, array('httpd/unix-directory'));
 		$row = $result->fetchRow();
 		return $row['id'];
 	}
@@ -59,11 +59,11 @@ class BackgroundWatcher {
 	 */
 	static private function getNextFileId($previous, $folder) {
 		if ($folder) {
-			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` = ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
+			$stmt = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` = ? ORDER BY `fileid` ASC', 1);
 		} else {
-			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` != ' . self::getFolderMimetype() . ' ORDER BY `fileid` ASC', 1);
+			$stmt = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `fileid` > ? AND `mimetype` != ? ORDER BY `fileid` ASC', 1);
 		}
-		$result = $query->execute(array($previous));
+		$result = \OC_DB::executeAudited($stmt, array($previous,self::getFolderMimetype()));
 		if ($row = $result->fetchRow()) {
 			return $row['fileid'];
 		} else {

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -238,7 +238,7 @@ class Cache {
 		$params[] = $id;
 
 		$sql = 'UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=? WHERE `fileid` = ?';
-		\OC_DB::executeAudited($sql,array($params));
+		\OC_DB::executeAudited($sql, $params);
 	}
 
 	/**

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -65,13 +65,11 @@ class Cache {
 	 */
 	public function getMimetypeId($mime) {
 		if (!isset($this->mimetypeIds[$mime])) {
-			$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?');
-			$result = $query->execute(array($mime));
+			$result = \OC_DB::executeAudited('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?', array($mime));
 			if ($row = $result->fetchRow()) {
 				$this->mimetypeIds[$mime] = $row['id'];
 			} else {
-				$query = \OC_DB::prepare('INSERT INTO `*PREFIX*mimetypes`(`mimetype`) VALUES(?)');
-				$query->execute(array($mime));
+				$result = \OC_DB::executeAudited('INSERT INTO `*PREFIX*mimetypes`(`mimetype`) VALUES(?)', array($mime));
 				$this->mimetypeIds[$mime] = \OC_DB::insertid('*PREFIX*mimetypes');
 			}
 			$this->mimetypes[$this->mimetypeIds[$mime]] = $mime;
@@ -81,8 +79,8 @@ class Cache {
 
 	public function getMimetype($id) {
 		if (!isset($this->mimetypes[$id])) {
-			$query = \OC_DB::prepare('SELECT `mimetype` FROM `*PREFIX*mimetypes` WHERE `id` = ?');
-			$result = $query->execute(array($id));
+			$sql = 'SELECT `mimetype` FROM `*PREFIX*mimetypes` WHERE `id` = ?';
+			$result = \OC_DB::executeAudited($sql, array($id));
 			if ($row = $result->fetchRow()) {
 				$this->mimetypes[$id] = $row['mimetype'];
 			} else {
@@ -109,10 +107,10 @@ class Cache {
 			$where = 'WHERE `fileid` = ?';
 			$params = array($file);
 		}
-		$query = \OC_DB::prepare(
-			'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `unencrypted_size`, `etag`
-			 FROM `*PREFIX*filecache` ' . $where);
-		$result = $query->execute($params);
+		$sql = 'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`,
+					   `storage_mtime`, `encrypted`, `unencrypted_size`, `etag`
+				FROM `*PREFIX*filecache` ' . $where;
+		$result = \OC_DB::executeAudited($sql, $params);
 		$data = $result->fetchRow();
 
 		//FIXME hide this HACK in the next database layer, or just use doctrine and get rid of MDB2 and PDO
@@ -153,14 +151,10 @@ class Cache {
 	public function getFolderContents($folder) {
 		$fileId = $this->getId($folder);
 		if ($fileId > -1) {
-			$query = \OC_DB::prepare(
-				'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `unencrypted_size`, `etag`
-			 	 FROM `*PREFIX*filecache` WHERE `parent` = ? ORDER BY `name` ASC');
-
-			$result = $query->execute(array($fileId));
-			if (\OC_DB::isError($result)) {
-				\OCP\Util::writeLog('cache', 'getFolderContents failed: ' . $result->getMessage(), \OCP\Util::ERROR);
-			}
+			$sql = 'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`,
+						   `storage_mtime`, `encrypted`, `unencrypted_size`, `etag`
+					FROM `*PREFIX*filecache` WHERE `parent` = ? ORDER BY `name` ASC';
+			$result = \OC_DB::executeAudited($sql,array($fileId));
 			$files = $result->fetchAll();
 			foreach ($files as &$file) {
 				$file['mimetype'] = $this->getMimetype($file['mimetype']);
@@ -214,12 +208,9 @@ class Cache {
 			$params[] = $this->getNumericStorageId();
 			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
 
-			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*filecache`(' . implode(', ', $queryParts) . ')'
-				. ' VALUES(' . implode(', ', $valuesPlaceholder) . ')');
-			$result = $query->execute($params);
-			if (\OC_DB::isError($result)) {
-				\OCP\Util::writeLog('cache', 'Insert to cache failed: ' . $result->getMessage(), \OCP\Util::ERROR);
-			}
+			$sql = 'INSERT INTO `*PREFIX*filecache`(' . implode(', ', $queryParts) . ')'
+				. ' VALUES(' . implode(', ', $valuesPlaceholder) . ')';
+			\OC_DB::executeAudited($sql,array($params));
 
 			return (int)\OC_DB::insertid('*PREFIX*filecache');
 		}
@@ -246,9 +237,8 @@ class Cache {
 		list($queryParts, $params) = $this->buildParts($data);
 		$params[] = $id;
 
-		$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=?'
-			. ' WHERE `fileid` = ?');
-		$query->execute($params);
+		$sql = 'UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=? WHERE `fileid` = ?';
+		\OC_DB::executeAudited($sql,array($params));
 	}
 
 	/**
@@ -295,9 +285,8 @@ class Cache {
 
 		$pathHash = md5($file);
 
-		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?');
-		$result = $query->execute(array($this->getNumericStorageId(), $pathHash));
-
+		$sql = 'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?';
+		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $pathHash));
 		if ($row = $result->fetchRow()) {
 			return $row['fileid'];
 		} else {
@@ -346,8 +335,9 @@ class Cache {
 				$this->remove($child['path']);
 			}
 		}
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?');
-		$query->execute(array($entry['fileid']));
+		
+		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+		\OC_DB::executeAudited($sql, array($entry['fileid']));
 
 		$permissionsCache = new Permissions($this->storageId);
 		$permissionsCache->remove($entry['fileid']);
@@ -370,32 +360,31 @@ class Cache {
 
 		if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 			//find all child entries
-			$query = \OC_DB::prepare('SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?');
-			$result = $query->execute(array($this->getNumericStorageId(), $source . '/%'));
+			$sql = 'SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?';
+			$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $source . '/%'));
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($source);
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ? WHERE `fileid` = ?');
 
 			foreach ($childEntries as $child) {
 				$targetPath = $target . substr($child['path'], $sourceLength);
-				$query->execute(array($targetPath, md5($targetPath), $child['fileid']));
+				\OC_DB::executeAudited($query, array($targetPath, md5($targetPath), $child['fileid']));
 			}
 		}
 
-		$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ?, `name` = ?, `parent` =?'
-			. ' WHERE `fileid` = ?');
-		$query->execute(array($target, md5($target), basename($target), $newParentId, $sourceId));
+		$sql = 'UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?';
+		\OC_DB::executeAudited($sql, array($target, md5($target), basename($target), $newParentId, $sourceId));
 	}
 
 	/**
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear() {
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?');
-		$query->execute(array($this->getNumericStorageId()));
+		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?';
+		\OC_DB::executeAudited($sql, array($this->getNumericStorageId()));
 
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*storages` WHERE `id` = ?');
-		$query->execute(array($this->storageId));
+		$sql = 'DELETE FROM `*PREFIX*storages` WHERE `id` = ?';
+		\OC_DB::executeAudited($sql, array($this->storageId));
 	}
 
 	/**
@@ -408,11 +397,8 @@ class Cache {
 		$file = $this->normalize($file);
 
 		$pathHash = md5($file);
-		$query = \OC_DB::prepare('SELECT `size` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?');
-		$result = $query->execute(array($this->getNumericStorageId(), $pathHash));
-		if( \OC_DB::isError($result)) {
-			\OCP\Util::writeLog('cache', 'get status failed: ' . $result->getMessage(), \OCP\Util::ERROR);
-		}
+		$sql = 'SELECT `size` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?';
+		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $pathHash));
 		if ($row = $result->fetchRow()) {
 			if ((int)$row['size'] === -1) {
 				return self::SHALLOW;
@@ -439,11 +425,9 @@ class Cache {
 		// normalize pattern
 		$pattern = $this->normalize($pattern);
 
-		$query = \OC_DB::prepare('
-			SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `unencrypted_size`, `etag`
-			FROM `*PREFIX*filecache` WHERE `name` LIKE ? AND `storage` = ?'
-		);
-		$result = $query->execute(array($pattern, $this->getNumericStorageId()));
+		$sql = 'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `unencrypted_size`, `etag`
+				FROM `*PREFIX*filecache` WHERE `name` LIKE ? AND `storage` = ?';
+		$result = \OC_DB::executeAudited($sql, array($pattern, $this->getNumericStorageId()));
 		$files = array();
 		while ($row = $result->fetchRow()) {
 			$row['mimetype'] = $this->getMimetype($row['mimetype']);
@@ -465,12 +449,10 @@ class Cache {
 		} else {
 			$where = '`mimepart` = ?';
 		}
-		$query = \OC_DB::prepare('
-			SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `unencrypted_size`, `etag`
-			FROM `*PREFIX*filecache` WHERE ' . $where . ' AND `storage` = ?'
-		);
+		$sql = 'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `unencrypted_size`, `etag`
+				FROM `*PREFIX*filecache` WHERE ' . $where . ' AND `storage` = ?';
 		$mimetype = $this->getMimetypeId($mimetype);
-		$result = $query->execute(array($mimetype, $this->getNumericStorageId()));
+		$result = \OC_DB::executeAudited($sql, array($mimetype, $this->getNumericStorageId()));
 		$files = array();
 		while ($row = $result->fetchRow()) {
 			$row['mimetype'] = $this->getMimetype($row['mimetype']);
@@ -507,8 +489,8 @@ class Cache {
 		if ($id === -1) {
 			return 0;
 		}
-		$query = \OC_DB::prepare('SELECT `size` FROM `*PREFIX*filecache` WHERE `parent` = ? AND `storage` = ?');
-		$result = $query->execute(array($id, $this->getNumericStorageId()));
+		$sql = 'SELECT `size` FROM `*PREFIX*filecache` WHERE `parent` = ? AND `storage` = ?';
+		$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 		$totalSize = 0;
 		$hasChilds = 0;
 		while ($row = $result->fetchRow()) {
@@ -534,8 +516,8 @@ class Cache {
 	 * @return int[]
 	 */
 	public function getAll() {
-		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ?');
-		$result = $query->execute(array($this->getNumericStorageId()));
+		$sql = 'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ?';
+		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId()));
 		$ids = array();
 		while ($row = $result->fetchRow()) {
 			$ids[] = $row['fileid'];
@@ -555,10 +537,7 @@ class Cache {
 	public function getIncomplete() {
 		$query = \OC_DB::prepare('SELECT `path` FROM `*PREFIX*filecache`'
 			. ' WHERE `storage` = ? AND `size` = -1 ORDER BY `fileid` DESC',1);
-		$result = $query->execute(array($this->getNumericStorageId()));
-		if (\OC_DB::isError($result)) {
-			\OCP\Util::writeLog('cache', 'getIncomplete failed: ' . $result->getMessage(), \OCP\Util::ERROR);
-		}
+		$result = \OC_DB::executeAudited($query, array($this->getNumericStorageId()));
 		if ($row = $result->fetchRow()) {
 			return $row['path'];
 		} else {
@@ -573,8 +552,8 @@ class Cache {
 	 * @return array, first element holding the storage id, second the path
 	 */
 	static public function getById($id) {
-		$query = \OC_DB::prepare('SELECT `storage`, `path` FROM `*PREFIX*filecache` WHERE `fileid` = ?');
-		$result = $query->execute(array($id));
+		$sql = 'SELECT `storage`, `path` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+		$result = \OC_DB::executeAudited($sql, array($id));
 		if ($row = $result->fetchRow()) {
 			$numericId = $row['storage'];
 			$path = $row['path'];

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -208,9 +208,9 @@ class Cache {
 			$params[] = $this->getNumericStorageId();
 			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
 
-			$sql = 'INSERT INTO `*PREFIX*filecache`(' . implode(', ', $queryParts) . ')'
-				. ' VALUES(' . implode(', ', $valuesPlaceholder) . ')';
-			\OC_DB::executeAudited($sql,array($params));
+			$sql = 'INSERT INTO `*PREFIX*filecache` (' . implode(', ', $queryParts) . ')'
+				. ' VALUES (' . implode(', ', $valuesPlaceholder) . ')';
+			\OC_DB::executeAudited($sql, $params);
 
 			return (int)\OC_DB::insertid('*PREFIX*filecache');
 		}

--- a/lib/files/cache/legacy.php
+++ b/lib/files/cache/legacy.php
@@ -26,8 +26,8 @@ class Legacy {
 	 * @return int
 	 */
 	function getCount() {
-		$query = \OC_DB::prepare('SELECT COUNT(`id`) AS `count` FROM `*PREFIX*fscache` WHERE `user` = ?');
-		$result = $query->execute(array($this->user));
+		$sql = 'SELECT COUNT(`id`) AS `count` FROM `*PREFIX*fscache` WHERE `user` = ?';
+		$result = \OC_DB::executeAudited($sql, array($this->user));
 		if ($row = $result->fetchRow()) {
 			return $row['count'];
 		} else {
@@ -74,11 +74,11 @@ class Legacy {
 	 */
 	function get($path) {
 		if (is_numeric($path)) {
-			$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*fscache` WHERE `id` = ?');
+			$sql = 'SELECT * FROM `*PREFIX*fscache` WHERE `id` = ?';
 		} else {
-			$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*fscache` WHERE `path` = ?');
+			$sql = 'SELECT * FROM `*PREFIX*fscache` WHERE `path` = ?';
 		}
-		$result = $query->execute(array($path));
+		$result = \OC_DB::executeAudited($sql, array($path));
 		$data = $result->fetchRow();
 		$data['etag'] = $this->getEtag($data['path'], $data['user']);
 		return $data;
@@ -111,7 +111,7 @@ class Legacy {
 		if(is_null($query)){
 			$query = \OC_DB::prepare('SELECT `propertyvalue` FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ? AND `propertyname` = \'{DAV:}getetag\'');
 		}
-		$result = $query->execute(array($user, '/' . $relativePath));
+		$result = \OC_DB::executeAudited($query,array($user, '/' . $relativePath));
 		if ($row = $result->fetchRow()) {
 			return trim($row['propertyvalue'], '"');
 		} else {
@@ -126,8 +126,7 @@ class Legacy {
 	 * @return array
 	 */
 	function getChildren($id) {
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*fscache` WHERE `parent` = ?');
-		$result = $query->execute(array($id));
+		$result = \OC_DB::executeAudited('SELECT * FROM `*PREFIX*fscache` WHERE `parent` = ?', array($id));
 		$data = $result->fetchAll();
 		foreach ($data as $i => $item) {
 			$data[$i]['etag'] = $this->getEtag($item['path'], $item['user']);

--- a/lib/files/cache/permissions.php
+++ b/lib/files/cache/permissions.php
@@ -33,8 +33,8 @@ class Permissions {
 	 * @return int (-1 if file no permissions set)
 	 */
 	public function get($fileId, $user) {
-		$query = \OC_DB::prepare('SELECT `permissions` FROM `*PREFIX*permissions` WHERE `user` = ? AND `fileid` = ?');
-		$result = $query->execute(array($user, $fileId));
+		$sql = 'SELECT `permissions` FROM `*PREFIX*permissions` WHERE `user` = ? AND `fileid` = ?';
+		$result = \OC_DB::executeAudited($sql, array($user, $fileId));
 		if ($row = $result->fetchRow()) {
 			return $row['permissions'];
 		} else {
@@ -51,13 +51,11 @@ class Permissions {
 	 */
 	public function set($fileId, $user, $permissions) {
 		if (self::get($fileId, $user) !== -1) {
-			$query = \OC_DB::prepare('UPDATE `*PREFIX*permissions` SET `permissions` = ?'
-				. ' WHERE `user` = ? AND `fileid` = ?');
+			$sql = 'UPDATE `*PREFIX*permissions` SET `permissions` = ? WHERE `user` = ? AND `fileid` = ?';
 		} else {
-			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*permissions`(`permissions`, `user`, `fileid`)'
-				. ' VALUES(?, ?,? )');
+			$sql = 'INSERT INTO `*PREFIX*permissions`(`permissions`, `user`, `fileid`) VALUES(?, ?,? )';
 		}
-		$query->execute(array($permissions, $user, $fileId));
+		\OC_DB::executeAudited($sql, array($permissions, $user, $fileId));
 	}
 
 	/**
@@ -75,9 +73,9 @@ class Permissions {
 		$params[] = $user;
 		$inPart = implode(', ', array_fill(0, count($fileIds), '?'));
 
-		$query = \OC_DB::prepare('SELECT `fileid`, `permissions` FROM `*PREFIX*permissions`'
-			. ' WHERE `fileid` IN (' . $inPart . ') AND `user` = ?');
-		$result = $query->execute($params);
+		$sql = 'SELECT `fileid`, `permissions` FROM `*PREFIX*permissions`'
+			. ' WHERE `fileid` IN (' . $inPart . ') AND `user` = ?';
+		$result = \OC_DB::executeAudited($sql, $params);
 		$filePermissions = array();
 		while ($row = $result->fetchRow()) {
 			$filePermissions[$row['fileid']] = $row['permissions'];
@@ -93,11 +91,12 @@ class Permissions {
 	 * @return int[]
 	 */
 	public function getDirectoryPermissions($parentId, $user) {
-		$query = \OC_DB::prepare('SELECT `*PREFIX*permissions`.`fileid`, `permissions`
-			FROM `*PREFIX*permissions` INNER JOIN `*PREFIX*filecache` ON `*PREFIX*permissions`.`fileid` = `*PREFIX*filecache`.`fileid`
-			WHERE `*PREFIX*filecache`.`parent` = ? AND `*PREFIX*permissions`.`user` = ?');
+		$sql = 'SELECT `*PREFIX*permissions`.`fileid`, `permissions`
+			FROM `*PREFIX*permissions`
+			INNER JOIN `*PREFIX*filecache` ON `*PREFIX*permissions`.`fileid` = `*PREFIX*filecache`.`fileid`
+			WHERE `*PREFIX*filecache`.`parent` = ? AND `*PREFIX*permissions`.`user` = ?';
 
-		$result = $query->execute(array($parentId, $user));
+		$result = \OC_DB::executeAudited($sql, array($parentId, $user));
 		$filePermissions = array();
 		while ($row = $result->fetchRow()) {
 			$filePermissions[$row['fileid']] = $row['permissions'];
@@ -113,18 +112,17 @@ class Permissions {
 	 */
 	public function remove($fileId, $user = null) {
 		if (is_null($user)) {
-			$query = \OC_DB::prepare('DELETE FROM `*PREFIX*permissions` WHERE `fileid` = ?');
-			$query->execute(array($fileId));
+			\OC_DB::executeAudited('DELETE FROM `*PREFIX*permissions` WHERE `fileid` = ?', array($fileId));
 		} else {
-			$query = \OC_DB::prepare('DELETE FROM `*PREFIX*permissions` WHERE `fileid` = ? AND `user` = ?');
-			$query->execute(array($fileId, $user));
+			$sql = 'DELETE FROM `*PREFIX*permissions` WHERE `fileid` = ? AND `user` = ?';
+			\OC_DB::executeAudited($sql, array($fileId, $user));
 		}
 	}
 
 	public function removeMultiple($fileIds, $user) {
 		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*permissions` WHERE `fileid` = ? AND `user` = ?');
 		foreach ($fileIds as $fileId) {
-			$query->execute(array($fileId, $user));
+			\OC_DB::executeAudited($query, array($fileId, $user));
 		}
 	}
 
@@ -134,8 +132,8 @@ class Permissions {
 	 * @param int $fileId
 	 */
 	public function getUsers($fileId) {
-		$query = \OC_DB::prepare('SELECT `user` FROM `*PREFIX*permissions` WHERE `fileid` = ?');
-		$result = $query->execute(array($fileId));
+		$sql = 'SELECT `user` FROM `*PREFIX*permissions` WHERE `fileid` = ?';
+		$result = \OC_DB::executeAudited($sql, array($fileId));
 		$users = array();
 		while ($row = $result->fetchRow()) {
 			$users[] = $row['user'];

--- a/lib/files/cache/storage.php
+++ b/lib/files/cache/storage.php
@@ -32,13 +32,13 @@ class Storage {
 			$this->storageId = md5($this->storageId);
 		}
 
-		$query = \OC_DB::prepare('SELECT `numeric_id` FROM `*PREFIX*storages` WHERE `id` = ?');
-		$result = $query->execute(array($this->storageId));
+		$sql = 'SELECT `numeric_id` FROM `*PREFIX*storages` WHERE `id` = ?';
+		$result = \OC_DB::executeAudited($sql, array($this->storageId));
 		if ($row = $result->fetchRow()) {
 			$this->numericId = $row['numeric_id'];
 		} else {
-			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*storages`(`id`) VALUES(?)');
-			$query->execute(array($this->storageId));
+			$sql = 'INSERT INTO `*PREFIX*storages` (`id`) VALUES(?)';
+			\OC_DB::executeAudited($sql, array($this->storageId));
 			$this->numericId = \OC_DB::insertid('*PREFIX*storages');
 		}
 	}
@@ -48,8 +48,9 @@ class Storage {
 	}
 
 	public static function getStorageId($numericId) {
-		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*storages` WHERE `numeric_id` = ?');
-		$result = $query->execute(array($numericId));
+		
+		$sql = 'SELECT `id` FROM `*PREFIX*storages` WHERE `numeric_id` = ?';
+		$result = \OC_DB::executeAudited($sql, array($numericId));
 		if ($row = $result->fetchRow()) {
 			return $row['id'];
 		} else {

--- a/lib/files/cache/upgrade.php
+++ b/lib/files/cache/upgrade.php
@@ -78,7 +78,7 @@ class Upgrade {
 				VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
 		}
 		if (!$this->inCache($data['storage'], $data['path_hash'], $data['id'])) {
-			$insertQuery->execute(array($data['id'], $data['storage'],
+			\OC_DB::executeAudited($insertQuery, array($data['id'], $data['storage'],
 				$data['path'], $data['path_hash'], $data['parent'], $data['name'],
 				$data['mimetype'], $data['mimepart'], $data['size'], $data['mtime'], $data['encrypted'], $data['etag']));
 		}
@@ -97,7 +97,7 @@ class Upgrade {
 		if(is_null($query)) {
 			$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE (`storage` = ? AND `path_hash` = ?) OR `fileid` = ?');
 		}
-		$result = $query->execute(array($storage, $pathHash, $id));
+		$result = \OC_DB::executeAudited($query, array($storage, $pathHash, $id));
 		return (bool)$result->fetchRow();
 	}
 


### PR DESCRIPTION
This PR replaces all DB queries in the file cache with th OC_DB::executeAudited wrapper that checks for a database error and throws an exception that is logged and shown to the user. It will also show up in the phpunit tests and make db errors in the filecache much easier to spot.

@icewind1991 @DeepDiver1975 @karlitschek @MTGap @bartv2 @Raydiation @kabum 
