### PR TITLE
Simple console interface to update

### DIFF
--- a/console.php
+++ b/console.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright (c) 2013 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+require_once 'lib/base.php';
+
+// Don't do anything if ownCloud has not been installed
+if (!OC_Config::getValue('installed', false)) {
+	exit(0);
+}
+
+if (OC::$CLI) {
+	if ($argc > 1 && $argv[1] === 'update') {
+		$msg = function($msg) {
+			echo $msg."\n";
+		};
+		$failure = function($msg) {
+			echo 'Failure: ' . $msg . "\n";
+		};
+
+		$updater = new \OC\Updater(\OC_Log::$object);
+		$controller = new OC\Core\Controller\Update($updater);
+		$controller->doUpgrade($msg, $failure);
+	}
+}

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -3,34 +3,19 @@ set_time_limit(0);
 $RUNTIME_NOAPPS = true;
 require_once '../../lib/base.php';
 
-if (OC::checkUpgrade(false)) {
+if (OC::checkUpgrade(false)) { // to bad OC_EventSource starts output, otherwise this could also be in the controller
 	$eventSource = new OC_EventSource();
-	$updater = new \OC\Updater(\OC_Log::$object);
-	$updater->listen('\OC\Updater', 'maintenanceStart', function () use ($eventSource) {
-		$eventSource->send('success', 'Turned on maintenance mode');
-	});
-	$updater->listen('\OC\Updater', 'maintenanceEnd', function () use ($eventSource) {
-		$eventSource->send('success', 'Turned off maintenance mode');
-	});
-	$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($eventSource) {
-		$eventSource->send('success', 'Updated database');
-	});
-	$updater->listen('\OC\Updater', 'filecacheStart', function () use ($eventSource) {
-		$eventSource->send('success', 'Updating filecache, this may take really long...');
-	});
-	$updater->listen('\OC\Updater', 'filecacheDone', function () use ($eventSource) {
-		$eventSource->send('success', 'Updated filecache');
-	});
-	$updater->listen('\OC\Updater', 'filecacheProgress', function ($out) use ($eventSource) {
-		$eventSource->send('success', '... ' . $out . '% done ...');
-	});
-	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource) {
-		$eventSource->send('failure', $message);
+	$msg = function($msg) use ($eventSource) {
+		$eventSource->send('success', $msg);
+	};
+	$failure = function($msg) use ($eventSource) {
+		$eventSource->send('failure', $msg);
 		$eventSource->close();
-		OC_Config::setValue('maintenance', false);
-	});
+	};
 
-	$updater->upgrade();
+	$updater = new \OC\Updater(\OC_Log::$object);
+	$controller = new OC\Core\Controller\Update($updater);
+	$controller->doUpgrade($msg, $failure);
 
 	$eventSource->send('done', '');
 	$eventSource->close();

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -3,7 +3,8 @@ set_time_limit(0);
 $RUNTIME_NOAPPS = true;
 require_once '../../lib/base.php';
 
-if (OC::checkUpgrade(false)) { // to bad OC_EventSource starts output, otherwise this could also be in the controller
+// to bad OC_EventSource starts output, otherwise this could also be in the controller
+if (OC::checkUpgrade(false)) {
 	$eventSource = new OC_EventSource();
 	$msg = function($msg) use ($eventSource) {
 		$eventSource->send('success', $msg);

--- a/core/controller/update.php
+++ b/core/controller/update.php
@@ -9,8 +9,12 @@
 namespace OC\Core\Controller;
 
 class Update {
+	/**
+	 * @var \OC\Updater
+	 */
 	protected $updater;
 	protected $eventSource;
+
 
 	public function __construct($updater, $eventSource = null) {
 		$this->updater = $updater;
@@ -43,7 +47,7 @@ class Update {
 
 		try {
 			$this->updater->upgrade();
-		} catch(Exception $e) {
+		} catch(\Exception $e) {
 			$failure($e->getMessage());
 		}
 	}

--- a/core/controller/update.php
+++ b/core/controller/update.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright (c) 2013 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Controller;
+
+class Update {
+	protected $updater;
+	protected $eventSource;
+
+	public function __construct($updater, $eventSource = null) {
+		$this->updater = $updater;
+		$this->eventSource = $eventSource;
+	}
+
+	public function doUpgrade($msg, $failure) {
+		$this->updater->listen('\OC\Updater', 'maintenanceStart', function () use ($msg) {
+			$msg('Turned on maintenance mode');
+		});
+		$this->updater->listen('\OC\Updater', 'maintenanceEnd', function () use ($msg) {
+			$msg('Turned off maintenance mode');
+		});
+		$this->updater->listen('\OC\Updater', 'dbUpgrade', function () use ($msg) {
+			$msg('Updated database');
+		});
+		$this->updater->listen('\OC\Updater', 'filecacheStart', function () use ($msg) {
+			$msg('Updating filecache, this may take really long...');
+		});
+		$this->updater->listen('\OC\Updater', 'filecacheDone', function () use ($msg) {
+			$msg('Updated filecache');
+		});
+		$this->updater->listen('\OC\Updater', 'filecacheProgress', function ($out) use ($msg) {
+			$msg('... ' . $out . '% done ...');
+		});
+		$this->updater->listen('\OC\Updater', 'failure', function ($message) use ($failure) {
+			\OC_Config::setValue('maintenance', false);
+			$failure($message);
+		});
+
+		try {
+			$this->updater->upgrade();
+		} catch(Exception $e) {
+			$failure($e->getMessage());
+		}
+	}
+}


### PR DESCRIPTION
Simple for now, when doctrine is merged then we can use the Symfony2 Console component to make it more fancy.

Using this component doesn't add any code to 3rdparty, doctrine already depends on it. And then we can also add a setup console command and more.

@karlitschek @icewind1991 @DeepDiver1975 @MTGap @VicDeo 
