### PR TITLE
Remaining space and upload error notifications fixes

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -87,6 +87,7 @@ $error = false;
 
 $maxUploadFileSize = $storageStats['uploadMaxFilesize'];
 $maxHumanFileSize = OCP\Util::humanFileSize($maxUploadFileSize);
+$usedSpacePercent = $storageStats['usedSpacePercent'];
 
 $totalSize = 0;
 foreach ($files['size'] as $size) {
@@ -95,7 +96,8 @@ foreach ($files['size'] as $size) {
 if ($maxUploadFileSize >= 0 and $totalSize > $maxUploadFileSize) {
 	OCP\JSON::error(array('data' => array('message' => $l->t('Not enough storage available'),
 		'uploadMaxFilesize' => $maxUploadFileSize,
-		'maxHumanFilesize' => $maxHumanFileSize)));
+		'maxHumanFilesize' => $maxHumanFileSize,
+		'usedSpacePercent' => $usedSpacePercent)));
 	exit();
 }
 
@@ -136,7 +138,8 @@ if (strpos($dir, '..') === false) {
 							'originalname' => $files['tmp_name'][$i],
 							'uploadMaxFilesize' => $maxUploadFileSize,
 							'maxHumanFilesize' => $maxHumanFileSize,
-							'permissions' => $meta['permissions'] & $allowedPermissions
+							'permissions' => $meta['permissions'] & $allowedPermissions,
+							'usedSpacePercent' => $usedSpacePercent
 						);
 					}
 
@@ -163,7 +166,8 @@ if (strpos($dir, '..') === false) {
 					'originalname' => $files['tmp_name'][$i],
 					'uploadMaxFilesize' => $maxUploadFileSize,
 					'maxHumanFilesize' => $maxHumanFileSize,
-					'permissions' => $meta['permissions'] & $allowedPermissions
+					'permissions' => $meta['permissions'] & $allowedPermissions,
+					'usedSpacePercent' => $usedSpacePercent
 				);
 			}
 		}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -302,17 +302,16 @@ $(document).ready(function() {
 			fail: function(e, data) {
 				OC.Upload.log('fail', e, data);
 				if (typeof data.textStatus !== 'undefined' && data.textStatus !== 'success' ) {
+					//Hack to clear previous notifications and avoid the queue
+					OC.Notification.hide();
 					if (data.textStatus === 'abort') {
-						$('#notification').text(t('files', 'Upload cancelled.'));
+						OC.Notification.show(t('files', 'Upload cancelled.'));
 					} else {
 						// HTTP connection problem
-						$('#notification').text(data.errorThrown);
+						OC.Notification.show(data.errorThrown);
 					}
-					$('#notification').fadeIn();
 					//hide notification after 5 sec
-					setTimeout(function() {
-						$('#notification').fadeOut();
-					}, 5000);
+					setTimeout(OC.Notification.hide, 5000);
 				}
 				OC.Upload.deleteUpload(data);
 			},
@@ -332,10 +331,8 @@ $(document).ready(function() {
 					response = data.result[0].body.innerText;
 				}
 				var result=$.parseJSON(response);
-
 				delete data.jqXHR;
-
-				if (result.status === 'error' && result.data && result.data.message){
+				if (result.status !== 'undefined' && result.status === 'error' && result.data && result.data.message) {
 					data.textStatus = 'servererror';
 					data.errorThrown = result.data.message;
 					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');
@@ -358,6 +355,7 @@ $(document).ready(function() {
 					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');
 					fu._trigger('fail', e, data);
 				}
+				Files.updateMaxUploadFilesize(result);
 			},
 			/**
 			 * called after last upload

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -542,9 +542,10 @@ var FileList={
 		var fileNames = JSON.stringify(files);
 		$.post(OC.filePath('files', 'ajax', 'delete.php'),
 				{dir:$('#dir').val(),files:fileNames},
-				function(result) {
-					if (result.status === 'success') {
-						$.each(files,function(index,file) {
+				function(result){
+					if (result.status == 'success') {
+						Files.updateMaxUploadFilesize(result);
+						$.each(files,function(index,file){
 							var files = $('tr[data-file="'+file+'"]');
 							files.remove();
 							files.find('input[type="checkbox"]').removeAttr('checked');


### PR DESCRIPTION
This fixes several issues with remaining space and notifications:
- Upload errors for single file uploads were not being shown properly
- Max upload size was only refreshed every 5 min, so if you opened the page with a 100% quota even after deleting files you needed to wait for 5 min before you could upload new one.
- Upload errors were not using OC.Notification
- Percentage used was not being returned on uploads so quota warnings could not be shown

OC.Notifications still needs a full revamp as it is almost useless as it is now.
