### PR TITLE
Improve sorting performance of large lists of files

### DIFF
--- a/apps/files/ajax/rawlist.php
+++ b/apps/files/ajax/rawlist.php
@@ -33,6 +33,8 @@ if (is_array($mimetypes) && count($mimetypes)) {
 } else {
 	$files = array_merge($files, \OC\Files\Filesystem::getDirectoryContent($dir));
 }
+// Sort by name
+usort($files, array('\OCA\Files\Helper', 'fileCmp'));
 
 $result = array();
 foreach ($files as $file) {
@@ -50,8 +52,5 @@ foreach ($files as $file) {
 	$fileData['mimetype_icon'] = \OCA\Files\Helper::determineIcon($file);
 	$result[] = $fileData;
 }
-
-// Sort by name
-usort($result, array('\OCA\Files\Helper', 'fileCmp'));
 
 OC_JSON::success(array('data' => $result));

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -51,17 +51,20 @@ class Helper
 	/**
 	 * Comparator function to sort files alphabetically and have
 	 * the directories appear first
-	 * @param array $a file
-	 * @param array $b file
-	 * @return -1 if $a must come before $b, 1 otherwise
+	 *
+	 * @param \OCP\Files\FileInfo $a file
+	 * @param \OCP\Files\FileInfo $b file
+	 * @return int -1 if $a must come before $b, 1 otherwise
 	 */
 	public static function fileCmp($a, $b) {
-		if ($a['type'] === 'dir' and $b['type'] !== 'dir') {
+		$aType = $a->getType();
+		$bType = $b->getType();
+		if ($aType === 'dir' and $bType !== 'dir') {
 			return -1;
-		} elseif ($a['type'] !== 'dir' and $b['type'] === 'dir') {
+		} elseif ($aType !== 'dir' and $bType === 'dir') {
 			return 1;
 		} else {
-			return strnatcasecmp($a['name'], $b['name']);
+			return strnatcasecmp($a->getName(), $b->getName());
 		}
 	}
 

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -2,13 +2,15 @@
 
 namespace OCA\Files_Trashbin;
 
+use OC\Files\FileInfo;
+
 class Helper
 {
 	/**
 	 * Retrieves the contents of a trash bin directory.
 	 * @param string $dir path to the directory inside the trashbin
 	 * or empty to retrieve the root of the trashbin
-	 * @return array of files
+	 * @return \OCP\Files\FileInfo[]
 	 */
 	public static function getTrashFiles($dir){
 		$result = array();
@@ -52,6 +54,8 @@ class Helper
 
 		$files = array();
 		$id = 0;
+		list($storage, $internalPath) = $view->resolvePath($dir);
+		$absoluteDir = $view->getAbsolutePath($dir);
 		foreach ($result as $r) {
 			$i = array();
 			$i['id'] = $id++;
@@ -77,7 +81,7 @@ class Helper
 				$i['isPreviewAvailable'] = \OC::$server->getPreviewManager()->isMimeSupported($r['mime']);
 			}
 			$i['icon'] = \OCA\Files\Helper::determineIcon($i);
-			$files[] = $i;
+			$files[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i);
 		}
 
 		usort($files, array('\OCA\Files\Helper', 'fileCmp'));


### PR DESCRIPTION
Improves performance of `\OCA\Files\Helper::fileCmp` by about 50%.

This brings the time needed to load a folder with a large (~2000) number of files down to ~10s from ~15s on my local machine.

cc @karlitschek @DeepDiver1975 @PVince81 
