### PR TITLE
Files sharing actions + navigation fixes

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -130,7 +130,7 @@ if (strpos($dir, '..') === false) {
 							'originalname' => $files['tmp_name'][$i],
 							'uploadMaxFilesize' => $maxUploadFileSize,
 							'maxHumanFilesize' => $maxHumanFileSize,
-							'permissions' => $meta['permissions'],
+							'permissions' => $meta['permissions'] & OCP\PERMISSION_READ
 						);
 					}
 
@@ -156,7 +156,7 @@ if (strpos($dir, '..') === false) {
 					'originalname' => $files['tmp_name'][$i],
 					'uploadMaxFilesize' => $maxUploadFileSize,
 					'maxHumanFilesize' => $maxHumanFileSize,
-					'permissions' => $meta['permissions'],
+					'permissions' => $meta['permissions'] & OCP\PERMISSION_READ
 				);
 			}
 		}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -677,6 +677,7 @@ var FileList={
 };
 
 $(document).ready(function(){
+	var isPublic = !!$('#isPublic').val();
 
 	// handle upload events
 	var file_upload_start = $('#file_upload_start');
@@ -924,29 +925,32 @@ $(document).ready(function(){
 		return (params && params.dir) || '/';
 	}
 
-	// fallback to hashchange when no history support
-	if (!window.history.pushState){
-		$(window).on('hashchange', function(){
-			FileList.changeDirectory(parseCurrentDirFromUrl(), false);
-		});
-	}
-	window.onpopstate = function(e){
-		var targetDir;
-		if (e.state && e.state.dir){
-			targetDir = e.state.dir;
+	// disable ajax/history API for public app (TODO: until it gets ported)
+	if (!isPublic){
+		// fallback to hashchange when no history support
+		if (!window.history.pushState){
+			$(window).on('hashchange', function(){
+				FileList.changeDirectory(parseCurrentDirFromUrl(), false);
+			});
 		}
-		else{
-			// read from URL
-			targetDir = parseCurrentDirFromUrl();
+		window.onpopstate = function(e){
+			var targetDir;
+			if (e.state && e.state.dir){
+				targetDir = e.state.dir;
+			}
+			else{
+				// read from URL
+				targetDir = parseCurrentDirFromUrl();
+			}
+			if (targetDir){
+				FileList.changeDirectory(targetDir, false);
+			}
 		}
-		if (targetDir){
-			FileList.changeDirectory(targetDir, false);
-		}
-	}
 
-	if (parseInt($('#ajaxLoad').val(), 10) === 1){
-		// need to initially switch the dir to the one from the hash (IE8)
-		FileList.changeDirectory(parseCurrentDirFromUrl(), false, true);
+		if (parseInt($('#ajaxLoad').val(), 10) === 1){
+			// need to initially switch the dir to the one from the hash (IE8)
+			FileList.changeDirectory(parseCurrentDirFromUrl(), false, true);
+		}
 	}
 
 	FileList.createFileSummary();

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -705,7 +705,9 @@ function checkTrashStatus() {
 function onClickBreadcrumb(e){
 	var $el = $(e.target).closest('.crumb'),
 		$targetDir = $el.data('dir');
-	if ($targetDir !== undefined){
+		isPublic = !!$('#isPublic').val();
+
+	if ($targetDir !== undefined && !isPublic){
 		e.preventDefault();
 		FileList.changeDirectory(decodeURIComponent($targetDir));
 	}


### PR DESCRIPTION
This PR fixes issues with file actions after upload and also navigation to subdirs and breadcrumb clicks which were partially broken.

The fix for the navigation disabled ajax nav. Ajax nav is planned for OC7 for the public files app.

Please review @kabum @karlitschek @schiesbn @DeepDiver1975 
