### PR TITLE
fixing ajax call to getstoragestats.php

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -524,7 +524,7 @@ $(document).ready(function() {
 	// file space size sync
 	function update_storage_statistics() {
 		var currentDir = $('#dir').val() || '/';
-		$.getJSON(OC.filePath('files','ajax','getstoragestats.php?dir=' + encodeURIComponent(currentDir)),function(response) {
+		$.getJSON(OC.filePath('files','ajax','getstoragestats.php') + '?dir=' + encodeURIComponent(currentDir),function(response) {
 			Files.updateMaxUploadFilesize(response);
 		});
 	}


### PR DESCRIPTION
fixes stable5:

```
[Mon Dec 02 09:47:31 2013] [error] [client ::1] PHP Fatal error:  Class 'OCP\\JSON' not found in /home/deepdiver/Development/ownCloud/stable5/apps/files/ajax/getstoragestats.php on line 12, referer: http://localhost/oc/stable5/index.php/apps/files
[Mon Dec 02 09:47:31 2013] [error] [client ::1] PHP Stack trace:, referer: http://localhost/oc/stable5/index.php/apps/files
[Mon Dec 02 09:47:31 2013] [error] [client ::1] PHP   1. {main}() /home/deepdiver/Development/ownCloud/stable5/apps/files/ajax/getstoragestats.php:0, referer: http://localhost/oc/stable5/index.php/apps/files
```
