### PR TITLE
disable proxys for fopen call when a new file gets created from a link

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -63,7 +63,10 @@ if($source) {
 	}
 
 	$ctx = stream_context_create(null, array('notification' =>'progress'));
+	$proxyStatus = \OC_FileProxy::$enabled;
+	\OC_FileProxy::$enabled = false;
 	$sourceStream=fopen($source, 'rb', false, $ctx);
+	\OC_FileProxy::$enabled = $proxyStatus;
 	$result=\OC\Files\Filesystem::file_put_contents($target, $sourceStream);
 	if($result) {
 		$meta = \OC\Files\Filesystem::getFileInfo($target);


### PR DESCRIPTION
Creating a new file from a link uses fopen to open the open the URL in order to avoid the that stream wrapper from the files encryption app takes over I disabled the proxys for the fopen call.

cc @kabum @icewind1991 @DeepDiver1975 
