### PR TITLE
Remove %webroot% from CSS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,7 +26,7 @@ RewriteRule ^.well-known/carddav /remote.php/carddav/ [R]
 RewriteRule ^.well-known/caldav /remote.php/caldav/ [R]	
 RewriteRule ^apps/calendar/caldav.php remote.php/caldav/ [QSA,L]
 RewriteRule ^apps/contacts/carddav.php remote.php/carddav/ [QSA,L]
-RewriteRule ^apps/([^/]*)/(.*\.(css|php))$ index.php?app=$1&getfile=$2 [QSA,L]
+RewriteRule ^apps/([^/]*)/(.*\.(php))$ index.php?app=$1&getfile=$2 [QSA,L]
 RewriteRule ^remote/(.*) remote.php [QSA,L]
 </IfModule>
 <IfModule mod_mime.c>

--- a/apps/files/css/upload.css
+++ b/apps/files/css/upload.css
@@ -18,9 +18,6 @@
 	margin: -5px -3px;
 	cursor: pointer;
 	z-index: 10;
-	background-image: url('%webroot%/core/img/actions/upload.svg');
-	background-repeat: no-repeat;
-	background-position: center;
 	opacity: .65;
 }
 .file_upload_target { display:none; }
@@ -118,11 +115,6 @@
 }
 .oc-dialog .fileexists .conflict input[type='checkbox'] {
 	float: left;
-}
-.oc-dialog .fileexists .toggle {
-	background-image: url('%webroot%/core/img/actions/triangle-e.png');
-	width: 16px;
-	height: 16px;
 }
 .oc-dialog .fileexists #allfileslabel {
 	float:right;

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -23,7 +23,7 @@
 					<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 					<input type="file" id="file_upload_start" name='files[]'
 						   data-url="<?php print_unescaped(OCP\Util::linkTo('files', 'ajax/upload.php')); ?>" />
-					<a href="#" class="svg"></a>
+					<a href="#" class="svg icon icon-upload"></a>
 			</div>
 			<?php if ($_['trash']): ?>
 			<input id="trash" type="button" value="<?php p($l->t('Deleted files'));?>" class="button" <?php $_['trashEmpty'] ? p('disabled') : '' ?>></input>

--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -11,16 +11,13 @@
 	margin:	6px;
 }
 
