### PR TITLE
Add a "Wrong password." message, if the password for the public share was wrong.

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -79,7 +79,7 @@ if (isset($path)) {
 											 $linkItem['share_with']))) {
 					$tmpl = new OCP\Template('files_sharing', 'authenticate', 'guest');
 					$tmpl->assign('URL', $url);
-					$tmpl->assign('error', true);
+					$tmpl->assign('wrongpw', true);
 					$tmpl->printPage();
 					exit();
 				} else {

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -1,5 +1,8 @@
 <form action="<?php p($_['URL']); ?>" method="post">
 	<fieldset>
+		<?php if ($_['wrongpw']): ?>
+		<div class="warning"><?php p($l->t('Wrong password.')); ?></div>
+		<?php endif; ?>
 		<p class="infield">
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<input type="password" name="password" id="password" placeholder="" value="" autofocus />

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -1,7 +1,7 @@
 <form action="<?php p($_['URL']); ?>" method="post">
 	<fieldset>
 		<?php if ($_['wrongpw']): ?>
-		<div class="warning"><?php p($l->t('Wrong password.')); ?></div>
+		<div class="warning"><?php p($l->t('The password is wrong. Try again.')); ?></div>
 		<?php endif; ?>
 		<p class="infield">
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>


### PR DESCRIPTION
Fix #2725

Why hasn't anyone worked on this :|

@MTGap @jancborchardt @tanghus 

Suggestions in #2725 were very hard to choose from, and I especially loved

> »You typed in a wrong password you stupid idiot. Now because you can’t do anything right, we just deleted the file completely. You can clear that up with the person who shared the link with you. Good luck, dumbass.«

`Wrong password.` is pretty simple and should do the job though.
