### PR TITLE
Moved WebDAV check to client side JS

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -256,6 +256,7 @@ var OC={
 	 * @param {string} type the type of the file to link to (e.g. css,img,ajax.template)
 	 * @param {string} file the filename
 	 * @return {string} Absolute URL for a file in an app
+	 * @deprecated use OC.generateUrl() instead
 	 */
 	filePath:function(app,type,file){
 		var isCore=OC.coreApps.indexOf(app)!==-1,

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+(function() {
+	OC.SetupChecks = {
+		/**
+		 * Check whether the WebDAV connection works.
+		 *
+		 * @return $.Deferred object resolved with an array of error messages
+		 */
+		checkWebDAV: function() {
+			var deferred = $.Deferred();
+			var afterCall = function(xhr) {
+				var messages = [];
+				if (xhr.status !== 207 && xhr.status !== 401) {
+					messages.push(
+						t('core', 'Your web server is not yet properly setup to allow files synchronization because the WebDAV interface seems to be broken.')
+					);
+				}
+				deferred.resolve(messages);
+			};
+
+			$.ajax({
+				type: 'PROPFIND',
+				url: OC.linkToRemoteBase('webdav'),
+				data: '<?xml version="1.0"?>' +
+						'<d:propfind xmlns:d="DAV:">' +
+						'<d:prop><d:resourcetype/></d:prop>' +
+						'</d:propfind>',
+				complete: afterCall
+			});
+			return deferred.promise();
+		},
+
+		/**
+		 * Runs setup checks on the server side
+		 *
+		 * @return $.Deferred object resolved with an array of error messages
+		 */
+		checkSetup: function() {
+			var deferred = $.Deferred();
+			var afterCall = function(data, statusText, xhr) {
+				var messages = [];
+				if (xhr.status === 200 && data) {
+					if (!data.serverhasinternetconnection) {
+						messages.push(
+							t('core', 'This server has no working internet connection. This means that some of the features like mounting of external storage, notifications about updates or installation of 3rd party apps don´t work. Accessing files from remote and sending of notification emails might also not work. We suggest to enable internet connection for this server if you want to have all features.')
+						);
+					}
+				} else {
+					messages.push(t('core', 'Error occurred while checking server setup'));
+				}
+				deferred.resolve(messages);
+			};
+
+			$.ajax({
+				type: 'GET',
+				url: OC.generateUrl('settings/ajax/checksetup')
+			}).then(afterCall, afterCall);
+			return deferred.promise();
+		}
+	};
+})();
+

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1028,53 +1028,6 @@ class OC_Util {
 	}
 
 	/**
-	 * test if webDAV is working properly
-	 *
-	 * @return bool
-	 * @description
-	 * The basic assumption is that if the server returns 401/Not Authenticated for an unauthenticated PROPFIND
-	 * the web server it self is setup properly.
-	 *
-	 * Why not an authenticated PROPFIND and other verbs?
-	 *  - We don't have the password available
-	 *  - We have no idea about other auth methods implemented (e.g. OAuth with Bearer header)
-	 *
-	 */
-	public static function isWebDAVWorking() {
-		if (!function_exists('curl_init')) {
-			return true;
-		}
-		if (!\OC_Config::getValue("check_for_working_webdav", true)) {
-			return true;
-		}
-		$settings = array(
-			'baseUri' => OC_Helper::linkToRemote('webdav'),
-		);
-
-		$client = new \OC_DAVClient($settings);
-
-		$client->setRequestTimeout(10);
-
-		// for this self test we don't care if the ssl certificate is self signed and the peer cannot be verified.
-		$client->setVerifyPeer(false);
-		// also don't care if the host can't be verified
-		$client->setVerifyHost(0);
-
-		$return = true;
-		try {
-			// test PROPFIND
-			$client->propfind('', array('{DAV:}resourcetype'));
-		} catch (\Sabre\DAV\Exception\NotAuthenticated $e) {
-			$return = true;
-		} catch (\Exception $e) {
-			OC_Log::write('core', 'isWebDAVWorking: NO - Reason: ' . $e->getMessage() . ' (' . get_class($e) . ')', OC_Log::WARN);
-			$return = false;
-		}
-
-		return $return;
-	}
-
-	/**
 	 * Check if the setlocal call does not work. This can happen if the right
 	 * local packages are not available on the server.
 	 *

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -9,11 +9,12 @@ OC_Util::checkAdminUser();
 
 OCP\Util::addStyle('settings', 'settings');
 OCP\Util::addScript('settings', 'settings');
-OC_Util::addScript( "settings", "admin" );
-OC_Util::addScript( "settings", "log" );
-OC_Util::addScript( 'core', 'multiselect' );
+OCP\Util::addScript( "settings", "admin" );
+OCP\Util::addScript( "settings", "log" );
+OCP\Util::addScript( 'core', 'multiselect' );
 OCP\Util::addScript('core', 'select2/select2');
 OCP\Util::addStyle('core', 'select2/select2');
+OCP\Util::addScript('core', 'setupchecks');
 OC_App::setActiveNavigationEntry( "admin" );
 
 $tmpl = new OC_Template( 'settings', 'admin', 'user');
@@ -41,11 +42,9 @@ $tmpl->assign('mail_smtppassword', OC_Config::getValue( "mail_smtppassword", '' 
 $tmpl->assign('entries', $entries);
 $tmpl->assign('entriesremain', $entriesremain);
 $tmpl->assign('htaccessworking', $htaccessworking);
-$tmpl->assign('internetconnectionworking', OC_Util::isInternetConnectionEnabled() ? OC_Util::isInternetConnectionWorking() : 'disabled');
 $tmpl->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
 $tmpl->assign('isPhpCharSetUtf8', OC_Util::isPhpCharSetUtf8());
 $tmpl->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());
-$tmpl->assign('isWebDavWorking', OC_Util::isWebDAVWorking());
 $tmpl->assign('has_fileinfo', OC_Util::fileInfoLoaded());
 $tmpl->assign('old_php', OC_Util::isPHPoutdated());
 $tmpl->assign('backgroundjobs_mode', OC_Appconfig::getValue('core', 'backgroundjobs_mode', 'ajax'));

--- a/settings/ajax/checksetup.php
+++ b/settings/ajax/checksetup.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) 2014, Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+
+OCP\JSON::checkAdminUser();
+OCP\JSON::callCheck();
+
+\OC::$server->getSession()->close();
+
+// no warning when has_internet_connection is false in the config
+$hasInternet = true;
+if (OC_Util::isInternetConnectionEnabled()) {
+	$hasInternet = OC_Util::isInternetConnectionWorking();
+}
+
+OCP\JSON::success(
+	array(
+		'serverhasinternetconnection' => $hasInternet
+	)
+);

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -165,7 +165,7 @@ table.grid td.date{
 }
 
 /* ADMIN */
-span.securitywarning, span.connectionwarning {
+span.securitywarning, span.connectionwarning, .setupwarning {
 	color:#C33;
 	font-weight:bold;
 }
@@ -255,4 +255,16 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 	padding: 0;
 	border: 0;
 	overflow: auto;
+}
+
+#postsetupchecks .loading {
+	height: 50px;
+}
+
+#postsetupchecks.section .loading {
+	background-position: left center;
+}
+
+#postsetupchecks .hint, #postsetupchecks .setupwarning {
+	margin-top: 15px;
 }

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -122,4 +122,25 @@ $(document).ready(function(){
 	$('#shareapiExcludeGroups').change(function() {
 		$("#selectExcludedGroups").toggleClass('hidden', !this.checked);
 	});
+
+	// run setup checks then gather error messages
+	$.when(
+		OC.SetupChecks.checkWebDAV(),
+		OC.SetupChecks.checkSetup()
+	).then(function(check1, check2) {
+		var errors = [].concat(check1, check2);
+		var $el = $('#postsetupchecks');
+		var $errorsEl;
+		$el.find('.loading').addClass('hidden');
+		if (errors.length === 0) {
+			$el.find('.success').removeClass('hidden');
+		} else {
+			$errorsEl = $el.find('.errors');
+			for (var i = 0; i < errors.length; i++ ) {
+				$errorsEl.append('<div class="setupwarning">' + errors[i] + '</div>');
+			}
+			$errorsEl.removeClass('hidden');
+			$el.find('.hint').removeClass('hidden');
+		}
+	});
 });

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -98,3 +98,5 @@ $this->create('settings_ajax_setsecurity', '/settings/ajax/setsecurity.php')
 	->actionInclude('settings/ajax/setsecurity.php');
 $this->create('settings_ajax_excludegroups', '/settings/ajax/excludegroups.php')
 	->actionInclude('settings/ajax/excludegroups.php');
