### PR TITLE
only enable drag&drop upload if public upload is allowed

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -170,7 +170,7 @@ OC.Upload = {
 
 $(document).ready(function() {
 
-	if ( $('#file_upload_start').exists() ) {
+	if ( $('#file_upload_start').exists()&& $('#file_upload_start').is(':visible') ) {
 
 		var file_upload_param = {
 			dropZone: $('#content'), // restrict dropZone to content div


### PR DESCRIPTION
backport of #7631, original issue #7422 

cc @PVince81 can you give it a quick try (my file manager doesn't support drag&drop to the browser)? Thanks! 
