### PR TITLE
Update db_structure.xml

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -299,7 +299,7 @@
             <field>
                 <name>unencrypted_size</name>
                 <type>integer</type>
-                <default></default>
+                <default>0</default>
                 <notnull>true</notnull>
                 <length>8</length>
             </field>


### PR DESCRIPTION
Set the default value for unencrypted_size in table _dbprefix_filecache to 0. This prevents failed file uploads (with a blank page as a result) with PostgresSQL
