### PR TITLE
use stricter asserts where possible

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -105,14 +105,14 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 		$result = $this->files->rename($dir, $oldname, $newname);
 
 		$this->assertTrue($result['success']);
-		$this->assertEquals(123, $result['data']['id']);
-		$this->assertEquals('new_name', $result['data']['name']);
-		$this->assertEquals('/test', $result['data']['directory']);
-		$this->assertEquals(18, $result['data']['size']);
-		$this->assertEquals('httpd/unix-directory', $result['data']['mime']);
+		$this->assertSame(123, $result['data']['id']);
+		$this->assertSame('new_name', $result['data']['name']);
+		$this->assertSame('/test', $result['data']['directory']);
+		$this->assertSame(18, $result['data']['size']);
+		$this->assertSame('httpd/unix-directory', $result['data']['mime']);
 		$icon = \OC_Helper::mimetypeIcon('dir');
 		$icon = substr($icon, 0, -3) . 'svg';
-		$this->assertEquals($icon, $result['data']['icon']);
+		$this->assertSame($icon, $result['data']['icon']);
 		$this->assertFalse($result['data']['isPreviewAvailable']);
 	}
 
@@ -161,15 +161,15 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 		$result = $this->files->rename($dir, $oldname, $newname);
 
 		$this->assertTrue($result['success']);
-		$this->assertEquals(123, $result['data']['id']);
-		$this->assertEquals('newname', $result['data']['name']);
-		$this->assertEquals('/', $result['data']['directory']);
-		$this->assertEquals(18, $result['data']['size']);
-		$this->assertEquals('httpd/unix-directory', $result['data']['mime']);
-		$this->assertEquals('abcdef', $result['data']['etag']);
+		$this->assertSame(123, $result['data']['id']);
+		$this->assertSame('newname', $result['data']['name']);
+		$this->assertSame('/', $result['data']['directory']);
+		$this->assertSame(18, $result['data']['size']);
+		$this->assertSame('httpd/unix-directory', $result['data']['mime']);
+		$this->assertSame('abcdef', $result['data']['etag']);
 		$icon = \OC_Helper::mimetypeIcon('dir');
 		$icon = substr($icon, 0, -3) . 'svg';
-		$this->assertEquals($icon, $result['data']['icon']);
+		$this->assertSame($icon, $result['data']['icon']);
 		$this->assertFalse($result['data']['isPreviewAvailable']);
 	}
 
@@ -201,6 +201,6 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 		$result = $this->files->rename($dir, $oldname, $newname);
 
 		$this->assertFalse($result['success']);
-		$this->assertEquals('targetnotfound', $result['data']['code']);
+		$this->assertSame('targetnotfound', $result['data']['code']);
 	}
 }

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -246,7 +246,7 @@ class Util {
 		} else {
 			$row = $result->fetchRow();
 			if ($row && isset($row['recovery_enabled'])) {
-				$recoveryEnabled[] = $row['recovery_enabled'];
+				$recoveryEnabled[] = (int)$row['recovery_enabled'];
 			}
 		}
 
@@ -525,7 +525,7 @@ class Util {
 				$realSize = (($lastChunkNr * 6126) + strlen($lastChunkContent));
 
 				// store file size
-				$result = $realSize;
+				$result = (int)$realSize;
 			}
 		}
 

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -122,12 +122,12 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$decrypted = Encryption\Crypt::decryptPrivateKey($crypted, 'hat');
 
-		$this->assertEquals($this->genPrivateKey, $decrypted);
+		$this->assertSame($this->genPrivateKey, $decrypted);
 
 		//test private key decrypt with wrong password
 		$wrongPasswd = Encryption\Crypt::decryptPrivateKey($crypted, 'hat2');
 
-		$this->assertEquals(false, $wrongPasswd);
+		$this->assertFalse($wrongPasswd);
 
 	}
 
@@ -146,7 +146,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$decrypt = Encryption\Crypt::symmetricDecryptFileContent($crypted, 'hat');
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 	}
 
@@ -196,7 +196,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$manualDecrypt = Encryption\Crypt::symmetricDecryptFileContent($retreivedCryptedFile, $plainKeyfile);
 
 		// Check that decrypted data matches
-		$this->assertEquals($this->dataShort, $manualDecrypt);
+		$this->assertSame($this->dataShort, $manualDecrypt);
 
 		// Teardown
 		$this->view->unlink($this->userId . '/files/' . $filename);
@@ -281,7 +281,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		}
 
-		$this->assertEquals($this->dataLong . $this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong . $this->dataLong, $decrypt);
 
 		// Teardown
 
@@ -316,7 +316,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// tear down
 		$this->view->unlink($this->userId . '/files/' . $filename);
@@ -338,7 +338,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong, $decrypt);
 
 		// tear down
 		$this->view->unlink($this->userId . '/files/' . $filename);
@@ -368,7 +368,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$pair1 = Encryption\Crypt::createKeypair();
 
-		$this->assertEquals(2, count($pair1));
+		$this->assertSame(2, count($pair1));
 
 		$this->assertTrue(strlen($pair1['publicKey']) > 1);
 
@@ -382,7 +382,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$decrypt = Encryption\Crypt::multiKeyDecrypt($crypted['data'], $crypted['keys'][0], $pair1['privateKey']);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 	}
 
@@ -396,7 +396,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$decrypted = Encryption\Crypt::legacyBlockDecrypt($crypted, $this->pass);
 
-		$this->assertEquals($this->dataShort, $decrypted);
+		$this->assertSame($this->dataShort, $decrypted);
 
 	}
 
@@ -410,7 +410,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$decrypted = Encryption\Crypt::legacyBlockDecrypt($crypted, $this->pass);
 
-		$this->assertEquals($this->dataLong, $decrypted);
+		$this->assertSame($this->dataLong, $decrypted);
 	}
 
 	/**
@@ -429,7 +429,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong, $decrypt);
 
 		$newFilename = 'tmp-new-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
@@ -438,7 +438,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$newDecrypt = file_get_contents('crypt:///'. $this->userId . '/files/' . $newFilename);
 
-		$this->assertEquals($this->dataLong, $newDecrypt);
+		$this->assertSame($this->dataLong, $newDecrypt);
 
 		// tear down
 		$view->unlink($newFilename);
@@ -460,7 +460,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong, $decrypt);
 
 		$newFolder = '/newfolder' . uniqid();
 		$newFilename = 'tmp-new-' . uniqid();
@@ -471,7 +471,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$newDecrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $newFolder . '/' . $newFilename);
 
-		$this->assertEquals($this->dataLong, $newDecrypt);
+		$this->assertSame($this->dataLong, $newDecrypt);
 
 		// tear down
 		$view->unlink($newFolder);
@@ -498,7 +498,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $folder . $filename);
 
-		$this->assertEquals($this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong, $decrypt);
 
 		$newFolder = '/newfolder/subfolder' . uniqid();
 		$view->mkdir('/newfolder');
@@ -508,7 +508,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$newDecrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $newFolder . $filename);
 
-		$this->assertEquals($this->dataLong, $newDecrypt);
+		$this->assertSame($this->dataLong, $newDecrypt);
 
 		// tear down
 		$view->unlink($newFolder);
@@ -530,7 +530,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataLong, $decrypt);
+		$this->assertSame($this->dataLong, $decrypt);
 
 		// change password
 		\OC_User::setPassword($this->userId, 'test', null);
@@ -543,7 +543,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$newDecrypt = file_get_contents('crypt:///' . $this->userId . '/files/' . $filename);
 
-		$this->assertEquals($this->dataLong, $newDecrypt);
+		$this->assertSame($this->dataLong, $newDecrypt);
 
 		// tear down
 		// change password back
@@ -569,7 +569,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = $view->file_get_contents($filename);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFileLong = $view->file_put_contents($filename, $this->dataLong);
@@ -580,7 +580,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decryptLong = $view->file_get_contents($filename);
 
-		$this->assertEquals($this->dataLong, $decryptLong);
+		$this->assertSame($this->dataLong, $decryptLong);
 
 		// tear down
 		$view->unlink($filename);
@@ -604,7 +604,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = $view->file_get_contents($filename);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// tear down
 		$view->unlink($filename);
@@ -628,7 +628,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = $view->file_get_contents($filename);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// tear down
 		$view->unlink($filename);
@@ -652,7 +652,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		// Get file decrypted contents
 		$decrypt = fgets($handle);
 
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// tear down
 		$view->unlink($filename);

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -39,11 +39,11 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
+		$this->assertSame('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
 
 		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
+		$this->assertSame('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
 	}
 
 
@@ -57,11 +57,11 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(Encryption\Helper::isPartialFilePath($partFilename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
+		$this->assertSame('testfile.txt', Encryption\Helper::stripPartialFileExtension($partFilename));
 
 		$this->assertFalse(Encryption\Helper::isPartialFilePath($filename));
 
-		$this->assertEquals('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
+		$this->assertSame('testfile.txt', Encryption\Helper::stripPartialFileExtension($filename));
 	}
 
 	function testGetPathToRealFile() {
@@ -73,8 +73,8 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 		$versionPath = "/user/files_versions/foo/bar/test.txt.v456756835";
 		$cachePath = "/user/cache/transferid636483/foo/bar/test.txt";
 
-		$this->assertEquals($relativePath, Encryption\Helper::getPathToRealFile($versionPath));
-		$this->assertEquals($relativePath, Encryption\Helper::getPathToRealFile($cachePath));
+		$this->assertSame($relativePath, Encryption\Helper::getPathToRealFile($versionPath));
+		$this->assertSame($relativePath, Encryption\Helper::getPathToRealFile($cachePath));
 	}
 
 	function testGetUser() {
@@ -85,14 +85,14 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 		$path4 ="/" . "/" . self::TEST_ENCRYPTION_HELPER_USER1;
 
 		// if we are logged-in every path should return the currently logged-in user
-		$this->assertEquals(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path3));
+		$this->assertSame(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path3));
 
 		// now log out
 		\Test_Encryption_Util::logoutHelper();
 
 		// now we should only get the user from /user/files and user/cache paths
-		$this->assertEquals(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path1));
-		$this->assertEquals(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path2));
+		$this->assertSame(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path1));
+		$this->assertSame(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path2));
 
 		$this->assertFalse(Encryption\Helper::getUser($path3));
 		$this->assertFalse(Encryption\Helper::getUser($path4));

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -140,9 +140,9 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	 * @small
 	 */
 	function testGetFilenameFromShareKey() {
-		$this->assertEquals("file",
+		$this->assertSame("file",
 				\TestProtectedKeymanagerMethods::testGetFilenameFromShareKey("file.user.shareKey"));
-		$this->assertEquals("file.name.with.dots",
+		$this->assertSame("file.name.with.dots",
 				\TestProtectedKeymanagerMethods::testGetFilenameFromShareKey("file.name.with.dots.user.shareKey"));
 		$this->assertFalse(\TestProtectedKeymanagerMethods::testGetFilenameFromShareKey("file.txt"));
 	}

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -178,7 +178,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/Shared/' . $this->filename);
 
 		// check if data is the same as we previously written
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// cleanup
 		if ($withTeardown) {
@@ -239,7 +239,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '/files/Shared/' . $this->filename);
 
 		// check if data is the same as previously written
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// cleanup
 		if ($withTeardown) {
@@ -337,7 +337,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->subfolder . $this->subsubfolder . '/' . $this->filename);
 
 		// check if data is the same
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// cleanup
 		if ($withTeardown) {
@@ -415,7 +415,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->subsubfolder . '/' . $this->filename);
 
 		// check if data is the same
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// get the file info
 		$fileInfo = $this->view->getFileInfo(
@@ -445,7 +445,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4 . '/files/Shared/' . $this->filename);
 
 		// check if data is the same
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// cleanup
 		if ($withTeardown) {
@@ -549,7 +549,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$retrievedCryptedFile = file_get_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->filename);
 
 		// check if data is the same as we previously written
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// tear down
 
@@ -627,7 +627,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '/files/Shared/' . $this->filename);
 
 		// check if data is the same as we previously written
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile);
 
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -836,8 +836,8 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			'crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files' . $this->folder1 . $this->subfolder . $this->subsubfolder . '/' . $this->filename);
 
 		// check if data is the same as we previously written
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile1);
-		$this->assertEquals($this->dataShort, $retrievedCryptedFile2);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile1);
+		$this->assertSame($this->dataShort, $retrievedCryptedFile2);
 
 		// cleanup
 		$this->view->chroot('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/');
