### PR TITLE
New user agent added for the Freebox.

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -11,7 +11,7 @@ class OC_Request {
 	const USER_AGENT_IE = '/MSIE/';
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
-	const USER_AGENT_FREEBOX = '#Mozilla/5\.0$#';
+	const USER_AGENT_FREEBOX = '#^Mozilla/5\.0$#';
 
 	/**
 	 * @brief Check overwrite condition

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -11,6 +11,7 @@ class OC_Request {
 	const USER_AGENT_IE = '/MSIE/';
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
+	const USER_AGENT_FREEBOX = '#Mozilla/5\.0$#';
 
 	/**
 	 * @brief Check overwrite condition

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -153,7 +153,11 @@ class OC_Response {
 	 * @param string $type disposition type, either 'attachment' or 'inline'
 	 */
 	static public function setContentDispositionHeader( $filename, $type = 'attachment' ) {
-		if (OC_Request::isUserAgent(array(OC_Request::USER_AGENT_IE, OC_Request::USER_AGENT_ANDROID_MOBILE_CHROME))) {
+		if (OC_Request::isUserAgent(array(
+				OC_Request::USER_AGENT_IE,
+				OC_Request::USER_AGENT_ANDROID_MOBILE_CHROME,
+				OC_Request::USER_AGENT_FREEBOX
+			))) {
 			header( 'Content-Disposition: ' . rawurlencode($type) . '; filename="' . rawurlencode( $filename ) . '"' );
 		} else {
 			header( 'Content-Disposition: ' . rawurlencode($type) . '; filename*=UTF-8\'\'' . rawurlencode( $filename )

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -118,6 +118,16 @@ class Test_Request extends PHPUnit_Framework_TestCase {
 				),
 				true
 			),
+			array(
+				'Mozilla/5.0 (X11; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0',
+				OC_Request::USER_AGENT_FREEBOX,
+				false
+			),
+			array(
+				'Mozilla/5.0',
+				OC_Request::USER_AGENT_FREEBOX,
+				true
+			),
 		);
 	}
 }

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -128,6 +128,11 @@ class Test_Request extends PHPUnit_Framework_TestCase {
 				OC_Request::USER_AGENT_FREEBOX,
 				true
 			),
+			array(
+				'Fake Mozilla/5.0',
+				OC_Request::USER_AGENT_FREEBOX,
+				false
+			),
 		);
 	}
 }


### PR DESCRIPTION
The Freebox is the multimedia device of a french Internet provider: Free. This device provides a seedbox which uses the user agent "Mozilla/5.0". In the "Content-Disposition" header, if the "filename" key is used with the "filename*=UTF-8''" value, the seedbox does not take care about the header and saves the file name with the origin URL. This patch brings the support for the Freebox users.
