### PR TITLE
select statement always need to contain file_source respectively item_source

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1523,9 +1523,9 @@ class Share extends \OC\Share\Constants {
 		$select = '*';
 		if ($format == self::FORMAT_STATUSES) {
 			if ($fileDependent) {
-				$select = '`*PREFIX*share`.`id`, `*PREFIX*share`.`parent`, `share_type`, `path`, `share_with`, `uid_owner`';
+				$select = '`*PREFIX*share`.`id`, `*PREFIX*share`.`parent`, `share_type`, `path`, `share_with`, `uid_owner` , `file_source`';
 			} else {
-				$select = '`id`, `parent`, `share_type`, `share_with`, `uid_owner`';
+				$select = '`id`, `parent`, `share_type`, `share_with`, `uid_owner`, `item_source`';
 			}
 		} else {
 			if (isset($uidOwner)) {


### PR DESCRIPTION
fix #7957 

Test case:

Share a file and reload the page. Without this patch you won't see the share icon next to the shared file, with this patch the share icon should appear.

cc @PVince81 
