### PR TITLE
Don't popup meaningless alerts when dialog called on page leave

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -142,9 +142,7 @@ var OCdialogs = {
 		.fail(function(status, error) {
 			// If the method is called while navigating away
 			// from the page, it is probably not needed ;)
-			if(status === 0) {
-				return;
-			} else {
+			if(status !== 0) {
 				alert(t('core', 'Error loading file picker template: {error}', {error: error}));
 			}
 		});

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -243,7 +243,7 @@ var OCdialogs = {
 		var defer = $.Deferred();
 		if(!this.$messageTemplate) {
 			var self = this;
-			$.get(OC.filePath('core', 'templates', 'message.htm'), function(tmpl) {
+			$.get(OC.filePath('core', 'templates', 'message.html'), function(tmpl) {
 				self.$messageTemplate = $(tmpl);
 				defer.resolve(self.$messageTemplate);
 			})

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -139,8 +139,14 @@ var OCdialogs = {
 				}
 			});
 		})
-		.fail(function() {
-			alert(t('core', 'Error loading file picker template'));
+		.fail(function(status, error) {
+			// If the method is called while navigating away
+			// from the page, it is probably not needed ;)
+			if(status === 0) {
+				return;
+			} else {
+				alert(t('core', 'Error loading file picker template: {error}', {error: error}));
+			}
 		});
 	},
 	/**
@@ -206,8 +212,14 @@ var OCdialogs = {
 			});
 			OCdialogs.dialogs_counter++;
 		})
-		.fail(function() {
-			alert(t('core', 'Error loading file picker template'));
+		.fail(function(status, error) {
+			// If the method is called while navigating away from
+			// the page, we still want to deliver the message.
+			if(status === 0) {
+				alert(title + ': ' + content);
+			} else {
+				alert(t('core', 'Error loading message template: {error}', {error: error}));
+			}
 		});
 	},
 	_getFilePickerTemplate: function() {
@@ -219,8 +231,8 @@ var OCdialogs = {
 				self.$listTmpl = self.$filePickerTemplate.find('.filelist li:first-child').detach();
 				defer.resolve(self.$filePickerTemplate);
 			})
-			.fail(function() {
-				defer.reject();
+			.fail(function(jqXHR, textStatus, errorThrown) {
+				defer.reject(jqXHR.status, errorThrown);
 			});
 		} else {
 			defer.resolve(this.$filePickerTemplate);
@@ -231,12 +243,12 @@ var OCdialogs = {
 		var defer = $.Deferred();
 		if(!this.$messageTemplate) {
 			var self = this;
-			$.get(OC.filePath('core', 'templates', 'message.html'), function(tmpl) {
+			$.get(OC.filePath('core', 'templates', 'message.htm'), function(tmpl) {
 				self.$messageTemplate = $(tmpl);
 				defer.resolve(self.$messageTemplate);
 			})
-			.fail(function() {
-				defer.reject();
+			.fail(function(jqXHR, textStatus, errorThrown) {
+				defer.reject(jqXHR.status, errorThrown);
 			});
 		} else {
 			defer.resolve(this.$messageTemplate);


### PR DESCRIPTION
I noticed that when deleting users OC.dialogs.alert() [*] is called when refreshing or navigating away from the page. The request to get the template is then aborted by the browser, which then triggers an ajax error.

This patch shows the message in a window.alert instead. Same goes for info() and prompt() btw.

If the page is left while loading a filepicker, the error is silently ignored as there's nothing sensible to do there.

[*] When deleting a user it is apparently put in some deletion queue that is called on page leave. The error is triggered no matter if the user is actually deleted because the request is aborted before a response is sent back.
@raghunayyar if you use the same method in the new UI you should be aware of this.
btw, in the current user UI you can only delete one user. The next delete triggers an error. But that's a whole other subject :)

@Kondou-ger @bartv2 
