### PR TITLE
css selectors never have a : before []

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -483,7 +483,7 @@ $(document).ready(function() {
 		if (!$('.cruds', this).is(':visible')) {
 			$('a', this).hide();
 			if (!$('input[name="edit"]', this).is(':checked')) {
-				$('input:[type=checkbox]', this).hide();
+				$('input[type="checkbox"]', this).hide();
 				$('label', this).hide();
 			}
 		} else {


### PR DESCRIPTION
`input:[type=checkbox]` has a superflous `:` and should use `"` around 'checkbox' to make it `input[type="checkbox"]` because [] is not a pseudo class.

@kabum @karlitschek zero impact but stumbled over it. :+1: and merge pls
