### PR TITLE
sharing, allow user to disable password protection

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -604,6 +604,7 @@ $(document).ready(function() {
 			var itemType = $('#dropdown').data('item-type');
 			var itemSource = $('#dropdown').data('item-source');
 			var allowPublicUpload = $('#sharingDialogAllowPublicUpload').is(':checked');
+			var permissions = 0;
 
 			// Calculate permissions
 			if (allowPublicUpload) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -603,7 +603,17 @@ $(document).ready(function() {
 		if (!$('#showPassword').is(':checked') ) {
 			var itemType = $('#dropdown').data('item-type');
 			var itemSource = $('#dropdown').data('item-source');
-			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', OC.PERMISSION_READ);
+			var allowPublicUpload = $('#sharingDialogAllowPublicUpload').is(':checked');
+
+			// Calculate permissions
+			if (allowPublicUpload) {
+				permissions = OC.PERMISSION_UPDATE + OC.PERMISSION_CREATE + OC.PERMISSION_READ;
+			} else {
+				permissions = OC.PERMISSION_READ;
+			}
+
+
+			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', permissions);
 		} else {
 			$('#linkPassText').focus();
 		}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -463,7 +463,7 @@ class Share {
 				} else {
 					// reuse the already set password, but only if we change permissions
 					// otherwise the user disabled the password protection
-					if ($checkExists && (int)$permissions !== $oldPermissions) {
+					if ($checkExists && (int)$permissions !== (int)$oldPermissions) {
 						$shareWith = $checkExists['share_with'];
 					}
 				}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -106,22 +106,22 @@ class Share {
 		}
 		return false;
 	}
-	
+
 	/**
 	* @brief Prepare a path to be passed to DB as file_target
 	* @return string Prepared path
 	*/
 	public static function prepFileTarget( $path ) {
-	
+
 		// Paths in DB are stored with leading slashes, so add one if necessary
 		if ( substr( $path, 0, 1 ) !== '/' ) {
-		
+
 			$path = '/' . $path;
-		
+
 		}
-		
+
 		return $path;
-	
+
 	}
 
 	/**
@@ -256,7 +256,7 @@ class Share {
 		return self::getItems($itemType, $itemTarget, self::$shareTypeUserAndGroups, \OC_User::getUser(), null, $format,
 			$parameters, 1, $includeCollections);
 	}
-	
+
 	/**
 	* @brief Get the item of item type shared with the current user by source
 	* @param string Item type
@@ -450,6 +450,7 @@ class Share {
 					$uidOwner, self::FORMAT_NONE, null, 1)) {
 					// remember old token
 					$oldToken = $checkExists['token'];
+					$oldPermissions = $checkExists['permissions'];
 					//delete the old share
 					self::delete($checkExists['id']);
 				}
@@ -460,8 +461,11 @@ class Share {
 					$hasher = new \PasswordHash(8, $forcePortable);
 					$shareWith = $hasher->HashPassword($shareWith.\OC_Config::getValue('passwordsalt', ''));
 				} else {
-					// reuse the already set password
-					$shareWith = $checkExists['share_with'];
+					// reuse the already set password, but only if we change permissions
+					// otherwise the user disabled the password protection
+					if ($checkExists && (int)$permissions !== $oldPermissions) {
+						$shareWith = $checkExists['share_with'];
+					}
 				}
 
 				// Generate token


### PR DESCRIPTION
only remember the old password if the user changes the permissions, otherwise the user disabled the password protection. In this case the password should be set to null.
