### PR TITLE
finally remove the file size obfuscation as it had more disadvantages.

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -47,7 +47,7 @@ var FileList={
 
 		//size column
 		if(size!=t('files', 'Pending')){
-			simpleSize=simpleFileSize(size);
+			simpleSize = humanFileSize(size);
 		}else{
 			simpleSize=t('files', 'Pending');
 		}
@@ -55,7 +55,6 @@ var FileList={
 		var lastModifiedTime = Math.round(lastModified.getTime() / 1000);
 		td = $('<td></td>').attr({
 			"class": "filesize",
-			"title": humanFileSize(size),
 			"style": 'color:rgb('+sizeColor+','+sizeColor+','+sizeColor+')'
 		}).text(simpleSize);
 		tr.append(td);

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -756,9 +756,7 @@ function procesSelection(){
 		for(var i=0;i<selectedFolders.length;i++){
 			totalSize+=selectedFolders[i].size;
 		};
-		simpleSize=simpleFileSize(totalSize);
-		$('#headerSize').text(simpleSize);
-		$('#headerSize').attr('title',humanFileSize(totalSize));
+		$('#headerSize').text(humanFileSize(totalSize));
 		var selection='';
 		if(selectedFolders.length>0){
 			if(selectedFolders.length==1){

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -77,7 +77,7 @@
 					<?php endif; ?>
 				</span>
 			</th>
-			<th id="headerSize"><?php p($l->t('Size (MB)')); ?></th>
+			<th id="headerSize"><?php p($l->t('Size')); ?></th>
 			<th id="headerDate">
 				<span id="modified"><?php p($l->t( 'Modified' )); ?></span>
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -9,7 +9,6 @@ $totalsize = 0; ?>
 	} else {
 		$totalfiles++;
 	}
-	$simple_file_size = OCP\simple_file_size($file['size']);
 	// the bigger the file, the darker the shade of grey; megabytes*2
 	$simple_size_color = intval(160-$file['size']/(1024*1024)*2);
 	if($simple_size_color<0) $simple_size_color = 0;
@@ -52,9 +51,8 @@ $totalsize = 0; ?>
 			</a>
 		</td>
 		<td class="filesize"
-			title="<?php p(OCP\human_file_size($file['size'])); ?>"
 			style="color:rgb(<?php p($simple_size_color.','.$simple_size_color.','.$simple_size_color) ?>)">
-				<?php print_unescaped($simple_file_size); ?>
+				<?php print_unescaped(OCP\human_file_size($file['size'])); ?>
 		</td>
 		<td class="date">
 			<span class="modified"
@@ -91,7 +89,7 @@ $totalsize = 0; ?>
 			} ?>
 		</span></td>
 		<td class="filesize">
-		<?php print_unescaped(OCP\simple_file_size($totalsize)); ?>
+		<?php print_unescaped(OCP\human_file_size($totalsize)); ?>
 		</td>
 		<td></td>
 	</tr>

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -666,8 +666,6 @@ $(document).ready(function(){
 	$('.selectedActions a').tipsy({gravity:'s', fade:true, live:true});
 	$('a.delete').tipsy({gravity: 'e', fade:true, live:true});
 	$('a.action').tipsy({gravity:'s', fade:true, live:true});
-	$('#headerSize').tipsy({gravity:'s', fade:true, live:true});
-	$('td.filesize').tipsy({gravity:'s', fade:true, live:true});
 	$('td .modified').tipsy({gravity:'s', fade:true, live:true});
 
 	$('input').tipsy({gravity:'w', fade:true});
@@ -695,14 +693,6 @@ function humanFileSize(size) {
 		relativeSize=relativeSize.substr(0,relativeSize.length-2);
 	}
 	return relativeSize + ' ' + readableFormat;
-}
-
-function simpleFileSize(bytes) {
-	var mbytes = Math.round(bytes/(1024*1024/10))/10;
-	if(bytes == 0) { return '0'; }
-	else if(mbytes < 0.1) { return '< 0.1'; }
-	else if(mbytes > 1000) { return '> 1000'; }
-	else { return mbytes.toFixed(1); }
 }
 
 function formatDate(date){

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -77,6 +77,16 @@ function relative_modified_date($timestamp) {
 
 
 /**
+ * @brief DEPRECATED Return a human readable outout for a file size.
+ * @param $byte size of a file in byte
+ * @returns human readable interpretation of a file size
+ */
+function simple_file_size($bytes) {
+	return(\human_file_size($bytes));
+}
+
+
+/**
  * @brief Generate html code for an options block.
  * @param $options the options
  * @param $selected which one is selected?

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -77,16 +77,6 @@ function relative_modified_date($timestamp) {
 
 
 /**
- * @brief Return a human readable outout for a file size.
- * @param $byte size of a file in byte
- * @returns human readable interpretation of a file size
- */
-function simple_file_size($bytes) {
-	return(\simple_file_size($bytes));
-}
-
-
-/**
  * @brief Generate html code for an options block.
  * @param $options the options
  * @param $selected which one is selected?

--- a/lib/template.php
+++ b/lib/template.php
@@ -84,24 +84,6 @@ function human_file_size( $bytes ) {
 	return OC_Helper::humanFileSize( $bytes );
 }
 
-function simple_file_size($bytes) {
-	if ($bytes < 0) {
-		return '?';
-	}
-	$mbytes = round($bytes / (1024 * 1024), 1);
-	if ($bytes == 0) {
-		return '0';
-	}
-	if ($mbytes < 0.1) {
-		return '&lt; 0.1';
-	}
-	if ($mbytes > 1000) {
-		return '&gt; 1000';
-	} else {
-		return number_format($mbytes, 1);
-	}
-}
-
 function relative_modified_date($timestamp) {
 	$l=OC_L10N::get('lib');
 	$timediff = time() - $timestamp;


### PR DESCRIPTION
**TL;DR: No more »> 1000« or »230.5« but rather »4.6 GB« and »230.5 MB« etc.**

My reasoning for this always was that exact file size is not that important to people, but rather if it’s big or small. Now that’s 1) wrong and 2) already solved by having the grey tones of the text vary (bigger files have darker size text). What’s more correct is that people who don’t care about file size don’t look at it, but people who do care about file size do not want an obfuscated file size and then need to hover over it.

I was wrong, sorry.

So after hearing a remark about it again today I removed that all. Probably makes ownCloud a bit faster too and also gets rid of some more annoying tipsy JS.

Please review @owncloud/designers @karlitschek @bantu @DeepDiver1975 @butonic
