### PR TITLE
Add trailing slash in FTP root path when missing

### DIFF
--- a/apps/files_external/lib/ftp.php
+++ b/apps/files_external/lib/ftp.php
@@ -35,6 +35,9 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 			if ( ! $this->root || $this->root[0]!='/') {
 				$this->root='/'.$this->root;
 			}
+			if (substr($this->root, -1) !== '/') {
+				$this->root .= '/';
+			}
 		} else {
 			throw new \Exception();
 		}

--- a/apps/files_external/tests/ftp.php
+++ b/apps/files_external/tests/ftp.php
@@ -48,5 +48,17 @@ class FTP extends Storage {
 		$config['secure'] = 'true';
 		$instance = new \OC\Files\Storage\FTP($config);
 		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
+
+		$config['root'] = '';
+		$instance = new \OC\Files\Storage\FTP($config);
+		$this->assertEquals('ftps://ftp:ftp@localhost/somefile.txt', $instance->constructUrl('somefile.txt'));
+
+		$config['root'] = '/abc';
+		$instance = new \OC\Files\Storage\FTP($config);
+		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
+
+		$config['root'] = '/abc/';
+		$instance = new \OC\Files\Storage\FTP($config);
+		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
 	}
 }


### PR DESCRIPTION
Fixes #6093
