### PR TITLE
dispayNamesInGroup(s) should always return uid as key in the result array, fixes #5209

### DIFF
--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -268,7 +268,7 @@ class OC_Group {
 			$users = $group->searchDisplayName($search, $limit, $offset);
 			$displayNames = array();
 			foreach ($users as $user) {
-				$displayNames[] = $user->getDisplayName();
+				$displayNames[$user->getUID()] = $user->getDisplayName();
 			}
 			return $displayNames;
 		} else {

--- a/tests/lib/group.php
+++ b/tests/lib/group.php
@@ -109,6 +109,24 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), OC_Group::getGroups());
 	}
 
+	public function testDisplayNamesInGroup() {
+		OC_Group::useBackend(new OC_Group_Dummy());
+		$userBackend = new \OC_User_Dummy();
+		\OC_User::getManager()->registerBackend($userBackend);
+
+		$group1 = uniqid();
+		$user1 = 'uid1';
+		$user2 = 'uid2';
+		OC_Group::createGroup($group1);
+		$userBackend->createUser($user1, '');
+		$userBackend->createUser($user2, '');
+		OC_Group::addToGroup($user1, $group1);
+		OC_Group::addToGroup($user2, $group1);
+		//Dummy backend does not support setting displaynames, uid will always
+		//be returned. This checks primarily, that the return format is okay.
+		$expected = array($user1 => $user1, $user2 => $user2);
+		$this->assertEquals($expected, OC_Group::displayNamesInGroup($group1));
+	}
 
 	public function testUsersInGroup() {
 		OC_Group::useBackend(new OC_Group_Dummy());


### PR DESCRIPTION
Please review @schiesbn @icewind1991 @DeepDiver1975 or others
