### PR TITLE
Fix admin-dir_permissions redirection when cannot write warning is shown.

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -172,7 +172,7 @@ class Config {
 		$result = @file_put_contents($this->configFilename, $content);
 		if (!$result) {
 			$defaults = new \OC_Defaults;
-			$url = \OC_Helper::linkToDocs('admin-dir-permissions');
+			$url = \OC_Helper::linkToDocs('admin-dir_permissions');
 			throw new HintException(
 				"Can't write into config directory!",
 				'This can usually be fixed by '


### PR DESCRIPTION
This contribution is MIT licensed and released to public for usage without any restrictions.
