### PR TITLE
fix noise not repeating

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -24,7 +24,7 @@
 
 .icon-noise {
 	background-image: url('../img/noise.png');
-	background-repeat: no-repeat;
+	background-repeat: repeat;
 }
 
 


### PR DESCRIPTION
Of course the noise needs to be set to _repeat_. All the other icons are set to no-repeat above already.
(The noise is used so background areas don’t only have a single unnatural color. For example in the Pictures app.)

Please review @owncloud/designers 
