### PR TITLE
[stable5] executeAudited->execute Closes #5201

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -68,7 +68,7 @@ class Shared_Updater {
 
 		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share` WHERE `file_source`=?');
 		try	{
-			\OC_DB::executeAudited($query, array($fileSource));
+			$query->execute(array($fileSource));
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog('files_sharing', "can't remove share: " . $e->getMessage(), \OCP\Util::WARN);
 		}


### PR DESCRIPTION
Probably caused by a backport.
@schiesbn @DeepDiver1975 
