### PR TITLE
Allow addScript to add routed scripts

### DIFF
--- a/lib/private/router.php
+++ b/lib/private/router.php
@@ -135,6 +135,17 @@ class OC_Router {
 	}
 
 	/**
+	 * Determine if the match can be made to a specific URL
+	 *
+	 * @param string $url The url to find
+	 * @returns boolean True if the URL matches a route
+	 */
+	public function canMatch($url) {
+		$matcher = new UrlMatcher($this->root, $this->context);
+		return ($matcher->match($url)) ? true : false;
+	}
+
+	/**
 	 * Get the url generator
 	 *
 	 */

--- a/lib/private/template/jsresourcelocator.php
+++ b/lib/private/template/jsresourcelocator.php
@@ -36,11 +36,11 @@ class JSResourceLocator extends ResourceLocator {
 			return;
 		}
 		if (\OC::getRouter()->canMatch($app_url . '/' . $script . $this->form_factor . '.js')) {
-			$this->append($app_path, $script . $this->form_factor . '.js', $_SERVER['REQUEST_URI'] . $app_url);
+			$this->append($app_path, $script . $this->form_factor . '.js', $_SERVER['SCRIPT_NAME'] . $app_url);
 			return;
 		}
 		if (\OC::getRouter()->canMatch($app_url . '/' . $script . '.js')) {
-			$this->append($app_path, $script . '.js', $_SERVER['REQUEST_URI'] . $app_url);
+			$this->append($app_path, $script . '.js', $_SERVER['SCRIPT_NAME'] . $app_url);
 			return;
 		}
 		throw new \Exception('js file not found: script:'.$script);

--- a/lib/private/template/jsresourcelocator.php
+++ b/lib/private/template/jsresourcelocator.php
@@ -35,6 +35,9 @@ class JSResourceLocator extends ResourceLocator {
 		) {
 			return;
 		}
+		if (\OC::getRouter()->canMatch($app_url . '/' . $script . '.js')) {
+			return;
+		}
 		throw new \Exception('js file not found: script:'.$script);
 	}
 

--- a/lib/private/template/jsresourcelocator.php
+++ b/lib/private/template/jsresourcelocator.php
@@ -35,7 +35,12 @@ class JSResourceLocator extends ResourceLocator {
 		) {
 			return;
 		}
+		if (\OC::getRouter()->canMatch($app_url . '/' . $script . $this->form_factor . '.js')) {
+			$this->append($app_path, $script . $this->form_factor . '.js', $_SERVER['REQUEST_URI'] . $app_url);
+			return;
+		}
 		if (\OC::getRouter()->canMatch($app_url . '/' . $script . '.js')) {
+			$this->append($app_path, $script . '.js', $_SERVER['REQUEST_URI'] . $app_url);
 			return;
 		}
 		throw new \Exception('js file not found: script:'.$script);

--- a/lib/private/template/resourcelocator.php
+++ b/lib/private/template/resourcelocator.php
@@ -55,13 +55,24 @@ abstract class ResourceLocator {
 	 */
 	protected function appendIfExist($root, $file, $webroot = null) {
 		if (is_file($root.'/'.$file)) {
-			if (!$webroot) {
-				$webroot = $this->mapping[$root];
-			}
-			$this->resources[] = array($root, $webroot, $file);
-			return true;
+			return $this->append($root, $file, $webroot);
 		}
 		return false;
+	}
+
+	/*
+	 * Append the $file resource at $root
+	 * @param $root path to check
+	 * @param $file the filename
+	 * @param $web base for path, default map $root to $webroot
+	 * @return boolean Always true
+	 */
+	protected function append($root, $file, $webroot = null) {
+		if (!$webroot) {
+			$webroot = $this->mapping[$root];
+		}
+		$this->resources[] = array($root, $webroot, $file);
+		return true;
 	}
 
 	public function getResources() {


### PR DESCRIPTION
Util::addScript() can be used to add scripts only if the script exists as a file.

When creating a new route to a dynamically generated javascript file from an app, Util::addScript() can be used to queue the script for output, but because the template class checks for the existence of the script as a file, and the script is virtual due to the nature of it being routed, the script file isn't found and the template class errors out.

These commits also check the router for a URL that matches the file added via Util::addScript() after the existing checks to see if the file exists in the filesystem.  It allows apps to use Util::addScript() to add a script to the output that is generated by PHP via the router.

---

in app's routes.php:

``` php
/** @var OC_Route $route */
$this->create('my_app_js', '/js/custom.js')
    ->action(create_function('',"require_once __DIR__ . '/../js/custom.php';"));
```

in app's app.php:

``` php
OCP\Util::addScript('may_app', 'custom');
```
