### PR TITLE
Allow getting info or renaming part files through WebDAV

### DIFF
--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -38,7 +38,20 @@ class ObjectTree extends \Sabre_DAV_ObjectTree {
 			return $this->rootNode;
 		}
 
-		$info = $this->getFileView()->getFileInfo($path);
+		if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
+			// read from storage
+			$absPath = $this->getFileView()->getAbsolutePath($path);
+			list($storage, $internalPath) = Filesystem::resolvePath('/' . $absPath);
+			if ($storage) {
+				$scanner = $storage->getScanner($internalPath);
+				// get data directly
+				$info = $scanner->getData($internalPath);
+			}
+		}
+		else {
+			// read from cache
+			$info = $this->getFileView()->getFileInfo($path);
+		}
 
 		if (!$info) {
 			throw new \Sabre_DAV_Exception_NotFound('File with name ' . $path . ' could not be located');


### PR DESCRIPTION
When mounting an ownCloud (backend OC) inside another ownCloud (frontend
OC), the frontend OC will use WebDAV to upload file, which will create
part files. These part files need to be accessible for the frontend OC
to rename them to the actual file name.

This fix leaves the file cache untouched but gives direct access to part
file info when requested.

This means that part file can be accessed only when their path and name
are known. These won't appear in file listtings.

Fixes #6068

So far I've tested with OC1 -> OC2 -> SMB mount and it seems to work fine when accessing OC1 through WebDAV and syncing (with 50 MB file).
Part files are not visible in the UI or in the WebDAV file listing.
Will continue testing a bit with WebDAV access and sync clients.

Please review and test @schiesbn @butonic @DeepDiver1975 @karlitschek @icewind1991 
