### PR TITLE
fix app download url fail with spaces

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -222,6 +222,8 @@ class OC_App{
 			}else{
 				$appdata=OC_OCSClient::getApplication($app);
 				$download=OC_OCSClient::getApplicationDownload($app, 1);
+				// Replace spaces in download link without encoding entire URL
+				$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
 				if(isset($download['downloadlink']) and $download['downloadlink']!='') {
 					$info = array('source'=>'http', 'href'=>$download['downloadlink'], 'appdata'=>$appdata);
 					$app=OC_Installer::installApp($info);


### PR DESCRIPTION
Copy does not work with spaces in filenames.  Apps fail to download if they have a space in them.  Encoding the entire URL will cause errors as well.  Replace spaces with %20
