### PR TITLE
Installation: relabel 'Advanced' to more descriptive 'Storage & database'

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -67,7 +67,7 @@
 
 	<?php if(!$_['directoryIsSet'] OR !$_['dbIsSet'] OR count($_['errors']) > 0): ?>
 	<fieldset id="advancedHeader">
-		<legend><a id="showAdvanced"><?php p($l->t( 'Advanced' )); ?> <img class="svg" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" /></a></legend>
+		<legend><a id="showAdvanced"><?php p($l->t( 'Storage & database' )); ?> <img class="svg" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>" /></a></legend>
 	</fieldset>
 	<?php endif; ?>
 


### PR DESCRIPTION
A little bit of polish, hopefully makes the installation more understandable and puts a bit more emphasis on that the database can be changed (for people who don’t want to use SQLite). Please review @owncloud/designers @DeepDiver1975 

Backport yes/no @karlitschek
