### PR TITLE
add needUpgrade() check to addQueuedTask()

### DIFF
--- a/lib/public/backgroundjob.php
+++ b/lib/public/backgroundjob.php
@@ -173,8 +173,10 @@ class BackgroundJob {
 	 * @return int id of task
 	 */
 	public static function addQueuedTask($app, $class, $method, $parameters) {
-		self::registerJob('OC\BackgroundJob\Legacy\QueuedJob', array('app' => $app, 'klass' => $class, 'method' => $method, 'parameters' => $parameters));
-		return true;
+		if (!\OC::needUpgrade()) {
+			self::registerJob('OC\BackgroundJob\Legacy\QueuedJob', array('app' => $app, 'klass' => $class, 'method' => $method, 'parameters' => $parameters));
+			return true;
+		}
 	}
 
 	/**


### PR DESCRIPTION
An attempt at preventing

```
"An exception occurred while executing 'SELECT "id" FROM "oc_jobs" WHERE "class" = ? AND "argument" = ?': SQLSTATE[HY000]: General error: 1 no such table: oc_jobs".
```

when adding queued jobs. An addition to https://github.com/owncloud/core/pull/6406 which adds the `needUpgrade()` check to `addRegularTask()`

see related https://github.com/owncloud/core/issues/6313#issuecomment-32582948

@PVince81 @karlitschek @DeepDiver1975 @icewind1991 @schiesbn I tried to reporoduce the oc_jobs error with mysql or postgresql but could not provoke it. Any hints on reproducing it are welcome.
