### PR TITLE
- removed slash-adding for logout-header-redirect

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -641,7 +641,7 @@ class OC {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
 				OC_User::logout();
-				header("Location: " . OC::$WEBROOT . '/');
+				header("Location: " . OC::$WEBROOT);
 			} else {
 				if (is_null($file)) {
 					$param['file'] = 'index.php';

--- a/lib/base.php
+++ b/lib/base.php
@@ -641,7 +641,8 @@ class OC {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
 				OC_User::logout();
-				header("Location: " . OC::$WEBROOT);
+				// redirect to webroot and add slash if webroot is empty
+				header("Location: " . OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 			} else {
 				if (is_null($file)) {
 					$param['file'] = 'index.php';


### PR DESCRIPTION
this slash is not necessary for redirecting. 
-> with the removal your have the chance to manipulate OC::$WEBROOT for a different logout-redirection

possible usecases:
- log the site your are coming from(directly)
- write a logout-hook and manipulate webroot to the site your are coming from
- logout and get redirected to the site you're coming from..
