### PR TITLE
Add mimetype for MKV videos

### DIFF
--- a/lib/private/mimetypes.list.php
+++ b/lib/private/mimetypes.list.php
@@ -77,6 +77,7 @@ return array(
 	'md' => 'text/markdown',
 	'mdb' => 'application/msaccess',
 	'mdwn' => 'text/markdown',
+	'mkv' => 'video/x-matroska',
 	'mobi' => 'application/x-mobipocket-ebook',
 	'mov' => 'video/quicktime',
 	'mp3' => 'audio/mpeg',


### PR DESCRIPTION
This will make oC create previews for MKVs.

Test file: http://www.auby.no/files/video_tests/h264_720p_hp_5.1_3mbps_vorbis_styled_and_unstyled_subs_suzumiya.mkv

To test this just apply this change and upload the test file, if an preview is generated this change is most likely working as expecting.
