### PR TITLE
ocs share api: add "received_from" and "received_from_displayname" field

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -196,7 +196,8 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
 				null, 1);
 
-		$params = array('itemSource' => $fileInfo['fileid']);
+		$params = array('itemSource' => $fileInfo['fileid'],
+			'itemType' => 'file');
 
 		$result = Share\Api::getShare($params);
 


### PR DESCRIPTION
add "received_from" and "received_from_displayname" field in case of a reshared file to the output.

This fields are added if the user asks for all shares from a given file `ocs/v1.php/apps/files_sharing/api/v1/shares?path=folder&subfiles=true`, if the user asks for a specific share `ocs/v1.php/apps/files_sharing/api/v1/shares/shareID` or for the status of a specific file `ocs/v1.php/apps/files_sharing/api/v1/shares?path=file`.

cc @DeepDiver1975 
