### PR TITLE
[encryption] preserve timestamps and etags during encryption/decryption

### DIFF
--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -67,6 +67,7 @@ class Stream {
 	 * @var \OC\Files\View
 	 */
 	private $rootView; // a fsview object set to '/'
+
 	/**
 	 * @var \OCA\Encryption\Session
 	 */
@@ -528,19 +529,21 @@ class Stream {
 				\OC_FileProxy::$enabled = $proxyStatus;
 			}
 
+			// we need to update the file info for the real file, not for the
+			// part file.
+			$path = Helper::fixPartialFilePath($this->rawPath);
+
 			// get file info
-			$fileInfo = $this->rootView->getFileInfo($this->rawPath);
-			if (!is_array($fileInfo)) {
-				$fileInfo = array();
+			$fileInfo = $this->rootView->getFileInfo($path);
+			if (is_array($fileInfo)) {
+				// set encryption data
+				$fileInfo['encrypted'] = true;
+				$fileInfo['size'] = $this->size;
+				$fileInfo['unencrypted_size'] = $this->unencryptedSize;
+
+				// set fileinfo
+				$this->rootView->putFileInfo($path, $fileInfo);
 			}
-
-			// set encryption data
-			$fileInfo['encrypted'] = true;
-			$fileInfo['size'] = $this->size;
-			$fileInfo['unencrypted_size'] = $this->unencryptedSize;
-
-			// set fileinfo
-			$this->rootView->putFileInfo($this->rawPath, $fileInfo);
 
 		}
 

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -531,7 +531,7 @@ class Stream {
 
 			// we need to update the file info for the real file, not for the
 			// part file.
-			$path = Helper::fixPartialFilePath($this->rawPath);
+			$path = Helper::stripPartialFileExtension($this->rawPath);
 
 			// get file info
 			$fileInfo = $this->rootView->getFileInfo($path);

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -717,17 +717,17 @@ class Util {
 			// Encrypt unencrypted files
 			foreach ($found['encrypted'] as $encryptedFile) {
 
-				//get file info
-				$fileInfo = \OC\Files\Filesystem::getFileInfo($encryptedFile['path']);
-
 				//relative to data/<user>/file
 				$relPath = Helper::stripUserFilesPath($encryptedFile['path']);
+
+				//get file info
+				$fileInfo = \OC\Files\Filesystem::getFileInfo($relPath);
 
 				//relative to /data
 				$rawPath = $encryptedFile['path'];
 
 				//get timestamp
-				$timestamp = $this->view->filemtime($rawPath);
+				$timestamp = $fileInfo['mtime'];
 
 				//enable proxy to use OC\Files\View to access the original file
 				\OC_FileProxy::$enabled = true;
@@ -768,10 +768,10 @@ class Util {
 
 				$this->view->rename($relPath . '.part', $relPath);
 
-				$this->view->chroot($fakeRoot);
-
 				//set timestamp
-				$this->view->touch($rawPath, $timestamp);
+				$this->view->touch($relPath, $timestamp);
+
+				$this->view->chroot($fakeRoot);
 
 				// Add the file to the cache
 				\OC\Files\Filesystem::putFileInfo($relPath, array(
@@ -839,7 +839,7 @@ class Util {
 				$rawPath = '/' . $this->userId . '/files/' . $plainFile['path'];
 
 				// keep timestamp
-				$timestamp = $this->view->filemtime($rawPath);
+				$timestamp = $fileInfo['mtime'];
 
 				// Open plain file handle for binary reading
 				$plainHandle = $this->view->fopen($rawPath, 'rb');
@@ -858,10 +858,10 @@ class Util {
 
 				$this->view->rename($relPath . '.part', $relPath);
 
-				$this->view->chroot($fakeRoot);
-
 				// set timestamp
-				$this->view->touch($rawPath, $timestamp);
+				$this->view->touch($relPath, $timestamp);
+
+				$this->view->chroot($fakeRoot);
 
 				// Add the file to the cache
 				\OC\Files\Filesystem::putFileInfo($relPath, array(

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -281,6 +281,70 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->util->isSharedPath($path));
 	}
 
+	function testEncryptAll() {
+
+		$filename = "/encryptAll" . time() . ".txt";
+		$util = new Encryption\Util($this->view, $this->userId);
+
+		// disable encryption to upload a unencrypted file
+		\OC_App::disable('files_encryption');
+
+		$this->view->file_put_contents($this->userId . '/files/' . $filename, $this->dataShort);
+
+		$fileInfoUnencrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
+
+		$this->assertTrue(is_array($fileInfoUnencrypted));
+
+		// enable file encryption again
+		\OC_App::enable('files_encryption');
+
+		// encrypt all unencrypted files
+		$util->encryptAll('/' . $this->userId . '/' . 'files');
+
+		$fileInfoEncrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
+
+		$this->assertTrue(is_array($fileInfoEncrypted));
+
+		// check if mtime and etags unchanged
+		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
+		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+
+		$this->view->unlink($this->userId . '/files/' . $filename);
+	}
+
+
+	function testDecryptAll() {
+
+		$filename = "/decryptAll" . time() . ".txt";
+		$util = new Encryption\Util($this->view, $this->userId);
+
+		$this->view->file_put_contents($this->userId . '/files/' . $filename, $this->dataShort);
+
+		$fileInfoEncrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
+
+		print("\n File Info Encrypted\n");
+		print_r($fileInfoEncrypted);
+
+		$this->assertTrue(is_array($fileInfoEncrypted));
+
+		// encrypt all unencrypted files
+		$util->decryptAll('/' . $this->userId . '/' . 'files');
+
+		$fileInfoUnencrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
+
+		print("\n File Info Unencrypted\n");
+		print_r($fileInfoUnencrypted);
+
+		$this->assertTrue(is_array($fileInfoUnencrypted));
+
+		// check if mtime and etags unchanged
+		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
+		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+
+		$this->view->unlink($this->userId . '/files/' . $filename);
+
+	}
+
 	/**
 	 * @large
 	 */

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -322,18 +322,12 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$fileInfoEncrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
 
-		print("\n File Info Encrypted\n");
-		print_r($fileInfoEncrypted);
-
 		$this->assertTrue(is_array($fileInfoEncrypted));
 
 		// encrypt all unencrypted files
 		$util->decryptAll('/' . $this->userId . '/' . 'files');
 
 		$fileInfoUnencrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
-
-		print("\n File Info Unencrypted\n");
-		print_r($fileInfoUnencrypted);
 
 		$this->assertTrue(is_array($fileInfoUnencrypted));
 


### PR DESCRIPTION
- only update file cache with the encryption data if the file is already indexed. Otherwise we will have incomplete file cache entries 
- make sure that timestamp and etag always stays the same if a file gets encrypted/decrypted
