### PR TITLE
fix encryption for system wide mounted external storages

### DIFF
--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -21,4 +21,3 @@ if (!isset($_)) { //also provide standalone error page
 
 	exit;
 }
-?>

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -497,7 +497,8 @@ class Hooks {
 
 			// handle share-keys
 			$localKeyPath = $view->getLocalFile($baseDir . 'share-keys/' . $params['oldpath']);
-			$matches = glob(preg_quote($localKeyPath) . '*.shareKey');
+			$escapedPath = preg_replace('/(\*|\?|\[)/', '[$1]', $localKeyPath);
+			$matches = glob($escapedPath . '*.shareKey');
 			foreach ($matches as $src) {
 				$dst = \OC\Files\Filesystem::normalizePath(str_replace($params['oldpath'], $params['newpath'], $src));
 

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -476,10 +476,19 @@ class Hooks {
 		$util = new Util($view, $userId);
 
 		// Format paths to be relative to user files dir
-		$oldKeyfilePath = \OC\Files\Filesystem::normalizePath(
-			$userId . '/' . 'files_encryption' . '/' . 'keyfiles' . '/' . $params['oldpath']);
-		$newKeyfilePath = \OC\Files\Filesystem::normalizePath(
-			$userId . '/' . 'files_encryption' . '/' . 'keyfiles' . '/' . $params['newpath']);
+		if ($util->isSystemWideMountPoint($params['oldpath'])) {
+			$baseDir = 'files_encryption/';
+			$oldKeyfilePath = $baseDir . 'keyfiles/' . $params['oldpath'];
+		} else {
+			$baseDir = $userId . '/' . 'files_encryption/';
+			$oldKeyfilePath = $baseDir . 'keyfiles/' . $params['oldpath'];
+		}
+
+		if ($util->isSystemWideMountPoint($params['newpath'])) {
+			$newKeyfilePath =  $baseDir . 'keyfiles/' . $params['newpath'];
+		} else {
+			$newKeyfilePath = $baseDir . 'keyfiles/' . $params['newpath'];
+		}
 
 		// add key ext if this is not an folder
 		if (!$view->is_dir($oldKeyfilePath)) {
@@ -487,7 +496,7 @@ class Hooks {
 			$newKeyfilePath .= '.key';
 
 			// handle share-keys
-			$localKeyPath = $view->getLocalFile($userId . '/files_encryption/share-keys/' . $params['oldpath']);
+			$localKeyPath = $view->getLocalFile($baseDir . 'share-keys/' . $params['oldpath']);
 			$matches = glob(preg_quote($localKeyPath) . '*.shareKey');
 			foreach ($matches as $src) {
 				$dst = \OC\Files\Filesystem::normalizePath(str_replace($params['oldpath'], $params['newpath'], $src));
@@ -502,10 +511,8 @@ class Hooks {
 
 		} else {
 			// handle share-keys folders
-			$oldShareKeyfilePath = \OC\Files\Filesystem::normalizePath(
-				$userId . '/' . 'files_encryption' . '/' . 'share-keys' . '/' . $params['oldpath']);
-			$newShareKeyfilePath = \OC\Files\Filesystem::normalizePath(
-				$userId . '/' . 'files_encryption' . '/' . 'share-keys' . '/' . $params['newpath']);
+			$oldShareKeyfilePath = $baseDir . 'share-keys/' . $params['oldpath'];
+			$newShareKeyfilePath = $baseDir . 'share-keys/' . $params['newpath'];
 
 			// create destination folder if not exists
 			if (!$view->file_exists(dirname($newShareKeyfilePath))) {

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -497,7 +497,7 @@ class Hooks {
 
 			// handle share-keys
 			$localKeyPath = $view->getLocalFile($baseDir . 'share-keys/' . $params['oldpath']);
-			$escapedPath = preg_replace('/(\*|\?|\[)/', '[$1]', $localKeyPath);
+			$escapedPath = Helper::escapeGlobPattern($localKeyPath);
 			$matches = glob($escapedPath . '*.shareKey');
 			foreach ($matches as $src) {
 				$dst = \OC\Files\Filesystem::normalizePath(str_replace($params['oldpath'], $params['newpath'], $src));

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -123,7 +123,7 @@ class Helper {
 
 			$view->file_put_contents('/public-keys/' . $recoveryKeyId . '.public.key', $keypair['publicKey']);
 
-			// Encrypt private key empthy passphrase
+			// Encrypt private key empty passphrase
 			$encryptedPrivateKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($keypair['privateKey'], $recoveryPassword);
 
 			// Save private key

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -208,4 +208,13 @@ class Helper {
 		header('Location: ' . $location . '?p=' . $post);
 		exit();
 	}
+
+	/**
+	 * @brief glob uses different pattern than regular expressions, escape glob pattern only
+	 * @param unescaped path
+	 * @return escaped path
+	 */
+	public static function escapeGlobPattern($path) {
+		return preg_replace('/(\*|\?|\[)/', '[$1]', $path);
+	}
 }

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -488,7 +488,7 @@ class Keymanager {
 			$view->unlink($baseDir . $filePath);
 		} else {
 			$localKeyPath = $view->getLocalFile($baseDir . $filePath);
-			$escapedPath = preg_replace('/(\*|\?|\[)/', '[$1]', $localKeyPath);
+			$escapedPath = Helper::escapeGlobPattern($localKeyPath);
 			$matches = glob($escapedPath . '*.shareKey');
 			foreach ($matches as $ma) {
 				$result = unlink($ma);
@@ -549,8 +549,8 @@ class Keymanager {
 	private static function recursiveDelShareKeys($dir, $userIds) {
 		foreach ($userIds as $userId) {
 			$extension = '.' . $userId . '.shareKey';
-			$escapedDir = preg_replace('/(\*|\?|\[)/', '[$1]', $dir);
-			$escapedExtension = preg_replace('/(\*|\?|\[)/', '[$1]', $extension);
+			$escapedDir = Helper::escapeGlobPattern($dir);
+			$escapedExtension = Helper::escapeGlobPattern($extension);
 			$matches = glob($escapedDir . '/*' . $escapedExtension);
 		}
 		/** @var $matches array */

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -475,10 +475,19 @@ class Keymanager {
 	 */
 	public static function delAllShareKeys(\OC_FilesystemView $view, $userId, $filePath) {
 
-		if ($view->is_dir($userId . '/files/' . $filePath)) {
-			$view->unlink($userId . '/files_encryption/share-keys/' . $filePath);
+		$util = new util($view, $userId);
+
+		if ($util->isSystemWideMountPoint($filePath)) {
+			$baseDir = '/files_encryption/share-keys/';
 		} else {
-			$localKeyPath = $view->getLocalFile($userId . '/files_encryption/share-keys/' . $filePath);
+			$baseDir = $userId . '/files_encryption/share-keys/';
+		}
+
+
+		if ($view->is_dir($userId . '/files/' . $filePath)) {
+			$view->unlink($baseDir . $filePath);
+		} else {
+			$localKeyPath = $view->getLocalFile($baseDir . $filePath);
 			$matches = glob(preg_quote($localKeyPath) . '*.shareKey');
 			foreach ($matches as $ma) {
 				$result = unlink($ma);
@@ -503,7 +512,11 @@ class Keymanager {
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
 
-		$shareKeyPath = \OC\Files\Filesystem::normalizePath('/' . $owner . '/files_encryption/share-keys/' . $filename);
+		if ($util->isSystemWideMountPoint($filename)) {
+			$shareKeyPath = \OC\Files\Filesystem::normalizePath('/files_encryption/share-keys/' . $filename);
+		} else {
+			$shareKeyPath = \OC\Files\Filesystem::normalizePath('/' . $owner . '/files_encryption/share-keys/' . $filename);
+		}
 
 		if ($view->is_dir($shareKeyPath)) {
 

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -127,7 +127,7 @@ class Keymanager {
 		list($owner, $filename) = $util->getUidAndFilename($path);
 
 		// in case of system wide mount points the keys are stored directly in the data directory
-		if (self::isSystemWideMountPoint($filename)) {
+		if ($util->isSystemWideMountPoint($filename)) {
 			$basePath = '/files_encryption/keyfiles';
 		} else {
 			$basePath = '/' . $owner . '/files_encryption/keyfiles';
@@ -239,7 +239,7 @@ class Keymanager {
 		$filePath_f = ltrim($filename, '/');
 
 		// in case of system wide mount points the keys are stored directly in the data directory
-		if (self::isSystemWideMountPoint($filename)) {
+		if ($util->isSystemWideMountPoint($filename)) {
 			$keyfilePath = '/files_encryption/keyfiles/' . $filePath_f . '.key';
 		} else {
 			$keyfilePath = '/' . $owner . '/files_encryption/keyfiles/' . $filePath_f . '.key';
@@ -374,7 +374,7 @@ class Keymanager {
 		list($owner, $filename) = $util->getUidAndFilename($path);
 
 		// in case of system wide mount points the keys are stored directly in the data directory
-		if (self::isSystemWideMountPoint($filename)) {
+		if ($util->isSystemWideMountPoint($filename)) {
 			$basePath = '/files_encryption/share-keys';
 		} else {
 			$basePath = '/' . $owner . '/files_encryption/share-keys';
@@ -438,7 +438,7 @@ class Keymanager {
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
 
 		// in case of system wide mount points the keys are stored directly in the data directory
-		if (self::isSystemWideMountPoint($filename)) {
+		if ($util->isSystemWideMountPoint($filename)) {
 			$shareKeyPath = '/files_encryption/share-keys/' . $filename . '.' . $userId . '.shareKey';
 		} else {
 			$shareKeyPath = '/' . $owner . '/files_encryption/share-keys/' . $filename . '.' . $userId . '.shareKey';
@@ -568,20 +568,5 @@ class Keymanager {
 
 		return $targetPath;
 
-	}
-
-	/**
-	 * @brief check if the file is stored on a system wide mount point
-	 * @param $path relative to /data/user with leading '/'
-	 * @return boolean
-	 */
-	private static function isSystemWideMountPoint($path) {
-		$mount = \OC_Mount_Config::getSystemMountPoints();
-		foreach ($mount as $mountPoint => $data) {
-			if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -277,7 +277,14 @@ class Keymanager {
 	public static function deleteFileKey(\OC_FilesystemView $view, $userId, $path) {
 
 		$trimmed = ltrim($path, '/');
-		$keyPath = '/' . $userId . '/files_encryption/keyfiles/' . $trimmed;
+
+		$util = new Util($view, \OCP\User::getUser());
+
+		if($util->isSystemWideMountPoint($path)) {
+			$keyPath = '/files_encryption/keyfiles/' . $trimmed;
+		} else {
+			$keyPath = '/' . $userId . '/files_encryption/keyfiles/' . $trimmed;
+		}
 
 		$result = false;
 

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -591,7 +591,7 @@ class Keymanager {
 	 * @return boolean
 	 */
 	private static function isSystemWideMountPoint($path) {
-		$mount = OC_Mount_Config::getSystemMountPoints();
+		$mount = \OC_Mount_Config::getSystemMountPoints();
 		foreach ($mount as $mountPoint => $data) {
 			if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
 				return true;

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -488,7 +488,8 @@ class Keymanager {
 			$view->unlink($baseDir . $filePath);
 		} else {
 			$localKeyPath = $view->getLocalFile($baseDir . $filePath);
-			$matches = glob(preg_quote($localKeyPath) . '*.shareKey');
+			$escapedPath = preg_replace('/(\*|\?|\[)/', '[$1]', $localKeyPath);
+			$matches = glob($escapedPath . '*.shareKey');
 			foreach ($matches as $ma) {
 				$result = unlink($ma);
 				if (!$result) {
@@ -547,7 +548,10 @@ class Keymanager {
 	 */
 	private static function recursiveDelShareKeys($dir, $userIds) {
 		foreach ($userIds as $userId) {
-			$matches = glob(preg_quote($dir) . '/*' . preg_quote('.' . $userId . '.shareKey'));
+			$extension = '.' . $userId . '.shareKey';
+			$escapedDir = preg_replace('/(\*|\?|\[)/', '[$1]', $dir);
+			$escapedExtension = preg_replace('/(\*|\?|\[)/', '[$1]', $extension);
+			$matches = glob($escapedDir . '/*' . $escapedExtension);
 		}
 		/** @var $matches array */
 		foreach ($matches as $ma) {
@@ -556,7 +560,7 @@ class Keymanager {
 					'Could not delete shareKey; does not exist: "' . $ma . '"', \OCP\Util::ERROR);
 			}
 		}
-		$subdirs = $directories = glob(preg_quote($dir) . '/*', GLOB_ONLYDIR);
+		$subdirs = $directories = glob($escapedDir . '/*', GLOB_ONLYDIR);
 		foreach ($subdirs as $subdir) {
 			self::recursiveDelShareKeys($subdir, $userIds);
 		}

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1037,7 +1037,7 @@ class Util {
 		}
 
 		// check if it is a group mount
-		$mount = OC_Mount_Config::getSystemMountPoints();
+		$mount = \OC_Mount_Config::getSystemMountPoints();
 		foreach ($mount as $mountPoint => $data) {
 			if ($mountPoint == substr($ownerPath, 1, strlen($mountPoint))) {
 				$userIds = array_merge($userIds,

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1037,11 +1037,12 @@ class Util {
 		}
 
 		// check if it is a group mount
-		$mount = \OC_Mount_Config::getSystemMountPoints();
-		foreach ($mount as $mountPoint => $data) {
-			if ($mountPoint == substr($ownerPath, 1, strlen($mountPoint))) {
-				$userIds = array_merge($userIds,
-					$this->getUserWithAccessToMountPoint($data['applicable']['users'], $data['applicable']['groups']));
+		if (\OCP\App::isEnabled("files_external")) {
+			$mount = \OC_Mount_Config::getSystemMountPoints();
+			foreach ($mount as $mountPoint => $data) {
+				if ($mountPoint == substr($ownerPath, 1, strlen($mountPoint))) {
+					$userIds = array_merge($userIds, $this->getUserWithAccessToMountPoint($data['applicable']['users'], $data['applicable']['groups']));
+				}
 			}
 		}
 
@@ -1579,10 +1580,12 @@ class Util {
 	 * @return boolean
 	 */
 	public function isSystemWideMountPoint($path) {
-		$mount = \OC_Mount_Config::getSystemMountPoints();
-		foreach ($mount as $mountPoint => $data) {
-			if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
-				return true;
+		if (\OCP\App::isEnabled("files_external")) {
+			$mount = \OC_Mount_Config::getSystemMountPoints();
+			foreach ($mount as $mountPoint => $data) {
+				if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1573,4 +1573,19 @@ class Util {
 		return $relativePath;
 	}
 
+	/**
+	 * @brief check if the file is stored on a system wide mount point
+	 * @param $path relative to /data/user with leading '/'
+	 * @return boolean
+	 */
+	public function isSystemWideMountPoint($path) {
+		$mount = \OC_Mount_Config::getSystemMountPoints();
+		foreach ($mount as $mountPoint => $data) {
+			if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1205,7 +1205,7 @@ class Util {
 
 			return array(
 				$fileOwnerUid,
-				$filename
+				\OC_Filesystem::normalizePath($filename)
 			);
 		}
 

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -209,7 +209,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		\OC_User::setUserId(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
 
-		$filename = 'tmp-' . time() . '.test';
+		$filename = '/tmp-' . time() . '.test';
 
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -165,13 +165,19 @@ class Trashbin {
 
 			list($owner, $ownerPath) = self::getUidAndFilename($file_path);
 
+			$util = new \OCA\Encryption\Util(new \OC_FilesystemView('/'), $user);
 
 			// disable proxy to prevent recursive calls
 			$proxyStatus = \OC_FileProxy::$enabled;
 			\OC_FileProxy::$enabled = false;
 
-			// retain key files
-			$keyfile = \OC\Files\Filesystem::normalizePath($owner . '/files_encryption/keyfiles/' . $ownerPath);
+			if ($util->isSystemWideMountPoint($ownerPath)) {
+				$baseDir = '/files_encryption/';
+			} else {
+				$baseDir = $owner . '/files_encryption/';
+			}
+
+			$keyfile = \OC\Files\Filesystem::normalizePath($baseDir . '/keyfiles/' . $ownerPath);
 
 			if ($rootView->is_dir($keyfile) || $rootView->file_exists($keyfile . '.key')) {
 				// move keyfiles
@@ -185,7 +191,7 @@ class Trashbin {
 			}
 
 			// retain share keys
-			$sharekeys = \OC\Files\Filesystem::normalizePath($owner . '/files_encryption/share-keys/' . $ownerPath);
+			$sharekeys = \OC\Files\Filesystem::normalizePath($baseDir . '/share-keys/' . $ownerPath);
 
 			if ($rootView->is_dir($sharekeys)) {
 				$size += self::calculateSize(new \OC\Files\View($sharekeys));
@@ -394,6 +400,14 @@ class Trashbin {
 
 			list($owner, $ownerPath) = self::getUidAndFilename($target);
 
+			$util = new \OCA\Encryption\Util(new \OC_FilesystemView('/'), $user);
+
+			if ($util->isSystemWideMountPoint($ownerPath)) {
+				$baseDir = '/files_encryption/';
+			} else {
+				$baseDir = $owner . '/files_encryption/';
+			}
+
 			$path_parts = pathinfo($file);
 			$source_location = $path_parts['dirname'];
 
@@ -423,18 +437,18 @@ class Trashbin {
 
 					// handle keyfiles
 					$size += self::calculateSize(new \OC\Files\View($keyfile));
-					$rootView->rename($keyfile, $owner . '/files_encryption/keyfiles/' . $ownerPath);
+					$rootView->rename($keyfile, $baseDir . '/keyfiles/' . $ownerPath);
 
 					// handle share-keys
 					if ($timestamp) {
 						$sharekey .= '.d' . $timestamp;
 					}
 					$size += self::calculateSize(new \OC\Files\View($sharekey));
-					$rootView->rename($sharekey, $owner . '/files_encryption/share-keys/' . $ownerPath);
+					$rootView->rename($sharekey, $baseDir . '/share-keys/' . $ownerPath);
 				} else {
 					// handle keyfiles
 					$size += $rootView->filesize($keyfile);
-					$rootView->rename($keyfile, $owner . '/files_encryption/keyfiles/' . $ownerPath . '.key');
+					$rootView->rename($keyfile, $baseDir . '/keyfiles/' . $ownerPath . '.key');
 
 					// handle share-keys
 					$ownerShareKey = \OC\Files\Filesystem::normalizePath($user . '/files_trashbin/share-keys/' . $source_location . '/' . $filename . '.' . $user . '.shareKey');
@@ -445,7 +459,7 @@ class Trashbin {
 					$size += $rootView->filesize($ownerShareKey);
 
 					// move only owners key
-					$rootView->rename($ownerShareKey, $owner . '/files_encryption/share-keys/' . $ownerPath . '.' . $user . '.shareKey');
+					$rootView->rename($ownerShareKey, $baseDir . '/share-keys/' . $ownerPath . '.' . $user . '.shareKey');
 
 					// try to re-share if file is shared
 					$filesystemView = new \OC_FilesystemView('/');


### PR DESCRIPTION
If the admin mounts external storages for multiple users the encryption system must store the keys in a generic place and make sure that the files are encrypted to all users with access to this mount point.

This patch should provide this functionality.

cc @FlorinPeter 
