### PR TITLE
encryption: block file access if share keys are missing

### DIFF
--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -23,7 +23,7 @@ if (!isset($_)) { //also provide standalone error page
 		}
 	} else {
 		$errorCode = \OCA\Encryption\Crypt::ENCRYPTION_UNKNOWN_ERROR;
-		$errorMsg = $l->t("Unknwon error please check your system settings or contact your administrator");
+		$errorMsg = $l->t("Unknown error please check your system settings or contact your administrator");
 	}
 
 	if (isset($_GET['p']) && $_GET['p'] === '1') {

--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -5,12 +5,25 @@ if (!isset($_)) { //also provide standalone error page
 
 	$l = OC_L10N::get('files_encryption');
 
-	if (isset($_GET['i']) && $_GET['i'] === '0') {
-		$errorMsg = $l->t('Encryption app not initialized! Maybe the encryption app was re-enabled during your session. Please try to log out and log back in to initialize the encryption app.');
-		$init = '0';
+	if (isset($_GET['errorCode'])) {
+		$errorCode = $_GET['errorCode'];
+		switch ($errorCode) {
+			case \OCA\Encryption\Crypt::ENCRYPTION_NOT_INITIALIZED_ERROR:
+				$errorMsg = $l->t('Encryption app not initialized! Maybe the encryption app was re-enabled during your session. Please try to log out and log back in to initialize the encryption app.');
+				break;
+			case \OCA\Encryption\Crypt::ENCRYPTION_PRIVATE_KEY_NOT_VALID_ERROR:
+				$errorMsg = $l->t('Your private key is not valid! Likely your password was changed outside the ownCloud system (e.g. your corporate directory). You can update your private key password in your personal settings to recover access to your encrypted files.');
+				break;
+			case \OCA\Encryption\Crypt::ENCRYPTION_NO_SHARE_KEY_FOUND:
+				$errorMsg = $l->t('Can not decrypt this file, probably this is a shared file. Please ask the file owner to reshare the file with you.');
+				break;
+			default:
+				$errorMsg = $l->t("Unknwon error please check your system settings or contact your administrator");
+				break;
+		}
 	} else {
-		$errorMsg = $l->t('Your private key is not valid! Likely your password was changed outside the ownCloud system (e.g. your corporate directory). You can update your private key password in your personal settings to recover access to your encrypted files.');
-		$init = '1';
+		$errorCode = \OCA\Encryption\Crypt::ENCRYPTION_UNKNOWN_ERROR;
+		$errorMsg = $l->t("Unknwon error please check your system settings or contact your administrator");
 	}
 
 	if (isset($_GET['p']) && $_GET['p'] === '1') {
@@ -24,7 +37,7 @@ if (!isset($_)) { //also provide standalone error page
 		header('HTTP/1.0 404 ' . $errorMsg);
 		$tmpl = new OC_Template('files_encryption', 'invalid_private_key', 'guest');
 		$tmpl->assign('message', $errorMsg);
-		$tmpl->assign('init', $init);
+		$tmpl->assign('errorCode', $errorCode);
 		$tmpl->printPage();
 	}
 

--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -18,7 +18,7 @@ if (!isset($_)) { //also provide standalone error page
 				$errorMsg = $l->t('Can not decrypt this file, probably this is a shared file. Please ask the file owner to reshare the file with you.');
 				break;
 			default:
-				$errorMsg = $l->t("Unknwon error please check your system settings or contact your administrator");
+				$errorMsg = $l->t("Unknown error please check your system settings or contact your administrator");
 				break;
 		}
 	} else {
@@ -27,7 +27,7 @@ if (!isset($_)) { //also provide standalone error page
 	}
 
 	if (isset($_GET['p']) && $_GET['p'] === '1') {
-		header('HTTP/1.0 404 ' . $errorMsg);
+		header('HTTP/1.0 403 ' . $errorMsg);
 	}
 
 // check if ajax request

--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -34,7 +34,7 @@ if (!isset($_)) { //also provide standalone error page
 	if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
 		\OCP\JSON::error(array('data' => array('message' => $errorMsg)));
 	} else {
-		header('HTTP/1.0 404 ' . $errorMsg);
+		header('HTTP/1.0 403 ' . $errorMsg);
 		$tmpl = new OC_Template('files_encryption', 'invalid_private_key', 'guest');
 		$tmpl->assign('message', $errorMsg);
 		$tmpl->assign('errorCode', $errorCode);

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -33,6 +33,12 @@ require_once __DIR__ . '/../3rdparty/Crypt_Blowfish/Blowfish.php';
 
 class Crypt {
 
+	const ENCRYPTION_UNKNOWN_ERROR = -1;
+	const ENCRYPTION_NOT_INITIALIZED_ERROR = 1;
+	const ENCRYPTION_PRIVATE_KEY_NOT_VALID_ERROR = 2;
+	const ENCRYPTION_NO_SHARE_KEY_FOUND = 3;
+
+
 	/**
 	 * @brief return encryption mode client or server side encryption
 	 * @param string $user name (use system wide setting if name=null)
@@ -183,8 +189,8 @@ class Crypt {
 		// Fetch all file metadata from DB
 		$metadata = \OC\Files\Filesystem::getFileInfo($relPath, '');
 
-		// If a file is flagged with encryption in DB, but isn't a 
-		// valid content + IV combination, it's probably using the 
+		// If a file is flagged with encryption in DB, but isn't a
+		// valid content + IV combination, it's probably using the
 		// legacy encryption system
 		if (isset($metadata['encrypted'])
 			&& $metadata['encrypted'] === true
@@ -388,7 +394,7 @@ class Crypt {
 	 */
 	public static function multiKeyEncrypt($plainContent, array $publicKeys) {
 
-		// openssl_seal returns false without errors if $plainContent 
+		// openssl_seal returns false without errors if $plainContent
 		// is empty, so trigger our own error
 		if (empty($plainContent)) {
 
@@ -405,7 +411,7 @@ class Crypt {
 
 			$i = 0;
 
-			// Ensure each shareKey is labelled with its 
+			// Ensure each shareKey is labelled with its
 			// corresponding userId
 			foreach ($publicKeys as $userId => $publicKey) {
 
@@ -476,7 +482,7 @@ class Crypt {
 
 			}
 
-			// We encode the iv purely for string manipulation 
+			// We encode the iv purely for string manipulation
 			// purposes - it gets decoded before use
 			$iv = base64_encode($random);
 

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -235,16 +235,28 @@ class Helper {
 	/**
 	 * @brief redirect to a error page
 	 */
-	public static function redirectToErrorPage($session) {
+	public static function redirectToErrorPage($session, $errorCode = null) {
 
-		$init = $session->getInitialized();
+		if ($errorCode === null) {
+			$init = $session->getInitialized();
+			switch ($init) {
+				case \OCA\Encryption\Session::INIT_EXECUTED:
+					$errorCode = \OCA\Encryption\Crypt::ENCRYPTION_PRIVATE_KEY_NOT_VALID_ERROR;
+					break;
+				case \OCA\Encryption\Session::NOT_INITIALIZED:
+					$errorCode = \OCA\Encryption\Crypt::ENCRYPTION_NOT_INITIALIZED_ERROR;
+					break;
+				default:
+					$errorCode = \OCA\Encryption\Crypt::ENCRYPTION_UNKNOWN_ERROR;
+			}
+		}
 
 		$location = \OC_Helper::linkToAbsolute('apps/files_encryption/files', 'error.php');
 		$post = 0;
 		if(count($_POST) > 0) {
 			$post = 1;
 			}
-			header('Location: ' . $location . '?p=' . $post . '&i=' . $init);
+			header('Location: ' . $location . '?p=' . $post . '&errorCode=' . $errorCode);
 			exit();
 	}
 

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -254,16 +254,20 @@ class Stream {
 		// If a keyfile already exists
 		if ($this->encKeyfile) {
 
+			$shareKey = Keymanager::getShareKey($this->rootView, $this->userId, $this->relPath);
+
 			// if there is no valid private key return false
 			if ($this->privateKey === false) {
-
 				// if private key is not valid redirect user to a error page
-				\OCA\Encryption\Helper::redirectToErrorPage();
-
+				\OCA\Encryption\Helper::redirectToErrorPage($this->session);
 				return false;
 			}
 
-			$shareKey = Keymanager::getShareKey($this->rootView, $this->userId, $this->relPath);
+			if ($shareKey === false) {
+				// if no share key is available redirect user to a error page
+				\OCA\Encryption\Helper::redirectToErrorPage($this->session, \OCA\Encryption\Crypt::ENCRYPTION_NO_SHARE_KEY_FOUND);
+				return false;
+			}
 
 			$this->plainKey = Crypt::multiKeyDecrypt($this->encKeyfile, $shareKey, $this->privateKey);
 

--- a/apps/files_encryption/templates/invalid_private_key.php
+++ b/apps/files_encryption/templates/invalid_private_key.php
@@ -4,7 +4,7 @@
 
 		<?php p($_['message']); ?>
 		<br/>
-		<?php if($_['init']): ?>
+		<?php if($_['errorCode'] === \OCA\Encryption\Crypt::ENCRYPTION_PRIVATE_KEY_NOT_VALID_ERROR): ?>
 			<?php>p($l->t('Go directly to your ')); ?> <a href="<?php echo $location?>"><?php p($l->t('personal settings')); ?>.</a>
 		<?php endif; ?>
 		<br/>


### PR DESCRIPTION
block access to a file both over webdav and over the web interface if we can't decrypt it, e.g. because the share key is missing

cc @PVince81 This solves the problem we discussed today
