### PR TITLE
Add a (currently) empty system for running common repair steps

### DIFF
--- a/core/command/maintenance/repair.php
+++ b/core/command/maintenance/repair.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Command\Maintenance;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Repair extends Command {
+	/**
+	 * @var \OC\Repair $repair
+	 */
+	protected $repair;
+
+	/**
+	 * @param \OC\Repair $repair
+	 */
+	public function __construct($repair) {
+		$this->repair = $repair;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('maintenance:repair')
+			->setDescription('set single user mode');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->repair->listen('\OC\Repair', 'step', function ($description) use ($output) {
+			$output->writeln(' - ' . $description);
+		});
+		$this->repair->run();
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -14,3 +14,4 @@ $application->add(new OC\Core\Command\Maintenance\SingleUser());
 $application->add(new OC\Core\Command\App\Disable());
 $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());
+$application->add(new OC\Core\Command\Maintenance\Repair(new \OC\Repair()));

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+use OC\Hooks\BasicEmitter;
+
+class Repair extends BasicEmitter {
+	/**
+	 * run a series of repair steps for common problems
+	 * progress can be reported by emitting \OC\Repair::step events
+	 */
+	public function run() {
+		$this->emit('\OC\Repair', 'step', array('No repair steps configured at the moment'));
+	}
+}

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -37,7 +37,7 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * Check if a new version is available
-	 * @param string $updateUrl the url to check, i.e. 'http://apps.owncloud.com/updater.php'
+	 * @param string $updaterUrl the url to check, i.e. 'http://apps.owncloud.com/updater.php'
 	 * @return array | bool
 	 */
 	public function check($updaterUrl) {
@@ -116,6 +116,10 @@ class Updater extends BasicEmitter {
 		\OC_App::checkAppsRequirements();
 		// load all apps to also upgrade enabled apps
 		\OC_App::loadApps();
+
+		$repair = new Repair();
+		$repair->run();
+
 		\OC_Config::setValue('maintenance', false);
 		$this->emit('\OC\Updater', 'maintenanceEnd');
 	}


### PR DESCRIPTION
see #5259

repair steps are executed during the upgrade process and can be manually run using `occ maintenance:repair`

cc @karlitschek 
