### PR TITLE
Fixed quota wrapper to not wrap failed fopen streams

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -95,7 +95,7 @@ class Quota extends Wrapper {
 	public function fopen($path, $mode) {
 		$source = $this->storage->fopen($path, $mode);
 		$free = $this->free_space('');
-		if ($free >= 0 && $mode !== 'r') {
+		if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
 			return \OC\Files\Stream\Quota::wrap($source, $free);
 		} else {
 			return $source;


### PR DESCRIPTION
When calling fopen() on some storage types, these return false instead
of throwing an exception.

This fix makes sure that in case the stream wasn't opened (for example
when a file doesn't exist any more) the stream isn't wrapped.

Also added 'rb' as another case that doesn't need to be wrapped.

Fixes #6832 

Please review @karlitschek @icewind1991 @DeepDiver1975 @schiesbn 
This is quite important as it may cause the server to hang (as described in the issue)
