### PR TITLE
prevent autofill for password change settings, prevent leak of existing password

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -39,9 +39,11 @@ if($_['passwordChangeSupported']) {
 		<h2><?php p($l->t('Password'));?></h2>
 		<div id="passwordchanged"><?php echo $l->t('Your password was changed');?></div>
 		<div id="passworderror"><?php echo $l->t('Unable to change your password');?></div>
-		<input type="password" id="pass1" name="oldpassword" placeholder="<?php echo $l->t('Current password');?>" />
+		<input type="password" id="pass1" name="oldpassword"
+			placeholder="<?php echo $l->t('Current password');?>" autocomplete="off" />
 		<input type="password" id="pass2" name="personal-password"
-			placeholder="<?php echo $l->t('New password');?>" data-typetoggle="#personal-show" />
+			placeholder="<?php echo $l->t('New password');?>"
+			data-typetoggle="#personal-show" autocomplete="off" />
 		<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
 		<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password');?>" />
 		<br/>


### PR DESCRIPTION
This fixes issue #6552. What occurs is that the »New password« field gets prefilled by browser autofill with the existing password. Then the »show password« toggle could be used to know the password. That should never happen, because it makes the whole »old password« security question obsolete and also leaks sensible information.

This pull request simply disables autocomplete for the password fields. Please check if this fixes your issue @iliaselmatani

And review please @owncloud/designers @LukasReschke 
