### PR TITLE
Adding Lazy Image Load for Icons

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -31,6 +31,7 @@ OCP\Util::addscript('files', 'file-upload');
 OCP\Util::addscript('files', 'jquery.iframe-transport');
 OCP\Util::addscript('files', 'jquery.fileupload');
 OCP\Util::addscript('files', 'jquery-visibility');
+OCP\Util::addscript('files', 'jquery.lazyload');
 OCP\Util::addscript('files', 'filelist');
 
 OCP\App::setActiveNavigationEntry('files_index');

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -625,8 +625,10 @@ $(document).ready(function() {
 									tr.attr('data-id', result.data.id);
 									tr.attr('data-etag', result.data.etag);
 									tr.find('.filesize').text(humanFileSize(result.data.size));
-									FileActions.display(tr.find('td.filename'), true);
-									$('#fileList .lazy').lazyload();
+
+									var tds = tr.find('td.filename');
+									FileActions.display(tds, true);
+									tds.lazyload();
 								} else {
 									OC.dialogs.alert(result.data.message, t('core', 'Could not create file'));
 								}
@@ -686,8 +688,10 @@ $(document).ready(function() {
 							var tr = FileList.findFileEl(localName);
 							tr.data('mime', mime).data('id', id);
 							tr.attr('data-id', id);
-							FileActions.display(tr.find('td.filename'), true);
-							$('#fileList .lazy').lazyload();
+
+							var tds = tr.find('td.filename');
+							FileActions.display(tds, true);
+							tds.lazyload();
 						});
 						eventSource.listen('error',function(error) {
 							$('#uploadprogressbar').fadeOut();

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -619,7 +619,7 @@ $(document).ready(function() {
 									// TODO: ideally addFile should be able to receive
 									// all attributes and set them automatically,
 									// and also auto-load the preview
-									var tr = FileList.addFile(name, result.data.etag, 0, date, false, hidden);
+									var tr = FileList.addFile(name, 0, date, false, hidden, {etag: result.data.etag});
 									tr.attr('data-size', result.data.size);
 									tr.attr('data-mime', result.data.mime);
 									tr.attr('data-id', result.data.id);
@@ -682,7 +682,7 @@ $(document).ready(function() {
 							var id = data.id;
 							$('#uploadprogressbar').fadeOut();
 							var date = new Date();
-							FileList.addFile(localName, data.etag, size, date, false, hidden);
+							FileList.addFile(localName, size, date, false, hidden, {etag: data.etag});
 							var tr = FileList.findFileEl(localName);
 							tr.data('mime', mime).data('id', id);
 							tr.attr('data-id', id);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -619,17 +619,14 @@ $(document).ready(function() {
 									// TODO: ideally addFile should be able to receive
 									// all attributes and set them automatically,
 									// and also auto-load the preview
-									var tr = FileList.addFile(name, 0, date, false, hidden);
+									var tr = FileList.addFile(name, result.data.etag, 0, date, false, hidden);
 									tr.attr('data-size', result.data.size);
 									tr.attr('data-mime', result.data.mime);
 									tr.attr('data-id', result.data.id);
 									tr.attr('data-etag', result.data.etag);
 									tr.find('.filesize').text(humanFileSize(result.data.size));
-									var path = getPathForPreview(name);
-									Files.lazyLoadPreview(path, result.data.mime, function(previewpath) {
-										tr.find('td.filename').attr('style','background-image:url('+previewpath+')');
-									}, null, null, result.data.etag);
 									FileActions.display(tr.find('td.filename'), true);
+									$('#fileList .lazy').lazyload();
 								} else {
 									OC.dialogs.alert(result.data.message, t('core', 'Could not create file'));
 								}
@@ -685,15 +682,12 @@ $(document).ready(function() {
 							var id = data.id;
 							$('#uploadprogressbar').fadeOut();
 							var date = new Date();
-							FileList.addFile(localName, size, date, false, hidden);
+							FileList.addFile(localName, data.etag, size, date, false, hidden);
 							var tr = FileList.findFileEl(localName);
 							tr.data('mime', mime).data('id', id);
 							tr.attr('data-id', id);
-							var path = $('#dir').val()+'/'+localName;
-							Files.lazyLoadPreview(path, mime, function(previewpath) {
-								tr.find('td.filename').attr('style', 'background-image:url('+previewpath+')');
-							}, null, null, data.etag);
 							FileActions.display(tr.find('td.filename'), true);
+							$('#fileList .lazy').lazyload();
 						});
 						eventSource.listen('error',function(error) {
 							$('#uploadprogressbar').fadeOut();

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -971,8 +971,6 @@ $(document).ready(function() {
 					return;
 				}
 
-				$('#fileList .lazy').removeLazyload();				
-
 				// add as stand-alone row to filelist
 				var size=t('files', 'Pending');
 				if (data.files[0].size>=0) {
@@ -999,8 +997,10 @@ $(document).ready(function() {
 					data.context.attr('data-permissions', file.permissions);
 					data.context.data('permissions', file.permissions);
 				}
-				FileActions.display(data.context.find('td.filename'), true);
-				$('#fileList .lazy').lazyload();
+
+				var tds = data.context.find('td.filename');
+				FileActions.display(tds, true);
+				tds.lazyload();
 			}
 		}
 	});

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -755,6 +755,8 @@ window.FileList={
 				$connector.show();
 			}
 		}
+
+		$(".lazy").lazyload();
 	},
 	updateEmptyContent: function() {
 		var $fileList = $('#fileList');
@@ -848,6 +850,8 @@ window.FileList={
 
 $(document).ready(function() {
 	var isPublic = !!$('#isPublic').val();
+
+	$(".lazy").lazyload();
 
 	// handle upload events
 	var file_upload_start = $('#file_upload_start');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -26,6 +26,8 @@ window.FileList={
 		return $('#fileList tr').filterAttr('data-file', fileName);
 	},
 	update:function(fileListHtml) {
+		$('#fileList .lazy').removeLazyload();
+
 		var $fileList = $('#fileList');
 		$fileList.empty().html(fileListHtml);
 		FileList.updateEmptyContent();
@@ -969,6 +971,8 @@ $(document).ready(function() {
 					return;
 				}
 
+				$('#fileList .lazy').removeLazyload();				
+
 				// add as stand-alone row to filelist
 				var size=t('files', 'Pending');
 				if (data.files[0].size>=0) {
@@ -994,7 +998,6 @@ $(document).ready(function() {
 					data.context.data('permissions', file.permissions);
 				}
 				FileActions.display(data.context.find('td.filename'), true);
-
 				$('#fileList .lazy').lazyload();
 			}
 		}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -756,7 +756,7 @@ window.FileList={
 			}
 		}
 
-		$(".lazy").lazyload();
+		$('#fileList .lazy').lazyload();
 	},
 	updateEmptyContent: function() {
 		var $fileList = $('#fileList');
@@ -851,7 +851,7 @@ window.FileList={
 $(document).ready(function() {
 	var isPublic = !!$('#isPublic').val();
 
-	$(".lazy").lazyload();
+	$('#fileList .lazy').lazyload();
 
 	// handle upload events
 	var file_upload_start = $('#file_upload_start');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -115,7 +115,7 @@ window.FileList={
 		tr.append(td);
 		return tr;
 	},
-	addFile:function(name, etag, size, lastModified, loading, hidden, param) {
+	addFile:function(name, size, lastModified, loading, hidden, param) {
 		var imgurl;
 		var filepath = getPathForPreview(name);
 
@@ -133,7 +133,7 @@ window.FileList={
 		if (loading) {
 			imgurl = OC.imagePath('core', 'loading.gif');
 		} else {
-			imgurl = Files.getPreviewIconURL(filepath, null, null, etag)
+			imgurl = Files.getPreviewIconURL(filepath, null, null, param.etag)
 		}
 		var tr = this.createRow(
 			'file',
@@ -985,9 +985,11 @@ $(document).ready(function() {
 				}
 				//should the file exist in the list remove it
 				FileList.remove(file.name);
+				
+				param.etag = file.etag;
 
 				// create new file context
-				data.context = FileList.addFile(file.name, file.etag, file.size, date, false, false, param);
+				data.context = FileList.addFile(file.name, file.size, date, false, false, param);
 
 				// update file data
 				data.context.attr('data-mime',file.mime).attr('data-id',file.id).attr('data-etag', file.etag);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -55,8 +55,9 @@ window.FileList={
 		});
 		// filename td
 		td = $('<td></td>').attr({
-			"class": "filename",
-			"style": 'background-image:url('+iconurl+'); background-size: 32px;'
+			"class": "filename lazy",
+			"style": 'background-size: 32px;',
+			"data-original": iconurl
 		});
 		var rand = Math.random().toString(16).slice(2);
 		td.append('<input id="select-'+rand+'" type="checkbox" /><label for="select-'+rand+'"></label>');
@@ -112,8 +113,9 @@ window.FileList={
 		tr.append(td);
 		return tr;
 	},
-	addFile:function(name, size, lastModified, loading, hidden, param) {
+	addFile:function(name, etag, size, lastModified, loading, hidden, param) {
 		var imgurl;
+		var filepath = getPathForPreview(name);
 
 		if (!param) {
 			param = {};
@@ -121,7 +123,7 @@ window.FileList={
 
 		var download_url = null;
 		if (!param.download_url) {
-			download_url = OC.Router.generate('download', { file: $('#dir').val()+'/'+name });
+			download_url = OC.Router.generate('download', { file: filepath });
 		} else {
 			download_url = param.download_url;
 		}
@@ -129,7 +131,7 @@ window.FileList={
 		if (loading) {
 			imgurl = OC.imagePath('core', 'loading.gif');
 		} else {
-			imgurl = OC.imagePath('core', 'filetypes/file.png');
+			imgurl = Files.getPreviewIconURL(filepath, null, null, etag)
 		}
 		var tr = this.createRow(
 			'file',
@@ -981,7 +983,7 @@ $(document).ready(function() {
 				FileList.remove(file.name);
 
 				// create new file context
-				data.context = FileList.addFile(file.name, file.size, date, false, false, param);
+				data.context = FileList.addFile(file.name, file.etag, file.size, date, false, false, param);
 
 				// update file data
 				data.context.attr('data-mime',file.mime).attr('data-id',file.id).attr('data-etag', file.etag);
@@ -993,10 +995,7 @@ $(document).ready(function() {
 				}
 				FileActions.display(data.context.find('td.filename'), true);
 
-				var path = getPathForPreview(file.name);
-				Files.lazyLoadPreview(path, file.mime, function(previewpath) {
-					data.context.find('td.filename').attr('style','background-image:url('+previewpath+')');
-				}, null, null, file.etag);
+				$('#fileList .lazy').lazyload();
 			}
 		}
 	});

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -563,6 +563,7 @@ var dragOptions={
 				$(this).fadeTo(250, 1);
 			}
 			$('#fileList tr td.filename').addClass('ui-draggable');
+			$('.dragshadow .lazy').removeLazyload();
 		}
 };
 // sane browsers support using the distance option

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -518,16 +518,14 @@ var createDragShadow = function(event) {
 
 	$(selectedFiles).each(function(i,elem) {
 		var newtr = $('<tr/>').attr('data-dir', dir).attr('data-filename', elem.name).attr('data-origin', elem.origin);
-		newtr.append($('<td/>').addClass('filename').text(elem.name));
+		newtr.append($('<td/>').addClass('filename lazy').text(elem.name));
 		newtr.append($('<td/>').addClass('size').text(humanFileSize(elem.size)));
 		tbody.append(newtr);
 		if (elem.type === 'dir') {
-			newtr.find('td.filename').attr('style','background-image:url('+OC.imagePath('core', 'filetypes/folder.png')+')');
+			newtr.find('td.filename').attr('data-original',OC.imagePath('core', 'filetypes/folder.png'));
 		} else {
 			var path = getPathForPreview(elem.name);
-			Files.lazyLoadPreview(path, elem.mime, function(previewpath) {
-				newtr.find('td.filename').attr('style','background-image:url('+previewpath+')');
-			}, null, null, elem.etag);
+			newtr.find('td.filename').attr('data-original',Files.getPreviewIconURL(path, null, null, elem.etag));
 		}
 	});
 
@@ -548,6 +546,13 @@ var dragOptions={
 			else{
 				$(this).fadeTo(250, 0.2);
 			}
+			
+			$('.dragshadow .lazy').lazyload();
+		},
+		drag: function(event, ui) {
+			// force lazy image load check when the user drags more elements up into view
+			// when it is a long list. ordinarily only does this on scrolling not mouse movement.
+			$(window).scroll();
 		},
 		stop: function(event, ui) {
 			var $selectedFiles = $('td.filename input:checkbox:checked');

--- a/apps/files/js/jquery.lazyload.js
+++ b/apps/files/js/jquery.lazyload.js
@@ -1,0 +1,242 @@
+/*
+ * Lazy Load - jQuery plugin for lazy loading images
+ *
+ * Copyright (c) 2007-2013 Mika Tuupola
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   http://www.appelsiini.net/projects/lazyload
+ *
+ * Version:  1.9.1
+ *
+ */
+
+(function($, window, document, undefined) {
+    var $window = $(window);
+
+    $.fn.lazyload = function(options) {
+        var elements = this;
+        var $container;
+        var settings = {
+            threshold       : 0,
+            failure_limit   : 0,
+            event           : "scroll",
+            effect          : "show",
+            container       : window,
+            data_attribute  : "original",
+            skip_invisible  : true,
+            appear          : null,
+            load            : null,
+            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+        };
+
+        function update() {
+            var counter = 0;
+
+            elements.each(function() {
+                var $this = $(this);
+                if (settings.skip_invisible && !$this.is(":visible")) {
+                    return;
+                }
+                if ($.abovethetop(this, settings) ||
+                    $.leftofbegin(this, settings)) {
+                        /* Nothing. */
+                } else if (!$.belowthefold(this, settings) &&
+                    !$.rightoffold(this, settings)) {
+                        $this.trigger("appear");
+                        /* if we found an image we'll load, reset the counter */
+                        counter = 0;
+                } else {
+                    if (++counter > settings.failure_limit) {
+                        return false;
+                    }
+                }
+            });
+
+        }
+
+        if(options) {
+            /* Maintain BC for a couple of versions. */
+            if (undefined !== options.failurelimit) {
+                options.failure_limit = options.failurelimit;
+                delete options.failurelimit;
+            }
+            if (undefined !== options.effectspeed) {
+                options.effect_speed = options.effectspeed;
+                delete options.effectspeed;
+            }
+
+            $.extend(settings, options);
+        }
+
+        /* Cache container as jQuery as object. */
+        $container = (settings.container === undefined ||
+                      settings.container === window) ? $window : $(settings.container);
+
+        /* Fire one scroll event per scroll. Not one scroll event per image. */
+        if (0 === settings.event.indexOf("scroll")) {
+            $container.bind(settings.event, function() {
+                return update();
+            });
+        }
+
+        this.each(function() {
+            var self = this;
+            var $self = $(self);
+
+            self.loaded = false;
+
+            /* If no src attribute given use data:uri. */
+            if ($self.attr("src") === undefined || $self.attr("src") === false) {
+                if ($self.is("img")) {
+                    $self.attr("src", settings.placeholder);
+                }
+            }
+
+            /* When appear is triggered load original image. */
+            $self.one("appear", function() {
+                if (!this.loaded) {
+                    if (settings.appear) {
+                        var elements_left = elements.length;
+                        settings.appear.call(self, elements_left, settings);
+                    }
+                    $("<img />")
+                        .bind("load", function() {
+
+                            var original = $self.attr("data-" + settings.data_attribute);
+                            $self.hide();
+                            if ($self.is("img")) {
+                                $self.attr("src", original);
+                            } else {
+                                $self.css("background-image", "url('" + original + "')");
+                            }
+                            $self[settings.effect](settings.effect_speed);
+
+                            self.loaded = true;
+
+                            /* Remove image from array so it is not looped next time. */
+                            var temp = $.grep(elements, function(element) {
+                                return !element.loaded;
+                            });
+                            elements = $(temp);
+
+                            if (settings.load) {
+                                var elements_left = elements.length;
+                                settings.load.call(self, elements_left, settings);
+                            }
+                        })
+                        .attr("src", $self.attr("data-" + settings.data_attribute));
+                }
+            });
+
+            /* When wanted event is triggered load original image */
+            /* by triggering appear.                              */
+            if (0 !== settings.event.indexOf("scroll")) {
+                $self.bind(settings.event, function() {
+                    if (!self.loaded) {
+                        $self.trigger("appear");
+                    }
+                });
+            }
+        });
+
+        /* Check if something appears when window is resized. */
+        $window.bind("resize", function() {
+            update();
+        });
+
+        /* With IOS5 force loading images when navigating with back button. */
+        /* Non optimal workaround. */
+        if ((/(?:iphone|ipod|ipad).*os 5/gi).test(navigator.appVersion)) {
+            $window.bind("pageshow", function(event) {
+                if (event.originalEvent && event.originalEvent.persisted) {
+                    elements.each(function() {
+                        $(this).trigger("appear");
+                    });
+                }
+            });
+        }
+
+        /* Force initial check if images should appear. */
+        $(document).ready(function() {
+            update();
+        });
+
+        return this;
+    };
+
+    /* Convenience methods in jQuery namespace.           */
+    /* Use as  $.belowthefold(element, {threshold : 100, container : window}) */
+
+    $.belowthefold = function(element, settings) {
+        var fold;
+
+        if (settings.container === undefined || settings.container === window) {
+            fold = (window.innerHeight ? window.innerHeight : $window.height()) + $window.scrollTop();
+        } else {
+            fold = $(settings.container).offset().top + $(settings.container).height();
+        }
+
+        return fold <= $(element).offset().top - settings.threshold;
+    };
+
+    $.rightoffold = function(element, settings) {
+        var fold;
+
+        if (settings.container === undefined || settings.container === window) {
+            fold = $window.width() + $window.scrollLeft();
+        } else {
+            fold = $(settings.container).offset().left + $(settings.container).width();
+        }
+
+        return fold <= $(element).offset().left - settings.threshold;
+    };
+
+    $.abovethetop = function(element, settings) {
+        var fold;
+
+        if (settings.container === undefined || settings.container === window) {
+            fold = $window.scrollTop();
+        } else {
+            fold = $(settings.container).offset().top;
+        }
+
+        return fold >= $(element).offset().top + settings.threshold  + $(element).height();
+    };
+
+    $.leftofbegin = function(element, settings) {
+        var fold;
+
+        if (settings.container === undefined || settings.container === window) {
+            fold = $window.scrollLeft();
+        } else {
+            fold = $(settings.container).offset().left;
+        }
+
+        return fold >= $(element).offset().left + settings.threshold + $(element).width();
+    };
+
+    $.inviewport = function(element, settings) {
+         return !$.rightoffold(element, settings) && !$.leftofbegin(element, settings) &&
+                !$.belowthefold(element, settings) && !$.abovethetop(element, settings);
+     };
+
+    /* Custom selectors for your convenience.   */
+    /* Use as $("img:below-the-fold").something() or */
+    /* $("img").filter(":below-the-fold").something() which is faster */
+
+    $.extend($.expr[":"], {
+        "below-the-fold" : function(a) { return $.belowthefold(a, {threshold : 0}); },
+        "above-the-top"  : function(a) { return !$.belowthefold(a, {threshold : 0}); },
+        "right-of-screen": function(a) { return $.rightoffold(a, {threshold : 0}); },
+        "left-of-screen" : function(a) { return !$.rightoffold(a, {threshold : 0}); },
+        "in-viewport"    : function(a) { return $.inviewport(a, {threshold : 0}); },
+        /* Maintain BC for couple of versions. */
+        "above-the-fold" : function(a) { return !$.belowthefold(a, {threshold : 0}); },
+        "right-of-fold"  : function(a) { return $.rightoffold(a, {threshold : 0}); },
+        "left-of-fold"   : function(a) { return !$.rightoffold(a, {threshold : 0}); }
+    });
+
+})(jQuery, window, document);

--- a/apps/files/js/jquery.lazyload.js
+++ b/apps/files/js/jquery.lazyload.js
@@ -16,6 +16,15 @@
 (function($, window, document, undefined) {
     var $window = $(window);
 
+    $.fn.removeLazyload = function() {
+        this.each(function() {
+            if (this.removeLazyload) {
+                this.removeLazyload();
+                this.removeLazyload = null;
+            }
+        });
+    };
+
     $.fn.lazyload = function(options) {
         var elements = this;
         var $container;
@@ -95,6 +104,16 @@
                 }
             }
 
+            self.removeLazyload = function() {
+                self.loaded = true;
+
+                /* Remove image from array so it is not looped next time. */
+                var temp = $.grep(elements, function(e) {
+                                return (e !== self);
+                            });
+                elements = $(temp);
+            };
+
             /* When appear is triggered load original image. */
             $self.one("appear", function() {
                 if (!this.loaded) {
@@ -114,13 +133,7 @@
                             }
                             $self[settings.effect](settings.effect_speed);
 
-                            self.loaded = true;
-
-                            /* Remove image from array so it is not looped next time. */
-                            var temp = $.grep(elements, function(element) {
-                                return !element.loaded;
-                            });
-                            elements = $(temp);
+                            self.removeLazyload();
 
                             if (settings.load) {
                                 var elements_left = elements.length;

--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -19,11 +19,11 @@ $totalsize = 0; ?>
 		data-etag="<?php p($file['etag']);?>"
 		data-permissions="<?php p($file['permissions']); ?>">
 		<?php if(isset($file['isPreviewAvailable']) and $file['isPreviewAvailable']): ?>
-		<td class="filename svg preview-icon"
+		<td class="filename svg preview-icon lazy"
 		<?php else: ?>
-		<td class="filename svg"
+		<td class="filename svg lazy"
 		<?php endif; ?>
-		    style="background-image:url(<?php print_unescaped($file['icon']); ?>)"
+		    data-original="<?php print_unescaped($file['icon']); ?>"
 			>
 		<?php if(!isset($_['readonly']) || !$_['readonly']): ?>
 			<input id="select-<?php p($file['fileid']); ?>" type="checkbox" />

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -2,6 +2,8 @@
 // Load other apps for file previews
 OC_App::loadApps();
 
+OCP\Util::addscript('files', 'jquery.lazyload');
+
 $appConfig = \OC::$server->getAppConfig();
 
 if ($appConfig->getValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {

--- a/apps/files_trashbin/index.php
+++ b/apps/files_trashbin/index.php
@@ -17,6 +17,8 @@ OCP\Util::addScript('files_trashbin', 'filelist');
 OCP\Util::addscript('files', 'files');
 OCP\Util::addScript('files_trashbin', 'trash');
 
+OCP\Util::addscript('files', 'jquery.lazyload');
+
 $dir = isset($_GET['dir']) ? stripslashes($_GET['dir']) : '';
 
 $isIE8 = false;

--- a/apps/files_trashbin/templates/part.list.php
+++ b/apps/files_trashbin/templates/part.list.php
@@ -21,17 +21,17 @@
 		data-dirlisting=0
 		<?php endif; ?>>
 		<?php if($file['isPreviewAvailable']): ?>
-		<td class="filename svg preview-icon"
+		<td class="filename svg preview-icon lazy"
 		<?php else: ?>
-		<td class="filename svg"
+		<td class="filename svg lazy"
 		<?php endif; ?>
 		<?php if($file['type'] === 'dir'): ?>
-			style="background-image:url(<?php print_unescaped(OCP\mimetype_icon('dir')); ?>)"
+			data-original="<?php print_unescaped(OCP\mimetype_icon('dir')); ?>"
 		<?php else: ?>
 				<?php if($file['isPreviewAvailable']): ?>
-				style="background-image:url(<?php print_unescaped(OCA\Files_Trashbin\Trashbin::preview_icon(!$_['dirlisting'] ? ($file['name'].'.d'.$file['timestamp']) : ($file['directory'].'/'.$file['name']))); ?>)"
+				data-original="<?php print_unescaped(OCA\Files_Trashbin\Trashbin::preview_icon(!$_['dirlisting'] ? ($file['name'].'.d'.$file['timestamp']) : ($file['directory'].'/'.$file['name']))); ?>"
 				<?php else: ?>
-				style="background-image:url(<?php print_unescaped(OCP\mimetype_icon($file['mimetype'])); ?>)"
+				data-original="<?php print_unescaped(OCP\mimetype_icon($file['mimetype'])); ?>"
 				<?php endif; ?>
 		<?php endif; ?>
 			>


### PR DESCRIPTION
This is my first fork and pull request, so I hope nothing is wrong with it.
I originally submitted a feature request for changing always loading file icon images to lazy loading them to save on bandwidth when opening a folder with many pictures inside it.
The original issue can be read here at https://github.com/owncloud/core/issues/6591 and all my reasoning for the need of this addition.

I have made small changes to the owncloud's core app "files" that achieves this functionality and am submitting it here so hopefully it can be incorporated.
The main addition is the JQuery Lazy Load library that I found at http://www.appelsiini.net/projects/lazyload , which can be used, as is, with no modifications. The library is released under the MIT License, which I believe it compatible with owncloud's APGL. Correct me if I am wrong.
The main changes to the file listing is replacing the background image style for the icon and putting it into a custom attribute that Lazy Load recognizes and works with.
The only other change is the call to the Lazy Load function in JS to monitor the user scrolling and position in the document.

I have tested this with owncloud 6.0.0a and found no issues in IE8 and FF26. The images that are not in view don't load when opening a directory (verified with firebug's net panel), the images are loaded correctly when scrolled into view, and cached images still show up rather instantly. I didn't see any problems with applying the changes to the master in git.
