### PR TITLE
Added backup for config.php in autotest.sh script

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -12,6 +12,16 @@ DATABASEUSER=oc_autotest$EXECUTOR_NUMBER
 ADMINLOGIN=admin$EXECUTOR_NUMBER
 BASEDIR=$PWD
 
+if ! [ -w config -a -w config/config.php ]; then
+	echo "Please enable write permissions on config and config/config.php" >&2
+	exit 1
+fi
+
+# Back up existing (dev) config if one exists
+if [ -f config/config.php ]; then
+	mv config/config.php config/config-autotest-backup.php
+fi
+
 # use tmpfs for datadir - should speedup unit test execution
 if [ -d /dev/shm ]; then
   DATADIR=/dev/shm/data-autotest$EXECUTOR_NUMBER
@@ -156,6 +166,13 @@ if [ -z "$1" ]
 	execute_tests 'oci'
 else
 	execute_tests $1 $2 $3
+fi
+
+cd $BASEDIR
+
+# Restore existing config
+if [ -f config/config-autotest-backup.php ]; then
+	mv config/config-autotest-backup.php config/config.php
 fi
 
 #


### PR DESCRIPTION
The script now checks for config.php existance and backs it up before
running the test, then restores it back at the end. This avoids the
situation where devs lose their manually edited config if they forgot to
back it up before running the unit tests.

The script now also checks for config.php permissions beforehand to
avoid displaying an annoying HTML page output in the console with an
error message.

I'm not familiar with Windows scripting, so someone else might want to update autotest.cmd in a similar way.

@DeepDiver1975 @schiesbn @karlitschek please review.
