### PR TITLE
use 'download.zip' as default name for zip downloads instead of 'owncloud.zip'

### DIFF
--- a/lib/files.php
+++ b/lib/files.php
@@ -82,7 +82,7 @@ class OC_Files {
 			if ($basename) {
 				$name = $basename . '.zip';
 			} else {
-				$name = 'owncloud.zip';
+				$name = 'download.zip';
 			}
 			
 			set_time_limit($executionTime);


### PR DESCRIPTION
Makes customizations easier by not having to patch core.

@karlitschek @DeepDiver1975 

will check stable6 and master as well
