### PR TITLE
Replaced time() with uniqid() to make sure the file name is unique

### DIFF
--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -155,7 +155,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testSymmetricStreamEncryptShortFileContent() {
 
-		$filename = 'tmp-' . time() . '.test';
+		$filename = 'tmp-' . uniqid() . '.test';
 
 		$util = new Encryption\Util(new \OC_FilesystemView(), $this->userId);
 
@@ -214,7 +214,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	function testSymmetricStreamEncryptLongFileContent() {
 
 		// Generate a a random filename
-		$filename = 'tmp-' . time() . '.test';
+		$filename = 'tmp-' . uniqid() . '.test';
 
 		$util = new Encryption\Util(new \OC_FilesystemView(), $this->userId);
 
@@ -297,7 +297,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testSymmetricStreamDecryptShortFileContent() {
 
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///'. $this->userId . '/files/' . $filename, $this->dataShort);
@@ -327,7 +327,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testSymmetricStreamDecryptLongFileContent() {
 
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -418,7 +418,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testRenameFile() {
 
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -431,7 +431,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFilename = 'tmp-new-' . time();
+		$newFilename = 'tmp-new-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 		$view->rename($filename, $newFilename);
 
@@ -449,7 +449,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testMoveFileIntoFolder() {
 
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -462,8 +462,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFolder = '/newfolder' . time();
-		$newFilename = 'tmp-new-' . time();
+		$newFolder = '/newfolder' . uniqid();
+		$newFilename = 'tmp-new-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 		$view->mkdir($newFolder);
 		$view->rename($filename, $newFolder . '/' . $newFilename);
@@ -484,8 +484,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
-		$filename = '/tmp-' . time();
-		$folder = '/folder' . time();
+		$filename = '/tmp-' . uniqid();
+		$folder = '/folder' . uniqid();
 
 		$view->mkdir($folder);
 
@@ -500,7 +500,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFolder = '/newfolder/subfolder' . time();
+		$newFolder = '/newfolder/subfolder' . uniqid();
 		$view->mkdir('/newfolder');
 
 		$view->rename($folder, $newFolder);
@@ -519,7 +519,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 */
 	function testChangePassphrase() {
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -557,7 +557,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 */
 	function testViewFilePutAndGetContents() {
 
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -590,7 +590,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @large
 	 */
 	function testTouchExistingFile() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -614,7 +614,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 */
 	function testTouchFile() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		$view->touch($filename);
@@ -638,7 +638,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 */
 	function testFopenFile() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -143,7 +143,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		$key = $this->randomKey;
 
-		$file = 'unittest-' . time() . '.txt';
+		$file = 'unittest-' . uniqid() . '.txt';
 
 		$util = new Encryption\Util($this->view, $this->userId);
 
@@ -196,7 +196,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	function testRecursiveDelShareKeys() {
 
 		// generate filename
-		$filename = '/tmp-' . time() . '.txt';
+		$filename = '/tmp-' . uniqid() . '.txt';
 
 		// create folder structure
 		$this->view->mkdir('/'.Test_Encryption_Keymanager::TEST_USER.'/files/folder1');

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -80,7 +80,7 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 
 		// init short data
 		$this->data = 'hats';
-		$this->filename = 'enc_proxy_tests-' . time() . '.txt';
+		$this->filename = 'enc_proxy_tests-' . uniqid() . '.txt';
 
 	}
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -99,7 +99,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testStreamOptions() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -122,7 +122,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testStreamSetBlocking() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -144,7 +144,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 */
 	function testStreamSetTimeout() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -163,7 +163,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testStreamSetWriteBuffer() {
-		$filename = '/tmp-' . time();
+		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -187,9 +187,9 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	 */
 	function testStreamFromLocalFile() {
 
-		$filename = '/' . $this->userId . '/files/' . 'tmp-' . time().'.txt';
+		$filename = '/' . $this->userId . '/files/' . 'tmp-' . uniqid().'.txt';
 
-		$tmpFilename = "/tmp/" . time() . ".txt";
+		$tmpFilename = "/tmp/" . uniqid() . ".txt";
 
 		// write an encrypted file
 		$cryptedFile = $this->view->file_put_contents($filename, $this->dataShort);

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -119,7 +119,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	function testDeleteFile() {
 
 		// generate filename
-		$filename = 'tmp-' . time() . '.txt';
+		$filename = 'tmp-' . uniqid() . '.txt';
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' .\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename, $this->dataShort);
@@ -223,7 +223,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	function testPermanentDeleteFile() {
 
 		// generate filename
-		$filename = 'tmp-' . time() . '.txt';
+		$filename = 'tmp-' . uniqid() . '.txt';
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' .$this->userId. '/files/' . $filename, $this->dataShort);

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -142,8 +142,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		self::loginHelper($this->userId);
 
-		$unencryptedFile = '/tmpUnencrypted-' . time() . '.txt';
-		$encryptedFile =  '/tmpEncrypted-' . time() . '.txt';
+		$unencryptedFile = '/tmpUnencrypted-' . uniqid() . '.txt';
+		$encryptedFile =  '/tmpEncrypted-' . uniqid() . '.txt';
 
 		// Disable encryption proxy to write a unencrypted file
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -254,7 +254,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		\OC_User::setUserId(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
 
-		$filename = '/tmp-' . time() . '.test';
+		$filename = '/tmp-' . uniqid() . '.test';
 
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -282,7 +282,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	function testGetFileSize() {
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
 
-		$filename = 'tmp-' . time();
+		$filename = 'tmp-' . uniqid();
 		$externalFilename = '/' . $this->userId . '/files/' . $filename;
 
 		// Test for 0 byte files
@@ -318,7 +318,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	function testEncryptAll() {
 
-		$filename = "/encryptAll" . time() . ".txt";
+		$filename = "/encryptAll" . uniqid() . ".txt";
 		$util = new Encryption\Util($this->view, $this->userId);
 
 		// disable encryption to upload a unencrypted file
@@ -350,7 +350,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	function testDecryptAll() {
 
-		$filename = "/decryptAll" . time() . ".txt";
+		$filename = "/decryptAll" . uniqid() . ".txt";
 		$util = new Encryption\Util($this->view, $this->userId);
 
 		$this->view->file_put_contents($this->userId . '/files/' . $filename, $this->dataShort);

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -113,7 +113,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	function testWebdavPUT() {
 
 		// generate filename
-		$filename = '/tmp-' . time() . '.txt';
+		$filename = '/tmp-' . uniqid() . '.txt';
 
 		// set server vars
 		$_SERVER['REQUEST_METHOD'] = 'OPTIONS';


### PR DESCRIPTION
The cache isn't cleared properly because unlink() doesn't remove the
cache entry which caused side-effects when reusing the same file name
(which randomly happens when time() returns the same value)

This fix first makes sure the unit tests don't fail any more.
The unlink() case with the cache will be investigated separately (CC @icewind1991 FYI)

This should fix the random errors we sometimes see on PHP533 which possibly, for some reason, returns the same time() value twice in a row more often than other versions.

Please review @DeepDiver1975 @schiesbn @karlitschek 
