### PR TITLE
Various fixes for the streamwrapper based SMB backend

### DIFF
--- a/apps/files_external/3rdparty/smb4php/smb.php
+++ b/apps/files_external/3rdparty/smb4php/smb.php
@@ -307,7 +307,8 @@ class smb {
 			trigger_error('rename(): error in URL', E_USER_ERROR);
 		}
 		smb::clearstatcache ($url_from);
-		return smb::execute ('rename "'.$from['path'].'" "'.$to['path'].'"', $to);
+		$result = smb::execute ('rename "'.$from['path'].'" "'.$to['path'].'"', $to);
+		return $result !== false;
 	}
 
 	function mkdir ($url, $mode, $options) {

--- a/apps/files_external/3rdparty/smb4php/smb.php
+++ b/apps/files_external/3rdparty/smb4php/smb.php
@@ -181,6 +181,8 @@ class smb {
 						return false;
 					}elseif(substr($regs[0],0,31)=='NT_STATUS_OBJECT_PATH_NOT_FOUND'){
 						return false;
+					}elseif(substr($regs[0],0,31)=='NT_STATUS_OBJECT_NAME_NOT_FOUND'){
+						return false;
 					}elseif(substr($regs[0],0,29)=='NT_STATUS_FILE_IS_A_DIRECTORY'){
 						return false;
 					}
@@ -430,7 +432,10 @@ class smb_stream_wrapper extends smb {
 			case 'rb':
 			case 'a':
 			case 'a+':  $this->tmpfile = tempnam('/tmp', 'smb.down.');
-				smb::execute ('get "'.$pu['path'].'" "'.$this->tmpfile.'"', $pu);
+				$result = smb::execute ('get "'.$pu['path'].'" "'.$this->tmpfile.'"', $pu);
+				if($result === false){
+					return $result;
+				}
 				break;
 			case 'w':
 			case 'w+':

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -8,7 +8,7 @@
 
 namespace OC\Files\Storage;
 
-abstract class StreamWrapper extends Common{
+abstract class StreamWrapper extends Common {
 	abstract public function constructUrl($path);
 
 	public function mkdir($path) {
@@ -16,7 +16,7 @@ abstract class StreamWrapper extends Common{
 	}
 
 	public function rmdir($path) {
-		if($this->file_exists($path)) {
+		if ($this->file_exists($path)) {
 			$success = rmdir($this->constructUrl($path));
 			clearstatcache();
 			return $success;
@@ -34,11 +34,11 @@ abstract class StreamWrapper extends Common{
 	}
 
 	public function isReadable($path) {
-		return true;//not properly supported
+		return true; //not properly supported
 	}
 
 	public function isUpdatable($path) {
-		return true;//not properly supported
+		return true; //not properly supported
 	}
 
 	public function file_exists($path) {
@@ -55,15 +55,19 @@ abstract class StreamWrapper extends Common{
 		return fopen($this->constructUrl($path), $mode);
 	}
 
-	public function touch($path, $mtime=null) {
-		if(is_null($mtime)) {
-			$fh = $this->fopen($path, 'a');
-			fwrite($fh, '');
-			fclose($fh);
+	public function touch($path, $mtime = null) {
+		if ($this->file_exists($path)) {
+			if (is_null($mtime)) {
+				$fh = $this->fopen($path, 'a');
+				fwrite($fh, '');
+				fclose($fh);
 
-			return true;
+				return true;
+			} else {
+				return false; //not supported
+			}
 		} else {
-			return false;//not supported
+			$this->file_put_contents($path, '');
 		}
 	}
 

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -17,6 +17,14 @@ abstract class StreamWrapper extends Common {
 
 	public function rmdir($path) {
 		if ($this->file_exists($path)) {
+			$dh = $this->opendir($path);
+			while (($file = readdir($dh)) !== false) {
+				if ($this->is_dir($path . '/' . $file)) {
+					$this->rmdir($path . '/' . $file);
+				} else {
+					$this->unlink($path . '/' . $file);
+				}
+			}
 			$success = rmdir($this->constructUrl($path));
 			clearstatcache();
 			return $success;

--- a/apps/files_external/tests/smb.php
+++ b/apps/files_external/tests/smb.php
@@ -15,7 +15,7 @@ class SMB extends Storage {
 	public function setUp() {
 		$id = uniqid();
 		$this->config = include('files_external/tests/config.php');
-		if ( ! is_array($this->config) or ! isset($this->config['smb']) or ! $this->config['smb']['run']) {
+		if (!is_array($this->config) or !isset($this->config['smb']) or !$this->config['smb']['run']) {
 			$this->markTestSkipped('Samba backend not configured');
 		}
 		$this->config['smb']['root'] .= $id; //make sure we have an new empty folder to work in
@@ -27,5 +27,11 @@ class SMB extends Storage {
 		if ($this->instance) {
 			\OCP\Files::rmdirr($this->instance->constructUrl(''));
 		}
+	}
+
+	public function testRenameWithSpaces() {
+		$this->instance->mkdir('with spaces');
+		$result = $this->instance->rename('with spaces', 'foo bar');
+		$this->assertTrue($result);
 	}
 }

--- a/apps/files_external/tests/smb.php
+++ b/apps/files_external/tests/smb.php
@@ -33,5 +33,6 @@ class SMB extends Storage {
 		$this->instance->mkdir('with spaces');
 		$result = $this->instance->rename('with spaces', 'foo bar');
 		$this->assertTrue($result);
+		$this->assertTrue($this->instance->is_dir('foo bar'));
 	}
 }


### PR DESCRIPTION
Fixes:
- fopen on non existing files
- rename incorrectly reporting an error
- recursive rmdir
- touch to create new files

Now all storage test cases succeed for the SMB backend except for one mtime related test due to timezones not being taken into account.

For #5042 and probably more SMB related issues.

cc @DeepDiver1975 
