### PR TITLE
Added .ocdata file to check for data folder validity

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -536,6 +536,7 @@ class OC {
 					echo $error['hint'] . "\n\n";
 				}
 			} else {
+				OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 				OC_Template::printGuestPage('', 'error', array('errors' => $errors));
 			}
 			exit;

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -12,6 +12,7 @@ class OC_Response {
 	const STATUS_TEMPORARY_REDIRECT = 307;
 	const STATUS_NOT_FOUND = 404;
 	const STATUS_INTERNAL_SERVER_ERROR = 500;
+	const STATUS_SERVICE_UNAVAILABLE = 503;
 
 	/**
 	* @brief Enable response caching by sending correct HTTP headers
@@ -73,6 +74,9 @@ class OC_Response {
 				break;
 			case self::STATUS_INTERNAL_SERVER_ERROR;
 				$status = $status . ' Internal Server Error';
+				break;
+			case self::STATUS_SERVICE_UNAVAILABLE;
+				$status = $status . ' Service Unavailable';
 				break;
 		}
 		header($protocol.' '.$status);

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -106,6 +106,10 @@ class OC_Setup {
 			//guess what this does
 			OC_Installer::installShippedApps();
 
+			// create empty file in data dir, so we can later find
+			// out that this is indeed an ownCloud data directory
+			file_put_contents(OC_Config::getValue('datadirectory', OC::$SERVERROOT.'/data').'/.ocdata', '');
+
 			//create htaccess files for apache hosts
 			if (isset($_SERVER['SERVER_SOFTWARE']) && strstr($_SERVER['SERVER_SOFTWARE'], 'Apache')) {
 				self::createHtaccess();

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -105,6 +105,11 @@ class Updater extends BasicEmitter {
 		}
 		$this->emit('\OC\Updater', 'maintenanceStart');
 
+		// create empty file in data dir, so we can later find
+		// out that this is indeed an ownCloud data directory
+		// (in case it didn't exist before)
+		file_put_contents(\OC_Config::getValue('datadirectory', \OC::$SERVERROOT.'/data').'/.ocdata', '');
+
 		/*
 		 * START CONFIG CHANGES FOR OLDER VERSIONS
 		 */

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+/**
+ * Tests for server check functions
+ */
+class Test_Util_CheckServer extends PHPUnit_Framework_TestCase {
+
+	private $datadir;
+
+	public function setUp() {
+		$this->datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data');
+
+		file_put_contents($this->datadir . '/.ocdata', '');
+	}
+
+	public function tearDown() {
+		// clean up
+		@unlink($this->datadir . '/.ocdata');
+	}
+
+	/**
+	 * Test that checkServer() returns no errors in the regular case.
+	 */
+	public function testCheckServer() {
+		$result = \OC_Util::checkServer();
+		$this->assertEmpty($result);
+	}
+
+	/**
+	 * Test that checkServer() does not check the data dir validity
+	 * when the server is not installed yet (else the setup cannot
+	 * be run...)
+	 */
+	public function testCheckServerSkipDataDirValidityOnSetup() {
+		// simulate old version that didn't have it
+		unlink($this->datadir . '/.ocdata');
+
+		$session = \OC::$server->getSession();
+		$oldInstalled = \OC_Config::getValue('installed', false);
+
+		// simulate that the server isn't setup yet
+		\OC_Config::setValue('installed', false);
+
+		// even though ".ocdata" is missing, the error isn't
+		// triggered to allow setup to run
+		$result = \OC_Util::checkServer();
+		$this->assertEmpty($result);
+
+		// restore config
+		\OC_Config::setValue('installed', $oldInstalled);
+	}
+
+	/**
+	 * Test that checkServer() does not check the data dir validity
+	 * when an upgrade is required (else the upgrade cannot be
+	 * performed...)
+	 */
+	public function testCheckServerSkipDataDirValidityOnUpgrade() {
+		// simulate old version that didn't have it
+		unlink($this->datadir . '/.ocdata');
+
+		$session = \OC::$server->getSession();
+		$oldCurrentVersion = $session->get('OC_Version');
+		$oldInstallVersion = \OC_Config::getValue('version', '0.0.0');
+
+		// upgrade condition to simulate needUpgrade() === true
+		$session->set('OC_Version', array(6, 0, 0, 2));
+		\OC_Config::setValue('version', '6.0.0.1');
+
+		// even though ".ocdata" is missing, the error isn't
+		// triggered to allow for upgrade
+		$result = \OC_Util::checkServer();
+		$this->assertEmpty($result);
+
+		// restore versions
+		$session->set('OC_Version', $oldCurrentVersion);
+		\OC_Config::setValue('version', $oldInstallVersion);
+	}
+
+	/**
+	 * Test that checkDataDirectoryValidity returns no error
+	 * when ".ocdata" is present.
+	 */
+	public function testCheckDataDirValidity() {
+		$result = \OC_Util::checkDataDirectoryValidity($this->datadir);
+		$this->assertEmpty($result);
+	}
+
+	/**
+	 * Test that checkDataDirectoryValidity and checkServer 
+	 * both return an error when ".ocdata" is missing.
+	 */
+	public function testCheckDataDirValidityWhenFileMissing() {
+		unlink($this->datadir . '/.ocdata');
+		$result = \OC_Util::checkDataDirectoryValidity($this->datadir);
+		$this->assertEquals(1, count($result));
+
+		$result = \OC_Util::checkServer();
+		$this->assertEquals(1, count($result));
+	}
+
+}

--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -83,6 +83,7 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 		$knownEntries = array(
 			'owncloud.log' => true,
 			'owncloud.db' => true,
+			'.ocdata' => true,
 			'..' => true,
 			'.' => true
 		);

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
 
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel when updating major/minor version number.
-$OC_Version=array(6, 90, 0, 1);
+$OC_Version=array(6, 90, 0, 2);
 
 // The human readable string
 $OC_VersionString='7.0 pre alpha';


### PR DESCRIPTION
In environments where the data folder is mount from another partition,
it is important to check that the data folder we see is actually the
real one. If the mount failed for some reasons, this fix will make
ownCloud temporarily unavailable instead of causing unpredictable
behavior.

Fixes #7488 

Please review/test @jcfischer @DeepDiver1975 @karlitschek 
#### To test:
- [x] Initial ".ocdata" file creation on setup
- [x] ".ocdata" file creation after upgrade
#### For each of these tests, check that the sync client goes to "service unavailable mode" and the web UI shows an error message:
- [x] Manually remove ".ocdata" file to simulate the issue, then recreate it.
- [x] Test with real FS mount on "data" dir: umount, check, then remount
- [x] Test when "data" dir is mounted in a subdir of a real FS mount: umount, check, then remount.
- [x] ./occ shows error when ".ocdata" missing
