### PR TITLE
fix key removal for re-shares

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -428,7 +428,7 @@ class Hooks {
 			$view = new \OC_FilesystemView('/');
 			$userId = \OCP\User::getUser();
 			$util = new Util($view, $userId);
-			$path = $util->fileIdToPath($params['itemSource']);
+			$path = $util->fileIdToPath($params['fileSource']);
 
 			// check if this is a re-share
 			if ($params['itemParent']) {
@@ -437,7 +437,7 @@ class Hooks {
 				$parent = $util->getShareParent($params['itemParent']);
 
 				// get target path
-				$targetPath = $util->fileIdToPath($params['itemSource']);
+				$targetPath = $path;
 				$targetPathSplit = array_reverse(explode('/', $targetPath));
 
 				// init values
@@ -471,7 +471,7 @@ class Hooks {
 			// get the path including mount point only if not a shared folder
 			if (strncmp($path, '/Shared', strlen('/Shared') !== 0)) {
 				// get path including the the storage mount point
-				$path = $util->getPathWithMountPoint($params['itemSource']);
+				$path = $util->getPathWithMountPoint($params['fileSource']);
 			}
 
 			// if we unshare a folder we need a list of all (sub-)files

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -213,25 +213,25 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	function testReShareFile($withTeardown = true) {
 		$this->testShareFile(false);
 
-		// login as user1
+		// login as user2
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		// get the file info
 		$fileInfo = $this->view->getFileInfo(
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/Shared/' . $this->filename);
 
-		// share the file with user2
+		// share the file with user3
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, OCP\PERMISSION_ALL);
 
 		// login as admin
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
-		// check if share key for user2 exists
+		// check if share key for user3 exists
 		$this->assertTrue($this->view->file_exists(
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files_encryption/share-keys/'
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '.shareKey'));
 
-		// login as user2
+		// login as user3
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 		// get file contents

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -173,7 +173,7 @@ class Share {
 				FROM
 				`*PREFIX*share`
 				WHERE
-				`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
+				`file_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
 			);
 
 			$result = $query->execute(array($source, self::SHARE_TYPE_USER));
@@ -192,7 +192,7 @@ class Share {
 				FROM
 				`*PREFIX*share`
 				WHERE
-				`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
+				`file_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
 			);
 
 			$result = $query->execute(array($source, self::SHARE_TYPE_GROUP));
@@ -213,7 +213,7 @@ class Share {
 					FROM
 					`*PREFIX*share`
 					WHERE
-					`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
+					`file_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
 				);
 
 				$result = $query->execute(array($source, self::SHARE_TYPE_LINK));
@@ -900,6 +900,10 @@ class Share {
 			'itemParent'    => $item['parent'],
 			'uidOwner'      => $item['uid_owner'],
 		);
+
+		if(isset($item['file_source'])) {
+			$hookParams['fileSource'] = $item['file_source'];
+		}
 
 		\OC_Hook::emit('OCP\Share', 'pre_unshare', $hookParams + array(
 			'fileSource'	=> $item['file_source'],


### PR DESCRIPTION
we need to check "file_source" instead of "item_source"

Steps to test:
- user1 creates folder which contains a file
- user1 shares the folder to user2
- user2 shares the file from the folder as public link
- check if all share-keys in data/user1/files_encryption/share-keys/folder exists (user1, user2 and pubkey)
- user2 removes the public link again
-  check if the pubkey was removed from the share-keys.
