### PR TITLE
finally fix the paths for the OCS Share API

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -477,7 +477,90 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 	}
 
-		/**
+	/**
+	 * @brief test multiple shared folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareMultipleSharedFolder() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder . $this->subfolder);
+
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// share folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+
+		// ask for shared/subfolder
+		$expectedPath1 = '/Shared' . $this->subfolder;
+		$_GET['path'] = $expectedPath1;
+
+		$result1 = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result1->succeeded());
+
+		// test should return one share within $this->folder
+		$data1 = $result1->getData();
+		$share1 = reset($data1);
+
+		// ask for shared/folder/subfolder
+		$expectedPath2 = '/Shared' . $this->folder . $this->subfolder;
+		$_GET['path'] = $expectedPath2;
+
+		$result2 = Share\Api::getAllShares(array());
+
+		$this->assertTrue($result2->succeeded());
+
+		// test should return one share within $this->folder
+		$data2 = $result2->getData();
+		$share2 = reset($data2);
+
+
+		// validate results
+		// we should get exactly one result each time
+		$this->assertEquals(1, count($data1));
+		$this->assertEquals(1, count($data2));
+
+		$this->assertEquals($expectedPath1, $share1['path']);
+		$this->assertEquals($expectedPath2, $share2['path']);
+
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
 	 * @brief test re-re-share of folder if the path gets constructed correctly
 	 * @medium
 	 */
@@ -784,4 +867,24 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		$this->assertTrue($result3->succeeded());
 
 	}
+
+	function testCorrectPath() {
+		$path = "/foo/bar/test.txt";
+		$folder = "/correct/path";
+		$expectedResult = "/correct/path/test.txt";
+
+		$shareApiDummy = new TestShareApi();
+
+		$this->assertSame($expectedResult, $shareApiDummy->correctPathTest($path, $folder));
+	}
+
+}
+
+/**
+ * @brief dumnmy class to test protected methods
+ */
+class TestShareApi extends \OCA\Files\Share\Api {
+	public function correctPathTest($path, $folder) {
+		return self::correctPath($path, $folder);
+}
 }

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -1250,10 +1250,12 @@ class Share {
 			// Remove root from file source paths if retrieving own shared items
 			if (isset($uidOwner) && isset($row['path'])) {
 				if (isset($row['parent'])) {
+					// FIXME: Doesn't always construct the correct path, example:
+					// Folder '/a/b', share '/a' and '/a/b' to user2
+					// user2 reshares /Shared/b and ask for share status of /Shared/a/b
+					// expected result: path=/Shared/a/b; actual result /Shared/b because of the parent
 					$query = \OC_DB::prepare('SELECT `file_target` FROM `*PREFIX*share` WHERE `id` = ?');
 					$parentResult = $query->execute(array($row['parent']));
-					//$query = \OC_DB::prepare('SELECT `file_target` FROM `*PREFIX*share` WHERE `id` = ?');
-					//$parentResult = $query->execute(array($row['id']));
 					if (\OC_DB::isError($result)) {
 						\OC_Log::write('OCP\Share', 'Can\'t select parent: ' .
 								\OC_DB::getErrorMessage($result) . ', select=' . $select . ' where=' . $where,


### PR DESCRIPTION
Finally fix the paths for the OCS Share API.
This is a work around in the OCS Share API code because at the moment it is not possible to construct always the correct path directly in the sharing code. I will try to fix it directly in the sharing code for OC7

fix: #7673 
