### PR TITLE
fix quota calculation for Home Storage

### DIFF
--- a/lib/files/storage/home.php
+++ b/lib/files/storage/home.php
@@ -28,4 +28,14 @@ class Home extends Local {
 	public function getId() {
 		return 'home::' . $this->user;
 	}
+	
+	/**
+	 * get the owner of a path
+	 *
+	 * @param string $path The path to get the owner
+	 * @return string uid or false
+	 */
+	public function getOwner($path) {
+		return $this->user;
+	}
 }


### PR DESCRIPTION
The owner of a home storage is the user. Without this the implementation from Storag\Common will be used, returning the logged in user, which is problematic when you want to write code that allows reading the current quota as an administrator. As a result OC_FileProxy_Quota::getFreeSpace will correctly resolve the storage for '/someuser/files' but then use the current user to resolve the storage for '/currentuser/'. The two storage ids are unequal causing the method to always return -1.

Fixes a customer issue.
- [x] forward port to stable6: https://github.com/owncloud/core/pull/6456
- [ ] forward port to master

@icewind1991 @karlitschek @DeepDiver1975 
