### PR TITLE
Deleting all files in trash now only sends a single flag

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -681,8 +681,9 @@ var FileList={
 		var $fileList = $('#fileList');
 		var permissions = $('#permissions').val();
 		var isCreatable = (permissions & OC.PERMISSION_CREATE) !== 0;
-		$('#emptycontent').toggleClass('hidden', !isCreatable || $fileList.find('tr').exists());
-		$('#filestable th').toggleClass('hidden', $fileList.find('tr').exists() === false);
+		var exists = $fileList.find('tr:first').exists();
+		$('#emptycontent').toggleClass('hidden', !isCreatable || exists);
+		$('#filestable th').toggleClass('hidden', !exists);
 	},
 	showMask: function() {
 		// in case one was shown before

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -3,10 +3,19 @@
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
-$files = $_POST['files'];
-$dirlisting = $_POST['dirlisting'];
-$list = json_decode($files);
-
+// "empty trash" command
+$deleteAll = false;
+if (isset($_POST['allfiles']) and $_POST['allfiles'] === 'true'){
+	$user = \OCP\User::getUser();
+	$list = OCA\Files_Trashbin\Helper::getTrashFiles('/');
+	$deleteAll = true;
+	$dirlisting = '0';
+}
+else {
+	$files = $_POST['files'];
+	$dirlisting = $_POST['dirlisting'];
+	$list = json_decode($files);
+}
 $error = array();
 $success = array();
 
@@ -14,22 +23,30 @@ $success = array();
 $i = 0;
 foreach ($list as $file) {
 	if ( $dirlisting === '0') {
-		$delimiter = strrpos($file, '.d');
-		$filename = substr($file, 0, $delimiter);
-		$timestamp =  substr($file, $delimiter+2);
+		if ($deleteAll) {
+			$filename = $file['name'];
+			$timestamp = $file['timestamp'];
+		}
+		else {
+			$delimiter = strrpos($file, '.d');
+			$filename = substr($file, 0, $delimiter);
+			$timestamp =  substr($file, $delimiter+2);
+		}
 	} else {
 		$filename = $file;
 		$timestamp = null;
 	}
 
 	OCA\Files_Trashbin\Trashbin::delete($filename, $timestamp);
-	if (!OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
+	if (OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
+		$error[] = $filename;
+		OC_Log::write('trashbin','can\'t delete ' . $filename . ' permanently.', OC_Log::ERROR);
+	}
+	// only list deleted files if not deleting everything
+	else if (!$deleteAll) {
 		$success[$i]['filename'] = $file;
 		$success[$i]['timestamp'] = $timestamp;
 		$i++;
-	} else {
-		$error[] = $filename;
-		OC_Log::write('trashbin','can\'t delete ' . $filename . ' permanently.', OC_Log::ERROR);
 	}
 }
 

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -22,3 +22,10 @@ FileList.reload = function(){
 FileList.linkTo = function(dir){
 	return OC.linkTo('files_trashbin', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
 }
+
+FileList.updateEmptyContent = function(){
+	var $fileList = $('#fileList');
+	var exists = $fileList.find('tr:first').exists();
+	$('#emptycontent').toggleClass('hidden', exists);
+	$('#filestable th').toggleClass('hidden', !exists);
+}

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -19,6 +19,7 @@ $(document).ready(function() {
 						}
 						enableActions();
 						FileList.updateFileSummary();
+						FileList.updateEmptyContent();
 					}
 			);
 
@@ -45,6 +46,7 @@ $(document).ready(function() {
 					}
 					enableActions();
 					FileList.updateFileSummary();
+					FileList.updateEmptyContent();
 				}
 		);
 
@@ -122,34 +124,60 @@ $(document).ready(function() {
 					}
 					enableActions();
 					FileList.updateFileSummary();
+					FileList.updateEmptyContent();
 				}
 		);
 	});
 
 	$('.delete').click('click', function(event) {
 		event.preventDefault();
-		var files = getSelectedFiles('file');
-		var fileslist = JSON.stringify(files);
-		var dirlisting = getSelectedFiles('dirlisting')[0];
+		var allFiles = $('#select_all').is(':checked');
+		var files = [];
+		var params = {};
+		if (allFiles) {
+			params = {
+			   allfiles: true
+			};
+		}
+		else {
+			files = getSelectedFiles('file');
+			params = {
+				files: JSON.stringify(files),
+				dirlisting: getSelectedFiles('dirlisting')[0]
+			};
+		};
 
 		disableActions();
-		for (var i = 0; i < files.length; i++) {
-			var deleteAction = $('tr').filterAttr('data-file', files[i]).children("td.date").children(".action.delete");
-			deleteAction.removeClass('delete-icon').addClass('progress-icon');
+		if (allFiles) {
+			FileList.showMask();
+		}
+		else {
+			for (var i = 0; i < files.length; i++) {
+				var deleteAction = $('tr').filterAttr('data-file', files[i]).children("td.date").children(".action.delete");
+				deleteAction.removeClass('delete-icon').addClass('progress-icon');
+			}
 		}
 
 		$.post(OC.filePath('files_trashbin', 'ajax', 'delete.php'),
-				{files: fileslist, dirlisting: dirlisting},
+				params,
 				function(result) {
-					for (var i = 0; i < result.data.success.length; i++) {
-						var row = document.getElementById(result.data.success[i].filename);
-						row.parentNode.removeChild(row);
+					if (allFiles) {
+						FileList.hideMask();
+						// simply remove all files
+						$('#fileList').empty();
+					}
+					else {
+						for (var i = 0; i < result.data.success.length; i++) {
+							var row = document.getElementById(result.data.success[i].filename);
+							row.parentNode.removeChild(row);
+						}
 					}
 					if (result.status !== 'success') {
 						OC.dialogs.alert(result.data.message, t('core', 'Error'));
 					}
 					enableActions();
 					FileList.updateFileSummary();
+					FileList.updateEmptyContent();
 				}
 		);
 

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -4,9 +4,7 @@
 </div>
 <div id='notification'></div>
 
-<?php if (isset($_['files']) && count($_['files']) === 0 && $_['dirlisting'] === false && !$_['ajaxLoad']):?>
-	<div id="emptycontent"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
-<?php endif; ?>
+<div id="emptycontent" <?php if (!(isset($_['files']) && count($_['files']) === 0 && $_['dirlisting'] === false && !$_['ajaxLoad'])):?>class="hidden"<?php endif; ?>><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 
 <input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>


### PR DESCRIPTION
To prevent having to send the list of all files for deletion, only set a flag "allfiles". This should make it a bit smoother when deleting 5000+ files.

Also fixes some "empty trash" message issues.
