### PR TITLE
Fixes for quota stream fseek

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -95,7 +95,7 @@ class Quota extends Wrapper {
 	public function fopen($path, $mode) {
 		$source = $this->storage->fopen($path, $mode);
 		$free = $this->free_space('');
-		if ($free >= 0) {
+		if ($free >= 0 && $mode !== 'r') {
 			return \OC\Files\Stream\Quota::wrap($source, $free);
 		} else {
 			return $source;

--- a/lib/private/files/stream/quota.php
+++ b/lib/private/files/stream/quota.php
@@ -81,6 +81,8 @@ class Quota {
 		} else {
 			$this->limit -= $offset;
 		}
+		// this wrapper needs to return "true" for success.
+		// the fseek call itself returns 0 on succeess
 		return !fseek($this->source, $offset, $whence);
 	}
 

--- a/lib/private/files/stream/quota.php
+++ b/lib/private/files/stream/quota.php
@@ -66,12 +66,22 @@ class Quota {
 	}
 
 	public function stream_seek($offset, $whence = SEEK_SET) {
-		if ($whence === SEEK_SET) {
+		if ($whence === SEEK_END){
+			// go to the end to find out last position's offset
+			$oldOffset = $this->stream_tell();
+			if (fseek($this->source, 0, $whence) !== 0){
+				return false;
+			}
+			$whence = SEEK_SET;
+			$offset = $this->stream_tell() + $offset;
+			$this->limit += $oldOffset - $offset;
+		}
+		else if ($whence === SEEK_SET) {
 			$this->limit += $this->stream_tell() - $offset;
 		} else {
 			$this->limit -= $offset;
 		}
-		fseek($this->source, $offset, $whence);
+		return !fseek($this->source, $offset, $whence);
 	}
 
 	public function stream_tell() {

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -58,4 +58,26 @@ class Quota extends \Test\Files\Storage\Storage {
 		fclose($stream);
 		$this->assertEquals('foobarqwe', $instance->file_get_contents('foo'));
 	}
+
+	public function testReturnRegularStreamOnRead(){
+		$instance = $this->getLimitedStorage(9);
+
+		// create test file first
+		$stream = $instance->fopen('foo', 'w+');
+		fwrite($stream, 'blablacontent');
+		fclose($stream);
+
+		$stream = $instance->fopen('foo', 'r');
+		$meta = stream_get_meta_data($stream);
+		$this->assertEquals('plainfile', $meta['wrapper_type']);
+		fclose($stream);
+	}
+
+	public function testReturnQuotaStreamOnWrite(){
+		$instance = $this->getLimitedStorage(9);
+		$stream = $instance->fopen('foo', 'w+');
+		$meta = stream_get_meta_data($stream);
+		$this->assertEquals('user-space', $meta['wrapper_type']);
+		fclose($stream);
+	}
 }

--- a/tests/lib/files/stream/quota.php
+++ b/tests/lib/files/stream/quota.php
@@ -75,4 +75,76 @@ class Quota extends \PHPUnit_Framework_TestCase {
 		rewind($stream);
 		$this->assertEquals('qwerty', fread($stream, 100));
 	}
+
+	public function testFseekReturnsSuccess() {
+		$stream = $this->getStream('w+', 100);
+		fwrite($stream, '0123456789');
+		$this->assertEquals(0, fseek($stream, 3, SEEK_SET));
+		$this->assertEquals(0, fseek($stream, -1, SEEK_CUR));
+		$this->assertEquals(0, fseek($stream, -4, SEEK_END));
+	}
+
+	public function testWriteAfterSeekEndWithEnoughSpace() {
+		$stream = $this->getStream('w+', 100);
+		fwrite($stream, '0123456789');
+		fseek($stream, -3, SEEK_END);
+		$this->assertEquals(11, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdefghijk', fread($stream, 100));
+	}
+
+	public function testWriteAfterSeekEndWithNotEnoughSpace() {
+		$stream = $this->getStream('w+', 13);
+		fwrite($stream, '0123456789');
+		// seek forward first to potentially week out
+		// potential limit calculation errors
+		fseek($stream, 4, SEEK_SET);
+		// seek to the end
+		fseek($stream, -3, SEEK_END);
+		$this->assertEquals(6, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdef', fread($stream, 100));
+	}
+
+	public function testWriteAfterSeekSetWithEnoughSpace() {
+		$stream = $this->getStream('w+', 100);
+		fwrite($stream, '0123456789');
+		fseek($stream, 7, SEEK_SET);
+		$this->assertEquals(11, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdefghijk', fread($stream, 100));
+	}
+
+	public function testWriteAfterSeekSetWithNotEnoughSpace() {
+		$stream = $this->getStream('w+', 13);
+		fwrite($stream, '0123456789');
+		fseek($stream, 7, SEEK_SET);
+		$this->assertEquals(6, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdef', fread($stream, 100));
+	}
+
+	public function testWriteAfterSeekCurWithEnoughSpace() {
+		$stream = $this->getStream('w+', 100);
+		fwrite($stream, '0123456789');
+		rewind($stream);
+		fseek($stream, 3, SEEK_CUR);
+		fseek($stream, 5, SEEK_CUR);
+		fseek($stream, -1, SEEK_CUR);
+		$this->assertEquals(11, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdefghijk', fread($stream, 100));
+	}
+
+	public function testWriteAfterSeekCurWithNotEnoughSpace() {
+		$stream = $this->getStream('w+', 13);
+		fwrite($stream, '0123456789');
+		rewind($stream);
+		fseek($stream, 3, SEEK_CUR);
+		fseek($stream, 5, SEEK_CUR);
+		fseek($stream, -1, SEEK_CUR);
+		$this->assertEquals(6, fwrite($stream, 'abcdefghijk'));
+		rewind($stream);
+		$this->assertEquals('0123456abcdef', fread($stream, 100));
+	}
 }


### PR DESCRIPTION
- Fixed quota stream fseek to work with SEEK_END and provide a return value
- The quota stream now doesn't wrap files opened in read-only mode
- Fixes #5524

Please review @icewind1991 @DeepDiver1975 @schiesbn 
