### PR TITLE
files_encryption: Fix getFileSize()

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -587,11 +587,18 @@ class Util {
 		) {
 
 			// get the size from filesystem
-			$fullPath = $this->view->getLocalFile($path);
 			$size = $this->view->filesize($path);
 
+			// fast path, else the calculation for $lastChunkNr is bogus
+			if ($size === 0) {
+				\OC_FileProxy::$enabled = $proxyStatus;
+				return 0;
+			}
+
 			// calculate last chunk nr
-			$lastChunkNr = floor($size / 8192);
+			// next highest is end of chunks, one subtracted is last one
+			// we have to read the last chunk, we can't just calculate it (because of padding etc)
+			$lastChunkNr = ceil($size/ 8192) - 1;
 			$lastChunkSize = $size - ($lastChunkNr * 8192);
 
 			// open stream

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -231,6 +231,34 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
+	/**
+	 * @brief Test that data that is read by the crypto stream wrapper
+	 */
+	function testGetFileSize() {
+		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
+
+		$filename = 'tmp-' . time();
+		$externalFilename = '/' . $this->userId . '/files/' . $filename;
+
+		// Test for 0 byte files
+		$problematicFileSizeData = "";
+		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
+		$this->assertTrue(is_int($cryptedFile));
+		$this->assertEquals($this->util->getFileSize($externalFilename), 0);
+		$decrypt = $this->view->file_get_contents($externalFilename);
+		$this->assertEquals($problematicFileSizeData, $decrypt);
+		$this->view->unlink($this->userId . '/files/' . $filename);
+
+		// Test a file with 18377 bytes as in https://github.com/owncloud/mirall/issues/1009
+		$problematicFileSizeData = str_pad("", 18377, "abc");
+		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
+		$this->assertTrue(is_int($cryptedFile));
+		$this->assertEquals($this->util->getFileSize($externalFilename), 18377);
+		$decrypt = $this->view->file_get_contents($externalFilename);
+		$this->assertEquals($problematicFileSizeData, $decrypt);
+		$this->view->unlink($this->userId . '/files/' . $filename);
+	}
+
 	function testIsSharedPath() {
 		$sharedPath = '/user1/files/Shared/test';
 		$path = '/user1/files/test';


### PR DESCRIPTION
For certain file sizes (in this case encrypted file in bugreport had 24576 bytes), we rounded to the wrong chunk number
and the returned bogus results. 

This should fix https://github.com/owncloud/mirall/issues/1009
