### PR TITLE
create parent folders for the data directory if they don't exist yet

### DIFF
--- a/lib/util.php
+++ b/lib/util.php
@@ -207,7 +207,7 @@ class OC_Util {
 		$CONFIG_DATADIRECTORY = OC_Config::getValue( "datadirectory", OC::$SERVERROOT."/data" );
 		// Create root dir.
 		if(!is_dir($CONFIG_DATADIRECTORY)) {
-			$success=@mkdir($CONFIG_DATADIRECTORY);
+			$success=@mkdir($CONFIG_DATADIRECTORY, 0770, true);
 			if ($success) {
 				$errors = array_merge($errors, self::checkDataDirectoryPermissions($CONFIG_DATADIRECTORY));
 			} else {


### PR DESCRIPTION
Currently the creation if the data directory fails if the parent directory doesn't exists. This fix creates the data directory recursively so that missing parent directories get created.
