### PR TITLE
Do not pass PDO::FETCH_NUM (integer 3) as limit parameter to OC_DB::prepare().

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -1183,7 +1183,7 @@ class PDOStatementWrapper{
 	public function numRows() {
 		$regex = '/^SELECT\s+(?:ALL\s+|DISTINCT\s+)?(?:.*?)\s+FROM\s+(.*)$/i';
 		if (preg_match($regex, $this->statement->queryString, $output) > 0) {
-			$query = OC_DB::prepare("SELECT COUNT(*) FROM {$output[1]}", PDO::FETCH_NUM);
+			$query = OC_DB::prepare("SELECT COUNT(*) FROM {$output[1]}");
 			return $query->execute($this->lastArguments)->fetchColumn();
 		}else{
 			return $this->statement->rowCount();


### PR DESCRIPTION
It's pretty clear that passing PDO::FETCH_NUM was never intended. Passing a limit is pointless as aggregation without group by returns only one row.

Discovered in #5000
Regression from 0e2b957dacb86c510c59721f63879f1c9d93d5d4

@DeepDiver1975 @icewind1991 @karlitschek @ringmaster @kabum 
