### PR TITLE
Fix setting the max-upload-size for really large values.

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -280,9 +280,7 @@ class OC_Files {
 				return false;
 			$size -= 1;
 		} else {
-			$size = OC_Helper::humanFileSize($size);
-			$size = substr($size, 0, -1); //strip the B
-			$size = str_replace(' ', '', $size); //remove the space between the size and the postfix
+			$size = OC_Helper::phpFileSize($size);
 		}
 
 		//don't allow user to break his config -- broken or malicious size input

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -306,6 +306,32 @@ class OC_Helper {
 	}
 
 	/**
+	 * @brief Make a php file size
+	 * @param int $bytes file size in bytes
+	 * @return string a php parseable file size
+	 *
+	 * Makes 2048 to 2k and 2^41 to 2048G
+	 */
+	public static function phpFileSize($bytes) {
+		if ($bytes < 0) {
+			return "?";
+		}
+		if ($bytes < 1024) {
+			return $bytes . "B";
+		}
+		$bytes = round($bytes / 1024, 1);
+		if ($bytes < 1024) {
+			return $bytes . "K";
+		}
+		$bytes = round($bytes / 1024, 1);
+		if ($bytes < 1024) {
+			return $bytes . "M";
+		}
+		$bytes = round($bytes / 1024, 1);
+		return $bytes . "G";
+	}
+
+	/**
 	 * @brief Make a computer file size
 	 * @param string $str file size in human readable format
 	 * @return int a file size in bytes

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -31,6 +31,28 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @dataProvider phpFileSizeProvider
+	 */
+	public function testPhpFileSize($expected, $input)
+	{
+		$result = OC_Helper::phpFileSize($input);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function phpFileSizeProvider()
+	{
+		return array(
+			array('0B', 0),
+			array('1K', 1024),
+			array('9.5M', 10000000),
+			array('1.3G', 1395864371),
+			array('465.7G', 500000000000),
+			array('465661.3G', 500000000000000),
+			array('465661287.3G', 500000000000000000),
+		);
+	}
+
+	/**
 	 * @dataProvider computerFileSizeProvider
 	 */
 	function testComputerFileSize($expected, $input) {


### PR DESCRIPTION
php can only parse filesize units up to gigabytes, not terabytes or petabytes. The old code could add this
php_value upload_max_filesize 1000T
php_value post_max_size 1000T
to .htaccess, which gets parsed as 1000 Byte by PHP.

Please consider to merge this in the stable6 branch.
