### PR TITLE
Use the correct resolve method to resolve file storage (x-sendfile)

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -148,8 +148,9 @@ class OC_Files {
 			set_time_limit($executionTime);
 		} else {
 			if ($xsendfile) {
+				$view = \OC\Files\Filesystem::getView();
 				/** @var $storage \OC\Files\Storage\Storage */
-				list($storage) = \OC\Files\Filesystem::resolvePath($filename);
+				list($storage) = $view->resolvePath($filename);
 				if ($storage->isLocal()) {
 					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
 				} else {


### PR DESCRIPTION
When detecting whether the file to be downloaded is on external storage,
the correct path needs to be used.

It turns out that \OC\Files\View is needed to resolve the path correctly
relative to the user's home.

Please review @icewind1991 @schiesbn @josh4trunks 
