### PR TITLE
Fixed max upload size input field style

### DIFF
--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -5,7 +5,7 @@
 		<h2><?php p($l->t('File handling')); ?></h2>
 		<?php if($_['uploadChangable']):?>
 			<label for="maxUploadSize"><?php p($l->t( 'Maximum upload size' )); ?> </label>
-			<input name='maxUploadSize' id="maxUploadSize" value='<?php p($_['uploadMaxFilesize']) ?>'/>
+			<input type="text" name='maxUploadSize' id="maxUploadSize" value='<?php p($_['uploadMaxFilesize']) ?>'/>
 			<?php if($_['displayMaxPossibleUploadSize']):?>
 				(<?php p($l->t('max. possible: ')); p($_['maxPossibleUploadSize']) ?>)
 			<?php endif;?>


### PR DESCRIPTION
Added "type=text" makes it look like nice like all other fields

Please review this quick one @karlitschek @jancborchardt @kabum @DeepDiver1975 

The field is only visible if your `.htaccess` file is writable, that's probably why nobody noticed that it looked odd :wink: 
