### PR TITLE
Fixing Issue #6301 on master branch

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -382,8 +382,7 @@ class OC_Mount_Config {
 	 * @return array
 	 */
 	public static function getCertificates() {
-		$view = \OCP\Files::getStorage('files_external');
-		$path=\OCP\Config::getSystemValue('datadirectory').$view->getAbsolutePath("").'uploads/';
+		$path=OC_User::getHome(OC_User::getUser()) . '/files_external/uploads/';
 		\OCP\Util::writeLog('files_external', 'checking path '.$path, \OCP\Util::INFO);
 		if ( ! is_dir($path)) {
 			//path might not exist (e.g. non-standard OC_User::getHome() value)
@@ -405,8 +404,7 @@ class OC_Mount_Config {
 	 * creates certificate bundle
 	 */
 	public static function createCertificateBundle() {
-		$view = \OCP\Files::getStorage("files_external");
-		$path = \OCP\Config::getSystemValue('datadirectory').$view->getAbsolutePath("");
+		$path=OC_User::getHome(OC_User::getUser()) . '/files_external';
 
 		$certs = OC_Mount_Config::getCertificates();
 		$fh_certs = fopen($path."/rootcerts.crt", 'w');

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -65,15 +65,15 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 		$this->ready = true;
 
-			$settings = array(
-				'baseUri' => $this->createBaseUri(),
-				'userName' => $this->user,
-				'password' => $this->password,
-			);
+		$settings = array(
+			'baseUri' => $this->createBaseUri(),
+			'userName' => $this->user,
+			'password' => $this->password,
+		);
 
 		$this->client = new \Sabre_DAV_Client($settings);
 
-		if ($this->certPath) {
+		if ($this->secure === true && $this->certPath) {
 			$this->client->addTrustedCertificates($this->certPath);
 		}
 	}
@@ -169,12 +169,14 @@ class DAV extends \OC\Files\Storage\Common{
 				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().str_replace(' ', '%20', $path));
 				curl_setopt($curl, CURLOPT_FILE, $fp);
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-                                curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
-                                curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-                                if($this->certPath){
-                                  curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
-                                }
-
+				if ($this->secure === true) {
+					curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+					curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+					if($this->certPath){
+						curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
+					}
+				}
+				
 				curl_exec ($curl);
 				curl_close ($curl);
 				rewind($fp);
@@ -262,11 +264,13 @@ class DAV extends \OC\Files\Storage\Common{
 		curl_setopt($curl, CURLOPT_INFILE, $source); // file pointer
 		curl_setopt($curl, CURLOPT_INFILESIZE, filesize($path));
 		curl_setopt($curl, CURLOPT_PUT, true);
-                curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
-                curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-                if($this->certPath){
-                  curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
-                }
+		if ($this->secure === true) {
+			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+			if($this->certPath){
+				curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
+			}
+		}
 		curl_exec ($curl);
 		curl_close ($curl);
 	}

--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -14,6 +14,7 @@ class DAV extends \OC\Files\Storage\Common{
 	private $host;
 	private $secure;
 	private $root;
+	private $certPath;
 	private $ready;
 	/**
 	 * @var \Sabre_DAV_Client
@@ -39,6 +40,12 @@ class DAV extends \OC\Files\Storage\Common{
 				}
 			} else {
 				$this->secure = false;
+			}
+			if ($this->secure === true) {
+				$certPath=\OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
+				if (file_exists($certPath)) {
+					$this->certPath=$certPath;
+				}
 			}
 			$this->root=isset($params['root'])?$params['root']:'/';
 			if ( ! $this->root || $this->root[0]!='/') {
@@ -66,12 +73,8 @@ class DAV extends \OC\Files\Storage\Common{
 
 		$this->client = new \Sabre_DAV_Client($settings);
 
-		$caview = \OCP\Files::getStorage('files_external');
-		if ($caview) {
-			$certPath=\OCP\Config::getSystemValue('datadirectory').$caview->getAbsolutePath("").'rootcerts.crt';
-			if (file_exists($certPath)) {
-				$this->client->addTrustedCertificates($certPath);
-			}
+		if ($this->certPath) {
+			$this->client->addTrustedCertificates($this->certPath);
 		}
 	}
 
@@ -166,6 +169,11 @@ class DAV extends \OC\Files\Storage\Common{
 				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().str_replace(' ', '%20', $path));
 				curl_setopt($curl, CURLOPT_FILE, $fp);
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+                                curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+                                curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+                                if($this->certPath){
+                                  curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
+                                }
 
 				curl_exec ($curl);
 				curl_close ($curl);
@@ -254,6 +262,11 @@ class DAV extends \OC\Files\Storage\Common{
 		curl_setopt($curl, CURLOPT_INFILE, $source); // file pointer
 		curl_setopt($curl, CURLOPT_INFILESIZE, filesize($path));
 		curl_setopt($curl, CURLOPT_PUT, true);
+                curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+                curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+                if($this->certPath){
+                  curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
+                }
 		curl_exec ($curl);
 		curl_close ($curl);
 	}
@@ -331,3 +344,4 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 	}
 }
+


### PR DESCRIPTION
Added private var $certPath to store the user root cert

Move logic to determine the $certPath path to the constructor and modify to get the path from OC_User::getHome()

Add curl options to use the certificate to avoid certificate errors with self-signed certicates in the downdload/upload method so we don't get blank files
