### PR TITLE
encryption: prevent the creation of ghost files in the proxy.

### DIFF
--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -169,7 +169,7 @@ class Keymanager {
 	 */
 	public static function fixPartialFilePath($path) {
 
-		if (preg_match('/\.part$/', $path) || preg_match('/\.etmp$/', $path)) {
+		if (preg_match('/\.part$/', $path)) {
 
 			$newLength = strlen($path) - 5;
 			$fPath = substr($path, 0, $newLength);
@@ -191,7 +191,7 @@ class Keymanager {
 	 */
 	public static function isPartialFilePath($path) {
 
-		if (preg_match('/\.part$/', $path) || preg_match('/\.etmp$/', $path)) {
+		if (preg_match('/\.part$/', $path)) {
 
 			return true;
 

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -116,7 +116,7 @@ class Proxy extends \OC_FileProxy {
 					return true;
 				}
 
-				$handle = fopen('crypt://' . $relativePath . '.etmp', 'w');
+				$handle = fopen('crypt://' . $relativePath . '.part', 'w');
 				if (is_resource($handle)) {
 
 					// write data to stream
@@ -130,10 +130,10 @@ class Proxy extends \OC_FileProxy {
 					\OC_FileProxy::$enabled = false;
 
 					// get encrypted content
-					$data = $view->file_get_contents($path . '.etmp');
+					$data = $view->file_get_contents($path . '.part');
 
 					// remove our temp file
-					$view->unlink($path . '.etmp');
+					$view->unlink($path . '.part');
 
 					// re-enable proxy - our work is done
 					\OC_FileProxy::$enabled = $proxyStatus;


### PR DESCRIPTION
The proxy first streams the files to a tmp file which than will be moved to the right location. Sometimes this creates ghost files in the file cache which will not disappear.

Renaming .etmp files to .part files, which are already handled by the file cache and the sync client correctly, should solve this issue.

cc @FlorinPeter
