### PR TITLE
Fix internet detection to use OC_Util::getUrlContent

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -892,6 +892,11 @@ class OC_Util {
 			return false;
 		}
 
+		// in case the connection is via proxy return true to avoid connecting to owncloud.org
+		if(OC_Config::getValue('proxy', '') != '') {
+			return true;
+		}
+
 		// try to connect to owncloud.org to see if http connections to the internet are possible.
 		$connected = @fsockopen("www.owncloud.org", 80);
 		if ($connected) {


### PR DESCRIPTION
When using owncloud behind a proxy with a firewall restricting the port 80, it timeouts when detecting internet availability.
By using OC_Util::getUrlContent instead of fsockopen, the detections is done properly handling both proxy and no proxy cases.
