### PR TITLE
Fix webdav session login user comparison

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -527,7 +527,7 @@ class OC {
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
 		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('user_id')
-			&& $_SERVER['PHP_AUTH_USER'] != self::$session->get('loginname')) {
+			&& $_SERVER['PHP_AUTH_USER'] !== self::$session->get('loginname')) {
 			$sessionUser = self::$session->get('loginname');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];
 			OC_Log::write('core',

--- a/lib/base.php
+++ b/lib/base.php
@@ -526,10 +526,9 @@ class OC {
 
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
-
 		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('user_id')
-			&& $_SERVER['PHP_AUTH_USER'] != self::$session->get('user_id')) {
-			$sessionUser = self::$session->get('user_id');
+			&& $_SERVER['PHP_AUTH_USER'] != self::$session->get('loginname')) {
+			$sessionUser = self::$session->get('loginname');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];
 			OC_Log::write('core',
 				"Session user-id ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
@@ -804,7 +803,7 @@ class OC {
 			if ( OC_Config::getValue('log_authfailip', false) ) {
 				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
 				OC_Log::WARN);
-			} else { 
+			} else {
 				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:set log_authfailip=true in conf',
                                 OC_Log::WARN);
 			}

--- a/lib/base.php
+++ b/lib/base.php
@@ -526,6 +526,7 @@ class OC {
 
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
+
 		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('user_id')
 			&& $_SERVER['PHP_AUTH_USER'] !== self::$session->get('loginname')) {
 			$sessionUser = self::$session->get('loginname');

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -113,6 +113,38 @@ class Session implements Emitter, \OCP\IUserSession {
 	}
 
 	/**
+	 * set the login name
+	 *
+	 * @param string login name for the logged in user
+	 */
+	public function setLoginname($loginname) {
+		if (is_null($loginname)) {
+			$this->session->remove('loginname');
+		} else {
+			$this->session->set('loginname', $loginname);
+		}
+	}
+
+	/**
+	 * get the login name of the current user
+	 *
+	 * @return string
+	 */
+	public function getLoginname() {
+		if ($this->activeUser) {
+			return $this->session->get('loginname');
+		} else {
+			$uid = $this->session->get('user_id');
+			if ($uid) {
+				$this->activeUser = $this->manager->get($uid);
+				return $this->session->get('loginname');
+			} else {
+				return null;
+			}
+		}
+	}
+
+	/**
 	 * try to login with the provided credentials
 	 *
 	 * @param string $uid
@@ -126,6 +158,7 @@ class Session implements Emitter, \OCP\IUserSession {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
 					$this->setUser($user);
+					$this->setLoginname($uid);
 					$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
 					return true;
 				} else {
@@ -143,6 +176,7 @@ class Session implements Emitter, \OCP\IUserSession {
 	public function logout() {
 		$this->manager->emit('\OC\User', 'logout');
 		$this->setUser(null);
+		$this->setLoginname(null);
 		$this->unsetMagicInCookie();
 	}
 

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -52,9 +52,20 @@ class Session extends \PHPUnit_Framework_TestCase {
 
 	public function testLoginValidPasswordEnabled() {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
-		$session->expects($this->once())
+		$session->expects($this->exactly(2))
 			->method('set')
-			->with('user_id', 'foo');
+			->with($this->callback(function($key) {
+						switch($key) {
+							case 'user_id':
+							case 'loginname':
+								return true;
+								break;
+							default:
+								return false;
+								break;
+						}
+					},
+					'foo'));
 
 		$manager = $this->getMock('\OC\User\Manager');
 


### PR DESCRIPTION
On WebDAV sessions (as supported by our client) the provided loginname was compared to the username. They  don't match for LDAP users, for example. It's bad because re-login needs to be done over and over, but functionality itself is not restricted. Needs to be part of next/first maintenance release for OC 6.

Please review @icewind1991 @bartv2 @bantu 

cc @danimo 
