### PR TITLE
Fixing apache login

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -544,12 +544,12 @@ class OC {
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
 
-		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('user_id')
+		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('loginname')
 			&& $_SERVER['PHP_AUTH_USER'] !== self::$session->get('loginname')) {
 			$sessionUser = self::$session->get('loginname');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];
 			OC_Log::write('core',
-				"Session user-id ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
+				"Session loginname ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
 				OC_Log::WARN);
 			OC_User::logout();
 		}

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -246,6 +246,8 @@ class OC_User {
 			session_regenerate_id(true);
 			self::setUserId($uid);
 			self::setDisplayName($uid);
+			self::getUserSession()->setLoginName($uid);
+
 			OC_Hook::emit( "OC_User", "post_login", array( "uid" => $uid, 'password'=>'' ));
 			return true;
 		}

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -115,13 +115,13 @@ class Session implements Emitter, \OCP\IUserSession {
 	/**
 	 * set the login name
 	 *
-	 * @param string login name for the logged in user
+	 * @param string $loginName for the logged in user
 	 */
-	public function setLoginname($loginname) {
-		if (is_null($loginname)) {
+	public function setLoginName($loginName) {
+		if (is_null($loginName)) {
 			$this->session->remove('loginname');
 		} else {
-			$this->session->set('loginname', $loginname);
+			$this->session->set('loginname', $loginName);
 		}
 	}
 
@@ -130,7 +130,7 @@ class Session implements Emitter, \OCP\IUserSession {
 	 *
 	 * @return string
 	 */
-	public function getLoginname() {
+	public function getLoginName() {
 		if ($this->activeUser) {
 			return $this->session->get('loginname');
 		} else {
@@ -158,7 +158,7 @@ class Session implements Emitter, \OCP\IUserSession {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
 					$this->setUser($user);
-					$this->setLoginname($uid);
+					$this->setLoginName($uid);
 					$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
 					return true;
 				} else {
@@ -176,7 +176,7 @@ class Session implements Emitter, \OCP\IUserSession {
 	public function logout() {
 		$this->manager->emit('\OC\User', 'logout');
 		$this->setUser(null);
-		$this->setLoginname(null);
+		$this->setLoginName(null);
 		$this->unsetMagicInCookie();
 	}
 


### PR DESCRIPTION
In case authentication is based on our IApacheBackend interface the loginname is never set and the check regarding php login name to be equal to the php environment PHP_AUTH_USER is failing.

@blizzz 
