### PR TITLE
Added dateOnly argument to relative_modified_date

### DIFF
--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -115,7 +115,6 @@ function relative_modified_date($timestamp, $dateOnly = false) {
 	$diffhours = round($diffminutes/60);
 	$diffdays = round($diffhours/24);
 	$diffmonths = round($diffdays/31);
-	\OC_Log::write('functions', '################ ' . $timediff . ' ' . $diffhours, \OC_Log::DEBUG);
 
 	if(!$dateOnly && $timediff < 60) { return $l->t('seconds ago'); }
 	else if(!$dateOnly && $timediff < 3600) { return $l->n('%n minute ago', '%n minutes ago', $diffminutes); }

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -104,9 +104,9 @@ function strip_time($timestamp){
  * @param bool $dateOnly whether to strip time information
  * @return formatted timestamp
  */
-function relative_modified_date($timestamp, $fromTime, $dateOnly = false) {
+function relative_modified_date($timestamp, $fromTime = null, $dateOnly = false) {
 	$l=OC_L10N::get('lib');
-	if (!isset($fromTime)){
+	if (!isset($fromTime) || $fromTime === null){
 		$fromTime = time();
 	}
 	if ($dateOnly){

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -100,17 +100,20 @@ function strip_time($timestamp){
  * @brief Formats timestamp relatively to the current time using
  * a human-friendly format like "x minutes ago" or "yesterday"
  * @param int $timestamp timestamp to format
+ * @param int $fromTime timestamp to compare from, defaults to current time
  * @param bool $dateOnly whether to strip time information
  * @return formatted timestamp
  */
-function relative_modified_date($timestamp, $dateOnly = false) {
+function relative_modified_date($timestamp, $fromTime, $dateOnly = false) {
 	$l=OC_L10N::get('lib');
-	$time = time();
+	if (!isset($fromTime)){
+		$fromTime = time();
+	}
 	if ($dateOnly){
-		$time = strip_time($time);
+		$fromTime = strip_time($fromTime);
 		$timestamp = strip_time($timestamp);
 	}
-	$timediff = $time - $timestamp;
+	$timediff = $fromTime - $timestamp;
 	$diffminutes = round($timediff/60);
 	$diffhours = round($diffminutes/60);
 	$diffdays = round($diffhours/24);
@@ -119,11 +122,14 @@ function relative_modified_date($timestamp, $dateOnly = false) {
 	if(!$dateOnly && $timediff < 60) { return $l->t('seconds ago'); }
 	else if(!$dateOnly && $timediff < 3600) { return $l->n('%n minute ago', '%n minutes ago', $diffminutes); }
 	else if(!$dateOnly && $timediff < 86400) { return $l->n('%n hour ago', '%n hours ago', $diffhours); }
-	else if((date('G', $time)-$diffhours) >= 0) { return $l->t('today'); }
-	else if((date('G', $time)-$diffhours) >= -24) { return $l->t('yesterday'); }
+	else if((date('G', $fromTime)-$diffhours) >= 0) { return $l->t('today'); }
+	else if((date('G', $fromTime)-$diffhours) >= -24) { return $l->t('yesterday'); }
+	// 86400 * 31 days = 2678400
 	else if($timediff < 2678400) { return $l->n('%n day go', '%n days ago', $diffdays); }
+	// 86400 * 60 days = 518400
 	else if($timediff < 5184000) { return $l->t('last month'); }
-	else if((date('n', $time)-$diffmonths) > 0) { return $l->n('%n month ago', '%n months ago', $diffmonths); }
+	else if((date('n', $fromTime)-$diffmonths) > 0) { return $l->n('%n month ago', '%n months ago', $diffmonths); }
+	// 86400 * 365.25 days * 2 = 63113852
 	else if($timediff < 63113852) { return $l->t('last year'); }
 	else { return $l->t('years ago'); }
 }

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -90,8 +90,8 @@ function human_file_size( $bytes ) {
  * @param $timestamp unix timestamp
  * @returns human readable interpretation of the timestamp
  */
-function relative_modified_date($timestamp, $dateOnly = false) {
-	return(\relative_modified_date($timestamp, $dateOnly));
+function relative_modified_date($timestamp, $fromTime, $dateOnly = false) {
+	return(\relative_modified_date($timestamp, $fromTime, $dateOnly));
 }
 
 

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -90,8 +90,8 @@ function human_file_size( $bytes ) {
  * @param $timestamp unix timestamp
  * @returns human readable interpretation of the timestamp
  */
-function relative_modified_date($timestamp, $fromTime = null, $dateOnly = false) {
-	return(\relative_modified_date($timestamp, $fromTime, $dateOnly));
+function relative_modified_date($timestamp, $dateOnly = false) {
+	return(\relative_modified_date($timestamp, null, $dateOnly));
 }
 
 

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -90,8 +90,8 @@ function human_file_size( $bytes ) {
  * @param $timestamp unix timestamp
  * @returns human readable interpretation of the timestamp
  */
-function relative_modified_date($timestamp) {
-	return(\relative_modified_date($timestamp));
+function relative_modified_date($timestamp, $dateOnly = false) {
+	return(\relative_modified_date($timestamp, $dateOnly));
 }
 
 

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -90,7 +90,7 @@ function human_file_size( $bytes ) {
  * @param $timestamp unix timestamp
  * @returns human readable interpretation of the timestamp
  */
-function relative_modified_date($timestamp, $fromTime, $dateOnly = false) {
+function relative_modified_date($timestamp, $fromTime = null, $dateOnly = false) {
 	return(\relative_modified_date($timestamp, $fromTime, $dateOnly));
 }
 

--- a/tests/lib/template.php
+++ b/tests/lib/template.php
@@ -46,7 +46,6 @@ class Test_TemplateFunctions extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("This is a good string!", $result);
 	}
 
-
 	public function testPrintUnescaped() {
 		$htmlString = "<script>alert('xss');</script>";
 
@@ -66,5 +65,194 @@ class Test_TemplateFunctions extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("This is a good string!", $result);
 	}
 
+	// ---------------------------------------------------------------------------
+	// Test relative_modified_date with dates only
+	// ---------------------------------------------------------------------------
+	public function testRelativeDateToday(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
 
+		$this->assertEquals('today', $result);
+
+		// 2 hours ago is still today
+		$elementTime = $currentTime - 2 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('today', $result);
+	}
+
+	public function testRelativeDateYesterday(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 24 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('yesterday', $result);
+
+		// yesterday - 2 hours is still yesterday
+		$elementTime = $currentTime - 26 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('yesterday', $result);
+	}
+
+	public function testRelativeDate2DaysAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 48 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('2 days ago', $result);
+
+		// 2 days ago minus 4 hours is still 2 days ago
+		$elementTime = $currentTime - 52 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('2 days ago', $result);
+	}
+
+	public function testRelativeDateLastMonth(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 31;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('last month', $result);
+
+		$elementTime = $currentTime - 86400 * 35;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('last month', $result);
+	}
+
+	public function testRelativeDateMonthsAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 60;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('2 months ago', $result);
+
+		$elementTime = $currentTime - 86400 * 65;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('2 months ago', $result);
+	}
+
+	public function testRelativeDateLastYear(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 365;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('last year', $result);
+
+		$elementTime = $currentTime - 86400 * 450;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('last year', $result);
+	}
+
+	public function testRelativeDateYearsAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 365.25 * 2;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('years ago', $result);
+
+		$elementTime = $currentTime - 86400 * 365.25 * 3;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('years ago', $result);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Test relative_modified_date with timestamps only (date + time value)
+	// ---------------------------------------------------------------------------
+
+	public function testRelativeTimeSecondsAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 5;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('seconds ago', $result);
+	}
+
+	public function testRelativeTimeMinutesAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 190;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('3 minutes ago', $result);
+	}
+
+	public function testRelativeTimeHoursAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 7500;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('2 hours ago', $result);
+	}
+
+	public function testRelativeTime2DaysAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 48 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('2 days ago', $result);
+
+		// 2 days ago minus 4 hours is still 2 days ago
+		$elementTime = $currentTime - 52 * 3600;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('2 days ago', $result);
+	}
+
+	public function testRelativeTimeLastMonth(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 31;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('last month', $result);
+
+		$elementTime = $currentTime - 86400 * 35;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('last month', $result);
+	}
+
+	public function testRelativeTimeMonthsAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 60;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('2 months ago', $result);
+
+		$elementTime = $currentTime - 86400 * 65;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('2 months ago', $result);
+	}
+
+	public function testRelativeTimeLastYear(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 365;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('last year', $result);
+
+		$elementTime = $currentTime - 86400 * 450;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('last year', $result);
+	}
+
+	public function testRelativeTimeYearsAgo(){
+		$currentTime = 1380703592;
+		$elementTime = $currentTime - 86400 * 365.25 * 2;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('years ago', $result);
+
+		$elementTime = $currentTime - 86400 * 365.25 * 3;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('years ago', $result);
+	}
 }


### PR DESCRIPTION
Improved the template function relative_modified_date by adding an
optional dateOnly argument which will output "today" or "yesterday" or
"x days ago".

This will be used by the activity app to display "Today", "Yesterday" instead of "seconds ago" or "1 days ago".

Please review @karlitschek @Kondou-ger @bartv2
