### PR TITLE
Send URI instead of filepath to NGINX for X-Accel

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -152,7 +152,7 @@ class OC_Files {
 				/** @var $storage \OC\Files\Storage\Storage */
 				list($storage) = $view->resolvePath($filename);
 				if ($storage->isLocal()) {
-					self::addSendfileHeader(\OC\Files\Filesystem::getLocalFile($filename));
+					self::addSendfileHeader($filename);
 				} else {
 					\OC\Files\Filesystem::readfile($filename);
 				}
@@ -167,9 +167,11 @@ class OC_Files {
 	 */
 	private static function addSendfileHeader($filename) {
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			if (isset($_SERVER['HTTP_RANGE']) &&
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
@@ -185,6 +187,7 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
+			$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}


### PR DESCRIPTION
Sends URI "**/WEBROOT?**/data/**USER**/files/**filename**" to NGINX instead of the full file path.

The NGINX section of the Sendfile documentation has already been updated for this commit as seen [here.](https://github.com/owncloud/documentation/blob/master/admin_manual/configuration/xsendfile.rst#configuration-2)

---

Replaces https://github.com/owncloud/core/pull/7838
Fixes #7754
