### PR TITLE
introduce pre-disable-app hook and first usage in files_encryption

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -22,6 +22,9 @@ if (!OC_Config::getValue('maintenance', false)) {
 	// Filesystem related hooks
 	OCA\Encryption\Helper::registerFilesystemHooks();
 
+	// App manager related hooks
+	OCA\Encryption\Helper::registerAppHooks();
+
 	stream_wrapper_register('crypt', 'OCA\Encryption\Stream');
 
 	// check if we are logged in

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -543,4 +543,17 @@ class Hooks {
 
 		\OC_FileProxy::$enabled = $proxyStatus;
 	}
+
+	/**
+	 * set migration status back to '0' so that all new files get encrypted
+	 * if the app gets enabled again
+	 * @param array $params contains the app ID
+	 */
+	public static function preDisable($params) {
+		if ($params['app'] === 'files_encryption') {
+			$query = \OC_DB::prepare('UPDATE `*PREFIX*encryption` SET `migration_status`=0');
+			$query->execute();
+		}
+	}
+
 }

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -63,6 +63,15 @@ class Helper {
 	}
 
 	/**
+	 * @brief register filesystem related hooks
+	 *
+	 */
+	public static function registerAppHooks() {
+
+		\OCP\Util::connectHook('OC_App', 'pre_disable', 'OCA\Encryption\Hooks', 'preDisable');
+	}
+
+	/**
 	 * @brief setup user for files_encryption
 	 *
 	 * @param Util $util

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -63,7 +63,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief register filesystem related hooks
+	 * @brief register app management related hooks
 	 *
 	 */
 	public static function registerAppHooks() {

--- a/lib/app.php
+++ b/lib/app.php
@@ -259,6 +259,7 @@ class OC_App{
 	 */
 	public static function disable( $app ) {
 		// check if app is a shipped app or not. if not delete
+		\OC_Hook::emit('OC_App', 'pre_disable', array('app' => $app));
 		OC_Appconfig::setValue( $app, 'enabled', 'no' );
 
 		// check if app is a shipped app or not. if not delete


### PR DESCRIPTION
This pull request introduces a pre-disable-app hook which enables app to execute some final operations before they get disabled.

Here it is used in files_encryption to reset the migration status once the app gets disabled. That's necessary to make sure that all new files get encrypted if the file gets activates again.

cc @FlorinPeter
