### PR TITLE
Backport of sharing fixes to stable5

### DIFF
--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -178,4 +178,25 @@
   </declaration>
  </table>
 
+ <table>
+  <name>*dbprefix*timestamp</name>
+  <declaration>
+   <field>
+    <name>id</name>
+    <autoincrement>1</autoincrement>
+    <type>integer</type>
+    <default>0</default>
+    <notnull>true</notnull>
+    <length>4</length>
+   </field>
+
+   <field>
+    <name>timestamptest</name>
+    <type>timestamp</type>
+    <default></default>
+    <notnull>false</notnull>
+   </field>
+  </declaration>
+ </table>
+
 </database>

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -75,4 +75,25 @@
 
  </table>
 
+ <table>
+  <name>*dbprefix*timestamp</name>
+  <declaration>
+   <field>
+    <name>id</name>
+    <autoincrement>1</autoincrement>
+    <type>integer</type>
+    <default>0</default>
+    <notnull>true</notnull>
+    <length>4</length>
+   </field>
+
+   <field>
+    <name>timestamptest</name>
+    <type>timestamp</type>
+    <default></default>
+    <notnull>false</notnull>
+   </field>
+  </declaration>
+ </table>
+
 </database>

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -130,4 +130,42 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $result->numRows());
 
 	}
+
+	/**
+	* Tests whether the database is configured so it accepts and returns dates
+	* in the expected format.
+	*/
+	public function testTimestampDateFormat() {
+		$table = '*PREFIX*'.$this->test_prefix.'timestamp';
+		$column = 'timestamptest';
+
+		$expectedFormat = 'Y-m-d H:i:s';
+		$now = new \DateTime;
+
+		$query = OC_DB::prepare("INSERT INTO `$table` (`$column`) VALUES (?)");
+		$result = $query->execute(array($now->format($expectedFormat)));
+		$this->assertEquals(
+			1,
+			$result,
+			"Database failed to accept dates in the format '$expectedFormat'."
+		);
+
+		$id = OC_DB::insertid($table);
+		$query = OC_DB::prepare("SELECT * FROM `$table` WHERE `id` = ?");
+		$result = $query->execute(array($id));
+		$row = $result->fetchRow();
+
+		$dateFromDb = \DateTime::createFromFormat($expectedFormat, $row[$column]);
+		$this->assertInstanceOf(
+			'\DateTime',
+			$dateFromDb,
+			"Database failed to return dates in the format '$expectedFormat'."
+		);
+
+		$this->assertEquals(
+			$now->format('c u'),
+			$dateFromDb->format('c u'),
+			'Failed asserting that the returned date is the same as the inserted.'
+		);
+	}
 }

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -140,10 +140,10 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$column = 'timestamptest';
 
 		$expectedFormat = 'Y-m-d H:i:s';
-		$now = new \DateTime;
+		$expected = new \DateTime;
 
 		$query = OC_DB::prepare("INSERT INTO `$table` (`$column`) VALUES (?)");
