### PR TITLE
fix visual glitch, do not use black border for input fields

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -193,7 +193,6 @@ input[name="adminpass-clone"] { padding-left:1.8em; width:11.7em !important; }
 #body-login input[type="text"],
 #body-login input[type="password"],
 #body-login input[type="email"] {
-	border: 1px solid #323233;
 	-moz-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;
 	-webkit-box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;
 	box-shadow: 0 1px 0 rgba(255,255,255,.15), 0 1px 1px rgba(0,0,0,.25) inset;


### PR DESCRIPTION
In stable5, the input fields on log in and installation have an ugly black border for whatever reason (probably backport of something?).

This fixes that. Please review @owncloud/designers
