### PR TITLE
File name in public sharing page now appears as link

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -4,25 +4,25 @@ body {
 
 #header {
 	background: #1d2d44 url('%webroot%/core/img/noise.png') repeat;
-	height:2.5em;
+	height: 32px;
 	left:0;
-	line-height:2.5em;
+	line-height: 32px;
 	position:fixed;
 	right:0;
 	top:0;
 	z-index:100;
-	padding:.5em;
+	padding: 7px;
 }
 
 #details {
 	color:#fff;
 	float: left;
-	vertical-align: top;
+	height: 32px;
+	line-height: 32px;
 }
-#details a{
+#details a {
 	color: white;
 	text-decoration: underline;
-	display: inline-block;
 	max-width: 200px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -34,13 +34,18 @@ body {
 	font-weight:700;
 	margin: 0 0.4em 0 0;
 	padding: 0 5px;
-	height: 27px;
+	height: 32px;
 	float: left;
 
 }
 
 .header-right #details {
-	margin-right: 2em;
+	margin-right: 28px;
+}
+
+.header-right {
+	padding: 0;
+	height: 32px;
 }
 
 #public_upload {
@@ -100,7 +105,7 @@ thead{
 #data-upload-form {
 	position: relative;
 	right: 0;
-	height: 27px;
+	height: 32px;
 	overflow: hidden;
 	padding: 0;
 	float: right;
@@ -119,26 +124,19 @@ thead{
 	width: 100% !important;
 }
 
-#download span {
-	position: relative;
-	bottom: 3px;
-}
-
 #publicUploadButtonMock {
 	position:relative;
 	display:block;
 	width:100%;
-	height:27px;
+	height: 32px;
 	cursor:pointer;
 	z-index:10;
 	background-image:url('%webroot%/core/img/actions/upload.svg');
 	background-repeat:no-repeat;
-	background-position:7px 6px;
+	background-position:7px 8px;
 }
 
 #publicUploadButtonMock span {
 	margin: 0 5px 0 28px;
-	position: relative;
-	top: -2px;
 	color: #555;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -17,6 +17,16 @@ body {
 #details {
 	color:#fff;
 	float: left;
+	vertical-align: top;
+}
+#details a{
+	color: white;
+	text-decoration: underline;
+	display: inline-block;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 #public_upload,

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -17,8 +17,15 @@
 				<span id="details"><?php p($l->t('%s shared the folder %s with you',
 						array($_['displayName'], $_['fileTarget']))) ?></span>
 			<?php else: ?>
-				<span id="details"><?php p($l->t('%s shared the file %s with you',
-						array($_['displayName'], $_['fileTarget']))) ?></span>
+				<span id="details"><?php print_unescaped($l->t('%s shared the file %s with you',
+					array(
+						$_['displayName'],
+						// sanitizeHTML messes up with original arguments (by reference), so need to make a copy first...
+						'<a href="' . OC_Util::sanitizeHTML($url = $_['downloadURL']). '">' .
+						OC_Util::sanitizeHTML($f = $_['fileTarget']) .
+						'</a>'
+					)
+				)) ?></span>
 			<?php endif; ?>
 
 


### PR DESCRIPTION
Fixes #1167 and should make it easier for users to find out that they
can copy the link for embedding.

Please review @kabum @karlitschek @schiesbn @jancborchardt 
