### PR TITLE
fix h3 style, move out from settings to apps CSS

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -253,8 +253,10 @@ button.loading {
 }
 .section h2 {
 	font-size: 20px;
-	font-weight: normal;
 	margin-bottom: 7px;
+}
+.section h3 {
+	font-size: 16px;
 }
 /* slight position correction of checkboxes and radio buttons */
 .section input[type="checkbox"],

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -94,7 +94,6 @@ select.quota.active { background: #fff; }
 
 /* APPS */
 .appinfo { margin: 1em 40px; }
-h3 { font-size: 1.4em; font-weight: bold; }
 #app-navigation {
 	padding-bottom: 0px;
 }


### PR DESCRIPTION
The defined h3 style looked more prominent than our h2 style, so I adjusted it. Also removed the bold, which looks out of place with our new slimmer design, as well because the h2 aren’t bold.

Please review @owncloud-designers

(Note to self: Much like the h2 and section styles around it here which are backported to stable6 https://github.com/owncloud/core/pull/7915#issuecomment-39198135, this should be backported too.) – We’ll see after this one is merged.
