### PR TITLE
Hardening: Remove dangerous characters + Subdirectory Check

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -118,7 +118,7 @@ class OC_L10N implements \OCP\IL10N {
 			return;
 		}
 		$app = OC_App::cleanAppId($this->app);
-		$lang = $this->lang;
+		$lang = str_replace(array('\0', '/', '\\', '..'), '', $this->lang);
 		$this->app = true;
 		// Find the right language
 		if(is_null($lang) || $lang == '') {
@@ -163,7 +163,7 @@ class OC_L10N implements \OCP\IL10N {
 				}
 			}
 
-			if(file_exists(OC::$SERVERROOT.'/core/l10n/l10n-'.$lang.'.php')) {
+			if(file_exists(OC::$SERVERROOT.'/core/l10n/l10n-'.$lang.'.php') && OC_Helper::issubdirectory(OC::$SERVERROOT.'/core/l10n/l10n-'.$lang.'.php', OC::$SERVERROOT.'/core/l10n/')) {
 				// Include the file, save the data from $CONFIG
 				include OC::$SERVERROOT.'/core/l10n/l10n-'.$lang.'.php';
 				if(isset($LOCALIZATIONS) && is_array($LOCALIZATIONS)) {


### PR DESCRIPTION
If an user is able to create folders in /core/l10n/ he is able to include arbitrary PHP files with today's logic. 

Therefore I've added an `issubdirectory` check and removed all potential dangerous characters from `$lang`.

I think this may be useful to backport as we had recently an issue where users on IIS could create arbitrary folders.
