### PR TITLE
Files App: No decimal points for kB and Byte and blocking uploading files of the size zro

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -223,7 +223,7 @@ $(document).ready(function() {
 				//examine file
 				var file = data.files[0];
 			
-				if (file.type === '' && file.size === 4096) {
+				if ((file.type === '' && file.size === 4096) || file.size === 0) {
 					data.textStatus = 'dirorzero';
 					data.errorThrown = t('files', 'Unable to upload {filename} as it is a directory or has 0 bytes',
 						{filename: file.name}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -825,7 +825,10 @@ function humanFileSize(size) {
 	order = Math.min(humanList.length - 1, order);
 	var readableFormat = humanList[order];
 	var relativeSize = (size / Math.pow(1024, order)).toFixed(1);
-	if(relativeSize.substr(relativeSize.length-2,2)=='.0'){
+	if(order < 2){
+		relativeSize = relativeSize.toFixed(0);
+	}
+	else if(relativeSize.substr(relativeSize.length-2,2)=='.0'){
 		relativeSize=relativeSize.substr(0,relativeSize.length-2);
 	}
 	return relativeSize + ' ' + readableFormat;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -826,7 +826,7 @@ function humanFileSize(size) {
 	var readableFormat = humanList[order];
 	var relativeSize = (size / Math.pow(1024, order)).toFixed(1);
 	if(order < 2){
-		relativeSize = relativeSize.toFixed(0);
+		relativeSize = parseFloat(relativeSize).toFixed(0);
 	}
 	else if(relativeSize.substr(relativeSize.length-2,2)=='.0'){
 		relativeSize=relativeSize.substr(0,relativeSize.length-2);

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -252,7 +252,7 @@ class OC_Helper {
 		if ($bytes < 1024) {
 			return "$bytes B";
 		}
-		$bytes = round($bytes / 1024, 1);
+		$bytes = round($bytes / 1024, 0);
 		if ($bytes < 1024) {
 			return "$bytes kB";
 		}


### PR DESCRIPTION
The first issue is #5604: The IE 10 can't upload files of the size zero. Therefore, block uploading files of the size of zero from all Browsers.

The second Issue #5371:  The human readable size information shouldn't round by kB and Byte. My approach was to change the rounding settings the humanFileSize function (JS and PHP).

I hope the provided solutions are helpful.
