### PR TITLE
[enc] don't create users files folder

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -135,7 +135,6 @@ class Util {
 		// Set directories to check / create
 		$setUpDirs = array(
 			$this->userDir,
-			$this->userFilesDir,
 			$this->publicKeyDir,
 			$this->encryptionDir,
 			$this->keyfilesPath,


### PR DESCRIPTION
don't create users files folder, let ownCloud core handle it.

fix #7456 

cc @PVince81 @ser72 
