### PR TITLE
Make default language configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -56,6 +56,9 @@ $CONFIG = array(
 /* Theme to use for ownCloud */
 "theme" => "",
 
+/* ownCLoud default language (optional) - overrides automatic language detection on public pages like login or shared items. This has no effect on the users's language preference configured under "personal -> language" once they have logged in */
+"default_language" => "en",
+
 /* Path to the 3rdparty directory */
 "3rdpartyroot" => "",
 
@@ -144,7 +147,7 @@ $CONFIG = array(
 /* Enable/disable X-Frame-Restriction */
 /* HIGH SECURITY RISK IF DISABLED*/
 "xframe_restriction" => true,
-	
+
 /* The directory where the user data is stored, default to data in the owncloud
  * directory. The sqlite database is also stored here, when sqlite is used.
  */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -56,7 +56,7 @@ $CONFIG = array(
 /* Theme to use for ownCloud */
 "theme" => "",
 
-/* ownCLoud default language (optional) - overrides automatic language detection on public pages like login or shared items. This has no effect on the users's language preference configured under "personal -> language" once they have logged in */
+/* ownCloud default language (optional) - overrides automatic language detection on public pages like login or shared items. This has no effect on the users's language preference configured under "personal -> language" once they have logged in */
 "default_language" => "en",
 
 /* Path to the 3rdparty directory */

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -286,10 +286,10 @@ class OC_L10N{
 			}
 		}
 
-    $configuredLanguage = OC_Config::getValue('language', 'not_set');
+    $default_language = OC_Config::getValue('default_language', false);
 
-    if($configuredLanguage !== 'not_set') {
-      return $configuredLanguage;
+    if($default_language !== false) {
+      return $default_language;
     }
 
 		if(isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -286,6 +286,12 @@ class OC_L10N{
 			}
 		}
 
+    $configuredLanguage = OC_Config::getValue('language', 'not_set');
+
+    if($configuredLanguage !== 'not_set') {
+      return $configuredLanguage;
+    }
+
 		if(isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
 			$accepted_languages = preg_split('/,\s*/', strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']));
 			if(is_array($app)) {


### PR DESCRIPTION
It would be nice to have the ablility to force the default language for the public pages like login etc via config.php like 

``` php
   <?php
     $CONFIG = array (
     // [...]
     'language' => 'en',
   );
```

This request enables this feature. If no language is set in config.php, the autodetection still applies
