### PR TITLE
make sure the first breadcrumb item is inserted before any other elements in the topbar

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -387,7 +387,7 @@ OC.Breadcrumb={
 			existing.removeClass('last');
 			existing.last().after(crumb);
 		}else{
-			OC.Breadcrumb.container.append(crumb);
+			OC.Breadcrumb.container.prepend(crumb);
 		}
 		OC.Breadcrumb.crumbs.push(crumb);
 		return crumb;


### PR DESCRIPTION
This makes sure breadcrumbs are always at the front of the topbar when using OC.Breadcrumb

cc @DeepDiver1975 @karlitschek @butonic 
