### PR TITLE
fix hidden groups in Firefox on Mac - fix 2571

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -93,3 +93,7 @@ table.shareAPI td { padding-bottom: 0.8em; }
 /* HELP */
 .pressed {background-color:#DDD;}
 
+/* fix hidden groups in firefox */
+ul.multiselectoptions > li {
+	overflow: visible !important;
+}


### PR DESCRIPTION
cc @georgehrke 

fixes #2571 

Just reproducable on stable5 and firefox for Mac
