### PR TITLE
Remove cancel button from filepicker

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -117,10 +117,6 @@ var OCdialogs = {
 				text: t('core', 'Choose'),
 				click: functionToCall,
 				defaultButton: true
-				},
-				{
-				text: t('core', 'Cancel'),
-				click: function(){self.$filePicker.ocdialog('close'); }
 			}];
 
 			self.$filePicker.ocdialog({


### PR DESCRIPTION
Having the cancel button in the bottom right corner was a bit confusing.
It's useless anyways, since there's a X in the top right.

@jancborchardt @tanghus @owncloud/designers 
