### PR TITLE
Do not retrieve storage stats for trash bin

### DIFF
--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -25,6 +25,11 @@ $(document).ready(function() {
 		enableActions();
 	}
 
+	Files.updateStorageStatistics = function() {
+		// no op because the trashbin doesn't have
+		// storage info like free space / used space
+	};
+
 	if (typeof FileActions !== 'undefined') {
 		FileActions.register('all', 'Restore', OC.PERMISSION_READ, OC.imagePath('core', 'actions/history'), function(filename) {
 			var tr = FileList.findFileEl(filename);


### PR DESCRIPTION
When navigating into a subfolder inside the trashbin, a warning appeared in the log:

```
PHP Fatal error:  Call to a member function getStorage() on a non-object in /srv/www/htdocs/owncloud/lib/private/helper.php on line 890, referer: http://localhost/owncloud/index.php/apps/files_trashbin?dir=/a.d1395136424
```

This is because the "updateStorageStats" function was still called and tried to retrieve the free space, etc for the trashbin folder, which doesn't make sense.

This prevents the call to happen.

Please review @karlitschek @schiesbn @icewind1991 
