### PR TITLE
Public cache etc.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -570,7 +570,7 @@ class OC {
 			}
 			// NOTE: This will be replaced to use OCP
 			$userSession = \OC_User::getUserSession();
-			$userSession->listen('postLogin', array('OC\Cache\File', 'loginListener'));
+			$userSession->listen('postLogin', '\OC\Cache\File', 'loginListener');
 		}
 	}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -568,7 +568,9 @@ class OC {
 			} catch (Exception $e) {
 
 			}
-			OC_Hook::connect('OC_User', 'post_login', 'OC\Cache\File', 'loginListener');
+			// NOTE: This will be replaced to use OCP
+			$userSession = \OC_User::getUserSession();
+			$userSession->listen('postLogin', array('OC\Cache\File', 'loginListener'))
 		}
 	}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -564,11 +564,11 @@ class OC {
 		if (OC_Config::getValue('installed', false)) { //don't try to do this before we are properly setup
 			// register cache cleanup jobs
 			try { //if this is executed before the upgrade to the new backgroundjob system is completed it will throw an exception
-				\OCP\BackgroundJob::registerJob('OC_Cache_FileGlobalGC');
+				\OCP\BackgroundJob::registerJob('OC\Cache\FileGlobalGC');
 			} catch (Exception $e) {
 
 			}
-			OC_Hook::connect('OC_User', 'post_login', 'OC_Cache_File', 'loginListener');
+			OC_Hook::connect('OC_User', 'post_login', 'OC\Cache\File', 'loginListener');
 		}
 	}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -570,7 +570,7 @@ class OC {
 			}
 			// NOTE: This will be replaced to use OCP
 			$userSession = \OC_User::getUserSession();
-			$userSession->listen('postLogin', array('OC\Cache\File', 'loginListener'))
+			$userSession->listen('postLogin', array('OC\Cache\File', 'loginListener'));
 		}
 	}
 

--- a/lib/cache.php
+++ b/lib/cache.php
@@ -6,7 +6,7 @@
  * See the COPYING-README file.
  */
 
