### PR TITLE
Fix cancel action when uploading existing files

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -388,8 +388,7 @@ $(document).ready(function(){
 	});
 	$('#notification:first-child').on('click', '.cancel', function() {
 		if ($('#notification > span').attr('data-isNewFile')) {
-			FileList.deleteCanceled = false;
-			FileList.deleteFiles = [$('#notification > span').attr('data-oldName')];
+			FileActions.actions.all.Delete.action($('#notification > span').attr('data-oldName'));
 		}
 	});
 	FileList.useUndo=(window.onbeforeunload)?true:false;


### PR DESCRIPTION
This is a partial fix for #3728 and fixes the behaviour of the "cancel" button when uploading a file that already exists.

However when uploading multiple existing files the notification only allows to cancel or replace one of the conflicting files (the other files are always "suggest new name") @MTGap I believe this was your work?

Only stable5 is currently effected since master doesn't show the notification at all (maybe related to the upload cleanup @butonic ?), should be cherry-picked into master after merge anyway.

cc @karlitschek @DeepDiver1975
