### PR TITLE
Moved updater hooks to registerHooks() method, fix enc unit tests

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -14,10 +14,7 @@ OC_Search::registerProvider('OC_Search_Provider_File');
 
 // cache hooks must be connected before all other apps.
 // since 'files' is always loaded first the hooks need to be connected here
-\OC_Hook::connect('OC_Filesystem', 'post_write', '\OC\Files\Cache\Updater', 'writeHook');
-\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
-\OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
-\OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');
+\OC\Files\Cache\Updater::registerHooks();
 
 \OCP\BackgroundJob::addRegularTask('\OC\Files\Cache\BackgroundWatcher', 'checkNext');
 

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -100,6 +100,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	public static function tearDownAfterClass() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -27,6 +27,7 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 	public static function tearDownAfterClass() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -99,6 +99,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Keymanager::TEST_USER);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -69,6 +69,9 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 	}
 
 	function setUp() {
+		// to make sure the cache follows file operations
+		\OC\Files\Cache\Updater::registerHooks();
+
 		// set user id
 		\OC_User::setUserId(\Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1);
 		$this->userId = \Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1;
@@ -81,7 +84,11 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 		// init short data
 		$this->data = 'hats';
 		$this->filename = 'enc_proxy_tests-' . uniqid() . '.txt';
+	}
 
+	function tearDown() {
+		OC_Hook::clear();
+		\Test_Encryption_Util::cleanup();
 	}
 
 	public static function tearDownAfterClass() {

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -125,6 +125,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_User::deleteUser(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 		\OC_User::deleteUser(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 		\OC_User::deleteUser(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -96,6 +96,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	public static function tearDownAfterClass() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Stream::TEST_ENCRYPTION_STREAM_USER1);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	function testStreamOptions() {

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -110,6 +110,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	public static function tearDownAfterClass() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -115,6 +115,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
 		\OC_User::deleteUser(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
+		self::cleanUp();
 	}
 
 	/**
@@ -455,6 +456,15 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		\OC\Files\Filesystem::tearDown();
+	}
+
+	/**
+	 * Remove key directories
+	 */
+	public static function cleanup() {
+		$view = new \OC_FilesystemView('/');
+		$view->unlink('owncloud_private_key');
+		$view->unlink('public-keys');
 	}
 
 	/**

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -105,6 +105,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	public static function tearDownAfterClass() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Webdav::TEST_ENCRYPTION_WEBDAV_USER1);
+		\Test_Encryption_Util::cleanup();
 	}
 
 	/**

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -215,4 +215,14 @@ class Updater {
 	static public function deleteHook($params) {
 		self::deleteUpdate($params['path']);
 	}
+
+	/**
+	 * Register hooks for cache
+	 */
+	static public function registerHooks() {
+		\OC_Hook::connect('OC_Filesystem', 'post_write', '\OC\Files\Cache\Updater', 'writeHook');
+		\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
+		\OC_Hook::connect('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Updater', 'deleteHook');
+		\OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Updater', 'renameHook');
+	}
 }


### PR DESCRIPTION
- moved cache updater hooks to a static method Updater::registerHooks()
- call registerHooks() from proxy encryption test to make sure that the
  cache follows file operations
- added test cleanup code for encryption tests to remove key folders

This should reduce a bit the number of cleanup warnings for the encryption test suites.

Note, I tried registering updater hooks and clearing them hooks from the other encryption tests but it seems to fail for some reason. Something to investigate another time.

Please review @schiesbn @DeepDiver1975 @karlitschek 
