### PR TITLE
Fix breadcrumb to reinit dnd after ajax nav #5064

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -98,6 +98,8 @@ Files={
 	lastWidth: 0,
 
 	initBreadCrumbs: function () {
+		var $controls = $('#controls');
+
 		Files.lastWidth = 0;
 		Files.breadcrumbs = [];
 
@@ -118,7 +120,10 @@ Files={
 		});
 
 		// event handlers for breadcrumb items
-		$('#controls .crumb a').on('click', onClickBreadcrumb);
+		$controls.find('.crumb a').on('click', onClickBreadcrumb);
+
+		// setup drag and drop
+		$controls.find('.crumb:not(.last)').droppable(crumbDropOptions);
 	},
 
 	resizeBreadcrumbs: function (width, firstRun) {
@@ -176,11 +181,8 @@ $(document).ready(function() {
 
 	$('#file_action_panel').attr('activeAction', false);
 
-	$('div.crumb:not(.last)').droppable(crumbDropOptions);
-	$('ul#apps>li:first-child').data('dir','');
-	if($('div.crumb').length){
-		$('ul#apps>li:first-child').droppable(crumbDropOptions);
-	}
+	// allow dropping on the "files" app icon
+	$('ul#apps li:first-child').data('dir','').droppable(crumbDropOptions);
 
 	// Triggers invisible file input
 	$('#upload a').on('click', function() {


### PR DESCRIPTION
Now correctly reinitializing the breadcrumb drop zone after ajax
navigation.

This also fixes dropping onto the "files" app icon.
Note that dragging onto the "files' app icon while being in the root dir doesn't do anything.

I've tested it in Firefox 24 , Chrome 30 and IE8.

Please review @DeepDiver1975 @karlitschek @schiesbn
