### PR TITLE
[stable5] Backport exception logger for Sabre connector

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -49,6 +49,7 @@ $server->addPlugin(new Sabre_DAV_Locks_Plugin($lockBackend));
 $server->addPlugin(new Sabre_DAV_Browser_Plugin(false)); // Show something in the Browser, but no upload
 $server->addPlugin(new OC_Connector_Sabre_QuotaPlugin());
 $server->addPlugin(new OC_Connector_Sabre_MaintenancePlugin());
+$server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('webdav'));
 
 // And off we go!
 $server->exec();

--- a/lib/connector/sabre/exceptionloggerplugin.php
+++ b/lib/connector/sabre/exceptionloggerplugin.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
+ *
+ * @license AGPL3
+ */
+
+class OC_Connector_Sabre_ExceptionLoggerPlugin extends Sabre_DAV_ServerPlugin
+{
+	private $appName;
+
+	/**
+	 * @param string $loggerAppName app name to use when logging
+	 */
+	public function __construct($loggerAppName = 'webdav') {
+		$this->appName = $loggerAppName;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre_DAV_Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Sabre_DAV_Server $server
+	 * @return void
+	 */
+	public function initialize(Sabre_DAV_Server $server) {
+
+		$server->subscribeEvent('exception', array($this, 'logException'), 10);
+	}
+
+	/**
+	 * Log exception
+	 *
+	 * @internal param Exception $e exception
+	 */
+	public function logException($e) {
+		$exceptionClass = get_class($e);
+		if ($exceptionClass !== 'Sabre_DAV_Exception_NotAuthenticated') {
+			\OCP\Util::logException($this->appName, $e);
+		}
+	}
+}

--- a/lib/connector/sabre/file.php
+++ b/lib/connector/sabre/file.php
@@ -81,7 +81,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 		if ($renameOkay === false || $fileExists === false) {
 			\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
 			\OC\Files\Filesystem::unlink($partpath);
-			throw new Sabre_DAV_Exception();
+			throw new Sabre_DAV_Exception('Could not rename part file to final file');
 		}
 
 

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -78,6 +78,43 @@ class Util {
 	}
 
 	/**
+	 * write exception into the log. Include the stack trace
+	 * if DEBUG mode is enabled
+	 * @param string $app app name
+	 * @param Exception $ex exception to log
+	 */
+	public static function logException( $app, \Exception $ex ) {
+		$class = get_class($ex);
+		if ($class !== 'Exception') {
+			$message = $class . ': ';
+		}
+		$message .= $ex->getMessage();
+		if ($ex->getCode()) {
+			$message .= ' [' . $ex->getCode() . ']';
+		}
+		\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
+		if (defined('DEBUG') and DEBUG) {
+			// also log stack trace
+			$stack = explode("\n", $ex->getTraceAsString());
+			// first element is empty
+			array_shift($stack);
+			foreach ($stack as $s) {
+				\OCP\Util::writeLog($app, 'Exception: ' . $s, \OCP\Util::FATAL);
+			}
+
+			// include cause
+			while (method_exists($ex, 'getPrevious') && $ex = $ex->getPrevious()) {
+				$message .= ' - Caused by:' . ' ';
+				$message .= $ex->getMessage();
+				if ($ex->getCode()) {
+					$message .= '[' . $ex->getCode() . '] ';
+				}
+				\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
+			}
+		}
+	}
+
+	/**
 	 * @brief add a css file
 	 * @param string $url
 	 */


### PR DESCRIPTION
To improve sync issue debugging on stable5.

Backport of https://github.com/owncloud/core/pull/6907

Note: I had to copy the method `OCP\Util::logException` from master because it didn't exist on stable5. It is currently only used by the sabre exception logger.

I've tested sync upload + sync download and also tried to trigger an error by adding a "throw" in `connector/file.php` to simulate an error. The exception was logged properly.

Please review @karlitschek @DeepDiver1975 @tanghus 
