### PR TITLE
[stable5] fix upload to /Shared

### DIFF
--- a/lib/connector/sabre/file.php
+++ b/lib/connector/sabre/file.php
@@ -53,6 +53,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		// mark file as partial while uploading (ignored by the scanner)
 		$partpath = $this->path . '.part';
 
+		// if file is located in /Shared we write the part file to the users
+		// root folder because we can't create new files in /shared
+		// we extend the name with a random number to avoid overwriting a existing file
+		if (dirname($partpath) === 'Shared') {
+			$partpath = pathinfo($partpath, PATHINFO_FILENAME) . rand() . '.part';
+		}
+
 		\OC\Files\Filesystem::file_put_contents($partpath, $data);
 
 		//detect aborted upload


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/5193/ which should fix https://github.com/owncloud/core/issues/5126

write the part file to the users root folder if the updated file is located in /Shared because we can't create new files in Shared/

@DeepDiver1975 @dragotin please have a look, Thanks!
