### PR TITLE
Leave size as -1 for updated folders during a shallow scan

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -80,11 +80,10 @@ class Scanner {
 				}
 				$newData = $data;
 				if ($cacheData = $this->cache->get($file)) {
-					if ($checkExisting && $data['size'] === -1) {
-						$data['size'] = $cacheData['size'];
-					}
-					if ($data['mtime'] === $cacheData['mtime'] &&
-						$data['size'] === $cacheData['size']) {
+					if ($data['mtime'] === $cacheData['mtime']) {
+						if ($checkExisting) {
+							$data['size'] = $cacheData['size'];
+						}
 						$data['etag'] = $cacheData['etag'];
 					}
 					// Only update metadata that has changed

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -102,6 +102,23 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 
 		$cachedDataFolder = $this->cache->get('');
 		$this->assertNotEquals($cachedDataFolder['size'], -1);
+
+		$this->storage->mkdir('folder/subfolder');
+		$this->scanner->scan('folder');
+		$this->assertTrue($this->cache->inCache('folder/subfolder'));
+		$cachedData = $this->cache->get('folder/subfolder');
+		$this->assertEquals(0, $cachedData['size']);
+
+		$textData = "dummy file data\n";
+		$textSize = strlen("dummy file data\n");
+		$this->storage->file_put_contents('folder/subfolder/bar.txt', $textData);
+		$this->scanner->scan('folder', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
+		$cachedData = $this->cache->get('folder/subfolder');
+		$this->assertEquals(-1, $cachedData['size']);
+
+		$this->scanner->scan('folder/subfolder', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
+		$cachedData = $this->cache->get('folder/subfolder');
+		$this->assertEquals($textSize, $cachedData['size']);
 	}
 
 	function testBackgroundScan(){


### PR DESCRIPTION
The tests seem to be temperamental, a bad effect of using time() :(

I'm not sure if this resolves the problem, but the code looks right to me.

@icewind1991 @jvillafanez
