### PR TITLE
check if we are writing to user/files, otherwise skip encryption

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -47,7 +47,8 @@ class Proxy extends \OC_FileProxy {
 	 */
 	private static function shouldEncrypt($path) {
 
-		if (\OCP\App::isEnabled('files_encryption') === false || Crypt::mode() !== 'server') {
+		if (\OCP\App::isEnabled('files_encryption') === false || Crypt::mode() !== 'server' ||
+				strpos($path, '/' . \OCP\User::getUser() . '/files') !== 0) {
 			return false;
 		}
 


### PR DESCRIPTION
only encrypt files if they are stored under `data/<user>/files`
