### PR TITLE
Fixed files view regular file actions in IE8

### DIFF
--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -36,7 +36,7 @@ $totalsize = 0; ?>
 		<?php else: ?>
 			<a class="name" href="<?php p(rtrim($_['downloadURL'],'/').'/'.trim($directory,'/').'/'.$name); ?>">
 				<label class="filetext" title="" for="select-<?php p($file['fileid']); ?>"></label>
-				<span class="nametext"><?php print_unescaped(htmlspecialchars($file['basename']));?><span class='extension'><?php p($file['extension']);?></span>
+				<span class="nametext"><?php print_unescaped(htmlspecialchars($file['basename']));?><span class='extension'><?php p($file['extension']);?></span></span>
 			</a>
 		<?php endif; ?>
 			<?php if($file['type'] == 'dir'):?>


### PR DESCRIPTION
Fixes #5256

A missing closing span broken the container in IE8 which prevented the
file actions to be appended properly.

@karlitschek @raghunayyar @DeepDiver1975 @schiesbn  please review

It's just a missing span, so should be a quick one :-)
