### PR TITLE
use assertSame and assertNotSame for etag checks

### DIFF
--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -344,7 +344,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		// check if mtime and etags unchanged
 		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
-		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+		$this->assertSame($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
 
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
@@ -373,7 +373,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		// check if mtime and etags unchanged
 		$this->assertEquals($fileInfoEncrypted['mtime'], $fileInfoUnencrypted['mtime']);
-		$this->assertEquals($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
+		$this->assertSame($fileInfoEncrypted['etag'], $fileInfoUnencrypted['etag']);
 		// file should no longer be encrypted
 		$this->assertEquals(0, $fileInfoUnencrypted['encrypted']);
 

--- a/tests/lib/appframework/http/ResponseTest.php
+++ b/tests/lib/appframework/http/ResponseTest.php
@@ -78,7 +78,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetEtag() {
 		$this->childResponse->setEtag('hi');
-		$this->assertEquals('hi', $this->childResponse->getEtag());
+		$this->assertSame('hi', $this->childResponse->getEtag());
 	}
 
 

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -150,8 +150,8 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder'), 'storage_mtime' => $this->storage->filemtime('folder')));
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertTrue(is_string($oldData['etag']), 'Expected a string');
-		$this->assertTrue(is_string($newData['etag']), 'Expected a string');
+		$this->assertInternalType('string', $oldData['etag']);
+		$this->assertInternalType('string', $newData['etag']);
 		$this->assertNotSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals($oldData['size'], $newData['size']);
 
@@ -219,11 +219,11 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		// manipulate etag to simulate an empty etag
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG);
 		$data0 = $this->cache->get('folder/bar.txt');
-		$this->assertTrue(is_string($data0['etag']), 'Expected a string');
+		$this->assertInternalType('string', $data0['etag']);
 		$data1 = $this->cache->get('folder');
-		$this->assertTrue(is_string($data1['etag']), 'Expected a string');
+		$this->assertInternalType('string', $data1['etag']);
 		$data2 = $this->cache->get('');
-		$this->assertTrue(is_string($data2['etag']), 'Expected a string');
+		$this->assertInternalType('string', $data2['etag']);
 		$data0['etag'] = '';
 		$this->cache->put('folder/bar.txt', $data0);
 
@@ -232,15 +232,15 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 
 		// verify cache content
 		$newData0 = $this->cache->get('folder/bar.txt');
-		$this->assertTrue(is_string($newData0['etag']), 'Expected a string');
+		$this->assertInternalType('string', $newData0['etag']);
 		$this->assertNotEmpty($newData0['etag']);
 		
 		$newData1 = $this->cache->get('folder');
-		$this->assertTrue(is_string($newData1['etag']), 'Expected a string');
+		$this->assertInternalType('string', $newData1['etag']);
 		$this->assertNotSame($data1['etag'], $newData1['etag']);
 		
 		$newData2 = $this->cache->get('');
-		$this->assertTrue(is_string($newData2['etag']), 'Expected a string');
+		$this->assertInternalType('string', $newData2['etag']);
 		$this->assertNotSame($data2['etag'], $newData2['etag']);
 	}
 }

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -150,13 +150,15 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->cache->put('folder', array('mtime' => $this->storage->filemtime('folder'), 'storage_mtime' => $this->storage->filemtime('folder')));
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertNotEquals($oldData['etag'], $newData['etag']);
+		$this->assertTrue(is_string($oldData['etag']), 'Expected a string');
+		$this->assertTrue(is_string($newData['etag']), 'Expected a string');
+		$this->assertNotSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals($oldData['size'], $newData['size']);
 
 		$oldData = $newData;
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals(-1, $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
@@ -164,17 +166,17 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->assertNotEquals(-1, $oldData['size']);
 		$this->scanner->scanFile('', \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals($oldData['size'], $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals($oldData['size'], $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
-		$this->assertEquals($oldData['etag'], $newData['etag']);
+		$this->assertSame($oldData['etag'], $newData['etag']);
 		$this->assertEquals($oldData['size'], $newData['size']);
 	}
 
@@ -217,8 +219,11 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		// manipulate etag to simulate an empty etag
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG);
 		$data0 = $this->cache->get('folder/bar.txt');
+		$this->assertTrue(is_string($data0['etag']), 'Expected a string');
 		$data1 = $this->cache->get('folder');
+		$this->assertTrue(is_string($data1['etag']), 'Expected a string');
 		$data2 = $this->cache->get('');
+		$this->assertTrue(is_string($data2['etag']), 'Expected a string');
 		$data0['etag'] = '';
 		$this->cache->put('folder/bar.txt', $data0);
 
@@ -227,10 +232,15 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 
 		// verify cache content
 		$newData0 = $this->cache->get('folder/bar.txt');
-		$newData1 = $this->cache->get('folder');
-		$newData2 = $this->cache->get('');
+		$this->assertTrue(is_string($newData0['etag']), 'Expected a string');
 		$this->assertNotEmpty($newData0['etag']);
-		$this->assertNotEquals($data1['etag'], $newData1['etag']);
-		$this->assertNotEquals($data2['etag'], $newData2['etag']);
+		
+		$newData1 = $this->cache->get('folder');
+		$this->assertTrue(is_string($newData1['etag']), 'Expected a string');
+		$this->assertNotSame($data1['etag'], $newData1['etag']);
+		
+		$newData2 = $this->cache->get('');
+		$this->assertTrue(is_string($newData2['etag']), 'Expected a string');
+		$this->assertNotSame($data2['etag'], $newData2['etag']);
 	}
 }

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -96,10 +96,14 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		Filesystem::file_put_contents('foo.txt', 'asd');
 		$cachedData = $this->cache->get('foo.txt');
 		$this->assertEquals(3, $cachedData['size']);
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $fooCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
 		$cachedData = $this->cache->get('');
 		$this->assertEquals(2 * $textSize + $imageSize + 3, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$rootCachedData = $cachedData;
 
 		$this->assertFalse($this->cache->inCache('bar.txt'));
@@ -110,7 +114,9 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$mtime = $cachedData['mtime'];
 		$cachedData = $this->cache->get('');
 		$this->assertEquals(2 * $textSize + $imageSize + 2 * 3, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $mtime);
 	}
 
