### PR TITLE
[WIP] fixing filetype icons

### DIFF
--- a/lib/private/mimetypes.list.php
+++ b/lib/private/mimetypes.list.php
@@ -29,6 +29,7 @@ return array(
 	'avi'=>'video/x-msvideo',
 	'bash' => 'text/x-shellscript',
 	'blend'=>'application/x-blender',
+	'bin' => 'application/x-bin',
 	'cc' => 'text/x-c',
 	'cdr' => 'application/coreldraw',
 	'cpp' => 'text/x-c++src',


### PR DESCRIPTION
Time to fix files for which we don’t yet show apt filetype icons. Which ones do you notice where the icon is off?

cc @owncloud/designers @DeepDiver1975 @icewind1991 which others do you know?
