### PR TITLE
Fix public upload progress bar

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -717,7 +717,7 @@ Files.lazyLoadPreview = function(path, mime, ready, width, height, etag) {
 			console.warn('Files.lazyLoadPreview(): missing etag argument');
 		}
 
-		if ( $('#publicUploadButtonMock').length ) {
+		if ( $('#public_upload').length ) {
 			urlSpec.t = $('#dirToken').val();
 			previewURL = OC.Router.generate('core_ajax_public_preview', urlSpec);
 		} else {

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -149,5 +149,5 @@ thead{
 	width: 300px;
 }
 .public_actions {
-	padding: 0.3em;
+	padding: 4px;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -141,10 +141,13 @@ thead{
 .directLink {
 	margin-bottom: 20px;
 }
-	.directLink label {
-		font-weight: normal;
-	}
-	.directLink input {
-		margin-left: 10px;
-		width: 300px;
-	}
+.directLink label {
+	font-weight: normal;
+}
+.directLink input {
+	margin-left: 10px;
+	width: 300px;
+}
+.public_actions {
+	padding: 0.3em;
+}

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -59,7 +59,8 @@ $(document).ready(function() {
 	});
 
 	// Add Uploadprogress Wrapper to controls bar
-	$('#controls').append($('#additional_controls div#uploadprogresswrapper'));
+	$('#controls').append($('#controls .actions div#uploadprogresswrapper'));
+	$('#uploadprogresswrapper').addClass('public_actions');
 
 	// Cancel upload trigger
 	$('#cancel_upload_button').click(function() {

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -53,20 +53,8 @@
 			</div>
 
 		</div>
-
-		<div id="additional_controls" style="display:none">
-			<div id="uploadprogresswrapper">
-				<div id="uploadprogressbar"></div>
-				<input id="cancel_upload_button" type="button" class="stop" style="display:none"
-				       value="<?php p($l->t('Cancel upload'));?>"
-					/>
-			</div>
-
-
-
-
+		<div>
 			<?php endif; ?>
-
 		</div>
 	</div></header>
 <div id="content">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -24,9 +24,10 @@
 
 
 			<?php if (!isset($_['folder']) || $_['allowZipDownload']): ?>
-				<a href="<?php p($_['downloadURL']); ?>" class="button" id="download"><img
-						class="svg" alt="Download" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>"
-						/><span><?php p($l->t('Download'))?></span></a>
+				<a href="<?php p($_['downloadURL']); ?>" class="button" id="download">
+					<img class="svg" alt="Download" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>" />
+					<span><?php p($l->t('Download'))?></span>
+				</a>
 			<?php endif; ?>
 
 			<?php if ($_['allowPublicUploadEnabled']):?>
@@ -43,9 +44,10 @@
 			<?php endif;?>
 
 
-			<div id="data-upload-form" class="button" title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
+			<div id="data-upload-form" title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
 				<input id="file_upload_start" type="file" name="files[]" data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" multiple>
-				<a href="#" id="publicUploadButtonMock" class="svg">
+				<a href="#" id="public_upload" class="button">
+					<img class="svg" alt="Upload" src="<?php print_unescaped(OCP\image_path("core", "actions/upload.svg")); ?>" />
 					<span><?php p($l->t('Upload'))?></span>
 				</a>
 			</div>


### PR DESCRIPTION
The native actions menu with progress bar was being loaded into public view but hidden using css.  This is what was causing problems as there were two divs defined at uploadprogressbar.

Removed unnecessary additional progress bar html wrapper and children, modified jquery to move wrapper div out of hidden actions div, and append to bottom of content.

Added css class to upload wrapper to mimic padding from "actions" class.
#6522
