### PR TITLE
Public view fixes

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -25,7 +25,7 @@
 						   data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" />
 					<a href="#" class="svg"></a>
 			</div>
-			<?php if (!$_['isPublic'] && $_['trash'] ): ?>
+			<?php if ($_['trash']): ?>
 			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
 			<?php endif; ?>
 			<div id="uploadprogresswrapper">

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -25,7 +25,7 @@
 						   data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" />
 					<a href="#" class="svg"></a>
 			</div>
-			<?php if ($_['trash'] ): ?>
+			<?php if (!$_['isPublic'] && $_['trash'] ): ?>
 			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>
 			<?php endif; ?>
 			<div id="uploadprogresswrapper">
@@ -111,8 +111,9 @@
 <input type="hidden" name="ajaxLoad" id="ajaxLoad" value="<?php p($_['ajaxLoad']); ?>" />
 <input type="hidden" name="allowZipDownload" id="allowZipDownload" value="<?php p($_['allowZipDownload']); ?>" />
 <input type="hidden" name="usedSpacePercent" id="usedSpacePercent" value="<?php p($_['usedSpacePercent']); ?>" />
+<?php if (!$_['isPublic']) :?>
 <input type="hidden" name="encryptedFiles" id="encryptedFiles" value="<?php $_['encryptedFiles'] ? p('1') : p('0'); ?>" />
 <input type="hidden" name="encryptedInitStatus" id="encryptionInitStatus" value="<?php p($_['encryptionInitStatus']) ?>" />
 <input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled" value="<?php p($_['mailNotificationEnabled']) ?>" />
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />
-
+<?php endif;

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -238,6 +238,7 @@ if (isset($path)) {
 			$folder->assign('usedSpacePercent', 0);
 			$folder->assign('fileHeader', $fileHeader);
 			$folder->assign('disableSharing', true);
+			$folder->assign('trash', false);
 			$folder->assign('emptyContent', $emptyContent);
 			$folder->assign('ajaxLoad', false);
 			$tmpl->assign('folder', $folder->fetchPage());

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -221,6 +221,8 @@ if (isset($path)) {
 			$breadcrumbNav->assign('breadcrumb', $breadcrumb);
 			$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files') . $urlLinkIdentifiers . '&path=');
 			$maxUploadFilesize=OCP\Util::maxUploadFilesize($path);
+			$fileHeader = (!isset($files) or count($files) > 0);
+			$emptyContent = ($allowPublicUploadEnabled and !$fileHeader);
 			$folder = new OCP\Template('files', 'index', '');
 			$folder->assign('fileList', $list->fetchPage());
 			$folder->assign('breadcrumb', $breadcrumbNav->fetchPage());
@@ -234,6 +236,10 @@ if (isset($path)) {
 			$folder->assign('uploadMaxHumanFilesize', OCP\Util::humanFileSize($maxUploadFilesize));
 			$folder->assign('allowZipDownload', intval(OCP\Config::getSystemValue('allowZipDownload', true)));
 			$folder->assign('usedSpacePercent', 0);
+			$folder->assign('fileHeader', $fileHeader);
+			$folder->assign('disableSharing', true);
+			$folder->assign('emptyContent', $emptyContent);
+			$folder->assign('ajaxLoad', false);
 			$tmpl->assign('folder', $folder->fetchPage());
 			$maxInputFileSize = OCP\Config::getSystemValue('maxZipInputSize', OCP\Util::computerFileSize('800 MB'));
 			$allowZip = OCP\Config::getSystemValue('allowZipDownload', true)


### PR DESCRIPTION
fix undefined index errors in public share view and disable "share" action.

@PVince81 You introduced the ajaxLoad parameter in the files index.php template, right? Is this also useful for the public share view? For now I set it to false, see L243 apps/files_sharing/public.php. Feel free to update it if you think that it makes sense to set it to true in some circumstances.
