### PR TITLE
Fix 4613

### DIFF
--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -218,6 +218,7 @@ class Filesystem {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
+		\OC_Util::setupFS($user);
 		$parser = new \OC\ArrayParser();
 
 		$root = \OC_User::getHome($user);


### PR DESCRIPTION
When an app (here: Full Text Search) uses the Filesystem before a login is done, setupFS will not be executed for the user after login. For new users without home folder (which will be created in setupFS only) it means that ownCloud will die with 500 and the server runs in a infinity loop.

I did not check whether the app behaves wrongly, because it is a possible and evil pitfall for other apps too.

@icewind1991 or do you know a better place or way to solve this?

And other reviewers please, e.g. @butonic @schiesbn @MTGap 
