### PR TITLE
Don't load the apps when we need to upgrade

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -472,7 +472,7 @@ class OC {
 		// This includes plugins for users and filesystems as well
 		global $RUNTIME_NOAPPS;
 		global $RUNTIME_APPTYPES;
-		if (!$RUNTIME_NOAPPS) {
+		if (!$RUNTIME_NOAPPS && !self::checkUpgrade(false)) {
 			if ($RUNTIME_APPTYPES) {
 				OC_App::loadApps($RUNTIME_APPTYPES);
 			} else {


### PR DESCRIPTION
The loading can call functions that require new tables, like oc_jobs
