### PR TITLE
Allow true and false as filenames.

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -35,7 +35,7 @@ $dir = $_GET["dir"];
 
 $files_list = json_decode($files);
 // in case we get only a single file
-if ($files_list === NULL ) {
+if (!is_array($files_list)) {
 	$files_list = array($files);
 }
 


### PR DESCRIPTION
Check expected type after JSON decode instead of checking what is not expected.

This will also allow "true" and "false" as filenames instead of only "null".

Fixes #3631
