### PR TITLE
cancel sharing if some users doesn't have a working encryption set-up.

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -238,6 +238,7 @@ class Hooks {
 	 */
 	public static function preShared($params) {
 
+		$l = new \OC_L10N('files_encryption');
 		$users = array();
 		$view = new \OC\Files\View('/public-keys/');
 
@@ -259,7 +260,7 @@ class Hooks {
 
 		if (count($notConfigured) > 0) {
 			$params['run'] = false;
-			$params['error'] = 'Following users are not set up for encryption: ' . join(', ' , $notConfigured);
+			$params['error'] = $l->t('Following users are not set up for encryption:') . ' ' . join(', ' , $notConfigured);
 		}
 		
 	}

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -250,21 +250,18 @@ class Hooks {
 				break;
 		}
 
-		$error = false;
+		$notConfigured = array();
 		foreach ($users as $user) {
 			if (!$view->file_exists($user . '.public.key')) {
-				$error = true;
-				break;
+				$notConfigured[] = $user;
 			}
 		}
 
-		if ($error) // Set flag var 'run' to notify emitting
-			// script that hook execution failed
-		{
-			$params['run']->run = false;
+		if (count($notConfigured) > 0) {
+			$params['run'] = false;
+			$params['error'] = 'Following users are not set up for encryption: ' . join(', ' , $notConfigured);
 		}
-		// TODO: Make sure files_sharing provides user
-		// feedback on failed share
+		
 	}
 
 	/**

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -881,8 +881,13 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the file
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
-
+		try {
+			\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
+		} catch (Exception $e) {
+			$this->assertEquals(0, strpos($e->getMessage(), "Following users are not set up for encryption"));
+		}
+		
+		
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1288,6 +1288,8 @@ class Share {
 		if ($shareType == self::SHARE_TYPE_GROUP) {
 			$groupItemTarget = self::generateTarget($itemType, $itemSource, $shareType, $shareWith['group'],
 				$uidOwner, $suggestedItemTarget);
+			$run = true;
+			$error = '';
 			\OC_Hook::emit('OCP\Share', 'pre_shared', array(
 				'itemType' => $itemType,
 				'itemSource' => $itemSource,
@@ -1297,8 +1299,15 @@ class Share {
 				'uidOwner' => $uidOwner,
 				'permissions' => $permissions,
 				'fileSource' => $fileSource,
-				'token' => $token
+				'token' => $token,
+				'run' => &$run,
+				'error' => &$error
 			));
+			
+			if ($run === false) {
+				throw new \Exception($error);
+			}
+			
 			if (isset($fileSource)) {
 				if ($parentFolder) {
 					if ($parentFolder === true) {
@@ -1374,6 +1383,8 @@ class Share {
 		} else {
 			$itemTarget = self::generateTarget($itemType, $itemSource, $shareType, $shareWith, $uidOwner,
 				$suggestedItemTarget);
+			$run = true;
+			$error = '';
 			\OC_Hook::emit('OCP\Share', 'pre_shared', array(
 				'itemType' => $itemType,
 				'itemSource' => $itemSource,
@@ -1383,8 +1394,15 @@ class Share {
 				'uidOwner' => $uidOwner,
 				'permissions' => $permissions,
 				'fileSource' => $fileSource,
-				'token' => $token
+				'token' => $token,
+				'run' => &$run,
+				'error' => &$error
 			));
+			
+			if ($run === false) {
+				throw new \Exception($error);
+			}
+			
 			if (isset($fileSource)) {
 				if ($parentFolder) {
 					if ($parentFolder === true) {


### PR DESCRIPTION
Cancel sharing  if some users doesn't have a working encryption set-up and show a warning.

Issue: https://github.com/owncloud/core/issues/4253

cc @FlorinPeter @MTGap
