### PR TITLE
Adds a workaround for mime type detection of empty files.

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -399,6 +399,11 @@ class OC_Helper {
 
 		$mimeType = self::getFileNameMimeType($path);
 
+		// Workaround for https://bugs.php.net/bug.php?id=58023
+		if($mimeType=='application/octet-stream' && filesize($path) == 0){
+			return 'inode/x-empty';
+		}
+
 		if($mimeType=='application/octet-stream' and function_exists('finfo_open')
 			and function_exists('finfo_file') and $finfo=finfo_open(FILEINFO_MIME)) {
 			$info = @strtolower(finfo_file($finfo, $path));

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -400,7 +400,7 @@ class OC_Helper {
 		$mimeType = self::getFileNameMimeType($path);
 
 		// Workaround for https://bugs.php.net/bug.php?id=58023
-		if($mimeType=='application/octet-stream' && filesize($path) == 0){
+		if($mimeType === 'application/octet-stream' && filesize($path) === 0){
 			return 'inode/x-empty';
 		}
 


### PR DESCRIPTION
If you upload an empty file with no extension, php and the the apache process crashes on my system.
This bug was reported to PHP some years ago, but isn't fixed yet: https://bugs.php.net/bug.php?id=58023

My patch returns the same mime type the command `file --mime-type` would return, but only if the file has no extension and `self::getFileNameMimeType()` therefore returns `application/octet-stream`.
