### PR TITLE
An admin should not be able to add remote and public services on its own

### DIFF
--- a/core/ajax/appconfig.php
+++ b/core/ajax/appconfig.php
@@ -9,7 +9,10 @@ OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
 $action=isset($_POST['action'])?$_POST['action']:$_GET['action'];
-$app=OC_App::cleanAppId(isset($_POST['app'])?$_POST['app']:$_GET['app']);
+
+if(isset($_POST['app']) || isset($_GET['app'])) {
+	$app=OC_App::cleanAppId(isset($_POST['app'])?$_POST['app']:$_GET['app']);
+}
 
 // An admin should not be able to add remote and public services
 // on its own. This should only be possible programmatically.

--- a/core/ajax/appconfig.php
+++ b/core/ajax/appconfig.php
@@ -15,7 +15,7 @@ $app=OC_App::cleanAppId(isset($_POST['app'])?$_POST['app']:$_GET['app']);
 // on its own. This should only be possible programmatically.
 // This change is due the fact that an admin may not be expected 
 // to execute arbitrary code in every environment.
-if($app === 'core' && (substr($_POST['key'],0,7) === 'remote_' || substr($_POST['key'],0,7) === 'public_')) {
+if($app === 'core' && isset($_POST['key']) &&(substr($_POST['key'],0,7) === 'remote_' || substr($_POST['key'],0,7) === 'public_')) {
 	OC_JSON::error(array('data' => array('message' => 'Unexpected error!')));
 	return;
 }

--- a/core/ajax/appconfig.php
+++ b/core/ajax/appconfig.php
@@ -9,28 +9,40 @@ OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
 $action=isset($_POST['action'])?$_POST['action']:$_GET['action'];
+$app=OC_App::cleanAppId(isset($_POST['app'])?$_POST['app']:$_GET['app']);
+
+// An admin should not be able to add remote and public services
+// on its own. This should only be possible programmatically.
+// This change is due the fact that an admin may not be expected 
+// to execute arbitrary code in every environment.
+if($app === 'core' && (substr($_POST['key'],0,7) === 'remote_' || substr($_POST['key'],0,7) === 'public_')) {
+	OC_JSON::error(array('data' => array('message' => 'Unexpected error!')));
+	return;
+}
+
 $result=false;
 switch($action) {
 	case 'getValue':
-		$result=OC_Appconfig::getValue($_GET['app'], $_GET['key'], $_GET['defaultValue']);
+		$result=OC_Appconfig::getValue($app, $_GET['key'], $_GET['defaultValue']);
 		break;
 	case 'setValue':
-		$result=OC_Appconfig::setValue($_POST['app'], $_POST['key'], $_POST['value']);
+		$result=OC_Appconfig::setValue($app, $_POST['key'], $_POST['value']);
 		break;
 	case 'getApps':
 		$result=OC_Appconfig::getApps();
 		break;
 	case 'getKeys':
-		$result=OC_Appconfig::getKeys($_GET['app']);
+		$result=OC_Appconfig::getKeys($app);
 		break;
 	case 'hasKey':
-		$result=OC_Appconfig::hasKey($_GET['app'], $_GET['key']);
+		$result=OC_Appconfig::hasKey($app, $_GET['key']);
 		break;
 	case 'deleteKey':
-		$result=OC_Appconfig::deleteKey($_POST['app'], $_POST['key']);
+		$result=OC_Appconfig::deleteKey($app, $_POST['key']);
 		break;
 	case 'deleteApp':
-		$result=OC_Appconfig::deleteApp($_POST['app']);
+		$result=OC_Appconfig::deleteApp($app);
 		break;
 }
 OC_JSON::success(array('data'=>$result));
+


### PR DESCRIPTION
An admin should not be able to add remote and public services. This should only be possible programmatically.

Backport to stable5 and stable6 requested.

@karlitschek 
