### PR TITLE
limit search to files by adding an additional mount point there

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -39,8 +39,7 @@ class Helper
 		}
 
 		if($file['isPreviewAvailable']) {
-			$relativePath = substr($file['path'], 6);
-			return \OC_Helper::previewIcon($relativePath);
+			return \OC_Helper::previewIcon($file['path']);
 		}
 		return \OC_Helper::mimetypeIcon($file['mimetype']);
 	}

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -306,6 +306,7 @@ class Filesystem {
 
 		$root = \OC_User::getHome($user);
 		self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
+		self::mount('\OC\Files\Storage\Local', array('datadir' => $root.'/files'), $user.'/files');
 		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 
 		//move config file to it's new position


### PR DESCRIPTION
@icewind1991 @andrewsbrown this PR supersedes https://github.com/owncloud/core/pull/4918
The search SQL uses the storage id, so I mount a separate locla storage for the users files folder.
@icewind1991 this fixes the problem of finding results outside "/files" in effect really jailing the user to that folder. You like this app
@andrewsbrown could you test search results for files external and shared files? you can use webdav with http://demo.owncloud.org/ 
@schiesbn trashcan still works as expected
sharing works as well.
@georgehrke removed a hack that truncated the 'files/' prefix in the file helper
