### PR TITLE
allow empty configvalue in appconfig

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -32,7 +32,7 @@
 			<field>
 				<name>configvalue</name>
 				<type>clob</type>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 			</field>
 
 			<index>


### PR DESCRIPTION
we cannot know what kind of data apps will store in the appconfig configdata column. currently trying to insert an empty string will fail on oracle because it treats '' as NULL:

``` sql
ORA-01400: cannot insert NULL into ("OC_AUTOTEST"."oc_appconfig"."configvalue")
INSERT INTO "oc_appconfig" ( "appid", "configkey", "configvalue" ) VALUES( :param1, :param2, :↯param3 )
```

This PR removes the notnull constraint, allowing apps to insert '' or NULL into the column, even on oracle.

@Kondou-ger @karlitschek @DeepDiver1975 @bartv2 

also see related test in https://github.com/owncloud/core/pull/4292
