### PR TITLE
+FollowSymLinks is required for the rewrite engine

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,4 @@
+Options +SymLinksIfOwnerMatch
 <IfModule mod_fcgid.c>
 <IfModule mod_setenvif.c>
 <IfModule mod_headers.c>


### PR DESCRIPTION
Alternatively +SymLinksIfOwnerMatch can be used. Otherwise the user will get a 403 forbidden.
