### PR TITLE
LDAP: use memcache if available

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -80,7 +80,12 @@ class Connection {
 	public function __construct($configPrefix = '', $configID = 'user_ldap') {
 		$this->configPrefix = $configPrefix;
 		$this->configID = $configID;
-		$this->cache = \OC_Cache::getGlobalCache();
+		$memcache = new \OC\Memcache\Factory();
+		if($memcache->isAvailable()) {
+			$this->cache = $memcache->create();
+		} else {
+			$this->cache = \OC_Cache::getGlobalCache();
+		}
 		$this->config['hasPagedResultSupport'] = (function_exists('ldap_control_paged_result')
 			&& function_exists('ldap_control_paged_result_response'));
 	}


### PR DESCRIPTION
Since OC_Cache was split up into (File)Cache and Memcache (https://github.com/owncloud/core/pull/2395, why actually?) and there is no common interface anymore, we need to have this adjustment so that LDAP backend can have advantage of the fastest available cache.

@icewind1991 @karlitschek @bartv2 
