### PR TITLE
enable testing individual tests

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -132,9 +132,9 @@ EOF
 	php -f enable_all.php
 	if [ "$1" == "sqlite" ] ; then
 		# coverage only with sqlite - causes segfault on ci.tmit.eu - reason unknown
-		phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-$1.xml --coverage-clover autotest-clover-$1.xml --coverage-html coverage-html-$1
+		phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-$1.xml --coverage-clover autotest-clover-$1.xml --coverage-html coverage-html-$1 $2 $3
 	else
-		phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-$1.xml
+		phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-$1.xml $2 $3
 	fi
 }
 
@@ -149,7 +149,7 @@ if [ -z "$1" ]
 	# we will add oci as soon as it's stable
 	#execute_tests 'oci'
 else
-	execute_tests $1
+	execute_tests $1 $2 $3
 fi
 
 #


### PR DESCRIPTION
needed this to save time debugging oracle problems with sharing:

this PR allows you to test a single class like

``` sh
$ ./autotest.sh oci Test_Share lib/share/share.php
```

@DeepDiver1975 @MTGap @kabum @IMM0rtalis partially fixes https://github.com/owncloud/core/issues/3851 (autotest.cmd adaptation is missing) 
