### PR TITLE
Delay checking if the Shared folder should be visible until the storage is used

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -29,9 +29,11 @@ class Shared extends \OC\Files\Storage\Common {
 
 	private $sharedFolder;
 	private $files = array();
+	private $user;
 
 	public function __construct($arguments) {
 		$this->sharedFolder = $arguments['sharedFolder'];
+		$this->user = $arguments['user'];
 	}
 
 	public function getId() {
@@ -391,14 +393,13 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	public static function setup($options) {
-		if (!\OCP\User::isLoggedIn() || \OCP\User::getUser() != $options['user']
-			|| \OCP\Share::getItemsSharedWith('file')
-		) {
-			$user_dir = $options['user_dir'];
-			\OC\Files\Filesystem::mount('\OC\Files\Storage\Shared',
-				array('sharedFolder' => '/Shared'),
-				$user_dir . '/Shared/');
-		}
+		$user_dir = $options['user_dir'];
+		\OC\Files\Filesystem::mount('\OC\Files\Storage\Shared',
+			array(
+				'sharedFolder' => '/Shared',
+				'user' => $options['user']
+			),
+			$user_dir . '/Shared/');
 	}
 
 	public function hasUpdated($path, $time) {
@@ -446,4 +447,12 @@ class Shared extends \OC\Files\Storage\Common {
 		return null;
 	}
 
+	/**
+	 * check whether the storage should be shown
+	 *
+	 * @return bool
+	 */
+	public function isVisible() {
+		return !\OCP\User::isLoggedIn() || \OCP\User::getUser() != $this->user || \OCP\Share::getItemsSharedWith('file');
+	}
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -30,6 +30,7 @@ class Shared extends \OC\Files\Storage\Common {
 	private $sharedFolder;
 	private $files = array();
 	private $user;
+	private $visible;
 
 	public function __construct($arguments) {
 		$this->sharedFolder = $arguments['sharedFolder'];
@@ -453,6 +454,9 @@ class Shared extends \OC\Files\Storage\Common {
 	 * @return bool
 	 */
 	public function isVisible() {
-		return !\OCP\User::isLoggedIn() || \OCP\User::getUser() != $this->user || \OCP\Share::getItemsSharedWith('file');
+		if (is_null($this->visible)) {
+			$this->visible = !\OCP\User::isLoggedIn() || \OCP\User::getUser() != $this->user || \OCP\Share::getItemsSharedWith('file');;
+		}
+		return $this->visible;
 	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -370,4 +370,13 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	public function free_space($path) {
 		return \OC\Files\SPACE_UNKNOWN;
 	}
+
+	/**
+	 * check whether the storage should be shown
+	 *
+	 * @return bool
+	 */
+	public function isVisible() {
+		return true;
+	}
 }

--- a/lib/private/files/storage/storage.php
+++ b/lib/private/files/storage/storage.php
@@ -61,4 +61,10 @@ interface Storage extends \OCP\Files\Storage {
 	 */
 	public function getStorageCache();
 
+	/**
+	 * check whether the storage should be shown
+	 *
+	 * @return bool
+	 */
+	public function isVisible();
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -427,9 +427,19 @@ class Wrapper implements \OC\Files\Storage\Storage {
 
 	/**
 	 * Returns true
+	 *
 	 * @return true
 	 */
 	public function test() {
 		return $this->storage->test();
+	}
+
+	/**
+	 * check whether the storage should be shown
+	 *
+	 * @return bool
+	 */
+	public function isVisible() {
+		return $this->storage->isVisible();
 	}
 }

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -898,7 +898,7 @@ class View {
 			$dirLength = strlen($path);
 			foreach ($mountPoints as $mountPoint) {
 				$subStorage = Filesystem::getStorage($mountPoint);
-				if ($subStorage) {
+				if ($subStorage and $subStorage->isVisible()) {
 					$subCache = $subStorage->getCache('');
 
 					if ($subCache->getStatus('') === Cache\Cache::NOT_FOUND) {


### PR DESCRIPTION
This prevents having to get the files shared with the user every time the filesystem is setup.
Saves about 10 database queries in my test setup

Done by adding an `isVisible()` method to the storage api which can be used to hide a storage from the result of `View->getDirectoryContent()`

cc @karlitschek @DeepDiver1975 @PVince81 
