### PR TITLE
[stable5] Added requesttoken back for IE8

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -29,6 +29,7 @@
 						   value="<?php p($_['uploadMaxFilesize']) ?>">
 					<!-- Send the requesttoken, this is needed for older IE versions
 						 because they don't send the CSRF token via HTTP header in this case -->
+					<input type="hidden" id="requesttoken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 					<?php if(isset($_['dirToken'])):?>
 					<input type="hidden" id="publicUploadRequestToken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 					<input type="hidden" id="dirToken" name="dirToken" value="<?php p($_['dirToken']) ?>" />


### PR DESCRIPTION
Fixes broken IE8 download in OC 5: #8004 

Please review @butonic @LukasReschke @felixboehm @schiesbn 

I've tested these in Chromium and IE8 and they worked fine:
- [x] regular upload
- [x] public upload in base dir
- [x] public upload in subdir
