### PR TITLE
fix style of public share page

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -4,14 +4,14 @@ body {
 
 #header {
 	background: #1d2d44 url('%webroot%/core/img/noise.png') repeat;
-	height:2.5em;
+	height:32px;
 	left:0;
-	line-height:2.5em;
+	line-height:32px;
 	position:fixed;
 	right:0;
 	top:0;
 	z-index:100;
-	padding:.5em;
+	padding:7px;
 }
 
 #details {
@@ -24,13 +24,18 @@ body {
 	font-weight:700;
 	margin: 0 0.4em 0 0;
 	padding: 0 5px;
-	height: 27px;
+	height: 32px;
 	float: left;
 
 }
 
 .header-right #details {
-	margin-right: 2em;
+	margin-right: 28px;
+}
+
+.header-right {
+	padding: 0;
+	height: 32px;
 }
 
 #public_upload {
@@ -90,7 +95,7 @@ thead{
 #data-upload-form {
 	position: relative;
 	right: 0;
-	height: 27px;
+	height: 32px;
 	overflow: hidden;
 	padding: 0;
 	float: right;
@@ -109,27 +114,20 @@ thead{
 	width: 100% !important;
 }
 
-#download span {
-	position: relative;
-	bottom: 3px;
-}
-
 #publicUploadButtonMock {
 	position:relative;
 	display:block;
 	width:100%;
-	height:27px;
+	height:32px;
 	cursor:pointer;
 	z-index:10;
 	background-image:url('%webroot%/core/img/actions/upload.svg');
 	background-repeat:no-repeat;
-	background-position:7px 6px;
+	background-position:7px 8px;
 }
 
 #publicUploadButtonMock span {
 	margin: 0 5px 0 28px;
-	position: relative;
-	top: -2px;
 	color: #555;
 }
 


### PR DESCRIPTION
Old:
![public-share-old](https://f.cloud.github.com/assets/245432/1429029/399ab07c-40ac-11e3-9b15-548b54cdb3b1.png)
New:
![public-share-new](https://f.cloud.github.com/assets/245432/1429033/3da880cc-40ac-11e3-974b-37a443501a42.png)

Was part of #5418 which isn't merged.

Tested in IE8, Firefox and Chrome.

cc @owncloud/designers 
