### PR TITLE
Allow setting the frequency of which the file watcher checks for updates

### DIFF
--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -12,6 +12,14 @@ namespace OC\Files\Cache;
  * check the storage backends for updates and change the cache accordingly
  */
 class Watcher {
+	const CHECK_NEVER = 0; // never check the underlying filesystem for updates
+	const CHECK_ONCE = 1; // check the underlying filesystem for updates once every request for each file
+	const CHECK_ALWAYS = 2; // always check the underlying filesystem for updates
+
+	protected $watchPolicy = self::CHECK_ONCE;
+
+	protected $checkedPaths = array();
+
 	/**
 	 * @var \OC\Files\Storage\Storage $storage
 	 */
@@ -23,7 +31,7 @@ class Watcher {
 	protected $cache;
 
 	/**
-	 * @var Scanner $scanner;
+	 * @var Scanner $scanner ;
 	 */
 	protected $scanner;
 
@@ -37,26 +45,38 @@ class Watcher {
 	}
 
 	/**
+	 * @param int $policy either \OC\Files\Cache\Watcher::UPDATE_NEVER, \OC\Files\Cache\Watcher::UPDATE_ONCE, \OC\Files\Cache\Watcher::UPDATE_ALWAYS
+	 */
+	public function setPolicy($policy) {
+		$this->watchPolicy = $policy;
+	}
+
+	/**
 	 * check $path for updates
 	 *
 	 * @param string $path
 	 * @return boolean | array true if path was updated, otherwise the cached data is returned
 	 */
 	public function checkUpdate($path) {
-		$cachedEntry = $this->cache->get($path);
-		if ($this->storage->hasUpdated($path, $cachedEntry['storage_mtime'])) {
-			if ($this->storage->is_dir($path)) {
-				$this->scanner->scan($path, Scanner::SCAN_SHALLOW);
-			} else {
-				$this->scanner->scanFile($path);
+		if ($this->watchPolicy === self::CHECK_ALWAYS or ($this->watchPolicy === self::CHECK_ONCE and array_search($path, $this->checkedPaths) === false)) {
+			$cachedEntry = $this->cache->get($path);
+			$this->checkedPaths[] = $path;
+			if ($this->storage->hasUpdated($path, $cachedEntry['storage_mtime'])) {
+				if ($this->storage->is_dir($path)) {
+					$this->scanner->scan($path, Scanner::SCAN_SHALLOW);
+				} else {
+					$this->scanner->scanFile($path);
+				}
+				if ($cachedEntry['mimetype'] === 'httpd/unix-directory') {
+					$this->cleanFolder($path);
+				}
+				$this->cache->correctFolderSize($path);
+				return true;
 			}
-			if ($cachedEntry['mimetype'] === 'httpd/unix-directory') {
-				$this->cleanFolder($path);
-			}
-			$this->cache->correctFolderSize($path);
-			return true;
+			return $cachedEntry;
+		} else {
+			return false;
 		}
-		return $cachedEntry;
 	}
 
 	/**

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -11,7 +11,7 @@ namespace Test\Files\Cache;
 class Watcher extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @var \OC\Files\Storage\Storage[] $storages;
+	 * @var \OC\Files\Storage\Storage[] $storages
 	 */
 	private $storages = array();
 
@@ -103,6 +103,60 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$entry = $cache->get('foo.txt');
 		$this->assertEquals('httpd/unix-directory', $entry['mimetype']);
 		$this->assertTrue($cache->inCache('foo.txt/bar.txt'));
+	}
+
+	public function testPolicyNever() {
+		$storage = $this->getTestStorage();
+		$cache = $storage->getCache();
+		$updater = $storage->getWatcher();
+
+		//set the mtime to the past so it can detect an mtime change
+		$cache->put('foo.txt', array('storage_mtime' => 10));
+
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_NEVER);
+
+		$storage->file_put_contents('foo.txt', 'q');
+		$this->assertFalse($updater->checkUpdate('foo.txt'));
+
+		$cache->put('foo.txt', array('storage_mtime' => 20));
+		$storage->file_put_contents('foo.txt', 'w');
+		$this->assertFalse($updater->checkUpdate('foo.txt'));
+	}
+
+	public function testPolicyOnce() {
+		$storage = $this->getTestStorage();
+		$cache = $storage->getCache();
+		$updater = $storage->getWatcher();
+
+		//set the mtime to the past so it can detect an mtime change
+		$cache->put('foo.txt', array('storage_mtime' => 10));
+
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_ONCE);
+
+		$storage->file_put_contents('foo.txt', 'q');
+		$this->assertTrue($updater->checkUpdate('foo.txt'));
+
+		$cache->put('foo.txt', array('storage_mtime' => 20));
+		$storage->file_put_contents('foo.txt', 'w');
+		$this->assertFalse($updater->checkUpdate('foo.txt'));
+	}
+
+	public function testPolicyAlways() {
+		$storage = $this->getTestStorage();
+		$cache = $storage->getCache();
+		$updater = $storage->getWatcher();
+
+		//set the mtime to the past so it can detect an mtime change
+		$cache->put('foo.txt', array('storage_mtime' => 10));
+
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_ALWAYS);
+
+		$storage->file_put_contents('foo.txt', 'q');
+		$this->assertTrue($updater->checkUpdate('foo.txt'));
+
+		$cache->put('foo.txt', array('storage_mtime' => 20));
+		$storage->file_put_contents('foo.txt', 'w');
+		$this->assertTrue($updater->checkUpdate('foo.txt'));
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -7,6 +7,8 @@
 
 namespace Test\Files;
 
+use OC\Files\Cache\Watcher;
+
 class TemporaryNoTouch extends \OC\Files\Storage\Temporary {
 	public function touch($path, $mtime = null) {
 		return false;
@@ -249,6 +251,7 @@ class View extends \PHPUnit_Framework_TestCase {
 	function testWatcher() {
 		$storage1 = $this->getTestStorage();
 		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		$storage1->getWatcher()->setPolicy(Watcher::CHECK_ALWAYS);
 
 		$rootView = new \OC\Files\View('');
 


### PR DESCRIPTION
Allow setting the watcher to only check for update once every request (default), every time (mostly useful for tests) or never (if we know the underlying filesystem doesn't change anyway)

@DeepDiver1975  as discussed.

cc @PVince81 
