### PR TITLE
Prevent closing the create dropdown when right clicking in Firefox

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -465,7 +465,11 @@ $(document).ready(function() {
 		crumb.text(text);
 	}
 
-	$(document).click(function() {
+	$(document).click(function(ev) {
+		// do not close when clicking in the dropdown
+		if ($(ev.target).closest('#new').length){
+			return;
+		}
 		$('#new>ul').hide();
 		$('#new').removeClass('active');
 		if ($('#new .error').length > 0) {


### PR DESCRIPTION
Firefox sends a click event on the document when right clicking which
makes pasting with right click into the field impossible.

Fixes #5498

Please review @jancborchardt @karlitschek @bantu
