### PR TITLE
Emit signals for part files

### DIFF
--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -678,7 +678,7 @@ class View {
 	private function runHooks($hooks, $path, $post = false) {
 		$prefix = ($post) ? 'post_' : '';
 		$run = true;
-		if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot()) {
+		if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path)) {
 			foreach ($hooks as $hook) {
 				if ($hook != 'read') {
 					\OC_Hook::emit(

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -350,7 +350,16 @@ class View {
 				return false;
 			}
 			$run = true;
-			if ($this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path1)) {
+			if ($this->fakeRoot == Filesystem::getRoot() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
+				// if it was a rename from a part file to a regular file it was a write and not a rename operation
+				\OC_Hook::emit(
+					Filesystem::CLASSNAME, Filesystem::signal_write,
+					array(
+						Filesystem::signal_param_path => $path2,
+						Filesystem::signal_param_run => &$run
+					)
+				);
+			} elseif ($this->fakeRoot == Filesystem::getRoot()) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, Filesystem::signal_rename,
 					array(
@@ -388,7 +397,16 @@ class View {
 						}
 					}
 				}
-				if ($this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path1) && $result !== false) {
+				if ($this->fakeRoot == Filesystem::getRoot() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false) {
+					// if it was a rename from a part file to a regular file it was a write and not a rename operation
+					\OC_Hook::emit(
+						Filesystem::CLASSNAME,
+						Filesystem::signal_post_write,
+						array(
+							Filesystem::signal_param_path => $path2,
+						)
+					);
+				} elseif ($this->fakeRoot == Filesystem::getRoot() && $result !== false) {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_post_rename,


### PR DESCRIPTION
This should fix issue: https://github.com/owncloud/core/issues/3797

Currently we don't emit any post signals for part file operations. So the sharing app will never get a notification about newly uploaded files and therefore never update the etags for the share-folders.

This patch emits a post_write hook after a successful rename from a .part file to a regular file, because it this case the operation wasn't a rename but actually a "2-step-write" operation.

cc @MTGap @icewind1991 please have a look at it.
