### PR TITLE
Backport of #4856 to stable5: Fix Sharing "Expiration Date" for Shares of type Link (i.e. Token)

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -293,7 +293,18 @@ class Share {
 		if (\OC_DB::isError($result)) {
 			\OC_Log::write('OCP\Share', \OC_DB::getErrorMessage($result) . ', token=' . $token, \OC_Log::ERROR);
 		}
-		return $result->fetchRow();
+		$row = $result->fetchRow();
+
+		if (!empty($row['expiration'])) {
+			$now = new \DateTime();
+			$expirationDate = new \DateTime($row['expiration'], new \DateTimeZone('UTC'));
+			if ($now > $expirationDate) {
+				self::delete($row['id']);
+				return false;
+			}
+		}
+
+		return $row;
 	}
 
 	/**


### PR DESCRIPTION
Follows #4954 which actually missed #4856 changes.

@DeepDiver1975 
