### PR TITLE
Allow XML entity loader for MDB2 schema loader

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -41,7 +41,9 @@ class MDB2SchemaReader {
 	 */
 	public function loadSchemaFromFile($file) {
 		$schema = new \Doctrine\DBAL\Schema\Schema();
+		$loadEntities = libxml_disable_entity_loader(false);
 		$xml = simplexml_load_file($file);
+		libxml_disable_entity_loader($loadEntities);
 		foreach ($xml->children() as $child) {
 			/**
 			 * @var \SimpleXMLElement $child


### PR DESCRIPTION
Fixes #7466 

@LukasReschke @karlitschek @DeepDiver1975 

I'll grep the code to find other potential cases.
