### PR TITLE
Chainable Response in AppFramework

### DIFF
--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -66,6 +66,7 @@ class JSONResponse extends Response {
 	 * Sets values in the data json array
 	 * @param array|object $data an array or object which will be transformed
 	 *                             to JSON
+	 * @return JSONResponse Reference to this object
 	 */
 	public function setData($data){
 		$this->data = $data;

--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -69,6 +69,8 @@ class JSONResponse extends Response {
 	 */
 	public function setData($data){
 		$this->data = $data;
+
+		return $this;
 	}
 
 

--- a/lib/public/appframework/http/response.php
+++ b/lib/public/appframework/http/response.php
@@ -89,6 +89,7 @@ class Response {
 	 * function
 	 * @param string $name The name of the HTTP header
 	 * @param string $value The value, null will delete it
+	 * @return Response Reference to this object
 	 */
 	public function addHeader($name, $value) {
 		if(is_null($value)) {
@@ -133,6 +134,7 @@ class Response {
 	/**
 	* Set response status
 	* @param int $status a HTTP status code, see also the STATUS constants
+	* @return Response Reference to this object
 	*/
 	public function setStatus($status) {
 		$this->status = $status;
@@ -170,6 +172,7 @@ class Response {
 	/**
 	 * Set the ETag
 	 * @param string $ETag
+	 * @return Response Reference to this object
 	 */
 	public function setETag($ETag) {
 		$this->ETag = $ETag;
@@ -181,6 +184,7 @@ class Response {
 	/**
 	 * Set "last modified" date
 	 * @param \DateTime $lastModified
+	 * @return Response Reference to this object
 	 */
 	public function setLastModified($lastModified) {
 		$this->lastModified = $lastModified;

--- a/lib/public/appframework/http/response.php
+++ b/lib/public/appframework/http/response.php
@@ -80,6 +80,7 @@ class Response {
 			$this->addHeader('Cache-Control', 'no-cache, must-revalidate');
 		}
 
+		return $this;
 	}
 
 
@@ -95,6 +96,8 @@ class Response {
 		} else {
 			$this->headers[$name] = $value;
 		}
+
+		return $this;
 	}
 
 
@@ -133,6 +136,8 @@ class Response {
 	*/
 	public function setStatus($status) {
 		$this->status = $status;
+
+		return $this;
 	}
 
 
@@ -168,6 +173,8 @@ class Response {
 	 */
 	public function setETag($ETag) {
 		$this->ETag = $ETag;
+
+		return $this;
 	}
 
 
@@ -177,6 +184,8 @@ class Response {
 	 */
 	public function setLastModified($lastModified) {
 		$this->lastModified = $lastModified;
+
+		return $this;
 	}
 
 

--- a/lib/public/appframework/http/templateresponse.php
+++ b/lib/public/appframework/http/templateresponse.php
@@ -74,6 +74,7 @@ class TemplateResponse extends Response {
 	 * Sets template parameters
 	 * @param array $params an array with key => value structure which sets template
 	 *                      variables
+	 * @return TemplateResponse Reference to this object
 	 */
 	public function setParams(array $params){
 		$this->params = $params;
@@ -106,6 +107,7 @@ class TemplateResponse extends Response {
 	 *                         settings header and footer, user renders the normal
 	 *                         normal page including footer and header and blank
 	 *                         just renders the plain template
+	 * @return TemplateResponse Reference to this object
 	 */
 	public function renderAs($renderAs){
 		$this->renderAs = $renderAs;

--- a/lib/public/appframework/http/templateresponse.php
+++ b/lib/public/appframework/http/templateresponse.php
@@ -77,6 +77,8 @@ class TemplateResponse extends Response {
 	 */
 	public function setParams(array $params){
 		$this->params = $params;
+
+		return $this;
 	}
 
 
@@ -107,6 +109,8 @@ class TemplateResponse extends Response {
 	 */
 	public function renderAs($renderAs){
 		$this->renderAs = $renderAs;
+
+		return $this;
 	}
 
 

--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -28,6 +28,7 @@ namespace OC\AppFramework\Http;
 
 
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http;
 
 //require_once(__DIR__ . "/../classloader.php");
 
@@ -93,6 +94,15 @@ class JSONResponseTest extends \PHPUnit_Framework_TestCase {
 		$expected = '["hi"]';
 		$this->assertEquals($expected, $response->render());
 		$this->assertEquals($code, $response->getStatus());
+	}
+
+	public function testChainability() {
+		$params = array('hi', 'yo');
+		$this->json->setData($params)
+			->setStatus(Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->json->getStatus());
+		$this->assertEquals(array('hi', 'yo'), $this->json->getData());
 	}
 
 }

--- a/tests/lib/appframework/http/ResponseTest.php
+++ b/tests/lib/appframework/http/ResponseTest.php
@@ -117,5 +117,25 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 +0000', $headers['Last-Modified']);
 	}
 
+	public function testChainability() {
+		$lastModified = new \DateTime(null, new \DateTimeZone('GMT'));
+		$lastModified->setTimestamp(1);
+
+		$this->childResponse->setEtag('hi')
+			->setStatus(Http::STATUS_NOT_FOUND)
+			->setLastModified($lastModified)
+			->cacheFor(33)
+			->addHeader('hello', 'world');
+
+		$headers = $this->childResponse->getHeaders();
+
+		$this->assertEquals('world', $headers['hello']);
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->childResponse->getStatus());
+		$this->assertEquals('hi', $this->childResponse->getEtag());
+		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 +0000', $headers['Last-Modified']);
+		$this->assertEquals('max-age=33, must-revalidate',
+			$headers['Cache-Control']);
+
+	}
 
 }

--- a/tests/lib/appframework/http/TemplateResponseTest.php
+++ b/tests/lib/appframework/http/TemplateResponseTest.php
@@ -25,6 +25,7 @@
 namespace OC\AppFramework\Http;
 
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http;
 
 
 class TemplateResponseTest extends \PHPUnit_Framework_TestCase {
@@ -96,6 +97,15 @@ class TemplateResponseTest extends \PHPUnit_Framework_TestCase {
 		$render = 'myrender';
 		$this->tpl->renderAs($render);
 		$this->assertEquals($render, $this->tpl->getRenderAs());
+	}
+
+	public function testChainability() {
+		$params = array('hi' => 'yo');
+		$this->tpl->setParams($params)
+			->setStatus(Http::STATUS_NOT_FOUND);
+
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->tpl->getStatus());
+		$this->assertEquals(array('hi' => 'yo'), $this->tpl->getParams());
 	}
 
 }


### PR DESCRIPTION
Makes is possible to chain method calls like in e.g. the routes (I'm aware the example makes no sense :smile: ):

``` php
return $response->setEtag(md5('Hello world'))
    ->setStatus(Http::STATUS_NOT_FOUND)
    ->setLastModified(new DateTime('now'))
    ->cacheFor(33)
    ->addHeader('Cache-Control', 'must-revalidate');
```

@Raydiation @bartv2 @DeepDiver1975 @karlitschek @babelouest 
