### PR TITLE
[stable6] Show warning page when accessing server from an untrusted domain

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -680,6 +680,22 @@ class OC {
 			exit();
 		}
 
+		$host = OC_Request::insecureServerHost();
+		// if the host passed in headers isn't trusted
+		if (!OC::$CLI
+			// overwritehost is always trusted
+			&& OC_Request::getOverwriteHost() === null
+			&& !OC_Request::isTrustedDomain($host)) {
+
+			header('HTTP/1.1 400 Bad Request');
+			header('Status: 400 Bad Request');
+			OC_Template::printErrorPage(
+				'You are accessing the server from an untrusted domain.',
+				'Please contact your administrator'
+			);
+			return;
+		}
+
 		$request = OC_Request::getPathInfo();
 		if (substr($request, -3) !== '.js') { // we need these files during the upgrade
 			self::checkMaintenanceMode();

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -57,7 +57,8 @@ class OC_Request {
 		$host = null;
 		if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
 			if (strpos($_SERVER['HTTP_X_FORWARDED_HOST'], ",") !== false) {
-				$host = trim(array_pop(explode(",", $_SERVER['HTTP_X_FORWARDED_HOST'])));
+				$parts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
+				$host = trim(current($parts));
 			} else {
 				$host = $_SERVER['HTTP_X_FORWARDED_HOST'];
 			}

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -12,6 +12,8 @@ class OC_Request {
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
 
+	const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost)(:[0-9]+|)$/';
+
 	/**
 	 * @brief Check overwrite condition
 	 * @param string $type
@@ -35,6 +37,9 @@ class OC_Request {
 	public static function isTrustedDomain($domain) {
 		$trustedList = \OC_Config::getValue('trusted_domains', array());
 		if (empty($trustedList)) {
+			return true;
+		}
+		if (preg_match(self::REGEX_LOCALHOST, $domain) === 1) {
 			return true;
 		}
 		return in_array($domain, $trustedList);

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -24,17 +24,64 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Checks whether a domain is considered as trusted. This is used to prevent Host Header Poisoning.
+	 * @brief Checks whether a domain is considered as trusted from the list
+	 * of trusted domains. If no trusted domains have been configured, returns
+	 * true.
+	 * This is used to prevent Host Header Poisoning.
 	 * @param string $host
-	 * @return bool
+	 * @return bool true if the given domain is trusted or if no trusted domains
+	 * have been configured
 	 */
 	public static function isTrustedDomain($domain) {
-		$trustedList = \OC_Config::getValue('trusted_domains', array(''));
+		$trustedList = \OC_Config::getValue('trusted_domains', array());
+		if (empty($trustedList)) {
+			return true;
+		}
 		return in_array($domain, $trustedList);
 	}
 
 	/**
-	 * @brief Returns the server host
+	 * @brief Returns the unverified server host from the headers without checking
+	 * whether it is a trusted domain
+	 * @returns string the server host
+	 *
+	 * Returns the server host, even if the website uses one or more
+	 * reverse proxies
+	 */
+	public static function insecureServerHost() {
+		$host = null;
+		if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+			if (strpos($_SERVER['HTTP_X_FORWARDED_HOST'], ",") !== false) {
+				$host = trim(array_pop(explode(",", $_SERVER['HTTP_X_FORWARDED_HOST'])));
+			} else {
+				$host = $_SERVER['HTTP_X_FORWARDED_HOST'];
+			}
+		} else {
+			if (isset($_SERVER['HTTP_HOST'])) {
+				$host = $_SERVER['HTTP_HOST'];
+			} else if (isset($_SERVER['SERVER_NAME'])) {
+				$host = $_SERVER['SERVER_NAME'];
+			}
+		}
+		return $host;
+	}
+
+	/**
+	 * Returns the overwritehost setting from the config if set and
+	 * if the overwrite condition is met
+	 * @return overwritehost value or null if not defined or the defined condition
+	 * isn't met
+	 */
+	public static function getOverwriteHost() {
+		if(OC_Config::getValue('overwritehost', '') !== '' and self::isOverwriteCondition()) {
+			return OC_Config::getValue('overwritehost');
+		}
+		return null;
+	}
+
+	/**
+	 * @brief Returns the server host from the headers, or the first configured
+	 * trusted domain if the host isn't in the trusted list
 	 * @returns string the server host
 	 *
 	 * Returns the server host, even if the website uses one or more
@@ -44,29 +91,20 @@ class OC_Request {
 		if(OC::$CLI) {
 			return 'localhost';
 		}
-		if(OC_Config::getValue('overwritehost', '') !== '' and self::isOverwriteCondition()) {
-			return OC_Config::getValue('overwritehost');
+
+		// overwritehost is always trusted
+		$host = self::getOverwriteHost();
+		if ($host !== null) {
+			return $host;
 		}
-		if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-			if (strpos($_SERVER['HTTP_X_FORWARDED_HOST'], ",") !== false) {
-				$host = trim(array_pop(explode(",", $_SERVER['HTTP_X_FORWARDED_HOST'])));
-			}
-			else{
-				$host = $_SERVER['HTTP_X_FORWARDED_HOST'];
-			}
-		} else {
-			if (isset($_SERVER['HTTP_HOST'])) {
-				$host = $_SERVER['HTTP_HOST'];
-			}
-			else if (isset($_SERVER['SERVER_NAME'])) {
-				$host = $_SERVER['SERVER_NAME'];
-			}
-		}
+
+		// get the host from the headers
+		$host = self::insecureServerHost();
 
 		// Verify that the host is a trusted domain if the trusted domains
 		// are defined
 		// If no trusted domain is provided the first trusted domain is returned
-		if(self::isTrustedDomain($host) || \OC_Config::getValue('trusted_domains', "") === "") {
+		if (self::isTrustedDomain($host)) {
 			return $host;
 		} else {
 			$trustedList = \OC_Config::getValue('trusted_domains', array(''));

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -120,4 +120,141 @@ class Test_Request extends PHPUnit_Framework_TestCase {
 			),
 		);
 	}
+
+	public function testInsecureServerHost() {
+		unset($_SERVER['HTTP_X_FORWARDED_HOST']);
+		unset($_SERVER['HTTP_HOST']);
+		unset($_SERVER['SERVER_NAME']);
+		$_SERVER['SERVER_NAME'] = 'from.server.name:8080';
+		$host = OC_Request::insecureServerHost();
+		$this->assertEquals('from.server.name:8080', $host);
+
+		$_SERVER['HTTP_HOST'] = 'from.host.header:8080';
+		$host = OC_Request::insecureServerHost();
+		$this->assertEquals('from.host.header:8080', $host);
+
+		$_SERVER['HTTP_X_FORWARDED_HOST'] = 'from.forwarded.host:8080';
+		$host = OC_Request::insecureServerHost();
+		$this->assertEquals('from.forwarded.host:8080', $host);
+
+		$_SERVER['HTTP_X_FORWARDED_HOST'] = 'from.forwarded.host2:8080,another.one:9000';
+		$host = OC_Request::insecureServerHost();
+		$this->assertEquals('from.forwarded.host2:8080', $host);
+
+		// clean up
+		unset($_SERVER['HTTP_X_FORWARDED_HOST']);
+		unset($_SERVER['HTTP_HOST']);
+		unset($_SERVER['SERVER_NAME']);
+	}
+
+	public function testGetOverwriteHost() {
+		unset($_SERVER['REMOTE_ADDR']);
+		OC_Config::deleteKey('overwritecondaddr');
+		OC_Config::deleteKey('overwritehost');
+		$host = OC_Request::getOverwriteHost();
+		$this->assertNull($host);
+
+		OC_Config::setValue('overwritehost', '');
+		$host = OC_Request::getOverwriteHost();
+		$this->assertNull($host);
+
+		OC_Config::setValue('overwritehost', 'host.one.test:8080');
+		$host = OC_Request::getOverwriteHost();
+		$this->assertEquals('host.one.test:8080', $host);
+
+		$_SERVER['REMOTE_ADDR'] = 'somehost.test:8080';
+		OC_Config::setValue('overwritecondaddr', '^somehost\..*$');
+		$host = OC_Request::getOverwriteHost();
+		$this->assertEquals('host.one.test:8080', $host);
+
+		OC_Config::setValue('overwritecondaddr', '^somethingelse.*$');
+		$host = OC_Request::getOverwriteHost();
+		$this->assertNull($host);
+
+		// clean up
+		unset($_SERVER['REMOTE_ADDR']);
+		OC_Config::deleteKey('overwritecondaddr');
+		OC_Config::deleteKey('overwritehost');
+	}
+
+	/**
+	 * @dataProvider trustedDomainDataProvider
+	 */
+	public function testIsTrustedDomain($trustedDomains, $testDomain, $result) {
+		OC_Config::deleteKey('trusted_domains');
+		if ($trustedDomains !== null) {
+			OC_Config::setValue('trusted_domains', $trustedDomains);
+		}
+
+		$this->assertEquals($result, OC_Request::isTrustedDomain($testDomain));
+
+		// clean up
+		OC_Config::deleteKey('trusted_domains');
+	}
+
+	public function trustedDomainDataProvider() {
+		$trustedHostTestList = array('host.one.test:8080', 'host.two.test:8080');
+		return array(
+			// empty defaults to true
+			array(null, 'host.one.test:8080', true),
+			array('', 'host.one.test:8080', true),
+			array(array(), 'host.one.test:8080', true),
+
+			// trust list when defined
+			array($trustedHostTestList, 'host.two.test:8080', true),
+			array($trustedHostTestList, 'host.two.test:9999', false),
+			array($trustedHostTestList, 'host.three.test:8080', false),
+
+			// trust localhost regardless of trust list
+			array($trustedHostTestList, 'localhost', true),
+			array($trustedHostTestList, 'localhost:8080', true),
+			array($trustedHostTestList, '127.0.0.1', true),
+			array($trustedHostTestList, '127.0.0.1:8080', true),
+
+			// do not trust invalid localhosts
+			array($trustedHostTestList, 'localhost:1:2', false),
+			array($trustedHostTestList, 'localhost: evil.host', false),
+		);
+	}
+
+	public function testServerHost() {
+		OC_Config::deleteKey('overwritecondaddr');
+		OC_Config::setValue('overwritehost', 'overwritten.host:8080');
+		OC_Config::setValue(
+			'trusted_domains',
+			array(
+				'trusted.host:8080',
+				'second.trusted.host:8080'
+			)
+		);
+		$_SERVER['HTTP_HOST'] = 'trusted.host:8080';
+
+		// CLI always gives localhost
+		$oldCLI = OC::$CLI;
+		OC::$CLI = true;
+		$host = OC_Request::serverHost();
+		$this->assertEquals('localhost', $host);
+		OC::$CLI = false;
+
+		// overwritehost overrides trusted domain
+		$host = OC_Request::serverHost();
+		$this->assertEquals('overwritten.host:8080', $host);
+
+		// trusted domain returned when used
+		OC_Config::deleteKey('overwritehost');
+		$host = OC_Request::serverHost();
+		$this->assertEquals('trusted.host:8080', $host);
+
+		// trusted domain returned when untrusted one in header
+		$_SERVER['HTTP_HOST'] = 'untrusted.host:8080';
+		OC_Config::deleteKey('overwritehost');
+		$host = OC_Request::serverHost();
+		$this->assertEquals('trusted.host:8080', $host);
+
+		// clean up
+		OC_Config::deleteKey('overwritecondaddr');
+		OC_Config::deleteKey('overwritehost');
+		unset($_SERVER['HTTP_HOST']);
+		OC::$CLI = $oldCLI;
+	}
 }


### PR DESCRIPTION
Added early check for the requested domain host and show a warning
page if the domain is not trusted.

Please review @karlitschek @LukasReschke 

I haven't added localhost yet.
Should I add it:
1) Hard-coded in isTrustedDomain(), making sure to allow "localhost", "127.0.0.1", "localhost:8080", etc
or
2) Auto-add it to the config.php when the migration is run. Doing it here might miss people who already migrated, and I don't really want to add yet another code block with hard-coded version numbers to add these additionally

If you think that 1) isn't an issue I'll go with that approach.
