### PR TITLE
Security Update: session fixation

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -243,7 +243,6 @@ class OC_User {
 		OC_Hook::emit( "OC_User", "pre_login", array( "run" => &$run, "uid" => $uid ));
 
 		if($uid) {
-			session_regenerate_id(true);
 			self::setUserId($uid);
 			self::setDisplayName($uid);
 			OC_Hook::emit( "OC_User", "post_login", array( "uid" => $uid, 'password'=>'' ));

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -157,6 +157,7 @@ class Session implements Emitter, \OCP\IUserSession {
 		if($user !== false) {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
+					session_regenerate_id(true);
 					$this->setUser($user);
 					$this->setLoginname($uid);
 					$this->manager->emit('\OC\User', 'postLogin', array($user, $password));


### PR DESCRIPTION
Previous version is vulnerable to session fixation attack in some situations, guessing non-apache-module-php5 environment. Regeneration of session id should be done here.
