### PR TITLE
Fixing issues found with running 'autotest-js' locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,11 @@ nbproject
 # Node Modules
 /build/node_modules/
 
+# nodejs
+/build/lib/
+/npm-debug.log
+
+
 # Tests - auto-generated files
 /data-autotest
 /tests/coverage*

--- a/build/package.json
+++ b/build/package.json
@@ -14,7 +14,9 @@
                 "karma": "*",
                 "karma-jasmine": "*",
                 "karma-junit-reporter": "*",
-	            "karma-coverage": "*"
+	            "karma-coverage": "*",
+                "karma-phantomjs-launcher": "*",
+                "phantomjs": "*"
         },
         "engine": "node >= 0.8"
 }


### PR DESCRIPTION
I have been off and on with @PVince81 for a few days trying to figure out why I couldn't run 'autotest-js' locally to add and fix testing errors in another branch. I resorted to creating an issue in karma for help in https://github.com/karma-runner/karma/issues/933 . The newest version of karma allowed us to see a better error message and it turns out the packages required for phantomjs were missing. So that is what my additions in "package.json" are. With these changes, I was able to run 'autotest-js' on a clean installation in Ubuntu 12.04 without any issues.
The additions to gitignore are files and directories that nodejs/npm created during the execution of 'autotest-js'.
