### PR TITLE
Email footer customization

### DIFF
--- a/core/templates/altmail.php
+++ b/core/templates/altmail.php
@@ -1,7 +1,4 @@
 <?php
 print_unescaped($l->t("Hey there,\n\njust letting you know that %s shared %s with you.\nView it: %s\n\nCheers!", array($_['user_displayname'], $_['filename'], $_['link'])));
 ?>
-
---
-<?php p($theme->getName() . ' - ' . $theme->getSlogan()); ?>
-<?php print_unescaped("\n".$theme->getBaseUrl());
+<?php p($theme->getEmailFooter()); ?>

--- a/core/templates/mail.php
+++ b/core/templates/mail.php
@@ -19,9 +19,9 @@ print_unescaped($l->t('Hey there,<br><br>just letting you know that %s shared »
 <tr><td bgcolor="#f8f8f8" colspan="2">&nbsp;</td></tr>
 <tr>
 <td bgcolor="#f8f8f8" width="20px">&nbsp;</td>
-<td bgcolor="#f8f8f8" style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
+<td bgcolor="#f8f8f8" style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
 <?php p($theme->getEmailFooterHtml()); ?>
-<br><a href="<?php print_unescaped($theme->getBaseUrl()); ?>"><?php print_unescaped($theme->getBaseUrl());?></a></td>
+</td>
 </tr>
 <tr>
 <td bgcolor="#f8f8f8" colspan="2">&nbsp;</td>

--- a/core/templates/mail.php
+++ b/core/templates/mail.php
@@ -20,8 +20,7 @@ print_unescaped($l->t('Hey there,<br><br>just letting you know that %s shared »
 <tr>
 <td bgcolor="#f8f8f8" width="20px">&nbsp;</td>
 <td bgcolor="#f8f8f8" style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
-<?php p($theme->getName()); ?> -
-<?php p($theme->getSlogan()); ?>
+<?php p($theme->getEmailFooterHtml()); ?>
 <br><a href="<?php print_unescaped($theme->getBaseUrl()); ?>"><?php print_unescaped($theme->getBaseUrl());?></a></td>
 </tr>
 <tr>

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -131,5 +131,17 @@ class OC_Defaults {
 
 		return $footer;
 	}
+	
+        public function getEmailFooter() {
+                if ($this->themeExist('getEmailFooter')) {
+                        $emailfooter = $this->theme->getEmailFooter();
+                } else {
+                        $emailfooter="\n--\n";
+                        $emailfooter.=$defaults->getName() . "\n";
+                        $emailfooter.=$defaults->getSlogan() . "\n";
+                }
+
+                return $emailfooter;
+        }
 
 }

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -144,4 +144,16 @@ class OC_Defaults {
                 return $emailfooter;
         }
 
+        public function getEmailFooterHtml() {
+                if ($this->themeExist('getEmailFooterHtml')) {
+                        $emailfooter = $this->theme->getEmailFooterHtml();
+                } else {
+                        $emailfooter="<br>--<br>";
+                        $emailfooter.=$defaults->getName() . " - ";
+                        $emailfooter.=$defaults->getSlogan() . "<br>";
+                }
+
+                return $emailfooter;
+        }
+
 }

--- a/lib/defaults.php
+++ b/lib/defaults.php
@@ -139,6 +139,7 @@ class OC_Defaults {
                         $emailfooter="\n--\n";
                         $emailfooter.=$defaults->getName() . "\n";
                         $emailfooter.=$defaults->getSlogan() . "\n";
+                        $emailfooter.=$defaults->getBaseUrl();
                 }
 
                 return $emailfooter;
@@ -148,9 +149,14 @@ class OC_Defaults {
                 if ($this->themeExist('getEmailFooterHtml')) {
                         $emailfooter = $this->theme->getEmailFooterHtml();
                 } else {
-                        $emailfooter="<br>--<br>";
-                        $emailfooter.=$defaults->getName() . " - ";
-                        $emailfooter.=$defaults->getSlogan() . "<br>";
+                        $emailfooter='--<br>';
+                        $emailfooter.=$defaults->getName() . ' - ';
+                        $emailfooter.=$defaults->getSlogan() . '<br>';
+                        $emailfooter.='<br><a href="';
+                        $emailfooter.=$defaults->getBaseUrl();
+                        $emailfooter.='">';
+                        $emailfooter.=$defaults->getBaseUrl();
+                        $emailfooter.='</a>';
                 }
 
                 return $emailfooter;

--- a/lib/mail.php
+++ b/lib/mail.php
@@ -115,12 +115,7 @@ class OC_Mail {
 
 		$defaults = new OC_Defaults();
 
-		$txt="\n--\n";
-		$txt.=$defaults->getName() . "\n";
-		$txt.=$defaults->getSlogan() . "\n";
-
-		return($txt);
-
+                return( $defaults->getEmailFooter() );
 	}
 
 	/**


### PR DESCRIPTION
Make email footers customizable via theme setting.

The custom text has to be placed in the defaults.php file of the theme.

Example:

class OC_Theme {

```
    public function getEmailFooter() {
            $txt=   "\n\mExample email footer\n\n";
            return( $txt );
    }
```

}
