### PR TITLE
Replace plus sign with space in files app URL #4932

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -895,6 +895,10 @@ $(document).ready(function(){
 		$(window).trigger('beforeunload');
 	});
 
+	function decodeQuery(query){
+		return query.replace(/\+/g, ' ');
+	}
+
 	function parseHashQuery(){
 		var hash = window.location.hash,
 			pos = hash.indexOf('?'),
@@ -911,11 +915,11 @@ $(document).ready(function(){
 			dir = '/';
 		// try and parse from URL hash first
 		if (query){
-			params = OC.parseQueryString(query);
+			params = OC.parseQueryString(decodeQuery(query));
 		}
 		// else read from query attributes
 		if (!params){
-			params = OC.parseQueryString(location.search);
+			params = OC.parseQueryString(decodeQuery(location.search));
 		}
 		return (params && params.dir) || '/';
 	}


### PR DESCRIPTION
Some apps create URLs to the files app and encode the spaces of a
directory using plus signs.

This fix ensures that plus signs are properly converted back to spaces
when parsing the URL on the JS side.

Fixes #4932 and https://github.com/owncloud/apps/issues/1376
