### PR TITLE
Introduce OC.generateUrl() in master

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -175,6 +175,30 @@ var OC={
 	appswebroots:(typeof oc_appswebroots !== 'undefined') ? oc_appswebroots:false,
 	currentUser:(typeof oc_current_user!=='undefined')?oc_current_user:false,
 	coreApps:['', 'admin','log','search','settings','core','3rdparty'],
+
+	/**
+	 * Generates the absolute url for the given relative url, which can contain parameters.
+	 *
+	 * @returns {string}
+	 * @param {string} url
+	 * @param params
+	 */
+	generateUrl: function(url, params) {
+		var _build = function (text, vars) {
+			return text.replace(/{([^{}]*)}/g,
+				function (a, b) {
+					var r = vars[b];
+					return typeof r === 'string' || typeof r === 'number' ? r : a;
+				}
+			);
+		};
+		if (url.charAt(0) !== '/') {
+			url = '/' + url;
+
+		}
+		return OC.webroot + '/index.php' + _build(url, params);
+	},
+
 	/**
 	 * get an absolute url to a file in an appen
 	 * @param app the id of the app the file belongs to

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -276,5 +276,14 @@ describe('Core base tests', function() {
 		});
 
 	});
+	describe('Generate Url', function() {
+		it('returns absolute urls', function() {
+			expect(OC.generateUrl('heartbeat')).toEqual(OC.webroot + '/index.php/heartbeat');
+			expect(OC.generateUrl('/heartbeat')).toEqual(OC.webroot + '/index.php/heartbeat');
+		});
+		it('substitutes parameters', function() {
+			expect(OC.generateUrl('apps/files/download{file}', {file: '/Welcome.txt'})).toEqual(OC.webroot + '/index.php/apps/files/download/Welcome.txt');
+		});
+	});
 });
 


### PR DESCRIPTION
In order to allow smooth migration of https://github.com/owncloud/core/pull/7494 we first introduce the new function and afterwards kill OC.router

Backport is available in: https://github.com/owncloud/core/pull/7578
