### PR TITLE
for oracle use BITAND() instead of & in sharing permissions sql

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -662,9 +662,13 @@ class Share {
 					// Remove the permissions for all reshares of this item
 					if (!empty($ids)) {
 						$ids = "'".implode("','", $ids)."'";
-						$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `permissions` = `permissions` & ?'
-							.' WHERE `id` IN ('.$ids.')');
-						$query->execute(array($permissions));
+						// the binary operator & works on sqlite, mysql, postgresql and mssql
+						$sql = 'UPDATE `*PREFIX*share` SET `permissions` = `permissions` & ? WHERE `id` IN ('.$ids.')';
+						if (\OC_Config::getValue('dbtype', 'sqlite') === 'oci') {
+							// guess which dbms does not handle & and uses a function for this
+							$sql = 'UPDATE `*PREFIX*share` SET `permissions` = BITAND(`permissions`,?) WHERE `id` IN ('.$ids.')';
+						}
+						\OC_DB::executeAudited($sql, array($permissions));
 					}
 				}
 			}


### PR DESCRIPTION
@icewind1991 @DeepDiver1975 @MTGap oracle needs BITAND() instead of & in sql. If you have a better idea than the conditional, I'm all for it. No, the doctrine DBAL does not solve this problem.

Also, @Raydiation I saw a lot of occurrences of  & in SQL in the news app, would be awesome if you could add this fix to the news app as well.

quick shell command to search for possible occurences:

``` sh
find . -name "*.php" -follow -exec grep " & " {} + | grep \` 
```
