### PR TITLE
Use display name from magic cookie, fixes #4884

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -769,6 +769,7 @@ class OC {
 				OC_User::setMagicInCookie($_COOKIE['oc_username'], $token);
 				// login
 				OC_User::setUserId($_COOKIE['oc_username']);
+				OC_User::setDisplayName($_COOKIE['oc_username'], $_COOKIE['display_name']);
 				OC_Util::redirectToDefaultPage();
 				// doesn't return
 			}


### PR DESCRIPTION
Sets the display name after restoring a session from cookie. Fixes #4884.

One-liner! Please review @schiesbn @PVince81 @bartv2 @xtruthx or others
