### PR TITLE
remove bold from legend, table header, label - less obtrusive

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -696,8 +696,6 @@ tbody tr:hover, tr:active { background-color:#f8f8f8; }
 }
 #body-settings .personalblock#quota { position:relative; padding:0; }
 #body-settings #controls+.helpblock { position:relative; margin-top:3em; }
-.personalblock > legend { margin-top:2em; }
-.personalblock > legend, th, dt, label { font-weight:bold; }
 code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", monospace; }
 
 #quota div {


### PR DESCRIPTION
Check it out @owncloud/designers 

We really need to tone down the bolding in ownCloud. :) Only use it for things which actually require attention, like new/unread things for example.
