### PR TITLE
always encrypt files to owner

### DIFF
--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -545,7 +545,7 @@ class Stream {
 				$util = new Util($this->rootView, $this->userId);
 
 				// Get all users sharing the file includes current user
-				$uniqueUserIds = $util->getSharingUsersArray($sharingEnabled, $this->relPath, $this->userId);
+				$uniqueUserIds = $util->getSharingUsersArray($sharingEnabled, $this->relPath);
 				$checkedUserIds = $util->filterShareReadyUsers($uniqueUserIds);
 
 				// Fetch public keys for all sharing users

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1124,8 +1124,9 @@ class Util {
 	 * @brief Find, sanitise and format users sharing a file
 	 * @note This wraps other methods into a portable bundle
 	 * @param boolean $sharingEnabled
+	 * @param string $filePath path relativ to current users files folder
 	 */
-	public function getSharingUsersArray($sharingEnabled, $filePath, $currentUserId = false) {
+	public function getSharingUsersArray($sharingEnabled, $filePath) {
 
 		$appConfig = \OC::$server->getAppConfig();
 
@@ -1144,12 +1145,14 @@ class Util {
 
 		$ownerPath = \OCA\Encryption\Helper::stripPartialFileExtension($ownerPath);
 
-		$userIds = array();
+		// always add owner to the list of users with access to the file
+		$userIds = array($owner);
+
 		if ($sharingEnabled) {
 
 			// Find out who, if anyone, is sharing the file
-			$result = \OCP\Share::getUsersSharingFile($ownerPath, $owner, true);
-			$userIds = $result['users'];
+			$result = \OCP\Share::getUsersSharingFile($ownerPath, $owner);
+			$userIds = \array_merge($userIds, $result['users']);
 			if ($result['public']) {
 				$userIds[] = $this->publicShareKeyId;
 			}
@@ -1163,11 +1166,6 @@ class Util {
 			$recoveryKeyId = $appConfig->getValue('files_encryption', 'recoveryKeyId');
 			// Add recoveryAdmin to list of users sharing
 			$userIds[] = $recoveryKeyId;
-		}
-
-		// add current user if given
-		if ($currentUserId !== false) {
-			$userIds[] = $currentUserId;
 		}
 
 		// check if it is a group mount

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -63,9 +63,9 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Find which users can access a shared item
-	 * @param $path to the file
-	 * @param $user owner of the file
-	 * @param include owner to the list of users with access to the file
+	 * @param string $path to the file
+	 * @param string $user owner of the file
+	 * @param bool $includeOwner include owner to the list of users with access to the file
 	 * @return array
 	 * @note $path needs to be relative to user data dir, e.g. 'file.txt'
 	 *       not '/admin/data/file.txt'


### PR DESCRIPTION
always add owner to the list of users with access to the file. This makes sure that we never end up with en empty list of user, for example if sharing was disabled.

fix #7833 

cc @PVince81 
