### PR TITLE
replace 'size' with 'unencrypted_size' if encryption is enabled

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -92,12 +92,11 @@ class Shared_Cache extends Cache {
 		} else {
 			$query = \OC_DB::prepare(
 				'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`,'
-				.' `size`, `mtime`, `encrypted`'
+				.' `size`, `mtime`, `encrypted`, `unencrypted_size`'
 				.' FROM `*PREFIX*filecache` WHERE `fileid` = ?');
 			$result = $query->execute(array($file));
 			$data = $result->fetchRow();
 			$data['fileid'] = (int)$data['fileid'];
-			$data['size'] = (int)$data['size'];
 			$data['mtime'] = (int)$data['mtime'];
 			$data['storage_mtime'] = (int)$data['storage_mtime'];
 			$data['encrypted'] = (bool)$data['encrypted'];
@@ -105,6 +104,12 @@ class Shared_Cache extends Cache {
 			$data['mimepart'] = $this->getMimetype($data['mimepart']);
 			if ($data['storage_mtime'] === 0) {
 				$data['storage_mtime'] = $data['mtime'];
+			}
+			if ($data['encrypted'] or ($data['unencrypted_size'] > 0 and $data['mimetype'] === 'httpd/unix-directory')) {
+				$data['encrypted_size'] = (int)$data['size'];
+				$data['size'] = (int)$data['unencrypted_size'];
+			} else {
+				$data['size'] = (int)$data['size'];
 			}
 			return $data;
 		}
@@ -334,6 +339,12 @@ class Shared_Cache extends Cache {
 				}
 				$row['mimetype'] = $this->getMimetype($row['mimetype']);
 				$row['mimepart'] = $this->getMimetype($row['mimepart']);
+				if ($row['encrypted'] or ($row['unencrypted_size'] > 0 and $row['mimetype'] === 'httpd/unix-directory')) {
+					$row['encrypted_size'] = $row['size'];
+					$row['size'] = $row['unencrypted_size'];
+				} else {
+					$row['size'] = $row['size'];
+				}
 				$files[] = $row;
 			}
 		}

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -91,10 +91,17 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 				$file['name'] = basename($item['file_target']);
 				$file['mimetype'] = $item['mimetype'];
 				$file['mimepart'] = $item['mimepart'];
-				$file['size'] = $item['size'];
 				$file['mtime'] = $item['mtime'];
 				$file['encrypted'] = $item['encrypted'];
 				$file['etag'] = $item['etag'];
+				$storage = \OC\Files\Filesystem::getStorage('/');
+				$cache = $storage->getCache();
+				if ($item['encrypted'] or ($item['unencrypted_size'] > 0 and $cache->getMimetype($item['mimetype']) === 'httpd/unix-directory')) {
+					$file['size'] = $item['unencrypted_size'];
+					$file['encrypted_size'] = $item['size'];
+				} else {
+					$file['size'] = $item['size'];
+				}
 				$files[] = $file;
 			}
 			return $files;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1152,7 +1152,7 @@ class Share {
 						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `*PREFIX*share`.`parent`, `uid_owner`, '
 							.'`share_type`, `share_with`, `file_source`, `path`, `file_target`, '
 							.'`permissions`, `expiration`, `storage`, `*PREFIX*filecache`.`parent` as `file_parent`, '
-							.'`name`, `mtime`, `mimetype`, `mimepart`, `size`, `encrypted`, `etag`, `mail_send`';
+							.'`name`, `mtime`, `mimetype`, `mimepart`, `size`, `unencrypted_size`, `encrypted`, `etag`, `mail_send`';
 					} else {
 						$select = '`*PREFIX*share`.`id`, `item_type`, `item_source`, `item_target`,
 							`*PREFIX*share`.`parent`, `share_type`, `share_with`, `uid_owner`,


### PR DESCRIPTION
Make sure that we replace the encrypted size with the unencrypted size in the share back-end.

This should fix #7106 
and maybe also #6217 

cc @PVince81 
