### PR TITLE
Add overlay noscript message to fix #6032

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -58,3 +58,8 @@
 .ie9 #navigation {
 	width: 100px;
 }
+
+/* IE8 isn't able to display transparent background. So it is specified using a gradient */
+.ie8 #nojavascript {
+	filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='#4c320000', endColorstr='#4c320000'); /* IE */
+}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -66,6 +66,13 @@ body { background:#fefefe; font:normal .8em/1.6em "Helvetica Neue",Helvetica,Ari
 	left: 50%;
 	margin-left: -25%;
 }
+#nojavascript a {
+	color: #ccc;
+	text-decoration: underline;
+}
+#nojavascript a:hover {
+	color: #aaa;
+}
 
 /* INPUTS */
 input[type="text"],

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -46,6 +46,27 @@ body { background:#fefefe; font:normal .8em/1.6em "Helvetica Neue",Helvetica,Ari
 	opacity: 1;
 }
 
+#nojavascript {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	z-index: 999;
+	width: 100%;
+	text-align: center;
+	background-color: rgba(50,0,0,0.5);
+	color: white;
+	text-shadow: 0px 0px 5px black;
+	line-height: 125%;
+	font-size: x-large;
+}
+#nojavascript div {
+	width: 50%;
+	top: 50%;
+	position: absolute;
+	left: 50%;
+	margin-left: -25%;
+}
+
 /* INPUTS */
 input[type="text"],
 input[type="password"],

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -61,7 +61,7 @@ body { background:#fefefe; font:normal .8em/1.6em "Helvetica Neue",Helvetica,Ari
 }
 #nojavascript div {
 	width: 50%;
-	top: 50%;
+	top: 40%;
 	position: absolute;
 	left: 50%;
 	margin-left: -25%;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -37,6 +37,7 @@
 	</head>
 
 	<body id="<?php p($_['bodyid']);?>">
+	<noscript><div id="nojavascript"><div>ownCloud requires JavaScript to be enabled for correct operation.  Please enable JavaScript and re-load this interface.</div></div></noscript>
 	<div id="notification-container">
 		<div id="notification"></div>
 		<?php if ($_['updateAvailable']): ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -37,7 +37,7 @@
 	</head>
 
 	<body id="<?php p($_['bodyid']);?>">
-	<noscript><div id="nojavascript"><div><?php p($l->t('ownCloud requires JavaScript to be enabled for correct operation.  Please enable JavaScript and re-load this interface.')); ?></div></div></noscript>
+	<noscript><div id="nojavascript"><div><?php print_unescaped($l->t('ownCloud requires JavaScript to be enabled for correct operation.  Please <a href="http://enable-javascript.com/" target="_blank">enable JavaScript</a> and re-load this interface.')); ?></div></div></noscript>
 	<div id="notification-container">
 		<div id="notification"></div>
 		<?php if ($_['updateAvailable']): ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -37,7 +37,7 @@
 	</head>
 
 	<body id="<?php p($_['bodyid']);?>">
-	<noscript><div id="nojavascript"><div><?php print_unescaped($l->t('ownCloud requires JavaScript to be enabled for correct operation.  Please <a href="http://enable-javascript.com/" target="_blank">enable JavaScript</a> and re-load this interface.')); ?></div></div></noscript>
+	<noscript><div id="nojavascript"><div><?php print_unescaped($l->t('This application requires JavaScript to be enabled for correct operation.  Please <a href="http://enable-javascript.com/" target="_blank">enable JavaScript</a> and re-load this interface.')); ?></div></div></noscript>
 	<div id="notification-container">
 		<div id="notification"></div>
 		<?php if ($_['updateAvailable']): ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -37,7 +37,7 @@
 	</head>
 
 	<body id="<?php p($_['bodyid']);?>">
-	<noscript><div id="nojavascript"><div>ownCloud requires JavaScript to be enabled for correct operation.  Please enable JavaScript and re-load this interface.</div></div></noscript>
+	<noscript><div id="nojavascript"><div><?php p($l->t('ownCloud requires JavaScript to be enabled for correct operation.  Please enable JavaScript and re-load this interface.')); ?></div></div></noscript>
 	<div id="notification-container">
 		<div id="notification"></div>
 		<?php if ($_['updateAvailable']): ?>


### PR DESCRIPTION
How about this as an alternative to #6193?:

![image](https://f.cloud.github.com/assets/127738/1683086/da9f18b4-5db7-11e3-8db6-011d1325c263.png)

The subdued red background is an overlay that prevents mouse access to the application.  The message informs of what needs to be done to re-enable regular operation.

Note that this seems to work on my Chrome 32, as in the screenshot.
