### PR TITLE
Use 'command -v' to detect whether and where software is installed (instead of 'which')

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -438,7 +438,7 @@ class OC_Mount_Config {
 	 */
 	public static function checksmbclient() {
 		if(function_exists('shell_exec')) {
-			$output=shell_exec('which smbclient 2> /dev/null');
+			$output=shell_exec('command -v smbclient 2> /dev/null');
 			return !empty($output);
 		}else{
 			return false;

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -464,7 +464,7 @@ class OC_Installer{
 		// is the code checker enabled?
 		if(OC_Config::getValue('appcodechecker', true)) {
 			// check if grep is installed
-			$grep = exec('which grep');
+			$grep = exec('command -v grep');
 			if($grep=='') {
 				OC_Log::write('core',
 					'grep not installed. So checking the code of the app "'.$appname.'" was not possible',

--- a/lib/private/preview/movies.php
+++ b/lib/private/preview/movies.php
@@ -9,7 +9,7 @@
 namespace OC\Preview;
 
 function findBinaryPath($program) {
-	exec('which ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
+	exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
 	if ($returnCode === 0 && count($output) > 0) {
 		return escapeshellcmd($output[0]);
 	}

--- a/lib/private/preview/office-cl.php
+++ b/lib/private/preview/office-cl.php
@@ -64,12 +64,12 @@ if (!\OC_Util::runningOnWindows()) {
 				$cmd = \OC_Config::getValue('preview_libreoffice_path', null);
 			}
 
-			$whichLibreOffice = shell_exec('which libreoffice');
+			$whichLibreOffice = shell_exec('command -v libreoffice');
 			if($cmd === '' && !empty($whichLibreOffice)) {
 				$cmd = 'libreoffice';
 			}
 
-			$whichOpenOffice = shell_exec('which openoffice');
+			$whichOpenOffice = shell_exec('command -v openoffice');
 			if($cmd === '' && !empty($whichOpenOffice)) {
 				$cmd = 'openoffice';
 			}

--- a/lib/private/preview/office.php
+++ b/lib/private/preview/office.php
@@ -11,9 +11,9 @@ if (extension_loaded('imagick') && count(@\Imagick::queryFormats("PDF")) === 1) 
 
 	// LibreOffice preview is currently not supported on Windows
 	if (!\OC_Util::runningOnWindows()) {
-		$whichLibreOffice = ($isShellExecEnabled ? shell_exec('which libreoffice') : '');
+		$whichLibreOffice = ($isShellExecEnabled ? shell_exec('command -v libreoffice') : '');
 		$isLibreOfficeAvailable = !empty($whichLibreOffice);
-		$whichOpenOffice = ($isShellExecEnabled ? shell_exec('which libreoffice') : '');
+		$whichOpenOffice = ($isShellExecEnabled ? shell_exec('command -v libreoffice') : '');
 		$isOpenOfficeAvailable = !empty($whichOpenOffice);
 		//let's see if there is libreoffice or openoffice on this machine
 		if($isShellExecEnabled && ($isLibreOfficeAvailable || $isOpenOfficeAvailable || is_string(\OC_Config::getValue('preview_libreoffice_path', null)))) {


### PR DESCRIPTION
With this commit, the external command `which` isn't used anymore. `command -v` should be available for all POSIX conform environments.

Fixes https://github.com/owncloud/core/issues/5911
Fixes executable paths not being detected on ArchLinux (and probably other distros). Detection used to always fail:

> which: no libreoffice in ((null))
