### PR TITLE
Added warning for trusted_domains after CLI upgrade

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -27,6 +27,12 @@ class Upgrade extends Command {
 		;
 	}
 
+	/**
+	 * Execute the upgrade command
+	 *
+	 * @param InputInterface $input input interface
+	 * @param OutputInterface $output output interface
+	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		global $RUNTIME_NOAPPS;
 
@@ -69,6 +75,9 @@ class Upgrade extends Command {
 			});
 
 			$updater->upgrade();
+
+			$this->postUpgradeCheck($input, $output);
+
 			return self::ERROR_SUCCESS;
 		} else if(\OC_Config::getValue('maintenance', false)) {
 			//Possible scenario: ownCloud core is updated but an app failed
@@ -82,6 +91,23 @@ class Upgrade extends Command {
 		} else {
 			$output->writeln('<info>ownCloud is already latest version</info>');
 			return self::ERROR_UP_TO_DATE;
+		}
+	}
+
+	/**
+	 * Perform a post upgrade check (specific to the command line tool)
+	 *
+	 * @param InputInterface $input input interface
+	 * @param OutputInterface $output output interface
+	 */
+	protected function postUpgradeCheck(InputInterface $input, OutputInterface $output) {
+		$trustedDomains = \OC_Config::getValue('trusted_domains', array());
+		if (empty($trustedDomains)) {
+			$output->write(
+				'<warning>The setting "trusted_domains" could not be ' .
+				'set automatically by the upgrade script, ' .
+				'please set it manually</warning>'
+			);
 		}
 	}
 }

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -108,7 +108,7 @@ class Updater extends BasicEmitter {
 		/*
 		 * START CONFIG CHANGES FOR OLDER VERSIONS
 		 */
-		if (version_compare($currentVersion, '6.90.1', '<')) {
+		if (!\OC::$CLI && version_compare($currentVersion, '6.90.1', '<')) {
 			// Add the overwriteHost config if it is not existant
 			// This is added to prevent host header poisoning
 			\OC_Config::setValue('trusted_domains', \OC_Config::getValue('trusted_domains', array(\OC_Request::serverHost()))); 


### PR DESCRIPTION
If trusted_domains is not set after a CLI upgrade, show a warning in the
output.

Note: the CLI upgrade will not set "trusted_domains" to "localhost" any more as it doesn't make sense. "localhost" is always considered as trusted internally.
This makes it possible, for each upgrade, to show the warning again if the admin always forgets to set the trusted_domains...

Fixes #7663

Note: there will be a code conflict with https://github.com/owncloud/core/pull/7611 in which I'm still 

Please review @LukasReschke @karlitscheck
