### PR TITLE
On an auth failure the uid and the IP address should be logged to the st...

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -145,6 +145,9 @@ $CONFIG = array(
  (watch out, this option can increase the size of your log file)*/
 "log_query" => false,
 
+/* Enable or disable the logging of IP addresses in case of webform auth failures */
+"log_authfailip" => false,
+
 /*
  * Configure the size in bytes log rotation should happen, 0 or false disables the rotation.
  * This rotates the current owncloud logfile to a new name, this way the total log usage

--- a/lib/base.php
+++ b/lib/base.php
@@ -730,11 +730,10 @@ class OC {
 			// Someone wants to log in :
 		} elseif (OC::tryFormLogin()) {
 			$error[] = 'invalidpassword';
-			if ( OC_Config::getValue('log_authfailip', '') ) {
+			if ( OC_Config::getValue('log_authfailip', false) ) {
 				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
 				OC_Log::WARN);
-			}
-			else { 
+			} else { 
 				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:set log_authfailip=true in conf',
                                 OC_Log::WARN);
 			}

--- a/lib/base.php
+++ b/lib/base.php
@@ -730,8 +730,14 @@ class OC {
 			// Someone wants to log in :
 		} elseif (OC::tryFormLogin()) {
 			$error[] = 'invalidpassword';
-			OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
-			OC_Log::ERROR);
+			if ( OC_Config::getValue('log_authfailip', '') ) {
+				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
+				OC_Log::WARN);
+			}
+			else { 
+				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:set log_authfailip=true in conf',
+                                OC_Log::WARN);
+			}
 		}
 
 		OC_Util::displayLoginPage(array_unique($error));

--- a/lib/base.php
+++ b/lib/base.php
@@ -730,6 +730,8 @@ class OC {
 			// Someone wants to log in :
 		} elseif (OC::tryFormLogin()) {
 			$error[] = 'invalidpassword';
+			OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
+			OC_Log::ERROR);
 		}
 
 		OC_Util::displayLoginPage(array_unique($error));


### PR DESCRIPTION
...andard log file.

  This update works for a standard setup, when using a proxy for the server one can probably use the X-forwarded-for header
  instead of the remote address.
