### PR TITLE
disable avatar loading on public guest page

### DIFF
--- a/core/js/avatar.js
+++ b/core/js/avatar.js
@@ -1,7 +1,9 @@
 $(document).ready(function(){
-	$('#header .avatardiv').avatar(OC.currentUser, 32);
-	// Personal settings
-	$('#avatar .avatardiv').avatar(OC.currentUser, 128);
+	if (OC.currentUser) {
+		$('#header .avatardiv').avatar(OC.currentUser, 32);
+		// Personal settings
+		$('#avatar .avatardiv').avatar(OC.currentUser, 128);
+	}
 	// User settings
 	$.each($('td.avatar .avatardiv'), function(i, element) {
 		$(element).avatar($(element).parent().parent().data('uid'), 32);


### PR DESCRIPTION
@Kondou-ger did you add the avatars code? Could you review this PR and verify that without it file uploads to public folders shared via link won't work? In chromium the js execution stops when trying to access a member on the user object that is passed in ... it is null. Don't know if this is the correct fix or if you would solve it differently.
