### PR TITLE
Fix 'Upload button tooltip doesn't disappear' #7461

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -361,6 +361,7 @@ $(document).ready(function() {
 			 */
 			done:function(e, data) {
 				OC.Upload.log('done', e, data);
+				$('.tipsy').remove(); // otherwise the 'Upload max.' tooltip remains visible
 				// handle different responses (json or body from iframe for ie)
 				var response;
 				if (typeof data.result === 'string') {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -320,6 +320,7 @@ $(document).ready(function() {
 			 */
 			start: function(e) {
 				OC.Upload.log('start', e, null);
+				$('.tipsy').remove(); // otherwise the 'Upload max.' tooltip remains visible
 			},
 			submit: function(e, data) {
 				OC.Upload.rememberUpload(data);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -361,7 +361,6 @@ $(document).ready(function() {
 			 */
 			done:function(e, data) {
 				OC.Upload.log('done', e, data);
-				$('.tipsy').remove(); // otherwise the 'Upload max.' tooltip remains visible
 				// handle different responses (json or body from iframe for ie)
 				var response;
 				if (typeof data.result === 'string') {


### PR DESCRIPTION
The tipsy toolbox must be removed when the upload starts, otherwise the tooltip remains in the DOM and covers the progress bar.  @jancborchardt please review my fix for the mentioned issue.
