### PR TITLE
don't check for config file permissions when using phpunit

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -175,7 +175,8 @@ class OC {
 
 	public static function checkConfig() {
 		if (file_exists(OC::$SERVERROOT . "/config/config.php")
-			and !is_writable(OC::$SERVERROOT . "/config/config.php")) {
+			and !is_writable(OC::$SERVERROOT . "/config/config.php")
+			and !defined('PHPUNIT_RUN')) {
 			$defaults = new OC_Defaults();
 			OC_Template::printErrorPage(
 				"Can't write into config directory!",


### PR DESCRIPTION
This makes running unit tests a bit easier since they aren't usually run as the webserver's user

cc @karlitschek @DeepDiver1975 @bartv2 
