### PR TITLE
Skip Test_Archive_TAR in php 5.5 for now

### DIFF
--- a/tests/lib/archive/tar.php
+++ b/tests/lib/archive/tar.php
@@ -10,6 +10,12 @@ require_once 'archive.php';
 
 if (!OC_Util::runningOnWindows()) {
 class Test_Archive_TAR extends Test_Archive {
+	public function setUp() {
+		if (floatval(phpversion())>=5.5) {
+			$this->markTestSkipped('php 5.5 changed unpack function.');
+			return;
+		}
+	}
 	protected function getExisting() {
 		$dir = OC::$SERVERROOT . '/tests/data';
 		return new OC_Archive_TAR($dir . '/data.tar.gz');


### PR DESCRIPTION
php 5.5 changed the format string of unpack, this breaks Archive_TAR
