### PR TITLE
Encryption set init status on enable

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -560,7 +560,6 @@ class Hooks {
 	 * @param array $params contains the app ID
 	 */
 	public static function postEnable($params) {
-		error_log("app was enabled!");
 		if ($params['app'] === 'files_encryption') {
 			$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
 			$session->setInitialized(\OCA\Encryption\Session::NOT_INITIALIZED);

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -555,4 +555,16 @@ class Hooks {
 		}
 	}
 
+	/**
+	 * set the init status to 'NOT_INITIALIZED' (0) if the app gets enabled
+	 * @param array $params contains the app ID
+	 */
+	public static function postEnable($params) {
+		error_log("app was enabled!");
+		if ($params['app'] === 'files_encryption') {
+			$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
+			$session->setInitialized(\OCA\Encryption\Session::NOT_INITIALIZED);
+		}
+	}
+
 }

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -69,6 +69,7 @@ class Helper {
 	public static function registerAppHooks() {
 
 		\OCP\Util::connectHook('OC_App', 'pre_disable', 'OCA\Encryption\Hooks', 'preDisable');
+		\OCP\Util::connectHook('OC_App', 'post_disable', 'OCA\Encryption\Hooks', 'postEnable');
 	}
 
 	/**

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1278,7 +1278,7 @@ class Util {
 		// If no record is found
 		if (empty($migrationStatus)) {
 			\OCP\Util::writeLog('Encryption library', "Could not get migration status for " . $this->userId . ", no record found", \OCP\Util::ERROR);
-			return false;
+			return self::MIGRATION_OPEN;
 			// If a record is found
 		} else {
 			return (int)$migrationStatus[0];

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -249,6 +249,7 @@ class OC_App{
 				if(isset($appdata['id'])) {
 					OC_Appconfig::setValue( $app, 'ocsid', $appdata['id'] );
 				}
+				\OC_Hook::emit('OC_App', 'post_enable', array('app' => $app));
 			}
 		}else{
 			throw new \Exception($l->t("No app name specified"));


### PR DESCRIPTION
Introduce a new signal if a app gets enabled and use it to set the init status of the encryption app to "not initialized" to display a warning that the user should logout and login again to initialize the encryption app correctly.
