### PR TITLE
CSS is now loaded directly instead via PHP

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -147,7 +147,7 @@ class OC_Setup {
 		$content.= "RewriteRule ^.well-known/host-meta /public.php?service=host-meta [QSA,L]\n";
 		$content.= "RewriteRule ^.well-known/carddav /remote.php/carddav/ [R]\n";
 		$content.= "RewriteRule ^.well-known/caldav /remote.php/caldav/ [R]\n";
-		$content.= "RewriteRule ^apps/([^/]*)/(.*\.(css|php))$ index.php?app=$1&getfile=$2 [QSA,L]\n";
+		$content.= "RewriteRule ^apps/([^/]*)/(.*\.(php))$ index.php?app=$1&getfile=$2 [QSA,L]\n";
 		$content.= "RewriteRule ^remote/(.*) remote.php [QSA,L]\n";
 		$content.= "</IfModule>\n";
 		$content.= "<IfModule mod_mime.c>\n";


### PR DESCRIPTION
269f24cf9617397aaf501b27ec1af2c8e3154cf8 was not changed in setup.php which prevented loading of CSS files in some environments (e.g. my local setup) for apps.

@DeepDiver1975 
