### PR TITLE
Fix logout link HTML.

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -325,7 +325,7 @@ class OC_User {
 			return $backend->getLogoutAttribute();
 		}
 
-		return "href=" . link_to('', 'index.php') . "?logout=true";
+		return 'href="' . link_to('', 'index.php') . '?logout=true"';
 	}
 
 	/**


### PR DESCRIPTION
- Bug fix
- Trivial change
- Regression from d8ada370d76acc10e602d25db6af5be936880d4c et al.

Without this patch the markup is `<a id="logout" href=/projects/owncloud/core/index.php?logout=true>`

@DeepDiver1975 @karlitschek
