### PR TITLE
Fix webroot for update page

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -12,7 +12,14 @@ var oc_current_user = document.getElementsByTagName('head')[0].getAttribute('dat
 var oc_requesttoken = document.getElementsByTagName('head')[0].getAttribute('data-requesttoken');
 
 if (typeof oc_webroot === "undefined") {
-	oc_webroot = location.pathname.substr(0, location.pathname.lastIndexOf('/'));
+	oc_webroot = location.pathname;
+	var pos = oc_webroot.indexOf('/index.php/');
+	if (pos !== -1) {
+		oc_webroot = oc_webroot.substr(0, pos);
+	}
+	else {
+		oc_webroot = oc_webroot.substr(0, oc_webroot.lastIndexOf('/'));
+	}
 }
 if (oc_debug !== true || typeof console === "undefined" || typeof console.log === "undefined") {
 	if (!window.console) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -265,6 +265,7 @@ class OC {
 					$minimizerCSS->clearCache();
 					$minimizerJS = new OC_Minimizer_JS();
 					$minimizerJS->clearCache();
+					OC_Util::addScript('config'); // needed for web root
 					OC_Util::addScript('update');
 					$tmpl = new OC_Template('', 'update.admin', 'guest');
 					$tmpl->assign('version', OC_Util::getVersionString());


### PR DESCRIPTION
On the update page, config.js was missing which caused oc_webroot to not
be available. That would trigger the faulty oc_webroot fallback that
didn't take URLs like "/owncloud/index.php/files/apps" into account.

This fix adds config.js in the update page and also a fix for the
oc_webroot fallback, in case it is used elsewhere.

This fixes the issue mentionned in #6294 when using the non-"index.php" URL.
