### PR TITLE
lib/private/files.php: adapted to minimally changed ZipStreamer API

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -22,7 +22,7 @@
  */
 
 // TODO: get rid of this using proper composer packages
-require_once 'mcnetic/phpzipstreamer/ZipStreamer.php';
+require_once 'mcnetic/phpzipstreamer/src/ZipStreamer.php';
 
 class GET_TYPE {
 	const FILE = 1;
@@ -109,7 +109,7 @@ class OC_Files {
 			}
 		} else {
 			self::validateZipDownload($dir, $files);
-			$zip = new ZipStreamer(false);
+			$zip = new ZipStreamer\ZipStreamer();
 		}
 		OC_Util::obEnd();
 		if ($zip or \OC\Files\Filesystem::isReadable($filename)) {


### PR DESCRIPTION
The ZipStreamer API and repository structure was changed to support better encapsulation and extendability, and to be able to implement unit tests and travis ci integration, and to support PSR4 autoloading. Merge this pull request while switching to current master branch of ZipStreamer.
