### PR TITLE
Fix calculating size for empty folders

### DIFF
--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -127,6 +127,11 @@ class Cache extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1025, $this->cache->calculateFolderSize($file1));
 
+		$this->cache->remove($file2);
+		$this->cache->remove($file3);
+		$this->cache->remove($file4);
+		$this->assertEquals(0, $this->cache->calculateFolderSize($file1));
+
 		$this->cache->remove('folder');
 		$this->assertFalse($this->cache->inCache('folder/foo'));
 		$this->assertFalse($this->cache->inCache('folder/bar'));


### PR DESCRIPTION
Fix for #3698. If no children were found of the folder, the method assumed that the size didn't have to be changed.

@icewind1991 @karlitschek @MTRichards @roha4000 @lmaestro
