### PR TITLE
Do not override button background image

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -204,18 +204,18 @@ textarea:disabled {
 /* Primary action button, use sparingly */
 .primary, input[type="submit"].primary, input[type="button"].primary, button.primary, .button.primary {
 	border: 1px solid #1d2d44;
-	background: #35537a;
+	background-color: #35537a;
 	color: #ddd;
 }
 	.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,
 	.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {
 		border: 1px solid #1d2d44;
-		background: #304d76;
+		background-color: #304d76;
 		color: #fff;
 	}
 	.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {
 		border: 1px solid #1d2d44;
-		background: #1d2d44;
+		background-color: #1d2d44;
 		color: #bbb;
 	}
 
@@ -233,7 +233,7 @@ textarea:disabled {
 }
 
 input[type="submit"].enabled {
-	background: #66f866;
+	background-color: #66f866;
 	border: 1px solid #5e5;
 }
 


### PR DESCRIPTION
Use a weaker CSS declaration for the background color of buttons. This enables the use of background images in buttons without the need for an !important declaration to override owncloud/core CSS.

This change is necessary to fix https://github.com/owncloud/contacts/issues/351 after the introduction of https://github.com/owncloud/core/pull/6912 and https://github.com/owncloud/core/pull/7310

CC @jancborchardt
