### PR TITLE
No decimal points for Kilobyte and Byte #5371.

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -827,7 +827,7 @@ function humanFileSize(size) {
 	var relativeSize = (size / Math.pow(1024, order)).toFixed(1);
 	if(order < 2){
 		relativeSize = parseFloat(relativeSize).toFixed(0);
-    }
+	}
 	else if(relativeSize.substr(relativeSize.length-2,2)==='.0'){
 		relativeSize=relativeSize.substr(0,relativeSize.length-2);
 	}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -825,7 +825,10 @@ function humanFileSize(size) {
 	order = Math.min(humanList.length - 1, order);
 	var readableFormat = humanList[order];
 	var relativeSize = (size / Math.pow(1024, order)).toFixed(1);
-	if(relativeSize.substr(relativeSize.length-2,2)=='.0'){
+	if(order < 2){
+		relativeSize = parseFloat(relativeSize).toFixed(0);
+    }
+	else if(relativeSize.substr(relativeSize.length-2,2)==='.0'){
 		relativeSize=relativeSize.substr(0,relativeSize.length-2);
 	}
 	return relativeSize + ' ' + readableFormat;

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -252,7 +252,7 @@ class OC_Helper {
 		if ($bytes < 1024) {
 			return "$bytes B";
 		}
-		$bytes = round($bytes / 1024, 1);
+		$bytes = round($bytes / 1024, 0);
 		if ($bytes < 1024) {
 			return "$bytes kB";
 		}


### PR DESCRIPTION
The human readable size information shouldn't round by kB and Byte. My approach was to change the rounding settings the humanFileSize function (JS and PHP).

This Pull Request is under the MIT license.

Please see for more details #5736, #6020

@jancborchardt here is @simonkoennecke. I couldn't change the commit history with git rebase...

Hopefully I didn't forget something :)
