### PR TITLE
Fixed display name change for IE8

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -31,7 +31,7 @@ function changeDisplayName(){
         // Ajax foo
         $.post( 'ajax/changedisplayname.php', post, function(data){
             if( data.status === "success" ){
-                $('#oldDisplayName').text($('#displayName').val());
+                $('#oldDisplayName').val($('#displayName').val());
                 // update displayName on the top right expand button
                 $('#expandDisplayName').text($('#displayName').val());
                 updateAvatar();


### PR DESCRIPTION
After saving the display name, the oldDisplayName field's value was
wrongly set with text(), which would append the text inside the input
element which is considered as an invalid operation in IE8.

This fix for #5054 correctly puts the old value into the field with a val() call.

:four: bytes change!

Please review @DeepDiver1975 @karlitschek @schiesbn 
