### PR TITLE
Obfuscate passwords in ext storage config

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -25,5 +25,6 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 }
 
 // connecting hooks
-OCP\Util::connectHook( 'OC_User', 'post_login', 'OC\Files\Storage\iRODS', 'login' );
+OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
+OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\iRODS', 'login');
 

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -173,7 +173,7 @@ class OC_Mount_Config {
 	 */
 	public static function initMountPointsHook($data) {
 		$mountPoints = self::getAbsoluteMountPoints($data['user']);
-		foreach ($mountPoints as $mountPoints => $options) {
+		foreach ($mountPoints as $mountPoint => $options) {
 			\OC\Files\Filesystem::mount($options['class'], $options['options'], $mountPoint);
 		}
 	}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -50,6 +50,7 @@ class OC_Mount_Config {
 	*/
 	public static function getBackends() {
 
+		// FIXME: do not rely on php key order for the options order in the UI
 		$backends['\OC\Files\Storage\Local']=array(
 				'backend' => 'Local',
 				'configuration' => array(
@@ -649,7 +650,9 @@ class OC_Mount_Config {
 	private static function encryptPasswords($options) {
 		if (isset($options['password'])) {
 			$options['password_encrypted'] = self::encryptPassword($options['password']);
-			unset($options['password']);
+			// do not unset the password, we want to keep the keys order
+			// on load... because that's how the UI currently works
+			$options['password'] = '';
 		}
 		return $options;
 	}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -700,8 +700,6 @@ class OC_Mount_Config {
 	 * Returns the encryption cipher
 	 */
 	private static function getCipher() {
-		// note: not caching this to make it thread safe as we'll use
-		// a different IV for each password
 		if (!class_exists('Crypt_AES', false)) {
 			include('Crypt/AES.php');
 		}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -24,7 +24,6 @@ set_include_path(
 	get_include_path() . PATH_SEPARATOR .
 	\OC_App::getAppPath('files_external') . '/3rdparty/phpseclib/phpseclib'
 );
-include('Crypt/AES.php');
 
 /**
  * Class to configure mount.json globally and for users
@@ -703,6 +702,9 @@ class OC_Mount_Config {
 	private static function getCipher() {
 		// note: not caching this to make it thread safe as we'll use
 		// a different IV for each password
+		if (!class_exists('Crypt_AES', false)) {
+			include('Crypt/AES.php');
+		}
 		$cipher = new Crypt_AES(CRYPT_AES_MODE_CBC);
 		$cipher->setKey(\OCP\Config::getSystemValue('passwordsalt'));
 		return $cipher;

--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -37,7 +37,7 @@ class SMB extends \OC\Files\Storage\StreamWrapper{
 				$this->share = substr($this->share, 0, -1);
 			}
 		} else {
-			throw new \Exception();
+			throw new \Exception('Invalid configuration');
 		}
 	}
 

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -245,6 +245,8 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('\OC\Files\Storage\SMB', $config['ext']['class']);
 		$savedMountConfig = $config['ext']['configuration'];
 		$this->assertEquals($mountConfig, $savedMountConfig);
+		// key order needs to be preserved for the UI...
+		$this->assertEquals(array_keys($mountConfig), array_keys($savedMountConfig));
 	}
 
 	/**
@@ -281,6 +283,8 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('\OC\Files\Storage\SMB', $config['ext']['class']);
 		$savedMountConfig = $config['ext']['configuration'];
 		$this->assertEquals($mountConfig, $savedMountConfig);
+		// key order needs to be preserved for the UI...
+		$this->assertEquals(array_keys($mountConfig), array_keys($savedMountConfig));
 	}
 
 	/**
@@ -316,8 +320,8 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$config = $this->readUserConfig();
 		$savedConfig = $config[$mountType][$applicable]['/' . self::TEST_USER1 . '/files/ext']['options'];
 
-		// no more clear text password in file
-		$this->assertFalse(isset($savedConfig['password']));
+		// no more clear text password in file (kept because of key order)
+		$this->assertEquals('', $savedConfig['password']);
 
 		// encrypted password is present
 		$this->assertNotEquals($mountConfig['password'], $savedConfig['password_encrypted']);

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -113,7 +113,7 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 	 * Test adding a global mount point
 	 */
 	public function testAddGlobalMountPoint() {
-		$mountType = OC_Mount_Config::MOUNT_TYPE_GLOBAL;
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
 		$applicable = 'all';
 		$isPersonal = false;
 
@@ -185,5 +185,77 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$isPersonal = false;
 		$this->assertFalse(OC_Mount_Config::addMountPoint('/ext', $storageClass, array(), $mountType, $applicable, $isPersonal));
 
+	}
+
+	/**
+	 * Test reading and writing global config
+	 */
+	public function testReadWriteGlobalConfig() {
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
+		$applicable = 'all';
+		$isPersonal = false;
+		$mountConfig = array(
+			'host' => 'smbhost',
+			'user' => 'smbuser',
+			'password' => 'smbpassword',
+			'share' => 'smbshare',
+			'root' => 'smbroot'
+		);
+
+		// write config
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				'\OC\Files\Storage\SMB',
+				$mountConfig,
+				$mountType,
+				$applicable,
+				$isPersonal
+			)
+		);
+
+		// re-read config
+		$config = OC_Mount_Config::getSystemMountPoints();
+		$this->assertEquals(1, count($config));
+		$this->assertTrue(isset($config['ext']));
+		$this->assertEquals('\OC\Files\Storage\SMB', $config['ext']['class']);
+		$savedMountConfig = $config['ext']['configuration'];
+		$this->assertEquals($mountConfig, $savedMountConfig);
+	}
+
+	/**
+	 * Test reading and writing config
+	 */
+	public function testReadWritePersonalConfig() {
+		$mountType = OC_Mount_Config::MOUNT_TYPE_USER;
+		$applicable = 'test';
+		$isPersonal = true;
+		$mountConfig = array(
+			'host' => 'smbhost',
+			'user' => 'smbuser',
+			'password' => 'smbpassword',
+			'share' => 'smbshare',
+			'root' => 'smbroot'
+		);
+
+		// write config
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				'\OC\Files\Storage\SMB',
+				$mountConfig,
+				$mountType,
+				$applicable,
+				$isPersonal
+			)
+		);
+
+		// re-read config
+		$config = OC_Mount_Config::getPersonalMountPoints();
+		$this->assertEquals(1, count($config));
+		$this->assertTrue(isset($config['ext']));
+		$this->assertEquals('\OC\Files\Storage\SMB', $config['ext']['class']);
+		$savedMountConfig = $config['ext']['configuration'];
+		$this->assertEquals($mountConfig, $savedMountConfig);
 	}
 }

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -320,79 +320,9 @@ class Filesystem {
 		else {
 			self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
 		}
-		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
-		$mount_file = \OC_Config::getValue("mount_file", $datadir . "/mount.json");
-
-		//move config file to it's new position
-		if (is_file(\OC::$SERVERROOT . '/config/mount.json')) {
-			rename(\OC::$SERVERROOT . '/config/mount.json', $mount_file);
-		}
-		// Load system mount points
-		if (is_file(\OC::$SERVERROOT . '/config/mount.php') or is_file($mount_file)) {
-			if (is_file($mount_file)) {
-				$mountConfig = json_decode(file_get_contents($mount_file), true);
-			} elseif (is_file(\OC::$SERVERROOT . '/config/mount.php')) {
-				$mountConfig = $parser->parsePHP(file_get_contents(\OC::$SERVERROOT . '/config/mount.php'));
-			}
-			if (isset($mountConfig['global'])) {
-				foreach ($mountConfig['global'] as $mountPoint => $options) {
-					self::mount($options['class'], $options['options'], $mountPoint);
-				}
-			}
-			if (isset($mountConfig['group'])) {
-				foreach ($mountConfig['group'] as $group => $mounts) {
-					if (\OC_Group::inGroup($user, $group)) {
-						foreach ($mounts as $mountPoint => $options) {
-							$mountPoint = self::setUserVars($user, $mountPoint);
-							foreach ($options as &$option) {
-								$option = self::setUserVars($user, $option);
-							}
-							self::mount($options['class'], $options['options'], $mountPoint);
-						}
-					}
-				}
-			}
-			if (isset($mountConfig['user'])) {
-				foreach ($mountConfig['user'] as $mountUser => $mounts) {
-					if ($mountUser === 'all' or strtolower($mountUser) === strtolower($user)) {
-						foreach ($mounts as $mountPoint => $options) {
-							$mountPoint = self::setUserVars($user, $mountPoint);
-							foreach ($options as &$option) {
-								$option = self::setUserVars($user, $option);
-							}
-							self::mount($options['class'], $options['options'], $mountPoint);
-						}
-					}
-				}
-			}
-		}
-		// Load personal mount points
-		if (is_file($root . '/mount.php') or is_file($root . '/mount.json')) {
-			if (is_file($root . '/mount.json')) {
-				$mountConfig = json_decode(file_get_contents($root . '/mount.json'), true);
-			} elseif (is_file($root . '/mount.php')) {
-				$mountConfig = $parser->parsePHP(file_get_contents($root . '/mount.php'));
-			}
-			if (isset($mountConfig['user'][$user])) {
-				foreach ($mountConfig['user'][$user] as $mountPoint => $options) {
-					self::mount($options['class'], $options['options'], $mountPoint);
-				}
-			}
-		}
 
 		// Chance to mount for other storages
 		\OC_Hook::emit('OC_Filesystem', 'post_initMountPoints', array('user' => $user, 'user_dir' => $root));
-	}
-
-	/**
-	 * fill in the correct values for $user
-	 *
-	 * @param string $user
-	 * @param string $input
-	 * @return string
-	 */
-	private static function setUserVars($user, $input) {
-		return str_replace('$user', $user, $input);
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -495,4 +495,13 @@ class Util {
 	public static function isValidFileName($file) {
 		return \OC_Util::isValidFileName($file);
 	}
+
+	/**
+	 * @brief Generates a cryptographic secure pseudo-random string
+	 * @param Int $length of the random string
+	 * @return String
+	 */
+	public static function generateRandomBytes($length = 30) {
+		return \OC_Util::generateRandomBytes($length);
+	}
 }


### PR DESCRIPTION
Fixes #7717

Uses phpseclib (hi @bantu !) to encrypt/decrypt the password using the "passwordsalt" as key.
The logic is in OC_Mount_Config and will encrypt any "password" field and rename it to "password_encrypted" and back again when reading.

Issues:
1) Needs #7792 to be merged first because it uses the same unit test base code

2) The actual mounting code in `OC\Filesystem\initMountPoints` (which I discovered too late) cannot decrypt the passwords because it uses its own config reading routine.

Here are potential solutions for this, in order of complexity:

a) Quick and dirty: add password decryption code directly in `OC\Filesystem\initMountPoints` and/or make it use `OC_MountConfig` from `files_external` to load the config (which includes password decryption). But that needs phpseclib to be available in core.

b) A bit less dirty: create a utility class "MountConfig" in core to handle mount point config (read/write) and includes password encryption/decryption code. That utility class "MountConfig" can be used by `OC\Filesystem\initMountPoints` and also by `OC_MountConfig`.
Also needs phpseclib available in core.

c) Move the ext storage config loading code from `OC\Filesystem\initMountPoints` to the `files_external` app and call it with a hook.
But I'm not sure whether we want to refactor that part now, keeping a possible backport in mind.

d) Start over with the PR and put the password decryption code directly in `smb.php` and other storages classes (common.php) or a utility class.
I don't like that solution because it's not that generic, and there is also fallback code needed.

@bantu @icewind1991 what do you think ?
