### PR TITLE
Reuse the data retrieved from the cache in checkUpdate

### DIFF
--- a/apps/files_sharing/lib/watcher.php
+++ b/apps/files_sharing/lib/watcher.php
@@ -32,7 +32,7 @@ class Shared_Watcher extends Watcher {
 	 * @param string $path
 	 */
 	public function checkUpdate($path) {
-		if ($path != '' && parent::checkUpdate($path)) {
+		if ($path != '' && parent::checkUpdate($path) === true) {
 			// since checkUpdate() has already updated the size of the subdirs,
 			// only apply the update to the owner's parent dirs
 

--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -40,7 +40,7 @@ class Watcher {
 	 * check $path for updates
 	 *
 	 * @param string $path
-	 * @return boolean true if path was updated, false otherwise
+	 * @return boolean | array true if path was updated, otherwise the cached data is returned
 	 */
 	public function checkUpdate($path) {
 		$cachedEntry = $this->cache->get($path);
@@ -56,7 +56,7 @@ class Watcher {
 			$this->cache->correctFolderSize($path);
 			return true;
 		}
-		return false;
+		return $cachedEntry;
 	}
 
 	/**

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -801,6 +801,7 @@ class View {
 		 * @var string $internalPath
 		 */
 		list($storage, $internalPath) = Filesystem::resolvePath($path);
+		$data = null;
 		if ($storage) {
 			$cache = $storage->getCache($internalPath);
 			$permissionsCache = $storage->getPermissionsCache($internalPath);
@@ -811,10 +812,12 @@ class View {
 				$scanner->scan($internalPath, Cache\Scanner::SCAN_SHALLOW);
 			} else {
 				$watcher = $storage->getWatcher($internalPath);
-				$watcher->checkUpdate($internalPath);
+				$data = $watcher->checkUpdate($internalPath);
 			}
 
-			$data = $cache->get($internalPath);
+			if (!is_array($data)) {
+				$data = $cache->get($internalPath);
+			}
 
 			if ($data and $data['fileid']) {
 				if ($includeMountPoints and $data['mimetype'] === 'httpd/unix-directory') {


### PR DESCRIPTION
`Watcher->checkUpdate` already fetches the cached fileinfo from the database, if the file hasn't changed this data can be reused instead of re-reading it from the database 2 lines later.

Saves 1 database call for every call to `View->getFileInfo`

cc @DeepDiver1975 @karlitschek @PVince81 
