### PR TITLE
Added missing "grid" class on external storage's table

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -2,7 +2,7 @@
 	<fieldset class="personalblock">
 	<h2><?php p($l->t('External Storage')); ?></h2>
 		<?php if (isset($_['dependencies']) and ($_['dependencies']<>'')) print_unescaped(''.$_['dependencies'].''); ?>
-		<table id="externalStorage" data-admin='<?php print_unescaped(json_encode($_['isAdminPage'])); ?>'>
+		<table id="externalStorage" class="grid" data-admin='<?php print_unescaped(json_encode($_['isAdminPage'])); ?>'>
 			<thead>
 				<tr>
 					<th></th>


### PR DESCRIPTION
I missed this table while fixing https://github.com/owncloud/core/pull/5299

It adds back the correct formatting for the external storage config table.

Please review @karlitschek @schiesbn @jancborchardt @DeepDiver1975 
