### PR TITLE
Fixed directory deletion for SMB and FTP storages

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -17,7 +17,7 @@ $success = true;
 
 //Now delete
 foreach ($files as $file) {
-	if (($dir === '' && $file === 'Shared') || !\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
+	if (($dir === '' && $file === 'Shared') || !\OC\Files\Filesystem::deleteFileOrDir($dir . '/' . $file)) {
 		$filesWithError .= $file . "\n";
 		$success = false;
 	}

--- a/apps/files_external/3rdparty/smb4php/smb.php
+++ b/apps/files_external/3rdparty/smb4php/smb.php
@@ -160,7 +160,7 @@ class smb {
 					$i = ($mode == 'servers') ? array ($name, "server") : array ($name, "workgroup", $master);
 					break;
 				case 'files':
-					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|S|R]+)$/", trim ($regs[1]), $regs2)
+					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|S|R|N]+)$/", trim ($regs[1]), $regs2)
 						? array (trim ($regs2[2]), trim ($regs2[1]))
 						: array ('', trim ($regs[1]));
 					list ($his, $im) = array (

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -183,6 +183,11 @@ class Dropbox extends \OC\Files\Storage\Common {
 		return false;
 	}
 
+	public function deleteFileOrFolder($path) {
+		// no detection needed
+		return $this->unlink($path);
+	}
+
 	public function unlink($path) {
 		try {
 			$this->dropbox->delete($this->root.$path);

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -188,6 +188,11 @@ class SFTP extends \OC\Files\Storage\Common {
 		}
 	}
 
+	public function deleteFileOrFolder($path) {
+		// no detection needed
+		return $this->unlink($path);
+	}
+
 	public function unlink($path) {
 		try {
 			return $this->client->delete($this->absPath($path), true);

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -145,6 +145,11 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 	}
 
+	public function deleteFileOrFolder($path) {
+		// no detection needed
+		return $this->unlink($path);
+	}
+
 	public function unlink($path) {
 		$this->init();
 		return $this->simpleResponse('DELETE', $path, null, 204);

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -626,6 +626,10 @@ class Filesystem {
 		return self::$defaultInstance->unlink($path);
 	}
 
+	static public function deleteFileOrDir($path) {
+		return self::$defaultInstance->deleteFileOrDir($path);
+	}
+
 	static public function rename($path1, $path2) {
 		return self::$defaultInstance->rename($path1, $path2);
 	}

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -141,6 +141,19 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	/**
+	 * @brief Delete file or folder.
+	 * This implementation calls is_dir() first to find out whether to
+	 * use rmdir() or unlink()
+	 * @param string $path
+	 */
+	public function deleteFileOrDir($path) {
+		if ($this->is_dir($path)) {
+			return $this->rmdir($path);
+		}
+		return $this->unlink($path);
+	}
+
+	/**
 	 * @brief Deletes all files and folders recursively within a directory
 	 * @param string $directory The directory whose contents will be deleted
 	 * @param bool $empty Flag indicating whether directory will be emptied

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -234,6 +234,15 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	}
 
 	/**
+	 * Delete a file or directory
+	 * @param string $path
+	 * @return bool
+	 */
+	public function deleteFileOrDir($path) {
+		return $this->storage->deleteFileOrDir($path);
+	}
+
+	/**
 	 * see http://php.net/manual/en/function.rename.php
 	 *
 	 * @param string $path1

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -335,6 +335,10 @@ class View {
 		return $this->basicOperation('unlink', $path, array('delete'));
 	}
 
+	public function deleteFileOrDir($path) {
+		return $this->basicOperation('deleteFileOrDir', $path, array('delete'));
+	}
+
 	public function deleteAll($directory, $empty = false) {
 		return $this->rmdir($directory);
 	}

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -68,6 +68,14 @@ interface Storage {
 	public function rmdir($path);
 
 	/**
+	 * Deletes the given file or folder.
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
+	public function deleteFileOrDir($path);
+
+	/**
 	 * see http://php.net/manual/en/function.opendir.php
 	 *
 	 * @param string $path

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -246,7 +246,22 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->mkdir('folder/bar');
 		$this->instance->file_put_contents('folder/asd.txt', 'foobar');
 		$this->instance->file_put_contents('folder/bar/foo.txt', 'asd');
-		$this->instance->rmdir('folder');
+		$this->assertTrue($this->instance->rmdir('folder'));
+		$this->assertFalse($this->instance->file_exists('folder/asd.txt'));
+		$this->assertFalse($this->instance->file_exists('folder/bar/foo.txt'));
+		$this->assertFalse($this->instance->file_exists('folder/bar'));
+		$this->assertFalse($this->instance->file_exists('folder'));
+	}
+
+	public function testDeleteFileOrDir() {
+		$this->instance->mkdir('folder');
+		$this->instance->mkdir('folder/bar');
+		$this->instance->file_put_contents('folder/asd.txt', 'foobar');
+		$this->instance->file_put_contents('folder/bar/foo.txt', 'asd');
+		$this->instance->file_put_contents('folder/delfile.txt', 'foobar');
+		$this->assertTrue($this->instance->deleteFileOrDir('folder/delfile.txt'));
+		$this->assertFalse($this->instance->file_exists('folder/delfile.txt'));
+		$this->assertTrue($this->instance->deleteFileOrDir('folder'));
 		$this->assertFalse($this->instance->file_exists('folder/asd.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar/foo.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar'));


### PR DESCRIPTION
Added deleteFileOrDir() operation

Some storages need to use different calls for deleting files or folders, usually unlink() and rmdir().

For this, added a new operation deleteFileOrDir() which default implementation will first detect whether the given argument is a file or a directory to decide which operation to use.

Some storage implementations don't need to distinguish them, in which case they reimplement deleteFileOrDir() to save the extra is_dir() detection.

Fixes #4532 (SMB dir deletion)
Fixes #5941 (FTP dir deletion)

This is based on @icewind1991's suggestion here: https://github.com/owncloud/core/issues/4531#issuecomment-29291826
I tried to not break the existing APIs.
Currently, only the ajax delete.php is using that new call.

If not acceptable, the alternative is to do the is_dir() detection in delete.php for now...

Please review @icewind1991 @karlitschek @DeepDiver1975 @schiesbn 
