### PR TITLE
Don't display hidden files in file lists.

### DIFF
--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -827,6 +827,10 @@ class View {
 
 			$ids = array();
 			foreach ($files as $i => $file) {
+				
+				// Do NOT display hidden files / folders - names starting with a dot (.) - in file lists
+				if( substr(strrchr($f['path'], "/"), 1, 1) === '.') unset($files[$fk]);
+				
 				$files[$i]['type'] = $file['mimetype'] === 'httpd/unix-directory' ? 'dir' : 'file';
 				$ids[] = $file['fileid'];
 


### PR DESCRIPTION
Do NOT display hidden files / folders - names starting with a dot (.) - in file lists.  TODO: Add a config var for this, on a per-user basis.
