### PR TITLE
Fix array access syntax for older PHP

### DIFF
--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -169,8 +169,9 @@ class Cache extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(916, $this->cache->calculateFolderSize($file1));
 		// direct cache entry retrieval returns the original values
-		$this->assertEquals(1025, $this->cache->get($file1)['size']);
-		$this->assertEquals(916, $this->cache->get($file1)['unencrypted_size']);
+		$entry = $this->cache->get($file1);
+		$this->assertEquals(1025, $entry['size']);
+		$this->assertEquals(916, $entry['unencrypted_size']);
 
 		$this->cache->remove($file2);
 		$this->cache->remove($file3);


### PR DESCRIPTION
There was a syntax error when running tests in PHP 5.3.10.

Older PHP versions don't seem to like accessing arrays directly that were returned from a function call...

Please review @schiesbn @DeepDiver1975 @karlitschek 
