### PR TITLE
use on to add event listener instead of deprecated jquery bind

### DIFF
--- a/core/js/oc-requesttoken.js
+++ b/core/js/oc-requesttoken.js
@@ -1,3 +1,4 @@
-$(document).bind('ajaxSend', function(elm, xhr, s) {
+$(document).on('ajaxSend',function(elm, xhr, s) {
 	xhr.setRequestHeader('requesttoken', oc_requesttoken);
 });
+


### PR DESCRIPTION
jquery bind() is deprecated, use on() to register the ajaxSend event handler. seems to work more reliable. At least I had that a break point on the setRequestHeader line would be triggered more often when using on.

@VicDeo @karlitschek @kabum 
