### PR TITLE
Fixed Dropbox/Google storage async save call

### DIFF
--- a/apps/files_external/js/dropbox.js
+++ b/apps/files_external/js/dropbox.js
@@ -23,9 +23,12 @@ $(document).ready(function() {
 							$(token).val(result.access_token);
 							$(token_secret).val(result.access_token_secret);
 							$(configured).val('true');
-							OC.MountConfig.saveStorage(tr);
-							$(tr).find('.configuration input').attr('disabled', 'disabled');
-							$(tr).find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
+							OC.MountConfig.saveStorage(tr, function(status) {
+								if (status) {
+									$(tr).find('.configuration input').attr('disabled', 'disabled');
+									$(tr).find('.configuration').append('<span id="access" style="padding-left:0.5em;">'+t('files_external', 'Access granted')+'</span>');
+								}
+							});
 						} else {
 							OC.dialogs.alert(result.data.message, t('files_external', 'Error configuring Dropbox storage'));
 						}
@@ -77,7 +80,6 @@ $(document).ready(function() {
 		var tr = $(this).parent().parent();
 		var app_key = $(this).parent().find('[data-parameter="app_key"]').val();
 		var app_secret = $(this).parent().find('[data-parameter="app_secret"]').val();
-		var statusSpan = $(tr).find('.status span');
 		if (app_key != '' && app_secret != '') {
 			var tr = $(this).parent().parent();
 			var configured = $(this).parent().find('[data-parameter="configured"]');
@@ -88,10 +90,9 @@ $(document).ready(function() {
 					$(configured).val('false');
 					$(token).val(result.data.request_token);
 					$(token_secret).val(result.data.request_token_secret);
-					OC.MountConfig.saveStorage(tr);
-					statusSpan.removeClass();
-					statusSpan.addClass('waiting');
-					window.location = result.data.url;
+					OC.MountConfig.saveStorage(tr, function() {
+						window.location = result.data.url;
+					});
 				} else {
 					OC.dialogs.alert(result.data.message, t('files_external', 'Error configuring Dropbox storage'));
 				}

--- a/apps/files_external/js/google.js
+++ b/apps/files_external/js/google.js
@@ -32,11 +32,14 @@ $(document).ready(function() {
 							if (result && result.status == 'success') {
 								$(token).val(result.data.token);
 								$(configured).val('true');
-								OC.MountConfig.saveStorage(tr);
-								$(tr).find('.configuration input').attr('disabled', 'disabled');
-								$(tr).find('.configuration').append($('<span/>')
-									.attr('id', 'access')
-									.text(t('files_external', 'Access granted')));
+								OC.MountConfig.saveStorage(tr, function(status) {
+									if (status) {
+										$(tr).find('.configuration input').attr('disabled', 'disabled');
+										$(tr).find('.configuration').append($('<span/>')
+											.attr('id', 'access')
+											.text(t('files_external', 'Access granted')));
+									}
+								});
 							} else {
 								OC.dialogs.alert(result.data.message,
 									t('files_external', 'Error configuring Google Drive storage')
@@ -99,7 +102,6 @@ $(document).ready(function() {
 		var configured = $(this).parent().find('[data-parameter="configured"]');
 		var client_id = $(this).parent().find('[data-parameter="client_id"]').val();
 		var client_secret = $(this).parent().find('[data-parameter="client_secret"]').val();
-		var statusSpan = $(tr).find('.status span');
 		if (client_id != '' && client_secret != '') {
 			var token = $(this).parent().find('[data-parameter="token"]');
 			$.post(OC.filePath('files_external', 'ajax', 'google.php'),
@@ -112,10 +114,9 @@ $(document).ready(function() {
 					if (result && result.status == 'success') {
 						$(configured).val('false');
 						$(token).val('false');
-						OC.MountConfig.saveStorage(tr);
-						statusSpan.removeClass();
-						statusSpan.addClass('waiting');
-						window.location = result.data.url;
+						OC.MountConfig.saveStorage(tr, function(status) {
+							window.location = result.data.url;
+						});
 					} else {
 						OC.dialogs.alert(result.data.message,
 							t('files_external', 'Error configuring Google Drive storage')

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -12,7 +12,7 @@ function updateStatus(statusEl, result){
 }
 
 OC.MountConfig={
-	saveStorage:function(tr) {
+	saveStorage:function(tr, callback) {
 		var mountPoint = $(tr).find('.mountPoint input').val();
 		if (mountPoint == '') {
 			return false;
@@ -84,9 +84,15 @@ OC.MountConfig={
 						},
 						success: function(result) {
 							status = updateStatus(statusSpan, result);
+							if (callback) {
+								callback(status);
+							}
 						},
 						error: function(result){
 							status = updateStatus(statusSpan, result);
+							if (callback) {
+								callback(status);
+							}
 						}
 					});
 				});
@@ -137,9 +143,15 @@ OC.MountConfig={
 					},
 					success: function(result) {
 						status = updateStatus(statusSpan, result);
+						if (callback) {
+							callback(status);
+						}
 					},
 					error: function(result){
 						status = updateStatus(statusSpan, result);
+						if (callback) {
+							callback(status);
+						}
 					}
 				});
 			}


### PR DESCRIPTION
When clicking "Grant access", the settings for Dropbox/Google were saved
through a call that gets cancelled when redirecting to the grant page
(for example in Firefox)

This fix makes sure the "save settings" call finished before redirecting
to the grant page.

Fixes #6176

Please review @karlitschek @schiesbn @icewind1991 
Please test this branch @ser72 
