### PR TITLE
Don't render empty JSONResponse

### DIFF
--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -58,8 +58,10 @@ class JSONResponse extends Response {
 	 * Returns the rendered json
 	 * @return string the rendered json
 	 */
-	public function render(){
-		return json_encode($this->data);
+	public function render() {
+		return (is_array($this->data) && count($this->data))
+			? json_encode($this->data)
+			: null;
 	}
 
 	/**

--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -46,7 +46,7 @@ class JSONResponse extends Response {
 	 * @param array|object $data the object or array that should be transformed
 	 * @param int $statusCode the Http status code, defaults to 200
 	 */
-	public function __construct($data=array(), $statusCode=Http::STATUS_OK) {
+	public function __construct($data = null, $statusCode = Http::STATUS_OK) {
 		$this->data = $data;
 		$this->setStatus($statusCode);
 		$this->addHeader('X-Content-Type-Options', 'nosniff');
@@ -58,10 +58,8 @@ class JSONResponse extends Response {
 	 * Returns the rendered json
 	 * @return string the rendered json
 	 */
-	public function render() {
-		return (is_array($this->data) && count($this->data))
-			? json_encode($this->data)
-			: null;
+	public function render(){
+		return $this->data === null ? $this->data : json_encode($this->data);
 	}
 
 	/**


### PR DESCRIPTION
The App Framework sends a `Content-Length` header for browsers to know how much to read before they can close the connection.
As JSONResponse initializes it's data with an empty array this is encoded as JSON and thus `Content-Length` is set to `2` causing the browser to wait for the two remaining bytes which never comes.
I noticed this while adding support for HEAD requests,

@DeepDiver1975 @karlitschek 
