### PR TITLE
Change default mimetype detection for storage backends to only use filename

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -142,7 +142,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 			return false;
 		} else {
 			$directoryHandle = $this->opendir($directory);
-			if(is_resource($directoryHandle)) {
+			if (is_resource($directoryHandle)) {
 				while (($contents = readdir($directoryHandle)) !== false) {
 					if (!\OC\Files\Filesystem::isIgnoredDir($contents)) {
 						$path = $directory . '/' . $contents;
@@ -165,27 +165,13 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	public function getMimeType($path) {
-		if (!$this->file_exists($path)) {
-			return false;
-		}
 		if ($this->is_dir($path)) {
 			return 'httpd/unix-directory';
-		}
-		$source = $this->fopen($path, 'r');
-		if (!$source) {
+		} elseif ($this->file_exists($path)) {
+			return \OC_Helper::getFileNameMimeType($path);
+		} else {
 			return false;
 		}
-		$head = fread($source, 8192); //8kb should suffice to determine a mimetype
-		if ($pos = strrpos($path, '.')) {
-			$extension = substr($path, $pos);
-		} else {
-			$extension = '';
-		}
-		$tmpFile = \OC_Helper::tmpFile($extension);
-		file_put_contents($tmpFile, $head);
-		$mime = \OC_Helper::getMimeType($tmpFile);
-		unlink($tmpFile);
-		return $mime;
 	}
 
 	public function hash($type, $path, $raw = false) {
@@ -227,7 +213,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 
 	private function addLocalFolder($path, $target) {
 		$dh = $this->opendir($path);
-		if(is_resource($dh)) {
+		if (is_resource($dh)) {
 			while (($file = readdir($dh)) !== false) {
 				if ($file !== '.' and $file !== '..') {
 					if ($this->is_dir($path . '/' . $file)) {
@@ -298,7 +284,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 		return $this->watcher;
 	}
 
-	public function getStorageCache(){
+	public function getStorageCache() {
 		if (!isset($this->storageCache)) {
 			$this->storageCache = new \OC\Files\Cache\Storage($this);
 		}

--- a/lib/private/files/storage/commontest.php
+++ b/lib/private/files/storage/commontest.php
@@ -54,7 +54,7 @@ class CommonTest extends \OC\Files\Storage\Common{
 		return $this->storage->stat($path);
 	}
 	public function filetype($path) {
-		return $this->storage->filetype($path);
+		return @$this->storage->filetype($path);
 	}
 	public function isReadable($path) {
 		return $this->storage->isReadable($path);

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -203,14 +203,6 @@ if (\OC_Util::runningOnWindows()) {
 			return $return;
 		}
 
-		public function getMimeType($path) {
-			if ($this->isReadable($path)) {
-				return \OC_Helper::getMimeType($this->datadir . $path);
-			} else {
-				return false;
-			}
-		}
-
 		private function delTree($dir) {
 			$dirRelative = $dir;
 			$dir = $this->datadir . $dir;

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -210,14 +210,6 @@ class MappedLocal extends \OC\Files\Storage\Common{
 		return $return;
 	}
 
-	public function getMimeType($path) {
-		if($this->isReadable($path)) {
-			return \OC_Helper::getMimeType($this->buildPath($path));
-		}else{
-			return false;
-		}
-	}
-
 	private function delTree($dir, $isLogicPath=true) {
 		$dirRelative=$dir;
 		if ($isLogicPath) {


### PR DESCRIPTION
This speeds up mimetype detection for external storages in some cases.

cc @karlitschek @DeepDiver1975 
