### PR TITLE
add OC.Breadcrumb.show(dir, filename, link)

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -370,6 +370,68 @@ OC.Notification={
 OC.Breadcrumb={
 	container:null,
 	crumbs:[],
+	show:function(dir, filename, link){
+		OC.Breadcrumb.clear();
+		var path = dir.split('/');
+		
+		//add home
+		var link = OC.linkTo('files','index.php');
+		
+		var crumb=$('<div/>');
+		crumb.addClass('crumb');
+
+		var crumbLink=$('<a/>');
+		crumbLink.attr('href',link);
+		
+		var crumbImg=$('<img/>');
+		crumbImg.attr('src',OC.imagePath('core','places/home'));
+		crumbLink.append(crumbImg);
+		crumb.append(crumbLink);
+		OC.Breadcrumb.crumbs.push(crumb);
+		
+		//add path parts
+		var pathurl = '';
+		jQuery.each(path, function(i,name) {
+			if (name !== '') {
+				pathurl = pathurl+'/'+name;
+				var link = OC.linkTo('files','index.php')+'?dir='+encodeURIComponent(pathurl);
+				
+				var crumb=$('<div/>');
+				crumb.addClass('crumb');
+
+				var crumbLink=$('<a/>');
+				crumbLink.attr('href',link);
+				crumbLink.text(name);
+				crumb.append(crumbLink);
+				OC.Breadcrumb.crumbs.push(crumb);
+			}
+		});
+		
+		//add filename (optional)
+		if (filename && link) {
+				pathurl = pathurl+'/'+filename;
+				
+				var crumb=$('<div/>');
+				crumb.addClass('crumb');
+
+				var crumbLink=$('<a/>');
+				crumbLink.attr('href',link);
+				crumbLink.text(filename);
+				crumb.append(crumbLink);
+				OC.Breadcrumb.crumbs.push(crumb);
+		}
+		
+		// update crumb array
+		var lastCrumb = OC.Breadcrumb.crumbs.pop();
+		lastCrumb = jQuery(lastCrumb).addClass('last');
+		OC.Breadcrumb.crumbs.push(lastCrumb);
+		var crumbs = OC.Breadcrumb.crumbs;
+		crumbs.reverse();
+		jQuery.each(crumbs, function(i,crumb){
+			OC.Breadcrumb.container.prepend(crumb);
+		});
+		
+	},
 	push:function(name, link){
 		if(!OC.Breadcrumb.container){//default
 			OC.Breadcrumb.container=$('#controls');

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -370,67 +370,43 @@ OC.Notification={
 OC.Breadcrumb={
 	container:null,
 	crumbs:[],
-	show:function(dir, filename, link){
+	show:function(dir, leafname, leaflink){
 		OC.Breadcrumb.clear();
-		var path = dir.split('/');
 		
-		//add home
-		var link = OC.linkTo('files','index.php');
-		
-		var crumb=$('<div/>');
-		crumb.addClass('crumb');
+		// show home + path in subdirectories
+		if (dir && dir !== '/') {
+			//add home
+			var link = OC.linkTo('files','index.php');
 
-		var crumbLink=$('<a/>');
-		crumbLink.attr('href',link);
-		
-		var crumbImg=$('<img/>');
-		crumbImg.attr('src',OC.imagePath('core','places/home'));
-		crumbLink.append(crumbImg);
-		crumb.append(crumbLink);
-		OC.Breadcrumb.crumbs.push(crumb);
-		
-		//add path parts
-		var pathurl = '';
-		jQuery.each(path, function(i,name) {
-			if (name !== '') {
-				pathurl = pathurl+'/'+name;
-				var link = OC.linkTo('files','index.php')+'?dir='+encodeURIComponent(pathurl);
-				
-				var crumb=$('<div/>');
-				crumb.addClass('crumb');
+			var crumb=$('<div/>');
+			crumb.addClass('crumb');
 
-				var crumbLink=$('<a/>');
-				crumbLink.attr('href',link);
-				crumbLink.text(name);
-				crumb.append(crumbLink);
-				OC.Breadcrumb.crumbs.push(crumb);
-			}
-		});
-		
-		//add filename (optional)
-		if (filename && link) {
-				pathurl = pathurl+'/'+filename;
-				
-				var crumb=$('<div/>');
-				crumb.addClass('crumb');
+			var crumbLink=$('<a/>');
+			crumbLink.attr('href',link);
 
-				var crumbLink=$('<a/>');
-				crumbLink.attr('href',link);
-				crumbLink.text(filename);
-				crumb.append(crumbLink);
-				OC.Breadcrumb.crumbs.push(crumb);
+			var crumbImg=$('<img/>');
+			crumbImg.attr('src',OC.imagePath('core','places/home'));
+			crumbLink.append(crumbImg);
+			crumb.append(crumbLink);
+			OC.Breadcrumb.container.prepend(crumb);
+			OC.Breadcrumb.crumbs.push(crumb);
+
+			//add path parts
+			var segments = dir.split('/');
+			var pathurl = '';
+			jQuery.each(segments, function(i,name) {
+				if (name !== '') {
+					pathurl = pathurl+'/'+name;
+					var link = OC.linkTo('files','index.php')+'?dir='+encodeURIComponent(pathurl);
+					OC.Breadcrumb.push(name, link);
+				}
+			});
 		}
 		
-		// update crumb array
-		var lastCrumb = OC.Breadcrumb.crumbs.pop();
-		lastCrumb = jQuery(lastCrumb).addClass('last');
-		OC.Breadcrumb.crumbs.push(lastCrumb);
-		var crumbs = OC.Breadcrumb.crumbs;
-		crumbs.reverse();
-		jQuery.each(crumbs, function(i,crumb){
-			OC.Breadcrumb.container.prepend(crumb);
-		});
-		
+		//add leafname
+		if (leafname && leaflink) {
+				OC.Breadcrumb.push(leafname, leaflink);
+		}
 	},
 	push:function(name, link){
 		if(!OC.Breadcrumb.container){//default


### PR DESCRIPTION
This adds a cenvenience method tho change the breadcrumbs at will, even when other controls are present.
The breadcrumbs will be prepended to the #controls, leaving any actions / buttons intact.

I needed this to fix the texteditor showing the wrong crumbs.

Test this in the console via `OC.Breadcrumb.show('/Shared/p+i&c t u r äs/df/s/gf/jj/')` or to reset to current folder `OC.Breadcrumb.show($('#dir').val())`

The two parameters `filename` and `link` are optional and will add the corresponding leaf.

This also always adds the Home icon. @owncloud/designers I assume the Home icon should always be present in the file app ... currently it is only visible in subfolders, but that's another issue.

@kabum @karlitschek @icewind1991 @jancborchardt please review
