### PR TITLE
Fix files_external webdav up and download when path contains ' '

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -171,7 +171,7 @@ class DAV extends \OC\Files\Storage\Common{
 				$curl = curl_init();
 				$fp = fopen('php://temp', 'r+');
 				curl_setopt($curl, CURLOPT_USERPWD, $this->user.':'.$this->password);
-				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().$path);
+				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().str_replace(' ', '%20', $path));
 				curl_setopt($curl, CURLOPT_FILE, $fp);
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
@@ -256,7 +256,7 @@ class DAV extends \OC\Files\Storage\Common{
 
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_USERPWD, $this->user.':'.$this->password);
-		curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().$target);
+		curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().str_replace(' ', '%20', $target));
 		curl_setopt($curl, CURLOPT_BINARYTRANSFER, true);
 		curl_setopt($curl, CURLOPT_INFILE, $source); // file pointer
 		curl_setopt($curl, CURLOPT_INFILESIZE, filesize($path));


### PR DESCRIPTION
I wanted to mount a webdav share in owncloud and stumbled over this. listing files works fine because it is done with sabredav. fopening a file is done with curl and will fail when the path contains ' '. this PR replaces it with %20 for fopen and upload via curl. 

@MTGap @icewind1991 @DeepDiver1975 please review
