### PR TITLE
Add "single user mode"

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -235,4 +235,7 @@ $CONFIG = array(
 'openssl' => array(
 	//'config' => '/absolute/location/of/openssl.cnf',
 ),
+
+/* whether usage of the instance should be restricted to admin users only */
+'singleuser' => false,
 );

--- a/core/command/maintenance/singleuser.php
+++ b/core/command/maintenance/singleuser.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Command\Maintenance;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SingleUser extends Command {
+
+	protected function configure() {
+		$this
+			->setName('maintenance:singleuser')
+			->setDescription('set single user mode')
+			->addOption(
+				'on',
+				null,
+				InputOption::VALUE_NONE,
+				'enable single user mode'
+			)
+			->addOption(
+				'off',
+				null,
+				InputOption::VALUE_NONE,
+				'disable single user mode'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ($input->getOption('on')) {
+			\OC_Config::setValue('singleuser', true);
+			$output->writeln('Single user mode enabled');
+		} elseif ($input->getOption('off')) {
+			\OC_Config::setValue('singleuser', false);
+			$output->writeln('Single user mode disabled');
+		} else {
+			if (\OC_Config::getValue('singleuser', false)) {
+				$output->writeln('Single user mode is currently enabled');
+			} else {
+				$output->writeln('Single user mode is currently disabled');
+			}
+		}
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -10,3 +10,4 @@
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Db\GenerateChangeScript());
 $application->add(new OC\Core\Command\Upgrade());
+$application->add(new OC\Core\Command\Maintenance\SingleUser());

--- a/core/templates/singleuser.user.php
+++ b/core/templates/singleuser.user.php
@@ -1,0 +1,10 @@
+<ul>
+	<li class='update'>
+		<?php p($l->t('This ownCloud instance is currently in single user mode.')) ?><br /><br />
+		<?php p($l->t('This means only administrators can use the instance.')) ?><br /><br />
+		<?php p($l->t('Contact your system administrator if this message persists or appeared unexpectedly.')) ?>
+		<br /><br />
+		<?php p($l->t('Thank you for your patience.')); ?><br /><br />
+		<a class="button" <?php print_unescaped(OC_User::getLogoutAttribute()); ?>><?php p($l->t('Log out')); ?></a>
+	</li>
+</ul>

--- a/public.php
+++ b/public.php
@@ -5,6 +5,7 @@ try {
 
 	require_once 'lib/base.php';
 	OC::checkMaintenanceMode();
+	OC::checkSingleUserMode();
 	if (!isset($_GET['service'])) {
 		header('HTTP/1.0 404 Not Found');
 		exit;


### PR DESCRIPTION
While the instance is in single user mode only users in the admin group can use the instance.
This can give admins the time to configure or update the instance without regular users "getting in the way"

single user mode can be controlled by
- `occ maintenance:singleuser --on`
- `occ maintenance:singleuser --off`
- manually setting the `singleuser` option in config.php

cc @karlitschek
