### PR TITLE
Fixed user dir existence check when creating new user

### DIFF
--- a/settings/ajax/createuser.php
+++ b/settings/ajax/createuser.php
@@ -28,6 +28,10 @@ $password = $_POST["password"];
 
 // Return Success story
 try {
+	// check whether the user's files home exists
+	$userDirectory = OC_User::getHome($username) . '/files/';
+	$homeExists = file_exists($userDirectory);
+
 	if (!OC_User::createUser($username, $password)) {
 		OC_JSON::error(array('data' => array( 'message' => 'User creation failed for '.$username )));
 		exit();
@@ -38,10 +42,6 @@ try {
 		}
 		OC_Group::addToGroup( $username, $i );
 	}
-
-	// check whether the user's files home exists
-	$userDirectory = OC_User::getHome($username) . '/files/';
-	$homeExists = file_exists($userDirectory);
 
 	OC_JSON::success(array("data" =>
 				array(


### PR DESCRIPTION
The check was done too later. It turns out that createUser() had already
created the dir, which caused the warning message to be shown every
time.