-input[type="submit"]{
+input[type='submit'] {
 	width: 45px;
 	height: 45px;
 	margin:	6px;
-	background-image: url('%webroot%/core/img/actions/confirm.svg');
-	background-repeat: no-repeat;
-	background-position: center;
 }
 
-#body-login input[type="submit"] {
+#body-login input[type='submit'] {
 	position: absolute;
 	top: 0px;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -3,7 +3,7 @@ body {
 }
 
 #header {
-	background: #1d2d44 url('%webroot%/core/img/noise.png') repeat;
+	background-color: #1d2d44;
 	height:32px;
 	left:0;
 	line-height:32px;
@@ -119,23 +119,6 @@ thead{
 	top: 0;
 	left: 0;
 	width: 100% !important;
-}
-
-#publicUploadButtonMock {
-	position:relative;
-	display:block;
-	width:100%;
-	height:32px;
-	cursor:pointer;
-	z-index:10;
-	background-image:url('%webroot%/core/img/actions/upload.svg');
-	background-repeat:no-repeat;
-	background-position:7px 8px;
-}
-
-#publicUploadButtonMock span {
-	margin: 0 5px 0 28px;
-	color: #555;
 }
 
 .directLink {

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -9,7 +9,7 @@
 		<p class="infield">
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<input type="password" name="password" id="password" placeholder="" value="" autofocus />
-			<input type="submit" value="" class="svg" />
+			<input type="submit" value="" class="svg icon icon-confirm" />
 		</p>
 	</fieldset>
 </form>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -9,7 +9,7 @@
 <input type="hidden" name="sharingToken" value="<?php p($_['sharingToken']) ?>" id="sharingToken">
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
-<header><div id="header">
+<header><div id="header" class="icon icon-noise">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
 		                                                                                          src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="<?php p($theme->getName()); ?>" /></a>
 		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -1,0 +1,240 @@
+.icon {
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+
+
+
+/* general assets */
+
+.icon-breadcrumb {
+	background-image: url('../img/breadcrumb.svg');
+}
+
+.icon-loading {
+	background-image: url('../img/loading.gif');
+}
+.icon-loading-dark {
+	background-image: url('../img/loading-dark.gif');
+}
+.icon-loading-small {
+	background-image: url('../img/loading-small.gif');
+}
+
+.icon-noise {
+	background-image: url('../img/noise.png');
+	background-repeat: no-repeat;
+}
+
+
+
+
+/* action icons */
+
+.icon-add {
+	background-image: url('../img/actions/add.svg');
+}
+
+.icon-caret {
+	background-image: url('../img/actions/caret.svg');
+}
+.icon-caret-dark {
+	background-image: url('../img/actions/caret-dark.svg');
+}
+
+.icon-checkmark {
+	background-image: url('../img/actions/checkmark.svg');
+}
+
+.icon-clock {
+	background-image: url('../img/actions/clock.svg');
+}
+
+.icon-close {
+	background-image: url('../img/actions/close.svg');
+}
+
+.icon-confirm {
+	background-image: url('../img/actions/confirm.svg');
+}
+
+.icon-delete {
+	background-image: url('../img/actions/delete.svg');
+}
+.icon-delete-hover {
+	background-image: url('../img/actions/delete-hover.svg');
+}
+
+.icon-download {
+	background-image: url('../img/actions/download.svg');
+}
+
+.icon-history {
+	background-image: url('../img/actions/history.svg');
+}
+
+.icon-info {
+	background-image: url('../img/actions/info.svg');
+}
+
+.icon-lock {
+	background-image: url('../img/actions/lock.svg');
+}
+
+.icon-logout {
+	background-image: url('../img/actions/logout.svg');
+}
+
+.icon-mail {
+	background-image: url('../img/actions/mail.svg');
+}
+
+.icon-more {
+	background-image: url('../img/actions/more.svg');
+}
+
+.icon-password {
+	background-image: url('../img/actions/password.svg');
+}
+
+.icon-pause {
+	background-image: url('../img/actions/pause.svg');
+}
+.icon-pause-big {
+	background-image: url('../img/actions/pause-big.svg');
+}
+
+.icon-play {
+	background-image: url('../img/actions/play.svg');
+}
+.icon-play-add {
+	background-image: url('../img/actions/play-add.svg');
+}
+.icon-play-big {
+	background-image: url('../img/actions/play-big.svg');
+}
+.icon-play-next {
+	background-image: url('../img/actions/play-next.svg');
+}
+.icon-play-previous {
+	background-image: url('../img/actions/play-previous.svg');
+}
+
+.icon-public {
+	background-image: url('../img/actions/public.svg');
+}
+
+.icon-rename {
+	background-image: url('../img/actions/rename.svg');
+}
+
+.icon-search {
+	background-image: url('../img/actions/search.svg');
+}
+
+.icon-settings {
+	background-image: url('../img/actions/settings.svg');
+}
+
+.icon-share {
+	background-image: url('../img/actions/share.svg');
+}
+.icon-shared {
+	background-image: url('../img/actions/shared.svg');
+}
+
+.icon-sound {
+	background-image: url('../img/actions/sound.svg');
+}
+.icon-sound-off {
+	background-image: url('../img/actions/sound-off.svg');
+}
+
+.icon-star {
+	background-image: url('../img/actions/star.svg');
+}
+
+.icon-starred {
+	background-image: url('../img/actions/starred.svg');
+}
+
+.icon-toggle {
+	background-image: url('../img/actions/toggle.svg');
+}
+
+.icon-triangle-e {
+	background-image: url('../img/actions/triangle-e.svg');
+}
+.icon-triangle-n {
+	background-image: url('../img/actions/triangle-n.svg');
+}
+.icon-triangle-s {
+	background-image: url('../img/actions/triangle-s.svg');
+}
+
+.icon-upload {
+	background-image: url('../img/actions/upload.svg');
+}
+.icon-upload-white {
+	background-image: url('../img/actions/upload-white.svg');
+}
+
+.icon-user {
+	background-image: url('../img/actions/user.svg');
+}
+
+.icon-view-close {
+	background-image: url('../img/actions/view-close.svg');
+}
+.icon-view-next {
+	background-image: url('../img/actions/view-next.svg');
+}
+.icon-view-pause {
+	background-image: url('../img/actions/view-pause.svg');
+}
+.icon-view-play {
+	background-image: url('../img/actions/view-play.svg');
+}
+.icon-view-previous {
+	background-image: url('../img/actions/view-previous.svg');
+}
+
+
+
+
+/* places icons */
+
+.icon-calendar-dark {
+	background-image: url('../img/places/calendar-dark.svg');
+}
+
+.icon-contacts-dark {
+	background-image: url('../img/places/contacts-dark.svg');
+}
+
+.icon-file {
+	background-image: url('../img/places/file.svg');
+}
+.icon-files {
+	background-image: url('../img/places/files.svg');
+}
+.icon-folder {
+	background-image: url('../img/places/folder.svg');
+}
+
+.icon-home {
+	background-image: url('../img/places/home.svg');
+}
+
+.icon-link {
+	background-image: url('../img/places/link.svg');
+}
+
+.icon-music {
+	background-image: url('../img/places/music.svg');
+}
+
+.icon-picture {
+	background-image: url('../img/places/picture.svg');
+}

--- a/lib/base.php
+++ b/lib/base.php
@@ -331,6 +331,7 @@ class OC {
 		}
 
 		OC_Util::addStyle("styles");
+		OC_Util::addStyle("icons");
 		OC_Util::addStyle("apps");
 		OC_Util::addStyle("fixes");
 		OC_Util::addStyle("multiselect");


### PR DESCRIPTION
Move from the performance-killing %webroot% in CSS to instead have an icons.css file where apps can refer icons from core directly via HTML classes.

This pull request includes the icons file and cleaning up of the apps in the core repo. Still to follow is cleaning up of all apps and actually ripping out the webroot and appswebroot substitution method from core.

Please review @DeepDiver1975 @PVince81 @owncloud/designers 

Btw @butonic I removed the .toggle rule in upload.css because it seemed to get used nowhere. Let me know if that’s wrong: https://github.com/owncloud/core/compare/replace-webroot-in-css?expand=1#diff-1e59de7cf00a99e45afecad263368216L122
