### PR TITLE
oc_cache needs to disable file proxys for read/write operation.

### DIFF
--- a/lib/cache/file.php
+++ b/lib/cache/file.php
@@ -29,22 +29,30 @@ class OC_Cache_File{
 	}
 
 	public function get($key) {
+		$result = null;
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
 		if ($this->hasKey($key)) {
 			$storage = $this->getStorage();
-			return $storage->file_get_contents($key);
+			$result = $storage->file_get_contents($key);
 		}
-		return null;
+		\OC_FileProxy::$enabled = $proxyStatus;
+		return $result;
 	}
 
 	public function set($key, $value, $ttl=0) {
 		$storage = $this->getStorage();
+		$result = false;
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
 		if ($storage and $storage->file_put_contents($key, $value)) {
 			if ($ttl === 0) {
 				$ttl = 86400; // 60*60*24
 			}
-			return $storage->touch($key, time() + $ttl);
+			$result = $storage->touch($key, time() + $ttl);
 		}
-		return false;
+		\OC_FileProxy::$enabled = $proxyStatus;
+		return $result;
 	}
 
 	public function hasKey($key) {


### PR DESCRIPTION
Otherwise the operation will go through the encryption app which will not work.

Fixes issue: https://github.com/owncloud/core/issues/4296

cc @tanghus @bartv2 
