### PR TITLE
Encode spaces in download link URL

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -222,6 +222,8 @@ class OC_App{
 			}else{
 				$appdata=OC_OCSClient::getApplication($app);
 				$download=OC_OCSClient::getApplicationDownload($app, 1);
+				// Replace spaces in download link without encoding entire URL
+				$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
 				if(isset($download['downloadlink']) and $download['downloadlink']!='') {
 					$info = array('source'=>'http', 'href'=>$download['downloadlink'], 'appdata'=>$appdata);
 					$app=OC_Installer::installApp($info);


### PR DESCRIPTION
Encode spaces with %20 to prevent errors when installing downloaded app.  Needed for copy() to work with spaces in URL.
