### PR TITLE
Fix APCIterator syntax in \OC\Memcache\APCu::clear

### DIFF
--- a/lib/private/memcache/apcu.php
+++ b/lib/private/memcache/apcu.php
@@ -12,7 +12,7 @@ class APCu extends APC {
 	public function clear($prefix = '') {
 		$ns = $this->getNamespace() . $prefix;
 		$ns = preg_quote($ns, '/');
-		$iter = new \APCIterator('/^'.$ns.'/');
+		$iter = new \APCIterator('user', '/^'.$ns.'/');
 		return apc_delete($iter);
 	}
 


### PR DESCRIPTION
see http://www.php.net/manual/en/apciterator.construct.php

This got past automated testing since jenkins doesn't have APCu installed.

cc @DeepDiver1975 @bartv2 @karlitschek 
