### PR TITLE
Made admin password field required on client side

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -54,7 +54,7 @@
 		</p>
 		<p class="infield groupbottom">
 			<input type="password" name="adminpass" data-typetoggle="#show" id="adminpass" placeholder=""
-				value="<?php p(OC_Helper::init_var('adminpass')); ?>" />
+				value="<?php p(OC_Helper::init_var('adminpass')); ?>" required />
 			<label for="adminpass" class="infield"><?php p($l->t( 'Password' )); ?></label>
 			<img class="svg" id="adminpass-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt="" />
 			<input type="checkbox" id="show" name="show" />


### PR DESCRIPTION
The admin login field is required on client side, but the admin password field is required only on server side. If empty password provided then server returns error and red warning. This change checks for empty password on client side (the same way it's done for login).

Fix for case described in https://github.com/syncloud/owncloud-setup/issues/19

MIT licensed
