### PR TITLE
Fix for smb4php fseek

### DIFF
--- a/apps/files_external/3rdparty/smb4php/smb.php
+++ b/apps/files_external/3rdparty/smb4php/smb.php
@@ -460,7 +460,8 @@ class smb_stream_wrapper extends smb {
 
 	function stream_tell () { return ftell($this->stream); }
 
-	function stream_seek ($offset, $whence=null) { return fseek($this->stream, $offset, $whence); }
+	// PATCH: the wrapper must return true when fseek succeeded by returning 0.
+	function stream_seek ($offset, $whence=null) { return fseek($this->stream, $offset, $whence) === 0; }
 
 	function stream_flush () {
 		if ($this->mode <> 'r' && $this->need_flush) {


### PR DESCRIPTION
The stream_fseek function must return a boolean which will be mapped
to 0 for success and -1 for failure for the caller.

This patch fixes stream_fseek of smb4php to also respect this
convention.

Since the encryption app is relying on fseek to detect whether a file is
encrypted by reading the last bit of data, this will fix #5023

Please review @schiesbn @icewind1991 @karlitschek @DeepDiver1975 

I took the liberty to patch the library because there is no other way, and also because the upstream project is inactive since 2007. Also, I think @icewind1991 has prepared a new implementation which is planned for OC7.
