### PR TITLE
Workaround for CURLOPT_FOLLOWLOCATION

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -997,7 +997,7 @@ class OC_Util {
 	 * If not, file_get_contents is used.
 	 */
 	public static function getUrlContent($url) {
-		if (function_exists('curl_init')) {
+		if (function_exists('curl_init') AND ini_get('open_basedir') === '' AND ini_get('safe_mode') === 'Off') {
 			$curl = curl_init();
 
 			curl_setopt($curl, CURLOPT_HEADER, 0);


### PR DESCRIPTION
Fix CURLOPT_FOLLOWLOCATION bug with open_basedir or safe_mode restriction enabled.
Bug Description:
https://github.com/owncloud/core/issues/1916
