### PR TITLE
Improved footer

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -5,6 +5,9 @@
 <header><div id="header">
 	<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
 		src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="ownCloud" /></a>
+	<?php if (OC_Util::getEditionString() !== ''): ?>
+		<div id="logo-claim" style="display:none;">Enterprise Edition</div>
+	<?php endif; ?>
 	<div class="header-right">
 	<?php if (isset($_['folder'])): ?>
 		<span id="details"><?php p($l->t('%s shared the folder %s with you',

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -5,9 +5,7 @@
 <header><div id="header">
 	<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
 		src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="ownCloud" /></a>
-	<?php if (OC_Util::getEditionString() !== ''): ?>
-		<div id="logo-claim" style="display:none;">Enterprise Edition</div>
-	<?php endif; ?>
+	<div id="logo-claim" style="display:none;"><?php p(OC_Defaults::getLogoClaim()); ?></div>
 	<div class="header-right">
 	<?php if (isset($_['folder'])): ?>
 		<span id="details"><?php p($l->t('%s shared the folder %s with you',

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -40,8 +40,7 @@
 	<?php endif; ?>
 </div>
 <footer>
-	<p class="info"><a href="<?php p(OC_Defaults::getBaseUrl()); ?>"><?php p(OC_Defaults::getEntity()) ?></a>
-		<?php OC_Util::getEditionString() === '' ? print_unescaped(' &ndash; ') : print_unescaped('<br/>'); ?>
-		<?php p(OC_Defaults::getSlogan()); ?>
+	<p class="info">
+		<?php print_unescaped(OC_Defaults::getLongFooter()); ?>
 	</p>
 </footer>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -43,10 +43,7 @@
 		</div>
 		<footer>
 			<p class="info">
-				<?php OC_Util::getEditionString() === '' ? '' : p('© 2013 '); ?>
-				<a href="<?php p(OC_Defaults::getBaseUrl())?>">
-					<?php  p(OC_Defaults::getEntity()); ?></a>
-				<?php OC_Util::getEditionString() === '' ? print_unescaped(' &ndash; ') : print_unescaped('<br/>'); ?>
-			<?php p(OC_Defaults::getSlogan()); ?></p></footer>
+				<?php print_unescaped(OC_Defaults::getLongFooter()); ?>
+			</p></footer>
 	</body>
 </html>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -35,9 +35,7 @@
 		<div id="login">
 			<header><div id="header">
 				<img src="<?php print_unescaped(image_path('', 'logo.svg')); ?>" class="svg" alt="ownCloud" />
-				<?php if (OC_Util::getEditionString() !== ''): ?>
-				<div id="logo-claim" style="display:none;">Enterprise Edition</div>
-				<?php endif; ?>
+				<div id="logo-claim" style="display:none;"><?php p(OC_Defaults::getLogoClaim()); ?></div>
 			</div></header>
 			<?php print_unescaped($_['content']); ?>
 		</div>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -39,9 +39,7 @@
 	<header><div id="header">
 			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
 				src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="ownCloud" /></a>
-			<?php if (OC_Util::getEditionString() !== ''): ?>
-			<div id="logo-claim" style="display:none;">Enterprise Edition</div>
-			<?php endif; ?>
+			<div id="logo-claim" style="display:none;"><?php p(OC_Defaults::getLogoClaim()); ?></div>
 			<ul id="settings" class="svg">
 				<span id="expand">
 					<span id="expandDisplayName"><?php  p(trim($_['user_displayname']) != '' ? $_['user_displayname'] : $_['user_uid']) ?></span>

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -71,4 +71,26 @@ class OC_Defaults {
 		}
 	}
 
+	public static function getShortFooter() {
+		if (OC_Util::getEditionString() === '') {
+			$footer = "<a href=\"". self::getBaseUrl() . "\" target=\"_blank\">" .self::getEntity() . "</a>".
+				' – ' . self::getSlogan();
+		} else {
+			$footer = "© 2013 <a href=\"".self::getBaseUrl()."\" target=\"_blank\">".self::getEntity()."</a>".
+				" – " . self::getSlogan();
+		}
+
+		return $footer;
+	}
+
+	public static function getLongFooter() {
+		if (OC_Util::getEditionString() === '') {
+			$footer = self::getShortFooter();
+		} else {
+			$footer = "© 2013 <a href=\"".self::getBaseUrl()."\" target=\"_blank\">".self::getEntity()."</a>".
+				"<br/>" . self::getSlogan();
+		}
+		return $footer;
+	}
+
 }

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -5,91 +5,97 @@
  * community edition. Use the get methods to always get the right strings.
  */
 
+if (file_exists(OC::$SERVERROOT . '/themes/' . OC_Util::getTheme() . '/defaults.php')) {
+	require_once 'themes/' . OC_Util::getTheme() . '/defaults.php';
+}
+
 class OC_Defaults {
 
-	private static $communityEntity = "ownCloud";
-	private static $communityName = "ownCloud";
-	private static $communityBaseUrl = "http://owncloud.org";
-	private static $communitySyncClientUrl = " http://owncloud.org/sync-clients/";
-	private static $communityDocBaseUrl = "http://doc.owncloud.org";
-	private static $communitySlogan = "web services under your control";
+	private static $defaultEntity = "ownCloud";
+	private static $defaultName = "ownCloud";
+	private static $defaultBaseUrl = "http://owncloud.org";
+	private static $defaultSyncClientUrl = " http://owncloud.org/sync-clients/";
+	private static $defaultDocBaseUrl = "http://doc.owncloud.org";
+	private static $defaultSlogan = "web services under your control";
 
-	private static $enterpriseEntity = "ownCloud Inc.";
-	private static $enterpriseName = "ownCloud Enterprise Edition";
-	private static $enterpriseBaseUrl = "https://owncloud.com";
-	private static $enterpriseDocBaseUrl = "http://doc.owncloud.com";
-	private static $enterpiseSyncClientUrl = "https://owncloud.com/products/desktop-clients";
-	private static $enterpriseSlogan = "Your Cloud, Your Data, Your Way!";
+	private function themeExist($method) {
+		if (OC_Util::getTheme() !== '' &&
+			//class_exists('OC_Theme') &&
+			method_exists('OC_Theme', $method)) {
 
+			return true;
+		}
+
+		return false;
+	}
 
 	public static function getBaseUrl() {
-		if (OC_Util::getEditionString() === '') {
-			return self::$communityBaseUrl;
+		if (self::themeExist('getBaseUrl')) {
+			return OC_Theme::getBaseUrl();
 		} else {
-			return self::$enterpriseBaseUrl;
+			return self::$defaultBaseUrl;
 		}
 	}
 
 	public static function getSyncClientUrl() {
-		if (OC_Util::getEditionString() === '') {
-			return self::$communitySyncClientUrl;
+		if (self::themeExist('getSyncClientUrl')) {
+			return OC_Theme::getSyncClientUrl();
 		} else {
-			return self::$enterpiseSyncClientUrl;
+			return self::$defaultSyncClientUrl;
 		}
 	}
 
 	public static function getDocBaseUrl() {
-		if (OC_Util::getEditionString() === '') {
-			return self::$communityDocBaseUrl;
+		if (self::themeExist('getDocBaseUrl')) {
+			return OC_Theme::getDocBaseUrl();
 		} else {
-			return self::$enterpriseDocBaseUrl;
+			return self::$defaultDocBaseUrl;
 		}
 	}
 
 	public static function getName() {
-		if (OC_Util::getEditionString() === '') {
-			return self::$communityName;
+		if (self::themeExist('getName')) {
+			return OC_Theme::getName();
 		} else {
-			return self::$enterpriseName;
+			return self::$defaultName;
 		}
 	}
 
 	public static function getEntity() {
-		if (OC_Util::getEditionString() === '') {
-			return self::$communityEntity;
+		if (self::themeExist('getEntity')) {
+			return OC_Theme::getEntity();
 		} else {
-			return self::$enterpriseEntity;
+			return self::$defaultEntity;
 		}
 	}
 
 	public static function getSlogan() {
 		$l = OC_L10N::get('core');
-		if (OC_Util::getEditionString() === '') {
-			return $l->t(self::$communitySlogan);
+		if (self::themeExist('getSlogan')) {
+			return OC_Theme::getSlogan();
 		} else {
-			return self::$enterpriseSlogan;
+			return $l->t(self::$defaultSlogan);
 		}
 	}
 
 	public static function getShortFooter() {
-		if (OC_Util::getEditionString() === '') {
+		if (self::themeExist('getShortFooter')) {
+			$footer = OC_Theme::getShortFooter();
+		} else {
 			$footer = "<a href=\"". self::getBaseUrl() . "\" target=\"_blank\">" .self::getEntity() . "</a>".
 				' – ' . self::getSlogan();
-		} else {
-			$footer = "© 2013 <a href=\"".self::getBaseUrl()."\" target=\"_blank\">".self::getEntity()."</a>".
-				" – " . self::getSlogan();
 		}
 
 		return $footer;
 	}
 
 	public static function getLongFooter() {
-		if (OC_Util::getEditionString() === '') {
-			$footer = self::getShortFooter();
+		if (self::themeExist('getLongFooter')) {
+			$footer = OC_Theme::getLongFooter();
 		} else {
-			$footer = "© 2013 <a href=\"".self::getBaseUrl()."\" target=\"_blank\">".self::getEntity()."</a>".
-				"<br/>" . self::getSlogan();
+			$footer = self::getShortFooter();
 		}
+
 		return $footer;
 	}
 

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -19,7 +19,7 @@ class OC_Defaults {
 	private static $defaultSlogan = "web services under your control";
 	private static $defaultLogoClaim = "ownCloud Community";
 
-	private function themeExist($method) {
+	private static function themeExist($method) {
 		if (OC_Util::getTheme() !== '' && method_exists('OC_Theme', $method)) {
 			return true;
 		}

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -19,13 +19,9 @@ class OC_Defaults {
 	private static $defaultSlogan = "web services under your control";
 
 	private function themeExist($method) {
-		if (OC_Util::getTheme() !== '' &&
-			//class_exists('OC_Theme') &&
-			method_exists('OC_Theme', $method)) {
-
+		if (OC_Util::getTheme() !== '' && method_exists('OC_Theme', $method)) {
 			return true;
 		}
-
 		return false;
 	}
 

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -17,6 +17,7 @@ class OC_Defaults {
 	private static $defaultSyncClientUrl = " http://owncloud.org/sync-clients/";
 	private static $defaultDocBaseUrl = "http://doc.owncloud.org";
 	private static $defaultSlogan = "web services under your control";
+	private static $defaultLogoClaim = "ownCloud Community";
 
 	private function themeExist($method) {
 		if (OC_Util::getTheme() !== '' && method_exists('OC_Theme', $method)) {
@@ -71,6 +72,14 @@ class OC_Defaults {
 			return OC_Theme::getSlogan();
 		} else {
 			return $l->t(self::$defaultSlogan);
+		}
+	}
+
+	public static function getLogoClaim() {
+		if (self::themeExist('getLogoClaim')) {
+			return OC_Theme::getLogoClaim();
+		} else {
+			return self::$defaultLogoClaim;
 		}
 	}
 

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -17,7 +17,7 @@ class OC_Defaults {
 	private static $defaultSyncClientUrl = " http://owncloud.org/sync-clients/";
 	private static $defaultDocBaseUrl = "http://doc.owncloud.org";
 	private static $defaultSlogan = "web services under your control";
-	private static $defaultLogoClaim = "ownCloud Community";
+	private static $defaultLogoClaim = "";
 
 	private static function themeExist($method) {
 		if (OC_Util::getTheme() !== '' && method_exists('OC_Theme', $method)) {

--- a/lib/mail.php
+++ b/lib/mail.php
@@ -114,8 +114,8 @@ class OC_Mail {
 	public static function getfooter() {
 
 		$txt="\n--\n";
-		$txt.="ownCloud\n";
-		$txt.="Your Cloud, Your Data, Your Way!\n";
+		$txt.=OC_Defaults::getName() . "\n";
+		$txt.=OC_Defaults::getSlogan() . "\n";
 		return($txt);
 
 	}

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -228,8 +228,8 @@ endfor;?>
 <fieldset class="personalblock">
 	<legend><strong><?php p($l->t('Version'));?></strong></legend>
 	<strong><?php p(OC_Defaults::getName()); ?></strong> <?php p(OC_Util::getVersionString()); ?>
-	(<?php print_unescaped(OC_Updater::ShowUpdatingHint()); ?>)<br/>
 <?php if (OC_Util::getEditionString() === ''): ?>
+	(<?php print_unescaped(OC_Updater::ShowUpdatingHint()); ?>)<br/>
 	<?php print_unescaped($l->t('Developed by the <a href="http://ownCloud.org/contact" target="_blank">ownCloud community</a>, the <a href="https://github.com/owncloud" target="_blank">source code</a> is licensed under the <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank"><abbr title="Affero General Public License">AGPL</abbr></a>.')); ?>
 <?php endif; ?>
 </fieldset>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -225,13 +225,16 @@ endfor;?>
 
 </fieldset>
 
-<fieldset class="personalblock credits-footer">
-<?php if (OC_Util::getEditionString() === ''): ?>
+<fieldset class="personalblock">
 	<legend><strong><?php p($l->t('Version'));?></strong></legend>
-	<strong>ownCloud</strong> <?php p(OC_Util::getVersionString()); ?> <?php p(OC_Util::getEditionString()); ?>
+	<strong><?php p(OC_Defaults::getName()); ?></strong> <?php p(OC_Util::getVersionString()); ?>
 	(<?php print_unescaped(OC_Updater::ShowUpdatingHint()); ?>)<br/>
+<?php if (OC_Util::getEditionString() === ''): ?>
 	<?php print_unescaped($l->t('Developed by the <a href="http://ownCloud.org/contact" target="_blank">ownCloud community</a>, the <a href="https://github.com/owncloud" target="_blank">source code</a> is licensed under the <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank"><abbr title="Affero General Public License">AGPL</abbr></a>.')); ?>
-<?php else: ?>
-    <p>© 2013 <a href="<?php p(OC_Defaults::getBaseUrl()); ?>" target="_blank"><?php p(OC_Defaults::getEntity()); ?></a> – <?php p(OC_Defaults::getSlogan()); ?></p>
 <?php endif; ?>
+</fieldset>
+<fieldset class="personalblock credits-footer">
+<p>
+	<?php print_unescaped(OC_Defaults::getShortFooter()); ?>
+</p>
 </fieldset>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -108,13 +108,15 @@ if($_['passwordChangeSupported']) {
 	print_unescaped($form);
 };?>
 
-<fieldset class="personalblock credits-footer">
-<?php if (OC_Util::getEditionString() === ''): ?>
+<fieldset class="personalblock">
 	<legend><strong><?php p($l->t('Version'));?></strong></legend>
-	<strong>ownCloud</strong> <?php p(OC_Util::getVersionString()); ?>
-	<?php p(OC_Util::getEditionString()); ?> <br />
+	<strong><?php p(OC_Defaults::getName()); ?></strong> <?php p(OC_Util::getVersionString()); ?><br/>
+<?php if (OC_Util::getEditionString() === ''): ?>
 	<?php print_unescaped($l->t('Developed by the <a href="http://ownCloud.org/contact" target="_blank">ownCloud community</a>, the <a href="https://github.com/owncloud" target="_blank">source code</a> is licensed under the <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank"><abbr title="Affero General Public License">AGPL</abbr></a>.')); ?>
-<?php else: ?>
-    <p>© 2013 <a href="<?php p(OC_Defaults::getBaseUrl()); ?>" target="_blank"><?php p(OC_Defaults::getEntity()); ?></a> – <?php p(OC_Defaults::getSlogan()); ?></p>
 <?php endif; ?>
+</fieldset>
+<fieldset class="personalblock credits-footer">
+<p>
+	<?php print_unescaped(OC_Defaults::getShortFooter()); ?>
+</p>
 </fieldset>


### PR DESCRIPTION
@MTRichards and @jancborchardt please have a look.

Like discussed in #3791 I moved the construction of the footer to defaults.php which allows us to change the footer in one central place.

During this changes I discovered that for the enterprise theme we don't show the version at all which is probably bad because this way it is not possible to find out which ownCloud version is deployed. So I moved this out of the footer for the personal and admin settings. Please have a look if this works for the enterprise edition.
