### PR TITLE
prevent user from creating or renaming sth. to an existing filename

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -64,7 +64,7 @@ if (\OC\Files\Filesystem::file_exists($target)) {
 			'data'		=> array(
 				'message'	=> $l10n->t(
 					"The name %s is already used in the folder %s. Please choose a different name.",
-					array($target, $dir))
+					array($filename, $dir))
 				)
 			);
 	OCP\JSON::error($result);

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -56,6 +56,21 @@ function progress($notification_code, $severity, $message, $message_code, $bytes
 
 $target = $dir.'/'.$filename;
 
+$l10n = \OC_L10n::get('files');
+
+if (\OC\Files\Filesystem::file_exists($target)) {
+		$result = array(
+			'success' 	=> false,
+			'data'		=> array(
+				'message'	=> $l10n->t(
+					"The name %s is already used in the folder %s. Please choose a different name.",
+					array($newname, $dir))
+				)
+			);
+	OCP\JSON::error($result);
+	exit();
+}
+
 if($source) {
 	if(substr($source, 0, 8)!='https://' and substr($source, 0, 7)!='http://') {
 		OCP\JSON::error(array("data" => array( "message" => "Not a valid source" )));

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -64,7 +64,7 @@ if (\OC\Files\Filesystem::file_exists($target)) {
 			'data'		=> array(
 				'message'	=> $l10n->t(
 					"The name %s is already used in the folder %s. Please choose a different name.",
-					array($newname, $dir))
+					array($target, $dir))
 				)
 			);
 	OCP\JSON::error($result);

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -20,15 +20,6 @@ if($source) {
 	OC_JSON::callCheck();
 }
 
-if($filename == '') {
-	OCP\JSON::error(array("data" => array( "message" => "Empty Filename" )));
-	exit();
-}
-if(strpos($filename, '/')!==false) {
-	OCP\JSON::error(array("data" => array( "message" => "Invalid Filename" )));
-	exit();
-}
-
 function progress($notification_code, $severity, $message, $message_code, $bytes_transferred, $bytes_max) {
 	static $filesize = 0;
 	static $lastsize = 0;
@@ -54,9 +45,27 @@ function progress($notification_code, $severity, $message, $message_code, $bytes
 	}
 }
 
-$target = $dir.'/'.$filename;
-
 $l10n = \OC_L10n::get('files');
+
+$result = array(
+	'success' 	=> false,
+	'data'		=> NULL
+	);
+
+if(trim($filename) === '') {
+	$result['data'] = array('message' => $l10n->t('Filename cannot not be empty.'));
+	OCP\JSON::error($result);
+	exit();
+}
+
+if(strpos($filename, '/') !== false) {
+	$result['data'] = array('message' => $l10n->t('Filename must not contain /. Please choose a different name.'));
+	OCP\JSON::error($result);
+	exit();
+}
+
+//TODO why is stripslashes used on foldername in newfolder.php but not here?
+$target = $dir.'/'.$filename;
 
 if (\OC\Files\Filesystem::file_exists($target)) {
 		$result = array(

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -35,7 +35,7 @@ function progress($notification_code, $severity, $message, $message_code, $bytes
 				if (!isset($filesize)) {
 				} else {
 					$progress = (int)(($bytes_transferred/$filesize)*100);
-					if($progress>$lastsize) {//limit the number or messages send
+					if($progress>$lastsize) { //limit the number or messages send
 						$eventSource->send('progress', $progress);
 					}
 					$lastsize=$progress;
@@ -53,13 +53,13 @@ $result = array(
 	);
 
 if(trim($filename) === '') {
-	$result['data'] = array('message' => $l10n->t('Filename cannot not be empty.'));
+	$result['data'] = array('message' => $l10n->t('File name cannot not be empty.'));
 	OCP\JSON::error($result);
 	exit();
 }
 
 if(strpos($filename, '/') !== false) {
-	$result['data'] = array('message' => $l10n->t('Filename must not contain /. Please choose a different name.'));
+	$result['data'] = array('message' => $l10n->t('File name must not contain "/". Please choose a different name.'));
 	OCP\JSON::error($result);
 	exit();
 }
@@ -69,7 +69,7 @@ $target = $dir.'/'.$filename;
 
 if (\OC\Files\Filesystem::file_exists($target)) {
 	$result['data'] = array('message' => $l10n->t(
-			"The name %s is already used in the folder %s. Please choose a different name.",
+			'The name %s is already used in the folder %s. Please choose a different name.',
 			array($filename, $dir))
 		);
 	OCP\JSON::error($result);
@@ -78,7 +78,7 @@ if (\OC\Files\Filesystem::file_exists($target)) {
 
 if($source) {
 	if(substr($source, 0, 8)!='https://' and substr($source, 0, 7)!='http://') {
-		OCP\JSON::error(array("data" => array( "message" => "Not a valid source" )));
+		OCP\JSON::error(array('data' => array( 'message' => $l10n->t('Not a valid source') )));
 		exit();
 	}
 
@@ -91,7 +91,7 @@ if($source) {
 		$id = $meta['fileid'];
 		$eventSource->send('success', array('mime'=>$mime, 'size'=>\OC\Files\Filesystem::filesize($target), 'id' => $id));
 	} else {
-		$eventSource->send('error', "Error while downloading ".$source. ' to '.$target);
+		$eventSource->send('error', $l10n->t('Error while downloading %s to %s', array($source, $target)));
 	}
 	$eventSource->close();
 	exit();
@@ -124,4 +124,4 @@ if($source) {
 	}
 }
 
-OCP\JSON::error(array("data" => array( "message" => "Error when creating the file" )));
+OCP\JSON::error(array('data' => array( 'message' => $l10n->t('Error when creating the file') )));

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -68,14 +68,10 @@ if(strpos($filename, '/') !== false) {
 $target = $dir.'/'.$filename;
 
 if (\OC\Files\Filesystem::file_exists($target)) {
-		$result = array(
-			'success' 	=> false,
-			'data'		=> array(
-				'message'	=> $l10n->t(
-					"The name %s is already used in the folder %s. Please choose a different name.",
-					array($filename, $dir))
-				)
-			);
+	$result['data'] = array('message' => $l10n->t(
+			"The name %s is already used in the folder %s. Please choose a different name.",
+			array($filename, $dir))
+		);
 	OCP\JSON::error($result);
 	exit();
 }

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -18,13 +18,13 @@ $result = array(
 	);
 
 if(trim($foldername) === '') {
-	$result['data'] = array('message' => $l10n->t('Foldername cannot not be empty.'));
+	$result['data'] = array('message' => $l10n->t('Folder name cannot not be empty.'));
 	OCP\JSON::error($result);
 	exit();
 }
 
 if(strpos($foldername, '/') !== false) {
-	$result['data'] = array('message' => $l10n->t('Foldername must not contain /. Please choose a different name.'));
+	$result['data'] = array('message' => $l10n->t('Folder name must not contain "/". Please choose a different name.'));
 	OCP\JSON::error($result);
 	exit();
 }
@@ -53,4 +53,4 @@ if(\OC\Files\Filesystem::mkdir($target)) {
 	exit();
 }
 
-OCP\JSON::error(array('data' => array( 'message' => 'Error when creating the folder' )));
+OCP\JSON::error(array('data' => array( 'message' => $l10n->t('Error when creating the folder') )));

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -10,25 +10,47 @@ OCP\JSON::callCheck();
 $dir = isset( $_POST['dir'] ) ? stripslashes($_POST['dir']) : '';
 $foldername = isset( $_POST['foldername'] ) ? stripslashes($_POST['foldername']) : '';
 
-if(trim($foldername) == '') {
-	OCP\JSON::error(array("data" => array( "message" => "Empty Foldername" )));
-	exit();
-}
-if(strpos($foldername, '/')!==false) {
-	OCP\JSON::error(array("data" => array( "message" => "Invalid Foldername" )));
+$l10n = \OC_L10n::get('files');
+
+$result = array(
+	'success' 	=> false,
+	'data'		=> NULL
+	);
+
+if(trim($foldername) === '') {
+	$result['data'] = array('message' => $l10n->t('Foldername cannot not be empty.'));
+	OCP\JSON::error($result);
 	exit();
 }
 
-if(\OC\Files\Filesystem::mkdir($dir . '/' . stripslashes($foldername))) {
-	if ( $dir != '/') {
+if(strpos($foldername, '/') !== false) {
+	$result['data'] = array('message' => $l10n->t('Foldername must not contain /. Please choose a different name.'));
+	OCP\JSON::error($result);
+	exit();
+}
+
+//TODO why is stripslashes used on foldername here but not in newfile.php?
+$target = $dir . '/' . stripslashes($foldername);
+		
+if (\OC\Files\Filesystem::file_exists($target)) {
+	$result['data'] = array('message' => $l10n->t(
+			'The name %s is already used in the folder %s. Please choose a different name.',
+			array($foldername, $dir))
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
+if(\OC\Files\Filesystem::mkdir($target)) {
+	if ( $dir !== '/') {
 		$path = $dir.'/'.$foldername;
 	} else {
 		$path = '/'.$foldername;
 	}
 	$meta = \OC\Files\Filesystem::getFileInfo($path);
 	$id = $meta['fileid'];
-	OCP\JSON::success(array("data" => array('id'=>$id)));
+	OCP\JSON::success(array('data' => array('id' => $id)));
 	exit();
 }
 
-OCP\JSON::error(array("data" => array( "message" => "Error when creating the folder" )));
+OCP\JSON::error(array('data' => array( 'message' => 'Error when creating the folder' )));

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -49,7 +49,13 @@
 		background-repeat:no-repeat; cursor:pointer; }
 #new>ul>li>p { cursor:pointer; padding-top: 7px; padding-bottom: 7px;}
 
-
+#new .error, #fileList .error {
+	color: #e9322d;
+	border-color: #e9322d;
+	-webkit-box-shadow: 0 0 6px #f8b9b7;
+	-moz-box-shadow: 0 0 6px #f8b9b7;
+	box-shadow: 0 0 6px #f8b9b7;
+}
 
 /* FILE TABLE */
 

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -508,11 +508,11 @@ $(document).ready(function() {
 		var checkInput = function () {
 			var filename = input.val();
 			if (type === 'web' && filename.length === 0) {
-				throw t('files', 'URL cannot be empty.');
+				throw t('files', 'URL cannot be empty');
 			} else if (type !== 'web' && !Files.isFileNameValid(filename)) {
 				// Files.isFileNameValid(filename) throws an exception itself
 			} else if ($('#dir').val() === '/' && filename === 'Shared') {
-				throw t('files','Invalid name. Usage of \'Shared\' is reserved by ownCloud');
+				throw t('files', 'In the home folder \'Shared\' is a reserved filename');
 			} else if (FileList.inList(filename)) {
 				throw t('files', '{new_name} already exists', {new_name: filename});
 			} else {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -53,12 +53,12 @@ OC.Upload = {
 	 */
 	cancelUploads:function() {
 		this.log('canceling uploads');
-		jQuery.each(this._uploads,function(i, jqXHR){
+		jQuery.each(this._uploads,function(i, jqXHR) {
 			jqXHR.abort();
 		});
 		this._uploads = [];
 	},
-	rememberUpload:function(jqXHR){
+	rememberUpload:function(jqXHR) {
 		if (jqXHR) {
 			this._uploads.push(jqXHR);
 		}
@@ -68,10 +68,10 @@ OC.Upload = {
 	 * returns true if any hxr has the state 'pending'
 	 * @returns {boolean}
 	 */
-	isProcessing:function(){
+	isProcessing:function() {
 		var count = 0;
 		
-		jQuery.each(this._uploads,function(i, data){
+		jQuery.each(this._uploads,function(i, data) {
 			if (data.state() === 'pending') {
 				count++;
 			}
@@ -114,7 +114,7 @@ OC.Upload = {
 	 * handle skipping an upload
 	 * @param {object} data
 	 */
-	onSkip:function(data){
+	onSkip:function(data) {
 		this.log('skip', null, data);
 		this.deleteUpload(data);
 	},
@@ -122,12 +122,12 @@ OC.Upload = {
 	 * handle replacing a file on the server with an uploaded file
 	 * @param {object} data
 	 */
-	onReplace:function(data){
+	onReplace:function(data) {
 		this.log('replace', null, data);
-		if (data.data){
+		if (data.data) {
 			data.data.append('resolution', 'replace');
 		} else {
-			data.formData.push({name:'resolution',value:'replace'}); //hack for ie8
+			data.formData.push({name:'resolution', value:'replace'}); //hack for ie8
 		}
 		data.submit();
 	},
@@ -135,12 +135,12 @@ OC.Upload = {
 	 * handle uploading a file and letting the server decide a new name
 	 * @param {object} data
 	 */
-	onAutorename:function(data){
+	onAutorename:function(data) {
 		this.log('autorename', null, data);
 		if (data.data) {
 			data.data.append('resolution', 'autorename');
 		} else {
-			data.formData.push({name:'resolution',value:'autorename'}); //hack for ie8
+			data.formData.push({name:'resolution', value:'autorename'}); //hack for ie8
 		}
 		data.submit();
 	},
@@ -162,7 +162,7 @@ OC.Upload = {
 	 * @param {function} callbacks.onChooseConflicts
 	 * @param {function} callbacks.onCancel
 	 */
-	checkExistingFiles: function (selection, callbacks){
+	checkExistingFiles: function (selection, callbacks) {
 		// TODO check filelist before uploading and show dialog on conflicts, use callbacks
 		callbacks.onNoConflicts(selection);
 	}
@@ -215,7 +215,7 @@ $(document).ready(function() {
 				var selection = data.originalFiles.selection;
 			
 				// add uploads
-				if ( selection.uploads.length < selection.filesToUpload ){
+				if ( selection.uploads.length < selection.filesToUpload ) {
 					// remember upload
 					selection.uploads.push(data);
 				}
@@ -335,7 +335,7 @@ $(document).ready(function() {
 
 				delete data.jqXHR;
 				
-				if(typeof result[0] === 'undefined') {
+				if (typeof result[0] === 'undefined') {
 					data.textStatus = 'servererror';
 					data.errorThrown = t('files', 'Could not get result from server.');
 					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');
@@ -368,13 +368,13 @@ $(document).ready(function() {
 		var fileupload = $('#file_upload_start').fileupload(file_upload_param);
 		window.file_upload_param = fileupload;
 
-		if(supportAjaxUploadWithProgress()) {
+		if (supportAjaxUploadWithProgress()) {
 
 			// add progress handlers
 			fileupload.on('fileuploadadd', function(e, data) {
 				OC.Upload.log('progress handle fileuploadadd', e, data);
 				//show cancel button
-				//if(data.dataType !== 'iframe') { //FIXME when is iframe used? only for ie?
+				//if (data.dataType !== 'iframe') { //FIXME when is iframe used? only for ie?
 				//	$('#uploadprogresswrapper input.stop').show();
 				//}
 			});
@@ -419,7 +419,9 @@ $(document).ready(function() {
 		// http://stackoverflow.com/a/6700/11236
 		var size = 0, key;
 		for (key in obj) {
-			if (obj.hasOwnProperty(key)) size++;
+			if (obj.hasOwnProperty(key)) {
+				size++;
+			}
 		}
 		return size;
 	};
@@ -432,56 +434,61 @@ $(document).ready(function() {
 	});
 
 	//add multiply file upload attribute to all browsers except konqueror (which crashes when it's used)
-	if(navigator.userAgent.search(/konqueror/i)==-1){
-		$('#file_upload_start').attr('multiple','multiple');
+	if (navigator.userAgent.search(/konqueror/i) === -1) {
+		$('#file_upload_start').attr('multiple', 'multiple');
 	}
 
 	//if the breadcrumb is to long, start by replacing foldernames with '...' except for the current folder
 	var crumb=$('div.crumb').first();
-	while($('div.controls').height()>40 && crumb.next('div.crumb').length>0){
+	while($('div.controls').height() > 40 && crumb.next('div.crumb').length > 0) {
 		crumb.children('a').text('...');
-		crumb=crumb.next('div.crumb');
+		crumb = crumb.next('div.crumb');
 	}
 	//if that isn't enough, start removing items from the breacrumb except for the current folder and it's parent
-	var crumb=$('div.crumb').first();
-	var next=crumb.next('div.crumb');
-	while($('div.controls').height()>40 && next.next('div.crumb').length>0){
+	var crumb = $('div.crumb').first();
+	var next = crumb.next('div.crumb');
+	while($('div.controls').height()>40 && next.next('div.crumb').length > 0) {
 		crumb.remove();
-		crumb=next;
-		next=crumb.next('div.crumb');
+		crumb = next;
+		next = crumb.next('div.crumb');
 	}
 	//still not enough, start shorting down the current folder name
 	var crumb=$('div.crumb>a').last();
-	while($('div.controls').height()>40 && crumb.text().length>6){
-		var text=crumb.text()
-		text=text.substr(0,text.length-6)+'...';
+	while($('div.controls').height() > 40 && crumb.text().length > 6) {
+		var text=crumb.text();
+		text = text.substr(0,text.length-6)+'...';
 		crumb.text(text);
 	}
 
-	$(document).click(function(){
+	$(document).click(function() {
 		$('#new>ul').hide();
 		$('#new').removeClass('active');
-		$('#new li').each(function(i,element){
-			if($(element).children('p').length==0){
+		if ($('#new .error').length > 0) {
+			$('#new .error').tipsy('hide');
+		}
+		$('#new li').each(function(i,element) {
+			if ($(element).children('p').length === 0) {
 				$(element).children('form').remove();
 				$(element).append('<p>'+$(element).data('text')+'</p>');
 			}
 		});
 	});
-	$('#new').click(function(event){
+	$('#new').click(function(event) {
 		event.stopPropagation();
 	});
-	$('#new>a').click(function(){
+	$('#new>a').click(function() {
 		$('#new>ul').toggle();
 		$('#new').toggleClass('active');
 	});
-	$('#new li').click(function(){
-		if($(this).children('p').length==0){
+	$('#new li').click(function() {
+		if ($(this).children('p').length === 0) {
 			return;
 		}
+		
+		$('#new .error').tipsy('hide');
 
-		$('#new li').each(function(i,element){
-			if($(element).children('p').length==0){
+		$('#new li').each(function(i,element) {
+			if ($(element).children('p').length === 0) {
 				$(element).children('form').remove();
 				$(element).append('<p>'+$(element).data('text')+'</p>');
 			}
@@ -491,132 +498,164 @@ $(document).ready(function() {
 		var text=$(this).children('p').text();
 		$(this).data('text',text);
 		$(this).children('p').remove();
+		
+		// add input field
 		var form=$('<form></form>');
 		var input=$('<input type="text">');
 		form.append(input);
 		$(this).append(form);
+
+		var checkInput = function () {
+			var filename = input.val();
+			if (type === 'web' && filename.length === 0) {
+				throw t('files', 'URL cannot be empty.');
+			} else if (type !== 'web' && !Files.isFileNameValid(filename)) {
+				// Files.isFileNameValid(filename) throws an exception itself
+			} else if ($('#dir').val() === '/' && filename === 'Shared') {
+				throw t('files','Invalid name. Usage of \'Shared\' is reserved by ownCloud');
+			} else if (FileList.inList(filename)) {
+				throw t('files', '{new_name} already exists', {new_name: filename});
+			} else {
+				return true;
+			}
+		};
+
+		// verify filename on typing
+		input.keyup(function(event) {
+			try {
+				checkInput();
+				input.tipsy('hide');
+				input.removeClass('error');
+			} catch (error) {
+				input.attr('title', error);
+				input.tipsy({gravity: 'w', trigger: 'manual'});
+				input.tipsy('show');
+				input.addClass('error');
+			}
+		});
+
 		input.focus();
-		form.submit(function(event){
+		form.submit(function(event) {
 			event.stopPropagation();
 			event.preventDefault();
-			var newname=input.val();
-			if(type == 'web' && newname.length == 0) {
-				OC.Notification.show(t('files', 'URL cannot be empty.'));
-				return false;
-			} else if (type != 'web' && !Files.isFileNameValid(newname)) {
-				return false;
-			} else if( type == 'folder' && $('#dir').val() == '/' && newname == 'Shared') {
-				OC.Notification.show(t('files','Invalid folder name. Usage of \'Shared\' is reserved by ownCloud'));
-				return false;
-			}
-			if (FileList.lastAction) {
-				FileList.lastAction();
-			}
-			var name = getUniqueName(newname);
-			if (newname != name) {
-				FileList.checkName(name, newname, true);
-				var hidden = true;
-			} else {
-				var hidden = false;
-			}
-			switch(type){
-				case 'file':
-					$.post(
-						OC.filePath('files','ajax','newfile.php'),
-						{dir:$('#dir').val(),filename:name},
-						function(result){
-							if (result.status == 'success') {
-								var date=new Date();
-								// TODO: ideally addFile should be able to receive
-								// all attributes and set them automatically,
-								// and also auto-load the preview
-								var tr = FileList.addFile(name,0,date,false,hidden);
-								tr.attr('data-size',result.data.size);
-								tr.attr('data-mime',result.data.mime);
-								tr.attr('data-id', result.data.id);
-								tr.find('.filesize').text(humanFileSize(result.data.size));
-								var path = getPathForPreview(name);
-								lazyLoadPreview(path, result.data.mime, function(previewpath){
-									tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
-								});
-								FileActions.display(tr.find('td.filename'), true);
-							} else {
-								OC.dialogs.alert(result.data.message, t('core', 'Error'));
+			try {
+				checkInput();
+				var newname = input.val();
+				if (FileList.lastAction) {
+					FileList.lastAction();
+				}
+				var name = getUniqueName(newname);
+				if (newname !== name) {
+					FileList.checkName(name, newname, true);
+					var hidden = true;
+				} else {
+					var hidden = false;
+				}
+				switch(type) {
+					case 'file':
+						$.post(
+							OC.filePath('files', 'ajax', 'newfile.php'),
+							{dir:$('#dir').val(), filename:name},
+							function(result) {
+								if (result.status === 'success') {
+									var date = new Date();
+									// TODO: ideally addFile should be able to receive
+									// all attributes and set them automatically,
+									// and also auto-load the preview
+									var tr = FileList.addFile(name, 0, date, false, hidden);
+									tr.attr('data-size', result.data.size);
+									tr.attr('data-mime', result.data.mime);
+									tr.attr('data-id', result.data.id);
+									tr.find('.filesize').text(humanFileSize(result.data.size));
+									var path = getPathForPreview(name);
+									lazyLoadPreview(path, result.data.mime, function(previewpath) {
+										tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
+									});
+									FileActions.display(tr.find('td.filename'), true);
+								} else {
+									OC.dialogs.alert(result.data.message, t('core', 'Could not create file'));
+								}
 							}
-						}
-					);
-					break;
-				case 'folder':
-					$.post(
-						OC.filePath('files','ajax','newfolder.php'),
-						{dir:$('#dir').val(),foldername:name},
-						function(result){
-							if (result.status == 'success') {
-								var date=new Date();
-								FileList.addDir(name,0,date,hidden);
-								var tr=$('tr').filterAttr('data-file',name);
-								tr.attr('data-id', result.data.id);
-							} else {
-								OC.dialogs.alert(result.data.message, t('core', 'Error'));
+						);
+						break;
+					case 'folder':
+						$.post(
+							OC.filePath('files','ajax','newfolder.php'),
+							{dir:$('#dir').val(), foldername:name},
+							function(result) {
+								if (result.status === 'success') {
+									var date=new Date();
+									FileList.addDir(name, 0, date, hidden);
+									var tr=$('tr[data-file="'+name+'"]');
+									tr.attr('data-id', result.data.id);
+								} else {
+									OC.dialogs.alert(result.data.message, t('core', 'Could not create folder'));
+								}
 							}
+						);
+						break;
+					case 'web':
+						if (name.substr(0,8) !== 'https://' && name.substr(0,7) !== 'http://') {
+							name = 'http://' + name;
 						}
-					);
-					break;
-				case 'web':
-					if(name.substr(0,8)!='https://' && name.substr(0,7)!='http://'){
-						name='http://'+name;
-					}
-					var localName=name;
-					if(localName.substr(localName.length-1,1)=='/'){//strip /
-						localName=localName.substr(0,localName.length-1)
-					}
-					if(localName.indexOf('/')){//use last part of url
-						localName=localName.split('/').pop();
-					} else { //or the domain
-						localName=(localName.match(/:\/\/(.[^\/]+)/)[1]).replace('www.','');
-					}
-					localName = getUniqueName(localName);
-					//IE < 10 does not fire the necessary events for the progress bar.
-					if($('html.lte9').length === 0) {
-						$('#uploadprogressbar').progressbar({value:0});
-						$('#uploadprogressbar').fadeIn();
-					}
-
-					var eventSource=new OC.EventSource(OC.filePath('files','ajax','newfile.php'),{dir:$('#dir').val(),source:name,filename:localName});
-					eventSource.listen('progress',function(progress){
+						var localName=name;
+						if (localName.substr(localName.length-1,1)==='/') {//strip /
+							localName=localName.substr(0,localName.length-1);
+						}
+						if (localName.indexOf('/')) {//use last part of url
+							localName=localName.split('/').pop();
+						} else { //or the domain
+							localName=(localName.match(/:\/\/(.[^\/]+)/)[1]).replace('www.','');
+						}
+						localName = getUniqueName(localName);
 						//IE < 10 does not fire the necessary events for the progress bar.
-						if($('html.lte9').length === 0) {
-							$('#uploadprogressbar').progressbar('value',progress);
+						if ($('html.lte9').length === 0) {
+							$('#uploadprogressbar').progressbar({value:0});
+							$('#uploadprogressbar').fadeIn();
 						}
-					});
-					eventSource.listen('success',function(data){
-						var mime=data.mime;
-						var size=data.size;
-						var id=data.id;
-						$('#uploadprogressbar').fadeOut();
-						var date=new Date();
-						FileList.addFile(localName,size,date,false,hidden);
-						var tr=$('tr').filterAttr('data-file',localName);
-						tr.data('mime',mime).data('id',id);
-						tr.attr('data-id', id);
-						var path = $('#dir').val()+'/'+localName;
-						lazyLoadPreview(path, mime, function(previewpath){
-							tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
+
+						var eventSource=new OC.EventSource(OC.filePath('files','ajax','newfile.php'),{dir:$('#dir').val(),source:name,filename:localName});
+						eventSource.listen('progress',function(progress) {
+							//IE < 10 does not fire the necessary events for the progress bar.
+							if ($('html.lte9').length === 0) {
+								$('#uploadprogressbar').progressbar('value',progress);
+							}
 						});
-					});
-					eventSource.listen('error',function(error){
-						$('#uploadprogressbar').fadeOut();
-						alert(error);
-					});
-					break;
+						eventSource.listen('success',function(data) {
+							var mime = data.mime;
+							var size = data.size;
+							var id = data.id;
+							$('#uploadprogressbar').fadeOut();
+							var date = new Date();
+							FileList.addFile(localName, size, date, false, hidden);
+							var tr = $('tr[data-file="'+localName+'"]');
+							tr.data('mime', mime).data('id', id);
+							tr.attr('data-id', id);
+							var path = $('#dir').val()+'/'+localName;
+							lazyLoadPreview(path, mime, function(previewpath) {
+								tr.find('td.filename').attr('style', 'background-image:url('+previewpath+')');
+							});
+							FileActions.display(tr.find('td.filename'), true);
+						});
+						eventSource.listen('error',function(error) {
+							$('#uploadprogressbar').fadeOut();
+							alert(error);
+						});
+						break;
+				}
+				var li=form.parent();
+				form.remove();
+				/* workaround for IE 9&10 click event trap, 2 lines: */
+				$('input').first().focus();
+				$('#content').focus();
+				li.append('<p>'+li.data('text')+'</p>');
+				$('#new>a').click();
+			} catch (error) {
+				input.attr('title', error);
+				input.tipsy({gravity: 'w', trigger: 'manual'});
+				input.tipsy('show');
+				input.addClass('error');
 			}
-			var li=form.parent();
-			form.remove();
-			/* workaround for IE 9&10 click event trap, 2 lines: */
-			$('input').first().focus();
-			$('#content').focus();
-			li.append('<p>'+li.data('text')+'</p>');
-			$('#new>a').click();
 		});
 	});
 	window.file_upload_param = file_upload_param;

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -21,13 +21,13 @@ function supportAjaxUploadWithProgress() {
 		var fi = document.createElement('INPUT');
 		fi.type = 'file';
 		return 'files' in fi;
-	};
+	}
 
 	// Are progress events supported?
 	function supportAjaxUploadProgressEvents() {
 		var xhr = new XMLHttpRequest();
 		return !! (xhr && ('upload' in xhr) && ('onprogress' in xhr.upload));
-	};
+	}
 
 	// Is FormData supported?
 	function supportFormData() {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -359,7 +359,7 @@ var FileList={
 				if (!Files.isFileNameValid(filename)) {
 					// Files.isFileNameValid(filename) throws an exception itself
 				} else if($('#dir').val() === '/' && filename === 'Shared') {
-					throw t('files','Invalid name. Usage of \'Shared\' is reserved by ownCloud');
+					throw t('files','In the home folder \'Shared\' is a reserved filename');
 				} else if (FileList.inList(filename)) {
 					throw t('files', '{new_name} already exists', {new_name: filename});
 				}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1,7 +1,7 @@
 var FileList={
 	useUndo:true,
-	postProcessList: function(){
-		$('#fileList tr').each(function(){
+	postProcessList: function() {
+		$('#fileList tr').each(function() {
 			//little hack to set unescape filenames in attribute
 			$(this).attr('data-file',decodeURIComponent($(this).attr('data-file')));
 		});
@@ -11,20 +11,20 @@ var FileList={
 			permissions = $('#permissions').val(),
 			isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
 		$fileList.empty().html(fileListHtml);
-		$('#emptycontent').toggleClass('hidden', !isCreatable || $fileList.find('tr').length > 0);
+		$('#emptycontent').toggleClass('hidden', !isCreatable || $fileList.find('tr').exists());
 		$fileList.find('tr').each(function () {
 			FileActions.display($(this).children('td.filename'));
 		});
 		$fileList.trigger(jQuery.Event("fileActionsReady"));
 		FileList.postProcessList();
 		// "Files" might not be loaded in extending apps
-		if (window.Files){
+		if (window.Files) {
 			Files.setupDragAndDrop();
 		}
 		FileList.updateFileSummary();
 		$fileList.trigger(jQuery.Event("updated"));
 	},
-	createRow:function(type, name, iconurl, linktarget, size, lastModified, permissions){
+	createRow:function(type, name, iconurl, linktarget, size, lastModified, permissions) {
 		var td, simpleSize, basename, extension;
 		//containing tr
 		var tr = $('<tr></tr>').attr({
@@ -45,7 +45,7 @@ var FileList={
 			"href": linktarget
 		});
 		//split extension from filename for non dirs
-		if (type != 'dir' && name.indexOf('.')!=-1) {
+		if (type !== 'dir' && name.indexOf('.') !== -1) {
 			basename=name.substr(0,name.lastIndexOf('.'));
 			extension=name.substr(name.lastIndexOf('.'));
 		} else {
@@ -54,11 +54,11 @@ var FileList={
 		}
 		var name_span=$('<span></span>').addClass('nametext').text(basename);
 		link_elem.append(name_span);
-		if(extension){
+		if (extension) {
 			name_span.append($('<span></span>').addClass('extension').text(extension));
 		}
 		//dirs can show the number of uploaded files
-		if (type == 'dir') {
+		if (type === 'dir') {
 			link_elem.append($('<span></span>').attr({
 				'class': 'uploadtext',
 				'currentUploads': 0
@@ -68,9 +68,9 @@ var FileList={
 		tr.append(td);
 
 		//size column
-		if(size!=t('files', 'Pending')){
+		if (size !== t('files', 'Pending')) {
 			simpleSize = humanFileSize(size);
-		}else{
+		} else {
 			simpleSize=t('files', 'Pending');
 		}
 		var sizeColor = Math.round(160-Math.pow((size/(1024*1024)),2));
@@ -92,7 +92,7 @@ var FileList={
 		tr.append(td);
 		return tr;
 	},
-	addFile:function(name,size,lastModified,loading,hidden,param){
+	addFile:function(name, size, lastModified, loading, hidden, param) {
 		var imgurl;
 
 		if (!param) {
@@ -122,9 +122,9 @@ var FileList={
 		);
 
 		FileList.insertElement(name, 'file', tr);
-		if(loading){
-			tr.data('loading',true);
-		}else{
+		if (loading) {
+			tr.data('loading', true);
+		} else {
 			tr.find('td.filename').draggable(dragOptions);
 		}
 		if (hidden) {
@@ -132,7 +132,7 @@ var FileList={
 		}
 		return tr;
 	},
-	addDir:function(name,size,lastModified,hidden){
+	addDir:function(name, size, lastModified, hidden) {
 
 		var tr = this.createRow(
 			'dir',
@@ -144,7 +144,7 @@ var FileList={
 			$('#permissions').val()
 		);
 
-		FileList.insertElement(name,'dir',tr);
+		FileList.insertElement(name, 'dir', tr);
 		var td = tr.find('td.filename');
 		td.draggable(dragOptions);
 		td.droppable(folderDropOptions);
@@ -158,25 +158,26 @@ var FileList={
 	 * @brief Changes the current directory and reload the file list.
 	 * @param targetDir target directory (non URL encoded)
 	 * @param changeUrl false if the URL must not be changed (defaults to true)
+	 * @param {boolean} force set to true to force changing directory
 	 */
-	changeDirectory: function(targetDir, changeUrl, force){
+	changeDirectory: function(targetDir, changeUrl, force) {
 		var $dir = $('#dir'),
 			url,
 			currentDir = $dir.val() || '/';
 		targetDir = targetDir || '/';
-		if (!force && currentDir === targetDir){
+		if (!force && currentDir === targetDir) {
 			return;
 		}
 		FileList.setCurrentDir(targetDir, changeUrl);
 		FileList.reload();
 	},
-	linkTo: function(dir){
+	linkTo: function(dir) {
 		return OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
 	},
-	setCurrentDir: function(targetDir, changeUrl){
+	setCurrentDir: function(targetDir, changeUrl) {
 		$('#dir').val(targetDir);
-		if (changeUrl !== false){
-			if (window.history.pushState && changeUrl !== false){
+		if (changeUrl !== false) {
+			if (window.history.pushState && changeUrl !== false) {
 				url = FileList.linkTo(targetDir);
 				window.history.pushState({dir: targetDir}, '', url);
 			}
@@ -189,9 +190,9 @@ var FileList={
 	/**
 	 * @brief Reloads the file list using ajax call
 	 */
-	reload: function(){
+	reload: function() {
 		FileList.showMask();
-		if (FileList._reloadCall){
+		if (FileList._reloadCall) {
 			FileList._reloadCall.abort();
 		}
 		FileList._reloadCall = $.ajax({
@@ -200,7 +201,7 @@ var FileList={
 				dir : $('#dir').val(),
 				breadcrumb: true
 			},
-			error: function(result){
+			error: function(result) {
 				FileList.reloadCallback(result);
 			},
 			success: function(result) {
@@ -208,7 +209,7 @@ var FileList={
 			}
 		});
 	},
-	reloadCallback: function(result){
+	reloadCallback: function(result) {
 		var $controls = $('#controls');
 
 		delete FileList._reloadCall;
@@ -219,17 +220,17 @@ var FileList={
 			return;
 		}
 
-		if (result.status === 404){
+		if (result.status === 404) {
 			// go back home
 			FileList.changeDirectory('/');
 			return;
 		}
 
-		if (result.data.permissions){
+		if (result.data.permissions) {
 			FileList.setDirectoryPermissions(result.data.permissions);
 		}
 
-		if(typeof(result.data.breadcrumb) != 'undefined'){
+		if (typeof(result.data.breadcrumb) !== 'undefined') {
 			$controls.find('.crumb').remove();
 			$controls.prepend(result.data.breadcrumb);
 
@@ -238,81 +239,83 @@ var FileList={
 			Files.resizeBreadcrumbs(width, true);
 
 			// in case svg is not supported by the browser we need to execute the fallback mechanism
-			if(!SVGSupport()) {
+			if (!SVGSupport()) {
 				replaceSVG();
 			}
 		}
 
 		FileList.update(result.data.files);
 	},
-	setDirectoryPermissions: function(permissions){
+	setDirectoryPermissions: function(permissions) {
 		var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
 		$('#permissions').val(permissions);
 		$('.creatable').toggleClass('hidden', !isCreatable);
 		$('.notCreatable').toggleClass('hidden', isCreatable);
 	},
-	remove:function(name){
-		$('tr').filterAttr('data-file',name).find('td.filename').draggable('destroy');
-		$('tr').filterAttr('data-file',name).remove();
+	remove:function(name) {
+		$('tr[data-file="'+name+'"]').find('td.filename').draggable('destroy');
+		$('tr[data-file="'+name+'"]').remove();
 		FileList.updateFileSummary();
-		if($('tr[data-file]').length==0){
+		if ( ! $('tr[data-file]').exists() ) {
 			$('#emptycontent').removeClass('hidden');
 		}
 	},
-	insertElement:function(name,type,element){
+	insertElement:function(name, type, element) {
 		//find the correct spot to insert the file or folder
 		var pos, fileElements=$('tr[data-file][data-type="'+type+'"]:visible');
-		if(name.localeCompare($(fileElements[0]).attr('data-file'))<0){
-			pos=-1;
-		}else if(name.localeCompare($(fileElements[fileElements.length-1]).attr('data-file'))>0){
-			pos=fileElements.length-1;
-		}else{
-			for(pos=0;pos<fileElements.length-1;pos++){
-				if(name.localeCompare($(fileElements[pos]).attr('data-file'))>0 && name.localeCompare($(fileElements[pos+1]).attr('data-file'))<0){
+		if (name.localeCompare($(fileElements[0]).attr('data-file')) < 0) {
+			pos = -1;
+		} else if (name.localeCompare($(fileElements[fileElements.length-1]).attr('data-file')) > 0) {
+			pos = fileElements.length - 1;
+		} else {
+			for(pos = 0; pos<fileElements.length-1; pos++) {
+				if (name.localeCompare($(fileElements[pos]).attr('data-file')) > 0
+					&& name.localeCompare($(fileElements[pos+1]).attr('data-file')) < 0)
+				{
 					break;
 				}
 			}
 		}
-		if(fileElements.length){
-			if(pos==-1){
+		if (fileElements.exists()) {
+			if (pos === -1) {
 				$(fileElements[0]).before(element);
-			}else{
+			} else {
 				$(fileElements[pos]).after(element);
 			}
-		}else if(type=='dir' && $('tr[data-file]').length>0){
+		} else if (type === 'dir' && $('tr[data-file]').exists()) {
 			$('tr[data-file]').first().before(element);
-		} else if(type=='file' && $('tr[data-file]').length>0) {
+		} else if (type === 'file' && $('tr[data-file]').exists()) {
 			$('tr[data-file]').last().before(element);
-		}else{
+		} else {
 			$('#fileList').append(element);
 		}
 		$('#emptycontent').addClass('hidden');
 		FileList.updateFileSummary();
 	},
-	loadingDone:function(name, id){
-		var mime, tr=$('tr').filterAttr('data-file',name);
-		tr.data('loading',false);
-		mime=tr.data('mime');
-		tr.attr('data-mime',mime);
-		if (id != null) {
+	loadingDone:function(name, id) {
+		var mime, tr = $('tr[data-file="'+name+'"]');
+		tr.data('loading', false);
+		mime = tr.data('mime');
+		tr.attr('data-mime', mime);
+		if (id) {
 			tr.attr('data-id', id);
 		}
 		var path = getPathForPreview(name);
-		lazyLoadPreview(path, mime, function(previewpath){
+		lazyLoadPreview(path, mime, function(previewpath) {
 			tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
 		});
 		tr.find('td.filename').draggable(dragOptions);
 	},
-	isLoading:function(name){
-		return $('tr').filterAttr('data-file',name).data('loading');
+	isLoading:function(name) {
+		return $('tr[data-file="'+name+'"]').data('loading');
 	},
-	rename:function(name){
+	rename:function(oldname) {
 		var tr, td, input, form;
-		tr=$('tr').filterAttr('data-file',name);
+		tr = $('tr[data-file="'+oldname+'"]');
 		tr.data('renaming',true);
-		td=tr.children('td.filename');
-		input=$('<input type="text" class="filename"/>').val(name);
-		form=$('<form></form>');
+		td = tr.children('td.filename');
+		input = $('<input type="text" class="filename"/>').val(oldname);
+		form = $('<form></form>');
 		form.append(input);
 		td.children('a.name').hide();
 		td.append(form);
@@ -322,18 +325,29 @@ var FileList={
 		if (len === -1) {
 			len = input.val().length;
 		}
-		input.selectRange(0,len);
+		input.selectRange(0, len);
 
-		form.submit(function(event){
+		var checkInput = function () {
+			var filename = input.val();
+			if (filename !== oldname) {
+				if (!Files.isFileNameValid(filename)) {
+					// Files.isFileNameValid(filename) throws an exception itself
+				} else if($('#dir').val() === '/' && filename === 'Shared') {
+					throw t('files','Invalid name. Usage of \'Shared\' is reserved by ownCloud');
+				} else if (FileList.inList(filename)) {
+					throw t('files', '{new_name} already exists', {new_name: filename});
+				}
+			}
+			return true;
+		};
+		
+		form.submit(function(event) {
 			event.stopPropagation();
 			event.preventDefault();
-			var newname=input.val();
-			if (!Files.isFileNameValid(newname)) {
-				return false;
-			} else if (newname != name) {
-				if (FileList.checkName(name, newname, false)) {
-					newname = name;
-				} else {
+			try {
+				var newname = input.val();
+				if (newname !== oldname) {
+					checkInput();
 					// save background image, because it's replaced by a spinner while async request
 					var oldBackgroundImage = td.css('background-image');
 					// mark as loading
@@ -343,16 +357,16 @@ var FileList={
 						data: {
 							dir : $('#dir').val(),
 							newname: newname,
-							file: name
+							file: oldname
 						},
 						success: function(result) {
 							if (!result || result.status === 'error') {
-								OC.Notification.show(result.data.message);
-								newname = name;
+								OC.dialogs.alert(result.data.message, t('core', 'Could not rename file'));
 								// revert changes
+								newname = oldname;
 								tr.attr('data-file', newname);
 								var path = td.children('a.name').attr('href');
-								td.children('a.name').attr('href', path.replace(encodeURIComponent(name), encodeURIComponent(newname)));
+								td.children('a.name').attr('href', path.replace(encodeURIComponent(oldname), encodeURIComponent(newname)));
 								if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
 									var basename=newname.substr(0,newname.lastIndexOf('.'));
 								} else {
@@ -360,7 +374,7 @@ var FileList={
 								}
 								td.find('a.name span.nametext').text(basename);
 								if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
-									if (td.find('a.name span.extension').length === 0 ) {
+									if ( ! td.find('a.name span.extension').exists() ) {
 										td.find('a.name span.nametext').append('<span class="extension"></span>');
 									}
 									td.find('a.name span.extension').text(newname.substr(newname.lastIndexOf('.')));
@@ -368,70 +382,76 @@ var FileList={
 								tr.find('.fileactions').effect('highlight', {}, 5000);
 								tr.effect('highlight', {}, 5000);
 							}
+							// reinsert row
+							tr.detach();
+							FileList.insertElement( tr.attr('data-file'), tr.attr('data-type'),tr );
 							// remove loading mark and recover old image
 							td.css('background-image', oldBackgroundImage);
 						}
 					});
 				}
-			}
-			tr.data('renaming',false);
-			tr.attr('data-file', newname);
-			var path = td.children('a.name').attr('href');
-			td.children('a.name').attr('href', path.replace(encodeURIComponent(name), encodeURIComponent(newname)));
-			if (newname.indexOf('.') > 0 && tr.data('type') != 'dir') {
-				var basename=newname.substr(0,newname.lastIndexOf('.'));
-			} else {
-				var basename=newname;
-			}
-			td.find('a.name span.nametext').text(basename);
-			if (newname.indexOf('.') > 0 && tr.data('type') != 'dir') {
-				if (td.find('a.name span.extension').length == 0 ) {
-					td.find('a.name span.nametext').append('<span class="extension"></span>');
+				input.tipsy('hide');
+				tr.data('renaming',false);
+				tr.attr('data-file', newname);
+				var path = td.children('a.name').attr('href');
+				// FIXME this will fail if the path contains the filename.
+				td.children('a.name').attr('href', path.replace(encodeURIComponent(oldname), encodeURIComponent(newname)));
+				var basename = newname;
+				if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
+					basename = newname.substr(0, newname.lastIndexOf('.'));
+				} 
+				td.find('a.name span.nametext').text(basename);
+				if (newname.indexOf('.') > 0 && tr.data('type') !== 'dir') {
+					if ( ! td.find('a.name span.extension').exists() ) {
+						td.find('a.name span.nametext').append('<span class="extension"></span>');
+					}
+					td.find('a.name span.extension').text(newname.substr(newname.lastIndexOf('.')));
 				}
-				td.find('a.name span.extension').text(newname.substr(newname.lastIndexOf('.')));
+				form.remove();
+				td.children('a.name').show();
+			} catch (error) {
+				input.attr('title', error);
+				input.tipsy({gravity: 'w', trigger: 'manual'});
+				input.tipsy('show');
+				input.addClass('error');
 			}
-			form.remove();
-			td.children('a.name').show();
 			return false;
 		});
-		input.keyup(function(event){
-			if (event.keyCode == 27) {
+		input.keyup(function(event) {
+			// verify filename on typing
+			try {
+				checkInput();
+				input.tipsy('hide');
+				input.removeClass('error');
+			} catch (error) {
+				input.attr('title', error);
+				input.tipsy({gravity: 'w', trigger: 'manual'});
+				input.tipsy('show');
+				input.addClass('error');
+			}
+			if (event.keyCode === 27) {
+				input.tipsy('hide');
 				tr.data('renaming',false);
 				form.remove();
 				td.children('a.name').show();
 			}
 		});
-		input.click(function(event){
+		input.click(function(event) {
 			event.stopPropagation();
 			event.preventDefault();
 		});
-		input.blur(function(){
+		input.blur(function() {
 			form.trigger('submit');
 		});
 	},
-	checkName:function(oldName, newName, isNewFile) {
-		if (isNewFile || $('tr').filterAttr('data-file', newName).length > 0) {
-			var html;
-			if(isNewFile){
-				html = t('files', '{new_name} already exists', {new_name: escapeHTML(newName)})+'<span class="replace">'+t('files', 'replace')+'</span><span class="suggest">'+t('files', 'suggest name')+'</span>&nbsp;<span class="cancel">'+t('files', 'cancel')+'</span>';
-			}else{
-				html = t('files', '{new_name} already exists', {new_name: escapeHTML(newName)})+'<span class="replace">'+t('files', 'replace')+'</span><span class="cancel">'+t('files', 'cancel')+'</span>';
-			}
-			html = $('<span>' + html + '</span>');
-			html.attr('data-oldName', oldName);
-			html.attr('data-newName', newName);
-			html.attr('data-isNewFile', isNewFile);
-            OC.Notification.showHtml(html);
-			return true;
-		} else {
-			return false;
-		}
+	inList:function(filename) {
+		return $('#fileList tr[data-file="'+filename+'"]').length;
 	},
 	replace:function(oldName, newName, isNewFile) {
 		// Finish any existing actions
-		$('tr').filterAttr('data-file', oldName).hide();
-		$('tr').filterAttr('data-file', newName).hide();
-		var tr = $('tr').filterAttr('data-file', oldName).clone();
+		$('tr[data-file="'+oldName+'"]').hide();
+		$('tr[data-file="'+newName+'"]').hide();
+		var tr = $('tr[data-file="'+oldName+'"]').clone();
 		tr.attr('data-replace', 'true');
 		tr.attr('data-file', newName);
 		var td = tr.children('td.filename');
@@ -460,14 +480,14 @@ var FileList={
 			FileList.finishReplace();
 		};
 		if (!isNewFile) {
-            OC.Notification.showHtml(t('files', 'replaced {new_name} with {old_name}', {new_name: newName}, {old_name: oldName})+'<span class="undo">'+t('files', 'undo')+'</span>');
+			OC.Notification.showHtml(t('files', 'replaced {new_name} with {old_name}', {new_name: newName}, {old_name: oldName})+'<span class="undo">'+t('files', 'undo')+'</span>');
 		}
 	},
 	finishReplace:function() {
 		if (!FileList.replaceCanceled && FileList.replaceOldName && FileList.replaceNewName) {
 			$.ajax({url: OC.filePath('files', 'ajax', 'rename.php'), async: false, data: { dir: $('#dir').val(), newname: FileList.replaceNewName, file: FileList.replaceOldName }, success: function(result) {
-				if (result && result.status == 'success') {
-					$('tr').filterAttr('data-replace', 'true').removeAttr('data-replace');
+				if (result && result.status === 'success') {
+					$('tr[data-replace="true"').removeAttr('data-replace');
 				} else {
 					OC.dialogs.alert(result.data.message, 'Error moving file');
 				}
@@ -478,12 +498,12 @@ var FileList={
 			}});
 		}
 	},
-	do_delete:function(files){
-		if(files.substr){
+	do_delete:function(files) {
+		if (files.substr) {
 			files=[files];
 		}
 		for (var i=0; i<files.length; i++) {
-			var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date").children(".action.delete");
+			var deleteAction = $('tr[data-file="'+files[i]+'"]').children("td.date").children(".action.delete");
 			deleteAction.removeClass('delete-icon').addClass('progress-icon');
 		}
 		// Finish any existing actions
@@ -494,10 +514,10 @@ var FileList={
 		var fileNames = JSON.stringify(files);
 		$.post(OC.filePath('files', 'ajax', 'delete.php'),
 				{dir:$('#dir').val(),files:fileNames},
-				function(result){
-					if (result.status == 'success') {
-						$.each(files,function(index,file){
-							var files = $('tr').filterAttr('data-file',file);
+				function(result) {
+					if (result.status === 'success') {
+						$.each(files,function(index,file) {
+							var files = $('tr[data-file="'+file+'"]');
 							files.remove();
 							files.find('input[type="checkbox"]').removeAttr('checked');
 							files.removeClass('selected');
@@ -507,14 +527,14 @@ var FileList={
 						FileList.updateFileSummary();
 					} else {
 						$.each(files,function(index,file) {
-							var deleteAction = $('tr').filterAttr('data-file',files[i]).children("td.date").children(".action.delete");
+							var deleteAction = $('tr[data-file="'+files[i]+'"]').children("td.date").children(".action.delete");
 							deleteAction.removeClass('progress-icon').addClass('delete-icon');
 						});
 					}
 				});
 	},
 	createFileSummary: function() {
-		if( $('#fileList tr').length > 0 ) {
+		if ( $('#fileList tr').exists() ) {
 			var totalDirs = 0;
 			var totalFiles = 0;
 			var totalSize = 0;
@@ -536,7 +556,7 @@ var FileList={
 			var infoVars = {
 				dirs: '<span class="dirinfo">'+directoryInfo+'</span><span class="connector">',
 				files: '</span><span class="fileinfo">'+fileInfo+'</span>'
-			}
+			};
 
 			var info = t('files', '{dirs} and {files}', infoVars);
 
@@ -618,10 +638,10 @@ var FileList={
 			}
 		}
 	},
-	showMask: function(){
+	showMask: function() {
 		// in case one was shown before
 		var $mask = $('#content .mask');
-		if ($mask.length){
+		if ($mask.exists()) {
 			return;
 		}
 
@@ -632,31 +652,31 @@ var FileList={
 		$('#content').append($mask);
 
 		// block UI, but only make visible in case loading takes longer
-		FileList._maskTimeout = window.setTimeout(function(){
+		FileList._maskTimeout = window.setTimeout(function() {
 			// reset opacity
 			$mask.removeClass('transparent');
 		}, 250);
 	},
-	hideMask: function(){
+	hideMask: function() {
 		var $mask = $('#content .mask').remove();
-		if (FileList._maskTimeout){
+		if (FileList._maskTimeout) {
 			window.clearTimeout(FileList._maskTimeout);
 		}
 	},
 	scrollTo:function(file) {
 		//scroll to and highlight preselected file
-		var scrolltorow = $('tr[data-file="'+file+'"]');
-		if (scrolltorow.length > 0) {
-			scrolltorow.addClass('searchresult');
-			$(window).scrollTop(scrolltorow.position().top);
+		var $scrolltorow = $('tr[data-file="'+file+'"]');
+		if ($scrolltorow.exists()) {
+			$scrolltorow.addClass('searchresult');
+			$(window).scrollTop($scrolltorow.position().top);
 			//remove highlight when hovered over
-			scrolltorow.one('hover', function(){
-				scrolltorow.removeClass('searchresult');
+			$scrolltorow.one('hover', function() {
+				$scrolltorow.removeClass('searchresult');
 			});
 		}
 	},
-	filter:function(query){
-		$('#fileList tr:not(.summary)').each(function(i,e){
+	filter:function(query) {
+		$('#fileList tr:not(.summary)').each(function(i,e) {
 			if ($(e).data('file').toLowerCase().indexOf(query.toLowerCase()) !== -1) {
 				$(e).addClass("searchresult");
 			} else {
@@ -665,18 +685,18 @@ var FileList={
 		});
 		//do not use scrollto to prevent removing searchresult css class
 		var first = $('#fileList tr.searchresult').first();
-		if (first.length !== 0) {
+		if (first.exists()) {
 			$(window).scrollTop(first.position().top);
 		}
 	},
-	unfilter:function(){
-		$('#fileList tr.searchresult').each(function(i,e){
+	unfilter:function() {
+		$('#fileList tr.searchresult').each(function(i,e) {
 			$(e).removeClass("searchresult");
 		});
 	}
 };
 
-$(document).ready(function(){
+$(document).ready(function() {
 	var isPublic = !!$('#isPublic').val();
 
 	// handle upload events
@@ -686,16 +706,16 @@ $(document).ready(function(){
 		OC.Upload.log('filelist handle fileuploaddrop', e, data);
 
 		var dropTarget = $(e.originalEvent.target).closest('tr, .crumb');
-		if(dropTarget && (dropTarget.data('type') === 'dir' || dropTarget.hasClass('crumb'))) { // drag&drop upload to folder
+		if (dropTarget && (dropTarget.data('type') === 'dir' || dropTarget.hasClass('crumb'))) { // drag&drop upload to folder
 
 			// remember as context
 			data.context = dropTarget;
 
 			var dir = dropTarget.data('file');
 			// if from file list, need to prepend parent dir
-			if (dir){
+			if (dir) {
 				var parentDir = $('#dir').val() || '/';
-				if (parentDir[parentDir.length - 1] != '/'){
+				if (parentDir[parentDir.length - 1] !== '/') {
 					parentDir += '/';
 				}
 				dir = parentDir + dir;
@@ -719,12 +739,12 @@ $(document).ready(function(){
 		OC.Upload.log('filelist handle fileuploadadd', e, data);
 
 		//finish delete if we are uploading a deleted file
-		if(FileList.deleteFiles && FileList.deleteFiles.indexOf(data.files[0].name)!==-1){
+		if (FileList.deleteFiles && FileList.deleteFiles.indexOf(data.files[0].name)!==-1) {
 			FileList.finishDelete(null, true); //delete file before continuing
 		}
 
 		// add ui visualization to existing folder
-		if(data.context && data.context.data('type') === 'dir') {
+		if (data.context && data.context.data('type') === 'dir') {
 			// add to existing folder
 
 			// update upload counter ui
@@ -734,7 +754,7 @@ $(document).ready(function(){
 			uploadtext.attr('currentUploads', currentUploads);
 
 			var translatedText = n('files', 'Uploading %n file', 'Uploading %n files', currentUploads);
-			if(currentUploads === 1) {
+			if (currentUploads === 1) {
 				var img = OC.imagePath('core', 'loading.gif');
 				data.context.find('td.filename').attr('style','background-image:url('+img+')');
 				uploadtext.text(translatedText);
@@ -761,7 +781,7 @@ $(document).ready(function(){
 		}
 		var result=$.parseJSON(response);
 
-		if(typeof result[0] !== 'undefined' && result[0].status === 'success') {
+		if (typeof result[0] !== 'undefined' && result[0].status === 'success') {
 			var file = result[0];
 
 			if (data.context && data.context.data('type') === 'dir') {
@@ -772,7 +792,7 @@ $(document).ready(function(){
 				currentUploads -= 1;
 				uploadtext.attr('currentUploads', currentUploads);
 				var translatedText = n('files', 'Uploading %n file', 'Uploading %n files', currentUploads);
-				if(currentUploads === 0) {
+				if (currentUploads === 0) {
 					var img = OC.imagePath('core', 'filetypes/folder.png');
 					data.context.find('td.filename').attr('style','background-image:url('+img+')');
 					uploadtext.text(translatedText);
@@ -789,18 +809,18 @@ $(document).ready(function(){
 
 			} else {
 				// only append new file if dragged onto current dir's crumb (last)
-				if (data.context && data.context.hasClass('crumb') && !data.context.hasClass('last')){
+				if (data.context && data.context.hasClass('crumb') && !data.context.hasClass('last')) {
 					return;
 				}
 
 				// add as stand-alone row to filelist
 				var size=t('files', 'Pending');
-				if (data.files[0].size>=0){
+				if (data.files[0].size>=0) {
 					size=data.files[0].size;
 				}
 				var date=new Date();
 				var param = {};
-				if ($('#publicUploadRequestToken').length) {
+				if ($('#publicUploadRequestToken').exists()) {
 					param.download_url = document.location.href + '&download&path=/' + $('#dir').val() + '/' + file.name;
 				}
 				//should the file exist in the list remove it
@@ -813,14 +833,14 @@ $(document).ready(function(){
 				data.context.attr('data-mime',file.mime).attr('data-id',file.id);
 
 				var permissions = data.context.data('permissions');
-				if(permissions !== file.permissions) {
+				if (permissions !== file.permissions) {
 					data.context.attr('data-permissions', file.permissions);
 					data.context.data('permissions', file.permissions);
 				}
 				FileActions.display(data.context.find('td.filename'), true);
 
 				var path = getPathForPreview(file.name);
-				lazyLoadPreview(path, file.mime, function(previewpath){
+				lazyLoadPreview(path, file.mime, function(previewpath) {
 					data.context.find('td.filename').attr('style','background-image:url('+previewpath+')');
 				});
 			}
@@ -854,10 +874,10 @@ $(document).ready(function(){
 	});
 
 	$('#notification').hide();
-	$('#notification').on('click', '.undo', function(){
+	$('#notification').on('click', '.undo', function() {
 		if (FileList.deleteFiles) {
-			$.each(FileList.deleteFiles,function(index,file){
-				$('tr').filterAttr('data-file',file).show();
+			$.each(FileList.deleteFiles,function(index,file) {
+				$('tr[data-file="'+file+'"]').show();
 			});
 			FileList.deleteCanceled=true;
 			FileList.deleteFiles=null;
@@ -867,10 +887,10 @@ $(document).ready(function(){
 				FileList.deleteCanceled = false;
 				FileList.deleteFiles = [FileList.replaceOldName];
 			} else {
-				$('tr').filterAttr('data-file', FileList.replaceOldName).show();
+				$('tr[data-file="'+FileList.replaceOldName+'"]').show();
 			}
-			$('tr').filterAttr('data-replace', 'true').remove();
-			$('tr').filterAttr('data-file', FileList.replaceNewName).show();
+			$('tr[data-replace="true"').remove();
+			$('tr[data-file="'+FileList.replaceNewName+'"]').show();
 			FileList.replaceCanceled = true;
 			FileList.replaceOldName = null;
 			FileList.replaceNewName = null;
@@ -885,7 +905,7 @@ $(document).ready(function(){
 		});
 	});
 	$('#notification:first-child').on('click', '.suggest', function() {
-		$('tr').filterAttr('data-file', $('#notification > span').attr('data-oldName')).show();
+		$('tr[data-file="'+$('#notification > span').attr('data-oldName')+'"]').show();
 		OC.Notification.hide();
 	});
 	$('#notification:first-child').on('click', '.cancel', function() {
@@ -895,67 +915,67 @@ $(document).ready(function(){
 		}
 	});
 	FileList.useUndo=(window.onbeforeunload)?true:false;
-	$(window).bind('beforeunload', function (){
+	$(window).bind('beforeunload', function () {
 		if (FileList.lastAction) {
 			FileList.lastAction();
 		}
 	});
-	$(window).unload(function (){
+	$(window).unload(function () {
 		$(window).trigger('beforeunload');
 	});
 
-	function decodeQuery(query){
+	function decodeQuery(query) {
 		return query.replace(/\+/g, ' ');
 	}
 
-	function parseHashQuery(){
+	function parseHashQuery() {
 		var hash = window.location.hash,
 			pos = hash.indexOf('?'),
 			query;
-		if (pos >= 0){
+		if (pos >= 0) {
 			return hash.substr(pos + 1);
 		}
 		return '';
 	}
 
-	function parseCurrentDirFromUrl(){
+	function parseCurrentDirFromUrl() {
 		var query = parseHashQuery(),
 			params,
 			dir = '/';
 		// try and parse from URL hash first
-		if (query){
+		if (query) {
 			params = OC.parseQueryString(decodeQuery(query));
 		}
 		// else read from query attributes
-		if (!params){
+		if (!params) {
 			params = OC.parseQueryString(decodeQuery(location.search));
 		}
 		return (params && params.dir) || '/';
 	}
 
 	// disable ajax/history API for public app (TODO: until it gets ported)
-	if (!isPublic){
+	if (!isPublic) {
 		// fallback to hashchange when no history support
-		if (!window.history.pushState){
-			$(window).on('hashchange', function(){
+		if (!window.history.pushState) {
+			$(window).on('hashchange', function() {
 				FileList.changeDirectory(parseCurrentDirFromUrl(), false);
 			});
 		}
-		window.onpopstate = function(e){
+		window.onpopstate = function(e) {
 			var targetDir;
-			if (e.state && e.state.dir){
+			if (e.state && e.state.dir) {
 				targetDir = e.state.dir;
 			}
 			else{
 				// read from URL
 				targetDir = parseCurrentDirFromUrl();
 			}
-			if (targetDir){
+			if (targetDir) {
 				FileList.changeDirectory(targetDir, false);
 			}
-		}
+		};
 
-		if (parseInt($('#ajaxLoad').val(), 10) === 1){
+		if (parseInt($('#ajaxLoad').val(), 10) === 1) {
 			// need to initially switch the dir to the one from the hash (IE8)
 			FileList.changeDirectory(parseCurrentDirFromUrl(), false, true);
 		}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -1,18 +1,18 @@
 Files={
 	updateMaxUploadFilesize:function(response) {
-		if(response == undefined) {
+		if (response === undefined) {
 			return;
 		}
-		if(response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
+		if (response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
 			$('#max_upload').val(response.data.uploadMaxFilesize);
 			$('#upload.button').attr('original-title', response.data.maxHumanFilesize);
 			$('#usedSpacePercent').val(response.data.usedSpacePercent);
 			Files.displayStorageWarnings();
 		}
-		if(response[0] == undefined) {
+		if (response[0] === undefined) {
 			return;
 		}
-		if(response[0].uploadMaxFilesize !== undefined) {
+		if (response[0].uploadMaxFilesize !== undefined) {
 			$('#max_upload').val(response[0].uploadMaxFilesize);
 			$('#upload.button').attr('original-title', response[0].maxHumanFilesize);
 			$('#usedSpacePercent').val(response[0].usedSpacePercent);
@@ -22,23 +22,18 @@ Files={
 	},
 	isFileNameValid:function (name) {
 		if (name === '.') {
-			OC.Notification.show(t('files', '\'.\' is an invalid file name.'));
-			return false;
-		}
-		if (name.length == 0) {
-			OC.Notification.show(t('files', 'File name cannot be empty.'));
-			return false;
+			throw t('files', '\'.\' is an invalid file name.');
+		} else if (name.length === 0) {
+			throw t('files', 'File name cannot be empty.');
 		}
 
 		// check for invalid characters
 		var invalid_characters = ['\\', '/', '<', '>', ':', '"', '|', '?', '*'];
 		for (var i = 0; i < invalid_characters.length; i++) {
-			if (name.indexOf(invalid_characters[i]) != -1) {
-				OC.Notification.show(t('files', "Invalid name, '\\', '/', '<', '>', ':', '\"', '|', '?' and '*' are not allowed."));
-				return false;
+			if (name.indexOf(invalid_characters[i]) !== -1) {
+				throw t('files', "Invalid name, '\\', '/', '<', '>', ':', '\"', '|', '?' and '*' are not allowed.");
 			}
 		}
-		OC.Notification.hide();
 		return true;
 	},
 	displayStorageWarnings: function() {
@@ -78,18 +73,18 @@ Files={
 		}
 	},
 
-	setupDragAndDrop: function(){
+	setupDragAndDrop: function() {
 		var $fileList = $('#fileList');
 
 		//drag/drop of files
-		$fileList.find('tr td.filename').each(function(i,e){
+		$fileList.find('tr td.filename').each(function(i,e) {
 			if ($(e).parent().data('permissions') & OC.PERMISSION_DELETE) {
 				$(e).draggable(dragOptions);
 			}
 		});
 
-		$fileList.find('tr[data-type="dir"] td.filename').each(function(i,e){
-			if ($(e).parent().data('permissions') & OC.PERMISSION_CREATE){
+		$fileList.find('tr[data-type="dir"] td.filename').each(function(i,e) {
+			if ($(e).parent().data('permissions') & OC.PERMISSION_CREATE) {
 				$(e).droppable(folderDropOptions);
 			}
 		});
@@ -127,9 +122,9 @@ Files={
 	},
 
 	resizeBreadcrumbs: function (width, firstRun) {
-		if (width != Files.lastWidth) {
+		if (width !== Files.lastWidth) {
 			if ((width < Files.lastWidth || firstRun) && width < Files.breadcrumbsWidth) {
-				if (Files.hiddenBreadcrumbs == 0) {
+				if (Files.hiddenBreadcrumbs === 0) {
 					Files.breadcrumbsWidth -= $(Files.breadcrumbs[1]).get(0).offsetWidth;
 					$(Files.breadcrumbs[1]).find('a').hide();
 					$(Files.breadcrumbs[1]).append('<span>...</span>');
@@ -141,12 +136,12 @@ Files={
 					Files.breadcrumbsWidth -= $(Files.breadcrumbs[i]).get(0).offsetWidth;
 					$(Files.breadcrumbs[i]).hide();
 					Files.hiddenBreadcrumbs = i;
-					i++
+					i++;
 				}
 			} else if (width > Files.lastWidth && Files.hiddenBreadcrumbs > 0) {
 				var i = Files.hiddenBreadcrumbs;
 				while (width > Files.breadcrumbsWidth && i > 0) {
-					if (Files.hiddenBreadcrumbs == 1) {
+					if (Files.hiddenBreadcrumbs === 1) {
 						Files.breadcrumbsWidth -= $(Files.breadcrumbs[1]).get(0).offsetWidth;
 						$(Files.breadcrumbs[1]).find('span').remove();
 						$(Files.breadcrumbs[1]).find('a').show();
@@ -170,7 +165,7 @@ Files={
 };
 $(document).ready(function() {
 	// FIXME: workaround for trashbin app
-	if (window.trashBinApp){
+	if (window.trashBinApp) {
 		return;
 	}
 	Files.displayEncryptionWarning();
@@ -215,7 +210,7 @@ $(document).ready(function() {
 				var rows = $(this).parent().parent().parent().children('tr');
 				for (var i = start; i < end; i++) {
 					$(rows).each(function(index) {
-						if (index == i) {
+						if (index === i) {
 							var checkbox = $(this).children().children('input:checkbox');
 							$(checkbox).attr('checked', 'checked');
 							$(checkbox).parent().parent().addClass('selected');
@@ -232,23 +227,23 @@ $(document).ready(function() {
 			} else {
 				$(checkbox).attr('checked', 'checked');
 				$(checkbox).parent().parent().toggleClass('selected');
-				var selectedCount=$('td.filename input:checkbox:checked').length;
-				if (selectedCount == $('td.filename input:checkbox').length) {
+				var selectedCount = $('td.filename input:checkbox:checked').length;
+				if (selectedCount === $('td.filename input:checkbox').length) {
 					$('#select_all').attr('checked', 'checked');
 				}
 			}
 			procesSelection();
 		} else {
 			var filename=$(this).parent().parent().attr('data-file');
-			var tr=$('tr').filterAttr('data-file',filename);
+			var tr=$('tr[data-file="'+filename+'"]');
 			var renaming=tr.data('renaming');
-			if(!renaming && !FileList.isLoading(filename)){
+			if (!renaming && !FileList.isLoading(filename)) {
 				FileActions.currentFile = $(this).parent();
 				var mime=FileActions.getCurrentMimeType();
 				var type=FileActions.getCurrentType();
 				var permissions = FileActions.getCurrentPermissions();
 				var action=FileActions.getDefault(mime,type, permissions);
-				if(action){
+				if (action) {
 					event.preventDefault();
 					action(filename);
 				}
@@ -259,11 +254,11 @@ $(document).ready(function() {
 
 	// Sets the select_all checkbox behaviour :
 	$('#select_all').click(function() {
-		if($(this).attr('checked')){
+		if ($(this).attr('checked')) {
 			// Check all
 			$('td.filename input:checkbox').attr('checked', true);
 			$('td.filename input:checkbox').parent().parent().addClass('selected');
-		}else{
+		} else {
 			// Uncheck all
 			$('td.filename input:checkbox').attr('checked', false);
 			$('td.filename input:checkbox').parent().parent().removeClass('selected');
@@ -280,7 +275,7 @@ $(document).ready(function() {
 			var rows = $(this).parent().parent().parent().children('tr');
 			for (var i = start; i < end; i++) {
 				$(rows).each(function(index) {
-					if (index == i) {
+					if (index === i) {
 						var checkbox = $(this).children().children('input:checkbox');
 						$(checkbox).attr('checked', 'checked');
 						$(checkbox).parent().parent().addClass('selected');
@@ -290,10 +285,10 @@ $(document).ready(function() {
 		}
 		var selectedCount=$('td.filename input:checkbox:checked').length;
 		$(this).parent().parent().toggleClass('selected');
-		if(!$(this).attr('checked')){
+		if (!$(this).attr('checked')) {
 			$('#select_all').attr('checked',false);
-		}else{
-			if(selectedCount==$('td.filename input:checkbox').length){
+		} else {
+			if (selectedCount===$('td.filename input:checkbox').length) {
 				$('#select_all').attr('checked',true);
 			}
 		}
@@ -306,10 +301,11 @@ $(document).ready(function() {
 		var dir=$('#dir').val()||'/';
 		OC.Notification.show(t('files','Your download is being prepared. This might take some time if the files are big.'));
 		// use special download URL if provided, e.g. for public shared files
-		if ( (downloadURL = document.getElementById("downloadURL")) ) {
-			window.location=downloadURL.value+"&download&files="+encodeURIComponent(fileslist);
+		var downloadURL = document.getElementById("downloadURL");
+		if ( downloadURL ) {
+			window.location = downloadURL.value+"&download&files=" + encodeURIComponent(fileslist);
 		} else {
-			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
+			window.location = OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
 		}
 		return false;
 	});
@@ -376,12 +372,12 @@ $(document).ready(function() {
 	}
 });
 
-function scanFiles(force, dir, users){
+function scanFiles(force, dir, users) {
 	if (!OC.currentUser) {
 		return;
 	}
 
-	if(!dir){
+	if (!dir) {
 		dir = '';
 	}
 	force = !!force; //cast to bool
@@ -399,17 +395,17 @@ function scanFiles(force, dir, users){
 		scannerEventSource = new OC.EventSource(OC.filePath('files','ajax','scan.php'),{force: force,dir: dir});
 	}
 	scanFiles.cancel = scannerEventSource.close.bind(scannerEventSource);
-	scannerEventSource.listen('count',function(count){
-		console.log(count + ' files scanned')
+	scannerEventSource.listen('count',function(count) {
+		console.log(count + ' files scanned');
 	});
-	scannerEventSource.listen('folder',function(path){
-		console.log('now scanning ' + path)
+	scannerEventSource.listen('folder',function(path) {
+		console.log('now scanning ' + path);
 	});
-	scannerEventSource.listen('done',function(count){
+	scannerEventSource.listen('done',function(count) {
 		scanFiles.scanning=false;
 		console.log('done after ' + count + ' files');
 	});
-	scannerEventSource.listen('user',function(user){
+	scannerEventSource.listen('user',function(user) {
 		console.log('scanning files for ' + user);
 	});
 }
@@ -418,14 +414,14 @@ scanFiles.scanning=false;
 function boolOperationFinished(data, callback) {
 	result = jQuery.parseJSON(data.responseText);
 	Files.updateMaxUploadFilesize(result);
-	if(result.status == 'success'){
+	if (result.status === 'success') {
 		callback.call();
 	} else {
 		alert(result.data.message);
 	}
 }
 
-var createDragShadow = function(event){
+var createDragShadow = function(event) {
 	//select dragged file
 	var isDragSelected = $(event.target).parents('tr').find('td input:first').prop('checked');
 	if (!isDragSelected) {
@@ -435,7 +431,7 @@ var createDragShadow = function(event){
 
 	var selectedFiles = getSelectedFilesTrash();
 
-	if (!isDragSelected && selectedFiles.length == 1) {
+	if (!isDragSelected && selectedFiles.length === 1) {
 		//revert the selection
 		$(event.target).parents('tr').find('td input:first').prop('checked',false);
 	}
@@ -452,7 +448,7 @@ var createDragShadow = function(event){
 
 	var dir=$('#dir').val();
 
-	$(selectedFiles).each(function(i,elem){
+	$(selectedFiles).each(function(i,elem) {
 		var newtr = $('<tr/>').attr('data-dir', dir).attr('data-filename', elem.name);
 		newtr.append($('<td/>').addClass('filename').text(elem.name));
 		newtr.append($('<td/>').addClass('size').text(humanFileSize(elem.size)));
@@ -461,14 +457,14 @@ var createDragShadow = function(event){
 			newtr.find('td.filename').attr('style','background-image:url('+OC.imagePath('core', 'filetypes/folder.png')+')');
 		} else {
 			var path = getPathForPreview(elem.name);
-			lazyLoadPreview(path, elem.mime, function(previewpath){
+			lazyLoadPreview(path, elem.mime, function(previewpath) {
 				newtr.find('td.filename').attr('style','background-image:url('+previewpath+')');
 			});
 		}
 	});
 
 	return dragshadow;
-}
+};
 
 //options for file drag/drop
 var dragOptions={
@@ -478,7 +474,7 @@ var dragOptions={
 	stop: function(event, ui) {
 		$('#fileList tr td.filename').addClass('ui-draggable');
 	}
-}
+};
 // sane browsers support using the distance option
 if ( $('html.ie').length === 0) {
 	dragOptions['distance'] = 20;
@@ -491,20 +487,20 @@ var folderDropOptions={
 			return false;
 		}
 
-		var target=$.trim($(this).find('.nametext').text());
+		var target = $.trim($(this).find('.nametext').text());
 
 		var files = ui.helper.find('tr');
-		$(files).each(function(i,row){
+		$(files).each(function(i,row) {
 			var dir = $(row).data('dir');
 			var file = $(row).data('filename');
 			$.post(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: dir+'/'+target }, function(result) {
 				if (result) {
 					if (result.status === 'success') {
 						//recalculate folder size
-						var oldSize = $('#fileList tr').filterAttr('data-file',target).data('size');
-						var newSize = oldSize + $('#fileList tr').filterAttr('data-file',file).data('size');
-						$('#fileList tr').filterAttr('data-file',target).data('size', newSize);
-						$('#fileList tr').filterAttr('data-file',target).find('td.filesize').text(humanFileSize(newSize));
+						var oldSize = $('#fileList tr[data-file="'+target+'"]').data('size');
+						var newSize = oldSize + $('#fileList tr[data-file="'+file+'"]').data('size');
+						$('#fileList tr[data-file="'+target+'"]').data('size', newSize);
+						$('#fileList tr[data-file="'+target+'"]').find('td.filesize').text(humanFileSize(newSize));
 
 						FileList.remove(file);
 						procesSelection();
@@ -521,24 +517,24 @@ var folderDropOptions={
 		});
 	},
 	tolerance: 'pointer'
-}
+};
 
 var crumbDropOptions={
 	drop: function( event, ui ) {
 		var target=$(this).data('dir');
-		var dir=$('#dir').val();
-		while(dir.substr(0,1)=='/'){//remove extra leading /'s
+		var dir = $('#dir').val();
+		while(dir.substr(0,1) === '/') {//remove extra leading /'s
 				dir=dir.substr(1);
 		}
-		dir='/'+dir;
-		if(dir.substr(-1,1)!='/'){
-			dir=dir+'/';
+		dir = '/' + dir;
+		if (dir.substr(-1,1) !== '/') {
+			dir = dir + '/';
 		}
-		if(target==dir || target+'/'==dir){
+		if (target === dir || target+'/' === dir) {
 			return;
 		}
 		var files = ui.helper.find('tr');
-		$(files).each(function(i,row){
+		$(files).each(function(i,row) {
 			var dir = $(row).data('dir');
 			var file = $(row).data('filename');
 			$.post(OC.filePath('files', 'ajax', 'move.php'), { dir: dir, file: file, target: target }, function(result) {
@@ -559,13 +555,17 @@ var crumbDropOptions={
 		});
 	},
 	tolerance: 'pointer'
-}
+};
 
-function procesSelection(){
-	var selected=getSelectedFilesTrash();
-	var selectedFiles=selected.filter(function(el){return el.type=='file'});
-	var selectedFolders=selected.filter(function(el){return el.type=='dir'});
-	if(selectedFiles.length==0 && selectedFolders.length==0) {
+function procesSelection() {
+	var selected = getSelectedFilesTrash();
+	var selectedFiles = selected.filter(function(el) {
+		return el.type==='file';
+	});
+	var selectedFolders = selected.filter(function(el) {
+		return el.type==='dir';
+	});
+	if (selectedFiles.length === 0 && selectedFolders.length === 0) {
 		$('#headerName>span.name').text(t('files','Name'));
 		$('#headerSize').text(t('files','Size'));
 		$('#modified').text(t('files','Modified'));
@@ -574,22 +574,22 @@ function procesSelection(){
 	}
 	else {
 		$('.selectedActions').show();
-		var totalSize=0;
-		for(var i=0;i<selectedFiles.length;i++){
+		var totalSize = 0;
+		for(var i=0; i<selectedFiles.length; i++) {
 			totalSize+=selectedFiles[i].size;
 		};
-		for(var i=0;i<selectedFolders.length;i++){
+		for(var i=0; i<selectedFolders.length; i++) {
 			totalSize+=selectedFolders[i].size;
 		};
 		$('#headerSize').text(humanFileSize(totalSize));
-		var selection='';
-		if(selectedFolders.length>0){
+		var selection = '';
+		if (selectedFolders.length > 0) {
 			selection += n('files', '%n folder', '%n folders', selectedFolders.length);
-			if(selectedFiles.length>0){
-				selection+=' & ';
+			if (selectedFiles.length > 0) {
+				selection += ' & ';
 			}
 		}
-		if(selectedFiles.length>0){
+		if (selectedFiles.length>0) {
 			selection += n('files', '%n file', '%n files', selectedFiles.length);
 		}
 		$('#headerName>span.name').text(selection);
@@ -600,37 +600,37 @@ function procesSelection(){
 
 /**
  * @brief get a list of selected files
- * @param string property (option) the property of the file requested
- * @return array
+ * @param {string} property (option) the property of the file requested
+ * @return {array}
  *
  * possible values for property: name, mime, size and type
  * if property is set, an array with that property for each file is returnd
  * if it's ommited an array of objects with all properties is returned
  */
-function getSelectedFilesTrash(property){
+function getSelectedFilesTrash(property) {
 	var elements=$('td.filename input:checkbox:checked').parent().parent();
 	var files=[];
-	elements.each(function(i,element){
+	elements.each(function(i,element) {
 		var file={
 			name:$(element).attr('data-file'),
 			mime:$(element).data('mime'),
 			type:$(element).data('type'),
 			size:$(element).data('size')
 		};
-		if(property){
+		if (property) {
 			files.push(file[property]);
-		}else{
+		} else {
 			files.push(file);
 		}
 	});
 	return files;
 }
 
-function getMimeIcon(mime, ready){
-	if(getMimeIcon.cache[mime]){
+function getMimeIcon(mime, ready) {
+	if (getMimeIcon.cache[mime]) {
 		ready(getMimeIcon.cache[mime]);
-	}else{
-		$.get( OC.filePath('files','ajax','mimeicon.php'), {mime: mime}, function(path){
+	} else {
+		$.get( OC.filePath('files','ajax','mimeicon.php'), {mime: mime}, function(path) {
 			getMimeIcon.cache[mime]=path;
 			ready(getMimeIcon.cache[mime]);
 		});
@@ -655,7 +655,7 @@ function lazyLoadPreview(path, mime, ready, width, height) {
 		if ( ! height ) {
 			height = $('#filestable').data('preview-y');
 		}
-		if( $('#publicUploadButtonMock').length ) {
+		if ( $('#publicUploadButtonMock').length ) {
 			var previewURL = OC.Router.generate('core_ajax_public_preview', {file: path, x:width, y:height, t:$('#dirToken').val()});
 		} else {
 			var previewURL = OC.Router.generate('core_ajax_preview', {file: path, x:width, y:height});
@@ -669,8 +669,8 @@ function lazyLoadPreview(path, mime, ready, width, height) {
 	});
 }
 
-function getUniqueName(name){
-	if($('tr').filterAttr('data-file',name).length>0){
+function getUniqueName(name) {
+	if ($('tr[data-file="'+name+'"]').exists()) {
 		var parts=name.split('.');
 		var extension = "";
 		if (parts.length > 1) {
@@ -679,9 +679,9 @@ function getUniqueName(name){
 		var base=parts.join('.');
 		numMatch=base.match(/\((\d+)\)/);
 		var num=2;
-		if(numMatch && numMatch.length>0){
+		if (numMatch && numMatch.length>0) {
 			num=parseInt(numMatch[numMatch.length-1])+1;
-			base=base.split('(')
+			base=base.split('(');
 			base.pop();
 			base=$.trim(base.join('('));
 		}
@@ -695,19 +695,19 @@ function getUniqueName(name){
 }
 
 function checkTrashStatus() {
-	$.post(OC.filePath('files_trashbin', 'ajax', 'isEmpty.php'), function(result){
+	$.post(OC.filePath('files_trashbin', 'ajax', 'isEmpty.php'), function(result) {
 		if (result.data.isEmpty === false) {
 			$("input[type=button][id=trash]").removeAttr("disabled");
 		}
 	});
 }
 
-function onClickBreadcrumb(e){
+function onClickBreadcrumb(e) {
 	var $el = $(e.target).closest('.crumb'),
 		$targetDir = $el.data('dir');
 		isPublic = !!$('#isPublic').val();
 
-	if ($targetDir !== undefined && !isPublic){
+	if ($targetDir !== undefined && !isPublic) {
 		e.preventDefault();
 		FileList.changeDirectory(decodeURIComponent($targetDir));
 	}

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -25,7 +25,14 @@
 namespace OCA\Files;
 
 class App {
+	/**
+	 * @var \OC_L10N
+	 */
 	private $l10n;
+
+	/**
+	 * @var \OC\Files\View
+	 */
 	private $view;
 
 	public function __construct($view, $l10n) {

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -52,7 +52,15 @@ class App {
 			$result['data'] = array(
 				'message'	=> $this->l10n->t("Invalid folder name. Usage of 'Shared' is reserved by ownCloud")
 			);
-		} elseif(
+		// rename to existing file is denied
+		} else if ($this->view->file_exists($dir . '/' . $newname)) {
+			
+			$result['data'] = array(
+				'message'	=> $this->l10n->t(
+						"The name %s is already used in the folder %s. Please choose a different name.",
+						array($newname, $dir))
+			);
+		} else if (
 			// rename to "." is denied
 			$newname !== '.' and
 			// rename of  "/Shared" is denied

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -933,7 +933,7 @@ jQuery.fn.selectRange = function(start, end) {
  */
 jQuery.fn.exists = function(){
 	return this.length > 0;
-}
+};
 
 /**
  * Calls the server periodically every 15 mins to ensure that session doesnt

--- a/core/js/octemplate.js
+++ b/core/js/octemplate.js
@@ -82,7 +82,7 @@
 					}
 				);
 			} catch(e) {
-				console.error(e, 'data:', data)
+				console.error(e, 'data:', data);
 			}
 		},
 		options: {

--- a/core/templates/message.html
+++ b/core/templates/message.html
@@ -1,3 +1,3 @@
-<div id="{dialog_name}" title="{title}">
+<div id="{dialog_name}" title="{title} "><!-- the ' ' after {title} fixes ie8, see http://stackoverflow.com/a/5313137/828717 -->
 	<p><span class="ui-icon ui-icon-{type}"></span>{message}</p>
 </div>


### PR DESCRIPTION
- show tooltip when violating naming constraints while typing
- when target filename exists on server fallback to dialog to interrupt the users flow because something unexpected went wrong
- fixes #5062
- also fixes some whitespace and codestyle issues in files js
- uses css selector over filterAttr in touched js files

creating new files / folders / from url:
![bildschirmfoto vom 2013-10-22 17 19 42](https://f.cloud.github.com/assets/956847/1382993/185604b4-3b36-11e3-8759-b84da2f2b0de.png)
![bildschirmfoto vom 2013-10-22 17 19 18](https://f.cloud.github.com/assets/956847/1382994/188832c2-3b36-11e3-8fb8-f828bde85705.png)
![bildschirmfoto vom 2013-10-22 17 19 54](https://f.cloud.github.com/assets/956847/1382995/188e90c2-3b36-11e3-9f90-4d9160d59c3d.png)
![bildschirmfoto vom 2013-10-22 17 19 07](https://f.cloud.github.com/assets/956847/1382996/189091c4-3b36-11e3-816c-0d647ee827d4.png)

fallback dialog when file exists on server but web ui has not been refreshed:
![bildschirmfoto vom 2013-10-22 17 23 02](https://f.cloud.github.com/assets/956847/1382998/193b7f4e-3b36-11e3-949a-47618af00ba1.png)

renaming files:
![bildschirmfoto vom 2013-10-22 18 31 35](https://f.cloud.github.com/assets/956847/1383095/86c08f36-3b37-11e3-9265-e227eb93bdaa.png)

tested in chrome and IE8

@jancborchardt @PVince81 @ser72 @DeepDiver1975 please review
