### PR TITLE
do not check 'remember' log in by default

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -45,7 +45,7 @@
 		</a>
 		<?php endif; ?>
 		<?php if ($_['rememberLoginAllowed'] === true) : ?>
-		<input type="checkbox" name="remember_login" value="1" id="remember_login" checked />
+		<input type="checkbox" name="remember_login" value="1" id="remember_login" />
 		<label for="remember_login"><?php p($l->t('remember')); ?></label>
 		<?php endif; ?>
 		<input type="hidden" name="timezone-offset" id="timezone-offset"/>


### PR DESCRIPTION
Finally end the discussion of #3918.

Still TO DO:
- [ ] if the "remember" box is checked, the setting in config.php `session_lifetime` does not seem to work. (like @enoch85 said in #6866)
- [ ] if "remember" is checked, it should also remain checked when I logged out.

Can you help there @PVince81?
