### PR TITLE
Make the autoloader work with hhvm

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -90,7 +90,7 @@ class Autoloader {
 			list(, $app, $rest) = explode('\\', $class, 3);
 			$app = strtolower($app);
 			foreach (\OC::$APPSROOTS as $appDir) {
-				if (stream_resolve_include_path($appDir['path'] . '/' . $app)) {
+				if (stream_resolve_include_path($appDir['path'] . '/' . $app . '/appinfo/app.php')) {
 					$paths[] = $appDir['path'] . '/' . $app . '/' . strtolower(str_replace('\\', '/', $rest) . '.php');
 					// If not found in the root of the app directory, insert '/lib' after app id and try again.
 					$paths[] = $appDir['path'] . '/' . $app . '/lib/' . strtolower(str_replace('\\', '/', $rest) . '.php');


### PR DESCRIPTION
hhvm's version of `stream_resolve_include_path` doesnt work on directories. (see https://github.com/facebook/hhvm/issues/1476)

cc @PVince81 @DeepDiver1975 
