### PR TITLE
Use storage_mtime when determining if we can reuse cached data while scanning

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -122,7 +122,7 @@ class Scanner extends BasicEmitter {
 							$propagateETagChange = true;
 						}
 						// only reuse data if the file hasn't explicitly changed
-						if (isset($data['mtime']) && isset($cacheData['mtime']) && $data['mtime'] === $cacheData['mtime']) {
+						if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
 								$data['size'] = $cacheData['size'];
 							}

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -147,7 +147,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->scanner->scan('');
 		$oldData = $this->cache->get('');
 		$this->storage->unlink('folder/bar.txt');
-		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder')));
+		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder'), 'storage_mtime' => $this->storage->filemtime('folder')));
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
 		$this->assertNotEquals($oldData['etag'], $newData['etag']);

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -88,7 +88,7 @@ class Updater extends \PHPUnit_Framework_TestCase {
 	public function testWrite() {
 		$textSize = strlen("dummy file data\n");
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
-		$this->cache->put('foo.txt', array('mtime' => 100, 'storage_mtime' => 100));
+		$this->cache->put('foo.txt', array('mtime' => 100, 'storage_mtime' => 150));
 		$rootCachedData = $this->cache->get('');
 		$this->assertEquals(3 * $textSize + $imageSize, $rootCachedData['size']);
 

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -88,7 +88,7 @@ class Updater extends \PHPUnit_Framework_TestCase {
 	public function testWrite() {
 		$textSize = strlen("dummy file data\n");
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
-		$this->cache->put('foo.txt', array('mtime' => 100));
+		$this->cache->put('foo.txt', array('mtime' => 100, 'storage_mtime' => 100));
 		$rootCachedData = $this->cache->get('');
 		$this->assertEquals(3 * $textSize + $imageSize, $rootCachedData['size']);
 

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -11,12 +11,6 @@ namespace Test\Files;
 use OC\Files\Filesystem;
 use OCP\Share;
 
-class TemporaryNoTouch extends \OC\Files\Storage\Temporary {
-	public function touch($path, $mtime = null) {
-		return false;
-	}
-}
-
 class EtagTest extends \PHPUnit_Framework_TestCase {
 	private $datadir;
 
@@ -72,23 +66,6 @@ class EtagTest extends \PHPUnit_Framework_TestCase {
 		$scanner->backgroundScan('/');
 
 		$this->assertEquals($originalEtags, $this->getEtags($files));
-	}
-
-	public function testTouchNotSupported() {
-		$storage = new TemporaryNoTouch(array());
-		$scanner = $storage->getScanner();
-		Filesystem::mount($storage, array(), '/test/');
-		$past = time() - 100;
-		$storage->file_put_contents('test', 'foobar');
-		$scanner->scan('');
-		$view = new \OC\Files\View('');
-		$info = $view->getFileInfo('/test/test');
-
-		$view->touch('/test/test', $past);
-		$scanner->scanFile('test', \OC\Files\Cache\Scanner::REUSE_ETAG);
-
-		$info2 = $view->getFileInfo('/test/test');
-		$this->assertEquals($info['etag'], $info2['etag']);
 	}
 
 	private function getEtags($files) {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -545,4 +545,21 @@ class View extends \PHPUnit_Framework_TestCase {
 			$this->assertContains($item['name'], $names);
 		}
 	}
+
+	public function testTouchNotSupported() {
+		$storage = new TemporaryNoTouch(array());
+		$scanner = $storage->getScanner();
+		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		$past = time() - 100;
+		$storage->file_put_contents('test', 'foobar');
+		$scanner->scan('');
+		$view = new \OC\Files\View('');
+		$info = $view->getFileInfo('/test/test');
+
+		$view->touch('/test/test', $past);
+		$scanner->scanFile('test', \OC\Files\Cache\Scanner::REUSE_ETAG);
+
+		$info2 = $view->getFileInfo('/test/test');
+		$this->assertEquals($info['etag'], $info2['etag']);
+	}
 }


### PR DESCRIPTION
This fixes etag's being regenerated on storage backends that don't support touch

credit goes to @PVince81 

cc @karlitschek @DeepDiver1975 
