### PR TITLE
[stable5] Fix "restore all selected files"

### DIFF
--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -100,7 +100,7 @@ $(document).ready(function() {
 			var dirlisting=getSelectedFiles('dirlisting')[0];
 
 			for (var i=0; i<files.length; i++) {
-				var undeleteAction = $FileList.findFileEl(files[i]).children("td.date");
+				var undeleteAction = FileList.findFileEl(files[i]).children("td.date");
 				undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
 			}
 


### PR DESCRIPTION
:one: byte change

It seems that a typo sneaked in during a backport.

This fixes the case when selecting files in the trashbin and clicking
"Restore" on the tool bar to restore them all.

This is stable5 only.

Please review @karlitschek @icewind1991 @schiesbn 
