### PR TITLE
correctly propagate the return value of ldap_set_option

### DIFF
--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -91,7 +91,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	public function setOption($link, $option, $value) {
-		$this->invokeLDAPMethod('set_option', $link, $option, $value);
+		return $this->invokeLDAPMethod('set_option', $link, $option, $value);
 	}
 
 	public function sort($link, $result, $sortfilter) {


### PR DESCRIPTION
otherwise the second setOption call (LDAP_OPT_REFERRALS) won't be executed and in turn
paged searches will stop working with active directory
(Operations error on ldap_control_paged_result_response)
