### PR TITLE
Fix 4201, Group Search in Share Dialog only half-working

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -33,7 +33,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					if ($shareType === OCP\Share::SHARE_TYPE_LINK && $shareWith == '') {
 						$shareWith = null;
 					}
-					
+
 					$token = OCP\Share::shareItem(
 						$_POST['itemType'],
 						$_POST['itemSource'],
@@ -41,7 +41,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$shareWith,
 						$_POST['permissions']
 					);
-					
+
 					if (is_string($token)) {
 						OC_JSON::success(array('data' => array('token' => $token)));
 					} else {

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -176,10 +176,10 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 // 						}
 // 					}
 // 				}
+				$groups = OC_Group::getGroups($_GET['search']);
 				if ($sharePolicy == 'groups_only') {
-					$groups = OC_Group::getUserGroups(OC_User::getUser());
-				} else {
-					$groups = OC_Group::getGroups();
+					$usergroups = OC_Group::getUserGroups(OC_User::getUser());
+					$groups = array_intersect($groups, $usergroups);
 				}
 				$count = 0;
 				$users = array();
@@ -210,11 +210,10 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$count = 0;
 				foreach ($groups as $group) {
 					if ($count < 15) {
-						if (stripos($group, $_GET['search']) !== false
-							&& (!isset($_GET['itemShares'])
+						if (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
 							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
-							|| !in_array($group, $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP]))) {
+							|| !in_array($group, $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
 							$shareWith[] = array(
 								'label' => $group.' (group)',
 								'value' => array(


### PR DESCRIPTION
When looking for groups with a search string, the backends share method shall be used instead of comparing the name. Fixes #4201 

Please review @schiesbn @MTGap @butonic or others
