### PR TITLE
don't remember login if the encrypion app is enabled

### DIFF
--- a/apps/files_encryption/appinfo/info.xml
+++ b/apps/files_encryption/appinfo/info.xml
@@ -7,6 +7,7 @@
 	<author>Sam Tuke, Bjoern Schiessle, Florin Peter</author>
 	<require>4</require>
 	<shipped>true</shipped>
+	<rememberlogin>false</rememberlogin>
 	<types>
 		<filesystem/>
 	</types>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -32,9 +32,10 @@
 			<?php p($l->t('Lost your password?')); ?>
 		</a>
 		<?php endif; ?>
-
+		<?php if ($_['encryption_enabled'] === false) : ?>
 		<input type="checkbox" name="remember_login" value="1" id="remember_login" checked />
 		<label for="remember_login"><?php p($l->t('remember')); ?></label>
+		<?php endif; ?>
 		<input type="hidden" name="timezone-offset" id="timezone-offset"/>
 		<input type="submit" id="submit" class="login primary" value="<?php p($l->t('Log in')); ?>"/>
 	</fieldset>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -32,7 +32,7 @@
 			<?php p($l->t('Lost your password?')); ?>
 		</a>
 		<?php endif; ?>
-		<?php if ($_['encryption_enabled'] === false) : ?>
+		<?php if ($_['rememberLoginAllowed'] === true) : ?>
 		<input type="checkbox" name="remember_login" value="1" id="remember_login" checked />
 		<label for="remember_login"><?php p($l->t('remember')); ?></label>
 		<?php endif; ?>

--- a/lib/base.php
+++ b/lib/base.php
@@ -760,6 +760,7 @@ class OC {
 			|| !isset($_COOKIE["oc_token"])
 			|| !isset($_COOKIE["oc_username"])
 			|| !$_COOKIE["oc_remember_login"]
+			|| OC_App::isEnabled('files_encryption')
 		) {
 			return false;
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -760,7 +760,7 @@ class OC {
 			|| !isset($_COOKIE["oc_token"])
 			|| !isset($_COOKIE["oc_username"])
 			|| !$_COOKIE["oc_remember_login"]
-			|| OC_App::isEnabled('files_encryption')
+			|| !OC_Util::rememberLoginAllowed()
 		) {
 			return false;
 		}

--- a/lib/util.php
+++ b/lib/util.php
@@ -414,10 +414,10 @@ class OC_Util {
 				$encryptedFiles = true;
 			}
 		}
-		
+
 		return $encryptedFiles;
 	}
-	
+
 	/**
 	 * @brief Check for correct file permissions of data directory
 	 * @paran string $dataDirectory
@@ -467,6 +467,7 @@ class OC_Util {
 		}
 
 		$parameters['alt_login'] = OC_App::getAlternativeLogIns();
+		$parameters['encryption_enabled'] = OC_App::isEnabled('files_encryption');
 		OC_Template::printGuestPage("", "login", $parameters);
 	}
 
@@ -654,16 +655,16 @@ class OC_Util {
 		}
 		return $value;
 	}
-	
+
 	/**
 	 * @brief Public function to encode url parameters
 	 *
 	 * This function is used to encode path to file before output.
 	 * Encoding is done according to RFC 3986 with one exception:
-	 * Character '/' is preserved as is. 
+	 * Character '/' is preserved as is.
 	 *
 	 * @param string $component part of URI to encode
-	 * @return string 
+	 * @return string
 	 */
 	public static function encodePath($component) {
 		$encoded = rawurlencode($component);
@@ -810,7 +811,7 @@ class OC_Util {
 			}
 		}
 	}
-	
+
 	/**
 	 * @brief Check if the connection to the internet is disabled on purpose
 	 * @return bool

--- a/lib/util.php
+++ b/lib/util.php
@@ -467,7 +467,7 @@ class OC_Util {
 		}
 
 		$parameters['alt_login'] = OC_App::getAlternativeLogIns();
-		$parameters['encryption_enabled'] = OC_App::isEnabled('files_encryption');
+		$parameters['rememberLoginAllowed'] = self::rememberLoginAllowed();
 		OC_Template::printGuestPage("", "login", $parameters);
 	}
 
@@ -507,6 +507,17 @@ class OC_Util {
 			header( 'Location: '.OC_Helper::linkToAbsolute( '', 'index.php' ));
 			exit();
 		}
+	}
+
+	/**
+	 * Check if it is allowed to remember login.
+	 * E.g. if encryption is enabled the user needs to log-in every time he visites
+	 * ownCloud in order to decrypt the private key.
+	 *
+	 * @return bool
+	 */
+	public static function rememberLoginAllowed() {
+		return !OC_App::isEnabled('files_encryption');
 	}
 
 	/**

--- a/lib/util.php
+++ b/lib/util.php
@@ -511,13 +511,23 @@ class OC_Util {
 
 	/**
 	 * Check if it is allowed to remember login.
-	 * E.g. if encryption is enabled the user needs to log-in every time he visites
-	 * ownCloud in order to decrypt the private key.
+	 *
+	 * @note Every app can set 'rememberlogin' to 'false' to disable the remember login feature
 	 *
 	 * @return bool
 	 */
 	public static function rememberLoginAllowed() {
-		return !OC_App::isEnabled('files_encryption');
+
+		$apps = OC_App::getEnabledApps();
+
+		foreach ($apps as $app) {
+			$appInfo = OC_App::getAppInfo($app);
+			if (isset($appInfo['rememberlogin']) && $appInfo['rememberlogin'] === 'false') {
+				return false;
+			}
+
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
don't remember login if the encryption app is enabled because the user needs to log-in again in order to decrypt his private key with his password.

Fix for issue #4462 
