### PR TITLE
[master] Fixed used space to be based on unencrypted size

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -340,6 +340,13 @@ class Proxy extends \OC_FileProxy {
 
 		// if path is a folder do nothing
 		if ($view->is_dir($path)) {
+			$proxyState = \OC_FileProxy::$enabled;
+			\OC_FileProxy::$enabled = false;
+			$fileInfo = $view->getFileInfo($path);
+			\OC_FileProxy::$enabled = $proxyState;
+			if ($fileInfo['unencrypted_size'] > 0) {
+				return $fileInfo['unencrypted_size'];
+			}
 			return $size;
 		}
 

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -112,4 +112,24 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	function testPostFileSizeWithDirectory() {
+
+		$this->view->file_put_contents($this->filename, $this->data);
+
+		\OC_FileProxy::$enabled = false;
+
+		// get root size, must match the file's unencrypted size
+		$unencryptedSize = $this->view->filesize('');
+
+		\OC_FileProxy::$enabled = true;
+
+		$encryptedSize = $this->view->filesize('');
+
+		$this->assertTrue($encryptedSize !== $unencryptedSize);
+
+		// cleanup
+		$this->view->unlink($this->filename);
+
+	}
+
 }

--- a/lib/private/files/cache/homecache.php
+++ b/lib/private/files/cache/homecache.php
@@ -24,14 +24,19 @@ class HomeCache extends Cache {
 		$entry = $this->get($path);
 		if ($entry && $entry['mimetype'] === 'httpd/unix-directory') {
 			$id = $entry['fileid'];
-			$sql = 'SELECT SUM(`size`) FROM `*PREFIX*filecache` ' .
+			$sql = 'SELECT SUM(`size`) AS f1, ' .
+			   'SUM(`unencrypted_size`) AS f2 FROM `*PREFIX*filecache` ' .
 				'WHERE `parent` = ? AND `storage` = ? AND `size` >= 0';
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
-				list($sum) = array_values($row);
+				list($sum, $unencryptedSum) = array_values($row);
 				$totalSize = (int)$sum;
+				$unencryptedSize = (int)$unencryptedSum;
 				if ($entry['size'] !== $totalSize) {
 					$this->update($id, array('size' => $totalSize));
+				}
+				if ($entry['unencrypted_size'] !== $unencryptedSize) {
+					$this->update($id, array('unencrypted_size' => $unencryptedSize));
 				}
 			}
 		}

--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -36,6 +36,11 @@ class Quota extends Wrapper {
 		$cache = $this->getCache();
 		$data = $cache->get($path);
 		if (is_array($data) and isset($data['size'])) {
+			if (isset($data['unencrypted_size'])
+				&& $data['unencrypted_size'] > 0
+			) {
+				return $data['unencrypted_size'];
+			}
 			return $data['size'];
 		} else {
 			return \OC\Files\SPACE_NOT_COMPUTED;

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -53,6 +53,22 @@ class Quota extends \Test\Files\Storage\Storage {
 		$this->assertEquals(9, $instance->free_space(''));
 	}
 
+	public function testFreeSpaceWithUsedSpace() {
+		$instance = $this->getLimitedStorage(9);
+		$instance->getCache()->put(
+			'', array('size' => 3, 'unencrypted_size' => 0)
+		);
+		$this->assertEquals(6, $instance->free_space(''));
+	}
+
+	public function testFreeSpaceWithUsedSpaceAndEncryption() {
+		$instance = $this->getLimitedStorage(9);
+		$instance->getCache()->put(
+			'', array('size' => 7, 'unencrypted_size' => 3)
+		);
+		$this->assertEquals(6, $instance->free_space(''));
+	}
+
 	public function testFWriteNotEnoughSpace() {
 		$instance = $this->getLimitedStorage(9);
 		$stream = $instance->fopen('foo', 'w+');


### PR DESCRIPTION
This fixes the "used space" to be based on the unencrypted size, not encrypted size, to be consistent with how quota/space is handled when encryption is enabled.

The prerequisite was that unencrypted size of folders is propagated to the root folder.

Please review @karlitschek @schiesbn @ser72 
