### PR TITLE
[stable6] Fixed missing files on SMB storage

### DIFF
--- a/apps/files_external/3rdparty/smb4php/smb.php
+++ b/apps/files_external/3rdparty/smb4php/smb.php
@@ -164,7 +164,7 @@ class smb {
 					$i = ($mode == 'servers') ? array ($name, "server") : array ($name, "workgroup", $master);
 					break;
 				case 'files':
-					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|S|R]+)$/", trim ($regs[1]), $regs2)
+					list ($attr, $name) = preg_match ("/^(.*)[ ]+([D|A|H|S|R|N]+)$/", trim ($regs[1]), $regs2)
 						? array (trim ($regs2[2]), trim ($regs2[1]))
 						: array ('', trim ($regs[1]));
 					list ($his, $im) = array (


### PR DESCRIPTION
Files with attribute "N" weren't parsed out of the file list returned by
smbclient. It seems that these files appear when created on a Linux SMB
mount directly and that have no executable bit.

@icewind1991 for some reason it seems we missed fixing this on stable6 / stable5.

Please review @karlitschek @icewind1991 @schiesbn 
