### PR TITLE
LDAP: better check for emptiness, fixes #3815

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -210,6 +210,22 @@ class Connection {
 	}
 
 	/**
+	 * Special handling for reading Base Configuration
+	 *
+	 * @param $base the internal name of the config key
+	 * @param $value the value stored for the base
+	 */
+	private function readBase($base, $value) {
+		if(empty($value)) {
+			$value = '';
+		} else {
+			$value = preg_split('/\r\n|\r|\n/', $value);
+		}
+
+		$this->config[$base] = $value;
+	}
+
+	/**
 	 * Caches the general LDAP configuration.
 	 */
 	private function readConfiguration($force = false) {
@@ -224,14 +240,9 @@ class Connection {
 			$this->config['ldapAgentName']  = $this->$v('ldap_dn');
 			$this->config['ldapAgentPassword']
 				= base64_decode($this->$v('ldap_agent_password'));
-			$rawLdapBase                    = $this->$v('ldap_base');
-			$this->config['ldapBase']
-				= preg_split('/\r\n|\r|\n/', $rawLdapBase);
-			$this->config['ldapBaseUsers']
-				= preg_split('/\r\n|\r|\n/', ($this->$v('ldap_base_users')));
-			$this->config['ldapBaseGroups']
-				= preg_split('/\r\n|\r|\n/', $this->$v('ldap_base_groups'));
-			unset($rawLdapBase);
+			$this->readBase('ldapBase',       $this->$v('ldap_base'));
+			$this->readBase('ldapBaseUsers',  $this->$v('ldap_base_users'));
+			$this->readBase('ldapBaseGroups', $this->$v('ldap_base_groups'));
 			$this->config['ldapTLS']        = $this->$v('ldap_tls');
 			$this->config['ldapNoCase']     = $this->$v('ldap_nocase');
 			$this->config['turnOffCertCheck']

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -421,11 +421,21 @@ class Connection {
 	private function validateConfiguration() {
 		// first step: "soft" checks: settings that are not really
 		// necessary, but advisable. If left empty, give an info message
-		if(empty($this->config['ldapBaseUsers'])) {
+		if(empty($this->config['ldapBaseUsers']) ||
+			// this part handles return of preg_split in readConfiguration
+			(count($this->config['ldapBaseUsers'][0]) === 1
+				&& isset($this->config['ldapBaseUsers'][0])
+				&& empty($this->config['ldapBaseUsers'][0]))
+		) {
 			\OCP\Util::writeLog('user_ldap', 'Base tree for Users is empty, using Base DN', \OCP\Util::INFO);
 			$this->config['ldapBaseUsers'] = $this->config['ldapBase'];
 		}
-		if(empty($this->config['ldapBaseGroups'])) {
+		if(empty($this->config['ldapBaseGroups']) ||
+			// this part handles return of preg_split in readConfiguration
+			(count($this->config['ldapBaseGroups'][0]) === 1
+				&& isset($this->config['ldapBaseGroups'][0])
+				&& empty($this->config['ldapBaseGroups'][0]))
+		) {
 			\OCP\Util::writeLog('user_ldap', 'Base tree for Groups is empty, using Base DN', \OCP\Util::INFO);
 			$this->config['ldapBaseGroups'] = $this->config['ldapBase'];
 		}

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -421,21 +421,11 @@ class Connection {
 	private function validateConfiguration() {
 		// first step: "soft" checks: settings that are not really
 		// necessary, but advisable. If left empty, give an info message
-		if(empty($this->config['ldapBaseUsers']) ||
-			// this part handles return of preg_split in readConfiguration
-			(count($this->config['ldapBaseUsers'][0]) === 1
-				&& isset($this->config['ldapBaseUsers'][0])
-				&& empty($this->config['ldapBaseUsers'][0]))
-		) {
+		if(empty($this->config['ldapBaseUsers'])) {
 			\OCP\Util::writeLog('user_ldap', 'Base tree for Users is empty, using Base DN', \OCP\Util::INFO);
 			$this->config['ldapBaseUsers'] = $this->config['ldapBase'];
 		}
-		if(empty($this->config['ldapBaseGroups']) ||
-			// this part handles return of preg_split in readConfiguration
-			(count($this->config['ldapBaseGroups'][0]) === 1
-				&& isset($this->config['ldapBaseGroups'][0])
-				&& empty($this->config['ldapBaseGroups'][0]))
-		) {
+		if(empty($this->config['ldapBaseGroups'])) {
 			\OCP\Util::writeLog('user_ldap', 'Base tree for Groups is empty, using Base DN', \OCP\Util::INFO);
 			$this->config['ldapBaseGroups'] = $this->config['ldapBase'];
 		}


### PR DESCRIPTION
preg_split returns an array with one (empty) element, if an empty string (or null) is passed.

Reviewers please @FlorinPeter @DeepDiver1975 @bartv2 or others
