### PR TITLE
Fixed share with link checkbox missing as regular user

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -138,6 +138,7 @@ if ($needUpgrade) {
 	$tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 	$tmpl->assign("encryptedFiles", \OCP\Util::encryptedFiles());
 	$tmpl->assign("mailNotificationEnabled", \OC_Appconfig::getValue('core', 'shareapi_allow_mail_notification', 'yes'));
+	$tmpl->assign("allowShareWithLink", \OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
 	$tmpl->assign("encryptionInitStatus", $encryptionInitStatus);
 	$tmpl->assign('disableSharing', false);
 	$tmpl->assign('ajaxLoad', $ajaxLoad);

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -114,3 +114,5 @@
 <input type="hidden" name="encryptedFiles" id="encryptedFiles" value="<?php $_['encryptedFiles'] ? p('1') : p('0'); ?>" />
 <input type="hidden" name="encryptedInitStatus" id="encryptionInitStatus" value="<?php p($_['encryptionInitStatus']) ?>" />
 <input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled" value="<?php p($_['mailNotificationEnabled']) ?>" />
+<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />
+

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -203,18 +203,7 @@ OC.Share={
 			html += '<input id="shareWith" type="text" placeholder="'+t('core', 'Share with')+'" />';
 			html += '<ul id="shareWithList">';
 			html += '</ul>';
-			var linksAllowed = false;
-			$.ajax({
-				type: 'GET',
-				url: OC.filePath('core', 'ajax', 'appconfig.php'),
-				data: { action:'getValue', app:'core', key:'shareapi_allow_links', defaultValue:'yes' },
-				async: false,
-				success: function(result) {
-					if (result && result.status === 'success' && result.data === 'yes') {
-						linksAllowed = true;
-					}
-				}
-			});
+			var linksAllowed = $('#allowShareWithLink').val() === 'yes';
 			if (link && linksAllowed) {
 				html += '<div id="link">';
 				html += '<input type="checkbox" name="linkCheckbox" id="linkCheckbox" value="1" /><label for="linkCheckbox">'+t('core', 'Share with link')+'</label>';


### PR DESCRIPTION
Instead of loading the app config setting "shareapi_allow_links" using a
synchronous ajax call that fails when the user is not an admin, this fix
puts the flag directly in the template so it doesn't need to be loaded
afterwards.

Fixes #5428 

Please review @karlitschek @schiesbn @kabum @DeepDiver1975 
