### PR TITLE
Hook call for autosetup.php at the end of successful installation

### DIFF
--- a/config/autosetup.sample.php
+++ b/config/autosetup.sample.php
@@ -1,0 +1,10 @@
+<?php
+
+/* The autosetup.php should be used for automatic setup ownCloud after admin user is created and storage initialized */
+
+/* This line enables HTTPS */
+\OC_Config::setValue( "forcessl", true);
+
+/* This line sets VALUE to PARAMETER of the APPLICATION */
+\OC_Appconfig::setValue(APPLICATION, PARAMETER, VALUE);
+

--- a/core/setup.php
+++ b/core/setup.php
@@ -63,6 +63,14 @@ if(isset($_POST['install']) AND $_POST['install']=='true') {
 	}
 	else {
 		header( 'Location: '.OC_Helper::linkToRoute( 'post_setup_check' ));
+
+		$auto_file = OC::$SERVERROOT."/config/autosetup.php";
+		if( file_exists( $auto_file )) {
+			OC_Log::write('core', 'Autosetup file found, setting up owncloud...', OC_Log::INFO);
+			include $auto_file;
+			unlink($auto_file);
+		}
+
 		exit();
 	}
 }


### PR DESCRIPTION
The core/setup.php after successful installation of ownCloud (when DB already created) checks for config/autosetup.php file and executes it if there's such a file. In config/autosetup.php the one can put instractions needed to tweak ownCloud server after intallation. This is implementation for our https://github.com/syncloud/owncloud-setup/issues/14

This contribution is MIT licensed.
