### PR TITLE
Added filesApp flag as input field for files app detection

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -108,6 +108,7 @@
 </div>
 
 <!-- config hints for javascript -->
+<input type="hidden" name="filesApp" id="filesApp" value="1" />
 <input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" name="allowZipDownload" id="allowZipDownload" value="<?php p($_['allowZipDownload']); ?>" />
 <input type="hidden" name="usedSpacePercent" id="usedSpacePercent" value="<?php p($_['usedSpacePercent']); ?>" />

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -2,6 +2,7 @@
 	<div id="notification" style="display: none;"></div>
 </div>
 
+<input type="hidden" id="filesApp" name="filesApp" value="1">
 <input type="hidden" id="isPublic" name="isPublic" value="1">
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 <input type="hidden" name="downloadURL" value="<?php p($_['downloadURL']) ?>" id="downloadURL">


### PR DESCRIPTION
Since the files app can be reached under multiple URLs, either root,
files.php or public.php, a flag has been added to the DOM to help apps
(like file viewers) to detect whether they are currently in the files
app.

@karlitschek @DeepDiver1975 @schiesbn please review.

This is needed to fix the PDF viewer app (https://github.com/owncloud/apps/issues/1409)
