### PR TITLE
don't create empty versions

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -101,8 +101,11 @@ class Storage {
 				return false;
 			}
 
-			// we should have a source file to work with
-			if (!$files_view->file_exists($filename)) {
+			// we should have a source file to work with, and the file shouldn't
+			// be empty
+			$fileExists = $files_view->file_exists($filename);
+			$fileSize = $files_view->filesize($filename);
+			if ($fileExists === false || $fileSize === 0) {
 				return false;
 			}
 


### PR DESCRIPTION
Don't create empty versions. For example this happens frequently if you create a new text file in the web interface and than edit the file. After save, the first version (which was the empty file) gets versioned. This pull request prevent it.
