### PR TITLE
we create the cookies for the url path \OC::$WEBROOT - as a result we sh...

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -637,15 +637,15 @@ class OC_User {
 	public static function setMagicInCookie($username, $token) {
 		$secure_cookie = OC_Config::getValue("forcessl", false);
 		$expires = time() + OC_Config::getValue('remember_login_cookie_lifetime', 60*60*24*15);
-		setcookie("oc_username", $username, $expires, '', '', $secure_cookie);
-		setcookie("oc_token", $token, $expires, '', '', $secure_cookie, true);
-		setcookie("oc_remember_login", true, $expires, '', '', $secure_cookie);
+		setcookie("oc_username", $username, $expires, \OC::$WEBROOT, '', $secure_cookie);
+		setcookie("oc_token", $token, $expires, \OC::$WEBROOT, '', $secure_cookie, true);
+		setcookie("oc_remember_login", true, $expires, \OC::$WEBROOT, '', $secure_cookie);
 	}
 
 	/**
 	 * @brief Remove cookie for "remember username"
 	 */
-	public function unsetMagicInCookie() {
+	public static function unsetMagicInCookie() {
 		unset($_COOKIE["oc_username"]); //TODO: DI
 		unset($_COOKIE["oc_token"]);
 		unset($_COOKIE["oc_remember_login"]);


### PR DESCRIPTION
...all 'remove' them with the same path

 unsetMagicInCookie() is supposed to be static

@ser72 @dietmaroc @karlitschek @dragotin @danimo please retest! 
Please keep in mind that you have to remove existing cookies first. 
