### PR TITLE
Fixed table grid styles for IE8

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -41,8 +41,8 @@ table.nostyle td { padding: 0.2em 0; }
 
 /* USERS */
 form { display:inline; }
-table:not(.nostyle) th { height:2em; color:#999; }
-table:not(.nostyle) th, table:not(.nostyle) td { border-bottom:1px solid #ddd; padding:0 .5em; padding-left:.8em; text-align:left; font-weight:normal; }
+table.grid th { height:2em; color:#999; }
+table.grid th, table.grid td { border-bottom:1px solid #ddd; padding:0 .5em; padding-left:.8em; text-align:left; font-weight:normal; }
 td.name, td.password { padding-left:.8em; }
 td.password>img,td.displayName>img, td.remove>a, td.quota>img { visibility:hidden; }
 td.password, td.quota, td.displayName { width:12em; cursor:pointer; }
@@ -53,7 +53,7 @@ tr:hover>td.password>span, tr:hover>td.displayName>span { margin:0; cursor:point
 tr:hover>td.remove>a, tr:hover>td.password>img,tr:hover>td.displayName>img, tr:hover>td.quota>img { visibility:visible; cursor:pointer; }
 tr:hover>td.remove>a { float:right; }
 li.selected { background-color:#ddd; }
-table:not(.nostyle) { width:100%; }
+table.grid { width:100%; }
 #rightcontent { padding-left: 1em; }
 div.quota {
 	float: right;
@@ -127,6 +127,9 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 /* LOG */
 #log { white-space:normal; }
 #lessLog { display:none; }
+table.grid td.date{
+	white-space: nowrap;
+}
 
 /* ADMIN */
 span.securitywarning {color:#C33; font-weight:bold; }

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -118,7 +118,7 @@ if (!$_['internetconnectionworking']) {
 
 <fieldset class="personalblock" id="shareAPI">
 	<h2><?php p($l->t('Sharing'));?></h2>
-	<table class="shareAPI nostyle">
+	<table class="shareAPI">
 		<tr>
 			<td id="enable">
 				<input type="checkbox" name="shareapi_enabled" id="shareAPIEnabled"
@@ -176,7 +176,7 @@ if (!$_['internetconnectionworking']) {
 
 <fieldset class="personalblock" id="security">
 	<h2><?php p($l->t('Security'));?></h2>
-	<table class="nostyle">
+	<table>
 		<tr>
 			<td id="enable">
 				<input type="checkbox" name="forcessl"  id="enforceHTTPSEnabled"
@@ -217,7 +217,7 @@ if (!$_['internetconnectionworking']) {
 		<?php endif;
 endfor;?>
 </select>
-	<table id="log">
+	<table id="log" class="grid">
 		<?php foreach ($_['entries'] as $entry): ?>
 		<tr>
 			<td>
@@ -229,7 +229,7 @@ endfor;?>
 			<td>
 				<?php p($entry->message);?>
 			</td>
-			<td>
+			<td class="date">
 				<?php if(is_int($entry->time)){
 					p(OC_Util::formatDate($entry->time));
 				} else {

--- a/settings/templates/users.php
+++ b/settings/templates/users.php
@@ -78,7 +78,7 @@ $_['subadmingroups'] = array_flip($items);
 	</div>
 </div>
 
-<table class="hascontrols" data-groups="<?php p(json_encode($allGroups));?>">
+<table class="hascontrols grid" data-groups="<?php p(json_encode($allGroups));?>">
 	<thead>
 		<tr>
 			<?php if ($_['enableAvatars']): ?>


### PR DESCRIPTION
The selector :not() isn't supported in IE8, replaced it with the "grid"
class.
- Fixes the log table style in IE8 (#5057)
- Fixes the users table layout bug in IE8 (yay!)

@karlitschek @ringmaster @butonic @DeepDiver1975 please review
