### PR TITLE
fix public preview creation if a user is logged in

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -9,6 +9,8 @@ if(!\OC_App::isEnabled('files_sharing')){
 	exit;
 }
 
+\OC_User::setIncognitoMode(true);
+
 $file = array_key_exists('file', $_GET) ? (string) urldecode($_GET['file']) : '';
 $maxX = array_key_exists('x', $_GET) ? (int) $_GET['x'] : '36';
 $maxY = array_key_exists('y', $_GET) ? (int) $_GET['y'] : '36';
@@ -36,10 +38,12 @@ if(!isset($linkedItem['uid_owner']) || !isset($linkedItem['file_source'])) {
 
 $userId = $linkedItem['uid_owner'];
 \OC_Util::setupFS($userId);
+\OC\Files\Filesystem::initMountPoints($userId);
+$view = new \OC\Files\View('/' . $userId . '/files');
 
 $pathId = $linkedItem['file_source'];
-$path = \OC\Files\Filesystem::getPath($pathId);
-$pathInfo = \OC\Files\Filesystem::getFileInfo($path);
+$path = $view->getPath($pathId);
+$pathInfo = $view->getFileInfo($path);
 $sharedFile = null;
 
 if($linkedItem['item_type'] === 'folder') {
@@ -54,7 +58,7 @@ if($linkedItem['item_type'] === 'folder') {
 
 if($linkedItem['item_type'] === 'file') {
 	$parent = $pathInfo['parent'];
-	$path = \OC\Files\Filesystem::getPath($parent);
+	$path = $view->getPath($parent);
 	$sharedFile = $pathInfo['name'];
 }
 


### PR DESCRIPTION
Fixes broken preview creation for public link shares if you are logged in with a different user while opening the public link.

@PVince81 @kabum can you have a look at it? Thanks!
