### PR TITLE
Fix sharing test for oracle

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -978,7 +978,7 @@ class Share {
 					// Check if the same owner shared with the user twice
 					// through a group and user share - this is allowed
 					$id = $targets[$row[$column]];
-					if ($items[$id]['uid_owner'] == $row['uid_owner']) {
+					if (isset($items[$id]) && $items[$id]['uid_owner'] == $row['uid_owner']) {
 						// Switch to group share type to ensure resharing conditions aren't bypassed
 						if ($items[$id]['share_type'] != self::SHARE_TYPE_GROUP) {
 							$items[$id]['share_type'] = self::SHARE_TYPE_GROUP;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -963,6 +963,30 @@ class Share {
 		$switchedItems = array();
 		$mounts = array();
 		while ($row = $result->fetchRow()) {
+			if (isset($row['id'])) {
+				$row['id']=(int)$row['id'];
+			}
+			if (isset($row['share_type'])) {
+				$row['share_type']=(int)$row['share_type'];
+			}
+			if (isset($row['parent'])) {
+				$row['parent']=(int)$row['parent'];
+			}
+			if (isset($row['file_parent'])) {
+				$row['file_parent']=(int)$row['file_parent'];
+			}
+			if (isset($row['file_source'])) {
+				$row['file_source']=(int)$row['file_source'];
+			}
+			if (isset($row['permissions'])) {
+				$row['permissions']=(int)$row['permissions'];
+			}
+			if (isset($row['storage'])) {
+				$row['storage']=(int)$row['storage'];
+			}
+			if (isset($row['stime'])) {
+				$row['stime']=(int)$row['stime'];
+			}
 			// Filter out duplicate group shares for users with unique targets
 			if ($row['share_type'] == self::$shareTypeGroupUserUnique && isset($items[$row['parent']])) {
 				$row['share_type'] = self::SHARE_TYPE_GROUP;


### PR DESCRIPTION
@MTGap sharing tests are failing on oracle. I tried to debug it and got this far. The select statements are a mess and manually reassembling the result set is even messier. I have no idea if I should just skip the row when `$items[$id]` is not set (first commit) or if the results are just not ordered correctly for this to work. I hope you have a better understanding of what the lines do and can help me out.

The second commit introduces an ugly fix that corrects numeric column types if they are present (fixes another test).

We need sharing to work for OC5 EE on oracle and I will not test all sharing corner cases manually, because I simply don't know them. I have to rely on the testsuite. Unfortunately, the error messages are not really helping me to identify and fix sharing problems on oracle.

@icewind1991 @DeepDiver1975 maybe this is a problem with OC_DB::insertid() but I wrote a quick test that passes just fine:

``` php
    public function testLastInsertId() {
        $query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (?,?)');
        $result = OC_DB::executeAudited($query, array('insertid 1','uri_1'));
        $id1 = OC_DB::insertid('*PREFIX*'.$this->table2);
        // we don't know the id we should expect, so insert another row
        $query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (?,?)');
        $result = OC_DB::executeAudited($query, array('insertid 2','uri_2'));
        $id2 = OC_DB::insertid('*PREFIX*'.$this->table2);
        // now we can check if the two ids are in correct order
        $this->assertEquals($id1+1, $id2);
    }
```
