### PR TITLE
no warnings within unlinkDir() within the TestCleanupListener

### DIFF
--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -58,7 +58,7 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 	}
 
 	private function unlinkDir($dir) {
-		if ($dh = opendir($dir)) {
+		if ($dh = @opendir($dir)) {
 			while (($file = readdir($dh)) !== false) {
 				if ($file === '..' || $file === '.') {
 					continue;
@@ -68,12 +68,12 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 					$this->unlinkDir($path);
 				}
 				else {
-					unlink($path);
+					@unlink($path);
 				}
 			}
 			closedir($dh);
 		}
-		rmdir($dir);
+		@rmdir($dir);
 	}
 
 	private function cleanStrayDataFiles() {


### PR DESCRIPTION
My whole data dir was not writable and polluted my console output

@PVince81 I'm uncertain if this is right - but it helped me ..
