### PR TITLE
Fix public upload to not close session when encryption is on

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -58,7 +58,10 @@ if (empty($_POST['dirToken'])) {
 
 
 OCP\JSON::callCheck();
-\OC::$session->close();
+if (!\OCP\App::isEnabled('files_encryption')) {
+	// encryption app need to create keys later, so can't close too early
+	\OC::$session->close();
+}
 
 
 // get array with current storage stats (e.g. max file size)


### PR DESCRIPTION
The encryption app needs to create keys when uploading files, so the
session needs to be kept open in such case.

@DeepDiver1975 @schiesbn @karlitschek 
