### PR TITLE
Store and retrieve group data as JSON

### DIFF
--- a/settings/ajax/createuser.php
+++ b/settings/ajax/createuser.php
@@ -41,7 +41,7 @@ try {
 	OC_JSON::success(array("data" =>
 				array(
 					"username" => $username,
-					"groups" => implode( ", ", OC_Group::getUserGroups( $username )))));
+					"groups" => OC_Group::getUserGroups( $username ))));
 } catch (Exception $exception) {
 	OC_JSON::error(array("data" => array( "message" => $exception->getMessage())));
 }

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -89,10 +89,15 @@ var UserList = {
 		tr.attr('data-displayName', displayname);
 		tr.find('td.name').text(username);
 		tr.find('td.displayName > span').text(displayname);
-		var groupsSelect = $('<select multiple="multiple" class="groupsselect" data-placehoder="Groups" title="' + t('settings', 'Groups') + '"></select>').attr('data-username', username).attr('data-user-groups', [groups]);
+		var groupsSelect = $('<select multiple="multiple" class="groupsselect" data-placehoder="Groups" title="' + t('settings', 'Groups') + '"></select>')
+			.attr('data-username', username)
+			.attr('data-user-groups', [groups]);
 		tr.find('td.groups').empty();
 		if (tr.find('td.subadmins').length > 0) {
-			var subadminSelect = $('<select multiple="multiple" class="subadminsselect" data-placehoder="subadmins" title="' + t('settings', 'Group Admin') + '">').attr('data-username', username).attr('data-user-groups', [groups]).attr('data-subadmin', [subadmin]);
+			var subadminSelect = $('<select multiple="multiple" class="subadminsselect" data-placehoder="subadmins" title="' + t('settings', 'Group Admin') + '">')
+				.attr('data-username', username)
+				.attr('data-user-groups', [groups])
+				.attr('data-subadmin', [subadmin]);
 			tr.find('td.subadmins').empty();
 		}
 		$.each(this.availableGroups, function (i, group) {
@@ -244,7 +249,9 @@ var UserList = {
 							group: group
 						},
 						function (response) {
-							if(response.status === 'success' && UserList.availableGroups.indexOf(response.data.groupname) === -1 && response.data.action === 'add') {
+							if(response.status === 'success'
+									&& UserList.availableGroups.indexOf(response.data.groupname) === -1
+									&& response.data.action === 'add') {
 								UserList.availableGroups.push(response.data.groupname);
 							}
 							if(response.data.message) {

--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -89,10 +89,10 @@ var UserList = {
 		tr.attr('data-displayName', displayname);
 		tr.find('td.name').text(username);
 		tr.find('td.displayName > span').text(displayname);
-		var groupsSelect = $('<select multiple="multiple" class="groupsselect" data-placehoder="Groups" title="' + t('settings', 'Groups') + '"></select>').attr('data-username', username).attr('data-user-groups', groups);
+		var groupsSelect = $('<select multiple="multiple" class="groupsselect" data-placehoder="Groups" title="' + t('settings', 'Groups') + '"></select>').attr('data-username', username).attr('data-user-groups', [groups]);
 		tr.find('td.groups').empty();
 		if (tr.find('td.subadmins').length > 0) {
-			var subadminSelect = $('<select multiple="multiple" class="subadminsselect" data-placehoder="subadmins" title="' + t('settings', 'Group Admin') + '">').attr('data-username', username).attr('data-user-groups', groups).attr('data-subadmin', subadmin);
+			var subadminSelect = $('<select multiple="multiple" class="subadminsselect" data-placehoder="subadmins" title="' + t('settings', 'Group Admin') + '">').attr('data-username', username).attr('data-user-groups', [groups]).attr('data-subadmin', [subadmin]);
 			tr.find('td.subadmins').empty();
 		}
 		$.each(this.availableGroups, function (i, group) {
@@ -227,7 +227,7 @@ var UserList = {
 		var user = element.attr('data-username');
 		if ($(element).attr('class') == 'groupsselect') {
 			if (element.data('userGroups')) {
-				checked = String(element.data('userGroups')).split(', ');
+				checked = element.data('userGroups');
 			}
 			if (user) {
 				var checkHandeler = function (group) {
@@ -244,11 +244,10 @@ var UserList = {
 							group: group
 						},
 						function (response) {
-							if(response.status === 'success' && response.data.action === 'add') {
-								if(UserList.availableGroups.indexOf(response.data.gropname) === -1) {
-									UserList.availableGroups.push(response.data.gropname);
-								}
-							} else {
+							if(response.status === 'success' && UserList.availableGroups.indexOf(response.data.groupname) === -1 && response.data.action === 'add') {
+								UserList.availableGroups.push(response.data.groupname);
+							}
+							if(response.data.message) {
 								OC.Notification.show(response.data.message);
 							}
 						}
@@ -282,7 +281,7 @@ var UserList = {
 		}
 		if ($(element).attr('class') == 'subadminsselect') {
 			if (element.data('subadmin')) {
-				checked = String(element.data('subadmin')).split(', ');
+				checked = element.data('subadmin');
 			}
 			var checkHandeler = function (group) {
 				if (group == 'admin') {
@@ -321,7 +320,7 @@ var UserList = {
 $(document).ready(function () {
 
 	UserList.doSort();
-	UserList.availableGroups = $('#content table').attr('data-groups').split(', ');
+	UserList.availableGroups = $('#content table').data('groups');
 	$('tbody tr:last').bind('inview', function (event, isInView, visiblePartX, visiblePartY) {
 		OC.Router.registerLoadedCallback(function () {
 			UserList.update();
@@ -449,7 +448,7 @@ $(document).ready(function () {
 						t('settings', 'Error creating user'));
 				} else {
 					if (result.data.groups) {
-						var addedGroups = result.data.groups.split(', ');
+						var addedGroups = result.data.groups;
 						UserList.availableGroups = $.unique($.merge(UserList.availableGroups, addedGroups));
 					}
 					if($('tr[data-uid="' + username + '"]').length === 0) {

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -80,7 +80,7 @@ $_['subadmingroups'] = array_flip($items);
 	</div>
 </div>
 
-<table class="hascontrols" data-groups="<?php p(implode(', ', $allGroups));?>">
+<table class="hascontrols" data-groups="<?php p(json_encode($allGroups));?>">
 	<thead>
 		<tr>
 			<th id='headerName'><?php p($l->t('Login Name'))?></th>
@@ -110,7 +110,7 @@ $_['subadmingroups'] = array_flip($items);
 			<td class="groups"><select
 				class="groupsselect"
 				data-username="<?php p($user['name']) ;?>"
-				data-user-groups="<?php p($user['groups']) ;?>"
+				data-user-groups="<?php p(json_encode($user['groups'])) ;?>"
 				data-placeholder="groups" title="<?php p($l->t('Groups'))?>"
 				multiple="multiple">
 					<?php foreach($_["groups"] as $group): ?>
@@ -124,7 +124,7 @@ $_['subadmingroups'] = array_flip($items);
 			<td class="subadmins"><select
 				class="subadminsselect"
 				data-username="<?php p($user['name']) ;?>"
-				data-subadmin="<?php p($user['subadmin']);?>"
+				data-subadmin="<?php p(json_encode($user['subadmin']));?>"
 				data-placeholder="subadmins" title="<?php p($l->t('Group Admin'))?>"
 				multiple="multiple">
 					<?php foreach($_["subadmingroups"] as $group): ?>

--- a/settings/users.php
+++ b/settings/users.php
@@ -54,15 +54,16 @@ foreach($accessibleusers as $uid => $displayName) {
 	$name = $displayName;
 	if ( $displayName != $uid ) {
 		$name = $name . ' ('.$uid.')';
-	} 
-	
+	}
+
 	$users[] = array(
 		"name" => $uid,
-		"displayName" => $displayName, 
-		"groups" => join( ", ", /*array_intersect(*/OC_Group::getUserGroups($uid)/*, OC_SubAdmin::getSubAdminsGroups(OC_User::getUser()))*/),
-		'quota'=>$quota,
-		'isQuotaUserDefined'=>$isQuotaUserDefined,
-		'subadmin'=>implode(', ', OC_SubAdmin::getSubAdminsGroups($uid)));
+		"displayName" => $displayName,
+		"groups" => OC_Group::getUserGroups($uid),
+		'quota' => $quota,
+		'isQuotaUserDefined' => $isQuotaUserDefined,
+		'subadmin' => OC_SubAdmin::getSubAdminsGroups($uid),
+	);
 }
 
 foreach( $accessiblegroups as $i ) {


### PR DESCRIPTION
Encoding and using the jQuery's .data() allows JSON to be automatically decoded on the client side for use.
Storing group names containing commas is no problem for JSON, whereas prior code would use .split(',') to create too many array elements from multiple groups stored as strings, separated with commas.
Fixes #4351
