### PR TITLE
Disable versions app JS in public mode

### DIFF
--- a/apps/files_versions/js/versions.js
+++ b/apps/files_versions/js/versions.js
@@ -1,5 +1,12 @@
 $(document).ready(function(){
 
+	if ($('#isPublic').val()){
+		// no versions actions in public mode
+		// beware of https://github.com/owncloud/core/issues/4545
+		// as enabling this might hang Chrome
+		return;
+	}
+
 	if (typeof FileActions !== 'undefined') {
 		// Add versions button to 'files/index.php'
 		FileActions.register(


### PR DESCRIPTION
Since the version JS code isn't used in public link mode, disable it to
prevent Chrome freezing bugs due to the t() call being synchronous.

Fixes #4545

Please review @karlitschek @schiesbn @DeepDiver1975 
