### PR TITLE
Fixed uncaught TypeError

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -370,7 +370,7 @@ var FileList={
 			files=[files];
 		}
 		for (var i=0; i<files.length; i++) {
-			var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date").children(".action.delete");
+			var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date").children().last();
 			var oldHTML = deleteAction.html();
 			var newHTML = '<img class="move2trash" data-action="Delete" title="'+t('files', 'perform delete operation')+'" src="'+ OC.imagePath('core', 'loading.gif') +'"></a>';
 			deleteAction.html(newHTML);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -370,7 +370,7 @@ var FileList={
 			files=[files];
 		}
 		for (var i=0; i<files.length; i++) {
-			var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date").children().last();
+			var deleteAction = $('tr[data-file="'+files[i]+'"]').children("td.date").children().last();
 			var oldHTML = deleteAction.html();
 			var newHTML = '<img class="move2trash" data-action="Delete" title="'+t('files', 'perform delete operation')+'" src="'+ OC.imagePath('core', 'loading.gif') +'"></a>';
 			deleteAction.html(newHTML);


### PR DESCRIPTION
Without this fix it is not possible to unshare files/folders from the 'Shared' folder.
An uncaught TypeError occurred in line 343 because jQuery was looking for a tag with class="action delete", but in the 'Shared' folder this tag does not exist.
By using .children().last() the spinner will always be at the end of the row (just like in all the other folders) and unsharing works.
