### PR TITLE
Encryption improved error messages for Stable5

### DIFF
--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -4,7 +4,7 @@ if (!isset($_)) { //also provide standalone error page
 
 	$l = OC_L10N::get('files_encryption');
 
-	$errorMsg = $l->t('Your private key is not valid! Likely your password was changed outside the ownCloud system (e.g. your corporate directory). You can update your private key password in your personal settings to recover access to your encrypted files.');
+	$errorMsg = $l->t('Your private key is not valid or wasn\'t initialized correctly! Likely your password was changed outside the ownCloud system (e.g. your corporate directory). You can update your private key password in your personal settings to recover access to your encrypted files. If your log-in password didn\'t change than first try to log out and log in back in order to initialize your encryption keys');
 
 	if(isset($_GET['p']) && $_GET['p'] === '1') {
 		header('HTTP/1.0 404 ' . $errorMsg);


### PR DESCRIPTION
Small version of this pull request: #4691

For stable5 we just update the existing warning with the information that a simple re-login should help if the password wasn't changed.

Would be good to have the updated warning in OC5.0.11

cc @DeepDiver1975 @blizzz @karlitschek
