### PR TITLE
Update config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -184,7 +184,11 @@ $CONFIG = array(
  */
 // "datadirectory" => "",
 
-/* Enable maintenance mode to disable ownCloud */
+/* Enable maintenance mode to disable ownCloud
+   If you want to prevent users to login to ownCloud before you start doing some maintenance work, 
+   you need to set the value of the maintenance parameter to true. 
+   Please keep in mind that users who are already logged-in are kicked out of ownCloud instantly.
+*/
 "maintenance" => false,
 
 "apps_paths" => array(


### PR DESCRIPTION
Added text from http://doc.owncloud.com/server/5.0EE/admin_manual/configuration/configuration_maintenance.html
to better describe what the `maintenance` switch does.

/\* Enable maintenance mode to disable ownCloud
   If you want to prevent users to login to ownCloud before you start doing some maintenance work, 
   you need to set the value of the maintenance parameter to true. 
   Please keep in mind that users who are already logged-in are kicked out of ownCloud instantly.
*/
