### PR TITLE
No data corruption duriing parallel upload

### DIFF
--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -156,6 +156,22 @@ class Helper {
 		return $return;
 	}
 
+	/**
+	 * @brief Check if a path is a .part file
+	 * @param string $path Path that may identify a .part file
+	 * @return bool
+	 */
+	public static function isPartialFilePath($path) {
+
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+		if ( $extension === 'part' || $extension === 'etmp') {
+			return true;
+		} else {
+			return false;
+		}
+
+	}
+
 
 	/**
 	 * @brief Remove .path extension from a file path

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -158,6 +158,33 @@ class Helper {
 
 
 	/**
+	 * @brief Remove .path extension from a file path
+	 * @param string $path Path that may identify a .part file
+	 * @return string File path without .part extension
+	 * @note this is needed for reusing keys
+	 */
+	public static function fixPartialFilePath($path) {
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+
+		if ( $extension === 'part' || $extension === 'etmp') {
+
+			$newLength = strlen($path) - 5; // 5 = strlen(".part") = strlen(".etmp")
+			$fPath = substr($path, 0, $newLength);
+
+			// if path also contains a transaction id, we remove it too
+			$extension = pathinfo($fPath, PATHINFO_EXTENSION);
+			if(substr($extension, 0, 12) === 'ocTransferId') { // 12 = strlen("ocTransferId")
+				$newLength = strlen($fPath) - strlen($extension) -1;
+				$fPath = substr($fPath, 0, $newLength);
+			}
+			return $fPath;
+
+		} else {
+			return $path;
+		}
+	}
+
+	/**
 	 * @brief disable recovery
 	 *
 	 * @param $recoveryPassword

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -179,7 +179,7 @@ class Helper {
 	 * @return string File path without .part extension
 	 * @note this is needed for reusing keys
 	 */
