### PR TITLE
Do not use L10n when logging exceptions

### DIFF
--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -292,9 +292,8 @@ class OC_Template extends \OC\Template\Base {
 			if (!empty($hint)) {
 				$hint = '<pre>'.$hint.'</pre>';
 			}
-			$l = OC_L10N::get('lib');
 			while (method_exists($exception, 'previous') && $exception = $exception->previous()) {
-				$error_msg .= '<br/>'.$l->t('Caused by:').' ';
+				$error_msg .= '<br/>Caused by:' . ' ';
 				if ($exception->getCode()) {
 					$error_msg .= '['.$exception->getCode().'] ';
 				}

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -103,9 +103,8 @@ class Util {
 			}
 
 			// include cause
-			$l = \OC_L10N::get('lib');
 			while (method_exists($ex, 'getPrevious') && $ex = $ex->getPrevious()) {
-				$message .= ' - '.$l->t('Caused by:').' ';
+				$message .= ' - Caused by:' . ' ';
 				$message .= $ex->getMessage();
 				if ($ex->getCode()) {
 					$message .= '[' . $ex->getCode() . '] ';


### PR DESCRIPTION
In some specific situations, the L10N bundle isn't loadable yet (for
example when there is an issue with the app_config table). In such case,
we still want to be able to log the real exception.

This fixes errors that say "OC_L10N_String::__toString must not throw
exceptions"

Please review @DeepDiver1975 @karlitschek @schiesbn 
