### PR TITLE
Fixed filesize issue in watchr test

### DIFF
--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -53,6 +53,9 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$cache->put('bar.test', array('storage_mtime' => 10));
 		$storage->file_put_contents('bar.test', 'test data');
 
+		// make sure that PHP can read the new size correctly
+		clearstatcache();
+
 		$updater->checkUpdate('bar.test');
 		$cachedData = $cache->get('bar.test');
 		$this->assertEquals(9, $cachedData['size']);


### PR DESCRIPTION
Added clearstatcache to make sure we get the correct file size after
re-writing into the same file.

This failed on openSUSE 12.3 x86_64

Please review @DeepDiver1975 @karlitschek @bantu @icewind1991 

This also raises the question whether we'd need to clearstatcache before every filesize() call in the local storage, which is currently not the case (thus having this test failing on some linux boxes like mine)
