### PR TITLE
Added min width to files table

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -65,6 +65,9 @@
 	top: 44px;
 	width: 100%;
 }
+#filestable, #controls {
+	min-width: 680px;
+}
 #filestable tbody tr { background-color:#fff; height:2.5em; }
 #filestable tbody tr:hover, tbody tr:active {
 	background-color: rgb(240,240,240);


### PR DESCRIPTION
Having a too small widths for the files table doesn't make sense as it
overlaps file actions with the files themselves and make them
unclickable, especially when viewed on mobile phone.

The compromise that this fix introduces is to have a minimum width that
will trigger horizontal scrolling, which will at least make it possible
to click files on mobile phones.

This is of course just a quickfix, but does make it usable on my Nexus 4.

Please review @owncloud/designers @kabum 
