### PR TITLE
Add memcache caching to the joblist when available

### DIFF
--- a/lib/private/backgroundjob/memcachejoblist.php
+++ b/lib/private/backgroundjob/memcachejoblist.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\BackgroundJob;
+
+class MemCacheJobList extends JobList {
+	/**
+	 * @var \OCP\ICache $memCache
+	 */
+	private $memCache;
+
+	/**
+	 * @param \OCP\IDBConnection $conn
+	 * @param \OCP\IConfig $config
+	 * @param \OCP\ICache $memCache
+	 */
+	public function __construct($conn, $config, $memCache) {
+		parent::__construct($conn, $config);
+		$this->memCache = $memCache;
+	}
+
+	protected function encodeJob($job, $argument) {
+		if ($job instanceof Job) {
+			$class = get_class($job);
+		} else {
+			$class = $job;
+		}
+		return json_encode(array('class' => $class, 'argument' => $argument));
+	}
+
+	/**
+	 * copy the entries from the database backed joblist to the memcache
+	 */
+	protected function loadFromDB() {
+		if ($this->memCache->get('loaded')) {
+			return;
+		}
+		$jobs = parent::getAll();
+		foreach ($jobs as $job) {
+			$jobString = $this->encodeJob($job, $job->getArgument());
+			$jobId = md5($jobString);
+			$this->memCache->set('job_' . $jobId, $jobString);
+		}
+		$this->memCache->set('loaded', true);
+	}
+
+	public function add($job, $argument = null) {
+		if ($this->has($job, $argument)) {
+			return;
+		}
+		$jobString = $this->encodeJob($job, $argument);
+		$jobId = md5($jobString);
+		$this->memCache->set('job_' . $jobId, $jobString);
+
+		parent::add($job, $argument);
+	}
+
+	public function remove($job, $argument = null) {
+		$jobString = $this->encodeJob($job, $argument);
+		$jobId = md5($jobString);
+		$this->memCache->remove('job_' . $jobId);
+
+		parent::remove($job, $argument);
+	}
+
+	public function has($job, $argument) {
+		$this->loadFromDB();
+		$jobString = $this->encodeJob($job, $argument);
+		$jobId = md5($jobString);
+		return $this->memCache->hasKey('job_' . $jobId);
+	}
+}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -156,7 +156,12 @@ class Server extends SimpleContainer implements IServerContainer {
 			 * @var Server $c
 			 */
 			$config = $c->getConfig();
-			return new \OC\BackgroundJob\JobList($c->getDatabaseConnection(), $config);
+			$cacheFactory = $c->getMemCacheFactory();
+			if ($cacheFactory->isAvailable()) {
+				return new \OC\BackgroundJob\MemCacheJobList($c->getDatabaseConnection(), $config, $cacheFactory->create('joblist'));
+			} else {
+				return new \OC\BackgroundJob\JobList($c->getDatabaseConnection(), $config);
+			}
 		});
 	}
 
@@ -321,9 +326,9 @@ class Server extends SimpleContainer implements IServerContainer {
 	}
 
 	/**
-	 * Returns an \OCP\CacheFactory instance
+	 * Returns an \OCP\ICacheFactory instance
 	 *
-	 * @return \OCP\CacheFactory
+	 * @return \OCP\ICacheFactory
 	 */
 	function getMemCacheFactory() {
 		return $this->query('MemCacheFactory');


### PR DESCRIPTION
This prevents having to make a DB query for every registered background job to check if it exists every request.

cc @DeepDiver1975 @PVince81
