### PR TITLE
Prevent renaming/deleting mount points

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -904,7 +904,8 @@ class View {
 								$permissions = $subStorage->getPermissions($rootEntry['path']);
 								$subPermissionsCache->set($rootEntry['fileid'], $user, $permissions);
 							}
-							$rootEntry['permissions'] = $permissions;
+							// do not allow renaming/deleting the mount point
+							$rootEntry['permissions'] = $permissions & (\OCP\PERMISSION_ALL - (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_DELETE));
 
 							//remove any existing entry with the same name
 							foreach ($files as $i => $file) {


### PR DESCRIPTION
Fixed permissions returned for mount points to not include update and
delete permissions.

Fixes #5291 

Note that uploading files in the UI by dragging onto the mount point is still allowed, and so is uploading files when being in the mount point's folder.

Please review @karlitschek @schiesbn @DeepDiver1975 @icewind1991 
