### PR TITLE
Fix: 'Upload button tooltip doesn't disappear'

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -320,7 +320,8 @@ OC.Upload = {
 				 */
 				start: function(e) {
 					OC.Upload.log('start', e, null);
-					$('#upload').tipsy('hide'); // otherwise "Upload max." covers progress bar
+					//hide the tooltip otherwise it covers the progress bar
+					$('#upload').tipsy('hide');
 				},
 				submit: function(e, data) {
 					OC.Upload.rememberUpload(data);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -320,6 +320,7 @@ OC.Upload = {
 				 */
 				start: function(e) {
 					OC.Upload.log('start', e, null);
+					$('#upload').tipsy('hide'); // otherwise "Upload max." covers progress bar
 				},
 				submit: function(e, data) {
 					OC.Upload.rememberUpload(data);


### PR DESCRIPTION
Fixes issue #7461. Tipsy tooltip must be hidden when the upload starts. Otherwise it covers the progress bar and stays in DOM. Please review @PVince81  @jancborchardt.
