### PR TITLE
Add caching for getLocalFile on remote storages

### DIFF
--- a/apps/files_external/lib/webdav.php
+++ b/apps/files_external/lib/webdav.php
@@ -8,7 +8,7 @@
 
 namespace OC\Files\Storage;
 
-class DAV extends \OC\Files\Storage\Common{
+class DAV extends \OC\Files\Storage\Common {
 	private $password;
 	private $user;
 	private $host;
@@ -21,7 +21,7 @@ class DAV extends \OC\Files\Storage\Common{
 	 */
 	private $client;
 
-	private static $tempFiles=array();
+	private static $tempFiles = array();
 
 	public function __construct($params) {
 		if (isset($params['host']) && isset($params['user']) && isset($params['password'])) {
@@ -29,9 +29,9 @@ class DAV extends \OC\Files\Storage\Common{
 			//remove leading http[s], will be generated in createBaseUri()
 			if (substr($host, 0, 8) == "https://") $host = substr($host, 8);
 			else if (substr($host, 0, 7) == "http://") $host = substr($host, 7);
-			$this->host=$host;
-			$this->user=$params['user'];
-			$this->password=$params['password'];
+			$this->host = $host;
+			$this->user = $params['user'];
+			$this->password = $params['password'];
 			if (isset($params['secure'])) {
 				if (is_string($params['secure'])) {
 					$this->secure = ($params['secure'] === 'true');
@@ -42,25 +42,25 @@ class DAV extends \OC\Files\Storage\Common{
 				$this->secure = false;
 			}
 			if ($this->secure === true) {
-				$certPath=\OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
+				$certPath = \OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
 				if (file_exists($certPath)) {
-					$this->certPath=$certPath;
+					$this->certPath = $certPath;
 				}
 			}
-			$this->root=isset($params['root'])?$params['root']:'/';
-			if ( ! $this->root || $this->root[0]!='/') {
-				$this->root='/'.$this->root;
+			$this->root = isset($params['root']) ? $params['root'] : '/';
+			if (!$this->root || $this->root[0] != '/') {
+				$this->root = '/' . $this->root;
 			}
-			if (substr($this->root, -1, 1)!='/') {
-				$this->root.='/';
+			if (substr($this->root, -1, 1) != '/') {
+				$this->root .= '/';
 			}
 		} else {
 			throw new \Exception();
 		}
 	}
 
-	private function init(){
-		if($this->ready) {
+	private function init() {
+		if ($this->ready) {
 			return;
 		}
 		$this->ready = true;
@@ -78,28 +78,28 @@ class DAV extends \OC\Files\Storage\Common{
 		}
 	}
 
-	public function getId(){
+	public function getId() {
 		return 'webdav::' . $this->user . '@' . $this->host . '/' . $this->root;
 	}
 
 	protected function createBaseUri() {
-		$baseUri='http';
+		$baseUri = 'http';
 		if ($this->secure) {
-			$baseUri.='s';
+			$baseUri .= 's';
 		}
-		$baseUri.='://'.$this->host.$this->root;
+		$baseUri .= '://' . $this->host . $this->root;
 		return $baseUri;
 	}
 
 	public function mkdir($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		return $this->simpleResponse('MKCOL', $path, null, 201);
 	}
 
 	public function rmdir($path) {
 		$this->init();
-		$path=$this->cleanPath($path) . '/';
+		$path = $this->cleanPath($path) . '/';
 		// FIXME: some WebDAV impl return 403 when trying to DELETE
 		// a non-empty folder
 		return $this->simpleResponse('DELETE', $path, null, 204);
@@ -107,35 +107,35 @@ class DAV extends \OC\Files\Storage\Common{
 
 	public function opendir($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
-			$response=$this->client->propfind($this->encodePath($path), array(), 1);
-			$id=md5('webdav'.$this->root.$path);
+			$response = $this->client->propfind($this->encodePath($path), array(), 1);
+			$id = md5('webdav' . $this->root . $path);
 			$content = array();
-			$files=array_keys($response);
-			array_shift($files);//the first entry is the current directory
+			$files = array_keys($response);
+			array_shift($files); //the first entry is the current directory
 			foreach ($files as $file) {
 				$file = urldecode(basename($file));
-				$content[]=$file;
+				$content[] = $file;
 			}
 			\OC\Files\Stream\Dir::register($id, $content);
-			return opendir('fakedir://'.$id);
-		} catch(\Exception $e) {
+			return opendir('fakedir://' . $id);
+		} catch (\Exception $e) {
 			return false;
 		}
 	}
 
 	public function filetype($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
-			$response=$this->client->propfind($this->encodePath($path), array('{DAV:}resourcetype'));
+			$response = $this->client->propfind($this->encodePath($path), array('{DAV:}resourcetype'));
 			$responseType = array();
 			if (isset($response["{DAV:}resourcetype"])) {
-				$responseType=$response["{DAV:}resourcetype"]->resourceType;
+				$responseType = $response["{DAV:}resourcetype"]->resourceType;
 			}
-			return (count($responseType)>0 and $responseType[0]=="{DAV:}collection")?'dir':'file';
-		} catch(\Exception $e) {
+			return (count($responseType) > 0 and $responseType[0] == "{DAV:}collection") ? 'dir' : 'file';
+		} catch (\Exception $e) {
 			error_log($e->getMessage());
 			\OCP\Util::writeLog("webdav client", \OCP\Util::sanitizeHTML($e->getMessage()), \OCP\Util::ERROR);
 			return false;
@@ -144,11 +144,11 @@ class DAV extends \OC\Files\Storage\Common{
 
 	public function file_exists($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
 			$this->client->propfind($this->encodePath($path), array('{DAV:}resourcetype'));
-			return true;//no 404 exception
-		} catch(\Exception $e) {
+			return true; //no 404 exception
+		} catch (\Exception $e) {
 			return false;
 		}
 	}
@@ -160,34 +160,34 @@ class DAV extends \OC\Files\Storage\Common{
 
 	public function fopen($path, $mode) {
 		$this->init();
-		$path=$this->cleanPath($path);
-		switch($mode) {
+		$path = $this->cleanPath($path);
+		switch ($mode) {
 			case 'r':
 			case 'rb':
-				if ( ! $this->file_exists($path)) {
+				if (!$this->file_exists($path)) {
 					return false;
 				}
 				//straight up curl instead of sabredav here, sabredav put's the entire get result in memory
 				$curl = curl_init();
 				$fp = fopen('php://temp', 'r+');
-				curl_setopt($curl, CURLOPT_USERPWD, $this->user.':'.$this->password);
-				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().$this->encodePath($path));
+				curl_setopt($curl, CURLOPT_USERPWD, $this->user . ':' . $this->password);
+				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri() . $this->encodePath($path));
 				curl_setopt($curl, CURLOPT_FILE, $fp);
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 				if ($this->secure === true) {
 					curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
 					curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-					if($this->certPath){
+					if ($this->certPath) {
 						curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
 					}
 				}
-				
-				curl_exec ($curl);
+
+				curl_exec($curl);
 				$statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 				if ($statusCode !== 200) {
 					\OCP\Util::writeLog("webdav client", 'curl GET ' . curl_getinfo($curl, CURLINFO_EFFECTIVE_URL) . ' returned status code ' . $statusCode, \OCP\Util::ERROR);
 				}
-				curl_close ($curl);
+				curl_close($curl);
 				rewind($fp);
 				return $fp;
 			case 'w':
@@ -203,18 +203,19 @@ class DAV extends \OC\Files\Storage\Common{
 			case 'c':
 			case 'c+':
 				//emulate these
-				if (strrpos($path, '.')!==false) {
-					$ext=substr($path, strrpos($path, '.'));
+				if (strrpos($path, '.') !== false) {
+					$ext = substr($path, strrpos($path, '.'));
 				} else {
-					$ext='';
+					$ext = '';
 				}
-				$tmpFile = \OCP\Files::tmpFile($ext);
+				if ($this->file_exists($path)) {
+					$tmpFile = $this->getCachedFile($path);
+				} else {
+					$tmpFile = \OCP\Files::tmpFile($ext);
+				}
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
-				if($this->file_exists($path)) {
-					$this->getFile($path, $tmpFile);
-				}
-				self::$tempFiles[$tmpFile]=$path;
-				return fopen('close://'.$tmpFile, $mode);
+				self::$tempFiles[$tmpFile] = $path;
+				return fopen('close://' . $tmpFile, $mode);
 		}
 	}
 
@@ -227,32 +228,31 @@ class DAV extends \OC\Files\Storage\Common{
 
 	public function free_space($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
-			$response=$this->client->propfind($this->encodePath($path), array('{DAV:}quota-available-bytes'));
+			$response = $this->client->propfind($this->encodePath($path), array('{DAV:}quota-available-bytes'));
 			if (isset($response['{DAV:}quota-available-bytes'])) {
 				return (int)$response['{DAV:}quota-available-bytes'];
 			} else {
 				return \OC\Files\SPACE_UNKNOWN;
 			}
-		} catch(\Exception $e) {
+		} catch (\Exception $e) {
 			return \OC\Files\SPACE_UNKNOWN;
 		}
 	}
 
-	public function touch($path, $mtime=null) {
+	public function touch($path, $mtime = null) {
 		$this->init();
 		if (is_null($mtime)) {
-			$mtime=time();
+			$mtime = time();
 		}
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 
 		// if file exists, update the mtime, else create a new empty file
 		if ($this->file_exists($path)) {
 			try {
 				$this->client->proppatch($this->encodePath($path), array('{DAV:}lastmodified' => $mtime));
-			}
-			catch (\Sabre_DAV_Exception_NotImplemented $e) {
+			} catch (\Sabre_DAV_Exception_NotImplemented $e) {
 				return false;
 			}
 		} else {
@@ -261,23 +261,13 @@ class DAV extends \OC\Files\Storage\Common{
 		return true;
 	}
 
-	/**
-	 * @param string $path
-	 * @param string $target
-	 */
-	public function getFile($path, $target) {
+	protected function uploadFile($path, $target) {
 		$this->init();
-		$source=$this->fopen($path, 'r');
-		file_put_contents($target, $source);
-	}
-
-	public function uploadFile($path, $target) {
-		$this->init();
-		$source=fopen($path, 'r');
+		$source = fopen($path, 'r');
 
 		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_USERPWD, $this->user.':'.$this->password);
-		curl_setopt($curl, CURLOPT_URL, $this->createBaseUri().str_replace(' ', '%20', $target));
+		curl_setopt($curl, CURLOPT_USERPWD, $this->user . ':' . $this->password);
+		curl_setopt($curl, CURLOPT_URL, $this->createBaseUri() . str_replace(' ', '%20', $target));
 		curl_setopt($curl, CURLOPT_BINARYTRANSFER, true);
 		curl_setopt($curl, CURLOPT_INFILE, $source); // file pointer
 		curl_setopt($curl, CURLOPT_INFILESIZE, filesize($path));
@@ -285,26 +275,29 @@ class DAV extends \OC\Files\Storage\Common{
 		if ($this->secure === true) {
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-			if($this->certPath){
+			if ($this->certPath) {
 				curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
 			}
 		}
-		curl_exec ($curl);
+		curl_exec($curl);
 		$statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 		if ($statusCode !== 200) {
 			\OCP\Util::writeLog("webdav client", 'curl GET ' . curl_getinfo($curl, CURLINFO_EFFECTIVE_URL) . ' returned status code ' . $statusCode, \OCP\Util::ERROR);
 		}
-		curl_close ($curl);
+		curl_close($curl);
+		$this->removeCachedFile($target);
 	}
 
 	public function rename($path1, $path2) {
 		$this->init();
 		$path1 = $this->encodePath($this->cleanPath($path1));
-		$path2 = $this->createBaseUri().$this->encodePath($this->cleanPath($path2));
+		$path2 = $this->createBaseUri() . $this->encodePath($this->cleanPath($path2));
 		try {
-			$this->client->request('MOVE', $path1, null, array('Destination'=>$path2));
+			$this->client->request('MOVE', $path1, null, array('Destination' => $path2));
+			$this->removeCachedFile($path1);
+			$this->removeCachedFile($path2);
 			return true;
-		} catch(\Exception $e) {
+		} catch (\Exception $e) {
 			return false;
 		}
 	}
@@ -312,47 +305,48 @@ class DAV extends \OC\Files\Storage\Common{
 	public function copy($path1, $path2) {
 		$this->init();
 		$path1 = $this->encodePath($this->cleanPath($path1));
-		$path2 = $this->createBaseUri().$this->encodePath($this->cleanPath($path2));
+		$path2 = $this->createBaseUri() . $this->encodePath($this->cleanPath($path2));
 		try {
-			$this->client->request('COPY', $path1, null, array('Destination'=>$path2));
+			$this->client->request('COPY', $path1, null, array('Destination' => $path2));
+			$this->removeCachedFile($path2);
 			return true;
-		} catch(\Exception $e) {
+		} catch (\Exception $e) {
 			return false;
 		}
 	}
 
 	public function stat($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
 			$response = $this->client->propfind($this->encodePath($path), array('{DAV:}getlastmodified', '{DAV:}getcontentlength'));
 			return array(
-				'mtime'=>strtotime($response['{DAV:}getlastmodified']),
-				'size'=>(int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
+				'mtime' => strtotime($response['{DAV:}getlastmodified']),
+				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 			);
-		} catch(\Exception $e) {
+		} catch (\Exception $e) {
 			return array();
 		}
 	}
 
 	public function getMimeType($path) {
 		$this->init();
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
-			$response=$this->client->propfind($this->encodePath($path), array('{DAV:}getcontenttype', '{DAV:}resourcetype'));
+			$response = $this->client->propfind($this->encodePath($path), array('{DAV:}getcontenttype', '{DAV:}resourcetype'));
 			$responseType = array();
 			if (isset($response["{DAV:}resourcetype"])) {
-				$responseType=$response["{DAV:}resourcetype"]->resourceType;
+				$responseType = $response["{DAV:}resourcetype"]->resourceType;
 			}
-			$type=(count($responseType)>0 and $responseType[0]=="{DAV:}collection")?'dir':'file';
-			if ($type=='dir') {
+			$type = (count($responseType) > 0 and $responseType[0] == "{DAV:}collection") ? 'dir' : 'file';
+			if ($type == 'dir') {
 				return 'httpd/unix-directory';
 			} elseif (isset($response['{DAV:}getcontenttype'])) {
 				return $response['{DAV:}getcontenttype'];
 			} else {
 				return false;
 			}
-		} catch(\Exception $e) {
+		} catch (\Exception $e) {
 			return false;
 		}
 	}
@@ -368,6 +362,7 @@ class DAV extends \OC\Files\Storage\Common{
 
 	/**
 	 * URL encodes the given path but keeps the slashes
+	 *
 	 * @param string $path to encode
 	 * @return string encoded path
 	 */
@@ -382,11 +377,11 @@ class DAV extends \OC\Files\Storage\Common{
 	 * @param integer $expected
 	 */
 	private function simpleResponse($method, $path, $body, $expected) {
-		$path=$this->cleanPath($path);
+		$path = $this->cleanPath($path);
 		try {
-			$response=$this->client->request($method, $this->encodePath($path), $body);
-			return $response['statusCode']==$expected;
-		} catch(\Exception $e) {
+			$response = $this->client->request($method, $this->encodePath($path), $body);
+			return $response['statusCode'] == $expected;
+		} catch (\Exception $e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Fixes #6509

This adds caching for the common implementation of `getLocalFile` and caching for `fopen` in the webdav storage.
Additional caching can be add for other storage backends later.

cc @DeepDiver1975 @PVince81 
