### PR TITLE
Fix recursive scanner to reusing etags

### DIFF
--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -184,7 +184,7 @@ class Scanner extends BasicEmitter {
 			}
 			\OC_DB::commit();
 			foreach ($childQueue as $child) {
-				$childSize = $this->scanChildren($child, self::SCAN_RECURSIVE);
+				$childSize = $this->scanChildren($child, self::SCAN_RECURSIVE, $reuse);
 				if ($childSize === -1) {
 					$size = -1;
 				} else {

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -143,6 +143,24 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$newData = $this->cache->get('');
 		$this->assertEquals($oldData['etag'], $newData['etag']);
 		$this->assertEquals(-1, $newData['size']);
+
+		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
+		$oldData = $this->cache->get('');
+		$this->assertNotEquals(-1, $oldData['size']);
+		$this->scanner->scanFile('', \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
+		$newData = $this->cache->get('');
+		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertEquals($oldData['size'], $newData['size']);
+
+		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
+		$newData = $this->cache->get('');
+		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertEquals($oldData['size'], $newData['size']);
+
+		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
+		$newData = $this->cache->get('');
+		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertEquals($oldData['size'], $newData['size']);
 	}
 
 	public function testRemovedFile() {

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright (c) 2012 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Files\Utils;
+
+use OC\Files\Mount\Mount;
+use OC\Files\Storage\Temporary;
+
+class TestScanner extends \OC\Files\Utils\Scanner {
+	/**
+	 * @var \OC\Files\Mount\Mount[] $mounts
+	 */
+	private $mounts = array();
+
+	/**
+	 * @param \OC\Files\Mount\Mount $mount
+	 */
+	public function addMount($mount) {
+		$this->mounts[] = $mount;
+	}
+
+	protected function getMounts($dir) {
+		return $this->mounts;
+	}
+}
+
+class Scanner extends \PHPUnit_Framework_TestCase {
+	public function testReuseExistingRoot() {
+		$storage = new Temporary(array());
+		$mount = new Mount($storage, '');
+		$cache = $storage->getCache();
+
+		$storage->mkdir('folder');
+		$storage->file_put_contents('foo.txt', 'qwerty');
+		$storage->file_put_contents('folder/bar.txt', 'qwerty');
+
+		$scanner = new TestScanner('');
+		$scanner->addMount($mount);
+
+		$scanner->scan('');
+		$this->assertTrue($cache->inCache('folder/bar.txt'));
+		$oldRoot = $cache->get('');
+
+		$scanner->scan('');
+		$newRoot = $cache->get('');
+		$this->assertEquals($oldRoot, $newRoot);
+	}
+
+	public function testReuseExistingFile() {
+		$storage = new Temporary(array());
+		$mount = new Mount($storage, '');
+		$cache = $storage->getCache();
+
+		$storage->mkdir('folder');
+		$storage->file_put_contents('foo.txt', 'qwerty');
+		$storage->file_put_contents('folder/bar.txt', 'qwerty');
+
+		$scanner = new TestScanner('');
+		$scanner->addMount($mount);
+
+		$scanner->scan('');
+		$this->assertTrue($cache->inCache('folder/bar.txt'));
+		$old = $cache->get('folder/bar.txt');
+
+		$scanner->scan('');
+		$new = $cache->get('folder/bar.txt');
+		$this->assertEquals($old, $new);
+	}
+}


### PR DESCRIPTION
Fixes #440

@JacekZ please test if this solves the issue of new etags being generated when calling the scanner from occ

cc @DeepDiver1975 @karlitschek @MTGap 
