### PR TITLE
Fixed apps loading order

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -166,20 +166,22 @@ class OC_App{
 	 * get all enabled apps
 	 */
 	private static $enabledAppsCache = array();
-	public static function getEnabledApps() {
+	public static function getEnabledApps($forceRefresh = false) {
 		if(!OC_Config::getValue('installed', false)) {
 			return array();
 		}
-		if(!empty(self::$enabledAppsCache)) {
+		if(!$forceRefresh && !empty(self::$enabledAppsCache)) {
 			return self::$enabledAppsCache;
 		}
 		$apps=array('files');
 		$sql = 'SELECT `appid` FROM `*PREFIX*appconfig`'
-			.' WHERE `configkey` = \'enabled\' AND `configvalue`=\'yes\'';
+			. ' WHERE `configkey` = \'enabled\' AND `configvalue`=\'yes\''
+			. ' ORDER BY `appid`';
 		if (OC_Config::getValue( 'dbtype', 'sqlite' ) === 'oci') {
 			//FIXME oracle hack: need to explicitly cast CLOB to CHAR for comparison
 			$sql = 'SELECT `appid` FROM `*PREFIX*appconfig`'
-			.' WHERE `configkey` = \'enabled\' AND to_char(`configvalue`)=\'yes\'';
+			. ' WHERE `configkey` = \'enabled\' AND to_char(`configvalue`)=\'yes\''
+			. ' ORDER BY `appid`';
 		}
 		$query = OC_DB::prepare( $sql );
 		$result=$query->execute();

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -52,7 +52,7 @@ class OC_Appconfig {
 	 */
 	public static function getApps() {
 		// No magic in here!
-		$query = OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*appconfig`');
+		$query = OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*appconfig` ORDER BY `appid`');
 		$result = $query->execute();
 
 		$apps = array();

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -79,4 +79,17 @@ class Test_App extends PHPUnit_Framework_TestCase {
 		$this->assertFalse(OC_App::isAppVersionCompatible($oc, $app));
 	}
 
+	/**
+	 * Tests that the app order is correct
+	 */
+	public function testGetEnabledAppsIsSorted() {
+		$apps = \OC_App::getEnabledApps(true);
+		// copy array
+		$sortedApps = $apps;
+		sort($sortedApps);
+		// 'files' is always on top
+		unset($sortedApps[array_search('files', $sortedApps)]);
+		array_unshift($sortedApps, 'files');
+		$this->assertEquals($sortedApps, $apps);
+	}
 }

--- a/tests/lib/appconfig.php
+++ b/tests/lib/appconfig.php
@@ -35,7 +35,7 @@ class Test_Appconfig extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetApps() {
-		$query = \OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*appconfig`');
+		$query = \OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*appconfig` ORDER BY `appid`');
 		$result = $query->execute();
 		$expected = array();
 		while ($row = $result->fetchRow()) {


### PR DESCRIPTION
On SQLite the app order can be arbitrary and cause strange bugs.
On MySQL, the app order seems to be always alphabetical.

This fix enforces alphabetical order to make sure that all environments
behave the same and to reduce bugs related to app loading order.

Fixes #6442 

Please review @karlitschek @schiesbn @DeepDiver1975 @butonic @icewind1991 
