### PR TITLE
Fix warnings in logs when renaming over the web UI

### DIFF
--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -83,14 +83,17 @@ class App {
 			else {
 				$meta['type'] = 'file';
 			}
+			// these need to be set for determineIcon()
+			$meta['isPreviewAvailable'] = \OC::$server->getPreviewManager()->isMimeSupported($meta['mimetype']);
+			$meta['directory'] = $dir;
 			$fileinfo = array(
 				'id' => $meta['fileid'],
 				'mime' => $meta['mimetype'],
 				'size' => $meta['size'],
 				'etag' => $meta['etag'],
-				'directory' => $dir,
+				'directory' => $meta['directory'],
 				'name' => $newname,
-				'isPreviewAvailable' => \OC::$server->getPreviewManager()->isMimeSupported($meta['mimetype']),
+				'isPreviewAvailable' => $meta['isPreviewAvailable'],
 				'icon' => \OCA\Files\Helper::determineIcon($meta)
 			);
 			$result['success'] = true;


### PR DESCRIPTION
The determineIcon() method was expecting attributes to be set which
caused warnings about undefined indices in the error log.

This fix pre-initializes the array with 'directory' and
'isPreviewAvailable' to make them disappear.

Seen in #6975, @raghunayyar please try this branch and let me know whether that fixes your issue.

Please review @karlitschek @DeepDiver1975 @schiesbn 
