### PR TITLE
also emit hooks for views that are a subfolder of the user folder

### DIFF
--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -267,18 +267,18 @@ class View {
 			$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 			if (\OC_FileProxy::runPreProxies('file_put_contents', $absolutePath, $data)
 				and Filesystem::isValidPath($path)
-					and !Filesystem::isFileBlacklisted($path)
+				and !Filesystem::isFileBlacklisted($path)
 			) {
 				$path = $this->getRelativePath($absolutePath);
 				$exists = $this->file_exists($path);
 				$run = true;
-				if ($this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path)) {
+				if ($this->shouldEmitHooks($path)) {
 					if (!$exists) {
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
 							Filesystem::signal_create,
 							array(
-								Filesystem::signal_param_path => $path,
+								Filesystem::signal_param_path => $this->getHookPath($path),
 								Filesystem::signal_param_run => &$run
 							)
 						);
@@ -287,7 +287,7 @@ class View {
 						Filesystem::CLASSNAME,
 						Filesystem::signal_write,
 						array(
-							Filesystem::signal_param_path => $path,
+							Filesystem::signal_param_path => $this->getHookPath($path),
 							Filesystem::signal_param_run => &$run
 						)
 					);
@@ -300,18 +300,18 @@ class View {
 					list ($count, $result) = \OC_Helper::streamCopy($data, $target);
 					fclose($target);
 					fclose($data);
-					if ($this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path) && $result !== false) {
+					if ($this->shouldEmitHooks($path) && $result !== false) {
 						if (!$exists) {
 							\OC_Hook::emit(
 								Filesystem::CLASSNAME,
 								Filesystem::signal_post_create,
-								array(Filesystem::signal_param_path => $path)
+								array(Filesystem::signal_param_path => $this->getHookPath($path))
 							);
 						}
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
 							Filesystem::signal_post_write,
-							array(Filesystem::signal_param_path => $path)
+							array(Filesystem::signal_param_path => $this->getHookPath($path))
 						);
 					}
 					\OC_FileProxy::runPostProxies('file_put_contents', $absolutePath, $count);
@@ -353,21 +353,21 @@ class View {
 				return false;
 			}
 			$run = true;
-			if ($this->fakeRoot == Filesystem::getRoot() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
+			if ($this->shouldEmitHooks() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
 				// if it was a rename from a part file to a regular file it was a write and not a rename operation
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, Filesystem::signal_write,
 					array(
-						Filesystem::signal_param_path => $path2,
+						Filesystem::signal_param_path => $this->getHookPath($path2),
 						Filesystem::signal_param_run => &$run
 					)
 				);
-			} elseif ($this->fakeRoot == Filesystem::getRoot()) {
+			} elseif ($this->shouldEmitHooks()) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, Filesystem::signal_rename,
 					array(
-						Filesystem::signal_param_oldpath => $path1,
-						Filesystem::signal_param_newpath => $path2,
+						Filesystem::signal_param_oldpath => $this->getHookPath($path1),
+						Filesystem::signal_param_newpath => $this->getHookPath($path2),
 						Filesystem::signal_param_run => &$run
 					)
 				);
@@ -407,22 +407,22 @@ class View {
 						}
 					}
 				}
-				if ($this->fakeRoot == Filesystem::getRoot() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false) {
+				if ($this->shouldEmitHooks() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false) {
 					// if it was a rename from a part file to a regular file it was a write and not a rename operation
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_post_write,
 						array(
-							Filesystem::signal_param_path => $path2,
+							Filesystem::signal_param_path => $this->getHookPath($path2),
 						)
 					);
-				} elseif ($this->fakeRoot == Filesystem::getRoot() && $result !== false) {
+				} elseif ($this->shouldEmitHooks() && $result !== false) {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_post_rename,
 						array(
-							Filesystem::signal_param_oldpath => $path1,
-							Filesystem::signal_param_newpath => $path2
+							Filesystem::signal_param_oldpath => $this->getHookPath($path1),
+							Filesystem::signal_param_newpath => $this->getHookPath($path2)
 						)
 					);
 				}
@@ -454,13 +454,13 @@ class View {
 			}
 			$run = true;
 			$exists = $this->file_exists($path2);
-			if ($this->fakeRoot == Filesystem::getRoot()) {
+			if ($this->shouldEmitHooks()) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME,
 					Filesystem::signal_copy,
 					array(
-						Filesystem::signal_param_oldpath => $path1,
-						Filesystem::signal_param_newpath => $path2,
+						Filesystem::signal_param_oldpath => $this->getHookPath($path1),
+						Filesystem::signal_param_newpath => $this->getHookPath($path2),
 						Filesystem::signal_param_run => &$run
 					)
 				);
@@ -469,7 +469,7 @@ class View {
 						Filesystem::CLASSNAME,
 						Filesystem::signal_create,
 						array(
-							Filesystem::signal_param_path => $path2,
+							Filesystem::signal_param_path => $this->getHookPath($path2),
 							Filesystem::signal_param_run => &$run
 						)
 					);
@@ -479,7 +479,7 @@ class View {
 						Filesystem::CLASSNAME,
 						Filesystem::signal_write,
 						array(
-							Filesystem::signal_param_path => $path2,
+							Filesystem::signal_param_path => $this->getHookPath($path2),
 							Filesystem::signal_param_run => &$run
 						)
 					);
@@ -510,26 +510,26 @@ class View {
 						list($count, $result) = \OC_Helper::streamCopy($source, $target);
 					}
 				}
