### PR TITLE
fix encryption with LDAP, make sure that the owners home is mounted correctly

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -84,6 +84,8 @@ class Util {
 				$this->privateKeyPath =
 					'/owncloud_private_key/' . $this->userId . '.private.key'; // e.g. data/admin/admin.private.key
 				$this->isPublic = true;
+				// make sure that the owners home is mounted
+				\OC\Files\Filesystem::initMountPoints($GLOBALS['fileOwner']);
 			}
 
 		} else {
@@ -99,6 +101,8 @@ class Util {
 				$this->publicKeyDir . '/' . $this->userId . '.public.key'; // e.g. data/public-keys/admin.public.key
 			$this->privateKeyPath =
 				$this->encryptionDir . '/' . $this->userId . '.private.key'; // e.g. data/admin/admin.private.key
+			// make sure that the owners home is mounted
+			\OC\Files\Filesystem::initMountPoints($this->userId);
 		}
 	}
 


### PR DESCRIPTION
Make sure that the owners home is mounted correctly, this fixes #5944 
Patch was already tested successfully by @Elethiomel who opened the issue.

@blizzz maybe you can also have a look at it? Thanks!
