### PR TITLE
Load a separate config (if present) when running unit tests

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -57,6 +57,9 @@ class OC {
 	 * web path in 'url'
 	 */
 	public static $APPSROOTS = array();
+
+	public static $configDir;
+
 	/*
 	 * requested app
 	 */
@@ -99,6 +102,13 @@ class OC {
 			OC::$SERVERROOT . '/lib' . PATH_SEPARATOR .
 			get_include_path()
 		);
+
+		if(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/test_config/')) {
+			self::$configDir = OC::$SERVERROOT . '/test_config/';
+		} else {
+			self::$configDir = OC::$SERVERROOT . '/config/';
+		}
+		OC_Config::$object = new \OC\Config(self::$configDir);
 
 		OC::$SUBURI = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen(OC::$SERVERROOT)));
 		$scriptName = OC_Request::scriptName();
@@ -175,8 +185,8 @@ class OC {
 	}
 
 	public static function checkConfig() {
-		if (file_exists(OC::$SERVERROOT . "/config/config.php")
-			and !is_writable(OC::$SERVERROOT . "/config/config.php")
+		if (file_exists(self::$configDir . "/config.php")
+			and !is_writable(self::$configDir . "/config.php")
 		) {
 			$defaults = new OC_Defaults();
 			if (self::$CLI) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -103,8 +103,8 @@ class OC {
 			get_include_path()
 		);
 
-		if(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/test_config/')) {
-			self::$configDir = OC::$SERVERROOT . '/test_config/';
+		if(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
+			self::$configDir = OC::$SERVERROOT . '/tests/config/';
 		} else {
 			self::$configDir = OC::$SERVERROOT . '/config/';
 		}

--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -50,7 +50,7 @@ class Config {
 	protected $debugMode;
 
 	/**
-	 * @param $configDir path to the config dir, needs to end with '/'
+	 * @param string $configDir path to the config dir, needs to end with '/'
 	 */
 	public function __construct($configDir) {
 		$this->configDir = $configDir;

--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -38,7 +38,6 @@
  * This class is responsible for reading and writing config.php, the very basic
  * configuration file of ownCloud.
  */
-OC_Config::$object = new \OC\Config(OC::$SERVERROOT.'/config/');
 class OC_Config {
 
 	/**

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -312,7 +312,7 @@ class OC_Util {
 			.'" target="_blank">giving the webserver write access to the root directory</a>.';
 
 		// Check if config folder is writable.
-		if(!is_writable(OC::$SERVERROOT."/config/") or !is_readable(OC::$SERVERROOT."/config/")) {
+		if(!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
 			$errors[] = array(
 				'error' => "Can't write into config directory",
 				'hint' => 'This can usually be fixed by '


### PR DESCRIPTION
When phpunit tests are run, it will first check if the `test_config` folder is available and uses that instead of `config` for loading the config from.

This makes it easy to separate the instance used for testing from the one used in the browser

cc @PVince81 @karlitschek @DeepDiver1975 
