### PR TITLE
LDAP: the browser shall not autofill userdn and password, usually login ...

### DIFF
--- a/apps/user_ldap/templates/part.wizard-server.php
+++ b/apps/user_ldap/templates/part.wizard-server.php
@@ -41,7 +41,7 @@
 			<div class="tablerow">
 				<input type="text" id="ldap_dn" name="ldap_dn"
 				class="tablecell lwautosave"
-				placeholder="<?php p($l->t('User DN'));?>"
+				placeholder="<?php p($l->t('User DN'));?>" autocomplete="off"
 				title="<?php p($l->t('The DN of the client user with which the bind shall be done, e.g. uid=agent,dc=example,dc=com. For anonymous access, leave DN and Password empty.'));?>"
 				/>
 			</div>
@@ -49,7 +49,7 @@
 			<div class="tablerow">
 				<input type="password" id="ldap_agent_password"
 				class="tablecell lwautosave" name="ldap_agent_password"
-				placeholder="<?php p($l->t('Password'));?>"
+				placeholder="<?php p($l->t('Password'));?>" autocomplete="off"
 				title="<?php p($l->t('For anonymous access, leave DN and Password empty.'));?>"
 				/>
 			</div>


### PR DESCRIPTION
...credentials are inserted. fixes #6283

add just an HTML attribute.  Tested by the bug reporter and found it working.

@kabum @PVince81 or others, ty.
