### PR TITLE
manager checkPassword now returns User object, adjust internal user clas...

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -419,7 +419,7 @@ class OC_User {
 		$manager = self::getManager();
 		$username = $manager->checkPassword($uid, $password);
 		if ($username !== false) {
-			return $manager->get($username)->getUID();
+			return $username->getUID();
 		}
 		return false;
 	}

--- a/tests/lib/user.php
+++ b/tests/lib/user.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test;
+
+use OC\Hooks\PublicEmitter;
+
+class User extends \PHPUnit_Framework_TestCase {
+
+	public function testCheckPassword() {
+		/**
+		 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->getMock('\OC_User_Dummy');
+		$backend->expects($this->once())
+			->method('checkPassword')
+			->with($this->equalTo('foo'), $this->equalTo('bar'))
+			->will($this->returnValue('foo'));
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->will($this->returnCallback(function ($actions) {
+				if ($actions === \OC_USER_BACKEND_CHECK_PASSWORD) {
+					return true;
+				} else {
+					return false;
+				}
+			}));
+
+		$manager = \OC_User::getManager();
+		$manager->registerBackend($backend);
+
+		$uid = \OC_User::checkPassword('foo', 'bar');
+		$this->assertEquals($uid, 'foo');
+	}
+
+}


### PR DESCRIPTION
...s accordingly.

Should have been in https://github.com/owncloud/core/pull/4968

Found out by my (future) LDAP tests.

@DeepDiver1975 @icewind1991 @schiesbn or others pls
