### PR TITLE
Fix ldap login

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -893,7 +893,9 @@ abstract class Access {
 		if(!$testConnection->setConfiguration($credentials)) {
 			return false;
 		}
-		return $testConnection->bind();
+		$result=$testConnection->bind();
+		$this->connection->bind();
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
I've tracked down a bug in OC5 which often prevented ldap users from logging in. I think it still exists in OC6. Often errors like "automatic logon rejected" were triggered.

The reason is, that the cloned OCA\user_ldap\lib::Connection object used for binding with the candidate user/password is still sharing the underlying ldap connection with the original object, because it is a php resource.

Now, for example, when the bind succeeds, the ldap connection was no longer bound with the configured user name of he owncloud instance, but with the user trying to log in. This connection was later reused by userExists() and other functions. However, this new bound user can not be expected to have the permissions to search in the ldap directory and in our case it didn't. The problem didn't appear in any log because of the error control operator in @ldap_read($cr, $dn, $filter, array($attr)) in user_ldap/lib/access.php and because of the exception handling of the callers.

The ldap cache made this issue looking more random, because either successful queries or failed queries could make it into the cache. It depended on the history and timing of login and logout attempts.

My quick fix is to rebind to the owncloud user after the password test.

I submit this to stable5, because that is the version I was testing with. Hope, thats the right way to do it. Seems to be the same code and bug in the master branch, though.
