### PR TITLE
speedup for propfinds on shared folders

### DIFF
--- a/apps/files_sharing/lib/permissions.php
+++ b/apps/files_sharing/lib/permissions.php
@@ -71,6 +71,28 @@ class Shared_Permissions extends Permissions {
 	}
 
 	/**
+	 * get the permissions for all files in a folder
+	 *
+	 * @param int $parentId
+	 * @param string $user
+	 * @return int[]
+	 */
+	public function getDirectoryPermissions($parentId, $user) {
+		// Root of the Shared folder
+		if ($parentId === -1) {
+			return \OCP\Share::getItemsSharedWith('file', \OC_Share_Backend_File::FORMAT_PERMISSIONS);
+		}
+		$permissions = $this->get($parentId, $user);
+		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `parent` = ?');
+		$result = $query->execute(array($parentId));
+		$filePermissions = array();
+		while ($row = $result->fetchRow()) {
+			$filePermissions[$row['fileid']] = $permissions;
+		}
+		return $filePermissions;
+	}
+
+	/**
 	 * remove the permissions for a file
 	 *
 	 * @param int $fileId
@@ -83,4 +105,5 @@ class Shared_Permissions extends Permissions {
 	public function removeMultiple($fileIds, $user) {
 		// Not a valid action for Shared Permissions
 	}
+
 }

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -26,6 +26,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	const FORMAT_FILE_APP_ROOT = 2;
 	const FORMAT_OPENDIR = 3;
 	const FORMAT_GET_ALL = 4;
+	const FORMAT_PERMISSIONS = 5;
 
 	private $path;
 
@@ -125,6 +126,12 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 				$ids[] = $item['file_source'];
 			}
 			return $ids;
+		} else if ($format === self::FORMAT_PERMISSIONS) {
+			$filePermissions = array();
+			foreach ($items as $item) {
+				$filePermissions[$item['file_source']] = $item['permissions'];
+			}
+			return $filePermissions;
 		}
 		return array();
 	}

--- a/lib/files/cache/permissions.php
+++ b/lib/files/cache/permissions.php
@@ -89,14 +89,15 @@ class Permissions {
 	 * get the permissions for all files in a folder
 	 *
 	 * @param int $parentId
+	 * @param string $user
 	 * @return int[]
 	 */
