### PR TITLE
change View->deleteAll to an alias of View->rmdir since rmdir works recursive

### DIFF
--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -333,7 +333,7 @@ class View {
 	}
 
 	public function deleteAll($directory, $empty = false) {
-		return $this->basicOperation('deleteAll', $directory, array('delete'), $empty);
+		return $this->rmdir($directory);
 	}
 
 	public function rename($path1, $path2) {


### PR DESCRIPTION
deleteAll is not part of the `Storage` interface and redundant since rmdir is already recursive.

This fixes errors being thrown during upload from the quota storage wrapper.

cc @karlitschek @DeepDiver1975 @bartv2 
