### PR TITLE
Fixed ext storage webdav path encoding

### DIFF
--- a/apps/files_external/tests/config.php
+++ b/apps/files_external/tests/config.php
@@ -21,7 +21,11 @@ return array(
 		'host'=>'localhost',
 		'user'=>'test',
 		'password'=>'test',
-		'root'=>'/owncloud/files/webdav.php',
+		'root'=>'',
+		// wait delay in seconds after write operations
+		// (only in tests)
+		// set to higher value for lighttpd webdav
+		'wait'=> 0
 	),
 	'owncloud'=>array(
 		'run'=>true,

--- a/apps/files_external/tests/webdav.php
+++ b/apps/files_external/tests/webdav.php
@@ -18,6 +18,9 @@ class DAV extends Storage {
 		if ( ! is_array($this->config) or ! isset($this->config['webdav']) or ! $this->config['webdav']['run']) {
 			$this->markTestSkipped('WebDAV backend not configured');
 		}
+		if (isset($this->config['webdav']['wait'])) {
+			$this->waitDelay = $this->config['webdav']['wait'];
+		}
 		$this->config['webdav']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new \OC\Files\Storage\DAV($this->config['webdav']);
 		$this->instance->mkdir('/');

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -27,6 +27,17 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 	 * @var \OC\Files\Storage\Storage instance
 	 */
 	protected $instance;
+	protected $waitDelay = 0;
+
+	/**
+	 * Sleep for the number of seconds specified in the
+	 * $waitDelay attribute
+	 */
+	protected function wait() {
+		if ($this->waitDelay > 0) {
+			sleep($this->waitDelay);
+		}
+	}
 
 	/**
 	 * the root folder of the storage should always exist, be readable and be recognized as a directory
@@ -77,6 +88,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->instance->mkdir('/'.$directory)); //cant create existing folders
 		$this->assertTrue($this->instance->rmdir('/'.$directory));
 
+		$this->wait();
 		$this->assertFalse($this->instance->file_exists('/'.$directory));
 
 		$this->assertFalse($this->instance->rmdir('/'.$directory)); //cant remove non existing folders
@@ -97,6 +109,8 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 			array('folder'),
 			array(' folder'),
 			array('folder '),
+			array('folder with space'),
+			array('spéciäl földer'),
 		);
 	}
 	/**
@@ -144,6 +158,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->instance->file_get_contents('/source.txt'), $this->instance->file_get_contents('/target.txt'));
 
 		$this->instance->rename('/source.txt', '/target2.txt');
+		$this->wait();
 		$this->assertTrue($this->instance->file_exists('/target2.txt'));
 		$this->assertFalse($this->instance->file_exists('/source.txt'));
 		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target2.txt'));
@@ -225,6 +240,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->instance->file_exists('/lorem.txt'));
 
 		$this->assertTrue($this->instance->unlink('/lorem.txt'));
+		$this->wait();
 
 		$this->assertFalse($this->instance->file_exists('/lorem.txt'));
 	}
@@ -259,9 +275,11 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 	public function testRecursiveRmdir() {
 		$this->instance->mkdir('folder');
 		$this->instance->mkdir('folder/bar');
+		$this->wait();
 		$this->instance->file_put_contents('folder/asd.txt', 'foobar');
 		$this->instance->file_put_contents('folder/bar/foo.txt', 'asd');
 		$this->assertTrue($this->instance->rmdir('folder'));
+		$this->wait();
 		$this->assertFalse($this->instance->file_exists('folder/asd.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar/foo.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar'));
@@ -274,6 +292,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->file_put_contents('folder/asd.txt', 'foobar');
 		$this->instance->file_put_contents('folder/bar/foo.txt', 'asd');
 		$this->assertTrue($this->instance->unlink('folder'));
+		$this->wait();
 		$this->assertFalse($this->instance->file_exists('folder/asd.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar/foo.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar'));


### PR DESCRIPTION
- Some WebDAV servers like lighttpd need paths in URLs to be properly
  encoded
- Added error log output when curl connection failed
- Added check for 'resourcetype' in case the WebDAV server doesn't
  support/return it
- Fixed touch() to return false if the server doesn't implement
  PROPPATCH
- Added optional delay in WebDAV unit tests to use when testing against
  lighttpd's WebDAV
- Fixes #6831 

I ran the unit tests against ownCloud and lighttpd.
The only failing ones with lighttpd are related to recursive delete which don't seem to be supported by lighttpd (we can add this in a separate issue/PR)

@bourgeoa if you like you can test with this patch
