### PR TITLE
Fixed touch after chunk assembling

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -249,7 +249,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 			// allow sync clients to send the mtime along in a header
 			$mtime = OC_Request::hasModificationTime();
 			if ($mtime !== false) {
-				if($fs->touch($this->path, $mtime)) {
+				if($fs->touch($targetPath, $mtime)) {
 					header('X-OC-MTime: accepted');
 				}
 			}


### PR DESCRIPTION
Fixed touch after chunk assembling which was using the wrong path,
resulting in the creation of an extra file.

Fixes #6007

Please review @DeepDiver1975 @schiesbn @karlitschek 

FYI @dragotin 
