### PR TITLE
Return plausible isReadable() default impl for ext storage

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -300,14 +300,6 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function isReadable($path) {
-		return true;
-	}
-
-	public function isUpdatable($path) {
-		return true;
-	}
-
 	public function unlink($path) {
 		$path = $this->normalizePath($path);
 

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -146,14 +146,6 @@ class Dropbox extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function isReadable($path) {
-		return $this->file_exists($path);
-	}
-
-	public function isUpdatable($path) {
-		return $this->file_exists($path);
-	}
-
 	public function file_exists($path) {
 		if ($path == '' || $path == '/') {
 			return true;

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -317,10 +317,6 @@ class Google extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function isReadable($path) {
-		return $this->file_exists($path);
-	}
-
 	public function isUpdatable($path) {
 		$file = $this->getDriveFile($path);
 		if ($file) {

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -180,14 +180,6 @@ class SFTP extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function isReadable($path) {
-		return true;
-	}
-
-	public function isUpdatable($path) {
-		return true;
-	}
-
 	public function file_exists($path) {
 		try {
 			return $this->client->stat($this->absPath($path)) !== false;

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -42,11 +42,16 @@ abstract class StreamWrapper extends Common {
 	}
 
 	public function isReadable($path) {
-		return true; //not properly supported
+		// at least check whether it exists
+		// subclasses might want to implement this more thoroughly
+		return $this->file_exists($path);
 	}
 
 	public function isUpdatable($path) {
-		return true; //not properly supported
+		// at least check whether it exists
+		// subclasses might want to implement this more thoroughly
+		// a non-existing file/folder isn't updatable
+		return $this->file_exists($path);
 	}
 
 	public function file_exists($path) {

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -41,19 +41,6 @@ abstract class StreamWrapper extends Common {
 		return filetype($this->constructUrl($path));
 	}
 
-	public function isReadable($path) {
-		// at least check whether it exists
-		// subclasses might want to implement this more thoroughly
-		return $this->file_exists($path);
-	}
-
-	public function isUpdatable($path) {
-		// at least check whether it exists
-		// subclasses might want to implement this more thoroughly
-		// a non-existing file/folder isn't updatable
-		return $this->file_exists($path);
-	}
-
 	public function file_exists($path) {
 		return file_exists($this->constructUrl($path));
 	}

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -268,14 +268,6 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function isReadable($path) {
-		return true;
-	}
-
-	public function isUpdatable($path) {
-		return true;
-	}
-
 	public function unlink($path) {
 		$path = $this->normalizePath($path);
 

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -134,14 +134,6 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 	}
 
-	public function isReadable($path) {
-		return true;//not properly supported
-	}
-
-	public function isUpdatable($path) {
-		return true;//not properly supported
-	}
-
 	public function file_exists($path) {
 		$this->init();
 		$path=$this->cleanPath($path);

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -51,6 +51,19 @@ abstract class Common implements \OC\Files\Storage\Storage {
 		}
 	}
 
+	public function isReadable($path) {
+		// at least check whether it exists
+		// subclasses might want to implement this more thoroughly
+		return $this->file_exists($path);
+	}
+
+	public function isUpdatable($path) {
+		// at least check whether it exists
+		// subclasses might want to implement this more thoroughly
+		// a non-existing file/folder isn't updatable
+		return $this->file_exists($path);
+	}
+
 	public function isCreatable($path) {
 		if ($this->is_dir($path) && $this->isUpdatable($path)) {
 			return true;


### PR DESCRIPTION
When an ext storage doesn't implement isReadable(), always returning
true made the file scanner believe that the file exists and creates a
cache entry with the size zero.

This fix makes the default impl of isReadable() and isUpdatable() use file_exists() instead of blindly returning true.

Fixes #5649 

It seems the isUpdatable() fix doesn't fix file overwriting under the same conditions, I'll look into it as part of another related ticket #5348

Please review @icewind1991 @karlitschek @DeepDiver1975 @schiesbn 
