### PR TITLE
Fix validation of allowed personal backend

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -321,7 +321,7 @@ class OC_Mount_Config {
 			// Verify that the mount point applies for the current user
 			// Prevent non-admin users from mounting local storage and other disabled backends
 			$allowed_backends = self::getPersonalBackends();
-			if ($applicable != OCP\User::getUser() || !in_array($class, $allowed_backends)) {
+			if ($applicable != OCP\User::getUser() || !isset($allowed_backends[$class])) {
 				return false;
 			}
 			$mountPoint = '/'.$applicable.'/files/'.ltrim($mountPoint, '/');

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -28,6 +28,9 @@ class OC_Mount_Config {
 	const MOUNT_TYPE_GROUP = 'group';
 	const MOUNT_TYPE_USER = 'user';
 
+	// whether to skip backend test (for unit tests, as this static class is not mockable)
+	public static $skipTest = false;
+
 	/**
 	* Get details on each of the external storage backends, used for the mount config UI
 	* If a custom UI is needed, add the key 'custom' and a javascript file with that name will be loaded
@@ -275,6 +278,9 @@ class OC_Mount_Config {
 	}
 
 	private static function getBackendStatus($class, $options) {
+		if (self::$skipTest) {
+			return true;
+		}
 		foreach ($options as &$option) {
 			$option = str_replace('$user', OCP\User::getUser(), $option);
 		}

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -34,6 +34,66 @@ class Test_Mount_Config_Dummy_Storage {
  * Class Test_Mount_Config
  */
 class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
+
+	private $dataDir;
+	private $userHome;
+	private $oldAllowedBackends;
+	private $allBackends;
+
+	public function setUp() {
+		\OC_User::setUserId('test');
+		$this->userHome = \OC_User::getHome('test');
+		mkdir($this->userHome);
+
+		$this->dataDir = \OC_Config::getValue(
+			'datadirectory',
+			\OC::$SERVERROOT . '/data/'
+		);
+		$this->oldAllowedBackends = OCP\Config::getAppValue(
+			'files_external',
+			'user_mounting_backends',
+			''
+		);
+		$this->allBackends = OC_Mount_Config::getBackends();
+		OCP\Config::setAppValue(
+			'files_external',
+			'user_mounting_backends',
+			implode(',', array_keys($this->allBackends))
+		);
+
+		OC_Mount_Config::$skipTest = true;
+	}
+
+	public function tearDown() {
+		OC_Mount_Config::$skipTest = false;
+
+		@unlink($this->dataDir . '/mount.json');
+		@unlink($this->userHome . '/mount.json');
+		rmdir($this->userHome);
+
+		OCP\Config::setAppValue(
+			'files_external',
+			'user_mounting_backends',
+			$this->oldAllowedBackends
+		);
+	}
+
+	/**
+	 * Reads the global config, for checking
+	 */
+	private function readGlobalConfig() {
+		$configFile = $this->dataDir . '/mount.json';
+		return json_decode(file_get_contents($configFile), true);
+	}
+
+	/**
+	 * Reads the user config, for checking
+	 */
+	private function readUserConfig() {
+		$configFile = $this->userHome . '/mount.json';
+		return json_decode(file_get_contents($configFile), true);
+	}
+
 	/**
 	 * Test mount point validation
 	 */
@@ -42,35 +102,88 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$mountType = 'user';
 		$applicable = 'all';
 		$isPersonal = false;
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/Shared', $storageClass, array(), $mountType, $applicable, $isPersonal));
 
 	}
 
+	/**
+	 * Test adding a global mount point
+	 */
+	public function testAddGlobalMountPoint() {
+		$mountType = OC_Mount_Config::MOUNT_TYPE_GLOBAL;
+		$applicable = 'all';
+		$isPersonal = false;
+
+		$this->assertEquals(true, OC_Mount_Config::addMountPoint('/ext', '\OC\Files\Storage\SFTP', array(), $mountType, $applicable, $isPersonal));
+
+		$config = $this->readGlobalConfig();
+		$this->assertEquals(1, count($config));
+		$this->assertTrue(isset($config[$mountType]));
+		$this->assertTrue(isset($config[$mountType][$applicable]));
+		$this->assertTrue(isset($config[$mountType][$applicable]['/$user/files/ext']));
+		$this->assertEquals(
+			'\OC\Files\Storage\SFTP',
+			$config[$mountType][$applicable]['/$user/files/ext']['class']
+		);
+	}
+
+	/**
+	 * Test adding a personal mount point
+	 */
 	public function testAddMountPointSingleUser() {
-		\OC_User::setUserId('test');
-		$mountType = 'user';
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
 		$applicable = 'test';
 		$isPersonal = true;
-		// local
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/ext', '\OC\Files\storage\local', array(), $mountType, $applicable, $isPersonal));
-		// non-local
-		// FIXME: can't test this yet as the class (write operation) is not mockable
-		// $this->assertEquals(true, OC_Mount_Config::addMountPoint('/ext', '\OC\Files\Storage\SFTP', array(), $mountType, $applicable, $isPersonal));
 
+		$this->assertEquals(true, OC_Mount_Config::addMountPoint('/ext', '\OC\Files\Storage\SFTP', array(), $mountType, $applicable, $isPersonal));
+
+		$config = $this->readUserConfig();
+		$this->assertEquals(1, count($config));
+		$this->assertTrue(isset($config[$mountType]));
+		$this->assertTrue(isset($config[$mountType][$applicable]));
+		$this->assertTrue(isset($config[$mountType][$applicable]['/test/files/ext']));
+		$this->assertEquals(
+			'\OC\Files\Storage\SFTP',
+			$config[$mountType][$applicable]['/test/files/ext']['class']
+		);
 	}
 
-	public function testAddMountPointUnexistClass() {
-		\OC_User::setUserId('test');
-		$storageClass = 'Unexist_Storage';
-		$mountType = 'user';
+	/**
+	 * Test adding a personal mount point using disallowed backend
+	 */
+	public function testAddDisallowedBackendMountPointSingleUser() {
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
 		$applicable = 'test';
 		$isPersonal = true;
+
 		// local
-		// non-local
-		$this->assertEquals(false, OC_Mount_Config::addMountPoint('/ext', $storageClass, array(), $mountType, $applicable, $isPersonal));
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/ext', '\OC\Files\storage\local', array(), $mountType, $applicable, $isPersonal));
+
+		unset($this->allBackends['\OC\Files\Storage\SFTP']);
+		OCP\Config::setAppValue(
+			'files_external',
+			'user_mounting_backends',
+			implode(',', array_keys($this->allBackends))
+		);
+
+		// non-local but forbidden
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/ext', '\OC\Files\Storage\SFTP', array(), $mountType, $applicable, $isPersonal));
+
+		$this->assertFalse(file_exists($this->userHome . '/mount.json'));
+	}
+
+	/**
+	 * Test adding a mount point with an non-existant backend
+	 */
+	public function testAddMountPointUnexistClass() {
+		$storageClass = 'Unexist_Storage';
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
+		$applicable = 'test';
+		$isPersonal = false;
+		$this->assertFalse(OC_Mount_Config::addMountPoint('/ext', $storageClass, array(), $mountType, $applicable, $isPersonal));
 
 	}
 }


### PR DESCRIPTION
Fixes issue that makes it impossible for a user to add personal mount points, even when the backend is allowed.

This PR also improves the unit tests, and cover this fix.

Please review and test @nickvergessen @DeepDiver1975 @icewind1991 @karlitschek 
