### PR TITLE
allow empty user-dn and password

### DIFF
--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -172,7 +172,7 @@ var LdapWizard = {
 		pwd		= $('#ldap_agent_password').val();
 		base	= $('#ldap_base').val();
 
-		if(host && port && agent && pwd && base) {
+		if(host && port && base) {
 			$('.ldap_action_continue').removeAttr('disabled');
 			$('#ldapSettings').tabs('option', 'disabled', []);
 		} else {

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -172,7 +172,7 @@ var LdapWizard = {
 		pwd		= $('#ldap_agent_password').val();
 		base	= $('#ldap_base').val();
 
-		if(host && port && base) {
+		if((host && port  && base) && ((!agent && !pwd) || (agent && pwd))) {
 			$('.ldap_action_continue').removeAttr('disabled');
 			$('#ldapSettings').tabs('option', 'disabled', []);
 		} else {


### PR DESCRIPTION
help tooltip shows completely right: leave both blank for anonyous access. But if you leave it blank you can't edit any other settings, so basically one can not setup ldap with empty user-dn and password ...
