### PR TITLE
let admin specify timezone for log file entries

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -141,6 +141,9 @@ $CONFIG = array(
 /* date format to be used while writing to the owncloud logfile */
 'logdateformat' => 'F d, Y H:i:s',
 
+/* timezone used while writing to the owncloud logfile (default: UTC) */
+'logtimezone' => 'Europe/Berlin',
+
 /* Append all database queries and parameters to the log file.
  (watch out, this option can increase the size of your log file)*/
 "log_query" => false,

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -50,9 +50,11 @@ class OC_Log_Owncloud {
 		$minLevel=min(OC_Config::getValue( "loglevel", OC_Log::WARN ), OC_Log::ERROR);
 		if($level>=$minLevel) {
 			// default to ISO8601
-			$format = OC_Config::getValue('logdateformat', 'c');
-			$time = date($format, time());
-			$entry=array('app'=>$app, 'message'=>$message, 'level'=>$level, 'time'=> $time);
+			$format = OC_Config::getValue('logdateformat', 'Y-m-d H:i:s');
+			$logtimezone=OC_Config::getValue( "logtimezone", 'UTC' );
+			$timezone = new DateTimeZone($logtimezone);
+			$time = new DateTime(null, $timezone);
+			$entry=array('app'=>$app, 'message'=>$message, 'level'=>$level, 'time'=> $time->format($format));
 			$handle = @fopen(self::$logFile, 'a');
 			if ($handle) {
 				fwrite($handle, json_encode($entry)."\n");


### PR DESCRIPTION
let the admin specify the timezone for log file entries with the config switch 'logtimezone'
