### PR TITLE
Fixed SMB rename function to overwrite target file

### DIFF
--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -38,7 +38,7 @@ abstract class StreamWrapper extends Common {
 	}
 
 	public function filetype($path) {
-		return filetype($this->constructUrl($path));
+		return @filetype($this->constructUrl($path));
 	}
 
 	public function file_exists($path) {

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -142,10 +142,12 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target2.txt'));
 
 		// move to overwrite
-		$this->instance->rename('/target2.txt', '/target.txt');
-		$this->assertTrue($this->instance->file_exists('/target.txt'));
+		$testContents = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$this->instance->file_put_contents('/target3.txt', $testContents);
+		$this->instance->rename('/target2.txt', '/target3.txt');
+		$this->assertTrue($this->instance->file_exists('/target3.txt'));
 		$this->assertFalse($this->instance->file_exists('/target2.txt'));
-		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target.txt'));
+		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target3.txt'));
 	}
 
 	public function testLocal() {

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -139,6 +139,12 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->rename('/source.txt', '/target2.txt');
 		$this->assertTrue($this->instance->file_exists('/target2.txt'));
 		$this->assertFalse($this->instance->file_exists('/source.txt'));
+		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target2.txt'));
+
+		// move to overwrite
+		$this->instance->rename('/target2.txt', '/target.txt');
+		$this->assertTrue($this->instance->file_exists('/target.txt'));
+		$this->assertFalse($this->instance->file_exists('/target2.txt'));
 		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target.txt'));
 	}
 


### PR DESCRIPTION
When uploading files through WebDAV, a part file is created and a rename
operation is performed with the expectation that the part file
overwrites an existing file, if any.

This fix makes the SMB external storage delete the target file before
renaming, as smbclient doesn't support overwrite on move/rename.

Fixes #5348 

Requires https://github.com/owncloud/core/pull/5995 to be merged first before it can be tested.

Please review the code @schiesbn @icewind1991 @DeepDiver1975 @karlitschek 
