### PR TITLE
Use OCP\Share::unshare() instead of directly using OCP\Share::delete()

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -656,7 +656,7 @@ class Share {
 			);
 			\OC_Hook::emit('OCP\Share', 'pre_unshareAll', $hookParams);
 			foreach ($shares as $share) {
-				self::delete($share['id']);
+				self::unshareItem($share);
 			}
 			\OC_Hook::emit('OCP\Share', 'post_unshareAll', $hookParams);
 			return true;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -665,19 +665,16 @@ class Share {
 	public static function unshareAll($itemType, $itemSource) {
 		if ($shares = self::getItemShared($itemType, $itemSource)) {
 			// Pass all the vars we have for now, they may be useful
-			\OC_Hook::emit('OCP\Share', 'pre_unshareAll', array(
+			$hookParams = array(
 				'itemType' => $itemType,
 				'itemSource' => $itemSource,
-				'shares' => $shares
-			));
+				'shares' => $shares,
+			);
+			\OC_Hook::emit('OCP\Share', 'pre_unshareAll', $hookParams);
 			foreach ($shares as $share) {
 				self::delete($share['id']);
 			}
-			\OC_Hook::emit('OCP\Share', 'post_unshareAll', array(
-					'itemType' => $itemType,
-					'itemSource' => $itemSource,
-					'shares' => $shares
-			));
+			\OC_Hook::emit('OCP\Share', 'post_unshareAll', $hookParams);
 			return true;
 		}
 		return false;
@@ -850,6 +847,27 @@ class Share {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Unshares a share given a share data array
+	 * @param array $item Share data (usually database row)
+	 * @return null
+	 */
+	protected static function unshareItem(array $item) {
+		// Pass all the vars we have for now, they may be useful
+		$hookParams = array(
+			'itemType'		=> $item['item_type'],
+			'itemSource'	=> $item['item_source'],
+			'shareType'		=> $item['share_type'],
+			'shareWith'		=> $item['share_with'],
+			'itemParent'	=> $item['parent'],
+		);
+		\OC_Hook::emit('OCP\Share', 'pre_unshare', $hookParams + array(
+			'fileSource'	=> $item['file_source'],
+		));
+		self::delete($item['id']);
+		\OC_Hook::emit('OCP\Share', 'post_unshare', $hookParams);
 	}
 
 	/**

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -634,23 +634,7 @@ class Share {
 	public static function unshare($itemType, $itemSource, $shareType, $shareWith) {
 		if ($item = self::getItems($itemType, $itemSource, $shareType, $shareWith, \OC_User::getUser(),
 			self::FORMAT_NONE, null, 1)) {
-			// Pass all the vars we have for now, they may be useful
-			\OC_Hook::emit('OCP\Share', 'pre_unshare', array(
-				'itemType' => $itemType,
-				'itemSource' => $itemSource,
-				'fileSource' => $item['file_source'],
-				'shareType' => $shareType,
-				'shareWith' => $shareWith,
-				'itemParent' => $item['parent'],
-			));
-			self::delete($item['id']);
-			\OC_Hook::emit('OCP\Share', 'post_unshare', array(
-					'itemType' => $itemType,
-					'itemSource' => $itemSource,
-					'shareType' => $shareType,
-					'shareWith' => $shareWith,
-					'itemParent' => $item['parent'],
-			));
+			self::unshareItem($item);
 			return true;
 		}
 		return false;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -350,7 +350,7 @@ class Share {
 			$now = new \DateTime();
 			$expirationDate = new \DateTime($row['expiration'], new \DateTimeZone('UTC'));
 			if ($now > $expirationDate) {
-				self::delete($row['id']);
+				self::unshareItem($row);
 				return false;
 			}
 		}
@@ -1211,7 +1211,7 @@ class Share {
 			if (isset($row['expiration'])) {
 				$time = new \DateTime();
 				if ($row['expiration'] < date('Y-m-d H:i', $time->format('U') - $time->getOffset())) {
-					self::delete($row['id']);
+					self::unshareItem($row);
 					continue;
 				}
 			}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1091,7 +1091,7 @@ class Share {
 		// TODO Optimize selects
 		if ($format == self::FORMAT_STATUSES) {
 			if ($itemType == 'file' || $itemType == 'folder') {
-				$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`,'
+				$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `*PREFIX*share`.`parent`,'
 					.' `share_type`, `file_source`, `path`, `expiration`, `storage`, `mail_send`';
 			} else {
 				$select = '`id`, `item_type`, `item_source`, `parent`, `share_type`, `expiration`, `mail_send`';
@@ -1099,7 +1099,7 @@ class Share {
 		} else {
 			if (isset($uidOwner)) {
 				if ($itemType == 'file' || $itemType == 'folder') {
-					$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`,'
+					$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `*PREFIX*share`.`parent`,'
 						.' `share_type`, `share_with`, `file_source`, `path`, `permissions`, `stime`,'
 						.' `expiration`, `token`, `storage`, `mail_send`';
 				} else {
@@ -1112,7 +1112,7 @@ class Share {
 						&& $format == \OC_Share_Backend_File::FORMAT_GET_FOLDER_CONTENTS
 						|| $format == \OC_Share_Backend_File::FORMAT_FILE_APP_ROOT
 					) {
-						$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `uid_owner`, '
+						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `*PREFIX*share`.`parent`, `uid_owner`, '
 							.'`share_type`, `share_with`, `file_source`, `path`, `file_target`, '
 							.'`permissions`, `expiration`, `storage`, `*PREFIX*filecache`.`parent` as `file_parent`, '
 							.'`name`, `mtime`, `mimetype`, `mimepart`, `size`, `encrypted`, `etag`, `mail_send`';

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -135,15 +135,15 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared text.txt with user 2.'
 		);
-		$this->assertEquals(
-			array('test.txt'),
+		$this->assertContains(
+			'test.txt',
 			OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that test.txt is a shared file of user 1.'
 		);
 
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(
-			array('test.txt'),
+		$this->assertContains(
+			'test.txt',
 			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that user 2 has access to test.txt after initial sharing.'
 		);
@@ -328,22 +328,22 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared text.txt with group 1.'
 		);
-		$this->assertEquals(
-			array('test.txt'),
+		$this->assertContains(
+			'test.txt',
 			OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that test.txt is a shared file of user 1.'
 		);
 
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(
-			array('test.txt'),
+		$this->assertContains(
+			'test.txt',
 			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that user 2 has access to test.txt after initial sharing.'
 		);
 
 		OC_User::setUserId($this->user3);
-		$this->assertEquals(
-			array('test.txt'),
+		$this->assertContains(
+			'test.txt',
 			OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that user 3 has access to test.txt after initial sharing.'
 		);
@@ -581,6 +581,29 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertFalse(
 			OCP\Share::getShareByToken($token),
 			'Failed asserting that an expired share could not be found.'
+		);
+	}
+
+	public function testUnshareAll() {
+		$this->shareUserOneTestFileWithUserTwo();
+		$this->shareUserOneTestFileWithGroupOne();
+
+		OC_User::setUserId($this->user1);
+		$this->assertEquals(
+			array('test.txt', 'test.txt'),
+			OCP\Share::getItemsShared('test', 'test.txt'),
+			'Failed asserting that the test.txt file is shared exactly two times.'
+		);
+
+		$this->assertTrue(
+			OCP\Share::unshareAll('test', 'test.txt'),
+			'Failed asserting that user 1 successfully unshared all shares of the test.txt share.'
+		);
+
+		$this->assertEquals(
+			array(),
+			OCP\Share::getItemsShared('test'),
+			'Failed asserting that both shares of the test.txt file have been removed.'
 		);
 	}
 }


### PR DESCRIPTION
Fixes #4912 (partially) as suggested in https://github.com/owncloud/core/pull/4856#discussion_r6436470

@schiesbn 
