### PR TITLE
rely only on php DateTime to parse the db datetime string

### DIFF
--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -850,9 +850,8 @@ class Share {
 	protected static function expireItem(array $item) {
 		if (!empty($item['expiration'])) {
 			$now = new \DateTime();
-			$expirationDate = \Doctrine\DBAL\Types\Type::getType('datetime')
-				->convertToPhpValue($item['expiration'], \OC_DB::getConnection()->getDatabasePlatform());
-			if ($now > $expirationDate) {
+			$expires = new \DateTime($item['expiration']);
+			if ($now > $expires) {
 				self::unshareItem($item);
 				return true;
 			}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/6327

The whole conversion to a DateTime object via Doctrine seems unneccessary because only SQLServer uses a different datetime format. The default assumed by doctrine is Y-m-d H:i:s and SQLServer / SQLServer2008 uses Y-m-d H:i:s.000 / Y-m-d H:i:s.u. phps DateTime very well understands any of these formats. So why bother using doctrine here at all?

@bartv2 @karlitschek @PVince81 
