### PR TITLE
External storage space is now not counted in total space

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -28,8 +28,8 @@
 class OC_Files {
 	static $tmpFiles = array();
 
-	static public function getFileInfo($path){
-		return \OC\Files\Filesystem::getFileInfo($path);
+	static public function getFileInfo($path, $includeMountPoints = true){
+		return \OC\Files\Filesystem::getFileInfo($path, $includeMountPoints);
 	}
 
 	static public function getDirectoryContent($path){

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -725,6 +725,8 @@ class Filesystem {
 	 * get the filesystem info
 	 *
 	 * @param string $path
+	 * @param boolean $includeMountPoints whether to add mountpoint sizes,
+	 * defaults to true
 	 * @return array
 	 *
 	 * returns an associative array with the following keys:
@@ -734,8 +736,8 @@ class Filesystem {
 	 * - encrypted
 	 * - versioned
 	 */
-	public static function getFileInfo($path) {
-		return self::$defaultInstance->getFileInfo($path);
+	public static function getFileInfo($path, $includeMountPoints = true) {
+		return self::$defaultInstance->getFileInfo($path, $includeMountPoints);
 	}
 
 	/**

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -762,6 +762,8 @@ class View {
 	 * get the filesystem info
 	 *
 	 * @param string $path
+	 * @param boolean $includeMountPoints whether to add mountpoint sizes,
+	 * defaults to true
 	 * @return array
 	 *
 	 * returns an associative array with the following keys:
@@ -771,7 +773,7 @@ class View {
 	 * - encrypted
 	 * - versioned
 	 */
-	public function getFileInfo($path) {
+	public function getFileInfo($path, $includeMountPoints = true) {
 		$data = array();
 		if (!Filesystem::isValidPath($path)) {
 			return $data;
@@ -798,7 +800,7 @@ class View {
 			$data = $cache->get($internalPath);
 
 			if ($data and $data['fileid']) {
-				if ($data['mimetype'] === 'httpd/unix-directory') {
+				if ($includeMountPoints and $data['mimetype'] === 'httpd/unix-directory') {
 					//add the sizes of other mountpoints to the folder
 					$mountPoints = Filesystem::getMountPoints($path);
 					foreach ($mountPoints as $mountPoint) {

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -876,7 +876,8 @@ class OC_Helper {
 	 * @return array
 	 */
 	public static function getStorageInfo($path) {
-		$rootInfo = \OC\Files\Filesystem::getFileInfo($path);
+		// return storage info without adding mount points
+		$rootInfo = \OC\Files\Filesystem::getFileInfo($path, false);
 		$used = $rootInfo['size'];
 		if ($used < 0) {
 			$used = 0;

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -67,6 +67,11 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($storageSize * 3, $cachedData['size']);
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
 
+		// get cached data excluding mount points
+		$cachedData = $rootView->getFileInfo('/', false);
+		$this->assertEquals($storageSize, $cachedData['size']);
+		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
+
 		$cachedData = $rootView->getFileInfo('/folder');
 		$this->assertEquals($storageSize + $textSize, $cachedData['size']);
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);


### PR DESCRIPTION
Added argument to getFileInfo() to disable adding the size of
mountpoints to a directory's size.

Fixes #5924

Please review @karlitschek @schiesbn @icewind1991 @DeepDiver1975 
