### PR TITLE
fix thumbnail generation for subdirectories in the conflicts dialog

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -293,7 +293,7 @@ var OCdialogs = {
 				conflict.find('.replacement .size').text(humanFileSize(replacement.size));
 				conflict.find('.replacement .mtime').text(formatDate(replacement.lastModifiedDate));
 			}
-			var path = getPathForPreview(original.name);
+			var path = original.directory + '/' +original.name;
 			Files.lazyLoadPreview(path, original.mime, function(previewpath){
 				conflict.find('.original .icon').css('background-image','url('+previewpath+')');
 			}, 96, 96, original.etag);


### PR DESCRIPTION
Fixes generation of thumbnails for files in subdirectories, a bug that surfaced with https://github.com/owncloud/core/pull/7296 - Added the ability to Drag and Drop folders [chrome] 

@lukepolo @karlitschek @jancborchardt @MorrisJobke @georgehrke please review
