### PR TITLE
[Stable5] Exclude ext storage from quota

### DIFF
--- a/apps/files/ajax/getstoragestats.php
+++ b/apps/files/ajax/getstoragestats.php
@@ -3,7 +3,13 @@
 // only need filesystem apps
 $RUNTIME_APPTYPES = array('filesystem');
 
+$dir = '/';
+
+if (isset($_GET['dir'])) {
+	$dir = $_GET['dir'];
+}
+
 OCP\JSON::checkLoggedIn();
 
 // send back json
-OCP\JSON::success(array('data' => \OCA\files\lib\Helper::buildFileStorageStatistics('/')));
+OCP\JSON::success(array('data' => \OCA\files\lib\Helper::buildFileStorageStatistics($dir)));

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -523,7 +523,8 @@ $(document).ready(function() {
 
 	// file space size sync
 	function update_storage_statistics() {
-		$.getJSON(OC.filePath('files','ajax','getstoragestats.php'),function(response) {
+		var currentDir = $('#dir').val() || '/';
+		$.getJSON(OC.filePath('files','ajax','getstoragestats.php?dir=' + encodeURIComponent(currentDir)),function(response) {
 			Files.updateMaxUploadFilesize(response);
 		});
 	}

--- a/lib/fileproxy/quota.php
+++ b/lib/fileproxy/quota.php
@@ -74,7 +74,7 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 
 		$view = new \OC\Files\View("/".$owner."/files");
 
-		$rootInfo = $view->getFileInfo('/');
+		$rootInfo = $view->getFileInfo('/', false);
 		$usedSpace = isset($rootInfo['size'])?$rootInfo['size']:0;
 		return $totalSpace - $usedSpace;
 	}

--- a/lib/fileproxy/quota.php
+++ b/lib/fileproxy/quota.php
@@ -66,6 +66,11 @@ class OC_FileProxy_Quota extends OC_FileProxy{
 		if (!$owner) {
 			return -1;
 		}
+		list($rootStorage, $rootInternalPath) = \OC\Files\Filesystem::resolvePath('/' . $owner . '/');
+		// do not apply quota on external storage
+		if ($rootStorage->getId() !== $storage->getId()) {
+			return -1;
+		}
 
 		$totalSpace = $this->getQuota($owner);
 		if($totalSpace == -1) {

--- a/lib/files.php
+++ b/lib/files.php
@@ -28,8 +28,8 @@
 class OC_Files {
 	static $tmpFiles = array();
 
-	static public function getFileInfo($path){
-		return \OC\Files\Filesystem::getFileInfo($path);
+	static public function getFileInfo($path, $includeMountPoints = true){
+		return \OC\Files\Filesystem::getFileInfo($path, $includeMountPoints);
 	}
 
 	static public function getDirectoryContent($path){

--- a/lib/files/filesystem.php
+++ b/lib/files/filesystem.php
@@ -624,6 +624,8 @@ class Filesystem {
 	 * get the filesystem info
 	 *
 	 * @param string $path
+	 * @param boolean $includeMountPoints whether to add mountpoint sizes,
+	 * defaults to true
 	 * @return array
 	 *
 	 * returns an associative array with the following keys:
@@ -633,8 +635,8 @@ class Filesystem {
 	 * - encrypted
 	 * - versioned
 	 */
-	public static function getFileInfo($path) {
-		return self::$defaultInstance->getFileInfo($path);
+	public static function getFileInfo($path, $includeMountPoints = true) {
+		return self::$defaultInstance->getFileInfo($path, $includeMountPoints);
 	}
 
 	/**

--- a/lib/files/view.php
+++ b/lib/files/view.php
@@ -750,6 +750,8 @@ class View {
 	 * get the filesystem info
 	 *
 	 * @param string $path
+	 * @param boolean $includeMountPoints whether to add mountpoint sizes,
+	 * defaults to true
 	 * @return array
 	 *
 	 * returns an associative array with the following keys:
@@ -759,7 +761,7 @@ class View {
 	 * - encrypted
 	 * - versioned
 	 */
-	public function getFileInfo($path) {
+	public function getFileInfo($path, $includeMountPoints = true) {
 		$data = array();
 		if (!Filesystem::isValidPath($path)) {
 			return $data;
@@ -786,7 +788,7 @@ class View {
 			$data = $cache->get($internalPath);
 
 			if ($data and $data['fileid']) {
-				if ($data['mimetype'] === 'httpd/unix-directory') {
+				if ($includeMountPoints and $data['mimetype'] === 'httpd/unix-directory') {
 					//add the sizes of other mountpoints to the folder
 					$mountPoints = Filesystem::getMountPoints($path);
 					foreach ($mountPoints as $mountPoint) {

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -831,7 +831,8 @@ class OC_Helper {
 	 * @return array
 	 */
 	public static function getStorageInfo($path) {
-		$rootInfo = \OC\Files\Filesystem::getFileInfo($path);
+		// return storage info without adding mount points
+		$rootInfo = \OC\Files\Filesystem::getFileInfo($path, false);
 		$used = $rootInfo['size'];
 		if ($used < 0) {
 			$used = 0;

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -57,6 +57,11 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($storageSize * 3, $cachedData['size']);
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
 
+		// get cached data excluding mount points
+		$cachedData = $rootView->getFileInfo('/', false);
+		$this->assertEquals($storageSize, $cachedData['size']);
+		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
+
 		$cachedData = $rootView->getFileInfo('/folder');
 		$this->assertEquals($storageSize + $textSize, $cachedData['size']);
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);


### PR DESCRIPTION
Raised a backport PR because this needed additional changes to fix the quota calculation which was different in OC 5.

Please review @karlitschek @kabum @icewind1991 @DeepDiver1975 
