### PR TITLE
[stable6] Fixed wrong field name

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -146,7 +146,7 @@ class Proxy extends \OC_FileProxy {
 		if ( isset(self::$unencryptedSizes[$normalizedPath]) ) {
 			$view = new \OC_FilesystemView('/');
 			$view->putFileInfo($normalizedPath,
-					array('encrypted' => true, 'encrypted_size' => self::$unencryptedSizes[$normalizedPath]));
+					array('encrypted' => true, 'unencrypted_size' => self::$unencryptedSizes[$normalizedPath]));
 			unset(self::$unencryptedSizes[$normalizedPath]);
 		}
 


### PR DESCRIPTION
This re-fixes an issue where the unencrypted size isn't updated
correctly when saving a text file in the UI multiple times.

Fixes #7467 

Please review and test @schiesbn @karlitschek @icewind1991 @DeepDiver1975
