### PR TITLE
Fixed warning when browsing Shared folder

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -344,7 +344,7 @@ class Proxy extends \OC_FileProxy {
 			\OC_FileProxy::$enabled = false;
 			$fileInfo = $view->getFileInfo($path);
 			\OC_FileProxy::$enabled = $proxyState;
-			if ($fileInfo['unencrypted_size'] > 0) {
+			if (isset($fileInfo['unencrypted_size']) && $fileInfo['unencrypted_size'] > 0) {
 				return $fileInfo['unencrypted_size'];
 			}
 			return $size;


### PR DESCRIPTION
The virtual "Shared" folder doesn't have an unencrypted_size field.
This fix adds a check to prevent warnings in the log.

Introduced by https://github.com/owncloud/core/pull/7624

Please review @karlitschek @schiesbn 
