### PR TITLE
backport home storage to stable5

### DIFF
--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -67,6 +67,19 @@ class Cache {
 		return $this->numericId;
 	}
 
+	public static function storageExists($storageId) {
+		if (strlen($storageId) > 64) {
+			$storageId = md5($storageId);
+		}
+		$query = \OC_DB::prepare('SELECT `numeric_id` FROM `*PREFIX*storages` WHERE `id` = ?');
+		$result = $query->execute(array($storageId));
+		if ($row = $result->fetchRow()) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 	/**
 	 * normalize mimetypes
 	 *

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -221,7 +221,11 @@ class Filesystem {
 		$parser = new \OC\ArrayParser();
 
 		$root = \OC_User::getHome($user);
-		self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
+		if (\OC\Files\Cache\Cache::storageExists('local::' . $root . '/') or is_null($user)) {
+			self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
+		} else {
+			self::mount('\OC\Files\Storage\Home', array('user' => $user, 'datadir' => $root), $user);
+		}
 		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 
 		//move config file to it's new position

--- a/lib/files/storage/home.php
+++ b/lib/files/storage/home.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) 2012 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Storage;
+
+/**
+ * Specialized version of Local storage for home directory usage
+ */
+class Home extends Local {
+	/**
+	 * @var \OC\User\User $user
+	 */
+	protected $user;
+
+	public function __construct($arguments) {
+		$this->user = $arguments['user'];
+		$this->datadir = $arguments['datadir'];
+		if (substr($this->datadir, -1) !== '/') {
+			$this->datadir .= '/';
+		}
+	}
+
+	public function getId() {
+		return 'home::' . $this->user;
+	}
+}


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/5591 for stable5 necessary for user backends that implement getHome(). fixes https://github.com/owncloud/core/issues/5045

@icewind1991 I tried to backport this because I need it for a customer migration. please review

@karlitschek @DeepDiver1975 @VicDeo please review
