### PR TITLE
Fixed sharing status update for new/uploaded files

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -539,7 +539,7 @@ $(document).ready(function() {
 								lazyLoadPreview(path, result.data.mime, function(previewpath){
 									tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
 								});
-								FileActions.display(tr.find('td.filename'));
+								FileActions.display(tr.find('td.filename'), true);
 							} else {
 								OC.dialogs.alert(result.data.message, t('core', 'Error'));
 							}

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -61,7 +61,13 @@ var FileActions = {
 		var actions = this.get(mime, type, permissions);
 		return actions[name];
 	},
-	display: function (parent) {
+	/**
+	 * Display file actions for the given element
+	 * @param parent "td" element of the file for which to display actions
+	 * @param triggerEvent if true, triggers the fileActionsReady on the file
+	 * list afterwards (false by default)
+	 */
+	display: function (parent, triggerEvent) {
 		FileActions.currentFile = parent;
 		var actions = FileActions.get(FileActions.getCurrentMimeType(), FileActions.getCurrentType(), FileActions.getCurrentPermissions());
 		var file = FileActions.getCurrentFile();
@@ -136,6 +142,10 @@ var FileActions = {
 			element.data('action', actions['Delete']);
 			element.on('click', {a: null, elem: parent, actionFunc: actions['Delete']}, actionHandler);
 			parent.parent().children().last().append(element);
+		}
+
+		if (triggerEvent){
+			$('#fileList').trigger(jQuery.Event("fileActionsReady"));
 		}
 	},
 	getCurrentFile: function () {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -151,7 +151,7 @@ var FileList={
 		if (hidden) {
 			tr.hide();
 		}
-		FileActions.display(tr.find('td.filename'));
+		FileActions.display(tr.find('td.filename'), true);
 		return tr;
 	},
 	/**
@@ -817,7 +817,7 @@ $(document).ready(function(){
 					data.context.attr('data-permissions', file.permissions);
 					data.context.data('permissions', file.permissions);
 				}
-				FileActions.display(data.context.find('td.filename'));
+				FileActions.display(data.context.find('td.filename'), true);
 
 				var path = getPathForPreview(file.name);
 				lazyLoadPreview(path, file.mime, function(previewpath){

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -1,11 +1,19 @@
 $(document).ready(function() {
 
-	var disableSharing = $('#disableSharing').data('status');
+	var disableSharing = $('#disableSharing').data('status'),
+		sharesLoaded = false;
 
 	if (typeof OC.Share !== 'undefined' && typeof FileActions !== 'undefined'  && !disableSharing) {
-
 		$('#fileList').on('fileActionsReady',function(){
-			OC.Share.loadIcons('file');
+			if (!sharesLoaded){
+				OC.Share.loadIcons('file');
+				// assume that we got all shares, so switching directories
+				// will not invalidate that list
+				sharesLoaded = true;
+			}
+			else{
+				OC.Share.updateIcons('file');
+			}
 		});
 
 		FileActions.register('all', 'Share', OC.PERMISSION_READ, OC.imagePath('core', 'actions/share'), function(filename) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -4,57 +4,75 @@ OC.Share={
 	SHARE_TYPE_LINK:3,
 	SHARE_TYPE_EMAIL:4,
 	itemShares:[],
-	statuses:[],
+	statuses:{},
 	droppedDown:false,
+	/**
+	 * Loads ALL share statuses from server, stores them in OC.Share.statuses then
+	 * calls OC.Share.updateIcons() to update the files "Share" icon to "Shared"
+	 * according to their share status and share type.
+	 */
 	loadIcons:function(itemType) {
 		// Load all share icons
 		$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getItemsSharedStatuses', itemType: itemType }, function(result) {
 			if (result && result.status === 'success') {
+				OC.Share.statuses = {};
 				$.each(result.data, function(item, data) {
 					OC.Share.statuses[item] = data;
-					var hasLink = data['link'];
-					// Links override shared in terms of icon display
-					if (hasLink) {
-						var image = OC.imagePath('core', 'actions/public');
-					} else {
-						var image = OC.imagePath('core', 'actions/shared');
-					}
-					if (itemType != 'file' && itemType != 'folder') {
-						$('a.share[data-item="'+item+'"]').css('background', 'url('+image+') no-repeat center');
-					} else {
-						var file = $('tr[data-id="'+item+'"]');
-						if (file.length > 0) {
-							var action = $(file).find('.fileactions .action[data-action="Share"]');
-							var img = action.find('img').attr('src', image);
-							action.addClass('permanent');
-							action.html(' '+t('core', 'Shared')).prepend(img);
-						} else {
-							var dir = $('#dir').val();
-							if (dir.length > 1) {
-								var last = '';
-								var path = dir;
-								// Search for possible parent folders that are shared
-								while (path != last) {
-									if (path == data['path']) {
-										var actions = $('.fileactions .action[data-action="Share"]');
-										$.each(actions, function(index, action) {
-											var img = $(action).find('img');
-											if (img.attr('src') != OC.imagePath('core', 'actions/public')) {
-												img.attr('src', image);
-												$(action).addClass('permanent');
-												$(action).html(' '+t('core', 'Shared')).prepend(img);
-											}
-										});
-									}
-									last = path;
-									path = OC.Share.dirname(path);
-								}
-							}
-						}
-					}
 				});
+				OC.Share.updateIcons(itemType);
 			}
 		});
+	},
+	/**
+	 * Updates the files' "Share" icons according to the known
+	 * sharing states stored in OC.Share.statuses.
+	 * (not reloaded from server)
+	 */
+	updateIcons:function(itemType){
+		for (item in OC.Share.statuses){
+			var data = OC.Share.statuses[item];
+
+			var hasLink = data['link'];
+			// Links override shared in terms of icon display
+			if (hasLink) {
+				var image = OC.imagePath('core', 'actions/public');
+			} else {
+				var image = OC.imagePath('core', 'actions/shared');
+			}
+			if (itemType != 'file' && itemType != 'folder') {
+				$('a.share[data-item="'+item+'"]').css('background', 'url('+image+') no-repeat center');
+			} else {
+				var file = $('tr[data-id="'+item+'"]');
+				if (file.length > 0) {
+					var action = $(file).find('.fileactions .action[data-action="Share"]');
+					var img = action.find('img').attr('src', image);
+					action.addClass('permanent');
+					action.html(' '+t('core', 'Shared')).prepend(img);
+				} else {
+					var dir = $('#dir').val();
+					if (dir.length > 1) {
+						var last = '';
+						var path = dir;
+						// Search for possible parent folders that are shared
+						while (path != last) {
+							if (path == data['path']) {
+								var actions = $('.fileactions .action[data-action="Share"]');
+								$.each(actions, function(index, action) {
+									var img = $(action).find('img');
+									if (img.attr('src') != OC.imagePath('core', 'actions/public')) {
+										img.attr('src', image);
+										$(action).addClass('permanent');
+										$(action).html(' '+t('core', 'Shared')).prepend(img);
+									}
+								});
+							}
+							last = path;
+							path = OC.Share.dirname(path);
+						}
+					}
+				}
+			}
+		}
 	},
 	updateIcon:function(itemType, itemSource) {
 		var shares = false;

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -29,6 +29,7 @@ OC.Share={
 	 * (not reloaded from server)
 	 */
 	updateIcons:function(itemType){
+		var item;
 		for (item in OC.Share.statuses){
 			var data = OC.Share.statuses[item];
 


### PR DESCRIPTION
Creating new files, folders or uploading files now have their sharing
icon updated accordingly.

For this, the global share status list that is cached in
OC.Share.statuses is reused for new files.

Performance should improve as the sharing list is now only loaded once
per navigation session.

In OC.Share, split loadIcons into loadIcons + updateIcons.

https://github.com/owncloud/core/pull/5378 needs to be merged first, else you won't see the share icons for uploaded files.

Please review @karlitschek @schiesbn @DeepDiver1975 @kabum 
Fixes #4977
