### PR TITLE
change order of issubdirectory() calls to avoid error messages for non-apps

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -132,10 +132,10 @@ class OC_L10N implements \OCP\IL10N {
 			$i18ndir = self::findI18nDir($app);
 			// Localization is in /l10n, Texts are in $i18ndir
 			// (Just no need to define date/time format etc. twice)
-			if((OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC_App::getAppPath($app).'/l10n/')
-				|| OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC::$SERVERROOT.'/core/l10n/')
+			if((OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC::$SERVERROOT.'/core/l10n/')
 				|| OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC::$SERVERROOT.'/lib/l10n/')
 				|| OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC::$SERVERROOT.'/settings')
+				|| OC_Helper::issubdirectory($i18ndir.$lang.'.php', OC_App::getAppPath($app).'/l10n/')
 				)
 				&& file_exists($i18ndir.$lang.'.php')) {
 				// Include the file, save the data from $CONFIG


### PR DESCRIPTION
The issue was discussed here https://github.com/owncloud/core/issues/4828#issuecomment-33475102

The problem, for "settings" and "core" getAppPath() returns false which will lead to an error in issubdirectory(). The solution, first checks all the core paths and only is all this test fail we look for an apps folder.
