### PR TITLE
Fixed mtime reading from OpenStack API

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -251,6 +251,10 @@ class Swift extends \OC\Files\Storage\Common {
 			$mtime = $object->extra_headers['X-Object-Meta-Timestamp'];
 		}
 
+		if (!empty($mtime)) {
+			$mtime = floor($mtime);
+		}
+
 		$stat = array();
 		$stat['size'] = $object->content_length;
 		$stat['mtime'] = $mtime;


### PR DESCRIPTION
The API seems to return floating point values, which prevents
the hasUpdated() check to work and causes the scanner to rescan
everything every time.

This should improve the performance a bit, require less API calls.

@ser72 @icewind1991 
