### PR TITLE
Remove the JsonSerializable interface from \OC\Files\FileInfo

### DIFF
--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -8,7 +8,7 @@
 
 namespace OC\Files;
 
-class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess, \JsonSerializable {
+class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	/**
 	 * @var array $data
 	 */
@@ -50,10 +50,6 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess, \JsonSerializable {
 
 	public function offsetGet($offset) {
 		return $this->data[$offset];
-	}
-
-	public function jsonSerialize() {
-		return $this->data;
 	}
 
 	/**


### PR DESCRIPTION
Needed to make it compatible with php 5.3.

Afaik the only time this interface was needed was in the gallery app which has been fixed with https://github.com/owncloud/apps/commit/c2075766eeb2f6e6d56340e756964c04d0fb0fb3

cc @DeepDiver1975 @PVince81 
