### PR TITLE
Fix potential undefined variable in Scanner

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -108,9 +108,9 @@ class Scanner extends BasicEmitter {
 					// Only update metadata that has changed
 					$newData = array_diff($data, $cacheData);
 				}
-			}
-			if (!empty($newData)) {
-				$this->cache->put($file, $newData);
+				if (!empty($newData)) {
+					$this->cache->put($file, $newData);
+				}
 			}
 			return $data;
 		}


### PR DESCRIPTION
A simple fix to ensure that $newData will never be undefined. I don't think I've seen any issues related to this yet.

You'll probably have to click View File to see that the variable wasn't defined in the codes original placement.

@icewind1991 @karlitschek @DeepDiver1975 