-	public static function fixPartialFilePath($path) {
+	public static function stripPartialFileExtension($path) {
 		$extension = pathinfo($path, PATHINFO_EXTENSION);
 
 		if ( $extension === 'part' || $extension === 'etmp') {

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -155,7 +155,7 @@ class Keymanager {
 		if (self::isPartialFilePath($targetPath)) {
 
 			$result = $view->file_put_contents(
-				$basePath . '/' . self::fixPartialFilePath($targetPath) . '.key', $catfile);
+				$basePath . '/' . \OCA\Encryption\Helper::fixPartialFilePath($targetPath) . '.key', $catfile);
 
 		} else {
 
@@ -170,43 +170,17 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Remove .path extension from a file path
-	 * @param string $path Path that may identify a .part file
-	 * @return string File path without .part extension
-	 * @note this is needed for reusing keys
-	 */
-	public static function fixPartialFilePath($path) {
-
-		if (preg_match('/\.part$/', $path) || preg_match('/\.etmp$/', $path)) {
-
-			$newLength = strlen($path) - 5;
-			$fPath = substr($path, 0, $newLength);
-
-			return $fPath;
-
-		} else {
-
-			return $path;
-
-		}
-
-	}
-
-	/**
 	 * @brief Check if a path is a .part file
 	 * @param string $path Path that may identify a .part file
 	 * @return bool
 	 */
 	public static function isPartialFilePath($path) {
 
-		if (preg_match('/\.part$/', $path) || preg_match('/\.etmp$/', $path)) {
-
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+		if ( $extension === 'part' || $extension === 'etmp') {
 			return true;
-
 		} else {
-
 			return false;
-
 		}
 
 	}
@@ -226,7 +200,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = self::fixPartialFilePath($filename);
+		$filename = \OCA\Encryption\Helper::fixPartialFilePath($filename);
 		$filePath_f = ltrim($filename, '/');
 
 		// in case of system wide mount points the keys are stored directly in the data directory
@@ -386,7 +360,7 @@ class Keymanager {
 
 			// try reusing key file if part file
 			if (self::isPartialFilePath($shareKeyPath)) {
-				$writePath = $basePath . '/' . self::fixPartialFilePath($shareKeyPath) . '.' . $userId . '.shareKey';
+				$writePath = $basePath . '/' . \OCA\Encryption\Helper::fixPartialFilePath($shareKeyPath) . '.' . $userId . '.shareKey';
 			} else {
 				$writePath = $basePath . '/' . $shareKeyPath . '.' . $userId . '.shareKey';
 			}
@@ -422,7 +396,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = self::fixPartialFilePath($filename);
+		$filename = \OCA\Encryption\Helper::fixPartialFilePath($filename);
 		// in case of system wide mount points the keys are stored directly in the data directory
 		if ($util->isSystemWideMountPoint($filename)) {
 			$shareKeyPath = '/files_encryption/share-keys/' . $filename . '.' . $userId . '.shareKey';

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -155,7 +155,7 @@ class Keymanager {
 		if (Helper::isPartialFilePath($targetPath)) {
 
 			$result = $view->file_put_contents(
-				$basePath . '/' . Helper::fixPartialFilePath($targetPath) . '.key', $catfile);
+				$basePath . '/' . Helper::stripPartialFileExtension($targetPath) . '.key', $catfile);
 
 		} else {
 
@@ -184,7 +184,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = Helper::fixPartialFilePath($filename);
+		$filename = Helper::stripPartialFileExtension($filename);
 		$filePath_f = ltrim($filename, '/');
 
 		// in case of system wide mount points the keys are stored directly in the data directory
@@ -344,7 +344,7 @@ class Keymanager {
 
 			// try reusing key file if part file
 			if (Helper::isPartialFilePath($shareKeyPath)) {
-				$writePath = $basePath . '/' . Helper::fixPartialFilePath($shareKeyPath) . '.' . $userId . '.shareKey';
+				$writePath = $basePath . '/' . Helper::stripPartialFileExtension($shareKeyPath) . '.' . $userId . '.shareKey';
 			} else {
 				$writePath = $basePath . '/' . $shareKeyPath . '.' . $userId . '.shareKey';
 			}
@@ -380,7 +380,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = Helper::fixPartialFilePath($filename);
+		$filename = Helper::stripPartialFileExtension($filename);
 		// in case of system wide mount points the keys are stored directly in the data directory
 		if ($util->isSystemWideMountPoint($filename)) {
 			$shareKeyPath = '/files_encryption/share-keys/' . $filename . '.' . $userId . '.shareKey';

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -152,10 +152,10 @@ class Keymanager {
 		}
 
 		// try reusing key file if part file
-		if (self::isPartialFilePath($targetPath)) {
+		if (Helper::isPartialFilePath($targetPath)) {
 
 			$result = $view->file_put_contents(
-				$basePath . '/' . \OCA\Encryption\Helper::fixPartialFilePath($targetPath) . '.key', $catfile);
+				$basePath . '/' . Helper::fixPartialFilePath($targetPath) . '.key', $catfile);
 
 		} else {
 
@@ -166,22 +166,6 @@ class Keymanager {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		return $result;
-
-	}
-
-	/**
-	 * @brief Check if a path is a .part file
-	 * @param string $path Path that may identify a .part file
-	 * @return bool
-	 */
-	public static function isPartialFilePath($path) {
-
-		$extension = pathinfo($path, PATHINFO_EXTENSION);
-		if ( $extension === 'part' || $extension === 'etmp') {
-			return true;
-		} else {
-			return false;
-		}
 
 	}
 
@@ -200,7 +184,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = \OCA\Encryption\Helper::fixPartialFilePath($filename);
+		$filename = Helper::fixPartialFilePath($filename);
 		$filePath_f = ltrim($filename, '/');
 
 		// in case of system wide mount points the keys are stored directly in the data directory
@@ -359,8 +343,8 @@ class Keymanager {
 		foreach ($shareKeys as $userId => $shareKey) {
 
 			// try reusing key file if part file
-			if (self::isPartialFilePath($shareKeyPath)) {
-				$writePath = $basePath . '/' . \OCA\Encryption\Helper::fixPartialFilePath($shareKeyPath) . '.' . $userId . '.shareKey';
+			if (Helper::isPartialFilePath($shareKeyPath)) {
+				$writePath = $basePath . '/' . Helper::fixPartialFilePath($shareKeyPath) . '.' . $userId . '.shareKey';
 			} else {
 				$writePath = $basePath . '/' . $shareKeyPath . '.' . $userId . '.shareKey';
 			}
@@ -396,7 +380,7 @@ class Keymanager {
 		$util = new Util($view, \OCP\User::getUser());
 
 		list($owner, $filename) = $util->getUidAndFilename($filePath);
-		$filename = \OCA\Encryption\Helper::fixPartialFilePath($filename);
+		$filename = Helper::fixPartialFilePath($filename);
 		// in case of system wide mount points the keys are stored directly in the data directory
 		if ($util->isSystemWideMountPoint($filename)) {
 			$shareKeyPath = '/files_encryption/share-keys/' . $filename . '.' . $userId . '.shareKey';

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -342,7 +342,7 @@ class Proxy extends \OC_FileProxy {
 
 		$fileInfo = false;
 		// get file info from database/cache if not .part file
-		if (!Keymanager::isPartialFilePath($path)) {
+		if (!Helper::isPartialFilePath($path)) {
 			$fileInfo = $view->getFileInfo($path);
 		}
 
@@ -353,7 +353,7 @@ class Proxy extends \OC_FileProxy {
 				$fixSize = $util->getFileSize($path);
 				$fileInfo['unencrypted_size'] = $fixSize;
 				// put file info if not .part file
-				if (!Keymanager::isPartialFilePath($relativePath)) {
+				if (!Helper::isPartialFilePath($relativePath)) {
 					$view->putFileInfo($path, $fileInfo);
 				}
 			}
@@ -372,7 +372,7 @@ class Proxy extends \OC_FileProxy {
 				$fileInfo['unencrypted_size'] = $size;
 
 				// put file info if not .part file
-				if (!Keymanager::isPartialFilePath($relativePath)) {
+				if (!Helper::isPartialFilePath($relativePath)) {
 					$view->putFileInfo($path, $fileInfo);
 				}
 			}

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1138,10 +1138,7 @@ class Util {
 		// Make sure that a share key is generated for the owner too
 		list($owner, $ownerPath) = $this->getUidAndFilename($filePath);
 
-		$pathinfo = pathinfo($ownerPath);
-		if(array_key_exists('extension', $pathinfo) && $pathinfo['extension'] === 'part') {
-			$ownerPath = $pathinfo['dirname'] . '/' . $pathinfo['filename'];
-		}
+		$ownerPath = \OCA\Encryption\Helper::fixPartialFilePath($ownerPath);
 
 		$userIds = array();
 		if ($sharingEnabled) {

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1138,7 +1138,7 @@ class Util {
 		// Make sure that a share key is generated for the owner too
 		list($owner, $ownerPath) = $this->getUidAndFilename($filePath);
 
-		$ownerPath = \OCA\Encryption\Helper::fixPartialFilePath($ownerPath);
+		$ownerPath = \OCA\Encryption\Helper::stripPartialFileExtension($ownerPath);
 
 		$userIds = array();
 		if ($sharingEnabled) {

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -19,36 +19,36 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testFixPartialFilePath() {
+	function testStripPartialFileExtension() {
 
 		$partFilename = 'testfile.txt.part';
 		$filename = 'testfile.txt';
 
 		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($partFilename));
+		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
 
 		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($filename));
+		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
 	}
 
 
 	/**
 	 * @medium
 	 */
-	function testFixPartialFileWithTransferIdPath() {
+	function testStripPartialFileExtensionWithTransferIdPath() {
 
 		$partFilename = 'testfile.txt.ocTransferId643653835.part';
 		$filename = 'testfile.txt';
 
 		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($partFilename));
+		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
 
 		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($filename));
+		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
 	}
 
 }

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) 2012 Sam Tuke <samtuke@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../lib/crypt.php';
+require_once __DIR__ . '/../lib/keymanager.php';
+require_once __DIR__ . '/../lib/proxy.php';
+require_once __DIR__ . '/../lib/stream.php';
+require_once __DIR__ . '/../lib/util.php';
+require_once __DIR__ . '/../lib/helper.php';
+require_once __DIR__ . '/../appinfo/app.php';
+require_once __DIR__ . '/util.php';
+
+use OCA\Encryption;
+
+/**
+ * Class Test_Encryption_Keymanager
+ */
+class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @medium
+	 */
+	function testFixPartialFilePath() {
+
+		$partFilename = 'testfile.txt.part';
+		$filename = 'testfile.txt';
+
+		$this->assertTrue(Encryption\Keymanager::isPartialFilePath($partFilename));
+
+		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($partFilename));
+
+		$this->assertFalse(Encryption\Keymanager::isPartialFilePath($filename));
+
+		$this->assertEquals('testfile.txt', Encryption\Keymanager::fixPartialFilePath($filename));
+	}
+
+
+	/**
+	 * @medium
+	 */
+	function testFixPartialFileWithTransferIdPath() {
+
+		$partFilename = 'testfile.txt.ocTransferId643653835.part';
+		$filename = 'testfile.txt';
+
+		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
+
+		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($partFilename));
+
+		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
+
+		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($filename));
+	}
+
+}

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -1,25 +1,18 @@
 <?php
 /**
- * Copyright (c) 2012 Sam Tuke <samtuke@owncloud.com>
+ * Copyright (c) 2013 Bjoern Schiessle <schiessle@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
+
 require_once __DIR__ . '/../lib/helper.php';
-require_once __DIR__ . '/../appinfo/app.php';
-require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;
 
 /**
- * Class Test_Encryption_Keymanager
+ * Class Test_Encryption_Helper
  */
 class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 
@@ -31,13 +24,13 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 		$partFilename = 'testfile.txt.part';
 		$filename = 'testfile.txt';
 
-		$this->assertTrue(Encryption\Keymanager::isPartialFilePath($partFilename));
+		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
 
 		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($partFilename));
 
-		$this->assertFalse(Encryption\Keymanager::isPartialFilePath($filename));
+		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
 
-		$this->assertEquals('testfile.txt', Encryption\Keymanager::fixPartialFilePath($filename));
+		$this->assertEquals('testfile.txt', Encryption\Helper::fixPartialFilePath($filename));
 	}
 
 

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -191,23 +191,6 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testFixPartialFilePath() {
-
-		$partFilename = 'testfile.txt.part';
-		$filename = 'testfile.txt';
-
-		$this->assertTrue(Encryption\Keymanager::isPartialFilePath($partFilename));
-
-		$this->assertEquals('testfile.txt', Encryption\Keymanager::fixPartialFilePath($partFilename));
-
-		$this->assertFalse(Encryption\Keymanager::isPartialFilePath($filename));
-
-		$this->assertEquals('testfile.txt', Encryption\Keymanager::fixPartialFilePath($filename));
-	}
-
-	/**
-	 * @medium
-	 */
 	function testRecursiveDelShareKeys() {
 
 		// generate filename

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -225,7 +225,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		if ($chunk_handler->isComplete()) {
 
 			// we first assembly the target file as a part file
-			$partFile = $path . '/' . $info['name'] . '-' . $info['transferid'] . '.part';
+			$partFile = $path . '/' . $info['name'] . '.ocTransferId' . $info['transferid'] . '.part';
 			$chunk_handler->file_assemble($partFile);
 
 			// here is the final atomic rename

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -223,9 +223,22 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		}
 
 		if ($chunk_handler->isComplete()) {
-			$newPath = $path . '/' . $info['name'];
-			$chunk_handler->file_assemble($newPath);
-			return OC_Connector_Sabre_Node::getETagPropertyForPath($newPath);
+
+			// we first assembly the target file as a part file
+			$partFile = $path . '/' . $info['name'] . '-' . $info['transferid'] . '.part';
+			$chunk_handler->file_assemble($partFile);
+
+			// here is the final atomic rename
+			$fs = $this->getFS();
+			$targetPath = $path . '/' . $info['name'];
+			$renameOkay = $fs->rename($partFile, $targetPath);
+			$fileExists = $fs->file_exists($targetPath);
+			if ($renameOkay === false || $fileExists === false) {
+				\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
+				$fs->unlink($targetPath);
+				throw new Sabre_DAV_Exception();
+			}
+			return OC_Connector_Sabre_Node::getETagPropertyForPath($targetPath);
 		}
 
 		return null;

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -238,6 +238,15 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 				$fs->unlink($targetPath);
 				throw new Sabre_DAV_Exception();
 			}
+
+			// allow sync clients to send the mtime along in a header
+			$mtime = OC_Request::hasModificationTime();
+			if ($mtime !== false) {
+				if($fs->touch($this->path, $mtime)) {
+					header('X-OC-MTime: accepted');
+				}
+			}
+
 			return OC_Connector_Sabre_Node::getETagPropertyForPath($targetPath);
 		}
 


### PR DESCRIPTION
Fixes #5117

As described in #5117 a parallel upload of the same file can cause data corruption.
The root cause is that the re-assembly of the file chunks can result in parallel write to the same target file.

This patch introduces part files for the reassembly and uses rename to move the file to the final destination.

Additional Feature:
mtime handling on chunked upload
