### PR TITLE
Added isPublic flag in files_sharing template

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -2,6 +2,7 @@
 	<div id="notification" style="display: none;"></div>
 </div>
 
+<input type="hidden" id="isPublic" name="isPublic" value="1">
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 <input type="hidden" name="downloadURL" value="<?php p($_['downloadURL']) ?>" id="downloadURL">
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">


### PR DESCRIPTION
To make it possible for apps to find out whether they are running in
public mode, the flag "isPublic" will now be present in the DOM.

This is required to disable the editor app in public mode to fix #5059
