### PR TITLE
switch code checker on by default. apps are not allowed to access

### DIFF
--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -460,8 +460,7 @@ class OC_Installer{
 		);
 
 		// is the code checker enabled?
-		if(OC_Config::getValue('appcodechecker', false)) {
-
+		if(OC_Config::getValue('appcodechecker', true)) {
 			// check if grep is installed
 			$grep = exec('which grep');
 			if($grep=='') {


### PR DESCRIPTION
some of the internal classes where we have a public api for now
Please review @bartv2 @DeepDiver1975 @PVince81 @schiesbn 
