### PR TITLE
When reading the size of "files" mountpoints need to be excluded

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -734,7 +734,7 @@ class Trashbin {
 		// calculate available space for trash bin
 		// subtract size of files and current trash bin size from quota
 		if ($softQuota) {
-			$rootInfo = $view->getFileInfo('/files/');
+			$rootInfo = $view->getFileInfo('/files/', false);
 			$free = $quota - $rootInfo['size']; // remaining free space for user
 			if ($free > 0) {
 				$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $trashbinSize; // how much space can be used for versions

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -445,7 +445,7 @@ class Storage {
 			// subtract size of files and current versions size from quota
 			if ($softQuota) {
 				$files_view = new \OC\Files\View('/'.$uid.'/files');
-				$rootInfo = $files_view->getFileInfo('/');
+				$rootInfo = $files_view->getFileInfo('/', false);
 				$free = $quota-$rootInfo['size']; // remaining free space for user
 				if ( $free > 0 ) {
 					$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - ($versionsSize + $offset); // how much space can be used for versions


### PR DESCRIPTION
The versions and trashbin app are now passing "includeMountPoints=false"
to "getFileInfo()" to make sure that the calculated total size doesn't
include mount points like Shared or external storage.

This is because the default call (legacy) used to return the size of
mount points as well.

Fixes #6731
