### PR TITLE
find users which are in the same group

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -188,7 +188,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				while ($count < 15 && count($users) == $limit) {
 					$limit = 15 - $count;
 					if ($sharePolicy == 'groups_only') {
-						$users = OC_Group::DisplayNamesInGroups($groups, $_GET['search'], $limit, $offset);
+						$users = OC_Group::DisplayNamesInGroups($usergroups, $_GET['search'], $limit, $offset);
 					} else {
 						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);
 					}


### PR DESCRIPTION
fixes the user search in the share drop-down if "Allow users to only share with users in their groups" option is set in the admin settings.

fixes: https://github.com/owncloud/core/issues/5155
