### PR TITLE
[stable6] Also quote old column name during DB migration

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -82,6 +82,9 @@ class MDB2SchemaManager {
 		$platform = $this->conn->getDatabasePlatform();
 		foreach($schemaDiff->changedTables as $tableDiff) {
 			$tableDiff->name = $platform->quoteIdentifier($tableDiff->name);
+			foreach($tableDiff->changedColumns as $column) {
+				$column->oldColumnName = $platform->quoteIdentifier($column->oldColumnName);
+			}
 		}
 		
 		if ($generateSql) {

--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -228,7 +228,7 @@
 	<declaration>
 
 	<field>
-		<name>key</name>
+		<name>select</name>
 		<type>text</type>
 		<default></default>
 		<notnull>true</notnull>

--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -222,4 +222,19 @@
   </declaration>
  </table>
 
+<table>
+	<name>*dbprefix*migratekeyword</name>
+
+	<declaration>
+
+	<field>
+		<name>key</name>
+		<type>text</type>
+		<default></default>
+		<notnull>true</notnull>
+		<length>255</length>
+	</field>
+	</declaration>
+</table>
+
 </database>

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -125,7 +125,7 @@
 		<declaration>
 
 			<field>
-				<name>key</name>
+				<name>select</name>
 				<type>text</type>
 				<default></default>
 				<notnull>false</notnull>

--- a/tests/data/db_structure2.xml
+++ b/tests/data/db_structure2.xml
@@ -119,4 +119,19 @@
   </declaration>
  </table>
 
+	<table>
+		<name>*dbprefix*migratekeyword</name>
+
+		<declaration>
+
+			<field>
+				<name>key</name>
+				<type>text</type>
+				<default></default>
+				<notnull>false</notnull>
+				<length>255</length>
+			</field>
+		</declaration>
+	</table>
+
 </database>


### PR DESCRIPTION
This fixes alter table commands that didn't quote the old column name

Please review @bartv2 @DeepDiver1975 @bantu 

Fixes #7415 

I've tested this twice.
