### PR TITLE
Trashbin improvements

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -24,7 +24,7 @@
 #new>ul>li>p { cursor:pointer; }
 #new>ul>li>form>input { padding:0.3em; margin:-0.3em; }
 
-#trash { height:17px; margin: 0 1em; z-index:1010; float: right; }
+#trash { margin: 0 1em; z-index:1010; float: right; }
 
 #upload {
 	height:27px; padding:0; margin-left:0.2em; overflow:hidden;

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -126,6 +126,12 @@ if ($needUpgrade) {
 		$publicUploadEnabled = 'no';
 	}
 
+	$trashEnabled = \OCP\App::isEnabled('files_trashbin');
+	$trashEmpty = true;
+	if ($trashEnabled) {
+		$trashEmpty = \OCA\Files_Trashbin\Trashbin::isEmpty($user);
+	}
+	
 	OCP\Util::addscript('files', 'fileactions');
 	OCP\Util::addscript('files', 'files');
 	OCP\Util::addscript('files', 'keyboardshortcuts');
@@ -136,7 +142,8 @@ if ($needUpgrade) {
 	$tmpl->assign('isCreatable', \OC\Files\Filesystem::isCreatable($dir . '/'));
 	$tmpl->assign('permissions', $permissions);
 	$tmpl->assign('files', $files);
-	$tmpl->assign('trash', \OCP\App::isEnabled('files_trashbin'));
+	$tmpl->assign('trash', $trashEnabled);
+	$tmpl->assign('trashEmpty', $trashEmpty);
 	$tmpl->assign('uploadMaxFilesize', $maxUploadFilesize);
 	$tmpl->assign('uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 	$tmpl->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -392,6 +392,7 @@ var FileList={
 							files.removeClass('selected');
 						});
 						procesSelection();
