### PR TITLE
Store active tab in session to always open the last one used

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -517,7 +517,7 @@ class OC {
 		register_shutdown_function(array('OC_Helper', 'cleanTmp'));
 
 		//parse the given parameters
-		self::$REQUESTEDAPP = (isset($_GET['app']) && trim($_GET['app']) != '' && !is_null($_GET['app']) ? OC_App::cleanAppId(strip_tags($_GET['app'])) : OC_Config::getValue('defaultapp', 'files'));
+		self::$REQUESTEDAPP = (isset($_GET['app']) && trim($_GET['app']) != '' && !is_null($_GET['app']) ? OC_App::cleanAppId(strip_tags($_GET['app'])) : null);
 		if (substr_count(self::$REQUESTEDAPP, '?') != 0) {
 			$app = substr(self::$REQUESTEDAPP, 0, strpos(self::$REQUESTEDAPP, '?'));
 			$param = substr($_GET['app'], strpos($_GET['app'], '?') + 1);
@@ -694,8 +694,9 @@ class OC {
 				OC_User::logout();
 				header("Location: " . OC::$WEBROOT . '/');
 			} else {
-				if (is_null($file)) {
-					$param['file'] = 'index.php';
+				if (is_null($file) && is_null($app)) {
+					OC_Util::redirectToDefaultPage();
+					return;
 				}
 				$file_ext = substr($param['file'], -3);
 				if ($file_ext != 'php'

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -299,6 +299,7 @@ class OC_App{
 	 * highlighting the current position of the user.
 	 */
 	public static function setActiveNavigationEntry( $id ) {
+		OC::$session->set('activeNavigationEntry',$id);
 		OC::$server->getNavigationManager()->setActiveEntry($id);
 		return true;
 	}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -600,7 +600,20 @@ class OC_Util {
 			if ($defaultPage) {
 				$location = OC_Helper::makeURLAbsolute(OC::$WEBROOT.'/'.$defaultPage);
 			} else {
-				$location = OC_Helper::linkToAbsolute( 'files', 'index.php' );
+				$entries = OC_App::getNavigation();
+				//By default we redirect to the highest priority navigation entry, this is the files app that can not be disabled and is the top priority one
+				$link = $entries[0]['href'];
+				$navigationEntry = OC::$session->get('activeNavigationEntry');
+				//If there is an entry stored in session then try to redirect to that one
+				if (!is_null($navigationEntry)) {
+					foreach ($entries as $entry) {
+						if ($entry['id'] ===  $navigationEntry) {
+							$link = $entry['href'];
+							break;
+						}
+					}
+				}
+				$location = OC_Helper::makeURLAbsolute($link);
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);


### PR DESCRIPTION
PR for #494
Stores the last recently used tab on session so you always get that one if you don't especify one (via url).
This removes the feature of changing the default app via hidden pref but instead uses the app with the highest priority in the navigation bar as the default one.

This does not work after logout, not sure how I should persist user related information if not in session.
