### PR TITLE
Fix preview creation

### DIFF
--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -29,8 +29,15 @@ if($maxX === 0 || $maxY === 0) {
 }
 
 try{
-	$preview = new \OC\Preview(\OC_User::getUser(), 'files_trashbin/files');
-	$preview->setFile($file);
+	$preview = new \OC\Preview(\OC_User::getUser(), 'files_trashbin/files', $file);
+	$view = new \OC\Files\View('/'.\OC_User::getUser(). '/files_trashbin/files');
+	if ($view->is_dir($file)) {
+		$mimetype = 'httpd/unix-directory';
+	} else {
+		$mimetype = \OC_Helper::getFileNameMimeType(pathinfo($file, PATHINFO_FILENAME));
+	}
+	$preview->setMimetype($mimetype);
+	$preview->setMimetype($mimetype);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);
 	$preview->setScalingUp($scalingUp);

--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -37,7 +37,6 @@ try{
 		$mimetype = \OC_Helper::getFileNameMimeType(pathinfo($file, PATHINFO_FILENAME));
 	}
 	$preview->setMimetype($mimetype);
-	$preview->setMimetype($mimetype);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);
 	$preview->setScalingUp($scalingUp);

--- a/apps/files_versions/ajax/preview.php
+++ b/apps/files_versions/ajax/preview.php
@@ -37,8 +37,9 @@ if($maxX === 0 || $maxY === 0) {
 }
 
 try{
-	$preview = new \OC\Preview($user, 'files_versions');
-	$preview->setFile($file.'.v'.$version);
+	$preview = new \OC\Preview($user, 'files_versions', $file.'.v'.$version);
+	$mimetype = \OC_Helper::getFileNameMimeType($file);
+	$preview->setMimetype($mimetype);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);
 	$preview->setScalingUp($scalingUp);

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -173,6 +173,10 @@ class Preview {
 		return $this;
 	}
 
+	/**
+	 * @brief set mimetype explicitely
+	 * @param string $mimetype
+	 */
 	public function setMimetype($mimetype) {
 		$this->mimetype = $mimetype;
 	}

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -9,7 +9,7 @@
  * Thumbnails:
  * structure of filename:
  * /data/user/thumbnails/pathhash/x-y.png
- * 
+ *
  */
 namespace OC;
 
@@ -40,6 +40,7 @@ class Preview {
 	private $maxX;
 	private $maxY;
 	private $scalingup;
+	private $mimetype;
 
 	//preview images object
 	/**
@@ -59,11 +60,18 @@ class Preview {
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param bool $scalingUp Disable/Enable upscaling of previews
-	 * @return mixed (bool / string) 
+	 * @return mixed (bool / string)
 	 *					false if thumbnail does not exist
 	 *					path to thumbnail if thumbnail exists
 	*/
 	public function __construct($user='', $root='/', $file='', $maxX=1, $maxY=1, $scalingUp=true) {
+		//init fileviews
+		if($user === ''){
+			$user = \OC_User::getUser();
+		}
+		$this->fileView = new \OC\Files\View('/' . $user . '/' . $root);
+		$this->userView = new \OC\Files\View('/' . $user);
+
 		//set config
 		$this->configMaxX = \OC_Config::getValue('preview_max_x', null);
 		$this->configMaxY = \OC_Config::getValue('preview_max_y', null);
@@ -75,13 +83,6 @@ class Preview {
 		$this->setMaxY($maxY);
 		$this->setScalingUp($scalingUp);
 
-		//init fileviews
-		if($user === ''){
-			$user = \OC_User::getUser();
-		}
-		$this->fileView = new \OC\Files\View('/' . $user . '/' . $root);
-		$this->userView = new \OC\Files\View('/' . $user);
-		
 		$this->preview = null;
 
 		//check if there are preview backends
@@ -166,7 +167,14 @@ class Preview {
 	*/
 	public function setFile($file) {
 		$this->file = $file;
+		if ($file !== '') {
+			$this->mimetype = $this->fileView->getMimeType($this->file);
+		}
 		return $this;
+	}
+
+	public function setMimetype($mimetype) {
+		$this->mimetype = $mimetype;
 	}
 
 	/**
@@ -265,7 +273,7 @@ class Preview {
 
 		$fileInfo = $this->fileView->getFileInfo($file);
 		$fileId = $fileInfo['fileid'];
-		
+
 		$previewPath = $this->getThumbnailsFolder() . '/' . $fileId . '/';
 		$this->userView->deleteAll($previewPath);
 		$this->userView->rmdir($previewPath);
@@ -274,7 +282,7 @@ class Preview {
 
 	/**
 	 * @brief check if thumbnail or bigger version of thumbnail of file is cached
-	 * @return mixed (bool / string) 
+	 * @return mixed (bool / string)
 	 *				false if thumbnail does not exist
 	 *				path to thumbnail if thumbnail exists
 	*/
@@ -386,11 +394,10 @@ class Preview {
 		}
 
 		if(is_null($this->preview)) {
-			$mimetype = $this->fileView->getMimeType($file);
 			$preview = null;
 
 			foreach(self::$providers as $supportedMimetype => $provider) {
-				if(!preg_match($supportedMimetype, $mimetype)) {
+				if(!preg_match($supportedMimetype, $this->mimetype)) {
 					continue;
 				}
 
@@ -516,7 +523,7 @@ class Preview {
 			$cropY = 0;
 
 			$image->crop($cropX, $cropY, $x, $y);
-			
+
 			$this->preview = $image;
 			return;
 		}
@@ -598,7 +605,7 @@ class Preview {
 	public static function post_write($args) {
 		self::post_delete($args);
 	}
-	
+
 	public static function post_delete($args) {
 		$path = $args['path'];
 		if(substr($path, 0, 1) === '/') {


### PR DESCRIPTION
Now that we detect the mimetype only by the file extension we need to be able to set the mimetype explicitly in the Preview lib. Because for example files in the trash and versioned files have the timestamp as extension.

This patch extended the Previews lib and adapted the versions and trash bin preview generation code.

fix #6105
