### PR TITLE
Don't throw a fatal, if is_file() parameter isn't a 'valid path', but only a data/base64-string.

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -392,7 +392,7 @@ class OC_Image {
 	*/
 	public function loadFromFile($imagepath=false) {
 		// exif_imagetype throws "read error!" if file is less than 12 byte
-		if(!is_file($imagepath) || !file_exists($imagepath) || filesize($imagepath) < 12 || !is_readable($imagepath)) {
+		if(!@is_file($imagepath) || !file_exists($imagepath) || filesize($imagepath) < 12 || !is_readable($imagepath)) {
 			// Debug output disabled because this method is tried before loadFromBase64?
 			OC_Log::write('core', 'OC_Image->loadFromFile, couldn\'t load: '.$imagepath, OC_Log::DEBUG);
 			return false;


### PR DESCRIPTION
Related to #4283

Still wondering, how a path can't be a string …

@tanghus @icewind1991 @bartv2
