### PR TITLE
Fixed SFTP storage to overwrite on rename

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -285,6 +285,9 @@ class SFTP extends \OC\Files\Storage\Common {
 
 	public function rename($source, $target) {
 		try {
+			if (!$this->is_dir($target) && $this->file_exists($target)) {
+				$this->unlink($target);
+			}
 			return $this->client->rename(
 				$this->absPath($source),
 				$this->absPath($target)


### PR DESCRIPTION
This fixes an issue that it's not possible to overwrite files because the part file can't be renamed to an existing file on a SFTP storage.

I don't like to need to call `is_dir()` and `file_exists()` but this is a quick fix just to make SFTP work correctly with WebDAV. We can improve the overall performance in OC7.

Please review @icewind1991 @DeepDiver1975 @karlitschek @schiesbn 