@@ -913,7 +913,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		try {
 			\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
 		} catch (Exception $e) {
-			$this->assertEquals(0, strpos($e->getMessage(), "Following users are not set up for encryption"));
+			$this->assertSame(0, strpos($e->getMessage(), "Following users are not set up for encryption"));
 		}
 
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -111,7 +111,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$handle = $view->fopen($filename, 'r');
 
 		// check if stream is at position zero
-		$this->assertEquals(0, ftell($handle));
+		$this->assertSame(0, ftell($handle));
 
 		// set stream options
 		$this->assertTrue(flock($handle, LOCK_SH));
@@ -175,7 +175,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$handle = $view->fopen($filename, 'r');
 
 		// set stream options
-		$this->assertEquals(0, stream_set_write_buffer($handle, 1024));
+		$this->assertSame(0, stream_set_write_buffer($handle, 1024));
 
 		// tear down
 		$view->unlink($filename);
@@ -212,7 +212,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$contentFromTmpFile = stream_get_contents($handle);
 
 		// check if it was successful
-		$this->assertEquals($this->dataShort, $contentFromTmpFile);
+		$this->assertSame($this->dataShort, $contentFromTmpFile);
 
 		// clean up
 		unlink($tmpFilename);

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -126,11 +126,11 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	function testKeyPaths() {
 		$util = new Encryption\Util($this->view, $this->userId);
 
-		$this->assertEquals($this->publicKeyDir, $util->getPath('publicKeyDir'));
-		$this->assertEquals($this->encryptionDir, $util->getPath('encryptionDir'));
-		$this->assertEquals($this->keyfilesPath, $util->getPath('keyfilesPath'));
-		$this->assertEquals($this->publicKeyPath, $util->getPath('publicKeyPath'));
-		$this->assertEquals($this->privateKeyPath, $util->getPath('privateKeyPath'));
+		$this->assertSame($this->publicKeyDir, $util->getPath('publicKeyDir'));
+		$this->assertSame($this->encryptionDir, $util->getPath('encryptionDir'));
+		$this->assertSame($this->keyfilesPath, $util->getPath('keyfilesPath'));
+		$this->assertSame($this->publicKeyPath, $util->getPath('publicKeyPath'));
+		$this->assertSame($this->privateKeyPath, $util->getPath('privateKeyPath'));
 
 	}
 
