### PR TITLE
Do not send file list for select all on Download/delete

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -9,8 +9,21 @@ OCP\JSON::callCheck();
 // Get data
 $dir = stripslashes($_POST["dir"]);
 $files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
+$allFiles = isset($_POST["allfiles"]) ? $_POST["allfiles"] : $_POST["allfiles"];
+if ($allFiles === 'true') {
+	$allFiles = true;
+}
 
-$files = json_decode($files);
+// delete all files in dir ?
+if ($allFiles) {
+	$files = array();
+	$fileList = \OC\Files\Filesystem::getDirectoryContent($dir);
+	foreach ($fileList as $fileInfo) {
+		$files[] = $fileInfo['name'];
+	}
+} else {
+	$files = json_decode($files);
+}
 $filesWithError = '';
 
 $success = true;

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -364,23 +364,26 @@ $(document).ready(function() {
 	});
 
 	$('.download').click('click',function(event) {
-		var files=getSelectedFilesTrash('name');
-		var fileslist = JSON.stringify(files);
-		var dir=$('#dir').val()||'/';
-		OC.Notification.show(t('files','Your download is being prepared. This might take some time if the files are big.'));
-		// use special download URL if provided, e.g. for public shared files
-		var downloadURL = document.getElementById("downloadURL");
-		if ( downloadURL ) {
-			window.location = downloadURL.value+"&download&files=" + encodeURIComponent(fileslist);
-		} else {
-			window.location = OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
+		var files;
+		var dir = FileList.getCurrentDirectory();
+		if (FileList.isAllSelected()) {
+			files = OC.basename(dir);
+			dir = OC.dirname(dir) || '/';
 		}
+		else {
+			files = getSelectedFilesTrash('name');
+		}
+		OC.Notification.show(t('files','Your download is being prepared. This might take some time if the files are big.'));
+		OC.redirect(FileList.getDownloadUrl(files, dir));
 		return false;
 	});
 
 	$('.delete-selected').click(function(event) {
 		var files=getSelectedFilesTrash('name');
 		event.preventDefault();
+		if (FileList.isAllSelected()) {
+			files = null;
+		}
 		FileList.do_delete(files);
 		return false;
 	});

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -69,7 +69,7 @@ describe('FileActions tests', function() {
 		$tr.find('.action[data-action=Download]').click();
 
 		expect(redirectStub.calledOnce).toEqual(true);
-		expect(redirectStub.getCall(0).args[0]).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?files=test%20download%20File.txt&dir=%2Fsubdir&download');
+		expect(redirectStub.getCall(0).args[0]).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=test%20download%20File.txt');
 		redirectStub.restore();
 	});
 });

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -58,8 +58,15 @@ describe('FileList tests', function() {
 		expect($tr.attr('data-permissions')).toEqual('31');
 		//expect($tr.attr('data-mime')).toEqual('httpd/unix-directory');
 	});
