### PR TITLE
Redetect mime type whenever extension is renamed

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -422,12 +422,27 @@ var FileList={
 								}
 								tr.find('.fileactions').effect('highlight', {}, 5000);
 								tr.effect('highlight', {}, 5000);
+								// remove loading mark and recover old image
+								td.css('background-image', oldBackgroundImage);
+							}
+							else {
+								var fileInfo = result.data;
+								tr.attr('data-mime', fileInfo.mime);
+								tr.attr('data-etag', fileInfo.etag);
+								if (fileInfo.isPreviewAvailable) {
+									Files.lazyLoadPreview(fileInfo.directory + '/' + fileInfo.name, result.data.mime, function(previewpath) {
+										tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
+									}, null, null, result.data.etag);
+								}
+								else {
+									tr.find('td.filename').removeClass('preview').attr('style','background-image:url('+fileInfo.icon+')');
+								}
 							}
 							// reinsert row
 							tr.detach();
 							FileList.insertElement( tr.attr('data-file'), tr.attr('data-type'),tr );
-							// remove loading mark and recover old image
-							td.css('background-image', oldBackgroundImage);
+							// update file actions in case the extension changed
+							FileActions.display( tr.find('td.filename'), true);
 						}
 					});
 				}

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -76,12 +76,19 @@ class App {
 			$this->view->rename($dir . '/' . $oldname, $dir . '/' . $newname)
 		) {
 			// successful rename
-			$result['success'] = true;
-			$result['data'] = array(
-				'dir'		=> $dir,
-				'file'		=> $oldname,
-				'newname'	=> $newname
+			$meta = $this->view->getFileInfo($dir . '/' . $newname);
+			$fileinfo = array(
+				'id' => $meta['fileid'],
+				'mime' => $meta['mimetype'],
+				'size' => $meta['size'],
+				'etag' => $meta['etag'],
+				'directory' => $dir,
+				'name' => $newname,
+				'isPreviewAvailable' => \OC::$server->getPreviewManager()->isMimeSupported($meta['mimetype']),
+				'icon' => \OCA\Files\Helper::determineIcon($meta)
 			);
+			$result['success'] = true;
+			$result['data'] = $fileinfo;
 		} else {
 			// rename failed
 			$result['data'] = array(

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -86,6 +86,12 @@ class Updater {
 			if ($storageFrom === $storageTo) {
 				$cache = $storageFrom->getCache($internalFrom);
 				$cache->move($internalFrom, $internalTo);
+				if (pathinfo($internalFrom, PATHINFO_EXTENSION) !== pathinfo($internalTo, PATHINFO_EXTENSION)) {
+					// redetect mime type change
+					$mimeType = $storageTo->getMimeType($internalTo);
+					$fileId = $storageTo->getCache()->getId($internalTo);
+					$storageTo->getCache()->update($fileId, array('mimetype' => $mimeType));
+				}
 				$cache->correctFolderSize($internalFrom);
 				$cache->correctFolderSize($internalTo);
 				self::correctFolder($from, time());

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -202,6 +202,14 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
 	}
 
+	public function testRenameExtension() {
+		$fooCachedData = $this->cache->get('foo.txt');
+		$this->assertEquals('text/plain', $fooCachedData['mimetype']);
+		Filesystem::rename('foo.txt', 'foo.abcd');
+		$fooCachedData = $this->cache->get('foo.abcd');
+		$this->assertEquals('application/octet-stream', $fooCachedData['mimetype']);
+	}
+
 	public function testRenameWithMountPoints() {
 		$storage2 = new \OC\Files\Storage\Temporary(array());
 		$cache2 = $storage2->getCache();


### PR DESCRIPTION
Fix for #6087 

Whenever a file extension is changed, the mime type is now re-detected (using the file extension) and propagated to the file list UI.

Please review @icewind1991 @DeepDiver1975 @karlitschek @schiesbn 
