### PR TITLE
Fix autoloader regression

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -77,6 +77,7 @@ class Autoloader {
 			$paths[] = 'private/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OC\\') === 0) {
 			$paths[] = 'private/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+			$paths[] = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OCP\\') === 0) {
 			$paths[] = 'public/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 		} elseif (strpos($class, 'OCA\\') === 0) {

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -19,11 +19,11 @@ class AutoLoader extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testLeadingSlashOnClassName() {
-		$this->assertEquals(array('private/files/storage/local.php'), $this->loader->findClass('\OC\Files\Storage\Local'));
+		$this->assertEquals(array('private/files/storage/local.php', 'files/storage/local.php'), $this->loader->findClass('\OC\Files\Storage\Local'));
 	}
 
 	public function testNoLeadingSlashOnClassName() {
-		$this->assertEquals(array('private/files/storage/local.php'), $this->loader->findClass('OC\Files\Storage\Local'));
+		$this->assertEquals(array('private/files/storage/local.php', 'files/storage/local.php'), $this->loader->findClass('OC\Files\Storage\Local'));
 	}
 
 	public function testLegacyPath() {
@@ -54,7 +54,7 @@ class AutoLoader extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testLoadCoreNamespace() {
-		$this->assertEquals(array('private/foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
+		$this->assertEquals(array('private/foo/bar.php', 'foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
 	}
 
 	public function testLoadCore() {


### PR DESCRIPTION
Classes from core are not autoloaded anymore.
Check password recovery or avatars for instance.

> not a callable action
> # 0 /home/deo/public_html/office/lib/base.php(650): OC_Router->match('/avatar/Deo/32')
> # 1 /home/deo/public_html/office/index.php(30): OC::handleRequest()
> # 2 {main}

@DeepDiver1975 @icewind1991 @kabum @bantu 
