### PR TITLE
icons: automatically show delete hover instead of using explicit class

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -66,7 +66,8 @@
 .icon-delete {
 	background-image: url('../img/actions/delete.svg');
 }
-.icon-delete-hover {
+.icon-delete:hover,
+.icon-delete:focus {
 	background-image: url('../img/actions/delete-hover.svg');
 }
 


### PR DESCRIPTION
Fix the need for app developers to manually add the hover state.

Please review @tanghus @owncloud/designers 

Also, we should probably backport all the icons.css changes. This, and https://github.com/owncloud/core/pull/7382 (by @jbtbnl), and https://github.com/owncloud/core/commits/master/core/css/icons.css Ok @karlitschek @DeepDiver1975?
