### PR TITLE
Request: fix handling of empty overwritewebroot.

### DIFF
--- a/lib/request.php
+++ b/lib/request.php
@@ -83,7 +83,7 @@ class OC_Request {
 	 */
 	public static function requestUri() {
 		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
-		if (OC_Config::getValue('overwritewebroot') !== null and self::isOverwriteCondition()) {
+		if (($webroot = OC_Config::getValue('overwritewebroot')) !== null and self::isOverwriteCondition()) {
 			$uri = self::scriptName() . substr($uri, strlen($_SERVER['SCRIPT_NAME']));
 		}
 		return $uri;
@@ -98,10 +98,15 @@ class OC_Request {
 	 */
 	public static function scriptName() {
 		$name = $_SERVER['SCRIPT_NAME'];
-		if (OC_Config::getValue('overwritewebroot') !== null and self::isOverwriteCondition()) {
-			$serverroot = str_replace("\\", '/', substr(__DIR__, 0, -4));
-			$suburi = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen($serverroot)));
+		if (($webroot = OC_Config::getValue('overwritewebroot')) !== null and self::isOverwriteCondition()) {
+			$serverroot = str_replace("\\", '/', dirname(__DIR__));
+			$suburi = substr(realpath($_SERVER['SCRIPT_FILENAME']), strlen($serverroot));
+
 			$name = OC_Config::getValue('overwritewebroot', '') . $suburi;
+
+			if (strlen($webroot)) {
+				$name = '/' . $name;
+			}
 		}
 		return $name;
 	}

--- a/lib/request.php
+++ b/lib/request.php
@@ -83,7 +83,7 @@ class OC_Request {
 	 */
 	public static function requestUri() {
 		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
-		if (OC_Config::getValue('overwritewebroot', '') !== '' and self::isOverwriteCondition()) {
+		if (OC_Config::getValue('overwritewebroot') !== null and self::isOverwriteCondition()) {
 			$uri = self::scriptName() . substr($uri, strlen($_SERVER['SCRIPT_NAME']));
 		}
 		return $uri;
@@ -98,7 +98,7 @@ class OC_Request {
 	 */
 	public static function scriptName() {
 		$name = $_SERVER['SCRIPT_NAME'];
-		if (OC_Config::getValue('overwritewebroot', '') !== '' and self::isOverwriteCondition()) {
+		if (OC_Config::getValue('overwritewebroot') !== null and self::isOverwriteCondition()) {
 			$serverroot = str_replace("\\", '/', substr(__DIR__, 0, -4));
 			$suburi = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen($serverroot)));
 			$name = OC_Config::getValue('overwritewebroot', '') . $suburi;

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2013 Luke Carrier <luke@carrier.im>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+
+class Test_Request extends PHPUnit_Framework_TestCase {
+	protected $overwritewebroot;
+
+	protected function setUp() {
+		$this->server = isset($_SERVER) ? $_SERVER : null;
+		$this->overwritewebroot = OC_Config::getValue('overwritewebroot');
+	}
+
+	protected function setServer() {
+		$_SERVER = array(
+			'REQUEST_URI'     => '/owncloud/',
+			'SCRIPT_NAME'     => '/owncloud/index.php',
+			'SCRIPT_FILENAME' => dirname(dirname(__DIR__)) . '/index.php',
+		);
+	}
+
+	protected function resetConfig() {
+		$_SERVER = $this->server;
+		OC_Config::setValue('overwritewebroot', $this->overwritewebroot);
+	}
+
+	public function testRequestUriWithEmptyOverwritewebroot() {
+		OC_Config::setValue('overwritewebroot', '');
+		$this->setServer();
+
+		$this->assertEquals('/index.php', OC_Request::requestUri());
+
+		$this->resetConfig();
+	}
+
+	public function testRequestUriWithNullOverwritewebroot() {
+		OC_Config::deleteKey('overwritewebroot');
+		$this->setServer();
+
+		$this->assertEquals('/owncloud/', OC_Request::requestUri());
+
+		$this->resetConfig();
+	}
+
+	public function testRequestUriWithSetOverwritewebroot() {
+		OC_Config::setValue('overwritewebroot', 'theircloud');
+		$this->setServer();
+
+		$this->assertEquals('/theircloud/index.php', OC_Request::requestUri());
+
+		$this->resetConfig();
+	}
+
+	public function testScriptNameWithEmptyOverwritewebroot() {
+		OC_Config::setValue('overwritewebroot', '');
+		$this->setServer();
+
+		$this->assertEquals('/index.php', OC_Request::scriptName());
+
+		$this->resetConfig();
+	}
+
+	public function testScriptNameWithNullOverwritewebroot() {
+		OC_Config::deleteKey('overwritewebroot');
+		$this->setServer();
+
+		$this->assertEquals('/owncloud/index.php', OC_Request::scriptName());
+
+		$this->resetConfig();
+	}
+
+	public function testScriptNameWithSetOverwritewebroot() {
+		OC_Config::setValue('overwritewebroot', 'owncloud');
+		$this->setServer();
+
+		$this->assertEquals('/owncloud/index.php', OC_Request::scriptName());
+		$this->resetConfig();
+	}
+}


### PR DESCRIPTION
There are situations in which I believe an empty string value for `overwritewebroot` is required, such as when handling requests passed from the web root `/` to an installation in a subdirectory `/owncloud`, as is normal on an RPM installation on CentOS with nginx acting as SSL termination and a reverse proxy.

Unfortunately, such cases are presently impossible as this value is discarded or taken to mean 'not set'. For this reason, accept `OC_Config`'s default value of `null` when checking whether or not an `overwritewebroot` value has been configured.

Note: not particularly well tested; I'm not particularly familiar with ownCloud core either. Directions welcome.
