### PR TITLE
Fix namespace for OCP\Appframework\Http

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -24,7 +24,7 @@
 
 namespace OC\AppFramework\DependencyInjection;
 
-use OC\AppFramework\Http\Http;
+use OC\AppFramework\Http;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Core\API;

--- a/lib/private/appframework/http.php
+++ b/lib/private/appframework/http.php
@@ -22,10 +22,11 @@
  */
 
 
-namespace OC\AppFramework\Http;
+namespace OC\AppFramework;
 
+use OCP\AppFramework\Http as BaseHttp;
 
-class Http extends \OCP\AppFramework\Http\Http{
+class Http extends BaseHttp {
 
 	private $server;
 	private $protocolVersion;

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -25,6 +25,7 @@
 namespace OC\AppFramework\Http;
 
 use \OC\AppFramework\Middleware\MiddlewareDispatcher;
+use \OC\AppFramework\Http;
 use OCP\AppFramework\Controller;
 
 

--- a/lib/private/appframework/http/redirectresponse.php
+++ b/lib/private/appframework/http/redirectresponse.php
@@ -24,7 +24,8 @@
 
 namespace OC\AppFramework\Http;
 
-use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\Response,
+	OCP\AppFramework\Http;
 
 
 /**

--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -24,7 +24,7 @@
 
 namespace OC\AppFramework\Middleware\Security;
 
-use OC\AppFramework\Http\Http;
+use OC\AppFramework\Http;
 use OC\AppFramework\Http\RedirectResponse;
 use OC\AppFramework\Utility\MethodAnnotationReader;
 use OCP\AppFramework\Middleware;

--- a/lib/public/appframework/http.php
+++ b/lib/public/appframework/http.php
@@ -22,7 +22,7 @@
  */
 
 
-namespace OCP\AppFramework\Http;
+namespace OCP\AppFramework;
 
 
 class Http {

--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -24,6 +24,7 @@
 
 namespace OCP\AppFramework\Http;
 
+use OCP\AppFramework\Http;
 
 /**
  * A renderer for JSON calls

--- a/lib/public/appframework/http/response.php
+++ b/lib/public/appframework/http/response.php
@@ -24,6 +24,7 @@
 
 namespace OCP\AppFramework\Http;
 
+use OCP\AppFramework\Http;
 
 /**
  * Base class for responses. Also used to just send headers.

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -26,7 +26,7 @@ namespace OC\AppFramework\Http;
 
 use OC\AppFramework\Core\API;
 use OC\AppFramework\Middleware\MiddlewareDispatcher;
-
+use OCP\AppFramework\Http;
 //require_once(__DIR__ . "/../classloader.php");
 
 
@@ -53,7 +53,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->http = $this->getMockBuilder(
-			'\OC\AppFramework\Http\Http')
+			'\OC\AppFramework\Http')
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/appframework/http/HttpTest.php
+++ b/tests/lib/appframework/http/HttpTest.php
@@ -24,6 +24,7 @@
 
 namespace OC\AppFramework\Http;
 
+use OC\AppFramework\Http;
 
 //require_once(__DIR__ . "/../classloader.php");
 

--- a/tests/lib/appframework/http/RedirectResponseTest.php
+++ b/tests/lib/appframework/http/RedirectResponseTest.php
@@ -24,6 +24,7 @@
 
 namespace OC\AppFramework\Http;
 
+use OCP\AppFramework\Http;
 
 //require_once(__DIR__ . "/../classloader.php");
 

--- a/tests/lib/appframework/http/ResponseTest.php
+++ b/tests/lib/appframework/http/ResponseTest.php
@@ -25,7 +25,8 @@
 namespace OC\AppFramework\Http;
 
 
-use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\Response,
+	OCP\AppFramework\Http;
 
 
 class ResponseTest extends \PHPUnit_Framework_TestCase {

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -24,7 +24,7 @@
 
 namespace OC\AppFramework\Middleware\Security;
 
-use OC\AppFramework\Http\Http;
+use OC\AppFramework\Http;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\JSONResponse;


### PR DESCRIPTION
To avoid having to use OCP\Appframework\Http\Http in the public - and stable - API, OCP\Appframework\Http is now both a class and a namespace.
Basically the same method as used for Sabre VObject Property, Component etc except that Http has both a private and a public implementation.

Not strictly a bugfix, but OTOH urgent to have a stable and sensible API before releasing it.

@DeepDiver1975 @karlitschek 
