### PR TITLE
Make getPath work for shared files

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -400,6 +400,13 @@ class Shared_Cache extends Cache {
 		return false;
 	}
 
+	/**
+	 * get the path of a file on this storage by it's id
+	 *
+	 * @param int $id
+	 * @param string $pathEnd (optional) used internally for recursive calls
+	 * @return string | null
+	 */
 	public function getPathById($id, $pathEnd = '') {
 		// direct shares are easy
 		if ($path = $this->getShareById($id)) {

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -20,6 +20,7 @@
  */
 
 namespace OC\Files\Cache;
+
 use OCP\Share_Backend_Collection;
 
 /**
@@ -50,7 +51,7 @@ class Shared_Cache extends Cache {
 			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
 			$mount = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
 			if (is_array($mount)) {
-				$fullPath = $mount[key($mount)]->getMountPoint().$source['path'];
+				$fullPath = $mount[key($mount)]->getMountPoint() . $source['path'];
 				list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($fullPath);
 				if ($storage) {
 					$this->files[$target] = $internalPath;
@@ -75,7 +76,7 @@ class Shared_Cache extends Cache {
 	/**
 	 * get the stored metadata of a file or folder
 	 *
-	 * @param string/int $file
+	 * @param string /int $file
 	 * @return array
 	 */
 	public function get($file) {
@@ -95,8 +96,8 @@ class Shared_Cache extends Cache {
 		} else {
 			$query = \OC_DB::prepare(
 				'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`,'
-				.' `size`, `mtime`, `encrypted`, `unencrypted_size`'
-				.' FROM `*PREFIX*filecache` WHERE `fileid` = ?');
+				. ' `size`, `mtime`, `encrypted`, `unencrypted_size`'
+				. ' FROM `*PREFIX*filecache` WHERE `fileid` = ?');
 			$result = $query->execute(array($file));
 			$data = $result->fetchRow();
 			$data['fileid'] = (int)$data['fileid'];
@@ -288,8 +289,7 @@ class Shared_Cache extends Cache {
 			foreach ($files as $file) {
 				if ($file['mimetype'] === 'httpd/unix-directory') {
 					$exploreDirs[] = ltrim($dir . '/' . $file['name'], '/');
-				}
-				else if (($mimepart && $file['mimepart'] === $mimepart) || ($mimetype && $file['mimetype'] === $mimetype)) {
+				} else if (($mimepart && $file['mimepart'] === $mimepart) || ($mimetype && $file['mimetype'] === $mimetype)) {
 					// usersPath not reliable
 					//$file['path'] = $file['usersPath'];
 					$file['path'] = ltrim($dir . '/' . $file['name'], '/');
@@ -344,8 +344,6 @@ class Shared_Cache extends Cache {
 				if ($row['encrypted'] or ($row['unencrypted_size'] > 0 and $row['mimetype'] === 'httpd/unix-directory')) {
 					$row['encrypted_size'] = $row['size'];
 					$row['size'] = $row['unencrypted_size'];
-				} else {
-					$row['size'] = $row['size'];
 				}
 				$files[] = $row;
 			}
@@ -402,4 +400,41 @@ class Shared_Cache extends Cache {
 		return false;
 	}
 
+	public function getPathById($id, $pathEnd = '') {
+		// direct shares are easy
+		if ($path = $this->getShareById($id)) {
+			return $path . $pathEnd;
+		} else {
+			// if the item is a direct share we try and get the path of the parent and append the name of the item to it
+			list($parent, $name) = $this->getParentInfo($id);
+			if ($parent > 0) {
+				return $this->getPathById($parent, '/' . $name . $pathEnd);
+			} else {
+				return null;
+			}
+		}
+	}
+
+	private function getShareById($id) {
+		$item = \OCP\Share::getItemSharedWithBySource('file', $id);
+		if ($item) {
+			return trim($item['file_target'], '/');
+		}
+		$item = \OCP\Share::getItemSharedWithBySource('folder', $id);
+		if ($item) {
+			return trim($item['file_target'], '/');
+		}
+		return null;
+	}
+
+	private function getParentInfo($id) {
+		$sql = 'SELECT `parent`, `name` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+		$query = \OC_DB::prepare($sql);
+		$result = $query->execute(array($id));
+		if ($row = $result->fetchRow()) {
+			return array($row['parent'], $row['name']);
+		} else {
+			return array(-1, '');
+		}
+	}
 }

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -594,7 +594,7 @@ class Cache {
 	}
 
 	/**
-	 * get the storage id of the storage for a file and the internal path of the file
+	 * get the path of a file on this storage by it's id
 	 *
 	 * @param int $id
 	 * @return string | null
@@ -611,6 +611,8 @@ class Cache {
 
 	/**
 	 * get the storage id of the storage for a file and the internal path of the file
+	 * unlike getPathById this does not limit the search to files on this storage and
+	 * instead does a global search in the cache table
 	 *
 	 * @param int $id
 	 * @return array, first element holding the storage id, second the path

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -597,6 +597,22 @@ class Cache {
 	 * get the storage id of the storage for a file and the internal path of the file
 	 *
 	 * @param int $id
+	 * @return string | null
+	 */
+	public function getPathById($id) {
+		$sql = 'SELECT `path` FROM `*PREFIX*filecache` WHERE `fileid` = ? AND `storage` = ?';
+		$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
+		if ($row = $result->fetchRow()) {
+			return $row['path'];
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * get the storage id of the storage for a file and the internal path of the file
+	 *
+	 * @param int $id
 	 * @return array, first element holding the storage id, second the path
 	 */
 	static public function getById($id) {


### PR DESCRIPTION
Changes `getPath` to query the storages individually which allows the shared storage to overwrite the behaviour

cc @DeepDiver1975 @PVince81 
