### PR TITLE
OCShare - Move send email logic from ajax to "service" and add event

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -82,41 +82,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			}
 			break;
 		case 'email':
-			// read post variables
-			$user = OCP\USER::getUser();
-			$displayName = OCP\User::getDisplayName();
-			$type = $_POST['itemType'];
-			$link = $_POST['link'];
-			$file = $_POST['file'];
-			$to_address = $_POST['toaddress'];
-
-			// enable l10n support
-			$l = OC_L10N::get('core');
-
-			// setup the email
-			$subject = (string)$l->t('%s shared »%s« with you', array($displayName, $file));
-
-			$content = new OC_Template("core", "mail", "");
-			$content->assign ('link', $link);
-			$content->assign ('type', $type);
-			$content->assign ('user_displayname', $displayName);
-			$content->assign ('filename', $file);
-			$text = $content->fetchPage();
-
-			$content = new OC_Template("core", "altmail", "");
-			$content->assign ('link', $link);
-			$content->assign ('type', $type);
-			$content->assign ('user_displayname', $displayName);
-			$content->assign ('filename', $file);
-			$alttext = $content->fetchPage();
-
-			$default_from = OCP\Util::getDefaultEmailAddress('sharing-noreply');
-			$from_address = OCP\Config::getUserValue($user, 'settings', 'email', $default_from );
-
-			// send it out now
 			try {
-				OCP\Util::sendMail($to_address, $to_address, $subject, $text, $from_address, $displayName, 1, $alttext);
-				OCP\JSON::success();
+				$return = OCP\Share::sendNotificationEmail($_POST['itemType'], $_POST['itemSource'], $_POST['toaddress']);
+				($return) ? OC_JSON::success() : OC_JSON::error();
 			} catch (Exception $exception) {
 				OCP\JSON::error(array('data' => array('message' => OC_Util::sanitizeHTML($exception->getMessage()))));
 			}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -758,12 +758,10 @@ class Share {
 		return false;
 	}
 
-<<<<<<< HEAD
-=======
 	public static function sendNotificationEmail($itemType, $itemSource, $to_address) {
 		if ($item = self::getItems($itemType, $itemSource, self::SHARE_TYPE_LINK, null, \OC_User::getUser(),
 			self::FORMAT_NONE, null, 1, false)) {
-			if (!$item[token]) {
+			if (empty($item['token'])) {
 				$message = 'Trying to send email for '.$itemSource.' when it is not publicly shared';
 				\OC_Log::write('OCP\Share', $message, \OC_Log::ERROR);
 				throw new \Exception($message);
@@ -809,8 +807,6 @@ class Share {
 		return false;
 	}
 
-
->>>>>>> ac93eba... Move send email logic to core, add checks and event
 	/**
 	* @brief Get the backend class for the specified item type
 	* @param string $itemType

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -738,6 +738,13 @@ class Share {
 		throw new \Exception($message);
 	}
 
+	/**
+	* @brief Sets the expiration date of all shares for a file
+	* @param string Item type
+	* @param string Item source
+	* @param date Expiration date 
+	* @return Returns true on success or false on failure
+	*/
 	public static function setExpirationDate($itemType, $itemSource, $date) {
 		if ($items = self::getItems($itemType, $itemSource, null, null, \OC_User::getUser(),
 			self::FORMAT_NONE, null, -1, false)) {
@@ -758,7 +765,14 @@ class Share {
 		return false;
 	}
 
-	public static function sendNotificationEmail($itemType, $itemSource, $to_address) {
+	/**
+	* @brief Sends an email with the public link of a shrade file 
+	* @param string Item type
+	* @param string Item source
+	* @param string A single address to send the email 
+	* @return Returns true on success or false on failure
+	*/
+	public static function sendNotificationEmail($itemType, $itemSource, $toAddress) {
 		if ($item = self::getItems($itemType, $itemSource, self::SHARE_TYPE_LINK, null, \OC_User::getUser(),
 			self::FORMAT_NONE, null, 1, false)) {
 			if (empty($item['token'])) {
@@ -790,14 +804,14 @@ class Share {
 			$content->assign ('filename', $fileName);
 			$alttext = $content->fetchPage();
 	
-			$default_from = Util::getDefaultEmailAddress('sharing-noreply');
-			$from_address = Config::getUserValue($user, 'settings', 'email', $default_from );
+			$defaultFrom = Util::getDefaultEmailAddress('sharing-noreply');
+			$fromAddress = Config::getUserValue($user, 'settings', 'email', $defaultFrom );
 		
-			Util::sendMail($to_address, $to_address, $subject, $text, $from_address, $displayName, 1, $alttext);
+			Util::sendMail($toAddress, $toAddress, $subject, $text, $fromAddress, $displayName, 1, $alttext);
 			\OC_Hook::emit('OCP\Share', 'post_send_notification_email', array(
 				'itemType' => $itemType,
 				'itemSource' => $itemSource,
-				'to' => $to_address,
+				'to' => $toAddress,
 				'uidOwner' => \OC_User::getUser(),
 				'path' => $item['path']
 			));

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -758,6 +758,59 @@ class Share {
 		return false;
 	}
 
+<<<<<<< HEAD
+=======
+	public static function sendNotificationEmail($itemType, $itemSource, $to_address) {
+		if ($item = self::getItems($itemType, $itemSource, self::SHARE_TYPE_LINK, null, \OC_User::getUser(),
+			self::FORMAT_NONE, null, 1, false)) {
+			if (!$item[token]) {
+				$message = 'Trying to send email for '.$itemSource.' when it is not publicly shared';
+				\OC_Log::write('OCP\Share', $message, \OC_Log::ERROR);
+				throw new \Exception($message);
+			}
+			$user = \OC_User::getUser();
+			$displayName = User::getDisplayName();
+			$fileName = basename($item['path']);
+			$link = \OC_Helper::makeURLAbsolute('/public.php').'?service=files&t='.$item['token'];
+			// enable l10n support
+			$l = Util::getL10N('core');
+	
+			// setup the email
+			$subject = (string)$l->t('%s shared »%s« with you', array($displayName, $fileName));
+	
+			$content = new \OC_Template("core", "mail", "");
+			$content->assign ('link', $link);
+			$content->assign ('type', $itemType);
+			$content->assign ('user_displayname', $displayName);
+			$content->assign ('filename', $fileName);
+			$text = $content->fetchPage();
+	
+			$content = new \OC_Template("core", "altmail", "");
+			$content->assign ('link', $link);
+			$content->assign ('type', $itemType);
+			$content->assign ('user_displayname', $displayName);
+			$content->assign ('filename', $fileName);
+			$alttext = $content->fetchPage();
+	
+			$default_from = Util::getDefaultEmailAddress('sharing-noreply');
+			$from_address = Config::getUserValue($user, 'settings', 'email', $default_from );
+		
+			Util::sendMail($to_address, $to_address, $subject, $text, $from_address, $displayName, 1, $alttext);
+			\OC_Hook::emit('OCP\Share', 'post_send_notification_email', array(
+				'itemType' => $itemType,
+				'itemSource' => $itemSource,
+				'to' => $to_address,
+				'uidOwner' => \OC_User::getUser(),
+				'path' => $item['path']
+			));
+			
+			return true;
+		} 
+		return false;
+	}
+
+
+>>>>>>> ac93eba... Move send email logic to core, add checks and event
 	/**
 	* @brief Get the backend class for the specified item type
 	* @param string $itemType


### PR DESCRIPTION
This should improve security / antispam measures (previously there was no checks about the file, path, etc. so you could mess with the email sent by OC) and add event for email sending.
