### PR TITLE
fix enabling apps for oracle - cornercase

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -561,9 +561,29 @@ class OC_DB {
 	 * TODO: write more documentation
 	 */
 	public static function createDbFromStructure( $file ) {
-		$CONFIG_DBNAME  = OC_Config::getValue( "dbname", "owncloud" );
-		$CONFIG_DBTABLEPREFIX = OC_Config::getValue( "dbtableprefix", "oc_" );
-		$CONFIG_DBTYPE = OC_Config::getValue( "dbtype", "sqlite" );
+		$CONFIG_DBNAME  = OC_Config::getValue('dbname', 'owncloud');
+		$CONFIG_DBTABLEPREFIX = OC_Config::getValue('dbtableprefix', 'oc_');
+		$CONFIG_DBTYPE = OC_Config::getValue('dbtype', 'sqlite');
+		$CONFIG_DBHOST = OC_Config::getValue('dbhost', '');
+
+		if( $CONFIG_DBTYPE === 'oci'
+			&& $CONFIG_DBNAME === '' 
+			&& $CONFIG_DBHOST !== null && $CONFIG_DBHOST !== ''
+		) {
+			// we are connecting by user name, pwd and SID (host)
+			$CONFIG_DBUSER = OC_Config::getValue('dbuser', '');
+			$CONFIG_DBPASSWORD = OC_Config::getValue('dbpassword');
+			if ($CONFIG_DBUSER !== ''
+				&& $CONFIG_DBPASSWORD !== ''
+			) {
+				// use dbuser as dbname
+				$CONFIG_DBNAME = $CONFIG_DBUSER;
+			} else {
+				throw new DatabaseException('Please specify '
+					.'username and password when '
+					.'connecting via SID as the hostname.');
+			}
+		}
 
 		// cleanup the cached queries
 		self::$preparedQueries = array();

--- a/lib/db.php
+++ b/lib/db.php
@@ -567,8 +567,8 @@ class OC_DB {
 		$CONFIG_DBHOST = OC_Config::getValue('dbhost', '');
 
 		if( $CONFIG_DBTYPE === 'oci'
-			&& $CONFIG_DBNAME === '' 
-			&& $CONFIG_DBHOST !== null && $CONFIG_DBHOST !== ''
+			&& $CONFIG_DBNAME === ''
+			&& ! empty($CONFIG_DBHOST)
 		) {
 			// we are connecting by user name, pwd and SID (host)
 			$CONFIG_DBUSER = OC_Config::getValue('dbuser', '');

--- a/lib/db.php
+++ b/lib/db.php
@@ -581,7 +581,7 @@ class OC_DB {
 			} else {
 				throw new DatabaseException('Please specify '
 					.'username and password when '
-					.'connecting via SID as the hostname.');
+					.'connecting via SID as the hostname.', '');
 			}
 		}
 


### PR DESCRIPTION
Installing ownCloud on an oracle database is possible when using username, password, host AND database name (which becomes the SID). Later the dba might decide to give you username, password and an SID. no database name. Because that is fetched in the background by resolving oci8://username:password@SID with a lookup in the tnsnames.ora. Welcome to oracle hell. 

If you haven't noticed by now ... the database name in ownclouds config.php is ''. This causes any attempt to change the database schema to fail because 'A database needs a name!'. No more autmagic migration, no app installations.

This PR fixes that by using the username as the database name (which is valid for oracle ... google it if you don't believe me).

@karlitschek @DeepDiver1975 I need this because it fixes a customer setup. Please review thoroughly!
