### PR TITLE
prefer logo png from theme over svg from core

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -81,17 +81,35 @@ class URLGenerator implements IURLGenerator {
 		// Read the selected theme from the config file
 		$theme = \OC_Util::getTheme();
 
+		//if a theme has a png but not an svg always use the png
+		$basename = substr(basename($image),0,-4);
+
 		// Check if the app is in the app folder
 		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
 			return \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$image";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
+				&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
+			return \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$basename.png";
 		} elseif (file_exists(\OC_App::getAppPath($app) . "/img/$image")) {
 			return \OC_App::getAppWebPath($app) . "/img/$image";
+		} elseif (!file_exists(\OC_App::getAppPath($app) . "/img/$basename.svg")
+				&& file_exists(\OC_App::getAppPath($app) . "/img/$basename.png")) {
+			return \OC_App::getAppPath($app) . "/img/$basename.png";
 		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$image")) {
 			return \OC::$WEBROOT . "/themes/$theme/$app/img/$image";
+		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.svg")
+				&& file_exists(\OC::$WEBROOT . "/themes/$theme/$app/img/$basename.png"))) {
+			return \OC::$WEBROOT . "/themes/$theme/$app/img/$basename.png";
 		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/$app/img/$image")) {
 			return \OC::$WEBROOT . "/$app/img/$image";
+		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/$app/img/$basename.svg")
+				&& file_exists(\OC::$WEBROOT . "/$app/img/$basename.png"))) {
+			return \OC::$WEBROOT . "/$app/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$image")) {
 			return \OC::$WEBROOT . "/themes/$theme/core/img/$image";
+		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.svg")
+				&& file_exists(\OC::$SERVERROOT . "/themes/$theme/core/img/$basename.png")) {
+			return \OC::$WEBROOT . "/themes/$theme/core/img/$basename.png";
 		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$image")) {
 			return \OC::$WEBROOT . "/core/img/$image";
 		} else {


### PR DESCRIPTION
The logo images are specified in the php templates with eg `image_path('', 'logo-wide.svg')`. If that file exists the correct path will be served to the client in the html template. Then the `SVGSupport()` is checked in https://github.com/owncloud/core/blob/master/core/js/js.js#L701 which will replace `svg` with `png` in img tags and css background definitions.

fixes #5074
partially solves #5421, but not when an svg has been specified in css and is then 'fixed' by js to point to a png which does not exist in the theme but is then might be resolved to an image from core .... well theoretical problem ... might not even be a problem

@karlitschek @jancborchardt please review
