### PR TITLE
add new file above summary if it is the first file in the list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -171,6 +171,8 @@ var FileList={
 			}
 		}else if(type=='dir' && $('tr[data-file]').length>0){
 			$('tr[data-file]').first().before(element);
+		} else if(type=='file' && $('tr[data-file]').length>0) {
+			$('tr[data-file]').last().before(element);
 		}else{
 			$('#fileList').append(element);
 		}


### PR DESCRIPTION
If you add a new file to a directory which contains only other directories but no files than the new file was placed below the summary. This patch fixes it.

cc @Kondou-ger 
