### PR TITLE
removing pointless calls on quoteIdentifier() - reason: name on $tableDi...

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -77,6 +77,11 @@ class MDB2SchemaManager {
 		$comparator = new \Doctrine\DBAL\Schema\Comparator();
 		$schemaDiff = $comparator->compare($fromSchema, $toSchema);
 
+		$platform = $this->conn->getDatabasePlatform();
+		foreach($schemaDiff->changedTables as $tableDiff) {
+			$tableDiff->name = $platform->quoteIdentifier($tableDiff->name);
+		}
+		
 		if ($generateSql) {
 			return $this->generateChangeScript($schemaDiff);
 		}

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -61,6 +61,7 @@ class MDB2SchemaManager {
 		$toSchema = $schemaReader->loadSchemaFromFile($file);
 
 		// remove tables we don't know about
+		/** @var $table \Doctrine\DBAL\Schema\Table */
 		foreach($fromSchema->getTables() as $table) {
 			if (!$toSchema->hasTable($table->getName())) {
 				$fromSchema->dropTable($table->getName());
@@ -75,12 +76,6 @@ class MDB2SchemaManager {
 
 		$comparator = new \Doctrine\DBAL\Schema\Comparator();
 		$schemaDiff = $comparator->compare($fromSchema, $toSchema);
-
-		$platform = $this->conn->getDatabasePlatform();
-		$tables = $schemaDiff->newTables + $schemaDiff->changedTables + $schemaDiff->removedTables;
-		foreach($tables as $tableDiff) {
-			$tableDiff->name = $platform->quoteIdentifier($tableDiff->name);
-		}
 
 		if ($generateSql) {
 			return $this->generateChangeScript($schemaDiff);
@@ -110,6 +105,7 @@ class MDB2SchemaManager {
 		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $this->conn->getDatabasePlatform());
 		$fromSchema = $schemaReader->loadSchemaFromFile($file);
 		$toSchema = clone $fromSchema;
+		/** @var $table \Doctrine\DBAL\Schema\Table */
 		foreach($toSchema->getTables() as $table) {
 			$toSchema->dropTable($table->getName());
 		}


### PR DESCRIPTION
...ff doesn't exist and my design the name cannot be changed:

```
PHP Notice:  Undefined property: Doctrine\DBAL\Schema\Table::$name in /home/deepdiver/Development/ownCloud/core/lib/private/db/mdb2schemamanager.php on line 82
PHP Stack trace:
PHP   1. {main}() /home/deepdiver/Development/ownCloud/core/occ:0
PHP   2. require_once() /home/deepdiver/Development/ownCloud/core/occ:11
PHP   3. Symfony\Component\Console\Application->run() /home/deepdiver/Development/ownCloud/core/console.php:34
PHP   4. Symfony\Component\Console\Application->doRun() /home/deepdiver/Development/ownCloud/core/3rdparty/symfony/console/Symfony/Component/Console/Application.php:121
PHP   5. Symfony\Component\Console\Application->doRunCommand() /home/deepdiver/Development/ownCloud/core/3rdparty/symfony/console/Symfony/Component/Console/Application.php:191
PHP   6. Symfony\Component\Console\Command\Command->run() /home/deepdiver/Development/ownCloud/core/3rdparty/symfony/console/Symfony/Component/Console/Application.php:897
PHP   7. OC\Core\Command\Db\GenerateChangeScript->execute() /home/deepdiver/Development/ownCloud/core/3rdparty/symfony/console/Symfony/Component/Console/Command/Command.php:244
PHP   8. OC\DB\MDB2SchemaManager->updateDbFromStructure() /home/deepdiver/Development/ownCloud/core/core/command/db/generatechangescript.php:38
```

adding PHPDoc
