### PR TITLE
Still return quota value when free space is unknown

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -69,7 +69,14 @@ class Quota extends Wrapper {
 				return \OC\Files\SPACE_NOT_COMPUTED;
 			} else {
 				$free = $this->storage->free_space($path);
-				return min($free, (max($this->quota - $used, 0)));
+				$quotaFree = max($this->quota - $used, 0);
+				// if free space is known
+				if ($free >= 0) {
+					$free = min($free, $quotaFree);
+				} else {
+					$free = $quotaFree;
+				}
+				return $free;
 			}
 		}
 	}

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -61,6 +61,24 @@ class Quota extends \Test\Files\Storage\Storage {
 		$this->assertEquals(6, $instance->free_space(''));
 	}
 
+	public function testFreeSpaceWithUnknownDiskSpace() {
+		$storage = $this->getMock(
+			'\OC\Files\Storage\Local',
+			array('free_space'),
+			array(array('datadir' => $this->tmpDir))
+		);
+		$storage->expects($this->any())
+			->method('free_space')
+			->will($this->returnValue(-2));
+		$storage->getScanner()->scan('');
+
+		$instance = new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => 9));
+		$instance->getCache()->put(
+			'', array('size' => 3, 'unencrypted_size' => 0)
+		);
+		$this->assertEquals(6, $instance->free_space(''));
+	}
+
 	public function testFreeSpaceWithUsedSpaceAndEncryption() {
 		$instance = $this->getLimitedStorage(9);
 		$instance->getCache()->put(


### PR DESCRIPTION
Fixed the quota storage wrapper to correctly return the quota value when
the free space is not known (which usually happens when the disk_free_space
function is disabled)

Fixes #7553 

To test this, set this in php.ini:

```
disable_functions = disk_free_space
```

and check that the quota still works and appears correctly.

Please review @karlitschek @icewind1991 @schiesbn 
