### PR TITLE
Fix ldap login

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -898,7 +898,9 @@ class Access extends LDAPUtility {
 		if(!$testConnection->setConfiguration($credentials)) {
 			return false;
 		}
-		return $testConnection->bind();
+		$result=$testConnection->bind();
+		$this->connection->bind();
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
forward port of #5425
verified that issue still exists in OC6 and that the fix works
This contribution is MIT licensed.
@blizzz
