### PR TITLE
Fixed path normalization to prevent dot dirs

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -323,11 +323,9 @@ class DAV extends \OC\Files\Storage\Common{
 	}
 
 	public function cleanPath($path) {
-		if ( ! $path || $path[0]=='/') {
-			return substr($path, 1);
-		} else {
-			return $path;
-		}
+		$path = \OC\Files\Filesystem::normalizePath($path);
+		// remove leading slash
+		return substr($path, 1);
 	}
 
 	private function simpleResponse($method, $path, $body, $expected) {


### PR DESCRIPTION
Fixes #5945 where stat(.) would cause the backend OC to cache a dot dir
(only in older versions)

Please review @karlitschek @schiesbn @icewind1991 @DeepDiver1975 
