### PR TITLE
Adds margin to the SSL root certificate button

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -7,7 +7,10 @@ input#openid, input#webdav { width:20em; }
 
 
 /* PERSONAL */
-#rootcert_import { margin:0 30px 0 0; }
+#rootcert_import {
+	margin: 0 0 10px 0;
+	display: block;
+}
 
 /* Sync clients */
 .clientsbox { margin:12px; }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -7,6 +7,7 @@ input#openid, input#webdav { width:20em; }
 
 
 /* PERSONAL */
+#rootcert_import { margin:0 30px 0 0; }
 
 /* Sync clients */
 .clientsbox { margin:12px; }


### PR DESCRIPTION
Adds Margin the SSL root Certificate Upload button to fix #3612. This is fixing the buttons for me on Chrome 31 and Firefox on Mac OSX
This should go in if not the new upload way @jancborchardt suggested in that issue.
@owncloud/designers @karlitschek 
