### PR TITLE
Class Auto Loader: Cache paths in APC

### DIFF
--- a/lib/memcache/factory.php
+++ b/lib/memcache/factory.php
@@ -37,4 +37,33 @@ class Factory {
 	public function isAvailable() {
 		return XCache::isAvailable() || APCu::isAvailable() || APC::isAvailable() || Memcached::isAvailable();
 	}
+
+	/**
+	 * get a in-server cache instance, will return null if no backend is available
+	 *
+	 * @param string $prefix
+	 * @return \OC\Memcache\Cache
+	 */
+	public static function createLowLatency($prefix = '') {
+		if (XCache::isAvailable()) {
+			return new XCache($prefix);
+		} elseif (APCu::isAvailable()) {
+			return new APCu($prefix);
+		} elseif (APC::isAvailable()) {
+			return new APC($prefix);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * check if there is a in-server backend available
+	 *
+	 * @return bool
+	 */
+	public static function isAvailableLowLatency() {
+		return XCache::isAvailable() || APCu::isAvailable() || APC::isAvailable();
+	}
+
+
 }


### PR DESCRIPTION
Using benchmark_single.php (from administration repo) I can
measure a speed improvement of 5% to 20% loading the /index.php
when logged in. (when using nginx, APC and php-fpm).
