### PR TITLE
Fixed searchByMime in shared cache

### DIFF
--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+require_once __DIR__ . '/base.php';
+
+class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
+
+	function setUp() {
+		parent::setUp();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		// prepare user1's dir structure
+		$textData = "dummy file data\n";
+		$this->view->mkdir('container');
+		$this->view->mkdir('container/shareddir');
+		$this->view->mkdir('container/shareddir/subdir');
+		$this->view->mkdir('container/shareddir/emptydir');
+
+		$textData = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$this->view->file_put_contents('container/not shared.txt', $textData);
+		$this->view->file_put_contents('container/shared single file.txt', $textData);
+		$this->view->file_put_contents('container/shareddir/bar.txt', $textData);
+		$this->view->file_put_contents('container/shareddir/subdir/another.txt', $textData);
+		$this->view->file_put_contents('container/shareddir/subdir/another too.txt', $textData);
+		$this->view->file_put_contents('container/shareddir/subdir/not a text file.xml', '<xml></xml>');
+
+		list($this->ownerStorage, $internalPath) = $this->view->resolvePath('');
+		$this->ownerCache = $this->ownerStorage->getCache();
+		$this->ownerStorage->getScanner()->scan('');
+
+		// share "shareddir" with user2
+		$fileinfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$fileinfo = $this->view->getFileInfo('container/shared single file.txt');
+		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// retrieve the shared storage
+		$secondView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
+		list($this->sharedStorage, $internalPath) = $secondView->resolvePath('files/Shared/shareddir');
+		$this->sharedCache = $this->sharedStorage->getCache();
+	}
+
+	function tearDown() {
+		$this->sharedCache->clear();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileinfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+
+		$fileinfo = $this->view->getFileInfo('container/shared single file.txt');
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+
+		$this->view->deleteAll('container');
+
+		$this->ownerCache->clear();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test searching by mime type
+	 */
+	function testSearchByMime() {
+		$results = $this->sharedStorage->getCache()->searchByMime('text');
+		$check = array(
+				array(
+					'name' => 'shared single file.txt',
+					'path' => 'shared single file.txt'
+				),
+				array(
+					'name' => 'bar.txt',
+					'path' => 'shareddir/bar.txt'
+				),
+				array(
+					'name' => 'another too.txt',
+					'path' => 'shareddir/subdir/another too.txt'
+				),
+				array(
+					'name' => 'another.txt',
+					'path' => 'shareddir/subdir/another.txt'
+				),
+			);
+		$this->verifyFiles($check, $results);
+
+		$results2 = $this->sharedStorage->getCache()->searchByMime('text/plain');
+
+		$this->verifyFiles($check, $results);
+	}
+
+	/**
+	 * Checks that all provided attributes exist in the files list,
+	 * only the values provided in $examples will be used to check against
+	 * the file list. The files order also needs to be the same.
+	 *
+	 * @param array $examples array of example files
+	 * @param array $files array of files
+	 */
+	private function verifyFiles($examples, $files) {
+		$this->assertEquals(count($examples), count($files));
+		foreach ($files as $i => $file) {
+			foreach ($examples[$i] as $key => $value) {
+				$this->assertEquals($value, $file[$key]);
+			}
+		}
+	}
+}


### PR DESCRIPTION
- searchByMime now correctly returns files recursively search through
  all the dirs
- added unit test for searchByMime
- fixes #6496

Note: this is not a "full fix" of the search code as the "full fix" requires some refactoring to be done in the sharing API to allow "where" clauses from outside.
Also, didn't want to add a "where" clause to the `getFolderContents()` yet to prevent API changes.

So this is a "quick fix" which should be suitable for backporting.

Please review @karlitschek @schiesbn @icewind1991 @butonic @DeepDiver1975 
