### PR TITLE
remove user from cache if he was deleted successfully

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -187,18 +187,25 @@ class OC_User {
 	public static function deleteUser($uid) {
 		$user = self::getManager()->get($uid);
 		if ($user) {
-			$user->delete();
+			$result = $user->delete();
 
-			// We have to delete the user from all groups
-			foreach (OC_Group::getUserGroups($uid) as $i) {
-				OC_Group::removeFromGroup($uid, $i);
+			// if delete was successful we clean-up the rest
+			if ($result) {
+
+				// We have to delete the user from all groups
+				foreach (OC_Group::getUserGroups($uid) as $i) {
+					OC_Group::removeFromGroup($uid, $i);
+					}
+				// Delete the user's keys in preferences
+					OC_Preferences::deleteUser($uid);
+
+				// Delete user files in /data/
+				OC_Helper::rmdirr(OC_Config::getValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $uid . '/');
+
+				// Remove it from the Cache
+				self::getManager()->delete($uid);
 			}
-			// Delete the user's keys in preferences
-			OC_Preferences::deleteUser($uid);
 
-			// Delete user files in /data/
-			OC_Helper::rmdirr(OC_Config::getValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $uid . '/');
-			
 			return true;
 		} else {
 			return false;

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -119,6 +119,20 @@ class Manager extends PublicEmitter {
 	}
 
 	/**
+	 * remove deleted user from cache
+	 *
+	 * @param string $uid
+	 * @return bool
+	 */
+	public function delete($uid) {
+		if (isset($this->cachedUsers[$uid])) {
+			unset($this->cachedUsers[$uid]);
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Check if the password is valid for the user
 	 *
 	 * @param $loginname


### PR DESCRIPTION
If a user was successfully deleted we need to remove it from the user cache. Otherwise userExists() will still return true. This should also fixes the broken tests in https://github.com/owncloud/core/pull/5603

cc @PVince81 can you have a look at it? Thanks!
