### PR TITLE
Remove cursor:pointer CSS from li element

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -10,7 +10,7 @@ table { border-collapse:separate; border-spacing:0; white-space:nowrap; }
 caption, th, td { text-align:left; font-weight:normal; }
 table, td, th { vertical-align:middle; }
 a { border:0; color:#000; text-decoration:none;}
-a, a *, input, input *, select, .button span, li, label { cursor:pointer; }
+a, a *, input, input *, select, .button span, label { cursor:pointer; }
 ul { list-style:none; }
 body { background:#fefefe; font:normal .8em/1.6em "Helvetica Neue",Helvetica,Arial,FreeSans,sans-serif; color:#000; }
 


### PR DESCRIPTION
This is my _groundbreaking_ pull request to fix #7758

Originating from https://github.com/owncloud/core/commit/7474c907dc715e790145e4577306c9936f60fa1d#commitcomment-5608393

`cursor:pointer` should not be set as default for `li` elements because not all `li` elements are clickable. For example see Calendar -> Edit event -> Share. The users are listed and seem clickable because of the cursor but they are not.

CC @owncloud/designers @jancborchardt 
