### PR TITLE
Set the collation of existing database tables to mysql_bin for mysql

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -30,6 +30,12 @@ if (OC::checkUpgrade(false)) {
 		$eventSource->close();
 		OC_Config::setValue('maintenance', false);
 	});
+	$updater->listen('\OC\Updater', 'dbCollationStart', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Updating table collations, this can take a while'));
+	});
+	$updater->listen('\OC\Updater', 'dbCollationEnd', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Updated table collations'));
+	});
 
 	$updater->upgrade();
 

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -7,6 +7,7 @@
  */
 
 namespace OC;
+
 use OC\Hooks\BasicEmitter;
 
 /**
@@ -37,6 +38,7 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * Check if a new version is available
+	 *
 	 * @param string $updaterUrl the url to check, i.e. 'http://apps.owncloud.com/updater.php'
 	 * @return array | bool
 	 */
@@ -56,7 +58,7 @@ class Updater extends BasicEmitter {
 		$version = \OC_Util::getVersion();
 		$version['installed'] = \OC_Appconfig::getValue('core', 'installedat');
 		$version['updated'] = \OC_Appconfig::getValue('core', 'lastupdatedat');
-		$version['updatechannel'] = \OC_Util::getChannel(); 
+		$version['updatechannel'] = \OC_Util::getChannel();
 		$version['edition'] = \OC_Util::getEditionString();
 		$version['build'] = \OC_Util::getBuild();
 		$versionString = implode('x', $version);
@@ -103,6 +105,8 @@ class Updater extends BasicEmitter {
 		}
 		$this->emit('\OC\Updater', 'maintenanceStart');
 		try {
+			$this->setDBCollation();
+
 			\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 			$this->emit('\OC\Updater', 'dbUpgrade');
 
@@ -160,5 +164,40 @@ class Updater extends BasicEmitter {
 			}
 		}
 		$this->emit('\OC\Updater', 'filecacheDone');
+	}
+
+	/**
+	 * make sure the database collation is set to utf8_bin for mysql to prevent case insensitive string operations being default
+	 */
+	private function setDBCollation() {
+		if (\OC_Config::getValue('dbtype', 'sqlite3') !== 'mysql') {
+			return;
+		}
+		$db = \OC::$server->getDatabaseConnection();
+		$dbName = \OC_Config::getValue('dbname', 'owncloud');
+		$dbPrefix = \OC_Config::getValue('dbtableprefix', 'oc_');
+		$query = $db->prepare('SELECT COLLATION_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = ? AND table_schema = ?');
+		$query->execute(array($dbPrefix . 'appconfig', $dbName));
+		$row = $query->fetch();
+		// utf8_general_ci is the old default
+		if ($row['COLLATION_NAME'] === 'utf8_bin') {
+			return;
+		}
+		// at this point we know that we have to migrate, tell the user as early as possible since converting all table might take a while
+		$this->emit('\OC\Updater', 'dbCollationStart');
+		$query = $db->prepare('SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ?');
+		$query->execute(array($dbName));
+		while ($row = $query->fetch()) {
+			// don't touch tables that arent ours
+			if (strpos($row['TABLE_NAME'], $dbPrefix) === 0) {
+				$convertQuery = $db->prepare('ALTER TABLE `' . $row['TABLE_NAME'] . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;');
+				$convertQuery->execute();
+			}
+		}
+
+		// finally set the default collation for the database
+		$query = $db->prepare('ALTER DATABASE ' . $dbName . ' CHARACTER SET utf8 COLLATE utf8_bin;');
+		$query->execute();
+		$this->emit('\OC\Updater', 'dbCollationEnd');
 	}
 }

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
 
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel when updating major/minor version number.
-$OC_Version=array(6, 90, 0, 1);
+$OC_Version=array(6, 90, 0, 2);
 
 // The human readable string
 $OC_VersionString='7.0 pre alpha';


### PR DESCRIPTION
This adds an additional step to the upgrade progress checking the current collation of tables for mysql databases and setting them to `utf8_bin` from their default `utf8_unicode_ci`.

This fixes string operations being case insensitive, see #6850 

Naturally this needs testing in as many different installations as possible, the collation conversion itself should be fully safe since it converts from a lose collation to a collation with more strict comparisons

cc @karlitschek @DeepDiver1975 @PVince81 
