### PR TITLE
The APC User Cache doesn't return the cache_list anymore

### DIFF
--- a/lib/memcache/apcu.php
+++ b/lib/memcache/apcu.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright (c) 2012 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Memcache;
+
+class APCu extends APC {
+	public function clear($prefix = '') {
+		$ns = $this->getNamespace() . $prefix;
+		$ns = preg_quote($ns, '/');
+		$iter = new \APCIterator('/^'.$ns.'/');
+		return apc_delete($iter);
+	}
+
+	static public function isAvailable() {
+		if (!extension_loaded('apcu')) {
+			return false;
+		} elseif (!ini_get('apc.enable_cli') && \OC::$CLI) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+}

--- a/lib/memcache/factory.php
+++ b/lib/memcache/factory.php
@@ -18,6 +18,8 @@ class Factory {
 	function create($prefix = '') {
 		if (XCache::isAvailable()) {
 			return new XCache($prefix);
+		} elseif (APCu::isAvailable()) {
+			return new APCu($prefix);
 		} elseif (APC::isAvailable()) {
 			return new APC($prefix);
 		} elseif (Memcached::isAvailable()) {
@@ -33,6 +35,6 @@ class Factory {
 	 * @return bool
 	 */
 	public function isAvailable() {
-		return XCache::isAvailable() || APC::isAvailable() || Memcached::isAvailable();
+		return XCache::isAvailable() || APCu::isAvailable() || APC::isAvailable() || Memcached::isAvailable();
 	}
 }

--- a/tests/lib/memcache/apc.php
+++ b/tests/lib/memcache/apc.php
@@ -15,6 +15,10 @@ class APC extends Cache {
 			$this->markTestSkipped('The apc extension is not available.');
 			return;
 		}
+		if(\OC\Memcache\APCu::isAvailable()) {
+			$this->markTestSkipped('The apc extension is emulated by ACPu.');
+			return;
+		}
 		$this->instance=new \OC\Memcache\APC(uniqid());
 	}
 }

--- a/tests/lib/memcache/apcu.php
+++ b/tests/lib/memcache/apcu.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Memcache;
+
+class APCu extends Cache {
+	public function setUp() {
+		if(!\OC\Memcache\APCu::isAvailable()) {
+			$this->markTestSkipped('The APCu extension is not available.');
+			return;
+		}
+		$this->instance=new \OC\Memcache\APCu(uniqid());
+	}
+}


### PR DESCRIPTION
This is for the new APC released with php 5.5
