### PR TITLE
add MB indicator to size heading, fix #3987

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -77,7 +77,7 @@
 					<?php endif; ?>
 				</span>
 			</th>
-			<th id="headerSize"><?php p($l->t( 'Size' )); ?></th>
+			<th id="headerSize"><?php p($l->t('Size (MB)')); ?></th>
 			<th id="headerDate">
 				<span id="modified"><?php p($l->t( 'Modified' )); ?></span>
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>


### PR DESCRIPTION
Even though it was said multiple times before, for future reference:
- We will not use multiple cardinalities, reason see https://github.com/owncloud/android/issues/189
- We will not use »MiB« because that’s »Men in Black«, not filesizes (honestly, no one knows what MiB is, but MB is well known)
- We will not add »MB« to each and every list item.

Please review @bantu @Kondou-ger @owncloud/designers 
