### PR TITLE
External Storage: change confusing 'applicable' to 'available for', default to »All Users«

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -91,7 +91,10 @@
 							<select class="chzn-select"
 									multiple style="width:20em;"
 									data-placeholder="<?php p($l->t('None set')); ?>">
-								<option value="all" <?php if (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users'])) print_unescaped('selected="selected"');?> ><?php p($l->t('All Users')); ?></option>
+								<option value="all" selected="selected"
+									<?php if (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users'])) print_unescaped('selected="selected"');?> >
+									<?php p($l->t('All Users')); ?>
+								</option>
 								<optgroup label="<?php p($l->t('Groups')); ?>">
 								<?php foreach ($_['groups'] as $group): ?>
 									<option value="<?php p($group); ?>(group)"

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -10,7 +10,7 @@
 					<th><?php p($l->t('External storage')); ?></th>
 					<th><?php p($l->t('Configuration')); ?></th>
 					<!--<th><?php p($l->t('Options')); ?></th> -->
-					<?php if ($_['isAdminPage']) print_unescaped('<th>'.$l->t('Applicable').'</th>'); ?>
+					<?php if ($_['isAdminPage']) print_unescaped('<th>'.$l->t('Available for').'</th>'); ?>
 					<th>&nbsp;</th>
 				</tr>
 			</thead>

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -90,7 +90,7 @@
 														print_unescaped(json_encode($mount['applicable']['users'])); ?>'>
 							<select class="chzn-select"
 									multiple style="width:20em;"
-									data-placeholder="<?php p($l->t('None set')); ?>">
+									data-placeholder="<?php p($l->t('No user or group')); ?>">
 								<option value="all" selected="selected"
 									<?php if (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users'])) print_unescaped('selected="selected"');?> >
 									<?php p($l->t('All Users')); ?>

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -91,8 +91,8 @@
 							<select class="chzn-select"
 									multiple style="width:20em;"
 									data-placeholder="<?php p($l->t('No user or group')); ?>">
-								<option value="all" selected="selected"
-									<?php if (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users'])) print_unescaped('selected="selected"');?> >
+									<option value="all"
+									<?php if (empty($mount['class']) || (isset($mount['applicable']['users']) && in_array('all', $mount['applicable']['users']))) print_unescaped('selected="selected"');?> >
 									<?php p($l->t('All Users')); ?>
 								</option>
 								<optgroup label="<?php p($l->t('Groups')); ?>">


### PR DESCRIPTION
What does »Applicable« mean? Changed it to better understandable »Available for«
- [x] And there should not even be a »None set« option. The default should be »All users«. Please add that @schiesbn @nickvergessen 

cc @owncloud/designers
