### PR TITLE
Stable5 unshare vs delete

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -79,20 +79,11 @@
 			<th id="headerDate">
 				<span id="modified"><?php p($l->t( 'Modified' )); ?></span>
 				<?php if ($_['permissions'] & OCP\PERMISSION_DELETE): ?>
-<!-- 					NOTE: Temporary fix to allow unsharing of files in root of Shared folder -->
-					<?php if ($_['dir'] == '/Shared'): ?>
-						<span class="selectedActions"><a href="" class="delete-selected">
-							<?php p($l->t('Unshare'))?>
-							<img class="svg" alt="<?php p($l->t('Unshare'))?>"
-								 src="<?php print_unescaped(OCP\image_path("core", "actions/delete.svg")); ?>" />
-						</a></span>
-					<?php else: ?>
-						<span class="selectedActions"><a href="" class="delete-selected">
-							<?php p($l->t('Delete'))?>
-							<img class="svg" alt="<?php p($l->t('Delete'))?>"
-								 src="<?php print_unescaped(OCP\image_path("core", "actions/delete.svg")); ?>" />
-						</a></span>
-					<?php endif; ?>
+					<span class="selectedActions"><a href="" class="delete-selected">
+						<?php p($l->t('Delete'))?>
+						<img class="svg" alt="<?php p($l->t('Delete'))?>"
+							 src="<?php print_unescaped(OCP\image_path("core", "actions/delete.svg")); ?>" />
+					</a></span>
 				<?php endif; ?>
 			</th>
 		</tr>


### PR DESCRIPTION
OC5 doesn't support unsharing. Change string in group action to "delete"

fix #5044 
