### PR TITLE
Add bindParam to the database statement wrapper

### DIFF
--- a/lib/private/db/statementwrapper.php
+++ b/lib/private/db/statementwrapper.php
@@ -169,4 +169,18 @@ class OC_DB_StatementWrapper {
 	public function fetchOne($colnum = 0) {
 		return $this->statement->fetchColumn($colnum);
 	}
+
+	/**
+	 * Binds a PHP variable to a corresponding named or question mark placeholder in the
+	 * SQL statement that was use to prepare the statement.
+	 *
+	 * @param mixed $column Either the placeholder name or the 1-indexed placeholder index
+	 * @param mixed $variable The variable to bind
+	 * @param integer|null $type one of the  PDO::PARAM_* constants
+	 * @param integer|null $length max length when using an OUT bind
+	 * @return boolean
+	 */
+	public function bindParam($column, &$variable, $type = null, $length = null){
+		return $this->statement->bindParam($column, $variable, $type, $length);
+	}
 }


### PR DESCRIPTION
`bindParam` allows setting the type of the bound parameter explicitly which is needed in some cases to work around incorrect casting to string done by php (i.e. https://github.com/owncloud/news/issues/457)

No changes to the public api seems to be needed since `OCP\DB::prepare` says it returns a `\Doctrine\DBAL\Statement` (maybe change that in a future PR?)

cc @DeepDiver1975 @Raydiation @karlitschek 
