### PR TITLE
Correction: failure on sharing when user ID was prefixed by zero

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -551,7 +551,7 @@ $(document).ready(function() {
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
 		var shareType = $li.data('share-type');
-		var shareWith = $li.data('share-with');
+		var shareWith = $li.attr('data-share-with');
 		OC.Share.unshare(itemType, itemSource, shareType, shareWith, function() {
 			$li.remove();
 			var index = OC.Share.itemShares[shareType].indexOf(shareWith);
@@ -597,7 +597,7 @@ $(document).ready(function() {
 		OC.Share.setPermissions($('#dropdown').data('item-type'),
 			$('#dropdown').data('item-source'),
 			li.data('share-type'),
-			li.data('share-with'),
+			li.attr('data-share-with'),
 			permissions);
 	});
 
@@ -782,7 +782,7 @@ $(document).ready(function() {
 		}
 
 		var shareType = $li.data('share-type');
-		var shareWith = $li.data('share-with');
+		var shareWith = $li.attr('data-share-with');
 
 		$.post(OC.filePath('core', 'ajax', 'share.php'), {action: action, recipient: shareWith, shareType: shareType, itemSource: itemSource, itemType: itemType}, function(result) {
 			if (result.status !== 'success') {


### PR DESCRIPTION
We were facing a serious issue on sharing feature because our identifiers may be prefixed by zeroes.
Our user IDs, CPF (see http://pt.wikipedia.org/wiki/Cpf) - similar to ISS in US, have the possibility to start with "0". In those cases unsharing or modifying a shared resource caused a failure.

The root cause is that, according to jQuery, data() function tries to convert the value into a number, ripping out leading zeroes. See:
http://stackoverflow.com/questions/7962464/jquery-data-attribute-removes-leading-zeros

Therefore, the correction to this issue consisted in replacing
data("name")
by
attr("data-name")

So far we found this issue on sharing feature. However, it may appear somewhere else in ownCloud sourcecode - core and modules.
