### PR TITLE
there is no need to re-calculate the shares after a touch

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -207,16 +207,6 @@ class Proxy extends \OC_FileProxy {
 	}
 
 	/**
-	 * @param $path
-	 * @return bool
-	 */
-	public function postTouch($path) {
-		$this->handleFile($path);
-
-		return true;
-	}
-
-	/**
 	 * @brief remember initial fopen mode because sometimes it gets changed during the request
 	 * @param string $path path
 	 * @param string $mode type of access
@@ -404,39 +394,4 @@ class Proxy extends \OC_FileProxy {
 		return $size;
 	}
 
-	/**
-	 * @param $path
-	 */
-	public function handleFile($path) {
-
-		// Disable encryption proxy to prevent recursive calls
-		$proxyStatus = \OC_FileProxy::$enabled;
-		\OC_FileProxy::$enabled = false;
-
-		$view = new \OC_FilesystemView('/');
-		$session = new \OCA\Encryption\Session($view);
-		$userId = Helper::getUser($path);
-		$util = new Util($view, $userId);
-
-		// split the path parts
-		$pathParts = explode('/', $path);
-
-		// get relative path
-		$relativePath = \OCA\Encryption\Helper::stripUserFilesPath($path);
-
-		// only if file is on 'files' folder fix file size and sharing
-		if (isset($pathParts[2]) && $pathParts[2] === 'files' && $util->fixFileSize($path)) {
-
-			// get sharing app state
-			$sharingEnabled = \OCP\Share::isEnabled();
-
-			// get users
-			$usersSharing = $util->getSharingUsersArray($sharingEnabled, $relativePath);
-
-			// update sharing-keys
-			$util->setSharedFileKeyfiles($session, $usersSharing, $relativePath);
-		}
-
-		\OC_FileProxy::$enabled = $proxyStatus;
-	}
 }


### PR DESCRIPTION
We use touch in to cases:
- Create a new empty file
- Update the mtime

In both cases it is not necessary to re-calculate the shares. In case of the mtime update, which happens most of the time when the sync client uploads a file, we calculated the shares twice. Once if the upload was finished and a second time after the touch. So this changes should give us also some performance improvements.

cc @PVince81 we discussed this issue already, maybe you can have a look? Thanks!
