### PR TITLE
on updates MDB2 returns numrows instead of a result

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1060,7 +1060,7 @@ class Util {
 		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ? and `migration_status` = ?';
 		$args = array(self::MIGRATION_IN_PROGRESS, $this->userId, self::MIGRATION_OPEN);
 		$result = \OC_DB::executeAudited($sql, $args);
-		if ($result instanceof \PDOStatementWrapper && $result->numRows() > 0) {
+		if ($result instanceof \PDOStatementWrapper) {
 			$manipulatedRows = $result->numRows();
 		} else {
 			$manipulatedRows = $result; // mdb2 does not return a result on updates
@@ -1087,7 +1087,7 @@ class Util {
 		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ? and `migration_status` = ?';
 		$args = array(self::MIGRATION_COMPLETED, $this->userId, self::MIGRATION_IN_PROGRESS);
 		$result = \OC_DB::executeAudited($sql, $args);
-		if ($result instanceof \PDOStatementWrapper && $result->numRows() > 0) {
+		if ($result instanceof \PDOStatementWrapper) {
 			$manipulatedRows = $result->numRows();
 		} else {
 			$manipulatedRows = $result; // mdb2 does not return a result on updates

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1059,9 +1059,12 @@ class Util {
 
 		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ? and `migration_status` = ?';
 		$args = array(self::MIGRATION_IN_PROGRESS, $this->userId, self::MIGRATION_OPEN);
-		$query = \OCP\DB::prepare($sql);
-		$result = $query->execute($args);
-		$manipulatedRows = $result->numRows();
+		$result = \OC_DB::executeAudited($sql, $args);
+		if ($result instanceof \PDOStatementWrapper && $result->numRows() > 0) {
+			$manipulatedRows = $result->numRows();
+		} else {
+			$manipulatedRows = $result; // mdb2 does not return a result on updates
+		}
 
 		if ($manipulatedRows === 1) {
 			$return = true;
@@ -1083,9 +1086,12 @@ class Util {
 
 		$sql = 'UPDATE `*PREFIX*encryption` SET `migration_status` = ? WHERE `uid` = ? and `migration_status` = ?';
 		$args = array(self::MIGRATION_COMPLETED, $this->userId, self::MIGRATION_IN_PROGRESS);
-		$query = \OCP\DB::prepare($sql);
-		$result = $query->execute($args);
-		$manipulatedRows = $result->numRows();
+		$result = \OC_DB::executeAudited($sql, $args);
+		if ($result instanceof \PDOStatementWrapper && $result->numRows() > 0) {
+			$manipulatedRows = $result->numRows();
+		} else {
+			$manipulatedRows = $result; // mdb2 does not return a result on updates
+		}
 
 		if ($manipulatedRows === 1) {
 			$return = true;


### PR DESCRIPTION
Doc says inserts and updates return the number of affected rows instead of a result: http://pear.php.net/manual/en/package.database.mdb2.intro-query.php

so ... yet another difference between PDO and MDB2

cc @schiesbn @Raydiation @bartv2 @DeepDiver1975 @icewind1991 @MTGap 
