### PR TITLE
[encryption] fix redirectToErrorPage() call

### DIFF
--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -484,7 +484,7 @@ class Stream {
 			}
 
 			// if private key is not valid redirect user to a error page
-			\OCA\Encryption\Helper::redirectToErrorPage();
+			\OCA\Encryption\Helper::redirectToErrorPage($this->session);
 		}
 
 		if (


### PR DESCRIPTION
we need the session as parameter for the error handler.

fixes #5895
