### PR TITLE
find users which are in the same group

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -293,7 +293,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				while ($count < 15 && count($users) == $limit) {
 					$limit = 15 - $count;
 					if ($sharePolicy == 'groups_only') {
-						$users = OC_Group::DisplayNamesInGroups($groups, $_GET['search'], $limit, $offset);
+						$users = OC_Group::DisplayNamesInGroups($usergroups, $_GET['search'], $limit, $offset);
 					} else {
 						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);
 					}

--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -265,7 +265,7 @@ class OC_Group {
 	public static function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		$group = self::getManager()->get($gid);
 		if ($group) {
-			$users = $group->searchDisplayName($search . $limit, $offset);
+			$users = $group->searchDisplayName($search, $limit, $offset);
 			$displayNames = array();
 			foreach ($users as $user) {
 				$displayNames[] = $user->getDisplayName();


### PR DESCRIPTION
fixes the user search in the share drop-down if "Allow users to only share with users in their groups" option is set in the admin settings. To make it work on master also this issue needs to be solved: https://github.com/owncloud/core/issues/5209

Here is the same pull request for stable5 where it should work straight away: https://github.com/owncloud/core/pull/5211

Fixes: https://github.com/owncloud/core/issues/5155
