### PR TITLE
Remove duplicate call to groupExists

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -108,8 +108,8 @@ class Manager extends PublicEmitter {
 	public function createGroup($gid) {
 		if (!$gid) {
 			return false;
-		} else if ($this->groupExists($gid)) {
-			return $this->get($gid);
+		} else if ($group = $this->get($gid)) {
+			return $group;
 		} else {
 			$this->emit('\OC\Group', 'preCreate', array($gid));
 			foreach ($this->backends as $backend) {

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -76,12 +76,7 @@ class Manager extends PublicEmitter {
 		if (isset($this->cachedGroups[$gid])) {
 			return $this->cachedGroups[$gid];
 		}
-		foreach ($this->backends as $backend) {
-			if ($backend->groupExists($gid)) {
-				return $this->getGroupObject($gid);
-			}
-		}
-		return null;
+		return $this->getGroupObject($gid);
 	}
 
 	protected function getGroupObject($gid) {
@@ -90,6 +85,9 @@ class Manager extends PublicEmitter {
 			if ($backend->groupExists($gid)) {
 				$backends[] = $backend;
 			}
+		}
+		if (count($backends) === 0) {
+			return null;
 		}
 		$this->cachedGroups[$gid] = new Group($gid, $backends, $this->userManager, $this);
 		return $this->cachedGroups[$gid];

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -116,16 +116,22 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC_Group_Backend $backend
 		 */
+		$backendGroupCreated = false;
 		$backend = $this->getMock('\OC_Group_Database');
 		$backend->expects($this->any())
 			->method('groupExists')
 			->with('group1')
-			->will($this->returnValue(false));
+			->will($this->returnCallback(function () use (&$backendGroupCreated) {
+				return $backendGroupCreated;
+			}));
 		$backend->expects($this->once())
 			->method('implementsActions')
 			->will($this->returnValue(true));
 		$backend->expects($this->once())
-			->method('createGroup');
+			->method('createGroup')
+			->will($this->returnCallback(function () use (&$backendGroupCreated) {
+				$backendGroupCreated = true;
+			}));;
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -170,6 +176,10 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getGroups')
 			->with('1')
 			->will($this->returnValue(array('group1')));
+		$backend->expects($this->once())
+			->method('groupExists')
+			->with('group1')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -193,6 +203,9 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getGroups')
 			->with('1')
 			->will($this->returnValue(array('group1')));
+		$backend1->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC_Group_Backend $backend2
@@ -202,6 +215,9 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getGroups')
 			->with('1')
 			->will($this->returnValue(array('group12', 'group1')));
+		$backend2->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -228,6 +244,9 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getGroups')
 			->with('1', 2, 1)
 			->will($this->returnValue(array('group1')));
+		$backend1->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC_Group_Backend $backend2
@@ -237,6 +256,9 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getGroups')
 			->with('1', 1, 0)
 			->will($this->returnValue(array('group12')));
+		$backend2->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -263,6 +285,10 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getUserGroups')
 			->with('user1')
 			->will($this->returnValue(array('group1')));
+		$backend->expects($this->any())
+			->method('groupExists')
+			->with('group1')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -286,6 +312,10 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getUserGroups')
 			->with('user1')
 			->will($this->returnValue(array('group1')));
+		$backend1->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
+
 		/**
 		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC_Group_Backend $backend2
 		 */
@@ -294,6 +324,9 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->method('getUserGroups')
 			->with('user1')
 			->will($this->returnValue(array('group1', 'group2')));
+		$backend1->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager


### PR DESCRIPTION
Remove call to `groupExists()` in `Manager->get()` since we already check this inside `getGroupObject()`

cc @DeepDiver1975 @karlitschek @PVince81 
