### PR TITLE
new console command to generate sql migration scripts

### DIFF
--- a/core/command/db/generatechangescript.php
+++ b/core/command/db/generatechangescript.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright (c) 2013 Bart Visscher <bartv@thisnet.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Command\Db;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateChangeScript extends Command {
+	protected function configure() {
+		$this
+			->setName('db:generate-change-script')
+			->setDescription('generates the change script from the current connected db to db_structure.xml')
+			->addArgument(
+				'schema-xml',
+				InputArgument::OPTIONAL,
+				'the schema xml to be used as target schema',
+				\OC::$SERVERROOT . '/db_structure.xml'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$file = $input->getArgument('schema-xml');
+
+		$schemaManager = new \OC\DB\MDB2SchemaManager(\OC_DB::getConnection());
+
+		try {
+			$result = $schemaManager->updateDbFromStructure($file, true);
+			$output->writeln($result);
+		} catch (\Exception $e) {
+			$output->writeln('Failed to update database structure ('.$e.')');
+		}
+
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -6,4 +6,6 @@
  * See the COPYING-README file.
  */
 
+/** @var $application Symfony\Component\Console\Application */
 $application->add(new OC\Core\Command\Status);
+$application->add(new OC\Core\Command\Db\GenerateChangeScript());


### PR DESCRIPTION
Reason:
we need to have the possibility to generate and deliver pure sql migration scripts.
This is the first step into this direction.

We need this merged into ownCloud6 as it will allow us to understand W(hy)TF something like #5384 happens

@bartv2 @butonic @bantu @karlitschek @blizzz THX
