### PR TITLE
Check if web root has already been appended

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -149,6 +149,11 @@ class URLGenerator implements IURLGenerator {
 	public function getAbsoluteURL($url) {
 		$separator = $url[0] === '/' ? '' : '/';
 
-		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost(). \OC::$WEBROOT . $separator . $url;
+		// The ownCloud web root can already be prepended.
+		$webRoot = substr($url, 0, strlen(\OC::$WEBROOT)) === \OC::$WEBROOT
+			? ''
+			: \OC::$WEBROOT;
+
+		return \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost(). $webRoot . $separator . $url;
 	}
 }


### PR DESCRIPTION
This whole `linkTo`, `linkToAbsolute`, `linkToRemote`, `linkToRemoteBase` etc. etc. is a mess. We should move it all to the UrlGenerator class, decide on a standardized way and obsolete all the "helper" functions.

This is just a hack to make it work.

@PVince81 @jancborchardt @MorrisJobke 
