### PR TITLE
Fixing 4385 master

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -119,7 +119,7 @@ if ($needUpgrade) {
 	$tmpl->printPage();
 } else {
 	// information about storage capacities
-	$storageInfo=OC_Helper::getStorageInfo();
+	$storageInfo=OC_Helper::getStorageInfo($dir);
 	$maxUploadFilesize=OCP\Util::maxUploadFilesize($dir);
 	$publicUploadEnabled = \OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes');
 	if (OC_App::isEnabled('files_encryption')) {

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -11,7 +11,7 @@ class Helper
 		$maxHumanFilesize = $l->t('Upload') . ' max. ' . $maxHumanFilesize;
 
 		// information about storage capacities
-		$storageInfo = \OC_Helper::getStorageInfo();
+		$storageInfo = \OC_Helper::getStorageInfo($dir);
 
 		return array('uploadMaxFilesize' => $maxUploadFilesize,
 					 'maxHumanFilesize'  => $maxHumanFilesize,

--- a/lib/connector/sabre/directory.php
+++ b/lib/connector/sabre/directory.php
@@ -233,10 +233,10 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 	 * @return array
 	 */
 	public function getQuotaInfo() {
-		$rootInfo=\OC\Files\Filesystem::getFileInfo('');
+		$storageInfo = OC_Helper::getStorageInfo($this->path);
 		return array(
-			$rootInfo['size'],
-			\OC\Files\Filesystem::free_space()
+			$storageInfo['used'],
+			$storageInfo['total']
 		);
 
 	}

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -841,9 +841,12 @@ class OC_Helper {
 	}
 
 	/**
-	 * Calculate the disc space
+	 * Calculate the disc space for the given path
+	 *
+	 * @param string $path
+	 * @return array
 	 */
-	public static function getStorageInfo($path = '/') {
+	public static function getStorageInfo($path) {
 		$rootInfo = \OC\Files\Filesystem::getFileInfo($path);
 		$used = $rootInfo['size'];
 		if ($used < 0) {

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -843,13 +843,13 @@ class OC_Helper {
 	/**
 	 * Calculate the disc space
 	 */
-	public static function getStorageInfo() {
-		$rootInfo = \OC\Files\Filesystem::getFileInfo('/');
+	public static function getStorageInfo($path = '/') {
+		$rootInfo = \OC\Files\Filesystem::getFileInfo($path);
 		$used = $rootInfo['size'];
 		if ($used < 0) {
 			$used = 0;
 		}
-		$free = \OC\Files\Filesystem::free_space();
+		$free = \OC\Files\Filesystem::free_space($path);
 		if ($free >= 0) {
 			$total = $free + $used;
 		} else {

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -17,7 +17,7 @@ OC_Util::addScript( '3rdparty', 'chosen/chosen.jquery.min' );
 OC_Util::addStyle( '3rdparty', 'chosen' );
 OC_App::setActiveNavigationEntry( 'personal' );
 
-$storageInfo=OC_Helper::getStorageInfo();
+$storageInfo=OC_Helper::getStorageInfo('/');
 
 $email=OC_Preferences::getValue(OC_User::getUser(), 'settings', 'email', '');
 


### PR DESCRIPTION
refs #4385 

Basically negative values are set to 0 - this is the identical behavior users can observe in the web ui as well.

In addition the storage information is path specific and a parameter to reflect this has been introduced.

This should fix various issues reported in the past regarding wrong used space in conjunction with external mounts

@danimo @karlitschek @kabum @icewind1991 THX
