### PR TITLE
skip teardown if cache has not been set up

### DIFF
--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -151,9 +151,11 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 	}
 
 	function tearDown() {
-		$ids = $this->cache->getAll();
-		$permissionsCache = $this->storage->getPermissionsCache();
-		$permissionsCache->removeMultiple($ids, \OC_User::getUser());
-		$this->cache->clear();
+		if ($this->cache) {
+			$ids = $this->cache->getAll();
+			$permissionsCache = $this->storage->getPermissionsCache();
+			$permissionsCache->removeMultiple($ids, \OC_User::getUser());
+			$this->cache->clear();
+		}
 	}
 }


### PR DESCRIPTION
otherwise test execution aborts at this place. occured on oracle

@DeepDiver1975 @icewind1991 please review and :+1: 
