### PR TITLE
Fix the "addHeader($tag, $attributes, $text)" methods to not ignore the $text parameter 

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -26,7 +26,11 @@
 				foreach ($header['attributes'] as $name => $value) {
 					print_unescaped("$name='$value' ");
 				};
-				print_unescaped('/>');
+				if ($header['text'] !== null) {
+					print_unescaped('>'.$header['text'].'</'.$header['tag'].'>');
+				} else {
+					print_unescaped('/>');
+				}
 			?>
 		<?php endforeach; ?>
 	</head>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -28,7 +28,11 @@
 				foreach($header['attributes'] as $name=>$value) {
 					print_unescaped("$name='$value' ");
 				};
-				print_unescaped('/>');
+				if ($header['text'] !== null) {
+					print_unescaped('>'.$header['text'].'</'.$header['tag'].'>');
+				} else {
+					print_unescaped('/>');
+				}
 			?>
 		<?php endforeach; ?>
 	</head>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -30,7 +30,11 @@
 				foreach($header['attributes'] as $name=>$value) {
 					print_unescaped("$name='$value' ");
 				};
-				print_unescaped('/>');
+				if ($header['text'] !== null) {
+					print_unescaped('>'.$header['text'].'</'.$header['tag'].'>');
+				} else {
+					print_unescaped('/>');
+				}
 			?>
 		<?php endforeach; ?>
 	</head>

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -172,11 +172,14 @@ class OC_Template extends \OC\Template\Base {
 
 	/**
 	 * @brief Add a custom element to the header
+	 * If $text is null then the element will be written as empty element.
+	 * So use "" to get a closing tag.
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
+	 * @return void
 	 */
-	public function addHeader( $tag, $attributes, $text='') {
+	public function addHeader( $tag, $attributes, $text=null) {
 		$this->headers[]=array('tag'=>$tag,'attributes'=>$attributes, 'text'=>$text);
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -241,12 +241,14 @@ class OC_Util {
 
 	/**
 	 * @brief Add a custom element to the header
+	 * If $text is null then the element will be written as empty element.
+	 * So use "" to get a closing tag.
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
 	 * @return void
 	 */
-	public static function addHeader( $tag, $attributes, $text='') {
+	public static function addHeader( $tag, $attributes, $text=null) {
 		self::$headers[] = array(
 			'tag'=>$tag,
 			'attributes'=>$attributes,

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -105,11 +105,14 @@ class Util {
 
 	/**
 	 * @brief Add a custom element to the header
+	 * If $text is null then the element will be written as empty element.
+	 * So use "" to get a closing tag.
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
+	 * @return void
 	 */
-	public static function addHeader( $tag, $attributes, $text='') {
+	public static function addHeader( $tag, $attributes, $text=null) {
 		\OC_Util::addHeader( $tag, $attributes, $text );
 	}
 


### PR DESCRIPTION
Also support closing tags with no text content given, this is HTML after all
