### PR TITLE
Allow Windows users to specify OpenSSL options in the ownCloud config

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -36,14 +36,6 @@ class Hooks {
 	 */
 	public static function login($params) {
 		$l = new \OC_L10N('files_encryption');
-		//check if all requirements are met
-		if(!Helper::checkRequirements() || !Helper::checkConfiguration() ) {
-			$error_msg = $l->t("Missing requirements.");
-			$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
-			\OC_App::disable('files_encryption');
-			\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
-			\OCP\Template::printErrorPage($error_msg, $hint);
-		}
 
 		$view = new \OC_FilesystemView('/');
 
@@ -53,6 +45,15 @@ class Hooks {
 		}
 
 		$util = new Util($view, $params['uid']);
+
+		//check if all requirements are met
+		if(!$util->ready() && (!Helper::checkRequirements() || !Helper::checkConfiguration())) {
+			$error_msg = $l->t("Missing requirements.");
+			$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
+			\OC_App::disable('files_encryption');
+			\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
+			\OCP\Template::printErrorPage($error_msg, $hint);
+		}
 
 		// setup user, if user not ready force relogin
 		if (Helper::setupUser($util, $params['password']) === false) {

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -52,6 +52,7 @@ class Crypt {
 
 		$return = false;
 
+		$res = \OCA\Encryption\Helper::getOpenSSLPkey();
 		$res = openssl_pkey_new(array('private_key_bits' => 4096));
 
 		if ($res === false) {

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -52,15 +52,14 @@ class Crypt {
 
 		$return = false;
 
-		$res = \OCA\Encryption\Helper::getOpenSSLPkey();
-		$res = openssl_pkey_new(array('private_key_bits' => 4096));
+		$res = Helper::getOpenSSLPkey();
 
 		if ($res === false) {
 			\OCP\Util::writeLog('Encryption library', 'couldn\'t generate users key-pair for ' . \OCP\User::getUser(), \OCP\Util::ERROR);
 			while ($msg = openssl_error_string()) {
 				\OCP\Util::writeLog('Encryption library', 'openssl_pkey_new() fails:  ' . $msg, \OCP\Util::ERROR);
 			}
-		} elseif (openssl_pkey_export($res, $privateKey)) {
+		} elseif (openssl_pkey_export($res, $privateKey, null, Helper::getOpenSSLConfig())) {
 			// Get public key
 			$keyDetails = openssl_pkey_get_details($res);
 			$publicKey = $keyDetails['key'];
@@ -71,7 +70,9 @@ class Crypt {
 			);
 		} else {
 			\OCP\Util::writeLog('Encryption library', 'couldn\'t export users private key, please check your servers openSSL configuration.' . \OCP\User::getUser(), \OCP\Util::ERROR);
-			\OCP\Util::writeLog('Encryption library', openssl_error_string(), \OCP\Util::ERROR);
+			while($errMsg = openssl_error_string()) {
+				\OCP\Util::writeLog('Encryption library', $errMsg, \OCP\Util::ERROR);
+			}
 		}
 
 		return $return;

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -280,9 +280,22 @@ class Helper {
 	 * @return resource The pkey resource created
 	 */
 	public static function getOpenSSLPkey() {
+		static $res = null;
+		if (is_null($res)) {
+			$res = openssl_pkey_new(self::getOpenSSLConfig());
+		}
+		return $res;
+	}
+
+	/**
+	 * Return an array of OpenSSL config options, default + config
+	 * Used for multiple OpenSSL functions
+	 * @return array The combined defaults and config settings
+	 */
+	public static function getOpenSSLConfig() {
 		$config = array('private_key_bits' => 4096);
-		$config = array_merge(\OCP\Config::getSystemValue('openssl'), $config);
-		return openssl_pkey_new($config);
+		$config = array_merge(\OCP\Config::getSystemValue('openssl', array()), $config);
+		return $config;
 	}
 
 	/**

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -265,7 +265,7 @@ class Helper {
 	 * @return bool true if configuration seems to be OK
 	 */
 	public static function checkConfiguration() {
-		if(openssl_pkey_new(array('private_key_bits' => 4096))) {
+		if(self::getOpenSSLPkey()) {
 			return true;
 		} else {
 			while ($msg = openssl_error_string()) {
@@ -273,6 +273,16 @@ class Helper {
 			}
 			return false;
 		}
+	}
+
+	/**
+	 * Create an openssl pkey with config-supplied settings
+	 * @return resource The pkey resource created
+	 */
+	public static function getOpenSSLPkey() {
+		$config = array('private_key_bits' => 4096);
+		$config = array_merge(\OCP\Config::getSystemValue('openssl'), $config);
+		return openssl_pkey_new($config);
 	}
 
 	/**

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -277,7 +277,7 @@ class Helper {
 
 	/**
 	 * Create an openssl pkey with config-supplied settings
-	 * WARNING: This initializes and caches a new private keypair, which is computationally expensive
+	 * WARNING: This initializes a new private keypair, which is computationally expensive
 	 * @return resource The pkey resource created
 	 */
 	public static function getOpenSSLPkey() {

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -277,14 +277,11 @@ class Helper {
 
 	/**
 	 * Create an openssl pkey with config-supplied settings
+	 * WARNING: This initializes and caches a new private keypair, which is computationally expensive
 	 * @return resource The pkey resource created
 	 */
 	public static function getOpenSSLPkey() {
-		static $res = null;
-		if (is_null($res)) {
-			$res = openssl_pkey_new(self::getOpenSSLConfig());
-		}
-		return $res;
+		return openssl_pkey_new(self::getOpenSSLConfig());
 	}
 
 	/**

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -217,6 +217,6 @@ $CONFIG = array(
 
 // Extra SSL options to be used for configuration
 'openssl' => array(
-	//'config' => '/path/to/openssl.cnf',
+	//'config' => '/absolute/location/of/openssl.cnf',
 ),
 );

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -214,4 +214,9 @@ $CONFIG = array(
 'preview_libreoffice_path' => '/usr/bin/libreoffice',
 /* cl parameters for libreoffice / openoffice */
 'preview_office_cl_parameters' => '',
+
+// Extra SSL options to be used for configuration
+'openssl' => array(
+	//'config' => '/path/to/openssl.cnf',
+),
 );


### PR DESCRIPTION
PHP's OpenSSL support compiles in the location of the config file.  It is typically difficult to specify an alternative location in Windows IIS via environment variables.  This PR allows the location of the openssl.cnf (and potentially other options) to be specified in the ownCloud config file.  If no config option is provided, the defaults are used, which work as before (and succeeds on Linux).
