### PR TITLE
Ajax calls for "files" and "files_trashbin" apps

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -10,36 +10,34 @@ OCP\JSON::checkLoggedIn();
 
 // Load the files
 $dir = isset( $_GET['dir'] ) ? $_GET['dir'] : '';
+
+if (!\OC\Files\Filesystem::is_dir($dir . '/')) {
+	header("HTTP/1.0 404 Not Found");
+	exit();
+}
+
 $doBreadcrumb = isset($_GET['breadcrumb']);
 $data = array();
+$baseUrl = OCP\Util::linkTo('files', 'index.php') . '?dir=';
 
 // Make breadcrumb
 if($doBreadcrumb) {
-	$breadcrumb = array();
-	$pathtohere = "/";
-	foreach( explode( "/", $dir ) as $i ) {
-		if( $i != "" ) {
-			$pathtohere .= "$i/";
-			$breadcrumb[] = array( "dir" => $pathtohere, "name" => $i );
-		}
-	}
+	$breadcrumb = \OCA\files\lib\Helper::makeBreadcrumb($dir);
 
-	$breadcrumbNav = new OCP\Template( "files", "part.breadcrumb", "" );
-	$breadcrumbNav->assign( "breadcrumb", $breadcrumb, false );
+	$breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '');
+	$breadcrumbNav->assign('breadcrumb', $breadcrumb, false);
+	$breadcrumbNav->assign('baseURL', $baseUrl);
 
 	$data['breadcrumb'] = $breadcrumbNav->fetchPage();
 }
 
 // make filelist
-$files = array();
-foreach( \OC\Files\Filesystem::getDirectoryContent( $dir ) as $i ) {
-	$i["date"] = OCP\Util::formatDate($i["mtime"] );
-	$i['icon'] = \OCA\files\lib\Helper::determineIcon($i);
-	$files[] = $i;
-}
+$files = \OCA\files\lib\Helper::getFiles($dir);
 
-$list = new OCP\Template( "files", "part.list", "" );
-$list->assign( "files", $files, false );
-$data = array('files' => $list->fetchPage());
+$list = new OCP\Template("files", "part.list", "");
+$list->assign('files', $files, false);
+$list->assign('baseURL', $baseUrl, false);
+$list->assign('downloadURL', OCP\Util::linkToRoute('download', array('file' => '/')));
+$data['files'] = $list->fetchPage();
 
 OCP\JSON::success(array('data' => $data));

--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -20,6 +20,8 @@ $doBreadcrumb = isset($_GET['breadcrumb']);
 $data = array();
 $baseUrl = OCP\Util::linkTo('files', 'index.php') . '?dir=';
 
