### PR TITLE
Fixing share JS error

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -92,6 +92,7 @@ OC.Share={
 			}
 		}
 		if (shares) {
+			OC.Share.statuses[itemSource] = OC.Share.statuses[itemSource] || {};
 			OC.Share.statuses[itemSource]['link'] = link;
 		} else {
 			delete OC.Share.statuses[itemSource];

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -122,7 +122,12 @@ OC.Share={
 					callback(result.data);
 				}
 			} else {
-				OC.dialogs.alert(result.data.message, t('core', 'Error while sharing'));
+				if (result.data && result.data.message) {
+					var msg = result.data.message;
+				} else {
+					var msg = t('core', 'Error');
+				}
+				OC.dialogs.alert(msg, t('core', 'Error while sharing'));
 			}
 		});
 	},


### PR DESCRIPTION
Steps to reproduce:
- open js console
- open share dialog
- click "Share with link"

Console output: Uncaught TypeError: Cannot set property 'link' of undefined 
