### PR TITLE
need to use \OC_Image to escape OCP namespace

### DIFF
--- a/lib/public/image.php
+++ b/lib/public/image.php
@@ -25,5 +25,5 @@ namespace OCP;
 /**
  * This class provides functions to handle images
  */
-class Image extends OC_Image {
+class Image extends \OC_Image {
 }


### PR DESCRIPTION
fixes an internal server error when uploading an image
@bartv2 @icewind1991 @DeepDiver1975 
