### PR TITLE
Added FileList.setViewerMode to hide controls

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -251,6 +251,31 @@ var FileList={
 		$('.creatable').toggleClass('hidden', !isCreatable);
 		$('.notCreatable').toggleClass('hidden', isCreatable);
 	},
+	/**
+	 * Shows/hides action buttons
+	 *
+	 * @param show true for enabling, false for disabling
+	 */
+	showActions: function(show){
+		$('.actions,#file_action_panel').toggleClass('hidden', !show);
+		if (show){
+			// make sure to display according to permissions
+			var permissions =  $('#permissions').val();
+			var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
+			$('.creatable').toggleClass('hidden', !isCreatable);
+			$('.notCreatable').toggleClass('hidden', isCreatable);
+		}
+	},
+	/**
+	 * Enables/disables viewer mode.
+	 * In viewer mode, apps can embed themselves under the controls bar.
+	 * In viewer mode, the actions of the file list will be hidden.
+	 * @param show true for enabling, false for disabling
+	 */
+	setViewerMode: function(show){
+		this.showActions(!show);
+		$('#filestable').toggleClass('hidden', show);
+	},
 	remove:function(name){
 		$('tr').filterAttr('data-file',name).find('td.filename').draggable('destroy');
 		$('tr').filterAttr('data-file',name).remove();


### PR DESCRIPTION
Some files app embed themselves under the controls (like the text
editor). The new method FileList.setViewerMode() makes it possible to
properly show/hide the control buttons using the correct permissions.

Apps using this approach must call setViewerMode(true) when starting and
setViewerMode(false) upon closing to restore the controls.

This is needed for #5284

Please review @karlitschek @schiesbn @jancborchardt @Kondou-ger 
