### PR TITLE
getTheme() should also return the default theme if a empty theme is set in the config.php

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -813,9 +813,9 @@ class OC_Util {
 	 * @return string the theme
 	 */
 	public static function getTheme() {
-		$theme = OC_Config::getValue("theme");
+		$theme = OC_Config::getValue("theme", '');
 
-		if(!$theme) {
+		if($theme === '') {
 			
 			if(is_dir(OC::$SERVERROOT . '/themes/default')) {
 				$theme = 'default';

--- a/lib/util.php
+++ b/lib/util.php
@@ -815,7 +815,7 @@ class OC_Util {
 	public static function getTheme() {
 		$theme = OC_Config::getValue("theme");
 
-		if(is_null($theme)) {
+		if(!$theme) {
 			
 			if(is_dir(OC::$SERVERROOT . '/themes/default')) {
 				$theme = 'default';


### PR DESCRIPTION
we should also use the default theme if the theme is set to an empty string in the config.php

cc @jancborchardt 
