### PR TITLE
Fixed FTP storage unit tests to use the correct class

### DIFF
--- a/apps/files_external/tests/ftp.php
+++ b/apps/files_external/tests/ftp.php
@@ -34,19 +34,19 @@ class FTP extends Storage {
 						  'password' => 'ftp',
 						  'root' => '/',
 						  'secure' => false );
-		$instance = new OC_Filestorage_FTP($config);
+		$instance = new \OC\Files\Storage\FTP($config);
 		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = true;
-		$instance = new OC_Filestorage_FTP($config);
+		$instance = new \OC\Files\Storage\FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'false';
-		$instance = new OC_Filestorage_FTP($config);
+		$instance = new \OC\Files\Storage\FTP($config);
 		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'true';
-		$instance = new OC_Filestorage_FTP($config);
+		$instance = new \OC\Files\Storage\FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 	}
 }


### PR DESCRIPTION
Note: the testStat() still fails because PHP's FTP stat() doesn't return the mtime of directories...

Please review @karlitschek @schiesbn @DeepDiver1975 @icewind1991 
