### PR TITLE
Fixed ugly white space while loading file thumbnail

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -663,8 +663,16 @@ function lazyLoadPreview(path, mime, ready, width, height) {
 		$.get(previewURL, function() {
 			previewURL = previewURL.replace('(', '%28');
 			previewURL = previewURL.replace(')', '%29');
-			//set preview thumbnail URL
-			ready(previewURL + '&reload=true');
+			previewURL += '&reload=true';
+
+			// preload image to prevent delay
+			// this will make the browser cache the image
+			var img = new Image();
+			img.onload = function(){
+				//set preview thumbnail URL
+				ready(previewURL);
+			}
+			img.src = previewURL;
 		});
 	});
 }


### PR DESCRIPTION
Preview images are now pre-loaded before being set on the file element.

This fixes #5135 and prevents a white space to be displayed while the
thumbnails is being loaded.

I've tested in Chrome 30, Firefox 24 and IE8.

Please review @karlitschek @schiesbn @kabum @Kondou-ger @jancborchardt 
