### PR TITLE
Oracle current timestamp

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -536,7 +536,7 @@ class OC_DB {
 		 * http://www.sqlite.org/lang_createtable.html
 		 * http://docs.oracle.com/cd/B19306_01/server.102/b14200/functions037.htm
 		 */
-		if( $CONFIG_DBTYPE == 'pgsql' ) { //mysql support it too but sqlite doesn't
+		if( $CONFIG_DBTYPE === 'pgsql' || $CONFIG_DBTYPE === 'oci' ) { //mysql support it too but sqlite doesn't
 			$content = str_replace( '<default>0000-00-00 00:00:00</default>',
 				'<default>CURRENT_TIMESTAMP</default>', $content );
 		}


### PR DESCRIPTION
fixes installation on oracle when an app uses 0000-00-00 00:00:00 in database.xml (eg news)

@blizzz @DeepDiver1975 @bartv2 
