### PR TITLE
Added syntax help for autotest.sh

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -12,9 +12,35 @@ DATABASEUSER=oc_autotest$EXECUTOR_NUMBER
 ADMINLOGIN=admin$EXECUTOR_NUMBER
 BASEDIR=$PWD
 
+DBCONFIGS="sqlite mysql pgsql oci"
+
+function print_syntax {
+	echo -e "Syntax: ./autotest.sh [dbconfigname] [testfile]\n" >&2
+	echo -e "\t\"dbconfigname\" can be one of: $DBCONFIGS" >&2
+	echo -e "\t\"testfile\" is the name of a test file, for example lib/template.php" >&2
+	echo -e "\nExample: ./autotest.sh sqlite lib/template.php" >&2
+	echo "will run the test suite from \"tests/lib/template.php\"" >&2
+	echo -e "\nIf no arguments are specified, all tests will be run with all database configs" >&2
+}
+
 if ! [ -w config -a -w config/config.php ]; then
 	echo "Please enable write permissions on config and config/config.php" >&2
 	exit 1
+fi
+
+if [ $1 ]; then
+	FOUND=0
+	for DBCONFIG in $DBCONFIGS; do
+		if [ $1 = $DBCONFIG ]; then
+			FOUND=1
+			break
+		fi
+	done
+	if [ $FOUND = 0 ]; then
+		echo -e "Unknown database config name \"$1\"\n" >&2
+		print_syntax
+		exit 2
+	fi
 fi
 
 # Back up existing (dev) config if one exists
@@ -160,10 +186,10 @@ EOF
 #
 if [ -z "$1" ]
   then
-	execute_tests 'sqlite'
-	execute_tests 'mysql'
-	execute_tests 'pgsql'
-	execute_tests 'oci'
+	# run all known database configs
+	for DBCONFIG in $DBCONFIGS; do
+		execute_tests $DBCONFIG
+	done
 else
 	execute_tests $1 $2 $3
 fi


### PR DESCRIPTION
autotest.sh now checks for the validity of the db config name argument.
If the db config name is not known, it show syntax info.

This should save some time to people to understand how to use this
script. Before this fix, an invalid argument would return a big HTML
page in the output.

@DeepDiver1975 please review
