### PR TITLE
Fix ocs share api paths

### DIFF
--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -175,8 +175,10 @@ class Api {
 			if($share) {
 				$receivedFrom =  \OCP\Share::getItemSharedWithBySource($itemType, $file['fileid']);
 				if ($receivedFrom) {
-					$share['received_from'] = $receivedFrom['uid_owner'];
-					$share['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
+					reset($share);
+					$key = key($share);
+					$share[$key]['received_from'] = $receivedFrom['uid_owner'];
+					$share[$key]['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
 				}
 				$result = array_merge($result, $share);
 			}

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -34,15 +34,17 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		$this->folder = '/folder_share_api_test';
 		$this->subfolder  = '/subfolder_share_api_test';
+		$this->subsubfolder = '/subsubfolder_share_api_test';
 
-		$this->filename = 'share-api-test.txt';
+		$this->filename = '/share-api-test.txt';
 
 		// save file with content
 		$this->view->file_put_contents($this->filename, $this->data);
 		$this->view->mkdir($this->folder);
-		$this->view->mkdir($this->folder . '/' . $this->subfolder);
-		$this->view->file_put_contents($this->folder.'/'.$this->filename, $this->data);
-		$this->view->file_put_contents($this->folder.'/' . $this->subfolder . '/' .$this->filename, $this->data);
+		$this->view->mkdir($this->folder . $this->subfolder);
+		$this->view->mkdir($this->folder . $this->subfolder . $this->subsubfolder);
+		$this->view->file_put_contents($this->folder.$this->filename, $this->data);
+		$this->view->file_put_contents($this->folder . $this->subfolder . $this->filename, $this->data);
 	}
 
 	function tearDown() {
@@ -323,9 +325,9 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		$testValues=array(
 			array('query' => 'Shared/' . $this->folder,
-				'expectedResult' => '/Shared' . $this->folder . '/' . $this->filename),
+				'expectedResult' => '/Shared' . $this->folder . $this->filename),
 			array('query' => 'Shared/' . $this->folder . $this->subfolder,
-				'expectedResult' => '/Shared' . $this->folder . $this->subfolder . '/' . $this->filename),
+				'expectedResult' => '/Shared' . $this->folder . $this->subfolder . $this->filename),
 		);
 		foreach ($testValues as $value) {
 
@@ -351,6 +353,195 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		\OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
 				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+
+	}
+
+	/**
+	 * @brief reshare a sub folder and check if we get the correct path
+	 * @medium
+	 */
+	function testGetShareFromSubFolderReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo = $this->view->getFileInfo($this->folder . $this->subfolder);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subfolder
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$_GET['path'] = '/Shared';
+		$_GET['subfiles'] = 'true';
+
+		$result = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share within $this->folder
+		$data = $result->getData();
+
+		// we should get exactly one result
+		$this->assertEquals(1, count($data));
+
+		$expectedPath = '/Shared' . $this->subfolder;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
+	 * @brief test re-re-share of folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareFromFolderReReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder . $this->subfolder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder . $this->subfolder . $this->subsubfolder);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subsubfolder
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3, 31);
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user3
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+
+		$_GET['path'] = '/Shared';
+		$_GET['subfiles'] = 'true';
+
+		$result = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share within $this->folder
+		$data = $result->getData();
+
+		// we should get exactly one result
+		$this->assertEquals(1, count($data));
+
+		$expectedPath = '/Shared' . $this->subsubfolder;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+		/**
+	 * @brief test re-re-share of folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareFromFileReReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder . $this->subfolder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder. $this->subfolder . $this->filename);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subsubfolder
+		$result = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3, 31);
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user3
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+
+		$_GET['path'] = '/Shared';
+		$_GET['subfiles'] = 'true';
+
+		$result = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result->succeeded());
+
+		// test should return one share within $this->folder
+		$data = $result->getData();
+
+		// we should get exactly one result
+		$this->assertEquals(1, count($data));
+
+		$expectedPath = '/Shared' . $this->filename;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+
+		// cleanup
+		$result = \OCP\Share::unshare('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$result = \OCP\Share::unshare('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER3);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
 
 	}
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1252,18 +1252,23 @@ class Share {
 				if (isset($row['parent'])) {
 					$query = \OC_DB::prepare('SELECT `file_target` FROM `*PREFIX*share` WHERE `id` = ?');
 					$parentResult = $query->execute(array($row['parent']));
+					//$query = \OC_DB::prepare('SELECT `file_target` FROM `*PREFIX*share` WHERE `id` = ?');
+					//$parentResult = $query->execute(array($row['id']));
 					if (\OC_DB::isError($result)) {
 						\OC_Log::write('OCP\Share', 'Can\'t select parent: ' .
 								\OC_DB::getErrorMessage($result) . ', select=' . $select . ' where=' . $where,
 								\OC_Log::ERROR);
 					} else {
 						$parentRow = $parentResult->fetchRow();
-						$splitPath = explode('/', $row['path']);
 						$tmpPath = '/Shared' . $parentRow['file_target'];
+						// find the right position where the row path continues from the target path
+						$pos = strrpos($row['path'], $parentRow['file_target']);
+						$subPath = substr($row['path'], $pos);
+						$splitPath = explode('/', $subPath);
 						foreach (array_slice($splitPath, 2) as $pathPart) {
 							$tmpPath = $tmpPath . '/' . $pathPart;
 						}
-						$row['path'] =  $tmpPath;
+						$row['path'] = $tmpPath;
 					}
 				} else {
 					if (!isset($mounts[$row['storage']])) {


### PR DESCRIPTION
Fix sharing results for reshared files.

It is not that obvious how to retrieve the correct Shared/-path for the current user in all circumstances (re-shares, re-re-shares, sharing of sub(sub)files, sharing a sub-folder and than re-share a sub-sub-file, etc)

I added some tests which hopefully covers most possibility. But some creative testing during review would be appreciated. :wink: 

fix #7662 
