### PR TITLE
Enable oci testing stable5

### DIFF
--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -49,8 +49,9 @@
 
    <field>
     <name>description</name>
-    <type>clob</type>
+    <type>text</type>
     <notnull>false</notnull>
+    <length>1024</length>
    </field>
 
    <field>


### PR DESCRIPTION
backport of testsuite changes that allow execution completion for stable5
@DeepDiver1975 @bartv2 
