### PR TITLE
Use dedicated OC_Image loader methods in previews

### DIFF
--- a/lib/private/preview/image.php
+++ b/lib/private/preview/image.php
@@ -21,11 +21,11 @@ class Image extends Provider {
 			return false;
 		}
 
+		$image = new \OC_Image();
 		//check if file is encrypted
 		if($fileInfo['encrypted'] === true) {
-			$image = new \OC_Image(stream_get_contents($fileview->fopen($path, 'r')));
+			$image->loadFromData(stream_get_contents($fileview->fopen($path, 'r')));
 		}else{
-			$image = new \OC_Image();
 			$image->loadFromFile($fileview->getLocalFile($path));
 		}
 

--- a/lib/private/preview/movies.php
+++ b/lib/private/preview/movies.php
@@ -36,7 +36,8 @@ if (!\OC_Util::runningOnWindows()) {
 
 				shell_exec($cmd);
 
-				$image = new \OC_Image($tmpPath);
+				$image = new \OC_Image();
+				$image->loadFromFile($tmpPath);
 
 				unlink($absPath);
 				unlink($tmpPath);

--- a/lib/private/preview/mp3.php
+++ b/lib/private/preview/mp3.php
@@ -25,7 +25,8 @@ class MP3 extends Provider {
 		if(isset($tags['id3v2']['APIC'][0]['data'])) {
 			$picture = @$tags['id3v2']['APIC'][0]['data'];
 			unlink($tmpPath);
-			$image = new \OC_Image($picture);
+			$image = new \OC_Image();
+			$image->loadFromData($picture);
 			return $image->valid() ? $image : $this->getNoCoverThumbnail();
 		}
 
@@ -39,7 +40,8 @@ class MP3 extends Provider {
 			return false;
 		}
 
-		$image = new \OC_Image($icon);
+		$image = new \OC_Image();
+		$image->loadFromFile($icon);
 		return $image->valid() ? $image : false;
 	}
 

--- a/lib/private/preview/office-cl.php
+++ b/lib/private/preview/office-cl.php
@@ -48,7 +48,8 @@ if (!\OC_Util::runningOnWindows()) {
 				return false;
 			}
 
-			$image = new \OC_Image($pdf);
+			$image = new \OC_Image();
+			$image->loadFromData($pdf);
 
 			unlink($absPath);
 			unlink($absPath . '.pdf');

--- a/lib/private/preview/office-fallback.php
+++ b/lib/private/preview/office-fallback.php
@@ -80,7 +80,8 @@ class MSOfficeExcel extends Provider {
 		unlink($absPath);
 		unlink($tmpPath);
 
-		$image = new \OC_Image($pdf);
+		$image = new \OC_Image();
+		$image->loadFromData($pdf);
 
 		return $image->valid() ? $image : false;
 	}


### PR DESCRIPTION
This prevents excessive logging and disk access

@georgehrke @PVince81 @blizzz @karlitschek 
