### PR TITLE
use output buffering when including the irods libraries

### DIFF
--- a/apps/files_external/lib/irods.php
+++ b/apps/files_external/lib/irods.php
@@ -11,8 +11,10 @@ namespace OC\Files\Storage;
 set_include_path(get_include_path() . PATH_SEPARATOR .
 	\OC_App::getAppPath('files_external') . '/3rdparty/irodsphp/prods/src');
 
+ob_start();
 require_once 'ProdsConfig.inc.php';
 require_once 'ProdsStreamer.class.php';
+ob_end_clean();
 
 class iRODS extends \OC\Files\Storage\StreamWrapper{
 	private $password;


### PR DESCRIPTION
The irods libraries have `?>` and newlines at the end of the files causing `output already send` errors when logging in for me.

cc @DeepDiver1975 @MTGap @karlitschek 
