### PR TITLE
Remove usage of legacy OC_Appconfig

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -79,6 +79,8 @@ if (\OC\Files\Cache\Upgrade::needUpgrade($user)) { //dont load anything if we ne
 	$needUpgrade = false;
 }
 
+$config = \OC::$server->getConfig();
+
 // Make breadcrumb
 $breadcrumb = \OCA\Files\Helper::makeBreadcrumb($dir);
 
@@ -104,7 +106,7 @@ if ($needUpgrade) {
 	$freeSpace=$storageInfo['free'];
 	$uploadLimit=OCP\Util::uploadLimit();
 	$maxUploadFilesize=OCP\Util::maxUploadFilesize($dir);
-	$publicUploadEnabled = \OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes');
+	$publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');
 	// if the encryption app is disabled, than everything is fine (INIT_SUCCESSFUL status code)
 	$encryptionInitStatus = 2;
 	if (OC_App::isEnabled('files_encryption')) {
@@ -143,8 +145,8 @@ if ($needUpgrade) {
 	$tmpl->assign('isPublic', false);
 	$tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 	$tmpl->assign("encryptedFiles", \OCP\Util::encryptedFiles());
-	$tmpl->assign("mailNotificationEnabled", \OC_Appconfig::getValue('core', 'shareapi_allow_mail_notification', 'yes'));
-	$tmpl->assign("allowShareWithLink", \OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
+	$tmpl->assign("mailNotificationEnabled", $config->getAppValue('core', 'shareapi_allow_mail_notification', 'yes'));
+	$tmpl->assign("allowShareWithLink", $config->getAppValue('core', 'shareapi_allow_links', 'yes'));
 	$tmpl->assign("encryptionInitStatus", $encryptionInitStatus);
 	$tmpl->assign('disableSharing', false);
 	$tmpl->assign('ajaxLoad', $ajaxLoad);

--- a/apps/files_encryption/ajax/adminrecovery.php
+++ b/apps/files_encryption/ajax/adminrecovery.php
@@ -18,7 +18,7 @@ $l = OC_L10N::get('files_encryption');
 $return = false;
 // Enable recoveryAdmin
 
-$recoveryKeyId = OC_Appconfig::getValue('files_encryption', 'recoveryKeyId');
+$recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryKeyId');
 
 if (isset($_POST['adminEnableRecovery']) && $_POST['adminEnableRecovery'] === '1') {
 

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -111,10 +111,11 @@ class Helper {
 	public static function adminEnableRecovery($recoveryKeyId, $recoveryPassword) {
 
 		$view = new \OC\Files\View('/');
+		$appConfig = \OC::$server->getAppConfig();
 
 		if ($recoveryKeyId === null) {
 			$recoveryKeyId = 'recovery_' . substr(md5(time()), 0, 8);
-			\OC_Appconfig::setValue('files_encryption', 'recoveryKeyId', $recoveryKeyId);
+			$appConfig->setValue('files_encryption', 'recoveryKeyId', $recoveryKeyId);
 		}
 
 		if (!$view->is_dir('/owncloud_private_key')) {
@@ -147,7 +148,7 @@ class Helper {
 			\OC_FileProxy::$enabled = true;
 
 			// Set recoveryAdmin as enabled
-			\OC_Appconfig::setValue('files_encryption', 'recoveryAdminEnabled', 1);
+			$appConfig->setValue('files_encryption', 'recoveryAdminEnabled', 1);
 
 			$return = true;
 
@@ -155,7 +156,7 @@ class Helper {
 			$util = new \OCA\Encryption\Util(new \OC_FilesystemView('/'), \OCP\User::getUser());
 			$return = $util->checkRecoveryPassword($recoveryPassword);
 			if ($return) {
-				\OC_Appconfig::setValue('files_encryption', 'recoveryAdminEnabled', 1);
+				$appConfig->setValue('files_encryption', 'recoveryAdminEnabled', 1);
 			}
 		}
 
@@ -218,7 +219,7 @@ class Helper {
 
 		if ($return) {
 			// Set recoveryAdmin as disabled
-			\OC_Appconfig::setValue('files_encryption', 'recoveryAdminEnabled', 0);
+			\OC::$server->getAppConfig()->setValue('files_encryption', 'recoveryAdminEnabled', 0);
 		}
 
 		return $return;

--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -51,11 +51,13 @@ class Session {
 
 		}
 
-		$publicShareKeyId = \OC_Appconfig::getValue('files_encryption', 'publicShareKeyId');
+		$appConfig = \OC::$server->getAppConfig();
+
+		$publicShareKeyId = $appConfig->getValue('files_encryption', 'publicShareKeyId');
 
 		if ($publicShareKeyId === null) {
 			$publicShareKeyId = 'pubShare_' . substr(md5(time()), 0, 8);
-			\OC_Appconfig::setValue('files_encryption', 'publicShareKeyId', $publicShareKeyId);
+			$appConfig->setValue('files_encryption', 'publicShareKeyId', $publicShareKeyId);
 		}
 
 		if (

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -63,8 +63,10 @@ class Util {
 		$this->client = $client;
 		$this->userId = $userId;
 
-		$this->publicShareKeyId = \OC_Appconfig::getValue('files_encryption', 'publicShareKeyId');
-		$this->recoveryKeyId = \OC_Appconfig::getValue('files_encryption', 'recoveryKeyId');
+		$appConfig = \OC::$server->getAppConfig();
+
+		$this->publicShareKeyId = $appConfig->getValue('files_encryption', 'publicShareKeyId');
+		$this->recoveryKeyId = $appConfig->getValue('files_encryption', 'recoveryKeyId');
 
 		$this->userDir = '/' . $this->userId;
 		$this->fileFolderName = 'files';
@@ -1113,9 +1115,11 @@ class Util {
 	 */
 	public function getSharingUsersArray($sharingEnabled, $filePath, $currentUserId = false) {
 
+		$appConfig = \OC::$server->getAppConfig();
+
 		// Check if key recovery is enabled
 		if (
-			\OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled')
+			$appConfig->getValue('files_encryption', 'recoveryAdminEnabled')
 			&& $this->recoveryEnabledForUser()
 		) {
 			$recoveryEnabled = true;
@@ -1144,7 +1148,7 @@ class Util {
 		// Admin UID to list of users to share to
 		if ($recoveryEnabled) {
 			// Find recoveryAdmin user ID
-			$recoveryKeyId = \OC_Appconfig::getValue('files_encryption', 'recoveryKeyId');
+			$recoveryKeyId = $appConfig->getValue('files_encryption', 'recoveryKeyId');
 			// Add recoveryAdmin to list of users sharing
 			$userIds[] = $recoveryKeyId;
 		}

--- a/apps/files_encryption/settings-admin.php
+++ b/apps/files_encryption/settings-admin.php
@@ -11,7 +11,7 @@
 $tmpl = new OCP\Template('files_encryption', 'settings-admin');
 
 // Check if an adminRecovery account is enabled for recovering files after lost pwd
-$recoveryAdminEnabled = OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled', '0');
+$recoveryAdminEnabled = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryAdminEnabled', '0');
 
 $tmpl->assign('recoveryEnabled', $recoveryAdminEnabled);
 

--- a/apps/files_encryption/settings-personal.php
+++ b/apps/files_encryption/settings-personal.php
@@ -20,7 +20,7 @@ $privateKeySet = $session->getPrivateKey() !== false;
 // did we tried to initialize the keys for this session?
 $initialized = $session->getInitialized();
 
-$recoveryAdminEnabled = OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled');
+$recoveryAdminEnabled = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryAdminEnabled');
 $recoveryEnabledForUser = $util->recoveryEnabledForUser();
 
 $result = false;

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -61,7 +61,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend('database');
 
 		// enable resharing
-		\OC_Appconfig::setValue('core', 'shareapi_allow_resharing', 'yes');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_allow_resharing', 'yes');
 
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
@@ -531,7 +531,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
-		$publicShareKeyId = \OC_Appconfig::getValue('files_encryption', 'publicShareKeyId');
+		$publicShareKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'publicShareKeyId');
 
 		// check if share key for public exists
 		$this->assertTrue($this->view->file_exists(
@@ -662,7 +662,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		\OCA\Encryption\Helper::adminEnableRecovery(null, 'test123');
-		$recoveryKeyId = OC_Appconfig::getValue('files_encryption', 'recoveryKeyId');
+		$recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryKeyId');
 
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -755,7 +755,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(\OCA\Encryption\Helper::adminEnableRecovery(null, 'test123'));
 		$this->assertTrue(\OCA\Encryption\Helper::adminDisableRecovery('test123'));
-		$this->assertEquals(0, \OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled'));
+		$this->assertEquals(0, \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryAdminEnabled'));
 	}
 
 	/**
@@ -769,7 +769,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$result = \OCA\Encryption\Helper::adminEnableRecovery(null, 'test123');
 		$this->assertTrue($result);
 
-		$recoveryKeyId = OC_Appconfig::getValue('files_encryption', 'recoveryKeyId');
+		$recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryKeyId');
 
 		// login as user2
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
@@ -863,7 +863,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($util->setRecoveryForUser(0));
 
 		\OCA\Encryption\Helper::adminDisableRecovery('test123');
-		$this->assertEquals(0, \OC_Appconfig::getValue('files_encryption', 'recoveryAdminEnabled'));
+		$this->assertEquals(0, \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryAdminEnabled'));
 	}
 
 	/**

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -524,6 +524,7 @@ class Google extends \OC\Files\Storage\Common {
 	}
 
 	public function hasUpdated($path, $time) {
+		$appConfig = \OC::$server->getAppConfig();
 		if ($this->is_file($path)) {
 			return parent::hasUpdated($path, $time);
 		} else {
@@ -533,7 +534,7 @@ class Google extends \OC\Files\Storage\Common {
 			if ($folder) {
 				$result = false;
 				$folderId = $folder->getId();
-				$startChangeId = \OC_Appconfig::getValue('files_external', $this->getId().'cId');
+				$startChangeId = $appConfig->getValue('files_external', $this->getId().'cId');
 				$params = array(
 					'includeDeleted' => true,
 					'includeSubscribed' => true,
@@ -578,7 +579,7 @@ class Google extends \OC\Files\Storage\Common {
 						break;
 					}
 				}
-				\OC_Appconfig::setValue('files_external', $this->getId().'cId', $largestChangeId);
+				$appConfig->setValue('files_external', $this->getId().'cId', $largestChangeId);
 				return $result;
 			}
 		}

--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -218,7 +218,7 @@ class Api {
 				//allow password protection
 				$shareWith = isset($_POST['password']) ? $_POST['password'] : null;
 				//check public link share
-				$publicUploadEnabled = \OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes');
+				$publicUploadEnabled = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
 				if(isset($_POST['publicUpload']) && $publicUploadEnabled !== 'yes') {
 					return new \OC_OCS_Result(null, 403, "public upload disabled by the administrator");
 				}
@@ -317,7 +317,7 @@ class Api {
 		$shareType = $share['share_type'];
 		$permissions = isset($params['_put']['permissions']) ? (int)$params['_put']['permissions'] : null;
 
-		$publicUploadStatus = \OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes');
+		$publicUploadStatus = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
 		$publicUploadEnabled = ($publicUploadStatus === 'yes') ? true : false;
 
 
@@ -356,7 +356,7 @@ class Api {
 	 */
 	private static function updatePublicUpload($share, $params) {
 
-		$publicUploadEnabled = \OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes');
+		$publicUploadEnabled = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
 		if($publicUploadEnabled !== 'yes') {
 			return new \OC_OCS_Result(null, 403, "public upload disabled by the administrator");
 		}

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -2,7 +2,9 @@
 // Load other apps for file previews
 OC_App::loadApps();
 
-if (\OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
+$appConfig = \OC::$server->getAppConfig();
+
+if ($appConfig->getValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
 	header('HTTP/1.0 404 Not Found');
 	$tmpl = new OCP\Template('', '404', 'guest');
 	$tmpl->printPage();
@@ -151,7 +153,7 @@ if (isset($path)) {
 		$tmpl->assign('dirToken', $linkItem['token']);
 		$tmpl->assign('sharingToken', $token);
 		$allowPublicUploadEnabled = (bool) ($linkItem['permissions'] & OCP\PERMISSION_CREATE);
-		if (OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes') === 'no') {
+		if ($appConfig->getValue('core', 'shareapi_allow_public_upload', 'yes') === 'no') {
 			$allowPublicUploadEnabled = false;
 		}
 		if ($linkItem['item_type'] !== 'folder') {

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -722,7 +722,7 @@ class Trashbin {
 		$quota = \OC_Preferences::getValue($user, 'files', 'quota');
 		$view = new \OC\Files\View('/' . $user);
 		if ($quota === null || $quota === 'default') {
-			$quota = \OC_Appconfig::getValue('files', 'default_quota');
+			$quota = \OC::$server->getAppConfig()->getValue('files', 'default_quota');
 		}
 		if ($quota === null || $quota === 'none') {
 			$quota = \OC\Files\Filesystem::free_space('/');

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -487,7 +487,7 @@ class Storage {
 			$softQuota = true;
 			$quota = \OC_Preferences::getValue($uid, 'files', 'quota');
 			if ( $quota === null || $quota === 'default') {
-				$quota = \OC_Appconfig::getValue('files', 'default_quota');
+				$quota = \OC::$server->getAppConfig()->getValue('files', 'default_quota');
 			}
 			if ( $quota === null || $quota === 'none' ) {
 				$quota = \OC\Files\Filesystem::free_space('/');

--- a/lib/private/cache/fileglobal.php
+++ b/lib/private/cache/fileglobal.php
@@ -81,13 +81,14 @@ class FileGlobal {
 	}
 
 	static public function gc() {
-		$last_run = \OC_AppConfig::getValue('core', 'global_cache_gc_lastrun', 0);
+		$appConfig = \OC::$server->getAppConfig();
+		$last_run = $appConfig->getValue('core', 'global_cache_gc_lastrun', 0);
 		$now = time();
 		if (($now - $last_run) < 300) {
 			// only do cleanup every 5 minutes
 			return;
 		}
-		\OC_AppConfig::setValue('core', 'global_cache_gc_lastrun', $now);
+		$appConfig->setValue('core', 'global_cache_gc_lastrun', $now);
 		$cache_dir = self::getCacheDir();
 		if($cache_dir and is_dir($cache_dir)) {
 			$dh=opendir($cache_dir);

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -94,10 +94,11 @@ class OC_Setup {
 		}
 
 		if(count($error) == 0) {
-			OC_Appconfig::setValue('core', 'installedat', microtime(true));
-			OC_Appconfig::setValue('core', 'lastupdatedat', microtime(true));
-			OC_AppConfig::setValue('core', 'remote_core.css', '/core/minimizer.php');
-			OC_AppConfig::setValue('core', 'remote_core.js', '/core/minimizer.php');
+			$appConfig = \OC::$server->getAppConfig();
+			$appConfig->setValue('core', 'installedat', microtime(true));
+			$appConfig->setValue('core', 'lastupdatedat', microtime(true));
+			$appConfig->setValue('core', 'remote_core.css', '/core/minimizer.php');
+			$appConfig->setValue('core', 'remote_core.js', '/core/minimizer.php');
 
 			OC_Group::createGroup('admin');
 			OC_Group::addToGroup($username, 'admin');

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -91,9 +91,10 @@ class OC_Util {
 	}
 
 	public static function getUserQuota($user){
-		$userQuota = OC_Preferences::getValue($user, 'files', 'quota', 'default');
+		$config = \OC::$server->getConfig();
+		$userQuota = $config->getUserValue($user, 'files', 'quota', 'default');
 		if($userQuota === 'default') {
-			$userQuota = OC_AppConfig::getValue('files', 'default_quota', 'none');
+			$userQuota = $config->getAppValue('files', 'default_quota', 'none');
 		}
 		if($userQuota === 'none') {
 			return \OC\Files\SPACE_UNLIMITED;

--- a/remote.php
+++ b/remote.php
@@ -14,7 +14,7 @@ try {
 	}
 	$service=substr($path_info, 1, $pos-1);
 
-	$file = OC_AppConfig::getValue('core', 'remote_' . $service);
+	$file = \OC::$server->getAppConfig()->getValue('core', 'remote_' . $service);
 
 	if(is_null($file)) {
 		OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);


### PR DESCRIPTION
This is mostly for the apps shipped in core

More usages will be replaced in other PR's

cc @karlitschek @DeepDiver1975 @PVince81 
