### PR TITLE
Suppress warning in setup if config.php doesn't exist

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -144,7 +144,7 @@ class OC_Config{
 
 		//Include file and merge config
 		foreach($config_files as $file){
-			include $file;
+			@include $file;
 			if( isset( $CONFIG ) && is_array( $CONFIG )) {
 				self::$cache = array_merge(self::$cache, $CONFIG);
 			}


### PR DESCRIPTION
More of a cosmetic issue …

Delete config/config.php (and data-dir) to reset your instance, and let php-warnings show and you'll get:

```
Warning: include(/testcloud/config/config.php): failed to open stream: No such file or directory in /testcloud/lib/config.php on line 147

Warning: include(): Failed opening '/testcloud/config/config.php' for inclusion (include_path='/testcloud/lib:.:') in /home/http/testcloud/lib/config.php on line 147
```

@DeepDiver1975 @icewind1991 @Raydiation @karlitschek 
