### PR TITLE
[WIP] Prevent creating part files from the UI

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -106,6 +106,20 @@ $result = array();
 if (strpos($dir, '..') === false) {
 	$fileCount = count($files['name']);
 	for ($i = 0; $i < $fileCount; $i++) {
+		if (!\OCP\Util::isValidFileName($files['name'][$i])) {
+			$result[] = array(
+				'status' => 'invalidfilename',
+				'data' => array(
+					'message' =>
+						$l->t(
+							"Invalid name, '\\', '/', '<', '>', ':', '\"', '|', '?' and '*' are not allowed."
+						),
+					'name' => $files['name'][$i]
+				)
+			);
+			continue;
+		}
+
 		// $path needs to be normalized - this failed within drag'n'drop upload to a sub-folder
 		if (isset($_POST['resolution']) && $_POST['resolution']==='autorename') {
 			// append a number in brackets like 'filename (2).ext'

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -54,6 +54,15 @@ class App {
 			'data'		=> NULL
 		);
 
+		if (!\OCP\Util::isValidFileName($newname)) {
+			$result['data'] = array('message' =>
+				(string)$this->l10n->t(
+					"Invalid name, '\\', '/', '<', '>', ':', '\"', '|', '?' and '*' are not allowed."
+				)
+			);
+			return $result;
+		}
+
 		// rename to "/Shared" is denied
 		if( $dir === '/' and $newname === 'Shared' ) {
 			$result['data'] = array(

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1167,6 +1167,10 @@ class OC_Util {
 		if ($trimmed === '.' || $trimmed === '..') {
 			return false;
 		}
+		$path_parts = pathinfo($trimmed);
+		if ($path_parts['extension'] === 'part') {
+			return false;
+		}
 		foreach (str_split($trimmed) as $char) {
 			if (strpos(\OCP\FILENAME_INVALID_CHARS, $char) !== false) {
 				return false;


### PR DESCRIPTION
Fixes #7496 

This PR prevents users to create part files from the web UI.

Since we changed an important utility method (isValidFileName), a few things need to be retested:
- [x] Test that WebDAV upload still works
- [x] Test that sync client upload still works with small files (part files)
- [x] Test that sync client upload still works with small files (part files + chunking)
- [x] Test with external storage using a backend ownCloud with this branch (sync upload must still work) :no_entry_sign: FAIL
- [x] Test with external storage using a frontend ownCloud with this branch (sync upload must still 
- [ ] Improve error messages ? [minor]
- [ ] merge this once ownCloud 7.0 is EoL -> 9.0 
