### PR TITLE
Verify that a file exists before we share it

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -878,6 +878,29 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 		$this->assertSame($expectedResult, $shareApiDummy->correctPathTest($path, $folder));
 	}
 
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testShareNonExisting() {
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		$id = PHP_INT_MAX - 1;
+		\OCP\Share::shareItem('file', $id, \OCP\Share::SHARE_TYPE_LINK, \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+	}
+
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testShareNotOwner() {
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+		\OC\Files\Filesystem::file_put_contents('foo.txt', 'bar');
+		$info = \OC\Files\Filesystem::getFileInfo('foo.txt');
+
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+	}
+
 }
 
 /**

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -431,6 +431,16 @@ class Share extends \OC\Share\Constants {
 			$itemSourceName = $itemSource;
 		}
 
+		// verify that the file exists before we try to share it
+		if ($itemType === 'file' or $itemType === 'folder') {
+			$path = \OC\Files\Filesystem::getPath($itemSource);
+			if (!$path) {
+				$message = 'Sharing ' . $itemSourceName . ' failed, because the file does not exist';
+				\OC_Log::write('OCP\Share', $message, \OC_Log::ERROR);
+				throw new \Exception($message);
+			}
+		}
+
 		// Verify share type and sharing conditions are met
 		if ($shareType === self::SHARE_TYPE_USER) {
 			if ($shareWith == $uidOwner) {


### PR DESCRIPTION
Prevents invalid entries from getting into the share table and folder

cc @karlitschek @DeepDiver1975 @LukasReschke 
