### PR TITLE
Fix swift touch operation

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -374,7 +374,7 @@ class Swift extends \OC\Files\Storage\Common {
 					'X-Object-Meta-Timestamp' => $mtime
 				)
 			);
-			return $object->Update($settings);
+			return $object->UpdateMetadata($settings);
 		} else {
 			$object = $this->container->DataObject();
 			if (is_null($mtime)) {


### PR DESCRIPTION
The touch() operation now uses "UpdateMetadata()" instead of "Update()"
which doesn't clear the object's contents.

This fixes syncing, as the sync client needs to use touch to update the
object's mtime.

Should fix the syncing issue and "0 byte" issue mentionned in #7191

Please review/test @icewind1991 @yannickgrammont @joakimohman @leonardofln @ser72 
