### PR TITLE
Fix MiddleWare registration and execution.

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -137,7 +137,7 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 	 * @return boolean|null
 	 */
 	function registerMiddleWare(Middleware $middleWare) {
-		array_push($this->middleWares, $middleWare);
+		$this->query('MiddlewareDispatcher')->registerMiddleware($middleWare);
 	}
 
 	/**

--- a/lib/private/appframework/middleware/middlewaredispatcher.php
+++ b/lib/private/appframework/middleware/middlewaredispatcher.php
@@ -39,18 +39,10 @@ class MiddlewareDispatcher {
 	private $middlewares;
 
 	/**
-	 * @var int counter which tells us what middlware was executed once an
-	 *                  exception occurs
-	 */
-	private $middlewareCounter;
-
-
-	/**
 	 * Constructor
 	 */
-	public function __construct(){
+	public function __construct() {
 		$this->middlewares = array();
-		$this->middlewareCounter = 0;
 	}
 
 
@@ -73,19 +65,16 @@ class MiddlewareDispatcher {
 
 
 	/**
-	 * This is being run in normal order before the controller is being
-	 * called which allows several modifications and checks
+	 * This is being run on each registered MiddleWare before the controller
+	 * is called which allows several modifications and checks
+	 * NOTE: The security MiddleWare will always be checked first.
 	 *
 	 * @param Controller $controller the controller that is being called
 	 * @param string $methodName the name of the method that will be called on
 	 *                           the controller
 	 */
-	public function beforeController(Controller $controller, $methodName){
-		// we need to count so that we know which middlewares we have to ask in
-		// case theres an exception
-		for($i=0; $i<count($this->middlewares); $i++){
-			$this->middlewareCounter++;
-			$middleware = $this->middlewares[$i];
+	public function beforeController(Controller $controller, $methodName) {
+		foreach ($this->middlewares as $middleware) {
 			$middleware->beforeController($controller, $methodName);
 		}
 	}
@@ -94,9 +83,10 @@ class MiddlewareDispatcher {
 	/**
 	 * This is being run when either the beforeController method or the
 	 * controller method itself is throwing an exception. The middleware is asked
-	 * in reverse order to handle the exception and to return a response.
+	 * in the order it was registered to handle the exception and to return a response.
 	 * If the response is null, it is assumed that the exception could not be
-	 * handled and the error will be thrown again
+	 * handled and the error will be thrown again.
+	 * NOTE: The security MiddleWare will always be checked first.
 	 *
 	 * @param Controller $controller the controller that is being called
 	 * @param string $methodName the name of the method that will be called on
@@ -106,9 +96,8 @@ class MiddlewareDispatcher {
 	 * exception
 	 * @throws \Exception the passed in exception if it cant handle it
 	 */
-	public function afterException(Controller $controller, $methodName, \Exception $exception){
-		for($i=$this->middlewareCounter-1; $i>=0; $i--){
-			$middleware = $this->middlewares[$i];
+	public function afterException(Controller $controller, $methodName, \Exception $exception) {
+		foreach ($this->middlewares as $middleware) {
 			try {
 				return $middleware->afterException($controller, $methodName, $exception);
 			} catch(\Exception $exception){
@@ -129,9 +118,8 @@ class MiddlewareDispatcher {
 	 * @param Response $response the generated response from the controller
 	 * @return Response a Response object
 	 */
-	public function afterController(Controller $controller, $methodName, Response $response){
-		for($i=count($this->middlewares)-1; $i>=0; $i--){
-			$middleware = $this->middlewares[$i];
+	public function afterController(Controller $controller, $methodName, Response $response) {
+		foreach ($this->middlewares as $middleware) {
 			$response = $middleware->afterController($controller, $methodName, $response);
 		}
 		return $response;
@@ -148,9 +136,8 @@ class MiddlewareDispatcher {
 	 * @param string $output the generated output from a response
 	 * @return string the output that should be printed
 	 */
-	public function beforeOutput(Controller $controller, $methodName, $output){
-		for($i=count($this->middlewares)-1; $i>=0; $i--){
-			$middleware = $this->middlewares[$i];
+	public function beforeOutput(Controller $controller, $methodName, $output) {
+		foreach ($this->middlewares as $middleware) {
 			$output = $middleware->beforeOutput($controller, $methodName, $output);
 		}
 		return $output;

--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -56,7 +56,7 @@ class SecurityMiddleware extends Middleware {
 	 * @param IAppContainer $app
 	 * @param IRequest $request
 	 */
-	public function __construct(IAppContainer $app, IRequest $request){
+	public function __construct(IAppContainer $app, IRequest $request) {
 		$this->app = $app;
 		$this->request = $request;
 	}
@@ -70,24 +70,26 @@ class SecurityMiddleware extends Middleware {
 	 * @param string $methodName the name of the method
 	 * @throws SecurityException when a security check fails
 	 */
-	public function beforeController($controller, $methodName){
+	public function beforeController($controller, $methodName) {
 
 		// get annotations from comments
 		$annotationReader = new MethodAnnotationReader($controller, $methodName);
 
 		// this will set the current navigation entry of the app, use this only
 		// for normal HTML requests and not for AJAX requests
-		$this->app->getServer()->getNavigationManager()->setActiveEntry($this->app->getAppName());
+		if (stripos($this->request->getHeader('Accept'), 'html') !== false) {
+			$this->app->getServer()->getNavigationManager()->setActiveEntry($this->app->getAppName());
+		}
 
 		// security checks
 		$isPublicPage = $annotationReader->hasAnnotation('PublicPage');
-		if(!$isPublicPage) {
-			if(!$this->app->isLoggedIn()) {
+		if (!$isPublicPage) {
+			if (!$this->app->isLoggedIn()) {
 				throw new SecurityException('Current user is not logged in', Http::STATUS_UNAUTHORIZED);
 			}
 
-			if(!$annotationReader->hasAnnotation('NoAdminRequired')) {
-				if(!$this->app->isAdminUser()) {
+			if (!$annotationReader->hasAnnotation('NoAdminRequired')) {
+				if (!$this->app->isAdminUser()) {
 					throw new SecurityException('Logged in user must be an admin', Http::STATUS_FORBIDDEN);
 				}
 			}
@@ -112,10 +114,10 @@ class SecurityMiddleware extends Middleware {
 	 * @throws \Exception the passed in exception if it cant handle it
 	 * @return Response a Response object or null in case that the exception could not be handled
 	 */
-	public function afterException($controller, $methodName, \Exception $exception){
-		if($exception instanceof SecurityException){
+	public function afterException($controller, $methodName, \Exception $exception) {
+		if ($exception instanceof SecurityException) {
 
-			if (stripos($this->request->getHeader('Accept'),'html')===false) {
+			if (stripos($this->request->getHeader('Accept'), 'html') === false) {
 
 				$response = new JSONResponse(
 					array('message' => $exception->getMessage()),

--- a/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
@@ -147,14 +147,14 @@ class MiddlewareDispatcherTest extends \PHPUnit_Framework_TestCase {
 		$response = new Response();
 		$m1 = $this->getMock('\OCP\AppFramework\Middleware',
 				array('afterException', 'beforeController'));
-		$m1->expects($this->never())
-				->method('afterException');
+		$m1->expects($this->once())
+				->method('afterException')
+				->will($this->returnValue($response));
 
 		$m2 = $this->getMock('OCP\AppFramework\Middleware',
 				array('afterException', 'beforeController'));
-		$m2->expects($this->once())
-				->method('afterException')
-				->will($this->returnValue($response));
+		$m2->expects($this->never())
+				->method('afterException');
 
 		$this->dispatcher->registerMiddleware($m1);
 		$this->dispatcher->registerMiddleware($m2);
@@ -238,8 +238,8 @@ class MiddlewareDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->dispatcher->afterController($this->controller, $this->method, $this->response);
 
-		$this->assertEquals(2, $m1->afterControllerOrder);
-		$this->assertEquals(1, $m2->afterControllerOrder);
+		$this->assertEquals(1, $m1->afterControllerOrder);
+		$this->assertEquals(2, $m2->afterControllerOrder);
 	}
 
 
@@ -262,8 +262,8 @@ class MiddlewareDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->dispatcher->beforeOutput($this->controller, $this->method, $this->out);
 
-		$this->assertEquals(2, $m1->beforeOutputOrder);
-		$this->assertEquals(1, $m2->beforeOutputOrder);
+		$this->assertEquals(1, $m1->beforeOutputOrder);
+		$this->assertEquals(2, $m2->beforeOutputOrder);
 	}
 
 
@@ -282,7 +282,7 @@ class MiddlewareDispatcherTest extends \PHPUnit_Framework_TestCase {
 
 		$this->dispatcher->beforeOutput($this->controller, $this->method, $this->out);
 
-		$this->assertEquals(2, $m1->beforeOutputOrder);
-		$this->assertEquals(1, $m2->beforeOutputOrder);
+		$this->assertEquals(1, $m1->beforeOutputOrder);
+		$this->assertEquals(2, $m2->beforeOutputOrder);
 	}
 }


### PR DESCRIPTION
- Only SecurityMiddleware was registered. All others failed silently because they were just added to an array that wasn't used.
- Execute tests in the same order they were registered. The AppFramework **app** runs `afterException` in reverse order as how the middleware was registered. That meant that a controller method which should **not** run was executed **before** SecurityMiddleware kicked in!
- Removed unused counter in MiddlewareDispatcher.
- White-space fixes.

Testing the difference is a bit difficult, because before this patch SecurityMiddleware was the only one registered, so it actually worked. After this patch other middleware layers can get registered and will run after SecurityMiddleware.

@DeepDiver1975 @Raydiation @karlitschek 
