### PR TITLE
Remove Autoloader Cache Hack. Do not use Cache on Install.

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -150,7 +150,7 @@ class Autoloader {
 	 * @brief Sets the optional low-latency cache for class to path mapping.
 	 * @param \OC\Memcache\Cache $memoryCache Instance of memory cache.
 	 */
-	public function setMemoryCache(\OC\Memcache\Cache $memoryCache) {
+	public function setMemoryCache(\OC\Memcache\Cache $memoryCache = null) {
 		$this->memoryCache = $memoryCache;
 	}
 }

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -16,6 +16,12 @@ class Autoloader {
 	private $classPaths = array();
 
 	/**
+	 * Optional low-latency memory cache for class to path mapping.
+	 * @var \OC\Memcache\Cache
+	 */
+	protected $memoryCache;
+
+	/**
 	 * Add a custom prefix to the autoloader
 	 *
 	 * @param string $prefix
@@ -112,44 +118,39 @@ class Autoloader {
 	 * @param string $class
 	 * @return bool
 	 */
-	protected $memoryCache = null;
-	protected $constructingMemoryCache = true; // hack to prevent recursion
 	public function load($class) {
-		// Does this PHP have an in-memory cache? We cache the paths there
-		if ($this->constructingMemoryCache && !$this->memoryCache) {
-			$this->constructingMemoryCache = false;
-			try {
-				$this->memoryCache = \OC\Memcache\Factory::createLowLatency('Autoloader');
-			} catch(\Exception $ex) {
-				// no caching then - fine with me
-			}
-		}
+		$pathsToRequire = null;
 		if ($this->memoryCache) {
 			$pathsToRequire = $this->memoryCache->get($class);
-			if (is_array($pathsToRequire)) {
-				foreach ($pathsToRequire as $path) {
-					require_once $path;
-				}
-				return false;
-			}
 		}
 
-		// Use the normal class loading path
-		$paths = $this->findClass($class);
-		if (is_array($paths)) {
+		if (!is_array($pathsToRequire)) {
+			// No cache or cache miss
 			$pathsToRequire = array();
-			foreach ($paths as $path) {
-				if ($fullPath = stream_resolve_include_path($path)) {
-					require_once $fullPath;
+			foreach ($this->findClass($class) as $path) {
+				$fullPath = stream_resolve_include_path($path);
+				if ($fullPath) {
 					$pathsToRequire[] = $fullPath;
 				}
 			}
-
-			// Save in our memory cache
-			if ($this->memoryCache) {
-				$this->memoryCache->set($class, $pathsToRequire, 60); // cache 60 sec
-			}
 		}
+
+		if ($this->memoryCache) {
+			$this->memoryCache->set($class, $pathsToRequire, 60); // cache 60 sec
+		}
+
+		foreach ($pathsToRequire as $fullPath) {
+			require_once $fullPath;
+		}
+
 		return false;
+	}
+
+	/**
+	 * @brief Sets the optional low-latency cache for class to path mapping.
+	 * @param \OC\Memcache\Cache $memoryCache Instance of memory cache.
+	 */
+	public function setMemoryCache(\OC\Memcache\Cache $memoryCache) {
+		$this->memoryCache = $memoryCache;
 	}
 }

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -133,10 +133,10 @@ class Autoloader {
 					$pathsToRequire[] = $fullPath;
 				}
 			}
-		}
 
-		if ($this->memoryCache) {
-			$this->memoryCache->set($class, $pathsToRequire, 60); // cache 60 sec
+			if ($this->memoryCache) {
+				$this->memoryCache->set($class, $pathsToRequire, 60); // cache 60 sec
+			}
 		}
 
 		foreach ($pathsToRequire as $fullPath) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -371,6 +371,11 @@ class OC {
 		// register autoloader
 		require_once __DIR__ . '/autoloader.php';
 		self::$loader = new \OC\Autoloader();
+		spl_autoload_register(array(self::$loader, 'load'));
+		try {
+			self::$loader->setMemoryCache(\OC\Memcache\Factory::createLowLatency('Autoloader'));
+		} catch(\Exception $ex) {
+		}
 		self::$loader->registerPrefix('Doctrine\\Common', 'doctrine/common/lib');
 		self::$loader->registerPrefix('Doctrine\\DBAL', 'doctrine/dbal/lib');
 		self::$loader->registerPrefix('Symfony\\Component\\Routing', 'symfony/routing');
@@ -378,7 +383,6 @@ class OC {
 		self::$loader->registerPrefix('Sabre\\VObject', '3rdparty');
 		self::$loader->registerPrefix('Sabre_', '3rdparty');
 		self::$loader->registerPrefix('Patchwork', '3rdparty');
-		spl_autoload_register(array(self::$loader, 'load'));
 
 		// set some stuff
 		//ob_start();

--- a/lib/base.php
+++ b/lib/base.php
@@ -371,11 +371,6 @@ class OC {
 		// register autoloader
 		require_once __DIR__ . '/autoloader.php';
 		self::$loader = new \OC\Autoloader();
-		spl_autoload_register(array(self::$loader, 'load'));
-		try {
-			self::$loader->setMemoryCache(\OC\Memcache\Factory::createLowLatency('Autoloader'));
-		} catch(\Exception $ex) {
-		}
 		self::$loader->registerPrefix('Doctrine\\Common', 'doctrine/common/lib');
 		self::$loader->registerPrefix('Doctrine\\DBAL', 'doctrine/dbal/lib');
 		self::$loader->registerPrefix('Symfony\\Component\\Routing', 'symfony/routing');
@@ -383,6 +378,7 @@ class OC {
 		self::$loader->registerPrefix('Sabre\\VObject', '3rdparty');
 		self::$loader->registerPrefix('Sabre_', '3rdparty');
 		self::$loader->registerPrefix('Patchwork', '3rdparty');
+		spl_autoload_register(array(self::$loader, 'load'));
 
 		// set some stuff
 		//ob_start();
@@ -438,6 +434,14 @@ class OC {
 		}
 
 		self::initPaths();
+		if (OC_Config::getValue('instanceid', false)) {
+			// \OC\Memcache\Cache has a hidden dependency on
+			// OC_Util::getInstanceId() for namespacing. See #5409.
+			try {
+				self::$loader->setMemoryCache(\OC\Memcache\Factory::createLowLatency('Autoloader'));
+			} catch(\Exception $ex) {
+			}
+		}
 		OC_Util::isSetLocaleWorking();
 
 		// set debug mode if an xdebug session is active


### PR DESCRIPTION
Fixes #5409

The majority of lookups will stil be cached with this patch.

@DeepDiver1975 
