### PR TITLE
Allow app developers to add documentation links to the appinfo

### DIFF
--- a/apps/files_encryption/appinfo/info.xml
+++ b/apps/files_encryption/appinfo/info.xml
@@ -7,6 +7,10 @@
 	<author>Sam Tuke, Bjoern Schiessle, Florin Peter</author>
 	<require>4</require>
 	<shipped>true</shipped>
+	<documentation>
+		<user>http://doc.owncloud.org/server/6.0/user_manual/files/encryption.html</user>
+		<admin>http://doc.owncloud.org/server/6.0/admin_manual/configuration/configuration_encryption.html</admin>
+	</documentation>
 	<rememberlogin>false</rememberlogin>
 	<types>
 		<filesystem/>

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -555,6 +555,10 @@ class OC_App{
 			}elseif($child->getName()=='description') {
 				$xml=(string)$child->asXML();
 				$data[$child->getName()]=substr($xml, 13, -14);//script <description> tags
+			}elseif($child->getName()=='documentation') {
+				foreach($child as $subchild) {
+					$data["documentation"][$subchild->getName()] = (string)$subchild;
+				}
 			}else{
 				$data[$child->getName()]=(string)$child;
 			}

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -131,6 +131,12 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 .appslink { text-decoration: underline; }
 .score { color:#666; font-weight:bold; font-size:0.8em; }
 
+.appinfo .documentation {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
+
 /* LOG */
 #log { white-space:normal; }
 #lessLog { display:none; }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -129,7 +129,6 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 .app:hover, .app:active { max-width: inherit; }
 
 .appslink { text-decoration: underline; }
-.doclink { text-decoration: underline; }
 .score { color:#666; font-weight:bold; font-size:0.8em; }
 
 .appinfo .documentation {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -129,6 +129,7 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 .app:hover, .app:active { max-width: inherit; }
 
 .appslink { text-decoration: underline; }
+.doclink { text-decoration: underline; }
 .score { color:#666; font-weight:bold; font-size:0.8em; }
 
 .appinfo .documentation {

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -39,21 +39,27 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 		var userDocumentation = false;
 		var adminDocumentation = false;
-		if (typeof(app.documentation.user) !== 'undefined') {
-			userDocumentation = true;
-			page.find('span.userDocumentation').html("<a href='" + app.documentation.user + "'>" + t('settings', 'User Documentation') + "</a>");
-			page.find('p.documentation').show();
-		}
-		if (typeof(app.documentation.admin) !== 'undefined') {
-			adminDocumentation = true;
-			page.find('span.adminDocumentation').html("<a href='" + app.documentation.admin + "'>" + t('settings', 'Admin Documentation') + "</a>");
-			page.find('p.documentation').show();
+		if (typeof(app.documentation) !== 'undefined') {
+			if (typeof(app.documentation.user) !== 'undefined') {
+				userDocumentation = true;
+				page.find('span.userDocumentation').html("<a id='userDocumentation' href='" + app.documentation.user + "'>" + t('settings', 'User Documentation') + "</a>");
+				page.find('p.documentation').show();
+			}
+			if (typeof(app.documentation.admin) !== 'undefined') {
+				adminDocumentation = true;
+				page.find('span.adminDocumentation').html("<a id='adminDocumentation' href='" + app.documentation.admin + "'>" + t('settings', 'Admin Documentation') + "</a>");
+				page.find('p.documentation').show();
+			}
+
+			if(userDocumentation && adminDocumentation) {
+				page.find('span.userDocumentation').after(', ');
+			}
 		}
 
-		if(userDocumentation && adminDocumentation) {
-			page.find('span.userDocumentation').after(', ');
+		if (typeof(app.website) !== 'undefined') {
+			page.find('p.website').show();
+			page.find('a#websitelink').attr('href', app.website);
 		}
-
 
 		if (app.update !== false) {
 			page.find('input.update').show();
@@ -69,8 +75,8 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		page.find('input.enable').data('active', app.active);
 		if (app.internal === false) {
 			page.find('span.score').show();
-			page.find('p.appslink').show();
-			page.find('a.appslink').attr('href', 'http://apps.owncloud.com/content/show.php?content=' + app.id);
+			page.find('p.appstore').show();
+			page.find('a#appstorelink').attr('href', 'http://apps.owncloud.com/content/show.php?content=' + app.id);
 			page.find('small.externalapp').hide();
 		} else {
 			page.find('p.appslink').hide();

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -37,6 +37,24 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 		page.find('span.licence').text(appLicense);
 
+		var userDocumentation = false;
+		var adminDocumentation = false;
+		if (typeof(app.documentation.user) !== 'undefined') {
+			userDocumentation = true;
+			page.find('span.userDocumentation').html("<a href='" + app.documentation.user + "'>" + t('settings', 'User Documentation') + "</a>");
+			page.find('p.documentation').show();
+		}
+		if (typeof(app.documentation.admin) !== 'undefined') {
+			adminDocumentation = true;
+			page.find('span.adminDocumentation').html("<a href='" + app.documentation.admin + "'>" + t('settings', 'Admin Documentation') + "</a>");
+			page.find('p.documentation').show();
+		}
+
+		if(userDocumentation && adminDocumentation) {
+			page.find('span.userDocumentation').after(', ');
+		}
+
+
 		if (app.update !== false) {
 			page.find('input.update').show();
 			page.find('input.update').data('appid', app.id);
@@ -110,7 +128,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					element.val(t('settings','Disable'));
 				}
 			},'json')
-			.fail(function() { 
+			.fail(function() {
 				OC.Settings.Apps.showErrorMessage(t('settings', 'Error while enabling app'));
 				appitem.data('errormsg', t('settings', 'Error while enabling app'));
 				appitem.data('active',false);

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -70,7 +70,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		if (app.internal === false) {
 			page.find('span.score').show();
 			page.find('p.appslink').show();
-			page.find('a').attr('href', 'http://apps.owncloud.com/content/show.php?content=' + app.id);
+			page.find('a.appslink').attr('href', 'http://apps.owncloud.com/content/show.php?content=' + app.id);
 			page.find('small.externalapp').hide();
 		} else {
 			page.find('p.appslink').hide();

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -36,8 +36,8 @@
 	<p class="description"></p>
 	<p class="documentation hidden">
 		<?php p($l->t("Documentation:"));?>
-		<span class="userDocumentation appslink"></span>
-		<span class="adminDocumentation appslink"></span>
+		<span class="userDocumentation doclink"></span>
+		<span class="adminDocumentation doclink"></span>
 	</p>
 	<img src="" class="preview hidden" />
 	<p class="appslink hidden"><a href="#" target="_blank"><?php

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -34,6 +34,11 @@
 		class="version"></span><small class="externalapp" style="visibility:hidden;"></small></h3>
 	<span class="score"></span>
 	<p class="description"></p>
+	<p class="documentation hidden">
+		<?php p($l->t("Documentation:"));?>
+		<span class="userDocumentation appslink"></span>
+		<span class="adminDocumentation appslink"></span>
+	</p>
 	<img src="" class="preview hidden" />
 	<p class="appslink hidden"><a href="#" target="_blank"><?php
 		p($l->t('See application page at apps.owncloud.com'));?></a></p>

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -36,12 +36,14 @@
 	<p class="description"></p>
 	<p class="documentation hidden">
 		<?php p($l->t("Documentation:"));?>
-		<span class="userDocumentation doclink"></span>
-		<span class="adminDocumentation doclink"></span>
+		<span class="userDocumentation appslink"></span>
+		<span class="adminDocumentation appslink"></span>
 	</p>
 	<img src="" class="preview hidden" />
-	<p class="appslink hidden"><a href="#" target="_blank"><?php
+	<p class="appslink appstore hidden"><a id="appstorelink" href="#" target="_blank"><?php
 		p($l->t('See application page at apps.owncloud.com'));?></a></p>
+	<p class="appslink website hidden"><a id="websitelink" href="#" target="_blank"><?php
+		p($l->t('See application website'));?></a></p>
 	<p class="license hidden"><?php
 		print_unescaped($l->t('<span class="licence"></span>-licensed by <span class="author"></span>'));?></p>
 	<input class="enable hidden" type="submit" />


### PR DESCRIPTION
allow app developers to add links to the user and admin documentation to the info.xml. The links will be shown below the apps description.

You can test it with the encryption app, this branch already contains a updated info.xml for it.

@jancborchardt maybe you want to have a look at it to see how I present the documentation links.
