### PR TITLE
do not show 'Add app' and 'More apps' for themed ownCloud

### DIFF
--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -9,7 +9,7 @@
 
 
 <ul id="leftcontent" class="applist">
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if(OC_Config::getValue('appstoreenabled', true) === true): ?>
 	<li>
 		<a class="app-external" target="_blank" href="http://owncloud.org/dev"><?php p($l->t('Add your App'));?> …</a>
 	</li>
@@ -26,7 +26,7 @@
 	</li>
 	<?php endforeach;?>
 
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if(OC_Config::getValue('appstoreenabled', true) === true): ?>
 	<li>
 		<a class="app-external" target="_blank" href="http://apps.owncloud.com"><?php p($l->t('More Apps'));?> …</a>
 	</li>

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -9,9 +9,11 @@
 
 
 <ul id="leftcontent" class="applist">
+	<?php if (OC_Util::getEditionString() === ''): ?>
 	<li>
 		<a class="app-external" target="_blank" href="http://owncloud.org/dev"><?php p($l->t('Add your App'));?> …</a>
 	</li>
+	<?php endif; ?>
 
 	<?php foreach($_['apps'] as $app):?>
 	<li <?php if($app['active']) print_unescaped('class="active"')?> data-id="<?php p($app['id']) ?>"
@@ -24,9 +26,11 @@
 	</li>
 	<?php endforeach;?>
 
+	<?php if (OC_Util::getEditionString() === ''): ?>
 	<li>
 		<a class="app-external" target="_blank" href="http://apps.owncloud.com"><?php p($l->t('More Apps'));?> …</a>
 	</li>
+	<?php endif; ?>
 </ul>
 <div id="rightcontent">
 	<div class="appinfo">


### PR DESCRIPTION
Makes the »Add your app« and »More apps« elements in the App management not show up in themed versions.
Check it @karlitschek @DeepDiver1975 @schiesbn  

Maybe it makes even more sense for the future to have this as a config switch much like a custom 3rd party appstore. On/off and custom links for these functions.

(Also needs to be backported to stable6 for EE.)