-	public function getDirectoryPermissions($parentId) {
+	public function getDirectoryPermissions($parentId, $user) {
 		$query = \OC_DB::prepare('SELECT `*PREFIX*permissions`.`fileid`, `permissions`
- 			FROM  `*PREFIX*permissions` INNER JOIN  `*PREFIX*filecache` ON  `*PREFIX*permissions`.fileid =  `*PREFIX*filecache`.fileid
- 			WHERE  `*PREFIX*filecache`.parent = ?');
+			FROM `*PREFIX*permissions` INNER JOIN `*PREFIX*filecache` ON `*PREFIX*permissions`.`fileid` = `*PREFIX*filecache`.`fileid`
+			WHERE `*PREFIX*filecache`.`parent` = ? AND `*PREFIX*permissions`.`user` = ?');
 
-		$result = $query->execute(array($parentId));
+		$result = $query->execute(array($parentId, $user));
 		$filePermissions = array();
 		while ($row = $result->fetchRow()) {
 			$filePermissions[$row['fileid']] = $row['permissions'];

--- a/lib/files/cache/permissions.php
+++ b/lib/files/cache/permissions.php
@@ -86,6 +86,25 @@ class Permissions {
 	}
 
 	/**
+	 * get the permissions for all files in a folder
+	 *
+	 * @param int $parentId
+	 * @return int[]
+	 */
+	public function getDirectoryPermissions($parentId) {
+		$query = \OC_DB::prepare('SELECT `*PREFIX*permissions`.`fileid`, `permissions`
+ 			FROM  `*PREFIX*permissions` INNER JOIN  `*PREFIX*filecache` ON  `*PREFIX*permissions`.fileid =  `*PREFIX*filecache`.fileid
+ 			WHERE  `*PREFIX*filecache`.parent = ?');
+
+		$result = $query->execute(array($parentId));
+		$filePermissions = array();
+		while ($row = $result->fetchRow()) {
+			$filePermissions[$row['fileid']] = $row['permissions'];
+		}
+		return $filePermissions;
+	}
+
+	/**
 	 * remove the permissions for a file
 	 *
 	 * @param int $fileId

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -264,7 +264,7 @@ class View {
 			$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 			if (\OC_FileProxy::runPreProxies('file_put_contents', $absolutePath, $data)
 				and Filesystem::isValidPath($path)
-				and ! Filesystem::isFileBlacklisted($path)
+					and !Filesystem::isFileBlacklisted($path)
 			) {
 				$path = $this->getRelativePath($absolutePath);
 				$exists = $this->file_exists($path);
@@ -341,7 +341,7 @@ class View {
 			\OC_FileProxy::runPreProxies('rename', $absolutePath1, $absolutePath2)
 			and Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and ! Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isFileBlacklisted($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -434,7 +434,7 @@ class View {
 			\OC_FileProxy::runPreProxies('copy', $absolutePath1, $absolutePath2)
 			and Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and ! Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isFileBlacklisted($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -648,7 +648,7 @@ class View {
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (\OC_FileProxy::runPreProxies($operation, $absolutePath, $extraParam)
 			and Filesystem::isValidPath($path)
-			and ! Filesystem::isFileBlacklisted($path)
+				and !Filesystem::isFileBlacklisted($path)
 		) {
 			$path = $this->getRelativePath($absolutePath);
 			if ($path == null) {
@@ -812,18 +812,18 @@ class View {
 			}
 
 			$files = $cache->getFolderContents($internalPath); //TODO: mimetype_filter
+			$permissions = $permissionsCache->getDirectoryPermissions($cache->getId($internalPath));
 
 			$ids = array();
 			foreach ($files as $i => $file) {
 				$files[$i]['type'] = $file['mimetype'] === 'httpd/unix-directory' ? 'dir' : 'file';
 				$ids[] = $file['fileid'];
 
-				$permissions = $permissionsCache->get($file['fileid'], $user);
-				if ($permissions === -1) {
-					$permissions = $storage->getPermissions($file['path']);
-					$permissionsCache->set($file['fileid'], $user, $permissions);
+				if (!isset($permissions[$file['fileid']])) {
+					$permissions[$file['fileid']] = $storage->getPermissions($file['path']);
+					$permissionsCache->set($file['fileid'], $user, $permissions[$file['fileid']]);
 				}
-				$files[$i]['permissions'] = $permissions;
+				$files[$i]['permissions'] = $permissions[$file['fileid']];
 			}
 
 			//add a folder for any mountpoint in this directory and add the sizes of other mountpoints to the folders

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -812,7 +812,7 @@ class View {
 			}
 
 			$files = $cache->getFolderContents($internalPath); //TODO: mimetype_filter
-			$permissions = $permissionsCache->getDirectoryPermissions($cache->getId($internalPath));
+			$permissions = $permissionsCache->getDirectoryPermissions($cache->getId($internalPath), $user);
 
 			$ids = array();
 			foreach ($files as $i => $file) {


### PR DESCRIPTION
A PROPFIND request still takes ~10 times longer on a shared directory than on an unshared one, but without these patches it takes about ~200 times as long. These changes seem to work for me.

Before: ~70 seconds, after: ~4 seconds. Unshared access: ~0.3 seconds. 

PHP scripts do, by default, not execute for more than 30 seconds on Ubuntu, and most likely on other distributions too. Thus, PROPFINDs taking longer than 30 seconds won't work, breaking the OC sync client. (Maybe the webinterface too.)

This is a significant improvement and people ask for it: see http://mail.kde.org/pipermail/owncloud/2013-June/009758.html, ff, and issue #2846 .

@icewind1991 @MTGap Any objections? Are additional patches needed? 

@karlitschek Please consider this for 5.0.8 (RC2?) 
