### PR TITLE
Enable the use of 'optional' on password fields for mount configuration

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -181,16 +181,21 @@ $(document).ready(function() {
 		$.each(configurations, function(backend, parameters) {
 			if (backend == backendClass) {
 				$.each(parameters['configuration'], function(parameter, placeholder) {
-					if (placeholder.indexOf('*') != -1) {
-						td.append('<input type="password" data-parameter="'+parameter+'" placeholder="'+placeholder.substring(1)+'" />');
-					} else if (placeholder.indexOf('!') != -1) {
+					var is_optional = false;
+					if (placeholder.indexOf('&') === 0) {
+						is_optional = true;
+						placeholder = placeholder.substring(1);
+					}
+					if (placeholder.indexOf('*') === 0) {
+						var class_string = is_optional ? ' class="optional"' : '';
+						td.append('<input type="password"' + class_string + ' data-parameter="'+parameter+'" placeholder="'+placeholder.substring(1)+'" />');
+					else if (placeholder.indexOf('!') === 0) {
 						td.append('<label><input type="checkbox" data-parameter="'+parameter+'" />'+placeholder.substring(1)+'</label>');
-					} else if (placeholder.indexOf('&') != -1) {
-						td.append('<input type="text" class="optional" data-parameter="'+parameter+'" placeholder="'+placeholder.substring(1)+'" />');
-					} else if (placeholder.indexOf('#') != -1) {
+					else if (placeholder.indexOf('#') === 0) {
 						td.append('<input type="hidden" data-parameter="'+parameter+'" />');
-					} else {
-						td.append('<input type="text" data-parameter="'+parameter+'" placeholder="'+placeholder+'" />');
+					else {
+						var class_string = is_optional ? ' class="optional"' : '';
+						td.append('<input type="text"' + class_string + ' data-parameter="'+parameter+'" placeholder="'+placeholder+'" />');
 					}
 				});
 				if (parameters['custom'] && $('#externalStorage tbody tr.'+backendClass.replace(/\\/g, '\\\\')).length == 1) {

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -189,11 +189,11 @@ $(document).ready(function() {
 					if (placeholder.indexOf('*') === 0) {
 						var class_string = is_optional ? ' class="optional"' : '';
 						td.append('<input type="password"' + class_string + ' data-parameter="'+parameter+'" placeholder="'+placeholder.substring(1)+'" />');
-					else if (placeholder.indexOf('!') === 0) {
+					} else if (placeholder.indexOf('!') === 0) {
 						td.append('<label><input type="checkbox" data-parameter="'+parameter+'" />'+placeholder.substring(1)+'</label>');
-					else if (placeholder.indexOf('#') === 0) {
+					} else if (placeholder.indexOf('#') === 0) {
 						td.append('<input type="hidden" data-parameter="'+parameter+'" />');
-					else {
+					} else {
 						var class_string = is_optional ? ' class="optional"' : '';
 						td.append('<input type="text"' + class_string + ' data-parameter="'+parameter+'" placeholder="'+placeholder+'" />');
 					}

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -52,18 +52,18 @@
 											$placeholder = substr($placeholder, 1);
 										}
 									?>
-									<?php if (strpos($placeholder, '*') !== false): ?>
+									<?php if (strpos($placeholder, '*') === 0): ?>
 										<input type="password"
 											   <?php if ($is_optional): ?> class="optional"<?php endif; ?>
 											   data-parameter="<?php p($parameter); ?>"
 											   value="<?php p($value); ?>"
 											   placeholder="<?php p(substr($placeholder, 1)); ?>" />
-									<?php elseif (strpos($placeholder, '!') !== false): ?>
+									<?php elseif (strpos($placeholder, '!') === 0): ?>
 										<label><input type="checkbox"
 													  data-parameter="<?php p($parameter); ?>"
 													  <?php if ($value == 'true'): ?> checked="checked"<?php endif; ?>
 													  /><?php p(substr($placeholder, 1)); ?></label>
-									<?php elseif (strpos($placeholder, '#') !== false): ?>
+									<?php elseif (strpos($placeholder, '#') === 0): ?>
 										<input type="hidden"
 											   data-parameter="<?php p($parameter); ?>"
 											   value="<?php p($value); ?>" />

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -44,9 +44,17 @@
 						<?php if (isset($mount['configuration'])): ?>
 							<?php foreach ($mount['configuration'] as $parameter => $value): ?>
 								<?php if (isset($_['backends'][$mount['class']]['configuration'][$parameter])): ?>
-									<?php $placeholder = $_['backends'][$mount['class']]['configuration'][$parameter]; ?>
+									<?php
+										$placeholder = $_['backends'][$mount['class']]['configuration'][$parameter];
+										$is_optional = FALSE;
+										if (strpos($placeholder, '&') === 0) {
+											$is_optional = TRUE;
+											$placeholder = substr($placeholder, 1);
+										}
+									?>
 									<?php if (strpos($placeholder, '*') !== false): ?>
 										<input type="password"
+											   <?php if ($is_optional): ?> class="optional"<?php endif; ?>
 											   data-parameter="<?php p($parameter); ?>"
 											   value="<?php p($value); ?>"
 											   placeholder="<?php p(substr($placeholder, 1)); ?>" />
@@ -55,18 +63,13 @@
 													  data-parameter="<?php p($parameter); ?>"
 													  <?php if ($value == 'true'): ?> checked="checked"<?php endif; ?>
 													  /><?php p(substr($placeholder, 1)); ?></label>
-									<?php elseif (strpos($placeholder, '&') !== false): ?>
-										<input type="text"
-											   class="optional"
-											   data-parameter="<?php p($parameter); ?>"
-											   value="<?php p($value); ?>"
-											   placeholder="<?php p(substr($placeholder, 1)); ?>" />
 									<?php elseif (strpos($placeholder, '#') !== false): ?>
 										<input type="hidden"
 											   data-parameter="<?php p($parameter); ?>"
 											   value="<?php p($value); ?>" />
 									<?php else: ?>
 										<input type="text"
+											   <?php if ($is_optional): ?> class="optional"<?php endif; ?>
 											   data-parameter="<?php p($parameter); ?>"
 											   value="<?php p($value); ?>"
 											   placeholder="<?php p($placeholder); ?>" />


### PR DESCRIPTION
The use of the 'optional' modifier (&) was limited to text fields only. These commits enable its use to other fields, currently only additionally defined for password fields (*). This means that passwords can now be considered optional in some cases, for example this could be used for iRODS 'Use ownCloud login', where the username and password are taken from logon credentials.
