### PR TITLE
Added possibility to disallow create to a user

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -96,7 +96,7 @@ class OC_Util {
 		if($userQuota === 'default') {
 			$userQuota = OC_AppConfig::getValue('files', 'default_quota', 'none');
 		}
-		if($userQuota === 'none') {
+		if($userQuota === 'none' || $userQutoa === 'disallow') {
 			return \OC\Files\SPACE_UNLIMITED;
 		}else{
 			return OC_Helper::computerFileSize($userQuota);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -75,6 +75,11 @@ class OC_Util {
 				mkdir( $userDirectory, 0755, true );
 				OC_Util::copySkeleton($userDirectory);
 			}
+			if( OC_Preferences::getValue($user, 'files', 'quota') === 'disallow' ) {
+				chmod( $userDirectory, 0555 );
+			} else {
+				chmod( $userDirectory, 0755 );
+			}
 			//jail the user into his "home" directory
 			\OC\Files\Filesystem::init($user, $userDir);
 

--- a/settings/ajax/setquota.php
+++ b/settings/ajax/setquota.php
@@ -20,7 +20,7 @@ if(($username === '' && !OC_User::isAdminUser(OC_User::getUser()))
 
 //make sure the quota is in the expected format
 $quota=$_POST["quota"];
-if($quota !== 'none' and $quota !== 'default') {
+if($quota !== 'none' and $quota !== 'default' and $quota !== 'disallow') {
 	$quota= OC_Helper::computerFileSize($quota);
 	$quota=OC_Helper::humanFileSize($quota);
 }

--- a/settings/users.php
+++ b/settings/users.php
@@ -34,7 +34,7 @@ if($isadmin) {
 }
 
 // load preset quotas
-$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
+$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', 'disallow, 1 GB, 5 GB, 10 GB');
 $quotaPreset=explode(',', $quotaPreset);
 foreach($quotaPreset as &$preset) {
 	$preset=trim($preset);


### PR DESCRIPTION
I would like to add feature requested by issue #2696.

This is the approach I chose:
I add a "disallow" option in quotas.
This option removes writes on user's "files" folder, so it display a message to the user saying he can't write in this directory.
In my commit d5042cbc59e33dbb88aa174f17ecd884d1008e6a, I transform quota from 0 to unlimited to avoid displaying top message saying user hasn't enough free space in his directory. (He's considered as a limited user without write permission, so it's worth telling him he hasn't enough space, 'cause he can't write).

I don't know how to display a correctly translated "disallow" in quota list. Please help me.

P.S: It's my first commit to this project, please correct me if I don't respect standards/norms. I'm wide opened to all remarks.
If I misspoke, don't hesitate to tell me :-)

P.S2: I'm french, sorry for my english.
