### PR TITLE
Fix disabled status after sending a share link email

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -679,14 +679,14 @@ $(document).ready(function() {
 		var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
 		var email = $('#email').val();
 		if (email != '') {
-			$('#email').attr('disabled', "disabled");
+			$('#email').prop('disabled', true);
 			$('#email').val(t('core', 'Sending ...'));
-			$('#emailButton').attr('disabled', "disabled");
+			$('#emailButton').prop('disabled', true);
 
 			$.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'email', toaddress: email, link: link, itemType: itemType, itemSource: itemSource, file: file},
 				function(result) {
-					$('#email').attr('disabled', "false");
-					$('#emailButton').attr('disabled', "false");
+					$('#email').prop('disabled', false);
+					$('#emailButton').prop('disabled', false);
 				if (result && result.status == 'success') {
 					$('#email').css('font-weight', 'bold');
 					$('#email').animate({ fontWeight: 'normal' }, 2000, function() {


### PR DESCRIPTION
After the last JQuery update in core disabled status are not managed by attribute, that is now the "code" in the page, the status is now the property value for that attribute, so this minor change is needed to work as intended.
