### PR TITLE
Removed special handling of part files in shared storage rename

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -242,7 +242,10 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 			$fileExists = $fs->file_exists($targetPath);
 			if ($renameOkay === false || $fileExists === false) {
 				\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
-				$fs->unlink($targetPath);
+				// only delete if an error occurred and the target file was already created
+				if ($fileExists) {
+					$fs->unlink($targetPath);
+				}
 				throw new Sabre_DAV_Exception();
 			}
 


### PR DESCRIPTION
This fixes the issue introduced by the transfer id which itself wasn't
taken into account by the shortcut code for part file in the shared
storage class.

Fixes #6608 

Please review @DeepDiver1975 @karlitschek @icewind1991 @schiesbn 
