### PR TITLE
Workaround for IE 9 & 10 for clicking filelist after adding new item

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -342,6 +342,9 @@ $(document).ready(function() {
 			}
 			var li=form.parent();
 			form.remove();
+			/* workaround for IE 9&10 click event trap, 2 lines: */
+			$('input').first().focus();
+			$('#content').focus();
 			li.append('<p>'+li.data('text')+'</p>');
 			$('#new>a').click();
 		});


### PR DESCRIPTION
When adding a new folder to the file list via the web UI, the form used to accept the name of the new folder is destroyed after the form is submitted.  Since the input field in that form still has focus when it is destroyed, IE exhibits some odd behavior (you can still see the cursor blinking in the place where the destroyed and no-longer-visible input used to be), including being unable to fire click events on the rest of the page until a different input is focused.

This pull request programmatically focuses the first input field on the page, then the content area to produce the same effect as on other browsers. Doing so allows other elements on the page to be clicked, resolving issue #4619.

This issue occurs on IE9 and IE10 in both master and stable5.  This PR for master should be backported to stable5.
