### PR TITLE
Added error message for when target folder was removed

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -64,6 +64,15 @@ if(strpos($filename, '/') !== false) {
 	exit();
 }
 
+if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
+	$result['data'] = array('message' => (string)$l10n->t(
+			'The target folder has been moved or deleted.'),
+			'code' => 'targetnotfound'
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 //TODO why is stripslashes used on foldername in newfolder.php but not here?
 $target = $dir.'/'.$filename;
 

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -29,6 +29,15 @@ if(strpos($foldername, '/') !== false) {
 	exit();
 }
 
+if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
+	$result['data'] = array('message' => (string)$l10n->t(
+			'The target folder has been moved or deleted.'),
+			'code' => 'targetnotfound'
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 //TODO why is stripslashes used on foldername here but not in newfile.php?
 $target = $dir . '/' . stripslashes($foldername);
 		

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -8,6 +8,7 @@ OCP\JSON::setContentTypeHeader('text/plain');
 // If no token is sent along, rely on login only
 
 $allowedPermissions = OCP\PERMISSION_ALL;
+$errorCode = null;
 
 $l = OC_L10N::get('files');
 if (empty($_POST['dirToken'])) {
@@ -125,7 +126,8 @@ if (strpos($dir, '..') === false) {
 
 					$meta = \OC\Files\Filesystem::getFileInfo($target);
 					if ($meta === false) {
-						$error = $l->t('Upload failed. Could not get file info.');
+						$error = $l->t('The target folder has been moved or deleted.');
+						$errorCode = 'targetnotfound';
 					} else {
 						$result[] = array('status' => 'success',
 							'mime' => $meta['mimetype'],
@@ -177,5 +179,5 @@ if ($error === false) {
 	OCP\JSON::encodedPrint($result);
 	exit();
 } else {
-	OCP\JSON::error(array(array('data' => array_merge(array('message' => $error), $storageStats))));
+	OCP\JSON::error(array(array('data' => array_merge(array('message' => $error, 'code' => $errorCode), $storageStats))));
 }

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -315,6 +315,13 @@ $(document).ready(function() {
 					} else {
 						// HTTP connection problem
 						OC.Notification.show(data.errorThrown);
+						if (data.result) {
+							var result = JSON.parse(data.result);
+							if (result && result[0] && result[0].data && result[0].data.code === 'targetnotfound') {
+								// abort upload of next files if any
+								OC.Upload.cancelUploads();
+							}
+						}
 					}
 					//hide notification after 10 sec
 					setTimeout(function() {

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -59,6 +59,13 @@ class App {
 			$result['data'] = array(
 				'message'	=> $this->l10n->t("Invalid folder name. Usage of 'Shared' is reserved.")
 			);
+		// rename to non-existing folder is denied
+		} else if (!$this->view->file_exists($dir)) {
+			$result['data'] = array('message' => (string)$this->l10n->t(
+					'The target folder has been moved or deleted.',
+					array($dir)),
+					'code' => 'targetnotfound'
+				);
 		// rename to existing file is denied
 		} else if ($this->view->file_exists($dir . '/' . $newname)) {
 			


### PR DESCRIPTION
Whent trying to upload/rename/create files in a folder that was removed
or rename, the correct error message is now shown.

In the case of upload of multiple files, the upload is cancelled.

This situation can happen if the target folder was renamed or removed
from another browser window or client.

Fixes #6871 

Please review/test @DeepDiver1975 @karlitschek @schiesbn @ser72 