-namespace OC\Cache;
+namespace OC;
 
 class Cache {
 	/**
@@ -24,7 +24,7 @@ class Cache {
 	 */
 	static public function getGlobalCache() {
 		if (!self::$global_cache) {
-			self::$global_cache = new FileGlobal();
+			self::$global_cache = new Cache\FileGlobal();
 		}
 		return self::$global_cache;
 	}
@@ -35,7 +35,7 @@ class Cache {
 	 */
 	static public function getUserCache() {
 		if (!self::$user_cache) {
-			self::$user_cache = new File();
+			self::$user_cache = new Cache\File();
 		}
 		return self::$user_cache;
 	}

--- a/lib/cache.php
+++ b/lib/cache.php
@@ -6,7 +6,9 @@
  * See the COPYING-README file.
  */
 
-class OC_Cache {
+namespace OC\Cache;
+
+class Cache {
 	/**
 	 * @var OC_Cache $user_cache
 	 */
@@ -22,7 +24,7 @@ class OC_Cache {
 	 */
 	static public function getGlobalCache() {
 		if (!self::$global_cache) {
-			self::$global_cache = new OC_Cache_FileGlobal();
+			self::$global_cache = new FileGlobal();
 		}
 		return self::$global_cache;
 	}
@@ -33,7 +35,7 @@ class OC_Cache {
 	 */
 	static public function getUserCache() {
 		if (!self::$user_cache) {
-			self::$user_cache = new OC_Cache_File();
+			self::$user_cache = new File();
 		}
 		return self::$user_cache;
 	}

--- a/lib/cache.php
+++ b/lib/cache.php
@@ -10,17 +10,17 @@ namespace OC;
 
 class Cache {
 	/**
-	 * @var OC_Cache $user_cache
+	 * @var Cache $user_cache
 	 */
 	static protected $user_cache;
 	/**
-	 * @var OC_Cache $global_cache
+	 * @var Cache $global_cache
 	 */
 	static protected $global_cache;
 
 	/**
 	 * get the global cache
-	 * @return OC_Cache
+	 * @return Cache
 	 */
 	static public function getGlobalCache() {
 		if (!self::$global_cache) {
@@ -31,7 +31,7 @@ class Cache {
 
 	/**
 	 * get the user cache
-	 * @return OC_Cache
+	 * @return Cache
 	 */
 	static public function getUserCache() {
 		if (!self::$user_cache) {
@@ -87,7 +87,7 @@ class Cache {
 
 	/**
 	 * clear the user cache of all entries starting with a prefix
-	 * @param string prefix (optional)
+	 * @param string $prefix (optional)
 	 * @return bool
 	 */
 	static public function clear($prefix='') {
@@ -95,6 +95,11 @@ class Cache {
 		return $user_cache->clear($prefix);
 	}
 
+	/**
+	 * creates cache key based on the files given
+	 * @param $files
+	 * @return string
+	 */
 	static public function generateCacheKeyFromFiles($files) {
 		$key = '';
 		sort($files);

--- a/lib/cache/broker.php
+++ b/lib/cache/broker.php
@@ -6,7 +6,9 @@
  * See the COPYING-README file.
  */
 
-class OC_Cache_Broker {
+namespace OC\Cache;
+
+class Broker {
 	protected $fast_cache;
 	protected $slow_cache;
 

--- a/lib/cache/broker.php
+++ b/lib/cache/broker.php
@@ -9,7 +9,15 @@
 namespace OC\Cache;
 
 class Broker {
+
+	/**
+	 * @var \OC\Cache
+	 */
 	protected $fast_cache;
+
+	/**
+	 * @var \OC\Cache
+	 */
 	protected $slow_cache;
 
 	public function __construct($fast_cache, $slow_cache) {

--- a/lib/cache/file.php
+++ b/lib/cache/file.php
@@ -6,24 +6,25 @@
  * See the COPYING-README file.
  */
 
+namespace OC\Cache;
 
-class OC_Cache_File{
+class File {
 	protected $storage;
 	protected function getStorage() {
 		if (isset($this->storage)) {
 			return $this->storage;
 		}
-		if(OC_User::isLoggedIn()) {
-			\OC\Files\Filesystem::initMountPoints(OC_User::getUser());
+		if(\OC_User::isLoggedIn()) {
+			\OC\Files\Filesystem::initMountPoints(\OC_User::getUser());
 			$subdir = 'cache';
-			$view = new \OC\Files\View('/'.OC_User::getUser());
+			$view = new \OC\Files\View('/' . \OC_User::getUser());
 			if(!$view->file_exists($subdir)) {
 				$view->mkdir($subdir);
 			}
-			$this->storage = new \OC\Files\View('/'.OC_User::getUser().'/'.$subdir);
+			$this->storage = new \OC\Files\View('/' . \OC_User::getUser().'/'.$subdir);
 			return $this->storage;
 		}else{
-			OC_Log::write('core', 'Can\'t get cache storage, user not logged in', OC_Log::ERROR);
+			\OC_Log::write('core', 'Can\'t get cache storage, user not logged in', \OC_Log::ERROR);
 			return false;
 		}
 	}

--- a/lib/cache/fileglobal.php
+++ b/lib/cache/fileglobal.php
@@ -6,8 +6,9 @@
  * See the COPYING-README file.
  */
 
+namespace OC\Cache;
 
-class OC_Cache_FileGlobal{
+class FileGlobal {
 	static protected function getCacheDir() {
 		$cache_dir = get_temp_dir().'/owncloud-'.OC_Util::getInstanceId().'/';
 		if (!is_dir($cache_dir)) {
@@ -80,13 +81,13 @@ class OC_Cache_FileGlobal{
 	}
 
 	static public function gc() {
-		$last_run = OC_AppConfig::getValue('core', 'global_cache_gc_lastrun', 0);
+		$last_run = \OC_AppConfig::getValue('core', 'global_cache_gc_lastrun', 0);
 		$now = time();
 		if (($now - $last_run) < 300) {
 			// only do cleanup every 5 minutes
 			return;
 		}
-		OC_AppConfig::setValue('core', 'global_cache_gc_lastrun', $now);
+		\OC_AppConfig::setValue('core', 'global_cache_gc_lastrun', $now);
 		$cache_dir = self::getCacheDir();
 		if($cache_dir and is_dir($cache_dir)) {
 			$dh=opendir($cache_dir);

--- a/lib/cache/fileglobal.php
+++ b/lib/cache/fileglobal.php
@@ -10,7 +10,7 @@ namespace OC\Cache;
 
 class FileGlobal {
 	static protected function getCacheDir() {
-		$cache_dir = get_temp_dir().'/owncloud-'.OC_Util::getInstanceId().'/';
+		$cache_dir = get_temp_dir().'/owncloud-' . \OC_Util::getInstanceId().'/';
 		if (!is_dir($cache_dir)) {
 			mkdir($cache_dir);
 		}

--- a/lib/cache/fileglobalgc.php
+++ b/lib/cache/fileglobalgc.php
@@ -1,8 +1,9 @@
 <?php
 
+namespace OC\Cache;
 
-class OC_Cache_FileGlobalGC extends \OC\BackgroundJob\Job{
+class FileGlobalGC extends \OC\BackgroundJob\Job{
 	public function run($argument){
-		OC_Cache_FileGlobal::gc();
+		FileGlobal::gc();
 	}
 }

--- a/lib/cache/usercache.php
+++ b/lib/cache/usercache.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Tanghus (thomas@tanghus.net)
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OC\Cache;
+
+/**
+ * This interface defines method for accessing the file based user cache.
+ */
+class UserCache implements \OCP\ICache {
+
+	/**
+	 * @var OC\Cache\File $userCache
+	 */
+	protected $userCache;
+
+	public function __construct() {
+		$this->userCache = new File();
+	}
+
+	/**
+	 * Get a value from the user cache
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key) {
+		return $this->userCache->get($key);
+	}
+
+	/**
+	 * Set a value in the user cache
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24
+	 * @return bool
+	 */
+	public function set($key, $value, $ttl = 0) {
+		if (empty($key)) {
+			return false;
+		}
+		return $this->userCache->set($key, $value, $ttl);
+	}
+
+	/**
+	 * Check if a value is set in the user cache
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
+	public function hasKey($key) {
+		return $this->userCache->hasKey($key);
+	}
+
+	/**
+	 * Remove an item from the user cache
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
+	public function remove($key) {
+		return $this->userCache->remove($key);
+	}
+
+	/**
+	 * clear the user cache of all entries starting with a prefix
+	 * @param string prefix (optional)
+	 * @return bool
+	 */
+	public function clear($prefix = '') {
+		return $this->userCache->clear($prefix);
+	}
+}

--- a/lib/cache/usercache.php
+++ b/lib/cache/usercache.php
@@ -13,7 +13,7 @@ namespace OC\Cache;
 class UserCache implements \OCP\ICache {
 
 	/**
-	 * @var OC\Cache\File $userCache
+	 * @var \OC\Cache\File $userCache
 	 */
 	protected $userCache;
 
@@ -68,7 +68,7 @@ class UserCache implements \OCP\ICache {
 
 	/**
 	 * clear the user cache of all entries starting with a prefix
-	 * @param string prefix (optional)
+	 * @param string $prefix (optional)
 	 * @return bool
 	 */
 	public function clear($prefix = '') {

--- a/lib/filechunking.php
+++ b/lib/filechunking.php
@@ -29,7 +29,7 @@ class OC_FileChunking {
 
 	protected function getCache() {
 		if (!isset($this->cache)) {
-			$this->cache = new OC_Cache_File();
+			$this->cache = new \OC\Cache\File();
 		}
 		return $this->cache;
 	}

--- a/lib/legacy/cache.php
+++ b/lib/legacy/cache.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Tanghus (thomas@tanghus.net)
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+class Cache extends OC\Cache {
+}

--- a/lib/legacy/cache.php
+++ b/lib/legacy/cache.php
@@ -6,5 +6,5 @@
  * See the COPYING-README file.
  */
 
-class Cache extends OC\Cache {
+class OC_Cache extends \OC\Cache {
 }

--- a/lib/public/icache.php
+++ b/lib/public/icache.php
@@ -48,7 +48,7 @@ interface ICache {
 
 	/**
 	 * clear the user cache of all entries starting with a prefix
-	 * @param string prefix (optional)
+	 * @param string $prefix (optional)
 	 * @return bool
 	 */
 	public function clear($prefix = '');

--- a/lib/public/icache.php
+++ b/lib/public/icache.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Tanghus (thomas@tanghus.net)
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OCP;
+
+/**
+ * This interface defines method for accessing the file based user cache.
+ */
+interface ICache {
+
+	/**
+	 * Get a value from the user cache
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key);
+
+	/**
+	 * Set a value in the user cache
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24
+	 * @return bool
+	 */
+	public function set($key, $value, $ttl = 0);
+
+	/**
+	 * Check if a value is set in the user cache
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
+	public function hasKey($key);
+
+	/**
+	 * Remove an item from the user cache
+	 * 
+	 * @param string $key
+	 * @return bool
+	 */
+	public function remove($key);
+
+	/**
+	 * clear the user cache of all entries starting with a prefix
+	 * @param string prefix (optional)
+	 * @return bool
+	 */
+	public function clear($prefix = '');
+}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -62,4 +62,11 @@ interface IServerContainer {
 	 */
 	function getRootFolder();
 
+	/**
+	 * Returns an ICache instance
+	 *
+	 * @return \OCP\ICache
+	 */
+	function getCache();
+
 }

--- a/lib/server.php
+++ b/lib/server.php
@@ -17,10 +17,10 @@ use OCP\IServerContainer;
 class Server extends SimpleContainer implements IServerContainer {
 
 	function __construct() {
-		$this->registerService('ContactsManager', function($c){
+		$this->registerService('ContactsManager', function($c) {
 			return new ContactsManager();
 		});
-		$this->registerService('Request', function($c){
+		$this->registerService('Request', function($c) {
 			$params = array();
 
 			// we json decode the body only in case of content type json
@@ -46,16 +46,19 @@ class Server extends SimpleContainer implements IServerContainer {
 				)
 			);
 		});
-		$this->registerService('PreviewManager', function($c){
+		$this->registerService('PreviewManager', function($c) {
 			return new PreviewManager();
 		});
-		$this->registerService('RootFolder', function($c){
+		$this->registerService('RootFolder', function($c) {
 			// TODO: get user and user manager from container as well
 			$user = \OC_User::getUser();
 			$user = \OC_User::getManager()->get($user);
 			$manager = \OC\Files\Filesystem::getMountManager();
 			$view = new View();
 			return new Root($manager, $view, $user);
+		});
+		$this->registerService('UserCache', function($c) {
+			return new UserCache();
 		});
 	}
 
@@ -67,14 +70,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	}
 
 	/**
-	 * The current request object holding all information about the request currently being processed
-	 * is returned from this method.
+	 * The current request object holding all information about the request
+	 * currently being processed is returned from this method.
 	 * In case the current execution was not initiated by a web request null is returned
 	 *
 	 * @return \OCP\IRequest|null
 	 */
-	function getRequest()
-	{
+	function getRequest() {
 		return $this->query('Request');
 	}
 
@@ -83,8 +85,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	 *
 	 * @return \OCP\IPreview
 	 */
-	function getPreviewManager()
-	{
+	function getPreviewManager() {
 		return $this->query('PreviewManager');
 	}
 
@@ -93,8 +94,17 @@ class Server extends SimpleContainer implements IServerContainer {
 	 *
 	 * @return \OCP\Files\Folder
 	 */
-	function getRootFolder()
-	{
+	function getRootFolder() {
 		return $this->query('RootFolder');
 	}
+
+	/**
+	 * Returns an ICache instance
+	 *
+	 * @return \OCP\ICache
+	 */
+	function getCache() {
+		return $this->query('UserCache');
+	}
+
 }

--- a/tests/lib/cache.php
+++ b/tests/lib/cache.php
@@ -8,7 +8,7 @@
 
 abstract class Test_Cache extends PHPUnit_Framework_TestCase {
 	/**
-	 * @var OC_Cache cache;
+	 * @var \OC\Cache cache;
 	 */
 	protected $instance;
 

--- a/tests/lib/cache/usercache.php
+++ b/tests/lib/cache/usercache.php
@@ -22,14 +22,10 @@
 
 namespace Test\Cache;
 
-class FileCache extends \Test_Cache {
+class UserCache extends \Test_Cache {
 	private $user;
 	private $datadir;
 
-	function skip() {
-		//$this->skipUnless(OC_User::isLoggedIn());
-	}
-	
 	public function setUp() {
 		//clear all proxies and hooks so we can do clean testing
 		\OC_FileProxy::clearProxies();
@@ -59,10 +55,10 @@ class FileCache extends \Test_Cache {
 		\OC_User::setUserId('test');
 
 		//set up the users dir
-		$rootView = new \OC\Files\View('');
+		$rootView=new \OC\Files\View('');
 		$rootView->mkdir('/test');
 		
-		$this->instance=new \OC\Cache\File();
+		$this->instance=new \OC\Cache\UserCache();
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
- Namespace lib/cache/\* to use `OC\Cache` instead of `OC_Cache`
- Fix any usage of `OC_Cache_*` in core
- Create an interface OCP\ICache
- Implement the interface in OC\UserCache
- Add getCache to IServerContainer and Server to return a - non-static - OC\UserCache
- Add test for `OC\Cache\UserCache`

Refs #4863 

@DeepDiver1975 @karlitschek @icewind1991 
