### PR TITLE
Root size for home storage is now size of "files" subdir

### DIFF
--- a/lib/private/files/cache/homecache.php
+++ b/lib/private/files/cache/homecache.php
@@ -37,4 +37,17 @@ class HomeCache extends Cache {
 		}
 		return $totalSize;
 	}
+
+	public function get($path) {
+		$data = parent::get($path);
+		if ($path === '' or $path === '/') {
+			// only the size of the "files" dir counts
+			$filesData = parent::get('files');
+
+			if (isset($filesData['size'])) {
+				$data['size'] = $filesData['size'];
+			}
+		}
+		return $data;
+	}
 }

--- a/tests/lib/files/cache/homecache.php
+++ b/tests/lib/files/cache/homecache.php
@@ -92,4 +92,30 @@ class HomeCache extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->cache->inCache($dir1));
 		$this->assertFalse($this->cache->inCache($dir2));
 	}
+
+	public function testRootFolderSizeIsFilesSize() {
+		$dir1 = 'files';
+		$afile = 'test.txt';
+		$fileData = array();
+		$fileData[''] = array('size' => 1500, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory');
+		$fileData[$dir1] = array('size' => 1000, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory');
+		$fileData[$afile] = array('size' => 500, 'mtime' => 20);
+
+		$this->cache->put('', $fileData['']);
+		$this->cache->put($dir1, $fileData[$dir1]);
+
+		$this->assertTrue($this->cache->inCache($dir1));
+
+		// check that root size ignored the unknown sizes
+		$data = $this->cache->get('files');
+		$this->assertEquals(1000, $data['size']);
+		$data = $this->cache->get('');
+		$this->assertEquals(1000, $data['size']);
+
+		// clean up
+		$this->cache->remove('');
+		$this->cache->remove($dir1);
+
+		$this->assertFalse($this->cache->inCache($dir1));
+	}
 }


### PR DESCRIPTION
Fixes #4593 

This change should make it work as discussed: only files under "/files" will count in the total size and in the quota.
Metadata and app data, including trashbin are outside of it.

Please review @karlitschek @schiesbn @icewind1991 @DeepDiver1975 

@schiesbn not sure whether further changes are needed in trashbin/versions to make them work correctly with this change ?
