### PR TITLE
Fixes login / logout when HTTP Basic Headers are avilable.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -178,12 +178,12 @@ $CONFIG = array(
 /* Enable or disable the logging of IP addresses in case of webform auth failures */
 "log_authfailip" => false,
 
+<<<<<<< HEAD
 /* Whether ownCloud should log the last successfull cron exec */
 "cron_log" => true,
 
-/* Whether http-basic username must equal username to login */
-"basic_auth" => true,
-
+=======
+>>>>>>> Fixes login / logout when HTTP Basic Headers are avilable.
 /*
  * Configure the size in bytes log rotation should happen, 0 or false disables the rotation.
  * This rotates the current owncloud logfile to a new name, this way the total log usage

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -178,12 +178,9 @@ $CONFIG = array(
 /* Enable or disable the logging of IP addresses in case of webform auth failures */
 "log_authfailip" => false,
 
-<<<<<<< HEAD
 /* Whether ownCloud should log the last successfull cron exec */
 "cron_log" => true,
 
-=======
->>>>>>> Fixes login / logout when HTTP Basic Headers are avilable.
 /*
  * Configure the size in bytes log rotation should happen, 0 or false disables the rotation.
  * This rotates the current owncloud logfile to a new name, this way the total log usage

--- a/lib/base.php
+++ b/lib/base.php
@@ -741,13 +741,12 @@ class OC {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
 				if (isset($_SERVER['PHP_AUTH_USER'])) {
-					$cookie_path = OC::$WEBROOT ? : '/';
 					if (isset($_COOKIE['oc_ignore_php_auth_user'])) {
 						// Ignore HTTP Authentication for 5 more mintues.
-						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], time() + 300, $cookie_path);
+						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], time() + 300, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 					} elseif ($_SERVER['PHP_AUTH_USER'] === self::$session->get('loginname')) {
 						// Ignore HTTP Aunthentication to allow a different user to log in.
-						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, $cookie_path);
+						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 					}
 				}
 				OC_User::logout();

--- a/lib/base.php
+++ b/lib/base.php
@@ -745,7 +745,7 @@ class OC {
 						// Ignore HTTP Authentication for 5 more mintues.
 						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], time() + 300, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 					} elseif ($_SERVER['PHP_AUTH_USER'] === self::$session->get('loginname')) {
-						// Ignore HTTP Aunthentication to allow a different user to log in.
+						// Ignore HTTP Authentication to allow a different user to log in.
 						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
 					}
 				}

--- a/lib/base.php
+++ b/lib/base.php
@@ -744,7 +744,7 @@ class OC {
 					$cookie_path = OC::$WEBROOT ? : '/';
 					if (isset($_COOKIE['oc_ignore_php_auth_user'])) {
 						// Ignore HTTP Authentication for 5 more mintues.
-						setcookie('oc_ignore_php_auth_user', '', time() + 300, $cookie_path);
+						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], time() + 300, $cookie_path);
 					} elseif ($_SERVER['PHP_AUTH_USER'] === self::$session->get('loginname')) {
 						// Ignore HTTP Aunthentication to allow a different user to log in.
 						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, $cookie_path);

--- a/lib/base.php
+++ b/lib/base.php
@@ -538,17 +538,6 @@ class OC {
 		OC_User::useBackend(new OC_User_Database());
 		OC_Group::useBackend(new OC_Group_Database());
 
-		$basic_auth = OC_Config::getValue('basic_auth', true);
-		if ($basic_auth && isset($_SERVER['PHP_AUTH_USER']) && self::$session->exists('loginname')
-			&& $_SERVER['PHP_AUTH_USER'] !== self::$session->get('loginname')) {
-			$sessionUser = self::$session->get('loginname');
-			$serverUser = $_SERVER['PHP_AUTH_USER'];
-			OC_Log::write('core',
-				"Session loginname ($sessionUser) doesn't match SERVER[PHP_AUTH_USER] ($serverUser).",
-				OC_Log::WARN);
-			OC_User::logout();
-		}
-
 		// Load minimum set of apps - which is filesystem, authentication and logging
 		if (!self::checkUpgrade(false)) {
 			OC_App::loadApps(array('authentication'));
@@ -697,8 +686,10 @@ class OC {
 			self::checkUpgrade();
 		}
 
-		// Test it the user is already authenticated using Apaches AuthType Basic... very usable in combination with LDAP
-		OC::tryBasicAuthLogin();
+		if (!OC_User::isLoggedIn()) {
+			// Test it the user is already authenticated using Apaches AuthType Basic... very usable in combination with LDAP
+			OC::tryBasicAuthLogin();
+		}
 
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
@@ -748,6 +739,16 @@ class OC {
 			if (isset($_GET["logout"]) and ($_GET["logout"])) {
 				if (isset($_COOKIE['oc_token'])) {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
+				}
+				if (isset($_SERVER['PHP_AUTH_USER'])) {
+					$cookie_path = OC::$WEBROOT ? : '/';
+					if (isset($_COOKIE['oc_ignore_php_auth_user'])) {
+						// Ignore HTTP Authentication for 5 more mintues.
+						setcookie('oc_ignore_php_auth_user', '', time() + 300, $cookie_path);
+					} else {
+						// Ignore HTTP Aunthentication to allow a different user to log in.
+						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, $cookie_path);
+					}
 				}
 				OC_User::logout();
 				// redirect to webroot and add slash if webroot is empty
@@ -914,6 +915,7 @@ class OC {
 	protected static function tryBasicAuthLogin() {
 		if (!isset($_SERVER["PHP_AUTH_USER"])
 			|| !isset($_SERVER["PHP_AUTH_PW"])
+			|| (isset($_COOKIE['oc_ignore_php_auth_user']) && $_COOKIE['oc_ignore_php_auth_user'] === $_SERVER['PHP_AUTH_USER'])
 		) {
 			return false;
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -745,7 +745,7 @@ class OC {
 					if (isset($_COOKIE['oc_ignore_php_auth_user'])) {
 						// Ignore HTTP Authentication for 5 more mintues.
 						setcookie('oc_ignore_php_auth_user', '', time() + 300, $cookie_path);
-					} else {
+					} elseif ($_SERVER['PHP_AUTH_USER'] === self::$session->get('loginname')) {
 						// Ignore HTTP Aunthentication to allow a different user to log in.
 						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, $cookie_path);
 					}


### PR DESCRIPTION
This patch..
1. Ignores HTTP Basic Auth Headers when they are incorrect.
2. Adds a cookie 'oc_ignore_php_auth_user' when a user with successful 'BasicAuthLogin' wants to logout.
   - Fixes impossible logout with matching HTTP Basic User/Pass bug
3. Decreases the timelimit of the 'oc_ignore_php_auth_user' cookie to 5 minutes when a user who needed the cookie logs out.
   - Reallows HTTP Basic Auth for that browsing session
4.  HTTP Basic Username must match the value of the 'oc_ignore_php_auth_user' cookie for it to take affect.

---

Fixes https://github.com/owncloud/core/pull/6922 https://github.com/owncloud/core/issues/4556
In my opinion this is much cleaner and HTTP compliant than using http://whatever@domain.com as it has been depreciated in Chrome and IE.
