### PR TITLE
postgresql connect with specify db if 'postgres' does not work

### DIFF
--- a/lib/setup.php
+++ b/lib/setup.php
@@ -328,7 +328,13 @@ class OC_Setup {
 		$connection_string = "host='$e_host' dbname=postgres user='$e_user' password='$e_password'";
 		$connection = @pg_connect($connection_string);
 		if(!$connection) {
-			throw new Exception($l->t('PostgreSQL username and/or password not valid'));
+			// Try if we can connect to the DB with the specified name
+			$e_dbname = addslashes($dbname);
+			$connection_string = "host='$e_host' dbname='$e_dbname' user='$e_user' password='$e_password'";
+			$connection = @pg_connect($connection_string);
+
+			if(!$connection)
+				throw new DatabaseSetupException($l->t('PostgreSQL username and/or password not valid'));
 		}
 		$e_user = pg_escape_string($dbuser);
 		//check for roles creation rights in postgresql


### PR DESCRIPTION
Backport to `stable5` of #3684

> Hi, 
> here is my attempt to fix #675 
> the thing is basicaly that we try to connect to 'postgres' db wich is a "protected" db... 
> from local there is no trouble but from a remote location the postgres db is often no accessible...
> so the install fail...
> 
> here i change small things to connect to the specified db if the postgres fail
> 
> :)

cc @eMerzh @Kondou-ger @DeepDiver1975 @bartv2 @karlitschek 
