### PR TITLE
streamCopy() should return proper structure.

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -509,11 +509,11 @@ class OC_Helper {
 	 *
 	 * @param resource $source
 	 * @param resource $target
-	 * @return int the number of bytes copied
+	 * @return array the number of bytes copied and result
 	 */
 	public static function streamCopy($source, $target) {
 		if (!$source or !$target) {
-			return false;
+			return array(0, false);
 		}
 		$result = true;
 		$count = 0;

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -208,4 +208,38 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 			->will($this->returnValue(true)); // filename(1) (2) (3).ext exists
 		$this->assertEquals('dir/filename(1) (2) (4).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (2) (3).ext', $viewMock));
 	}
+
+	/**
+	 * @dataProvider streamCopyDataProvider
+	 */
+	public function testStreamCopy($expectedCount, $expectedResult, $source, $target) {
+
+		if (is_string($source)) {
+			$source = fopen($source, 'r');
+		}
+		if (is_string($target)) {
+			$target = fopen($target, 'w');
+		}
+
+		list($count, $result) = \OC_Helper::streamCopy($source, $target);
+
+		if (is_resource($source)) {
+			fclose($source);
+		}
+		if (is_resource($target)) {
+			fclose($target);
+		}
+
+		$this->assertSame($expectedCount, $count);
+		$this->assertSame($expectedResult, $result);
+	}
+
+
+	function streamCopyDataProvider() {
+		return array(
+			array(0, false, false, false),
+			array(0, false, \OC::$SERVERROOT . '/tests/data/lorem.txt', false),
+			array(446, true, \OC::$SERVERROOT . '/tests/data/lorem.txt', \OC::$SERVERROOT . '/tests/data/lorem-copy.txt'),
+		);
+	}
 }


### PR DESCRIPTION
Callers of streamCopy() expect an array to be returned containing count and result.

refs #5251

backport required as this could cause data loss/file deletion

@karlitschek @icewind1991 @bantu @bartv2 THX
