### PR TITLE
Fix quota calc by preventing root folder size to be overwritten by -1

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -506,9 +506,14 @@ class Cache {
 		$totalSize = 0;
 		$entry = $this->get($path);
 		if ($entry && $entry['mimetype'] === 'httpd/unix-directory') {
+			$isRoot = ($path === '/' or $path === '');
 			$id = $entry['fileid'];
 			$sql = 'SELECT SUM(`size`), MIN(`size`) FROM `*PREFIX*filecache` '.
 				'WHERE `parent` = ? AND `storage` = ?';
+			if ($isRoot) {
+				// filter out non-scanned dirs at the root
+				$sql .= ' AND size >= 0';
+			}
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
 				list($sum, $min) = array_values($row);

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -512,7 +512,7 @@ class Cache {
 				'WHERE `parent` = ? AND `storage` = ?';
 			if ($isRoot) {
 				// filter out non-scanned dirs at the root
-				$sql .= ' AND size >= 0';
+				$sql .= ' AND `size` >= 0';
 			}
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {


### PR DESCRIPTION
In some cases when a scan process is in progress (or not started yet),
the root folder might have a size of -1.

To make sure that the quota can still be calculated correctly, an
special SQL query is used to pre-calculate the root folder size by
summing the size of all known files, which is better than no value at
all.

Fixes #5509

Please review @DeepDiver1975 @icewind1991 @karlitschek 

This shouldn't happen too often, only when some race condition occurs.
If it is not acceptable to select that way (in case it still happens too often), we can replace it with an UPDATE that writes the value into the DB, which might have some other side effects related to scanners (but unlikely)
