### PR TITLE
Use streams when generating hashes of remote files

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -159,7 +159,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	public function hash($type, $path, $raw = false) {
-		$fh = $this->fopen($path, 'r');
+		$fh = $this->fopen($path, 'rb');
 		$ctx = hash_init($type);
 		hash_update_stream($ctx, $fh);
 		fclose($fh);

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -159,9 +159,11 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	public function hash($type, $path, $raw = false) {
-		$tmpFile = $this->getLocalFile($path);
-		$hash = hash_file($type, $tmpFile, $raw);
-		return $hash;
+		$fh = $this->fopen($path, 'r');
+		$ctx = hash_init($type);
+		hash_update_stream($ctx, $fh);
+		fclose($fh);
+		return hash_final($ctx, $raw);
 	}
 
 	public function search($query) {


### PR DESCRIPTION
Improves performance of the hash function on backends that support streaming for fopen

cc @DeepDiver1975 @PVince81 
