### PR TITLE
Fixing owncloud/core#4301

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -173,6 +173,7 @@ class DAV extends \OC\Files\Storage\Common{
 				curl_setopt($curl, CURLOPT_USERPWD, $this->user.':'.$this->password);
 				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().$path);
 				curl_setopt($curl, CURLOPT_FILE, $fp);
+				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
 				curl_exec ($curl);
 				curl_close ($curl);


### PR DESCRIPTION
Adding a CURLOPT_FOLLOWLOCATION for HTTP 301 support (e.g yandex disk uses those)
