### PR TITLE
EventSource and update fixes

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -14,7 +14,6 @@ if (OC::checkUpgrade(false)) {
 	OC_Log::write('core', 'starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, OC_Log::WARN);
 	$watcher = new UpdateWatcher($updateEventSource);
 	OC_Hook::connect('update', 'success', $watcher, 'success');
-	OC_Hook::connect('update', 'error', $watcher, 'error');
 	OC_Hook::connect('update', 'failure', $watcher, 'failure');
 	$watcher->success('Turned on maintenance mode');
 	try {
@@ -92,12 +91,6 @@ class UpdateWatcher {
 	public function success($message) {
 		OC_Util::obEnd();
 		$this->eventSource->send('success', $message);
-		ob_start();
-	}
-
-	public function error($message) {
-		OC_Util::obEnd();
-		$this->eventSource->send('error', $message);
 		ob_start();
 	}
 

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -5,11 +5,13 @@ require_once '../../lib/base.php';
 
 if (OC::checkUpgrade(false)) {
 	\OC_DB::enableCaching(false);
+
+	// initialize the event source before we enter maintenance mode because CSRF protection can terminate the script
+	$updateEventSource = new OC_EventSource();
 	OC_Config::setValue('maintenance', true);
 	$installedVersion = OC_Config::getValue('version', '0.0.0');
 	$currentVersion = implode('.', OC_Util::getVersion());
 	OC_Log::write('core', 'starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, OC_Log::WARN);
-	$updateEventSource = new OC_EventSource();
 	$watcher = new UpdateWatcher($updateEventSource);
 	OC_Hook::connect('update', 'success', $watcher, 'success');
 	OC_Hook::connect('update', 'error', $watcher, 'error');

--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -110,7 +110,11 @@ OC.EventSource.prototype={
 					this.listeners[type].push(callback);
 				}else{
 					this.source.addEventListener(type,function(e){
-						callback(JSON.parse(e.data));
+						if (typeof e.data != 'undefined') {
+							callback(JSON.parse(e.data));
+						} else {
+							callback('');
+						}
 					},false);
 				}
 			}else{

--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -23,13 +23,14 @@
  * wrapper for server side events (http://en.wikipedia.org/wiki/Server-sent_events)
  * includes a fallback for older browsers and IE
  *
- * use server side events with causion, to many open requests can hang the server
+ * use server side events with caution, to many open requests can hang the server
  */
 
 /**
  * create a new event source
- * @param string src
- * @param object data to be send as GET
+ * @param src
+ * @param data to be send as GET
+ * @constructor
  */
 OC.EventSource=function(src,data){
 	var dataStr='';

--- a/core/js/update.js
+++ b/core/js/update.js
@@ -5,6 +5,9 @@ $(document).ready(function () {
 	});
 	updateEventSource.listen('error', function(message) {
 		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));
+		message = 'Please reload the page.';
+		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));
+		updateEventSource.close();
 	});
 	updateEventSource.listen('failure', function(message) {
 		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));

--- a/lib/eventsource.php
+++ b/lib/eventsource.php
@@ -25,7 +25,7 @@
  * wrapper for server side events (http://en.wikipedia.org/wiki/Server-sent_events)
  * includes a fallback for older browsers and IE
  *
- * use server side events with causion, to many open requests can hang the server
+ * use server side events with caution, to many open requests can hang the server
  */
 class OC_EventSource{
 	private $fallback;
@@ -43,6 +43,7 @@ class OC_EventSource{
 			header("Content-Type: text/event-stream");
 		}
 		if( !OC_Util::isCallRegistered()) {
+			$this->send('error', 'Possible CSRF attack. Connection will be closed.');
 			exit();
 		}
 		flush();
@@ -51,10 +52,10 @@ class OC_EventSource{
 
 	/**
 	 * send a message to the client
-	 * @param string type
-	 * @param object data
+	 * @param string $type
+	 * @param object $data
 	 *
-	 * if only one paramater is given, a typeless message will be send with that paramater as data
+	 * if only one parameter is given, a typeless message will be send with that parameter as data
 	 */
 	public function send($type, $data=null) {
 		if(is_null($data)) {


### PR DESCRIPTION
fixes #4005 
- eventsource.php: in case of potential CSRF attack we send an error message from the EventSource to the browser
- eventsource.js: handle undefined data on event
- update.js: in case of error we close the event source - advise the user to reload the page
- update.php: EventSource initialization is now done before we enter the maintenance mode in order to allow browser reload in case of possible CSRF attack

@karlitschek @icewind1991 @MTGap @schiesbn @butonic THX
