### PR TITLE
always show app navigation scrollbar when too many apps in there

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -53,3 +53,8 @@
 .ie8 fieldset .warning, .ie8 #body-login .error {
 	background-color: #1B314D;
 }
+
+/* in IE9 the nav bar on the left side is too narrow and leave a white area - original width is 80px */
+.ie9 #navigation {
+	width: 100px;
+}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -568,7 +568,6 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	width: 80px;
 	margin-top:45px;
 	z-index: 75;
-	height: 100%;
 	background: #383c43 url('../img/noise.png') repeat;
 	overflow-y: auto;
 	-moz-box-sizing:border-box; box-sizing:border-box;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -586,6 +586,7 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	color: #fff;
 	white-space:nowrap; overflow:hidden; text-overflow:ellipsis; /* ellipsize long app names */
 	padding-bottom: 10px;
+	padding-left: 8px; /* prevent shift caused by scrollbar */
 }
 
 	/* icon opacity and hover effect */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -568,13 +568,12 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	width: 80px;
 	margin-top:45px;
 	z-index: 75;
-	background:#383c43 url('../img/noise.png') repeat;
-	overflow:hidden; box-sizing:border-box; -moz-box-sizing:border-box;
+	height: 100%;
+	background: #383c43 url('../img/noise.png') repeat;
+	overflow-y: auto;
+	-moz-box-sizing:border-box; box-sizing:border-box;
 	/* prevent ugly selection effect on accidental selection */
 	-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;
-}
-#navigation:hover {
-	overflow-y: auto; /* show scrollbar only on hover */
 }
 #apps {
 	height: 100%;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -570,6 +570,7 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	z-index: 75;
 	background: #383c43 url('../img/noise.png') repeat;
 	overflow-y: auto;
+	overflow-x: hidden;
 	-moz-box-sizing:border-box; box-sizing:border-box;
 	/* prevent ugly selection effect on accidental selection */
 	-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -586,7 +586,9 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	color: #fff;
 	white-space:nowrap; overflow:hidden; text-overflow:ellipsis; /* ellipsize long app names */
 	padding-bottom: 10px;
-	padding-left: 8px; /* prevent shift caused by scrollbar */
+	/* prevent shift caused by scrollbar */
+	padding-left: 8px;
+	width: 64px;
 }
 
 	/* icon opacity and hover effect */


### PR DESCRIPTION
This fixes:
- not knowing there are more apps
- the app icons jumping when hovering over the bar
- not being able to scroll the apps bar on mobile

Check it @owncloud/designers 
