### PR TITLE
Slightly better looking file actions. 

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -267,6 +267,7 @@ table td.filename form { font-size:14px; margin-left:48px; margin-right:48px; }
 	right: 0;
 	padding: 28px 14px 19px !important;
 }
+
 a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 
 /* Actions for selected files */
@@ -295,6 +296,10 @@ a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 	filter: alpha(opacity=0);
 	opacity: 0;
 	display:none;
+}
+
+#fileList a.action[data-action="Rename"] {
+	padding:18px 14px !important;
 }
 #fileList tr:hover a.action, #fileList a.action.permanent {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -258,6 +258,7 @@ table td.filename form { font-size:14px; margin-left:48px; margin-right:48px; }
 	position: absolute;
 	top: 14px;
 	right: 0;
+	font-size: 11px;
 }
 
 #fileList img.move2trash { display:inline; margin:-8px 0; padding:16px 8px 16px 8px !important; float:right; }

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -71,13 +71,15 @@ var FileActions = {
 		FileActions.currentFile = parent;
 		var actions = FileActions.get(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
 		var file = FileActions.getCurrentFile();
+		var nameLinks;
 		if (FileList.findFileEl(file).data('renaming')) {
 			return;
 		}
 
 		// recreate fileactions
-		parent.children('a.name').find('.fileactions').remove();
-		parent.children('a.name').append('<span class="fileactions" />');
+		nameLinks = parent.children('a.name');
+		nameLinks.find('.fileactions, .nametext .action').remove();
+		nameLinks.append('<span class="fileactions" />');
 		var defaultAction = FileActions.getDefault(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
 
 		var actionHandler = function (event) {
@@ -97,7 +99,16 @@ var FileActions = {
 			}
 
 			if ((name === 'Download' || action !== defaultAction) && name !== 'Delete') {
-				var img = FileActions.icons[name];
+				var img = FileActions.icons[name],
+					actionText = t('files', name),
+					actionContainer = 'a.name>span.fileactions';
+
+				if (name === 'Rename') {
+					// rename has only an icon which appears behind
+					// the file name
+					actionText = '';
+					actionContainer = 'a.name span.nametext';
+				}
 				if (img.call) {
 					img = img(file);
 				}
@@ -105,13 +116,13 @@ var FileActions = {
 				if (img) {
 					html += '<img class ="svg" src="' + img + '" />';
 				}
-				html += '<span> ' + t('files', name) + '</span></a>';
+				html += '<span> ' + actionText + '</span></a>';
 
 				var element = $(html);
 				element.data('action', name);
 				//alert(element);
 				element.on('click', {a: null, elem: parent, actionFunc: actions[name]}, actionHandler);
-				parent.find('a.name>span.fileactions').append(element);
+				parent.find(actionContainer).append(element);
 			}
 
 		};

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -477,6 +477,7 @@ var FileList={
 					td.find('a.name span.extension').text(newname.substr(newname.lastIndexOf('.')));
 				}
 				form.remove();
+				FileActions.display( tr.find('td.filename'), true);
 				td.children('a.name').show();
 			} catch (error) {
 				input.attr('title', error);

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -43,7 +43,18 @@ describe('FileActions tests', function() {
 
 		// actions defined after cal
 		expect($tr.find('.action[data-action=Download]').length).toEqual(1);
-		expect($tr.find('.action[data-action=Rename]').length).toEqual(1);
+		expect($tr.find('.nametext .action[data-action=Rename]').length).toEqual(1);
+		expect($tr.find('.action.delete').length).toEqual(1);
+	});
+	it('calling display() twice correctly replaces file actions', function() {
+		var $tr = FileList.addFile('testName.txt', 1234, new Date(), false, false, {download_url: 'test/download/url'});
+
+		FileActions.display($tr.find('td.filename'), true);
+		FileActions.display($tr.find('td.filename'), true);
+
+		// actions defined after cal
+		expect($tr.find('.action[data-action=Download]').length).toEqual(1);
+		expect($tr.find('.nametext .action[data-action=Rename]').length).toEqual(1);
 		expect($tr.find('.action.delete').length).toEqual(1);
 	});
 	it('redirects to download URL when clicking download', function() {


### PR DESCRIPTION
We discussed this as an interaction fix here : https://github.com/owncloud/core/issues/202
Takes out rename from the fileactions.js and makes it look better.
The approach is sort of hackish but couldn't find a better way. 

Big thanks to @Kondou-ger for the help!
cc @jancborchardt @DeepDiver1975 @owncloud/designers.
Check!
Cheers!
