### PR TITLE
LDAP: prevent other configuration from being deleted when deleting the f...

### DIFF
--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -118,10 +118,16 @@ class Helper {
 			return false;
 		}
 
+		$saveOtherConfigurations = '';
+		if(empty($prefix)) {
+			$saveOtherConfigurations = 'AND `Configkey` NOT LIKE \'s%\'';
+		}
+
 		$query = \OCP\DB::prepare('
 			DELETE
 			FROM `*PREFIX*appconfig`
 			WHERE `configkey` LIKE ?
+				'.$saveOtherConfigurations.'
 				AND `appid` = \'user_ldap\'
 				AND `configkey` NOT IN (\'enabled\', \'installed_version\', \'types\', \'bgjUpdateGroupsLastRun\')
 		');


### PR DESCRIPTION
...irst one which has an empty prefix for historical reasons

Background: the first configuration has an empty prefix, back from the days when only one configuration was possible.

All the other configkeys used do not start with 's', so this is approach is safe, though hacky. 

More proper approach would be to change all configuration prefixes, to be not-empty while keeping the order. Something for a major release.

Fixes #7153 

Reviews please @PVince81 @DeepDiver1975 @schiesbn or others
