### PR TITLE
Update util.php

### DIFF
--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -185,7 +185,7 @@ class Util {
 	 * reverse proxies
 	 */
 	public static function getServerHost() {
-		return(\OC_Request::serverHost());
+		return \OC_Config::getValue( 'mail_domain', \OC_Request::serverHost());
 	}
 
 	/**


### PR DESCRIPTION
Configuration option 'mail_domain' does not seem to override outgoing email domain part in ownCloud 5.0.7

This issue creates difficulties when mail is sent via AWS SES.
