### PR TITLE
Proper behavior of resolvePath()

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -110,7 +110,9 @@ class View {
 	 * @return array consisting of the storage and the internal path
 	 */
 	public function resolvePath($path) {
-		return Filesystem::resolvePath($this->getAbsolutePath($path));
+		$a = $this->getAbsolutePath($path);
+		$p = Filesystem::normalizePath($a);
+		return Filesystem::resolvePath($p);
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -416,4 +416,38 @@ class View extends \PHPUnit_Framework_TestCase {
 		$view->file_put_contents('/asd.txt', 'foo');
 		$this->assertNull($this->createHookPath);
 	}
+
+	/**
+	 * @dataProvider resolvePathTestProvider
+	 */
+	public function testResolvePath($expected, $pathToTest) {
+		$storage1 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, array(), '/');
+
+		$view = new \OC\Files\View('');
+
+		$result = $view->resolvePath($pathToTest);
+		$this->assertEquals($expected, $result[1]);
+
+		$exists = $view->file_exists($pathToTest);
+		$this->assertTrue($exists);
+
+		$exists = $view->file_exists($result[1]);
+		$this->assertTrue($exists);
+	}
+
+	function resolvePathTestProvider() {
+		return array(
+			array('foo.txt', 'foo.txt'),
+			array('foo.txt', '/foo.txt'),
+			array('folder', 'folder'),
+			array('folder', '/folder'),
+			array('folder', 'folder/'),
+			array('folder', '/folder/'),
+			array('folder/bar.txt', 'folder/bar.txt'),
+			array('folder/bar.txt', '/folder/bar.txt'),
+			array('', ''),
+			array('', '/'),
+		);
+	}
 }


### PR DESCRIPTION
the path need to be normalized before putting it into resolvePath()
otherwise the returned internalPath will not match followup calls to e.g. Cache::getID()

fixes #5255

```
dav:/oc/core/remote.php/webdav/test/> cd ..
dav:/oc/core/remote.php/webdav/> propget .
Fetching properties for `.':
DAV: getetag = "5256b3c6ecf55"
DAV: getlastmodified = Thu, 10 Oct 2013 14:03:15 GMT
DAV: resourcetype = <DAV:collection></DAV:collection>
DAV: quota-used-bytes = 17030195
DAV: quota-available-bytes = 80326975488
dav:/oc/core/remote.php/webdav/> cd test 
dav:/oc/core/remote.php/webdav/test/> put README.md 
Uploading README.md to `/oc/core/remote.php/webdav/test/README.md':
Progress: [=============================>] 100,0% of 981 bytes succeeded.
dav:/oc/core/remote.php/webdav/test/> cd ..
dav:/oc/core/remote.php/webdav/> propget .
Fetching properties for `.':
DAV: getetag = "5256b3f394aa6"
DAV: getlastmodified = Thu, 10 Oct 2013 14:04:31 GMT
DAV: resourcetype = <DAV:collection></DAV:collection>
DAV: quota-used-bytes = 17030195
DAV: quota-available-bytes = 80326946816
dav:/oc/core/remote.php/webdav/> 
```
