### PR TITLE
Init dummy session to render error pages

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -288,14 +288,14 @@ class OC {
 		$cookie_path = OC::$WEBROOT ?: '/';
 		ini_set('session.cookie_path', $cookie_path);
 
+		//set the session object to a dummy session so code relying on the session existing still works
+		self::$session = new \OC\Session\Memory('');
+		
 		try{
 			// set the session name to the instance id - which is unique
 			self::$session = new \OC\Session\Internal(OC_Util::getInstanceId());
 			// if session cant be started break with http 500 error
 		}catch (Exception $e){
-			//set the session object to a dummy session so code relying on the session existing still works
-			self::$session = new \OC\Session\Memory('');
-
 			OC_Log::write('core', 'Session could not be initialized',
 				OC_Log::ERROR);
 


### PR DESCRIPTION
@icewind1991 @DeepDiver1975 
Fixes blank page when config.php is not writeable https://github.com/owncloud/core/issues/3738
Alternate to  https://github.com/owncloud/core/pull/3580

ref https://github.com/owncloud/core/issues/3560
