### PR TITLE
File actions are now updated after create/upload file

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -523,8 +523,10 @@ $(document).ready(function() {
 						function(result){
 							if (result.status == 'success') {
 								var date=new Date();
-								FileList.addFile(name,0,date,false,hidden);
-								var tr=$('tr').filterAttr('data-file',name);
+								// TODO: ideally addFile should be able to receive
+								// all attributes and set them automatically,
+								// and also auto-load the preview
+								var tr = FileList.addFile(name,0,date,false,hidden);
 								tr.attr('data-size',result.data.size);
 								tr.attr('data-mime',result.data.mime);
 								tr.attr('data-id', result.data.id);
@@ -533,6 +535,7 @@ $(document).ready(function() {
 								lazyLoadPreview(path, result.data.mime, function(previewpath){
 									tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
 								});
+								FileActions.display(tr.find('td.filename'));
 							} else {
 								OC.dialogs.alert(result.data.message, t('core', 'Error'));
 							}


### PR DESCRIPTION
The file actions must explicitly be updated by calling
FileActions.display() on the file element after creating or uploading a
file.

Fixes #4971 and #4993 

Please review @schiesbn @kabum @frisco82 @raghunayyar 
