### PR TITLE
Correctly round bytes when converted from human readable format

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -308,7 +308,7 @@ class OC_Helper {
 
 	/**
 	 * @brief Make a computer file size
-	 * @param string $str file size in a fancy format
+	 * @param string $str file size in human readable format
 	 * @return int a file size in bytes
 	 *
 	 * Makes 2kB to 2048.
@@ -338,7 +338,7 @@ class OC_Helper {
 			$bytes *= $bytes_array[$matches[1]];
 		}
 
-		$bytes = round($bytes, 2);
+		$bytes = round($bytes);
 
 		return $bytes;
 	}

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -23,6 +23,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 			array('0 B', 0),
 			array('1 kB', 1024),
 			array('9.5 MB', 10000000),
+			array('1.3 GB', 1395864371),
 			array('465.7 GB', 500000000000),
 			array('454.7 TB', 500000000000000),
 			array('444.1 PB', 500000000000000000),
@@ -41,8 +42,9 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 		return array(
 			array(0.0, "0 B"),
 			array(1024.0, "1 kB"),
+			array(1395864371.0, '1.3 GB'),
 			array(9961472.0, "9.5 MB"),
-			array(500041567436.8, "465.7 GB"),
+			array(500041567437.0, "465.7 GB"),
 		);
 	}
 


### PR DESCRIPTION
Instead of leave two decimal places which is confusing, round the byte
values correctly to the closest byte.

Fixes #7757 

Please review @icewind1991 @schiesbn @karlitschek @bantu 
