### PR TITLE
[stable6] Fixed "select all" + download on public page

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -350,7 +350,12 @@ $(document).ready(function() {
 		// use special download URL if provided, e.g. for public shared files
 		var downloadURL = document.getElementById("downloadURL");
 		if ( downloadURL ) {
-			window.location = downloadURL.value+"&download&files=" + encodeURIComponent(fileslist);
+			// downloading all in root of public share ? (replacement for old "Download" button)
+			if ($('#isPublic').val() && dir === '/' && $('#select_all').is(':checked')) {
+				window.location = downloadURL.value;
+			} else {
+				window.location = downloadURL.value+"&download&files=" + encodeURIComponent(fileslist);
+			}
 		} else {
 			window.location = OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });
 		}


### PR DESCRIPTION
When a user has lots of files, selecting all and downloading would send
the whole list of files to the server.

This fix makes it use the simpler default download URL in such cases
(the one that was used by the "Download" button that is now removed on
the public page)

Fixes #7606

This is **stable 6 only**. On master, selecting all files already doesn't send the whole list.
