### PR TITLE
Now using PHP session lifetime as default value for the JS config

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -57,7 +57,7 @@ $array = array(
 	"firstDay" => json_encode($l->l('firstday', 'firstday')) ,
 	"oc_config" => json_encode(
 		array(
-			'session_lifetime' => \OCP\Config::getSystemValue('session_lifetime', 60 * 60 * 24),
+			'session_lifetime' => \OCP\Config::getSystemValue('session_lifetime', ini_get('session.gc_maxlifetime')),
 			'session_keepalive' => \OCP\Config::getSystemValue('session_keepalive', true)
 		)
 	)


### PR DESCRIPTION
This will fix the heartbeat when the session_lifetime config parameter
hasn't been set explicitly.

Please review @karlitschek @DeepDiver1975 @schiesbn @icewind1991 
