### PR TITLE
Fixed position of "delete" icon in files app

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -252,9 +252,7 @@ table td.filename form { font-size:.85em; margin-left:3em; margin-right:3em; }
 #fileList a.action.delete {
 	position: absolute;
 	right: 0;
-	top: 0;
-	margin: 0;
-	padding: 15px 14px 19px !important;
+	padding: 9px 14px 19px !important;
 }
 a.action>img { max-height:16px; max-width:16px; vertical-align:text-bottom; }
 


### PR DESCRIPTION
There was an issue where only Chrome allows setting position: relative
on a td element.

This fix now works in IE8, Firefox and Chrome.

Fixes #5056

@schiesbn @karlitschek @kabum please review
