### PR TITLE
remove password before writing it to the log file

### DIFF
--- a/lib/log.php
+++ b/lib/log.php
@@ -36,6 +36,8 @@ class OC_Log {
 				call_user_func(array(self::$class, 'init'));
 			}
 			$log_class=self::$class;
+			// remove username/passswords from URLs before writing the to the log file
+			$message = preg_replace('/\/\/(.*):(.*)@/', '//xxx:xxx@', $message);
 			$log_class::write($app, $message, $level);
 		}
 	}


### PR DESCRIPTION
remove username/passswords from URLs before writing to the log file.

@karlitschek This should solve the problem with samba user names & passwords in the log file

This is a quick solution for stable5, afaik @icewind1991 is working on the samba back-end for ownCloud6 which should solve the problem for OC6.
