### PR TITLE
use 'download.zip' as default name for zip downloads instead of 'owncloud.zip'

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -83,7 +83,7 @@ class OC_Files {
 			if ($basename) {
 				$name = $basename . '.zip';
 			} else {
-				$name = 'owncloud.zip';
+				$name = 'download.zip';
 			}
 			
 			set_time_limit($executionTime);


### PR DESCRIPTION
@karlitschek @DeepDiver1975 @VicDeo 

this is https://github.com/owncloud/core/pull/6860 for master
