### PR TITLE
wrap stat() call in a try/catch block

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -504,11 +504,12 @@ class OC {
 
 		if (!defined('PHPUNIT_RUN')) {
 			if (defined('DEBUG') and DEBUG) {
+				OC\Log\ErrorHandler::register(true);
 				set_exception_handler(array('OC_Template', 'printExceptionErrorPage'));
 			} else {
 				OC\Log\ErrorHandler::register();
-				OC\Log\ErrorHandler::setLogger(OC_Log::$object);
 			}
+			OC\Log\ErrorHandler::setLogger(OC_Log::$object);
 		}
 
 		// register the stream wrappers

--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -14,6 +14,15 @@ class ErrorHandler {
 	/** @var LoggerInterface */
 	private static $logger;
 
+	/**
+	 * @brief remove password in URLs
+	 * @param string $msg
+	 * @return string
+	 */
+	private static function removePassword($msg) {
+		return preg_replace('/\/\/(.*):(.*)@/', '//xxx:xxx@', $msg);
+	}
+
 	public static function register() {
 		$handler = new ErrorHandler();
 
@@ -32,14 +41,14 @@ class ErrorHandler {
 		if($error && self::$logger) {
 			//ob_end_clean();
 			$msg = $error['message'] . ' at ' . $error['file'] . '#' . $error['line'];
-			self::$logger->critical($msg, array('app' => 'PHP'));
+			self::$logger->critical(self::removePassword($msg), array('app' => 'PHP'));
 		}
 	}
 
 	// Uncaught exception handler
 	public static function onException($exception) {
 		$msg = $exception->getMessage() . ' at ' . $exception->getFile() . '#' . $exception->getLine();
-		self::$logger->critical($msg, array('app' => 'PHP'));
+		self::$logger->critical(self::removePassword($msg), array('app' => 'PHP'));
 	}
 
 	//Recoverable errors handler
@@ -48,7 +57,7 @@ class ErrorHandler {
 			return;
 		}
 		$msg = $message . ' at ' . $file . '#' . $line;
-		self::$logger->warning($msg, array('app' => 'PHP'));
+		self::$logger->warning(self::removePassword($msg), array('app' => 'PHP'));
 
 	}
 }

--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -23,10 +23,14 @@ class ErrorHandler {
 		return preg_replace('/\/\/(.*):(.*)@/', '//xxx:xxx@', $msg);
 	}
 
-	public static function register() {
+	public static function register($debug=false) {
 		$handler = new ErrorHandler();
 
-		set_error_handler(array($handler, 'onError'));
+		if ($debug) {
+			set_error_handler(array($handler, 'onAll'), E_ALL);
+		} else {
+			set_error_handler(array($handler, 'onError'));
+		}
 		register_shutdown_function(array($handler, 'onShutdown'));
 		set_exception_handler(array($handler, 'onException'));
 	}
@@ -57,7 +61,15 @@ class ErrorHandler {
 			return;
 		}
 		$msg = $message . ' at ' . $file . '#' . $line;
-		self::$logger->warning(self::removePassword($msg), array('app' => 'PHP'));
+		self::$logger->error(self::removePassword($msg), array('app' => 'PHP'));
 
 	}
+
+	//Recoverable handler which catch all errors, warnings and notices
+	public static function onAll($number, $message, $file, $line) {
+		$msg = $message . ' at ' . $file . '#' . $line;
+		self::$logger->debug(self::removePassword($msg), array('app' => 'PHP'));
+
+	}
+
 }

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -69,7 +69,6 @@ class OC_Log_Owncloud {
 			}
 			$time = new DateTime(null, $timezone);
 			// remove username/passswords from URLs before writing the to the log file
-			$message = preg_replace('/\/\/(.*):(.*)@/', '//xxx:xxx@', $message);
 			$entry=array('app'=>$app, 'message'=>$message, 'level'=>$level, 'time'=> $time->format($format));
 			$entry = json_encode($entry);
 			$handle = @fopen(self::$logFile, 'a');


### PR DESCRIPTION
If stat() fails a warning gets written directly to the syslog containing sensible data like username and password.

This PR wraps the stat() call in a try/catch block and writes the warning to the owncloud.log which allows us to remove the password and username.

cc @icewind1991 please have a look?
cc @PVince81 maybe you can also give it a try...
