### PR TITLE
replace spaces in download link without encoding entire URL

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -218,6 +218,8 @@ class OC_App{
 			}else{
 				$appdata=OC_OCSClient::getApplication($app);
 				$download=OC_OCSClient::getApplicationDownload($app, 1);
+				// Replace spaces in download link without encoding entire URL
+				$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
 				if(isset($download['downloadlink']) and $download['downloadlink']!='') {
 					$info = array('source'=>'http', 'href'=>$download['downloadlink'], 'appdata'=>$appdata);
 					$app=OC_Installer::installApp($info);

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -218,9 +218,9 @@ class OC_App{
 			}else{
 				$appdata=OC_OCSClient::getApplication($app);
 				$download=OC_OCSClient::getApplicationDownload($app, 1);
-				// Replace spaces in download link without encoding entire URL
-				$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
 				if(isset($download['downloadlink']) and $download['downloadlink']!='') {
+					// Replace spaces in download link without encoding entire URL
+					$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
 					$info = array('source'=>'http', 'href'=>$download['downloadlink'], 'appdata'=>$appdata);
 					$app=OC_Installer::installApp($info);
 				}


### PR DESCRIPTION
Reworked old PR to fix errors if app download link URL has spaces in it.

Original closed PR #4303
