### PR TITLE
Fixed download file from URL error messages

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -53,13 +53,13 @@ $result = array(
 	);
 
 if(trim($filename) === '') {
-	$result['data'] = array('message' => $l10n->t('File name cannot be empty.'));
+	$result['data'] = array('message' => (string)$l10n->t('File name cannot be empty.'));
 	OCP\JSON::error($result);
 	exit();
 }
 
 if(strpos($filename, '/') !== false) {
-	$result['data'] = array('message' => $l10n->t('File name must not contain "/". Please choose a different name.'));
+	$result['data'] = array('message' => (string)$l10n->t('File name must not contain "/". Please choose a different name.'));
 	OCP\JSON::error($result);
 	exit();
 }
@@ -68,7 +68,7 @@ if(strpos($filename, '/') !== false) {
 $target = $dir.'/'.$filename;
 
 if (\OC\Files\Filesystem::file_exists($target)) {
-	$result['data'] = array('message' => $l10n->t(
+	$result['data'] = array('message' => (string)$l10n->t(
 			'The name %s is already used in the folder %s. Please choose a different name.',
 			array($filename, $dir))
 		);
@@ -78,20 +78,32 @@ if (\OC\Files\Filesystem::file_exists($target)) {
 
 if($source) {
 	if(substr($source, 0, 8)!='https://' and substr($source, 0, 7)!='http://') {
-		OCP\JSON::error(array('data' => array( 'message' => $l10n->t('Not a valid source') )));
+		OCP\JSON::error(array('data' => array('message' => $l10n->t('Not a valid source'))));
+		exit();
+	}
+
+	if (!ini_get('allow_url_fopen')) {
+		$eventSource->send('error', array('message' => $l10n->t('Server is not allowed to open URLs, please check the server configuration')));
+		$eventSource->close();
 		exit();
 	}
 
 	$ctx = stream_context_create(null, array('notification' =>'progress'));
-	$sourceStream=fopen($source, 'rb', false, $ctx);
-	$result=\OC\Files\Filesystem::file_put_contents($target, $sourceStream);
+	$sourceStream=@fopen($source, 'rb', false, $ctx);
+	$result = 0;
+	if (is_resource($sourceStream)) {
+		$result=\OC\Files\Filesystem::file_put_contents($target, $sourceStream);
+	}
 	if($result) {
 		$meta = \OC\Files\Filesystem::getFileInfo($target);
 		$mime=$meta['mimetype'];
 		$id = $meta['fileid'];
-		$eventSource->send('success', array('mime'=>$mime, 'size'=>\OC\Files\Filesystem::filesize($target), 'id' => $id, 'etag' => $meta['etag']));
+		$eventSource->send('success', array('mime' => $mime, 'size' => \OC\Files\Filesystem::filesize($target), 'id' => $id, 'etag' => $meta['etag']));
 	} else {
-		$eventSource->send('error', $l10n->t('Error while downloading %s to %s', array($source, $target)));
+		$eventSource->send('error', array('message' => $l10n->t('Error while downloading %s to %s', array($source, $target))));
+	}
+	if (is_resource($sourceStream)) {
+		fclose($sourceStream);
 	}
 	$eventSource->close();
 	exit();

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -658,7 +658,12 @@ $(document).ready(function() {
 						});
 						eventSource.listen('error',function(error) {
 							$('#uploadprogressbar').fadeOut();
-							alert(error);
+							var message = (error && error.message) || t('core', 'Error fetching URL');
+							OC.Notification.show(message);
+							//hide notification after 10 sec
+							setTimeout(function() {
+								OC.Notification.hide();
+							}, 10000);
 						});
 						break;
 				}

--- a/lib/private/eventsource.php
+++ b/lib/private/eventsource.php
@@ -64,13 +64,13 @@ class OC_EventSource{
 		}
 		if($this->fallback) {
 			$response='<script type="text/javascript">window.parent.OC.EventSource.fallBackCallBack('
-				.$this->fallBackId.',"'.$type.'",'.json_encode($data).')</script>'.PHP_EOL;
+				.$this->fallBackId.',"' . $type . '",' . OCP\JSON::encode($data) . ')</script>' . PHP_EOL;
 			echo $response;
 		}else{
 			if($type) {
-				echo 'event: '.$type.PHP_EOL;
+				echo 'event: ' . $type.PHP_EOL;
 			}
-			echo 'data: '.json_encode($data).PHP_EOL;
+			echo 'data: ' . OCP\JSON::encode($data) . PHP_EOL;
 		}
 		echo PHP_EOL;
 		flush();

--- a/lib/private/json.php
+++ b/lib/private/json.php
@@ -109,7 +109,14 @@ class OC_JSON{
 		if($setContentType) {
 			self::setContentTypeHeader();
 		}
+		echo self::encode($data);
+	}
+
+	/**
+	 * Encode JSON
+	 */
+	public static function encode($data) {
 		array_walk_recursive($data, array('OC_JSON', 'to_string'));
-		echo json_encode($data);
+		return json_encode($data);
 	}
 }

--- a/lib/public/json.php
+++ b/lib/public/json.php
@@ -169,4 +169,12 @@ class JSON {
 	public static function checkAdminUser() {
 		return(\OC_JSON::checkAdminUser());
 	}
+
+	/**
+	 * Encode JSON
+	 * @param array $data
+	 */
+	public static function encode($data) {
+		return(\OC_JSON::encode($data));
+	}
 }


### PR DESCRIPTION
- L10N now converted to string to make them work with json_encode
- Added specific error message when server doesn't allow fopen on URLs
- Fixed client side to correctly show error message in a notification

Related to #6284 
Having error messages shown correctly might help debug issues better...

Please review @bantu @DeepDiver1975 @karlitschek @schiesbn 
