### PR TITLE
[webdav client] if the file doesn't exists; create a new one

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -234,7 +234,13 @@ class DAV extends \OC\Files\Storage\Common{
 			$mtime=time();
 		}
 		$path=$this->cleanPath($path);
-		$this->client->proppatch($path, array('{DAV:}lastmodified' => $mtime));
+
+		// if file exists, update the mtime, else create a new empty file
+		if ($this->file_exists($path)) {
+			$this->client->proppatch($path, array('{DAV:}lastmodified' => $mtime));
+		} else {
+			$this->file_put_contents($path, '');
+		}
 	}
 
 	public function getFile($path, $target) {


### PR DESCRIPTION
Touch() is used  to create new text files in the web interface, currently this doesn't work for webdav mounts.
Solution: Create a new empty file on touch() if the file doesn't exist.

cc @icewind1991 
