### PR TITLE
properly check if pdf and svg modules are installed

### DIFF
--- a/lib/private/preview/office.php
+++ b/lib/private/preview/office.php
@@ -6,7 +6,7 @@
  * See the COPYING-README file.
  */
 //both, libreoffice backend and php fallback, need imagick
-if (extension_loaded('imagick')) {
+if (extension_loaded('imagick') && count(\Imagick::queryFormats("PDF")) === 1) {
 	$isShellExecEnabled = \OC_Helper::is_function_enabled('shell_exec');
 
 	// LibreOffice preview is currently not supported on Windows

--- a/lib/private/preview/pdf.php
+++ b/lib/private/preview/pdf.php
@@ -7,7 +7,7 @@
  */
 namespace OC\Preview;
 
-if (extension_loaded('imagick')) {
+if (extension_loaded('imagick') && count(\Imagick::queryFormats("PDF")) === 1) {
 
 	class PDF extends Provider {
 

--- a/lib/private/preview/svg.php
+++ b/lib/private/preview/svg.php
@@ -7,7 +7,7 @@
  */
 namespace OC\Preview;
 
-if (extension_loaded('imagick')) {
+if (extension_loaded('imagick') && count(\Imagick::queryFormats("SVG")) === 1) {
 
 	class SVG extends Provider {
 

--- a/lib/private/preview/unknown.php
+++ b/lib/private/preview/unknown.php
@@ -22,7 +22,7 @@ class Unknown extends Provider {
 
 		$svgPath = substr_replace($path, 'svg', -3);
 
-		if (extension_loaded('imagick') && file_exists($svgPath)) {
+		if (extension_loaded('imagick') && file_exists($svgPath) && count(\Imagick::queryFormats("SVG")) === 1) {
 
 			// http://www.php.net/manual/de/imagick.setresolution.php#85284
 			$svg = new \Imagick();


### PR DESCRIPTION
The fact that imagick is installed does not imply that the pdf or svg modules are installed.
This patch makes sure that the pdf module is installed when using office and pdf previews and that the svg module is installed when using the svg and the unknown backend.

please review @DeepDiver1975 @PVince81 @karlitschek 
