### PR TITLE
Always check variable type before using readdir to avoid surprises, fixes #4667 #4658 and #4613

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -206,14 +206,16 @@ class Google extends \OC\Files\Storage\Common {
 	public function rmdir($path) {
 		if (trim($path, '/') === '') {
 			$dir = $this->opendir($path);
-			while (($file = readdir($dh)) !== false) {
-				if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
-					if (!$this->unlink($path.'/'.$file)) {
-						return false;
+			if(is_resource($dir)) {
+				while (($file = readdir($dir)) !== false) {
+					if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
+						if (!$this->unlink($path.'/'.$file)) {
+							return false;
+						}
 					}
 				}
+				closedir($dir);
 			}
-			closedir($dir);
 			$this->driveFiles = array();
 			return true;
 		} else {

--- a/apps/files_external/lib/irods.php
+++ b/apps/files_external/lib/irods.php
@@ -55,7 +55,7 @@ class iRODS extends \OC\Files\Storage\StreamWrapper{
 		} else {
 			throw new \Exception();
 		}
-		
+
 	}
 
 	public static function login( $params ) {
@@ -137,11 +137,13 @@ class iRODS extends \OC\Files\Storage\StreamWrapper{
 	private function collectionMTime($path) {
 		$dh = $this->opendir($path);
 		$lastCTime = $this->filemtime($path);
-		while (($file = readdir($dh)) !== false) {
-			if ($file != '.' and $file != '..') {
-				$time = $this->filemtime($file);
-				if ($time > $lastCTime) {
-					$lastCTime = $time;
+		if(is_resource($dh)) {
+			while (($file = readdir($dh)) !== false) {
+				if ($file != '.' and $file != '..') {
+					$time = $this->filemtime($file);
+					if ($time > $lastCTime) {
+						$lastCTime = $time;
+					}
 				}
 			}
 		}

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -89,11 +89,13 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 	private function shareMTime() {
 		$dh=$this->opendir('');
 		$lastCtime=0;
-		while (($file = readdir($dh)) !== false) {
-			if ($file!='.' and $file!='..') {
-				$ctime=$this->filemtime($file);
-				if ($ctime>$lastCtime) {
-					$lastCtime=$ctime;
+		if(is_resource($dh)) {
+			while (($file = readdir($dh)) !== false) {
+				if ($file!='.' and $file!='..') {
+					$ctime=$this->filemtime($file);
+					if ($ctime>$lastCtime) {
+						$lastCtime=$ctime;
+					}
 				}
 			}
 		}

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -23,22 +23,24 @@ if ($dir) {
 	$dirlisting = true;
 	$dirContent = $view->opendir($dir);
 	$i = 0;
-	while(($entryName = readdir($dirContent)) !== false) {
-		if ( $entryName != '.' && $entryName != '..' ) {
-			$pos = strpos($dir.'/', '/', 1);
-			$tmp = substr($dir, 0, $pos);
-			$pos = strrpos($tmp, '.d');
-			$timestamp = substr($tmp, $pos+2);
-			$result[] = array(
-					'id' => $entryName,
-					'timestamp' => $timestamp,
-					'mime' =>  $view->getMimeType($dir.'/'.$entryName),
-					'type' => $view->is_dir($dir.'/'.$entryName) ? 'dir' : 'file',
-					'location' => $dir,
-					);
+	if(is_resource($dirContent)) {
+		while(($entryName = readdir($dirContent)) !== false) {
+			if ( $entryName != '.' && $entryName != '..' ) {
+				$pos = strpos($dir.'/', '/', 1);
+				$tmp = substr($dir, 0, $pos);
+				$pos = strrpos($tmp, '.d');
+				$timestamp = substr($tmp, $pos+2);
+				$result[] = array(
+						'id' => $entryName,
+						'timestamp' => $timestamp,
+						'mime' =>  $view->getMimeType($dir.'/'.$entryName),
+						'type' => $view->is_dir($dir.'/'.$entryName) ? 'dir' : 'file',
+						'location' => $dir,
+						);
+			}
 		}
+		closedir($dirContent);
 	}
-	closedir($dirContent);
 
 } else {
 	$dirlisting = false;

--- a/lib/app.php
+++ b/lib/app.php
@@ -674,14 +674,16 @@ class OC_App{
 			}
 			$dh = opendir( $apps_dir['path'] );
 
-			while (($file = readdir($dh)) !== false) {
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
 
-				if ($file[0] != '.' and is_file($apps_dir['path'].'/'.$file.'/appinfo/app.php')) {
+					if ($file[0] != '.' and is_file($apps_dir['path'].'/'.$file.'/appinfo/app.php')) {
 
-					$apps[] = $file;
+						$apps[] = $file;
+
+					}
 
 				}
-
 			}
 
 		}
@@ -862,7 +864,7 @@ class OC_App{
 		foreach($apps as $app) {
 			// check if the app is compatible with this version of ownCloud
 			$info = OC_App::getAppInfo($app);
-			if(!isset($info['require']) 
+			if(!isset($info['require'])
 				or !self::isAppVersionCompatible($version, $info['require'])
 				// manually disable files_archive app since it has been removed
 				// and cause update problems
@@ -879,10 +881,10 @@ class OC_App{
 
 
 	/**
-	 * Compares the app version with the owncloud version to see if the app 
+	 * Compares the app version with the owncloud version to see if the app
 	 * requires a newer version than the currently active one
 	 * @param array $owncloudVersions array with 3 entries: major minor bugfix
-	 * @param string $appRequired the required version from the xml 
+	 * @param string $appRequired the required version from the xml
 	 * major.minor.bugfix
 	 * @return boolean true if compatible, otherwise false
 	 */

--- a/lib/archive.php
+++ b/lib/archive.php
@@ -119,7 +119,8 @@ abstract class OC_Archive{
 	 * @return bool
 	 */
 	function addRecursive($path, $source) {
-		if($dh=opendir($source) && is_resource($dh)) {
+		$dh=opendir($source);
+		if(is_resource($dh)) {
 			$this->addFolder($path);
 			while (($file = readdir($dh)) !== false) {
 				if($file=='.' or $file=='..') {

--- a/lib/archive.php
+++ b/lib/archive.php
@@ -119,7 +119,7 @@ abstract class OC_Archive{
 	 * @return bool
 	 */
 	function addRecursive($path, $source) {
-		if($dh=opendir($source)) {
+		if($dh=opendir($source) && is_resource($dh)) {
 			$this->addFolder($path);
 			while (($file = readdir($dh)) !== false) {
 				if($file=='.' or $file=='..') {

--- a/lib/cache/file.php
+++ b/lib/cache/file.php
@@ -99,13 +99,11 @@ class OC_Cache_File{
 			if(!is_resource($dh)) {
 				return null;
 			}
-			if(is_resource($dh)) {
-				while (($file = readdir($dh)) !== false) {
-					if($file!='.' and $file!='..') {
-						$mtime = $storage->filemtime('/'.$file);
-						if ($mtime < $now) {
-							$storage->unlink('/'.$file);
-						}
+			while (($file = readdir($dh)) !== false) {
+				if($file!='.' and $file!='..') {
+					$mtime = $storage->filemtime('/'.$file);
+					if ($mtime < $now) {
+						$storage->unlink('/'.$file);
 					}
 				}
 			}

--- a/lib/cache/file.php
+++ b/lib/cache/file.php
@@ -80,9 +80,11 @@ class OC_Cache_File{
 		$storage = $this->getStorage();
 		if($storage and $storage->is_dir('/')) {
 			$dh=$storage->opendir('/');
-			while (($file = readdir($dh)) !== false) {
-				if($file!='.' and $file!='..' and ($prefix==='' || strpos($file, $prefix) === 0)) {
-					$storage->unlink('/'.$file);
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
+					if($file!='.' and $file!='..' and ($prefix==='' || strpos($file, $prefix) === 0)) {
+						$storage->unlink('/'.$file);
+					}
 				}
 			}
 		}
@@ -94,11 +96,16 @@ class OC_Cache_File{
 		if($storage and $storage->is_dir('/')) {
 			$now = time();
 			$dh=$storage->opendir('/');
-			while (($file = readdir($dh)) !== false) {
-				if($file!='.' and $file!='..') {
-					$mtime = $storage->filemtime('/'.$file);
-					if ($mtime < $now) {
-						$storage->unlink('/'.$file);
+			if(!is_resource($dh)) {
+				return null;
+			}
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
+					if($file!='.' and $file!='..') {
+						$mtime = $storage->filemtime('/'.$file);
+						if ($mtime < $now) {
+							$storage->unlink('/'.$file);
+						}
 					}
 				}
 			}

--- a/lib/cache/fileglobal.php
+++ b/lib/cache/fileglobal.php
@@ -69,9 +69,11 @@ class OC_Cache_FileGlobal{
 		$prefix = $this->fixKey($prefix);
 		if($cache_dir and is_dir($cache_dir)) {
 			$dh=opendir($cache_dir);
-			while (($file = readdir($dh)) !== false) {
-				if($file!='.' and $file!='..' and ($prefix==='' || strpos($file, $prefix) === 0)) {
-					unlink($cache_dir.$file);
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
+					if($file!='.' and $file!='..' and ($prefix==='' || strpos($file, $prefix) === 0)) {
+						unlink($cache_dir.$file);
+					}
 				}
 			}
 		}
@@ -88,11 +90,13 @@ class OC_Cache_FileGlobal{
 		$cache_dir = self::getCacheDir();
 		if($cache_dir and is_dir($cache_dir)) {
 			$dh=opendir($cache_dir);
-			while (($file = readdir($dh)) !== false) {
-				if($file!='.' and $file!='..') {
-					$mtime = filemtime($cache_dir.$file);
-					if ($mtime < $now) {
-						unlink($cache_dir.$file);
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
+					if($file!='.' and $file!='..') {
+						$mtime = filemtime($cache_dir.$file);
+						if ($mtime < $now) {
+							unlink($cache_dir.$file);
+						}
 					}
 				}
 			}

--- a/lib/files/cache/scanner.php
+++ b/lib/files/cache/scanner.php
@@ -158,20 +158,22 @@ class Scanner extends BasicEmitter {
 		$newChildren = array();
 		if ($this->storage->is_dir($path) && ($dh = $this->storage->opendir($path))) {
 			\OC_DB::beginTransaction();
-			while (($file = readdir($dh)) !== false) {
-				$child = ($path) ? $path . '/' . $file : $file;
-				if (!Filesystem::isIgnoredDir($file)) {
-					$newChildren[] = $file;
-					$data = $this->scanFile($child, $reuse, true);
-					if ($data) {
-						if ($data['size'] === -1) {
-							if ($recursive === self::SCAN_RECURSIVE) {
-								$childQueue[] = $child;
-							} else {
-								$size = -1;
+			if(is_resource($dh)) {
+				while (($file = readdir($dh)) !== false) {
+					$child = ($path) ? $path . '/' . $file : $file;
+					if (!Filesystem::isIgnoredDir($file)) {
+						$newChildren[] = $file;
+						$data = $this->scanFile($child, $reuse, true);
+						if ($data) {
+							if ($data['size'] === -1) {
+								if ($recursive === self::SCAN_RECURSIVE) {
+									$childQueue[] = $child;
+								} else {
+									$size = -1;
+								}
+							} else if ($size !== -1) {
+								$size += $data['size'];
 							}
-						} else if ($size !== -1) {
-							$size += $data['size'];
 						}
 					}
 				}

--- a/lib/files/storage/common.php
+++ b/lib/files/storage/common.php
@@ -141,13 +141,15 @@ abstract class Common implements \OC\Files\Storage\Storage {
 			return false;
 		} else {
 			$directoryHandle = $this->opendir($directory);
-			while (($contents = readdir($directoryHandle)) !== false) {
-				if (!\OC\Files\Filesystem::isIgnoredDir($contents)) {
-					$path = $directory . '/' . $contents;
-					if ($this->is_dir($path)) {
-						$this->deleteAll($path);
-					} else {
-						$this->unlink($path);
+			if(is_resource($directoryHandle)) {
+				while (($contents = readdir($directoryHandle)) !== false) {
+					if (!\OC\Files\Filesystem::isIgnoredDir($contents)) {
+						$path = $directory . '/' . $contents;
+						if ($this->is_dir($path)) {
+							$this->deleteAll($path);
+						} else {
+							$this->unlink($path);
+						}
 					}
 				}
 			}
@@ -224,6 +226,9 @@ abstract class Common implements \OC\Files\Storage\Storage {
 
 	private function addLocalFolder($path, $target) {
 		if ($dh = $this->opendir($path)) {
+			if(!is_resource($dh)) {
+				return  null;
+			}
 			while (($file = readdir($dh)) !== false) {
 				if ($file !== '.' and $file !== '..') {
 					if ($this->is_dir($path . '/' . $file)) {
@@ -241,7 +246,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	protected function searchInDir($query, $dir = '') {
 		$files = array();
 		$dh = $this->opendir($dir);
-		if ($dh) {
+		if (is_resource($dh)) {
 			while (($item = readdir($dh)) !== false) {
 				if ($item == '.' || $item == '..') continue;
 				if (strstr(strtolower($item), strtolower($query)) !== false) {

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -489,9 +489,11 @@ class View {
 				} else {
 					if ($this->is_dir($path1) && ($dh = $this->opendir($path1))) {
 						$result = $this->mkdir($path2);
-						while (($file = readdir($dh)) !== false) {
-							if (!Filesystem::isIgnoredDir($file)) {
-								$result = $this->copy($path1 . '/' . $file, $path2 . '/' . $file);
+						if(is_resource($dh)) {
+							while (($file = readdir($dh)) !== false) {
+								if (!Filesystem::isIgnoredDir($file)) {
+									$result = $this->copy($path1 . '/' . $file, $path2 . '/' . $file);
+								}
 							}
 						}
 					} else {

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -109,10 +109,12 @@ class OC_Installer{
 		if(!is_file($extractDir.'/appinfo/info.xml')) {
 			//try to find it in a subdir
 			$dh=opendir($extractDir);
-			while (($folder = readdir($dh)) !== false) {
-				if($folder[0]!='.' and is_dir($extractDir.'/'.$folder)) {
-					if(is_file($extractDir.'/'.$folder.'/appinfo/info.xml')) {
-						$extractDir.='/'.$folder;
+			if(is_resource($dh)) {
+				while (($folder = readdir($dh)) !== false) {
+					if($folder[0]!='.' and is_dir($extractDir.'/'.$folder)) {
+						if(is_file($extractDir.'/'.$folder.'/appinfo/info.xml')) {
+							$extractDir.='/'.$folder;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
[Readdir](http://php.net/manual/en/function.readdir.php) is said to return false if a folder could not be opened, but if the provided variable is not a proper parameter null is passed. Because since https://github.com/owncloud/core/commit/f42b69d72fd456c32380b46af38eab9ef339e141 we are (correctly!) strictly checking for a false, we can end up in an infinite loop that kills the web server, as reported in #4667 #4658 and #4613 

please review @icewind1991 @karlitschek @schiesbn or others

P.S.: includes also fix a wrong var name.
