### PR TITLE
make sure that initial encryption also starts for a fresh installation

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -25,7 +25,9 @@ if (!OC_Config::getValue('maintenance', false)) {
 	// App manager related hooks
 	OCA\Encryption\Helper::registerAppHooks();
 
-	stream_wrapper_register('crypt', 'OCA\Encryption\Stream');
+	if(!in_array('crypt', stream_get_wrappers())) {
+		stream_wrapper_register('crypt', 'OCA\Encryption\Stream');
+	}
 
 	// check if we are logged in
 	if (OCP\User::isLoggedIn()) {

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -44,16 +44,16 @@ class Hooks {
 			\OC_Util::setupFS($params['uid']);
 		}
 
-		$util = new Util($view, $params['uid']);
-
 		//check if all requirements are met
-		if(!$util->ready() && (!Helper::checkRequirements() || !Helper::checkConfiguration())) {
+		if(!Helper::checkRequirements() || !Helper::checkConfiguration()) {
 			$error_msg = $l->t("Missing requirements.");
 			$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
 			\OC_App::disable('files_encryption');
 			\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
 			\OCP\Template::printErrorPage($error_msg, $hint);
 		}
+
+		$util = new Util($view, $params['uid']);
 
 		// setup user, if user not ready force relogin
 		if (Helper::setupUser($util, $params['password']) === false) {
@@ -73,7 +73,7 @@ class Hooks {
 
 			$userView = new \OC_FilesystemView('/' . $params['uid']);
 
-			// Set legacy encryption key if it exists, to support 
+			// Set legacy encryption key if it exists, to support
 			// depreciated encryption system
 			if (
 				$userView->file_exists('encryption.key')
@@ -249,7 +249,7 @@ class Hooks {
 			$params['run'] = false;
 			$params['error'] = $l->t('Following users are not set up for encryption:') . ' ' . join(', ' , $notConfigured);
 		}
-		
+
 	}
 
 	/**
@@ -260,7 +260,7 @@ class Hooks {
 		// NOTE: $params has keys:
 		// [itemType] => file
 		// itemSource -> int, filecache file ID
-		// [parent] => 
+		// [parent] =>
 		// [itemTarget] => /13
 		// shareWith -> string, uid of user being shared to
 		// fileTarget -> path of file being shared
@@ -301,13 +301,13 @@ class Hooks {
 					// NOTE: parent is folder but shared was a file!
 					// we try to rebuild the missing path
 					// some examples we face here
-					// user1 share folder1 with user2 folder1 has 
-					// the following structure 
+					// user1 share folder1 with user2 folder1 has
+					// the following structure
 					// /folder1/subfolder1/subsubfolder1/somefile.txt
 					// user2 re-share subfolder2 with user3
 					// user3 re-share somefile.txt user4
-					// so our path should be 
-					// /Shared/subfolder1/subsubfolder1/somefile.txt 
+					// so our path should be
+					// /Shared/subfolder1/subsubfolder1/somefile.txt
 					// while user3 is sharing
 
 					if ($params['itemType'] === 'file') {

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -44,13 +44,18 @@ class Hooks {
 			\OC_Util::setupFS($params['uid']);
 		}
 
-		//check if all requirements are met
-		if(!Helper::checkRequirements() || !Helper::checkConfiguration()) {
-			$error_msg = $l->t("Missing requirements.");
-			$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
-			\OC_App::disable('files_encryption');
-			\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
-			\OCP\Template::printErrorPage($error_msg, $hint);
+		$privateKey = \OCA\Encryption\Keymanager::getPrivateKey($view, $params['uid']);
+
+		// if no private key exists, check server configuration
+		if(!$privateKey) {
+			//check if all requirements are met
+			if(!Helper::checkRequirements() || !Helper::checkConfiguration()) {
+				$error_msg = $l->t("Missing requirements.");
+				$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
+				\OC_App::disable('files_encryption');
+				\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
+				\OCP\Template::printErrorPage($error_msg, $hint);
+			}
 		}
 
 		$util = new Util($view, $params['uid']);

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -201,10 +201,11 @@ class Util {
 		if (false === $this->recoveryEnabledForUser()) {
 
 			// create database configuration
-			$sql = 'INSERT INTO `*PREFIX*encryption` (`uid`,`mode`,`recovery_enabled`) VALUES (?,?,?)';
+			$sql = 'INSERT INTO `*PREFIX*encryption` (`uid`,`mode`,`recovery_enabled`,`migration_status`) VALUES (?,?,?,?)';
 			$args = array(
 				$this->userId,
 				'server-side',
+				0,
 				0
 			);
 			$query = \OCP\DB::prepare($sql);


### PR DESCRIPTION
remove `$util->ready()` from requirement check. This just checks if the directory structure is in place but this gets created anyway during the initial encryption. On the other hand this check blocks initial encryption if the encryption app was enabled for the first time.
