### PR TITLE
manually calculate unix_timestamp for oracle

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -754,6 +754,7 @@ class OC_DB {
 		}elseif( $type == 'oci'  ) {
 			$query = str_replace( '`', '"', $query );
 			$query = str_ireplace( 'NOW()', 'CURRENT_TIMESTAMP', $query );
+			$query = str_ireplace( 'UNIX_TIMESTAMP()', '((CAST(SYS_EXTRACT_UTC(systimestamp) AS DATE))-TO_DATE(\'1970101000000\',\'YYYYMMDDHH24MiSS\'))*24*3600', $query );
 		}elseif( $type == 'mssql' ) {
 			$query = preg_replace( "/\`(.*?)`/", "[$1]", $query );
 			$query = str_replace( 'NOW()', 'CURRENT_TIMESTAMP', $query );


### PR DESCRIPTION
looks weird ... welcome to oracle

the conversions and castings are necessary to get the correct timestamp for the used timezone. 

@DeepDiver1975 @karlitschek this fixes the unixtimestamp db test for oracle
