### PR TITLE
Added exception logger plugin for sabre connector

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -52,6 +52,7 @@ $server->addPlugin(new OC_Connector_Sabre_FilesPlugin());
 $server->addPlugin(new OC_Connector_Sabre_AbortedUploadDetectionPlugin());
 $server->addPlugin(new OC_Connector_Sabre_QuotaPlugin());
 $server->addPlugin(new OC_Connector_Sabre_MaintenancePlugin());
+$server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('webdav'));
 
 // And off we go!
 $server->exec();

--- a/lib/private/connector/sabre/exceptionloggerplugin.php
+++ b/lib/private/connector/sabre/exceptionloggerplugin.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
+ *
+ * @license AGPL3
+ */
+
+class OC_Connector_Sabre_ExceptionLoggerPlugin extends Sabre_DAV_ServerPlugin
+{
+	private $appName;
+
+	/**
+	 * @param string $loggerAppName app name to use when logging
+	 */
+	public function __construct($loggerAppName = 'webdav') {
+		$this->appName = $loggerAppName;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre_DAV_Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Sabre_DAV_Server $server
+	 * @return void
+	 */
+	public function initialize(Sabre_DAV_Server $server) {
+
+		$server->subscribeEvent('exception', array($this, 'logException'), 10);
+	}
+
+	/**
+	 * Log exception
+	 *
+	 * @internal param Exception $e exception
+	 */
+	public function logException($e) {
+		$exceptionClass = get_class($e);
+		if ($exceptionClass !== 'Sabre_DAV_Exception_NotAuthenticated') {
+			\OCP\Util::logException($this->appName, $e);
+		}
+	}
+}

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -79,7 +79,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 				\OC_Log::write('webdav', '\OC\Files\Filesystem::file_put_contents() failed', \OC_Log::ERROR);
 				$fs->unlink($partpath);
 				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
-				throw new Sabre_DAV_Exception();
+				throw new Sabre_DAV_Exception('Could not write file contents');
 			}
 		} catch (\OCP\Files\NotPermittedException $e) {
 			// a more general case - due to whatever reason the content could not be written
@@ -105,7 +105,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		if ($renameOkay === false || $fileExists === false) {
 			\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
 			$fs->unlink($partpath);
-			throw new Sabre_DAV_Exception();
+			throw new Sabre_DAV_Exception('Could not rename part file to final file');
 		}
 
 		// allow sync clients to send the mtime along in a header
@@ -246,7 +246,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 				if ($fileExists) {
 					$fs->unlink($targetPath);
 				}
-				throw new Sabre_DAV_Exception();
+				throw new Sabre_DAV_Exception('Could not rename part file assembled from chunks');
 			}
 
 			// allow sync clients to send the mtime along in a header

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -88,14 +88,18 @@ class Util {
 	 * @param Exception $ex exception to log
 	 */
 	public static function logException( $app, \Exception $ex ) {
-		$message = $ex->getMessage();
+		$class = get_class($ex);
+		if ($class !== 'Exception') {
+			$message = $class . ': ';
+		}
+		$message .= $ex->getMessage();
 		if ($ex->getCode()) {
 			$message .= ' [' . $ex->getCode() . ']';
 		}
 		\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
 		if (defined('DEBUG') and DEBUG) {
 			// also log stack trace
-			$stack = explode('#', $ex->getTraceAsString());
+			$stack = explode("\n", $ex->getTraceAsString());
 			// first element is empty
 			array_shift($stack);
 			foreach ($stack as $s) {


### PR DESCRIPTION
Whenever an exception occurs in the sabre connector code or code called
by it, it will be logged.

This plugin approach is needed because Sabre already catches exceptions
to return them to the client in the XML response, so they don't appear
logged in the web server log.

This will make it much easier to debug syncing issues.

Please review @karlitschek @DeepDiver1975 @schiesbn @icewind1991 
