### PR TITLE
autoloader: PSR-0 compliance, find generic classes via PSR-0 relative paths

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -101,13 +101,14 @@ class Autoloader {
 		} elseif (strpos($class, 'Test\\') === 0) {
 			$paths[] = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
 		} else {
-			foreach ($this->prefixPaths as $prefix => $dir) {
-				if (0 === strpos($class, $prefix)) {
-					$path = str_replace('\\', '/', $class) . '.php';
-					$path = str_replace('_', '/', $path);
-					$paths[] = $dir . '/' . $path;
-				}
+			$namespace = '';
+			$path = '';
+			if ($lastNsPos = strrpos($class, '\\')) {
+				$namespace = substr($class, 0, $lastNsPos);
+				$class = substr($class, $lastNsPos + 1);
+				$path = str_replace('\\', '/', $namespace) . '/';
 			}
+			$paths[] = $path . str_replace('_', '/', $class) . '.php';
 		}
 		return $paths;
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -168,6 +168,10 @@ class OC {
 			OC::$SERVERROOT . '/lib/private' . PATH_SEPARATOR .
 			OC::$SERVERROOT . '/config' . PATH_SEPARATOR .
 			OC::$THIRDPARTYROOT . '/3rdparty' . PATH_SEPARATOR .
+			OC::$THIRDPARTYROOT . '/3rdparty/doctrine/common/lib' . PATH_SEPARATOR .
+			OC::$THIRDPARTYROOT . '/3rdparty/doctrine/dbal/lib' . PATH_SEPARATOR .
+			OC::$THIRDPARTYROOT . '/3rdparty/symfony/routing' . PATH_SEPARATOR .
+			OC::$THIRDPARTYROOT . '/3rdparty/symfony/console' . PATH_SEPARATOR .
 			implode($paths, PATH_SEPARATOR) . PATH_SEPARATOR .
 			get_include_path() . PATH_SEPARATOR .
 			OC::$SERVERROOT
@@ -406,13 +410,6 @@ class OC {
 		// register autoloader
 		require_once __DIR__ . '/autoloader.php';
 		self::$loader = new \OC\Autoloader();
-		self::$loader->registerPrefix('Doctrine\\Common', 'doctrine/common/lib');
-		self::$loader->registerPrefix('Doctrine\\DBAL', 'doctrine/dbal/lib');
-		self::$loader->registerPrefix('Symfony\\Component\\Routing', 'symfony/routing');
-		self::$loader->registerPrefix('Symfony\\Component\\Console', 'symfony/console');
-		self::$loader->registerPrefix('Sabre\\VObject', '3rdparty');
-		self::$loader->registerPrefix('Sabre_', '3rdparty');
-		self::$loader->registerPrefix('Patchwork', '3rdparty');
 		spl_autoload_register(array(self::$loader, 'load'));
 
 		// set some stuff

--- a/lib/base.php
+++ b/lib/base.php
@@ -172,6 +172,7 @@ class OC {
 			OC::$THIRDPARTYROOT . '/3rdparty/doctrine/dbal/lib' . PATH_SEPARATOR .
 			OC::$THIRDPARTYROOT . '/3rdparty/symfony/routing' . PATH_SEPARATOR .
 			OC::$THIRDPARTYROOT . '/3rdparty/symfony/console' . PATH_SEPARATOR .
+                        OC::$THIRDPARTYROOT . '/3rdparty/Pimple' . PATH_SEPARATOR .
 			implode($paths, PATH_SEPARATOR) . PATH_SEPARATOR .
 			get_include_path() . PATH_SEPARATOR .
 			OC::$SERVERROOT


### PR DESCRIPTION
Firstly, this makes the autoloader more PSR-0 compliant: it allows underscores in namespaces, as the spec requires. (This is based on the PSR-0 spec's reference loader, https://gist.github.com/jwage/221634 , all errors mine! I haven't actually tested this bit yet, as OC doesn't use any modules that use a namespace with underscores in it, AFAICT. I'll hack up a test shortly.)

Secondly, instead of defining prefixes for specific classes and unconditionally including them in the result of findClass, it makes findClass simply return a PSR-0 style relative path for _any_ non-OC class, and adds the appropriate top level directories for modules that are not already PSR-0 compliant from 3rdparty/ to the include_path in base.php. This allows for the possibility that the libraries will not be found in the OwnCloud 3rdparty tree and instead a systemwide copy should be loaded (as downstream distributions might like to do).

I have tested that a Fedora OwnCloud package with this patch applies works in basic testing and successfully finds OC internal classes, classes in owncloud's 3rdparty directory, and classes that have been unbundled from OwnCloud in Fedora but are available in a PSR-0 compliant location on the system include path (/usr/share/php , /usr/share/pear etc). I haven't run the full test suite, or picked through the code looking for cases where a 'super helpful' autoloader might possibly DTWT; I'm still not enough of an expert to really be able to evaluate that possibility.

Consider this PR a trial balloon, if you like, there are other possible approaches here and you may not like the idea of the autoloader kicking in for all classes. Obviously an alternative to adding the PSR-0 top level directories for doctrine and symfony to the include path would be to move those modules themselves in 3rdparty/ so they're PSR-0 compliant wrt 3rdparty/ , that would be functionally equivalent to what happens in base.php here, more or less.

Basically the problem I'm trying to solve is that owncloud's prefixes don't work with downstream unbundling. Up till now in Fedora we've used an alternative patch which has findClass() check if its result worked (using stream_resolve_include_path) and if it didn't, try again without the prefix. That's one of the possible alternative approaches, and the patch that does that can be seen at http://pkgs.fedoraproject.org/cgit/owncloud.git/tree/owncloud-6.0.0-fix-autoloader.patch . Debian instead just patches the prefixes used in base.php when registering classes with the autoloader: http://patch-tracker.debian.org/patch/series/view/owncloud/6.0.0.a+dfsg-1/path/0007-Adapt-Doctrine-Symphony-Sabre-and-Patchwork-path.patch - we (Fedora maintainers) don't think that's a great approach, though.
