### PR TITLE
remove quoting on table and field names - required for mssql

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -8,6 +8,8 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Schema\Schema;
+
 class MDB2SchemaReader {
 	/**
 	 * @var string $DBNAME
@@ -36,11 +38,11 @@ class MDB2SchemaReader {
 
 	/**
 	 * @param string $file
-	 * @return \Doctrine\DBAL\Schema\Schema
+	 * @return Schema
 	 * @throws \DomainException
 	 */
 	public function loadSchemaFromFile($file) {
-		$schema = new \Doctrine\DBAL\Schema\Schema();
+		$schema = new Schema();
 		$xml = simplexml_load_file($file);
 		foreach ($xml->children() as $child) {
 			/**
@@ -64,7 +66,7 @@ class MDB2SchemaReader {
 	}
 
 	/**
-	 * @param\Doctrine\DBAL\Schema\Schema $schema
+	 * @param \Doctrine\DBAL\Schema\Schema $schema
 	 * @param \SimpleXMLElement $xml
 	 * @throws \DomainException
 	 */
@@ -78,7 +80,6 @@ class MDB2SchemaReader {
 				case 'name':
 					$name = (string)$child;
 					$name = str_replace('*dbprefix*', $this->DBTABLEPREFIX, $name);
-					$name = $this->platform->quoteIdentifier($name);
 					$table = $schema->createTable($name);
 					break;
 				case 'create':
@@ -117,7 +118,6 @@ class MDB2SchemaReader {
 					break;
 				default:
 					throw new \DomainException('Unknown element: ' . $child->getName());
-
 			}
 		}
 	}
@@ -136,7 +136,6 @@ class MDB2SchemaReader {
 			switch ($child->getName()) {
 				case 'name':
 					$name = (string)$child;
-					$name = $this->platform->quoteIdentifier($name);
 					break;
 				case 'type':
 					$type = (string)$child;
@@ -261,14 +260,12 @@ class MDB2SchemaReader {
 						switch ($field->getName()) {
 							case 'name':
 								$field_name = (string)$field;
-								$field_name = $this->platform->quoteIdentifier($field_name);
 								$fields[] = $field_name;
 								break;
 							case 'sorting':
 								break;
 							default:
 								throw new \DomainException('Unknown element: ' . $field->getName());
-
 						}
 					}
 					break;


### PR DESCRIPTION
@bartv2 @bantu @ringmaster @karlitschek 

This PR fixes schema migrations on mssql.

Tested on Sql-Server 2012 - migration unit tests ensure functionality on sqlite, mysql, pgsql and Oracle
