### PR TITLE
Fixed upload permissions distinction between public and logged in upload

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -7,6 +7,8 @@ OCP\JSON::setContentTypeHeader('text/plain');
 // If not, check the login.
 // If no token is sent along, rely on login only
 
+$allowedPermissions = OCP\PERMISSION_ALL;
+
 $l = OC_L10N::get('files');
 if (empty($_POST['dirToken'])) {
 	// The standard case, files are uploaded through logged in users :)
@@ -17,6 +19,9 @@ if (empty($_POST['dirToken'])) {
 		die();
 	}
 } else {
+	// return only read permissions for public upload
+	$allowedPermissions = OCP\PERMISSION_READ;
+
 	$linkItem = OCP\Share::getShareByToken($_POST['dirToken']);
 	if ($linkItem === false) {
 		OCP\JSON::error(array('data' => array_merge(array('message' => $l->t('Invalid Token')))));
@@ -130,7 +135,7 @@ if (strpos($dir, '..') === false) {
 							'originalname' => $files['tmp_name'][$i],
 							'uploadMaxFilesize' => $maxUploadFileSize,
 							'maxHumanFilesize' => $maxHumanFileSize,
-							'permissions' => $meta['permissions'] & OCP\PERMISSION_READ
+							'permissions' => $meta['permissions'] & $allowedPermissions
 						);
 					}
 
@@ -156,7 +161,7 @@ if (strpos($dir, '..') === false) {
 					'originalname' => $files['tmp_name'][$i],
 					'uploadMaxFilesize' => $maxUploadFileSize,
 					'maxHumanFilesize' => $maxHumanFileSize,
-					'permissions' => $meta['permissions'] & OCP\PERMISSION_READ
+					'permissions' => $meta['permissions'] & $allowedPermissions
 				);
 			}
 		}


### PR DESCRIPTION
Fixes #5370

It means that:
- when uploading a file while logged in, it will correctly show the file actions
- when uploading a file on a public link dir, it will only use read permissions, which shows only the Download link instead of all actions

Please review @karlitschek @DeepDiver1975 @schiesbn @kabum 
