### PR TITLE
LDAP: Read email and quota when mapping user, fixes #7785

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -106,7 +106,8 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	* @brief fetches the quota from LDAP and stores it as ownCloud user value
+	* @brief fetches the quota from LDAP and, if provided, stores it as ownCloud
+	* user value
 	* @param string the DN of the user
 	* @param string optional, the internal ownCloud name of the user
 	* @return null
@@ -135,7 +136,8 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	* @brief fetches the email from LDAP and stores it as ownCloud user value
+	* @brief fetches the email from LDAP and, if provided, stores it as ownCloud
+	* user value
 	* @param string the DN of the user
 	* @param string optional, the internal ownCloud name of the user
 	* @return null

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -105,6 +105,47 @@ class Access extends LDAPUtility {
 		return false;
 	}
 
+	public function updateQuota($dn, $ocname = null) {
+		$quota = null;
+		$quotaDefault = $this->connection->ldapQuotaDefault;
+		$quotaAttribute = $this->connection->ldapQuotaAttribute;
+		if(!empty($quotaDefault)) {
+			$quota = $quotaDefault;
+		}
+		if(!empty($quotaAttribute)) {
+			$aQuota = $this->readAttribute($dn, $quotaAttribute);
+
+			if($aQuota && (count($aQuota) > 0)) {
+				$quota = $aQuota[0];
+			}
+		}
+		if(!is_null($quota)) {
+			if(is_null($ocname)) {
+				$ocname = $this->dn2username($dn);
+			}
+			\OCP\Config::setUserValue($ocname, 'files', 'quota',
+				\OCP\Util::computerFileSize($quota));
+		}
+	}
+
+	public function updateEmail($dn, $ocname = null) {
+		$email = null;
+		$emailAttribute = $this->connection->ldapEmailAttribute;
+		if(!empty($emailAttribute)) {
+			$aEmail = $this->readAttribute($dn, $emailAttribute);
+			if($aEmail && (count($aEmail) > 0)) {
+				$email = $aEmail[0];
+			}
+			if(!is_null($email)) {
+				if(is_null($ocname)) {
+					$ocname = $this->dn2username($dn);
+				}
+				\OCP\Config::setUserValue($ocname, 'settings', 'email', $email);
+			}
+		}
+	}
+
+
 	/**
 	 * @brief checks wether the given attribute`s valua is probably a DN
 	 * @param $attr the attribute in question
@@ -596,6 +637,11 @@ class Access extends LDAPUtility {
 
 		if($insRows === 0) {
 			return false;
+		}
+
+		if($isUser) {
+			$this->updateEmail($dn, $ocname);
+			$this->updateQuota($dn, $ocname);
 		}
 
 		return true;

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -105,6 +105,12 @@ class Access extends LDAPUtility {
 		return false;
 	}
 
+	/**
+	* @brief fetches the quota from LDAP and stores it as ownCloud user value
+	* @param string the DN of the user
+	* @param string optional, the internal ownCloud name of the user
+	* @return null
+	*/
 	public function updateQuota($dn, $ocname = null) {
 		$quota = null;
 		$quotaDefault = $this->connection->ldapQuotaDefault;
@@ -128,6 +134,12 @@ class Access extends LDAPUtility {
 		}
 	}
 
+	/**
+	* @brief fetches the email from LDAP and stores it as ownCloud user value
+	* @param string the DN of the user
+	* @param string optional, the internal ownCloud name of the user
+	* @return null
+	*/
 	public function updateEmail($dn, $ocname = null) {
 		$email = null;
 		$emailAttribute = $this->connection->ldapEmailAttribute;
@@ -144,7 +156,6 @@ class Access extends LDAPUtility {
 			}
 		}
 	}
-
 
 	/**
 	 * @brief checks wether the given attribute`s valua is probably a DN

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -31,42 +31,11 @@ use OCA\user_ldap\lib\BackendUtility;
 class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 
 	private function updateQuota($dn) {
-		$quota = null;
-		$quotaDefault = $this->access->connection->ldapQuotaDefault;
-		$quotaAttribute = $this->access->connection->ldapQuotaAttribute;
-		if(!empty($quotaDefault)) {
-			$quota = $quotaDefault;
-		}
-		if(!empty($quotaAttribute)) {
-			$aQuota = $this->access->readAttribute($dn, $quotaAttribute);
-
-			if($aQuota && (count($aQuota) > 0)) {
-				$quota = $aQuota[0];
-			}
-		}
-		if(!is_null($quota)) {
-			\OCP\Config::setUserValue(	$this->access->dn2username($dn),
-										'files',
-										'quota',
-										\OCP\Util::computerFileSize($quota));
-		}
+		$this->access->updateQuota($dn);
 	}
 
 	private function updateEmail($dn) {
-		$email = null;
-		$emailAttribute = $this->access->connection->ldapEmailAttribute;
-		if(!empty($emailAttribute)) {
-			$aEmail = $this->access->readAttribute($dn, $emailAttribute);
-			if($aEmail && (count($aEmail) > 0)) {
-				$email = $aEmail[0];
-			}
-			if(!is_null($email)) {
-				\OCP\Config::setUserValue(	$this->access->dn2username($dn),
-											'settings',
-											'email',
-											$email);
-			}
-		}
+		$this->access->updateEmail($dn);
 	}
 
 	/**


### PR DESCRIPTION
Small-Footpring fix for #7785 on stable6. Puts methods to retrieve information for a specific user into LDAP interaction class, so it is available when creating the user reference in owncloud as well as through the user backend. More sophisticated fix for master is in a PR of it's own.

Please review (and if possible test :D) @uka-support @leo-b @PVince81  or others, please.
