### PR TITLE
Prevent using root as mount point for external storage

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -267,8 +267,8 @@ class OC_Mount_Config {
 										 $applicable,
 										 $isPersonal = false) {
 		$mountPoint = OC\Files\Filesystem::normalizePath($mountPoint);
-		if ($mountPoint === '' || $mountPoint === '/') {
-			// can't mount at root
+		if ($mountPoint === '' || $mountPoint === '/' || $mountPoint == '/Shared') {
+			// can't mount at root or "Shared" folder
 			return false;
 		}
 		if ($isPersonal) {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -266,6 +266,11 @@ class OC_Mount_Config {
 										 $mountType,
 										 $applicable,
 										 $isPersonal = false) {
+		$mountPoint = OC\Files\Filesystem::normalizePath($mountPoint);
+		if ($mountPoint === '' || $mountPoint === '/') {
+			// can't mount at root
+			return false;
+		}
 		if ($isPersonal) {
 			// Verify that the mount point applies for the current user
 			// Prevent non-admin users from mounting local storage

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * Copyright (c) 2013 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require_once __DIR__ . '/../../../lib/base.php';
+
+require __DIR__ . '/../lib/config.php';
+
+class Test_Mount_Config_Dummy_Storage {
+	public function test() {
+		return true;
+	}
+}
+
+/**
+ * Class Test_Mount_Config
+ */
+class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
+	/**
+	 * Test mount point validation
+	 */
+	public function testAddMountPointValidation() {
+		$storageClass = 'Test_Mount_Config_Dummy_Storage';
+		$mountType = 'user';
+		$applicable = 'all';
+		$isPersonal = false;
+		$this->assertEquals(false, OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
+
+	}
+}

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -44,6 +44,8 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$isPersonal = false;
 		$this->assertEquals(false, OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
 		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertEquals(false, OC_Mount_Config::addMountPoint('Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
 
 	}
 }


### PR DESCRIPTION
Fixes #5981

Currently there is no way to display a message, so this approach will only safeguard setting root as mountpoint and getting unexpected results.

I tried to write unit tests and cover a bit more but it seems that mocking/stubbing static classes don't work properly or are close to impossible, so I give up for now... The unit tests are minimal and only test for the "check root mount point" condition for now.

Please review @DeepDiver1975 @karlitschek @icewind1991 @schiesbn 