+$this->create('settings_ajax_checksetup', '/settings/ajax/checksetup')
+	->actionInclude('settings/ajax/checksetup.php');

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -72,21 +72,6 @@ if (!$_['htaccessworking']) {
 <?php
 }
 
-// is WebDAV working ?
-if (!$_['isWebDavWorking']) {
-	?>
-<div class="section">
-	<h2><?php p($l->t('Setup Warning'));?></h2>
-
-	<span class="securitywarning">
-		<?php p($l->t('Your web server is not yet properly setup to allow files synchronization because the WebDAV interface seems to be broken.')); ?>
-		<?php print_unescaped($l->t('Please double check the <a href="%s">installation guides</a>.', link_to_docs('admin-install'))); ?>
-	</span>
-
-</div>
-<?php
-}
-
 // Are doc blocks accessible?
 if (!$_['isAnnotationsWorking']) {
 	?>
@@ -183,20 +168,6 @@ if (!$_['isLocaleWorking']) {
 <?php
 }
 
-// is internet connection working ?
-if ($_['internetconnectionworking'] === false) {
-	?>
-	<div class="section">
-		<h2><?php p($l->t('Internet connection not working'));?></h2>
-
-		<span class="connectionwarning">
-		<?php p($l->t('This server has no working internet connection. This means that some of the features like mounting of external storage, notifications about updates or installation of 3rd party apps don´t work. Accessing files from remote and sending of notification emails might also not work. We suggest to enable internet connection for this server if you want to have all features.')); ?>
-	</span>
-
-	</div>
-<?php
-}
-
 if ($_['suggestedOverwriteWebroot']) {
 	?>
 	<div class="section">
@@ -210,7 +181,17 @@ if ($_['suggestedOverwriteWebroot']) {
 <?php
 }
 ?>
-
+<div id="postsetupchecks" class="section">
+	<h2><?php p($l->t('Connectivity checks'));?></h2>
+	<div class="loading"></div>
+	<div class="success hidden"><?php p($l->t('No problems found'));?></div>
+	<div class="errors hidden"></div>
+	<div class="hint hidden">
+		<span class="setupwarning"><?php
+			print_unescaped($l->t('Please double check the <a href=\'%s\'>installation guides</a>.', \OC_Helper::linkToDocs('admin-install')));
+		?></span>
+	</div>
+</div>
 <?php foreach ($_['forms'] as $form) {
 	print_unescaped($form);
 }


### PR DESCRIPTION
Moved WebDAV and internet checks to client side JS
- Added setup checks in JavaScript
- Moved isWebDAVWorking to JS using SetupChecks
- Moved internet connection checks to an ajax call that goes through the server

TODO:
- [x] Make it look less ugly
- [x] Test with reverse proxy cases
- [x] Test with IE8+

FYI @karlitschek @DeepDiver1975 
