### PR TITLE
move upload progress bar near upload button, more contextual

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -46,12 +46,22 @@
 	z-index:20; position:relative; cursor:pointer; overflow:hidden;
 }
 
-#uploadprogresswrapper { float: right; position: relative; }
+#uploadprogresswrapper {
+	position: relative;
+	display: inline;
+}
 #uploadprogresswrapper #uploadprogressbar {
-	position:relative; float: right;
-	margin-left: 12px; width:10em; height:1.5em; top:.4em;
+	position:relative;
+	float: left;
+	margin-left: 12px;
+	width: 130px;
+	height: 26px;
 	display:inline-block;
 }
+#uploadprogresswrapper #uploadprogressbar + stop {
+	font-size: 13px;
+}
+
 
 /* FILE TABLE */
 

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -50,7 +50,7 @@
 	position: relative;
 	display: inline;
 }
-#uploadprogresswrapper #uploadprogressbar {
+#uploadprogressbar {
 	position:relative;
 	float: left;
 	margin-left: 12px;
@@ -58,7 +58,7 @@
 	height: 26px;
 	display:inline-block;
 }
-#uploadprogresswrapper #uploadprogressbar + stop {
+#uploadprogressbar + stop {
 	font-size: 13px;
 }
 


### PR DESCRIPTION
Just move the upload bar from the far right of the bar to the left – directly right next to the upload button which triggered the upload action.

Please check @owncloud/designers
