### PR TITLE
Pretty print mount.json when possible

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -538,7 +538,12 @@ class OC_Mount_Config {
 			$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data/');
 			$file = \OC_Config::getValue('mount_file', $datadir . '/mount.json');
 		}
-		$content = json_encode($data);
+		$options = 0;
+		if (defined('JSON_PRETTY_PRINT')) {
+			// only for PHP >= 5.4
+			$options = JSON_PRETTY_PRINT;
+		}
+		$content = json_encode($data, $options);
 		@file_put_contents($file, $content);
 		@chmod($file, 0640);
 	}


### PR DESCRIPTION
I'm tired of having to look at unformatted mount.json when debugging and some admins might be frustrated as well.

So here, this will pretty print the mount.json on write.
Only works for PHP >= 5.4

Please review @DeepDiver1975 @bantu @karlitschek @icewind1991 
