### PR TITLE
Implement X-Sendfile2 for resume support in LigHTTPd

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -45,7 +45,8 @@ class OC_Files {
 	 */
 	public static function get($dir, $files, $only_header = false) {
 		$xsendfile = false;
-		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) || isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
+		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) ||
+			isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
 			isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			$xsendfile = true;
 		}
@@ -172,7 +173,8 @@ class OC_Files {
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
- 			if (isset($_SERVER['HTTP_RANGE']) && preg_match('/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/', $_SERVER['HTTP_RANGE'], $range)) {
+			if (isset($_SERVER['HTTP_RANGE']) &&
+				preg_match("/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/", $_SERVER['HTTP_RANGE'], $range)) {
  				if ($range['end'] == "") {
  					$range['end'] = filesize($filename) - 1;
  				}

--- a/lib/files.php
+++ b/lib/files.php
@@ -173,18 +173,18 @@ class OC_Files {
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
-		/*	if (isset($_SERVER['HTTP_RANGE']) &&
-		*		preg_match("/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/", $_SERVER['HTTP_RANGE'], $range)) {
- 		*		if ($range['end'] == "") {
- 		*			$range['end'] = filesize($filename) - 1;
- 		*		}
- 		*		header("Content-Range: bytes " . $range['start'] . "-" . $range['end'] . "/" . filesize($filename));
- 		*		header("HTTP/1.1 206 Partial content");
- 		*		header("X-Sendfile2: " . str_replace(",", "%2c", rawurlencode($filename)) . " " . $range['start'] . "-" . $range['end']);
- 		*	} else {
- 		*/
- 			header("X-Sendfile: " . $filename);
- 		//	}
+			if (isset($_SERVER['HTTP_RANGE']) && 
+				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
+				$filelength = filesize($filename);
+ 				if ($range[2] == "") {
+ 					$range[2] = $filelength - 1;
+ 				}
+ 				header("Content-Range: bytes $range[1]-$range[2]/" . $filelength);
+ 				header("HTTP/1.1 206 Partial content");
+ 				header("X-Sendfile2: " . str_replace(",", "%2c", rawurlencode($filename)) . " $range[1]-$range[2]");
+ 			} else {
+ 				header("X-Sendfile: " . $filename);
+ 			}
 		}
 		
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {

--- a/lib/files.php
+++ b/lib/files.php
@@ -45,7 +45,7 @@ class OC_Files {
 	 */
 	public static function get($dir, $files, $only_header = false) {
 		$xsendfile = false;
-		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) ||
+		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) || isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
 			isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			$xsendfile = true;
 		}
@@ -170,6 +170,18 @@ class OC_Files {
 	private static function addSendfileHeader($filename) {
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
 			header("X-Sendfile: " . $filename);
+ 		}
+ 		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
+ 			if (isset($_SERVER['HTTP_RANGE']) && preg_match('/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/', $_SERVER['HTTP_RANGE'], $range)) {
+ 				if ($range['end'] == "") {
+ 					$range['end'] = filesize($filename) - 1;
+ 				}
+ 				header("Content-Range: bytes " . $range['start'] . "-" . $range['end'] . "/" . filesize($filename));
+ 				header("HTTP/1.1 206 Partial content");
+ 				header("X-Sendfile2: " . str_replace(",", "%2c", rawurlencode($filename)) . " " . $range['start'] . "-" . $range['end']);
+ 			} else {
+ 				header("X-Sendfile: " . $filename);
+ 			}
 		}
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			header("X-Accel-Redirect: " . $filename);

--- a/lib/files.php
+++ b/lib/files.php
@@ -173,18 +173,20 @@ class OC_Files {
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
-			if (isset($_SERVER['HTTP_RANGE']) &&
-				preg_match("/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/", $_SERVER['HTTP_RANGE'], $range)) {
- 				if ($range['end'] == "") {
- 					$range['end'] = filesize($filename) - 1;
- 				}
- 				header("Content-Range: bytes " . $range['start'] . "-" . $range['end'] . "/" . filesize($filename));
- 				header("HTTP/1.1 206 Partial content");
- 				header("X-Sendfile2: " . str_replace(",", "%2c", rawurlencode($filename)) . " " . $range['start'] . "-" . $range['end']);
- 			} else {
- 				header("X-Sendfile: " . $filename);
- 			}
+		/*	if (isset($_SERVER['HTTP_RANGE']) &&
+		*		preg_match("/\Abytes=(?P<start>[0-9]+)-(?P<end>[0-9]*)\z/", $_SERVER['HTTP_RANGE'], $range)) {
+ 		*		if ($range['end'] == "") {
+ 		*			$range['end'] = filesize($filename) - 1;
+ 		*		}
+ 		*		header("Content-Range: bytes " . $range['start'] . "-" . $range['end'] . "/" . filesize($filename));
+ 		*		header("HTTP/1.1 206 Partial content");
+ 		*		header("X-Sendfile2: " . str_replace(",", "%2c", rawurlencode($filename)) . " " . $range['start'] . "-" . $range['end']);
+ 		*	} else {
+ 		*/
+ 			header("X-Sendfile: " . $filename);
+ 		//	}
 		}
+		
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			header("X-Accel-Redirect: " . $filename);
 		}


### PR DESCRIPTION
LigHTTPd does not support HTTP Range headers with the X-Sendfile header in the way Apache does. Instead, it needs to be handled in the backend. This commit does exactly that, using the X-Sendfile2 header to send ranges of files.
To accomplish this without breaking web servers that don't support X-Sendfile2, a new variable MOD_X_SENDFILE2_ENABLED was introduced to separate this method from X-Sendfile and X-Accel-Redirect.
