### PR TITLE
enable oracle testing by default

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -143,11 +143,10 @@ EOF
 #
 if [ -z "$1" ]
   then
-	execute_tests "sqlite"
+	execute_tests 'sqlite'
 	execute_tests 'mysql'
 	execute_tests 'pgsql'
-	# we will add oci as soon as it's stable
-	#execute_tests 'oci'
+	execute_tests 'oci'
 else
 	execute_tests $1 $2 $3
 fi


### PR DESCRIPTION
wohoo! all the tests are passing for oracle in master, so we can enable oracle testing by default! This means new pull requests will now also be tested on oracle :)
@karlitschek @DeepDiver1975 
