### PR TITLE
hide the logo claim in case the theme is not loaded

### DIFF
--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -36,7 +36,7 @@
 			<header><div id="header">
 				<img src="<?php print_unescaped(image_path('', 'logo.svg')); ?>" class="svg" alt="ownCloud" />
 				<?php if (OC_Util::getEditionString() !== ''): ?>
-				<div id="logo-claim">Enterprise Edition</div>
+				<div id="logo-claim" style="display:none;">Enterprise Edition</div>
 				<?php endif; ?>
 			</div></header>
 			<?php print_unescaped($_['content']); ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -44,7 +44,7 @@
 			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
 				src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="ownCloud" /></a>
 			<?php if (OC_Util::getEditionString() !== ''): ?>
-			<div id="logo-claim">Enterprise Edition</div>
+			<div id="logo-claim" style="display:none;">Enterprise Edition</div>
 			<?php endif; ?>
 			<ul id="settings" class="svg">
 				<span id="expand" tabindex="0" role="link">


### PR DESCRIPTION
This will fix the claim being shown and messing with the layout when the theme is not called correctly.

Please check @karlitschek @MTRichards @schiesbn, needs to be used with the changes I just made to the theme which make the claim visible again when the CSS is loaded.
