### PR TITLE
only perform files upgrade in case there are actually entries in the old...

### DIFF
--- a/lib/private/files/cache/upgrade.php
+++ b/lib/private/files/cache/upgrade.php
@@ -192,7 +192,15 @@ class Upgrade {
 	 */
 	static function needUpgrade($user) {
 		$cacheVersion = (int)\OCP\Config::getUserValue($user, 'files', 'cache_version', 4);
-		return $cacheVersion < 5;
+		if ($cacheVersion < 5) {
+			$legacy = new \OC\Files\Cache\Legacy($user);
+			if ($legacy->hasItems()) {
+				return true;
+			}
+			self::upgradeDone($user);
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
... fscache table

On the first login of a user we have that overlay dialog 'Upgrading filesystem cache ...'
Most of the time this popup is shown and triggers a redirect because there are no entries to be processed.

This pull request adds an additional check if there are entries to be processed and only if there is something to do the popup is shown.

@karlitschek @icewind1991 @bartv2 @blizzz @schiesbn @bantu THX
