### PR TITLE
avatars should also work with encryption after pr #5332 was merged

### DIFF
--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -51,10 +51,6 @@ class OC_Avatar {
 	 * @return void
 	*/
 	public function set ($data) {
-		if (\OC_App::isEnabled('files_encryption')) {
-			$l = \OC_L10N::get('lib');
-			throw new \Exception($l->t("Custom profile pictures don't work with encryption yet"));
-		}
 
 		$img = new OC_Image($data);
 		$type = substr($img->mimeType(), -3);

--- a/tests/lib/avatar.php
+++ b/tests/lib/avatar.php
@@ -9,7 +9,6 @@
 class Test_Avatar extends PHPUnit_Framework_TestCase {
 
 	public function testAvatar() {
-		$this->markTestSkipped("Setting custom avatars with encryption doesn't work yet");
 
 		$avatar = new \OC_Avatar(\OC_User::getUser());
 

--- a/tests/lib/avatar.php
+++ b/tests/lib/avatar.php
@@ -15,8 +15,8 @@ class Test_Avatar extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(false, $avatar->get());
 
 		$expected = new OC_Image(\OC::$SERVERROOT.'/tests/data/testavatar.png');
-		$avatar->set($expected->data());
 		$expected->resize(64);
+		$avatar->set($expected->data());
 		$this->assertEquals($expected->data(), $avatar->get()->data());
 
 		$avatar->remove();


### PR DESCRIPTION
avatars should also work with encryption enabled if this pr is merged: https://github.com/owncloud/core/pull/5332

cc @Kondou-ger 
