### PR TITLE
add 'body-public' ID to body in base layout so it can be identified via CSS

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -31,7 +31,7 @@
 		<?php endforeach; ?>
 	</head>
 
-	<body>
+	<body id="body-public">
 		<?php print_unescaped($_['content']); ?>
 	</body>
 </html>


### PR DESCRIPTION
Finally we can know in the CSS if it’s a public share. Please review @owncloud/designers @DeepDiver1975 
