### PR TITLE
Silence output of 'which' command used in smbclient detection

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -431,7 +431,7 @@ class OC_Mount_Config {
 	 */
 	public static function checksmbclient() {
 		if(function_exists('shell_exec')) {
-			$output=shell_exec('which smbclient');
+			$output=shell_exec('which smbclient 2> /dev/null');
 			return !empty($output);
 		}else{
 			return false;


### PR DESCRIPTION
Opening the admin panel always causes these lines to appear in my apache log:

which: no smbclient in (/sbin:/usr/sbin:/bin:/usr/bin)
which: no smbclient in (/sbin:/usr/sbin:/bin:/usr/bin)
which: no smbclient in (/sbin:/usr/sbin:/bin:/usr/bin)

As the output to stderr is not used, it can just be dropped. Detection of the command still works as before.
