### PR TITLE
Fixed totalDirs JS error

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -600,11 +600,11 @@ var FileList={
 			var $connector = $summary.find('.connector');
 
 			// Show only what's necessary, e.g.: no files: don't show "0 files"
-			if (totalDirs === 0) {
+			if (summary.totalDirs === 0) {
 				$dirInfo.hide();
 				$connector.hide();
 			}
-			if (totalFiles === 0) {
+			if (summary.totalFiles === 0) {
 				$fileInfo.hide();
 				$connector.hide();
 			}


### PR DESCRIPTION
@frisco82's commit moved the stats into a "summary" structure. But it seems his commit was based on an older version of master where my older commit aeac3186ee52fcadf57b34fc307f5441041cb43d wasn't there yet.

It clashed after the merge.

I think in the future we should retest after merging to rule out this kind of issues.

Please review @kabum @frisco82 @karlitschek @Kondou-ger 
