### PR TITLE
Reversed sides of original and replacement in file conflict dialog

### DIFF
--- a/apps/files/templates/fileexists.html
+++ b/apps/files/templates/fileexists.html
@@ -3,19 +3,19 @@
 	<span class="what">{what}<!-- If you select both versions, the copied file will have a number added to its name. --></span><br/>
 	<br/>
 	<table>
-		<th><label><input class="allnewfiles" type="checkbox" />New Files<span class="count"></span></label></th>
 		<th><label><input class="allexistingfiles" type="checkbox" />Already existing files<span class="count"></span></label></th>
+		<th><label><input class="allnewfiles" type="checkbox" />New Files<span class="count"></span></label></th>
 	</table>
 	<div class="conflicts">
 		<div class="template">
 			<div class="filename"></div>
-			<div class="replacement">
+			<div class="original">
 				<input type="checkbox" />
 				<span class="svg icon"></span>
 				<div class="mtime"></div>
 				<div class="size"></div>
 			</div>
-			<div class="original">
+			<div class="replacement">
 				<input type="checkbox" />
 				<span class="svg icon"></span>
 				<div class="mtime"></div>


### PR DESCRIPTION
Fixes #5094 

Now the dialog looks like this:
![fileconflict1](https://f.cloud.github.com/assets/277525/1375497/39834006-3a83-11e3-914b-0a8536eddfd3.png)

Please review @karlitschek @jancborchardt @butonic @Kondou-ger 
