### PR TITLE
Apps management as sticky footer and rename to 'Apps', fix #4622

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -501,6 +501,9 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 #navigation:hover {
 	overflow-y: auto; /* show scrollbar only on hover */
 }
+#apps {
+	height: 100%;
+}
 #navigation a span {
 	display: block;
 	text-decoration: none;
@@ -545,9 +548,24 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 		padding-top: 20px;
 	}
 
+/* Apps management as sticky footer, less obtrusive in the list */
+#navigation .wrapper {
+	min-height: 100%;
+	margin: 0 auto -72px;
+}
+#apps-management, #navigation .push {
+	height: 70px;
+}
 #apps-management {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=60)";
+	filter: alpha(opacity=60);
 	opacity: .6;
 }
+#apps-management .icon {
+	padding-bottom: 0;
+}
+
+
 
 
 /* USER MENU */

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -78,6 +78,7 @@
 
 		<nav><div id="navigation">
 			<ul id="apps" class="svg">
+				<div class="wrapper"><!-- for sticky footer of apps management -->
 				<?php foreach($_['navigation'] as $entry): ?>
 					<li data-id="<?php p($entry['id']); ?>">
 						<a href="<?php print_unescaped($entry['href']); ?>" title=""
@@ -89,15 +90,19 @@
 						</a>
 					</li>
 				<?php endforeach; ?>
+				<?php if(OC_User::isAdminUser(OC_User::getUser())): ?>
+					<div class="push"></div><!-- for for sticky footer of apps management -->
+				<?php endif; ?>
+				</div>
 
-				<!-- show "More apps" link to app administration directly in app navigation -->
+				<!-- show "More apps" link to app administration directly in app navigation, as sticky footer -->
 				<?php if(OC_User::isAdminUser(OC_User::getUser())): ?>
 					<li id="apps-management">
 						<a href="<?php print_unescaped(OC_Helper::linkToRoute('settings_apps').'?installed'); ?>" title=""
 							<?php if( $entry['active'] ): ?> class="active"<?php endif; ?>>
 							<img class="icon svg" src="<?php print_unescaped(OC_Helper::imagePath('settings', 'apps.svg')); ?>"/>
 							<span>
-								<?php p($l->t('More apps')); ?>
+								<?php p($l->t('Apps')); ?>
 							</span>
 						</a>
 					</li>


### PR DESCRIPTION
Fixes #4622, please review @karlitschek @kabum @Kondou-ger @owncloud/designers 
