### PR TITLE
Close session early on download stable5

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -24,6 +24,9 @@
 // Check if we are a user
 OCP\User::checkLoggedIn();
 
+// don't block php session during download
+session_write_close();
+
 $filename = $_GET["file"];
 
 if(!\OC\Files\Filesystem::file_exists($filename)) {


### PR DESCRIPTION
This PR unblocks ajax calls when a file download is in progress. Currently, the php session is locked for the whole download. When the music app downloads a track in the background any other requests to the server are stalled.

Basically a partial backport of https://github.com/owncloud/core/pull/7651/files#diff-bf5278fcb7b34e55ed3153c34f7dfdf1R32

@DeepDiver1975 @karlitschek @MorrisJobke 
