### PR TITLE
Fix for URL spaces not being encoded!

### DIFF
--- a/apps/files_external/3rdparty/aws-sdk-php/Guzzle/Parser/UriTemplate/UriTemplate.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Guzzle/Parser/UriTemplate/UriTemplate.php
@@ -36,7 +36,8 @@ class UriTemplate implements UriTemplateInterface
 
     public function expand($template, array $variables)
     {
-        $this->template = $template;
+        // URL encode spaces
+        $this->template = strtr($template, ' ', '%20');
         $this->variables = $variables;
 
         // Check to ensure that the preg_* function is needed


### PR DESCRIPTION
URL with spaces was not being encoded, simple fix, already commit on guzzle repo:
https://github.com/guzzle/guzzle/commit/dbdc6eaff89fb01d8c5595a5188e54069c9fb004
