### PR TITLE
Fix "headers are already sent" introduced with #6519

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -227,6 +227,7 @@ class OC_User {
 	 * Log in a user and regenerate a new session - if the password is ok
 	 */
 	public static function login($uid, $password) {
+		session_regenerate_id(true);
 		return self::getUserSession()->login($uid, $password);
 	}
 

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -157,7 +157,6 @@ class Session implements Emitter, \OCP\IUserSession {
 		if($user !== false) {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
-					session_regenerate_id(true);
 					$this->setUser($user);
 					$this->setLoginName($uid);
 					$this->manager->emit('\OC\User', 'postLogin', array($user, $password));


### PR DESCRIPTION
This should fix the the `headers are already sent` problem which have been introduced with #6519. I'm somewhat confused as the PHP log isn't reporting this problem, anyways, this should fix the unit tests.

Needs a backport to stable6.

\cc @DeepDiver1975
