### PR TITLE
Fix for extstorage + encryption where unencrypted size is not kept

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -349,7 +349,10 @@ class Proxy extends \OC_FileProxy {
 		$fileInfo = false;
 		// get file info from database/cache if not .part file
 		if (!Helper::isPartialFilePath($path)) {
+			$proxyState = \OC_FileProxy::$enabled;
+			\OC_FileProxy::$enabled = false;
 			$fileInfo = $view->getFileInfo($path);
+			\OC_FileProxy::$enabled = $proxyState;
 		}
 
 		// if file is encrypted return real file size

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -491,7 +491,8 @@ class Stream {
 		if (
 				$this->meta['mode'] !== 'r' &&
 				$this->meta['mode'] !== 'rb' &&
-				$this->size > 0
+				$this->size > 0 &&
+				$this->unencryptedSize > 0
 		) {
 
 			// only write keyfiles if it was a new file


### PR DESCRIPTION
Fix for external storage with encryption where the unencrypted size is
first written in the DB, then set back to zero, causing performance
issue because the file needs to be reopened every time to find out the
unencrypted size (and potentially needs a full redownload)

Please review @schiesbn (we debugged this together) @DeepDiver1975 @karlitschek
