### PR TITLE
[Encryption] Only create new key if no other key exists

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -179,9 +179,9 @@ class Hooks {
 		// the necessary keys)
 		if (Crypt::mode() === 'server') {
 
-			if ($params['uid'] === \OCP\User::getUser()) {
+			$view = new \OC_FilesystemView('/');
 
-				$view = new \OC_FilesystemView('/');
+			if ($params['uid'] === \OCP\User::getUser()) {
 
 				$session = new \OCA\Encryption\Session($view);
 
@@ -202,36 +202,41 @@ class Hooks {
 			} else { // admin changed the password for a different user, create new keys and reencrypt file keys
 
 				$user = $params['uid'];
-				$recoveryPassword = $params['recoveryPassword'];
-				$newUserPassword = $params['password'];
+				$util = new Util($view, $user);
+				$recoveryPassword = isset($params['recoveryPassword']) ? $params['recoveryPassword'] : null;
 
-				$view = new \OC_FilesystemView('/');
+				if (($util->recoveryEnabledForUser() && $recoveryPassword)
+						|| !$util->userKeysExists()) {
 
-				// make sure that the users home is mounted
-				\OC\Files\Filesystem::initMountPoints($user);
+					$recoveryPassword = $params['recoveryPassword'];
+					$newUserPassword = $params['password'];
 
-				$keypair = Crypt::createKeypair();
+					// make sure that the users home is mounted
+					\OC\Files\Filesystem::initMountPoints($user);
 
-				// Disable encryption proxy to prevent recursive calls
-				$proxyStatus = \OC_FileProxy::$enabled;
-				\OC_FileProxy::$enabled = false;
+					$keypair = Crypt::createKeypair();
 
-				// Save public key
-				$view->file_put_contents('/public-keys/' . $user . '.public.key', $keypair['publicKey']);
+					// Disable encryption proxy to prevent recursive calls
+					$proxyStatus = \OC_FileProxy::$enabled;
+					\OC_FileProxy::$enabled = false;
 
-				// Encrypt private key empty passphrase
-				$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], $newUserPassword);
+					// Save public key
+					$view->file_put_contents('/public-keys/' . $user . '.public.key', $keypair['publicKey']);
 
-				// Save private key
-				$view->file_put_contents(
-					'/' . $user . '/files_encryption/' . $user . '.private.key', $encryptedPrivateKey);
+					// Encrypt private key empty passphrase
+					$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], $newUserPassword);
 
-				if ($recoveryPassword) { // if recovery key is set we can re-encrypt the key files
-					$util = new Util($view, $user);
-					$util->recoverUsersFiles($recoveryPassword);
+					// Save private key
+					$view->file_put_contents(
+							'/' . $user . '/files_encryption/' . $user . '.private.key', $encryptedPrivateKey);
+
+					if ($recoveryPassword) { // if recovery key is set we can re-encrypt the key files
+						$util = new Util($view, $user);
+						$util->recoverUsersFiles($recoveryPassword);
+					}
+
+					\OC_FileProxy::$enabled = $proxyStatus;
 				}
-
-				\OC_FileProxy::$enabled = $proxyStatus;
 			}
 		}
 	}

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -101,15 +101,24 @@ class Util {
 			or !$this->view->file_exists($this->publicKeyPath)
 			or !$this->view->file_exists($this->privateKeyPath)
 		) {
-
 			return false;
-
 		} else {
-
 			return true;
-
 		}
+	}
 
+	/**
+	 * @breif check if the users private & public key exists
+	 * @return boolean
+	 */
+	public function userKeysExists() {
+		if (
+				$this->view->file_exists($this->privateKeyPath) &&
+				$this->view->file_exists($this->publicKeyPath)) {
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -108,7 +108,7 @@ class Util {
 	}
 
 	/**
-	 * @breif check if the users private & public key exists
+	 * @brief check if the users private & public key exists
 	 * @return boolean
 	 */
 	public function userKeysExists() {

--- a/apps/files_encryption/templates/settings-personal.php
+++ b/apps/files_encryption/templates/settings-personal.php
@@ -2,7 +2,7 @@
 	<fieldset class="personalblock">
 		<h2><?php p( $l->t( 'Encryption' ) ); ?></h2>
 
-		<?php if ( ! $_["privateKeySet"] && $_["initialized"] ): ?>
+		<?php if ( $_["initialized"] === '1' ): ?>
 			<p>
 				<a name="changePKPasswd" />
 				<label for="changePrivateKeyPasswd">


### PR DESCRIPTION
If the admin changes a users password and no recovery key exists we only generate a new key pair if no old key pair exists. This way the user can still recover his old key if he remembers the correct password

fix #6204 
