### PR TITLE
Replace deleteAll call with unlink call on rename

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -140,43 +140,6 @@ abstract class Common implements \OC\Files\Storage\Storage {
 		return $result;
 	}
 
-	/**
-	 * @brief Deletes all files and folders recursively within a directory
-	 * @param string $directory The directory whose contents will be deleted
-	 * @param bool $empty Flag indicating whether directory will be emptied
-	 * @returns bool
-	 *
-	 * @note By default the directory specified by $directory will be
-	 * deleted together with its contents. To avoid this set $empty to true
-	 */
-	public function deleteAll($directory, $empty = false) {
-		$directory = trim($directory, '/');
-		if (!$this->is_dir($directory) || !$this->isReadable($directory)) {
-			return false;
-		} else {
-			$directoryHandle = $this->opendir($directory);
-			if (is_resource($directoryHandle)) {
-				while (($contents = readdir($directoryHandle)) !== false) {
-					if (!\OC\Files\Filesystem::isIgnoredDir($contents)) {
-						$path = $directory . '/' . $contents;
-						if ($this->is_dir($path)) {
-							$this->deleteAll($path);
-						} else {
-							$this->unlink($path);
-						}
-					}
-				}
-			}
-			if ($empty === false) {
-				if (!$this->rmdir($directory)) {
-					return false;
-				}
-			}
-			return true;
-		}
-
-	}
-
 	public function getMimeType($path) {
 		if ($this->is_dir($path)) {
 			return 'httpd/unix-directory';

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -413,7 +413,7 @@ class View {
 						$result = $this->copy($path1, $path2);
 						if ($result === true) {
 							list($storage1, $internalPath1) = Filesystem::resolvePath($absolutePath1 . $postFix1);
-							$result = $storage1->deleteAll($internalPath1);
+							$result = $storage1->unlink($internalPath1);
 						}
 					} else {
 						$source = $this->fopen($path1 . $postFix1, 'r');


### PR DESCRIPTION
Replace deleteAll call with unlink call

The method deleteAll() doesn't officially exist on the Storage class as it's not defined on the interface, which means it fails on the Quota storage wrapper and might fail on some external storage classes.
Also, this here is the only use case for that one method.

I suggest to keep "deleteAll" in the OC6 backport in case it was used by third party apps, even though it's not in the public API.

Please review @karlitschek @icewind1991 @schiesbn 
