### PR TITLE
Fix @expectedException issue

### DIFF
--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -227,9 +227,11 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		try {
 			$manager->createUser('foo', 'bar');
 		} catch (\Exception $e) {
+			return;
 			// Don't use @expectedException to prevent
 			// "InvalidArgumentException: You must not expect the generic exception class."
 		}
+		$this->fail("Expected \Exception");
 	}
 
 	public function testCreateUserSingleBackendNotSupported() {
@@ -301,8 +303,10 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		try {
 			$manager->createUser('foo', 'bar');
 		} catch (\Exception $e) {
+			return;
 			// Don't use @expectedException to prevent
 			// "InvalidArgumentException: You must not expect the generic exception class."
 		}
+		$this->fail("Expected \Exception");
 	}
 }

--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -204,9 +204,6 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $user->getUID());
 	}
 
-	/**
-	 * @expectedException \Exception
-	 */
 	public function testCreateUserSingleBackendExists() {
 		/**
 		 * @var \OC_User_Dummy | \PHPUnit_Framework_MockObject_MockObject $backend
@@ -227,7 +224,12 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$manager = new \OC\User\Manager();
 		$manager->registerBackend($backend);
 
-		$manager->createUser('foo', 'bar');
+		try {
+			$manager->createUser('foo', 'bar');
+		} catch (\Exception $e) {
+			// Don't use @expectedException to prevent
+			// "InvalidArgumentException: You must not expect the generic exception class."
+		}
 	}
 
 	public function testCreateUserSingleBackendNotSupported() {
@@ -259,9 +261,6 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($manager->createUser('foo', 'bar'));
 	}
 
-	/**
-	 * @expectedException \Exception
-	 */
 	public function testCreateUserTwoBackendExists() {
 		/**
 		 * @var \OC_User_Dummy | \PHPUnit_Framework_MockObject_MockObject $backend1
@@ -299,6 +298,11 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
-		$manager->createUser('foo', 'bar');
+		try {
+			$manager->createUser('foo', 'bar');
+		} catch (\Exception $e) {
+			// Don't use @expectedException to prevent
+			// "InvalidArgumentException: You must not expect the generic exception class."
+		}
 	}
 }


### PR DESCRIPTION
Namely:

```
InvalidArgumentException: You must not expect the generic exception class.
```

Not very clean, but the tests throw an error on my laptop otherwise.
Catching a generic \Exception isn't really clean either …

@DeepDiver1975 @icewind1991 
