### PR TITLE
Add default parameter to OC\AllConfig/OCP\IConfig's getValue's

### DIFF
--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -25,11 +25,13 @@ class AllConfig implements \OCP\IConfig {
 
 	/**
 	 * Looks up a system wide defined value
+	 *
 	 * @param string $key the key of the value, under which it was saved
+	 * @param string $default the default value to be returned if the value isn't set
 	 * @return string the saved value
 	 */
-	public function getSystemValue($key) {
-		return \OCP\Config::getSystemValue($key, '');
+	public function getSystemValue($key, $default = '') {
+		return \OCP\Config::getSystemValue($key, $default);
 	}
 
 
@@ -45,12 +47,14 @@ class AllConfig implements \OCP\IConfig {
 
 	/**
 	 * Looks up an app wide defined value
+	 *
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
+	 * @param string $default the default value to be returned if the value isn't set
 	 * @return string the saved value
 	 */
-	public function getAppValue($appName, $key) {
-		return \OCP\Config::getAppValue($appName, $key, '');
+	public function getAppValue($appName, $key, $default = '') {
+		return \OCP\Config::getAppValue($appName, $key, $default);
 	}
 
 
@@ -70,8 +74,10 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
+	 * @param string $default the default value to be returned if the value isn't set
+	 * @return string
 	 */
-	public function getUserValue($userId, $appName, $key){
-		return \OCP\Config::getUserValue($userId, $appName, $key);
+	public function getUserValue($userId, $appName, $key, $default = null){
+		return \OCP\Config::getUserValue($userId, $appName, $key, $default);
 	}
 }

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -4,7 +4,7 @@
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
- * 
+ *
  */
 
 namespace OC;
@@ -15,6 +15,7 @@ namespace OC;
 class AllConfig implements \OCP\IConfig {
 	/**
 	 * Sets a new system wide value
+	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
 	 * @todo need a use case for this
@@ -37,6 +38,7 @@ class AllConfig implements \OCP\IConfig {
 
 	/**
 	 * Writes a new app wide value
+	 *
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
@@ -60,6 +62,7 @@ class AllConfig implements \OCP\IConfig {
 
 	/**
 	 * Set a user defined value
+	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
@@ -71,13 +74,14 @@ class AllConfig implements \OCP\IConfig {
 
 	/**
 	 * Shortcut for getting a user defined value
+	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param string $default the default value to be returned if the value isn't set
 	 * @return string
 	 */
-	public function getUserValue($userId, $appName, $key, $default = null){
+	public function getUserValue($userId, $appName, $key, $default = '') {
 		return \OCP\Config::getUserValue($userId, $appName, $key, $default);
 	}
 }

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -36,6 +36,7 @@ namespace OCP;
 interface IConfig {
 	/**
 	 * Sets a new system wide value
+	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
 	 * @todo need a use case for this
@@ -44,14 +45,17 @@ interface IConfig {
 
 	/**
 	 * Looks up a system wide defined value
+	 *
 	 * @param string $key the key of the value, under which it was saved
+	 * @param string $default the default value to be returned if the value isn't set
 	 * @return string the saved value
 	 */
-	public function getSystemValue($key);
+	public function getSystemValue($key, $default = '');
 
 
 	/**
 	 * Writes a new app wide value
+	 *
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
@@ -60,15 +64,18 @@ interface IConfig {
 
 	/**
 	 * Looks up an app wide defined value
+	 *
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
+	 * @param string $default the default value to be returned if the value isn't set
 	 * @return string the saved value
 	 */
-	public function getAppValue($appName, $key);
+	public function getAppValue($appName, $key, $default = '');
 
 
 	/**
 	 * Set a user defined value
+	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
@@ -78,9 +85,11 @@ interface IConfig {
 
 	/**
 	 * Shortcut for getting a user defined value
+	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
+	 * @param string $default the default value to be returned if the value isn't set
 	 */
-	public function getUserValue($userId, $appName, $key);
+	public function getUserValue($userId, $appName, $key, $default = '');
 }


### PR DESCRIPTION
Makes the public config interface a bit more usable.

Would like to use this as part of the fix for #6322

cc @PVince81 @karlitschek @DeepDiver1975 
