### PR TITLE
Fix4390 stable5

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -666,7 +666,7 @@ var folderDropOptions={
 			return false;
 		}
 
-		var target=$.trim($(this).find('.nametext').text());
+		var target = $(this).parent('tr').data('file');
 
 		var files = ui.helper.find('tr');
 		$(files).each(function(i,row){

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -666,7 +666,7 @@ var folderDropOptions={
 			return false;
 		}
 
-		var target = $(this).parent('tr').data('file');
+		var target = $(this).closest('tr').data('file');
 
 		var files = ui.helper.find('tr');
 		$(files).each(function(i,row){

--- a/lib/db.php
+++ b/lib/db.php
@@ -236,7 +236,7 @@ class OC_DB {
 
 			// Prepare options array
 			$options = array(
-					'portability' => MDB2_PORTABILITY_ALL - MDB2_PORTABILITY_FIX_CASE,
+					'portability' => MDB2_PORTABILITY_ALL - MDB2_PORTABILITY_FIX_CASE - MDB2_PORTABILITY_RTRIM,
 					'log_line_break' => '<br>',
 					'idxname_format' => '%s',
 					'debug' => true,

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -42,18 +42,21 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->instance->isUpdatable('/'), 'Root folder is not writable');
 	}
 
-	public function testDirectories() {
-		$this->assertFalse($this->instance->file_exists('/folder'));
+	/**
+	 * @dataProvider directoryProvider
+	 */
+	public function testDirectories($directory) {
+		$this->assertFalse($this->instance->file_exists('/'.$directory));
 
-		$this->assertTrue($this->instance->mkdir('/folder'));
+		$this->assertTrue($this->instance->mkdir('/'.$directory));
 
-		$this->assertTrue($this->instance->file_exists('/folder'));
-		$this->assertTrue($this->instance->is_dir('/folder'));
-		$this->assertFalse($this->instance->is_file('/folder'));
-		$this->assertEquals('dir', $this->instance->filetype('/folder'));
-		$this->assertEquals(0, $this->instance->filesize('/folder'));
-		$this->assertTrue($this->instance->isReadable('/folder'));
-		$this->assertTrue($this->instance->isUpdatable('/folder'));
+		$this->assertTrue($this->instance->file_exists('/'.$directory));
+		$this->assertTrue($this->instance->is_dir('/'.$directory));
+		$this->assertFalse($this->instance->is_file('/'.$directory));
+		$this->assertEquals('dir', $this->instance->filetype('/'.$directory));
+		$this->assertEquals(0, $this->instance->filesize('/'.$directory));
+		$this->assertTrue($this->instance->isReadable('/'.$directory));
+		$this->assertTrue($this->instance->isUpdatable('/'.$directory));
 
 		$dh = $this->instance->opendir('/');
 		$content = array();
@@ -62,14 +65,14 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 				$content[] = $file;
 			}
 		}
-		$this->assertEquals(array('folder'), $content);
+		$this->assertEquals(array($directory), $content);
 
-		$this->assertFalse($this->instance->mkdir('/folder')); //cant create existing folders
-		$this->assertTrue($this->instance->rmdir('/folder'));
+		$this->assertFalse($this->instance->mkdir('/'.$directory)); //cant create existing folders
+		$this->assertTrue($this->instance->rmdir('/'.$directory));
 
-		$this->assertFalse($this->instance->file_exists('/folder'));
+		$this->assertFalse($this->instance->file_exists('/'.$directory));
 
-		$this->assertFalse($this->instance->rmdir('/folder')); //cant remove non existing folders
+		$this->assertFalse($this->instance->rmdir('/'.$directory)); //cant remove non existing folders
 
 		$dh = $this->instance->opendir('/');
 		$content = array();
@@ -81,6 +84,14 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), $content);
 	}
 
+	public function directoryProvider()
+	{
+		return array(
+			array('folder'),
+			array(' folder'),
+			array('folder '),
+		);
+	}
 	/**
 	 * test the various uses of file_get_contents and file_put_contents
 	 */


### PR DESCRIPTION
fixes #4390 for stable5, needs forward port

fixes dnd into folders ending in whitespace on oracle
unnecessary portability option because only affects fixed length character columns. luckily we dont have that kind of columns: the text datatype is transformed into varchar by MDB2

@karlitschek @DeepDiver1975 please review

@bartv2 I don't know if doctrine also rtrims all data? could you check to make sure we don't have a problem in OC6? Maybe forward port the unit test? I'm busy with OC4.5 -> OC5 migration on oracle.
