### PR TITLE
prevent dimmed ocdialog div from scrolling

### DIFF
--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -43,7 +43,7 @@
 	background-color: #000;
 	opacity: .20;filter:Alpha(Opacity=20);
 	z-index: 999;
-	position: absolute;
+	position: fixed;
 	top: 0; left: 0;
 	width: 100%; height: 100%;
 }


### PR DESCRIPTION
prevents the dimmed background from scrolling when eg tho copy conflic dialog pops and the list of files is so long that it shows scrollbars. Files can still be scrolled (which is a good thing) but the dimmed background will not scroll away.

@tanghus @DeepDiver1975 
