### PR TITLE
Make OC_Avatar unit tests independent of currently loggedin user

### DIFF
--- a/tests/lib/avatar.php
+++ b/tests/lib/avatar.php
@@ -1,20 +1,28 @@
 <?php
+
 /**
  * Copyright (c) 2013 Christopher Schäpers <christopher@schaepers.it>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
  */
-
 class Test_Avatar extends PHPUnit_Framework_TestCase {
+
+	private $user;
+
+	public function setUp() {
+		$this->user = uniqid();
+		$storage = new \OC\Files\Storage\Temporary(array());
+		\OC\Files\Filesystem::mount($storage, array(), '/' . $this->user . '/');
+	}
 
 	public function testAvatar() {
 
-		$avatar = new \OC_Avatar(\OC_User::getUser());
+		$avatar = new \OC_Avatar($this->user);
 
 		$this->assertEquals(false, $avatar->get());
 
-		$expected = new OC_Image(\OC::$SERVERROOT.'/tests/data/testavatar.png');
+		$expected = new OC_Image(\OC::$SERVERROOT . '/tests/data/testavatar.png');
 		$expected->resize(64);
 		$avatar->set($expected->data());
 		$this->assertEquals($expected->data(), $avatar->get()->data());
@@ -25,11 +33,11 @@ class Test_Avatar extends PHPUnit_Framework_TestCase {
 
 	public function testAvatarApi() {
 		$avatarManager = \OC::$server->getAvatarManager();
-		$avatar = $avatarManager->getAvatar(\OC_User::getUser());
+		$avatar = $avatarManager->getAvatar($this->user);
 
 		$this->assertEquals(false, $avatar->get());
 
-		$expected = new OC_Image(\OC::$SERVERROOT.'/tests/data/testavatar.png');
+		$expected = new OC_Image(\OC::$SERVERROOT . '/tests/data/testavatar.png');
 		$expected->resize(64);
 		$avatar->set($expected->data());
 		$this->assertEquals($expected->data(), $avatar->get()->data());


### PR DESCRIPTION
Otherwise the test case will fail if the logged in user has an avatar.

This makes running the tests on a local dev environment a bit easier

cc @DeepDiver1975 @karlitschek @Kondou-ger 
