### PR TITLE
Fix ocs searching app support older version

### DIFF
--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -104,7 +104,7 @@ class OC_OCSClient{
 			$categoriesstring=$categories;
 		}
 
-		$version='&version='.implode('x', \OC_Util::getVersion());
+		$version='&version='.implode('x', range(1, \OC_Util::getVersion()[0]));
 		$filterurl='&filter='.urlencode($filter);
 		$url=OC_OCSClient::getAppStoreURL().'/content/data?categories='.urlencode($categoriesstring)
 			.'&sortmode=new&page='.urlencode($page).'&pagesize=100'.$filterurl.$version;


### PR DESCRIPTION
The ocs search syntax uses x as separater. 1x2x3 means search
1 or 2 or 3. It makes no sense to implode the version array with x.
isAppVersionCompatible() in lib/private/app.php logic means it supports
all major version less than current version. This fix makes the search
logic to be the same as the isAppVersionCompatible.
