### PR TITLE
Fixed summary visibility check

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -593,18 +593,19 @@ var FileList={
 				var fileSize = '<td class="filesize">'+humanFileSize(totalSize)+'</td>';
 			}
 
-			$('#fileList').append('<tr class="summary"><td><span class="info">'+info+'</span></td>'+fileSize+'<td></td></tr>');
+			var $summary = $('<tr class="summary"><td><span class="info">'+info+'</span></td>'+fileSize+'<td></td></tr>');
+			$('#fileList').append($summary);
 
-			var $dirInfo = $('.summary .dirinfo');
-			var $fileInfo = $('.summary .fileinfo');
-			var $connector = $('.summary .connector');
+			var $dirInfo = $summary.find('.dirinfo');
+			var $fileInfo = $summary.find('.fileinfo');
+			var $connector = $summary.find('.connector');
 
 			// Show only what's necessary, e.g.: no files: don't show "0 files"
-			if ($dirInfo.html().charAt(0) === "0") {
+			if (totalDirs === 0) {
 				$dirInfo.hide();
 				$connector.hide();
 			}
-			if ($fileInfo.html().charAt(0) === "0") {
+			if (totalFiles === 0) {
 				$fileInfo.hide();
 				$connector.hide();
 			}


### PR DESCRIPTION
Now using the integer values to check whether to show the summary parts
instead of trying to parse the html code.

In the french language, someone didn't translate it properly. They used "{dir}" instead of "{dirs}". (I'll check on transifex)
This made the summary value parsing that uses .html().charAt(0) fail, which broke other things like not being able to open the documents app from the file list... probably because the JS error somehow prevented viewer.js to be loaded.

Anyway, please review this fix @Kondou-ger @karlitschek @schiesbn 
