### PR TITLE
Shared_Cache::searchByMime Before passing search results, mime stuff needs to be translated

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -250,7 +250,14 @@ class Shared_Cache extends Cache {
 			FROM `*PREFIX*filecache` WHERE ' . $where . ' AND `fileid` IN (' . $placeholders . ')'
 		);
 		$result = $query->execute(array_merge(array($mimetype), $ids));
-		return $result->fetchAll();
+		
+		$files = array();
+		while ($row = $result->fetchRow()) {
+			$row['mimetype'] = $this->getMimetype($row['mimetype']);
+			$row['mimepart'] = $this->getMimetype($row['mimepart']);
+			$files[] = $row;
+		}
+		return $files;
 	}
 
 	/**


### PR DESCRIPTION
otherwise it will be returned as numerals.

@butonic @icewind1991 
