### PR TITLE
Conflicting Basic Auth Fixes

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -542,9 +542,9 @@ class OC {
 			$sessionUser = self::$session->get('loginname');
 			$serverUser = $_SERVER['PHP_AUTH_USER'];
 			OC_Log::write('core',
-				"Session loginname ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
+				"Overriding SERVER[PHP_AUTH_USER] ($serverUser) with session user-id ($sessionUser).",
 				OC_Log::WARN);
-			OC_User::logout();
+			OC_Util::redirectToDefaultPage($sessionUser);
 		}
 
 		// Load Apps
@@ -754,6 +754,10 @@ class OC {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
 				OC_User::logout();
+				if (isset($_SERVER['PHP_AUTH_USER'])) {
+					// clear current basic auth user from browser
+					OC_Util::redirectToDefaultPage("logout");
+				}
 				// redirect to webroot and add slash if webroot is empty
 				header("Location: " . OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 			} else {

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -667,7 +667,7 @@ class OC_Util {
 	 * @brief Redirect to the user default page
 	 * @return void
 	 */
-	public static function redirectToDefaultPage() {
+	public static function redirectToDefaultPage($basicUser) {
 		if(isset($_REQUEST['redirect_url'])) {
 			$location = OC_Helper::makeURLAbsolute(urldecode($_REQUEST['redirect_url']));
 		}
@@ -682,6 +682,9 @@ class OC_Util {
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);
+		if (isset($basicUser)) {
+			$location = preg_replace('/^(http|https):\/\/(.+)/i', '${1}://' . $basicUser . '@${2}', $location);
+		}
 		header( 'Location: '.$location );
 		exit();
 	}


### PR DESCRIPTION
This is a slight modification of @DamnDam's pull request https://github.com/owncloud/core/pull/6922

This fixes cases where..
1. A browser sends HTTP Basic Auth Headers that don't match a current ownCloud user.
   - Login form submittal is preferred.  HTTP Auth User is fixed with http(s)://user@domain/webroot
2. A browser sends HTTP Basic Auth Headers that do match a current user, then user tries logging out.  Previously it was impossible to logout without clearing your browser's history.
   - HTTP Auth User is overwritten with http(s)://logout@domain/webroot

---

Fixes https://github.com/owncloud/core/pull/6922 https://github.com/owncloud/core/issues/4556
