### PR TITLE
fixes checkboxes in Advanced Tab don't save unchecked state anymore, #6143

### DIFF
--- a/apps/user_ldap/ajax/setConfiguration.php
+++ b/apps/user_ldap/ajax/setConfiguration.php
@@ -27,6 +27,18 @@ OCP\JSON::checkAppEnabled('user_ldap');
 OCP\JSON::callCheck();
 
 $prefix = $_POST['ldap_serverconfig_chooser'];
+
+// Checkboxes are not submitted, when they are unchecked. Set them manually.
+// only legacy checkboxes (Advanced and Expert tab) need to be handled here,
+// the Wizard-like tabs handle it on their own
+$chkboxes = array('ldap_configuration_active', 'ldap_override_main_server',
+				  'ldap_nocase', 'ldap_turn_off_cert_check');
+foreach($chkboxes as $boxid) {
+	if(!isset($_POST[$boxid])) {
+		$_POST[$boxid] = 0;
+	}
+}
+
 $ldapWrapper = new OCA\user_ldap\lib\LDAP();
 $connection = new \OCA\user_ldap\lib\Connection($ldapWrapper, $prefix);
 $connection->setConfiguration($_POST);

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -518,13 +518,17 @@ var LdapWizard = {
 		loginfilter = $('#ldap_login_filter').val();
 
 		//FIXME: activates a manually deactivated configuration.
-		if(host && port && base && 	userfilter && loginfilter) {
+		if(host && port && base && userfilter && loginfilter) {
 			LdapWizard.updateStatusIndicator(true);
 			if($('#ldap_configuration_active').is(':checked')) {
 				return;
 			}
-			$('#ldap_configuration_active').prop('checked', true);
-			LdapWizard.save($('#ldap_configuration_active')[0]);
+			if(!LdapWizard.isConfigurationActiveControlLocked) {
+				//avoids a manually deactivated connection will be activated
+				//upon opening the admin page
+				$('#ldap_configuration_active').prop('checked', true);
+				LdapWizard.save($('#ldap_configuration_active')[0]);
+			}
 		} else {
 			if($('#ldap_configuration_active').is(':checked')) {
 				$('#ldap_configuration_active').prop('checked', false);
@@ -546,9 +550,12 @@ var LdapWizard = {
 		$(id + " + button").css('display', 'inline');
 	},
 
+	isConfigurationActiveControlLocked: true,
+
 	init: function() {
 		LdapWizard.basicStatusCheck();
 		LdapWizard.functionalityCheck();
+		LdapWizard.isConfigurationActiveControlLocked = false;
 	},
 
 	initGroupFilter: function() {


### PR DESCRIPTION
Fixes #6143 

Also fixes that manually disabled are enabled by the WIzard by opening admin page.

please review @PVince81 @schiesbn @karlitschek @DeepDiver1975 
