### PR TITLE
Check database migration on a copy of the table first

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -64,7 +64,9 @@ class MDB2SchemaManager {
 			return new SQLiteMigrator($this->conn);
 		} else if ($platform instanceof OraclePlatform) {
 			return new OracleMigrator($this->conn);
-		} else if ($platform instanceof MySqlPlatform or $platform instanceof PostgreSqlPlatform) {
+		} else if ($platform instanceof MySqlPlatform) {
+			return new MySQLMigrator($this->conn);
+		} else if ($platform instanceof PostgreSqlPlatform) {
 			return new Migrator($this->conn);
 		} else {
 			return new NoCheckMigrator($this->conn);

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -8,6 +8,10 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+
 class MDB2SchemaManager {
 	/**
 	 * @var \OC\DB\Connection $conn
@@ -31,7 +35,7 @@ class MDB2SchemaManager {
 	 *
 	 * TODO: write more documentation
 	 */
-	public function getDbStructure( $file, $mode = MDB2_SCHEMA_DUMP_STRUCTURE) {
+	public function getDbStructure($file, $mode = MDB2_SCHEMA_DUMP_STRUCTURE) {
 		$sm = $this->conn->getSchemaManager();
 
 		return \OC_DB_MDB2SchemaWriter::saveSchemaToFile($file, $sm);
@@ -44,7 +48,7 @@ class MDB2SchemaManager {
 	 *
 	 * TODO: write more documentation
 	 */
-	public function createDbFromStructure( $file ) {
+	public function createDbFromStructure($file) {
 		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $this->conn->getDatabasePlatform());
 		$toSchema = $schemaReader->loadSchemaFromFile($file);
 		return $this->executeSchemaChange($toSchema);
@@ -53,49 +57,40 @@ class MDB2SchemaManager {
 	/**
 	 * update the database scheme
 	 * @param string $file file to read structure from
+	 * @param bool $generateSql only return the sql needed for the upgrade
 	 * @return string|boolean
 	 */
 	public function updateDbFromStructure($file, $generateSql = false) {
-		$sm = $this->conn->getSchemaManager();
-		$fromSchema = $sm->createSchema();
-
-		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $this->conn->getDatabasePlatform());
-		$toSchema = $schemaReader->loadSchemaFromFile($file);
-
-		// remove tables we don't know about
-		/** @var $table \Doctrine\DBAL\Schema\Table */
-		foreach($fromSchema->getTables() as $table) {
-			if (!$toSchema->hasTable($table->getName())) {
-				$fromSchema->dropTable($table->getName());
-			}
-		}
-		// remove sequences we don't know about
-		foreach($fromSchema->getSequences() as $table) {
-			if (!$toSchema->hasSequence($table->getName())) {
-				$fromSchema->dropSequence($table->getName());
-			}
-		}
-
-		$comparator = new \Doctrine\DBAL\Schema\Comparator();
-		$schemaDiff = $comparator->compare($fromSchema, $toSchema);
 
 		$platform = $this->conn->getDatabasePlatform();
-		foreach($schemaDiff->changedTables as $tableDiff) {
-			$tableDiff->name = $platform->quoteIdentifier($tableDiff->name);
-			foreach($tableDiff->changedColumns as $column) {
-				$column->oldColumnName = $platform->quoteIdentifier($column->oldColumnName);
-			}
+		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $platform);
+		$toSchema = $schemaReader->loadSchemaFromFile($file);
+		if ($platform instanceof SqlitePlatform) {
+			$check = true;
+			$migrator = new SQLiteMigrator($this->conn);
+		} else if ($platform instanceof MySqlPlatform or $platform instanceof PostgreSqlPlatform) {
+			$check = true;
+			$migrator = new Migrator($this->conn);
+		} else {
+			// dont do the upgrade check for oracle
+			$check = false;
+			$migrator = new Migrator($this->conn);
 		}
 
 		if ($generateSql) {
-			return $this->generateChangeScript($schemaDiff);
+			return $migrator->generateChangeScript($toSchema);
+		} else {
+			if ($check) {
+				$migrator->checkMigrate($toSchema);
+			}
+			$migrator->migrate($toSchema);
+			return true;
 		}
-
-		return $this->executeSchemaChange($schemaDiff);
 	}
 
 	/**
 	 * remove all tables defined in a database structure xml file
+	 *
 	 * @param string $file the xml file describing the tables
 	 */
 	public function removeDBStructure($file) {
@@ -103,7 +98,7 @@ class MDB2SchemaManager {
 		$fromSchema = $schemaReader->loadSchemaFromFile($file);
 		$toSchema = clone $fromSchema;
 		/** @var $table \Doctrine\DBAL\Schema\Table */
-		foreach($toSchema->getTables() as $table) {
+		foreach ($toSchema->getTables() as $table) {
 			$toSchema->dropTable($table->getName());
 		}
 		$comparator = new \Doctrine\DBAL\Schema\Comparator();
@@ -117,26 +112,10 @@ class MDB2SchemaManager {
 	 */
 	private function executeSchemaChange($schema) {
 		$this->conn->beginTransaction();
-		foreach($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
+		foreach ($schema->toSql($this->conn->getDatabasePlatform()) as $sql) {
 			$this->conn->query($sql);
 		}
 		$this->conn->commit();
 		return true;
-	}
-
-	/**
-	 * @param \Doctrine\DBAL\Schema\Schema $schema
-	 * @return string
-	 */
-	public function generateChangeScript($schema) {
-
-		$script = '';
-		$sqls = $schema->toSql($this->conn->getDatabasePlatform());
-		foreach($sqls as $sql) {
-			$script .= $sql . ';';
-			$script .= PHP_EOL;
-		}
-
-		return $script;
 	}
 }

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -96,6 +96,15 @@ class MDB2SchemaManager {
 	}
 
 	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $schema
+	 * @return string
+	 */
+	public function generateChangeScript($schema) {
+		$migrator = $this->getMigrator();
+		return $migrator->generateChangeScript($schema);
+	}
+
+	/**
 	 * remove all tables defined in a database structure xml file
 	 *
 	 * @param string $file the xml file describing the tables

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -8,7 +8,9 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 class MDB2SchemaManager {
@@ -62,8 +64,10 @@ class MDB2SchemaManager {
 			return new SQLiteMigrator($this->conn);
 		} else if ($platform instanceof OraclePlatform) {
 			return new OracleMigrator($this->conn);
-		} else {
+		} else if ($platform instanceof MySqlPlatform or $platform instanceof PostgreSqlPlatform) {
 			return new Migrator($this->conn);
+		} else {
+			return new NoCheckMigrator($this->conn);
 		}
 	}
 

--- a/lib/private/db/migrationexception.php
+++ b/lib/private/db/migrationexception.php
@@ -13,7 +13,7 @@ class MigrationException extends \Exception {
 	private $table;
 
 	public function __construct($table, $message) {
-		$this->$table = $table;
+		$this->table = $table;
 		parent::__construct($message);
 	}
 

--- a/lib/private/db/migrationexception.php
+++ b/lib/private/db/migrationexception.php
@@ -16,4 +16,11 @@ class MigrationException extends \Exception {
 		$this->$table = $table;
 		parent::__construct($message);
 	}
+
+	/**
+	 * @return string
+	 */
+	public function getTable() {
+		return $this->table;
+	}
 }

--- a/lib/private/db/migrationexception.php
+++ b/lib/private/db/migrationexception.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+
+class MigrationException extends \Exception {
+	private $table;
+
+	public function __construct($table, $message) {
+		$this->$table = $table;
+		parent::__construct($message);
+	}
+}

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -144,16 +144,7 @@ class Migrator {
 		}
 
 		$comparator = new Comparator();
-		$schemaDiff = $comparator->compare($sourceSchema, $targetSchema);
-
-		foreach ($schemaDiff->changedTables as $tableDiff) {
-			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
-			foreach ($tableDiff->changedColumns as $column) {
-				$column->oldColumnName = $this->connection->quoteIdentifier($column->oldColumnName);
-			}
-		}
-
-		return $schemaDiff;
+		return $comparator->compare($sourceSchema, $targetSchema);
 	}
 
 	/**

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -37,6 +37,7 @@ class Migrator {
 
 	/**
 	 * @param Schema $targetSchema
+	 * @throws \OC\DB\MigrationException
 	 */
 	public function checkMigrate(Schema $targetSchema) {
 		/**

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -81,6 +81,8 @@ class Migrator {
 			$this->applySchema($schema);
 			$this->dropTable($tmpName);
 		} catch (DBALException $e) {
+			// pgsql needs to commit it's failed transaction before doing anything else
+			$this->connection->commit();
 			$this->dropTable($tmpName);
 			throw new MigrationException($table->getName(), $e->getMessage());
 		}
@@ -153,7 +155,7 @@ class Migrator {
 		$quotedSource = $this->connection->quoteIdentifier($sourceName);
 		$quotedTarget = $this->connection->quoteIdentifier($targetName);
 
-		$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' LIKE ' . $quotedSource);
+		$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' (LIKE ' . $quotedSource . ')');
 		$this->connection->exec('INSERT INTO ' . $quotedTarget . ' SELECT * FROM ' . $quotedSource);
 	}
 

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -88,11 +88,14 @@ class Migrator {
 	 * @return \Doctrine\DBAL\Schema\Table
 	 */
 	protected function renameTableSchema(Table $table, $newName) {
+		/**
+		 * @var \Doctrine\DBAL\Schema\Index[] $indexes
+		 */
 		$indexes = $table->getIndexes();
 		$newIndexes = array();
 		foreach ($indexes as $index) {
 			$indexName = uniqid(); // avoid conflicts in index names
-			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary(), $index->getFlags());
+			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}
 
 		// foreign keys are not supported so we just set it to an empty array

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+use \Doctrine\DBAL\DBALException;
+use \Doctrine\DBAL\Schema\Table;
+use \Doctrine\DBAL\Schema\Schema;
+use \Doctrine\DBAL\Schema\SchemaConfig;
+
+class Migrator {
+	/**
+	 * @var \Doctrine\DBAL\Connection $connection
+	 */
+	protected $connection;
+
+	/**
+	 * @param \Doctrine\DBAL\Connection $connection
+	 */
+	public function __construct(\Doctrine\DBAL\Connection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
+	 */
+	public function migrate(Schema $targetSchema) {
+		$this->applySchema($targetSchema);
+	}
+
+	/**
+	 * @param Schema $targetSchema
+	 */
+	public function checkMigrate(Schema $targetSchema) {
+		/**
+		 * @var \Doctrine\DBAL\Schema\Table[] $tables
+		 */
+		$tables = $targetSchema->getTables();
+
+		$existingTables = $this->connection->getSchemaManager()->listTableNames();
+
+		foreach ($tables as $table) {
+			// don't need to check for new tables
+			list(, $tableName) = explode('.', $table->getName());
+			if (array_search($tableName, $existingTables) !== false) {
+				$this->checkTableMigrate($table);
+			}
+		}
+	}
+
+	/**
+	 * Check the migration of a table on a copy so we can detect errors before messing with the real table
+	 *
+	 * @param \Doctrine\DBAL\Schema\Table $table
+	 */
+	protected function checkTableMigrate(Table $table) {
+		$name = $table->getName();
+		$tmpName = $name . '_copy_' . uniqid();
+
+		$this->copyTable($name, $tmpName);
+
+		//create the migration schema for the temporary table
+		$tmpTable = new Table($tmpName, $table->getColumns(), $table->getIndexes(), $table->getForeignKeys(), $table->_idGeneratorType, $table->getOptions());
+		$schemaConfig = new SchemaConfig();
+		$schemaConfig->setName($this->connection->getDatabase());
+		$schema = new Schema(array($tmpTable), array(), $schemaConfig);
+
+		try {
+			$this->applySchema($schema);
+			$this->dropTable($tmpName);
+		} catch (DBALException $e) {
+			$this->dropTable($tmpName);
+			throw new MigrationException($table->getName(), $e->getMessage());
+		}
+	}
+
+	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
+	 * @param \Doctrine\DBAL\Connection $connection
+	 */
+	protected function applySchema(Schema $targetSchema, \Doctrine\DBAL\Connection $connection = null) {
+		if (is_null($connection)) {
+			$connection = $this->connection;
+		}
+
+		$sourceSchema = $this->connection->getSchemaManager()->createSchema();
+
+		// remove tables we don't know about
+		/** @var $table \Doctrine\DBAL\Schema\Table */
+		foreach ($sourceSchema->getTables() as $table) {
+			if (!$targetSchema->hasTable($table->getName())) {
+				$sourceSchema->dropTable($table->getName());
+			}
+		}
+		// remove sequences we don't know about
+		foreach ($sourceSchema->getSequences() as $table) {
+			if (!$targetSchema->hasSequence($table->getName())) {
+				$sourceSchema->dropSequence($table->getName());
+			}
+		}
+
+		$comparator = new \Doctrine\DBAL\Schema\Comparator();
+		$schemaDiff = $comparator->compare($sourceSchema, $targetSchema);
+
+		foreach ($schemaDiff->changedTables as $tableDiff) {
+			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
+		}
+
+		$connection->beginTransaction();
+		foreach ($schemaDiff->toSql($connection->getDatabasePlatform()) as $sql) {
+			$connection->query($sql);
+		}
+		$connection->commit();
+	}
+
+	/**
+	 * @param string $sourceName
+	 * @param string $targetName
+	 */
+	protected function copyTable($sourceName, $targetName) {
+		$quotedSource = $this->connection->quoteIdentifier($sourceName);
+		$quotedTarget = $this->connection->quoteIdentifier($targetName);
+
+		$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' LIKE ' . $quotedSource);
+		$this->connection->exec('INSERT INTO ' . $quotedTarget . ' SELECT * FROM ' . $quotedSource);
+	}
+
+	/**
+	 * @param string $name
+	 */
+	protected function dropTable($name) {
+		$this->connection->exec('DROP TABLE ' . $this->connection->quoteIdentifier($name));
+	}
+}

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -78,6 +78,16 @@ class Migrator {
 	}
 
 	/**
+	 * Create a unique name for the temporary table
+	 *
+	 * @param string $name
+	 * @return string
+	 */
+	protected function generateTemporaryTableName($name) {
+		return 'oc_' . $name . '_' . uniqid();
+	}
+
+	/**
 	 * Check the migration of a table on a copy so we can detect errors before messing with the real table
 	 *
 	 * @param \Doctrine\DBAL\Schema\Table $table
@@ -85,7 +95,7 @@ class Migrator {
 	 */
 	protected function checkTableMigrate(Table $table) {
 		$name = $table->getName();
-		$tmpName = 'oc_' . uniqid();
+		$tmpName = $this->generateTemporaryTableName($name);
 
 		$this->copyTable($name, $tmpName);
 

--- a/lib/private/db/mysqlmigrator.php
+++ b/lib/private/db/mysqlmigrator.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+use Doctrine\DBAL\Schema\Schema;
+
+class MySQLMigrator extends Migrator {
+	/**
+	 * @param Schema $targetSchema
+	 * @param \Doctrine\DBAL\Connection $connection
+	 * @return \Doctrine\DBAL\Schema\SchemaDiff
+	 */
+	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+		$schemaDiff = parent::getDiff($targetSchema, $connection);
+
+		// identifiers need to be quoted for mysql
+		foreach ($schemaDiff->changedTables as $tableDiff) {
+			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
+			foreach ($tableDiff->changedColumns as $column) {
+				$column->oldColumnName = $this->connection->quoteIdentifier($column->oldColumnName);
+			}
+		}
+
+		return $schemaDiff;
+	}
+}

--- a/lib/private/db/nocheckmigrator.php
+++ b/lib/private/db/nocheckmigrator.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * migrator for database platforms that don't support the upgrade check
+ *
+ * @package OC\DB
+ */
+class NoCheckMigrator extends Migrator {
+	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
+	 * @throws \OC\DB\MigrationException
+	 */
+	public function checkMigrate(Schema $targetSchema) {}
+}

--- a/lib/private/db/oraclemigrator.php
+++ b/lib/private/db/oraclemigrator.php
@@ -10,15 +10,7 @@ namespace OC\DB;
 
 use Doctrine\DBAL\Schema\Schema;
 
-class OracleMigrator extends Migrator {
-	/**
-	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
-	 * @throws \OC\DB\MigrationException
-	 *
-	 * Migration testing is skipped for oracle
-	 */
-	public function checkMigrate(Schema $targetSchema) {}
-
+class OracleMigrator extends NoCheckMigrator {
 	/**
 	 * @param Schema $targetSchema
 	 * @param \Doctrine\DBAL\Connection $connection

--- a/lib/private/db/oraclemigrator.php
+++ b/lib/private/db/oraclemigrator.php
@@ -29,4 +29,12 @@ class OracleMigrator extends NoCheckMigrator {
 
 		return $schemaDiff;
 	}
+
+	/**
+	 * @param string $name
+	 * @return string
+	 */
+	protected function generateTemporaryTableName($name) {
+		return 'oc_' . uniqid();
+	}
 }

--- a/lib/private/db/oraclemigrator.php
+++ b/lib/private/db/oraclemigrator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+use Doctrine\DBAL\Schema\Schema;
+
+class OracleMigrator extends Migrator {
+	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
+	 * @throws \OC\DB\MigrationException
+	 *
+	 * Migration testing is skipped for oracle
+	 */
+	public function checkMigrate(Schema $targetSchema) {}
+
+	/**
+	 * @param Schema $targetSchema
+	 * @param \Doctrine\DBAL\Connection $connection
+	 * @return \Doctrine\DBAL\Schema\SchemaDiff
+	 */
+	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+		$schemaDiff = parent::getDiff($targetSchema, $connection);
+
+		// oracle forces us to quote the identifiers
+		foreach ($schemaDiff->changedTables as $tableDiff) {
+			$tableDiff->name = $this->connection->quoteIdentifier($tableDiff->name);
+			foreach ($tableDiff->changedColumns as $column) {
+				$column->oldColumnName = $this->connection->quoteIdentifier($column->oldColumnName);
+			}
+		}
+
+		return $schemaDiff;
+	}
+}

--- a/lib/private/db/sqlitemigrator.php
+++ b/lib/private/db/sqlitemigrator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\DB;
+
+use Doctrine\DBAL\DBALException;
+
+class SQLiteMigrator extends Migrator {
+	/**
+	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
+	 * @throws \OC\DB\MigrationException
+	 *
+	 * For sqlite we simple make a copy of the entire database, and test the migration on that
+	 */
+	public function checkMigrate(\Doctrine\DBAL\Schema\Schema $targetSchema) {
+		$dbFile = $this->connection->getDatabase();
+		$tmpFile = \OC_Helper::tmpFile('.db');
+		copy($dbFile, $tmpFile);
+
+		$connectionParams = array(
+			'path' => $tmpFile,
+			'driver' => 'pdo_sqlite',
+		);
+		$conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
+		try {
+			$this->applySchema($targetSchema, $conn);
+			$conn->close();
+			unlink($tmpFile);
+		} catch (DBALException $e) {
+			$conn->close();
+			unlink($tmpFile);
+			throw new MigrationException('', $e->getMessage());
+		}
+	}
+}

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\DB;
+
+use \Doctrine\DBAL\Schema\Schema;
+use \Doctrine\DBAL\Schema\SchemaConfig;
+
+class Migrator extends \PHPUnit_Framework_TestCase {
+	/**
+	 * @var \Doctrine\DBAL\Connection $connection
+	 */
+	private $connection;
+
+	private $tableName;
+
+	public function setUp() {
+		$this->tableName = 'test_' . uniqid();
+		$this->connection = \OC_DB::getConnection();
+		$this->tableName = $this->connection->getDatabase() . '.' . $this->tableName;
+	}
+
+	public function tearDown() {
+		$this->connection->exec('DROP TABLE ' . $this->tableName);
+	}
+
+	private function getInitialSchema() {
+		$schema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $schema->createTable($this->tableName);
+		$table->addColumn('id', 'integer');
+		$table->addColumn('name', 'string');
+		return $schema;
+	}
+
+	private function getNewSchema() {
+		$schema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $schema->createTable($this->tableName);
+		$table->addColumn('id', 'integer');
+		$table->addColumn('name', 'string');
+		$table->addUniqueIndex(array('id'));
+		return $schema;
+	}
+
+	private function getSchemaConfig() {
+		$config = new SchemaConfig();
+		$config->setName($this->connection->getDatabase());
+		return $config;
+	}
+
+	/**
+	 * @expectedException \OC\DB\MigrationException
+	 */
+	public function testDuplicateKeyUpgrade() {
+		$migrator = new \OC\DB\Migrator($this->connection);
+		$migrator->migrate($this->getInitialSchema());
+
+		$this->connection->insert($this->tableName, array('id' => 1, 'name' => 'foo'));
+		$this->connection->insert($this->tableName, array('id' => 2, 'name' => 'bar'));
+		$this->connection->insert($this->tableName, array('id' => 2, 'name' => 'qwerty'));
+
+		$migrator->checkMigrate($this->getNewSchema());
+		$this->fail('checkMigrate should have failed');
+	}
+
+	public function testUpgrade() {
+		$migrator = new \OC\DB\Migrator($this->connection);
+		$migrator->migrate($this->getInitialSchema());
+
+		$this->connection->insert($this->tableName, array('id' => 1, 'name' => 'foo'));
+		$this->connection->insert($this->tableName, array('id' => 2, 'name' => 'bar'));
+		$this->connection->insert($this->tableName, array('id' => 3, 'name' => 'qwerty'));
+
+		$newSchema = $this->getNewSchema();
+		$migrator->checkMigrate($newSchema);
+		$migrator->migrate($newSchema);
+		$this->assertTrue(true);
+	}
+}

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -22,6 +22,9 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 	private $tableName;
 
 	public function setUp() {
+		if ($this->connection->getDriver() instanceof \Doctrine\DBAL\Driver\OCI8\Driver) {
+			$this->markTestSkipped('DB migration tests arent supported on OCI');
+		}
 		$this->tableName = 'test_' . uniqid();
 		$this->connection = \OC_DB::getConnection();
 	}

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -22,11 +22,11 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 	private $tableName;
 
 	public function setUp() {
+		$this->connection = \OC_DB::getConnection();
 		if ($this->connection->getDriver() instanceof \Doctrine\DBAL\Driver\OCI8\Driver) {
 			$this->markTestSkipped('DB migration tests arent supported on OCI');
 		}
 		$this->tableName = 'test_' . uniqid();
-		$this->connection = \OC_DB::getConnection();
 	}
 
 	public function tearDown() {

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -20,25 +20,21 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 
 	private $tableName;
 
-	private $fullTableName;
-
 	public function setUp() {
 		$this->tableName = 'test_' . uniqid();
 		$this->connection = \OC_DB::getConnection();
 		if ($this->connection->getDriver() instanceof \Doctrine\DBAL\Driver\PDOSqlite\Driver) {
 			$this->markTestSkipped('Migration tests dont function on sqlite since sqlite doesnt give an error on existing duplicate data');
-		} else {
-			$this->fullTableName = $this->connection->getDatabase() . '.' . $this->tableName;
 		}
 	}
 
 	public function tearDown() {
-		$this->connection->exec('DROP TABLE ' . $this->fullTableName);
+		$this->connection->exec('DROP TABLE ' . $this->tableName);
 	}
 
 	private function getInitialSchema() {
 		$schema = new Schema(array(), array(), $this->getSchemaConfig());
-		$table = $schema->createTable($this->fullTableName);
+		$table = $schema->createTable($this->tableName);
 		$table->addColumn('id', 'integer');
 		$table->addColumn('name', 'string');
 		$table->addIndex(array('id'), $this->tableName . '_id');
@@ -47,7 +43,7 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 
 	private function getNewSchema() {
 		$schema = new Schema(array(), array(), $this->getSchemaConfig());
-		$table = $schema->createTable($this->fullTableName);
+		$table = $schema->createTable($this->tableName);
 		$table->addColumn('id', 'integer');
 		$table->addColumn('name', 'string');
 		$table->addUniqueIndex(array('id'), $this->tableName . '_id');

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -20,30 +20,33 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 
 	private $tableName;
 
+	private $fullTableName;
+
 	public function setUp() {
 		$this->tableName = 'test_' . uniqid();
 		$this->connection = \OC_DB::getConnection();
-		$this->tableName = $this->connection->getDatabase() . '.' . $this->tableName;
+		$this->fullTableName = $this->connection->getDatabase() . '.' . $this->tableName;
 	}
 
 	public function tearDown() {
-		$this->connection->exec('DROP TABLE ' . $this->tableName);
+		$this->connection->exec('DROP TABLE ' . $this->fullTableName);
 	}
 
 	private function getInitialSchema() {
 		$schema = new Schema(array(), array(), $this->getSchemaConfig());
-		$table = $schema->createTable($this->tableName);
+		$table = $schema->createTable($this->fullTableName);
 		$table->addColumn('id', 'integer');
 		$table->addColumn('name', 'string');
+		$table->addIndex(array('id'), $this->tableName . '_id');
 		return $schema;
 	}
 
 	private function getNewSchema() {
 		$schema = new Schema(array(), array(), $this->getSchemaConfig());
-		$table = $schema->createTable($this->tableName);
+		$table = $schema->createTable($this->fullTableName);
 		$table->addColumn('id', 'integer');
 		$table->addColumn('name', 'string');
-		$table->addUniqueIndex(array('id'));
+		$table->addUniqueIndex(array('id'), $this->tableName . '_id');
 		return $schema;
 	}
 


### PR DESCRIPTION
Make the database upgrade more reliable by first trying the schema update on a copy of the table
