### PR TITLE
ignore optional additional config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /data
 /owncloud
 /config/config.php
+/config/*.config.php
 /config/mount.php
 /apps/inc.php
 


### PR DESCRIPTION
You can add 'apps.config.php' and this gets merged into your config and doesn't get overwritten. This ignores those files.

cc @butonic @icewind1991 
