### PR TITLE
no content type is returned due to security reasons - in addition it loo...

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -204,12 +204,8 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 	 * @return mixed
 	 */
 	public function getContentType() {
-		if (isset($this->fileinfo_cache['mimetype'])) {
-			return $this->fileinfo_cache['mimetype'];
-		}
 
-		return \OC\Files\Filesystem::getMimeType($this->path);
-
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
...ks like there is no need to return the proper content type - tests will show

https://github.com/owncloud/core/pull/7681#issuecomment-37390018

refs #7681

@tanghus @dragotin @danimo @guruz @ogoffart @icewind1991 @karlitschek @LukasReschke 
