### PR TITLE
Password toggle login

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -255,9 +255,9 @@ input[name="adminpass-clone"] { padding-left:1.8em; width:11.7em !important; }
 #body-login input[type="password"],
 #body-login input[type="email"] {
 	border: 1px solid #323233;
-	-moz-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 3px rgba(0,0,0,.25) inset;
-	-webkit-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 3px rgba(0,0,0,.25) inset;
-	box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 3px rgba(0,0,0,.25) inset;
+	-moz-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;
+	-webkit-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;
+	box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;
 }
 
 /* Nicely grouping input field sets */

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -709,7 +709,6 @@ $(document).ready(function(){
 		});
 		label.hide();
 	};
-	setShowPassword($('#password'), $('label[for=show]'));
 	setShowPassword($('#adminpass'), $('label[for=show]'));
 	setShowPassword($('#pass2'), $('label[for=personal-show]'));
 	setShowPassword($('#dbpass'), $('label[for=dbpassword]'));

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -21,12 +21,10 @@
 		</p>
 
 		<p class="infield groupbottom">
-			<input type="password" name="password" id="password" value="" data-typetoggle="#show" placeholder=""
+			<input type="password" name="password" id="password" value="" placeholder=""
 				   required<?php p($_['user_autofocus'] ? '' : ' autofocus'); ?> />
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<img class="svg" id="password-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt=""/>
-			<input type="checkbox" id="show" name="show" />
-			<label for="show"></label>
 		</p>
 
 		<?php if (isset($_['invalidpassword']) && ($_['invalidpassword'])): ?>


### PR DESCRIPTION
Currently the toggle is in 3 places, always for the password field:
1. Installation page for choosing a password (and for the probably complex database password)
2. Log in page for putting in your password
3. Personal settings for changing a password (the »current password« field does not have it)

Now the installation page and the personal settings need this switch so you can double-check the password you just decided. But the log in page actually does not need it. So let’s just cut it there.

cc @raghunayyar @DeepDiver1975 @nono-gdv @kabum @karlitschek @MTRichards
