### PR TITLE
Include (group) in share dropdown for groups

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -302,6 +302,9 @@ OC.Share={
 		});
 	},
 	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, collection) {
+		if (shareType == 1) {
+			shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'group') + ')';
+		} 
 		if (!OC.Share.itemShares[shareType]) {
 			OC.Share.itemShares[shareType] = [];
 		}


### PR DESCRIPTION
Fix for #4973

Just adds (group) after the group name in the share dropdown if sharedWith is a group.
