### PR TITLE
Allow apps to add/modify config js output via hook.

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -10,8 +10,8 @@
 header("Content-type: text/javascript");
 
 // Disallow caching
-header("Cache-Control: no-cache, must-revalidate"); 
-header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); 
+header("Cache-Control: no-cache, must-revalidate");
+header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
 
 // Enable l10n support
 $l = OC_L10N::get('core');
@@ -62,7 +62,10 @@ $array = array(
 			'session_keepalive' => \OCP\Config::getSystemValue('session_keepalive', true)
 		)
 	)
-	);
+);
+
+// Allow hooks to modify the output values
+OC_Hook::emit('\OCP\Config', 'js', array('array' => &$array));
 
 // Echo it
 foreach ($array as  $setting => $value) {


### PR DESCRIPTION
This will allow apps to output some dynamic data in javascript that their static javscript files can act upon.

---

To use, connect the hook to a class method in the app in app.php:

``` php
OC_Hook::connect('\OCP\Config', 'js', '\OCA\Testapp\Testapp', 'getJs');
```

Then implement the connected method in the specified app class:

``` php
<?php

namespace OCA\Testapp;

class Testapp {
    public static function getJs(array $data) {
        $data['array']['testapp'] = 14;
    }
}
```

The value added to the array will appear in /index.php/core/js/oc.js

This PR replaces #6879.  **Intend to backport for 6.0.2**

---

@DeepDiver1975 @PVince81 @jancborchardt @kabum @icewind1991 ?
