### PR TITLE
flicker-free versions drop-down

### DIFF
--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -39,22 +39,6 @@ function createVersionsDropdown(filename, files) {
 
 	var historyUrl = OC.linkTo('files_versions', 'history.php') + '?path='+encodeURIComponent( $( '#dir' ).val() ).replace( /%2F/g, '/' )+'/'+encodeURIComponent( filename );
 
-	var html = '<div id="dropdown" class="drop drop-versions" data-file="'+escapeHTML(files)+'">';
-	html += '<div id="private">';
-	html += '<select data-placeholder="Saved versions" id="found_versions" class="chzen-select" style="width:16em;">';
-	html += '<option value=""></option>';
-	html += '</select>';
-	html += '</div>';
-	html += '<input type="button" value="All versions..." name="makelink" id="makelink" />';
-	html += '<input id="link" style="display:none; width:90%;" />';
-
-	if (filename) {
-		$('tr').filterAttr('data-file',filename).addClass('mouseOver');
-		$(html).appendTo($('tr').filterAttr('data-file',filename).find('td.filename'));
-	} else {
-		$(html).appendTo($('thead .share'));
-	}
-
 	$("#makelink").click(function() {
 		goToVersionPage(historyUrl);
 	});
@@ -68,14 +52,31 @@ function createVersionsDropdown(filename, files) {
 		success: function( versions ) {
 
 			if (versions) {
+
+				var html = '<div id="dropdown" class="drop drop-versions" data-file="'+escapeHTML(files)+'">';
+				html += '<div id="private">';
+				html += '<select data-placeholder="Saved versions" id="found_versions" class="chzen-select" style="width:16em;">';
+				html += '<option value=""></option>';
+				html += '</select>';
+				html += '</div>';
+				html += '<input type="button" value="All versions..." name="makelink" id="makelink" />';
+				html += '<input id="link" style="display:none; width:90%;" />';
+
 				$.each( versions, function(index, row ) {
 					addVersion( row );
 				});
 			} else {
-				$('#found_versions').hide();
-				$('#makelink').hide();
-				$('<div style="text-align:center;">No other versions available</div>').appendTo('#dropdown');
+				var html = '<div id="dropdown" class="drop drop-versions" data-file="'+escapeHTML(files)+'">';
+				html += '<div style="text-align:center;">No other versions available</div></div>';
 			}
+
+			if (filename) {
+				$('tr').filterAttr('data-file',filename).addClass('mouseOver');
+				$(html).appendTo($('tr').filterAttr('data-file',filename).find('td.filename'));
+			} else {
+				$(html).appendTo($('thead .share'));
+			}
+
 			$('#found_versions').change(function(){
 				var revision=parseInt($(this).val());
 				revertFile(files,revision);

--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -51,6 +51,7 @@ function createVersionsDropdown(filename, files) {
 		async: false,
 		success: function( versions ) {
 
+			// first decide which kind of dialog we need
 			if (versions) {
 
 				var html = '<div id="dropdown" class="drop drop-versions" data-file="'+escapeHTML(files)+'">';
@@ -62,9 +63,6 @@ function createVersionsDropdown(filename, files) {
 				html += '<input type="button" value="All versions..." name="makelink" id="makelink" />';
 				html += '<input id="link" style="display:none; width:90%;" />';
 
-				$.each( versions, function(index, row ) {
-					addVersion( row );
-				});
 			} else {
 				var html = '<div id="dropdown" class="drop drop-versions" data-file="'+escapeHTML(files)+'">';
 				html += '<div style="text-align:center;">No other versions available</div></div>';
@@ -75,6 +73,13 @@ function createVersionsDropdown(filename, files) {
 				$(html).appendTo($('tr').filterAttr('data-file',filename).find('td.filename'));
 			} else {
 				$(html).appendTo($('thead .share'));
+			}
+
+			// if versions are available populate the dialog
+			if (versions) {
+				$.each( versions, function(index, row ) {
+					addVersion( row );
+				});
 			}
 
 			$('#found_versions').change(function(){

--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -39,10 +39,6 @@ function createVersionsDropdown(filename, files) {
 
 	var historyUrl = OC.linkTo('files_versions', 'history.php') + '?path='+encodeURIComponent( $( '#dir' ).val() ).replace( /%2F/g, '/' )+'/'+encodeURIComponent( filename );
 
-	$("#makelink").click(function() {
-		goToVersionPage(historyUrl);
-	});
-
 	$.ajax({
 		type: 'GET',
 		url: OC.filePath('files_versions', 'ajax', 'getVersions.php'),
@@ -74,6 +70,10 @@ function createVersionsDropdown(filename, files) {
 			} else {
 				$(html).appendTo($('thead .share'));
 			}
+
+			$("#makelink").click(function() {
+				goToVersionPage(historyUrl);
+			});
 
 			// if versions are available populate the dialog
 			if (versions) {


### PR DESCRIPTION
 Create directly the correct version drop-down to open the drop-down flicker-free if no versions are available.

This will solve issue #102 for stable5. No backport to master needed, the new version drop down will solve the issue too.

cc @karlitschek @DeepDiver1975 
