### PR TITLE
SMB/CIFS mounts using ownCloud login, fixes #7843

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Copyright (c) 2012 Robin Appelman <icewind@owncloud.com>
+ * Copyright (c) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -13,6 +14,7 @@ OC::$CLASSPATH['OC\Files\Storage\OwnCloud'] = 'files_external/lib/owncloud.php';
 OC::$CLASSPATH['OC\Files\Storage\Google'] = 'files_external/lib/google.php';
 OC::$CLASSPATH['OC\Files\Storage\Swift'] = 'files_external/lib/swift.php';
 OC::$CLASSPATH['OC\Files\Storage\SMB'] = 'files_external/lib/smb.php';
+OC::$CLASSPATH['OC\Files\Storage\SMB_Auto'] = 'files_external/lib/smb_auto.php';
 OC::$CLASSPATH['OC\Files\Storage\AmazonS3'] = 'files_external/lib/amazons3.php';
 OC::$CLASSPATH['OC\Files\Storage\Dropbox'] = 'files_external/lib/dropbox.php';
 OC::$CLASSPATH['OC\Files\Storage\SFTP'] = 'files_external/lib/sftp.php';
@@ -27,4 +29,5 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 // connecting hooks
 OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
 OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\iRODS', 'login');
+OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_Auto', 'login');
 

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -14,7 +14,7 @@ OC::$CLASSPATH['OC\Files\Storage\OwnCloud'] = 'files_external/lib/owncloud.php';
 OC::$CLASSPATH['OC\Files\Storage\Google'] = 'files_external/lib/google.php';
 OC::$CLASSPATH['OC\Files\Storage\Swift'] = 'files_external/lib/swift.php';
 OC::$CLASSPATH['OC\Files\Storage\SMB'] = 'files_external/lib/smb.php';
-OC::$CLASSPATH['OC\Files\Storage\SMB_Auto'] = 'files_external/lib/smb_auto.php';
+OC::$CLASSPATH['OC\Files\Storage\SMB_OC'] = 'files_external/lib/smb_oc.php';
 OC::$CLASSPATH['OC\Files\Storage\AmazonS3'] = 'files_external/lib/amazons3.php';
 OC::$CLASSPATH['OC\Files\Storage\Dropbox'] = 'files_external/lib/dropbox.php';
 OC::$CLASSPATH['OC\Files\Storage\SFTP'] = 'files_external/lib/sftp.php';
@@ -29,5 +29,5 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 // connecting hooks
 OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
 OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\iRODS', 'login');
-OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_Auto', 'login');
+OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_OC', 'login');
 

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -5,6 +5,7 @@
 * @author Michael Gapczynski
 * @copyright 2012 Michael Gapczynski mtgap@owncloud.com
 * @copyright 2014 Vincent Petry <pvince81@owncloud.com>
+* @copyright 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -122,11 +123,18 @@ class OC_Mount_Config {
 						'password' => '*Password',
 						'share' => 'Share',
 						'root' => '&Root'));
