### PR TITLE
Update share.js

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -460,7 +460,7 @@ OC.Share={
 		} else {
 			//TODO add path param when showing a link to file in a subfolder of a public link share
 			var service='';
-			if(linkSharetype=='folder' || linkSharetype=='file'){
+			if(linkSharetype === 'folder' || linkSharetype === 'file'){
 				service='files';
 			}else{
 				service=linkSharetype;

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -468,7 +468,6 @@ OC.Share={
 			
 			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service='+service+'&t='+token;
 
-			//var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
 		}
 		$('#linkText').val(link);
 		$('#linkText').show('blind');

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -442,6 +442,10 @@ OC.Share={
 	showLink:function(token, password, itemSource) {
 		OC.Share.itemShares[OC.Share.SHARE_TYPE_LINK] = true;
 		$('#linkCheckbox').attr('checked', true);
+		
+		//check itemType
+		var linkSharetype=$('#dropdown').data('item-type');
+		
 		if (! token) {
 			//fallback to pre token link
 			var filename = $('tr').filterAttr('data-id', String(itemSource)).data('file');
@@ -455,7 +459,16 @@ OC.Share={
 			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&'+type+'='+encodeURIComponent(file);
 		} else {
 			//TODO add path param when showing a link to file in a subfolder of a public link share
-			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
+			var service='';
+			if(linkSharetype=='folder' || linkSharetype=='file'){
+				service='files';
+			}else{
+				service=linkSharetype;
+			}
+			
+			var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service='+service+'&t='+token;
+
+			//var link = parent.location.protocol+'//'+location.host+OC.linkTo('', 'public.php')+'?service=files&t='+token;
 		}
 		$('#linkText').val(link);
 		$('#linkText').show('blind');


### PR DESCRIPTION
Some more global definition to autogenerate a "Shared by Link" with token! Why we not add these lines for more global use of the public service feature? At the moment there is a pr for sharing a calendar by Link. With this little mod the calendar can work with the core share api and needs no own js share definition!
