### PR TITLE
Quota storage wrapper is now used for all users in sharing mode

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -22,9 +22,18 @@
  */
 
 class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
+	private static $user;
 
 	function setUp() {
 		// mock OC_L10n
+		if (!self::$user) {
+			self::$user = uniqid();
+		}
+		\OC_User::createUser(self::$user, 'password');
+		\OC_User::setUserId(self::$user);
+
+		\OC\Files\Filesystem::init(self::$user, '/' . self::$user . '/files');
+
 		$l10nMock = $this->getMock('\OC_L10N', array('t'), array(), '', false);
 		$l10nMock->expects($this->any())
 			->method('t')
@@ -37,6 +46,12 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 			->method('rename')
 			->will($this->returnValue(true));
 		$this->files = new \OCA\Files\App($viewMock, $l10nMock);
+	}
+
+	function tearDown() {
+		$result = \OC_User::deleteUser(self::$user);
+		$this->assertTrue($result);
+		\OC\Files\Filesystem::tearDown();
 	}
 
 	/**

--- a/lib/private/files/storage/home.php
+++ b/lib/private/files/storage/home.php
@@ -22,6 +22,12 @@ class Home extends Local {
 	 */
 	protected $user;
 
+	/**
+	 * @brief Construct a Home storage instance
+	 * @param array $arguments array with "user" containing the
+	 * storage owner and "legacy" containing "true" if the storage is
+	 * a legacy storage with "local::" URL instead of the new "home::" one.
+	 */
 	public function __construct($arguments) {
 		$this->user = $arguments['user'];
 		$datadir = $this->user->getHome();
@@ -40,10 +46,21 @@ class Home extends Local {
 		return $this->id;
 	}
 
+	/**
+	 * @return \OC\Files\Cache\HomeCache
+	 */
 	public function getCache($path = '') {
 		if (!isset($this->cache)) {
 			$this->cache = new \OC\Files\Cache\HomeCache($this);
 		}
 		return $this->cache;
+	}
+
+	/**
+	 * @brief Returns the owner of this home storage
+	 * @return \OC\User\User owner of this home storage
+	 */
+	public function getUser() {
+		return $this->user;
 	}
 }

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -57,21 +57,11 @@ class OC_Util {
 				// set up quota for home storages, even for other users
 				// which can happen when using sharing
 
-				if (strlen($mountPoint) > 1) {
-					// the user name will be extracted from the mountpoint
-					// with the format '/username/' (no suffix)
-					$user = null;
-					// find second separator
-					$nextSepPos = strpos($mountPoint, '/', 1);
-					// next separator is the last one, format matches
-					if ($nextSepPos === strlen($mountPoint) - 1) {
-						$user = substr($mountPoint, 1, $nextSepPos - 1);
-					}
-					if ($user) {
-						$quota = OC_Util::getUserQuota($user);
-						if ($quota !== \OC\Files\SPACE_UNLIMITED) {
-							return new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => $quota));
-						}
+				if ($storage instanceof \OC\Files\Storage\Home) {
+					$user = $storage->getUser()->getUID();
+					$quota = OC_Util::getUserQuota($user);
+					if ($quota !== \OC\Files\SPACE_UNLIMITED) {
+						return new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => $quota));
 					}
 				}
 

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -94,6 +94,55 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Tests that the home storage is not wrapped when no quota exists.
+	 */
+	function testHomeStorageWrapperWithoutQuota() {
+		$user1 = uniqid();
+		\OC_User::createUser($user1, 'test');
+		OC_Preferences::setValue($user1, 'files', 'quota', 'none');
+		\OC_User::setUserId($user1);
+
+		\OC_Util::setupFS($user1);
+
+		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
+		$this->assertNotNull($userMount);
+		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $userMount->getStorage());
+
+		// clean up
+		\OC_User::setUserId('');
+		\OC_User::deleteUser($user1);
+		OC_Preferences::deleteUser($user1);
+		\OC_Util::tearDownFS();
+	}
+
+	/**
+	 * Tests that the home storage is not wrapped when no quota exists.
+	 */
+	function testHomeStorageWrapperWithQuota() {
+		$user1 = uniqid();
+		\OC_User::createUser($user1, 'test');
+		OC_Preferences::setValue($user1, 'files', 'quota', '1024');
+		\OC_User::setUserId($user1);
+
+		\OC_Util::setupFS($user1);
+
+		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
+		$this->assertNotNull($userMount);
+		$this->assertInstanceOf('\OC\Files\Storage\Wrapper\Quota', $userMount->getStorage());
+
+		// ensure that root wasn't wrapped
+		$rootMount = \OC\Files\Filesystem::getMountManager()->find('/');
+		$this->assertNotNull($rootMount);
+		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $rootMount->getStorage());
+
+		// clean up
+		\OC_User::setUserId('');
+		\OC_User::deleteUser($user1);
+		OC_Preferences::deleteUser($user1);
+		\OC_Util::tearDownFS();
+	}
+
+	/**
 	 * @dataProvider baseNameProvider
 	 */
 	public function testBaseName($expected, $file)


### PR DESCRIPTION
When accessing a shared folder, the folder's owner appears as mountpoint
but wasn't wrapped by a quota storage wrapper.

This fix makes sure that all home storages are wrapped by a quota
storage wrapper, if applicable, to make sure quotas are respected when
uploading into shared folders.

@icewind1991 are "local://" based home dirs migrated to "home://" storages or should I add extra handling for those ?

Please review @icewind1991 @DeepDiver1975 @karlitschek 

I'll add unit tests soon.
