### PR TITLE
File conflicts dialog fixes

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -42,26 +42,6 @@ function supportAjaxUploadWithProgress() {
 OC.Upload = {
 	_uploads: [],
 	/**
-	 * cancels a single upload, 
-	 * @deprecated because it was only used when a file currently beeing uploaded was deleted. Now they are added after
-	 * they have been uploaded.
-	 * @param {string} dir
-	 * @param {string} filename
-	 * @returns {unresolved}
-	 */
-	cancelUpload:function(dir, filename) {
-		var self = this;
-		var deleted = false;
-		//FIXME _selections
-		jQuery.each(this._uploads, function(i, jqXHR) {
-			if (selection.dir === dir && selection.uploads[filename]) {
-				deleted = self.deleteSelectionUpload(selection, filename);
-				return false; // end searching through selections
-			}
-		});
-		return deleted;
-	},
-	/**
 	 * deletes the jqHXR object from a data selection
 	 * @param {object} data
 	 */

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -177,20 +177,7 @@ $(document).ready(function () {
 FileActions.register('all', 'Delete', OC.PERMISSION_DELETE, function () {
 	return OC.imagePath('core', 'actions/delete');
 }, function (filename) {
-	if (OC.Upload.cancelUpload($('#dir').val(), filename)) {
-		if (filename.substr) {
-			filename = [filename];
-		}
-		$.each(filename, function (index, file) {
-			var filename = $('tr').filterAttr('data-file', file);
-			filename.hide();
-			filename.find('input[type="checkbox"]').removeAttr('checked');
-			filename.removeClass('selected');
-		});
-		procesSelection();
-	} else {
-		FileList.do_delete(filename);
-	}
+	FileList.do_delete(filename);
 	$('.tipsy').remove();
 });
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -804,7 +804,7 @@ $(document).ready(function(){
 				data.context.attr('data-mime',file.mime).attr('data-id',file.id);
 
 				var permissions = data.context.data('permissions');
-				if(permissions != file.permissions) {
+				if(permissions !== file.permissions) {
 					data.context.attr('data-permissions', file.permissions);
 					data.context.data('permissions', file.permissions);
 				}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -367,7 +367,7 @@ $(document).ready(function() {
 			}
 		});
 	}
-	
+
 	//scroll to and highlight preselected file
 	if (getURLParameter('scrollto')) {
 		FileList.scrollTo(getURLParameter('scrollto'));
@@ -645,7 +645,7 @@ function lazyLoadPreview(path, mime, ready, width, height) {
 	// get mime icon url
 	getMimeIcon(mime, function(iconURL) {
 		ready(iconURL); // set mimeicon URL
-		
+
 		// now try getting a preview thumbnail URL
 		if ( ! width ) {
 			width = $('#filestable').data('preview-x');
@@ -654,9 +654,9 @@ function lazyLoadPreview(path, mime, ready, width, height) {
 			height = $('#filestable').data('preview-y');
 		}
 		if( $('#publicUploadButtonMock').length ) {
-			var previewURL = OC.Router.generate('core_ajax_public_preview', {file: encodeURIComponent(path), x:width, y:height, t:$('#dirToken').val()});
+			var previewURL = OC.Router.generate('core_ajax_public_preview', {file: path, x:width, y:height, t:$('#dirToken').val()});
 		} else {
-			var previewURL = OC.Router.generate('core_ajax_preview', {file: encodeURIComponent(path), x:width, y:height});
+			var previewURL = OC.Router.generate('core_ajax_preview', {file: path, x:width, y:height});
 		}
 		$.get(previewURL, function() {
 			previewURL = previewURL.replace('(', '%28');

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -19,8 +19,6 @@
 					<input type="hidden" name="MAX_FILE_SIZE" id="max_upload"
 						   value="<?php p($_['uploadMaxFilesize']) ?>">
 					<?php endif;?>
-					<!-- Send the requesttoken, this is needed for older IE versions
-						 because they don't send the CSRF token via HTTP header in this case -->
 					<input type="hidden" class="max_human_file_size"
 						   value="(max <?php p($_['uploadMaxHumanFilesize']); ?>)">
 					<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -294,7 +294,7 @@ var OCdialogs = {
 				conflict.find('.replacement .mtime').text(formatDate(replacement.lastModifiedDate));
 			}
 			var path = getPathForPreview(original.name);
-			lazyLoadPreview(path, original.type, function(previewpath){
+			lazyLoadPreview(path, original.mime, function(previewpath){
 				conflict.find('.original .icon').css('background-image','url('+previewpath+')');
 			}, 96, 96);
 			getCroppedPreview(replacement).then(


### PR DESCRIPTION
currently when you upload a file and then try to delete it you will get an exception. The reason is that a cancelUpload is tried which contains dead and broken code. Canceling individuals is currently not supported because we have no placeholders for individual uploads. The files are added after they have been uploaded.

This PR removes the old code cleans up several minor issues. see commits

@karlitschek @kabum @DeepDiver1975 
