### PR TITLE
Show the name of the shared folder in the breadcrumb when viewing a publicly shared folder

### DIFF
--- a/apps/files/templates/part.breadcrumb.php
+++ b/apps/files/templates/part.breadcrumb.php
@@ -1,6 +1,10 @@
 <div class="crumb <?php if(!count($_["breadcrumb"])) p('last');?>" data-dir=''>
 	<a href="<?php print_unescaped($_['baseURL']); ?>">
-		<img src="<?php print_unescaped(OCP\image_path('core', 'places/home.svg'));?>" class="svg" />
+		<?php if(isset($_['rootBreadCrumb'])):
+			echo $_['rootBreadCrumb'];
+		else:?>
+			<img src="<?php print_unescaped(OCP\image_path('core', 'places/home.svg'));?>" class="svg" />
+		<?php endif;?>
 	</a>
 </div>
 <?php for($i=0; $i<count($_["breadcrumb"]); $i++):

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -111,6 +111,7 @@ if (isset($path)) {
 		}
 	}
 	$basePath = $path;
+	$rootName = basename($path);
 	if (isset($_GET['path']) && \OC\Files\Filesystem::isReadable($basePath . $_GET['path'])) {
 		$getPath = \OC\Files\Filesystem::normalizePath($_GET['path']);
 		$path .= $getPath;
@@ -216,6 +217,7 @@ if (isset($path)) {
 			$list->assign('sharingroot', $basePath);
 			$breadcrumbNav = new OCP\Template('files', 'part.breadcrumb', '');
 			$breadcrumbNav->assign('breadcrumb', $breadcrumb);
+			$breadcrumbNav->assign('rootBreadCrumb', $rootName);
 			$breadcrumbNav->assign('baseURL', OCP\Util::linkToPublic('files') . $urlLinkIdentifiers . '&path=');
 			$maxUploadFilesize=OCP\Util::maxUploadFilesize($path);
 			$fileHeader = (!isset($files) or count($files) > 0);


### PR DESCRIPTION
Fixes #6716

cc @karlitschek @DeepDiver1975 @jancborchardt 
