### PR TITLE
[stable6] Added trusted domain warning if untrusted host used

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -713,6 +713,15 @@ function fillWindow(selector) {
 function initCore() {
 
 	/**
+	 * Shows a warning if the current domain isn't trusted
+	 */
+	function checkDomain() {
+		if (!$('head').data('trusteddomain')) {
+			OC.Notification.show(t('core', 'Warning: you are accessing this page from an untrusted domain. Please contact your administrator to fix this.'));
+		}
+	}
+
+	/**
 	 * Calls the server periodically to ensure that session doesnt
 	 * time out
 	 */
@@ -733,6 +742,8 @@ function initCore() {
 			}, interval * 1000);
 		});
 	}
+
+	window.setTimeout(checkDomain, 0);
 
 	// session heartbeat (defalts to enabled)
 	if (typeof(oc_config.session_keepalive) === 'undefined' ||

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -6,7 +6,7 @@
 <!--[if gt IE 9]><html class="ng-csp ie"><![endif]-->
 <!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 
-	<head data-requesttoken="<?php p($_['requesttoken']); ?>">
+<head data-requesttoken="<?php p($_['requesttoken']); ?>" data-trusteddomain="<?php p($_['trusteddomain']?'true':'false'); ?>">
 		<title>
 		<?php p($theme->getTitle()); ?>
 		</title>
@@ -39,6 +39,12 @@
 				<img src="<?php print_unescaped(image_path('', 'logo.svg')); ?>" class="svg" alt="<?php p($theme->getName()); ?>" />
 				<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 			</div></header>
+
+			<?php if (!$_['trusteddomain']) { ?>
+			<div class="error">
+				<?php p($l->t('Warning: you are accessing this page from an untrusted domain. Please contact your administrator to fix this.')); ?>
+			</div>
+			<?php } ?>
 
 			<?php print_unescaped($_['content']); ?>
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -6,7 +6,7 @@
 <!--[if gt IE 9]><html class="ng-csp ie"><![endif]-->
 <!--[if !IE]><!--><html class="ng-csp"><!--<![endif]-->
 
-	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
+	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>" data-trusteddomain="<?php p($_['trusteddomain']?'true':'false'); ?>">
 		<title>
 			<?php
 				p(!empty($_['application'])?$_['application'].' - ':'');

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -63,15 +63,7 @@ class OC_Request {
 			}
 		}
 
-		// Verify that the host is a trusted domain if the trusted domains
-		// are defined
-		// If no trusted domain is provided the first trusted domain is returned
-		if(self::isTrustedDomain($host) || \OC_Config::getValue('trusted_domains', "") === "") {
-			return $host;
-		} else {
-			$trustedList = \OC_Config::getValue('trusted_domains', array(''));
-			return $trustedList[0];
-		}
+		return $host;
 	}
 
 	/**

--- a/lib/private/template/base.php
+++ b/lib/private/template/base.php
@@ -17,6 +17,19 @@ class Base {
 	public function __construct( $template, $requesttoken, $l10n, $theme ) {
 		$this->vars = array();
 		$this->vars['requesttoken'] = $requesttoken;
+
+		// Check trusted domain
+		$this->vars['trusteddomain'] = true;
+		$trustedDomain = true;
+		$host = \OC_Request::serverHost();
+		// Verify that the host is a trusted domain if the trusted domains
+		// are defined
+		if (!\OC_Request::isTrustedDomain($host)
+			&& \OC_Config::getValue('trusted_domains', '') !== ''
+		) {
+			$this->vars['trusteddomain'] = false;
+		}
+
 		$this->l10n = $l10n;
 		$this->template = $template;
 		$this->theme = $theme;


### PR DESCRIPTION
- do not replace the current host any more but reuse it, even when
  untrusted
- show a warning on the login page inline and as notification in the app
  when an untrusted domain was used

TODOs:
- [x] show warning
- [ ] allow localhost as domain

Please review @karlitschek @LukasReschke @schiesbn 
