### PR TITLE
Fix resize issue for trash button in chrome and overflowing spinner in ....

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -14,7 +14,7 @@
 	padding: 0 !important; /* override default control bar button padding */
 }
 #trash {
-	margin-right: 12px;
+	margin-right: 8px;
 	float: right;
 	z-index: 1010;
 	padding: 10px;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -201,9 +201,9 @@ input[type="submit"].enabled {
 	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 	position: fixed;
+	right: 0;
+	left: 80px;
 	height: 44px;
-	width: 100%;
-	padding-right: 75px;
 	margin: 0;
 	background: #eee;
 	border-bottom: 1px solid #e7e7e7;

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -21,6 +21,8 @@
 		<p id="message" class="hidden">
 			<img class="float-spinner" src="<?php p(\OCP\Util::imagePath('core', 'loading-dark.gif'));?>"/>
 			<span id="messageText"></span>
+			<!-- the following div ensures that the spinner is always inside the #message div -->
+			<div style="clear: both;"></div>
 		</p>
 		<p class="infield grouptop">
 			<input type="text" name="user" id="user" placeholder=""


### PR DESCRIPTION
...update class

fixes #6108 

I added that div with `clear:both` because if the message in the `.update` div is really short the spinner is overflowing the div.

cc @owncloud/designers 
