### PR TITLE
add initial search in shared files

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -254,9 +254,12 @@ class Shared_Cache extends Cache {
 			$result = \OC_DB::executeAudited($sql, array_merge(array($pattern), $chunk));
 			
 			while ($row = $result->fetchRow()) {
-				$row['mimetype'] = $this->getMimetype($row['mimetype']);
-				$row['mimepart'] = $this->getMimetype($row['mimepart']);
-				$files[] = $row;
+				if (substr($row['path'], 0, 6)==='files/') {
+					$row['path'] = substr($row['path'],6); // remove 'files/' from path as it's relative to '/Shared'
+					$row['mimetype'] = $this->getMimetype($row['mimetype']);
+					$row['mimepart'] = $this->getMimetype($row['mimepart']);
+					$files[] = $row;
+				} // else skip results out of the files folder
 			}
 		}
 		return $files;

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -249,10 +249,10 @@ class Shared_Cache extends Cache {
 			while ($row = $result->fetchRow()) {
 				if (substr($row['path'], 0, 6)==='files/') {
 					$row['path'] = substr($row['path'],6); // remove 'files/' from path as it's relative to '/Shared'
-					$row['mimetype'] = $this->getMimetype($row['mimetype']);
-					$row['mimepart'] = $this->getMimetype($row['mimepart']);
-					$files[] = $row;
-				} // else skip results out of the files folder
+				}
+				$row['mimetype'] = $this->getMimetype($row['mimetype']);
+				$row['mimepart'] = $this->getMimetype($row['mimepart']);
+				$files[] = $row;
 			}
 		}
 		return $files;

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -290,10 +290,10 @@ class Shared_Cache extends Cache {
 			while ($row = $result->fetchRow()) {
 				if (substr($row['path'], 0, 6)==='files/') {
 					$row['path'] = substr($row['path'],6); // remove 'files/' from path as it's relative to '/Shared'
-					$row['mimetype'] = $this->getMimetype($row['mimetype']);
-					$row['mimepart'] = $this->getMimetype($row['mimepart']);
-					$files[] = $row;
-				} // else skip results out of the files folder
+				}
+				$row['mimetype'] = $this->getMimetype($row['mimetype']);
+				$row['mimepart'] = $this->getMimetype($row['mimepart']);
+				$files[] = $row;
 			}
 		}
 		return $files;

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -20,6 +20,7 @@
  */
 
 namespace OC\Files\Cache;
+use OCP\Share_Backend_Collection;
 
 /**
  * Metadata cache for shared files
@@ -320,13 +321,17 @@ class Shared_Cache extends Cache {
 	public function getAll() {
 		$ids = \OCP\Share::getItemsSharedWith('file', \OC_Share_Backend_File::FORMAT_GET_ALL);
 		$folderBackend = \OCP\Share::getBackend('folder');
-		foreach ($ids as $file) {
-			$children = $folderBackend->getChildren($file);
-			foreach ($children as $child) {
-				$ids[] = (int)$child['source'];
+		if ($folderBackend instanceof Share_Backend_Collection) {
+			foreach ($ids as $file) {
+				/** @var $folderBackend Share_Backend_Collection */
+				$children = $folderBackend->getChildren($file);
+				foreach ($children as $child) {
+					$ids[] = (int)$child['source'];
+				}
+
 			}
-			
 		}
+
 		return $ids;
 	}
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -745,8 +745,8 @@ class Share {
 
 	/**
 	* @brief Get the backend class for the specified item type
-	* @param string Item type
-	* @return Sharing backend object
+	* @param string $itemType
+	* @return Share_Backend
 	*/
 	public static function getBackend($itemType) {
 		if (isset(self::$backends[$itemType])) {

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -748,7 +748,7 @@ class Share {
 	* @param string Item type
 	* @return Sharing backend object
 	*/
-	private static function getBackend($itemType) {
+	public static function getBackend($itemType) {
 		if (isset(self::$backends[$itemType])) {
 			return self::$backends[$itemType];
 		} else if (isset(self::$backendTypes[$itemType]['class'])) {


### PR DESCRIPTION
@MTGap @icewind1991 customers start to ask for this. Not the best way to implement it because I use the folder backend get the children ids and then use those in a `IN (?,...,?)` SQL statement. This limits this implementation to the supported maximum length for a sql query ... which will be database specific. But it is a first implementation. I don't understand the sharing code well enough to implement a JOIN based implementation (actually that currently won't be possible because we have to recursively collect the children in a folder before we can filter their filename). 

@karlitschek @DeepDiver1975 @bartv2 please review.
