### PR TITLE
on filtering the share box users and groups whose name begins with the s...

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -355,7 +355,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					}
 				}
 				$sorter = new \OC\Share\SearchResultSorter($_GET['search'],
-														   'label');
+														   'label',
+														   new \OC\Log());
 				usort($shareWith, array($sorter, 'sort'));
 				OC_JSON::success(array('data' => $shareWith));
 			}

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -354,32 +354,11 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						break;
 					}
 				}
-				usort($shareWith, 'sortSearchFirst');
+				$sorter = new \OC\Share\SearchResultSorter($_GET['search'],
+														   'label');
+				usort($shareWith, array($sorter, 'sort'));
 				OC_JSON::success(array('data' => $shareWith));
 			}
 			break;
-	}
-}
-
-
-/**
- * User and Group names matching the search term at the beginning shall appear
- * on top of the share dialog.
- * Callback function for usort. http://php.net/usort
- */
-function sortSearchFirst($a, $b) {
-	$enc = 'UTF-8';
-	$nameA = mb_strtolower($a['label'], $enc);
-	$nameB = mb_strtolower($b['label'], $enc);
-	$term = mb_strtolower($_GET['search'], $enc);
-	$i = mb_strpos($nameA, $term, 0, 'UTF-8');
-	$j = mb_strpos($nameB, $term, 0, 'UTF-8');
-
-	if($i === $j) {
-		return 0;
-	} elseif ($i === 0) {
-		return -1;
-	} else {
-		return 1;
 	}
 }

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -354,8 +354,32 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						break;
 					}
 				}
+				usort($shareWith, 'sortSearchFirst');
 				OC_JSON::success(array('data' => $shareWith));
 			}
 			break;
