### PR TITLE
fix custom routes defined by apps

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -165,7 +165,11 @@ class OC_Request {
 		if (strpos($path_info, $name) === 0) {
 			$path_info = substr($path_info, strlen($name));
 		}
-		return $path_info;
+		if($path_info === '/'){
+			return '';
+		} else {
+			return $path_info;
+		}
 	}
 
 	/**

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -165,7 +165,7 @@ class OC_Request {
 		if (strpos($path_info, $name) === 0) {
 			$path_info = substr($path_info, strlen($name));
 		}
-		return rtrim($path_info, '/');
+		return $path_info;
 	}
 
 	/**


### PR DESCRIPTION
removing the trailing `/` from the path info breaks apps that define custom routes (news, notes).
This was introduced in https://github.com/owncloud/core/pull/6060

@DeepDiver1975 was there a specific purpose for the `rtrim`?

cc @karlitschek 
