### PR TITLE
Do not expire chunks while checking for their existence

### DIFF
--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -84,11 +84,6 @@ class File {
 	public function hasKey($key) {
 		$storage = $this->getStorage();
 		if ($storage && $storage->is_file($key)) {
-			$mtime = $storage->filemtime($key);
-			if ($mtime < time()) {
-				$storage->unlink($key);
-				return false;
-			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
The expiration should be done by the gc() function on login, not while
isComplete() is calling hasKey() for every chunk.

Note: there's a user that has a setup that for some reason cause the chunks to be expired a short while after they are uploaded. It happens for big files. For example when there are 200 chunks, when uploading chunk 100, the `isComplete` would call `hasKey` and expire chunks 1, 2, 3, etc. Not sure if something was wrong on their server with the mtime.

Still, I have the feeling that this code isn't useful, maybe outdated. It doesn't make sense to expire chunks at this stage, especially that we now have transaction ids. There is no case where a new transfer would happen to expire older chunks from the same file name.

Please review @DeepDiver1975 @karlitschek @schiesbn @icewind1991 @tanghus 
