### PR TITLE
Fix display name for user after sharing

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -305,8 +305,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 							&& $uid != OC_User::getUser()) {
 							$shareWith[] = array(
 								'label' => $displayName,
-								'value' => array('shareType' => OCP\Share::SHARE_TYPE_USER,
-								'shareWith' => $uid)
+								'value' => array(
+									'shareType' => OCP\Share::SHARE_TYPE_USER,
+									'shareWith' => $uid)
 							);
 							$count++;
 						}
@@ -324,7 +325,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
 							|| !in_array($group, $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
 							$shareWith[] = array(
-								'label' => $group.' ('.$l->t('group').')',
+								'label' => $group,
 								'value' => array(
 									'shareType' => OCP\Share::SHARE_TYPE_GROUP,
 									'shareWith' => $group

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -293,7 +293,7 @@ OC.Share={
 				// Default permissions are Edit (CRUD) and Share
 				var permissions = OC.PERMISSION_ALL;
 				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, function() {
-					OC.Share.addShareWith(shareType, shareWith, selected.item.value.shareWith, permissions, possiblePermissions);
+					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, possiblePermissions);
 					$('#shareWith').val('');
 					OC.Share.updateIcon(itemType, itemSource);
 				});
@@ -302,12 +302,14 @@ OC.Share={
 			})
 			// customize internal _renderItem function to display groups and users differently
 			.data("ui-autocomplete")._renderItem = function( ul, item ) {
-				var insert = $( "<a>" ).text( item.label );
-				if(item.label.length > 8 && item.label.substr(item.label.length-8) === ' (group)') {
-					// current label is group - wrap "strong" element
-					insert = insert.wrapInner('<strong>');
+				var insert = $( "<a>" );
+				var text = (item.value.shareType == 1)? item.label + ' ('+t('core', 'group')+')' : item.label;
+				insert.text( text );
+				if(item.value.shareType == 1) {
+					insert = insert.wrapInner('<strong></strong>');
 				}
 				return $( "<li>" )
+					.addClass((item.value.shareType == 1)?'group':'user')
 					.append( insert )
 					.appendTo( ul );
 			};


### PR DESCRIPTION
Fixed group bolding: 
- Now works in every language
- Groups are always bolded (it is not a great for UX if you have groups bolded and not bolded in the same list)

Added classes to autocomplete 'li' so they can be further styled (and then maybe remove the bolding to a better style with css).

Fixes #5427
