### PR TITLE
add missing default definition

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -776,6 +776,7 @@
 			<field>
 				<name>propertyvalue</name>
 				<type>text</type>
+				<default></default>
 				<notnull>true</notnull>
 				<length>255</length>
 			</field>


### PR DESCRIPTION
Doctrine reads the schema from the database and receives an emptystring default from postgresql for text columns without a default value. This PR adds the missing definition to the schema so doctrine will no longer consider this a diff.

PR for the apps repo is https://github.com/owncloud/apps/pull/1551

@karlitschek @DeepDiver1975 @bartv2 @kabum @PVince81 please review.

PS: I also suspect issues with oracle ... let us fix PSQL first.
