### PR TITLE
do not autocapitalize fields on mobile, fix user name input

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -48,13 +48,15 @@
 		<legend><?php print_unescaped($l->t( 'Create an <strong>admin account</strong>' )); ?></legend>
 		<p class="infield grouptop">
 			<input type="text" name="adminlogin" id="adminlogin" placeholder=""
-				value="<?php p($_['adminlogin']); ?>" autocomplete="off" autofocus required />
+				value="<?php p($_['adminlogin']); ?>"
+				autocomplete="off" autocapitalize="off" autocorrect="off" autofocus required />
 			<label for="adminlogin" class="infield"><?php p($l->t( 'Username' )); ?></label>
 			<img class="svg" src="<?php p(image_path('', 'actions/user.svg')); ?>" alt="" />
 		</p>
 		<p class="infield groupbottom">
 			<input type="password" name="adminpass" data-typetoggle="#show" id="adminpass" placeholder=""
-				value="<?php p($_['adminpass']); ?>" required />
+				value="<?php p($_['adminpass']); ?>"
+				autocomplete="off" autocapitalize="off" autocorrect="off" required />
 			<label for="adminpass" class="infield"><?php p($l->t( 'Password' )); ?></label>
 			<img class="svg" id="adminpass-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt="" />
 			<input type="checkbox" id="show" name="show" />
@@ -74,8 +76,9 @@
 		<div id="datadirContent">
 			<label for="directory"><?php p($l->t( 'Data folder' )); ?></label>
 			<input type="text" name="directory" id="directory"
-				placeholder="<?php p(OC::$SERVERROOT."/data"); ?>"
-				value="<?php p($_['directory']); ?>" />
+				placeholder="<?php p(OC::$SERVERROOT.'/data'); ?>"
+				value="<?php p($_['directory']); ?>"
+				autocomplete="off" autocapitalize="off" autocorrect="off" />
 		</div>
 	</fieldset>
 	<?php endif; ?>
@@ -103,11 +106,13 @@
 			<p class="infield grouptop">
 				<label for="dbuser" class="infield"><?php p($l->t( 'Database user' )); ?></label>
 				<input type="text" name="dbuser" id="dbuser" placeholder=""
-					value="<?php p($_['dbuser']); ?>" autocomplete="off" />
+					value="<?php p($_['dbuser']); ?>"
+					autocomplete="off" autocapitalize="off" autocorrect="off" />
 			</p>
 			<p class="infield groupmiddle">
 				<input type="password" name="dbpass" id="dbpass" placeholder="" data-typetoggle="#dbpassword" 
-					value="<?php p($_['dbpass']); ?>" />
+					value="<?php p($_['dbpass']); ?>"
+					autocomplete="off" autocapitalize="off" autocorrect="off" />
 				<label for="dbpass" class="infield"><?php p($l->t( 'Database password' )); ?></label>
 				<input type="checkbox" id="dbpassword" name="dbpassword" />
 				<label for="dbpassword"></label>
@@ -116,21 +121,24 @@
 				<label for="dbname" class="infield"><?php p($l->t( 'Database name' )); ?></label>
 				<input type="text" name="dbname" id="dbname" placeholder=""
 					value="<?php p($_['dbname']); ?>"
-					autocomplete="off" pattern="[0-9a-zA-Z$_-]+" />
+					autocomplete="off" autocapitalize="off" autocorrect="off"
+					pattern="[0-9a-zA-Z$_-]+" />
 			</p>
 			<?php if($_['hasOracle']): ?>
 			<div id="use_oracle_db">
 				<p class="infield groupmiddle">
 					<label for="dbtablespace" class="infield"><?php p($l->t( 'Database tablespace' )); ?></label>
 					<input type="text" name="dbtablespace" id="dbtablespace" placeholder=""
