### PR TITLE
DB: Set correct default value for numeric types

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -193,7 +193,7 @@ class MDB2SchemaReader {
 				} else {
 					$options['default'] = '';
 				}
-				if ($type == 'integer' || $type == 'numeric') {
+				if ($type == 'integer' || $type == 'decimal') {
 					$options['default'] = 0;
 				} elseif ($type == 'boolean') {
 					$options['default'] = false;

--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -193,7 +193,7 @@ class MDB2SchemaReader {
 				} else {
 					$options['default'] = '';
 				}
-				if ($type == 'integer') {
+				if ($type == 'integer' || $type == 'numeric') {
 					$options['default'] = 0;
 				} elseif ($type == 'boolean') {
 					$options['default'] = false;

--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -150,6 +150,9 @@ class MDB2SchemaReader {
 						case 'timestamp':
 							$type = 'datetime';
 							break;
+						case 'numeric':
+							$type = 'decimal';
+							break;
 					}
 					break;
 				case 'length':

--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -199,4 +199,26 @@
   </declaration>
  </table>
 
+ <table>
+  <name>*dbprefix*decimal</name>
+  <declaration>
+   <field>
+    <name>id</name>
+    <autoincrement>1</autoincrement>
+    <type>integer</type>
+    <default>0</default>
+    <notnull>true</notnull>
+    <length>4</length>
+   </field>
+
+   <field>
+    <name>decimaltest</name>
+    <type>decimal</type>
+    <default/>
+    <notnull>true</notnull>
+    <length>15</length>
+   </field>
+  </declaration>
+ </table>
+
 </database>

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -96,4 +96,26 @@
   </declaration>
  </table>
 
+ <table>
+  <name>*dbprefix*decimal</name>
+  <declaration>
+   <field>
+    <name>id</name>
+    <autoincrement>1</autoincrement>
+    <type>integer</type>
+    <default>0</default>
+    <notnull>true</notnull>
+    <length>4</length>
+   </field>
+
+   <field>
+    <name>decimaltest</name>
+    <type>decimal</type>
+    <default/>
+    <notnull>true</notnull>
+    <length>15</length>
+   </field>
+  </declaration>
+ </table>
+
 </database>


### PR DESCRIPTION
Set `0` as default value for columns with numeric data type instead of the
empty string `''`. Otherwise the database complains about an invalid
default value for this column.

To reproduce put the following in your `appinfo/database.xml`:

```
<field>
        <name>modified</name>
        <type>decimal</type>
        <default/>
        <notnull>true</notnull>
        <length>15</length>
</field>
```

See owncloud/mozilla_sync#14
