### PR TITLE
close encryption session after decryption was finished

### DIFF
--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -134,6 +134,14 @@ class Session {
 
 	}
 
+	/**
+	 * @brief remove encryption keys and init status from session
+	 */
+	public function closeSession() {
+		\OC::$session->remove('encryptionInitialized');
+		\OC::$session->remove('privateKey');
+	}
+
 
 	/**
 	 * @brief Gets status if we already tried to initialize the encryption app

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1772,4 +1772,12 @@ class Util {
 		return $session;
 	}
 
+	/*
+	 * @brief remove encryption related keys from the session
+	 */
+	public function closeEncryptionSession() {
+		$session = new \OCA\Encryption\Session($this->view);
+		$session->closeSession();
+	}
+
 }

--- a/settings/ajax/decryptall.php
+++ b/settings/ajax/decryptall.php
@@ -24,6 +24,8 @@ if ($result !== false) {
 		$successful = false;
 	}
 
+	$util->closeEncryptionSession();
+
 	if ($successful === true) {
 		\OCP\JSON::success(array('data' => array('message' => 'Files decrypted successfully')));
 	} else {


### PR DESCRIPTION
close encryption session after decryption was finished. This way we can detect if the admin enables the encryption again while we are logged in.

fix #7429 
