### PR TITLE
Routing performance

### DIFF
--- a/core/routes.php
+++ b/core/routes.php
@@ -7,7 +7,8 @@
  */
 
 // Post installation check
-/** @var $this OC_Router */
+
+/** @var $this OCP\Route\IRouter */
 $this->create('post_setup_check', '/post-setup-check')
 	->action('OC_Setup', 'postSetupCheck');
 

--- a/lib/private/route/cachingrouter.php
+++ b/lib/private/route/cachingrouter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Route;
+
+class CachingRouter extends Router {
+	/**
+	 * @var \OCP\ICache
+	 */
+	protected $cache;
+
+	/**
+	 * @param \OCP\ICache $cache
+	 */
+	public function __construct($cache) {
+		$this->cache = $cache;
+		parent::__construct();
+	}
+
+	/**
+	 * Generate url based on $name and $parameters
+	 *
+	 * @param string $name Name of the route to use.
+	 * @param array $parameters Parameters for the route
+	 * @param bool $absolute
+	 * @return string
+	 */
+	public function generate($name, $parameters = array(), $absolute = false) {
+		$key = $name . json_encode($parameters) . $absolute;
+		if ($this->cache->hasKey($key)) {
+			return $this->cache->get($key);
+		} else {
+			$url = parent::generate($name, $parameters, $absolute);
+			$this->cache->set($key, $url, 3600);
+			return $url;
+		}
+	}
+}

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -108,7 +108,7 @@ class Router implements IRouter {
 			}
 			$file = \OC_App::getAppPath($app) . '/appinfo/routes.php';
 			if (file_exists($file)) {
-				$routingFiles[$app] = array($file);
+				$routingFiles = array($app => $file);
 			} else {
 				$routingFiles = array();
 			}

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -178,9 +178,10 @@ class Router implements IRouter {
 	 */
 	public function match($url) {
 		if (substr($url, 0, 6) === '/apps/') {
+			// empty string / 'apps' / $app / rest of the route
 			list(, , $app,) = explode('/', $url, 4);
 			$this->loadRoutes($app);
-		} else if(substr($url, 0, 6) === '/core/') {
+		} else if(substr($url, 0, 6) === '/core/' or substr($url, 0, 5) === '/ocs/' or substr($url, 0, 10) === '/settings/') {
 			$this->loadRoutes('core');
 		} else {
 			$this->loadRoutes();

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -47,6 +47,8 @@ class Router implements IRouter {
 
 	protected $loaded = false;
 
+	protected $loadedApps = array();
+
 	public function __construct() {
 		$baseUrl = \OC_Helper::linkTo('', 'index.php');
 		if (!\OC::$CLI) {
@@ -93,27 +95,44 @@ class Router implements IRouter {
 	/**
 	 * loads the api routes
 	 */
-	public function loadRoutes() {
+	public function loadRoutes($app = null) {
 		if ($this->loaded) {
 			return;
 		}
-		$this->loaded = true;
-		foreach ($this->getRoutingFiles() as $app => $file) {
+		if (is_null($app)) {
+			$this->loaded = true;
+			$routingFiles = $this->getRoutingFiles();
+		} else {
+			if (isset($this->loadedApps[$app])) {
+				return;
+			}
+			$this->loadedApps[$app] = true;
+			$file = \OC_App::getAppPath($app) . '/appinfo/routes.php';
+			if (file_exists($file)) {
+				$routingFiles = array($file);
+			} else {
+				$routingFiles = array();
+			}
+		}
+		foreach ($routingFiles as $app => $file) {
 			$this->useCollection($app);
 			require_once $file;
 			$collection = $this->getCollection($app);
 			$collection->addPrefix('/apps/' . $app);
 			$this->root->addCollection($collection);
 		}
-		$this->useCollection('root');
-		require_once 'settings/routes.php';
-		require_once 'core/routes.php';
+		if (!isset($this->loadedApps['core'])) {
+			$this->loadedApps['core'] = true;
+			$this->useCollection('root');
+			require_once 'settings/routes.php';
+			require_once 'core/routes.php';
 
-		// include ocs routes
-		require_once 'ocs/routes.php';
-		$collection = $this->getCollection('ocs');
-		$collection->addPrefix('/ocs');
-		$this->root->addCollection($collection);
+			// include ocs routes
+			require_once 'ocs/routes.php';
+			$collection = $this->getCollection('ocs');
+			$collection->addPrefix('/ocs');
+			$this->root->addCollection($collection);
+		}
 	}
 
 	/**
@@ -158,7 +177,12 @@ class Router implements IRouter {
 	 * @throws \Exception
 	 */
 	public function match($url) {
-		$this->loadRoutes();
+		if (substr($url, 0, 6) === '/apps/') {
+			list(, , $app,) = explode('/', $url, 4);
+			$this->loadRoutes($app);
+		} else {
+			$this->loadRoutes();
+		}
 		$matcher = new UrlMatcher($this->root, $this->context);
 		$parameters = $matcher->match($url);
 		if (isset($parameters['action'])) {

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -158,6 +158,7 @@ class Router implements IRouter {
 	 * @throws \Exception
 	 */
 	public function match($url) {
+		$this->loadRoutes();
 		$matcher = new UrlMatcher($this->root, $this->context);
 		$parameters = $matcher->match($url);
 		if (isset($parameters['action'])) {
@@ -196,6 +197,7 @@ class Router implements IRouter {
 	 * @return string
 	 */
 	public function generate($name, $parameters = array(), $absolute = false) {
+		$this->loadRoutes();
 		return $this->getGenerator()->generate($name, $parameters, $absolute);
 	}
 

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -106,15 +106,15 @@ class Router implements IRouter {
 			if (isset($this->loadedApps[$app])) {
 				return;
 			}
-			$this->loadedApps[$app] = true;
 			$file = \OC_App::getAppPath($app) . '/appinfo/routes.php';
 			if (file_exists($file)) {
-				$routingFiles = array($file);
+				$routingFiles[$app] = array($file);
 			} else {
 				$routingFiles = array();
 			}
 		}
 		foreach ($routingFiles as $app => $file) {
+			$this->loadedApps[$app] = true;
 			$this->useCollection($app);
 			require_once $file;
 			$collection = $this->getCollection($app);
@@ -171,7 +171,7 @@ class Router implements IRouter {
 	}
 
 	/**
-	 * Find the route matching $url.
+	 * Find the route matching $url
 	 *
 	 * @param string $url The url to find
 	 * @throws \Exception
@@ -180,6 +180,8 @@ class Router implements IRouter {
 		if (substr($url, 0, 6) === '/apps/') {
 			list(, , $app,) = explode('/', $url, 4);
 			$this->loadRoutes($app);
+		} else if(substr($url, 0, 6) === '/core/') {
+			$this->loadRoutes('core');
 		} else {
 			$this->loadRoutes();
 		}

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -114,12 +114,14 @@ class Router implements IRouter {
 			}
 		}
 		foreach ($routingFiles as $app => $file) {
-			$this->loadedApps[$app] = true;
-			$this->useCollection($app);
-			require_once $file;
-			$collection = $this->getCollection($app);
-			$collection->addPrefix('/apps/' . $app);
-			$this->root->addCollection($collection);
+			if (!$this->loadedApps[$app]) {
+				$this->loadedApps[$app] = true;
+				$this->useCollection($app);
+				require_once $file;
+				$collection = $this->getCollection($app);
+				$collection->addPrefix('/apps/' . $app);
+				$this->root->addCollection($collection);
+			}
 		}
 		if (!isset($this->loadedApps['core'])) {
 			$this->loadedApps['core'] = true;
@@ -181,7 +183,7 @@ class Router implements IRouter {
 			// empty string / 'apps' / $app / rest of the route
 			list(, , $app,) = explode('/', $url, 4);
 			$this->loadRoutes($app);
-		} else if(substr($url, 0, 6) === '/core/' or substr($url, 0, 5) === '/ocs/' or substr($url, 0, 10) === '/settings/') {
+		} else if (substr($url, 0, 6) === '/core/' or substr($url, 0, 5) === '/ocs/' or substr($url, 0, 10) === '/settings/') {
 			$this->loadRoutes('core');
 		} else {
 			$this->loadRoutes();

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -159,7 +159,15 @@ class Server extends SimpleContainer implements IServerContainer {
 			return new \OC\BackgroundJob\JobList($c->getDatabaseConnection(), $config);
 		});
 		$this->registerService('Router', function ($c){
-			$router = new \OC\Route\Router();
+			/**
+			 * @var Server $c
+			 */
+			$cacheFactory = $c->getMemCacheFactory();
+			if ($cacheFactory->isAvailable()) {
+				$router = new \OC\Route\CachingRouter($cacheFactory->create('route'));
+			} else {
+				$router = new \OC\Route\Router();
+			}
 			return $router;
 		});
 	}
@@ -327,7 +335,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	/**
 	 * Returns an \OCP\CacheFactory instance
 	 *
-	 * @return \OCP\CacheFactory
+	 * @return \OCP\ICacheFactory
 	 */
 	function getMemCacheFactory() {
 		return $this->query('MemCacheFactory');
@@ -375,8 +383,6 @@ class Server extends SimpleContainer implements IServerContainer {
 	 * @return \OCP\Route\IRouter
 	 */
 	function getRouter(){
-		$router = $this->query('Router');
-		$router->loadRoutes();
-		return $router;
+		return $this->query('Router');
 	}
 }

--- a/lib/public/route/irouter.php
+++ b/lib/public/route/irouter.php
@@ -22,7 +22,7 @@ interface IRouter {
 	/**
 	 * loads the api routes
 	 */
-	public function loadRoutes();
+	public function loadRoutes($app = null);
 
 	/**
 	 * Sets the collection to use for adding routes

--- a/lib/public/route/irouter.php
+++ b/lib/public/route/irouter.php
@@ -10,8 +10,6 @@ namespace OCP\Route;
 
 interface IRouter {
 
-	public function __construct();
-
 	/**
 	 * Get the files to load the routes from
 	 *

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -6,7 +6,7 @@
  * See the COPYING-README file.
  */
 
-/** @var $this OC_Router */
+/** @var $this OCP\Route\IRouter */
 
 // Settings pages
 $this->create('settings_help', '/settings/help')


### PR DESCRIPTION
- When matching routes from an app or core, only load the routes we need
- Cache generated urls for routes to prevent having to load the routes for them

Combined this means that in a lot of cases we only need to load a small subset of the the routes which can lead to significant performance improvements depending on the route.

For loading a preview of a file it saved ~130ms on my local test instance.

cc @karlitschek @DeepDiver1975 @PVince81 
