### PR TITLE
fix public upload button layout

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -24,9 +24,10 @@
 
 
 			<?php if (!isset($_['folder']) || $_['allowZipDownload']): ?>
-				<a href="<?php p($_['downloadURL']); ?>" class="button" id="download"><img
-						class="svg" alt="Download" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>"
-						/><span><?php p($l->t('Download'))?></span></a>
+				<a href="<?php p($_['downloadURL']); ?>" class="button" id="download">
+					<img class="svg" alt="Download" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>" />
+					<span><?php p($l->t('Download'))?></span>
+				</a>
 			<?php endif; ?>
 
 			<?php if ($_['allowPublicUploadEnabled']):?>
@@ -43,9 +44,10 @@
 			<?php endif;?>
 
 
-			<div id="data-upload-form" class="button" title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
+			<div id="data-upload-form" title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
 				<input id="file_upload_start" type="file" name="files[]" data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" multiple>
-				<a href="#" id="publicUploadButtonMock" class="svg">
+				<a href="#" id="public_upload" class="button">
+					<img class="svg" alt="Upload" src="<?php print_unescaped(OCP\image_path("core", "actions/upload.svg")); ?>" />
 					<span><?php p($l->t('Upload'))?></span>
 				</a>
 			</div>


### PR DESCRIPTION
Modified template for public upload to correctly output upload button.  For some reason upload button image was being included as background instead of using same style for download.

Upload progress bar still needs to be fixed.
#6522
