### PR TITLE
Display admin option for public upload with encryption enabled

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -203,7 +203,6 @@ if (!$_['internetconnectionworking']) {
 				<em><?php p($l->t('Allow users to share items to the public with links')); ?></em>
 			</td>
 		</tr>
-		<?php if (!\OCP\App::isEnabled('files_encryption')) { ?>
 		<tr>
 			<td <?php if ($_['shareAPIEnabled'] == 'no') print_unescaped('class="hidden"');?>>
 				<input type="checkbox" name="shareapi_allow_public_upload" id="allowPublicUpload"
@@ -212,7 +211,6 @@ if (!$_['internetconnectionworking']) {
 				<em><?php p($l->t('Allow users to enable others to upload into their publicly shared folders')); ?></em>
 			</td>
 		</tr>
-		<?php } ?>
 		<tr>
 			<td <?php if ($_['shareAPIEnabled'] === 'no') print_unescaped('class="hidden"');?>>
 				<input type="checkbox" name="shareapi_allow_resharing" id="allowResharing"


### PR DESCRIPTION
Now that public upload works with encryption, the admin option to toggle
it must be made visible.

Fixes #7773 

It's a :two: liner :smile: 

Please review @ser72 @karlitschek @schiesbn @MorrisJobke 