-						value="<?php p($_['dbtablespace']); ?>" autocomplete="off" />
+						value="<?php p($_['dbtablespace']); ?>"
+						autocomplete="off" autocapitalize="off" autocorrect="off" />
 				</p>
 			</div>
 			<?php endif; ?>
 			<p class="infield groupbottom">
 				<label for="dbhost" class="infield"><?php p($l->t( 'Database host' )); ?></label>
 				<input type="text" name="dbhost" id="dbhost" placeholder=""
-					value="<?php p($_['dbhost']); ?>" />
+					value="<?php p($_['dbhost']); ?>"
+					autocomplete="off" autocapitalize="off" autocorrect="off" />
 			</p>
 		</div>
 		<?php endif; ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -26,15 +26,17 @@
 		</p>
 		<p class="infield grouptop">
 			<input type="text" name="user" id="user" placeholder=""
-				   value="<?php p($_['username']); ?>"<?php p($_['user_autofocus'] ? ' autofocus' : ''); ?>
-				   autocomplete="on" required/>
+				   value="<?php p($_['username']); ?>"
+				   <?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
+				   autocomplete="on" autocapitalize="off" autocorrect="off" required />
 			<label for="user" class="infield"><?php p($l->t('Username')); ?></label>
 			<img class="svg" src="<?php print_unescaped(image_path('', 'actions/user.svg')); ?>" alt=""/>
 		</p>
 
 		<p class="infield groupbottom">
 			<input type="password" name="password" id="password" value="" placeholder=""
-				   required<?php p($_['user_autofocus'] ? '' : ' autofocus'); ?> />
+				   <?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
+				   autocomplete="on" autocapitalize="off" autocorrect="off" required />
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<img class="svg" id="password-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt=""/>
 		</p>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -40,10 +40,12 @@ if($_['passwordChangeSupported']) {
 		<div id="passwordchanged"><?php echo $l->t('Your password was changed');?></div>
 		<div id="passworderror"><?php echo $l->t('Unable to change your password');?></div>
 		<input type="password" id="pass1" name="oldpassword"
-			placeholder="<?php echo $l->t('Current password');?>" autocomplete="off" />
+			placeholder="<?php echo $l->t('Current password');?>"
+			autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<input type="password" id="pass2" name="personal-password"
 			placeholder="<?php echo $l->t('New password');?>"
-			data-typetoggle="#personal-show" autocomplete="off" />
+			data-typetoggle="#personal-show"
+			autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
 		<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password');?>" />
 		<br/>
@@ -60,7 +62,9 @@ if($_['displayNameChangeSupported']) {
 <form id="displaynameform">
 	<fieldset class="personalblock">
 		<h2><?php echo $l->t('Full Name');?></h2>
-		<input type="text" id="displayName" name="displayName" value="<?php p($_['displayName'])?>" />
+		<input type="text" id="displayName" name="displayName"
+			value="<?php p($_['displayName'])?>"
+			autocomplete="on" autocapitalize="off" autocorrect="off" />
         <span class="msg"></span>
 		<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
 	</fieldset>
@@ -76,7 +80,9 @@ if($_['passwordChangeSupported']) {
 	<fieldset class="personalblock">
 		<h2><?php p($l->t('Email'));?></h2>
 		<input type="text" name="email" id="email" value="<?php p($_['email']); ?>"
-			placeholder="<?php p($l->t('Your email address'));?>" /><span class="msg"></span><br />
+			placeholder="<?php p($l->t('Your email address'));?>"
+			autocomplete="on" autocapitalize="off" autocorrect="off" />
+		<span class="msg"></span><br />
 		<em><?php p($l->t('Fill in an email address to enable password recovery'));?></em>
 	</fieldset>
 </form>


### PR DESCRIPTION
This fixes the issue that on mobile the username field capitalizes the first letter of the username. Since most usernames do not start with a capital letter – and it would fail because of wrong case – this should be disabled.
- also disable autocorrect
- and specify autocomplete for fields

Please review @owncloud/designers @DeepDiver1975 