+				$backends['\OC\Files\Storage\SMB_Auto'] = array(
+					'backend' => 'SMB / CIFS Auto',
+					'configuration' => array(
+						'host' => 'URL',
+						'username_as_share' => '!Username as share',
+						'share' => '&Share',
+						'root' => '&Root'));
 			}
 		}
 
 		if(OC_Mount_Config::checkcurl()){
-		   	$backends['\OC\Files\Storage\DAV']=array(
+			$backends['\OC\Files\Storage\DAV']=array(
 				'backend' => 'WebDAV',
 				'configuration' => array(
 					'host' => 'URL',
@@ -134,7 +142,7 @@ class OC_Mount_Config {
 					'password' => '*Password',
 					'root' => '&Root',
 					'secure' => '!Secure https://'));
-		   	$backends['\OC\Files\Storage\OwnCloud']=array(
+			$backends['\OC\Files\Storage\OwnCloud']=array(
 				'backend' => 'ownCloud',
 				'configuration' => array(
 					'host' => 'URL',
@@ -185,7 +193,7 @@ class OC_Mount_Config {
 	 * @return array of mount point string as key, mountpoint config as value
 	 */
 	public static function getAbsoluteMountPoints($user) {
-		$mountPoints = array();	
+		$mountPoints = array();
 
 		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 		$mount_file = \OC_Config::getValue("mount_file", $datadir . "/mount.json");

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -319,7 +319,7 @@ class OC_Mount_Config {
 						'backend' => $backends[$mount['class']]['backend'],
 						'options' => $mount['options'],
 						'applicable' => array('groups' => array($group), 'users' => array()),
-						'status' => self::getBackendStatus($mount['class'], $mount['options'])
+						'status' => self::getBackendStatus($mount['class'], $mount['options'], false)
 					);
 					$hash = self::makeConfigHash($config);
 					// If an existing config exists (with same class, mountpoint and options)
@@ -349,7 +349,7 @@ class OC_Mount_Config {
 						'backend' => $backends[$mount['class']]['backend'],
 						'options' => $mount['options'],
 						'applicable' => array('groups' => array(), 'users' => array($user)),
-						'status' => self::getBackendStatus($mount['class'], $mount['options'])
+						'status' => self::getBackendStatus($mount['class'], $mount['options'], true)
 					);
 					$hash = self::makeConfigHash($config);
 					// If an existing config exists (with same class, mountpoint and options)
@@ -389,7 +389,7 @@ class OC_Mount_Config {
 					'mountpoint' => substr($mountPoint, strlen($uid) + 8),
 					'backend' => $backends[$mount['class']]['backend'],
 					'options' => $mount['options'],
-					'status' => self::getBackendStatus($mount['class'], $mount['options'])
+					'status' => self::getBackendStatus($mount['class'], $mount['options'], true)
 				);
 			}
 		}
@@ -402,7 +402,7 @@ class OC_Mount_Config {
 	 * @param array $options backend configuration options
 	 * @return bool true if the connection succeeded, false otherwise
 	 */
-	private static function getBackendStatus($class, $options) {
+	private static function getBackendStatus($class, $options, $isPersonal) {
 		if (self::$skipTest) {
 			return true;
 		}
@@ -412,7 +412,7 @@ class OC_Mount_Config {
 		if (class_exists($class)) {
 			try {
 				$storage = new $class($options);
-				return $storage->test();
+				return $storage->test($isPersonal);
 			} catch (Exception $exception) {
 				\OCP\Util::logException('files_external', $exception);
 				return false;
@@ -479,7 +479,7 @@ class OC_Mount_Config {
 			$mountPoints[$mountType] = $mount;
 		}
 		self::writeData($isPersonal, $mountPoints);
-		return self::getBackendStatus($class, $classOptions);
+		return self::getBackendStatus($class, $classOptions, $isPersonal);
 	}
 
 	/**

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -123,8 +123,8 @@ class OC_Mount_Config {
 						'password' => '*Password',
 						'share' => 'Share',
 						'root' => '&Root'));
-				$backends['\OC\Files\Storage\SMB_Auto'] = array(
-					'backend' => 'SMB / CIFS Auto',
+				$backends['\OC\Files\Storage\SMB_OC'] = array(
+					'backend' => 'SMB / CIFS using OC login',
 					'configuration' => array(
 						'host' => 'URL',
 						'username_as_share' => '!Username as share',

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -349,7 +349,7 @@ class OC_Mount_Config {
 						'backend' => $backends[$mount['class']]['backend'],
 						'options' => $mount['options'],
 						'applicable' => array('groups' => array(), 'users' => array($user)),
-						'status' => self::getBackendStatus($mount['class'], $mount['options'], true)
+						'status' => self::getBackendStatus($mount['class'], $mount['options'], false)
 					);
 					$hash = self::makeConfigHash($config);
 					// If an existing config exists (with same class, mountpoint and options)

--- a/apps/files_external/lib/smb_auto.php
+++ b/apps/files_external/lib/smb_auto.php
@@ -43,4 +43,8 @@ class SMB_Auto extends \OC\Files\Storage\SMB{
 	public static function login( $params ) {
 		\OC::$session->set('smb-credentials', $params);
 	}
+
+	public function isSharable($path) {
+		return false;
+	}
 }

--- a/apps/files_external/lib/smb_auto.php
+++ b/apps/files_external/lib/smb_auto.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Storage;
+
+class SMB_Auto extends \OC\Files\Storage\SMB{
+	public function __construct($params) {
+		if (isset($params['host']) && \OC::$session->exists('smb-credentials')) {
+			$host=$params['host'];
+			$username_as_share = ($params['username_as_share'] === 'true');
+
+			$params_auth = \OC::$session->get('smb-credentials');
+			$user = \OC_User::getDisplayName($params_auth['uid']);
+			$password = $params_auth['password'];
+
+			$root=isset($params['root'])?$params['root']:'/';
+			$share = '';
+
+			if ($username_as_share) {
+				$share = '/'.$user;
+			} elseif (isset($params['share'])) {
+				$share = $params['share'];
+			} else {
+				throw new \Exception();
+			}
+			parent::__construct(array(
+				"user" => $user,
+				"password" => $password,
+				"host" => $host,
+				"share" => $share,
+				"root" => $root
+			));
+		} else {
+			throw new \Exception();
+		}
+	}
+
+	public static function login( $params ) {
+		\OC::$session->set('smb-credentials', $params);
+	}
+}

--- a/apps/files_external/lib/smb_auto.php
+++ b/apps/files_external/lib/smb_auto.php
@@ -15,7 +15,7 @@ class SMB_Auto extends \OC\Files\Storage\SMB{
 			$username_as_share = ($params['username_as_share'] === 'true');
 
 			$params_auth = \OC::$session->get('smb-credentials');
-			$user = \OC_User::getDisplayName($params_auth['uid']);
+			$user = \OC::$session->get('loginname');
 			$password = $params_auth['password'];
 
 			$root=isset($params['root'])?$params['root']:'/';

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -8,7 +8,7 @@
 
 namespace OC\Files\Storage;
 
-class SMB_Auto extends \OC\Files\Storage\SMB{
+class SMB_OC extends \OC\Files\Storage\SMB {
 	public function __construct($params) {
 		if (isset($params['host']) && \OC::$session->exists('smb-credentials')) {
 			$host=$params['host'];

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -54,8 +54,9 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 
 	public function test($isPersonal = true) {
 		if ($isPersonal) {
-			if ($this->stat(''))
+			if ($this->stat('')) {
 				return true;
+			}
 			return false;
 		} else {
 			$smb = new \smb();
@@ -67,23 +68,26 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 
 			// Share cannot be checked if dynamic
 			if ($this->username_as_share) {
-				if ($smb->look($pu))
+				if ($smb->look($pu)) {
 					return true;
-				else
+				} else {
 					return false;
+				}
 			}
-			if (!$pu['share'])
+			if (!$pu['share']) {
 				return false;
+			}
 
 			// The following error messages are expected due to anonymous login
 			$regexp = array(
 				'(NT_STATUS_ACCESS_DENIED)' => 'skip'
 			) + $smb->getRegexp();
 
-			if ($smb->client("-d 0 " . escapeshellarg('//' . $pu['host'] . '/' . $pu['share']) . " -c exit", $pu, $regexp))
+			if ($smb->client("-d 0 " . escapeshellarg('//' . $pu['host'] . '/' . $pu['share']) . " -c exit", $pu, $regexp)) {
 				return true;
-			else
+			} else {
 				return false;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR provides a new mount type, that uses the user's ownCloud login credentials to connect to the SMB/CIFS share. It also has the ability to use the username as the share name, for use with home shares. The username and password are stored as session variables, however I do not consider this a security risk as iRODS already does the same thing.

Fixes #7843 

Please review @blizzz @PVince81 @icewind1991 @DeepDiver1975
