### PR TITLE
fix sharing unit tests

### DIFF
--- a/tests/lib/share/backend.php
+++ b/tests/lib/share/backend.php
@@ -26,7 +26,7 @@ class Test_Share_Backend implements OCP\Share_Backend {
 	const FORMAT_SOURCE = 0;
 	const FORMAT_TARGET = 1;
 	const FORMAT_PERMISSIONS = 2;
-	
+
 	private $testItem1 = 'test.txt';
 	private $testItem2 = 'share.txt';
 
@@ -57,11 +57,11 @@ class Test_Share_Backend implements OCP\Share_Backend {
 	public function formatItems($items, $format, $parameters = null) {
 		$testItems = array();
 		foreach ($items as $item) {
-			if ($format == self::FORMAT_SOURCE) {
+			if ($format === self::FORMAT_SOURCE) {
 				$testItems[] = $item['item_source'];
-			} else if ($format == self::FORMAT_TARGET) {
+			} else if ($format === self::FORMAT_TARGET) {
 				$testItems[] = $item['item_target'];
-			} else if ($format == self::FORMAT_PERMISSIONS) {
+			} else if ($format === self::FORMAT_PERMISSIONS) {
 				$testItems[] = $item['permissions'];
 			}
 		}

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -622,21 +622,21 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		OC_User::setUserId($this->user1);
 		$this->assertEquals(
 			array('test.txt', 'test.txt'),
-			OCP\Share::getItemsShared('test', 'test.txt'),
+			OCP\Share::getItemsShared('test', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that the test.txt file is shared exactly two times by user1.'
 		);
 
 		OC_User::setUserId($this->user2);
 		$this->assertEquals(
 			array('test.txt'),
-			OCP\Share::getItemsShared('test', 'test.txt'),
+			OCP\Share::getItemsShared('test', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that the test.txt file is shared exactly once by user2.'
 		);
 
 		OC_User::setUserId($this->user3);
 		$this->assertEquals(
 			array('test.txt'),
-			OCP\Share::getItemsShared('test', 'test.txt'),
+			OCP\Share::getItemsShared('test', Test_Share_Backend::FORMAT_SOURCE),
 			'Failed asserting that the test.txt file is shared exactly once by user3.'
 		);
 


### PR DESCRIPTION
This tests passed successfully only by coincident in the past. Now they should be correct.
