### PR TITLE
OC_Config: handle failure of glob('*.config.php')

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -132,6 +132,9 @@ class OC_Config{
 
 		// read all file in config dir ending by config.php
 		$config_files = glob( OC::$SERVERROOT."/config/*.config.php");
+		if (!is_array($config_files)) {
+			$config_files = array();
+		}
 
 		//Filter only regular files
 		$config_files = array_filter($config_files, 'is_file');


### PR DESCRIPTION
Currently if glob('*.config.php') fails for some reason (it does on my host) it fails to read the config file since `$config_files` is not an array and always displays the setup page.

cc @karlitschek @DeepDiver1975 @tanghus @VicDeo 
