### PR TITLE
add options to disable the check for a working .htaccess file in data

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -129,6 +129,12 @@ $CONFIG = array(
 /* Are we connected to the internet or are we running in a closed network? */
 "has_internet_connection" => true,
 
+/* Check if the ownCloud WebDAV server is working correctly. Can be disabled if not needed in special situations*/
+"check_for_working_webdav" => true,
+
+/* Check if .htaccess protection of data is working correctly. Can be disabled if not needed in special situations*/
+"check_for_working_htaccess" => true,
+
 /* Place to log to, can be owncloud and syslog (owncloud is log menu item in admin menu) */
 "log_type" => "owncloud",
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -754,6 +754,10 @@ class OC_Util {
 	 * file in the data directory and trying to access via http
 	 */
 	public static function isHtAccessWorking() {
+		if (!\OC_Config::getValue("check_for_working_htaccess", true)) {
+			return true;
+		}
+		
 		// testdata
 		$fileName = '/htaccesstest.txt';
 		$testContent = 'testcontent';
@@ -800,6 +804,9 @@ class OC_Util {
 	 */
 	public static function isWebDAVWorking() {
 		if (!function_exists('curl_init')) {
+			return true;
+		}
+		if (!\OC_Config::getValue("check_for_working_webdav", true)) {
 			return true;
 		}
 		$settings = array(


### PR DESCRIPTION
and for a working WebDAV server. This are advanced settings that are needed in special situations where our check fail and the user runs into an http timeout.

Please review @PVince81 @schiesbn @DeepDiver1975 
