### PR TITLE
Fix 4802 – with certain group names user management is effectively unsable

### DIFF
--- a/settings/js/users.js
+++ b/settings/js/users.js
@@ -232,7 +232,7 @@ var UserList = {
 		var user = element.attr('data-username');
 		if ($(element).attr('class') == 'groupsselect') {
 			if (element.data('userGroups')) {
-				checked = element.data('userGroups');
+				checked = String(element.data('userGroups'));
 			}
 			if (user) {
 				var checkHandeler = function (group) {
@@ -288,7 +288,7 @@ var UserList = {
 		}
 		if ($(element).attr('class') == 'subadminsselect') {
 			if (element.data('subadmin')) {
-				checked = element.data('subadmin');
+				checked = String(element.data('subadmin'));
 			}
 			var checkHandeler = function (group) {
 				if (group == 'admin') {


### PR DESCRIPTION
to  String conversion was removed i https://github.com/owncloud/core/commit/cd7e57e8ec64ffef8faec750ebffbdc6138ec9a0 which lead to this problem.

fixes #4802 

Reviewers please @karlitschek @ringmaster @DeepDiver1975  or others
