### PR TITLE
Do not use xcache variable cache if cache size is 0.

### DIFF
--- a/lib/private/memcache/xcache.php
+++ b/lib/private/memcache/xcache.php
@@ -44,11 +44,15 @@ class XCache extends Cache {
 	static public function isAvailable(){
 		if (!extension_loaded('xcache')) {
 			return false;
-		} elseif (\OC::$CLI) {
-			return false;
-		}else{
-			return true;
 		}
+		if (\OC::$CLI) {
+			return false;
+		}
+		$var_size = (int) ini_get('xcache.var_size');
+		if (!$var_size) {
+			return false;
+		}
+		return true;
 	}
 }
 


### PR DESCRIPTION
Fixes #6351

This is possible because it is possible to only use xcache as an opcode cache but not a variable cache.

@DeepDiver1975 
