### PR TITLE
[WIP] Use exif_thumbnail to read exif image preview

### DIFF
--- a/lib/private/preview/image.php
+++ b/lib/private/preview/image.php
@@ -26,7 +26,14 @@ class Image extends Provider {
 		if($fileInfo['encrypted'] === true) {
 			$image->loadFromData(stream_get_contents($fileview->fopen($path, 'r')));
 		}else{
-			$image->loadFromFile($fileview->getLocalFile($path));
+			$preview = exif_thumbnail($fileview->getLocalFile($path), $maxX, $maxY);
+			if ($preview !== false) {
+				$image->loadFromData($preview);
+			}
+			else {
+				$image->loadFromFile($fileview->getLocalFile($path));
+			}
+			
 		}
 
 		return $image->valid() ? $image : false;


### PR DESCRIPTION
This should be much faster, but in some cases the exif preview might not be updated by image apps.
Still, nice performance improvement.

Please have a try and compare with master.

@georgehrke @jancborchardt 

Needs to be tested more thoroughly.
It might work with tiff files, not tried yet.
