### PR TITLE
[stable5] Fixes for update feed fetching and parsing

### DIFF
--- a/lib/updater.php
+++ b/lib/updater.php
@@ -27,7 +27,6 @@ class OC_Updater extends BasicEmitter {
 	 * @return array | bool
 	 */
 	static public function check($updaterUrl='http://apps.owncloud.com/updater.php') {
-		OC_Appconfig::setValue('core', 'lastupdatedat', microtime(true));
 		if ((\OC_Appconfig::getValue('core', 'lastupdatedat') + 1800) > time()) {
 			return json_decode(\OC_Appconfig::getValue('core', 'lastupdateResult'), true);
 		}

--- a/lib/updater.php
+++ b/lib/updater.php
@@ -74,7 +74,7 @@ class OC_Updater extends BasicEmitter {
 
 		if(OC_Config::getValue('updatechecker', true)==true) {
 			$data=OC_Updater::check();
-			if(isset($data['version']) and $data['version']<>'') {
+			if(isset($data['version']) && !empty($data['version'])) {
 				$txt='<span style="color:#AA0000; font-weight:bold;">'
 				.$l->t('%s is available. Get <a href="%s">more information</a>',
 				array($data['versionstring'], $data['web'])).'</span>';


### PR DESCRIPTION
The update feed never expires as the current time is stored into the settings right before the expiration check.
In addition there was a false positive while checking OC_Updater::check result.

Closes https://github.com/owncloud/core/issues/4824
https://github.com/owncloud/core/issues/5260#issuecomment-26060984
