### PR TITLE
Add missing slash in URLGenerator::getAbsoluteURL().

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -147,6 +147,7 @@ class URLGenerator implements IURLGenerator {
 	 * @return string the absolute version of the url
 	 */
 	public function getAbsoluteURL($url) {
-		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . '/' . $url;
+		$separator = $url[0] === '/' ? '' : '/';
+		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . $separator . $url;
 	}
 }

--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -147,6 +147,6 @@ class URLGenerator implements IURLGenerator {
 	 * @return string the absolute version of the url
 	 */
 	public function getAbsoluteURL($url) {
-		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . $url;
+		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . '/' . $url;
 	}
 }


### PR DESCRIPTION
It generated links like `http://$host.comindex.php` (without a slash)

@bartv2 @PVince81 @DeepDiver1975 

Refs. #6840
