### PR TITLE
changed HTTP FOUND code to the correct value 302

### DIFF
--- a/lib/response.php
+++ b/lib/response.php
@@ -7,7 +7,7 @@
  */
 
 class OC_Response {
-	const STATUS_FOUND = 304;
+	const STATUS_FOUND = 302;
 	const STATUS_NOT_MODIFIED = 304;
 	const STATUS_TEMPORARY_REDIRECT = 307;
 	const STATUS_NOT_FOUND = 404;


### PR DESCRIPTION
ownCloud sets the wrong HTTP Code when it send redirects to http/1.0 clients/proxies.
