### PR TITLE
OCS API: Pick non 100 status codes before defaulting to 100.

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -170,7 +170,7 @@ class OC_API {
 			$response = reset($thirdparty['failed']);
 			return $response;
 		} else {
-			$responses = array_merge($shipped['succeeded'], $thirdparty['succeeded']);
+			$responses = $thirdparty['succeeded'];
 		}
 		// Merge the successful responses
 		$meta = array();
@@ -182,8 +182,19 @@ class OC_API {
 			} else {
 				$data = array_merge_recursive($data, $response->getData());
 			}
+			$codes[] = $response->getStatusCode();
 		}
-		$result = new OC_OCS_Result($data, 100);
+
+		// Use any non 100 status codes
+		$statusCode = 100;
+		foreach($codes as $code) {
+			if($code != 100) {
+				$statusCode = $code;
+				break;
+			}
+		}
+
+		$result = new OC_OCS_Result($data, $statusCode);
 		return $result;
 	}
 	


### PR DESCRIPTION
At the moment the mergeResponses() method merges together responses from multiple methods that have registered on one route. 

Unfortunately due to the OCS status code style it is hard to decide which status code to return, so we have been incorrectly defaulting to 100. However, this is conflicting with the spec. 

This pull request detects any non 100 status codes and uses those instead of defaulting to 100. 

We should also move over to using HTTP style status codes to make things much clearer and easier for the API code to decide on.
