### PR TITLE
gitignore: Make paths relative to repository root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,24 @@
 # the default generated dir + db file
-data
-owncloud
-config/config.php
-config/mount.php
-apps/inc.php
+/data
+/owncloud
+/config/config.php
+/config/mount.php
+/apps/inc.php
 
 # ignore all apps except core ones
-apps*
-!apps/files
-!apps/files_encryption
-!apps/files_external
-!apps/files_sharing
-!apps/files_trashbin
-!apps/files_versions
-!apps/user_ldap
-!apps/user_webdavauth
+/apps*
+!/apps/files
+!/apps/files_encryption
+!/apps/files_external
+!/apps/files_sharing
+!/apps/files_trashbin
+!/apps/files_versions
+!/apps/user_ldap
+!/apps/user_webdavauth
 
 # ignore themes except the README
-themes/*
-!themes/README
+/themes/*
+!/themes/README
 
 # just sane ignores
 .*.sw[po]
@@ -76,7 +76,7 @@ nbproject
 /tests/phpunit.xml
 
 # Tests - auto-generated files
-data-autotest
+/data-autotest
 /tests/coverage*
 /tests/autoconfig*
 /tests/autotest*


### PR DESCRIPTION
Paths without the leading slash apply to all subdirectories, which especially
means that /tests/data is ignored, making it unnecessarily hard to add test
data.
