### PR TITLE
Removed unused versions md5 code

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -256,34 +256,15 @@ class Storage {
 			sort( $matches );
 
 			$files_view = new \OC\Files\View('/'.$uid.'/files');
-			$local_file = $files_view->getLocalFile($filename);
-			$local_file_md5 = \md5_file( $local_file );
 
 			foreach( $matches as $ma ) {
 				$parts = explode( '.v', $ma );
 				$version = ( end( $parts ) );
 				$key = $version.'#'.$filename;
-				$versions[$key]['cur'] = 0;
 				$versions[$key]['version'] = $version;
 				$versions[$key]['path'] = $filename;
 				$versions[$key]['size'] = $versions_fileview->filesize($filename.'.v'.$version);
-
-				// if file with modified date exists, flag it in array as currently enabled version
-				( \md5_file( $ma ) == $local_file_md5 ? $versions[$key]['fileMatch'] = 1 : $versions[$key]['fileMatch'] = 0 );
-
 			}
-
-			$versions = array_reverse( $versions );
-
-			foreach( $versions as $key => $value ) {
-				// flag the first matched file in array (which will have latest modification date) as current version
-				if ( $value['fileMatch'] ) {
-					$value['cur'] = 1;
-					break;
-				}
-			}
-
-			$versions = array_reverse( $versions );
 
 			// only show the newest commits
 			if( $count != 0 and ( count( $versions )>$count ) ) {

--- a/apps/files_versions/templates/history.php
+++ b/apps/files_versions/templates/history.php
@@ -24,9 +24,6 @@ if( isset( $_['message'] ) ) {
 		p(OCP\Util::formatDate( doubleval($v['version'])));
 		print_unescaped(' <a href="'.OCP\Util::linkTo('files_versions', 'history.php',
 			array('path' => $_['path'], 'revert' => $v['version'])) .'" class="button">Revert</a><br /><br />');
-		if ( $v['cur'] ) {
-			print_unescaped('  (<b>Current</b>)');
-		}
 		print_unescaped('<br /><br />');
 	}
 


### PR DESCRIPTION
It looks like md5 was used previously to identify the most recent file
in the versions list, which seem to be old code, as now the versions
list doesn't contain the current file any more.

This fix removes the md5 code which caused performance issues with big
files.

Fixes #7208 

Note: this is OC 5 only as this part has been removed already in OC 6 as part of other fixes.

Please review @karlitschek @schiesbn @DeepDiver1975 
