### PR TITLE
app migrate: Use = instead of LIKE as described in the comment above.

### DIFF
--- a/lib/migration/content.php
+++ b/lib/migration/content.php
@@ -112,7 +112,7 @@ class OC_Migration_Content{
 
 			foreach( $options['matchval'] as $matchval ) {
 				// Run the query for this match value (where x = y value)
-				$sql = 'SELECT * FROM `*PREFIX*' . $options['table'] . '` WHERE `' . $options['matchcol'] . '` LIKE ?';
+				$sql = 'SELECT * FROM `*PREFIX*' . $options['table'] . '` WHERE `' . $options['matchcol'] . '` = ?';
 				$query = OC_DB::prepare( $sql );
 				$results = $query->execute( array( $matchval ) );
 				$newreturns = $this->insertData( $results, $options );


### PR DESCRIPTION
The LIKE operator is not defined on integer (probably any non-text) columns on PostgreSQL.

Should fix #3836 (also see comments). Needs testing.

@butonic @tomneedham 