-		$result = $query->execute(array($now->format($expectedFormat)));
+		$result = $query->execute(array($expected->format($expectedFormat)));
 		$this->assertEquals(
 			1,
 			$result,
@@ -155,16 +155,16 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$result = $query->execute(array($id));
 		$row = $result->fetchRow();
 
-		$dateFromDb = \DateTime::createFromFormat($expectedFormat, $row[$column]);
+		$actual = \DateTime::createFromFormat($expectedFormat, $row[$column]);
 		$this->assertInstanceOf(
 			'\DateTime',
-			$dateFromDb,
+			$actual,
 			"Database failed to return dates in the format '$expectedFormat'."
 		);
 
 		$this->assertEquals(
-			$now->format('c u'),
-			$dateFromDb->format('c u'),
+			$expected,
+			$actual,
 			'Failed asserting that the returned date is the same as the inserted.'
 		);
 	}

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -266,6 +266,41 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 	public function testShareWithUserExpirationExpired()
 	{
+		$this->shareUserOneTestFileWithUserTwo();
+
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(
+			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00'),
+			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
+		);
+
+		OC_User::setUserId($this->user2);
+		$this->assertFalse(
+			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that user 2 no longer has access to test.txt after expiration.'
+		);
+	}
+
+	public function testShareWithUserExpirationValid()
+	{
+		$this->shareUserOneTestFileWithUserTwo();
+
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(
+			OCP\Share::setExpirationDate('test', 'test.txt', '2037-01-01 00:00'),
+			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
+		);
+
+		OC_User::setUserId($this->user2);
+		$this->assertEquals(
+			array('test.txt'),
+			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that user 2 still has access to test.txt after expiration date has been set.'
+		);
+	}
+
+	protected function shareUserOneTestFileWithUserTwo()
+	{
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
@@ -282,18 +317,6 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			array('test.txt'),
 			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that user 2 has access to test.txt after initial sharing.'
-		);
-
-		OC_User::setUserId($this->user1);
-		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00'),
-			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
-		);
-
-		OC_User::setUserId($this->user2);
-		$this->assertFalse(
-			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
-			'Failed asserting that user 2 no longer has access to test.txt after expiration.'
 		);
 	}
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -31,6 +31,8 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 	protected $resharing;
 
 	protected $dateInPast = '2000-01-01 00:00:00';
+
+	// Picked close to the "year 2038 problem" boundary.
 	protected $dateInFuture = '2037-01-01 00:00:00';
 
 	public function setUp() {

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -124,6 +124,27 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	protected function shareUserOneTestFileWithUserTwo()
+	{
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
+			'Failed asserting that user 1 successfully shared text.txt with user 2.'
+		);
+		$this->assertEquals(
+			array('test.txt'),
+			OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that test.txt is a shared file of user 1.'
+		);
+
+		OC_User::setUserId($this->user2);
+		$this->assertEquals(
+			array('test.txt'),
+			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that user 2 has access to test.txt after initial sharing.'
+		);
+	}
+
 	public function testShareWithUser() {
 		// Invalid shares
 		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the item owner';
@@ -149,10 +170,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		}
 
 		// Valid share
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
-		$this->assertEquals(array('test.txt'), OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE));
-		OC_User::setUserId($this->user2);
-		$this->assertEquals(array('test.txt'), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE));
+		$this->shareUserOneTestFileWithUserTwo();
 
 		// Attempt to share again
 		OC_User::setUserId($this->user1);
@@ -299,27 +317,6 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			array('test.txt'),
 			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that user 2 still has access to test.txt after expiration date has been set.'
-		);
-	}
-
-	protected function shareUserOneTestFileWithUserTwo()
-	{
-		OC_User::setUserId($this->user1);
-		$this->assertTrue(
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
-			'Failed asserting that user 1 successfully shared text.txt with user 2.'
-		);
-		$this->assertEquals(
-			array('test.txt'),
-			OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
-			'Failed asserting that test.txt is a shared file of user 1.'
-		);
-
-		OC_User::setUserId($this->user2);
-		$this->assertEquals(
-			array('test.txt'),
-			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
-			'Failed asserting that user 2 has access to test.txt after initial sharing.'
 		);
 	}
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -124,8 +124,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		}
 	}
 
