### PR TITLE
Do not add groups if user has no groups

### DIFF
--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -449,8 +449,10 @@ $(document).ready(function () {
 					OC.dialogs.alert(result.data.message,
 						t('settings', 'Error creating user'));
 				} else {
-					var addedGroups = result.data.groups.split(', ');
-					UserList.availableGroups = $.unique($.merge(UserList.availableGroups, addedGroups));
+					if (result.data.groups) {
+						var addedGroups = result.data.groups.split(', ');
+						UserList.availableGroups = $.unique($.merge(UserList.availableGroups, addedGroups));
+					}
 					if($('tr[data-uid="' + username + '"]').length === 0) {
 						UserList.add(username, username, result.data.groups, null, 'default', true);
 					}


### PR DESCRIPTION
Steps To reproduce:
- create a new user and don't add him into any group.

This user will have an empty checkbox in group list until the page is reloaded

Fixes https://github.com/owncloud/enterprise/issues/16