@@ -174,7 +174,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	 * @brief test setup of encryption directories
 	 */
 	function testSetupServerSide() {
-		$this->assertEquals(true, $this->util->setupServerSide($this->pass));
+		$this->assertTrue($this->util->setupServerSide($this->pass));
 	}
 
 	/**
@@ -182,7 +182,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	 * @brief test checking whether account is ready for encryption,
 	 */
 	function testUserIsReady() {
-		$this->assertEquals(true, $this->util->ready());
+		$this->assertTrue($this->util->ready());
 	}
 
 	/**
@@ -223,7 +223,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(OCA\Encryption\Hooks::login($params));
 
-		$this->assertEquals($this->legacyKey, \OC::$session->get('legacyKey'));
+		$this->assertSame($this->legacyKey, \OC::$session->get('legacyKey'));
 	}
 
 	/**
@@ -238,11 +238,11 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($util->setRecoveryForUser(1));
 
-		$this->assertEquals(1, $util->recoveryEnabledForUser());
+		$this->assertSame(1, $util->recoveryEnabledForUser());
 
 		$this->assertTrue($util->setRecoveryForUser(0));
 
-		$this->assertEquals(0, $util->recoveryEnabledForUser());
+		$this->assertSame(0, $util->recoveryEnabledForUser());
 
 		// Return the setting to it's previous state
 		$this->assertTrue($util->setRecoveryForUser($enabled));
@@ -271,9 +271,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		list($fileOwnerUid, $file) = $util->getUidAndFilename($filename);
 
-		$this->assertEquals(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1, $fileOwnerUid);
+		$this->assertSame(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1, $fileOwnerUid);
 
-		$this->assertEquals($file, $filename);
+		$this->assertSame($file, $filename);
 
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
@@ -291,18 +291,18 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$problematicFileSizeData = "";
 		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
 		$this->assertTrue(is_int($cryptedFile));
-		$this->assertEquals($this->util->getFileSize($externalFilename), 0);
+		$this->assertSame($this->util->getFileSize($externalFilename), 0);
 		$decrypt = $this->view->file_get_contents($externalFilename);
-		$this->assertEquals($problematicFileSizeData, $decrypt);
+		$this->assertSame($problematicFileSizeData, $decrypt);
 		$this->view->unlink($this->userId . '/files/' . $filename);
 
 		// Test a file with 18377 bytes as in https://github.com/owncloud/mirall/issues/1009
 		$problematicFileSizeData = str_pad("", 18377, "abc");
 		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
 		$this->assertTrue(is_int($cryptedFile));
-		$this->assertEquals($this->util->getFileSize($externalFilename), 18377);
+		$this->assertSame($this->util->getFileSize($externalFilename), 18377);
 		$decrypt = $this->view->file_get_contents($externalFilename);
-		$this->assertEquals($problematicFileSizeData, $decrypt);
+		$this->assertSame($problematicFileSizeData, $decrypt);
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
@@ -343,8 +343,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($fileInfoEncrypted instanceof \OC\Files\FileInfo);
 
 		// check if mtime and etags unchanged
-		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
-		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+		$this->assertSame($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
+		$this->assertSame($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
 
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
@@ -360,7 +360,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$fileInfoEncrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
 
 		$this->assertTrue($fileInfoEncrypted instanceof \OC\Files\FileInfo);
-		$this->assertEquals($fileInfoEncrypted['encrypted'], 1);
+		$this->assertSame($fileInfoEncrypted['encrypted'], 1);
 
 		// decrypt all encrypted files
 		$result = $util->decryptAll('/' . $this->userId . '/' . 'files');
@@ -372,10 +372,10 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($fileInfoUnencrypted instanceof \OC\Files\FileInfo);
 
 		// check if mtime and etags unchanged
-		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
-		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+		$this->assertSame($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
+		$this->assertSame($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
 		// file should no longer be encrypted
-		$this->assertEquals(0, $fileInfoUnencrypted['encrypted']);
+		$this->assertSame(0, $fileInfoUnencrypted['encrypted']);
 
 		$this->view->unlink($this->userId . '/files/' . $filename);
 
@@ -396,8 +396,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($fileInfoEncrypted1 instanceof \OC\Files\FileInfo);
 		$this->assertTrue($fileInfoEncrypted2 instanceof \OC\Files\FileInfo);
-		$this->assertEquals($fileInfoEncrypted1['encrypted'], 1);
-		$this->assertEquals($fileInfoEncrypted2['encrypted'], 1);
+		$this->assertSame($fileInfoEncrypted1['encrypted'], 1);
+		$this->assertSame($fileInfoEncrypted2['encrypted'], 1);
 
 		// rename keyfile for file1 so that the decryption for file1 fails
 		// Expected behaviour: decryptAll() returns false, file2 gets decrypted anyway
@@ -416,8 +416,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($fileInfoUnencrypted2 instanceof \OC\Files\FileInfo);
 
 		// file1 should be still encrypted; file2 should be decrypted
-		$this->assertEquals(1, $fileInfoUnencrypted1['encrypted']);
-		$this->assertEquals(0, $fileInfoUnencrypted2['encrypted']);
+		$this->assertSame(1, $fileInfoUnencrypted1['encrypted']);
+		$this->assertSame(0, $fileInfoUnencrypted2['encrypted']);
 
 		// keyfiles and share keys should still exist
 		$this->assertTrue($this->view->is_dir($this->userId . '/files_encryption/keyfiles/'));
@@ -439,8 +439,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($fileInfoUnencrypted2 instanceof \OC\Files\FileInfo);
 
 		// now both files should be decrypted
-		$this->assertEquals(0, $fileInfoUnencrypted1['encrypted']);
-		$this->assertEquals(0, $fileInfoUnencrypted2['encrypted']);
+		$this->assertSame(0, $fileInfoUnencrypted1['encrypted']);
+		$this->assertSame(0, $fileInfoUnencrypted2['encrypted']);
 
 		// keyfiles and share keys should be deleted
 		$this->assertFalse($this->view->is_dir($this->userId . '/files_encryption/keyfiles/'));
@@ -486,7 +486,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(OCA\Encryption\Hooks::login($params));
 
-		$this->assertEquals($this->legacyKey, \OC::$session->get('legacyKey'));
+		$this->assertSame($this->legacyKey, \OC::$session->get('legacyKey'));
 
 		$files = $util->findEncFiles('/' . \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER . '/files/');
 

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -291,7 +291,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$problematicFileSizeData = "";
 		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
 		$this->assertTrue(is_int($cryptedFile));
-		$this->assertSame($this->util->getFileSize($externalFilename), 0);
+		$this->assertSame(0, $this->util->getFileSize($externalFilename));
 		$decrypt = $this->view->file_get_contents($externalFilename);
 		$this->assertSame($problematicFileSizeData, $decrypt);
 		$this->view->unlink($this->userId . '/files/' . $filename);
@@ -300,7 +300,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$problematicFileSizeData = str_pad("", 18377, "abc");
 		$cryptedFile = $this->view->file_put_contents($externalFilename, $problematicFileSizeData);
 		$this->assertTrue(is_int($cryptedFile));
-		$this->assertSame($this->util->getFileSize($externalFilename), 18377);
+		$this->assertSame(18377, $this->util->getFileSize($externalFilename));
 		$decrypt = $this->view->file_get_contents($externalFilename);
 		$this->assertSame($problematicFileSizeData, $decrypt);
 		$this->view->unlink($this->userId . '/files/' . $filename);
@@ -360,7 +360,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$fileInfoEncrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
 
 		$this->assertTrue($fileInfoEncrypted instanceof \OC\Files\FileInfo);
-		$this->assertSame($fileInfoEncrypted['encrypted'], 1);
+		$this->assertTrue($fileInfoEncrypted['encrypted']);
 
 		// decrypt all encrypted files
 		$result = $util->decryptAll('/' . $this->userId . '/' . 'files');
@@ -396,8 +396,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($fileInfoEncrypted1 instanceof \OC\Files\FileInfo);
 		$this->assertTrue($fileInfoEncrypted2 instanceof \OC\Files\FileInfo);
-		$this->assertSame($fileInfoEncrypted1['encrypted'], 1);
-		$this->assertSame($fileInfoEncrypted2['encrypted'], 1);
+		$this->assertTrue($fileInfoEncrypted1['encrypted']);
+		$this->assertTrue($fileInfoEncrypted2['encrypted']);
 
 		// rename keyfile for file1 so that the decryption for file1 fails
 		// Expected behaviour: decryptAll() returns false, file2 gets decrypted anyway

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -156,7 +156,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 		$decrypt = file_get_contents('crypt:///' . $this->userId . '/files'. $filename);
 
 		// check if file content match with the written content
-		$this->assertEquals($this->dataShort, $decrypt);
+		$this->assertSame($this->dataShort, $decrypt);
 
 		// return filename for next test
 		return $filename;
@@ -179,7 +179,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 		$content = $this->handleWebdavRequest();
 
 		// check if file content match with the written content
-		$this->assertEquals($this->dataShort, $content);
+		$this->assertSame($this->dataShort, $content);
 
 		// return filename for next test
 		return $filename;

--- a/apps/files_external/tests/ftp.php
+++ b/apps/files_external/tests/ftp.php
@@ -35,30 +35,30 @@ class FTP extends Storage {
 						  'root' => '/',
 						  'secure' => false );
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
+		$this->assertSame('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = true;
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
+		$this->assertSame('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'false';
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
+		$this->assertSame('ftp://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['secure'] = 'true';
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
+		$this->assertSame('ftps://ftp:ftp@localhost/', $instance->constructUrl(''));
 
 		$config['root'] = '';
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftps://ftp:ftp@localhost/somefile.txt', $instance->constructUrl('somefile.txt'));
+		$this->assertSame('ftps://ftp:ftp@localhost/somefile.txt', $instance->constructUrl('somefile.txt'));
 
 		$config['root'] = '/abc';
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
+		$this->assertSame('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
 
 		$config['root'] = '/abc/';
 		$instance = new \OC\Files\Storage\FTP($config);
-		$this->assertEquals('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
+		$this->assertSame('ftps://ftp:ftp@localhost/abc/somefile.txt', $instance->constructUrl('somefile.txt'));
 	}
 }

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -42,10 +42,10 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$mountType = 'user';
 		$applicable = 'all';
 		$isPersonal = false;
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
 
 	}
 

--- a/apps/files_external/tests/smbfunctions.php
+++ b/apps/files_external/tests/smbfunctions.php
@@ -29,13 +29,13 @@ class SMBFunctions extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGetId() {
-		$this->assertEquals('smb::test@smbhost//sharename//rootdir/', $this->instance->getId());
+		$this->assertSame('smb::test@smbhost//sharename//rootdir/', $this->instance->getId());
 	}
 
 	public function testConstructUrl() {
-		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc'));
-		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc/'));
-		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc%2F", $this->instance->constructUrl('/abc/.'));
-		$this->assertEquals("smb://test:testpassword@smbhost/sharename/rootdir/abc%2Fdef", $this->instance->constructUrl('/abc/def'));
+		$this->assertSame("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc'));
+		$this->assertSame("smb://test:testpassword@smbhost/sharename/rootdir/abc", $this->instance->constructUrl('/abc/'));
+		$this->assertSame("smb://test:testpassword@smbhost/sharename/rootdir/abc%2F", $this->instance->constructUrl('/abc/.'));
+		$this->assertSame("smb://test:testpassword@smbhost/sharename/rootdir/abc%2Fdef", $this->instance->constructUrl('/abc/def'));
 	}
 }

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -233,7 +233,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		// get item to determine share ID
 		$result = \OCP\Share::getItemShared('file', $fileInfo['fileid']);
 
-		$this->assertEquals(1, count($result));
+		$this->assertSame(1, count($result));
 
 		// get first element
 		$share = reset($result);
@@ -245,7 +245,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		$this->assertTrue($result->succeeded());
 
 		// test should return one share created from testCreateShare()
-		$this->assertEquals(1, count($result->getData()));
+		$this->assertSame(1, count($result->getData()));
 
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
 			\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
@@ -363,9 +363,9 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		$result = Share\Api::getShare($params);
 
-		$this->assertEquals(404, $result->getStatusCode());
+		$this->assertSame(404, $result->getStatusCode());
         $meta = $result->getMeta();
-		$this->assertEquals('share doesn\'t exist', $meta['message']);
+		$this->assertSame('share doesn\'t exist', $meta['message']);
 
 	}
 
@@ -392,7 +392,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		$items = \OCP\Share::getItemShared('file', null);
 
 		// make sure that we found a link share and a user share
-		$this->assertEquals(count($items), 2);
+		$this->assertSame(count($items), 2);
 
 		$linkShare = null;
 		$userShare = null;
@@ -412,7 +412,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		// update permissions
 
-		$this->assertEquals('31', $userShare['permissions']);
+		$this->assertSame(31, $userShare['permissions']);
 
 		$params = array();
 		$params['id'] = $userShare['id'];
@@ -436,7 +436,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		$this->assertTrue(is_array($newUserShare));
 
-		$this->assertEquals('1', $newUserShare['permissions']);
+		$this->assertSame(1, $newUserShare['permissions']);
 
 		// update password for link share
 
@@ -487,7 +487,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		$items = \OCP\Share::getItemShared('file', null);
 
 		// make sure that we found a link share and a user share
-		$this->assertEquals(count($items), 1);
+		$this->assertSame(count($items), 1);
 
 		$linkShare = null;
 
@@ -522,7 +522,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		}
 
 		$this->assertTrue(is_array($updatedLinkShare));
-		$this->assertEquals(7, $updatedLinkShare['permissions']);
+		$this->assertSame(7, $updatedLinkShare['permissions']);
 
 		// cleanup
 
@@ -546,7 +546,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		$items = \OCP\Share::getItemShared('file', null);
 
-		$this->assertEquals(2, count($items));
+		$this->assertSame(2, count($items));
 
 		foreach ($items as $item) {
 			$result = Share\Api::deleteShare(array('id' => $item['id']));

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -2,9 +2,8 @@
 /**
  * ownCloud
  *
- * @author Vincent Petry, Bjoern Schiessle
+ * @author Vincent Petry
  * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
- *            2014 Bjoern Schiessle <schiessle@owncloud.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -221,7 +220,7 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 	 * @param array $results array of files
 	 */
 	private function verifyFiles($examples, $results) {
-		$this->assertEquals(count($examples), count($results));
+		$this->assertSame(count($examples), count($results));
 
 		foreach ($examples as $example) {
 			foreach ($results as $key => $result) {
@@ -242,7 +241,7 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 	 */
 	private function verifyKeys($example, $result) {
 		foreach ($example as $key => $value) {
-			$this->assertEquals($value, $result[$key]);
+			$this->assertSame($value, $result[$key]);
 		}
 	}
 

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -83,13 +83,13 @@ class Test_Files_Sharing_Permissions extends Test_Files_Sharing_Base {
 	 */
 	function testGetPermissions() {
 		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir');
-		$this->assertEquals(31, $sharedDirPerms);
+		$this->assertSame(31, $sharedDirPerms);
 		$sharedDirPerms = $this->sharedStorage->getPermissions('shareddir/textfile.txt');
-		$this->assertEquals(31, $sharedDirPerms);
+		$this->assertSame(31, $sharedDirPerms);
 		$sharedDirRestrictedPerms = $this->sharedStorage->getPermissions('shareddirrestricted');
-		$this->assertEquals(7, $sharedDirRestrictedPerms);
+		$this->assertSame(7, $sharedDirRestrictedPerms);
 		$sharedDirRestrictedPerms = $this->sharedStorage->getPermissions('shareddirrestricted/textfile.txt');
-		$this->assertEquals(7, $sharedDirRestrictedPerms);
+		$this->assertSame(7, $sharedDirRestrictedPerms);
 	}
 
 	/**
@@ -97,14 +97,14 @@ class Test_Files_Sharing_Permissions extends Test_Files_Sharing_Base {
 	 */
 	function testGetDirectoryPermissions() {
 		$contents = $this->secondView->getDirectoryContent('files/Shared/shareddir');
-		$this->assertEquals('subdir', $contents[0]['name']);
-		$this->assertEquals(31, $contents[0]['permissions']);
-		$this->assertEquals('textfile.txt', $contents[1]['name']);
-		$this->assertEquals(31, $contents[1]['permissions']);
+		$this->assertSame('subdir', $contents[0]['name']);
+		$this->assertSame(31, $contents[0]['permissions']);
+		$this->assertSame('textfile.txt', $contents[1]['name']);
+		$this->assertSame(31, $contents[1]['permissions']);
 		$contents = $this->secondView->getDirectoryContent('files/Shared/shareddirrestricted');
-		$this->assertEquals('subdir', $contents[0]['name']);
-		$this->assertEquals(7, $contents[0]['permissions']);
-		$this->assertEquals('textfile1.txt', $contents[1]['name']);
-		$this->assertEquals(7, $contents[1]['permissions']);
+		$this->assertSame('subdir', $contents[0]['name']);
+		$this->assertSame(7, $contents[0]['permissions']);
+		$this->assertSame('textfile1.txt', $contents[1]['name']);
+		$this->assertSame(7, $contents[1]['permissions']);
 	}
 }

--- a/apps/files_sharing/tests/watcher.php
+++ b/apps/files_sharing/tests/watcher.php
@@ -88,10 +88,10 @@ class Test_Files_Sharing_Watcher extends Test_Files_Sharing_Base {
 
 		// the owner's parent dirs must have increase size
 		$newSizes = self::getOwnerDirSizes('files/container/shareddir');
-		$this->assertEquals($initialSizes[''] + $dataLen, $newSizes['']);
-		$this->assertEquals($initialSizes['files'] + $dataLen, $newSizes['files']);
-		$this->assertEquals($initialSizes['files/container'] + $dataLen, $newSizes['files/container']);
-		$this->assertEquals($initialSizes['files/container/shareddir'] + $dataLen, $newSizes['files/container/shareddir']);
+		$this->assertSame($initialSizes[''] + $dataLen, $newSizes['']);
+		$this->assertSame($initialSizes['files'] + $dataLen, $newSizes['files']);
+		$this->assertSame($initialSizes['files/container'] + $dataLen, $newSizes['files/container']);
+		$this->assertSame($initialSizes['files/container/shareddir'] + $dataLen, $newSizes['files/container/shareddir']);
 
 		// no more updates
 		$result = $this->sharedStorage->getWatcher()->checkUpdate('shareddir');
@@ -119,11 +119,11 @@ class Test_Files_Sharing_Watcher extends Test_Files_Sharing_Base {
 
 		// the owner's parent dirs must have increase size
 		$newSizes = self::getOwnerDirSizes('files/container/shareddir/subdir');
-		$this->assertEquals($initialSizes[''] + $dataLen, $newSizes['']);
-		$this->assertEquals($initialSizes['files'] + $dataLen, $newSizes['files']);
-		$this->assertEquals($initialSizes['files/container'] + $dataLen, $newSizes['files/container']);
-		$this->assertEquals($initialSizes['files/container/shareddir'] + $dataLen, $newSizes['files/container/shareddir']);
-		$this->assertEquals($initialSizes['files/container/shareddir/subdir'] + $dataLen, $newSizes['files/container/shareddir/subdir']);
+		$this->assertSame($initialSizes[''] + $dataLen, $newSizes['']);
+		$this->assertSame($initialSizes['files'] + $dataLen, $newSizes['files']);
+		$this->assertSame($initialSizes['files/container'] + $dataLen, $newSizes['files/container']);
+		$this->assertSame($initialSizes['files/container/shareddir'] + $dataLen, $newSizes['files/container/shareddir']);
+		$this->assertSame($initialSizes['files/container/shareddir/subdir'] + $dataLen, $newSizes['files/container/shareddir/subdir']);
 
 		// no more updates
 		$result = $this->sharedStorage->getWatcher()->checkUpdate('shareddir/subdir');

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -43,17 +43,17 @@ class Test_Files_Versioning extends \PHPUnit_Framework_TestCase {
 		list($deleted, $size) = $testClass->callProtectedGetExpireList($startTime, $versions);
 
 		// we should have deleted 16 files each of the size 1
-		$this->assertEquals($sizeOfAllDeletedFiles, $size);
+		$this->assertSame($sizeOfAllDeletedFiles, $size);
 
 		// the deleted array should only contain versions which should be deleted
 		foreach($deleted as $key => $path) {
 			unset($versions[$key]);
-			$this->assertEquals("delete", substr($path, 0, strlen("delete")));
+			$this->assertSame("delete", substr($path, 0, strlen("delete")));
 		}
 
 		// the versions array should only contain versions which should be kept
 		foreach ($versions as $version) {
-			$this->assertEquals("keep", $version['path']);
+			$this->assertSame("keep", $version['path']);
 		}
 
 	}

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -130,7 +130,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'dt19');
-		$this->assertEquals('gunslinger', $result);
+		$this->assertSame('gunslinger', $result);
 	}
 
 	public function testCheckPasswordWrongPassword() {
@@ -162,7 +162,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::checkPassword('roland', 'dt19');
-		$this->assertEquals('gunslinger', $result);
+		$this->assertSame('gunslinger', $result);
 	}
 
 	public function testCheckPasswordPublicAPIWrongPassword() {
@@ -240,7 +240,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->getUsers();
-		$this->assertEquals(3, count($result));
+		$this->assertSame(3, count($result));
 	}
 
 	public function testGetUsersLimitOffset() {
@@ -249,7 +249,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->getUsers('', 1, 2);
-		$this->assertEquals(1, count($result));
+		$this->assertSame(1, count($result));
 	}
 
 	public function testGetUsersLimitOffset2() {
@@ -258,7 +258,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->getUsers('', 2, 1);
-		$this->assertEquals(2, count($result));
+		$this->assertSame(2, count($result));
 	}
 
 	public function testGetUsersSearchWithResult() {
@@ -267,7 +267,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->getUsers('yo');
-		$this->assertEquals(2, count($result));
+		$this->assertSame(2, count($result));
 	}
 
 	public function testGetUsersSearchEmptyResult() {
@@ -276,7 +276,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->getUsers('nix');
-		$this->assertEquals(0, count($result));
+		$this->assertSame(0, count($result));
 	}
 
 	public function testGetUsersViaAPINoParam() {
@@ -286,7 +286,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::getUsers();
-		$this->assertEquals(3, count($result));
+		$this->assertSame(3, count($result));
 	}
 
 	public function testGetUsersViaAPILimitOffset() {
@@ -296,7 +296,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::getUsers('', 1, 2);
-		$this->assertEquals(1, count($result));
+		$this->assertSame(1, count($result));
 	}
 
 	public function testGetUsersViaAPILimitOffset2() {
@@ -306,7 +306,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::getUsers('', 2, 1);
-		$this->assertEquals(2, count($result));
+		$this->assertSame(2, count($result));
 	}
 
 	public function testGetUsersViaAPISearchWithResult() {
@@ -316,7 +316,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::getUsers('yo');
-		$this->assertEquals(2, count($result));
+		$this->assertSame(2, count($result));
 	}
 
 	public function testGetUsersViaAPISearchEmptyResult() {
@@ -326,7 +326,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		\OC_User::useBackend($backend);
 
 		$result = \OCP\User::getUsers('nix');
-		$this->assertEquals(0, count($result));
+		$this->assertSame(0, count($result));
 	}
 
 	public function testUserExists() {
@@ -430,13 +430,13 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 
 		//absolut path
 		$result = $backend->getHome('gunslinger');
-		$this->assertEquals('/tmp/rolandshome/', $result);
+		$this->assertSame('/tmp/rolandshome/', $result);
 
 		//datadir-relativ path
 		$result = $backend->getHome('ladyofshadows');
 		$datadir = \OCP\Config::getSystemValue('datadirectory',
 											   \OC::$SERVERROOT.'/data');
-		$this->assertEquals($datadir.'/susannah/', $result);
+		$this->assertSame($datadir.'/susannah/', $result);
 
 		//no path at all – triggers OC default behaviour
 		$result = $backend->getHome('newyorker');
@@ -478,11 +478,11 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 
 		//with displayName
 		$result = $backend->getDisplayName('gunslinger');
-		$this->assertEquals('Roland Deschain', $result);
+		$this->assertSame('Roland Deschain', $result);
 
 		//empty displayname retrieved
 		$result = $backend->getDisplayName('newyorker');
-		$this->assertEquals(null, $result);
+		$this->assertNull($result);
 	}
 
 	public function testGetDisplayNamePublicAPI() {
@@ -494,11 +494,11 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 
 		//with displayName
 		$result = \OCP\User::getDisplayName('gunslinger');
-		$this->assertEquals('Roland Deschain', $result);
+		$this->assertSame('Roland Deschain', $result);
 
 		//empty displayname retrieved
 		$result = \OCP\User::getDisplayName('newyorker');
-		$this->assertEquals('newyorker', $result);
+		$this->assertSame('newyorker', $result);
 	}
 
 	//no test for getDisplayNames, because it just invokes getUsers and
@@ -528,7 +528,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 		$backend = new UserLDAP($access);
 
 		$result = $backend->countUsers();
-		$this->assertEquals(5, $result);
+		$this->assertSame(5, $result);
 	}
 
 	public function testCountUsersFailing() {

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -128,25 +128,20 @@ class Cache {
 		$result = \OC_DB::executeAudited($sql, $params);
 		$data = $result->fetchRow();
 
-		//FIXME hide this HACK in the next database layer, or just use doctrine and get rid of MDB2 and PDO
-		//PDO returns false, MDB2 returns null, oracle always uses MDB2, so convert null to false
-		if ($data === null) {
-			$data = false;
-		}
-
 		//merge partial data
-		if (!$data and  is_string($file)) {
+		if (!$data and is_string($file)) {
 			if (isset($this->partial[$file])) {
 				$data = $this->partial[$file];
 			}
 		} else {
 			//fix types
 			$data['fileid'] = (int)$data['fileid'];
+			$data['parent'] = (int)$data['parent'];
 			$data['size'] = (int)$data['size'];
 			$data['mtime'] = (int)$data['mtime'];
 			$data['storage_mtime'] = (int)$data['storage_mtime'];
 			$data['encrypted'] = (bool)$data['encrypted'];
-            $data['unencrypted_size'] = (int)$data['unencrypted_size'];
+			$data['unencrypted_size'] = (int)$data['unencrypted_size'];
 			$data['storage'] = $this->storageId;
 			$data['mimetype'] = $this->getMimetype($data['mimetype']);
 			$data['mimepart'] = $this->getMimetype($data['mimepart']);
@@ -192,6 +187,8 @@ class Cache {
 					$file['encrypted_size'] = $file['size'];
 					$file['size'] = $file['unencrypted_size'];
 				}
+				$file['size']=(int)$file['size'];
+				$file['mtime']=(int)$file['mtime'];
 			}
 			return $files;
 		} else {
@@ -320,7 +317,7 @@ class Cache {
 		$sql = 'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?';
 		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $pathHash));
 		if ($row = $result->fetchRow()) {
-			return $row['fileid'];
+			return (int)$row['fileid'];
 		} else {
 			return -1;
 		}

--- a/lib/private/files/cache/permissions.php
+++ b/lib/private/files/cache/permissions.php
@@ -36,7 +36,7 @@ class Permissions {
 		$sql = 'SELECT `permissions` FROM `*PREFIX*permissions` WHERE `user` = ? AND `fileid` = ?';
 		$result = \OC_DB::executeAudited($sql, array($user, $fileId));
 		if ($row = $result->fetchRow()) {
-			return $row['permissions'];
+			return (int)$row['permissions'];
 		} else {
 			return -1;
 		}
@@ -78,7 +78,7 @@ class Permissions {
 		$result = \OC_DB::executeAudited($sql, $params);
 		$filePermissions = array();
 		while ($row = $result->fetchRow()) {
-			$filePermissions[$row['fileid']] = $row['permissions'];
+			$filePermissions[(int)$row['fileid']] = (int)$row['permissions'];
 		}
 		return $filePermissions;
 	}

--- a/tests/lib/files/cache/homecache.php
+++ b/tests/lib/files/cache/homecache.php
@@ -89,8 +89,8 @@ class HomeCache extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->cache->inCache($dir2));
 
 		// check that files and root size ignored the unknown sizes
-		$this->assertEquals(1000, $this->cache->calculateFolderSize('files'));
-		$this->assertEquals(1000, $this->cache->calculateFolderSize(''));
+		$this->assertSame(1000, $this->cache->calculateFolderSize('files'));
+		$this->assertSame(1000, $this->cache->calculateFolderSize(''));
 
 		// clean up
 		$this->cache->remove('');
@@ -118,9 +118,9 @@ class HomeCache extends \PHPUnit_Framework_TestCase {
 
 		// check that root size ignored the unknown sizes
 		$data = $this->cache->get('files');
-		$this->assertEquals(1000, $data['size']);
+		$this->assertSame(1000, $data['size']);
 		$data = $this->cache->get('');
-		$this->assertEquals(1000, $data['size']);
+		$this->assertSame(1000, $data['size']);
 
 		// clean up
 		$this->cache->remove('');

--- a/tests/lib/files/cache/permissions.php
+++ b/tests/lib/files/cache/permissions.php
@@ -48,12 +48,12 @@ class Permissions extends \PHPUnit_Framework_TestCase {
 			$this->permissionsCache->set($id, $user, 10 + $id);
 			$expected[$id] = 10 + $id;
 		}
-		$this->assertSame($expected, $this->permissionsCache->getMultiple($ids, $user));
+		$this->assertEquals($expected, $this->permissionsCache->getMultiple($ids, $user));
 
 		$this->permissionsCache->removeMultiple(array(10, 9), $user);
 		unset($expected[9]);
 		unset($expected[10]);
-		$this->assertSame($expected, $this->permissionsCache->getMultiple($ids, $user));
+		$this->assertEquals($expected, $this->permissionsCache->getMultiple($ids, $user));
 
 		$this->permissionsCache->removeMultiple($ids, $user);
 	}

--- a/tests/lib/files/cache/permissions.php
+++ b/tests/lib/files/cache/permissions.php
@@ -24,36 +24,36 @@ class Permissions extends \PHPUnit_Framework_TestCase {
 		$ids = range(1, 10);
 		$user = uniqid();
 
-		$this->assertEquals(-1, $this->permissionsCache->get(1, $user));
+		$this->assertSame(-1, $this->permissionsCache->get(1, $user));
 		$this->assertNotContains($user, $this->permissionsCache->getUsers(1));
 		$this->permissionsCache->set(1, $user, 1);
-		$this->assertEquals(1, $this->permissionsCache->get(1, $user));
+		$this->assertSame(1, $this->permissionsCache->get(1, $user));
 		$this->assertContains($user, $this->permissionsCache->getUsers(1));
-		$this->assertEquals(-1, $this->permissionsCache->get(2, $user));
-		$this->assertEquals(-1, $this->permissionsCache->get(1, $user . '2'));
+		$this->assertSame(-1, $this->permissionsCache->get(2, $user));
+		$this->assertSame(-1, $this->permissionsCache->get(1, $user . '2'));
 
 		$this->permissionsCache->set(1, $user, 2);
-		$this->assertEquals(2, $this->permissionsCache->get(1, $user));
+		$this->assertSame(2, $this->permissionsCache->get(1, $user));
 
 		$this->permissionsCache->set(2, $user, 1);
-		$this->assertEquals(1, $this->permissionsCache->get(2, $user));
+		$this->assertSame(1, $this->permissionsCache->get(2, $user));
 
 		$this->permissionsCache->remove(1, $user);
-		$this->assertEquals(-1, $this->permissionsCache->get(1, $user));
+		$this->assertSame(-1, $this->permissionsCache->get(1, $user));
 		$this->permissionsCache->remove(1, $user . '2');
-		$this->assertEquals(1, $this->permissionsCache->get(2, $user));
+		$this->assertSame(1, $this->permissionsCache->get(2, $user));
 
 		$expected = array();
 		foreach ($ids as $id) {
 			$this->permissionsCache->set($id, $user, 10 + $id);
 			$expected[$id] = 10 + $id;
 		}
-		$this->assertEquals($expected, $this->permissionsCache->getMultiple($ids, $user));
+		$this->assertSame($expected, $this->permissionsCache->getMultiple($ids, $user));
 
 		$this->permissionsCache->removeMultiple(array(10, 9), $user);
 		unset($expected[9]);
 		unset($expected[10]);
-		$this->assertEquals($expected, $this->permissionsCache->getMultiple($ids, $user));
+		$this->assertSame($expected, $this->permissionsCache->getMultiple($ids, $user));
 
 		$this->permissionsCache->removeMultiple($ids, $user);
 	}
@@ -70,6 +70,6 @@ class Permissions extends \PHPUnit_Framework_TestCase {
 		$permissionsCache->set($id, 'test', 1);
 
 		$scanner->scan('');
-		$this->assertEquals(-1, $permissionsCache->get($id, 'test'));
+		$this->assertSame(-1, $permissionsCache->get($id, 'test'));
 	}
 }

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -44,20 +44,20 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->storage->file_put_contents('foo.txt', $data);
 		$this->scanner->scanFile('foo.txt');
 
-		$this->assertEquals($this->cache->inCache('foo.txt'), true);
+		$this->assertSame($this->cache->inCache('foo.txt'), true);
 		$cachedData = $this->cache->get('foo.txt');
-		$this->assertEquals($cachedData['size'], strlen($data));
-		$this->assertEquals($cachedData['mimetype'], 'text/plain');
+		$this->assertSame($cachedData['size'], strlen($data));
+		$this->assertSame($cachedData['mimetype'], 'text/plain');
 		$this->assertNotEquals($cachedData['parent'], -1); //parent folders should be scanned automatically
 
 		$data = file_get_contents(\OC::$SERVERROOT . '/core/img/logo.png');
 		$this->storage->file_put_contents('foo.png', $data);
 		$this->scanner->scanFile('foo.png');
 
-		$this->assertEquals($this->cache->inCache('foo.png'), true);
+		$this->assertSame($this->cache->inCache('foo.png'), true);
 		$cachedData = $this->cache->get('foo.png');
-		$this->assertEquals($cachedData['size'], strlen($data));
-		$this->assertEquals($cachedData['mimetype'], 'image/png');
+		$this->assertSame($cachedData['size'], strlen($data));
+		$this->assertSame($cachedData['mimetype'], 'image/png');
 	}
 
 	private function fillTestFolders() {
@@ -73,11 +73,11 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->fillTestFolders();
 
 		$this->scanner->scan('');
-		$this->assertEquals($this->cache->inCache(''), true);
-		$this->assertEquals($this->cache->inCache('foo.txt'), true);
-		$this->assertEquals($this->cache->inCache('foo.png'), true);
-		$this->assertEquals($this->cache->inCache('folder'), true);
-		$this->assertEquals($this->cache->inCache('folder/bar.txt'), true);
+		$this->assertSame($this->cache->inCache(''), true);
+		$this->assertSame($this->cache->inCache('foo.txt'), true);
+		$this->assertSame($this->cache->inCache('foo.png'), true);
+		$this->assertSame($this->cache->inCache('folder'), true);
+		$this->assertSame($this->cache->inCache('folder/bar.txt'), true);
 
 		$cachedDataText = $this->cache->get('foo.txt');
 		$cachedDataText2 = $this->cache->get('foo.txt');
@@ -85,27 +85,27 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$cachedDataFolder = $this->cache->get('');
 		$cachedDataFolder2 = $this->cache->get('folder');
 
-		$this->assertEquals($cachedDataImage['parent'], $cachedDataText['parent']);
-		$this->assertEquals($cachedDataFolder['fileid'], $cachedDataImage['parent']);
-		$this->assertEquals($cachedDataFolder['size'], $cachedDataImage['size'] + $cachedDataText['size'] + $cachedDataText2['size']);
-		$this->assertEquals($cachedDataFolder2['size'], $cachedDataText2['size']);
+		$this->assertSame($cachedDataImage['parent'], $cachedDataText['parent']);
+		$this->assertSame($cachedDataFolder['fileid'], $cachedDataImage['parent']);
+		$this->assertSame($cachedDataFolder['size'], $cachedDataImage['size'] + $cachedDataText['size'] + $cachedDataText2['size']);
+		$this->assertSame($cachedDataFolder2['size'], $cachedDataText2['size']);
 	}
 
 	function testShallow() {
 		$this->fillTestFolders();
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
-		$this->assertEquals($this->cache->inCache(''), true);
-		$this->assertEquals($this->cache->inCache('foo.txt'), true);
-		$this->assertEquals($this->cache->inCache('foo.png'), true);
-		$this->assertEquals($this->cache->inCache('folder'), true);
-		$this->assertEquals($this->cache->inCache('folder/bar.txt'), false);
+		$this->assertSame($this->cache->inCache(''), true);
+		$this->assertSame($this->cache->inCache('foo.txt'), true);
+		$this->assertSame($this->cache->inCache('foo.png'), true);
+		$this->assertSame($this->cache->inCache('folder'), true);
+		$this->assertSame($this->cache->inCache('folder/bar.txt'), false);
 
 		$cachedDataFolder = $this->cache->get('');
 		$cachedDataFolder2 = $this->cache->get('folder');
 
-		$this->assertEquals(-1, $cachedDataFolder['size']);
-		$this->assertEquals(-1, $cachedDataFolder2['size']);
+		$this->assertSame(-1, $cachedDataFolder['size']);
+		$this->assertSame(-1, $cachedDataFolder2['size']);
 
 		$this->scanner->scan('folder', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
 
@@ -128,7 +128,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->cache->inCache('folder/bar.txt'));
 		$this->assertFalse($this->cache->inCache('folder/2bar.txt'));
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(-1, $cachedData['size']);
+		$this->assertSame(-1, $cachedData['size']);
 
 		$this->scanner->backgroundScan();
 
@@ -150,32 +150,32 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder'), 'storage_mtime' => $this->storage->filemtime('folder')));
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertNotEquals($oldData['etag'], $newData['etag']);
-		$this->assertEquals($oldData['size'], $newData['size']);
+		$this->assertNotSame($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['size'], $newData['size']);
 
 		$oldData = $newData;
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
-		$this->assertEquals(-1, $newData['size']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
+		$this->assertSame(-1, $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
 		$oldData = $this->cache->get('');
 		$this->assertNotEquals(-1, $oldData['size']);
 		$this->scanner->scanFile('', \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
-		$this->assertEquals($oldData['size'], $newData['size']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['size'], $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
-		$this->assertEquals($oldData['size'], $newData['size']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['size'], $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
-		$this->assertEquals($oldData['size'], $newData['size']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['size'], $newData['size']);
 	}
 
 	public function testRemovedFile() {
@@ -230,7 +230,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$newData1 = $this->cache->get('folder');
 		$newData2 = $this->cache->get('');
 		$this->assertNotEmpty($newData0['etag']);
-		$this->assertNotEquals($data1['etag'], $newData1['etag']);
-		$this->assertNotEquals($data2['etag'], $newData2['etag']);
+		$this->assertNotSame($data1['etag'], $newData1['etag']);
+		$this->assertNotSame($data2['etag'], $newData2['etag']);
 	}
 }

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -90,27 +90,27 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
 		$this->cache->put('foo.txt', array('mtime' => 100, 'storage_mtime' => 150));
 		$rootCachedData = $this->cache->get('');
-		$this->assertEquals(3 * $textSize + $imageSize, $rootCachedData['size']);
+		$this->assertSame(3 * $textSize + $imageSize, $rootCachedData['size']);
 
 		$fooCachedData = $this->cache->get('foo.txt');
 		Filesystem::file_put_contents('foo.txt', 'asd');
 		$cachedData = $this->cache->get('foo.txt');
-		$this->assertEquals(3, $cachedData['size']);
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertSame(3, $cachedData['size']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(2 * $textSize + $imageSize + 3, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertSame(2 * $textSize + $imageSize + 3, $cachedData['size']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$rootCachedData = $cachedData;
 
 		$this->assertFalse($this->cache->inCache('bar.txt'));
 		Filesystem::file_put_contents('bar.txt', 'asd');
 		$this->assertTrue($this->cache->inCache('bar.txt'));
 		$cachedData = $this->cache->get('bar.txt');
-		$this->assertEquals(3, $cachedData['size']);
+		$this->assertSame(3, $cachedData['size']);
 		$mtime = $cachedData['mtime'];
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(2 * $textSize + $imageSize + 2 * 3, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertSame(2 * $textSize + $imageSize + 2 * 3, $cachedData['size']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $mtime);
 	}
 
@@ -123,42 +123,42 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		Filesystem::file_put_contents('folder/substorage/foo.txt', 'asd');
 		$this->assertTrue($cache2->inCache('foo.txt'));
 		$cachedData = $cache2->get('foo.txt');
-		$this->assertEquals(3, $cachedData['size']);
+		$this->assertSame(3, $cachedData['size']);
 		$mtime = $cachedData['mtime'];
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($mtime, $cachedData['mtime']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($mtime, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($mtime, $cachedData['mtime']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($mtime, $cachedData['mtime']);
 	}
 
 	public function testDelete() {
 		$textSize = strlen("dummy file data\n");
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
 		$rootCachedData = $this->cache->get('');
-		$this->assertEquals(3 * $textSize + $imageSize, $rootCachedData['size']);
+		$this->assertSame(3 * $textSize + $imageSize, $rootCachedData['size']);
 
 		$this->assertTrue($this->cache->inCache('foo.txt'));
 		Filesystem::unlink('foo.txt');
 		$this->assertFalse($this->cache->inCache('foo.txt'));
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(2 * $textSize + $imageSize, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertSame(2 * $textSize + $imageSize, $cachedData['size']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 		$rootCachedData = $cachedData;
 
 		Filesystem::mkdir('bar_folder');
 		$this->assertTrue($this->cache->inCache('bar_folder'));
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$rootCachedData = $cachedData;
 		Filesystem::rmdir('bar_folder');
 		$this->assertFalse($this->cache->inCache('bar_folder'));
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 	}
 
@@ -174,11 +174,11 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($cache2->inCache('foo.txt'));
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($substorageCachedData['mtime'], $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($folderCachedData['mtime'], $cachedData['mtime']);
 	}
 
@@ -186,7 +186,7 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$textSize = strlen("dummy file data\n");
 		$imageSize = filesize(\OC::$SERVERROOT . '/core/img/logo.png');
 		$rootCachedData = $this->cache->get('');
-		$this->assertEquals(3 * $textSize + $imageSize, $rootCachedData['size']);
+		$this->assertSame(3 * $textSize + $imageSize, $rootCachedData['size']);
 
 		$this->assertTrue($this->cache->inCache('foo.txt'));
 		$fooCachedData = $this->cache->get('foo.txt');
@@ -195,19 +195,19 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->cache->inCache('foo.txt'));
 		$this->assertTrue($this->cache->inCache('bar.txt'));
 		$cachedData = $this->cache->get('bar.txt');
-		$this->assertEquals($fooCachedData['fileid'], $cachedData['fileid']);
+		$this->assertSame($fooCachedData['fileid'], $cachedData['fileid']);
 		$mtime = $cachedData['mtime'];
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(3 * $textSize + $imageSize, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertSame(3 * $textSize + $imageSize, $cachedData['size']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 	}
 
 	public function testRenameExtension() {
 		$fooCachedData = $this->cache->get('foo.txt');
-		$this->assertEquals('text/plain', $fooCachedData['mimetype']);
+		$this->assertSame('text/plain', $fooCachedData['mimetype']);
 		Filesystem::rename('foo.txt', 'foo.abcd');
 		$fooCachedData = $this->cache->get('foo.abcd');
-		$this->assertEquals('application/octet-stream', $fooCachedData['mimetype']);
+		$this->assertSame('application/octet-stream', $fooCachedData['mimetype']);
 	}
 
 	public function testRenameWithMountPoints() {
@@ -223,18 +223,18 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($cache2->inCache('foo.txt'));
 		$this->assertTrue($cache2->inCache('bar.txt'));
 		$cachedData = $cache2->get('bar.txt');
-		$this->assertEquals($fooCachedData['fileid'], $cachedData['fileid']);
+		$this->assertSame($fooCachedData['fileid'], $cachedData['fileid']);
 		$mtime = $cachedData['mtime'];
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
-//		$this->assertEquals($mtime, $cachedData['mtime']);
+//		$this->assertSame($mtime, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
-//		$this->assertEquals($mtime, $cachedData['mtime']);
+//		$this->assertSame($mtime, $cachedData['mtime']);
 	}
 
 	public function testTouch() {
@@ -242,11 +242,11 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$fooCachedData = $this->cache->get('foo.txt');
 		Filesystem::touch('foo.txt');
 		$cachedData = $this->cache->get('foo.txt');
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($fooCachedData['mtime'], $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 		$rootCachedData = $cachedData;
 
@@ -255,15 +255,15 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$folderCachedData = $this->cache->get('folder');
 		Filesystem::touch('folder/bar.txt', $time);
 		$cachedData = $this->cache->get('folder/bar.txt');
-		$this->assertNotEquals($barCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($time, $cachedData['mtime']);
+		$this->assertNotSame($barCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($time, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($time, $cachedData['mtime']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($time, $cachedData['mtime']);
 	}
 
 	public function testTouchWithMountPoints() {
@@ -279,15 +279,15 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$time = 1371006070;
 		Filesystem::touch('folder/substorage/foo.txt', $time);
 		$cachedData = $cache2->get('foo.txt');
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($time, $cachedData['mtime']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($time, $cachedData['mtime']);
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
-		$this->assertEquals($time, $cachedData['mtime']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertSame($time, $cachedData['mtime']);
 	}
 
 	public function testUpdatePermissionsOnRescanOnlyForUpdatedFile() {
@@ -307,17 +307,17 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$permissionsCache->set($cache->getId('foo.png'), self::$user, 15);
 		FileSystem::file_put_contents('/foo.txt', 'asd');
 
-		$this->assertEquals(-1, $permissionsCache->get($cache->getId('foo.txt'), self::$user));
-		$this->assertEquals(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
+		$this->assertSame(-1, $permissionsCache->get($cache->getId('foo.txt'), self::$user));
+		$this->assertSame(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
 
 		FileSystem::getDirectoryContent('/');
 
-		$this->assertEquals(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
+		$this->assertSame(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
 
 		FileSystem::file_put_contents('/qwerty.txt', 'asd');
 		FileSystem::getDirectoryContent('/');
 
-		$this->assertEquals(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
+		$this->assertSame(15, $permissionsCache->get($cache->getId('foo.png'), self::$user));
 
 		\OC_User::setUserId($loggedInUser);
 	}

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -48,7 +48,7 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$updater->checkUpdate('');
 		$this->assertTrue($cache->inCache('bar.test'));
 		$cachedData = $cache->get('bar.test');
-		$this->assertEquals(3, $cachedData['size']);
+		$this->assertSame(3, $cachedData['size']);
 
 		$cache->put('bar.test', array('storage_mtime' => 10));
 		$storage->file_put_contents('bar.test', 'test data');
@@ -58,7 +58,7 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 
 		$updater->checkUpdate('bar.test');
 		$cachedData = $cache->get('bar.test');
-		$this->assertEquals(9, $cachedData['size']);
+		$this->assertSame(9, $cachedData['size']);
 
 		$cache->put('folder', array('storage_mtime' => 10));
 
@@ -85,7 +85,7 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$updater->checkUpdate('');
 
 		$entry = $cache->get('foo.txt');
-		$this->assertEquals('httpd/unix-directory', $entry['mimetype']);
+		$this->assertSame('httpd/unix-directory', $entry['mimetype']);
 		$this->assertFalse($cache->inCache('folder'));
 		$this->assertFalse($cache->inCache('folder/bar.txt'));
 
@@ -101,7 +101,7 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 		$updater->checkUpdate('foo.txt');
 
 		$entry = $cache->get('foo.txt');
-		$this->assertEquals('httpd/unix-directory', $entry['mimetype']);
+		$this->assertSame('httpd/unix-directory', $entry['mimetype']);
 		$this->assertTrue($cache->inCache('foo.txt/bar.txt'));
 	}
 

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -65,7 +65,7 @@ class EtagTest extends \PHPUnit_Framework_TestCase {
 		$scanner = new \OC\Files\Utils\Scanner($user1);
 		$scanner->backgroundScan('/');
 
-		$this->assertEquals($originalEtags, $this->getEtags($files));
+		$this->assertSame($originalEtags, $this->getEtags($files));
 	}
 
 	/**

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -52,86 +52,86 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 
 	public function testMount() {
 		\OC\Files\Filesystem::mount('\OC\Files\Storage\Local', self::getStorageData(), '/');
-		$this->assertEquals('/', \OC\Files\Filesystem::getMountPoint('/'));
-		$this->assertEquals('/', \OC\Files\Filesystem::getMountPoint('/some/folder'));
+		$this->assertSame('/', \OC\Files\Filesystem::getMountPoint('/'));
+		$this->assertSame('/', \OC\Files\Filesystem::getMountPoint('/some/folder'));
 		list(, $internalPath) = \OC\Files\Filesystem::resolvePath('/');
-		$this->assertEquals('', $internalPath);
+		$this->assertSame('', $internalPath);
 		list(, $internalPath) = \OC\Files\Filesystem::resolvePath('/some/folder');
-		$this->assertEquals('some/folder', $internalPath);
+		$this->assertSame('some/folder', $internalPath);
 
 		\OC\Files\Filesystem::mount('\OC\Files\Storage\Local', self::getStorageData(), '/some');
-		$this->assertEquals('/', \OC\Files\Filesystem::getMountPoint('/'));
-		$this->assertEquals('/some/', \OC\Files\Filesystem::getMountPoint('/some/folder'));
-		$this->assertEquals('/some/', \OC\Files\Filesystem::getMountPoint('/some/'));
-		$this->assertEquals('/some/', \OC\Files\Filesystem::getMountPoint('/some'));
+		$this->assertSame('/', \OC\Files\Filesystem::getMountPoint('/'));
+		$this->assertSame('/some/', \OC\Files\Filesystem::getMountPoint('/some/folder'));
+		$this->assertSame('/some/', \OC\Files\Filesystem::getMountPoint('/some/'));
+		$this->assertSame('/some/', \OC\Files\Filesystem::getMountPoint('/some'));
 		list(, $internalPath) = \OC\Files\Filesystem::resolvePath('/some/folder');
-		$this->assertEquals('folder', $internalPath);
+		$this->assertSame('folder', $internalPath);
 	}
 
 	public function testNormalize() {
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath(''));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('/'));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('/', false));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('//'));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('//', false));
-		$this->assertEquals('/path', \OC\Files\Filesystem::normalizePath('/path/'));
-		$this->assertEquals('/path/', \OC\Files\Filesystem::normalizePath('/path/', false));
-		$this->assertEquals('/path', \OC\Files\Filesystem::normalizePath('path'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo//bar/'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo//bar/', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo////bar'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/////bar'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/.'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/./'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/bar/./', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/./.'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/././'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/bar/././', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/./bar/'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/./bar/', false));
-		$this->assertEquals('/foo/.bar', \OC\Files\Filesystem::normalizePath('/foo/.bar/'));
-		$this->assertEquals('/foo/.bar/', \OC\Files\Filesystem::normalizePath('/foo/.bar/', false));
-		$this->assertEquals('/foo/.bar/tee', \OC\Files\Filesystem::normalizePath('/foo/.bar/tee'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath(''));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('/'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('/', false));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('//'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('//', false));
+		$this->assertSame('/path', \OC\Files\Filesystem::normalizePath('/path/'));
+		$this->assertSame('/path/', \OC\Files\Filesystem::normalizePath('/path/', false));
+		$this->assertSame('/path', \OC\Files\Filesystem::normalizePath('path'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo//bar/'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo//bar/', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo////bar'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/////bar'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/.'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/./'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/bar/./', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/./.'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/bar/././'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/bar/././', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('/foo/./bar/'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('/foo/./bar/', false));
+		$this->assertSame('/foo/.bar', \OC\Files\Filesystem::normalizePath('/foo/.bar/'));
+		$this->assertSame('/foo/.bar/', \OC\Files\Filesystem::normalizePath('/foo/.bar/', false));
+		$this->assertSame('/foo/.bar/tee', \OC\Files\Filesystem::normalizePath('/foo/.bar/tee'));
 
 		// normalize does not resolve '..' (by design)
-		$this->assertEquals('/foo/..', \OC\Files\Filesystem::normalizePath('/foo/../'));
+		$this->assertSame('/foo/..', \OC\Files\Filesystem::normalizePath('/foo/../'));
 
 		if (class_exists('Patchwork\PHP\Shim\Normalizer')) {
-			$this->assertEquals("/foo/bar\xC3\xBC", \OC\Files\Filesystem::normalizePath("/foo/baru\xCC\x88"));
+			$this->assertSame("/foo/bar\xC3\xBC", \OC\Files\Filesystem::normalizePath("/foo/baru\xCC\x88"));
 		}
 	}
 
 	public function testNormalizeWindowsPaths() {
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath(''));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('\\'));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('\\', false));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('\\\\'));
-		$this->assertEquals('/', \OC\Files\Filesystem::normalizePath('\\\\', false));
-		$this->assertEquals('/path', \OC\Files\Filesystem::normalizePath('\\path'));
-		$this->assertEquals('/path', \OC\Files\Filesystem::normalizePath('\\path', false));
-		$this->assertEquals('/path', \OC\Files\Filesystem::normalizePath('\\path\\'));
-		$this->assertEquals('/path/', \OC\Files\Filesystem::normalizePath('\\path\\', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\bar\\'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\\\bar\\', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\\\\\bar'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\\\\\\\bar'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.'));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.\\'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.\\', false));
-		$this->assertEquals('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\.\\bar\\'));
-		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\.\\bar\\', false));
-		$this->assertEquals('/foo/.bar', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\'));
-		$this->assertEquals('/foo/.bar/', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\', false));
-		$this->assertEquals('/foo/.bar/tee', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\tee'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath(''));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('\\'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('\\', false));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('\\\\'));
+		$this->assertSame('/', \OC\Files\Filesystem::normalizePath('\\\\', false));
+		$this->assertSame('/path', \OC\Files\Filesystem::normalizePath('\\path'));
+		$this->assertSame('/path', \OC\Files\Filesystem::normalizePath('\\path', false));
+		$this->assertSame('/path', \OC\Files\Filesystem::normalizePath('\\path\\'));
+		$this->assertSame('/path/', \OC\Files\Filesystem::normalizePath('\\path\\', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\bar\\'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\\\bar\\', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\\\\\bar'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\\\\\\\\\bar'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.'));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.\\'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\bar\\.\\.\\', false));
+		$this->assertSame('/foo/bar', \OC\Files\Filesystem::normalizePath('\\foo\\.\\bar\\'));
+		$this->assertSame('/foo/bar/', \OC\Files\Filesystem::normalizePath('\\foo\\.\\bar\\', false));
+		$this->assertSame('/foo/.bar', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\'));
+		$this->assertSame('/foo/.bar/', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\', false));
+		$this->assertSame('/foo/.bar/tee', \OC\Files\Filesystem::normalizePath('\\foo\\.bar\\tee'));
 
 		// normalize does not resolve '..' (by design)
-		$this->assertEquals('/foo/..', \OC\Files\Filesystem::normalizePath('\\foo\\..\\'));
+		$this->assertSame('/foo/..', \OC\Files\Filesystem::normalizePath('\\foo\\..\\'));
 
 		if (class_exists('Patchwork\PHP\Shim\Normalizer')) {
-			$this->assertEquals("/foo/bar\xC3\xBC", \OC\Files\Filesystem::normalizePath("\\foo\\baru\xCC\x88"));
+			$this->assertSame("/foo/bar\xC3\xBC", \OC\Files\Filesystem::normalizePath("\\foo\\baru\xCC\x88"));
 		}
 	}
 
@@ -174,7 +174,7 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
 		$this->assertInstanceOf('\OC\Files\Storage\Local', $homeMount);
-		$this->assertEquals('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
+		$this->assertSame('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
 	}
 
 	/**
@@ -190,7 +190,7 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
 		$this->assertInstanceOf('\OC\Files\Storage\Home', $homeMount);
-		$this->assertEquals('home::' . $userId, $homeMount->getId());
+		$this->assertSame('home::' . $userId, $homeMount->getId());
 
 		\OC_User::deleteUser($userId);
 	}
@@ -215,7 +215,7 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
 		$this->assertInstanceOf('\OC\Files\Storage\Home', $homeMount);
-		$this->assertEquals('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
+		$this->assertSame('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
 
 		\OC_User::deleteUser($userId);
 		// delete storage entry
@@ -224,6 +224,6 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 
 	public function dummyHook($arguments) {
 		$path = $arguments['path'];
-		$this->assertEquals($path, \OC\Files\Filesystem::normalizePath($path)); //the path passed to the hook should already be normalized
+		$this->assertSame($path, \OC\Files\Filesystem::normalizePath($path)); //the path passed to the hook should already be normalized
 	}
 }

--- a/tests/lib/files/mapper.php
+++ b/tests/lib/files/mapper.php
@@ -35,29 +35,29 @@ class Mapper extends \PHPUnit_Framework_TestCase {
 
 	public function testSlugifyPath() {
 		// with extension
-		$this->assertEquals('D:/text.txt', $this->mapper->slugifyPath('D:/text.txt'));
-		$this->assertEquals('D:/text-2.txt', $this->mapper->slugifyPath('D:/text.txt', 2));
-		$this->assertEquals('D:/a/b/text.txt', $this->mapper->slugifyPath('D:/a/b/text.txt'));
+		$this->assertSame('D:/text.txt', $this->mapper->slugifyPath('D:/text.txt'));
+		$this->assertSame('D:/text-2.txt', $this->mapper->slugifyPath('D:/text.txt', 2));
+		$this->assertSame('D:/a/b/text.txt', $this->mapper->slugifyPath('D:/a/b/text.txt'));
 
 		// without extension
-		$this->assertEquals('D:/text', $this->mapper->slugifyPath('D:/text'));
-		$this->assertEquals('D:/text-2', $this->mapper->slugifyPath('D:/text', 2));
-		$this->assertEquals('D:/a/b/text', $this->mapper->slugifyPath('D:/a/b/text'));
+		$this->assertSame('D:/text', $this->mapper->slugifyPath('D:/text'));
+		$this->assertSame('D:/text-2', $this->mapper->slugifyPath('D:/text', 2));
+		$this->assertSame('D:/a/b/text', $this->mapper->slugifyPath('D:/a/b/text'));
 
 		// with double dot
-		$this->assertEquals('D:/text.text.txt', $this->mapper->slugifyPath('D:/text.text.txt'));
-		$this->assertEquals('D:/text.text-2.txt', $this->mapper->slugifyPath('D:/text.text.txt', 2));
-		$this->assertEquals('D:/a/b/text.text.txt', $this->mapper->slugifyPath('D:/a/b/text.text.txt'));
+		$this->assertSame('D:/text.text.txt', $this->mapper->slugifyPath('D:/text.text.txt'));
+		$this->assertSame('D:/text.text-2.txt', $this->mapper->slugifyPath('D:/text.text.txt', 2));
+		$this->assertSame('D:/a/b/text.text.txt', $this->mapper->slugifyPath('D:/a/b/text.text.txt'));
 			
 		// foldername and filename with periods
-		$this->assertEquals('D:/folder.name.with.periods', $this->mapper->slugifyPath('D:/folder.name.with.periods'));
-		$this->assertEquals('D:/folder.name.with.periods/test-2.txt', $this->mapper->slugifyPath('D:/folder.name.with.periods/test.txt', 2));
-		$this->assertEquals('D:/folder.name.with.periods/test.txt', $this->mapper->slugifyPath('D:/folder.name.with.periods/test.txt'));
+		$this->assertSame('D:/folder.name.with.periods', $this->mapper->slugifyPath('D:/folder.name.with.periods'));
+		$this->assertSame('D:/folder.name.with.periods/test-2.txt', $this->mapper->slugifyPath('D:/folder.name.with.periods/test.txt', 2));
+		$this->assertSame('D:/folder.name.with.periods/test.txt', $this->mapper->slugifyPath('D:/folder.name.with.periods/test.txt'));
 
 		// foldername and filename with periods and spaces
-		$this->assertEquals('D:/folder.name.with.peri-ods', $this->mapper->slugifyPath('D:/folder.name.with.peri ods'));
-		$this->assertEquals('D:/folder.name.with.peri-ods/te-st-2.t-x-t', $this->mapper->slugifyPath('D:/folder.name.with.peri ods/te st.t x t', 2));
-		$this->assertEquals('D:/folder.name.with.peri-ods/te-st.t-x-t', $this->mapper->slugifyPath('D:/folder.name.with.peri ods/te st.t x t'));
+		$this->assertSame('D:/folder.name.with.peri-ods', $this->mapper->slugifyPath('D:/folder.name.with.peri ods'));
+		$this->assertSame('D:/folder.name.with.peri-ods/te-st-2.t-x-t', $this->mapper->slugifyPath('D:/folder.name.with.peri ods/te st.t x t', 2));
+		$this->assertSame('D:/folder.name.with.peri-ods/te-st.t-x-t', $this->mapper->slugifyPath('D:/folder.name.with.peri ods/te st.t x t'));
 
 		
 	}

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -47,7 +47,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->instance->isReadable('/'), 'Root folder is not readable');
 		$this->assertTrue($this->instance->is_dir('/'), 'Root folder is not a directory');
 		$this->assertFalse($this->instance->is_file('/'), 'Root folder is a file');
-		$this->assertEquals('dir', $this->instance->filetype('/'));
+		$this->assertSame('dir', $this->instance->filetype('/'));
 
 		//without this, any further testing would be useless, not an actual requirement for filestorage though
 		$this->assertTrue($this->instance->isUpdatable('/'), 'Root folder is not writable');
@@ -71,8 +71,8 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($this->instance->file_exists('/'.$directory));
 		$this->assertTrue($this->instance->is_dir('/'.$directory));
 		$this->assertFalse($this->instance->is_file('/'.$directory));
-		$this->assertEquals('dir', $this->instance->filetype('/'.$directory));
-		$this->assertEquals(0, $this->instance->filesize('/'.$directory));
+		$this->assertSame('dir', $this->instance->filetype('/'.$directory));
+		$this->assertSame(0, $this->instance->filesize('/'.$directory));
 		$this->assertTrue($this->instance->isReadable('/'.$directory));
 		$this->assertTrue($this->instance->isUpdatable('/'.$directory));
 
@@ -83,7 +83,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 				$content[] = $file;
 			}
 		}
-		$this->assertEquals(array($directory), $content);
+		$this->assertSame(array($directory), $content);
 
 		$this->assertFalse($this->instance->mkdir('/'.$directory)); //cant create existing folders
 		$this->assertTrue($this->instance->rmdir('/'.$directory));
@@ -100,7 +100,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 				$content[] = $file;
 			}
 		}
-		$this->assertEquals(array(), $content);
+		$this->assertSame(array(), $content);
 	}
 
 	public function directoryProvider()
@@ -123,31 +123,31 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		//fill a file with string data
 		$this->instance->file_put_contents('/lorem.txt', $sourceText);
 		$this->assertFalse($this->instance->is_dir('/lorem.txt'));
-		$this->assertEquals($sourceText, $this->instance->file_get_contents('/lorem.txt'), 'data returned from file_get_contents is not equal to the source data');
+		$this->assertSame($sourceText, $this->instance->file_get_contents('/lorem.txt'), 'data returned from file_get_contents is not equal to the source data');
 
 		//empty the file
 		$this->instance->file_put_contents('/lorem.txt', '');
-		$this->assertEquals('', $this->instance->file_get_contents('/lorem.txt'), 'file not emptied');
+		$this->assertSame('', $this->instance->file_get_contents('/lorem.txt'), 'file not emptied');
 	}
 
 	/**
 	 * test various known mimetypes
 	 */
 	public function testMimeType() {
-		$this->assertEquals('httpd/unix-directory', $this->instance->getMimeType('/'));
-		$this->assertEquals(false, $this->instance->getMimeType('/non/existing/file'));
+		$this->assertSame('httpd/unix-directory', $this->instance->getMimeType('/'));
+		$this->assertFalse($this->instance->getMimeType('/non/existing/file'));
 
 		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
 		$this->instance->file_put_contents('/lorem.txt', file_get_contents($textFile, 'r'));
-		$this->assertEquals('text/plain', $this->instance->getMimeType('/lorem.txt'));
+		$this->assertSame('text/plain', $this->instance->getMimeType('/lorem.txt'));
 
 		$pngFile = \OC::$SERVERROOT . '/tests/data/logo-wide.png';
 		$this->instance->file_put_contents('/logo-wide.png', file_get_contents($pngFile, 'r'));
-		$this->assertEquals('image/png', $this->instance->getMimeType('/logo-wide.png'));
+		$this->assertSame('image/png', $this->instance->getMimeType('/logo-wide.png'));
 
 		$svgFile = \OC::$SERVERROOT . '/tests/data/logo-wide.svg';
 		$this->instance->file_put_contents('/logo-wide.svg', file_get_contents($svgFile, 'r'));
-		$this->assertEquals('image/svg+xml', $this->instance->getMimeType('/logo-wide.svg'));
+		$this->assertSame('image/svg+xml', $this->instance->getMimeType('/logo-wide.svg'));
 	}
 
 	public function testCopyAndMove() {
@@ -155,13 +155,13 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->file_put_contents('/source.txt', file_get_contents($textFile));
 		$this->instance->copy('/source.txt', '/target.txt');
 		$this->assertTrue($this->instance->file_exists('/target.txt'));
-		$this->assertEquals($this->instance->file_get_contents('/source.txt'), $this->instance->file_get_contents('/target.txt'));
+		$this->assertSame($this->instance->file_get_contents('/source.txt'), $this->instance->file_get_contents('/target.txt'));
 
 		$this->instance->rename('/source.txt', '/target2.txt');
 		$this->wait();
 		$this->assertTrue($this->instance->file_exists('/target2.txt'));
 		$this->assertFalse($this->instance->file_exists('/source.txt'));
-		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target2.txt'));
+		$this->assertSame(file_get_contents($textFile), $this->instance->file_get_contents('/target2.txt'));
 
 		// move to overwrite
 		$testContents = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -169,7 +169,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->rename('/target2.txt', '/target3.txt');
 		$this->assertTrue($this->instance->file_exists('/target3.txt'));
 		$this->assertFalse($this->instance->file_exists('/target2.txt'));
-		$this->assertEquals(file_get_contents($textFile), $this->instance->file_get_contents('/target3.txt'));
+		$this->assertSame(file_get_contents($textFile), $this->instance->file_get_contents('/target3.txt'));
 	}
 
 	public function testLocal() {
@@ -177,7 +177,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->instance->file_put_contents('/lorem.txt', file_get_contents($textFile));
 		$localFile = $this->instance->getLocalFile('/lorem.txt');
 		$this->assertTrue(file_exists($localFile));
-		$this->assertEquals(file_get_contents($localFile), file_get_contents($textFile));
+		$this->assertSame(file_get_contents($localFile), file_get_contents($textFile));
 
 		$this->instance->mkdir('/folder');
 		$this->instance->file_put_contents('/folder/lorem.txt', file_get_contents($textFile));
@@ -191,15 +191,15 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		// test below require to use instance->getLocalFile because the physical storage might be different
 		$localFile = $this->instance->getLocalFile('/folder/lorem.txt');
 		$this->assertTrue(file_exists($localFile));
-		$this->assertEquals(file_get_contents($localFile), file_get_contents($textFile));
+		$this->assertSame(file_get_contents($localFile), file_get_contents($textFile));
 
 		$localFile = $this->instance->getLocalFile('/folder/bar.txt');
 		$this->assertTrue(file_exists($localFile));
-		$this->assertEquals(file_get_contents($localFile), 'asd');
+		$this->assertSame(file_get_contents($localFile), 'asd');
 
 		$localFile = $this->instance->getLocalFile('/folder/recursive/file.txt');
 		$this->assertTrue(file_exists($localFile));
-		$this->assertEquals(file_get_contents($localFile), 'foo');
+		$this->assertSame(file_get_contents($localFile), 'foo');
 	}
 
 	public function testStat() {
@@ -215,16 +215,16 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		// check that ($ctimeStart - 5) <= $mTime <= ($ctimeEnd + 1)
 		$this->assertGreaterThanOrEqual(($ctimeStart - 5), $mTime);
 		$this->assertLessThanOrEqual(($ctimeEnd + 1), $mTime);
-		$this->assertEquals(filesize($textFile), $this->instance->filesize('/lorem.txt'));
+		$this->assertSame(filesize($textFile), $this->instance->filesize('/lorem.txt'));
 
 		$stat = $this->instance->stat('/lorem.txt');
 		//only size and mtime are required in the result
-		$this->assertEquals($stat['size'], $this->instance->filesize('/lorem.txt'));
-		$this->assertEquals($stat['mtime'], $mTime);
+		$this->assertSame($stat['size'], $this->instance->filesize('/lorem.txt'));
+		$this->assertSame($stat['mtime'], $mTime);
 
 		if ($this->instance->touch('/lorem.txt', 100) !== false) {
 			$mTime = $this->instance->filemtime('/lorem.txt');
-			$this->assertEquals($mTime, 100);
+			$this->assertSame($mTime, 100);
 		}
 
 		$mtimeStart = time();
@@ -262,7 +262,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 
 		$fh = $this->instance->fopen('foo', 'r');
 		$content = stream_get_contents($fh);
-		$this->assertEquals(file_get_contents($textFile), $content);
+		$this->assertSame(file_get_contents($textFile), $content);
 	}
 
 	public function testTouchCreateFile() {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -61,22 +61,22 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView = new \OC\Files\View('');
 
 		$cachedData = $rootView->getFileInfo('/foo.txt');
-		$this->assertEquals($textSize, $cachedData['size']);
-		$this->assertEquals('text/plain', $cachedData['mimetype']);
+		$this->assertSame($textSize, $cachedData['size']);
+		$this->assertSame('text/plain', $cachedData['mimetype']);
 		$this->assertNotEquals(-1, $cachedData['permissions']);
 
 		$cachedData = $rootView->getFileInfo('/');
-		$this->assertEquals($storageSize * 3, $cachedData['size']);
-		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
+		$this->assertSame($storageSize * 3, $cachedData['size']);
+		$this->assertSame('httpd/unix-directory', $cachedData['mimetype']);
 
 		// get cached data excluding mount points
 		$cachedData = $rootView->getFileInfo('/', false);
-		$this->assertEquals($storageSize, $cachedData['size']);
-		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
+		$this->assertSame($storageSize, $cachedData['size']);
+		$this->assertSame('httpd/unix-directory', $cachedData['mimetype']);
 
 		$cachedData = $rootView->getFileInfo('/folder');
-		$this->assertEquals($storageSize + $textSize, $cachedData['size']);
-		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
+		$this->assertSame($storageSize + $textSize, $cachedData['size']);
+		$this->assertSame('httpd/unix-directory', $cachedData['mimetype']);
 
 		$folderData = $rootView->getDirectoryContent('/');
 		/**
@@ -86,16 +86,16 @@ class View extends \PHPUnit_Framework_TestCase {
 		 * foo.txt
 		 * substorage
 		 */
-		$this->assertEquals(4, count($folderData));
-		$this->assertEquals('folder', $folderData[0]['name']);
-		$this->assertEquals('foo.png', $folderData[1]['name']);
-		$this->assertEquals('foo.txt', $folderData[2]['name']);
-		$this->assertEquals('substorage', $folderData[3]['name']);
+		$this->assertSame(4, count($folderData));
+		$this->assertSame('folder', $folderData[0]['name']);
+		$this->assertSame('foo.png', $folderData[1]['name']);
+		$this->assertSame('foo.txt', $folderData[2]['name']);
+		$this->assertSame('substorage', $folderData[3]['name']);
 
-		$this->assertEquals($storageSize + $textSize, $folderData[0]['size']);
-		$this->assertEquals($imageSize, $folderData[1]['size']);
-		$this->assertEquals($textSize, $folderData[2]['size']);
-		$this->assertEquals($storageSize, $folderData[3]['size']);
+		$this->assertSame($storageSize + $textSize, $folderData[0]['size']);
+		$this->assertSame($imageSize, $folderData[1]['size']);
+		$this->assertSame($textSize, $folderData[2]['size']);
+		$this->assertSame($storageSize, $folderData[3]['size']);
 
 		$folderData = $rootView->getDirectoryContent('/substorage');
 		/**
@@ -104,10 +104,10 @@ class View extends \PHPUnit_Framework_TestCase {
 		 * foo.png
 		 * foo.txt
 		 */
-		$this->assertEquals(3, count($folderData));
-		$this->assertEquals('folder', $folderData[0]['name']);
-		$this->assertEquals('foo.png', $folderData[1]['name']);
-		$this->assertEquals('foo.txt', $folderData[2]['name']);
+		$this->assertSame(3, count($folderData));
+		$this->assertSame('folder', $folderData[0]['name']);
+		$this->assertSame('foo.png', $folderData[1]['name']);
+		$this->assertSame('foo.txt', $folderData[2]['name']);
 
 		$folderView = new \OC\Files\View('/folder');
 		$this->assertEquals($rootView->getFileInfo('/folder'), $folderView->getFileInfo('/'));
@@ -117,10 +117,10 @@ class View extends \PHPUnit_Framework_TestCase {
 		$id = $rootView->putFileInfo('/foo.txt', array('encrypted' => true));
 		$cachedData = $rootView->getFileInfo('/foo.txt');
 		$this->assertTrue($cachedData['encrypted']);
-		$this->assertEquals($cachedData['fileid'], $id);
+		$this->assertSame($cachedData['fileid'], $id);
 
 		$this->assertFalse($rootView->getFileInfo('/non/existing'));
-		$this->assertEquals(array(), $rootView->getDirectoryContent('/non/existing'));
+		$this->assertSame(array(), $rootView->getDirectoryContent('/non/existing'));
 	}
 
 	/**
@@ -138,14 +138,14 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		$cachedData = $rootView->getFileInfo('/foo.txt');
 		$id1 = $cachedData['fileid'];
-		$this->assertEquals('/foo.txt', $rootView->getPath($id1));
+		$this->assertSame('/foo.txt', $rootView->getPath($id1));
 
 		$cachedData = $rootView->getFileInfo('/substorage/foo.txt');
 		$id2 = $cachedData['fileid'];
-		$this->assertEquals('/substorage/foo.txt', $rootView->getPath($id2));
+		$this->assertSame('/substorage/foo.txt', $rootView->getPath($id2));
 
 		$folderView = new \OC\Files\View('/substorage');
-		$this->assertEquals('/foo.txt', $folderView->getPath($id2));
+		$this->assertSame('/foo.txt', $folderView->getPath($id2));
 		$this->assertNull($folderView->getPath($id1));
 	}
 
@@ -161,7 +161,7 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		$rootView = new \OC\Files\View('');
 		$folderContent = $rootView->getDirectoryContent('/');
-		$this->assertEquals(4, count($folderContent));
+		$this->assertSame(4, count($folderContent));
 	}
 
 	function testCacheIncompleteFolder() {
@@ -170,11 +170,11 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView = new \OC\Files\View('');
 
 		$entries = $rootView->getDirectoryContent('/');
-		$this->assertEquals(3, count($entries));
+		$this->assertSame(3, count($entries));
 
 		// /folder will already be in the cache but not scanned
 		$entries = $rootView->getDirectoryContent('/folder');
-		$this->assertEquals(1, count($entries));
+		$this->assertSame(1, count($entries));
 	}
 
 	public function testAutoScan() {
@@ -187,12 +187,12 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView = new \OC\Files\View('');
 
 		$cachedData = $rootView->getFileInfo('/');
-		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
-		$this->assertEquals(-1, $cachedData['size']);
+		$this->assertSame('httpd/unix-directory', $cachedData['mimetype']);
+		$this->assertSame(-1, $cachedData['size']);
 
 		$folderData = $rootView->getDirectoryContent('/substorage/folder');
-		$this->assertEquals('text/plain', $folderData[0]['mimetype']);
-		$this->assertEquals($textSize, $folderData[0]['size']);
+		$this->assertSame('text/plain', $folderData[0]['mimetype']);
+		$this->assertSame($textSize, $folderData[0]['size']);
 	}
 
 	/**
@@ -209,10 +209,10 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView = new \OC\Files\View('');
 
 		$results = $rootView->search('foo');
-		$this->assertEquals(6, count($results));
+		$this->assertSame(6, count($results));
 		$paths = array();
 		foreach ($results as $result) {
-			$this->assertEquals($result['path'], \OC\Files\Filesystem::normalizePath($result['path']));
+			$this->assertSame($result['path'], \OC\Files\Filesystem::normalizePath($result['path']));
 			$paths[] = $result['path'];
 		}
 		$this->assertContains('/foo.txt', $paths);
@@ -224,7 +224,7 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		$folderView = new \OC\Files\View('/folder');
 		$results = $folderView->search('bar');
-		$this->assertEquals(2, count($results));
+		$this->assertSame(2, count($results));
 		$paths = array();
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
@@ -233,7 +233,7 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertContains('/bar.txt', $paths);
 
 		$results = $folderView->search('foo');
-		$this->assertEquals(2, count($results));
+		$this->assertSame(2, count($results));
 		$paths = array();
 		foreach ($results as $result) {
 			$paths[] = $result['path'];
@@ -241,8 +241,8 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertContains('/anotherstorage/foo.txt', $paths);
 		$this->assertContains('/anotherstorage/foo.png', $paths);
 
-		$this->assertEquals(6, count($rootView->searchByMime('text')));
-		$this->assertEquals(3, count($folderView->searchByMime('text')));
+		$this->assertSame(6, count($rootView->searchByMime('text')));
+		$this->assertSame(3, count($folderView->searchByMime('text')));
 	}
 
 	/**
@@ -256,14 +256,14 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView = new \OC\Files\View('');
 
 		$cachedData = $rootView->getFileInfo('foo.txt');
-		$this->assertEquals(16, $cachedData['size']);
+		$this->assertSame(16, $cachedData['size']);
 
 		$rootView->putFileInfo('foo.txt', array('storage_mtime' => 10));
 		$storage1->file_put_contents('foo.txt', 'foo');
 		clearstatcache();
 
 		$cachedData = $rootView->getFileInfo('foo.txt');
-		$this->assertEquals(3, $cachedData['size']);
+		$this->assertSame(3, $cachedData['size']);
 	}
 
 	/**
@@ -365,14 +365,14 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView->touch('foo.txt', 500);
 
 		$cachedData = $rootView->getFileInfo('foo.txt');
-		$this->assertEquals(500, $cachedData['mtime']);
-		$this->assertEquals($oldCachedData['storage_mtime'], $cachedData['storage_mtime']);
+		$this->assertSame(500, $cachedData['mtime']);
+		$this->assertSame($oldCachedData['storage_mtime'], $cachedData['storage_mtime']);
 
 		$rootView->putFileInfo('foo.txt', array('storage_mtime' => 1000)); //make sure the watcher detects the change
 		$rootView->file_put_contents('foo.txt', 'asd');
 		$cachedData = $rootView->getFileInfo('foo.txt');
 		$this->assertGreaterThanOrEqual($cachedData['mtime'], $oldCachedData['mtime']);
-		$this->assertEquals($cachedData['storage_mtime'], $cachedData['mtime']);
+		$this->assertSame($cachedData['storage_mtime'], $cachedData['mtime']);
 	}
 
 	/**
@@ -395,7 +395,7 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		$subView->file_put_contents('/foo.txt', 'asd');
 		$this->assertNotNull($this->hookPath);
-		$this->assertEquals('/substorage/foo.txt', $this->hookPath);
+		$this->assertSame('/substorage/foo.txt', $this->hookPath);
 	}
 
 	private $hookPath;
@@ -478,7 +478,7 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->hookPath = null;
 
 		$view->file_put_contents('/asd.txt', 'foo');
-		$this->assertEquals('/asd.txt', $this->createHookPath);
+		$this->assertSame('/asd.txt', $this->createHookPath);
 		$this->createHookPath = null;
 
 		$view->file_put_contents('/asd.txt', 'foo');
@@ -495,7 +495,7 @@ class View extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('');
 
 		$result = $view->resolvePath($pathToTest);
-		$this->assertEquals($expected, $result[1]);
+		$this->assertSame($expected, $result[1]);
 
 		$exists = $view->file_exists($pathToTest);
 		$this->assertTrue($exists);
@@ -563,6 +563,6 @@ class View extends \PHPUnit_Framework_TestCase {
 		$scanner->scanFile('test', \OC\Files\Cache\Scanner::REUSE_ETAG);
 
 		$info2 = $view->getFileInfo('/test/test');
-		$this->assertEquals($info['etag'], $info2['etag']);
+		$this->assertSame($info['etag'], $info2['etag']);
 	}
 }


### PR DESCRIPTION
Solves the false positives when tests fail to compare strings, eg. 

```
10:04:55 1) Test\Files\Cache\Updater::testTouchWithMountPoints
10:04:55 Failed asserting that '530e005393326' is not equal to <string:530e005293045>.
```

Fixed by using assertSame, which checks the type first and then does the correct string comparison. I assume that assertEquals interprets one of the numbers as an INT and then fails because the numbers are too big.

This PR also uses stricter asserts in all core tests
- assertEquals -> assertSame (unless we are comparing objects or arrays)
- assertXXX(false -> assertFalse
- assertXXX(true -> assertTrue
- assertXXX(null -> assertNull
- assertNotEqual -> assertNotSame if appropriate (numbers still use assertNotEquals to catch 1 == '1')

@MorrisJobke @DeepDiver1975 @PVince81 @schiesbn @blizzz @icewind1991 @bantu this touches many tests, lets see what jenkins has to say. I already fixed `lib/private/files/cache/cache.php` and `lib/private/files/cache/permissions.php` which did not change the type of some db columns and caused some of the tests to fail on my local machine.
