### PR TITLE
Use autoloader for Archive and Pimple

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -413,6 +413,7 @@ class OC {
 		self::$loader->registerPrefix('Sabre\\VObject', '3rdparty');
 		self::$loader->registerPrefix('Sabre_', '3rdparty');
 		self::$loader->registerPrefix('Patchwork', '3rdparty');
+		self::$loader->registerPrefix('Archive', '3rdparty');
 		spl_autoload_register(array(self::$loader, 'load'));
 
 		// set some stuff

--- a/lib/base.php
+++ b/lib/base.php
@@ -414,6 +414,7 @@ class OC {
 		self::$loader->registerPrefix('Sabre_', '3rdparty');
 		self::$loader->registerPrefix('Patchwork', '3rdparty');
 		self::$loader->registerPrefix('Archive', '3rdparty');
+		self::$loader->registerPrefix('Pimple', 'Pimple');
 		spl_autoload_register(array(self::$loader, 'load'));
 
 		// set some stuff

--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -2,9 +2,6 @@
 
 namespace OC\AppFramework\Utility;
 
-// register 3rdparty autoloaders
-require_once 'Pimple/Pimple.php';
-
 /**
  * Class SimpleContainer
  *

--- a/lib/private/archive/tar.php
+++ b/lib/private/archive/tar.php
@@ -6,8 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once OC::$THIRDPARTYROOT . '/3rdparty/Archive/Tar.php';
-
 class OC_Archive_TAR extends OC_Archive{
 	const PLAIN=0;
 	const GZIP=1;


### PR DESCRIPTION
This makes life easier for downstreams who unbundle third party libraries. I've tested (in a very ugly and probably stupid way) that this will find Archive/Tar.php from OC's 3rdparty directory if it's there, or a system copy if OC's 3rdparty copy isn't there, on a test Fedora 20 instance.

Again, I'm just the monkey, I really don't know much about this stuff. All I know about OC's system of loading I learned today by bashing on it extremely inexpertly. Please check it carefully :)
