### PR TITLE
Fix parameter order for Storage\Local::hash

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -160,8 +160,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 
 	public function hash($type, $path, $raw = false) {
 		$tmpFile = $this->getLocalFile($path);
-		$hash = hash($type, $tmpFile, $raw);
-		unlink($tmpFile);
+		$hash = hash_file($type, $tmpFile, $raw);
 		return $hash;
 	}
 

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -256,7 +256,7 @@ if (\OC_Util::runningOnWindows()) {
 			return 0;
 		}
 
-		public function hash($path, $type, $raw = false) {
+		public function hash($type, $path, $raw = false) {
 			return hash_file($type, $this->datadir . $path, $raw);
 		}
 

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -276,7 +276,7 @@ class MappedLocal extends \OC\Files\Storage\Common{
 		return 0;
 	}
 
-	public function hash($path, $type, $raw=false) {
+	public function hash($type, $path, $raw=false) {
 		return hash_file($type, $this->buildPath($path), $raw);
 	}
 

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -64,17 +64,17 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider directoryProvider
 	 */
 	public function testDirectories($directory) {
-		$this->assertFalse($this->instance->file_exists('/'.$directory));
+		$this->assertFalse($this->instance->file_exists('/' . $directory));
 
-		$this->assertTrue($this->instance->mkdir('/'.$directory));
+		$this->assertTrue($this->instance->mkdir('/' . $directory));
 
-		$this->assertTrue($this->instance->file_exists('/'.$directory));
-		$this->assertTrue($this->instance->is_dir('/'.$directory));
-		$this->assertFalse($this->instance->is_file('/'.$directory));
-		$this->assertEquals('dir', $this->instance->filetype('/'.$directory));
-		$this->assertEquals(0, $this->instance->filesize('/'.$directory));
-		$this->assertTrue($this->instance->isReadable('/'.$directory));
-		$this->assertTrue($this->instance->isUpdatable('/'.$directory));
+		$this->assertTrue($this->instance->file_exists('/' . $directory));
+		$this->assertTrue($this->instance->is_dir('/' . $directory));
+		$this->assertFalse($this->instance->is_file('/' . $directory));
+		$this->assertEquals('dir', $this->instance->filetype('/' . $directory));
+		$this->assertEquals(0, $this->instance->filesize('/' . $directory));
+		$this->assertTrue($this->instance->isReadable('/' . $directory));
+		$this->assertTrue($this->instance->isUpdatable('/' . $directory));
 
 		$dh = $this->instance->opendir('/');
 		$content = array();
@@ -85,13 +85,13 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		}
 		$this->assertEquals(array($directory), $content);
 
-		$this->assertFalse($this->instance->mkdir('/'.$directory)); //cant create existing folders
-		$this->assertTrue($this->instance->rmdir('/'.$directory));
+		$this->assertFalse($this->instance->mkdir('/' . $directory)); //cant create existing folders
+		$this->assertTrue($this->instance->rmdir('/' . $directory));
 
 		$this->wait();
-		$this->assertFalse($this->instance->file_exists('/'.$directory));
+		$this->assertFalse($this->instance->file_exists('/' . $directory));
 
-		$this->assertFalse($this->instance->rmdir('/'.$directory)); //cant remove non existing folders
+		$this->assertFalse($this->instance->rmdir('/' . $directory)); //cant remove non existing folders
 
 		$dh = $this->instance->opendir('/');
 		$content = array();
@@ -103,8 +103,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), $content);
 	}
 
-	public function directoryProvider()
-	{
+	public function directoryProvider() {
 		return array(
 			array('folder'),
 			array(' folder'),
@@ -113,6 +112,7 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 			array('spéciäl földer'),
 		);
 	}
+
 	/**
 	 * test the various uses of file_get_contents and file_put_contents
 	 */
@@ -297,5 +297,22 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->instance->file_exists('folder/bar/foo.txt'));
 		$this->assertFalse($this->instance->file_exists('folder/bar'));
 		$this->assertFalse($this->instance->file_exists('folder'));
+	}
+
+	public function hashProvider(){
+		return array(
+			array('Foobar', 'md5'),
+			array('Foobar', 'sha1'),
+			array('Foobar', 'sha256'),
+		);
+	}
+
+	/**
+	 * @dataProvider hashProvider
+	 */
+	public function testHash($data, $type) {
+		$this->instance->file_put_contents('hash.txt', $data);
+		$this->assertEquals(hash($type, $data), $this->instance->hash($type, 'hash.txt'));
+		$this->assertEquals(hash($type, $data, true), $this->instance->hash($type, 'hash.txt', true));
 	}
 }


### PR DESCRIPTION
Fixes using the hash function on local storages.

cc @PVince81 @DeepDiver1975 
