### PR TITLE
Fix loading legacy global filecache gc backgroundjobs

### DIFF
--- a/lib/private/legacy/cache/fileglobalgc.php
+++ b/lib/private/legacy/cache/fileglobalgc.php
@@ -1,0 +1,4 @@
+<?php
+
+class OC_Cache_FileGlobalGC extends OC\Cache\FileGlobalGC{
+}


### PR DESCRIPTION
Fixes cron jobs not running if there still was a gc backgroundjob in the db that was created before the class was renamed

cc @DeepDiver1975 @bartv2 @karlitschek 
