### PR TITLE
Refresh if maintenance mode is over

### DIFF
--- a/core/js/maintenance-check.js
+++ b/core/js/maintenance-check.js
@@ -1,0 +1,20 @@
+// Check every 20 seconds via status.php if maintenance is over
+window.setInterval(checkStatus, 20000);
+
+function checkStatus() {
+	var request = new XMLHttpRequest();
+	var ocroot = location.pathname.substr(
+		0, location.pathname.indexOf('index.php')
+	);
+	request.open("GET", ocroot+'status.php', true);
+	request.send();
+	request.onreadystatechange = function() {
+		if (request.readyState === 4) {
+			var response = request.responseText;
+			var responseobj = JSON.parse(response);
+			if (responseobj.maintenance === 'false') {
+				window.location.reload();
+			}
+		}
+	};
+}

--- a/core/templates/update.user.php
+++ b/core/templates/update.user.php
@@ -1,7 +1,7 @@
 <ul>
 	<li class='update'>
 		<?php p($l->t('This ownCloud instance is currently being updated, which may take a while.')) ?><br/><br/>
-		<?php p($l->t('Please reload this page after a short time to continue using ownCloud.')) ?><br/><br/>
+		<?php p($l->t('This page will refresh itself when the ownCloud instance is available again.')) ?><br/><br/>
 		<?php p($l->t('Contact your system administrator if this message persists or appeared unexpectedly.')) ?><br/><br/>
 		<?php p($l->t('Thank you for your patience.')); ?><br/><br/>
 	</li>

--- a/lib/base.php
+++ b/lib/base.php
@@ -255,6 +255,7 @@ class OC {
 
 			// render error page
 			$tmpl = new OC_Template('', 'update.user', 'guest');
+			OC_Util::addscript('maintenance-check');
 			$tmpl->printPage();
 			die();
 		}

--- a/status.php
+++ b/status.php
@@ -25,9 +25,11 @@ try {
 
 	require_once 'lib/base.php';
 
-	if(OC_Config::getValue('installed')==1) $installed='true'; else $installed='false';
+	$installed = OC_Config::getValue('installed') == 1;
+	$maintenance = OC_Config::getValue('maintenance', false);
 	$values=array(
 		'installed'=>$installed,
+		'maintenance' => $maintenance,
 		'version'=>implode('.', OC_Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
 		'edition'=>OC_Util::getEditionString());


### PR DESCRIPTION
Using status.php for this.
I modified status.php to also show, whether we're in maintenance.

Checks every 20 seconds if maintenance is over, if yes: reload.

@karlitschek @tanghus @Raydiation 
