### PR TITLE
set unencrypted_size to 0 after decryption

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -770,7 +770,7 @@ class Util {
 				\OC\Files\Filesystem::putFileInfo($relPath, array(
 					'encrypted' => false,
 					'size' => $size,
-					'unencrypted_size' => $size,
+					'unencrypted_size' => 0,
 					'etag' => $fileInfo['etag']
 				));
 


### PR DESCRIPTION
...so that the unencrypted_size gets re-calculated if encryption was enabled again

cc @PVince81
