### PR TITLE
OCS API to get current user information

### DIFF
--- a/lib/private/ocs/cloud.php
+++ b/lib/private/ocs/cloud.php
@@ -64,8 +64,7 @@ class OC_OCS_Cloud {
 		// Check if they are viewing information on themselves
 		if($parameters['userid'] === OC_User::getUser()) {
 			// Self lookup
-			$quota = array();
-			$storage = OC_Helper::getStorageInfo();
+			$storage = OC_Helper::getStorageInfo('/');
 			$quota = array(
 				'free' =>  $storage['free'],
 				'used' =>  $storage['used'],
@@ -77,6 +76,16 @@ class OC_OCS_Cloud {
 			// No permission to view this user data
 			return new OC_OCS_Result(null, 997);
 		}
+	}
+
+	public static function getCurrentUser() {
+		$email=OC_Preferences::getValue(OC_User::getUser(), 'settings', 'email', '');
+		$data  = array(
+			'id' => OC_User::getUser(),
+			'display-name' => OC_User::getDisplayName(),
+			'email' => $email,
+		);
+		return new OC_OCS_Result($data);
 	}
 
 	public static function getUserPublickey($parameters) {

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -73,4 +73,11 @@ OC_API::register(
 	array('OC_OCS_Cloud', 'getUser'),
 	'core',
 	OC_API::USER_AUTH
-	);
+);
+OC_API::register(
+	'get',
+	'/cloud/user',
+	array('OC_OCS_Cloud', 'getCurrentUser'),
+	'core',
+	OC_API::USER_AUTH
+);


### PR DESCRIPTION
fixes #4548 
New OCS route:
 /ocs/cloud/user
Response:

```
 <?xml version="1.0"?>
 <ocs>
  <meta>
   <status>ok</status>
   <statuscode>100</statuscode>
   <message/>
  </meta>
  <data>
   <id>thomas</id>
   <display-name>DeepDiver</display-name>
   <email>no-response@domain.tld</email>
  </data>
 </ocs>
```
