### PR TITLE
Add LargeFileHelper / Add CURL filesize workaround / Fix some 32-bit filesize issues

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -156,7 +156,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 	/**
 	 * Returns the size of the node, in bytes
 	 *
-	 * @return int
+	 * @return int|float
 	 */
 	public function getSize() {
 		return $this->info->getSize();

--- a/lib/private/connector/sabre/server.php
+++ b/lib/private/connector/sabre/server.php
@@ -170,7 +170,7 @@ class OC_Connector_Sabre_Server extends Sabre_DAV_Server {
 						if ($node instanceof Sabre_DAV_IFile) {
 							$size = $node->getSize();
 							if (!is_null($size)) {
-								$newProperties[200][$prop] = (int)$node->getSize();
+								$newProperties[200][$prop] = 0 + $size;
 							}
 						}
 						break;

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -142,11 +142,11 @@ class Cache {
 		} else {
 			//fix types
 			$data['fileid'] = (int)$data['fileid'];
-			$data['size'] = (int)$data['size'];
+			$data['size'] = 0 + $data['size'];
 			$data['mtime'] = (int)$data['mtime'];
 			$data['storage_mtime'] = (int)$data['storage_mtime'];
 			$data['encrypted'] = (bool)$data['encrypted'];
-            $data['unencrypted_size'] = (int)$data['unencrypted_size'];
+            $data['unencrypted_size'] = 0 + $data['unencrypted_size'];
 			$data['storage'] = $this->storageId;
 			$data['mimetype'] = $this->getMimetype($data['mimetype']);
 			$data['mimepart'] = $this->getMimetype($data['mimepart']);
@@ -532,9 +532,9 @@ class Cache {
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
 				list($sum, $min, $unencryptedSum) = array_values($row);
-				$sum = (int)$sum;
-				$min = (int)$min;
-				$unencryptedSum = (int)$unencryptedSum;
+				$sum = 0 + $sum;
+				$min = 0 + $min;
+				$unencryptedSum = 0 + $unencryptedSum;
 				if ($min === -1) {
 					$totalSize = $min;
 				} else {

--- a/lib/private/files/cache/homecache.php
+++ b/lib/private/files/cache/homecache.php
@@ -36,8 +36,10 @@ class HomeCache extends Cache {
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
 				list($sum, $unencryptedSum) = array_values($row);
-				$totalSize = (int)$sum;
-				$unencryptedSize = (int)$unencryptedSum;
+				$totalSize = 0 + $sum;
+				$unencryptedSize = 0 + $unencryptedSum;
+				$entry['size'] += 0;
+				$entry['unencrypted_size'] += 0;
 				if ($entry['size'] !== $totalSize) {
 					$this->update($id, array('size' => $totalSize));
 				}

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -224,7 +224,7 @@ if (\OC_Util::runningOnWindows()) {
 		/**
 		* @brief Tries to get the filesize via various workarounds if necessary.
 		* @param string $fullPath
-		* @return mixed Number of bytes as float on success and workaround necessary, null otherwise.
+		* @return mixed Number of bytes on success and workaround necessary, null otherwise.
 		*/
 		private static function getFileSizeWithTricks($fullPath) {
 			if (PHP_INT_SIZE === 4) {
@@ -249,7 +249,7 @@ if (\OC_Util::runningOnWindows()) {
 		/**
 		* @brief Tries to get the filesize via a CURL HEAD request.
 		* @param string $fullPath
-		* @return mixed Number of bytes as float on success, null otherwise.
+		* @return mixed Number of bytes on success, null otherwise.
 		*/
 		private static function getFileSizeFromCurl($fullPath) {
 			if (function_exists('curl_init')) {
@@ -263,7 +263,7 @@ if (\OC_Util::runningOnWindows()) {
 					$matches = array();
 					preg_match('/Content-Length: (\d+)/', $data, $matches);
 					if (isset($matches[1])) {
-						return (float) $matches[1];
+						return 0 + $matches[1];
 					}
 				}
 			}
@@ -274,7 +274,7 @@ if (\OC_Util::runningOnWindows()) {
 		/**
 		* @brief Tries to get the filesize via COM and exec().
 		* @param string $fullPath
-		* @return mixed Number of bytes as float on success, null otherwise.
+		* @return mixed Number of bytes on success, null otherwise.
 		*/
 		private static function getFileSizeFromOS($fullPath) {
 			$name = strtolower(php_uname('s'));
@@ -287,11 +287,11 @@ if (\OC_Util::runningOnWindows()) {
 				}
 			} else if (strpos($name, 'bsd') !== false) {
 				if (\OC_Helper::is_function_enabled('exec')) {
-					return (float)exec('stat -f %z ' . escapeshellarg($fullPath));
+					return 0 + exec('stat -f %z ' . escapeshellarg($fullPath));
 				}
 			} else if (strpos($name, 'linux') !== false) {
 				if (\OC_Helper::is_function_enabled('exec')) {
-					return (float)exec('stat -c %s ' . escapeshellarg($fullPath));
+					return 0 + exec('stat -c %s ' . escapeshellarg($fullPath));
 				}
 			} else {
 				\OC_Log::write('core',

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -89,7 +89,7 @@ if (\OC_Util::runningOnWindows()) {
 		public function stat($path) {
 			$fullPath = $this->datadir . $path;
 			$statResult = stat($fullPath);
-			if (PHP_INT_SIZE === 4) {
+			if (PHP_INT_SIZE === 4 && !$this->is_dir($path)) {
 				$filesize = $this->filesize($path);
 				$statResult['size'] = $filesize;
 				$statResult[7] = $filesize;

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -112,10 +112,7 @@ if (\OC_Util::runningOnWindows()) {
 			$fullPath = $this->datadir . $path;
 			if (PHP_INT_SIZE === 4) {
 				$helper = new \OC\LargeFileHelper;
-				$filesize = $helper->getFilesize($fullPath);
-				if (!is_null($filesize)) {
-					return $filesize;
-				}
+				return $helper->getFilesize($fullPath);
 			}
 			return filesize($fullPath);
 		}

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -111,11 +111,10 @@ class MappedLocal extends \OC\Files\Storage\Common {
 	public function stat($path) {
 		$fullPath = $this->buildPath($path);
 		$statResult = stat($fullPath);
-
-		if ($statResult['size'] < 0) {
-			$size = self::getFileSizeFromOS($fullPath);
-			$statResult['size'] = $size;
-			$statResult[7] = $size;
+		if (PHP_INT_SIZE === 4) {
+			$filesize = $this->filesize($path);
+			$statResult['size'] = $filesize;
+			$statResult[7] = $filesize;
 		}
 		return $statResult;
 	}
@@ -131,15 +130,16 @@ class MappedLocal extends \OC\Files\Storage\Common {
 	public function filesize($path) {
 		if ($this->is_dir($path)) {
 			return 0;
-		} else {
-			$fullPath = $this->buildPath($path);
-			$fileSize = filesize($fullPath);
-			if ($fileSize < 0) {
-				return self::getFileSizeFromOS($fullPath);
-			}
-
-			return $fileSize;
 		}
+		$fullPath = $this->buildPath($path);
+		if (PHP_INT_SIZE === 4) {
+			$helper = new \OC\LargeFileHelper;
+			$filesize = $helper->getFilesize($fullPath);
+			if (!is_null($filesize)) {
+				return $filesize;
+			}
+		}
+		return filesize($fullPath);
 	}
 
 	public function isReadable($path) {
@@ -292,35 +292,6 @@ class MappedLocal extends \OC\Files\Storage\Common {
 			$this->cleanMapper($dir, false);
 		}
 		return $return;
-	}
-
-	/**
-	 * @param string $fullPath
-	 */
-	private static function getFileSizeFromOS($fullPath) {
-		$name = strtolower(php_uname('s'));
-		// Windows OS: we use COM to access the filesystem
-		if (strpos($name, 'win') !== false) {
-			if (class_exists('COM')) {
-				$fsobj = new \COM("Scripting.FileSystemObject");
-				$f = $fsobj->GetFile($fullPath);
-				return $f->Size;
-			}
-		} else if (strpos($name, 'bsd') !== false) {
-			if (\OC_Helper::is_function_enabled('exec')) {
-				return (float)exec('stat -f %z ' . escapeshellarg($fullPath));
-			}
-		} else if (strpos($name, 'linux') !== false) {
-			if (\OC_Helper::is_function_enabled('exec')) {
-				return (float)exec('stat -c %s ' . escapeshellarg($fullPath));
-			}
-		} else {
-			\OC_Log::write('core',
-				'Unable to determine file size of "' . $fullPath . '". Unknown OS: ' . $name,
-				\OC_Log::ERROR);
-		}
-
-		return 0;
 	}
 
 	public function hash($type, $path, $raw = false) {

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -134,10 +134,7 @@ class MappedLocal extends \OC\Files\Storage\Common {
 		$fullPath = $this->buildPath($path);
 		if (PHP_INT_SIZE === 4) {
 			$helper = new \OC\LargeFileHelper;
-			$filesize = $helper->getFilesize($fullPath);
-			if (!is_null($filesize)) {
-				return $filesize;
-			}
+			return $helper->getFilesize($fullPath);
 		}
 		return filesize($fullPath);
 	}

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -111,7 +111,7 @@ class MappedLocal extends \OC\Files\Storage\Common {
 	public function stat($path) {
 		$fullPath = $this->buildPath($path);
 		$statResult = stat($fullPath);
-		if (PHP_INT_SIZE === 4) {
+		if (PHP_INT_SIZE === 4 && !$this->is_dir($path)) {
 			$filesize = $this->filesize($path);
 			$statResult['size'] = $filesize;
 			$statResult[7] = $filesize;

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -25,8 +25,10 @@ class LargeFileHelper {
 	const POW_2_53_MINUS_1 = '9007199254740991';
 
 	/**
-	* @brief Constructor. Checks whether our assumptions hold on the platform
-	*        we are on, throws an exception if they do not hold.
+	* @brief Checks whether our assumptions hold on the PHP platform we are on.
+	*
+	* @throws \RunTimeException if our assumptions do not hold on the current
+	*                           PHP platform.
 	*/
 	public function __construct() {
 		$pow_2_53 = floatval(self::POW_2_53_MINUS_1) + 1.0;
@@ -42,6 +44,9 @@ class LargeFileHelper {
 	*        string. Passed strings will be checked for being base-10.
 	*
 	* @param int|float|string $number Number containing unsigned integer data
+	*
+	* @throws \UnexpectedValueException if $number is not a float, not an int
+	*                                   and not a base-10 string.
 	*
 	* @return string Unsigned integer base-10 string
 	*/

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -13,6 +13,30 @@ namespace OC;
  */
 class LargeFileHelper {
 	/**
+	* @brief Formats a signed integer or float as an unsigned integer base-10
+	*        string. Passed strings will be checked for being base-10.
+	*
+	* @param int|float|string $number Number containing unsigned integer data
+	*
+	* @return string Unsigned integer base-10 string
+	*/
+	public function formatUnsignedInteger($number) {
+		if (is_float($number)) {
+			// Undo the effect of the php.ini setting 'precision'.
+			return number_format($number, 0, '', '');
+		} else if (is_string($number) && ctype_digit($number)) {
+			return $number;
+		} else if (is_int($number)) {
+			// Interpret signed integer as unsigned integer.
+			return sprintf('%u', $number);
+		} else {
+			throw new \UnexpectedValueException(
+				'Expected int, float or base-10 string'
+			);
+		}
+	}
+
+	/**
 	* @brief Tries to get the filesize of a file via various workarounds that
 	*        even work for large files on 32-bit platforms.
 	*

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -13,6 +13,31 @@ namespace OC;
  */
 class LargeFileHelper {
 	/**
+	* pow(2, 53) as a base-10 string.
+	* @var string
+	*/
+	const POW_2_53 = '9007199254740992';
+
+	/**
+	* pow(2, 53) - 1 as a base-10 string.
+	* @var string
+	*/
+	const POW_2_53_MINUS_1 = '9007199254740991';
+
+	/**
+	* @brief Constructor. Checks whether our assumptions hold on the platform
+	*        we are on, throws an exception if they do not hold.
+	*/
+	public function __construct() {
+		$pow_2_53 = floatval(self::POW_2_53_MINUS_1) + 1.0;
+		if ($this->formatUnsignedInteger($pow_2_53) !== self::POW_2_53) {
+			throw new \RunTimeException(
+				'This class assumes floats to be double precision or "better".'
+			);
+		}
+	}
+
+	/**
 	* @brief Formats a signed integer or float as an unsigned integer base-10
 	*        string. Passed strings will be checked for being base-10.
 	*

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -62,7 +62,7 @@ class LargeFileHelper {
 	}
 
 	/**
-	* @brief Tries to get the filesize of a file via various workarounds that
+	* @brief Tries to get the size of a file via various workarounds that
 	*        even work for large files on 32-bit platforms.
 	*
 	* @param string $filename Path to the file.
@@ -70,31 +70,31 @@ class LargeFileHelper {
 	* @return null|int|float Number of bytes as number (float or int) or
 	*                        null on failure.
 	*/
-	public function getFilesize($filename) {
-		$filesize = $this->getFilesizeViaCurl($filename);
-		if (!is_null($filesize)) {
-			return $filesize;
+	public function getFileSize($filename) {
+		$fileSize = $this->getFileSizeViaCurl($filename);
+		if (!is_null($fileSize)) {
+			return $fileSize;
 		}
-		$filesize = $this->getFilesizeViaCOM($filename);
-		if (!is_null($filesize)) {
-			return $filesize;
+		$fileSize = $this->getFileSizeViaCOM($filename);
+		if (!is_null($fileSize)) {
+			return $fileSize;
 		}
-		$filesize = $this->getFilesizeViaExec($filename);
-		if (!is_null($filesize)) {
-			return $filesize;
+		$fileSize = $this->getFileSizeViaExec($filename);
+		if (!is_null($fileSize)) {
+			return $fileSize;
 		}
-		return $this->getFilesizeNative($filename);
+		return $this->getFileSizeNative($filename);
 	}
 
 	/**
-	* @brief Tries to get the filesize of a file via a CURL HEAD request.
+	* @brief Tries to get the size of a file via a CURL HEAD request.
 	*
 	* @param string $filename Path to the file.
 	*
 	* @return null|int|float Number of bytes as number (float or int) or
 	*                        null on failure.
 	*/
-	public function getFilesizeViaCurl($filename) {
+	public function getFileSizeViaCurl($filename) {
 		if (function_exists('curl_init')) {
 			$ch = curl_init("file://$filename");
 			curl_setopt($ch, CURLOPT_NOBODY, true);
@@ -114,14 +114,14 @@ class LargeFileHelper {
 	}
 
 	/**
-	* @brief Tries to get the filesize of a file via the Windows DOM extension.
+	* @brief Tries to get the size of a file via the Windows DOM extension.
 	*
 	* @param string $filename Path to the file.
 	*
 	* @return null|int|float Number of bytes as number (float or int) or
 	*                        null on failure.
 	*/
-	public function getFilesizeViaCOM($filename) {
+	public function getFileSizeViaCOM($filename) {
 		if (class_exists('COM')) {
 			$fsobj = new \COM("Scripting.FileSystemObject");
 			$file = $fsobj->GetFile($filename);
@@ -131,14 +131,14 @@ class LargeFileHelper {
 	}
 
 	/**
-	* @brief Tries to get the filesize of a file via an exec() call.
+	* @brief Tries to get the size of a file via an exec() call.
 	*
 	* @param string $filename Path to the file.
 	*
 	* @return null|int|float Number of bytes as number (float or int) or
 	*                        null on failure.
 	*/
-	public function getFilesizeViaExec($filename) {
+	public function getFileSizeViaExec($filename) {
 		if (\OC_Helper::is_function_enabled('exec')) {
 			$os = strtolower(php_uname('s'));
 			$arg = escapeshellarg($filename);
@@ -160,19 +160,19 @@ class LargeFileHelper {
 	}
 
 	/**
-	* @brief Gets the filesize via a filesize() call and converts negative
-	*        signed int to positive float. As the result of filesize() will
-	*        wrap around after a filesize of 2^32 bytes = 4 GiB, this should
-	*        only be used as a last resort.
+	* @brief Gets the size of a file via a filesize() call and converts
+	*        negative signed int to positive float. As the result of filesize()
+	*        will wrap around after a file size of 2^32 bytes = 4 GiB, this
+	*        should only be used as a last resort.
 	*
 	* @param string $filename Path to the file.
 	*
 	* @return int|float Number of bytes as number (float or int).
 	*/
-	public function getFilesizeNative($filename) {
+	public function getFileSizeNative($filename) {
 		$result = filesize($filename);
 		if ($result < 0) {
-			// For filesizes between 2 GiB and 4 GiB, filesize() will return a
+			// For file sizes between 2 GiB and 4 GiB, filesize() will return a
 			// negative int, as the PHP data type int is signed. Interpret the
 			// returned int as an unsigned integer and put it into a float.
 			return (float) sprintf('%u', $result);

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright (c) 2014 Andreas Fischer <bantu@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+/**
+ * Helper class for large files on 32-bit platforms.
+ */
+class LargeFileHelper {
+	/**
+	* @brief Tries to get the filesize of a file via various workarounds that
+	*        even work for large files on 32-bit platforms.
+	*
+	* @param string $filename Path to the file.
+	*
+	* @return null|int|float Number of bytes as number (float or int) or
+	*                        null on failure.
+	*/
+	public function getFilesize($filename) {
+		$filesize = $this->getFilesizeViaCurl($filename);
+		if (!is_null($filesize)) {
+			return $filesize;
+		}
+		$filesize = $this->getFilesizeViaCOM($filename);
+		if (!is_null($filesize)) {
+			return $filesize;
+		}
+		$filesize = $this->getFilesizeViaExec($filename);
+		if (!is_null($filesize)) {
+			return $filesize;
+		}
+		return null;
+	}
+
+	/**
+	* @brief Tries to get the filesize of a file via a CURL HEAD request.
+	*
+	* @param string $filename Path to the file.
+	*
+	* @return null|int|float Number of bytes as number (float or int) or
+	*                        null on failure.
+	*/
+	public function getFilesizeViaCurl($filename) {
+		if (function_exists('curl_init')) {
+			$ch = curl_init("file://$filename");
+			curl_setopt($ch, CURLOPT_NOBODY, true);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_HEADER, true);
+			$data = curl_exec($ch);
+			curl_close($ch);
+			if ($data !== false) {
+				$matches = array();
+				preg_match('/Content-Length: (\d+)/', $data, $matches);
+				if (isset($matches[1])) {
+					return 0 + $matches[1];
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	* @brief Tries to get the filesize of a file via the Windows DOM extension.
+	*
+	* @param string $filename Path to the file.
+	*
+	* @return null|int|float Number of bytes as number (float or int) or
+	*                        null on failure.
+	*/
+	public function getFilesizeViaCOM($filename) {
+		if (class_exists('COM')) {
+			$fsobj = new \COM("Scripting.FileSystemObject");
+			$file = $fsobj->GetFile($filename);
+			return 0 + $file->Size;
+		}
+		return null;
+	}
+
+	/**
+	* @brief Tries to get the filesize of a file via an exec() call.
+	*
+	* @param string $filename Path to the file.
+	*
+	* @return null|int|float Number of bytes as number (float or int) or
+	*                        null on failure.
+	*/
+	public function getFilesizeViaExec($filename) {
+		if (\OC_Helper::is_function_enabled('exec')) {
+			$os = strtolower(php_uname('s'));
+			if (strpos($os, 'linux') !== false) {
+				return 0 + exec('stat -c %s ' . escapeshellarg($filename));
+			} else if (strpos($os, 'bsd') !== false) {
+				return 0 + exec('stat -f %z ' . escapeshellarg($filename));
+			}
+		}
+		return null;
+	}
+}

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -92,10 +92,15 @@ class LargeFileHelper {
 	public function getFilesizeViaExec($filename) {
 		if (\OC_Helper::is_function_enabled('exec')) {
 			$os = strtolower(php_uname('s'));
+			$result = '';
 			if (strpos($os, 'linux') !== false) {
-				return 0 + exec('stat -c %s ' . escapeshellarg($filename));
+				$result = trim(exec('stat -c %s ' . escapeshellarg($filename)));
 			} else if (strpos($os, 'bsd') !== false) {
-				return 0 + exec('stat -f %z ' . escapeshellarg($filename));
+				$result = trim(exec('stat -f %z ' . escapeshellarg($filename)));
+			}
+
+			if (ctype_digit($result)) {
+				return 0 + $result;
 			}
 		}
 		return null;

--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -83,7 +83,7 @@ class LargeFileHelper {
 		if (!is_null($filesize)) {
 			return $filesize;
 		}
-		return null;
+		return $this->getFilesizeNative($filename);
 	}
 
 	/**
@@ -157,6 +157,27 @@ class LargeFileHelper {
 			return $result;
 		}
 		return null;
+	}
+
+	/**
+	* @brief Gets the filesize via a filesize() call and converts negative
+	*        signed int to positive float. As the result of filesize() will
+	*        wrap around after a filesize of 2^32 bytes = 4 GiB, this should
+	*        only be used as a last resort.
+	*
+	* @param string $filename Path to the file.
+	*
+	* @return int|float Number of bytes as number (float or int).
+	*/
+	public function getFilesizeNative($filename) {
+		$result = filesize($filename);
+		if ($result < 0) {
+			// For filesizes between 2 GiB and 4 GiB, filesize() will return a
+			// negative int, as the PHP data type int is signed. Interpret the
+			// returned int as an unsigned integer and put it into a float.
+			return (float) sprintf('%u', $result);
+		}
+		return $result;
 	}
 
 	protected function exec($cmd) {

--- a/tests/lib/largefilehelper.php
+++ b/tests/lib/largefilehelper.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright (c) 2014 Andreas Fischer <bantu@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test;
+
+/**
+* Tests whether LargeFileHelper is able to determine filesize at all.
+* Large files are not considered yet.
+*/
+class LargeFileHelper extends \PHPUnit_Framework_TestCase {
+	protected $filename;
+	protected $filesize;
+	protected $helper;
+
+	public function setUp() {
+		parent::setUp();
+		$this->filename = __DIR__ . '/../data/data.tar.gz';
+		$this->filesize = 4195;
+		$this->helper = new \OC\LargeFileHelper;
+	}
+
+	public function testGetFilesizeViaCurl() {
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped(
+				'The PHP curl extension is required for this test.'
+			);
+		}
+		$this->assertSame(
+			$this->filesize,
+			$this->helper->getFilesizeViaCurl($this->filename)
+		);
+	}
+
+	public function testGetFilesizeViaCOM() {
+		if (!extension_loaded('COM')) {
+			$this->markTestSkipped(
+				'The PHP Windows COM extension is required for this test.'
+			);
+		}
+		$this->assertSame(
+			$this->filesize,
+			$this->helper->getFilesizeViaDOM($this->filename)
+		);
+	}
+
+	public function testGetFilesizeViaExec() {
+		if (!\OC_Helper::is_function_enabled('exec')) {
+			$this->markTestSkipped(
+				'The exec() function needs to be enabled for this test.'
+			);
+		}
+		$this->assertSame(
+			$this->filesize,
+			$this->helper->getFilesizeViaExec($this->filename)
+		);
+	}
+}

--- a/tests/lib/largefilehelper.php
+++ b/tests/lib/largefilehelper.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (c) 2014 Andreas Fischer <bantu@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test;
+
+class LargeFileHelper extends \PHPUnit_Framework_TestCase {
+	protected $helper;
+
+	public function setUp() {
+		parent::setUp();
+		$this->helper = new \OC\LargeFileHelper;
+	}
+
+	public function testFormatUnsignedIntegerFloat() {
+		$this->assertSame(
+			'9007199254740992',
+			$this->helper->formatUnsignedInteger((float) 9007199254740992)
+		);
+	}
+
+	public function testFormatUnsignedIntegerInt() {
+		$this->assertSame(
+			PHP_INT_SIZE === 4 ? '4294967295' : '18446744073709551615',
+			$this->helper->formatUnsignedInteger(-1)
+		);
+	}
+
+	public function testFormatUnsignedIntegerString() {
+		$this->assertSame(
+			'9007199254740993',
+			$this->helper->formatUnsignedInteger('9007199254740993')
+		);
+	}
+
+	/**
+	* @expectedException \UnexpectedValueException
+	*/
+	public function testFormatUnsignedIntegerStringException() {
+		$this->helper->formatUnsignedInteger('900ABCD254740993');
+	}
+}

--- a/tests/lib/largefilehelpergetfilesize.php
+++ b/tests/lib/largefilehelpergetfilesize.php
@@ -59,4 +59,11 @@ class LargeFileHelperGetFilesize extends \PHPUnit_Framework_TestCase {
 			$this->helper->getFilesizeViaExec($this->filename)
 		);
 	}
+
+	public function testGetFilesizeNative() {
+		$this->assertSame(
+			$this->filesize,
+			$this->helper->getFilesizeNative($this->filename)
+		);
+	}
 }

--- a/tests/lib/largefilehelpergetfilesize.php
+++ b/tests/lib/largefilehelpergetfilesize.php
@@ -9,61 +9,61 @@
 namespace Test;
 
 /**
-* Tests whether LargeFileHelper is able to determine filesize at all.
+* Tests whether LargeFileHelper is able to determine file size at all.
 * Large files are not considered yet.
 */
-class LargeFileHelperGetFilesize extends \PHPUnit_Framework_TestCase {
+class LargeFileHelperGetFileSize extends \PHPUnit_Framework_TestCase {
 	protected $filename;
-	protected $filesize;
+	protected $fileSize;
 	protected $helper;
 
 	public function setUp() {
 		parent::setUp();
 		$this->filename = __DIR__ . '/../data/data.tar.gz';
-		$this->filesize = 4195;
+		$this->fileSize = 4195;
 		$this->helper = new \OC\LargeFileHelper;
 	}
 
-	public function testGetFilesizeViaCurl() {
+	public function testGetFileSizeViaCurl() {
 		if (!extension_loaded('curl')) {
 			$this->markTestSkipped(
 				'The PHP curl extension is required for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->filesize,
-			$this->helper->getFilesizeViaCurl($this->filename)
+			$this->fileSize,
+			$this->helper->getFileSizeViaCurl($this->filename)
 		);
 	}
 
-	public function testGetFilesizeViaCOM() {
+	public function testGetFileSizeViaCOM() {
 		if (!extension_loaded('COM')) {
 			$this->markTestSkipped(
 				'The PHP Windows COM extension is required for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->filesize,
-			$this->helper->getFilesizeViaDOM($this->filename)
+			$this->fileSize,
+			$this->helper->getFileSizeViaDOM($this->filename)
 		);
 	}
 
-	public function testGetFilesizeViaExec() {
+	public function testGetFileSizeViaExec() {
 		if (!\OC_Helper::is_function_enabled('exec')) {
 			$this->markTestSkipped(
 				'The exec() function needs to be enabled for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->filesize,
-			$this->helper->getFilesizeViaExec($this->filename)
+			$this->fileSize,
+			$this->helper->getFileSizeViaExec($this->filename)
 		);
 	}
 
-	public function testGetFilesizeNative() {
+	public function testGetFileSizeNative() {
 		$this->assertSame(
-			$this->filesize,
-			$this->helper->getFilesizeNative($this->filename)
+			$this->fileSize,
+			$this->helper->getFileSizeNative($this->filename)
 		);
 	}
 }

--- a/tests/lib/largefilehelpergetfilesize.php
+++ b/tests/lib/largefilehelpergetfilesize.php
@@ -44,7 +44,7 @@ class LargeFileHelperGetFileSize extends \PHPUnit_Framework_TestCase {
 		}
 		$this->assertSame(
 			$this->fileSize,
-			$this->helper->getFileSizeViaDOM($this->filename)
+			$this->helper->getFileSizeViaCOM($this->filename)
 		);
 	}
 

--- a/tests/lib/largefilehelpergetfilesize.php
+++ b/tests/lib/largefilehelpergetfilesize.php
@@ -12,7 +12,7 @@ namespace Test;
 * Tests whether LargeFileHelper is able to determine filesize at all.
 * Large files are not considered yet.
 */
-class LargeFileHelper extends \PHPUnit_Framework_TestCase {
+class LargeFileHelperGetFilesize extends \PHPUnit_Framework_TestCase {
 	protected $filename;
 	protected $filesize;
 	protected $helper;


### PR DESCRIPTION
Fixes #4979, #6516 and possibly others of
https://github.com/owncloud/core/issues?labels=php%3A32-bit-integer&state=open

Determination of file size on 32-bit systems (curl extension highly recommended).
Corrects the display of used and available storage in "Personal".
Corrects the reported filesize that is reported via WebDAV.
