### PR TITLE
DB: Only change default if it is actually set

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -186,7 +186,7 @@ class MDB2SchemaReader {
 			}
 		}
 		if (isset($name) && isset($type)) {
-			if (empty($options['default'])) {
+			if (isset($options['default']) && empty($options['default'])) {
 				if (empty($options['notnull']) || !$options['notnull']) {
 					unset($options['default']);
 					$options['notnull'] = false;


### PR DESCRIPTION
Only change the default modifier of a database field when it is actually
set in the `appinfo/database.xml` file. Otherwise, it is not
possible to have a field with a not-null modifier and without a default
value.

Fixes owncloud/core#5819
