### PR TITLE
add reshare option for the OCS Share API

### DIFF
--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -132,7 +132,8 @@ class Api {
 		// if there are no shares than there are also no reshares
 		if (count($shares) > 0) {
 			$ids = array();
-			$path = reset($shares)['path'];
+			$firstShare = reset($shares);
+			$path = $firstShare['path'];
 			foreach ($shares as $share) {
 				$ids[] = $share['id'];
 			}

--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -36,10 +36,17 @@ class Api {
 			$params['itemSource'] = self::getFileId($_GET['path']);
 			$params['path'] = $_GET['path'];
 			$params['itemType'] = self::getItemType($_GET['path']);
-			if (isset($_GET['subfiles']) && $_GET['subfiles'] === 'true') {
+
+			if ( isset($_GET['reshares']) && $_GET['reshares'] !== 'false' ) {
+				$params['reshares'] = true;
+			} else {
+				$params['reshares'] = false;
+			}
+
+			if (isset($_GET['subfiles']) && $_GET['subfiles'] !== 'false') {
 				return self::getSharesFromFolder($params);
 			}
-			return self::getShare($params);
+			return self::collectShares($params);
 		}
 
 		$share = \OCP\Share::getItemShared('file', null);
@@ -59,34 +66,49 @@ class Api {
 	 * @return \OC_OCS_Result share information
 	 */
 	public static function getShare($params) {
-		// either the $params already contains a itemSource if we come from
-		//  getAllShare() or we need to translate the shareID to a itemSource
-		if(isset($params['itemSource'])) {
-			$itemSource = $params['itemSource'];
-			$itemType = $params['itemType'];
-			$getSpecificShare = true;
-		} else {
-			$s = self::getShareFromId($params['id']);
-			$itemSource = $s['item_source'];
-			$itemType = $s['item_type'];
-			$getSpecificShare = false;
-		}
+
+		$s = self::getShareFromId($params['id']);
+		$params['itemSource'] = $s['item_source'];
+		$params['itemType'] = $s['item_type'];
+		$params['specificShare'] = true;
+
+		return self::collectShares($params);
+	}
+
+	/**
+	 * @brief collect all share information, either of a specific share or all
+	 *        shares for a given path
+	 * @param array $params
+	 * @return \OC_OCS_Result
+	 */
+	private static function collectShares($params) {
+
+		$itemSource = $params['itemSource'];
+		$itemType = $params['itemType'];
+		$getSpecificShare = isset($params['specificShare']) ? $params['specificShare'] : false;
 
 		if ($itemSource !== null) {
 			$shares = \OCP\Share::getItemShared($itemType, $itemSource);
-			$reshare =  \OCP\Share::getItemSharedWithBySource($itemType, $itemSource);
+			$receivedFrom = \OCP\Share::getItemSharedWithBySource($itemType, $itemSource);
 			// if a specific share was specified only return this one
-			if ($getSpecificShare === false) {
+			if ($getSpecificShare === true) {
 				foreach ($shares as $share) {
-					if ($share['id'] === (int)$params['id']) {
+					if ($share['id'] === (int) $params['id']) {
 						$shares = array('element' => $share);
 						break;
 					}
 				}
 			}
-			if ($reshare) {
-				$shares['received_from'] = $reshare['uid_owner'];
-				$shares['received_from_displayname'] = \OCP\User::getDisplayName($reshare['uid_owner']);
+
+			// include also reshares in the lists. This means that the result
+			// will contain every user with access to the file.
+			if ($params['reshares'] === true) {
+				$shares = self::addReshares($shares, $itemSource);
+			}
+
+			if ($receivedFrom) {
+				$shares['received_from'] = $receivedFrom['uid_owner'];
+				$shares['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
 			}
 		} else {
 			$shares = null;
@@ -97,6 +119,45 @@ class Api {
 		} else {
 			return new \OC_OCS_Result($shares);
 		}
+	}
+
+	/**
+	 * @brief add reshares to a array of shares
+	 * @param array $shares array of shares
+	 * @param int $itemSource item source ID
+	 * @return array new shares array which includes reshares
+	 */
+	private static function addReshares($shares, $itemSource) {
+
+		// if there are no shares than there are also no reshares
+		if (count($shares) > 0) {
+			$ids = array();
+			$path = reset($shares)['path'];
+			foreach ($shares as $share) {
+				$ids[] = $share['id'];
+			}
+		} else {
+			return $shares;
+		}
+
+		$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `file_source`, `path` , `permissions`, `stime`, `expiration`, `token`, `storage`, `mail_send`, `mail_send`';
+		$getReshares = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` WHERE `*PREFIX*share`.`file_source` = ? AND `*PREFIX*share`.`item_type` IN (\'file\', \'folder\')');
+		$reshares = $getReshares->execute(array($itemSource))->fetchAll();
+
+		foreach ($reshares as $key => $reshare) {
+			// remove reshares we already have in the shares array.
+			if (in_array($reshare['id'], $ids)) {
+				unset($reshares[$key]);
+				continue;
+			}
+			if (isset($reshare['share_with']) && $reshare['share_with'] !== '') {
+				$reshares[$key]['share_with_displayname'] = \OCP\User::getDisplayName($reshare['share_with']);
+			}
+			// add correct path to the result
+			$reshares[$key]['path'] = $path;
+		}
+
+		return array_merge($shares, $reshares);
 	}
 
 	/**
@@ -119,10 +180,10 @@ class Api {
 			// workaround because folders are named 'dir' in this context
 			$itemType = $file['type'] === 'file' ? 'file' : 'folder';
 			$share = \OCP\Share::getItemShared($itemType, $file['fileid']);
-			$reshare =  \OCP\Share::getItemSharedWithBySource($itemType, $file['fileid']);
-			if ($reshare) {
-				$share['received_from'] = $reshare['uid_owner'];
-				$share['received_from_displayname'] = \OCP\User::getDisplayName($reshare['uid_owner']);
+			$receivedFrom =  \OCP\Share::getItemSharedWithBySource($itemType, $file['fileid']);
+			if ($receivedFrom) {
+				$share['received_from'] = $receivedFrom['uid_owner'];
+				$share['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
 			}
 			if ($share) {
 				$share['filename'] = $file['name'];

--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -102,7 +102,7 @@ class Api {
 
 			// include also reshares in the lists. This means that the result
 			// will contain every user with access to the file.
-			if ($params['reshares'] === true) {
+			if (isset($params['reshares']) && $params['reshares'] === true) {
 				$shares = self::addReshares($shares, $itemSource);
 			}
 

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -197,10 +197,9 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
 				null, 1);
 
-		$params = array('itemSource' => $fileInfo['fileid'],
-			'itemType' => 'file');
+		$params = array('path' => $this->filename);
 
-		$result = Share\Api::getShare($params);
+		$result = Share\Api::getAllShares($params);
 
 		$this->assertTrue($result->succeeded());
 

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -31,6 +31,7 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 
 	const TEST_FILES_SHARING_API_USER1 = "test-share-user1";
 	const TEST_FILES_SHARING_API_USER2 = "test-share-user2";
+	const TEST_FILES_SHARING_API_USER3 = "test-share-user3";
 
 	public $stateFilesEncryption;
 	public $filename;
@@ -54,6 +55,7 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 		// create users
 		self::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1, true);
 		self::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, true);
+		self::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3, true);
 
 	}
 
@@ -101,6 +103,7 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 		// cleanup users
 		\OC_User::deleteUser(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
 		\OC_User::deleteUser(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		\OC_User::deleteUser(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3);
 	}
 
 	/**
@@ -197,9 +200,9 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
 				null, 1);
 
-		$params = array('path' => $this->filename);
+		$_GET['path'] = $this->filename;
 
-		$result = Share\Api::getAllShares($params);
+		$result = Share\Api::getAllShares(array());
 
 		$this->assertTrue($result->succeeded());
 
@@ -210,6 +213,60 @@ class Test_Files_Sharing_Api extends \PHPUnit_Framework_TestCase {
 				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
 
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testGetShareFromSourceWithReshares() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		// share the file as user1 to user2
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// login as user2 and reshare the file to user3
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3, 31);
+
+		// login as user1 again
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		$_GET['path'] = $this->filename;
+
+		$result = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share
+		$this->assertTrue(count($result->getData()) === 1);
+
+		// now also ask for the reshares
+		$_GET['reshares'] = 'true';
+
+		$result = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result->succeeded());
+
+		// now we should get two shares, the initial share and the reshare
+		$this->assertTrue(count($result->getData()) === 2);
+
+		// unshare files again
+
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3);
+
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
 
 	}
 


### PR DESCRIPTION
Add a reshare option to the OCS Share API. Usage:

```
/ocs/v1.php/apps/files_sharing/api/v1/shares?path=file.txt&reshares
```

Will not only return the shares from the current user for `file.txt` but also possible reshares.

cc @karlitschek @PVince81 @DeepDiver1975 
