### PR TITLE
Add check for apc.enabled option

### DIFF
--- a/lib/private/memcache/apc.php
+++ b/lib/private/memcache/apc.php
@@ -50,6 +50,8 @@ class APC extends Cache {
 	static public function isAvailable() {
 		if (!extension_loaded('apc')) {
 			return false;
+		} elseif (!ini_get('apc.enabled')) {
+			return false;
 		} elseif (!ini_get('apc.enable_cli') && \OC::$CLI) {
 			return false;
 		} else {


### PR DESCRIPTION
Sometimes it's not possible to disable APC entirely and some of
apc_\* functions are disabled. Only thing which is possible is
to disable 'apc.enable' option.
