### PR TITLE
Prompt to fix browser credentials if they don't match username

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -534,9 +534,9 @@ class OC {
 			OC_Log::write('core',
 				"Session user-id ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
 				OC_Log::WARN);
-			header('WWW-Authenticate: Basic realm="Please Reauthenticate with ownCloud"');
-			header('HTTP/1.0 401 Unauthorized');
-			// OC_User::logout();
+			$url = 'http://' . $sessionUser . '@' . $_SERVER['SERVER_NAME'] . OC::$WEBROOT . OC::$SUBURI;
+			header("Location: $url");
+			exit();
 		}
 
 		// Load Apps

--- a/lib/base.php
+++ b/lib/base.php
@@ -532,10 +532,9 @@ class OC {
 			$sessionUser = self::$session->get('user_id');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];
 			OC_Log::write('core',
-				"Session user-id ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
+				"Overriding SERVER[PHP_AUTH_USER] ($serverUser) with session user-id ($sessionUser).",
 				OC_Log::WARN);
-			$url = 'http://' . $sessionUser . '@' . $_SERVER['SERVER_NAME'] . OC::$WEBROOT . OC::$SUBURI;
-			header("Location: $url");
+			OC_Util::redirectToDefaultPage($sessionUser);
 			exit();
 		}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -534,7 +534,9 @@ class OC {
 			OC_Log::write('core',
 				"Session user-id ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
 				OC_Log::WARN);
-			OC_User::logout();
+			header('WWW-Authenticate: Basic realm="Please Reauthenticate with ownCloud"');
+			header('HTTP/1.0 401 Unauthorized');
+			// OC_User::logout();
 		}
 
 		// Load Apps

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -636,7 +636,7 @@ class OC_Util {
 	 * @brief Redirect to the user default page
 	 * @return void
 	 */
-	public static function redirectToDefaultPage() {
+	public static function redirectToDefaultPage($basicUser) {
 		if(isset($_REQUEST['redirect_url'])) {
 			$location = OC_Helper::makeURLAbsolute(urldecode($_REQUEST['redirect_url']));
 		}
@@ -651,6 +651,9 @@ class OC_Util {
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);
+		if (isset($basicUser)) {
+			$location = preg_replace('/^(http|https):\/\/(.*)/i', '${1}://' . $basicUser . '@${2}', $location);
+		}
 		header( 'Location: '.$location );
 		exit();
 	}


### PR DESCRIPTION
Browsers will keep sending credentials until given a 401 and told to reauthenticate.  This fixes cases where a user's browser has a credential with an non-mathcing username likely set by another application running on another subdirectory.
