### PR TITLE
Cache: don't check if the parent exists in the cache if we are already sure it does

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -75,9 +75,10 @@ class Scanner extends BasicEmitter {
 	 *
 	 * @param string $file
 	 * @param int $reuseExisting
+	 * @param bool $parentExists
 	 * @return array with metadata of the scanned file
 	 */
-	public function scanFile($file, $reuseExisting = 0) {
+	public function scanFile($file, $reuseExisting = 0, $parentExists = false) {
 		if (!self::isPartialFile($file)
 			and !Filesystem::isFileBlacklisted($file)
 		) {
@@ -85,7 +86,7 @@ class Scanner extends BasicEmitter {
 			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
 			$data = $this->getData($file);
 			if ($data) {
-				if ($file) {
+				if ($file and !$parentExists) {
 					$parent = dirname($file);
 					if ($parent === '.' or $parent === '/') {
 						$parent = '';
@@ -162,7 +163,7 @@ class Scanner extends BasicEmitter {
 				$child = ($path) ? $path . '/' . $file : $file;
 				if (!Filesystem::isIgnoredDir($file)) {
 					$newChildren[] = $file;
-					$data = $this->scanFile($child, $reuse);
+					$data = $this->scanFile($child, $reuse, true);
 					if ($data) {
 						if ($data['size'] === -1) {
 							if ($recursive === self::SCAN_RECURSIVE) {

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -75,10 +75,10 @@ class Scanner extends BasicEmitter {
 	 *
 	 * @param string $file
 	 * @param int $reuseExisting
-	 * @param bool $parentExists
+	 * @param bool $parentExistsInCache
 	 * @return array with metadata of the scanned file
 	 */
-	public function scanFile($file, $reuseExisting = 0, $parentExists = false) {
+	public function scanFile($file, $reuseExisting = 0, $parentExistsInCache = false) {
 		if (!self::isPartialFile($file)
 			and !Filesystem::isFileBlacklisted($file)
 		) {
@@ -86,7 +86,7 @@ class Scanner extends BasicEmitter {
 			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
 			$data = $this->getData($file);
 			if ($data) {
-				if ($file and !$parentExists) {
+				if ($file and !$parentExistsInCache) {
 					$parent = dirname($file);
 					if ($parent === '.' or $parent === '/') {
 						$parent = '';


### PR DESCRIPTION
Gives an performance increase of about 25% for scanning files :)

cc @DeepDiver1975 @karlitschek @MTGap @bartv2 
