### PR TITLE
disable autocomplete for shared link password input, fix #7419

### DIFF
--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -8,7 +8,10 @@
 		<?php endif; ?>
 		<p class="infield">
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
-			<input type="password" name="password" id="password" placeholder="" value="" autofocus />
+			<input type="password" name="password" id="password"
+				placeholder="" value=""
+				autocomplete="off" autocapitalize="off" autocorrect="off"
+				autofocus />
 			<input type="submit" value="" class="svg icon icon-confirm" />
 		</p>
 	</fieldset>


### PR DESCRIPTION
Fix https://github.com/owncloud/core/issues/7419

Please review @ser72 @owncloud/designers 

We could also backport this if we want to. @DeepDiver1975 @karlitschek?
