### PR TITLE
[oc6] don't allow to create a file or folder named 'Shared' in the root folder

### DIFF
--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -18,7 +18,7 @@ if(\OC\Files\Filesystem::file_exists($target . '/' . $file)) {
 	exit;
 }
 
-if ($dir != '' || $file != 'Shared') {
+if ($target != '' || strtolower($file) != 'shared') {
 	$targetFile = \OC\Files\Filesystem::normalizePath($target . '/' . $file);
 	$sourceFile = \OC\Files\Filesystem::normalizePath($dir . '/' . $file);
 	if(\OC\Files\Filesystem::rename($sourceFile, $targetFile)) {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -70,7 +70,7 @@ OC.Upload = {
 	 */
 	isProcessing:function() {
 		var count = 0;
-		
+
 		jQuery.each(this._uploads,function(i, data) {
 			if (data.state() === 'pending') {
 				count++;
@@ -196,13 +196,13 @@ $(document).ready(function() {
 			add: function(e, data) {
 				OC.Upload.log('add', e, data);
 				var that = $(this);
-			
+
 				// we need to collect all data upload objects before starting the upload so we can check their existence
 				// and set individual conflict actions. unfortunately there is only one variable that we can use to identify
 				// the selection a data upload is part of, so we have to collect them in data.originalFiles
 				// turning singleFileUploads off is not an option because we want to gracefully handle server errors like
 				// already exists
-			
+
 				// create a container where we can store the data objects
 				if ( ! data.originalFiles.selection ) {
 					// initialize selection and remember number of files to upload
@@ -213,40 +213,40 @@ $(document).ready(function() {
 					};
 				}
 				var selection = data.originalFiles.selection;
-			
+
 				// add uploads
 				if ( selection.uploads.length < selection.filesToUpload ) {
 					// remember upload
 					selection.uploads.push(data);
 				}
-			
+
 				//examine file
 				var file = data.files[0];
 				try {
 					// FIXME: not so elegant... need to refactor that method to return a value
-					Files.isFileNameValid(file.name);
+					Files.isFileNameValid(file.name, FileList.getCurrentDirectory());
 				}
 				catch (errorMessage) {
 					data.textStatus = 'invalidcharacters';
 					data.errorThrown = errorMessage;
 				}
-			
+
 				if (file.type === '' && file.size === 4096) {
 					data.textStatus = 'dirorzero';
 					data.errorThrown = t('files', 'Unable to upload {filename} as it is a directory or has 0 bytes',
 						{filename: file.name}
 					);
 				}
-			
+
 				// add size
 				selection.totalBytes += file.size;
-			
+
 				//check max upload size
 				if (selection.totalBytes > $('#max_upload').val()) {
 					data.textStatus = 'notenoughspace';
 					data.errorThrown = t('files', 'Not enough space available');
 				}
-			
+
 				// end upload for whole selection on error
 				if (data.errorThrown) {
 					// trigger fileupload fail
@@ -257,12 +257,12 @@ $(document).ready(function() {
 
 				// check existing files when all is collected
 				if ( selection.uploads.length >= selection.filesToUpload ) {
-				
+
 					//remove our selection hack:
 					delete data.originalFiles.selection;
 
 					var callbacks = {
-					
+
 						onNoConflicts: function (selection) {
 							$.each(selection.uploads, function(i, upload) {
 								upload.submit();
@@ -285,7 +285,7 @@ $(document).ready(function() {
 					};
 
 					OC.Upload.checkExistingFiles(selection, callbacks);
-				
+
 				}
 
 				return true; // continue adding files
@@ -408,7 +408,7 @@ $(document).ready(function() {
 			});
 			fileupload.on('fileuploadstop', function(e, data) {
 				OC.Upload.log('progress handle fileuploadstop', e, data);
-				
+
 				$('#uploadprogresswrapper input.stop').fadeOut();
 				$('#uploadprogressbar').fadeOut();
 			    Files.updateStorageStatistics();
@@ -500,7 +500,7 @@ $(document).ready(function() {
 		if ($(this).children('p').length === 0) {
 			return;
 		}
-		
+
 		$('#new .error').tipsy('hide');
 
 		$('#new li').each(function(i,element) {
@@ -514,7 +514,7 @@ $(document).ready(function() {
 		var text=$(this).children('p').text();
 		$(this).data('text',text);
 		$(this).children('p').remove();
-		
+
 		// add input field
 		var form = $('<form></form>');
 		var input = $('<input type="text">');
@@ -531,7 +531,7 @@ $(document).ready(function() {
 				throw t('files', 'URL cannot be empty');
 			} else if (type !== 'web' && !Files.isFileNameValid(filename)) {
 				// Files.isFileNameValid(filename) throws an exception itself
-			} else if ($('#dir').val() === '/' && filename === 'Shared') {
+			} else if (FileList.getCurrentDirectory() === '/' && filename.toLowerCase() === 'shared') {
 				throw t('files', 'In the home folder \'Shared\' is a reserved filename');
 			} else if (FileList.inList(filename)) {
 				throw t('files', '{new_name} already exists', {new_name: filename});

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -380,15 +380,12 @@ var FileList={
 			len = input.val().length;
 		}
 		input.selectRange(0, len);
-
 		var checkInput = function () {
 			var filename = input.val();
 			if (filename !== oldname) {
-				if (!Files.isFileNameValid(filename)) {
-					// Files.isFileNameValid(filename) throws an exception itself
-				} else if($('#dir').val() === '/' && filename === 'Shared') {
-					throw t('files','In the home folder \'Shared\' is a reserved filename');
-				} else if (FileList.inList(filename)) {
+				// Files.isFileNameValid(filename) throws an exception itself
+				Files.isFileNameValid(filename, FileList.getCurrentDirectory());
+				if (FileList.inList(filename)) {
 					throw t('files', '{new_name} already exists', {new_name: filename});
 				}
 			}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -67,10 +67,21 @@ Files={
 		return fileName;
 	},
 
-	isFileNameValid:function (name) {
-		if (name === '.') {
-			throw t('files', '\'.\' is an invalid file name.');
-		} else if (name.length === 0) {
+	/**
+	 * Checks whether the given file name is valid.
+	 * @param name file name to check
+	 * @return true if the file name is valid.
+	 * Throws a string exception with an error message if
+	 * the file name is not valid
+	 */
+	isFileNameValid: function (name, root) {
+		var trimmedName = name.trim();
+		if (trimmedName === '.'
+				|| trimmedName === '..'
+				|| (root === '/' &&  trimmedName.toLowerCase() === 'shared'))
+		{
+			throw t('files', '"{name}" is an invalid file name.', {name: name});
+		} else if (trimmedName.length === 0) {
 			throw t('files', 'File name cannot be empty.');
 		}
 

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -50,7 +50,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 	 */
 	public function createFile($name, $data = null) {
 
-		if ($name === 'Shared' && empty($this->path)) {
+		if (strtolower($name) === 'shared' && empty($this->path)) {
 			throw new \Sabre_DAV_Exception_Forbidden();
 		}
 
@@ -86,7 +86,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node implements Sa
 	 */
 	public function createDirectory($name) {
 
-		if ($name === 'Shared' && empty($this->path)) {
+		if (strtolower($name) === 'shared' && empty($this->path)) {
 			throw new \Sabre_DAV_Exception_Forbidden();
 		}
 

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -94,6 +94,9 @@ class ObjectTree extends \Sabre_DAV_ObjectTree {
 		}
 		if ($sourceDir !== $destinationDir) {
 			// for a full move we need update privileges on sourcePath and sourceDir as well as destinationDir
+			if (ltrim($destinationDir, '/') === '' && strtolower($sourceNode->getName()) === 'shared') {
+				throw new \Sabre_DAV_Exception_Forbidden();
+			}
 			if (!$fs->isUpdatable($sourceDir)) {
 				throw new \Sabre_DAV_Exception_Forbidden();
 			}


### PR DESCRIPTION
don't allow to create a file or folder named 'Shared' in the root folder, also exclude all combinations of lower and upper case letters

Backport of #7531 

Tested:
- [x] sync client created "Shared" or "shared" file inside root: forbidden
- [x] sync client created "Shared" or "shared" dir inside subdir: ok
- [x] sync client move "Shared" or "shared" to a different subdir: ok
- [x] sync client move "Shared" or "shared" from the subdir to the root: forbidden
- [x] sync client update file in existing "Shared" directory: ok
- [x] WebDAV create "Shared" or "shared" dir in root: forbidden
- [x] WebDAV create "Shared" or "shared" file in root: forbidden
- [x] WebDAV create "Shared" or "shared" dir in subdir: ok
- [x] Web UI create file/folder called "Shared" or "shared" in root: forbidden
- [x] Web UI create file/folder called "Shared" or "shared" in subdir: ok
- [x] Web UI upload file called "Shared" or "shared" in root: forbidden
- [x] Web UI upload file called "Shared" or "shared" in subdir: ok
- [x] Web UI: Move "Shared" from subdir to root: forbidden

cc @PVince81 
