### PR TITLE
Cache folder is now configurable

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -273,6 +273,15 @@ $CONFIG = array(
 /* all css and js files will be served by the web server statically in one js file and ons css file*/
 'asset-pipeline.enabled' => false,
 
- /* where mount.json file should be stored, defaults to data/mount.json */
- 'mount_file' => '',
+/* where mount.json file should be stored, defaults to data/mount.json */
+'mount_file' => '',
+
+/*
+ * Location of the cache folder, defaults to "data/$user/cache" where "$user" is the current user.
+ *
+ * When specified, the format will change to "$cache_path/$user" where "$cache_path" is the configured
+ * cache directory and "$user" is the user.
+ *
+ */
+'cache_path' => ''
 );

--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Copyright (c) 2012 Bart Visscher <bartv@thisnet.nl>
+ * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -10,22 +11,22 @@ namespace OC\Cache;
 
 class File {
 	protected $storage;
+
+	/**
+	 * Returns the cache storage for the logged in user
+	 * @return cache storage
+	 */
 	protected function getStorage() {
 		if (isset($this->storage)) {
 			return $this->storage;
 		}
 		if(\OC_User::isLoggedIn()) {
 			\OC\Files\Filesystem::initMountPoints(\OC_User::getUser());
-			$subdir = 'cache';
-			$view = new \OC\Files\View('/' . \OC_User::getUser());
-			if(!$view->file_exists($subdir)) {
-				$view->mkdir($subdir);
-			}
-			$this->storage = new \OC\Files\View('/' . \OC_User::getUser().'/'.$subdir);
+			$this->storage = new \OC\Files\View('/' . \OC_User::getUser() . '/cache');
 			return $this->storage;
 		}else{
 			\OC_Log::write('core', 'Can\'t get cache storage, user not logged in', \OC_Log::ERROR);
-			return false;
+			throw new \OC\ForbiddenException('Can\t get cache storage, user not logged in');
 		}
 	}
 

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -351,17 +351,6 @@ class Filesystem {
 	}
 
 	/**
-	 * fill in the correct values for $user
-	 *
-	 * @param string $user
-	 * @param string $input
-	 * @return string
-	 */
-	private static function setUserVars($user, $input) {
-		return str_replace('$user', $user, $input);
-	}
-
-	/**
 	 * get the default filesystem view
 	 *
 	 * @return View

--- a/lib/private/forbiddenexception.php
+++ b/lib/private/forbiddenexception.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+/**
+ * Exception thrown whenever access to a resource has
+ * been forbidden or whenever a user isn't authenticated.
+ */
+class ForbiddenException extends \Exception {
+}


### PR DESCRIPTION
Fixes #7623 

CC @icewind1991 @karlitschek @schiesbn (small heads up)

TODO:
- [x] Make cache dir configurable
- [x] Make encryption app use the setting (or use the cache class)
- [x] Check other locations in the code that might use it
- [ ] Check what happens when cache is full (chunks need to be cleant up automatically, waiting for another PR to be merged to check this)
