### PR TITLE
Fix mail template to use p() for colors

### DIFF
--- a/core/templates/mail.php
+++ b/core/templates/mail.php
@@ -2,9 +2,9 @@
 <tr><td>
 <table cellspacing="0" cellpadding="0" border="0" width="600px">
 <tr>
-<td bgcolor="<?php print_unescaped($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
-<td bgcolor="<?php print_unescaped($theme->getMailHeaderColor());?>">
-<img src="<?php print_unescaped(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
+<img src="<?php p(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
 </td>
 </tr>
 <tr><td colspan="2">&nbsp;</td></tr>
@@ -27,7 +27,7 @@ p($l->t('Cheers!'));
 <td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
 <?php p($theme->getName()); ?> -
 <?php p($theme->getSlogan()); ?>
-<br><a href="<?php print_unescaped($theme->getBaseUrl()); ?>"><?php print_unescaped($theme->getBaseUrl());?></a>
+<br><a href="<?php p($theme->getBaseUrl()); ?>"><?php p($theme->getBaseUrl());?></a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Now using p() instead of print_unescaped() for colors and URLs

@LukasReschke @jancborchardt @karlitschek 
