### PR TITLE
only check ldap_errno if an ldap_* function actually fails

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -63,7 +63,6 @@ class Access extends LDAPUtility {
 			return false;
 		}
 		//all or nothing! otherwise we get in trouble with.
-		$this->initPagedSearch($filter, array($dn), $attr, 99999, 0);
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {
@@ -707,6 +706,9 @@ class Access extends LDAPUtility {
 		$linkResources = array_pad(array(), count($base), $cr);
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
+		if ($pagedSearchOK) {
+			$this->ldap->controlPagedResult($cr, 0, false, "");
+		}
 		if(!is_array($sr) || $error !== 0) {
 			\OCP\Util::writeLog('user_ldap',
 				'Error when searching: '.$this->ldap->error($cr).
@@ -1236,9 +1238,9 @@ class Access extends LDAPUtility {
 		if($this->connection->hasPagedResultSupport && !is_null($limit)) {
 			$offset = intval($offset); //can be null
 			\OCP\Util::writeLog('user_ldap',
-				'initializing paged search for  Filter'.$filter.' base '.print_r($bases, true)
+				'initializing paged search for  Filter '.$filter.' base '.print_r($bases, true)
 				.' attr '.print_r($attr, true). ' limit ' .$limit.' offset '.$offset,
-				\OCP\Util::INFO);
+				\OCP\Util::DEBUG);
 			//get the cookie from the search for the previous search, required by LDAP
 			foreach($bases as $base) {
 
@@ -1260,7 +1262,7 @@ class Access extends LDAPUtility {
 				}
 				if(!is_null($cookie)) {
 					if($offset > 0) {
-						\OCP\Util::writeLog('user_ldap', 'Cookie '.$cookie, \OCP\Util::INFO);
+						\OCP\Util::writeLog('user_ldap', 'Cookie '.CRC32($cookie), \OCP\Util::INFO);
 					}
 					$pagedSearchOK = $this->ldap->controlPagedResult(
 						$this->connection->getConnectionResource(), $limit,

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -707,7 +707,7 @@ class Access extends LDAPUtility {
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
 		if ($pagedSearchOK) {
-			$this->ldap->controlPagedResult($cr, 0, false, "");
+			$this->ldap->controlPagedResult($cr, 999999, false, "");
 		}
 		if(!is_array($sr) || $error !== 0) {
 			\OCP\Util::writeLog('user_ldap',

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -78,7 +78,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	public function nextEntry($link, $result) {
-		return $this->invokeLDAPMethod('next_entry', $link, $result);
+		return ldap_next_entry($link, $result);
 	}
 
 	public function read($link, $baseDN, $filter, $attr) {
@@ -139,7 +139,9 @@ class LDAP implements ILDAPWrapper {
 		if(function_exists($func)) {
 			$this->preFunctionCall($func, $arguments);
 			$result = call_user_func_array($func, $arguments);
-			$this->postFunctionCall();
+			if ($result === FALSE) {
+				$this->postFunctionCall();
+			}
 			return $result;
 		}
 	}

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -78,7 +78,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	public function nextEntry($link, $result) {
-		return ldap_next_entry($link, $result);
+		return $this->invokeLDAPMethod('next_entry', $link, $result);
 	}
 
 	public function read($link, $baseDN, $filter, $attr) {

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -799,6 +799,7 @@ class Wizard extends LDAPUtility {
 		\OCP\Util::writeLog('user_ldap', 'Wiz: Setting LDAP Options ', \OCP\Util::DEBUG);
 		//set LDAP options
 		$this->ldap->setOption($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
+		$this->ldap->setOption($cr, LDAP_OPT_REFERRALS, 0);
 		$this->ldap->setOption($cr, LDAP_OPT_NETWORK_TIMEOUT, self::LDAP_NW_TIMEOUT);
 		if($tls) {
 			$isTlsWorking = @$this->ldap->startTls($cr);


### PR DESCRIPTION
fix wizard errors
reset search paging right after the search, not before some of the possible next search operations
cookie contains binary characters, don't log it
  (avoids json_encode(): Invalid UTF-8 sequence in argument errors)
