### PR TITLE
Allow setting the config dir to use as enviroment variable for phpunit

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -103,7 +103,9 @@ class OC {
 			get_include_path()
 		);
 
-		if(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
+		if(defined('PHPUNIT_CONFIG_DIR')) {
+			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
+		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
 		} else {
 			self::$configDir = OC::$SERVERROOT . '/config/';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,9 +3,14 @@
 
 define('PHPUNIT_RUN', 1);
 
-require_once __DIR__.'/../lib/base.php';
+$configDir = getenv('CONFIG_DIR');
+if ($configDir) {
+	define('PHPUNIT_CONFIG_DIR', $configDir);
+}
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+require_once __DIR__ . '/../lib/base.php';
+
+if (!class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
This allows for setting the config to use for running the tests either by setting the env variable in the command line or in the phpunit.xml:

``` xml
<php>
    <env name="CONFIG_DIR" value="tests/config/mysql"/>
</php>
```

This makes it easy to have multiple test "profiles" to test for example different db backends without having to manually switch the config file around or having multiple installations with different config files

cc @karlitschek @DeepDiver1975 @PVince81 
