### PR TITLE
Fixed encryption migration when entry is missing in DB

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -205,7 +205,7 @@ class Util {
 				$this->userId,
 				'server-side',
 				0,
-				0
+				self::MIGRATION_OPEN
 			);
 			$query = \OCP\DB::prepare($sql);
 			$query->execute($args);
@@ -1285,6 +1285,17 @@ class Util {
 		// If no record is found
 		if (empty($migrationStatus)) {
 			\OCP\Util::writeLog('Encryption library', "Could not get migration status for " . $this->userId . ", no record found", \OCP\Util::ERROR);
+			// insert missing entry in DB with status open
+			$sql = 'INSERT INTO `*PREFIX*encryption` (`uid`,`mode`,`recovery_enabled`,`migration_status`) VALUES (?,?,?,?)';
+			$args = array(
+				$this->userId,
+				'server-side',
+				0,
+				self::MIGRATION_OPEN
+			);
+			$query = \OCP\DB::prepare($sql);
+			$query->execute($args);
+
 			return self::MIGRATION_OPEN;
 			// If a record is found
 		} else {


### PR DESCRIPTION
When resetting the DB and some users still have encrypted files, the
migration state isn't read properly becaue the migration entries are
missing. This causes the wrong file size to be returned.

This fix inserts the missing migration entry when this condition is met.

Fixes #5541

Please review @schiesbn @karlitschek @DeepDiver1975 
