### PR TITLE
Meanwhile, the quota value is stored human-readable in the DB

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -130,8 +130,7 @@ class Access extends LDAPUtility {
 			if(is_null($ocname)) {
 				$ocname = $this->dn2username($dn);
 			}
-			\OCP\Config::setUserValue($ocname, 'files', 'quota',
-				\OCP\Util::computerFileSize($quota));
+			\OCP\Config::setUserValue($ocname, 'files', 'quota', $quota);
 		}
 	}
 


### PR DESCRIPTION
ownCloud can read the quota from the LDAP server (needs configuration in the Advanced tab, Special Attributes section). It is required by us that the quota is submitted in a human readable form, e.g. 5 GB. When the value is fetched it is stored as plain and usual ownCloud user preference.

Originally it was stored internally in bytes, so that the retrieved value was converted.

Meanwhile, however, the user preference is stored in human readable from and display in the web interface as stored in the database. So, instead of lovely "5 GB" the byte representation was shown on the users page. Obviously, this is not very user friendly.

Thus, it we need to leave away the convertion. This PR is doing exactly this and fixing #8028 

Steps to test:
1. Make sure LDAP is configured and the  quota field set. Have one LDAP user (userA,) with a quota (5 GB) configured in LDAP (for quick test, you can misuse the carlicence attribute, e.g.)
2. prio to applying this patch, login as UserA, log out, log in as admin, go to the Users page. The byte representation of 5 GB will be shown for userA.
3. apply this patch, log in as userA, log our, log in as admin, go the Users page. Now "5 GB" is shown as it should.

Reviewers please @PVince81 @Xenopathic @ser72 or others, thanks!
