### PR TITLE
Do not call changeDirectory() when no dir set on breadcrumb

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -701,7 +701,10 @@ function checkTrashStatus() {
 }
 
 function onClickBreadcrumb(e){
-	var $el = $(e.target).closest('.crumb');
-	e.preventDefault();
-	FileList.changeDirectory(decodeURIComponent($el.data('dir')));
+	var $el = $(e.target).closest('.crumb'),
+		$targetDir = $el.data('dir');
+	if ($targetDir !== undefined){
+		e.preventDefault();
+		FileList.changeDirectory(decodeURIComponent($targetDir));
+	}
 }


### PR DESCRIPTION
Some apps like the files_trashbin app do not set a directory on its
"home" breadcrumb link.

This fix makes sure that the click event doesn't do anything in that
case and lets the browser open the link.

This fixes the "home" icon in the trashbin app which now correctly
reopens the files app.

Please review @karlitschek @schiesbn @DeepDiver1975 