+	}
+}
+
+
+/**
+ * User and Group names matching the search term at the beginning shall appear
+ * on top of the share dialog.
+ * Callback function for usort. http://php.net/usort
+ */
+function sortSearchFirst($a, $b) {
+	$enc = 'UTF-8';
+	$nameA = mb_strtolower($a['label'], $enc);
+	$nameB = mb_strtolower($b['label'], $enc);
+	$term = mb_strtolower($_GET['search'], $enc);
+	$i = mb_strpos($nameA, $term, 0, 'UTF-8');
+	$j = mb_strpos($nameB, $term, 0, 'UTF-8');
+
+	if($i === $j) {
+		return 0;
+	} else if ($i === 0) {
+		return -1;
+	} else {
+		return 1;
 	}
 }

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -377,7 +377,7 @@ function sortSearchFirst($a, $b) {
 
 	if($i === $j) {
 		return 0;
-	} else if ($i === 0) {
+	} elseif ($i === 0) {
 		return -1;
 	} else {
 		return 1;

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -21,10 +21,10 @@ class SearchResultSorter {
 	 * @param $encoding optional, encoding to use, defaults to UTF-8
 	 * @param $log optional, an \OC\Log instance
 	 */
-	public function __construct($search, $key, $encoding = 'UTF-8', \OC\Log $log = null) {
+	public function __construct($search, $key, \OC\Log $log = null, $encoding = 'UTF-8') {
 		$this->encoding = $encoding;
 		$this->key = $key;
-		$this->log = is_null($log) ? new \OC\Log() : $log;
+		$this->log = $log;
 		$this->search = mb_strtolower($search, $this->encoding);
 	}
 
@@ -35,8 +35,10 @@ class SearchResultSorter {
 	 */
 	public function sort($a, $b) {
 		if(!isset($a[$this->key]) || !isset($b[$this->key])) {
-			$this->log->error('Sharing dialogue: cannot sort due to missing array key',
-							  array('app' => 'core'));
+			if(!is_null($this->log)) {
+				$this->log->error('Sharing dialogue: cannot sort due to ' .
+								  'missing array key', array('app' => 'core'));
+			}
 			return 0;
 		}
 		$nameA = mb_strtolower($a[$this->key], $this->encoding);

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -27,7 +27,7 @@ class SearchResultSorter {
 
 	/**
 	 * User and Group names matching the search term at the beginning shall appear
-	 * on top of the share dialog.
+	 * on top of the share dialog. Following entries in alphabetical order.
 	 * Callback function for usort. http://php.net/usort
 	 */
 	public function sort($a, $b) {
@@ -41,8 +41,9 @@ class SearchResultSorter {
 		$i = mb_strpos($nameA, $this->search, 0, $this->encoding);
 		$j = mb_strpos($nameB, $this->search, 0, $this->encoding);
 
-		if($i === $j) {
-			return 0;
+		if($i === $j || $i > 0 && $j > 0) {
+			return strcmp(mb_strtolower($nameA, $this->encoding),
+						  mb_strtolower($nameB, $this->encoding));
 		} elseif ($i === 0) {
 			return -1;
 		} else {

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.bzoc>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ *
+ */
+namespace OC\Share;
+
+class SearchResultSorter {
+	private $search;
+	private $encoding;
+	private $key;
+
+	/**
+	 * @param $search the search term as was given by the user
+	 * @param $key the array key containing the value that should be compared
+	 * against
+	 * @param $encoding optional, encoding to use, defaults to UTF-8
+	 */
+	public function __construct($search, $key, $encoding = 'UTF-8') {
+		$this->encoding = $encoding;
+		$this->key = $key;
+		$this->search = mb_strtolower($search, $this->encoding);
+	}
+
+	/**
+	 * User and Group names matching the search term at the beginning shall appear
+	 * on top of the share dialog.
+	 * Callback function for usort. http://php.net/usort
+	 */
+	public function sort($a, $b) {
+		if(!isset($a[$this->key]) || !isset($b[$this->key])) {
+			\OCP\Util::writeLog('core', 'Sharing: cannot sort due to missing'.
+										'array key', \OC_Log::ERROR);
+			return 0;
+		}
+		$nameA = mb_strtolower($a[$this->key], $this->encoding);
+		$nameB = mb_strtolower($b[$this->key], $this->encoding);
+		$i = mb_strpos($nameA, $this->search, 0, $this->encoding);
+		$j = mb_strpos($nameB, $this->search, 0, $this->encoding);
+
+		if($i === $j) {
+			return 0;
+		} elseif ($i === 0) {
+			return -1;
+		} else {
+			return 1;
+		}
+	}
+}
+

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.bzoc>
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -12,16 +12,19 @@ class SearchResultSorter {
 	private $search;
 	private $encoding;
 	private $key;
+	private $log;
 
 	/**
 	 * @param $search the search term as was given by the user
 	 * @param $key the array key containing the value that should be compared
 	 * against
 	 * @param $encoding optional, encoding to use, defaults to UTF-8
+	 * @param $log optional, an \OC\Log instance
 	 */
-	public function __construct($search, $key, $encoding = 'UTF-8') {
+	public function __construct($search, $key, $encoding = 'UTF-8', \OC\Log $log = null) {
 		$this->encoding = $encoding;
 		$this->key = $key;
+		$this->log = is_null($log) ? new \OC\Log() : $log;
 		$this->search = mb_strtolower($search, $this->encoding);
 	}
 
@@ -32,8 +35,8 @@ class SearchResultSorter {
 	 */
 	public function sort($a, $b) {
 		if(!isset($a[$this->key]) || !isset($b[$this->key])) {
-			\OCP\Util::writeLog('core', 'Sharing: cannot sort due to missing'.
-										'array key', \OC_Log::ERROR);
+			$this->log->error('Sharing dialogue: cannot sort due to missing array key',
+							  array('app' => 'core'));
 			return 0;
 		}
 		$nameA = mb_strtolower($a[$this->key], $this->encoding);

--- a/tests/lib/share/searchresultsorter.php
+++ b/tests/lib/share/searchresultsorter.php
@@ -25,11 +25,11 @@ class Test_Share_Search extends \PHPUnit_Framework_TestCase {
 		$sorter = new \OC\Share\SearchResultSorter($search, 'foobar');
 
 		$result = array(
-						array('foobar' => 'woot'),
-						array('foobar' => 'linux'),
-						array('foobar' => 'Linus'),
-						array('foobar' => 'Bicyclerepairwoman'),
-					   );
+			array('foobar' => 'woot'),
+			array('foobar' => 'linux'),
+			array('foobar' => 'Linus'),
+			array('foobar' => 'Bicyclerepairwoman'),
+		);
 
 		usort($result, array($sorter, 'sort'));
 		$this->assertTrue($result[0]['foobar'] === 'Linus');

--- a/tests/lib/share/searchresultsorter.php
+++ b/tests/lib/share/searchresultsorter.php
@@ -37,4 +37,11 @@ class Test_Share_Search extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($result[2]['foobar'] === 'Bicyclerepairwoman');
 		$this->assertTrue($result[3]['foobar'] === 'woot');
 	}
+
+	/**
+     * @expectedException PHPUnit_Framework_Error
+     */
+	public function testSortWrongLog() {
+		$sorter = new \OC\Share\SearchResultSorter('foo', 'bar', 'UTF-8', 'foobar');
+	}
 }

--- a/tests/lib/share/searchresultsorter.php
+++ b/tests/lib/share/searchresultsorter.php
@@ -1,0 +1,40 @@
+<?php
+/**
+* ownCloud
+*
+* @author Arthur Schiwon
+* @copyright 2014 Arthur Schiwon <blizzz@owncloud.com>
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+class Test_Share_Search extends \PHPUnit_Framework_TestCase {
+	public function testSort() {
+		$search = 'lin';
+		$sorter = new \OC\Share\SearchResultSorter($search, 'foobar');
+
+		$result = array(
+						array('foobar' => 'woot'),
+						array('foobar' => 'linux'),
+						array('foobar' => 'Linus'),
+						array('foobar' => 'Bicyclerepairwoman'),
+					   );
+
+		usort($result, array($sorter, 'sort'));
+		$this->assertTrue($result[0]['foobar'] === 'Linus');
+		$this->assertTrue($result[1]['foobar'] === 'linux');
+		$this->assertTrue($result[2]['foobar'] === 'Bicyclerepairwoman');
+		$this->assertTrue($result[3]['foobar'] === 'woot');
+	}
+}


### PR DESCRIPTION
...earch term shall appear on top, fixes #6430

![sharebox](https://f.cloud.github.com/assets/2184312/1920043/72b58226-7de0-11e3-856e-8fa0593ac01f.png)

(You need another backend like LDAP to test this properly, for local users and groups only the start of the name is matched against the search string).

Please review @schiesbn @PVince81 @bantu or others
