### PR TITLE
drop OC_User_IMAP use from sample config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -210,12 +210,6 @@ $CONFIG = array(
 		'writable' => true,
 	),
 ),
-'user_backends'=>array(
-	array(
-		'class'=>'OC_User_IMAP',
-		'arguments'=>array('{imap.gmail.com:993/imap/ssl}INBOX')
-	)
-),
 //links to custom clients
 'customclient_desktop' => '', //http://owncloud.org/sync-clients/
 'customclient_android' => '', //https://play.google.com/store/apps/details?id=com.owncloud.android


### PR DESCRIPTION
OC_User_IMAP doesn't actually exist in OC 6 any more. Anyone who bases their config on the sample will have a log jammed with "User backend OC_User_IMAP not found" errors (several of which you can already find from Google).