-	protected function shareUserOneTestFileWithUserTwo()
-	{
+	protected function shareUserOneTestFileWithUserTwo() {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
@@ -285,8 +284,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('test1.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 	}
 
-	public function testShareWithUserExpirationExpired()
-	{
+	public function testShareWithUserExpirationExpired() {
 		$this->shareUserOneTestFileWithUserTwo();
 
 		OC_User::setUserId($this->user1);
@@ -302,8 +300,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testShareWithUserExpirationValid()
-	{
+	public function testShareWithUserExpirationValid() {
 		$this->shareUserOneTestFileWithUserTwo();
 
 		OC_User::setUserId($this->user1);
@@ -320,8 +317,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	protected function shareUserOneTestFileWithGroupOne()
-	{
+	protected function shareUserOneTestFileWithGroupOne() {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ),
@@ -489,8 +485,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), OCP\Share::getItemsShared('test'));
 	}
 
-	public function testShareWithGroupExpirationExpired()
-	{
+	public function testShareWithGroupExpirationExpired() {
 		$this->shareUserOneTestFileWithGroupOne();
 
 		OC_User::setUserId($this->user1);
@@ -512,8 +507,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testShareWithGroupExpirationValid()
-	{
+	public function testShareWithGroupExpirationValid() {
 		$this->shareUserOneTestFileWithGroupOne();
 
 		OC_User::setUserId($this->user1);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -270,7 +270,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00'),
+			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00:00'),
 			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
 		);
 
@@ -287,7 +287,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', '2037-01-01 00:00'),
+			OCP\Share::setExpirationDate('test', 'test.txt', '2037-01-01 00:00:00'),
 			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
 		);
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -264,6 +264,39 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('test1.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 	}
 
+	public function testShareWithUserExpirationExpired()
+	{
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
+			'Failed asserting that user 1 successfully shared text.txt with user 2.'
+		);
+		$this->assertEquals(
+			array('test.txt'),
+			OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that test.txt is a shared file of user 1.'
+		);
+
+		OC_User::setUserId($this->user2);
+		$this->assertEquals(
+			array('test.txt'),
+			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that user 2 has access to test.txt after initial sharing.'
+		);
+
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(
+			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00'),
+			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
+		);
+
+		OC_User::setUserId($this->user2);
+		$this->assertFalse(
+			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
+			'Failed asserting that user 2 no longer has access to test.txt after expiration.'
+		);
+	}
+
 	public function testShareWithGroup() {
 		// Invalid shares
 		$message = 'Sharing test.txt failed, because the group foobar does not exist';

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -29,11 +29,8 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 	protected $group1;
 	protected $group2;
 	protected $resharing;
-
-	protected $dateInPast = '2000-01-01 00:00:00';
-
-	// Picked close to the "year 2038 problem" boundary.
-	protected $dateInFuture = '2037-01-01 00:00:00';
+	protected $dateInFuture;
+	protected $dateInPast;
 
 	public function setUp() {
 		OC_User::clearBackends();
@@ -63,6 +60,12 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		OC::registerShareHooks();
 		$this->resharing = OC_Appconfig::getValue('core', 'shareapi_allow_resharing', 'yes');
 		OC_Appconfig::setValue('core', 'shareapi_allow_resharing', 'yes');
+
+		// 20 Minutes in the past, 20 minutes in the future.
+		$now = time();
+		$dateFormat = 'Y-m-d H:i:s';
+		$this->dateInPast = date($dateFormat, $now - 20 * 60);
+		$this->dateInFuture = date($dateFormat, $now + 20 * 60);
 	}
 
 	public function tearDown() {

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -30,6 +30,9 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 	protected $group2;
 	protected $resharing;
 
+	protected $dateInPast = '2000-01-01 00:00:00';
+	protected $dateInFuture = '2037-01-01 00:00:00';
+
 	public function setUp() {
 		OC_User::clearBackends();
 		OC_User::useBackend('dummy');
@@ -270,7 +273,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', '2000-01-01 00:00:00'),
+			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInPast),
 			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
 		);
 
@@ -287,7 +290,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', '2037-01-01 00:00:00'),
+			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInFuture),
 			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
 		);
 


### PR DESCRIPTION
Backport of #4825 (without the Doctrine commits).
Backport of #4856

The Doctrine commits are not required because MDB2 already sends the Oracle queries for us. See https://github.com/owncloud/3rdparty/blob/stable5/MDB2/Driver/oci8.php#L408
