### PR TITLE
Fix to not destroy draggable when no draggable was set

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -300,7 +300,10 @@ var FileList={
 	},
 	remove:function(name){
 		var fileEl = FileList.findFileEl(name);
-		fileEl.find('td.filename').draggable('destroy');
+		if (fileEl.data('permissions') & OC.PERMISSION_DELETE) {
+			// file is only draggable when delete permissions are set
+			fileEl.find('td.filename').draggable('destroy');
+		}
 		fileEl.remove();
 		FileList.updateFileSummary();
 		if ( ! $('tr[data-file]').exists() ) {


### PR DESCRIPTION
When a dir has no delete permission, the draggable isn't initialized on
files. This fix makes sure we don't try to destroy a draggable when it
wasn't inited in the first place.

(this happenned when uploading + overwriting a file)

Fixes #6254 

Please review @butonic @karlitschek @schiesbn @DeepDiver1975 
