### PR TITLE
Fix scanner hooks throwing errors

### DIFF
--- a/lib/files/utils/scanner.php
+++ b/lib/files/utils/scanner.php
@@ -62,10 +62,10 @@ class Scanner extends PublicEmitter {
 	protected function attachListener($mount) {
 		$scanner = $mount->getStorage()->getScanner();
 		$emitter = $this;
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount, &$emitter) {
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount, $emitter) {
 			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFile', array($mount->getMountPoint() . $path));
 		});
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount, &$emitter) {
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount, $emitter) {
 			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFolder', array($mount->getMountPoint() . $path));
 		});
 	}

--- a/lib/files/utils/scanner.php
+++ b/lib/files/utils/scanner.php
@@ -10,6 +10,7 @@ namespace OC\Files\Utils;
 
 use OC\Hooks\BasicEmitter;
 use OC\Files\Filesystem;
+use OC\Hooks\PublicEmitter;
 
 /**
  * Class Scanner
@@ -20,7 +21,7 @@ use OC\Files\Filesystem;
  *
  * @package OC\Files\Utils
  */
-class Scanner extends BasicEmitter {
+class Scanner extends PublicEmitter {
 	/**
 	 * @var string $user
 	 */
@@ -60,11 +61,12 @@ class Scanner extends BasicEmitter {
 	 */
 	protected function attachListener($mount) {
 		$scanner = $mount->getStorage()->getScanner();
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount) {
-			$this->emit('\OC\Files\Utils\Scanner', 'scanFile', array($mount->getMountPoint() . $path));
+		$emitter = $this;
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount, &$emitter) {
+			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFile', array($mount->getMountPoint() . $path));
 		});
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount) {
-			$this->emit('\OC\Files\Utils\Scanner', 'scanFolder', array($mount->getMountPoint() . $path));
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount, &$emitter) {
+			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFolder', array($mount->getMountPoint() . $path));
 		});
 	}
 

--- a/lib/files/utils/scanner.php
+++ b/lib/files/utils/scanner.php
@@ -8,7 +8,6 @@
 
 namespace OC\Files\Utils;
 
-use OC\Hooks\BasicEmitter;
 use OC\Files\Filesystem;
 use OC\Hooks\PublicEmitter;
 


### PR DESCRIPTION
"caused" by a difference in behavior with closures between 5.3 and 5.4

Should fixed #4206

cc @schiesbn @DeepDiver1975 @bartv2 @karlitschek 
