### PR TITLE
[ie8] Fix lazy CSS loading and missing borders in search dropdown

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -226,8 +226,12 @@ var OC={
 		var path=OC.filePath(app,'css',style+'.css');
 		if(OC.addStyle.loaded.indexOf(path)===-1){
 			OC.addStyle.loaded.push(path);
-			style=$('<link rel="stylesheet" type="text/css" href="'+path+'"/>');
-			$('head').append(style);
+			if (document.createStyleSheet) {
+				document.createStyleSheet(path);
+			} else {
+				style=$('<link rel="stylesheet" type="text/css" href="'+path+'"/>');
+				$('head').append(style);
+			}
 		}
 	},
 	basename: function(path) {

--- a/search/css/results.css
+++ b/search/css/results.css
@@ -17,6 +17,10 @@
  	width:26.5em;
  	z-index:75;
  }
+ 
+ .ie8 #searchresults {
+	 border: 1px solid #666 !important;
+ }
 
  #searchresults li.resultHeader {
  	background-color:#eee;


### PR DESCRIPTION
- IE8 doesn't apply stylesheets added with jQuery. http://stackoverflow.com/a/6079832
  It causes e.g. invisible search dropdown  https://github.com/owncloud/core/issues/3716#issuecomment-20197304
- Added border to the search results in IE as it doesn't support box-shadow.

cc @DeepDiver1975 @jancborchardt 
