### PR TITLE
Now removing stray old cookies from 5.0.12

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -652,5 +652,10 @@ class OC_User {
 		setcookie('oc_username', '', time()-3600, \OC::$WEBROOT);
 		setcookie('oc_token', '', time()-3600, \OC::$WEBROOT);
 		setcookie('oc_remember_login', '', time()-3600, \OC::$WEBROOT);
+		// old cookies might be stored under /webroot/ instead of /webroot
+		// and Firefox doesn't like it!
+		setcookie('oc_username', '', time()-3600, \OC::$WEBROOT . '/');
+		setcookie('oc_token', '', time()-3600, \OC::$WEBROOT . '/');
+		setcookie('oc_remember_login', '', time()-3600, \OC::$WEBROOT . '/');
 	}
 }


### PR DESCRIPTION
Cookies from 5.0.12 seemed to have an extra slash in the path.
Firefox doesn't allow to remove them if the trailing slash isn't there,
thus making it impossible to logout correctly.

This fix adds extra code to delete such stray cookies.
