### PR TITLE
[enc] remember original fopen access type in pre-proxy

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -38,6 +38,7 @@ class Proxy extends \OC_FileProxy {
 
 	private static $blackList = null; //mimetypes blacklisted from encryption
 	private static $unencryptedSizes = array(); // remember unencrypted size
+	private static $fopenMode = array(); // remember the fopen mode
 
 	/**
 	 * Check if a file requires encryption
@@ -214,6 +215,16 @@ class Proxy extends \OC_FileProxy {
 	}
 
 	/**
+	 * @brief remember initial fopen mode because sometimes it gets changed during the request
+	 * @param string $path path
+	 * @param string $mode type of access
+	 */
+	public function preFopen($path, $mode) {
+		self::$fopenMode[$path] = $mode;
+	}
+
+
+	/**
 	 * @param $path
 	 * @param $result
 	 * @return resource
@@ -240,7 +251,15 @@ class Proxy extends \OC_FileProxy {
 		$proxyStatus = \OC_FileProxy::$enabled;
 		\OC_FileProxy::$enabled = false;
 
-		$meta = stream_get_meta_data($result);
+		// if we remember the mode from the pre proxy we re-use it
+		// oterwise we fall back to stream_get_meta_data()
+		if (isset(self::$fopenMode[$path])) {
+			$mode = self::$fopenMode[$path];
+			unset(self::$fopenMode[$path]);
+		} else {
+			$meta = stream_get_meta_data($result);
+			$mode = $meta['mode'];
+		}
 
 		$view = new \OC_FilesystemView('');
 
@@ -258,14 +277,15 @@ class Proxy extends \OC_FileProxy {
 
 			// Open the file using the crypto stream wrapper
 			// protocol and let it do the decryption work instead
-			$result = fopen('crypt://' . $path, $meta['mode']);
+			$result = fopen('crypt://' . $path, $mode);
 
 		} elseif (
-			self::shouldEncrypt($path)
-			and $meta['mode'] !== 'r'
-				and $meta['mode'] !== 'rb'
+				self::shouldEncrypt($path)
+				and $mode !== 'r'
+				and $mode !== 'rb'
+
 		) {
-			$result = fopen('crypt://' . $path, $meta['mode']);
+			$result = fopen('crypt://' . $path, $mode);
 		}
 
 		// Re-enable the proxy

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -167,6 +167,9 @@ class Stream {
 		} else {
 
 			$this->meta = stream_get_meta_data($this->handle);
+			// sometimes fopen changes the mode, e.g. for a url "r" convert to "r+"
+			// but we need to remember the original access type
+			$this->meta['mode'] = $mode;
 
 		}
 


### PR DESCRIPTION
remember original fopen access type in pre-proxy because sometimes they change during the fopen call, e.g. 'r' becomes 'r+' if we open an URL.

This fixes failing downloads of unencrypted files while encryption is enabled from a ftp mount.

@PVince81 this could also solve the webdav problems we discussed yesterday, but at the moment I don't have a webdav to test. Will try it tomorrow.

@ser72 This could also solve the S3 issue you reported #7428. Maybe you can give it a try...
