### PR TITLE
[ocs API] getData() always needs to return an array

### DIFF
--- a/lib/private/ocs/result.php
+++ b/lib/private/ocs/result.php
@@ -29,7 +29,13 @@ class OC_OCS_Result{
 	 * @param $data mixed the data to return
 	 */
 	public function __construct($data=null, $code=100, $message=null) {
-		$this->data = $data;
+		if ($data === null) {
+			$this->data = array();
+		} elseif (!is_array($data)) {
+			$this->data = array($this->data);
+		} else {
+			$this->data = $data;
+		}
 		$this->statusCode = $code;
 		$this->message = $message;
 	}
@@ -49,7 +55,7 @@ class OC_OCS_Result{
 	public function setItemsPerPage(int $items) {
 		$this->perPage = $items;
 	}
-	
+
 	/**
 	 * get the status code
 	 * @return int
@@ -57,7 +63,7 @@ class OC_OCS_Result{
 	public function getStatusCode() {
 		return $this->statusCode;
 	}
-	
+
 	/**
 	 * get the meta data for the result
 	 * @return array
@@ -76,15 +82,15 @@ class OC_OCS_Result{
 		return $meta;
 
 	}
-	
+
 	/**
 	 * get the result data
-	 * @return array|string|int 
+	 * @return array
 	 */
 	public function getData() {
 		return $this->data;
 	}
-	
+
 	/**
 	 * return bool if the method succedded
 	 * @return bool


### PR DESCRIPTION
As discussed in this issue getData() always needs to return an array: #6745 

Otherwise we will get this kind of warnings:

```
Warning:  array_merge_recursive(): Argument #2 is not an array in /home/src/owncloud/web/oc/lib/private/api.php on line 170
```

I tested it with the OCS Share API successfully.

cc @tomneedham please also have a look at it, thanks!
