### PR TITLE
Use the proper content-type

### DIFF
--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -23,6 +23,8 @@
 
 require_once '../lib/base.php';
 
+header('Content-type: application/xml');
+
 $url=OCP\Util::getServerProtocol().'://'.substr(OCP\Util::getServerHost().OCP\Util::getRequestUri(), 0, -17).'ocs/v1.php/';
 
 echo('


### PR DESCRIPTION
We should use the proper content-type `application/xml` instead of the default `text/html` here.

Backport requested.

@tomneedham @karlitschek 
