### PR TITLE
Updates ownCloud title to Application - ownCloud

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -8,9 +8,10 @@
 
 	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
 		<title>
-			<?php p(!empty($_['application'])?$_['application'].' | ':'');
-			p($theme->getTitle());
-			p(trim($_['user_displayname']) != '' ?' ('.$_['user_displayname'].') ':'') ?>
+			<?php
+				p(!empty($_['application'])?$_['application'].' - ':'');
+				p($theme->getTitle());
+			?>
 		</title>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
A fix for https://github.com/owncloud/core/issues/5369
- [x] we show the username on the top right always, we should cut the username from the title as it is completely unnecessary there.
- [x] the | pipe bar is ugly and we should use a simple - dash instead.
- [ ] gotta check various apps that @PVince81 said that change things. (News App as an example changes it to ' | ' @Raydiation @zimba12 can you check? :) This is working for the Music app correctly so I am assuming it is coming from the News Repo)

@owncloud/designers @karlitschek 
