### PR TITLE
Fixed total space display when data size exceeds quota

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -30,6 +30,13 @@ class Quota extends Wrapper {
 	}
 
 	/**
+	 * @return quota value
+	 */
+	public function getQuota() {
+		return $this->quota;
+	}
+
+	/**
 	 * @param string $path
 	 */
 	protected function getSize($path) {

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -914,13 +914,22 @@ class OC_Helper {
 		if ($used < 0) {
 			$used = 0;
 		}
-		$free = \OC\Files\Filesystem::free_space($path);
+		$quota = 0;
+		// TODO: need a better way to get total space from storage
+		$storage = $rootInfo->getStorage();
+		if ($storage instanceof \OC\Files\Storage\Wrapper\Quota) {
+			$quota = $storage->getQuota();
+		}
+		$free = $storage->free_space('');
 		if ($free >= 0) {
 			$total = $free + $used;
 		} else {
 			$total = $free; //either unknown or unlimited
 		}
 		if ($total > 0) {
+			if ($quota > 0 && $total > $quota) {
+				$total = $quota;
+			}
 			// prevent division by zero or error codes (negative values)
 			$relative = round(($used / $total) * 10000) / 100;
 		} else {

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+/**
+ * Test the storage functions of OC_Helper
+ */
+class Test_Helper_Storage extends PHPUnit_Framework_TestCase {
+	private $user;
+	private $storageMock;
+
+	public function setUp() {
+		$this->user = 'user_' . uniqid();
+		\OC\Files\Filesystem::tearDown();
+		\OC\Files\Filesystem::init($this->user, '/' . $this->user . '/files');
+
+		$this->storageMock = $this->getMock(
+			'\OC\Files\Storage\Temporary',
+			array('free_space'),
+			array('')
+		);
+
+		\OC\Files\Filesystem::clearMounts();
+
+		$this->storageMock->expects($this->once())
+			->method('free_space')
+			->will($this->returnValue(12));
+	}
+
+	public function tearDown() {
+		$this->user = null;
+
+		$this->storageMock->getCache()->clear();
+		\OC\Files\Filesystem::tearDown();
+	}
+
+	/**
+	 * Test getting the storage info
+	 */
+	function testGetStorageInfo() {
+		\OC\Files\Filesystem::mount($this->storageMock, array(), '/' . $this->user . '/files');
+		$this->storageMock->file_put_contents('test.txt', '01234');
+
+		$storageInfo = \OC_Helper::getStorageInfo('');
+		$this->assertEquals(12, $storageInfo['free']);
+		$this->assertEquals(5, $storageInfo['used']);
+		$this->assertEquals(17, $storageInfo['total']);
+	}
+
+	/**
+	 * Test getting the storage info with quota enabled
+	 */
+	function testGetStorageInfoWithQuota() {
+		$this->storageMock->file_put_contents('test.txt', '01234');
+		$this->storageMock = new \OC\Files\Storage\Wrapper\Quota(
+			array(
+				'storage' => $this->storageMock,
+				'quota' => 7
+			)
+		);
+		\OC\Files\Filesystem::mount($this->storageMock, array(), '/' . $this->user . '/files');
+
+		$storageInfo = \OC_Helper::getStorageInfo('');
+		$this->assertEquals(2, $storageInfo['free']);
+		$this->assertEquals(5, $storageInfo['used']);
+		$this->assertEquals(7, $storageInfo['total']);
+	}
+
+	/**
+	 * Test getting the storage info when data exceeds quota
+	 */
+	function testGetStorageInfoWhenSizeExceedsQuota() {
+		$this->storageMock->file_put_contents('test.txt', '0123456789');
+		$this->storageMock = new \OC\Files\Storage\Wrapper\Quota(
+			array(
+				'storage' => $this->storageMock,
+				'quota' => 7
+			)
+		);
+		\OC\Files\Filesystem::mount($this->storageMock, array(), '/' . $this->user . '/files');
+
+		$storageInfo = \OC_Helper::getStorageInfo('');
+		$this->assertEquals(0, $storageInfo['free']);
+		$this->assertEquals(10, $storageInfo['used']);
+		// total = quota
+		$this->assertEquals(7, $storageInfo['total']);
+	}
+
+	/**
+	 * Test getting the storage info when the remaining
+	 * free storage space is less than the quota
+	 */
+	function testGetStorageInfoWhenFreeSpaceLessThanQuota() {
+		$this->storageMock->file_put_contents('test.txt', '01234');
+		$this->storageMock = new \OC\Files\Storage\Wrapper\Quota(
+			array(
+				'storage' => $this->storageMock,
+				'quota' => 18
+			)
+		);
+		\OC\Files\Filesystem::mount($this->storageMock, array(), '/' . $this->user . '/files');
+
+		$storageInfo = \OC_Helper::getStorageInfo('');
+		$this->assertEquals(12, $storageInfo['free']);
+		$this->assertEquals(5, $storageInfo['used']);
+		// total = free + used (because quota > total)
+		$this->assertEquals(17, $storageInfo['total']);
+	}
+}


### PR DESCRIPTION
The total space display in the personal page now shows the quota value
instead of used space when used space exceeds the quota (soft quota).

Fixes #7645 

Please review @icewind1991 @karlitschek @DeepDiver1975 @schiesbn 
