### PR TITLE
Return SPACE_UNKNOWN if disk_free_space is disabled

### DIFF
--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -256,7 +256,7 @@ if (\OC_Util::runningOnWindows()) {
 
 		public function free_space($path) {
 			$space = @disk_free_space($this->datadir . $path);
-			if ($space === false) {
+			if ($space === false || is_null($space)) {
 				return \OC\Files\SPACE_UNKNOWN;
 			}
 			return $space;


### PR DESCRIPTION
Fixes oC incorrectly reporting a full storage.

Fixes #6592 

Testable by disabling disk_free_space in php.ini and checking your filesystem quota

cc @DeepDiver1975 @karlitschek @seberm
