### PR TITLE
Fixed array syntax to work with PHP 5.3

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -104,7 +104,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			}
 
 			// don't send a mail to the user who shared the file
-			$recipientList = array_diff($recipientList, [\OCP\User::getUser()]);
+			$recipientList = array_diff($recipientList, array(\OCP\User::getUser()));
 
 			// send mail to all recipients with an email address
 			foreach ($recipientList as $recipient) {


### PR DESCRIPTION
It seems that array brackets are only supported starting with PHP 5.4.
Fixed the array brackets to be compatible and not cause a syntax error
in PHP 5.3.

Please review @schiesbn @karlitschek 
