### PR TITLE
trash bin: fix isEmpty() function

### DIFF
--- a/apps/files_trashbin/lib/trash.php
+++ b/apps/files_trashbin/lib/trash.php
@@ -689,7 +689,7 @@ class Trashbin {
 			}
 		}
 	}
-	
+
 	/**
 	 * clean up the trash bin
 	 * @param current size of the trash bin
@@ -892,16 +892,17 @@ class Trashbin {
 		//Listen to post write hook
 		\OCP\Util::connectHook('OC_Filesystem', 'post_write', "OCA\Files_Trashbin\Hooks", "post_write_hook");
 	}
-	
+
 	/**
 	 * @brief check if trash bin is empty for a given user
 	 * @param string $user
 	 */
 	public static function isEmpty($user) {
 
-		$trashSize = self::getTrashbinSize($user);
+		$view = new \OC\Files\View('/' . $user . '/files_trashbin');
+		$content = $view->getDirectoryContent('/files');
 
-		if ($trashSize !== false && $trashSize > 0) {
+		if ($content) {
 			return false;
 		}
 


### PR DESCRIPTION
The trash bin can also contain empty files. Don't use the trash bin size as indicator to decide if the trash bin is empty or not. Fix for https://github.com/owncloud/core/issues/4588

cc @DeepDiver1975 please have a look
