### PR TITLE
update wording of email field

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -83,7 +83,7 @@ if($_['passwordChangeSupported']) {
 			placeholder="<?php p($l->t('Your email address'));?>"
 			autocomplete="on" autocapitalize="off" autocorrect="off" />
 		<span class="msg"></span><br />
-		<em><?php p($l->t('Fill in an email address to enable password recovery'));?></em>
+		<em><?php p($l->t('Fill in an email address to enable password recovery and receive notifications'));?></em>
 	</fieldset>
 </form>
 <?php


### PR DESCRIPTION
fixes #7505

cc @jancborchardt @PVince81 

Maybe one of you want to review (I mention you because you recently added changes to owncloud):
@ganomi @elchi @McNetic @miicha @ccerrillo @jbtbnl @MartialGeek @vsapronov @jcfischer @zombiehugs @AxelRb @GuillaumeAmat @petemcfarlane @frisco82 @ogasser @leo-b @tripflex @pellaeon @nickvergessen 

We need two thumbs up to merge into core. Thumbs up can be done by "colon"+1"colon". 
How to review: Check out this pull request and test if it works.

```
git fetch origin
git checkout -b email-field-wording origin/email-field-wording
```
