### PR TITLE
Add path encoding to public API.

### DIFF
--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -7,8 +7,7 @@
 <?php endif;?>
 <?php for($i=0; $i<count($_["breadcrumb"]); $i++):
 	$crumb = $_["breadcrumb"][$i];
-	$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
-	$dir = str_replace('%2F', '/', $dir); ?>
+	$dir = \OCP\Util::encodePath($crumb["dir"]); ?>
 	<div class="crumb <?php if($i == count($_["breadcrumb"])-1) p('last');?> svg"
 		 data-dir='<?php p($dir);?>'>
 	<a href="<?php p($_['baseURL'].$dir); ?>"><?php p($crumb["name"]); ?></a>

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -17,10 +17,8 @@ $totalsize = 0; ?>
 	// the older the file, the brighter the shade of grey; days*14
 	$relative_date_color = round((time()-$file['mtime'])/60/60/24*14);
 	if($relative_date_color>160) $relative_date_color = 160;
-	$name = rawurlencode($file['name']);
-	$name = str_replace('%2F', '/', $name);
-	$directory = rawurlencode($file['directory']);
-	$directory = str_replace('%2F', '/', $directory); ?>
+	$name = \OCP\Util::encodePath($file['name']);
+	$directory = \OCP\Util::encodePath($file['directory']); ?>
 	<tr data-id="<?php p($file['fileid']); ?>"
 		data-file="<?php p($name);?>"
 		data-type="<?php ($file['type'] == 'dir')?p('dir'):p('file')?>"

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -101,12 +101,15 @@ $breadcrumbNav->assign('home', OCP\Util::linkTo('files', 'index.php'));
 
 $list = new OCP\Template('files_trashbin', 'part.list', '');
 $list->assign('files', $files);
-$list->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php'). '?dir='.$dir);
-$list->assign('downloadURL', OCP\Util::linkTo('files_trashbin', 'download.php') . '?file='.$dir);
+
+$encodedDir = \OCP\Util::encodePath($dir);
+$list->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php'). '?dir='.$encodedDir);
+$list->assign('downloadURL', OCP\Util::linkTo('files_trashbin', 'download.php') . '?file='.$encodedDir);
 $list->assign('disableSharing', true);
 $list->assign('dirlisting', $dirlisting);
-$tmpl->assign('dirlisting', $dirlisting);
 $list->assign('disableDownloadActions', true);
+
+$tmpl->assign('dirlisting', $dirlisting);
 $tmpl->assign('breadcrumb', $breadcrumbNav->fetchPage());
 $tmpl->assign('fileList', $list->fetchPage());
 $tmpl->assign('files', $files);

--- a/apps/files_trashbin/templates/part.breadcrumb.php
+++ b/apps/files_trashbin/templates/part.breadcrumb.php
@@ -11,8 +11,7 @@
 <?php endif;?>
 <?php for($i=0; $i<count($_["breadcrumb"]); $i++):
 	$crumb = $_["breadcrumb"][$i];
-	$dir = str_replace('+', '%20', urlencode($crumb["dir"]));
-	$dir = str_replace('%2F', '/', $dir); ?>
+	$dir = \OCP\Util::encodePath($crumb["dir"]); ?>
 	<div class="crumb <?php if($i == count($_["breadcrumb"])-1) p('last');?> svg"
 		 data-dir='<?php p($dir);?>'>
 	<a href="<?php p($_['baseURL'].$dir); ?>"><?php p($crumb["name"]); ?></a>

--- a/apps/files_trashbin/templates/part.list.php
+++ b/apps/files_trashbin/templates/part.list.php
@@ -4,10 +4,8 @@
 	// the older the file, the brighter the shade of grey; days*14
 	$relative_date_color = round((time()-$file['date'])/60/60/24*14);
 	if($relative_date_color>200) $relative_date_color = 200;
-	$name = str_replace('+', '%20', urlencode($file['name']));
-	$name = str_replace('%2F', '/', $name);
-	$directory = str_replace('+', '%20', urlencode($file['directory']));
-	$directory = str_replace('%2F', '/', $directory); ?>
+	$name = \OCP\Util::encodePath($file['name']);
+	$directory = \OCP\Util::encodePath($file['directory']); ?>
 	<tr data-filename="<?php p($file['name']);?>"
 		data-type="<?php ($file['type'] == 'dir')?p('dir'):p('file')?>"
 		data-mime="<?php p($file['mimetype'])?>"

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -355,6 +355,20 @@ class Util {
 	public static function sanitizeHTML( $value ) {
 		return(\OC_Util::sanitizeHTML($value));
 	}
+		
+	/**
+	 * @brief Public function to encode url parameters
+	 *
+	 * This function is used to encode path to file before output.
+	 * Encoding is done according to RFC 3986 with one exception:
+	 * Character '/' is preserved as is. 
+	 *
+	 * @param string $component part of URI to encode
+	 * @return string 
+	 */
+	public static function encodePath($component) {
+		return(\OC_Util::encodePath($component));
+	}
 
 	/**
 	* @brief Returns an array with all keys from input lowercased or uppercased. Numbered indices are left as is.

--- a/lib/util.php
+++ b/lib/util.php
@@ -539,7 +539,22 @@ class OC_Util {
 		}
 		return $value;
 	}
-
+	
+	/**
+	 * @brief Public function to encode url parameters
+	 *
+	 * This function is used to encode path to file before output.
+	 * Encoding is done according to RFC 3986 with one exception:
+	 * Character '/' is preserved as is. 
+	 *
+	 * @param string $component part of URI to encode
+	 * @return string 
+	 */
+	public static function encodePath($component) {
+		$encoded = rawurlencode($component);
+		$encoded = str_replace('%2F', '/', $encoded);
+		return $encoded;
+	}
 
 	/**
 	 * Check if the htaccess file is working by creating a test file in the data directory and trying to access via http

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -37,6 +37,12 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$result = OC_Util::sanitizeHTML($goodString);
 		$this->assertEquals("This is an harmless string.", $result);
 	}
+	
+	function testEncodePath(){
+		$component = '/§#@test%&^ä/-child';
+		$result = OC_Util::encodePath($component);
+		$this->assertEquals("/%C2%A7%23%40test%25%26%5E%C3%A4/-child", $result);
+	}
 
 	function testGenerate_random_bytes() {
 		$result = strlen(OC_Util::generate_random_bytes(59));


### PR DESCRIPTION
Better attempt to fix https://github.com/owncloud/core/issues/3856

Supersedes https://github.com/owncloud/core/pull/3877

To reproduce:
- create a directory named a#@ in Web UI
- create two nested subdirectories under a#@: a#@/1 and a#@/1/2
- Delete a#@ 
- Go to 'Deleted files'
- Check if it is possible to browse into '2'

@schiesbn, @icewind1991
