### PR TITLE
add hover/focus states for star icons to hint at action

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -156,11 +156,15 @@
 	background-image: url('../img/actions/sound-off.svg');
 }
 
-.icon-star {
+.icon-star,
+.icon-starred:hover,
+.icon-starred:focus {
 	background-image: url('../img/actions/star.svg');
 }
 
-.icon-starred {
+.icon-starred,
+.icon-star:hover,
+.icon-star:focus {
 	background-image: url('../img/actions/starred.svg');
 }
 


### PR DESCRIPTION
As mentioned by @tanghus in https://github.com/owncloud/core/commit/25e9b7a7423da5d8631d365250e7e5e5955b87b2#commitcomment-5563957

Please review @owncloud/designers 

This one should be backported as well, just like #7472 – ok @karlitschek?
