### PR TITLE
Fix for CSS in files table - make #fileTable visible by using padding-to...

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -145,6 +145,10 @@ input[type="submit"].enabled { background:#66f866; border:1px solid #5e5; -moz-b
 }
 #controls .button { display:inline-block; }
 
+#controls ~ #fileTable {
+    padding-top: 3em;
+}
+
 #content { position:relative; height:100%; width:100%; }
 #content .hascontrols { position: relative; top: 2.9em; }
 #content-wrapper {


### PR DESCRIPTION
(Pull request for https://github.com/owncloud/core/issues/3463)
- Makes action row in files table visible by putting #fileTable down (padding-top) because it's behind #controls
