### PR TITLE
Fix usersPath bug

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -131,19 +131,15 @@ class Shared_Cache extends Cache {
 			foreach ($files as &$file) {
 				$file['mimetype'] = $this->getMimetype($file['mimetype']);
 				$file['mimepart'] = $this->getMimetype($file['mimepart']);
+				$file['usersPath'] = 'files/Shared/' . ltrim($file['path'], '/');
 			}
 			return $files;
 		} else {
-			if ($cache = $this->getSourceCache($folder)) {
+			$cache = $this->getSourceCache($folder);
+			if ($cache) {
 				$sourceFolderContent = $cache->getFolderContents($this->files[$folder]);
 				foreach ($sourceFolderContent as $key => $c) {
-					$ownerPathParts = explode('/', \OC_Filesystem::normalizePath($c['path']));
-					$userPathParts = explode('/', \OC_Filesystem::normalizePath($folder));
-					$usersPath = 'files/Shared/'.$userPathParts[1];
-					foreach (array_slice($ownerPathParts, 3) as $part) {
-						$usersPath .= '/'.$part;
-					}
-					$sourceFolderContent[$key]['usersPath'] = $usersPath;
+					$sourceFolderContent[$key]['usersPath'] = 'files/Shared/' . $folder . '/' . $c['name'];
 				}
 
 				return $sourceFolderContent;

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -145,7 +145,6 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 	}
 
 	function testGetFolderContentsInSubdir() {
-		//$results = $this->sharedStorage->getCache()->getFolderContents('shareddir');
 		$results = $this->user2View->getDirectoryContent('/Shared/shareddir');
 
 		$this->verifyFiles(
@@ -183,7 +182,6 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
 
 		$thirdView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
-		//list($this->sharedStorage, $internalPath) = $thirdView->resolvePath('files/Shared');
 		$results = $thirdView->getDirectoryContent('/Shared/subdir');
 
 		$this->verifyFiles(
@@ -191,21 +189,18 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 				array(
 					'name' => 'another too.txt',
 					'path' => 'files/container/shareddir/subdir/another too.txt',
-					//'path' => '/subdir/another too.txt',
 					'mimetype' => 'text/plain',
 					'usersPath' => 'files/Shared/subdir/another too.txt'
 				),
 				array(
 					'name' => 'another.txt',
 					'path' => 'files/container/shareddir/subdir/another.txt',
-					//'path' => '/subdir/another.txt',
 					'mimetype' => 'text/plain',
 					'usersPath' => 'files/Shared/subdir/another.txt'
 				),
 				array(
 					'name' => 'not a text file.xml',
 					'path' => 'files/container/shareddir/subdir/not a text file.xml',
-					//'path' => '/subdir/not a text file.xml',
 					'mimetype' => 'application/xml',
 					'usersPath' => 'files/Shared/subdir/not a text file.xml'
 				),
@@ -220,19 +215,35 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * Checks that all provided attributes exist in the files list,
-	 * only the values provided in $examples will be used to check against
-	 * the file list. The files order also needs to be the same.
+	 * Check if 'results' contains the expected 'examples' only.
 	 *
 	 * @param array $examples array of example files
-	 * @param array $files array of files
+	 * @param array $results array of files
 	 */
-	private function verifyFiles($examples, $files) {
-		$this->assertEquals(count($examples), count($files));
-		foreach ($files as $i => $file) {
-			foreach ($examples[$i] as $key => $value) {
-				$this->assertEquals($value, $file[$key]);
+	private function verifyFiles($examples, $results) {
+		$this->assertEquals(count($examples), count($results));
+
+		foreach ($examples as $example) {
+			foreach ($results as $key => $result) {
+				if ($result['name'] === $example['name']) {
+					$this->verifyKeys($example, $result);
+					unset($results[$key]);
+					break;
+				}
 			}
 		}
+		$this->assertTrue(empty($results));
 	}
+
+	/**
+	 * @brief verify if each value from the result matches the expected result
+	 * @param array $example array with the expected results
+	 * @param array $result array with the results
+	 */
+	private function verifyKeys($example, $result) {
+		foreach ($example as $key => $value) {
+			$this->assertEquals($value, $result[$key]);
+		}
+	}
+
 }

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -2,8 +2,9 @@
 /**
  * ownCloud
  *
- * @author Vincent Petry
+ * @author Vincent Petry, Bjoern Schiessle
  * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
+ *            2014 Bjoern Schiessle <schiessle@owncloud.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -23,13 +24,19 @@ require_once __DIR__ . '/base.php';
 
 class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 
+	/**
+	 * @var OC_FilesystemView
+	 */
+	public $user2View;
+
 	function setUp() {
 		parent::setUp();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
+		$this->user2View = new \OC\Files\View('/'. self::TEST_FILES_SHARING_API_USER2 . '/files');
+
 		// prepare user1's dir structure
-		$textData = "dummy file data\n";
 		$this->view->mkdir('container');
 		$this->view->mkdir('container/shareddir');
 		$this->view->mkdir('container/shareddir/subdir');
@@ -113,6 +120,103 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 		$results2 = $this->sharedStorage->getCache()->searchByMime('text/plain');
 
 		$this->verifyFiles($check, $results);
+	}
+
+	function testGetFolderContentsInRoot() {
+		$results = $this->user2View->getDirectoryContent('/Shared/');
+
+		$this->verifyFiles(
+			array(
+				array(
+					'name' => 'shareddir',
+					'path' => '/shareddir',
+					'mimetype' => 'httpd/unix-directory',
+					'usersPath' => 'files/Shared/shareddir'
+				),
+				array(
+					'name' => 'shared single file.txt',
+					'path' => '/shared single file.txt',
+					'mimetype' => 'text/plain',
+					'usersPath' => 'files/Shared/shared single file.txt'
+				),
+			),
+			$results
+		);
+	}
+
+	function testGetFolderContentsInSubdir() {
+		//$results = $this->sharedStorage->getCache()->getFolderContents('shareddir');
+		$results = $this->user2View->getDirectoryContent('/Shared/shareddir');
+
+		$this->verifyFiles(
+			array(
+				array(
+					'name' => 'bar.txt',
+					'path' => 'files/container/shareddir/bar.txt',
+					'mimetype' => 'text/plain',
+					'usersPath' => 'files/Shared/shareddir/bar.txt'
+				),
+				array(
+					'name' => 'emptydir',
+					'path' => 'files/container/shareddir/emptydir',
+					'mimetype' => 'httpd/unix-directory',
+					'usersPath' => 'files/Shared/shareddir/emptydir'
+				),
+				array(
+					'name' => 'subdir',
+					'path' => 'files/container/shareddir/subdir',
+					'mimetype' => 'httpd/unix-directory',
+					'usersPath' => 'files/Shared/shareddir/subdir'
+				),
+			),
+			$results
+		);
+	}
+
+	function testGetFolderContentsWhenSubSubdirShared() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileinfo = $this->view->getFileInfo('container/shareddir/subdir');
+		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER3, 31);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+
+		$thirdView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
+		//list($this->sharedStorage, $internalPath) = $thirdView->resolvePath('files/Shared');
+		$results = $thirdView->getDirectoryContent('/Shared/subdir');
+
+		$this->verifyFiles(
+			array(
+				array(
+					'name' => 'another too.txt',
+					'path' => 'files/container/shareddir/subdir/another too.txt',
+					//'path' => '/subdir/another too.txt',
+					'mimetype' => 'text/plain',
+					'usersPath' => 'files/Shared/subdir/another too.txt'
+				),
+				array(
+					'name' => 'another.txt',
+					'path' => 'files/container/shareddir/subdir/another.txt',
+					//'path' => '/subdir/another.txt',
+					'mimetype' => 'text/plain',
+					'usersPath' => 'files/Shared/subdir/another.txt'
+				),
+				array(
+					'name' => 'not a text file.xml',
+					'path' => 'files/container/shareddir/subdir/not a text file.xml',
+					//'path' => '/subdir/not a text file.xml',
+					'mimetype' => 'application/xml',
+					'usersPath' => 'files/Shared/subdir/not a text file.xml'
+				),
+			),
+			$results
+		);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER3);
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue with `SharedCache::getFolderContents()`:

The `usersPath` attribute is now returned correctly when sharing a sub-sub-sub-dir.