-	it('returns correct download URL', function() {
-		expect(FileList.getDownloadUrl('some file.txt')).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?files=some%20file.txt&dir=%2Fsubdir&download');
-		expect(FileList.getDownloadUrl('some file.txt', '/anotherpath/abc')).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?files=some%20file.txt&dir=%2Fanotherpath%2Fabc&download');
+	describe('Download Url', function() {
+		it('returns correct download URL for single files', function() {
+			expect(FileList.getDownloadUrl('some file.txt')).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=some%20file.txt');
+			expect(FileList.getDownloadUrl('some file.txt', '/anotherpath/abc')).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fanotherpath%2Fabc&files=some%20file.txt');
+			$('#dir').val('/');
+			expect(FileList.getDownloadUrl('some file.txt')).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2F&files=some%20file.txt');
+		});
+		it('returns correct download URL for multiple files', function() {
+			expect(FileList.getDownloadUrl(['a b c.txt', 'd e f.txt'])).toEqual(OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+		});
 	});
 });

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC, FileList, FileActions */
+
 // Override download path to files_sharing/public.php
 function fileDownloadPath(dir, file) {
 	var url = $('#downloadURL').val();
@@ -28,12 +40,20 @@ $(document).ready(function() {
 
 		// override since the format is different
 		FileList.getDownloadUrl = function(filename, dir) {
-			// we use this because we need the service and token attributes
-			var tr = FileList.findFileEl(filename);
-			if (tr.length > 0) {
-				return $(tr).find('a.name').attr('href') + '&download';
+			if ($.isArray(filename)) {
+				filename = JSON.stringify(filename);
 			}
-			return null;
+			var path = dir || FileList.getCurrentDirectory();
+			var params = {
+				service: 'files',
+				t: $('#sharingToken').val(),
+				path: path,
+				download: null
+			};
+			if (filename) {
+				params.files = filename;
+			}
+			return OC.filePath('', '', 'public.php') + '?' + OC.buildQueryString(params);
 		};
 	}
 

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -2,42 +2,38 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
+$folder = isset($_POST['dir']) ? $_POST['dir'] : '/';
 
 // "empty trash" command
 if (isset($_POST['allfiles']) and $_POST['allfiles'] === 'true'){
 	$deleteAll = true;
-	$folder = isset($_POST['dir']) ? $_POST['dir'] : '/';
 	if ($folder === '/' || $folder === '') {
 		OCA\Files_Trashbin\Trashbin::deleteAll();
 		$list = array();
 	} else {
-		$dirname = dirname($folder);
-		if ( $dirname !== '/' && $dirname !== '.' ) {
-			$dirlisting = '1';
-		} else {
-			$dirlisting = '0';
-		}
 		$list[] = $folder;
+		$folder = dirname($folder);
 	}
 }
 else {
 	$deleteAll = false;
 	$files = $_POST['files'];
-	$dirlisting = $_POST['dirlisting'];
 	$list = json_decode($files);
 }
+
+$folder = rtrim($folder, '/') . '/';
 $error = array();
 $success = array();
 
 $i = 0;
 foreach ($list as $file) {
-	if ( $dirlisting === '0') {
+	if ($folder === '/') {
 		$file = ltrim($file, '/');
 		$delimiter = strrpos($file, '.d');
 		$filename = substr($file, 0, $delimiter);
 		$timestamp =  substr($file, $delimiter+2);
 	} else {
-		$filename = $file;
+		$filename = $folder . '/' . $file;
 		$timestamp = null;
 	}
 

--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -1,5 +1,29 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/* global OC, t, FileList, FileActions */
 
 $(document).ready(function() {
+	function removeCallback(result) {
+		if (result.status !== 'success') {
+			OC.dialogs.alert(result.data.message, t('core', 'Error'));
+		}
+
+		var files = result.data.success;
+		for (var i = 0; i < files.length; i++) {
+			FileList.findFileEl(OC.basename(files[i].filename)).remove();
+		}
+		FileList.updateFileSummary();
+		FileList.updateEmptyContent();
+		enableActions();
+	}
 
 	if (typeof FileActions !== 'undefined') {
 		FileActions.register('all', 'Restore', OC.PERMISSION_READ, OC.imagePath('core', 'actions/history'), function(filename) {
@@ -7,22 +31,12 @@ $(document).ready(function() {
 			var deleteAction = tr.children("td.date").children(".action.delete");
 			deleteAction.removeClass('delete-icon').addClass('progress-icon');
 			disableActions();
-			$.post(OC.filePath('files_trashbin', 'ajax', 'undelete.php'),
-					{files: JSON.stringify([$('#dir').val() + '/' + filename]), dirlisting: tr.attr('data-dirlisting')},
-					function(result) {
-						for (var i = 0; i < result.data.success.length; i++) {
-							var row = document.getElementById(result.data.success[i].filename);
-							row.parentNode.removeChild(row);
-						}
-						if (result.status !== 'success') {
-							OC.dialogs.alert(result.data.message, t('core', 'Error'));
-						}
-						enableActions();
-						FileList.updateFileSummary();
-						FileList.updateEmptyContent();
-					}
+			$.post(OC.filePath('files_trashbin', 'ajax', 'undelete.php'), {
+					files: JSON.stringify([filename]),
+					dir: FileList.getCurrentDirectory()
+				},
+			    removeCallback
 			);
-
 		});
 	};
 
@@ -34,22 +48,12 @@ $(document).ready(function() {
 		var deleteAction = tr.children("td.date").children(".action.delete");
 		deleteAction.removeClass('delete-icon').addClass('progress-icon');
 		disableActions();
-		$.post(OC.filePath('files_trashbin', 'ajax', 'delete.php'),
-				{files: JSON.stringify([$('#dir').val() + '/' +filename]), dirlisting: tr.attr('data-dirlisting')},
-				function(result) {
-					for (var i = 0; i < result.data.success.length; i++) {
-						var row = document.getElementById(result.data.success[i].filename);
-						row.parentNode.removeChild(row);
-					}
-					if (result.status !== 'success') {
-						OC.dialogs.alert(result.data.message, t('core', 'Error'));
-					}
-					enableActions();
-					FileList.updateFileSummary();
-					FileList.updateEmptyContent();
-				}
+		$.post(OC.filePath('files_trashbin', 'ajax', 'delete.php'), {
+				files: JSON.stringify([filename]),
+				dir: FileList.getCurrentDirectory()
+			},
+			removeCallback
 		);
-
 	});
 
 	// Sets the select_all checkbox behaviour :
@@ -68,29 +72,45 @@ $(document).ready(function() {
 
 	$('.undelete').click('click', function(event) {
 		event.preventDefault();
-		var files = getSelectedFiles('file');
-		var fileslist = JSON.stringify(files);
-		var dirlisting = getSelectedFiles('dirlisting')[0];
+		var allFiles = $('#select_all').is(':checked');
+		var files = [];
+		var params = {};
 		disableActions();
-		for (var i = 0; i < files.length; i++) {
-			var deleteAction = FileList.findFileEl(files[i]).children("td.date").children(".action.delete");
-			deleteAction.removeClass('delete-icon').addClass('progress-icon');
+		if (allFiles) {
+			FileList.showMask();
+			params = {
+				allfiles: true,
+				dir: FileList.getCurrentDirectory()
+			};
+		}
+		else {
+			files = getSelectedFiles('name');
+			for (var i = 0; i < files.length; i++) {
+				var deleteAction = FileList.findFileEl(files[i]).children("td.date").children(".action.delete");
+				deleteAction.removeClass('delete-icon').addClass('progress-icon');
+			}
+			params = {
+				files: JSON.stringify(files),
+				dir: FileList.getCurrentDirectory()
+			};
 		}
 
 		$.post(OC.filePath('files_trashbin', 'ajax', 'undelete.php'),
-				{files: fileslist, dirlisting: dirlisting},
-				function(result) {
-					for (var i = 0; i < result.data.success.length; i++) {
-						var row = document.getElementById(result.data.success[i].filename);
-						row.parentNode.removeChild(row);
-					}
+			params,
+			function(result) {
+				if (allFiles) {
 					if (result.status !== 'success') {
 						OC.dialogs.alert(result.data.message, t('core', 'Error'));
 					}
+					FileList.hideMask();
+					// simply remove all files
+					FileList.update('');
 					enableActions();
-					FileList.updateFileSummary();
-					FileList.updateEmptyContent();
 				}
+				else {
+					removeCallback(result);
+				}
+			}
 		);
 	});
 
@@ -101,17 +121,17 @@ $(document).ready(function() {
 		var params = {};
 		if (allFiles) {
 			params = {
-			   allfiles: true,
-			   dir: $('#dir').val()
+				allfiles: true,
+				dir: FileList.getCurrentDirectory()
 			};
 		}
 		else {
-			files = getSelectedFiles('file');
+			files = getSelectedFiles('name');
 			params = {
 				files: JSON.stringify(files),
-				dirlisting: getSelectedFiles('dirlisting')[0]
+				dir: FileList.getCurrentDirectory()
 			};
-		};
+		}
 
 		disableActions();
 		if (allFiles) {
@@ -128,22 +148,17 @@ $(document).ready(function() {
 				params,
 				function(result) {
 					if (allFiles) {
+						if (result.status !== 'success') {
+							OC.dialogs.alert(result.data.message, t('core', 'Error'));
+						}
 						FileList.hideMask();
 						// simply remove all files
-						$('#fileList').empty();
+						FileList.update('');
+						enableActions();
 					}
 					else {
-						for (var i = 0; i < result.data.success.length; i++) {
-							var row = document.getElementById(result.data.success[i].filename);
-							row.parentNode.removeChild(row);
-						}
+						removeCallback(result);
 					}
-					if (result.status !== 'success') {
-						OC.dialogs.alert(result.data.message, t('core', 'Error'));
-					}
-					enableActions();
-					FileList.updateFileSummary();
-					FileList.updateEmptyContent();
 				}
 		);
 
@@ -208,11 +223,9 @@ function getSelectedFiles(property){
 	var files=[];
 	elements.each(function(i,element){
 		var file={
-			name:$(element).attr('data-filename'),
-			file:$('#dir').val() + "/" + $(element).attr('data-file'),
+			name:$(element).attr('data-file'),
 			timestamp:$(element).attr('data-timestamp'),
-			type:$(element).attr('data-type'),
-			dirlisting:$(element).attr('data-dirlisting')
+			type:$(element).attr('data-type')
 		};
 		if(property){
 			files.push(file[property]);

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -103,7 +103,12 @@ class OC_Files {
 			if ($xsendfile) {
 				$filename = OC_Helper::moveToNoClean($filename);
 			}
-			$name = $files . '.zip';
+			// downloading root ?
+			if ($files === '') {
+				$name = 'download.zip';
+			} else {
+				$name = $files . '.zip';
+			}
 			set_time_limit($executionTime);
 		} else {
 			$zip = false;
@@ -198,6 +203,8 @@ class OC_Files {
 		$dirname=basename($dir);
 		$zip->addEmptyDir($internalDir.$dirname);
 		$internalDir.=$dirname.='/';
+		// prevent absolute dirs
+		$internalDir = ltrim($internalDir, '/');
 		$files=OC_Files::getDirectoryContent($dir);
 		foreach($files as $file) {
 			$filename=$file['name'];


### PR DESCRIPTION
- When all files are selected, do not send the whole file list
- Download will trigger download for the parent folder, also works
  with root
- Delete will send "allfiles" to the server that will find the filelist
  or the passed directory by itself

Note: this is not only a performance improvement but is also mandatory for infinite scrolling (can't select all elements that haven't appeared yet)

Please review @karlitschek @DeepDiver1975 @kabum @schiesbn 
