### PR TITLE
fix label to checkbox binding in admin -> force-https

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -179,7 +179,7 @@ if (!$_['internetconnectionworking']) {
 	<table class="nostyle">
 		<tr>
 			<td id="enable">
-				<input type="checkbox" name="forcessl"  id="enforceHTTPSEnabled"
+				<input type="checkbox" name="forcessl"  id="forcessl"
 					<?php if ($_['enforceHTTPSEnabled']) {
 						print_unescaped('checked="checked" ');
 						print_unescaped('value="false"');


### PR DESCRIPTION
Clicking the label will trigger the checkbox.

Minor usability fix. I looked into the history of the file because I thought that this error must have occurred on accident because all the other checkboxes and labels on that page worked correctly. As it turns out @LukasReschke wrote it like this to begin with (https://github.com/owncloud/core/commit/466cdab680d74cad2cbb902efa3e3c2f9e35f767) – sorry, Lukas, for the blame ;-) it's not the best way to start the contribution to a project by pointing fingers at people but a) its really minor and you probably just overlooked it and b) I wanna show that I researched the matter before creating a pull request.

Technical Background:
Html form elements should get connected to label texts by pointing the 'for' attribute of the label to the 'id' attribute of the form element. As a result, checkbox-labels for example check the checkbox when the user clicks on the label text:

``` html
<input type="checkbox" id="getSpam"><label for="getSpam">Sign up for Spam</label>
```
