### PR TITLE
Fix file cache updater

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -38,6 +38,11 @@ class Hooks {
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function login($params) {
+
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
+
 		$l = new \OC_L10N('files_encryption');
 
 		$view = new \OC_FilesystemView('/');
@@ -129,11 +134,12 @@ class Hooks {
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function postCreateUser($params) {
-		$view = new \OC_FilesystemView('/');
 
-		$util = new Util($view, $params['uid']);
-
-		Helper::setupUser($util, $params['password']);
+		if (\OCP\App::isEnabled('files_encryption')) {
+			$view = new \OC_FilesystemView('/');
+			$util = new Util($view, $params['uid']);
+			Helper::setupUser($util, $params['password']);
+		}
 	}
 
 	/**
@@ -141,26 +147,31 @@ class Hooks {
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function postDeleteUser($params) {
-		$view = new \OC_FilesystemView('/');
 
-		// cleanup public key
-		$publicKey = '/public-keys/' . $params['uid'] . '.public.key';
+		if (\OCP\App::isEnabled('files_encryption')) {
+			$view = new \OC_FilesystemView('/');
 
-		// Disable encryption proxy to prevent recursive calls
-		$proxyStatus = \OC_FileProxy::$enabled;
-		\OC_FileProxy::$enabled = false;
+			// cleanup public key
+			$publicKey = '/public-keys/' . $params['uid'] . '.public.key';
 
-		$view->unlink($publicKey);
+			// Disable encryption proxy to prevent recursive calls
+			$proxyStatus = \OC_FileProxy::$enabled;
+			\OC_FileProxy::$enabled = false;
 
-		\OC_FileProxy::$enabled = $proxyStatus;
+			$view->unlink($publicKey);
+
+			\OC_FileProxy::$enabled = $proxyStatus;
+		}
 	}
 
 	/**
 	 * @brief If the password can't be changed within ownCloud, than update the key password in advance.
 	 */
 	public static function preSetPassphrase($params) {
-		if ( ! \OC_User::canUserChangePassword($params['uid']) ) {
-			self::setPassphrase($params);
+		if (\OCP\App::isEnabled('files_encryption')) {
+			if ( ! \OC_User::canUserChangePassword($params['uid']) ) {
+				self::setPassphrase($params);
+			}
 		}
 	}
 
@@ -169,6 +180,10 @@ class Hooks {
 	 * @param array $params keys: uid, password
 	 */
 	public static function setPassphrase($params) {
+
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
 
 		// Only attempt to change passphrase if server-side encryption
 		// is in use (client-side encryption does not have access to
@@ -240,6 +255,10 @@ class Hooks {
 	 */
 	public static function preShared($params) {
 
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
+
 		$l = new \OC_L10N('files_encryption');
 		$users = array();
 		$view = new \OC\Files\View('/public-keys/');
@@ -271,6 +290,10 @@ class Hooks {
 	 * @brief
 	 */
 	public static function postShared($params) {
+
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
 
 		// NOTE: $params has keys:
 		// [itemType] => file
@@ -378,6 +401,10 @@ class Hooks {
 	 */
 	public static function postUnshare($params) {
 
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
+
 		// NOTE: $params has keys:
 		// [itemType] => file
 		// [itemSource] => 13
@@ -466,6 +493,11 @@ class Hooks {
 	 * of the stored versions along the actual file
 	 */
 	public static function postRename($params) {
+
+		if (\OCP\App::isEnabled('files_encryption') === false) {
+			return true;
+		}
+
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
 		\OC_FileProxy::$enabled = false;
@@ -558,9 +590,11 @@ class Hooks {
 	 * @param array $params contains the app ID
 	 */
 	public static function preDisable($params) {
-		if ($params['app'] === 'files_encryption') {
-			$query = \OC_DB::prepare('UPDATE `*PREFIX*encryption` SET `migration_status`=0');
-			$query->execute();
+		if (\OCP\App::isEnabled('files_encryption')) {
+			if ($params['app'] === 'files_encryption') {
+				$query = \OC_DB::prepare('UPDATE `*PREFIX*encryption` SET `migration_status`=0');
+				$query->execute();
+			}
 		}
 	}
 

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -49,13 +49,6 @@ class Shared_Updater {
 				}
 				$users = $reshareUsers;
 			}
-			// Correct folders of shared file owner
-			$target = substr($target, 8);
-			if ($uidOwner !== $uid && $source = \OC_Share_Backend_File::getSource($target)) {
-				\OC\Files\Filesystem::initMountPoints($uidOwner);
-				$source = '/'.$uidOwner.'/'.$source['path'];
-				\OC\Files\Cache\Updater::correctFolder($source, $info['mtime']);
-			}
 		}
 	}
 

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -287,10 +287,6 @@ class Cache {
 	 * @return int
 	 */
 	public function getId($file) {
-		// if no file is given return -1
-		if ($file === '') {
-			return -1;
-		}
 		// normalize path
 		$file = $this->normalize($file);
 

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -287,6 +287,10 @@ class Cache {
 	 * @return int
 	 */
 	public function getId($file) {
+		// if no file is given return -1
+		if ($file === '') {
+			return -1;
+		}
 		// normalize path
 		$file = $this->normalize($file);
 
@@ -518,7 +522,7 @@ class Cache {
 				if ($entry['size'] !== $totalSize) {
 					$this->update($id, array('size' => $totalSize));
 				}
-				
+
 			}
 		}
 		return $totalSize;

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -82,7 +82,7 @@ class Updater {
 	 * @param string $filename
 	 * @return array with the oweners uid and the owners path
 	 */
-	public static function getUidAndFilename($filename) {
+	private static function getUidAndFilename($filename) {
 		$uid = \OC\Files\Filesystem::getOwner($filename);
 		\OC\Files\Filesystem::initMountPoints($uid);
 		if ( $uid != \OCP\User::getUser() ) {

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -102,13 +102,10 @@ class Updater {
 			$id = $cache->getId($internalPath);
 
 			while ($id !== -1) {
-				error_log("while loop: " . $id);
 				$cache->update($id, array('mtime' => $time, 'etag' => $storage->getETag($internalPath)));
 				//$id = $cache->getParentId($internalPath);
 				$internalPath = dirname($internalPath);
-				//if ($internalPath === '.') {
-				//	$internalPath = '';
-				//}
+				// check storage for parent in case we change the storage in this step
 				list($storage, $internalPath) = $view->resolvePath($internalPath);
 				$cache = $storage->getCache();
 				$id = $cache->getId($internalPath);

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -86,10 +86,6 @@ class Updater {
 	 * @param string $time
 	 */
 	static public function correctFolder($path, $time) {
-		//Shared folder gets handles by the files_sharing app
-		//if (strpos($path, '/Shared' === 0)) {
-		//	return true;
-		//}
 
 		if ($path !== '' && $path !== '/') {
 

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -94,17 +94,24 @@ class Updater {
 			 * @var string $internalPath
 			 */
 			list($storage, $internalPath) = self::resolvePath(dirname($path));
+			$owner = \OC\Files\Filesystem::getOwner($path);
+			$view = new \OC\Files\View($owner);
+
 
 			$cache = $storage->getCache();
 			$id = $cache->getId($internalPath);
 
 			while ($id !== -1) {
+				error_log("while loop: " . $id);
 				$cache->update($id, array('mtime' => $time, 'etag' => $storage->getETag($internalPath)));
-				$id = $cache->getParentId($internalPath);
+				//$id = $cache->getParentId($internalPath);
 				$internalPath = dirname($internalPath);
-				if ($internalPath === '.') {
-					$internalPath = '';
-				}
+				//if ($internalPath === '.') {
+				//	$internalPath = '';
+				//}
+				list($storage, $internalPath) = $view->resolvePath($internalPath);
+				$cache = $storage->getCache();
+				$id = $cache->getId($internalPath);
 
 			}
 

--- a/lib/files/cache/updater.php
+++ b/lib/files/cache/updater.php
@@ -100,11 +100,12 @@ class Updater {
 
 			while ($id !== -1) {
 				$cache->update($id, array('mtime' => $time, 'etag' => $storage->getETag($internalPath)));
+				$id = $cache->getParentId($internalPath);
 				$internalPath = dirname($internalPath);
 				if ($internalPath === '.') {
 					$internalPath = '';
 				}
-				$id = $cache->getId($internalPath);
+
 			}
 
 		}

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -46,6 +46,10 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		if (!self::$user) {
 			self::$user = uniqid();
 		}
+
+		\OC_User::createUser(self::$user, 'password');
+		\OC_User::setUserId(self::$user);
+
 		\OC\Files\Filesystem::init(self::$user, '/' . self::$user . '/files');
 
 		Filesystem::clearMounts();
@@ -63,6 +67,7 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		if ($this->cache) {
 			$this->cache->clear();
 		}
+		\OC_User::deleteUser(self::$user);
 		Filesystem::tearDown();
 	}
 

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -21,6 +21,8 @@ class Updater extends \PHPUnit_Framework_TestCase {
 	 */
 	private $scanner;
 
+	private $stateFilesEncryption;
+
 	/**
 	 * @var \OC\Files\Cache\Cache $cache
 	 */
@@ -29,6 +31,12 @@ class Updater extends \PHPUnit_Framework_TestCase {
 	private static $user;
 
 	public function setUp() {
+
+		// remember files_encryption state
+		$this->stateFilesEncryption = \OC_App::isEnabled('files_encryption');
+		// we want to tests with the encryption app disabled
+		\OC_App::disable('files_encryption');
+
 		$this->storage = new \OC\Files\Storage\Temporary(array());
 		$textData = "dummy file data\n";
 		$imgData = file_get_contents(\OC::$SERVERROOT . '/core/img/logo.png');
@@ -69,6 +77,10 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		}
 		\OC_User::deleteUser(self::$user);
 		Filesystem::tearDown();
+		// reset app files_encryption
+		if ($this->stateFilesEncryption) {
+			\OC_App::enable('files_encryption');
+		}
 	}
 
 	public function testWrite() {


### PR DESCRIPTION
This fixes bug https://github.com/owncloud/core/issues/5098
For a detailed explanation how to reproduce it look at: https://github.com/owncloud/mirall/issues/1056#issuecomment-25524490

@icewind1991 please have a look. correctFolder() always assumed that we are operating on a folder owned by the current user which of course is wrong in case of a shared file. That's why I changed resolvePath() to resolve the path to the owners path and updated the correctFolder() method to loop though the correct folder tree.

Also affects master, will port it once the fix is merged for stable5.
