### PR TITLE
name users after test

### DIFF
--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -36,8 +36,8 @@ use OCA\Encryption;
  */
 class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
-	const TEST_ENCRYPTION_HOOKS_USER1 = "test-proxy-user1";
-	const TEST_ENCRYPTION_HOOKS_USER2 = "test-proxy-user2";
+	const TEST_ENCRYPTION_HOOKS_USER1 = "test-encryption-hooks-user1";
+	const TEST_ENCRYPTION_HOOKS_USER2 = "test-encryption-hooks-user2";
 
 	/**
 	 * @var \OC_FilesystemView


### PR DESCRIPTION
use unique user names for the hook test. Hopefully this will fix the failing tests on stable6