+$permissions = \OCA\files\lib\Helper::getDirPermissions($dir);
+
 // Make breadcrumb
 if($doBreadcrumb) {
 	$breadcrumb = \OCA\files\lib\Helper::makeBreadcrumb($dir);
@@ -38,6 +40,8 @@ $list = new OCP\Template("files", "part.list", "");
 $list->assign('files', $files, false);
 $list->assign('baseURL', $baseUrl, false);
 $list->assign('downloadURL', OCP\Util::linkToRoute('download', array('file' => '/')));
+$list->assign('isPublic', false);
 $data['files'] = $list->fetchPage();
+$data['permissions'] = $permissions;
 
 OCP\JSON::success(array('data' => $data));

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -338,7 +338,7 @@ table.dragshadow td.size {
 }
 .mask {
 	z-index: 50;
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -336,3 +336,25 @@ table.dragshadow td.size {
 	text-align: center;
 	margin-left: -200px;
 }
+.mask {
+	z-index: 50;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: white;
+	background-repeat: no-repeat no-repeat;
+	background-position: 50%;
+	opacity: 0.7;
+	filter: alpha(opacity=70);
+	transition: opacity 100ms;
+	-moz-transition: opacity 100ms;
+	-o-transition: opacity 100ms;
+	-ms-transition: opacity 100ms;
+	-webkit-transition: opacity 100ms;
+}
+.mask.transparent{
+	opacity: 0;
+}
+

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -65,19 +65,7 @@ $breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '');
 $breadcrumbNav->assign('breadcrumb', $breadcrumb);
 $breadcrumbNav->assign('baseURL', OCP\Util::linkTo('files', 'index.php') . '?dir=');
 
-$permissions = OCP\PERMISSION_READ;
-if (\OC\Files\Filesystem::isCreatable($dir . '/')) {
-	$permissions |= OCP\PERMISSION_CREATE;
-}
-if (\OC\Files\Filesystem::isUpdatable($dir . '/')) {
-	$permissions |= OCP\PERMISSION_UPDATE;
-}
-if (\OC\Files\Filesystem::isDeletable($dir . '/')) {
-	$permissions |= OCP\PERMISSION_DELETE;
-}
-if (\OC\Files\Filesystem::isSharable($dir . '/')) {
-	$permissions |= OCP\PERMISSION_SHARE;
-}
+$permissions = \OCA\files\lib\Helper::getDirPermissions($dir);
 
 if ($needUpgrade) {
 	OCP\Util::addscript('files', 'upgrade');

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -41,13 +41,40 @@ if (!\OC\Files\Filesystem::is_dir($dir . '/')) {
 	exit();
 }
 
+$isIE8 = false;
+preg_match('/MSIE (.*?);/', $_SERVER['HTTP_USER_AGENT'], $matches);
+if (count($matches) > 0 && $matches[1] <= 8){
+	$isIE8 = true;
+}
+
+// if IE8 and "?dir=path" was specified, reformat the URL to use a hash like "#?dir=path"
+if ($isIE8 && isset($_GET['dir'])){
+	if ($dir === ''){
+		$dir = '/';
+	}
+	header('Location: ' . OCP\Util::linkTo('files', 'index.php') . '#?dir=' . \OCP\Util::encodePath($dir));
+	exit();
+}
+
+$ajaxLoad = false;
 $files = array();
 $user = OC_User::getUser();
 if (\OC\Files\Cache\Upgrade::needUpgrade($user)) { //dont load anything if we need to upgrade the cache
 	$needUpgrade = true;
 	$freeSpace = 0;
 } else {
-	$files = \OCA\files\lib\Helper::getFiles($dir);
+	if ($isIE8){
+		// after the redirect above, the URL will have a format
+		// like "files#?dir=path" which means that no path was given
+		// (dir is not set). In that specific case, we don't return any
+		// files because the client will take care of switching the dir
+		// to the one from the hash, then ajax-load the initial file list
+		$files = array();
+		$ajaxLoad = true;
+	}
+	else{
+		$files = \OCA\files\lib\Helper::getFiles($dir);
+	}
 	$freeSpace = \OC\Files\Filesystem::free_space($dir);
 	$needUpgrade = false;
 }
@@ -106,5 +133,6 @@ if ($needUpgrade) {
 	$tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 	$tmpl->assign("encryptedFiles", \OCP\Util::encryptedFiles());
 	$tmpl->assign('disableSharing', false);
+	$tmpl->assign('ajaxLoad', $ajaxLoad);
 	$tmpl->printPage();
 }

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -196,13 +196,12 @@ FileActions.register('all', 'Rename', OC.PERMISSION_UPDATE, function () {
 	FileList.rename(filename);
 });
 
-
 FileActions.register('dir', 'Open', OC.PERMISSION_READ, '', function (filename) {
-	var dir = $('#dir').val();
+	var dir = $('#dir').val() || '/';
 	if (dir !== '/') {
 		dir = dir + '/';
 	}
-	window.location = OC.linkTo('files', 'index.php') + '?dir=' + encodeURIComponent(dir + filename);
+	FileList.changeDirectory(dir + filename);
 });
 
 FileActions.setDefault('dir', 'Open');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -600,6 +600,7 @@ var FileList={
 		$mask = $('<div class="mask transparent"></div>');
 
 		$mask.css('background-image', 'url('+ OC.imagePath('core', 'loading.gif') + ')');
+		$mask.css('background-repeat', 'no-repeat');
 		$('#content').append($mask);
 
 		// block UI, but only make visible in case loading takes longer

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -19,6 +19,7 @@ var FileList={
 		if (window.Files){
 			Files.setupDragAndDrop();
 		}
+		FileList.updateFileSummary();
 		$fileList.trigger(jQuery.Event("updated"));
 	},
 	createRow:function(type, name, iconurl, linktarget, size, lastModified, permissions){

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -7,9 +7,11 @@ var FileList={
 		});
 	},
 	update:function(fileListHtml) {
-		var $fileList = $('#fileList');
+		var $fileList = $('#fileList'),
+			permissions = $('#permissions').val(),
+			isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
 		$fileList.empty().html(fileListHtml);
-		$('#emptycontent').toggleClass('hidden', $fileList.find('tr').length > 0);
+		$('#emptycontent').toggleClass('hidden', !isCreatable || $fileList.find('tr').length > 0);
 		$fileList.find('tr').each(function () {
 			FileActions.display($(this).children('td.filename'));
 		});
@@ -216,6 +218,10 @@ var FileList={
 			return;
 		}
 
+		if (result.data.permissions){
+			FileList.setDirectoryPermissions(result.data.permissions);
+		}
+
 		if(typeof(result.data.breadcrumb) != 'undefined'){
 			$controls.find('.crumb').remove();
 			$controls.prepend(result.data.breadcrumb);
@@ -231,6 +237,12 @@ var FileList={
 		}
 
 		FileList.update(result.data.files);
+	},
+	setDirectoryPermissions: function(permissions){
+		var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
+		$('#permissions').val(permissions);
+		$('.creatable').toggleClass('hidden', !isCreatable);
+		$('.notCreatable').toggleClass('hidden', isCreatable);
 	},
 	remove:function(name){
 		$('tr').filterAttr('data-file',name).find('td.filename').draggable('destroy');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -218,8 +218,10 @@ var FileList={
 		if(typeof(result.data.breadcrumb) != 'undefined'){
 			$controls.find('.crumb').remove();
 			$controls.prepend(result.data.breadcrumb);
-			// TODO: might need refactor breadcrumb code into a new file
-			//resizeBreadcrumbs(true);
+
+			var width = $(window).width();
+			Files.initBreadCrumbs();
+			Files.resizeBreadcrumbs(width, true);
 
 			// in case svg is not supported by the browser we need to execute the fallback mechanism
 			if(!SVGSupport()) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -220,7 +220,13 @@ var FileList={
 			$controls.prepend(result.data.breadcrumb);
 			// TODO: might need refactor breadcrumb code into a new file
 			//resizeBreadcrumbs(true);
+
+			// in case svg is not supported by the browser we need to execute the fallback mechanism
+			if(!SVGSupport()) {
+				replaceSVG();
+			}
 		}
+
 		FileList.update(result.data.files);
 	},
 	remove:function(name){

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -182,6 +182,10 @@ Files={
 	}
 };
 $(document).ready(function() {
+	// FIXME: workaround for trashbin app
+	if (window.trashBinApp){
+		return;
+	}
 	Files.displayEncryptionWarning();
 	Files.bindKeyboardShortcuts(document, jQuery);
 

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -111,6 +111,72 @@ Files={
 				$(e).droppable(folderDropOptions);
 			}
 		});
+	},
+
+	lastWidth: 0,
+
+	initBreadCrumbs: function () {
+		Files.lastWidth = 0;
+		Files.breadcrumbs = [];
+
+		// initialize with some extra space
+		Files.breadcrumbsWidth = 64;
+		if ( document.getElementById("navigation") ) {
+			Files.breadcrumbsWidth += $('#navigation').get(0).offsetWidth;
+		}
+		Files.hiddenBreadcrumbs = 0;
+
+		$.each($('.crumb'), function(index, breadcrumb) {
+			Files.breadcrumbs[index] = breadcrumb;
+			Files.breadcrumbsWidth += $(breadcrumb).get(0).offsetWidth;
+		});
+
+
+		$.each($('#controls .actions>div'), function(index, action) {
+			Files.breadcrumbsWidth += $(action).get(0).offsetWidth;
+		});
+	},
+
+	resizeBreadcrumbs: function (width, firstRun) {
+		if (width != Files.lastWidth) {
+			if ((width < Files.lastWidth || firstRun) && width < Files.breadcrumbsWidth) {
+				if (Files.hiddenBreadcrumbs == 0) {
+					Files.breadcrumbsWidth -= $(Files.breadcrumbs[1]).get(0).offsetWidth;
+					$(Files.breadcrumbs[1]).find('a').hide();
+					$(Files.breadcrumbs[1]).append('<span>...</span>');
+					Files.breadcrumbsWidth += $(Files.breadcrumbs[1]).get(0).offsetWidth;
+					Files.hiddenBreadcrumbs = 2;
+				}
+				var i = Files.hiddenBreadcrumbs;
+				while (width < Files.breadcrumbsWidth && i > 1 && i < Files.breadcrumbs.length - 1) {
+					Files.breadcrumbsWidth -= $(Files.breadcrumbs[i]).get(0).offsetWidth;
+					$(Files.breadcrumbs[i]).hide();
+					Files.hiddenBreadcrumbs = i;
+					i++
+				}
+			} else if (width > Files.lastWidth && Files.hiddenBreadcrumbs > 0) {
+				var i = Files.hiddenBreadcrumbs;
+				while (width > Files.breadcrumbsWidth && i > 0) {
+					if (Files.hiddenBreadcrumbs == 1) {
+						Files.breadcrumbsWidth -= $(Files.breadcrumbs[1]).get(0).offsetWidth;
+						$(Files.breadcrumbs[1]).find('span').remove();
+						$(Files.breadcrumbs[1]).find('a').show();
+						Files.breadcrumbsWidth += $(Files.breadcrumbs[1]).get(0).offsetWidth;
+					} else {
+						$(Files.breadcrumbs[i]).show();
+						Files.breadcrumbsWidth += $(Files.breadcrumbs[i]).get(0).offsetWidth;
+						if (Files.breadcrumbsWidth > width) {
+							Files.breadcrumbsWidth -= $(Files.breadcrumbs[i]).get(0).offsetWidth;
+							$(Files.breadcrumbs[i]).hide();
+							break;
+						}
+					}
+					i--;
+					Files.hiddenBreadcrumbs = i;
+				}
+			}
+			Files.lastWidth = width;
+		}
 	}
 };
 $(document).ready(function() {
@@ -273,72 +339,15 @@ $(document).ready(function() {
 	//do a background scan if needed
 	scanFiles();
 
-	var lastWidth = 0;
-	var breadcrumbs = [];
-	var breadcrumbsWidth = 0;
-	if ( document.getElementById("navigation") ) {
-		breadcrumbsWidth = $('#navigation').get(0).offsetWidth;
-	}
-	var hiddenBreadcrumbs = 0;
-
-	$.each($('.crumb'), function(index, breadcrumb) {
-		breadcrumbs[index] = breadcrumb;
-		breadcrumbsWidth += $(breadcrumb).get(0).offsetWidth;
-	});
-
-
-	$.each($('#controls .actions>div'), function(index, action) {
-		breadcrumbsWidth += $(action).get(0).offsetWidth;
-	});
-
-	function resizeBreadcrumbs(firstRun) {
-		var width = $(this).width();
-		if (width != lastWidth) {
-			if ((width < lastWidth || firstRun) && width < breadcrumbsWidth) {
-				if (hiddenBreadcrumbs == 0) {
-					breadcrumbsWidth -= $(breadcrumbs[1]).get(0).offsetWidth;
-					$(breadcrumbs[1]).find('a').hide();
-					$(breadcrumbs[1]).append('<span>...</span>');
-					breadcrumbsWidth += $(breadcrumbs[1]).get(0).offsetWidth;
-					hiddenBreadcrumbs = 2;
-				}
-				var i = hiddenBreadcrumbs;
-				while (width < breadcrumbsWidth && i > 1 && i < breadcrumbs.length - 1) {
-					breadcrumbsWidth -= $(breadcrumbs[i]).get(0).offsetWidth;
-					$(breadcrumbs[i]).hide();
-					hiddenBreadcrumbs = i;
-					i++
-				}
-			} else if (width > lastWidth && hiddenBreadcrumbs > 0) {
-				var i = hiddenBreadcrumbs;
-				while (width > breadcrumbsWidth && i > 0) {
-					if (hiddenBreadcrumbs == 1) {
-						breadcrumbsWidth -= $(breadcrumbs[1]).get(0).offsetWidth;
-						$(breadcrumbs[1]).find('span').remove();
-						$(breadcrumbs[1]).find('a').show();
-						breadcrumbsWidth += $(breadcrumbs[1]).get(0).offsetWidth;
-					} else {
-						$(breadcrumbs[i]).show();
-						breadcrumbsWidth += $(breadcrumbs[i]).get(0).offsetWidth;
-						if (breadcrumbsWidth > width) {
-							breadcrumbsWidth -= $(breadcrumbs[i]).get(0).offsetWidth;
-							$(breadcrumbs[i]).hide();
-							break;
-						}
-					}
-					i--;
-					hiddenBreadcrumbs = i;
-				}
-			}
-			lastWidth = width;
-		}
-	}
+	Files.initBreadCrumbs();
 
 	$(window).resize(function() {
-		resizeBreadcrumbs(false);
+		var width = $(this).width();
+		Files.resizeBreadcrumbs(width, false);
 	});
 
-	resizeBreadcrumbs(true);
+	var width = $(this).width();
+	Files.resizeBreadcrumbs(width, true);
 
 	// event handlers for breadcrumb items
 	$('#controls').delegate('.crumb a', 'click', onClickBreadcrumb);

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -94,29 +94,34 @@ Files={
 			OC.Notification.show(t('files_encryption', 'Encryption was disabled but your files are still encrypted. Please go to your personal settings to decrypt your files.'));
 			return;
 		}
+	},
+
+	setupDragAndDrop: function(){
+		var $fileList = $('#fileList');
+
+		//drag/drop of files
+		$fileList.find('tr td.filename').each(function(i,e){
+			if ($(e).parent().data('permissions') & OC.PERMISSION_DELETE) {
+				$(e).draggable(dragOptions);
+			}
+		});
+
+		$fileList.find('tr[data-type="dir"] td.filename').each(function(i,e){
+			if ($(e).parent().data('permissions') & OC.PERMISSION_CREATE){
+				$(e).droppable(folderDropOptions);
+			}
+		});
 	}
 };
 $(document).ready(function() {
 	Files.displayEncryptionWarning();
 	Files.bindKeyboardShortcuts(document, jQuery);
-	$('#fileList tr').each(function(){
-		//little hack to set unescape filenames in attribute
-		$(this).attr('data-file',decodeURIComponent($(this).attr('data-file')));
-	});
+
+	FileList.postProcessList();
+	Files.setupDragAndDrop();
 
 	$('#file_action_panel').attr('activeAction', false);
 
-	//drag/drop of files
-	$('#fileList tr td.filename').each(function(i,e){
-		if ($(e).parent().data('permissions') & OC.PERMISSION_DELETE) {
-			$(e).draggable(dragOptions);
-		}
-	});
-	$('#fileList tr[data-type="dir"] td.filename').each(function(i,e){
-		if ($(e).parent().data('permissions') & OC.PERMISSION_CREATE){
-			$(e).droppable(folderDropOptions);
-		}
-	});
 	$('div.crumb:not(.last)').droppable(crumbDropOptions);
 	$('ul#apps>li:first-child').data('dir','');
 	if($('div.crumb').length){
@@ -335,6 +340,9 @@ $(document).ready(function() {
 
 	resizeBreadcrumbs(true);
 
+	// event handlers for breadcrumb items
+	$('#controls').delegate('.crumb a', 'click', onClickBreadcrumb);
+
 	// display storage warnings
 	setTimeout ( "Files.displayStorageWarnings()", 100 );
 	OC.Notification.setDefault(Files.displayStorageWarnings);
@@ -413,10 +421,6 @@ function boolOperationFinished(data, callback) {
 	} else {
 		alert(result.data.message);
 	}
-}
-
-function updateBreadcrumb(breadcrumbHtml) {
-	$('p.nav').empty().html(breadcrumbHtml);
 }
 
 var createDragShadow = function(event){
@@ -680,4 +684,10 @@ function checkTrashStatus() {
 			$("input[type=button][id=trash]").removeAttr("disabled");
 		}
 	});
+}
+
+function onClickBreadcrumb(e){
+	var $el = $(e.target).closest('.crumb');
+	e.preventDefault();
+	FileList.changeDirectory(decodeURIComponent($el.data('dir')));
 }

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -131,10 +131,12 @@ Files={
 			Files.breadcrumbsWidth += $(breadcrumb).get(0).offsetWidth;
 		});
 
-
 		$.each($('#controls .actions>div'), function(index, action) {
 			Files.breadcrumbsWidth += $(action).get(0).offsetWidth;
 		});
+
+		// event handlers for breadcrumb items
+		$('#controls .crumb a').on('click', onClickBreadcrumb);
 	},
 
 	resizeBreadcrumbs: function (width, firstRun) {
@@ -348,9 +350,6 @@ $(document).ready(function() {
 
 	var width = $(this).width();
 	Files.resizeBreadcrumbs(width, true);
-
-	// event handlers for breadcrumb items
-	$('#controls').delegate('.crumb a', 'click', onClickBreadcrumb);
 
 	// display storage warnings
 	setTimeout ( "Files.displayStorageWarnings()", 100 );

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -111,4 +111,26 @@ class Helper
 		}
 		return $breadcrumb;
 	}
+
+	/**
+	 * Returns the numeric permissions for the given directory.
+	 * @param string $dir directory without trailing slash
+	 * @return numeric permissions
+	 */
+	public static function getDirPermissions($dir){
+		$permissions = \OCP\PERMISSION_READ;
+		if (\OC\Files\Filesystem::isCreatable($dir . '/')) {
+			$permissions |= \OCP\PERMISSION_CREATE;
+		}
+		if (\OC\Files\Filesystem::isUpdatable($dir . '/')) {
+			$permissions |= \OCP\PERMISSION_UPDATE;
+		}
+		if (\OC\Files\Filesystem::isDeletable($dir . '/')) {
+			$permissions |= \OCP\PERMISSION_DELETE;
+		}
+		if (\OC\Files\Filesystem::isSharable($dir . '/')) {
+			$permissions |= \OCP\PERMISSION_SHARE;
+		}
+		return $permissions;
+	}
 }

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -45,5 +45,70 @@ class Helper
 		return \OC_Helper::mimetypeIcon($file['mimetype']);
 	}
 
+	/**
+	 * Comparator function to sort files alphabetically and have
+	 * the directories appear first
+	 * @param array $a file
+	 * @param array $b file
+	 * @return -1 if $a must come before $b, 1 otherwise
+	 */
+	public static function fileCmp($a, $b) {
+		if ($a['type'] === 'dir' and $b['type'] !== 'dir') {
+			return -1;
+		} elseif ($a['type'] !== 'dir' and $b['type'] === 'dir') {
+			return 1;
+		} else {
+			return strnatcasecmp($a['name'], $b['name']);
+		}
+	}
 
+	/**
+	 * Retrieves the contents of the given directory and
+	 * returns it as a sorted array.
+	 * @param string $dir path to the directory
+	 * @return array of files
+	 */
+	public static function getFiles($dir) {
+		$content = \OC\Files\Filesystem::getDirectoryContent($dir);
+		$files = array();
+
+		foreach ($content as $i) {
+			$i['date'] = \OCP\Util::formatDate($i['mtime']);
+			if ($i['type'] === 'file') {
+				$fileinfo = pathinfo($i['name']);
+				$i['basename'] = $fileinfo['filename'];
+				if (!empty($fileinfo['extension'])) {
+					$i['extension'] = '.' . $fileinfo['extension'];
+				} else {
+					$i['extension'] = '';
+				}
+			}
+			$i['directory'] = $dir;
+			$i['isPreviewAvailable'] = \OCP\Preview::isMimeSupported($i['mimetype']);
+			$i['icon'] = \OCA\files\lib\Helper::determineIcon($i);
+			$files[] = $i;
+		}
+
+		usort($files, array('\OCA\files\lib\Helper', 'fileCmp'));
+
+		return $files;
+	}
+
+	/**
+	 * Splits the given path into a breadcrumb structure.
+	 * @param string $dir path to process
+	 * @return array where each entry is a hash of the absolute
+	 * directory path and its name
+	 */
+	public static function makeBreadcrumb($dir){
+		$breadcrumb = array();
+		$pathtohere = '';
+		foreach (explode('/', $dir) as $i) {
+			if ($i !== '') {
+				$pathtohere .= '/' . $i;
+				$breadcrumb[] = array('dir' => $pathtohere, 'name' => $i);
+			}
+		}
+		return $breadcrumb;
+	}
 }

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -38,7 +38,9 @@
 				</form>
 			</div>
 			<?php if ($_['trash'] ): ?>
-			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
+				<div id="trash" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>>
+					<a><?php p($l->t('Deleted files'));?></a>
+				</div>
 			<?php endif; ?>
 			<div id="uploadprogresswrapper">
 				<div id="uploadprogressbar"></div>

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -55,7 +55,7 @@
 	<input type="hidden" name="permissions" value="<?php p($_['permissions']); ?>" id="permissions">
 </div>
 
-<div id="emptycontent" <?php if (!isset($_['files']) or !$_['isCreatable'] or count($_['files']) > 0):?>class="hidden"<?php endif; ?>><?php p($l->t('Nothing in here. Upload something!'))?></div>
+<div id="emptycontent" <?php if (!isset($_['files']) or !$_['isCreatable'] or count($_['files']) > 0 or !$_['ajaxLoad']):?>class="hidden"<?php endif; ?>><?php p($l->t('Nothing in here. Upload something!'))?></div>
 
 <input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 
@@ -120,6 +120,7 @@
 </div>
 
 <!-- config hints for javascript -->
+<input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" name="allowZipDownload" id="allowZipDownload" value="<?php p($_['allowZipDownload']); ?>" />
 <input type="hidden" name="usedSpacePercent" id="usedSpacePercent" value="<?php p($_['usedSpacePercent']); ?>" />
 <input type="hidden" name="encryptedFiles" id="encryptedFiles" value="<?php $_['encryptedFiles'] ? p('1') : p('0'); ?>" />

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -2,7 +2,7 @@
 <div id="controls">
 	<?php print_unescaped($_['breadcrumb']); ?>
 	<?php if ($_['isCreatable']):?>
-		<div class="actions <?php if (isset($_['files']) and count($_['files'])==0):?>emptyfolder<?php endif; ?>">
+		<div class="actions <?php if (isset($_['files']) and count($_['files'])==0):?>emptycontent<?php endif; ?>">
 			<div id="new" class="button">
 				<a><?php p($l->t('New'));?></a>
 				<ul>
@@ -55,9 +55,9 @@
 	<input type="hidden" name="permissions" value="<?php p($_['permissions']); ?>" id="permissions">
 </div>
 
-<?php if (isset($_['files']) and $_['isCreatable'] and count($_['files'])==0):?>
-	<div id="emptycontent"><?php p($l->t('Nothing in here. Upload something!'))?></div>
-<?php endif; ?>
+<div id="emptycontent" <?php if (!isset($_['files']) or !$_['isCreatable'] or count($_['files']) > 0):?>class="hidden"<?php endif; ?>><?php p($l->t('Nothing in here. Upload something!'))?></div>
+
+<input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 
 <table id="filestable" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="36" data-preview-y="36">
 	<thead>
@@ -82,7 +82,7 @@
 			<th id="headerDate">
 				<span id="modified"><?php p($l->t( 'Modified' )); ?></span>
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>
-<!-- 					NOTE: Temporary fix to allow unsharing of files in root of Shared folder -->
+<!--					NOTE: Temporary fix to allow unsharing of files in root of Shared folder -->
 					<?php if ($_['dir'] == '/Shared'): ?>
 						<span class="selectedActions"><a href="" class="delete-selected">
 							<?php p($l->t('Unshare'))?>

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -1,8 +1,7 @@
 <!--[if IE 8]><style>input[type="checkbox"]{padding:0;}table td{position:static !important;}</style><![endif]-->
 <div id="controls">
 	<?php print_unescaped($_['breadcrumb']); ?>
-	<?php if ($_['isCreatable']):?>
-		<div class="actions <?php if (isset($_['files']) and count($_['files'])==0):?>emptycontent<?php endif; ?>">
+		<div class="actions creatable <?php if (!$_['isCreatable']):?>hidden<?php endif; ?> <?php if (isset($_['files']) and count($_['files'])==0):?>emptycontent<?php endif; ?>">
 			<div id="new" class="button">
 				<a><?php p($l->t('New'));?></a>
 				<ul>
@@ -50,10 +49,9 @@
 			</div>
 		</div>
 		<div id="file_action_panel"></div>
-	<?php elseif( !$_['isPublic'] ):?>
-		<div class="actions"><input type="button" disabled value="<?php p($l->t('You don’t have write permissions here.'))?>"></div>
-		<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
-	<?php endif;?>
+		<div class="notCreatable notPublic <?php if ($_['isCreatable'] or $_['isPublic'] ):?>hidden<?php endif; ?>">
+			<div class="actions"><input type="button" disabled value="<?php p($l->t('You don’t have write permissions here.'))?>"></div>
+		</div>
 	<input type="hidden" name="permissions" value="<?php p($_['permissions']); ?>" id="permissions">
 </div>
 

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -1,4 +1,6 @@
-<input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>">
+<?php $totalfiles = 0;
+$totaldirs = 0;
+$totalsize = 0; ?>
 <?php foreach($_['files'] as $file):
 	// the bigger the file, the darker the shade of grey; megabytes*2
 	$simple_size_color = intval(160-$file['size']/(1024*1024)*2);

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
 
 	if (typeof OC.Share !== 'undefined' && typeof FileActions !== 'undefined'  && !disableSharing) {
 
-		$('#fileList').one('fileActionsReady',function(){
+		$('#fileList').on('fileActionsReady',function(){
 			OC.Share.loadIcons('file');
 		});
 

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -147,6 +147,7 @@ if (isset($path)) {
 		$tmpl->assign('mimetype', \OC\Files\Filesystem::getMimeType($path));
 		$tmpl->assign('fileTarget', basename($linkItem['file_target']));
 		$tmpl->assign('dirToken', $linkItem['token']);
+		$tmpl->assign('disableSharing', true);
 		$allowPublicUploadEnabled = (bool) ($linkItem['permissions'] & OCP\PERMISSION_CREATE);
 		if (\OCP\App::isEnabled('files_encryption')) {
 			$allowPublicUploadEnabled = false;
@@ -206,7 +207,6 @@ if (isset($path)) {
 			}
 			$list = new OCP\Template('files', 'part.list', '');
 			$list->assign('files', $files);
-			$list->assign('disableSharing', true);
 			$list->assign('baseURL', OCP\Util::linkToPublic('files') . $urlLinkIdentifiers . '&path=');
 			$list->assign('downloadURL',
 				OCP\Util::linkToPublic('files') . $urlLinkIdentifiers . '&download&path=');

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -1,0 +1,51 @@
+<?php
+
+// only need filesystem apps
+$RUNTIME_APPTYPES=array('filesystem');
+
+// Init owncloud
+
+
+OCP\JSON::checkLoggedIn();
+
+// Load the files
+$dir = isset( $_GET['dir'] ) ? $_GET['dir'] : '';
+$doBreadcrumb = isset( $_GET['breadcrumb'] ) ? true : false;
+$data = array();
+
+// Make breadcrumb
+if($doBreadcrumb) {
+	$breadcrumb = \OCA\files_trashbin\lib\Helper::makeBreadcrumb($dir);
+
+	$breadcrumbNav = new OCP\Template('files_trashbin', 'part.breadcrumb', '');
+	$breadcrumbNav->assign('breadcrumb', $breadcrumb, false);
+	$breadcrumbNav->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php') . '?dir=');
+	$breadcrumbNav->assign('home', OCP\Util::linkTo('files', 'index.php'));
+
+	$data['breadcrumb'] = $breadcrumbNav->fetchPage();
+}
+
+// make filelist
+$files = \OCA\files_trashbin\lib\Helper::getTrashFiles($dir);
+
+if ($files === null){
+	header("HTTP/1.0 404 Not Found");
+	exit();
+}
+
+$dirlisting = false;
+if ($dir && $dir !== '/') {
+    $dirlisting = true;
+}
+
+$encodedDir = \OCP\Util::encodePath($dir);
+$list = new OCP\Template('files_trashbin', 'part.list', '');
+$list->assign('files', $files, false);
+$list->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php'). '?dir='.$encodedDir);
+$list->assign('downloadURL', OCP\Util::linkToRoute('download', array('file' => '/')));
+$list->assign('dirlisting', $dirlisting);
+$list->assign('disableDownloadActions', true);
+$data['files'] = $list->fetchPage();
+
+OCP\JSON::success(array('data' => $data));
+

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -14,6 +14,7 @@ OCP\Util::addStyle('files', 'files');
 OCP\Util::addScript('files', 'filelist');
 // filelist overrides
 OCP\Util::addScript('files_trashbin', 'filelist');
+OCP\Util::addscript('files', 'files');
 
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -10,92 +10,27 @@ OCP\Util::addScript('files_trashbin', 'disableDefaultActions');
 OCP\Util::addScript('files', 'fileactions');
 $tmpl = new OCP\Template('files_trashbin', 'index', 'user');
 
-$user = \OCP\User::getUser();
-$view = new OC_Filesystemview('/'.$user.'/files_trashbin/files');
-
 OCP\Util::addStyle('files', 'files');
 OCP\Util::addScript('files', 'filelist');
+// filelist overrides
+OCP\Util::addScript('files_trashbin', 'filelist');
 
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 
-$result = array();
-if ($dir) {
-	$dirlisting = true;
-	$dirContent = $view->opendir($dir);
-	$i = 0;
-	if(is_resource($dirContent)) {
-		while(($entryName = readdir($dirContent)) !== false) {
-			if (!\OC\Files\Filesystem::isIgnoredDir($entryName)) {
-				$pos = strpos($dir.'/', '/', 1);
-				$tmp = substr($dir, 0, $pos);
-				$pos = strrpos($tmp, '.d');
-				$timestamp = substr($tmp, $pos+2);
-				$result[] = array(
-						'id' => $entryName,
-						'timestamp' => $timestamp,
-						'mime' =>  $view->getMimeType($dir.'/'.$entryName),
-						'type' => $view->is_dir($dir.'/'.$entryName) ? 'dir' : 'file',
-						'location' => $dir,
-						);
-			}
-		}
-		closedir($dirContent);
-	}
-} else {
-	$dirlisting = false;
-	$query = \OC_DB::prepare('SELECT `id`,`location`,`timestamp`,`type`,`mime` FROM `*PREFIX*files_trash` WHERE `user` = ?');
-	$result = $query->execute(array($user))->fetchAll();
+$files = \OCA\files_trashbin\lib\Helper::getTrashFiles($dir);
+
+// Redirect if directory does not exist
+if ($files === null){
+	header('Location: ' . OCP\Util::linkTo('files_trashbin', 'index.php'));
+	exit();
 }
 
-$files = array();
-foreach ($result as $r) {
-	$i = array();
-	$i['name'] = $r['id'];
-	$i['date'] = OCP\Util::formatDate($r['timestamp']);
-	$i['timestamp'] = $r['timestamp'];
-	$i['mimetype'] = $r['mime'];
-	$i['type'] = $r['type'];
-	if ($i['type'] === 'file') {
-		$fileinfo = pathinfo($r['id']);
-		$i['basename'] = $fileinfo['filename'];
-		$i['extension'] = isset($fileinfo['extension']) ? ('.'.$fileinfo['extension']) : '';
-	}
-	$i['directory'] = $r['location'];
-	if ($i['directory'] === '/') {
-		$i['directory'] = '';
-	}
-	$i['permissions'] = OCP\PERMISSION_READ;
-	$i['isPreviewAvailable'] = \OCP\Preview::isMimeSupported($r['mime']);
-	$i['icon'] = \OCA\files\lib\Helper::determineIcon($i);
-	$files[] = $i;
+$dirlisting = false;
+if ($dir && $dir !== '/') {
+    $dirlisting = true;
 }
 
-function fileCmp($a, $b) {
-	if ($a['type'] === 'dir' and $b['type'] !== 'dir') {
-		return -1;
-	} elseif ($a['type'] !== 'dir' and $b['type'] === 'dir') {
-		return 1;
-	} else {
-		return strnatcasecmp($a['name'], $b['name']);
-	}
-}
-
-usort($files, "fileCmp");
-
-// Make breadcrumb
-$pathtohere = '';
-$breadcrumb = array();
-foreach (explode('/', $dir) as $i) {
-	if ($i !== '') {
-		if ( preg_match('/^(.+)\.d[0-9]+$/', $i, $match) ) {
-			$name = $match[1];
-		} else {
-			$name = $i;
-		}
-		$pathtohere .= '/' . $i;
-		$breadcrumb[] = array('dir' => $pathtohere, 'name' => $name);
-	}
-}
+$breadcrumb = \OCA\files_trashbin\lib\Helper::makeBreadcrumb($dir);
 
 $breadcrumbNav = new OCP\Template('files_trashbin', 'part.breadcrumb', '');
 $breadcrumbNav->assign('breadcrumb', $breadcrumb);
@@ -108,7 +43,6 @@ $list->assign('files', $files);
 $encodedDir = \OCP\Util::encodePath($dir);
 $list->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php'). '?dir='.$encodedDir);
 $list->assign('downloadURL', OCP\Util::linkTo('files_trashbin', 'download.php') . '?file='.$encodedDir);
-$list->assign('disableSharing', true);
 $list->assign('dirlisting', $dirlisting);
 $list->assign('disableDownloadActions', true);
 
@@ -116,6 +50,7 @@ $tmpl->assign('dirlisting', $dirlisting);
 $tmpl->assign('breadcrumb', $breadcrumbNav->fetchPage());
 $tmpl->assign('fileList', $list->fetchPage());
 $tmpl->assign('files', $files);
-$tmpl->assign('dir', \OC\Files\Filesystem::normalizePath($view->getAbsolutePath()));
+$tmpl->assign('dir', $dir);
+$tmpl->assign('disableSharing', true);
 
 $tmpl->printPage();

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -18,7 +18,30 @@ OCP\Util::addscript('files', 'files');
 
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 
-$files = \OCA\files_trashbin\lib\Helper::getTrashFiles($dir);
+$isIE8 = false;
+preg_match('/MSIE (.*?);/', $_SERVER['HTTP_USER_AGENT'], $matches);
+if (count($matches) > 0 && $matches[1] <= 8){
+	$isIE8 = true;
+}
+
+// if IE8 and "?dir=path" was specified, reformat the URL to use a hash like "#?dir=path"
+if ($isIE8 && isset($_GET['dir'])){
+	if ($dir === ''){
+		$dir = '/';
+	}
+	header('Location: ' . OCP\Util::linkTo('files_trashbin', 'index.php') . '#?dir=' . \OCP\Util::encodePath($dir));
+	exit();
+}
+
+$ajaxLoad = false;
+
+if (!$isIE8){
+	$files = \OCA\files_trashbin\lib\Helper::getTrashFiles($dir);
+}
+else{
+	$files = array();
+	$ajaxLoad = true;
+}
 
 // Redirect if directory does not exist
 if ($files === null){
@@ -53,5 +76,6 @@ $tmpl->assign('fileList', $list->fetchPage());
 $tmpl->assign('files', $files);
 $tmpl->assign('dir', $dir);
 $tmpl->assign('disableSharing', true);
+$tmpl->assign('ajaxLoad', true);
 
 $tmpl->printPage();

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -19,11 +19,6 @@ FileList.reload = function(){
 	});
 }
 
-FileList.setCurrentDir = function(targetDir, changeUrl){
-	$('#dir').val(targetDir);
-	// Note: IE8 handling ignored for now
-	if (window.history.pushState && changeUrl !== false){
-		url = OC.linkTo('files_trashbin', 'index.php')+"?dir="+ encodeURIComponent(targetDir).replace(/%2F/g, '/'),
-		window.history.pushState({dir: targetDir}, '', url);
-	}
+FileList.linkTo = function(dir){
+	return OC.linkTo('files_trashbin', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
 }

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -1,0 +1,29 @@
+// override reload with own ajax call
+FileList.reload = function(){
+	FileList.showMask();
+	if (FileList._reloadCall){
+		FileList._reloadCall.abort();
+	}
+	$.ajax({
+		url: OC.filePath('files_trashbin','ajax','list.php'),
+		data: {
+			dir : $('#dir').val(),
+			breadcrumb: true
+		},
+		error: function(result) {
+			FileList.reloadCallback(result);
+		},
+		success: function(result) {
+			FileList.reloadCallback(result);
+		}
+	});
+}
+
+FileList.setCurrentDir = function(targetDir, changeUrl){
+	$('#dir').val(targetDir);
+	// Note: IE8 handling ignored for now
+	if (window.history.pushState && changeUrl !== false){
+		url = OC.linkTo('files_trashbin', 'index.php')+"?dir="+ encodeURIComponent(targetDir).replace(/%2F/g, '/'),
+		window.history.pushState({dir: targetDir}, '', url);
+	}
+}

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -171,9 +171,15 @@ $(document).ready(function() {
 				action(filename);
 			}
 		}
+
+		// event handlers for breadcrumb items
+		$('#controls').delegate('.crumb:not(.home) a', 'click', onClickBreadcrumb);
 	});
 
-	FileActions.actions.dir = {};
+	FileActions.actions.dir = {
+		// only keep 'Open' action for navigation
+		'Open': FileActions.actions.dir.Open
+	};
 });
 
 function processSelection(){
@@ -246,3 +252,9 @@ function disableActions() {
 	$(".action").css("display", "none");
 	$(":input:checkbox").css("display", "none");
 }
+function onClickBreadcrumb(e){
+	var $el = $(e.target).closest('.crumb');
+	e.preventDefault();
+	FileList.changeDirectory(decodeURIComponent($el.data('dir')));
+}
+

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace OCA\files_trashbin\lib;
+
+class Helper
+{
+	/**
+	 * Retrieves the contents of a trash bin directory.
+	 * @param string $dir path to the directory inside the trashbin
+	 * or empty to retrieve the root of the trashbin
+	 * @return array of files
+	 */
+	public static function getTrashFiles($dir){
+		$result = array();
+		$user = \OCP\User::getUser();
+
+		if ($dir && $dir !== '/') {
+			$view = new \OC_Filesystemview('/'.$user.'/files_trashbin/files');
+			$dirContent = $view->opendir($dir);
+			if ($dirContent === false){
+				return null;
+			}
+			if(is_resource($dirContent)){
+				while(($entryName = readdir($dirContent)) !== false) {
+					if (!\OC\Files\Filesystem::isIgnoredDir($entryName)) {
+						$pos = strpos($dir.'/', '/', 1);
+						$tmp = substr($dir, 0, $pos);
+						$pos = strrpos($tmp, '.d');
+						$timestamp = substr($tmp, $pos+2);
+						$result[] = array(
+								'id' => $entryName,
+								'timestamp' => $timestamp,
+								'mime' =>  $view->getMimeType($dir.'/'.$entryName),
+								'type' => $view->is_dir($dir.'/'.$entryName) ? 'dir' : 'file',
+								'location' => $dir,
+								);
+					}
+				}
+				closedir($dirContent);
+			}
+		} else {
+			$query = \OC_DB::prepare('SELECT `id`,`location`,`timestamp`,`type`,`mime` FROM `*PREFIX*files_trash` WHERE `user` = ?');
+			$result = $query->execute(array($user))->fetchAll();
+		}
+
+		$files = array();
+		foreach ($result as $r) {
+			$i = array();
+			$i['name'] = $r['id'];
+			$i['date'] = \OCP\Util::formatDate($r['timestamp']);
+			$i['timestamp'] = $r['timestamp'];
+			$i['mimetype'] = $r['mime'];
+			$i['type'] = $r['type'];
+			if ($i['type'] === 'file') {
+				$fileinfo = pathinfo($r['id']);
+				$i['basename'] = $fileinfo['filename'];
+				$i['extension'] = isset($fileinfo['extension']) ? ('.'.$fileinfo['extension']) : '';
+			}
+			$i['directory'] = $r['location'];
+			if ($i['directory'] === '/') {
+				$i['directory'] = '';
+			}
+			$i['permissions'] = \OCP\PERMISSION_READ;
+			$i['isPreviewAvailable'] = \OCP\Preview::isMimeSupported($r['mime']);
+			$i['icon'] = \OCA\files\lib\Helper::determineIcon($i);
+			$files[] = $i;
+		}
+
+		usort($files, array('\OCA\files\lib\Helper', 'fileCmp'));
+
+		return $files;
+	}
+
+	/**
+	 * Splits the given path into a breadcrumb structure.
+	 * @param string $dir path to process
+	 * @return array where each entry is a hash of the absolute
+	 * directory path and its name
+	 */
+	public static function makeBreadcrumb($dir){
+		// Make breadcrumb
+		$pathtohere = '';
+		$breadcrumb = array();
+		foreach (explode('/', $dir) as $i) {
+			if ($i !== '') {
+				if ( preg_match('/^(.+)\.d[0-9]+$/', $i, $match) ) {
+					$name = $match[1];
+				} else {
+					$name = $i;
+				}
+				$pathtohere .= '/' . $i;
+				$breadcrumb[] = array('dir' => $pathtohere, 'name' => $name);
+			}
+		}
+		return $breadcrumb;
+	}
+}

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -9,6 +9,9 @@
 	<div id="emptycontent"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 <?php endif; ?>
 
+<input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
+<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
+
 <table id="filestable">
 	<thead>
 		<tr>

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -5,10 +5,11 @@
 </div>
 <div id='notification'></div>
 
-<?php if (isset($_['files']) && count($_['files']) === 0 && $_['dirlisting'] === false):?>
+<?php if (isset($_['files']) && count($_['files']) === 0 && $_['dirlisting'] === false && !$_['ajaxLoad']):?>
 	<div id="emptycontent"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 <?php endif; ?>
 
+<input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 

--- a/apps/files_trashbin/templates/part.breadcrumb.php
+++ b/apps/files_trashbin/templates/part.breadcrumb.php
@@ -1,11 +1,11 @@
-<div class="crumb">
+<div class="crumb home">
 		<a href="<?php print_unescaped($_['home']); ?>">
 			<img src="<?php print_unescaped(OCP\image_path('core', 'places/home.svg'));?>" class="svg" />
 		</a>
 </div>
 <?php if(count($_["breadcrumb"])):?>
 	<div class="crumb svg"
-		 data-dir='<?php print_unescaped($_['baseURL']); ?>'>
+		 data-dir='/'>
 	<a href="<?php p($_['baseURL']); ?>"><?php p($l->t("Deleted Files")); ?></a>
 	</div>
 <?php endif;?>

--- a/apps/files_trashbin/templates/part.list.php
+++ b/apps/files_trashbin/templates/part.list.php
@@ -1,4 +1,3 @@
-<input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>">
 <?php foreach($_['files'] as $file):
 	$relative_deleted_date = OCP\relative_modified_date($file['timestamp']);
 	// the older the file, the brighter the shade of grey; days*14
@@ -12,7 +11,7 @@
 		data-permissions='<?php p($file['permissions']); ?>'
 		<?php if ( $_['dirlisting'] ): ?>
 		id="<?php p($file['directory'].'/'.$file['name']);?>"
-		data-file="<?php p($file['directory'].'/'.$file['name']);?>"
+		data-file="<?php p($name);?>"
 		data-timestamp=''
 		data-dirlisting=1
 		<?php  else: ?>

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -322,6 +322,38 @@ var OC={
 		return date.getDate()+'.'+(date.getMonth()+1)+'.'+date.getFullYear()+', '+date.getHours()+':'+date.getMinutes();
 	},
 	/**
+	 * Parses a URL query string into a JS map
+	 * @param queryString query string in the format param1=1234&param2=abcde&param3=xyz
+	 * @return map containing key/values matching the URL parameters
+	 */
+	parseQueryString:function(queryString){
+		var parts,
+			components,
+			result = {},
+			key,
+			value;
+		if (!queryString){
+			return null;
+		}
+		if (queryString[0] === '?'){
+			queryString = queryString.substr(1);
+		}
+		parts = queryString.split('&');
+		for (var i = 0; i < parts.length; i++){
+			components = parts[i].split('=');
+			if (!components.length){
+				continue;
+			}
+			key = decodeURIComponent(components[0]);
+			if (!key){
+				continue;
+			}
+			value = components[1];
+			result[key] = value && decodeURIComponent(value);
+		}
+		return result;
+	},
+	/**
 	 * Opens a popup with the setting for an app.
 	 * @param appid String. The ID of the app e.g. 'calendar', 'contacts' or 'files'.
 	 * @param loadJS boolean or String. If true 'js/settings.js' is loaded. If it's a string


### PR DESCRIPTION
Frontend:
- The files app list now uses ajax calls to refresh the list.
- Added support the browser back button (history API).
- Added mask + spinner while loading file list

Backend:
- Added utility function in core JS for parsing query strings.
- Moved file list + breadcrumb template data code to helper
  functions
- Fixed some file paths in trashbin app to be similar to the files app

TODO:
- [x] breadcrumb resizing after ajax call
- [ ] test in other apps (encryption?)
- [x] IE8 testing
- [x] firefox testing
- [ ] opera testing
- [x] chrome testing
- [ ] ios browser
- [x] android browser
- [x] IE8 url adoption
