### PR TITLE
SVG support detection

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -712,11 +712,11 @@ SVGSupport.checkMimeType=function(){
 						if(value[0]==='"'){
 							value=value.substr(1,value.length-2);
 						}
-						headers[parts[0]]=value;
+						headers[parts[0].toLowerCase()]=value;
 					}
 				}
 			});
-			if(headers["Content-Type"]!=='image/svg+xml'){
+			if(headers["content-type"]!=='image/svg+xml'){
 				replaceSVG();
 				SVGSupport.checkMimeType.correct=false;
 			}


### PR DESCRIPTION
The SVGSupport checkMimeType method was failing on my setup as the headers are all returned in lowercase. I have lowercased all the indexes and modified the if statement so that it doesn't matter what case the headers are returned in
