### PR TITLE
Add a test to update the db with the same schema

### DIFF
--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -94,6 +94,9 @@ class MDB2SchemaReader {
 				case 'name':
 					$name = (string)$child;
 					$name = str_replace('*dbprefix*', $this->DBTABLEPREFIX, $name);
+					if (isset($name[$this->schemaConfig->getMaxIdentifierLength()])) {
+						throw new \DomainException('Table name is too long: ' . $name);
+					}
 					$name = $this->platform->quoteIdentifier($name);
 					$table = $schema->createTable($name);
 					break;
@@ -152,6 +155,9 @@ class MDB2SchemaReader {
 			switch ($child->getName()) {
 				case 'name':
 					$name = (string)$child;
+					if (isset($name[$this->schemaConfig->getMaxIdentifierLength()])) {
+						throw new \DomainException('Column name is too long on table "' . $table->getName() . '": ' . $name);
+					}
 					$name = $this->platform->quoteIdentifier($name);
 					break;
 				case 'type':
@@ -271,6 +277,9 @@ class MDB2SchemaReader {
 			switch ($child->getName()) {
 				case 'name':
 					$name = (string)$child;
+					if (isset($name[$this->schemaConfig->getMaxIdentifierLength()])) {
+						throw new \DomainException('Index name is too long on table "' . $table->getName() . '": ' . $name);
+					}
 					break;
 				case 'primary':
 					$primary = $this->asBool($child);

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -47,6 +47,7 @@ class DBSchemaTest extends TestCase {
 	protected function tearDown() {
 		unlink($this->schema_file);
 		unlink($this->schema_file2);
+		$this->mockDBPrefix('oc_');
 
 		parent::tearDown();
 	}
@@ -93,10 +94,17 @@ class DBSchemaTest extends TestCase {
 
 		$randomPrefix = strtolower($this->getUniqueID('', 2, false) . '_');
 		$content = file_get_contents($dbfile);
-		// Add prefix to index names to make them unique
-		#$content = str_replace('<name>', '<name>*dbprefix*', $content);
-		#$content = str_replace('*dbprefix**dbprefix*', '*dbprefix*', $content);
+
+		// Add prefix to index names to make them unique for testing (oc_ exists in parallel)
+		$content = str_replace('<name>', '<name>*dbprefix*', $content);
+		$content = str_replace('*dbprefix**dbprefix*', '*dbprefix*', $content);
 		$content = str_replace('*dbprefix*', $randomPrefix, $content);
+
+		// Shorten index names that are too long, now that we added the prefix to make them unique
+		$content = preg_replace_callback('/<name>([a-zA-Z0-9_]{28,})<\/name>/', function($match) use ($randomPrefix) {
+			return $randomPrefix . substr(md5($match[1]), 0, 26);
+		}, $content);
+
 		file_put_contents($schema_file, $content);
 
 		$this->mockDBPrefix($randomPrefix);

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -10,6 +10,7 @@ namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use OC_DB;
 use OCP\Security\ISecureRandom;
 use Test\TestCase;
@@ -128,7 +129,13 @@ class DBSchemaTest extends TestCase {
 		$connection = \OC::$server->getDatabaseConnection();
 		$this->invokePrivate($connection, 'tablePrefix', [$prefix]);
 		/** @var Connection $connection */
-		$connection->getConfiguration()->setFilterSchemaAssetsExpression('/^' . $prefix . '/');
+
+		if ($connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$filterExpression = '/^"' . preg_quote($prefix) . '/';
+		} else {
+			$filterExpression = '/^' . preg_quote($prefix) . '/';
+		}
+		$connection->getConfiguration()->setFilterSchemaAssetsExpression($filterExpression);
 
 		\OC::$server->getConfig()->setSystemValue('dbtableprefix', $prefix);
 	}

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -9,6 +9,7 @@
 namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Connection;
 use OC_DB;
 use OCP\Security\ISecureRandom;
 use Test\TestCase;
@@ -90,25 +91,38 @@ class DBSchemaTest extends TestCase {
 		$dbfile = \OC::$SERVERROOT.'/db_structure.xml';
 		$schema_file = 'static://live_db_scheme';
 
-		$randomPrefix = strtolower($this->getUniqueID('', 4) . '_');
+		$randomPrefix = strtolower($this->getUniqueID('', 2, false) . '_');
 		$content = file_get_contents($dbfile);
 		// Add prefix to index names to make them unique
-		$content = str_replace('<name>', '<name>*dbprefix*', $content);
-		$content = str_replace('*dbprefix**dbprefix*', '*dbprefix*', $content);
-		$content = str_replace('*dbprefix*', 'oc_' . $randomPrefix, $content);
+		#$content = str_replace('<name>', '<name>*dbprefix*', $content);
+		#$content = str_replace('*dbprefix**dbprefix*', '*dbprefix*', $content);
+		$content = str_replace('*dbprefix*', $randomPrefix, $content);
 		file_put_contents($schema_file, $content);
 
+		$this->mockDBPrefix($randomPrefix);
+
 		// The method OC_DB::tableExists() adds the prefix itself
-		$this->assertTableNotExist($randomPrefix . 'filecache');
+		$this->assertTableNotExist('filecache');
 		\OC_DB::createDbFromStructure($schema_file);
-		$this->assertTableExist($randomPrefix . 'filecache');
+		$this->assertTableExist('filecache');
 		\OC_DB::updateDbFromStructure($schema_file);
-		$this->assertTableExist($randomPrefix . 'filecache');
+		$this->assertTableExist('filecache');
 		\OC_DB::removeDBStructure($schema_file);
-		$this->assertTableNotExist($randomPrefix . 'filecache');
+		$this->assertTableNotExist('filecache');
+
+		$this->mockDBPrefix('oc_');
 
 		unlink($schema_file);
 		$this->assertTrue(true, 'Asserting that no error occurred when updating with the same schema that is already installed');
+	}
+
+	protected function mockDBPrefix($prefix) {
+		$connection = \OC::$server->getDatabaseConnection();
+		$this->invokePrivate($connection, 'tablePrefix', [$prefix]);
+		/** @var Connection $connection */
+		$connection->getConfiguration()->setFilterSchemaAssetsExpression('/^' . $prefix . '/');
+
+		\OC::$server->getConfig()->setSystemValue('dbtableprefix', $prefix);
 	}
 
 	/**

--- a/tests/lib/DB/DBSchemaTest.php
+++ b/tests/lib/DB/DBSchemaTest.php
@@ -86,6 +86,31 @@ class DBSchemaTest extends TestCase {
 		$this->assertTableNotExist($this->table2);
 	}
 
+	public function testSchemaUnchanged() {
+		$dbfile = \OC::$SERVERROOT.'/db_structure.xml';
+		$schema_file = 'static://live_db_scheme';
+
+		$randomPrefix = strtolower($this->getUniqueID('', 4) . '_');
+		$content = file_get_contents($dbfile);
+		// Add prefix to index names to make them unique
+		$content = str_replace('<name>', '<name>*dbprefix*', $content);
+		$content = str_replace('*dbprefix**dbprefix*', '*dbprefix*', $content);
+		$content = str_replace('*dbprefix*', 'oc_' . $randomPrefix, $content);
+		file_put_contents($schema_file, $content);
+
+		// The method OC_DB::tableExists() adds the prefix itself
+		$this->assertTableNotExist($randomPrefix . 'filecache');
+		\OC_DB::createDbFromStructure($schema_file);
+		$this->assertTableExist($randomPrefix . 'filecache');
+		\OC_DB::updateDbFromStructure($schema_file);
+		$this->assertTableExist($randomPrefix . 'filecache');
+		\OC_DB::removeDBStructure($schema_file);
+		$this->assertTableNotExist($randomPrefix . 'filecache');
+
+		unlink($schema_file);
+		$this->assertTrue(true, 'Asserting that no error occurred when updating with the same schema that is already installed');
+	}
+
 	/**
 	 * @param string $table
 	 */

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -201,14 +201,16 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @param string $prefix
 	 * @param int $length
+	 * @param bool $allowNumbers
 	 * @return string
 	 */
-	protected static function getUniqueID($prefix = '', $length = 13) {
-		return $prefix . \OC::$server->getSecureRandom()->generate(
-			$length,
-			// Do not use dots and slashes as we use the value for file names
-			ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER
-		);
+	protected static function getUniqueID($prefix = '', $length = 13, $allowNumbers = true) {
+		$chars = ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER;
+		if ($allowNumbers) {
+			$chars .= ISecureRandom::CHAR_DIGITS;
+		}
+
+		return $prefix . \OC::$server->getSecureRandom()->generate($length, $chars);
 	}
 
 	public static function tearDownAfterClass() {


### PR DESCRIPTION
Updating the schema with the current one should not change anything, yet it fails badly and even breaks subsequent tests.

I only added a test method that will force a schema update. That causes MDB2 to fetch the schema from the DB, compare it to the one in `db_structure.xml` and execute any necessary updates. This mechanism seems more fragile than we think.

@bartv2 could you test this with doctrine?

@icewind1991 the filecache tests seem to insert rows missing `storage_mtime` and `unencrypted_size` which are defined as

``` xml

            <field>
                <name>storage_mtime</name>
                <type>integer</type>
                <default></default>
                <notnull>true</notnull>
                <length>4</length>
            </field>

            <field>
                <name>unencrypted_size</name>
                <type>integer</type>
                <default></default>
                <notnull>true</notnull>
                <length>8</length>
            </field>
```

I don't know why that only shows up after forcing a db schema update. In any case these definitions will not work on oracle because it treats '' as null. using `<default></default>` in combination with `<notnull>true</notnull>` is simply wrong.
