### PR TITLE
Fix new file creation

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -61,7 +61,10 @@ if($source) {
 	}
 
 	$ctx = stream_context_create(null, array('notification' =>'progress'));
+	$proxyStatus = \OC_FileProxy::$enabled;
+	\OC_FileProxy::$enabled = false;
 	$sourceStream=fopen($source, 'rb', false, $ctx);
+	\OC_FileProxy::$enabled = $proxyStatus;
 	$target=$dir.'/'.$filename;
 	$result=\OC\Files\Filesystem::file_put_contents($target, $sourceStream);
 	if($result) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -311,10 +311,6 @@ $(document).ready(function() {
 		$('#new').toggleClass('active');
 	});
 	$('#new li').click(function(){
-		if($(this).children('p').length==0){
-			return;
-		}
-
 		$('#new li').each(function(i,element){
 			if($(element).children('p').length==0){
 				$(element).children('form').remove();


### PR DESCRIPTION
Don't return here, otherwise we will never reach the point to update the mime info for the new file which will keep the file in a undefined state until the next page reload.

cc @karlitschek @DeepDiver1975 

cc @icewind1991 please have a look, the return statement was introduced by one of your commits. I don't see the need for it. Without it everything works as expected and the issue mentioned above is fixed.
