### PR TITLE
Add displayname for admins on external api

### DIFF
--- a/lib/private/ocs/cloud.php
+++ b/lib/private/ocs/cloud.php
@@ -61,17 +61,25 @@ class OC_OCS_Cloud {
 	 *                           the user from whom the information will be returned
 	 */
 	public static function getUser($parameters) {
+		$return  = array();
 		// Check if they are viewing information on themselves
 		if($parameters['userid'] === OC_User::getUser()) {
 			// Self lookup
 			$storage = OC_Helper::getStorageInfo('/');
-			$quota = array(
+			$return['quota'] = array(
 				'free' =>  $storage['free'],
 				'used' =>  $storage['used'],
 				'total' =>  $storage['total'],
 				'relative' => $storage['relative'],
 				);
-			return new OC_OCS_Result(array('quota' => $quota));
+		}
+		if(OC_User::isAdminUser(OC_User::getUser()) 
+			|| OC_Subadmin::isUserAccessible(OC_User::getUser(), $parameters['userid'])) {
+			// Is an admin/subadmin so can see display name
+			$return['displayname'] = OC_User::getDisplayName($parameters['userid']);
+		}
+		if(count($return)) {
+			return new OC_OCS_Result($return);
 		} else {
 			// No permission to view this user data
 			return new OC_OCS_Result(null, 997);

--- a/lib/private/ocs/cloud.php
+++ b/lib/private/ocs/cloud.php
@@ -75,8 +75,12 @@ class OC_OCS_Cloud {
 		}
 		if(OC_User::isAdminUser(OC_User::getUser()) 
 			|| OC_Subadmin::isUserAccessible(OC_User::getUser(), $parameters['userid'])) {
-			// Is an admin/subadmin so can see display name
-			$return['displayname'] = OC_User::getDisplayName($parameters['userid']);
+			if(OC_User::userExists($parameters['userid'])) {
+				// Is an admin/subadmin so can see display name
+				$return['displayname'] = OC_User::getDisplayName($parameters['userid']);
+			} else {
+				return new OC_OCS_Result(null, 101);
+			}
 		}
 		if(count($return)) {
 			return new OC_OCS_Result($return);


### PR DESCRIPTION
Allows admins to view the displayname of users through the external api.

See https://github.com/owncloud/enterprise/pull/116
