### PR TITLE
Remove necessity of icon class

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -1,4 +1,4 @@
-.icon {
+[class^="icon-"], [class*=" icon-"] {
 	background-repeat: no-repeat;
 	background-position: center;
 }


### PR DESCRIPTION
This removes the necessity of an icon class and therefore reduces the amount of classes for HTML elements containing an icon with one.

@jancborchardt please review.
Let's wait for #7366 to be fixed before merging this.
