### PR TITLE
Fixed clicking on the "Home" breadcrumb in the trash app

### DIFF
--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -228,9 +228,4 @@ function disableActions() {
 	$(".action").css("display", "none");
 	$(":input:checkbox").css("display", "none");
 }
-function onClickBreadcrumb(e){
-	var $el = $(e.target).closest('.crumb');
-	e.preventDefault();
-	FileList.changeDirectory(decodeURIComponent($el.data('dir')));
-}
 


### PR DESCRIPTION
Clicking on the "home" breadcrumb now correctly brings the user back to
the files app.

Note: the click function is already implemented correctly in files.js in the files app.

Please review @karlitschek @schiesbn @DeepDiver1975 
