### PR TITLE
Fixed hidden search results

### DIFF
--- a/search/css/results.css
+++ b/search/css/results.css
@@ -14,7 +14,7 @@
 	position:fixed;
 	right:0;
 	text-overflow:ellipsis;
-	top:20px;
+	top:45px;
 	width:380px;
 	z-index:75;
 }


### PR DESCRIPTION
The #searchresults container is partly hidden by the header (#header). This will fix it.
