### PR TITLE
deactivate show password toggle for IE

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -673,7 +673,16 @@ button.loading {
 
 
 
+
+
 /* ---- BROWSER-SPECIFIC FIXES ---- */
+
 ::-moz-focus-inner {
 	border: 0; /* remove dotted outlines in Firefox */
+}
+
+/* deactivate show password toggle for IE. Does not work for 8 and 9+ have their own implementation. */
+.ie #show, .ie #show+label {
+	display: none;
+	visibility: hidden;
 }


### PR DESCRIPTION
Does not work for IE8 anyway. And 9+ have their own implementation for showing passwords, which creates a strange overlay.

Please check @owncloud/designers @butonic @DeepDiver1975 (@lmaestro this fixes one of the issues reported by you)
