### PR TITLE
Stable6 legacy settings popup

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -833,7 +833,7 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .popup {
 	background-color: #fff;
 	border-radius: 3px;
-	box-shadow: 0 0 20px #aaa;
+	box-shadow: 0 0 10px #aaa;
 	color: #333;
 	padding: 10px;
 	position: fixed !important;
@@ -845,7 +845,7 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .popup h2 { font-weight:bold; font-size:1.2em; }
 .arrow { border-bottom:10px solid white; border-left:10px solid transparent; border-right:10px solid transparent; display:block; height:0; position:absolute; width:0; z-index:201; }
 .arrow.left { left:-13px; bottom:1.2em; -webkit-transform:rotate(270deg); -moz-transform:rotate(270deg); -o-transform:rotate(270deg); -ms-transform:rotate(270deg); transform:rotate(270deg); }
-.arrow.up { top:-8px; right:2em; }
+.arrow.up { top:-8px; right:6px; }
 .arrow.down { -webkit-transform:rotate(180deg); -moz-transform:rotate(180deg); -o-transform:rotate(180deg); -ms-transform:rotate(180deg); transform:rotate(180deg); }
 .help-includes {
 	overflow: hidden;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -829,8 +829,16 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 #tagsdialog .taglist li:hover, #tagsdialog .taglist li:active { background:#eee; }
 #tagsdialog .addinput { width: 90%; clear: both; }
 
-/* ---- APP SETTINGS ---- */
-.popup { background-color:white; border-radius:10px 10px 10px 10px; box-shadow:0 0 20px #888; color:#333; padding:10px; position:fixed !important; z-index:100; }
+/* ---- APP SETTINGS - LEGACY, DO NOT USE THE POPUP! ---- */
+.popup {
+	background-color: #fff;
+	border-radius: 3px;
+	box-shadow: 0 0 20px #aaa;
+	color: #333;
+	padding: 10px;
+	position: fixed !important;
+	z-index: 100;
+}
 .popup.topright { top:7em; right:1em; }
 .popup.bottomleft { bottom:1em; left:33em; }
 .popup .close { position:absolute; top:0.2em; right:0.2em; height:20px; width:20px; background:url('../img/actions/close.svg') no-repeat center; }


### PR DESCRIPTION
Stable6 version of https://github.com/owncloud/core/pull/5968 – it’s just a small fix, but most likely only relevant for stable6 anyway since Calendar will switch to the slide-out settings in ownCloud 7.

Only merge in **after the ownCloud 6 release**. Check it @owncloud/designers 