-				if ($this->fakeRoot == Filesystem::getRoot() && $result !== false) {
+				if ($this->shouldEmitHooks() && $result !== false) {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_post_copy,
 						array(
-							Filesystem::signal_param_oldpath => $path1,
-							Filesystem::signal_param_newpath => $path2
+							Filesystem::signal_param_oldpath => $this->getHookPath($path1),
+							Filesystem::signal_param_newpath => $this->getHookPath($path2)
 						)
 					);
 					if (!$exists) {
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
 							Filesystem::signal_post_create,
-							array(Filesystem::signal_param_path => $path2)
+							array(Filesystem::signal_param_path => $this->getHookPath($path2))
 						);
 					}
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_post_write,
-						array(Filesystem::signal_param_path => $path2)
+						array(Filesystem::signal_param_path => $this->getHookPath($path2))
 					);
 				}
 				return $result;
@@ -620,11 +620,11 @@ class View {
 			if ($path == null) {
 				return false;
 			}
-			if (Filesystem::$loaded && $this->fakeRoot == Filesystem::getRoot()) {
+			if ($this->shouldEmitHooks($path)) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME,
 					Filesystem::signal_read,
-					array(Filesystem::signal_param_path => $path)
+					array(Filesystem::signal_param_path => $this->getHookPath($path))
 				);
 			}
 			list($storage, $internalPath) = Filesystem::resolvePath($absolutePath . $postFix);
@@ -658,7 +658,7 @@ class View {
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (\OC_FileProxy::runPreProxies($operation, $absolutePath, $extraParam)
 			and Filesystem::isValidPath($path)
-				and !Filesystem::isFileBlacklisted($path)
+			and !Filesystem::isFileBlacklisted($path)
 		) {
 			$path = $this->getRelativePath($absolutePath);
 			if ($path == null) {
@@ -674,7 +674,7 @@ class View {
 					$result = $storage->$operation($internalPath);
 				}
 				$result = \OC_FileProxy::runPostProxies($operation, $this->getAbsolutePath($path), $result);
-				if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot() && $result !== false) {
+				if ($this->shouldEmitHooks($path) && $result !== false) {
 					if ($operation != 'fopen') { //no post hooks for fopen, the file stream is still open
 						$this->runHooks($hooks, $path, true);
 					}
@@ -685,10 +685,35 @@ class View {
 		return null;
 	}
 
+	/**
+	 * get the path relative to the default root for hook usage
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	private function getHookPath($path) {
+		if (!Filesystem::getView()) {
+			return $path;
+		}
+		return Filesystem::getView()->getRelativePath($this->getAbsolutePath($path));
+	}
+
+	private function shouldEmitHooks($path = '') {
+		if ($path && Cache\Scanner::isPartialFile($path)) {
+			return false;
+		}
+		if (!Filesystem::$loaded) {
+			return false;
+		}
+		$defaultRoot = Filesystem::getRoot();
+		return (strlen($this->fakeRoot) >= strlen($defaultRoot)) && (substr($this->fakeRoot, 0, strlen($defaultRoot)) === $defaultRoot);
+	}
+
 	private function runHooks($hooks, $path, $post = false) {
+		$path = $this->getHookPath($path);
 		$prefix = ($post) ? 'post_' : '';
 		$run = true;
-		if (Filesystem::$loaded and $this->fakeRoot == Filesystem::getRoot() && !Cache\Scanner::isPartialFile($path)) {
+		if ($this->shouldEmitHooks($path)) {
 			foreach ($hooks as $hook) {
 				if ($hook != 'read') {
 					\OC_Hook::emit(

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -25,7 +25,7 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		//login
 		\OC_User::createUser('test', 'test');
-		$this->user=\OC_User::getUser();
+		$this->user = \OC_User::getUser();
 		\OC_User::setUserId('test');
 
 		\OC\Files\Filesystem::clearMounts();
@@ -323,6 +323,35 @@ class View extends \PHPUnit_Framework_TestCase {
 		$cachedData = $rootView->getFileInfo('foo.txt');
 		$this->assertGreaterThanOrEqual($cachedData['mtime'], $oldCachedData['mtime']);
 		$this->assertEquals($cachedData['storage_mtime'], $cachedData['mtime']);
+	}
+
+	/**
+	 * @medium
+	 */
+	function testViewHooks() {
+		$storage1 = $this->getTestStorage();
+		$storage2 = $this->getTestStorage();
+		$defaultRoot = \OC\Files\Filesystem::getRoot();
+		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		\OC\Files\Filesystem::mount($storage2, array(), $defaultRoot . '/substorage');
+		\OC_Hook::connect('OC_Filesystem', 'post_write', $this, 'dummyHook');
+
+		$rootView = new \OC\Files\View('');
+		$subView = new \OC\Files\View($defaultRoot . '/substorage');
+		$this->hookPath = null;
+
+		$rootView->file_put_contents('/foo.txt', 'asd');
+		$this->assertNull($this->hookPath);
+
+		$subView->file_put_contents('/foo.txt', 'asd');
+		$this->assertNotNull($this->hookPath);
+		$this->assertEquals('/substorage/foo.txt', $this->hookPath);
+	}
+
+	private $hookPath;
+
+	function dummyHook($params) {
+		$this->hookPath = $params['path'];
 	}
 
 	/**


### PR DESCRIPTION
Previously only filesystem views that had `/$user/files` as root would emit hooks, with this change also views like `/$user/files/foo/bar` will emit hooks.

This fixes the issue for the notes app where the cache isn't updated because a view is used.

cc @DeepDiver1975 @MTGap @Raydiation 
