### PR TITLE
Do not add lots of whitespace and linebreaks to the content of <title> in the HTML head

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -7,9 +7,7 @@
 <!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 
 	<head>
-		<title>
-		<?php p($theme->getTitle()); ?>
-		</title>
+		<title><?php p($theme->getTitle()); ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<link rel="shortcut icon" href="<?php print_unescaped(image_path('', 'favicon.png')); ?>" />
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path('', 'favicon-touch.png')); ?>" />

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -7,9 +7,7 @@
 <!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 
 	<head data-requesttoken="<?php p($_['requesttoken']); ?>">
-		<title>
-		<?php p($theme->getTitle()); ?>
-		</title>
+		<title><?php p($theme->getTitle()); ?></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="apple-itunes-app" content="app-id=543672169">
 		<link rel="shortcut icon" href="<?php print_unescaped(image_path('', 'favicon.png')); ?>" />

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -7,11 +7,12 @@
 <!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 
 	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
-		<title>
-			<?php p(!empty($_['application'])?$_['application'].' | ':'');
-			p($theme->getTitle());
-			p(trim($_['user_displayname']) != '' ?' ('.$_['user_displayname'].') ':'') ?>
-		</title>
+		<?php $title =
+			(!empty($_['application']) ? $_['application'].' | ' : '').
+			$theme->getTitle().
+			(trim($_['user_displayname']) != '' ? ' ('.$_['user_displayname'].') ' : '');
+		?>
+		<title><?php p($title); ?></title>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<meta name="apple-itunes-app" content="app-id=543672169">


### PR DESCRIPTION
All created html pages currently have lots of whitespace around the actual title. E.g. in the (upcoming) Documents app I see this:
--- 8< ---
        <title>
            Documents | ownCloud (kossebau)         </title>
--- 8< ---
while it better should be this
--- 8< ---
<title>Documents | ownCloud (kossebau)</title>
--- 8< ---

At least makes no perfect impression to anyone who looks inside the created HTML ;)
Also wastes a few bytes on every transfer, well, still.

Was an easy fix, so here it is.
