### PR TITLE
Send "SET NAMES utf8" to MySQL for PHP below 5.3.6

### DIFF
--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -101,6 +101,9 @@ class OC_DB {
 					);
 					$connectionParams['adapter'] = '\OC\DB\Adapter';
 					$connectionParams['wrapperClass'] = 'OC\DB\Connection';
+					// Send "SET NAMES utf8". Only required on PHP 5.3 below 5.3.6.
+					// See http://stackoverflow.com/questions/4361459/php-pdo-charset-set-names#4361485
+					$eventManager->addEventSubscriber(new \Doctrine\DBAL\Event\Listeners\MysqlSessionInit);
 					break;
 				case 'pgsql':
 					$connectionParams = array(


### PR DESCRIPTION
Fixes #6273 
Fixes #6333

Specifying charset via Doctrine parameter / PDO DSN does not work on PHP below 5.3.6.
See http://stackoverflow.com/questions/4361459/php-pdo-charset-set-names#4361485

@DeepDiver1975 
