### PR TITLE
Fixes for "max upload size" value showed in the UI

### DIFF
--- a/apps/files/ajax/getstoragestats.php
+++ b/apps/files/ajax/getstoragestats.php
@@ -3,7 +3,13 @@
 // only need filesystem apps
 $RUNTIME_APPTYPES = array('filesystem');
 
+$dir = '/';
+
+if (isset($_GET['dir'])) {
+	$dir = $_GET['dir'];
+}
+
 OCP\JSON::checkLoggedIn();
 
 // send back json
-OCP\JSON::success(array('data' => \OCA\Files\Helper::buildFileStorageStatistics('/')));
+OCP\JSON::success(array('data' => \OCA\Files\Helper::buildFileStorageStatistics($dir)));

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -404,7 +404,7 @@ $(document).ready(function() {
 				
 				$('#uploadprogresswrapper input.stop').fadeOut();
 				$('#uploadprogressbar').fadeOut();
-				
+			    Files.updateStorageStatistics();
 			});
 			fileupload.on('fileuploadfail', function(e, data) {
 				OC.Upload.log('progress handle fileuploadfail', e, data);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -152,6 +152,9 @@ var FileList={
 		FileActions.display(tr.find('td.filename'), true);
 		return tr;
 	},
+	getCurrentDirectory: function(){
+		return $('#dir').val() || '/';
+	},
 	/**
 	 * @brief Changes the current directory and reload the file list.
 	 * @param targetDir target directory (non URL encoded)
@@ -223,6 +226,10 @@ var FileList={
 			FileList.changeDirectory('/');
 			return;
 		}
+
+		// TODO: should rather return upload file size through
+		// the files list ajax call
+		Files.updateStorageStatistics(true);
 
 		if (result.data.permissions) {
 			FileList.setDirectoryPermissions(result.data.permissions);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -554,6 +554,7 @@ var FileList={
 						checkTrashStatus();
 						FileList.updateFileSummary();
 						FileList.updateEmptyContent();
+						Files.updateStorageStatistics();
 					} else {
 						$.each(files,function(index,file) {
 							var deleteAction = $('tr[data-file="'+files[i]+'"]').children("td.date").children(".action.delete");


### PR DESCRIPTION
This fix brings the following:
1) Update the "max upload size" value after scanFiles() is done and also after file uploads to reflect a more actual value
2) The "max upload size" aka storage statistics are now shown based on which directory the user is currently in, which can change between "user storage", "external storage" and "shared storage of another user"

Note that for the "shared storage" case I need to look into why it's not using the quota stream wrapper, which I'll address in a separate PR.

Please review @karlitschek @icewind1991 @DeepDiver1975 
