### PR TITLE
Config to disable basic_auth username checking

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -178,6 +178,9 @@ $CONFIG = array(
 /* Enable or disable the logging of IP addresses in case of webform auth failures */
 "log_authfailip" => false,
 
+/* Whether http-basic username must equal username to login */
+"basic_auth" => true,
+
 /*
  * Configure the size in bytes log rotation should happen, 0 or false disables the rotation.
  * This rotates the current owncloud logfile to a new name, this way the total log usage

--- a/lib/base.php
+++ b/lib/base.php
@@ -554,7 +554,8 @@ class OC {
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
 
-		if (isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('loginname')
+		$basic_auth = OC_Config::getValue('basic_auth', true);
+		if ($basic_auth && isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('loginname')
 			&& $_SERVER['PHP_AUTH_USER'] !== self::$session->get('loginname')) {
 			$sessionUser = self::$session->get('loginname');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];


### PR DESCRIPTION
This can be confusing and/or annoying. (And I didn't really get what this block is used for anyways …)

My testinstall is protected via http-basic (so no one can hack my lazy-password of 123456), so I had to comment this block out before, getting conflicts everytime I did a `git branch` or `git pull` making me `git stash` everytime.

I've also seen some guys in #owncloud asking why their installation doesn't work with http-basic, telling them to comment out named block isn't really nice either.

@blizz @DeepDiver1975 @tanghus (?)
@karlitschek Should this be backported? This isn't a major bug, but pretty annoying, when this happens.
