### PR TITLE
EventSource and update fixes [master]

### DIFF
--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -110,7 +110,11 @@ OC.EventSource.prototype={
 					this.listeners[type].push(callback);
 				}else{
 					this.source.addEventListener(type,function(e){
-						callback(JSON.parse(e.data));
+						if (typeof e.data != 'undefined') {
+							callback(JSON.parse(e.data));
+						} else {
+							callback('');
+						}
 					},false);
 				}
 			}else{

--- a/core/js/update.js
+++ b/core/js/update.js
@@ -5,6 +5,9 @@ $(document).ready(function () {
 	});
 	updateEventSource.listen('error', function(message) {
 		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));
+		message = 'Please reload the page.';
+		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));
+		updateEventSource.close();
 	});
 	updateEventSource.listen('failure', function(message) {
 		$('<span>').addClass('error').append(message).append('<br />').appendTo($('.update'));

--- a/lib/eventsource.php
+++ b/lib/eventsource.php
@@ -25,7 +25,7 @@
  * wrapper for server side events (http://en.wikipedia.org/wiki/Server-sent_events)
  * includes a fallback for older browsers and IE
  *
- * use server side events with causion, to many open requests can hang the server
+ * use server side events with caution, to many open requests can hang the server
  */
 class OC_EventSource{
 	private $fallback;
@@ -43,6 +43,7 @@ class OC_EventSource{
 			header("Content-Type: text/event-stream");
 		}
 		if( !OC_Util::isCallRegistered()) {
+			$this->send('error', 'Possible CSRF attack. Connection will be closed.');
 			exit();
 		}
 		flush();
@@ -51,10 +52,10 @@ class OC_EventSource{
 
 	/**
 	 * send a message to the client
-	 * @param string type
-	 * @param object data
+	 * @param string $type
+	 * @param object $data
 	 *
-	 * if only one paramater is given, a typeless message will be send with that paramater as data
+	 * if only one parameter is given, a typeless message will be send with that parameter as data
 	 */
 	public function send($type, $data=null) {
 		if(is_null($data)) {


### PR DESCRIPTION
- eventsource.php: in case of potential CSRF attack we send an error message from the EventSource to the browser
- eventsource.js: handle undefined data on event
- update.js: in case of error we close the event source - advise the user to reload the page

refs backport of #4014 in order to fix #4005 in master

@karlitschek @icewind1991 @MTGap @butonic @schiesbn THX
