### PR TITLE
Fixed folder icon for home storage

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -30,7 +30,7 @@ class Helper
 					if ($sid[0] === 'shared') {
 						return \OC_Helper::mimetypeIcon('dir-shared');
 					}
-					if ($sid[0] !== 'local') {
+					if ($sid[0] !== 'local' and $sid[0] !== 'home') {
 						return \OC_Helper::mimetypeIcon('dir-external');
 					}
 				}


### PR DESCRIPTION
Fixes #5713 

Please review @blizzz @karlitschek @georgehrke @DeepDiver1975 

Should be quick. This is needed because now we have a new "home" storage for home dirs, added recently by @icewind1991 
