### PR TITLE
Incognito mode

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -54,6 +54,9 @@ class OC_User {
 
 	private static $_setupedBackends = array();
 
+	// bool, stores if a user want to access a resource anonymously, e.g if he opens a public link
+	private static $incognitoMode = false;
+
 	/**
 	 * @brief registers backend
 	 * @param string $backend name of the backend
@@ -320,6 +323,15 @@ class OC_User {
 	}
 
 	/**
+	 * @brief set incognito mode, e.g. if a user wants to open a public link
+	 * @param bool $status
+	 */
+	public static function setIncognitoMode($status) {
+		self::$incognitoMode = $status;
+
+	}
+
+	/**
 	 * Supplies an attribute to the logout hyperlink. The default behaviour
 	 * is to return an href with '?logout=true' appended. However, it can
 	 * supply any attribute(s) which are valid for <a>.
@@ -354,7 +366,7 @@ class OC_User {
 	 */
 	public static function getUser() {
 		$uid = OC::$session ? OC::$session->get('user_id') : null;
-		if (!is_null($uid)) {
+		if (!is_null($uid) && self::$incognitoMode === false) {
 			return $uid;
 		} else {
 			return false;

--- a/public.php
+++ b/public.php
@@ -20,6 +20,7 @@ try {
 
 	OC_Util::checkAppEnabled($app);
 	OC_App::loadApp($app);
+	OC_User::setIncognitoMode(true);
 
 	require_once OC_App::getAppPath($app) .'/'. $parts[1];
 


### PR DESCRIPTION
Allow to set an incognito mode to hide the user even if he is logged in.
This is for example useful if we access files via public.php. Where we always want to act like no user is logged in, even if you are logged-in in parallel. Will be used here https://github.com/owncloud/core/pull/5976 and probably also in other places.

cc @PVince81 @karlitschek implementation like discussed this morning.

Maybe some other people with some knowledge regarding user management can also have a look... @blizzz @DeepDiver1975 @bartv2 ? Thanks!
