### PR TITLE
[OC6] file upload exception handling

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -365,7 +365,7 @@ $(document).ready(function() {
 				} else if (result[0].status !== 'success') {
 					//delete data.jqXHR;
 					data.textStatus = 'servererror';
-					data.errorThrown = result.data.message; // error message has been translated on server
+					data.errorThrown = result[0].data.message; // error message has been translated on server
 					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');
 					fu._trigger('fail', e, data);
 				}

--- a/lib/private/connector/sabre/exception/entitytoolarge.php
+++ b/lib/private/connector/sabre/exception/entitytoolarge.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * EntityTooLarge
+ *
+ * This exception is thrown whenever a user tries to upload a file which exceeds hard limitations
+ *
+ */
+class OC_Connector_Sabre_Exception_EntityTooLarge extends Sabre_DAV_Exception {
+
+    /**
+     * Returns the HTTP statuscode for this exception
+     *
+     * @return int
+     */
+    public function getHTTPCode() {
+
+//        return 413;
+
+	    return 450;
+    }
+
+}

--- a/lib/private/connector/sabre/exception/entitytoolarge.php
+++ b/lib/private/connector/sabre/exception/entitytoolarge.php
@@ -1,23 +1,22 @@
 <?php
 
 /**
- * EntityTooLarge
+ * Entity Too Large
  *
  * This exception is thrown whenever a user tries to upload a file which exceeds hard limitations
  *
  */
 class OC_Connector_Sabre_Exception_EntityTooLarge extends Sabre_DAV_Exception {
 
-    /**
-     * Returns the HTTP statuscode for this exception
-     *
-     * @return int
-     */
-    public function getHTTPCode() {
+	/**
+	 * Returns the HTTP status code for this exception
+	 *
+	 * @return int
+	 */
+	public function getHTTPCode() {
 
-//        return 413;
+		return 413;
 
-	    return 450;
-    }
+	}
 
 }

--- a/lib/private/connector/sabre/exception/unsupportedmediatype.php
+++ b/lib/private/connector/sabre/exception/unsupportedmediatype.php
@@ -8,15 +8,15 @@
  */
 class OC_Connector_Sabre_Exception_UnsupportedMediaType extends Sabre_DAV_Exception {
 
-    /**
-     * Returns the HTTP status code for this exception
-     *
-     * @return int
-     */
-    public function getHTTPCode() {
+	/**
+	 * Returns the HTTP status code for this exception
+	 *
+	 * @return int
+	 */
+	public function getHTTPCode() {
 
-        return 415;
+		return 415;
 
-    }
+	}
 
 }

--- a/lib/private/connector/sabre/exception/unsupportedmediatype.php
+++ b/lib/private/connector/sabre/exception/unsupportedmediatype.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Unsupported Media Type
+ *
+ * This exception is thrown whenever a user tries to upload a file which holds content which is not allowed
+ *
+ */
+class OC_Connector_Sabre_Exception_UnsupportedMediaType extends Sabre_DAV_Exception {
+
+    /**
+     * Returns the HTTP status code for this exception
+     *
+     * @return int
+     */
+    public function getHTTPCode() {
+
+        return 415;
+
+    }
+
+}

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -87,14 +87,21 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 				throw new Sabre_DAV_Exception();
 			}
 		} catch (\OCP\Files\NotPermittedException $e) {
-			throw new Sabre_DAV_Exception_Forbidden();
+			// a more general case - due to whatever reason the content could not be written
+			throw new Sabre_DAV_Exception_Forbidden($e->getMessage());
+
 		} catch (\OCP\Files\EntityTooLargeException $e) {
-			throw new OC_Connector_Sabre_Exception_EntityTooLarge();
+			// the file is too big to be stored
+			throw new OC_Connector_Sabre_Exception_EntityTooLarge($e->getMessage());
+
 		} catch (\OCP\Files\InvalidContentException $e) {
-			throw new OC_Connector_Sabre_Exception_UnsupportedMediaType();
+			// the file content is not permitted
+			throw new OC_Connector_Sabre_Exception_UnsupportedMediaType($e->getMessage());
+
 		} catch (\OCP\Files\InvalidPathException $e) {
-			// TODO: add specific exception here
-			throw new Sabre_DAV_Exception_Forbidden();
+			// the path for the file was not valid
+			// TODO: find proper http status code for this case
+			throw new Sabre_DAV_Exception_Forbidden($e->getMessage());
 		}
 
 		// rename to correct path

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -88,6 +88,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 			}
 		} catch (\OCP\Files\NotPermittedException $e) {
 			throw new Sabre_DAV_Exception_Forbidden();
+		} catch (\OCP\Files\EntityTooLargeException $e) {
+			throw new OC_Connector_Sabre_Exception_EntityTooLarge();
+		} catch (\OCP\Files\InvalidContentException $e) {
+			throw new OC_Connector_Sabre_Exception_UnsupportedMediaType();
+		} catch (\OCP\Files\InvalidPathException $e) {
+			// TODO: add specific exception here
+			throw new Sabre_DAV_Exception_Forbidden();
 		}
 
 		// rename to correct path

--- a/lib/public/files/entitytoolargeexception.php
+++ b/lib/public/files/entitytoolargeexception.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Müller <thomas.mueller@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\Files;
+
+class EntityTooLargeException extends \Exception {}

--- a/lib/public/files/invalidcontentexception.php
+++ b/lib/public/files/invalidcontentexception.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Müller <thomas.mueller@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\Files;
+
+class InvalidContentException extends \Exception {}

--- a/lib/public/files/invalidpathexception.php
+++ b/lib/public/files/invalidpathexception.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright (c) 2013 Thomas Müller <thomas.mueller@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\Files;
+
+class InvalidPathException extends \Exception {}


### PR DESCRIPTION
refs #4011 
fixes https://github.com/owncloud/mirall/issues/971

with the introduction of new more specific exceptions we have now the capability to inform the 
desktop and mobile clients (web as well for sure) about the cause of an failing upload.

Especially the desktop client can adjust its retry behavior based on these status codes.

@dragotin @danimo for review regarding desktop client
@rperezb for the mobile side
@icewind1991 @bartv2 @bantu @butonic 

THX
