### PR TITLE
Don't double-slash filenames at the root.

### DIFF
--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -14,7 +14,7 @@ $(document).ready(function(){
 				// Action to perform when clicked
 				if (scanFiles.scanning){return;}//workaround to prevent additional http request block scanning feedback
 
-				var file = $('#dir').val()+'/'+filename;
+				var file = $('#dir').val().replace(/(?!<=\/)$|\/$/, '/' + filename);
 				var createDropDown = true;
 				// Check if drop down is already visible for a different file
 				if (($('#dropdown').length > 0) ) {


### PR DESCRIPTION
Replace either the end of the dir string that isn't preceded by a slash or the slash at the end of the dir string with a slash and the filename.
This prevents the root directory from ending up as two slashes, which breaks files_versions on Windows servers. See #4079 for an explanation.
