### PR TITLE
[stable5] Skip non-oc tables on upgrade 

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -592,7 +592,7 @@ class OC_DB {
 		// read file
 		$content = file_get_contents( $file );
 
-		$previousSchema = self::$schema->getDefinitionFromDatabase();
+		$previousSchema = self::$schema->getDefinitionFromDatabase($CONFIG_DBTABLEPREFIX);
 		if (PEAR::isError($previousSchema)) {
 			$error = $previousSchema->getMessage();
 			$detail = $previousSchema->getDebugInfo();


### PR DESCRIPTION
Do not validate alien tables in DB if oC shares the same DB with other software.

Resubmit of https://github.com/owncloud/core/pull/4029 for stable5
Requires 3rdparty https://github.com/owncloud/3rdparty/pull/43

Ref 
#3848
#3642

cc @DeepDiver1975 
