### PR TITLE
Adding plural translations to ownCloud

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -33,7 +33,7 @@ if (oc_debug !== true || typeof console === "undefined" || typeof console.log ==
  * @return string
  */
 function t(app, text, vars, count){
-	if( !( t.cache[app] )){
+	if( !( t.cache[app] )) {
 		$.ajax(OC.filePath('core','ajax','translations.php'),{
 			async:false,//todo a proper sollution for this without sync ajax calls
 			data:{'app': app},
@@ -49,8 +49,7 @@ function t(app, text, vars, count){
 		}
 	}
 	var _build = function (text, vars, count) {
-		// FIXME: replace %n with content of count
-		return text.replace(/{([^{}]*)}/g,
+		return text.replace(/%n/g, count).replace(/{([^{}]*)}/g,
 			function (a, b) {
 				var r = vars[b];
 				return typeof r === 'string' || typeof r === 'number' ? r : a;
@@ -62,7 +61,7 @@ function t(app, text, vars, count){
 		translation = t.cache[app][text];
 	}
 
-	if(typeof vars === 'object' || typeof count !== 'undefined' ) {
+	if(typeof vars === 'object' || count !== undefined ) {
 		return _build(translation, vars, count);
 	} else {
 		return translation;
@@ -79,8 +78,8 @@ t.cache={};
  * @param vars (optional) FIXME
  * @return string
  */
-function tp(app, text_singular, text_plural, count, vars){
-	if(count==1){
+function n(app, text_singular, text_plural, count, vars){
+	if(count === 1) {
 		return t(app, text_singular, vars, count);
 	}
 	else{

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1,6 +1,6 @@
 /**
  * Disable console output unless DEBUG mode is enabled.
- * Add 
+ * Add
  *	 define('DEBUG', true);
  * To the end of config/config.php to enable debug mode.
  * The undefined checks fix the broken ie8 console
@@ -28,9 +28,11 @@ if (oc_debug !== true || typeof console === "undefined" || typeof console.log ==
  * translate a string
  * @param app the id of the app for which to translate the string
  * @param text the string to translate
+ * @param vars (optional) FIXME
+ * @param count (optional) number to replace %n with
  * @return string
  */
-function t(app,text, vars){
+function t(app, text, vars, count){
 	if( !( t.cache[app] )){
 		$.ajax(OC.filePath('core','ajax','translations.php'),{
 			async:false,//todo a proper sollution for this without sync ajax calls
@@ -46,7 +48,8 @@ function t(app,text, vars){
 			t.cache[app] = [];
 		}
 	}
-	var _build = function (text, vars) {
+	var _build = function (text, vars, count) {
+		// FIXME: replace %n with content of count
 		return text.replace(/{([^{}]*)}/g,
 			function (a, b) {
 				var r = vars[b];
@@ -54,30 +57,44 @@ function t(app,text, vars){
 			}
 		);
 	};
+	var translation = text;
 	if( typeof( t.cache[app][text] ) !== 'undefined' ){
-		if(typeof vars === 'object') {
-			return _build(t.cache[app][text], vars);
-		} else {
-			return t.cache[app][text];
-		}
+		translation = t.cache[app][text];
 	}
-	else{
-		if(typeof vars === 'object') {
-			return _build(text, vars);
-		} else {
-			return text;
-		}
+
+	if(typeof vars === 'object' || typeof count !== 'undefined' ) {
+		return _build(translation, vars, count);
+	} else {
+		return translation;
 	}
 }
 t.cache={};
 
-/*
+/**
+ * translate a string
+ * @param app the id of the app for which to translate the string
+ * @param text_singular the string to translate for exactly one object
+ * @param text_plural the string to translate for n objects
+ * @param count number to determine whether to use singular or plural
+ * @param vars (optional) FIXME
+ * @return string
+ */
+function tp(app, text_singular, text_plural, count, vars){
+	if(count==1){
+		return t(app, text_singular, vars, count);
+	}
+	else{
+		return t(app, text_plural, vars, count);
+	}
+}
+
+/**
 * Sanitizes a HTML string
-* @param string
+* @param s string
 * @return Sanitized string
 */
 function escapeHTML(s) {
-		return s.toString().split('&').join('&amp;').split('<').join('&lt;').split('"').join('&quot;');
+	return s.toString().split('&').join('&amp;').split('<').join('&lt;').split('"').join('&quot;');
 }
 
 /**
@@ -741,7 +758,7 @@ OC.get=function(name) {
 	var namespaces = name.split(".");
 	var tail = namespaces.pop();
 	var context=window;
-	
+
 	for(var i = 0; i < namespaces.length; i++) {
 		context = context[namespaces[i]];
 		if(!context){
@@ -760,7 +777,7 @@ OC.set=function(name, value) {
 	var namespaces = name.split(".");
 	var tail = namespaces.pop();
 	var context=window;
-	
+
 	for(var i = 0; i < namespaces.length; i++) {
 		if(!context[namespaces[i]]){
 			context[namespaces[i]]={};

--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -138,14 +138,14 @@ elsif( $task eq 'write' ){
 				# Do we use singular or plural?
 				if( defined( $string->msgstr_n() )){
 					my @variants = ();
-					my $identifier = $string->msgid()."::".$string->msgid_plural()
+					my $identifier = $string->msgid()."::".$string->msgid_plural();
 					$identifier =~ s/"/_/g;
 
 					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
 						push( @variants, $string->msgstr_n()->{$variant} );
 					}
 
-					push( @strings, "\"$identifier\" => array(".join(@variants, ",").")";
+					push( @strings, "\"$identifier\" => array(".join(@variants, ",").")");
 				}
 				else{
 					next if $string->msgstr() eq '""';

--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -102,10 +102,10 @@ if( $task eq 'read' ){
 			next if $ignore{$file};
 			my $keywords = '';
 			if( $file =~ /\.js$/ ){
-				$keywords = '--keyword=t:2 --keyword=tp:2,3';
+				$keywords = '--keyword=t:2 --keyword=n:2,3';
 			}
 			else{
-				$keywords = '--keyword=t --keyword=tp:1,2';
+				$keywords = '--keyword=t --keyword=n:1,2';
 			}
 			my $language = ( $file =~ /\.js$/ ? 'Python' : 'PHP');
 			my $joinexisting = ( -e $output ? '--join-existing' : '');
@@ -137,10 +137,15 @@ elsif( $task eq 'write' ){
 
 				# Do we use singular or plural?
 				if( defined( $string->msgstr_n() )){
-					next if $string->msgstr_n()->{"0"} eq '""' ||
-					  $string->msgstr_n()->{"1"} eq '""';
-					push( @strings, $string->msgid()." => ".$string->msgstr_n()->{"0"} );
-					push( @strings, $string->msgid_plural()." => ".$string->msgstr_n()->{"1"} );
+					my @variants = ();
+					my $identifier = $string->msgid()."::".$string->msgid_plural()
+					$identifier =~ s/"/_/g;
+
+					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
+						push( @variants, $string->msgstr_n()->{$variant} );
+					}
+
+					push( @strings, "\"$identifier\" => array(".join(@variants, ",").")";
 				}
 				else{
 					next if $string->msgstr() eq '""';

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -176,13 +176,28 @@ class OC_L10N{
 	 *
 	 * Returns the translation. If no translation is found, $text will be
 	 * returned. %n will be replaced with the number of objects.
+	 *
+	 * In case there is more than one plural form you can add a function
+	 * "selectplural" in core/l10n/l10n-*.php
+	 *
+	 * Example:
+	 *
+	 *   [...]
+	 *   'selectplural' => function($i){return $i == 1 ? 0 : $i == 2 ? 1 : 2},
+	 *   [...]
 	 */
-	public function tp($text_singular, $text_plural, $count, $parameters = array()) {
-		if($count == 1){
-			return new OC_L10N_String($this, $text_singular, $parameters, $count);
+	public function n($text_singular, $text_plural, $count, $parameters = array()) {
+		$identifier = "_${text_singular}__${text_plural}_";
+		if(array_key_exists( $this->localizations, "selectplural") && array_key_exists($this->translations, $identifier)) {
+			return new OC_L10N_String( $this, $identifier, $parameters, $count );
 		}
 		else{
-			return new OC_L10N_String($this, $text_plural, $parameters, $count);
+			if($count === 1) {
+				return new OC_L10N_String($this, $text_singular, $parameters, $count);
+			}
+			else{
+				return new OC_L10N_String($this, $text_plural, $parameters, $count);
+			}
 		}
 	}
 
@@ -218,6 +233,17 @@ class OC_L10N{
 	public function getTranslations() {
 		$this->init();
 		return $this->translations;
+	}
+
+	/**
+	 * @brief get localizations
+	 * @returns Fetch all localizations
+	 *
+	 * Returns an associative array with all localizations
+	 */
+	public function getLocalizations() {
+		$this->init();
+		return $this->localizations;
 	}
 
 	/**

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -168,6 +168,26 @@ class OC_L10N{
 
 	/**
 	 * @brief Translating
+	 * @param $text_singular String the string to translate for exactly one object
+	 * @param $text_plural String the string to translate for n objects
+	 * @param $count Integer Number of objects
+	 * @param array $parameters default:array() Parameters for sprintf
+	 * @return \OC_L10N_String Translation or the same text
+	 *
+	 * Returns the translation. If no translation is found, $text will be
+	 * returned. %n will be replaced with the number of objects.
+	 */
+	public function tp($text_singular, $text_plural, $count, $parameters = array()) {
+		if($count == 1){
+			return new OC_L10N_String($this, $text_singular, $parameters, $count);
+		}
+		else{
+			return new OC_L10N_String($this, $text_plural, $parameters, $count);
+		}
+	}
+
+	/**
+	 * @brief Translating
 	 * @param $textArray The text array we need a translation for
 	 * @returns Translation or the same text
 	 *

--- a/lib/l10n/string.php
+++ b/lib/l10n/string.php
@@ -18,10 +18,17 @@ class OC_L10N_String{
 
 	public function __toString() {
 		$translations = $this->l10n->getTranslations();
+		$localizations = $this->l10n->getLocalizations();
 
 		$text = $this->text;
 		if(array_key_exists($this->text, $translations)) {
-			$text = $translations[$this->text];
+			if(is_array($translations[$this->text])) {
+				$id = $localizations["selectplural"]( $count );
+				$text = $translations[$this->text][$id]
+			}
+			else{
+				$text = $translations[$this->text];
+			}
 		}
 		// Replace %n first (won't interfere with vsprintf)
 		$text = str_replace('%n', $this->count, $text);

--- a/lib/l10n/string.php
+++ b/lib/l10n/string.php
@@ -24,7 +24,7 @@ class OC_L10N_String{
 		if(array_key_exists($this->text, $translations)) {
 			if(is_array($translations[$this->text])) {
 				$id = $localizations["selectplural"]( $count );
-				$text = $translations[$this->text][$id]
+				$text = $translations[$this->text][$id];
 			}
 			else{
 				$text = $translations[$this->text];

--- a/lib/l10n/string.php
+++ b/lib/l10n/string.php
@@ -8,18 +8,23 @@
 
 class OC_L10N_String{
 	protected $l10n;
-	public function __construct($l10n, $text, $parameters) {
+	public function __construct($l10n, $text, $parameters, $count = 1) {
 		$this->l10n = $l10n;
 		$this->text = $text;
 		$this->parameters = $parameters;
+		$this->count = $count;
 
 	}
 
 	public function __toString() {
 		$translations = $this->l10n->getTranslations();
+
+		$text = $this->text;
 		if(array_key_exists($this->text, $translations)) {
-			return vsprintf($translations[$this->text], $this->parameters);
+			$text = $translations[$this->text];
 		}
-		return vsprintf($this->text, $this->parameters);
+		// Replace %n first (won't interfere with vsprintf)
+		$text = str_replace('%n', $this->count, $text);
+		return vsprintf($text, $this->parameters);
 	}
 }


### PR DESCRIPTION
This PR adds the possibility to use plural in translations.
Closes #3935
# Help needed

I'm not very familiar with javascript. Please have a look at the **FIXME** -parts in js.js
# How does it work?

The new function OC_L10n::tp( $text_singular, $text_plural, $count, $vars ) uses the singular translation if $count is exactly 1 or the plural translation if $count is not 1.

This should be the same behaviour gettext shows.

In the translations **%n** will be replaced with the content of $count.
# Possible improvements

The content of $count could be checked/sanitized.
