### PR TITLE
[SMB] Fix stat and unlink

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -569,8 +569,18 @@ var FileList={
 						FileList.updateEmptyContent();
 						Files.updateStorageStatistics();
 					} else {
+						if (result.status === 'error' && result.data.message) {
+							OC.Notification.show(result.data.message);
+						}
+						else {
+							OC.Notification.show(t('files', 'Error deleting file.'));
+						}
+						// hide notification after 10 sec
+						setTimeout(function() {
+							OC.Notification.hide();
+						}, 10000);
 						$.each(files,function(index,file) {
-							var deleteAction = $('tr[data-file="'+files[i]+'"]').children("td.date").children(".action.delete");
+							var deleteAction = $('tr[data-file="' + file + '"] .action.delete');
 							deleteAction.removeClass('progress-icon').addClass('delete-icon');
 						});
 					}

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -47,8 +47,13 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 
 	public function constructUrl($path) {
 		if (substr($path, -1)=='/') {
-			$path=substr($path, 0, -1);
+			$path = substr($path, 0, -1);
 		}
+		if (substr($path, 0, 1)=='/') {
+			$path = substr($path, 1);
+		}
+		// remove trailing dots which some versions of samba don't seem to like
+		$path = rtrim($path, '.');
 		$path = urlencode($path);
 		$user = urlencode($this->user);
 		$pass = urlencode($this->password);

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -82,6 +82,18 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 	}
 
 	/**
+	 * Unlinks file
+	 * @param string @path
+	 */
+	public function unlink($path) {
+		unlink($this->constructUrl($path));
+		clearstatcache();
+		// smb4php still returns false even on success so
+		// check here whether file was really deleted
+		return !file_exists($path);
+	}
+
+	/**
 	 * check if a file or folder has been updated since $time
 	 * @param string $path
 	 * @param int $time

--- a/apps/files_external/tests/smbfunctions.php
+++ b/apps/files_external/tests/smbfunctions.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2013 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Files\Storage;
+
+class SMBFunctions extends \PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+		$id = uniqid();
+		// dummy config
+		$this->config = array(
+			'run'=>false,
+			'user'=>'test',
+			'password'=>'testpassword',
+			'host'=>'smbhost',
+			'share'=>'/sharename',
+			'root'=>'/rootdir/',
+		);
+
+		$this->instance = new \OC\Files\Storage\SMB($this->config);
+	}
+
+	public function tearDown() {
+	}
+
+	public function testGetId() {
+		$this->assertEquals('smb::test@smbhost//sharename//rootdir/', $this->instance->getId());
+	}
+
+	public function testConstructUrl() {
+		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc'));
+		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc/'));
+		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc%2F", $this->instance->constructUrl('/abc/.'));
+		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc%2Fdef", $this->instance->constructUrl('/abc/def'));
+	}
+}

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -182,8 +182,9 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->instance->hasUpdated('/lorem.txt', $ctimeStart - 5));
 		$this->assertTrue($this->instance->hasUpdated('/', $ctimeStart - 5));
 
-		$this->assertTrue(($ctimeStart - 5) <= $mTime);
-		$this->assertTrue($mTime <= ($ctimeEnd + 1));
+		// check that ($ctimeStart - 5) <= $mTime <= ($ctimeEnd + 1)
+		$this->assertGreaterThanOrEqual(($ctimeStart - 5), $mTime);
+		$this->assertLessThanOrEqual(($ctimeEnd + 1), $mTime);
 		$this->assertEquals(filesize($textFile), $this->instance->filesize('/lorem.txt'));
 
 		$stat = $this->instance->stat('/lorem.txt');
@@ -200,6 +201,17 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 
 		$this->instance->unlink('/lorem.txt');
 		$this->assertTrue($this->instance->hasUpdated('/', $mtimeStart - 5));
+	}
+
+	public function testUnlink() {
+		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
+		$this->instance->file_put_contents('/lorem.txt', file_get_contents($textFile));
+
+		$this->assertTrue($this->instance->file_exists('/lorem.txt'));
+
+		$this->assertTrue($this->instance->unlink('/lorem.txt'));
+
+		$this->assertFalse($this->instance->file_exists('/lorem.txt'));
 	}
 
 	public function testFOpen() {


### PR DESCRIPTION
Also:
- fixed delete action to show error message as notification
- added unit tests for getId() and constructUrl() for SMB module
- added storage unit test for unlink operation
- added workaround to detect successful unlink operation for SMB
- fixes #5778
- fixes #5866

Please review @icewind1991 @DeepDiver1975 @karlitschek

Note: I've put the fixes together because they all rely on stat() to work at all.
