### PR TITLE
Fix user's displayName being overwritten by (old) cookie. #3694

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -866,7 +866,6 @@ class OC {
 				OC_User::setMagicInCookie($_COOKIE['oc_username'], $token);
 				// login
 				OC_User::setUserId($_COOKIE['oc_username']);
-				OC_User::setDisplayName($_COOKIE['oc_username'], $_COOKIE['display_name']);
 				OC_Util::redirectToDefaultPage();
 				// doesn't return
 			}


### PR DESCRIPTION
In the current master (and 6.0.0 up to current RC3), the user's displayName is being overwritten with the "display_name" cookie.

This cookie is never set by ownCloud (maybe old versions did), so the displayName set by the user was always overwritten with their username on login.

This PR also fixes an array index warning in the logs ("display_name" not existing).
