### PR TITLE
restrict height of settings and make scrollable

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -187,6 +187,9 @@
 }
 #app-settings.open #app-settings-content {
 	display: block;
+	/* restrict height of settings and make scrollable */
+	max-height: 300px;
+	overflow-y: scroll;
 }
 
 .settings-button {


### PR DESCRIPTION
This fixes apps with too long settings, like the redesigned Calendar.

Please review @jbtbnl @owncloud/designers @georgehrke 
