### PR TITLE
Fix sharing defaults

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -157,6 +157,7 @@ var OC={
 	PERMISSION_UPDATE:2,
 	PERMISSION_DELETE:8,
 	PERMISSION_SHARE:16,
+	PERMISSION_ALL:31,
 	webroot:oc_webroot,
 	appswebroots:(typeof oc_appswebroots !== 'undefined') ? oc_appswebroots:false,
 	currentUser:(typeof oc_current_user!=='undefined')?oc_current_user:false,

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -256,7 +256,7 @@ OC.Share={
 				var shareType = selected.item.value.shareType;
 				var shareWith = selected.item.value.shareWith;
 				$(this).val(shareWith);
-				// Default permissions are Edit and Share (all)
+				// Default permissions are Edit (CRUD) and Share
 				var permissions = OC.PERMISSION_ALL;
 				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, function() {
 					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, possiblePermissions);

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -256,8 +256,8 @@ OC.Share={
 				var shareType = selected.item.value.shareType;
 				var shareWith = selected.item.value.shareWith;
 				$(this).val(shareWith);
-				// Default permissions are Read and Share
-				var permissions = OC.PERMISSION_READ | OC.PERMISSION_SHARE;
+				// Default permissions are Edit and Share (all)
+				var permissions = OC.PERMISSION_ALL;
 				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, function() {
 					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, possiblePermissions);
 					$('#shareWith').val('');


### PR DESCRIPTION
The intention of sharing is to allow other people to collaborate, It does not make sense to limit them to readonly but allow them resharing by default. Thats nonsense.

This PR allows editing (CRUD) and resharing by default.

cc @jancborchardt @DeepDiver1975 @MTGap @MTRichards @karlitschek @kabum 
