### PR TITLE
DB: Support DECIMAL(precision,scale) syntax in XML

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -183,6 +183,14 @@ class MDB2SchemaReader {
 					$primary = $this->asBool($child);
 					$options['primary'] = $primary;
 					break;
+				case 'precision':
+					$precision = (string)$child;
+					$options['precision'] = $precision;
+					break;
+				case 'scale':
+					$scale = (string)$child;
+					$options['scale'] = $scale;
+					break;
 				default:
 					throw new \DomainException('Unknown element: ' . $child->getName());
 

--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -216,7 +216,8 @@
     <type>decimal</type>
     <default/>
     <notnull>true</notnull>
-    <length>15</length>
+    <precision>12</precision>
+    <scale>2</scale>
    </field>
   </declaration>
  </table>

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -113,7 +113,8 @@
     <type>decimal</type>
     <default/>
     <notnull>true</notnull>
-    <length>15</length>
+    <precision>12</precision>
+    <scale>2</scale>
    </field>
   </declaration>
  </table>

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -40,6 +40,7 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$this->table1 = $this->test_prefix.'cntcts_addrsbks';
 		$this->table2 = $this->test_prefix.'cntcts_cards';
 		$this->table3 = $this->test_prefix.'vcategory';
+		$this->table4 = $this->test_prefix.'decimal';
 	}
 
 	public function tearDown() {
@@ -172,4 +173,32 @@ class Test_DB extends PHPUnit_Framework_TestCase {
 		$actual = OC_DB::prepare("SELECT `fullname` FROM `$table`")->execute()->fetchOne();
 		$this->assertSame($expected, $actual);
 	}
+
+	public function testDecimal() {
+		$table = "*PREFIX*" . $this->table4;
+		$rowname = 'decimaltest';
+
+		// Insert, select and delete decimal(12,2) values
+		$inserts = array('1337133713.37', '1234567890');
+		$expects = array('1337133713.37', '1234567890.00');
+
+		for ($i = 0; $i < count($inserts); $i++) {
+			$insert = $inserts[$i];
+			$expect = $expects[$i];
+
+			$query = OC_DB::prepare('INSERT INTO `' . $table . '` (`' . $rowname . '`) VALUES (?)');
+			$result = $query->execute(array($insert));
+			$this->assertEquals(1, $result);
+			$query = OC_DB::prepare('SELECT `' . $rowname . '` FROM `' . $table . '`');
+			$result = $query->execute();
+			$this->assertTrue((bool)$result);
+			$row = $result->fetchRow();
+			$this->assertArrayHasKey($rowname, $row);
+			$this->assertEquals($expect, $row[$rowname]);
+			$query = OC_DB::prepare('DELETE FROM `' . $table . '`');
+			$result = $query->execute();
+			$this->assertTrue((bool)$result);
+		}
+	}
+
 }

--- a/tests/lib/db/mdb2schemareader.php
+++ b/tests/lib/db/mdb2schemareader.php
@@ -39,7 +39,7 @@ class MDB2SchemaReader extends \PHPUnit_Framework_TestCase {
 		$this->assertCount(1, $schema->getTables());
 
 		$table = $schema->getTable('test_table');
-		$this->assertCount(7, $table->getColumns());
+		$this->assertCount(8, $table->getColumns());
 
 		$this->assertEquals(4, $table->getColumn('integerfield')->getLength());
 		$this->assertTrue($table->getColumn('integerfield')->getAutoincrement());

--- a/tests/lib/db/mdb2schemareader.php
+++ b/tests/lib/db/mdb2schemareader.php
@@ -69,6 +69,9 @@ class MDB2SchemaReader extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($table->getColumn('booleanfield_true')->getDefault());
 		$this->assertFalse($table->getColumn('booleanfield_false')->getDefault());
 
+		$this->assertEquals(12, $table->getColumn('decimalfield_precision_scale')->getPrecision());
+		$this->assertEquals(2, $table->getColumn('decimalfield_precision_scale')->getScale());
+
 		$this->assertCount(2, $table->getIndexes());
 		$this->assertEquals(array('integerfield'), $table->getIndex('primary')->getUnquotedColumns());
 		$this->assertTrue($table->getIndex('primary')->isPrimary());

--- a/tests/lib/db/testschema.xml
+++ b/tests/lib/db/testschema.xml
@@ -53,6 +53,12 @@
 				<type>boolean</type>
 				<default>false</default>
 			</field>
+			<field>
+				<name>decimalfield_precision_scale</name>
+				<type>decimal</decimal>
+				<precision>12</precision>
+				<scale>2</scale>
+			</field>
 
 			<index>
 				<name>index_primary</name>

--- a/tests/lib/db/testschema.xml
+++ b/tests/lib/db/testschema.xml
@@ -55,7 +55,7 @@
 			</field>
 			<field>
 				<name>decimalfield_precision_scale</name>
-				<type>decimal</decimal>
+				<type>decimal</type>
 				<precision>12</precision>
 				<scale>2</scale>
 			</field>


### PR DESCRIPTION
Add support for specifying the precision and scale of a decimal data
type to the XML description language.

See owncloud/core#6475
