### PR TITLE
fix autoconfig

### DIFF
--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -20,7 +20,7 @@ class Controller {
 			$errors = array('errors' => $e);
 
 			if(count($e) > 0) {
-				$options = array_merge($post, $opts, $errors);
+				$options = array_merge($opts, $post, $errors);
 				$this->display($options);
 			}
 			else {
@@ -28,7 +28,8 @@ class Controller {
 			}
 		}
 		else {
-			$this->display($opts);
+			$options = array_merge($opts, $post);
+			$this->display($options);
 		}
 	}
 
@@ -41,6 +42,7 @@ class Controller {
 			'dbname' => '',
 			'dbtablespace' => '',
 			'dbhost' => '',
+			'dbtype' => '',
 		);
 		$parameters = array_merge($defaults, $post);
 


### PR DESCRIPTION
In array_merge, $post overrides $opts (concerns data directory).
Always merge $post before calling display().
Default value for dbtype which may still be undefined in display().

Fixes several problems related to autoconfig:
- installation.php only showed $AUTOCONFIG data if it was called after
  install() had come back with errors
- if autoconfig.php was set, installation.php showed an editable field
  with the wrong data in it; then, regardless of any changes, the value
  from autoconfig.php was used
- installation.php used undefined indeces (dbtype, dbIsSet,
  directoryIsSet)
