### PR TITLE
refactored/cleaned up lib/private/files.php and switched get() to ZipStreamer

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -51,7 +51,7 @@ class OC_Files {
 			$xsendfile = true;
 		}
 
-		if (is_array($files) && count($files) == 1) {
+		if (is_array($files) && count($files) === 1) {
 			$files = $files[0];
 		}
 
@@ -178,7 +178,7 @@ class OC_Files {
 			if (isset($_SERVER['HTTP_RANGE']) && 
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
- 				if ($range[2] == "") {
+ 				if ($range[2] === "") {
  					$range[2] = $filelength - 1;
  				}
  				header("Content-Range: bytes $range[1]-$range[2]/" . $filelength);
@@ -280,7 +280,7 @@ class OC_Files {
 		}
 
 		//don't allow user to break his config -- broken or malicious size input
-		if (intval($size) == 0) {
+		if (intval($size) === 0) {
 			return false;
 		}
 
@@ -302,7 +302,7 @@ class OC_Files {
 			if ($content !== null) {
 				$htaccess = $content;
 			}
-			if ($hasReplaced == 0) {
+			if ($hasReplaced === 0) {
 				$htaccess .= "\n" . $setting;
 			}
 		}


### PR DESCRIPTION
This commit mainly adds the ability for owncloud to use ZipStreamer instead of the builtin ZipArchive. This reduces disk i/o greatly, as the current implementation creates one temp file for each file to be added to the zip, and then again a temp file of the complete zip, before starting to send the temp zip to the client.
 The ZipStreamer creates the zip file on the fly in memory and directly sends the data to the client, no temp file needed at all. The ZipStreamer class was added in a second pull request to 3rdparty.
(this is a replacement for pull request #3439)
