### PR TITLE
Log JSON output to file instead of stdout making phpunit usable from the console again.

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -16,6 +16,10 @@
 		</whitelist>
 	</filter>
 	<listeners>
-		<listener class="PHPUnit_Util_Log_JSON"></listener>
+		<listener class="PHPUnit_Util_Log_JSON">
+			<arguments>
+				<string>phpunit.log.json</string>
+			</arguments>
+		</listener>
 	</listeners>
 </phpunit>


### PR DESCRIPTION
`PHPUnit_Util_Log_JSON` currently spams to stdout making PHPUnit basically unusable from the console. See https://gist.github.com/bantu/b311ec2bec73c6a96816

This patch changes the output to a file called phpunit.log.json to keep users of `PHPUnit_Util_Log_JSON` happy.

References:
https://github.com/sebastianbergmann/phpunit/blob/master/PHPUnit/Util/Log/JSON.php#L57
https://github.com/sebastianbergmann/phpunit/blob/master/PHPUnit/Util/Printer.php#L87
http://phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.test-listeners
