### PR TITLE
Mobile styles baby steps

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -1,0 +1,14 @@
+@media (max-width: 600px) {
+
+
+/* When hovering/tapping a row on mobile, hide file info and display the file actions instead */
+#filestable tr:hover .nametext,
+#filestable tr:hover .filesize,
+#filestable tr:hover .date {
+	display: none;
+}
+#filestable tr:hover .fileactions {
+	left: 44px;
+}
+
+}

--- a/lib/base.php
+++ b/lib/base.php
@@ -284,6 +284,7 @@ class OC {
 		}
 
 		OC_Util::addStyle("styles");
+		OC_Util::addStyle('mobile');
 		OC_Util::addStyle("apps");
 		OC_Util::addStyle("fixes");
 		OC_Util::addStyle("multiselect");


### PR DESCRIPTION
First start, taking a stab at how we could fix the file actions on smartphones. For example fix #5504 by only showing the file actions on hover (equals tap on the file) cc @absynth47215

@PVince81 do you know about the most sophisticated media query at the moment to determine if it’s a smartphone? On tablets it should work just like on desktop, this »mobile« stuff we only need as soon as the width goes below where we can display all the info properly in one line.
