### PR TITLE
Fix OC_User::getDisplayName to persist between (browser) sessions. Fixes #3694

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -372,6 +372,8 @@ class OC_User {
 			return self::determineDisplayName($user);
 		} else if( isset($_SESSION['display_name']) AND $_SESSION['display_name'] ) {
 			return $_SESSION['display_name'];
+		} else if ( $user = $this->getUser() ) {
+			return self::determineDisplayName($user);
 		}
 		else{
 			return false;

--- a/lib/user.php
+++ b/lib/user.php
@@ -372,7 +372,7 @@ class OC_User {
 			return self::determineDisplayName($user);
 		} else if( isset($_SESSION['display_name']) AND $_SESSION['display_name'] ) {
 			return $_SESSION['display_name'];
-		} else if ( $user = $this->getUser() ) {
+		} else if ( $user = self::getUser() ) {
 			return self::determineDisplayName($user);
 		}
 		else{


### PR DESCRIPTION
See #3694. "display_name" is only present in $_SESSION after setting it on the settings page. The session is lost after browser restart, only user_id is reloaded from the cookie.

This fix fetches the display name from the backend by using the user_id session variable.

(The whole `$_SESSION['display_name']` is pointless, but as the user backend is being rewritten for OC6, I won't mess around there)
