### PR TITLE
WebDAV Auth Connector: Check if already logged in

### DIFF
--- a/lib/connector/sabre/auth.php
+++ b/lib/connector/sabre/auth.php
@@ -60,4 +60,25 @@ class OC_Connector_Sabre_Auth extends Sabre_DAV_Auth_Backend_AbstractBasic {
 		}
 		return $user;
 	}
+
+	/**
+	  * Override function here. We want to cache authentication cookies
+	  * in the syncing client to avoid HTTP-401 roundtrips.
+	  * If the sync client supplies the cookies, then OC_User::isLoggedIn()
+	  * will return true and we can see this WebDAV request as already authenticated,
+	  * even if there are no HTTP Basic Auth headers.
+	  * In other case, just fallback to the parent implementation.
+	  *
+	  * @return bool
+	  */
+	public function authenticate(Sabre_DAV_Server $server, $realm) {
+		if (OC_User::isLoggedIn()) {
+			$user = OC_User::getUser();
+			OC_Util::setupFS($user);
+			$this->currentUser = $user;
+			return true;
+		}
+
+		return parent::authenticate($server, $realm);
+    }
 }


### PR DESCRIPTION
See code comment on what it does.

Basically, we don't need our WebDAV server to do the basic auth handling if the session is already authenticated (by cookie).

So this one will work, given the correct cookies:
`curl -v -X PROPFIND -H "Cookie: oc0b4d3e5b1b=biljubj3n0pnmougco5hddg317"  http://127.0.0.1/remote.php/webdav`

And this one will still ask for HTTP auth:
`curl -v -X PROPFIND http://127.0.0.1/remote.php/webdav`
