### PR TITLE
on mssql the schema migration sometimes fails due to an already existing...

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -19,6 +19,8 @@ class MDB2SchemaManager {
 	 */
 	public function __construct($conn) {
 		$this->conn = $conn;
+		$this->conn->close();
+		$this->conn->connect();
 	}
 
 	/**


### PR DESCRIPTION
... transaction - error: 'New transaction is not allowed because there are other threads running in the session.'

The solution is to simple reconnect to the database to start with a fresh connection

@karlitschek @bantu @bartv2 @ringmaster 
