### PR TITLE
phpunit: Remove PHPUnit_Util_Log_JSON which spammed to stdout on console

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -15,7 +15,4 @@
 			</exclude>
 		</whitelist>
 	</filter>
-	<listeners>
-		<listener class="PHPUnit_Util_Log_JSON"></listener>
-	</listeners>
 </phpunit>


### PR DESCRIPTION
`PHPUnit_Util_Log_JSON` currently spams to stdout making PHPUnit basically unusable from the console. See https://gist.github.com/bantu/b311ec2bec73c6a96816

This patch removes `PHPUnit_Util_Log_JSON`.

Alternative patch to #3846 as requested by @MTGap.
