### PR TITLE
fix appearance of error message - .errors is outdated

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -6,18 +6,19 @@
 <form action="index.php" method="post">
 <input type="hidden" name="install" value="true" />
 	<?php if(count($_['errors']) > 0): ?>
-	<ul class="errors">
+	<fieldset class="warning">
+		<legend><strong><?php p($l->t('Error'));?></strong></legend>
 		<?php foreach($_['errors'] as $err): ?>
-		<li>
+		<p>
 			<?php if(is_array($err)):?>
 				<?php print_unescaped($err['error']); ?>
-				<p class='hint'><?php print_unescaped($err['hint']); ?></p>
+				<span class='hint'><?php print_unescaped($err['hint']); ?></span>
 			<?php else: ?>
 				<?php print_unescaped($err); ?>
 			<?php endif; ?>
-		</li>
+		</p>
 		<?php endforeach; ?>
-	</ul>
+	</fieldset>
 	<?php endif; ?>
 	<?php if($_['vulnerableToNullByte']): ?>
 	<fieldset class="warning">


### PR DESCRIPTION
fix error warning appearance on installation page. To improve the recognition value

cc @owncloud/designers 

Before:
![error-box-on-installation-before](https://f.cloud.github.com/assets/245432/1681604/d0609c30-5d97-11e3-9630-296ebfb65cab.png)
After:
![error-box-on-installation-after](https://f.cloud.github.com/assets/245432/1681605/d060eed8-5d97-11e3-95b3-647b7bc1b16e.png)
