### PR TITLE
Use UrlGenerator in OC\Util::redirectToDefaultPage(). Fix #7936

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -78,8 +78,7 @@ class OC_Helper {
 	 * Returns a absolute url to the given app and file.
 	 */
 	public static function linkToAbsolute($app, $file, $args = array()) {
-		$urlLinkTo = self::linkTo($app, $file, $args);
-		return self::makeURLAbsolute($urlLinkTo);
+		return self::linkTo($app, $file, $args);
 	}
 
 	/**

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -701,17 +701,18 @@ class OC_Util {
 	 * @return void
 	 */
 	public static function redirectToDefaultPage() {
+		$urlGenerator = \OC::$server->getURLGenerator();
 		if(isset($_REQUEST['redirect_url'])) {
-			$location = OC_Helper::makeURLAbsolute(urldecode($_REQUEST['redirect_url']));
+			$location = $urlGenerator->getAbsoluteURL(urldecode($_REQUEST['redirect_url']));
 		}
 		else if (isset(OC::$REQUESTEDAPP) && !empty(OC::$REQUESTEDAPP)) {
-			$location = OC_Helper::linkToAbsolute( OC::$REQUESTEDAPP, 'index.php' );
+			$location = $urlGenerator->getAbsoluteURL('/index.php/apps/'.OC::$REQUESTEDAPP.'/index.php');
 		} else {
 			$defaultPage = OC_Appconfig::getValue('core', 'defaultpage');
 			if ($defaultPage) {
-				$location = OC_Helper::makeURLAbsolute(OC::$WEBROOT.'/'.$defaultPage);
+				$location = $urlGenerator->getAbsoluteURL($defaultPage);
 			} else {
-				$location = OC_Helper::linkToAbsolute( 'files', 'index.php' );
+				$location = $urlGenerator->getAbsoluteURL('/index.php/files/index.php');
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -703,7 +703,7 @@ class OC_Util {
 	public static function redirectToDefaultPage() {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		if(isset($_REQUEST['redirect_url'])) {
-			$location = $urlGenerator->getAbsoluteURL(urldecode($_REQUEST['redirect_url']));
+			$location = urldecode($_REQUEST['redirect_url']);
 		}
 		else if (isset(OC::$REQUESTEDAPP) && !empty(OC::$REQUESTEDAPP)) {
 			$location = $urlGenerator->getAbsoluteURL('/index.php/apps/'.OC::$REQUESTEDAPP.'/index.php');


### PR DESCRIPTION
Fix double subdir when redirecting. The same function was being called twice on one occasion, on another it already prepended `OC::$WEBROOT`.

@MorrisJobke @PVince81 
