### PR TITLE
return only existing users in group

### DIFF
--- a/lib/group/group.php
+++ b/lib/group/group.php
@@ -77,7 +77,7 @@ class Group {
 		foreach ($userIds as $userId) {
 			$user = $this->userManager->get($userId);
 			if(!is_null($user)) {
-				$users[$userId] = $user;
+				$users[] = $user;
 			}
 		}
 		$this->users = $users;

--- a/lib/group/group.php
+++ b/lib/group/group.php
@@ -75,7 +75,10 @@ class Group {
 		}
 
 		foreach ($userIds as $userId) {
-			$users[] = $this->userManager->get($userId);
+			$user = $this->userManager->get($userId);
+			if(!is_null($user)) {
+				$users[$userId] = $user;
+			}
 		}
 		$this->users = $users;
 		return $users;
@@ -173,7 +176,10 @@ class Group {
 				$offset -= count($userIds);
 			}
 			foreach ($userIds as $userId) {
-				$users[$userId] = $this->userManager->get($userId);
+				$user = $this->userManager->get($userId);
+				if(!is_null($user)) {
+					$users[$userId] = $user;
+				}
 			}
 			if (!is_null($limit) and $limit <= 0) {
 				return array_values($users);
@@ -205,7 +211,10 @@ class Group {
 				$offset -= count($userIds);
 			}
 			foreach ($userIds as $userId) {
-				$users[$userId] = $this->userManager->get($userId);
+				$user = $this->userManager->get($userId);
+				if(!is_null($user)) {
+					$users[$userId] = $user;
+				}
 			}
 			if (!is_null($limit) and $limit <= 0) {
 				return array_values($users);

--- a/tests/lib/group/group.php
+++ b/tests/lib/group/group.php
@@ -43,8 +43,8 @@ class Group extends \PHPUnit_Framework_TestCase {
 		$users = $group->getUsers();
 
 		$this->assertEquals(2, count($users));
-		$user1 = $users[0];
-		$user2 = $users[1];
+		$user1 = $users['user1'];
+		$user2 = $users['user2'];
 		$this->assertEquals('user1', $user1->getUID());
 		$this->assertEquals('user2', $user2->getUID());
 	}
@@ -68,9 +68,9 @@ class Group extends \PHPUnit_Framework_TestCase {
 		$users = $group->getUsers();
 
 		$this->assertEquals(3, count($users));
-		$user1 = $users[0];
-		$user2 = $users[1];
-		$user3 = $users[2];
+		$user1 = $users['user1'];
+		$user2 = $users['user2'];
+		$user3 = $users['user3'];
 		$this->assertEquals('user1', $user1->getUID());
 		$this->assertEquals('user2', $user2->getUID());
 		$this->assertEquals('user3', $user3->getUID());


### PR DESCRIPTION
In a local group also users from other backends can be added. However, it might be, that those user are not removed from this group when they are deleted, resulting in leftovers. It is also possible, that the other backend is not available at the moment (server down e.g.). The method should only return users that are existing. Otherwise, it can happen that somewhere down the code null is returned instead of a user instance which again can result in a 500 error (found out with @raghunayyar new user management frontend). 

Please review @icewind1991 @DeepDiver1975 @bartv2 
