### PR TITLE
PHP version warning

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -437,9 +437,9 @@ class OC_Util {
 			);
 			$webServerRestart = true;
 		}
-		if(version_compare(phpversion(), '5.3.8', '<')) {
+		if(version_compare(phpversion(), '5.3.3', '<')) {
 			$errors[] = array(
-				'error'=>'PHP 5.3.8 or higher is required.',
+				'error'=>'PHP 5.3.3 or higher is required.',
 				'hint'=>'Please ask your server administrator to update PHP to the latest version.'
 					.' Your PHP version is no longer supported by ownCloud and the PHP community.'
 			);
@@ -872,6 +872,14 @@ class OC_Util {
 	 */
 	public static function fileInfoLoaded() {
 		return function_exists('finfo_open');
+	}
+
+	/**
+	 * @brief Check if a PHP version older then 5.3.8 is installed.
+	 * @return bool
+	 */
+	public static function isPHPoutdated() {
+		return version_compare(phpversion(), '5.3.8', '<');
 	}
 
 	/**

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -28,6 +28,7 @@ $tmpl->assign('internetconnectionworking', OC_Util::isInternetConnectionEnabled(
 $tmpl->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
 $tmpl->assign('isWebDavWorking', OC_Util::isWebDAVWorking());
 $tmpl->assign('has_fileinfo', OC_Util::fileInfoLoaded());
+$tmpl->assign('old_php', OC_Util::isPHPoutdated());
 $tmpl->assign('backgroundjobs_mode', OC_Appconfig::getValue('core', 'backgroundjobs_mode', 'ajax'));
 $tmpl->assign('shareAPIEnabled', OC_Appconfig::getValue('core', 'shareapi_enabled', 'yes'));
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -72,6 +72,20 @@ if (!$_['has_fileinfo']) {
 <?php
 }
 
+// is PHP at least at 5.3.8?
+if ($_['old_php']) {
+	?>
+<fieldset class="personalblock">
+	<h2><?php p($l->t('Your PHP version is outdated'));?></h2>
+
+		<span class="connectionwarning">
+		<?php p($l->t('Your PHP version is outdated. We strongly recommend to update to 5.3.8 or newer because older versions are known to be broken. It is possible that this installation is not working correctly.')); ?>
+	</span>
+
+</fieldset>
+<?php
+}
+
 // is locale working ?
 if (!$_['isLocaleWorking']) {
 	?>


### PR DESCRIPTION
remove the hard requirement for 5.3.8 and add a warning instead.
Please review @schiesbn @PVince81 @DeepDiver1975 
