### PR TITLE
Add 'mail_from_address' configuration

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -80,6 +80,12 @@ $CONFIG = array(
 /* Domain name used by ownCloud for the sender mail address, e.g. no-reply@example.com */
 "mail_domain" => "example.com",
 
+/* FROM address used by ownCloud for the sender mail address, e.g. owncloud@example.com
+   This setting overwrites the built in 'sharing-noreply' and 'lostpassword-noreply'
+   FROM addresses, that ownCloud uses
+*/
+"mail_from_address" => "owncloud",
+
 /* Enable SMTP class debugging */
 "mail_smtpdebug" => false,
 

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -254,6 +254,10 @@ class Util {
 	 * Example: when given lostpassword-noreply as $user_part param,
 	 *     and is currently accessed via http(s)://example.com/,
 	 *     it would return 'lostpassword-noreply@example.com'
+	 *
+	 * If the configuration value 'mail_from_address' is set in
+	 * config.php, this value will override the $user_part that
+	 * is passed to this function
 	 */
 	public static function getDefaultEmailAddress($user_part) {
 		$user_part = \OC_Config::getValue('mail_from_address', $user_part);

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -256,6 +256,7 @@ class Util {
 	 *     it would return 'lostpassword-noreply@example.com'
 	 */
 	public static function getDefaultEmailAddress($user_part) {
+		$user_part = \OC_Config::getValue('mail_from_address', $user_part);
 		$host_name = self::getServerHostName();
 		$host_name = \OC_Config::getValue('mail_domain', $host_name);
 		$defaultEmailAddress = $user_part.'@'.$host_name;

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -88,6 +88,15 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		OC_Config::deleteKey('mail_domain');
 	}
 
+	function testGetConfiguredEmailAddressFromConfig() {
+		OC_Config::setValue('mail_domain', 'example.com');
+		OC_Config::setValue('mail_from_address', 'owncloud');
+		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
+		$this->assertEquals('owncloud@example.com', $email);
+		OC_Config::deleteKey('mail_domain');
+		OC_Config::deleteKey('mail_from_address');
+	}
+
 	function testGetInstanceIdGeneratesValidId() {
 		OC_Config::deleteKey('instanceid');
 		$this->assertStringStartsWith('oc', OC_Util::getInstanceId());


### PR DESCRIPTION
In environments where there are rules for the email addresses, the "from
address" that owncloud uses has to be configurable.

This patch adds a new configuration variable 'mail_from_address'.
If it is configured, owncloud will use this as the sender of _all_
emails. (OwnCloud uses 'sharing-noreply' and 'password-noreply' by
default). By using the 'mail_from_address' configuration, only this
email address will be used.
