### PR TITLE
LDAP: case insensitive replace for more robustness

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -991,7 +991,7 @@ abstract class Access {
 	 * internally we store them for usage in LDAP filters
 	 */
 	private function DNasBaseParameter($dn) {
-		return str_replace('\\5c', '\\', $dn);
+		return str_ireplace('\\5c', '\\', $dn);
 	}
 
 	/**


### PR DESCRIPTION
Because the \5c is brought there by ownCloud it should be enough to do the replacement case sensitive. However, if you do something funny with the database, things can do look different. So, although this problem is not brought by ownCloud and usually does not happen, let us still take care of it.

Quick review @karlitschek @DeepDiver1975 or others please
