### PR TITLE
Fixed image preview in trashbin subdirs

### DIFF
--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -34,7 +34,17 @@ try{
 	if ($view->is_dir($file)) {
 		$mimetype = 'httpd/unix-directory';
 	} else {
-		$mimetype = \OC_Helper::getFileNameMimeType(pathinfo($file, PATHINFO_FILENAME));
+		$pathInfo = pathinfo($file);
+		$fileName = $pathInfo['basename'];
+		// if in root dir
+		if ($pathInfo['dirname'] === '.') {
+			// cut off the .d* suffix
+			$i = strrpos($fileName, '.');
+			if ($i !== false) {
+				$fileName = substr($fileName, 0, $i);
+			}
+		}
+		$mimetype = \OC_Helper::getFileNameMimeType($fileName);
 	}
 	$preview->setMimetype($mimetype);
 	$preview->setMaxX($maxX);


### PR DESCRIPTION
There are two cases of file names passed to `preview.php`.

1) Files from the root of the trashbin look like `/somefile.jpg.d12345`.
2) Files inside directories of the trashbin look like `/somedir.d12345/somefile.jpg`

For case 2) the code was wrong and passing `somefile` to the mime type preview without extension, which caused it to be of type `application/octet-stream` which produced the wrong icon preview.

Please review @schiesbn @karlitschek @DeepDiver1975 @georgehrke 
