### PR TITLE
Added ownCloud backend for external storage

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -9,6 +9,7 @@
 OC::$CLASSPATH['OC\Files\Storage\StreamWrapper'] = 'files_external/lib/streamwrapper.php';
 OC::$CLASSPATH['OC\Files\Storage\FTP'] = 'files_external/lib/ftp.php';
 OC::$CLASSPATH['OC\Files\Storage\DAV'] = 'files_external/lib/webdav.php';
+OC::$CLASSPATH['OC\Files\Storage\OwnCloud'] = 'files_external/lib/owncloud.php';
 OC::$CLASSPATH['OC\Files\Storage\Google'] = 'files_external/lib/google.php';
 OC::$CLASSPATH['OC\Files\Storage\SWIFT'] = 'files_external/lib/swift.php';
 OC::$CLASSPATH['OC\Files\Storage\SMB'] = 'files_external/lib/smb.php';

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -106,14 +106,24 @@ class OC_Mount_Config {
 			}
 		}
 
-		if(OC_Mount_Config::checkcurl()) $backends['\OC\Files\Storage\DAV']=array(
-			'backend' => 'ownCloud / WebDAV',
-			'configuration' => array(
-				'host' => 'URL',
-				'user' => 'Username',
-				'password' => '*Password',
-				'root' => '&Root',
-				'secure' => '!Secure https://'));
+		if(OC_Mount_Config::checkcurl()){
+		   	$backends['\OC\Files\Storage\DAV']=array(
+				'backend' => 'WebDAV',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'password' => '*Password',
+					'root' => '&Root',
+					'secure' => '!Secure https://'));
+		   	$backends['\OC\Files\Storage\OwnCloud']=array(
+				'backend' => 'ownCloud',
+				'configuration' => array(
+					'host' => 'URL',
+					'user' => 'Username',
+					'password' => '*Password',
+					'root' => '&Remote subfolder',
+					'secure' => '!Secure https://'));
+		}
 
 		$backends['\OC\Files\Storage\SFTP']=array(
 			'backend' => 'SFTP',

--- a/apps/files_external/lib/owncloud.php
+++ b/apps/files_external/lib/owncloud.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) 2013 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Storage;
+
+/**
+ * ownCloud backend for external storage based on DAV backend.
+ *
+ * The ownCloud URL consists of three parts:
+ * http://%host/%context/remote.php/webdav/%root
+ *
+ */
+class OwnCloud extends \OC\Files\Storage\DAV{
+	const OC_URL_SUFFIX = 'remote.php/webdav';
+
+	public function __construct($params) {
+		// extract context path from host if specified
+		// (owncloud install path on host)
+		$host = $params['host'];
+		$contextPath = '';
+		$hostSlashPos = strpos($host, '/');
+		if ($hostSlashPos !== false){
+			$contextPath = substr($host, $hostSlashPos);
+			$host = substr($host, 0, $hostSlashPos);
+		}
+
+		if (substr($contextPath , 1) !== '/'){
+			$contextPath .= '/';
+		}
+
+		if (isset($params['root'])){
+			$root = $params['root'];
+			if (substr($root, 1) !== '/'){
+				$root = '/' . $root;
+			}
+		}
+		else{
+			$root = '/';
+		}
+
+		$params['host'] = $host;
+		$params['root'] = $contextPath . self::OC_URL_SUFFIX . $root;
+
+		parent::__construct($params);
+	}
+}

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -79,7 +79,7 @@ class DAV extends \OC\Files\Storage\Common{
 		return 'webdav::' . $this->user . '@' . $this->host . '/' . $this->root;
 	}
 
-	private function createBaseUri() {
+	protected function createBaseUri() {
 		$baseUri='http';
 		if ($this->secure) {
 			$baseUri.='s';

--- a/apps/files_external/tests/config.php
+++ b/apps/files_external/tests/config.php
@@ -23,6 +23,13 @@ return array(
 		'password'=>'test',
 		'root'=>'/owncloud/files/webdav.php',
 	),
+	'owncloud'=>array(
+		'run'=>true,
+		'host'=>'localhost/owncloud',
+		'user'=>'test',
+		'password'=>'test',
+		'root'=>'',
+	),
 	'google'=>array(
 		'run'=> false,
 		'configured' => 'true',

--- a/apps/files_external/tests/owncloud.php
+++ b/apps/files_external/tests/owncloud.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) 2013 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Files\Storage;
+
+class OwnCloud extends Storage {
+
+	private $config;
+
+	public function setUp() {
+		$id = uniqid();
+		$this->config = include('files_external/tests/config.php');
+		if ( ! is_array($this->config) or ! isset($this->config['owncloud']) or ! $this->config['owncloud']['run']) {
+			$this->markTestSkipped('ownCloud backend not configured');
+		}
+		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
+		$this->instance = new \OC\Files\Storage\OwnCloud($this->config['owncloud']);
+		$this->instance->mkdir('/');
+	}
+
+	public function tearDown() {
+		if ($this->instance) {
+			$this->instance->rmdir('/');
+		}
+	}
+}


### PR DESCRIPTION
To make it possible to use the short ownCloud URL (without specifying
webdav.php or remote.php), a new backend is available for ownCloud.

The user must specify the host + context path in the "Url" field (which
is mapped to the "host" parameter) and the subdir to mount in the "Root"
field.

This is to prevent confusion because some users forget to append
webdav.php or remote.php to the WebDAV URL.

Fixes #4923