+						checkTrashStatus();
 					} else {
 						$.each(files,function(index,file) {
 							var deleteAction = $('tr').filterAttr('data-file',file).children("td.date").children(".move2trash");

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -121,10 +121,10 @@ $(document).ready(function() {
 	});
 
 	// Show trash bin
-	$('#trash a').live('click', function() {
+	$('#trash').on('click', function() {
 		window.location=OC.filePath('files_trashbin', '', 'index.php');
 	});
-
+	
 	var lastChecked;
 
 	// Sets the file link behaviour :
@@ -844,4 +844,12 @@ function getUniqueName(name){
 		return getUniqueName(name);
 	}
 	return name;
+}
+
+function checkTrashStatus() {
+	$.post(OC.filePath('files_trashbin', 'ajax', 'isEmpty.php'), function(result){
+		if (result.data.isEmpty === false) {
+			$("input[type=button][id=trash]").removeAttr("disabled");
+		}
+	});
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -124,7 +124,7 @@ $(document).ready(function() {
 	$('#trash').on('click', function() {
 		window.location=OC.filePath('files_trashbin', '', 'index.php');
 	});
-	
+
 	var lastChecked;
 
 	// Sets the file link behaviour :

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -38,9 +38,7 @@
 				</form>
 			</div>
 			<?php if ($_['trash'] ): ?>
-			<div id="trash" class="button">
-				<a><?php p($l->t('Deleted files'));?></a>
-			</div>
+			<input id="trash" type="button" value="<?php p($l->t('Deleted Files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
 			<?php endif; ?>
 			<div id="uploadprogresswrapper">
 				<div id="uploadprogressbar"></div>

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -38,7 +38,7 @@
 				</form>
 			</div>
 			<?php if ($_['trash'] ): ?>
-			<input id="trash" type="button" value="<?php p($l->t('Deleted Files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
+			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
 			<?php endif; ?>
 			<div id="uploadprogresswrapper">
 				<div id="uploadprogressbar"></div>

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -8,8 +8,7 @@ $(document).ready(function() {
 			var undeleteAction = $('tr').filterAttr('data-file',filename).children("td.date");
 			var files = tr.attr('data-file');
 			undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
-			$(".action").css("display", "none");
-			$(":input:checkbox").css("display", "none");
+			disableActions();
 			$.post(OC.filePath('files_trashbin','ajax','undelete.php'),
 				{files:JSON.stringify([files]), dirlisting:tr.attr('data-dirlisting') },
 				function(result){
@@ -20,8 +19,7 @@ $(document).ready(function() {
 					if (result.status != 'success') {
 						OC.dialogs.alert(result.data.message, t('core', 'Error'));
 					}
-					$(".action").css("display", "inline");
-					$(":input:checkbox").css("display", "inline");
+					enableActions();
 				});
 
 			});
@@ -38,7 +36,7 @@ $(document).ready(function() {
 			var newHTML = '<img class="move2trash" data-action="Delete" title="'+t('files', 'delete file permanently')+'" src="'+ OC.imagePath('core', 'loading.gif') +'"></a>';
 			var files = tr.attr('data-file');
 			deleteAction[0].outerHTML = newHTML;
-
+			disableActions();
 			$.post(OC.filePath('files_trashbin','ajax','delete.php'),
 				{files:JSON.stringify([files]), dirlisting:tr.attr('data-dirlisting') },
 				function(result){
@@ -49,6 +47,7 @@ $(document).ready(function() {
 					if (result.status != 'success') {
 						OC.dialogs.alert(result.data.message, t('core', 'Error'));
 					}
+					enableActions();
 				});
 
 			});
@@ -102,7 +101,7 @@ $(document).ready(function() {
 			var files=getSelectedFiles('file');
 			var fileslist = JSON.stringify(files);
 			var dirlisting=getSelectedFiles('dirlisting')[0];
-
+			disableActions();
 			for (var i=0; i<files.length; i++) {
 				var undeleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date");
 				undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
@@ -118,6 +117,7 @@ $(document).ready(function() {
 						if (result.status != 'success') {
 							OC.dialogs.alert(result.data.message, t('core', 'Error'));
 						}
+						enableActions();
 					});
 			});
 
@@ -129,6 +129,7 @@ $(document).ready(function() {
 			var fileslist = JSON.stringify(files);
 			var dirlisting=getSelectedFiles('dirlisting')[0];
 
+			disableActions();
 			for (var i=0; i<files.length; i++) {
 				var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date");
 				deleteAction[0].innerHTML = deleteAction[0].innerHTML+spinner;
@@ -144,6 +145,7 @@ $(document).ready(function() {
 						if (result.status != 'success') {
 							OC.dialogs.alert(result.data.message, t('core', 'Error'));
 						}
+						enableActions();
 					});
 			});
 
@@ -239,4 +241,14 @@ function getSelectedFiles(property){
 
 function fileDownloadPath(dir, file) {
 	return OC.filePath('files_trashbin', '', 'download.php') + '?file='+encodeURIComponent(file);
+}
+
+function enableActions() {
+	$(".action").css("display", "inline");
+	$(":input:checkbox").css("display", "inline");
+}
+
+function disableActions() {
+	$(".action").css("display", "none");
+	$(":input:checkbox").css("display", "none");
 }

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -8,6 +8,8 @@ $(document).ready(function() {
 			var undeleteAction = $('tr').filterAttr('data-file',filename).children("td.date");
 			var files = tr.attr('data-file');
 			undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
+			$(".action").css("display", "none");
+			$(":input:checkbox").css("display", "none");
 			$.post(OC.filePath('files_trashbin','ajax','undelete.php'),
 				{files:JSON.stringify([files]), dirlisting:tr.attr('data-dirlisting') },
 				function(result){
@@ -18,6 +20,8 @@ $(document).ready(function() {
 					if (result.status != 'success') {
 						OC.dialogs.alert(result.data.message, t('core', 'Error'));
 					}
+					$(".action").css("display", "inline");
+					$(":input:checkbox").css("display", "inline");
 				});
 
 			});

--- a/apps/files_trashbin/lib/hooks.php
+++ b/apps/files_trashbin/lib/hooks.php
@@ -56,4 +56,8 @@ class Hooks {
 			Trashbin::deleteUser($uid);
 			}
 	}
+	
+	public static function post_write_hook($params) {
+		Trashbin::resizeTrash(\OCP\User::getUser());
+	}
 }

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -868,5 +868,20 @@ class Trashbin {
 		//Listen to delete user signal
 		\OCP\Util::connectHook('OC_User', 'pre_deleteUser', "OCA\Files_Trashbin\Hooks", "deleteUser_hook");
 	}
+	
+	/**
+	 * @brief check if trash bin is empty for a given user
+	 * @param string $user
+	 */
+	public static function isEmpty($user) {
+
+		$trashSize = self::getTrashbinSize($user);
+
+		if ($trashSize !== false && $trashSize > 0) {
+			return false;
+		}
+
+		return true;
+	}
 
 }

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -25,7 +25,7 @@ namespace OCA\Files_Trashbin;
 class Trashbin {
 	// how long do we keep files in the trash bin if no other value is defined in the config file (unit: days)
 
-	const DEFAULT_RETENTION_OBLIGATION = 180;
+	const DEFAULT_RETENTION_OBLIGATION = 30;
 
 	// unit: percentage; 50% of available disk space/quota
 	const DEFAULTMAXSIZE = 50;

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -807,6 +807,7 @@ class Trashbin {
 	private static function getUniqueFilename($location, $filename, $view) {
 		$ext = pathinfo($filename, PATHINFO_EXTENSION);
 		$name = pathinfo($filename, PATHINFO_FILENAME);
+		$l = \OC_L10N::get('files_trashbin');
 
 		// if extension is not empty we set a dot in front of it
 		if ($ext !== '') {
@@ -815,9 +816,9 @@ class Trashbin {
 
 		if ($view->file_exists('files' . $location . '/' . $filename)) {
 			$i = 2;
-			$uniqueName = $name . " (restored)" . $ext;
+			$uniqueName = $name . " (".$l->t("restored").")". $ext;
 			while ($view->file_exists('files' . $location . '/' . $uniqueName)) {
-				$uniqueName = $name . " (restored " . $i . ")" . $ext;
+				$uniqueName = $name . " (".$l->t("restored") . " " . $i . ")" . $ext;
 				$i++;
 			}
 

--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -72,6 +72,11 @@ class Trashbin {
 		$mime = $view->getMimeType('files' . $file_path);
 
 		if ($view->is_dir('files' . $file_path)) {
+			$dirContent = $view->getDirectoryContent('files' . $file_path);
+			// no need to move empty folders to the trash bin
+			if (empty($dirContent)) {
+				return true;
+			}
 			$type = 'dir';
 		} else {
 			$type = 'file';

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -114,8 +114,8 @@ $CONFIG = array(
 /* Password to use for sendmail mail, depends on mail_smtpauth if this is used */
 "mail_smtppassword" => "",
 
-/* How long should ownCloud keep deleted files in the trash bin, default value:  180 days */
-'trashbin_retention_obligation' => 180,
+/* How long should ownCloud keep deleted files in the trash bin, default value:  30 days */
+'trashbin_retention_obligation' => 30,
 
 /* allow user to change his display name, if it is supported by the back-end */
 'allow_user_to_change_display_name' => true,


### PR DESCRIPTION
Some trash bin improvements:
- nicer unique names (file (restored).txt instead of file.txt.restored) ( #3131 )
- don't copy empty folders to the trash
- disable "deleted files" button if the trash bin is empty (#4114)
- expire trash if a new file was uploaded and the trash bin exceeds the new max size
- hide delete permanently button during restore ( https://github.com/owncloud/core/issues/2856)

UPD by vicdeo added one more link to related issue

cc @jancborchardt 
