### PR TITLE
Added .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,28 @@
+{
+	"camelCase": true,
+	"eqeqeq": true,
+	"immed": true,
+	"latedef": false,
+	"noarg": true,
+	"nonbsp": true,
+	"undef": true,
+	"unused": true,
+	"trailing": true,
+	"maxparams": 5,
+	"curly": true,
+	"jquery": true,
+	"maxlen": 80,
+	"indent": 4,
+	"browser": true,
+	"globals": {
+		"console": true,
+		"it": true,
+		"itx": true,
+		"expect": true,
+		"describe": true,
+		"beforeEach": true,
+		"afterEach": true,
+		"sinon": true,
+		"fakeServer": true
+	}
+}

--- a/apps/files/js/admin.js
+++ b/apps/files/js/admin.js
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
 function switchPublicFolder()
 {
 	var publicEnable = $('#publicEnable').is(':checked');
@@ -10,7 +20,7 @@ function switchPublicFolder()
 $(document).ready(function(){
 	switchPublicFolder(); // Execute the function after loading DOM tree
 	$('#publicEnable').click(function(){
-			switchPublicFolder(); // To get rid of onClick()
+		switchPublicFolder(); // To get rid of onClick()
 	});
 
 	$('#allowZipDownload').bind('change', function() {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
 /**
  * The file upload code uses several hooks to interact with blueimps jQuery file upload library:
  * 1. the core upload handling hooks are added when initializing the plugin,
@@ -7,6 +17,8 @@
  *    - TODO pictures upload button
  *    - TODO music upload button
  */
+
+/* global OC, t, n */
 
 /**
  * Function that will allow us to know if Ajax uploads are supported

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC, FileList	*/
+/* global trashBinApp */
 var FileActions = {
 	actions: {},
 	defaults: {},
@@ -45,8 +57,9 @@ var FileActions = {
 		return filteredActions;
 	},
 	getDefault: function (mime, type, permissions) {
+		var mimePart;
 		if (mime) {
-			var mimePart = mime.substr(0, mime.indexOf('/'));
+			mimePart = mime.substr(0, mime.indexOf('/'));
 		}
 		var name = false;
 		if (mime && FileActions.defaults[mime]) {
@@ -130,13 +143,14 @@ var FileActions = {
 		parent.parent().children().last().find('.action.delete').remove();
 		if (actions['Delete']) {
 			var img = FileActions.icons['Delete'];
+			var html;
 			if (img.call) {
 				img = img(file);
 			}
 			if (typeof trashBinApp !== 'undefined' && trashBinApp) {
-				var html = '<a href="#" original-title="' + t('files', 'Delete permanently') + '" class="action delete delete-icon" />';
+				html = '<a href="#" original-title="' + t('files', 'Delete permanently') + '" class="action delete delete-icon" />';
 			} else {
-				var html = '<a href="#" class="action delete delete-icon" />';
+				html = '<a href="#" class="action delete delete-icon" />';
 			}
 			var element = $(html);
 			element.data('action', actions['Delete']);
@@ -163,10 +177,11 @@ var FileActions = {
 };
 
 $(document).ready(function () {
+	var downloadScope;
 	if ($('#allowZipDownload').val() == 1) {
-		var downloadScope = 'all';
+		downloadScope = 'all';
 	} else {
-		var downloadScope = 'file';
+		downloadScope = 'file';
 	}
 
 	if (typeof disableDownloadActions == 'undefined' || !disableDownloadActions) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1,4 +1,16 @@
-var FileList={
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC, t, n, FileList, FileActions, Files */
+/* global procesSelection, dragOptions, SVGSupport, replaceSVG */
+window.FileList={
 	useUndo:true,
 	postProcessList: function() {
 		$('#fileList tr').each(function() {
@@ -191,6 +203,7 @@ var FileList={
 		return OC.linkTo('files', 'index.php')+"?dir="+ encodeURIComponent(dir).replace(/%2F/g, '/');
 	},
 	setCurrentDir: function(targetDir, changeUrl) {
+		var url;
 		$('#dir').val(targetDir);
 		if (changeUrl !== false) {
 			if (window.history.pushState && changeUrl !== false) {
@@ -833,7 +846,7 @@ $(document).ready(function() {
 					{name: 'requesttoken', value: oc_requesttoken}
 				];
 			};
-		} 
+		}
 
 	});
 	file_upload_start.on('fileuploadadd', function(e, data) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -1,4 +1,16 @@
-Files={
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC, t, n, FileList, FileActions */
+/* global getURLParameter, isPublic */
+var Files = {
 	// file space size sync
 	_updateStorageStatistics: function() {
 		Files._updateStorageStatisticsTimeout = null;
@@ -654,10 +666,10 @@ function procesSelection() {
 		var totalSize = 0;
 		for(var i=0; i<selectedFiles.length; i++) {
 			totalSize+=selectedFiles[i].size;
-		};
+		}
 		for(var i=0; i<selectedFolders.length; i++) {
 			totalSize+=selectedFolders[i].size;
-		};
+		}
 		$('#headerSize').text(humanFileSize(totalSize));
 		var selection = '';
 		if (selectedFolders.length > 0) {
@@ -769,10 +781,11 @@ Files.lazyLoadPreview = function(path, mime, ready, width, height, etag) {
 		}
 		img.src = previewURL;
 	});
-}
+};
 
 function getUniqueName(name) {
 	if (FileList.findFileEl(name).exists()) {
+		var numMatch;
 		var parts=name.split('.');
 		var extension = "";
 		if (parts.length > 1) {
@@ -806,7 +819,7 @@ function checkTrashStatus() {
 
 function onClickBreadcrumb(e) {
 	var $el = $(e.target).closest('.crumb'),
-		$targetDir = $el.data('dir');
+		$targetDir = $el.data('dir'),
 		isPublic = !!$('#isPublic').val();
 
 	if ($targetDir !== undefined && !isPublic) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -79,17 +79,25 @@ var Files = {
 		return fileName;
 	},
 
-	isFileNameValid:function (name) {
-		if (name === '.') {
-			throw t('files', '\'.\' is an invalid file name.');
-		} else if (name.length === 0) {
+	/**
+	 * Checks whether the given file name is valid.
+	 * @param name file name to check
+	 * @return true if the file name is valid.
+	 * Throws a string exception with an error message if
+	 * the file name is not valid
+	 */
+	isFileNameValid: function (name) {
+		var trimmedName = name.trim();
+		if (trimmedName === '.' || trimmedName === '..') {
+			throw t('files', '"{name}" is an invalid file name.', {name: name});
+		} else if (trimmedName.length === 0) {
 			throw t('files', 'File name cannot be empty.');
 		}
-
 		// check for invalid characters
-		var invalid_characters = ['\\', '/', '<', '>', ':', '"', '|', '?', '*'];
+		var invalid_characters =
+			['\\', '/', '<', '>', ':', '"', '|', '?', '*', '\n'];
 		for (var i = 0; i < invalid_characters.length; i++) {
-			if (name.indexOf(invalid_characters[i]) !== -1) {
+			if (trimmedName.indexOf(invalid_characters[i]) !== -1) {
 				throw t('files', "Invalid name, '\\', '/', '<', '>', ':', '\"', '|', '?' and '*' are not allowed.");
 			}
 		}

--- a/apps/files/js/upgrade.js
+++ b/apps/files/js/upgrade.js
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC */
 $(document).ready(function () {
 	var eventSource, total, bar = $('#progressbar');
 	console.log('start');

--- a/apps/files/js/upload.js
+++ b/apps/files/js/upload.js
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC */
 function Upload(fileSelector) {
 	if ($.support.xhrFileUpload) {
 		return new XHRUpload(fileSelector.target.files);

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -18,7 +18,10 @@
 * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 *
 */
+
+/* global OC, FileActions, FileList */
 describe('FileActions tests', function() {
+	var $filesTable;
 	beforeEach(function() {
 		// init horrible parameters
 		var $body = $('body');

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -18,6 +18,8 @@
 * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 *
 */
+
+/* global OC, FileList */
 describe('FileList tests', function() {
 	beforeEach(function() {
 		// init horrible parameters

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -18,6 +18,8 @@
 * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 *
 */
+
+/* global Files */
 describe('Files tests', function() {
 	describe('File name validation', function() {
 		it('Validates correct file names', function() {
@@ -36,12 +38,14 @@ describe('Files tests', function() {
 				'und Ümläüte sind auch willkommen'
 			];
 			for ( var i = 0; i < fileNames.length; i++ ) {
+				var error = false;
 				try {
 					expect(Files.isFileNameValid(fileNames[i])).toEqual(true);
 				}
 				catch (e) {
-					fail();
+					error = e;
 				}
+				expect(error).toEqual(false);
 			}
 		});
 		it('Detects invalid file names', function() {
@@ -69,7 +73,6 @@ describe('Files tests', function() {
 				var threwException = false;
 				try {
 					Files.isFileNameValid(fileNames[i]);
-					fail();
 				}
 				catch (e) {
 					threwException = true;

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -73,6 +73,7 @@ describe('Files tests', function() {
 				var threwException = false;
 				try {
 					Files.isFileNameValid(fileNames[i]);
+					console.error('Invalid file name not detected:', fileNames[i]);
 				}
 				catch (e) {
 					threwException = true;


### PR DESCRIPTION
- Added `.jshintrc`
- Also fixes a few JSHint warnings in files app
- Added "global" comment on top of files app to suppress warning and
  also inform devs about what globals are use

I've started to use JSHint and (using Syntastic in vim) on another branch and would like this to go in earlier (than my other big PR). I think it is useful, especially that it can also find some coding errors.
When using globals, you need to add a comment at the top of the file in the form:

`/* global OC, FileList, FileActions */` to suppress globals warnings. This is also a neat way to show all globals that are used in one place (and hopefully one day getting rid of globals altogether).

Your IDE might be able to pick up the `.jshintrc` in the project or you might need to configure it to do so.

@DeepDiver1975 we could integrate this in Jenkins later but I think we should be tolerant with some of the rules (like the max 80 characters) so they should only be treated as warnings most of the cases.

Please review @DeepDiver1975 @karlitschek @jancborchardt @Kondou-ger @bantu @kabum 
