### PR TITLE
Do not pass numeric strings to strtotime() when formatting dates.

### DIFF
--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -386,8 +386,7 @@ class OC_L10N {
 			case 'time':
 				if($data instanceof DateTime) {
 					return $data->format($this->localizations[$type]);
-				}
-				elseif(is_string($data) && !is_numeric($data)) {
+				} elseif(is_string($data) && !is_numeric($data)) {
 					$data = strtotime($data);
 				}
 				$locales = array(self::findLanguage());

--- a/lib/l10n.php
+++ b/lib/l10n.php
@@ -387,7 +387,7 @@ class OC_L10N {
 				if($data instanceof DateTime) {
 					return $data->format($this->localizations[$type]);
 				}
-				elseif(is_string($data)) {
+				elseif(is_string($data) && !is_numeric($data)) {
 					$data = strtotime($data);
 				}
 				$locales = array(self::findLanguage());

--- a/tests/lib/l10n.php
+++ b/tests/lib/l10n.php
@@ -53,10 +53,15 @@ class Test_L10n extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	* Issue #4360: Do not call strtotime() on numeric strings.
-	*/
+	 * Issue #4360: Do not call strtotime() on numeric strings.
+	 */
 	public function testNumericStringToDateTime() {
 		$l = new OC_L10N('test');
 		$this->assertSame('February 13, 2009 23:31', $l->l('datetime', '1234567890'));
+	}
+
+	public function testNumericToDateTime() {
+		$l = new OC_L10N('test');
+		$this->assertSame('February 13, 2009 23:31', $l->l('datetime', 1234567890));
 	}
 }

--- a/tests/lib/l10n.php
+++ b/tests/lib/l10n.php
@@ -52,4 +52,11 @@ class Test_L10n extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('5 oken', (string)$l->n('%n window', '%n windows', 5));
 	}
 
+	/**
+	* Issue #4360: Do not call strtotime() on numeric strings.
+	*/
+	public function testNumericStringToDateTime() {
+		$l = new OC_L10N('test');
+		$this->assertSame('February 13, 2009 23:31', $l->l('datetime', '1234567890'));
+	}
 }


### PR DESCRIPTION
strtotime() will return false and the date will be formatted as the 0-timestamp
(e.g. January 1, 1970 00:00) otherwise.

Fixes #2494
