### PR TITLE
check only permission from link-share to decide if public upload is enabled or disabled

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -177,7 +177,9 @@ OC.Share={
 				if (allowPublicUploadStatus) {
 					return true;
 				}
-				allowPublicUploadStatus = (value.permissions & OC.PERMISSION_CREATE) ? true : false;
+				if (value.share_type === OC.Share.SHARE_TYPE_LINK) {
+					allowPublicUploadStatus = (value.permissions & OC.PERMISSION_CREATE) ? true : false;
+				}
 			});
 
 			html += '<input id="shareWith" type="text" placeholder="'+t('core', 'Share with')+'" />';

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -174,11 +174,9 @@ OC.Share={
 			var allowPublicUploadStatus = false;
 
 			$.each(data.shares, function(key, value) {
-				if (allowPublicUploadStatus) {
-					return true;
-				}
 				if (value.share_type === OC.Share.SHARE_TYPE_LINK) {
 					allowPublicUploadStatus = (value.permissions & OC.PERMISSION_CREATE) ? true : false;
+					return true;
 				}
 			});
 


### PR DESCRIPTION
Only consider the permission of the public link share to decide if public upload is activated or not and ignore the permissions of other shares. 
