### PR TITLE
Added isLocal() method to storage, used for xsendfile

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -131,7 +131,7 @@ class OC_Files {
 				}
 				if ($xsendfile) {
 					list($storage) = \OC\Files\Filesystem::resolvePath(\OC\Files\Filesystem::getView()->getAbsolutePath($filename));
-					if ($storage instanceof \OC\Files\Storage\Local) {
+					if ($storage->isLocal()) {
 						self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
 					}
 				}

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -370,4 +370,13 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	public function free_space($path) {
 		return \OC\Files\SPACE_UNKNOWN;
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isLocal() {
+		// the common implementation returns a temporary file by
+		// default, which is not local
+		return false;
+	}
 }

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -298,5 +298,12 @@ if (\OC_Util::runningOnWindows()) {
 		public function hasUpdated($path, $time) {
 			return $this->filemtime($path) > $time;
 		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function isLocal() {
+			return true;
+		}
 	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -432,4 +432,12 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	public function test() {
 		return $this->storage->test();
 	}
+
+	/**
+	 * Returns the wrapped storage's value for isLocal()
+	 * @return bool wrapped storage's isLocal() value
+	 */
+	public function isLocal() {
+		return $this->storage->isLocal();
+	}
 }

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -315,4 +315,15 @@ interface Storage {
 	 * @return string
 	 */
 	public function getETag($path);
+
+	/**
+	 * Returns whether the storage is local, which means that files
+	 * are stored on the local filesystem instead of remotely.
+	 * Calling getLocalFile() for local storages should always
+	 * return the local files, whereas for non-local storages
+	 * it might return a temporary file.
+	 *
+	 * @return bool true if the files are stored locally, false otherwise
+	 */
+	public function isLocal();
 }


### PR DESCRIPTION
Added isLocal() method to Storage to find out whether the storage is
local or not.
This method is used for the x-sendfile logic to find out whether to add
the headers.

Fixes #7073 
