### PR TITLE
add an option to set custom list of admin groups

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -32,6 +32,9 @@ $CONFIG = array(
 /* Force use of HTTPS connection (true = use HTTPS) */
 "forcessl" => false,
 
+/* Define different admin group(s) than the default "admin" */
+"admin_groups" => "",
+
 /* Blacklist a specific file and disallow the upload of files with this name - WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING. */
 "blacklisted_files" => array('.htaccess'),
 

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -354,12 +354,30 @@ class OC_User {
 	}
 
 	/**
+	 * @brief Check if the user is in one of the groups
+	 * @param string $uid
+	 * @param array $gids
+	 */
+	private static function isInOneOfGroups($uid, $gids) {
+		foreach ($gids as $gid) {
+			if (OC_Group::inGroup($uid, $gid)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * @brief Check if the user is an admin user
 	 * @param string $uid uid of the admin
 	 * @return bool
 	 */
 	public static function isAdminUser($uid) {
-		if (OC_Group::inGroup($uid, 'admin') && self::$incognitoMode === false) {
+		$adminGroups = OC_Config::getValue('admin_groups');
+		if (is_null($adminGroups) || '' === $adminGroups) {
+			$adminGroups = 'admin';
+		}
+		if (self::isInOneOfGroups($uid, split(',', $adminGroups)) && self::$incognitoMode === false) {
 			return true;
 		}
 		return false;

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -50,6 +50,7 @@ if (OC_Request::serverProtocol() === 'https') {
 }
 $tmpl->assign('isConnectedViaHTTPS', $connectedHTTPS);
 $tmpl->assign('enforceHTTPSEnabled', OC_Config::getValue( "forcessl", false));
+$tmpl->assign('adminGroups', OC_Config::getValue( "admin_groups", ''));
 
 $tmpl->assign('allowLinks', OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
 $tmpl->assign('allowPublicUpload', OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes'));

--- a/settings/ajax/setsecurity.php
+++ b/settings/ajax/setsecurity.php
@@ -8,6 +8,21 @@
 OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
+function validate_admin_groups($value) {
+	$value = trim($value);
+	if (0 === preg_match('/^([_a-z][-0-9_a-z]*(,[_a-z][-0-9_a-z]*)*)?$/', $value)) {
+		return false;
+	} else {
+		return $value;
+	}
+}
+
 OC_Config::setValue( 'forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
+$adminGroups = filter_var($_POST['adminGroups'], FILTER_CALLBACK, array('options' => 'validate_admin_groups'));
+if ($adminGroups) {
+	OC_Config::setValue( 'admin_groups', $adminGroups);
+} else {
+	OC_Config::deleteKey( 'admin_groups');
+}
 
 echo 'true';

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -33,6 +33,7 @@ $(document).ready(function(){
 
 	$('#security').change(function(){
 		$.post(OC.filePath('settings','ajax','setsecurity.php'), { enforceHTTPS: $('#forcessl').val() },function(){} );
+		$.post(OC.filePath('settings','ajax','setsecurity.php'), { adminGroups: $('#admin_groups').val() },function(){} );
 	});
 
 	$('#mail_smtpauth').change(function() {

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -268,6 +268,19 @@ if (!$_['internetconnectionworking']) {
 				?>
 			</td>
 		</tr>
+		<tr>
+			<td id="enable">
+				<label for="admin_groups"><?php p($l->t('Admin Groups'));?></label><input type="text" name="admin_groups"  id="admin_groups"  placeholder="<?php p($l->t('Optional; comma-separated'));?>"  title="<?php p($l->t('Admin Groups'));?>" value="<?php p($_['adminGroups']) ?>" /><br />
+				<em><?php p($l->t(
+					'Define admin groups, separeted by comma. Members of these groups can access the admin page. If not set, defaults to "admin".',
+					$theme->getName()
+				)); ?></em><br />
+				<em><?php p($l->t(
+					'Be careful not to misconfigure this, as you can no longer access the admin page then.',
+					$theme->getName()
+				)); ?></em>
+			</td>
+		</tr>
 	</table>
 </fieldset>
 
@@ -277,7 +290,7 @@ if (!$_['internetconnectionworking']) {
 	<p><?php p($l->t('This is used for sending out notifications.')); ?></p>
 
 	<p>
-		<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label> 
+		<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label>
 		<select name='mail_smtpmode' id='mail_smtpmode'>
 			<?php foreach ($mail_smtpmode as $smtpmode):
 				$selected = '';


### PR DESCRIPTION
This commit enables to optionally set a single or a list of admin groups (as opposed to the current hardcoded "admin"). It falls back to "admin" if list is empty.
This is very useful in an environment where the "admin" group is already otherwise in use, there already exists a differently named group ("Administrators" or whatnot) or a group of users should be able to administrate owncloud but not other services ("owncloud_admins"). Especially large ldap environments will have this requirement.
