### PR TITLE
fixing getRawPathInfo() once more

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -159,7 +159,7 @@ class OC_Request {
 				throw new Exception("The requested uri($requestUri) cannot be processed by the script '$scriptName')");
 			}
 		}
-		if (strpos($path_info, '/'.$name.'/') === 0) {
+		if (strpos($path_info, '/'.$name) === 0) {
 			$path_info = substr($path_info, strlen($name) + 1);
 		}
 		if (strpos($path_info, $name) === 0) {

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -42,6 +42,13 @@ class Test_Request extends PHPUnit_Framework_TestCase {
 			array('/core/ajax/translations.php', 'index.php/core/ajax/translations.php', 'index.php'),
 			array('/core/ajax/translations.php', '/index.php/core/ajax/translations.php', '/index.php'),
 			array('/core/ajax/translations.php', '//index.php/core/ajax/translations.php', '/index.php'),
+			array('', '/oc/core', '/oc/core/index.php'),
+			array('', '/oc/core/', '/oc/core/index.php'),
+			array('', '/oc/core/index.php', '/oc/core/index.php'),
+			array('/core/ajax/translations.php', '/core/ajax/translations.php', 'index.php'),
+			array('/core/ajax/translations.php', '//core/ajax/translations.php', '/index.php'),
+			array('/core/ajax/translations.php', '/oc/core/ajax/translations.php', '/oc/index.php'),
+			array('/1', '/oc/core/1', '/oc/core/index.php'),
 		);
 	}
 
@@ -60,9 +67,7 @@ class Test_Request extends PHPUnit_Framework_TestCase {
 
 	function rawPathInfoThrowsExceptionProvider() {
 		return array(
-			array('core/ajax/translations.php', '/index.php'),
-			array('/core/ajax/translations.php', '/index.php'),
-			array('//core/ajax/translations.php', '/index.php'),
+			array('/oc/core1', '/oc/core/index.php'),
 		);
 	}
 }


### PR DESCRIPTION
fixes #6050
#6035 was implemented by me under the assumption that the script name (e.g. index.php, public.php ...) is required in the url - this was a misunderstanding as #6050 has shown.

Previous to the patches in #6035 the request to the owncloud url without the index.php was silently failing and redirected to index.php - accidentally correct. :wink:

Within the unit tests you will find a lot of examples on how this function works now.
