### PR TITLE
LDAP: Adjust help link to documentation

### DIFF
--- a/apps/user_ldap/templates/part.settingcontrols.php
+++ b/apps/user_ldap/templates/part.settingcontrols.php
@@ -3,7 +3,7 @@
 	<button class="ldap_action_test_connection" name="ldap_action_test_connection">
 		<?php p($l->t('Test Configuration'));?>
 	</button>
-	<a href="<?php p($theme->getDocBaseUrl()); ?>/server/5.0/admin_manual/auth_ldap.html"
+	<a href="<?php print_unescaped(link_to_docs('admin-ldap')); ?>"
 		target="_blank">
 		<img src="<?php print_unescaped(OCP\Util::imagePath('', 'actions/info.png')); ?>"
 			style="height:1.75ex" />

--- a/apps/user_ldap/templates/part.wizardcontrols.php
+++ b/apps/user_ldap/templates/part.wizardcontrols.php
@@ -7,7 +7,7 @@
 	<button class="ldap_action_continue" name="ldap_action_continue" type="button">
 		<?php p($l->t('Continue'));?>
 	</button>
-	<a href="<?php p($theme->getDocBaseUrl()); ?>/server/5.0/admin_manual/auth_ldap.html"
+	<a href="<?php print_unescaped(link_to_docs('admin-ldap')); ?>"
 		target="_blank">
 		<img src="<?php print_unescaped(OCP\Util::imagePath('', 'actions/info.png')); ?>"
 			style="height:1.75ex" />


### PR DESCRIPTION
The old link points to OC 5 doc, it should point to OC 6 doc.

Not a showstopper ;)

@karlitschek @PVince81 
