### PR TITLE
OC_OCS_Result Class, Only accept 100 code as success

### DIFF
--- a/lib/private/ocs/result.php
+++ b/lib/private/ocs/result.php
@@ -96,7 +96,7 @@ class OC_OCS_Result{
 	 * @return bool
 	 */
 	public function succeeded() {
-		return (substr($this->statusCode, 0, 1) === '1');
+		return ($this->statusCode == 100);
 	}
 
 

--- a/tests/lib/api.php
+++ b/tests/lib/api.php
@@ -37,7 +37,7 @@ class Test_API extends PHPUnit_Framework_TestCase {
 	function dataProviderTestOneResult() {
 		return array(
 			array(100, true),
-			array(101, true),
+			array(101, false),
 			array(997, false),
 		);
 	}


### PR DESCRIPTION
See spec: http://freedesktop.org/wiki/Specifications/open-collaboration-services/

Only 100 codes seem to be an actual successful response.

Mentioning those I know using the api code / involved: @karlitschek @ser72 @DeepDiver1975 @schiesbn @PVince81 

I think this should be the first step in moving to HTTP codes, both in the OCS methods and other apps. This would solve quite a few issues including https://github.com/owncloud/core/issues/7858

I would like to push for HTTP response codes in ownCloud 7. 

This lets us send a proper HTTP header instead (or in addition to) sending it in the body.

TODO:
- [x] Adjust unit tests https://github.com/owncloud/core/blob/master/tests/lib/api.php
