### PR TITLE
change bold 'deleted files' button to normal for less focus

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -18,6 +18,7 @@
 	float: right;
 	z-index: 1010;
 	padding: 10px;
+	font-weight: normal;
 }
 #new>a {
 	padding: 14px 10px;


### PR DESCRIPTION
We have too much bold text in ownCloud and need to tone it down a bit. The »Deleted Files« button is big enough as it is, no need for bold text.

Please check @owncloud/designers @schiesbn 
