### PR TITLE
Fixed public upload error that prevents upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -348,4 +348,5 @@ $(document).ready(function() {
 			$('#new>a').click();
 		});
 	});
+	window.file_upload_param = file_upload_param;
 });


### PR DESCRIPTION
Public upload is broken because the file_upload_param variable expected
to exist by public.js didn't.

This fix sets the variable scope to the window to make it accessible
outside.
