### PR TITLE
[WIP] [Experimental] Files app infinite scroll

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -36,12 +36,7 @@ if($doBreadcrumb) {
 // make filelist
 $files = \OCA\Files\Helper::getFiles($dir);
 
-$list = new OCP\Template("files", "part.list", "");
-$list->assign('files', $files, false);
-$list->assign('baseURL', $baseUrl, false);
-$list->assign('downloadURL', OCP\Util::linkToRoute('download', array('file' => '/')));
-$list->assign('isPublic', false);
-$data['files'] = $list->fetchPage();
+$data['files'] = $files;
 $data['permissions'] = $permissions;
 
 OCP\JSON::success(array('data' => $data));

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -74,6 +74,17 @@
 #filestable tbody tr.searchresult {
 	background-color: rgb(240,240,240);
 }
+#filestable tbody tr{
+	opacity: 1;
+	transition: opacity 500ms;
+	-moz-transition: opacity 500ms;
+	-o-transition: opacity 500ms;
+	-ms-transition: opacity 500ms;
+	-webkit-transition: opacity 500ms;
+}
+#filestable tbody tr.invisible{
+	opacity:0;
+}
 tbody a { color:#000; }
 span.extension, span.uploading, td.date { color:#999; }
 span.extension { text-transform:lowercase; -ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)"; filter:alpha(opacity=70); opacity:.7; -webkit-transition:opacity 300ms; -moz-transition:opacity 300ms; -o-transition:opacity 300ms; transition:opacity 300ms; }

--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -31,6 +31,7 @@ OCP\Util::addscript('files', 'file-upload');
 OCP\Util::addscript('files', 'jquery.iframe-transport');
 OCP\Util::addscript('files', 'jquery.fileupload');
 OCP\Util::addscript('files', 'jquery-visibility');
+OCP\Util::addscript('files', 'jquery-visibility');
 OCP\Util::addscript('files', 'filelist');
 
 OCP\App::setActiveNavigationEntry('files_index');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1,19 +1,76 @@
 var FileList={
+	rowsPerPage: 20,
+	totalFiles: 0,
+	isEmpty: true,
 	useUndo:true,
-	postProcessList: function() {
-		$('#fileList tr').each(function() {
+	postProcessList: function(newEls) {
+		if (!newEls){
+			newEls = $('#fileList tr');
+		}
+		newEls.each(function() {
 			//little hack to set unescape filenames in attribute
+			//FIXME: find out whether this is still needed
 			$(this).attr('data-file',decodeURIComponent($(this).attr('data-file')));
 		});
 	},
-	update:function(fileListHtml) {
-		var $fileList = $('#fileList');
-		$fileList.empty().html(fileListHtml);
+	makeAppear: function($els){
+		// first make them invisible
+		$els.addClass('invisible');
+		// then defer animation
+		window.setTimeout(function(){
+			$els.removeClass('invisible');
+		}, 0);
+	},
+
+	/**
+	 * Updates the file list with the given files array as JSON
+	 */
+	update:function(filesArray, append) {
+		var $fileList = $('#fileList'),
+			currentDir = $('#dir').val(),
+		    max = filesArray.length;
+
+		if (!append){
+			$fileList.empty();
+			FileList.totalFiles = filesArray.length;
+			FileList.isEmpty = !filesArray.length;
+		}
+		else{
+			if (!filesArray.length){
+				return;
+			}
+		}
+
+		FileList.files = filesArray;
+
+		if (max > FileList.rowsPerPage){
+			max = FileList.rowsPerPage;
+		}
+
+		var newEls = [];
+		while (max > 0){
+			var file = filesArray.shift(),
+				downloadUrl = OC.Router.generate('download', { file: currentDir + '/' + name }),
+				fileEl = FileList.createRow(file.type, file.name, file.icon, downloadUrl, file.size, new Date(file.mtime), file.permissions);
+
+			newEls.push(fileEl);
+			// TODO: add extra attributes ?
+			$fileList.append(fileEl);
+			max--;
+		}
+
+		// convert to jQuery array
+		newEls = $($.map(newEls, function(el){return el.get();}));
+
+		FileList.makeAppear(newEls);
+
 		FileList.updateEmptyContent();
-		$fileList.find('tr').each(function () {
+
+		newEls.each(function () {
 			FileActions.display($(this).children('td.filename'));
 		});
 		$fileList.trigger(jQuery.Event("fileActionsReady"));
+
 		FileList.postProcessList();
 		// "Files" might not be loaded in extending apps
 		if (window.Files) {
@@ -128,6 +185,7 @@ var FileList={
 		if (hidden) {
 			tr.hide();
 		}
+		FileList.makeAppear(tr);
 		return tr;
 	},
 	addDir:function(name, size, lastModified, hidden) {
@@ -150,6 +208,7 @@ var FileList={
 			tr.hide();
 		}
 		FileActions.display(tr.find('td.filename'), true);
+		FileList.makeAppear(tr);
 		return tr;
 	},
 	getCurrentDirectory: function(){
@@ -581,7 +640,7 @@ var FileList={
 				});
 	},
 	createFileSummary: function() {
-		if( $('#fileList tr').exists() ) {
+		if ( FileList.totalFiles > 0 ) {
 			var summary = this._calculateFileSummary();
 
 			// Get translations
@@ -641,10 +700,13 @@ var FileList={
 		return result;
 	},
 	updateFileSummary: function() {
-		var $summary = $('.summary');
+		var $summary = $('#fileList .summary');
+
+		// always make it the last element
+		$('#fileList tbody').append($summary.detach());
 
 		// Check if we should remove the summary to show "Upload something"
-		if ($('#fileList tr').length === 1 && $summary.length === 1) {
+		if (FileList.totalFiles === 0 && $summary.length === 1) {
 			$summary.remove();
 		}
 		// If there's no summary create one (createFileSummary checks if there's data)
@@ -652,7 +714,7 @@ var FileList={
 			FileList.createFileSummary();
 		}
 		// There's a summary and data -> Update the summary
-		else if ($('#fileList tr').length > 1 && $summary.length === 1) {
+		else if (FileList.totalFiles > 0 && $summary.length === 1) {
 			var fileSummary = this._calculateFileSummary();
 			var $dirInfo = $('.summary .dirinfo');
 			var $fileInfo = $('.summary .fileinfo');
@@ -685,8 +747,8 @@ var FileList={
 		var $fileList = $('#fileList');
 		var permissions = $('#permissions').val();
 		var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
-		$('#emptycontent').toggleClass('hidden', !isCreatable || $fileList.find('tr').exists());
-		$('#filestable th').toggleClass('hidden', $fileList.find('tr').exists() === false);
+		$('#emptycontent').toggleClass('hidden', !isCreatable || FileList.isEmpty);
+		$('#filestable th').toggleClass('hidden', !FileList.isEmpty);
 	},
 	showMask: function() {
 		// in case one was shown before
@@ -1030,4 +1092,14 @@ $(document).ready(function() {
 	}
 
 	FileList.createFileSummary();
+
+	// init infinite scrolling
+	$('#filestable').after('<div style="height: 300px"></div>');
+	// TODO: unbind when no more files to display
+	$(window).on('scroll', function(ev){
+		var body = document.body;
+		if ( body.scrollTop + body.clientHeight >= body.scrollHeight - 32 ){
+			FileList.update(FileList.files, true);
+		}
+	});
 });

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -232,6 +232,10 @@ var FileList={
 			FileList.changeDirectory('/');
 			return;
 		}
+		// aborted ?
+		if (result.status === 0){
+			return;
+		}
 
 		// TODO: should rather return upload file size through
 		// the files list ajax call
@@ -1021,10 +1025,8 @@ $(document).ready(function() {
 			}
 		};
 
-		if (parseInt($('#ajaxLoad').val(), 10) === 1) {
-			// need to initially switch the dir to the one from the hash (IE8)
-			FileList.changeDirectory(parseCurrentDirFromUrl(), false, true);
-		}
+		// trigger ajax load
+		FileList.changeDirectory(parseCurrentDirFromUrl(), false, true);
 	}
 
 	FileList.createFileSummary();

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -73,20 +73,29 @@ class Helper
 		$files = array();
 
 		foreach ($content as $i) {
-			$i['date'] = \OCP\Util::formatDate($i['mtime']);
+			$entry = array();
+
+			$entry['date'] = \OCP\Util::formatDate($i['mtime']);
 			if ($i['type'] === 'file') {
 				$fileinfo = pathinfo($i['name']);
-				$i['basename'] = $fileinfo['filename'];
+				$entry['basename'] = $fileinfo['filename'];
 				if (!empty($fileinfo['extension'])) {
-					$i['extension'] = '.' . $fileinfo['extension'];
+					$entry['extension'] = '.' . $fileinfo['extension'];
 				} else {
-					$i['extension'] = '';
+					$entry['extension'] = '';
 				}
 			}
 			$i['directory'] = $dir;
 			$i['isPreviewAvailable'] = \OC::$server->getPreviewManager()->isMimeSupported($i['mimetype']);
-			$i['icon'] = \OCA\Files\Helper::determineIcon($i);
-			$files[] = $i;
+			// only pick out the needed attributes
+			$entry['icon'] = \OCA\Files\Helper::determineIcon($i);
+			$entry['directory'] = $i['directory'];
+			$entry['name'] = $i['name'];
+			$entry['permissions'] = $i['permissions'];
+			$entry['mimetype'] = $i['mimetype'];
+			$entry['size'] = $i['size'];
+			$entry['type'] = $i['type'];
+			$files[] = $entry;
 		}
 
 		usort($files, array('\OCA\Files\Helper', 'fileCmp'));

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -65,8 +65,8 @@
 					</span>
 				</div>
 			</th>
-			<th <?php if (!$_['fileHeader']):?>class="hidden"<?php endif; ?> id="headerSize"><?php p($l->t('Size')); ?></th>
-			<th <?php if (!$_['fileHeader']):?>class="hidden"<?php endif; ?> id="headerDate">
+			<th class="hidden" id="headerSize"><?php p($l->t('Size')); ?></th>
+			<th class="hidden" id="headerDate">
 				<span id="modified"><?php p($l->t( 'Modified' )); ?></span>
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>
 <!--					NOTE: Temporary fix to allow unsharing of files in root of Shared folder -->

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -1,6 +1,6 @@
 <div id="controls">
 	<?php print_unescaped($_['breadcrumb']); ?>
-		<div class="actions creatable <?php if (!$_['isCreatable']):?>hidden<?php endif; ?>">
+		<div class="actions creatable hidden">
 			<div id="new" class="button">
 				<a><?php p($l->t('New'));?></a>
 				<ul>
@@ -42,14 +42,14 @@
 	<input type="hidden" name="permissions" value="<?php p($_['permissions']); ?>" id="permissions">
 </div>
 
-<div id="emptycontent" <?php if (!$_['emptyContent']):?>class="hidden"<?php endif; ?>><?php p($l->t('Nothing in here. Upload something!'))?></div>
+<div id="emptycontent" class="hidden"><?php p($l->t('Nothing in here. Upload something!'))?></div>
 
 <input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 
 <table id="filestable" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="36" data-preview-y="36">
 	<thead>
 		<tr>
-			<th <?php if (!$_['fileHeader']):?>class="hidden"<?php endif; ?> id='headerName'>
+			<th class="hidden" id='headerName'>
 				<div id="headerName-container">
 					<input type="checkbox" id="select_all" />
 					<label for="select_all"></label>
@@ -88,7 +88,6 @@
 		</tr>
 	</thead>
 	<tbody id="fileList">
-		<?php print_unescaped($_['fileList']); ?>
 	</tbody>
 </table>
 <div id="editor"></div><!-- FIXME Do not use this div in your app! It is deprecated and will be removed in the future! -->
@@ -108,7 +107,6 @@
 
 <!-- config hints for javascript -->
 <input type="hidden" name="filesApp" id="filesApp" value="1" />
-<input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" name="allowZipDownload" id="allowZipDownload" value="<?php p($_['allowZipDownload']); ?>" />
 <input type="hidden" name="usedSpacePercent" id="usedSpacePercent" value="<?php p($_['usedSpacePercent']); ?>" />
 <input type="hidden" name="encryptedFiles" id="encryptedFiles" value="<?php $_['encryptedFiles'] ? p('1') : p('0'); ?>" />

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -33,27 +33,6 @@ if ($isIE8 && isset($_GET['dir'])){
 	exit();
 }
 
-$ajaxLoad = false;
-
-if (!$isIE8){
-	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir);
-}
-else{
-	$files = array();
-	$ajaxLoad = true;
-}
-
-// Redirect if directory does not exist
-if ($files === null){
-	header('Location: ' . OCP\Util::linkTo('files_trashbin', 'index.php'));
-	exit();
-}
-
-$dirlisting = false;
-if ($dir && $dir !== '/') {
-    $dirlisting = true;
-}
-
 $breadcrumb = \OCA\Files_Trashbin\Helper::makeBreadcrumb($dir);
 
 $breadcrumbNav = new OCP\Template('files_trashbin', 'part.breadcrumb', '');
@@ -61,21 +40,8 @@ $breadcrumbNav->assign('breadcrumb', $breadcrumb);
 $breadcrumbNav->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php') . '?dir=');
 $breadcrumbNav->assign('home', OCP\Util::linkTo('files', 'index.php'));
 
-$list = new OCP\Template('files_trashbin', 'part.list', '');
-$list->assign('files', $files);
-
-$encodedDir = \OCP\Util::encodePath($dir);
-$list->assign('baseURL', OCP\Util::linkTo('files_trashbin', 'index.php'). '?dir='.$encodedDir);
-$list->assign('downloadURL', OCP\Util::linkTo('files_trashbin', 'download.php') . '?file='.$encodedDir);
-$list->assign('dirlisting', $dirlisting);
-$list->assign('disableDownloadActions', true);
-
-$tmpl->assign('dirlisting', $dirlisting);
 $tmpl->assign('breadcrumb', $breadcrumbNav->fetchPage());
-$tmpl->assign('fileList', $list->fetchPage());
-$tmpl->assign('files', $files);
 $tmpl->assign('dir', $dir);
 $tmpl->assign('disableSharing', true);
-$tmpl->assign('ajaxLoad', true);
 
 $tmpl->printPage();

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -4,11 +4,8 @@
 </div>
 <div id='notification'></div>
 
-<?php if (isset($_['files']) && count($_['files']) === 0 && $_['dirlisting'] === false && !$_['ajaxLoad']):?>
-	<div id="emptycontent"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
-<?php endif; ?>
+<div id="emptycontent" class="hidden"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 
-<input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 
@@ -42,6 +39,5 @@
 		</tr>
 	</thead>
 	<tbody id="fileList">
-		<?php print_unescaped($_['fileList']); ?>
 	</tbody>
 </table>


### PR DESCRIPTION
:construction: WIP

This is an experiment with infinite scrolling and big file lists.

This changes the following:
1) Files app file list is pure-ajax (no more pre-rendering)
2) Ajax call returns a JSON list of files
3) The UI caches the JSON list and only appends the first 20 files
4) When the user scrolls down, the UI will append the next 20 files

I managed to make this work with 12000 entries at first. It seems Chrome didn't have a problem caching them.

The bottleneck in the browser (before these commits) was when appending ALL 12000 elements into the DOM.

I've also discovered very unefficient jQuery usage like $('tr') which is called many many times and would lock up the browser every time when trying to select the 12000 elements.

Since these changes are too big to be included into OC6, I'll use some of these insights to tweak the performance of the file list OC6.

I'll leave this PR here if someone wants to try it out. (it is NOT ready as it breaks the trash + sharing apps at the moment)

@karlitschek @schiesbn @DeepDiver1975 @jancborchardt 
