### PR TITLE
[stable5] Don't use xcache in case admin auth is enabled

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -32,7 +32,7 @@ class OC_Cache {
 	static public function getGlobalCache($fast=false) {
 		if (!self::$global_cache) {
 			self::$global_cache_fast = null;
-			if (!self::$global_cache_fast && function_exists('xcache_set')) {
+			if (!self::$global_cache_fast && OC_Cache_XCache::available()) {
 				self::$global_cache_fast = new OC_Cache_XCache(true);
 			}
 			if (!self::$global_cache_fast && function_exists('apc_store')) {
@@ -61,7 +61,7 @@ class OC_Cache {
 	static public function getUserCache($fast=false) {
 		if (!self::$user_cache) {
 			self::$user_cache_fast = null;
-			if (!self::$user_cache_fast && function_exists('xcache_set')) {
+			if (!self::$user_cache_fast && OC_Cache_XCache::available()) {
 				self::$user_cache_fast = new OC_Cache_XCache();
 			}
 			if (!self::$user_cache_fast && function_exists('apc_store')) {

--- a/lib/cache/xcache.php
+++ b/lib/cache/xcache.php
@@ -16,6 +16,22 @@ class OC_Cache_XCache {
 		}
 	}
 
+	public static function available()
+	{
+		if (!extension_loaded('xcache')) {
+			return false;
+		}
+		if (\OC::$CLI) {
+			return false;
+		}
+		// as soon as admin auth is enabled we can run into issues with admin ops like xcache_clear_cache
+		if (ini_get('xcache.admin.enable_auth')) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * entries in XCache gets namespaced to prevent collisions between owncloud instances and users
 	 */

--- a/lib/util.php
+++ b/lib/util.php
@@ -851,7 +851,11 @@ class OC_Util {
 		}
 		// XCache
 		if (function_exists('xcache_clear_cache')) {
-			xcache_clear_cache(XC_TYPE_VAR, 0);
+			if (ini_get('xcache.admin.enable_auth')) {
+				OC_Log::write('core', 'XCache will not be cleared because "xcache.admin.enable_auth" is enabled in php.ini.', \OC_Log::WARN);
+			} else {
+				xcache_clear_cache(XC_TYPE_VAR, 0);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Stable5 version of #4378

As soon as admin auth is enabled in php.ini for xcache all admin operations can cause php fatal error.
This is actually a pretty bad design within XCache.

In case admin auth is enabled we simple ignore xcache.

fixes #3417 in stable5

@karlitschek backport to stable5 is necessary and I'd love to see this in 5.0.10, because this can cause update to break. (btw: first reported with 4.5 and nobody gave a :shit::imp: )

@icewind1991 @bartv2 @bantu @butonic @ringmaster THX
