### PR TITLE
use preDelete instead of postDelete hook

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -661,9 +661,9 @@ class OC {
 	 */
 	public static function registerPreviewHooks() {
 		OC_Hook::connect('OC_Filesystem', 'post_write', 'OC\Preview', 'post_write');
-		OC_Hook::connect('OC_Filesystem', 'delete', 'OC\Preview', 'post_delete');
-		OC_Hook::connect('\OCP\Versions', 'delete', 'OC\Preview', 'post_delete');
-		OC_Hook::connect('\OCP\Trashbin', 'delete', 'OC\Preview', 'post_delete');
+		OC_Hook::connect('OC_Filesystem', 'preDelete', 'OC\Preview', 'post_delete');
+		OC_Hook::connect('\OCP\Versions', 'preDelete', 'OC\Preview', 'post_delete');
+		OC_Hook::connect('\OCP\Trashbin', 'preDelete', 'OC\Preview', 'post_delete');
 	}
 
 	/**


### PR DESCRIPTION
:warning::warning::warning: DO NOT MERGE YET :warning::warning::warning:

use preDelete instead of postDelete hook.
requires https://github.com/owncloud/core/pull/7668 and https://github.com/owncloud/core/pull/7669 to be merged
