### PR TITLE
refactor upload js & html to always use only js to fill form data

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -46,6 +46,15 @@ $(document).ready(function() {
 				$('#uploadprogresswrapper input.stop').show();
 			}
 		},
+		submit: function(e, data) {
+			if ( ! data.formData ) {
+				// noone set update parameters, we set the minimum
+				data.formData = {
+					requesttoken: oc_requesttoken,
+							 dir: $('#dir').val()
+				};
+			}
+		},
 		/**
 		 * called after the first add, does NOT have the data param
 		 * @param e
@@ -141,15 +150,8 @@ $(document).ready(function() {
 			$('#uploadprogressbar').fadeOut();
 		}
 	};
-	var file_upload_handler = function() {
-		$('#file_upload_start').fileupload(file_upload_param);
-	};
-
-
-
-	if ( document.getElementById('data-upload-form') ) {
-		$(file_upload_handler);
-	}
+	$('#file_upload_start').fileupload(file_upload_param);
+	
 	$.assocArraySize = function(obj) {
 		// http://stackoverflow.com/a/6700/11236
 		var size = 0, key;

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -16,26 +16,18 @@
 			</div>
 			<div id="upload" class="button"
 				 title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
-				<form data-upload-id='1'
-					  id="data-upload-form"
-					  class="file_upload_form"
-					  action="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>"
-					  method="post"
-					  enctype="multipart/form-data"
-					  target="file_upload_target_1">
 					<?php if($_['uploadMaxFilesize'] >= 0):?>
 					<input type="hidden" name="MAX_FILE_SIZE" id="max_upload"
 						   value="<?php p($_['uploadMaxFilesize']) ?>">
 					<?php endif;?>
 					<!-- Send the requesttoken, this is needed for older IE versions
 						 because they don't send the CSRF token via HTTP header in this case -->
-					<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" id="requesttoken">
 					<input type="hidden" class="max_human_file_size"
 						   value="(max <?php p($_['uploadMaxHumanFilesize']); ?>)">
 					<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
-					<input type="file" id="file_upload_start" name='files[]'/>
+					<input type="file" id="file_upload_start" name='files[]'
+						   data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" />
 					<a href="#" class="svg"></a>
-				</form>
 			</div>
 			<?php if ($_['trash'] ): ?>
 			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -7,8 +7,6 @@ function fileDownloadPath(dir, file) {
 	return url;
 }
 
-var form_data;
-
 $(document).ready(function() {
 
 	$('#data-upload-form').tipsy({gravity:'ne', fade:true});
@@ -50,19 +48,20 @@ $(document).ready(function() {
 		});
 	}
 
-  // Add some form data to the upload handler
-  file_upload_param.formData = {
-    MAX_FILE_SIZE: $('#uploadMaxFilesize').val(),
-    requesttoken: $('#publicUploadRequestToken').val(),
-    dirToken: $('#dirToken').val(),
-    appname: 'files_sharing',
-    subdir: $('input#dir').val()
-  };
+	var file_upload_start = $('#file_upload_start');
+	file_upload_start.on('fileuploadadd', function(e, data) {
+		// Add custom data to the upload handler
+		data.formData = {
+			requesttoken: $('#publicUploadRequestToken').val(),
+			dirToken: $('#dirToken').val(),
+			subdir: $('input#dir').val()
+		};
+	});
 
-  // Add Uploadprogress Wrapper to controls bar
-  $('#controls').append($('#additional_controls div#uploadprogresswrapper'));
+	// Add Uploadprogress Wrapper to controls bar
+	$('#controls').append($('#additional_controls div#uploadprogresswrapper'));
 
-  // Cancel upload trigger
-  $('#cancel_upload_button').click(Files.cancelUploads);
+	// Cancel upload trigger
+	$('#cancel_upload_button').click(Files.cancelUploads);
 
 });


### PR DESCRIPTION
This PR unifies the way we fill the form data we send along with upload requests. Instead of constructing the form data from the html form element it is now added in the submit hook. By default we send the requesttoken as well as the dir. The form data can be overridden by setting `data.formData` in a onsubmit hook. The public upload now uses that. This enables uploads in the pictures and music apps in the future.

Tested in chromium, iceweasel 17.0.8 and IE8

@DeepDiver1975 @karlitschek @icewind1991 @Kondou-ger please review. 
