### PR TITLE
Fixed chunking and insufficient storage check

### DIFF
--- a/lib/private/connector/sabre/quotaplugin.php
+++ b/lib/private/connector/sabre/quotaplugin.php
@@ -56,8 +56,19 @@ class OC_Connector_Sabre_QuotaPlugin extends Sabre_DAV_ServerPlugin {
 				$uri='/'.$uri;
 			}
 			list($parentUri, $newName) = Sabre_DAV_URLUtil::splitPath($uri);
+			$req = $this->server->httpRequest;
+			if ($req->getHeader('OC-Chunked')) {
+				$info = OC_FileChunking::decodeName($newName);
+				$chunkHandler = new OC_FileChunking($info);
+				// substract the already uploaded size to see whether
+				// there is still enough space for the remaining chunks
+				$length -= $chunkHandler->getCurrentSize();
+			}
 			$freeSpace = $this->getFreeSpace($parentUri);
 			if ($freeSpace !== \OC\Files\SPACE_UNKNOWN && $length > $freeSpace) {
+				if (isset($chunkHandler)) {
+					$chunkHandler->cleanup();
+				}
 				throw new Sabre_DAV_Exception_InsufficientStorage();
 			}
 		}

--- a/lib/private/filechunking.php
+++ b/lib/private/filechunking.php
@@ -64,17 +64,43 @@ class OC_FileChunking {
 		return $parts == $this->info['chunkcount'];
 	}
 
+	/**
+	 * Assembles the chunks into the file specified by the path.
+	 * Chunks are deleted afterwards.
+	 *
+	 * @param string $f target path
+	 *
+	 * @return assembled file size
+	 *
+	 * @throws \OC\InsufficientStorageException when file could not be fully
+	 * assembled due to lack of free space
+	 */
 	public function assemble($f) {
 		$cache = $this->getCache();
 		$prefix = $this->getPrefix();
 		$count = 0;
-		for($i=0; $i < $this->info['chunkcount']; $i++) {
+		for ($i = 0; $i < $this->info['chunkcount']; $i++) {
 			$chunk = $cache->get($prefix.$i);
+			// remove after reading to directly save space
+			$cache->remove($prefix.$i);
 			$count += fwrite($f, $chunk);
 		}
 
-		$this->cleanup();
 		return $count;
+	}
+
+	/**
+	 * Returns the size of the chunks already present
+	 * @return size in bytes
+	 */
+	public function getCurrentSize() {
+		$cache = $this->getCache();
+		$prefix = $this->getPrefix();
+		$total = 0;
+		for ($i = 0; $i < $this->info['chunkcount']; $i++) {
+			$total += $cache->size($prefix.$i);
+		}
+		return $total;
 	}
 
 	/**
@@ -128,7 +154,15 @@ class OC_FileChunking {
 	}
 
 	/**
-	 * @param string $path
+	 * Assembles the chunks into the file specified by the path.
+	 * Also triggers the relevant hooks and proxies.
+	 *
+	 * @param string $path target path
+	 *
+	 * @return assembled file size or false if file could not be created
+	 *
+	 * @throws \OC\InsufficientStorageException when file could not be fully
+	 * assembled due to lack of free space
 	 */
 	public function file_assemble($path) {
 		$absolutePath = \OC\Files\Filesystem::normalizePath(\OC\Files\Filesystem::getView()->getAbsolutePath($path));


### PR DESCRIPTION
- fixed free space detection based on the already uploaded chunks
- now deleting chunks as soon as it is read out before writing it into
  the part file, which reduces the space needed when assembling part
  files

Fixes #6540

~~Cannot be tested until https://github.com/owncloud/core/issues/7630 is merged.~~
Note: I developed this against stable6 so I'd be able to test.
Will need re-testing.

CC @ser72 
