### PR TITLE
Fixed getLocalFile() condition for x-send-file

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -131,9 +131,11 @@ class OC_Files {
 				if ($filesize > -1) {
 					header("Content-Length: ".$filesize);
 				}
-				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
-				if ($storage instanceof \OC\Files\Storage\Local) {
-					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
+				if ($xsendfile) {
+					list($storage) = \OC\Files\Filesystem::resolvePath(\OC\Files\Filesystem::getView()->getAbsolutePath($filename));
+					if ($storage instanceof \OC\Files\Storage\Local) {
+						self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
+					}
 				}
 			}
 		} elseif ($zip or !\OC\Files\Filesystem::file_exists($filename)) {


### PR DESCRIPTION
Until now, addSendfileHeader() was called even when no x-send-file
headers were set. Even though the method itself doesn't do anything, a
call to getLocalFile() was done and would trigger a full download when
using external storage.

Additionally, the storage resolution code is wrong and always returns
the local storage of the root filesystem, which caused the code to be
run anyway.

This commit fixes both issues.

Note: this will improve the download performance for external storage as it will need one less full file download.

Please review @karlitschek @DeepDiver1975 @schiesbn @icewind1991 @bantu 
