### PR TITLE
Fixed IE8 misaligned date

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -105,8 +105,6 @@ table th#headerDate, table td.date {
 	box-sizing: border-box;
 	position: relative;
 	min-width: 11em;
-	display: block;
-	height: 51px;
 }
 
 /* Multiselect bar */
@@ -161,8 +159,6 @@ table td.filename .nametext, .uploadtext, .modified { float:left; padding:.3em 0
 }
 .modified {
 	position: relative;
-	top: 11px;
-	left: 5px;
 }
 
 /* TODO fix usability bug (accidental file/folder selection) */


### PR DESCRIPTION
Removed display: block to let the element be displayed inline and let
itself aligned by vertical-align: middle of the parent

This works in IE8 and other browsers.

Fixes #5288 

Please review @kabum @ringmaster 
I've only tested in IE8, would be good to know whether it works in IE9 and IE10 as well.
