### PR TITLE
Fixed isPreviewAvailable warnings in log

### DIFF
--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -18,7 +18,7 @@ $totalsize = 0; ?>
 		data-size="<?php p($file['size']);?>"
 		data-etag="<?php p($file['etag']);?>"
 		data-permissions="<?php p($file['permissions']); ?>">
-		<?php if($file['isPreviewAvailable']): ?>
+		<?php if(isset($file['isPreviewAvailable']) and $file['isPreviewAvailable']): ?>
 		<td class="filename svg preview-icon"
 		<?php else: ?>
 		<td class="filename svg"

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -189,8 +189,8 @@ if (isset($path)) {
 					} else {
 						$i['extension'] = '';
 					}
-					$i['isPreviewAvailable'] = \OC::$server->getPreviewManager()->isMimeSupported($i['mimetype']);
 				}
+				$i['isPreviewAvailable'] = \OC::$server->getPreviewManager()->isMimeSupported($i['mimetype']);
 				$i['directory'] = $getPath;
 				$i['permissions'] = OCP\PERMISSION_READ;
 				$i['icon'] = determineIcon($i, $basePath, $token);


### PR DESCRIPTION
isPreviewAvailable wasn't always set as the files formatting code is
slightly different than the one from the files app.

Fixes #6423
