### PR TITLE
Use close.png instead of delete.png for closing dialogs

### DIFF
--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -35,7 +35,7 @@
 	position:absolute;
 	top:7px; right:7px;
 	height:20px; width:20px;
-	background:url('../img/actions/delete.svg') no-repeat center;
+	background:url('../img/actions/close.svg') no-repeat center;
 }
 
 .oc-dialog-dim {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -437,7 +437,7 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .popup { background-color:white; border-radius:10px 10px 10px 10px; box-shadow:0 0 20px #888; color:#333; padding:10px; position:fixed !important; z-index:200; }
 .popup.topright { top:7em; right:1em; }
 .popup.bottomleft { bottom:1em; left:33em; }
-.popup .close { position:absolute; top:0.2em; right:0.2em; height:20px; width:20px; background:url('../img/actions/delete.svg') no-repeat center; }
+.popup .close { position:absolute; top:0.2em; right:0.2em; height:20px; width:20px; background:url('../img/actions/close.svg') no-repeat center; }
 .popup h2 { font-weight:bold; font-size:1.2em; }
 .arrow { border-bottom:10px solid white; border-left:10px solid transparent; border-right:10px solid transparent; display:block; height:0; position:absolute; width:0; z-index:201; }
 .arrow.left { left:-13px; bottom:1.2em; -webkit-transform:rotate(270deg); -moz-transform:rotate(270deg); -o-transform:rotate(270deg); -ms-transform:rotate(270deg); transform:rotate(270deg); }


### PR DESCRIPTION
After #3757 ocdialogs and probably dialogs using `.popup` look a bit weird …

@jancborchardt @tanghus @kabum 
