### PR TITLE
Added fix to correctly parse non-array error messages

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -334,8 +334,13 @@ $(document).ready(function() {
 				var result=$.parseJSON(response);
 
 				delete data.jqXHR;
-				
-				if (typeof result[0] === 'undefined') {
+
+				if (result.status === 'error' && result.data && result.data.message){
+					data.textStatus = 'servererror';
+					data.errorThrown = result.data.message;
+					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');
+					fu._trigger('fail', e, data);
+				} else if (typeof result[0] === 'undefined') {
 					data.textStatus = 'servererror';
 					data.errorThrown = t('files', 'Could not get result from server.');
 					var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload');


### PR DESCRIPTION
Some apps like the antivirus app return messages in a non-array format.

Please review @karlitschek @butonic @schiesbn @DeepDiver1975 
