### PR TITLE
OC_Updater::ShowUpdatingHint no longer exists in master

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -234,7 +234,7 @@ endfor;?>
 	<legend><strong><?php p($l->t('Version'));?></strong></legend>
 	<strong><?php p(OC_Defaults::getName()); ?></strong> <?php p(OC_Util::getVersionString()); ?>
 <?php if (OC_Util::getEditionString() === ''): ?>
-	(<?php print_unescaped(OC_Updater::ShowUpdatingHint()); ?>)<br/>
+	<br/>
 	<?php print_unescaped($l->t('Developed by the <a href="http://ownCloud.org/contact" target="_blank">ownCloud community</a>, the <a href="https://github.com/owncloud" target="_blank">source code</a> is licensed under the <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank"><abbr title="Affero General Public License">AGPL</abbr></a>.')); ?>
 <?php endif; ?>
 </fieldset>


### PR DESCRIPTION
Removed OC_Updater::ShowUpdatingHint since for master we show update notification on all pages

To reproduce pull recent master and browse to the admin page:

![admin](https://f.cloud.github.com/assets/991300/744366/11a3cb2a-e3fb-11e2-9184-a7162d75c691.png)

@schiesbn @DeepDiver1975 
