### PR TITLE
Tune legacy cache webdav properties prefixing

### DIFF
--- a/apps/files/appinfo/update.php
+++ b/apps/files/appinfo/update.php
@@ -3,17 +3,19 @@
 // fix webdav properties,add namespace in front of the property, update for OC4.5
 $installedVersion=OCP\Config::getAppValue('files', 'installed_version');
 if (version_compare($installedVersion, '1.1.6', '<')) {
-	$query = OC_DB::prepare( 'SELECT `propertyname`, `propertypath`, `userid` FROM `*PREFIX*properties`' );
-	$result = $query->execute();
-	$updateQuery = OC_DB::prepare('UPDATE `*PREFIX*properties`'
-								.' SET `propertyname` = ?'
-								.' WHERE `userid` = ?'
-								.' AND `propertypath` = ?');
-	while( $row = $result->fetchRow()) {
-		if ( $row['propertyname'][0] != '{' ) {
-			$updateQuery->execute(array('{DAV:}' + $row['propertyname'], $row['userid'], $row['propertypath']));
-		}
+	// SQL92 string concatenation is ||, some of the DBMS don't know that
+	if (OC_Config::getValue('dbtype') === 'mysql') {
+		$concat = 'concat(\'{DAV:}\', `propertyname`)';
+	} else if (OC_Config::getValue('dbtype') === 'mssql') {
+		$concat = '\'{DAV:}\' + `propertyname`';
+	} else {
+		$concat = '\'{DAV:}\' || `propertyname`';
 	}
+	$query = OC_DB::executeAudited('
+		UPDATE `*PREFIX*properties`
+		SET    `propertyname` = ' . $concat . '
+		WHERE  `propertyname` NOT LIKE \'{%\'
+	');
 }
 
 //update from OC 3


### PR DESCRIPTION
@felixboehm reported lengthy upgrades from OC4.5 to OC5. Other than adding indexes this might help as well because it prefixes the webdav properties in one SQL statement instead of individual UPDATE statements. The performance could be further improved with an index on the `propertyname` column:

``` sql
create index oc_properties_propertyname on oc_properties(propertyname);
```

Since we are talking 500.000+ rows creating the index might take even longer than executing the update.
@icewind1991 could you check I did not screw up the SQL?
@felixboehm would be awesome if you could check the performance. If there is a mysql DB you can try to further improve the performance by disabling index updates prior to executing the update:

``` sql
ALTER TABLE `oc_properties` DISABLE KEYS;
```

and enabling them afterwards:

``` sql
ALTER TABLE `oc_properties` ENABLE KEYS;
```

You can also prepare this optimization in advance of the migration. Just delete `apps/files/appinfo/update.php` and execute the following SQL (assuming you are on mysql):

``` sql
ALTER TABLE `oc_properties` DISABLE KEYS;
UPDATE `oc_properties` SET `propertyname` = concat('{DAV:}', `propertyname`) WHERE `propertyname` LIKE '{%'";
ALTER TABLE `oc_properties` ENABLE KEYS;
```
