### PR TITLE
Setting for disabling password and displayName change

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -186,4 +186,8 @@ $CONFIG = array(
 'customclient_desktop' => '', //http://owncloud.org/sync-clients/
 'customclient_android' => '', //https://play.google.com/store/apps/details?id=com.owncloud.android
 'customclient_ios' => '' //https://itunes.apple.com/us/app/owncloud/id543672169?mt=8
+
+// Enable or disable possibleActions of the user
+"disablepasswordchange" => false,
+"disabledisplaynamechange" => false,
 );

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -77,8 +77,8 @@ $tmpl->assign('email', $email);
 $tmpl->assign('languages', $languages);
 $tmpl->assign('commonlanguages', $commonlanguages);
 $tmpl->assign('activelanguage', $userLang);
-$tmpl->assign('passwordChangeSupported', OC_User::canUserChangePassword(OC_User::getUser()));
-$tmpl->assign('displayNameChangeSupported', OC_User::canUserChangeDisplayName(OC_User::getUser()));
+$tmpl->assign('passwordChangeSupported', !OC_Config::getValue('disablepasswordchange', false) && OC_User::canUserChangePassword(OC_User::getUser()));
+$tmpl->assign('displayNameChangeSupported', !OC_Config::getValue('disabledisplaynamechange', false) && OC_User::canUserChangeDisplayName(OC_User::getUser()));
 $tmpl->assign('displayName', OC_User::getDisplayName());
 
 $forms=OC_App::getForms('personal');


### PR DESCRIPTION
Currently if we enable a backend that implements the setDisplayName
and the setPassword functions, then the users is allowed to change
his password, reset it or change his displayName.

In some cases, for example when using external user
auth like openid, saml, we need to disable this kind
of functionalities, but is not possible.

Reseting local passwords makes no sense when using external auth,
due external auth ignore the local password.
Showing these controls to the user in this case would only create
confusion.

Even though openid or saml backend does not implement the
setDisplayName and the setPassword functions, the
canUserChangePassword and the canUserChangeDisplayName
(of the OC_User class) loops on all the active backends
and since the OC_User_Database is active, then this functions
always returns True.

I suggest to add 2 parameters on the settings
for disabling password and displayName change.

I made an implementation that guarantee backwards compatibility.

Many people asked for this:

owncloud/core #1408
owncloud/core #3785
http://forum.owncloud.org/viewtopic.php?f=3&t=4609
