### PR TITLE
Increase chunk transfer size for iRODS

### DIFF
--- a/apps/files_external/lib/irods.php
+++ b/apps/files_external/lib/irods.php
@@ -3,6 +3,10 @@
  * Copyright (c) 2013 Thomas Müller <thomas.mueller@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
+ *
+ * The iRODS class was the result of a collaboration together with INCF (http://www.incf.org)
+ * and OwnCloud(tm).
+ *
  * See the COPYING-README file.
  */
 

--- a/apps/files_external/lib/irods.php
+++ b/apps/files_external/lib/irods.php
@@ -88,6 +88,16 @@ class iRODS extends \OC\Files\Storage\StreamWrapper{
 		return 'rods://'.$userWithZone.':'.$this->password.'@'.$this->host.':'.$this->port.$this->root.$path;
 	}
 
+	public function fopen($path, $mode) {
+		$fh = fopen($this->constructUrl($path), $mode);
+		if ($fh) {
+			// override the default 8k php stream chunk
+			// size for non-file streams.
+			stream_set_chunk_size($fh, 1024*1024);
+		}
+		return $fh;
+	}
+
 	public function filetype($path) {
 		return @filetype($this->constructUrl($path));
 	}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -201,7 +201,8 @@ class View {
 		@ob_end_clean();
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
-			$chunkSize = 8192; // 8 kB chunks
+            //$chunkSize = 8192; // 8 kB chunks
+            $chunkSize = 1024 * 1024; // 1M chunks
 			while (!feof($handle)) {
 				echo fread($handle, $chunkSize);
 				flush();

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -201,8 +201,7 @@ class View {
 		@ob_end_clean();
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
-            //$chunkSize = 8192; // 8 kB chunks
-            $chunkSize = 1024 * 1024; // 1M chunks
+			$chunkSize = 1024 * 1024; // 1M chunks
 			while (!feof($handle)) {
 				echo fread($handle, $chunkSize);
 				flush();

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -525,9 +525,10 @@ class OC_Helper {
 			return array(0, false);
 		}
 		$result = true;
-		$count = 0;
+        $count = 0;
+        $chunkSize = 1024 * 1024;
 		while (!feof($source)) {
-			if (($c = fwrite($target, fread($source, 8192))) === false) {
+			if (($c = fwrite($target, fread($source, $chunkSize))) === false) {
 				$result = false;
 			} else {
 				$count += $c;


### PR DESCRIPTION
While testing the iRODS extension, I noticed that the transfer rates were suboptimal. Tracing with `strace` revealed a 8kb chunk size when transferring a `2.5GB` file filled with zeros:

```
# lsof /tmp/php86IZkm
COMMAND  PID     USER   FD   TYPE DEVICE   SIZE/OFF NODE NAME
apache2 3009 www-data   17r   REG  253,1 2671771648   59 /tmp/php86IZkm
```

Actual data packets being sent by process id 3009 above (with a single apache thread), those messages appear every 0.5 seconds with a payload of 8192 bytes each:

```
sendto(16, "\0\0\0\210<MsgHeader_PI><type>RODS_API"..., 222, MSG_DONTWAIT, NULL, 0) = 222
sendto(16, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 8192, MSG_DONTWAIT, NULL, 0) = 8192

sendto(16, "\0\0\0\210<MsgHeader_PI><type>RODS_API"..., 222, MSG_DONTWAIT, NULL, 0) = 222
sendto(16, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 8192, MSG_DONTWAIT, NULL, 0) = 8192
```

Before the patch it took around 24h to upload. After this patch, the transfer takes less than an hour.

With native iRODS `iput` commands, the transfer takes around 1minute, so there's still room for improvement.

Thanks to @cansmith and @DeepDiver1975.
