### PR TITLE
Scanner test: ensure mtime in the cache is the same as on the storage to...

### DIFF
--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -132,6 +132,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->scanner->scan('');
 		$oldData = $this->cache->get('');
 		$this->storage->unlink('folder/bar.txt');
+		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder')));
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
 		$this->assertNotEquals($oldData['etag'], $newData['etag']);


### PR DESCRIPTION
... prevent random failures

This should prevent the random `Test\Files\Cache\Scanner::testReuseExisting` failures for jenkins

cc @karlitschek @DeepDiver1975 @MTGap 
