### PR TITLE
fix viewport size on windows phone

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -987,6 +987,17 @@ OC.set=function(name, value) {
 	context[tail]=value;
 };
 
+// fix device width on windows phone
+(function() {
+	if ("-ms-user-select" in document.documentElement.style && navigator.userAgent.match(/IEMobile\/10\.0/)) {
+		var msViewportStyle = document.createElement("style");
+		msViewportStyle.appendChild(
+			document.createTextNode("@-ms-viewport{width:auto!important}")
+		);
+		document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
+	}
+})();
+
 /**
  * select a range in an input field
  * @link http://stackoverflow.com/questions/499126/jquery-set-cursor-position-in-text-area


### PR DESCRIPTION
Without this fix IE on windows phone uses the actual screen resolution as device width (~720px)

with this fix it uses the scaled "physical pixels" as device width (~320px)

see http://mattstow.com/responsive-design-in-ie10-on-windows-phone-8.html
