### PR TITLE
Do not use realpath() on includes.

### DIFF
--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -25,7 +25,7 @@
 
 namespace OCA\Encryption;
 
-require_once realpath(dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php');
+require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
 
 /**
  * Class for common cryptography functionality

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -25,7 +25,7 @@
 
 namespace OCA\Encryption;
 
-require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
+require_once __DIR__ . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
 
 /**
  * Class for common cryptography functionality

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -7,16 +7,16 @@
  * See the COPYING-README file.
  */
 
-require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../lib/helper.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../lib/helper.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 
@@ -67,12 +67,12 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$this->pass = \Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1;
 
 		// set content for encrypting / decrypting in tests
-		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
+		$this->dataLong = file_get_contents(__DIR__ . '/../lib/crypt.php');
 		$this->dataShort = 'hats';
-		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
-		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
-		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
-		$this->legacyEncryptedDataKey = dirname(__FILE__) . '/encryption.key';
+		$this->dataUrl = __DIR__ . '/../lib/crypt.php';
+		$this->legacyData = __DIR__ . '/legacy-text.txt';
+		$this->legacyEncryptedData = __DIR__ . '/legacy-encrypted-text.txt';
+		$this->legacyEncryptedDataKey = __DIR__ . '/encryption.key';
 		$this->randomKey = Encryption\Crypt::generateKey();
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -67,12 +67,12 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$this->pass = \Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1;
 
 		// set content for encrypting / decrypting in tests
-		$this->dataLong = file_get_contents(realpath(dirname(__FILE__) . '/../lib/crypt.php'));
+		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
 		$this->dataShort = 'hats';
-		$this->dataUrl = realpath(dirname(__FILE__) . '/../lib/crypt.php');
-		$this->legacyData = realpath(dirname(__FILE__) . '/legacy-text.txt');
-		$this->legacyEncryptedData = realpath(dirname(__FILE__) . '/legacy-encrypted-text.txt');
-		$this->legacyEncryptedDataKey = realpath(dirname(__FILE__) . '/encryption.key');
+		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
+		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
+		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
+		$this->legacyEncryptedDataKey = dirname(__FILE__) . '/encryption.key';
 		$this->randomKey = Encryption\Crypt::generateKey();
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -7,16 +7,16 @@
  * See the COPYING-README file.
  */
 
-require_once realpath(dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php');
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../lib/helper.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../lib/helper.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -6,15 +6,15 @@
  * See the COPYING-README file.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../lib/helper.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../lib/helper.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -57,11 +57,11 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 	function setUp() {
 		// set content for encrypting / decrypting in tests
-		$this->dataLong = file_get_contents(realpath(dirname(__FILE__) . '/../lib/crypt.php'));
+		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
 		$this->dataShort = 'hats';
-		$this->dataUrl = realpath(dirname(__FILE__) . '/../lib/crypt.php');
-		$this->legacyData = realpath(dirname(__FILE__) . '/legacy-text.txt');
-		$this->legacyEncryptedData = realpath(dirname(__FILE__) . '/legacy-encrypted-text.txt');
+		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
+		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
+		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
 		$this->randomKey = Encryption\Crypt::generateKey();
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -6,15 +6,15 @@
  * See the COPYING-README file.
  */
 
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../lib/helper.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../lib/helper.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 
@@ -57,11 +57,11 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 	function setUp() {
 		// set content for encrypting / decrypting in tests
-		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
+		$this->dataLong = file_get_contents(__DIR__ . '/../lib/crypt.php');
 		$this->dataShort = 'hats';
-		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
-		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
-		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
+		$this->dataUrl = __DIR__ . '/../lib/crypt.php';
+		$this->legacyData = __DIR__ . '/legacy-text.txt';
+		$this->legacyEncryptedData = __DIR__ . '/legacy-encrypted-text.txt';
 		$this->randomKey = Encryption\Crypt::generateKey();
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -20,16 +20,16 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php');
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../lib/helper.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../lib/helper.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -20,16 +20,16 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../lib/helper.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../lib/helper.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -20,14 +20,14 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -20,14 +20,14 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -20,15 +20,15 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/../../files_trashbin/appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/../../files_trashbin/appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -20,15 +20,15 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/../../files_trashbin/appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/../../files_trashbin/appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -69,12 +69,12 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->pass = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1;
 
 		// set content for encrypting / decrypting in tests
-		$this->dataUrl = realpath(dirname(__FILE__) . '/../lib/crypt.php');
+		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
 		$this->dataShort = 'hats';
-		$this->dataLong = file_get_contents(realpath(dirname(__FILE__) . '/../lib/crypt.php'));
-		$this->legacyData = realpath(dirname(__FILE__) . '/legacy-text.txt');
-		$this->legacyEncryptedData = realpath(dirname(__FILE__) . '/legacy-encrypted-text.txt');
-		$this->legacyEncryptedDataKey = realpath(dirname(__FILE__) . '/encryption.key');
+		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
+		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
+		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
+		$this->legacyEncryptedDataKey = dirname(__FILE__) . '/encryption.key';
 		$this->legacyKey = "30943623843030686906\0\0\0\0";
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -6,13 +6,13 @@
  * See the COPYING-README file.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -6,13 +6,13 @@
  * See the COPYING-README file.
  */
 
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../appinfo/app.php';
 
 use OCA\Encryption;
 
@@ -69,12 +69,12 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->pass = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1;
 
 		// set content for encrypting / decrypting in tests
-		$this->dataUrl = dirname(__FILE__) . '/../lib/crypt.php';
+		$this->dataUrl = __DIR__ . '/../lib/crypt.php';
 		$this->dataShort = 'hats';
-		$this->dataLong = file_get_contents(dirname(__FILE__) . '/../lib/crypt.php');
-		$this->legacyData = dirname(__FILE__) . '/legacy-text.txt';
-		$this->legacyEncryptedData = dirname(__FILE__) . '/legacy-encrypted-text.txt';
-		$this->legacyEncryptedDataKey = dirname(__FILE__) . '/encryption.key';
+		$this->dataLong = file_get_contents(__DIR__ . '/../lib/crypt.php');
+		$this->legacyData = __DIR__ . '/legacy-text.txt';
+		$this->legacyEncryptedData = __DIR__ . '/legacy-encrypted-text.txt';
+		$this->legacyEncryptedDataKey = __DIR__ . '/encryption.key';
 		$this->legacyKey = "30943623843030686906\0\0\0\0";
 
 		$keypair = Encryption\Crypt::createKeypair();

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -20,14 +20,14 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../lib/base.php');
-require_once realpath(dirname(__FILE__) . '/../lib/crypt.php');
-require_once realpath(dirname(__FILE__) . '/../lib/keymanager.php');
-require_once realpath(dirname(__FILE__) . '/../lib/proxy.php');
-require_once realpath(dirname(__FILE__) . '/../lib/stream.php');
-require_once realpath(dirname(__FILE__) . '/../lib/util.php');
-require_once realpath(dirname(__FILE__) . '/../appinfo/app.php');
-require_once realpath(dirname(__FILE__) . '/util.php');
+require_once dirname(__FILE__) . '/../../../lib/base.php';
+require_once dirname(__FILE__) . '/../lib/crypt.php';
+require_once dirname(__FILE__) . '/../lib/keymanager.php';
+require_once dirname(__FILE__) . '/../lib/proxy.php';
+require_once dirname(__FILE__) . '/../lib/stream.php';
+require_once dirname(__FILE__) . '/../lib/util.php';
+require_once dirname(__FILE__) . '/../appinfo/app.php';
+require_once dirname(__FILE__) . '/util.php';
 
 use OCA\Encryption;
 

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -20,14 +20,14 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../../lib/base.php';
-require_once dirname(__FILE__) . '/../lib/crypt.php';
-require_once dirname(__FILE__) . '/../lib/keymanager.php';
-require_once dirname(__FILE__) . '/../lib/proxy.php';
-require_once dirname(__FILE__) . '/../lib/stream.php';
-require_once dirname(__FILE__) . '/../lib/util.php';
-require_once dirname(__FILE__) . '/../appinfo/app.php';
-require_once dirname(__FILE__) . '/util.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 


### PR DESCRIPTION
If the file does not exist, realpath() returns false and "include false;" produces "Failed opening '' for inclusion" which is a useless error message.

'include' works just fine with symlinks, "./" and "../".
