### PR TITLE
remove the form, it isn't needed here

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -206,6 +206,8 @@ $(document).ready(function(){
 
 	$('button:button[name="submitDecryptAll"]').click(function() {
 		var privateKeyPassword = $('#decryptAll input:password[id="privateKeyPassword"]').val();
+		$('#decryptAll button:button[name="submitDecryptAll"]').prop("disabled", true);
+		$('#decryptAll input:password[name="privateKeyPassword"]').prop("disabled", true);
 		OC.Encryption.decryptAll(privateKeyPassword);
 	});
 
@@ -214,6 +216,8 @@ $(document).ready(function(){
 		if (privateKeyPassword !== '' ) {
 			$('#decryptAll button:button[name="submitDecryptAll"]').removeAttr("disabled");
 			if(event.which === 13) {
+				$('#decryptAll button:button[name="submitDecryptAll"]').prop("disabled", true);
+				$('#decryptAll input:password[name="privateKeyPassword"]').prop("disabled", true);
 				OC.Encryption.decryptAll(privateKeyPassword);
 			}
 		} else {
@@ -280,6 +284,7 @@ OC.Encryption = {
 		$.post('ajax/decryptall.php', {password:password}, function(data) {
 			if (data.status === "error") {
 				OC.Encryption.msg.finishedDecrypting('#decryptAll .msg', data);
+				$('#decryptAll input:password[name="privateKeyPassword"]').removeAttr("disabled");
 			} else {
 				OC.Encryption.msg.finishedDecrypting('#decryptAll .msg', data);
 			}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -283,10 +283,9 @@ OC.Encryption = {
 			} else {
 				OC.Encryption.msg.finishedDecrypting('#decryptAll .msg', data);
 			}
-		}
-		);
+		});
 	}
-}
+};
 
 OC.Encryption.msg={
 	startDecrypting:function(selector){

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -146,29 +146,27 @@ if($_['passwordChangeSupported']) {
 };?>
 
 <?php if($_['enableDecryptAll']): ?>
-<form id="decryptAll">
-	<fieldset class="personalblock">
-		<h2>
-			<?php p( $l->t( 'Encryption' ) ); ?>
-		</h2>
-		<?php p($l->t( "The encryption app is no longer enabled, please decrypt all your files" )); ?>
-		<p>
-			<input
-				type="password"
-				name="privateKeyPassword"
-				id="privateKeyPassword" />
-			<label for="privateKeyPassword"><?php p($l->t( "Log-in password" )); ?></label>
-			<br />
-			<button
-				type="button"
-				disabled
-				name="submitDecryptAll"><?php p($l->t( "Decrypt all Files" )); ?>
-			</button>
-			<span class="msg"></span>
-		</p>
+<fieldset class="personalblock" id="decryptAll">
+	<h2>
+		<?php p( $l->t( 'Encryption' ) ); ?>
+	</h2>
+	<?php p($l->t( "The encryption app is no longer enabled, please decrypt all your files" )); ?>
+	<p>
+		<input
+			type="password"
+			name="privateKeyPassword"
+			id="privateKeyPassword" />
+		<label for="privateKeyPassword"><?php p($l->t( "Log-in password" )); ?></label>
 		<br />
-	</fieldset>
-</form>
+		<button
+			type="button"
+			disabled
+			name="submitDecryptAll"><?php p($l->t( "Decrypt all Files" )); ?>
+		</button>
+		<span class="msg"></span>
+	</p>
+	<br />
+</fieldset>
 <?php endif; ?>
 
 <fieldset class="personalblock">


### PR DESCRIPTION
remove the form from the "decrypt all" input/button. This way we prevent a page reload if the user presses enter in the input field to start the decryption. Otherwise the user will never see the success/error message at the end of the decryption.

cc @PVince81 
