### PR TITLE
due to internal implementations touch will always be successful - $mtime...

### DIFF
--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -147,12 +147,6 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	 *  Even if the modification time is set to a custom value the access time is set to now.
 	 */
 	public function touch($mtime) {
-
-		// touch is only allowed if the update privilege is granted
-		if (!\OC\Files\Filesystem::isUpdatable($this->path)) {
-			throw new \Sabre_DAV_Exception_Forbidden();
-		}
-
 		\OC\Files\Filesystem::touch($this->path, $mtime);
 	}
 


### PR DESCRIPTION
... will be stored in the cache

from desktop client perspective it is necessary to set the mtime under every condition

@icewind1991 @dragotin @danimo @karlitschek @bartv2 THX
