### PR TITLE
Return true when touch succeeds

### DIFF
--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -68,6 +68,7 @@ abstract class StreamWrapper extends Common {
 			}
 		} else {
 			$this->file_put_contents($path, '');
+			return true;
 		}
 	}
 

--- a/apps/files_external/tests/smb.php
+++ b/apps/files_external/tests/smb.php
@@ -29,6 +29,11 @@ class SMB extends Storage {
 		}
 	}
 
+	public function directoryProvider() {
+		// doesn't support leading/trailing spaces
+		return array(array('folder'));
+	}
+
 	public function testRenameWithSpaces() {
 		$this->instance->mkdir('with spaces');
 		$result = $this->instance->rename('with spaces', 'foo bar');

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -236,7 +236,8 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 
 	public function testTouchCreateFile() {
 		$this->assertFalse($this->instance->file_exists('foo'));
-		$this->instance->touch('foo');
+		// returns true on success
+		$this->assertTrue($this->instance->touch('foo'));
 		$this->assertTrue($this->instance->file_exists('foo'));
 	}
 


### PR DESCRIPTION
Forgot this for my ext storage touch() fixes...

Fixes SMB empty file creation status (it's created, but didn't appear, needed browser refresh).

Please approve :wink: 
@icewind1991 @karlitschek @schiesbn @icewind1991 
