### PR TITLE
updated description of the files encryption app

### DIFF
--- a/apps/files_encryption/appinfo/info.xml
+++ b/apps/files_encryption/appinfo/info.xml
@@ -2,7 +2,7 @@
 <info>
 	<id>files_encryption</id>
 	<name>Encryption</name>
-	<description>The new ownCloud 5 files encryption system. After the app was enabled you need to re-login to initialize your encryption keys.</description>
+	<description>The ownCloud files encryption system provides server side-encryption. After the app was enabled you need to re-login to initialize your encryption keys.</description>
 	<licence>AGPL</licence>
 	<author>Sam Tuke, Bjoern Schiessle, Florin Peter</author>
 	<require>4</require>


### PR DESCRIPTION
Just update the description of the files encryption app, suggested by @dragotin #6804 . I think for OC6 we can say that it is no longer the "new encryption system".

Easy to review... @karlitschek @PVince81 @dragotin @DeepDiver1975 