@@ -127,11 +133,15 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$mtime = $cachedData['mtime'];
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $substorageCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($mtime, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $folderCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($mtime, $cachedData['mtime']);
 	}
 
@@ -146,19 +156,25 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->cache->inCache('foo.txt'));
 		$cachedData = $this->cache->get('');
 		$this->assertEquals(2 * $textSize + $imageSize, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 		$rootCachedData = $cachedData;
 
 		Filesystem::mkdir('bar_folder');
 		$this->assertTrue($this->cache->inCache('bar_folder'));
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$rootCachedData = $cachedData;
 		Filesystem::rmdir('bar_folder');
 		$this->assertFalse($this->cache->inCache('bar_folder'));
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 	}
 
@@ -174,11 +190,15 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($cache2->inCache('foo.txt'));
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $substorageCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($substorageCachedData['mtime'], $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $folderCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($folderCachedData['mtime'], $cachedData['mtime']);
 	}
 
@@ -199,7 +219,9 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$mtime = $cachedData['mtime'];
 		$cachedData = $this->cache->get('');
 		$this->assertEquals(3 * $textSize + $imageSize, $cachedData['size']);
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 	}
 
 	public function testRenameExtension() {
@@ -227,12 +249,16 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$mtime = $cachedData['mtime'];
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $substorageCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
 //		$this->assertEquals($mtime, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $folderCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
 //		$this->assertEquals($mtime, $cachedData['mtime']);
 	}
@@ -242,11 +268,15 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$fooCachedData = $this->cache->get('foo.txt');
 		Filesystem::touch('foo.txt');
 		$cachedData = $this->cache->get('foo.txt');
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $fooCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($fooCachedData['mtime'], $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertGreaterThanOrEqual($rootCachedData['mtime'], $cachedData['mtime']);
 		$rootCachedData = $cachedData;
 
@@ -255,14 +285,20 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$folderCachedData = $this->cache->get('folder');
 		Filesystem::touch('folder/bar.txt', $time);
 		$cachedData = $this->cache->get('folder/bar.txt');
-		$this->assertNotEquals($barCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $barCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($barCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($time, $cachedData['mtime']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $folderCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 
 		$cachedData = $this->cache->get('');
-		$this->assertNotEquals($rootCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $rootCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($rootCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($time, $cachedData['mtime']);
 	}
 
@@ -279,14 +315,20 @@ class Updater extends \PHPUnit_Framework_TestCase {
 		$time = 1371006070;
 		Filesystem::touch('folder/substorage/foo.txt', $time);
 		$cachedData = $cache2->get('foo.txt');
-		$this->assertNotEquals($fooCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $fooCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($fooCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($time, $cachedData['mtime']);
 
 		$cachedData = $cache2->get('');
-		$this->assertNotEquals($substorageCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $substorageCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 
 		$cachedData = $this->cache->get('folder');
-		$this->assertNotEquals($folderCachedData['etag'], $cachedData['etag']);
+		$this->assertInternalType('string', $folderCachedData['etag']);
+		$this->assertInternalType('string', $cachedData['etag']);
+		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		$this->assertEquals($time, $cachedData['mtime']);
 	}
 

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -122,6 +122,7 @@ class Updater extends \PHPUnit_Framework_TestCase {
 
 	public function testWriteWithMountPoints() {
 		$storage2 = new \OC\Files\Storage\Temporary(array());
+		$storage2->getScanner()->scan(''); //initialize etags
 		$cache2 = $storage2->getCache();
 		Filesystem::mount($storage2, array(), '/' . self::$user . '/files/folder/substorage');
 		$folderCachedData = $this->cache->get('folder');

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -65,7 +65,11 @@ class EtagTest extends \PHPUnit_Framework_TestCase {
 		$scanner = new \OC\Files\Utils\Scanner($user1);
 		$scanner->backgroundScan('/');
 
-		$this->assertEquals($originalEtags, $this->getEtags($files));
+		$newEtags = $this->getEtags($files);
+		// loop over array and use assertSame over assertEquals to prevent false positives
+		foreach ($originalEtags as $file => $originalEtag) {
+			$this->assertSame($originalEtag, $newEtags[$file]);
+		}
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -563,6 +563,6 @@ class View extends \PHPUnit_Framework_TestCase {
 		$scanner->scanFile('test', \OC\Files\Cache\Scanner::REUSE_ETAG);
 
 		$info2 = $view->getFileInfo('/test/test');
-		$this->assertEquals($info['etag'], $info2['etag']);
+		$this->assertSame($info['etag'], $info2['etag']);
 	}
 }


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/7436, split from https://github.com/owncloud/core/pull/7438, added type checking when using assertNotSame.

@PVince81 @bantu @DeepDiver1975 @MorrisJobke @schiesbn should now be an easy review.
