### PR TITLE
Add overwritehost config on setup and upgrade

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -53,6 +53,9 @@ $CONFIG = array(
 /* The optional authentication for the proxy to use to connect to the internet. The format is: [username]:[password] */
 "proxyuserpwd" => "",
 
+/* List of trusted domains, to prevent host header poisoning ownCloud is only using these Host headers */
+'trusted_domains' => array('demo.owncloud.org'),
+
 /* Theme to use for ownCloud */
 "theme" => "",
 

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -25,6 +25,16 @@ class OC_Request {
 	}
 
 	/**
+	 * @brief Checks whether a domain is considered as trusted. This is used to prevent Host Header Poisoning.
+	 * @param string $host
+	 * @return bool
+	 */
+	public static function isTrustedDomain($domain) {
+		$trustedList = \OC_Config::getValue('trusted_domains', array(''));
+		return in_array($domain, $trustedList);
+	}
+
+	/**
 	 * @brief Returns the server host
 	 * @returns string the server host
 	 *
@@ -43,21 +53,27 @@ class OC_Request {
 				$host = trim(array_pop(explode(",", $_SERVER['HTTP_X_FORWARDED_HOST'])));
 			}
 			else{
-				$host=$_SERVER['HTTP_X_FORWARDED_HOST'];
+				$host = $_SERVER['HTTP_X_FORWARDED_HOST'];
 			}
-		}
-		else{
+		} else {
 			if (isset($_SERVER['HTTP_HOST'])) {
-				return $_SERVER['HTTP_HOST'];
+				$host = $_SERVER['HTTP_HOST'];
 			}
 			if (isset($_SERVER['SERVER_NAME'])) {
-				return $_SERVER['SERVER_NAME'];
+				$host = $_SERVER['SERVER_NAME'];
 			}
-			return 'localhost';
 		}
-		return $host;
-	}
 
+		// Verify that the host is a trusted domain if the trusted domains
+		// are defined
+		// If no trusted domain is provided the first trusted domain is returned
+		if(self::isTrustedDomain($host) || \OC_Config::getValue('trusted_domains', "") === "") {
+			return $host;
+		} else {
+			$trustedList = \OC_Config::getValue('trusted_domains', array(''));
+			return $trustedList[0];
+		}
+	}
 
 	/**
 	* @brief Returns the server protocol
@@ -71,14 +87,14 @@ class OC_Request {
 		}
 		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
 			$proto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
-		}else{
-			if(isset($_SERVER['HTTPS']) and !empty($_SERVER['HTTPS']) and ($_SERVER['HTTPS']!='off')) {
-				$proto = 'https';
-			}else{
-				$proto = 'http';
-			}
+			// Verify that the protocol is always HTTP or HTTPS
+			// default to http if an invalid value is provided
+			return $proto === 'https' ? 'https' : 'http';
 		}
-		return $proto;
+		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+			return 'https';
+		}
+		return 'http';
 	}
 
 	/**

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -65,6 +65,7 @@ class OC_Setup {
 		OC_Config::setValue('passwordsalt', $salt);
 
 		//write the config file
+		OC_Config::setValue('trusted_domains', array(OC_Request::serverHost())); 
 		OC_Config::setValue('datadirectory', $datadir);
 		OC_Config::setValue('dbtype', $dbtype);
 		OC_Config::setValue('version', implode('.', OC_Util::getVersion()));

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -102,6 +102,20 @@ class Updater extends BasicEmitter {
 			$this->log->debug('starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, array('app' => 'core'));
 		}
 		$this->emit('\OC\Updater', 'maintenanceStart');
+
+		/*
+		 * START CONFIG CHANGES FOR OLDER VERSIONS
+		 */
+		if (version_compare($currentVersion, '6.90.1', '<')) {
+			// Add the overwriteHost config if it is not existant
+			// This is added to prevent host header poisoning
+			\OC_Config::setValue('trusted_domains', \OC_Config::getValue('trusted_domains', array(\OC_Request::serverHost()))); 
+		}
+		/*
+		 * STOP CONFIG CHANGES FOR OLDER VERSIONS
+		 */
+
+
 		try {
 			\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 			$this->emit('\OC\Updater', 'dbUpgrade');
@@ -162,3 +176,4 @@ class Updater extends BasicEmitter {
 		$this->emit('\OC\Updater', 'filecacheDone');
 	}
 }
+


### PR DESCRIPTION
~~overwritehost should always be configured to prevent Host Header Poisoning, this commit adds the config option on upgrade and on new installations automatically.~~

~~Backport to stable5 and stable6 requested. But I assume the code base is too different for a simple cherry pick.~~

This PR adds a new "trusted_domains" config option, on update and setup the config is automatically set with the current host header if no value is provided.
