### PR TITLE
remove dotted outlines in Firefox, fix #3712

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -664,3 +664,10 @@ button.loading {
 	background-position: right 10px center; background-repeat: no-repeat;
 	padding-right: 30px;
 }
+
+
+
+/* ---- BROWSER-SPECIFIC FIXES ---- */
+::-moz-focus-inner {
+	border: 0; /* remove dotted outlines in Firefox */
+}


### PR DESCRIPTION
cc @owncloud/designers 

This also fixes the tiny UI issue in the News app ( https://github.com/owncloud/news/issues/145 ). @Raydiation @zimba12 please check.
