### PR TITLE
[WIP/DISCUSSION] replace part files

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -312,6 +312,14 @@
 				<length>40</length>
 			</field>
 
+			<field>
+				<name>status</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<length>1</length>
+			</field>
+
 			<index>
 				<name>fs_storage_path_hash</name>
 				<unique>true</unique>

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -118,7 +118,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		}
 
 		//update file status
-		$fs->setStatus($path);
+		$fs->setStatus($path, \OC\Files\FILE_UPLOADED);
 
 		return $this->getETagPropertyForPath($this->path);
 	}

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -63,21 +63,20 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 			return $this->createFileChunked($data);
 		}
 
-		// mark file as partial while uploading (ignored by the scanner)
-		$partpath = $this->path . '.part';
+		$path = $this->path;
 
 		// if file is located in /Shared we write the part file to the users
 		// root folder because we can't create new files in /shared
 		// we extend the name with a random number to avoid overwriting a existing file
-		if (dirname($partpath) === 'Shared') {
-			$partpath = pathinfo($partpath, PATHINFO_FILENAME) . rand() . '.part';
+		if (dirname($path) === 'Shared') {
+			$path = pathinfo($path, PATHINFO_FILENAME) . rand();
 		}
 
 		try {
-			$putOkay = $fs->file_put_contents($partpath, $data);
+			$putOkay = $fs->file_put_contents($path, $data);
 			if ($putOkay === false) {
 				\OC_Log::write('webdav', '\OC\Files\Filesystem::file_put_contents() failed', \OC_Log::ERROR);
-				$fs->unlink($partpath);
+				$fs->unlink($path);
 				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
 				throw new Sabre_DAV_Exception();
 			}
@@ -100,12 +99,14 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		}
 
 		// rename to correct path
-		$renameOkay = $fs->rename($partpath, $this->path);
-		$fileExists = $fs->file_exists($this->path);
-		if ($renameOkay === false || $fileExists === false) {
-			\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
-			$fs->unlink($partpath);
-			throw new Sabre_DAV_Exception();
+		if ($path !== $this->path) {
+			$renameOkay = $fs->rename($path, $this->path);
+			$fileExists = $fs->file_exists($this->path);
+			if ($renameOkay === false || $fileExists === false) {
+				\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
+				$fs->unlink($path);
+				throw new Sabre_DAV_Exception();
+			}
 		}
 
 		// allow sync clients to send the mtime along in a header
@@ -115,6 +116,9 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 				header('X-OC-MTime: accepted');
 			}
 		}
+
+		//update file status
+		$fs->setStatus($path);
 
 		return $this->getETagPropertyForPath($this->path);
 	}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -35,7 +35,15 @@ const SPACE_NOT_COMPUTED = -1;
 const SPACE_UNKNOWN = -2;
 const SPACE_UNLIMITED = -3;
 
+const FILE_NEW = 0;                   // new file but upload not completed
+const FILE_UPLOADED = 1;              // upload completed, file can be indexed by the file cache
+const FILE_CACHED = 2;                //file cache filled
+const FILE_META_INDEXED = 4;          //e.g. audio meta data
+const FILE_CONTENT_INDEXED = 8;       // e.g. pdf content
+const FILE_THUMBNAILS_GENERATED = 16; // gallery thumbnails generated
+
 class Filesystem {
+
 	/**
 	 * @var Mount\Manager $mounts
 	 */

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1061,6 +1061,31 @@ class View {
 	}
 
 	/**
+	 * set file status
+	 * @param string $path
+	 * @param int $status file status
+	 * @return bool
+	 */
+	public function setStatus($path, $status) {
+		list($storage, $internalPath) = $this->resolvePath($path);
+		if ($storage) {
+			return $storage->setStatus($internalPath, $status);
+		}
+	}
+
+	/**
+	 * get current file status
+	 * @param string $path
+	 * @return int
+	 */
+	public function getStatus($path) {
+		list($storage, $internalPath) = $this->resolvePath($path);
+		if ($storage) {
+			return $storage->getStatus($internalPath);
+		}
+	}
+
+	/**
 	 * Get the path of a file by id, relative to the view
 	 *
 	 * Note that the resulting path is not guarantied to be unique for the id, multiple paths can point to the same file


### PR DESCRIPTION
Don't merge this pull request! It is work in progress and need some discussion!

cc @DeepDiver1975 @butonic @icewind1991 @PVince81 

This is more or less a skeleton  to replace the part files with some flags in the file cache as discussed with Jörn during the developer meeting in Stuttgart. It still misses the file cache code to set/get the flags.

The main idea was to hide files as long as they are not complete and only show them if the upload was completed. This works nicely for new files but during implementation and discussion with Vincent I discovered some other issues with this approach:

How do we handle file updates? Right now a file update gets written to the part file and moved to the original file once the part file is completed. Without the .part files we would write to the real file directly. During this file operation we could either set the file state to "incomplete" which would result in following problem:
- During upload the file would disappear from the web interface and from possible webdav mounts which would be quite irritating for the user.
- It could even happen that the sync client would delete the local copy of the file because he would think that the file is gone. 

Or we would keep the file state "completed":
- The file would stay in the web interface
- But which file size would we show to the user during upload?
- What would happen if the user tries to download/open the file during upload?

Regarding pull request  #5447, I don't think the switch from part files to the flags would solve the issue. We would still have the problem that we could assemble two parallel upload to the same target file. So here we would still need some kind of part files with a random id.

Right now I'm no longer sure if this is really the right approach. Especially if we would have to introduce some kind of part files again to solve #5447 after we replaced them with the flags.

Did I missed something? What do you think?
