### PR TITLE
LDAP: Wizard cannot determine Base DN in some cases, fixes #6670

### DIFF
--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -240,6 +240,7 @@ var LdapWizard = {
 					LdapWizard.hideSpinner('#ldap_base');
 					LdapWizard.showInfoBox('Please specify a Base DN');
 					LdapWizard.showInfoBox('Could not determine Base DN');
+					$('#ldap_base').prop('disabled', false);
 				}
 			);
 		}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -729,7 +729,7 @@ class Access extends LDAPUtility {
 			}
 		} else {
 			if(!is_null($limit)) {
-				\OCP\Util::writeLog('user_ldap', 'Paged search failed :(', \OCP\Util::INFO);
+				\OCP\Util::writeLog('user_ldap', 'Paged search was not available', \OCP\Util::INFO);
 			}
 		}
 	}

--- a/apps/user_ldap/lib/ildapwrapper.php
+++ b/apps/user_ldap/lib/ildapwrapper.php
@@ -145,9 +145,11 @@ interface ILDAPWrapper {
 	 * @param $baseDN The DN of the entry to read from
 	 * @param $filter An LDAP filter
 	 * @param $attr array of the attributes to read
+	 * @param $attrsonly optional, 1 if only attribute types shall be returned
+	 * @param $limit optional, limits the result entries
 	 * @return an LDAP search result resource, false on error
 	 */
-	public function search($link, $baseDN, $filter, $attr);
+	public function search($link, $baseDN, $filter, $attr, $attrsonly = 0, $limit = 0);
 
 	/**
 	 * @brief Sets the value of the specified option to be $value

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -85,9 +85,9 @@ class LDAP implements ILDAPWrapper {
 		return $this->invokeLDAPMethod('read', $link, $baseDN, $filter, $attr);
 	}
 
-	public function search($link, $baseDN, $filter, $attr) {
-		return $this->invokeLDAPMethod('search', $link, $baseDN,
-										$filter, $attr);
+	public function search($link, $baseDN, $filter, $attr, $attrsonly = 0, $limit = 0) {
+		return $this->invokeLDAPMethod('search', $link, $baseDN, $filter,
+										$attr, $attrsonly, $limit);
 	}
 
 	public function setOption($link, $option, $value) {

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -567,6 +567,10 @@ class Wizard extends LDAPUtility {
 		//get a result set > 0 on a proper base
 		$rr = $this->ldap->search($cr, $base, 'objectClass=*', array('dn'), 0, 1);
 		if(!$this->ldap->isResource($rr)) {
+			$errorNo  = $this->ldap->errno($cr);
+			$errorMsg = $this->ldap->error($cr);
+			\OCP\Util::writeLog('user_ldap', 'Wiz: Could not search base '.$base.
+							' Error '.$errorNo.': '.$errorMsg, \OCP\Util::INFO);
 			return false;
 		}
 		$entries = $this->ldap->countEntries($cr, $rr);

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -1014,6 +1014,7 @@ class Wizard extends LDAPUtility {
 			$this->configuration->ldapPort);
 
 		$this->ldap->setOption($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
+		$this->ldap->setOption($cr, LDAP_OPT_REFERRALS, 0);
 		$this->ldap->setOption($cr, LDAP_OPT_NETWORK_TIMEOUT, self::LDAP_NW_TIMEOUT);
 		if($this->configuration->ldapTLS === 1) {
 			$this->ldap->startTls($cr);


### PR DESCRIPTION
- disables LDAP referals in Wizard, main fix
- enables Base DN field for editing in Wizard, when Base DN cannot be determined automatically, side fix
- improves performance in Wizard when detecting user attributes and testing base dn (found during debugging)
- also rephrases a log message, resolves #7023 

fixes #6670

please review @PVince81 @ringmaster @DeepDiver1975 or others
