### PR TITLE
don't die silently when owncloud log cannot be initialized

### DIFF
--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -68,7 +68,11 @@ class ErrorHandler {
 	//Recoverable handler which catch all errors, warnings and notices
 	public static function onAll($number, $message, $file, $line) {
 		$msg = $message . ' at ' . $file . '#' . $line;
-		self::$logger->debug(self::removePassword($msg), array('app' => 'PHP'));
+		if (is_object(self::$logger)) {
+			self::$logger->debug(self::removePassword($msg), array('app' => 'PHP'));
+		} else {
+			syslog(LOG_ERR, 'logger not initialized correctly: ' . self::removePassword($msg));
+		}
 
 	}
 

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -45,7 +45,7 @@ class OC_Log_Owncloud {
 		* is_writable() on directories used to be pretty unreliable on Windows
 		* for at least some time.
 		*/
-		if (!file_exists(self::$logFile) && !@touch(self::$logFile)) {
+		if (!file_exists(self::$logFile) && !touch(self::$logFile)) {
 			self::$logFile = $defaultLogFile;
 		}
 	}


### PR DESCRIPTION
Just faced the white screen of death because the permissions of the data folder were borked ... as a result the owncloud log class could not be initialized. A @ prevented any error from showing up and then I got the following log:

```

[Tue Feb 18 12:19:45.453385 2014] [:error] [pid 9803] [client ::1:57190] PHP Fatal error:  Call to a member function debug() on a non-object in /home/jfd/Repositories/oc/core/lib/private/log/errorhandler.php on line 71
[Tue Feb 18 12:19:45.453440 2014] [:error] [pid 9803] [client ::1:57190] PHP Stack trace:
[Tue Feb 18 12:19:45.453536 2014] [:error] [pid 9803] [client ::1:57190] PHP   1. {main}() /home/jfd/Repositories/oc/core/index.php:0
[Tue Feb 18 12:19:45.453584 2014] [:error] [pid 9803] [client ::1:57190] PHP   2. require_once() /home/jfd/Repositories/oc/core/index.php:28
[Tue Feb 18 12:19:45.453646 2014] [:error] [pid 9803] [client ::1:57190] PHP   3. OC::init() /home/jfd/Repositories/oc/core/lib/base.php:975
[Tue Feb 18 12:19:45.453689 2014] [:error] [pid 9803] [client ::1:57190] PHP   4. spl_autoload_call(*uninitialized*) /home/jfd/Repositories/oc/core/lib/base.php:512
[Tue Feb 18 12:19:45.453766 2014] [:error] [pid 9803] [client ::1:57190] PHP   5. OC\\Autoloader->load($class = *uninitialized*) /home/jfd/Repositories/oc/core/lib/base.php:0
[Tue Feb 18 12:19:45.453808 2014] [:error] [pid 9803] [client ::1:57190] PHP   6. require_once() /home/jfd/Repositories/oc/core/lib/autoloader.php:143
[Tue Feb 18 12:19:45.453866 2014] [:error] [pid 9803] [client ::1:57190] PHP   7. OC\\Log->__construct() /home/jfd/Repositories/oc/core/lib/private/legacy/log.php:16
[Tue Feb 18 12:19:45.453908 2014] [:error] [pid 9803] [client ::1:57190] PHP   8. call_user_func(*uninitialized*) /home/jfd/Repositories/oc/core/lib/private/log.php:117
[Tue Feb 18 12:19:45.453966 2014] [:error] [pid 9803] [client ::1:57190] PHP   9. OC_Log_Owncloud::init() /home/jfd/Repositories/oc/core/lib/private/log.php:117
[Tue Feb 18 12:19:45.454008 2014] [:error] [pid 9803] [client ::1:57190] PHP  10. touch(*uninitialized*) /home/jfd/Repositories/oc/core/lib/private/log/owncloud.php:48
[Tue Feb 18 12:19:45.454133 2014] [:error] [pid 9803] [client ::1:57190] PHP  11. OC\\Log\\ErrorHandler->onAll($number = *uninitialized*, $message = *uninitialized*, $file = *uninitialized*, $line = *uninitialized*, *uninitialized*) /home/jfd/Repositories/oc/core/lib/private/log/owncloud.php:48
```

@DeepDiver1975 @PVince81 please review
