### PR TITLE
 [6.0.2RC1] Share folder as link -- no public upload, drag&drop still works #7422 

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -180,7 +180,7 @@ OC.Upload = {
 	},
 
 	init: function() {
-		if ( $('#file_upload_start').exists() ) {
+		if ( $('#file_upload_start').exists() && $('#file_upload_start').is(':visible')) {
 
 			var file_upload_param = {
 				dropZone: $('#content'), // restrict dropZone to content div


### PR DESCRIPTION
regards Issue: [6.0.2RC1] Share folder as link -- no public upload, drag&drop still works #7422
