### PR TITLE
Expand exception stack trace in log in debug mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@ try {
 	OC::handleRequest();
 
 } catch (Exception $ex) {
-	\OCP\Util::logException($ex);
+	\OCP\Util::logException('index', $ex);
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);

--- a/index.php
+++ b/index.php
@@ -23,34 +23,6 @@
 
 $RUNTIME_NOAPPS = true; //no apps, yet
 
-function logException($ex) {
-	$message = $ex->getMessage();
-	if ($ex->getCode()) {
-		$message .= ' [' . $message . ']';
-	}
-	\OCP\Util::writeLog('index', $message, \OCP\Util::FATAL);
-	if (defined('DEBUG') and DEBUG) {
-		// also log stack trace
-		$stack = explode('#', $ex->getTraceAsString());
-		// first element is empty
-		array_shift($stack);
-		foreach ($stack as $s) {
-			\OCP\Util::writeLog('index', $s, \OCP\Util::FATAL);
-		}
-
-		// include cause
-		$l = OC_L10N::get('lib');
-		while (method_exists($ex, 'getPrevious') && $ex = $ex->getPrevious()) {
-			$message .= ' - '.$l->t('Caused by:').' ';
-			$message .= $ex->getMessage();
-			if ($ex->getCode()) {
-				$message .= '['.$ex->getCode().'] ';
-			}
-			\OCP\Util::writeLog('index', $message, \OCP\Util::FATAL);
-		}
-	}
-}
-
 try {
 	
 	require_once 'lib/base.php';
@@ -58,7 +30,7 @@ try {
 	OC::handleRequest();
 
 } catch (Exception $ex) {
-	logException($ex);
+	\OCP\Util::logException($ex);
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -78,6 +78,39 @@ class Util {
 	}
 
 	/**
+	 * @brief write exception into the log. Include the stack trace
+	 * if DEBUG mode is enabled
+	 * @param Exception $ex exception to log
+	 */
+	public static function logException( \Exception $ex ) {
+		$message = $ex->getMessage();
+		if ($ex->getCode()) {
+			$message .= ' [' . $ex->getCode() . ']';
+		}
+		\OCP\Util::writeLog('index', 'Exception: ' . $message, \OCP\Util::FATAL);
+		if (defined('DEBUG') and DEBUG) {
+			// also log stack trace
+			$stack = explode('#', $ex->getTraceAsString());
+			// first element is empty
+			array_shift($stack);
+			foreach ($stack as $s) {
+				\OCP\Util::writeLog('index', 'Exception: ' . $s, \OCP\Util::FATAL);
+			}
+
+			// include cause
+			$l = \OC_L10N::get('lib');
+			while (method_exists($ex, 'getPrevious') && $ex = $ex->getPrevious()) {
+				$message .= ' - '.$l->t('Caused by:').' ';
+				$message .= $ex->getMessage();
+				if ($ex->getCode()) {
+					$message .= '[' . $ex->getCode() . '] ';
+				}
+				\OCP\Util::writeLog('index', 'Exception: ' . $message, \OCP\Util::FATAL);
+			}
+		}
+	}
+
+	/**
 	 * @brief get l10n object
 	 * @param string $app
 	 * @return OC_L10N

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -82,19 +82,19 @@ class Util {
 	 * if DEBUG mode is enabled
 	 * @param Exception $ex exception to log
 	 */
-	public static function logException( \Exception $ex ) {
+	public static function logException( $app, \Exception $ex ) {
 		$message = $ex->getMessage();
 		if ($ex->getCode()) {
 			$message .= ' [' . $ex->getCode() . ']';
 		}
-		\OCP\Util::writeLog('index', 'Exception: ' . $message, \OCP\Util::FATAL);
+		\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
 		if (defined('DEBUG') and DEBUG) {
 			// also log stack trace
 			$stack = explode('#', $ex->getTraceAsString());
 			// first element is empty
 			array_shift($stack);
 			foreach ($stack as $s) {
-				\OCP\Util::writeLog('index', 'Exception: ' . $s, \OCP\Util::FATAL);
+				\OCP\Util::writeLog($app, 'Exception: ' . $s, \OCP\Util::FATAL);
 			}
 
 			// include cause
@@ -105,7 +105,7 @@ class Util {
 				if ($ex->getCode()) {
 					$message .= '[' . $ex->getCode() . '] ';
 				}
-				\OCP\Util::writeLog('index', 'Exception: ' . $message, \OCP\Util::FATAL);
+				\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
 			}
 		}
 	}


### PR DESCRIPTION
Log exception stack trace in debug mode instead of just the message.

Based on the discussion in https://github.com/owncloud/core/pull/5273

Please review @karlitschek @DeepDiver1975 @tanghus 
