### PR TITLE
Add \OC::$WEBROOT to URLGenerator::getAbsoluteURL()

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -148,6 +148,7 @@ class URLGenerator implements IURLGenerator {
 	 */
 	public function getAbsoluteURL($url) {
 		$separator = $url[0] === '/' ? '' : '/';
-		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . $separator . $url;
+
+		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost(). \OC::$WEBROOT . $separator . $url;
 	}
 }

--- a/tests/lib/urlgenerator.php
+++ b/tests/lib/urlgenerator.php
@@ -12,22 +12,46 @@ class Test_Urlgenerator extends PHPUnit_Framework_TestCase {
 	/**
 	 * @small
 	 * @brief test absolute URL construction
-	 * @dataProvider provideURLs
+	 * @dataProvider provideDocRootURLs
 	 */
-	function testGetAbsoluteURL($url, $expectedResult) {
+	function testGetAbsoluteURLDocRoot($url, $expectedResult) {
 
+		\OC::$WEBROOT = '';
 		$urlGenerator = new \OC\URLGenerator(null);
 		$result = $urlGenerator->getAbsoluteURL($url);
 
 		$this->assertEquals($expectedResult, $result);
 	}
 
-	public function provideURLs() {
+	/**
+	 * @small
+	 * @brief test absolute URL construction
+	 * @dataProvider provideSubDirURLs
+	 */
+	function testGetAbsoluteURLSubDir($url, $expectedResult) {
+
+		\OC::$WEBROOT = '/owncloud';
+		$urlGenerator = new \OC\URLGenerator(null);
+		$result = $urlGenerator->getAbsoluteURL($url);
+
+		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function provideDocRootURLs() {
 		return array(
 			array("index.php", "http://localhost/index.php"),
 			array("/index.php", "http://localhost/index.php"),
 			array("/apps/index.php", "http://localhost/apps/index.php"),
 			array("apps/index.php", "http://localhost/apps/index.php"),
+			);
+	}
+
+	public function provideSubDirURLs() {
+		return array(
+			array("index.php", "http://localhost/owncloud/index.php"),
+			array("/index.php", "http://localhost/owncloud/index.php"),
+			array("/apps/index.php", "http://localhost/owncloud/apps/index.php"),
+			array("apps/index.php", "http://localhost/owncloud/apps/index.php"),
 			);
 	}
 }


### PR DESCRIPTION
URLGenerator::getAbsoluteURL() didn't take ownCloud instances running in a subdir into account. 
This caused e.g. AppFramework SecurityMiddleware to [redirect to Document root](https://github.com/owncloud/core/blob/fix_urlGenerator2/lib/private/appframework/middleware/security/securitymiddleware.php#L128) instead of to the ownCloud instance.

Tested both with ownCloud in a subdir and in the DocRoot of a VirtualHost.

I can't believe none of us noticed that in #6935 :grin: 

@PVince81 @DeepDiver1975 @karlitschek @bartv2 
