### PR TITLE
fix setting dialog headlines for the encryption app

### DIFF
--- a/apps/files_encryption/templates/settings-admin.php
+++ b/apps/files_encryption/templates/settings-admin.php
@@ -1,10 +1,7 @@
 <form id="encryption">
 	<fieldset class="personalblock">
 
-		<p>
-			<strong><?php p($l->t('Encryption')); ?></strong>
-			<br/>
-		</p>
+		<h2><?php p($l->t('Encryption')); ?></h2>
 
 		<p>
 			<?php p($l->t("Enable recovery key (allow to recover users files in case of password loss):")); ?>

--- a/apps/files_encryption/templates/settings-personal.php
+++ b/apps/files_encryption/templates/settings-personal.php
@@ -1,8 +1,6 @@
 <form id="encryption">
 	<fieldset class="personalblock">
-		<legend>
-			<?php p( $l->t( 'Encryption' ) ); ?>
-		</legend>
+		<h2><?php p( $l->t( 'Encryption' ) ); ?></h2>
 
 		<?php if ( ! $_["privateKeySet"] && $_["initialized"] ): ?>
 			<p>
@@ -38,9 +36,8 @@
 			</p>
 		<?php endif; ?>
 
-		<br />
-
 		<?php if ( $_["recoveryEnabled"] && $_["privateKeySet"] ): ?>
+			<br />
 			<p>
 				<label for="userEnableRecovery"><?php p( $l->t( "Enable password recovery:" ) ); ?></label>
 				<br />
@@ -65,6 +62,5 @@
 			</p>
 		<?php endif; ?>
 
-		<br />
 	</fieldset>
 </form>


### PR DESCRIPTION
the visual presentation of the headlines in the personal/admin settings changed for oc6. This pull request updated the encryption app settings.

cc @PVince81 really small pr, do you want to have a look? Thanks!
