### PR TITLE
LDAP: create a new instance of Configuration on clone, fixes #7803

### DIFF
--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -119,9 +119,9 @@ class Configuration {
 
 		$cta = $this->getConfigTranslationArray();
 		foreach($config as $inputkey => $val) {
-			if(strpos($inputkey, '_') !== false && isset($cta[$inputkey])) {
+			if(strpos($inputkey, '_') !== false && array_key_exists($inputkey, $cta)) {
 				$key = $cta[$inputkey];
-			} elseif(isset($this->config[$inputkey])) {
+			} elseif(array_key_exists($inputkey, $this->config)) {
 				$key = $inputkey;
 			} else {
 				continue;

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -78,6 +78,8 @@ class Connection extends LDAPUtility {
 		//a cloned instance inherits the connection resource. It may use it,
 		//but it may not disconnect it
 		$this->dontDestruct = true;
+		$this->configuration = new Configuration($this->configPrefix,
+												 !is_null($this->configID));
 	}
 
 	public function __get($name) {

--- a/apps/user_ldap/tests/connection.php
+++ b/apps/user_ldap/tests/connection.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* ownCloud
+*
+* @author Arthur Schiwon
+* @copyright 2013 Arthur Schiwon blizzz@owncloud.com
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+namespace OCA\user_ldap\tests;
+
+class Test_Connection extends \PHPUnit_Framework_TestCase {
+
+	public function testOriginalAgentUnchangedOnClone() {
+		//background: upon login a bind is done with the user credentials
+		//which is valid for the whole LDAP resource. It needs to be reset
+		//to the agent's credentials
+		$lw  = $this->getMock('\OCA\user_ldap\lib\ILDAPWrapper');
+
+		$connection = new \OCA\user_ldap\lib\Connection($lw, '', null);
+		$agent = array(
+			'ldapAgentName' => 'agent',
+			'ldapAgentPassword' => '123456',
+		);
+		$connection->setConfiguration($agent);
+
+		$testConnection = clone $connection;
+		$user = array(
+			'ldapAgentName' => 'user',
+			'ldapAgentPassword' => 'password',
+		);
+		$testConnection->setConfiguration($user);
+
+		$agentName = $connection->ldapAgentName;
+		$agentPawd = $connection->ldapAgentPassword;
+
+		$this->assertSame($agentName, $agent['ldapAgentName']);
+		$this->assertSame($agentPawd, $agent['ldapAgentPassword']);
+	}
+
+}


### PR DESCRIPTION
Upon login a bind is done with the user credentials which is valid for the whole LDAP resource. It needs to be reset to the agent's credentials. So on the authentication check, the Connection instance is cloned, but the underlying Configuration is a class of it's own since OC 6. I.e. when cloning a new instance of it needs to be created. 

Unit test included.

Please test and review @uka-support @Xenopathic or others
