### PR TITLE
Fix 'Undefined variable: message' in OCP\Util::logException

### DIFF
--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -89,14 +89,11 @@ class Util {
 	 */
 	public static function logException( $app, \Exception $ex ) {
 		$class = get_class($ex);
-		if ($class !== 'Exception') {
-			$message = $class . ': ';
-		}
-		$message .= $ex->getMessage();
+		$message = $class . ': ' . $ex->getMessage();
 		if ($ex->getCode()) {
 			$message .= ' [' . $ex->getCode() . ']';
 		}
-		\OCP\Util::writeLog($app, 'Exception: ' . $message, \OCP\Util::FATAL);
+		\OCP\Util::writeLog($app, $message, \OCP\Util::FATAL);
 		if (defined('DEBUG') and DEBUG) {
 			// also log stack trace
 			$stack = explode("\n", $ex->getTraceAsString());


### PR DESCRIPTION
If the exception caught was _not_ a subclass of `\Exception` it would echo `Undefined variable: message` because it tried to append data to an undefined variable.

This patch prevents that and slightly changes the log message in case of the exception being a subclass.

Before: `Exception: MyException: message`
Now: `MyException: message`

@PVince81 @MorrisJobke @karlitschek 
