### PR TITLE
use https as submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty"]
 	path = 3rdparty
-	url = git://github.com/owncloud/3rdparty.git
+	url = https://github.com/owncloud/3rdparty.git


### PR DESCRIPTION
git:// domains might not be allowed in all environments, while cloning
https through a proxy is fine. -> Make checkout in restrictive
environments possible.
