### PR TITLE
Allow using "/" in "overwritewebroot"

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -41,7 +41,7 @@ $CONFIG = array(
 /* The automatic protocol detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the protocol detection. For example "https" */
 "overwriteprotocol" => "",
 
-/* The automatic webroot detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the automatic detection. For example "/domain.tld/ownCloud" */
+/* The automatic webroot detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the automatic detection. For example "/domain.tld/ownCloud". The value "/" can be used to remove the root. */
 "overwritewebroot" => "",
 
 /* The automatic detection of ownCloud can fail in certain reverse proxy situations. This option allows to define a manually override condition as regular expression for the remote ip address. For example "^10\.0\.0\.[1-3]$" */

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -166,10 +166,11 @@ class OC_Request {
 	 */
 	public static function scriptName() {
 		$name = $_SERVER['SCRIPT_NAME'];
-		if (OC_Config::getValue('overwritewebroot', '') !== '' and self::isOverwriteCondition()) {
+		$overwriteWebRoot = OC_Config::getValue('overwritewebroot', '');
+		if ($overwriteWebRoot !== '' and self::isOverwriteCondition()) {
 			$serverroot = str_replace("\\", '/', substr(__DIR__, 0, -strlen('lib/private/')));
 			$suburi = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen($serverroot)));
-			$name = OC_Config::getValue('overwritewebroot', '') . $suburi;
+			$name = '/' . ltrim($overwriteWebRoot . $suburi, '/');
 		}
 		return $name;
 	}


### PR DESCRIPTION
Whenever the reverse proxy is using "/" as the webroot, it is now
possible to set that value in "overwritewebroot"

Fixes #7870 

Please review @internalfx @fanchthesystem
You need to set "/" for "overwritewebroot" to make it work.

I've tested this with both "/" and another value like "/ocproxy" in a reverse proxy environment.
