### PR TITLE
use a non-recursive chmod on the datadir

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -344,35 +344,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Recursive editing of file permissions
-	 * @param string $path path to file or folder
-	 * @param int $filemode unix style file permissions
-	 * @return bool
-	 */
-	static function chmodr($path, $filemode) {
-		if (!is_dir($path))
-			return chmod($path, $filemode);
-		$dh = opendir($path);
-		if(is_resource($dh)) {
-			while (($file = readdir($dh)) !== false) {
-				if ($file != '.' && $file != '..') {
-					$fullpath = $path . '/' . $file;
-					if (is_link($fullpath))
-						return false;
-					elseif (!is_dir($fullpath) && !@chmod($fullpath, $filemode))
-						return false; elseif (!self::chmodr($fullpath, $filemode))
-						return false;
-				}
-			}
-			closedir($dh);
-		}
-		if (@chmod($path, $filemode))
-			return true;
-		else
-			return false;
-	}
-
-	/**
 	 * @brief Recursive copying of folders
 	 * @param string $src source folder
 	 * @param string $dest target folder

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -526,7 +526,7 @@ class OC_Util {
 				.' cannot be listed by other users.';
 			$perms = substr(decoct(@fileperms($dataDirectory)), -3);
 			if (substr($perms, -1) != '0') {
-				OC_Helper::chmodr($dataDirectory, 0770);
+				chmod($dataDirectory, 0770);
 				clearstatcache();
 				$perms = substr(decoct(@fileperms($dataDirectory)), -3);
 				if (substr($perms, 2, 1) != '0') {


### PR DESCRIPTION
Chmod'ing only to datadir also achieves the goal of making the datadir inaccessible for other users.

Fixes #7711 

(this was the only use of `OC_Helper::chmodr`)

cc @karlitschek @ser72 @DeepDiver1975 
