### PR TITLE
Add a CLI script for manually triggering checking a folder for updates

### DIFF
--- a/apps/files/triggerupdate.php
+++ b/apps/files/triggerupdate.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once __DIR__ . '/../../lib/base.php';
+
+if (OC::$CLI) {
+	if (count($argv) === 2) {
+		$file = $argv[1];
+		list(, $user) = explode('/', $file);
+		OC_Util::setupFS($user);
+		$view = new \OC\Files\View('');
+		/**
+		 * @var \OC\Files\Storage\Storage $storage
+		 */
+		list($storage, $internalPath) = $view->resolvePath($file);
+		$watcher = $storage->getWatcher($internalPath);
+		$watcher->checkUpdate($internalPath);
+	} else {
+		echo "Usage: php triggerupdate.php /path/to/file\n";
+	}
+} else {
+	echo "This script can be run from the command line only\n";
+}


### PR DESCRIPTION
This adds the ability to create external scripts or daemons that can trigger a filecache update.

This can make the filecache more responsive to outside changes in cases where the host isn't limited to php scripts only and there is the option to run background daemons.

For an example daemon that detects changes in the configured data directory, see https://github.com/icewind1991/oc-notify

cc @karlitschek @DeepDiver1975 @MTGap 
