### PR TITLE
correct LDAP user count on setup with many users (occ user:report)

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -782,6 +782,7 @@ class Access extends LDAPUtility {
 		}
 
 		$counter = 0;
+		$count = null;
 		$cr = $this->connection->getConnectionResource();
 
 		do {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -777,8 +777,7 @@ class Access extends LDAPUtility {
 		\OCP\Util::writeLog('user_ldap', 'Count filter:  '.print_r($filter, true), \OCP\Util::DEBUG);
 
 		if(is_null($limit)) {
-			//TODO replace 400 with $this->connection->ldapPagingSize; once PR 6221 is merged and move it to callee countUsers()
-			$limit = 400;
+			$limit = $this->connection->ldapPagingSize;
 		}
 
 		$counter = 0;

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1184,7 +1184,7 @@ class Access extends LDAPUtility {
 		}
 		$offset -= $limit;
 		//we work with cache here
-		$cachekey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' . $limit . '-' . $offset;
+		$cachekey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' . intval($limit) . '-' . intval($offset);
 		$cookie = '';
 		if(isset($this->cookies[$cachekey])) {
 			$cookie = $this->cookies[$cachekey];
@@ -1206,7 +1206,7 @@ class Access extends LDAPUtility {
 	 */
 	private function setPagedResultCookie($base, $filter, $limit, $offset, $cookie) {
 		if(!empty($cookie)) {
-			$cachekey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' .$limit . '-' . $offset;
+			$cachekey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' .intval($limit) . '-' . intval($offset);
 			$this->cookies[$cachekey] = $cookie;
 		}
 	}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -794,20 +794,29 @@ class Access extends LDAPUtility {
 			}
 			list($sr, $pagedSearchOK) = $search;
 
-			foreach($sr as $key => $res) {
-				$count = $this->ldap->countEntries($cr, $res);
-				if($count !== false) {
-					$counter += $count;
-				}
-				if($count === $limit) {
-					$continue = true;
-				}
-			}
+			$count = $this->countEntriesInSearchResults($sr, $limit, $continue);
+			$counter += $count;
 
 			$this->processPagedSearchStatus($sr, $filter, $base, $count, $limit,
 										$offset, $pagedSearchOK, $skipHandling);
 			$offset += $limit;
 		} while($continue);
+
+		return $counter;
+	}
+
+	private function countEntriesInSearchResults($searchResults, $limit,
+																&$hasHitLimit) {
+		$cr = $this->connection->getConnectionResource();
+		$count = 0;
+
+		foreach($searchResults as $res) {
+			$count = intval($this->ldap->countEntries($cr, $res));
+			$counter += $count;
+			if($count === $limit) {
+				$hasHitLimit = true;
+			}
+		}
 
 		return $counter;
 	}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -786,6 +786,7 @@ class Access extends LDAPUtility {
 		$cr = $this->connection->getConnectionResource();
 
 		do {
+			$continue = false;
 			$search = $this->executeSearch($filter, $base, $attr,
 										   $limit, $offset);
 			if($search === false) {
@@ -798,12 +799,15 @@ class Access extends LDAPUtility {
 				if($count !== false) {
 					$counter += $count;
 				}
+				if($count === $limit) {
+					$continue = true;
+				}
 			}
 
 			$this->processPagedSearchStatus($sr, $filter, $base, $count, $limit,
 										$offset, $pagedSearchOK, $skipHandling);
 			$offset += $limit;
-		} while($count === $limit);
+		} while($continue);
 
 		return $counter;
 	}


### PR DESCRIPTION
- Currently, the user count cannot be higher than the size limit on the LDAP server
- Paged Search will be done in future. 
  - OpenLDAP still follows the configured sizeLimit. Nothing we can do
  - AD counts all users now
  - other servers not tested
- [x] replace hard coded chunk size with ldapPagingSize from PR #6221, once it is merged
- [x] evaluate unit test on Access:count. Real conditions cannot be reached without test LDAP server though. Loop and addition can be ensured however…

Open for comments @leo-b @PVince81  @DeepDiver1975 or others

How to test?
1. configure access to an AD with more than 1k users that are accessible for ownCloud. Do not have other LDAP servers active (well, it works with others but then you need to apply maths ;) ).
2. run `occ user:report` in master. Total LDAP users will be 1000k (with default AD sizeLimit)
3. run `occ user:report` in this branch. Total LDAP users will be correct now.

Test will not work with OpenLDAP (see above)
