### PR TITLE
Added JS exception dialog for failed ajax calls

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -746,7 +746,19 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 #oc-dialog-filepicker-content .filepicker_element_selected { background-color:lightblue;}
 .ui-dialog {position:fixed !important;}
 span.ui-icon {float: left; margin: 3px 7px 30px 0;}
-
+#oc-dialog-exception-content{
+	overflow: auto;
+	/* IE8 will ignore this and will show horizontal scrollbars */
+	word-break: break-word;
+}
+	#oc-dialog-exception-content .label{
+		font-weight: bold;
+		display: inline-block;
+		width: 50px;
+	}
+	#oc-dialog-exception-content .value{
+		color: #666;
+	}
 .loading { background: url('../img/loading.gif') no-repeat center; cursor: wait; }
 .move2trash { /* decrease spinner size */
 	width: 16px;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -695,6 +695,16 @@ function fillWindow(selector) {
 }
 
 $(document).ready(function(){
+	// catch ajax errors and display an exception dialog
+	$(document).bind('ajaxError', function(event, jqXHR, ajaxSettings, thrownError){
+		var exception = jqXHR.responseJSON && jqXHR.responseJSON.exception;
+		if (!exception){
+			return;
+		}
+		console.error(t('core', 'Server-side exception'), exception);
+		OC.dialogs.exception(exception, ajaxSettings);
+	});
+
 	sessionHeartBeat();
 
 	if(!SVGSupport()){ //replace all svg images with png images for browser that dont support svg

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -248,7 +248,12 @@ var OCdialogs = {
 				url: url,
 				data: ajaxSettings && ajaxSettings.data,
 				stack: exception.stack,
-				hint: exception.hint
+				hint: exception.hint,
+				errorLabel: t('core', 'Error:'),
+				urlLabel: t('core', 'URL:'),
+				dataLabel: t('core', 'Data:'),
+				hintLabel: t('core', 'Hint:'),
+				stackLabel: t('core', 'Stack:')
 			});
 
 			if (!ajaxSettings){

--- a/core/templates/exception.html
+++ b/core/templates/exception.html
@@ -1,12 +1,12 @@
 <div id="{dialog_name}" title="{title}">
-	<div><span class="label">Error: </span><span class="value">{message}</span></div>
+	<div><span class="label">{errorLabel} </span><span class="value">{message}</span></div>
 	<div class="connection">
-		<div><span class="label">URL: </span><span class="value">{url}</span></div>
-		<div><span class="label">Data: </span><span class="value">{data}</span></div>
+		<div><span class="label">{urlLabel} </span><span class="value">{url}</span></div>
+		<div><span class="label">{dataLabel} </span><span class="value">{data}</span></div>
 	</div>
-	<div class="hint"><span class="label">Hint: </span><span class="value">{hint}</span></div>
+	<div class="hint"><span class="label">{hintLabel} </span><span class="value">{hint}</span></div>
 	<div class="stack">
-		<div class="label">Stack: </div>
+		<div class="label">{stackLabel} </div>
 		<pre class="value">{stack}</pre>
 	</ul>
 	</div>

--- a/core/templates/exception.html
+++ b/core/templates/exception.html
@@ -1,0 +1,13 @@
+<div id="{dialog_name}" title="{title}">
+	<div><span class="label">Error: </span><span class="value">{message}</span></div>
+	<div class="connection">
+		<div><span class="label">URL: </span><span class="value">{url}</span></div>
+		<div><span class="label">Data: </span><span class="value">{data}</span></div>
+	</div>
+	<div class="hint"><span class="label">Hint: </span><span class="value">{hint}</span></div>
+	<div class="stack">
+		<div class="label">Stack: </div>
+		<pre class="value">{stack}</pre>
+	</ul>
+	</div>
+</div>

--- a/index.php
+++ b/index.php
@@ -33,5 +33,10 @@ try {
 	//show the user a detailed error page
 	\OCP\Util::writeLog('index', $ex->getMessage(), \OCP\Util::FATAL);
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	OC_Template::printExceptionErrorPage($ex);
+	if (strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest'){
+		OC_Template::printExceptionJson($ex);
+	}
+	else{
+		OC_Template::printExceptionErrorPage($ex);
+	}
 }

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -293,7 +293,7 @@ class OC_Template extends \OC\Template\Base {
 				$hint = '<pre>'.$hint.'</pre>';
 			}
 			$l = OC_L10N::get('lib');
-			while (method_exists($exception, 'previous') && $exception = $exception->previous()) {
+			while (method_exists($exception, 'getPrevious') && $exception = $exception->getPrevious()) {
 				$error_msg .= '<br/>'.$l->t('Caused by:').' ';
 				if ($exception->getCode()) {
 					$error_msg .= '['.$exception->getCode().'] ';
@@ -307,5 +307,31 @@ class OC_Template extends \OC\Template\Base {
 			}
 		}
 		self::printErrorPage($error_msg, $hint);
+	}
+
+	public static function printExceptionJson(Exception $exception){
+		$message = $exception->getMessage();
+		$exceptionJson = array(
+			'code' => $exception->getCode()
+		);
+		if (defined('DEBUG') and DEBUG) {
+			$exceptionJson['stack'] = $exception->getTraceAsString();
+			// include cause
+			$l = OC_L10N::get('lib');
+			while (method_exists($exception, 'getPrevious') && $exception = $exception->getPrevious()) {
+				$message .= ' - '.$l->t('Caused by:').' ';
+				if ($exception->getCode()) {
+					$message .= '['.$exception->getCode().'] ';
+				}
+				$message .= $exception->getMessage() . "\n";
+			};
+		}
+		else{
+			if ($exception instanceof \OC\HintException){
+				$exceptionJson['hint'] = $exception->getHint();
+			}
+		}
+		$exceptionJson['message'] = $message;
+		\OCP\JSON::encodedPrint(array('exception' => $exceptionJson));
 	}
 }


### PR DESCRIPTION
All failed ajax calls in the app will display an exception dialog.
This is achieved using a global listener to "ajaxError".
The dialog will show the exception returned by the server in JSON format
with a stack trace if available.

Fixes #5226
