### PR TITLE
Mark an app as loaded before we start loading it

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -63,8 +63,8 @@ class OC_App{
 		ob_start();
 		foreach( $apps as $app ) {
 			if((is_null($types) or self::isType($app, $types)) && !in_array($app, self::$loadedApps)) {
-				self::loadApp($app);
 				self::$loadedApps[] = $app;
+				self::loadApp($app);
 			}
 		}
 		ob_end_clean();


### PR DESCRIPTION
This prevent `loadApp` being called twice for the app if loading the app causes `loadApps` to be called (i.e. by triggering the filesystem setup)

cc @karlitschek @DeepDiver1975 @PVince81 
