### PR TITLE
Fixed unit test scripts + coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ nbproject
 # Tests - auto-generated files
 /data-autotest
 /tests/coverage*
+/tests/karma-coverage
 /tests/autoconfig*
 /tests/autotest*
 /tests/data/lorem-copy.txt

--- a/autotest-js.sh
+++ b/autotest-js.sh
@@ -33,5 +33,5 @@ then
 	exit 2
 fi
 
-KARMA_TESTSUITE="$1" $KARMA start tests/karma.config.js --single-run
+NODE_PATH='build/node_modules' KARMA_TESTSUITE="$1" $KARMA start tests/karma.config.js --single-run
 

--- a/core/js/core.json
+++ b/core/js/core.json
@@ -1,28 +1,23 @@
 {
+	"libraries": [
+		"jquery-1.10.0.min.js",
+		"jquery-migrate-1.2.1.min.js",
+		"jquery-ui-1.10.0.custom.js",
+		"jquery-showpassword.js",
+		"jquery.infieldlabel.js",
+		"jquery.placeholder.js",
+		"jquery-tipsy.js"
+	],
 	"modules": [
-	"jquery-1.10.0.min.js",
-	"jquery-migrate-1.2.1.min.js",
-	"jquery-ui-1.10.0.custom.js",
-	"jquery-showpassword.js",
-	"jquery.infieldlabel.js",
-	"jquery.placeholder.js",
-	"jquery-tipsy.js",
-	"compatibility.js",
-	"jquery.ocdialog.js",
-	"oc-dialogs.js",
-	"js.js",
-	"octemplate.js",
-	"eventsource.js",
-	"config.js",
-	"multiselect.js",
-	"search.js",
-	"router.js",
-	"oc-requesttoken.js",
-	"styles.js",
-	"apps.js",
-	"fixes.js",
-	"jquery-ui-2.10.0.custom.js",
-	"jquery-tipsy.js",
-	"jquery.ocdialog.js"
+		"compatibility.js",
+		"jquery.ocdialog.js",
+		"oc-dialogs.js",
+		"js.js",
+		"octemplate.js",
+		"eventsource.js",
+		"config.js",
+		"multiselect.js",
+		"router.js",
+		"oc-requesttoken.js"
 	]
 }

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -18,11 +18,110 @@
 * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 *
 */
+
+/* global OC */
 describe('Core base tests', function() {
 	describe('Base values', function() {
 		it('Sets webroots', function() {
 			expect(OC.webroot).toBeDefined();
 			expect(OC.appswebroots).toBeDefined();
+		});
+	});
+	describe('basename', function() {
+		it('Returns the nothing if no file name given', function() {
+			expect(OC.basename('')).toEqual('');
+		});
+		it('Returns the nothing if dir is root', function() {
+			expect(OC.basename('/')).toEqual('');
+		});
+		it('Returns the same name if no path given', function() {
+			expect(OC.basename('some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if root path given', function() {
+			expect(OC.basename('/some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if double root path given', function() {
+			expect(OC.basename('//some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if subdir given without root', function() {
+			expect(OC.basename('subdir/some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if subdir given with root', function() {
+			expect(OC.basename('/subdir/some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if subdir given with double root', function() {
+			expect(OC.basename('//subdir/some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns the base name if subdir has dot', function() {
+			expect(OC.basename('/subdir.dat/some name.txt')).toEqual('some name.txt');
+		});
+		it('Returns dot if file name is dot', function() {
+			expect(OC.basename('/subdir/.')).toEqual('.');
+		});
+		// TODO: fix the source to make it work like PHP's basename
+		it('Returns the dir itself if no file name given', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.basename('subdir/')).toEqual('subdir');
+			expect(OC.basename('subdir/')).toEqual('');
+		});
+		it('Returns the dir itself if no file name given with root', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.basename('/subdir/')).toEqual('subdir');
+			expect(OC.basename('/subdir/')).toEqual('');
+		});
+	});
+	describe('dirname', function() {
+		it('Returns the nothing if no file name given', function() {
+			expect(OC.dirname('')).toEqual('');
+		});
+		it('Returns the root if dir is root', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.dirname('/')).toEqual('/');
+			expect(OC.dirname('/')).toEqual('');
+		});
+		it('Returns the root if dir is double root', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.dirname('//')).toEqual('/');
+			expect(OC.dirname('//')).toEqual('/'); // oh no...
+		});
+		it('Returns dot if dir is dot', function() {
+			expect(OC.dirname('.')).toEqual('.');
+		});
+		it('Returns dot if no root given', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.dirname('some dir')).toEqual('.');
+			expect(OC.dirname('some dir')).toEqual('some dir'); // oh no...
+		});
+		it('Returns the dir name if file name and root path given', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.dirname('/some name.txt')).toEqual('/');
+			expect(OC.dirname('/some name.txt')).toEqual('');
+		});
+		it('Returns the dir name if double root path given', function() {
+			expect(OC.dirname('//some name.txt')).toEqual('/'); // how lucky...
+		});
+		it('Returns the dir name if subdir given without root', function() {
+			expect(OC.dirname('subdir/some name.txt')).toEqual('subdir');
+		});
+		it('Returns the dir name if subdir given with root', function() {
+			expect(OC.dirname('/subdir/some name.txt')).toEqual('/subdir');
+		});
+		it('Returns the dir name if subdir given with double root', function() {
+			// TODO: fix the source to make it work like PHP's dirname
+			// expect(OC.dirname('//subdir/some name.txt')).toEqual('/subdir');
+			expect(OC.dirname('//subdir/some name.txt')).toEqual('//subdir'); // oh...
+		});
+		it('Returns the dir name if subdir has dot', function() {
+			expect(OC.dirname('/subdir.dat/some name.txt')).toEqual('/subdir.dat');
+		});
+		it('Returns the dir name if file name is dot', function() {
+			expect(OC.dirname('/subdir/.')).toEqual('/subdir');
+		});
+		it('Returns the dir name if no file name given', function() {
+			expect(OC.dirname('subdir/')).toEqual('subdir');
+		});
+		it('Returns the dir name if no file name given with root', function() {
+			expect(OC.dirname('/subdir/')).toEqual('/subdir');
 		});
 	});
 	describe('Link functions', function() {


### PR DESCRIPTION
Tried to add more apps (others break).
"preprocessors" is now populated automatically based on the tested apps.

I tried adding more apps but the others break, as some part rely on libraries loaded only on the settings page... It's still a big mess and I guess we will some day need requireJS or something similar.

Anyway, first things first: writing unit tests for the files app and improve everything gradually.

@DeepDiver1975
