### PR TITLE
Fixed sharing results to include the correct permissions

### DIFF
--- a/apps/files_sharing/lib/permissions.php
+++ b/apps/files_sharing/lib/permissions.php
@@ -42,6 +42,19 @@ class Shared_Permissions extends Permissions {
 		}
 	}
 
+	private function getFile($fileId, $user) {
+		if ($fileId == -1) {
+			return \OCP\PERMISSION_READ;
+		}
+		$source = \OCP\Share::getItemSharedWithBySource('file', $fileId, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE,
+			null, false);
+		if ($source) {
+			return $source['permissions'];
+		} else {
+			return -1;
+		}
+	}
+
 	/**
 	 * set the permissions of a file
 	 *
@@ -82,7 +95,7 @@ class Shared_Permissions extends Permissions {
 		if ($parentId === -1) {
 			return \OCP\Share::getItemsSharedWith('file', \OC_Share_Backend_File::FORMAT_PERMISSIONS);
 		}
-		$permissions = $this->get($parentId, $user);
+		$permissions = $this->getFile($parentId, $user);
 		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `parent` = ?');
 		$result = $query->execute(array($parentId));
 		$filePermissions = array();

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * @copyright 2013 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+require_once __DIR__ . '/base.php';
+
+class Test_Files_Sharing_Permissions extends Test_Files_Sharing_Base {
+
+	function setUp() {
+		parent::setUp();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		// prepare user1's dir structure
+		$textData = "dummy file data\n";
+		$this->view->mkdir('container');
+		$this->view->mkdir('container/shareddir');
+		$this->view->mkdir('container/shareddir/subdir');
+		$this->view->mkdir('container/shareddirrestricted');
+		$this->view->mkdir('container/shareddirrestricted/subdir');
+		$this->view->file_put_contents('container/shareddir/textfile.txt', $textData);
+		$this->view->file_put_contents('container/shareddirrestricted/textfile1.txt', $textData);
+
+		list($this->ownerStorage, $internalPath) = $this->view->resolvePath('');
+		$this->ownerCache = $this->ownerStorage->getCache();
+		$this->ownerStorage->getScanner()->scan('');
+
+		// share "shareddir" with user2
+		$fileinfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+		$fileinfo2 = $this->view->getFileInfo('container/shareddirrestricted');
+		\OCP\Share::shareItem('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 7);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// retrieve the shared storage
+		$this->secondView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
+		list($this->sharedStorage, $internalPath) = $this->secondView->resolvePath('files/Shared/shareddir');
+		$this->sharedCache = $this->sharedStorage->getCache();
+	}
+
+	function tearDown() {
+		$this->sharedCache->clear();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileinfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+		$fileinfo2 = $this->view->getFileInfo('container/shareddirrestricted');
+		\OCP\Share::unshare('folder', $fileinfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+
+		$this->view->deleteAll('container');
+
+		$this->ownerCache->clear();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the permissions of shared directory are returned correctly
+	 */
+	function testGetPermissions() {
+		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir');
+		$this->assertEquals(31, $sharedDirPerms);
+		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir/textfile.txt');
+		$this->assertEquals(31, $sharedDirPerms);
+		$sharedDirRestrictedPerms = $this->sharedStorage->getPermissions('shareddirrestricted');
+		$this->assertEquals(7, $sharedDirRestrictedPerms);
+		$sharedDirRestrictedPerms = $this->sharedStorage->getPermissions('shareddirrestricted/textfile.txt');
+		$this->assertEquals(7, $sharedDirRestrictedPerms);
+	}
+
+	/**
+	 * Test that the permissions of shared directory are returned correctly
+	 */
+	function testGetDirectoryPermissions() {
+		$contents = $this->secondView->getDirectoryContent('files/Shared/shareddir');
+		$this->assertEquals('subdir', $contents[0]['name']);
+		$this->assertEquals(31, $contents[0]['permissions']);
+		$this->assertEquals('textfile.txt', $contents[1]['name']);
+		$this->assertEquals(31, $contents[1]['permissions']);
+		$contents = $this->secondView->getDirectoryContent('files/Shared/shareddirrestricted');
+		$this->assertEquals('subdir', $contents[0]['name']);
+		$this->assertEquals(7, $contents[0]['permissions']);
+		$this->assertEquals('textfile1.txt', $contents[1]['name']);
+		$this->assertEquals(7, $contents[1]['permissions']);
+	}
+}


### PR DESCRIPTION
Passing $includeCollections would return more than one entry which gives
mixed up file permissions.

Added a method getFile() that doesn't set $includeCollections to make
sure we only get one result which is the file itself.

Fixes #6265 

Please review @karlitschek @schiesbn @bartv2 
