### PR TITLE
don't specify path to 3rdparty directory when registering Pimple autoloader

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -3,7 +3,7 @@
 namespace OC\AppFramework\Utility;
 
 // register 3rdparty autoloaders
-require_once __DIR__ . '/../../../../3rdparty/Pimple/Pimple.php';
+require_once 'Pimple/Pimple.php';
 
 /**
  * Class SimpleContainer


### PR DESCRIPTION
The core 3rdparty directory is in the include_path from lib/base.php anyway, so this is unnecessary, and causes problems for downstream distributors who unbundle Pimple.
