### PR TITLE
use setResolution to speed up preview generation of svgs and make OC_Image::crop preserve transparency

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -870,6 +870,14 @@ class OC_Image {
 			imagedestroy($process);
 			return false;
 		}
+
+		// preserve transparency
+		if($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
+			imagecolortransparent($process, imagecolorallocatealpha($process, 0, 0, 0, 127));
+			imagealphablending($process, false);
+			imagesavealpha($process, true);
+		}
+
 		imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $w, $h, $w, $h);
 		if ($process == false) {
 			OC_Log::write('core', __METHOD__.'(): Error resampling process image '.$w.'x'.$h, OC_Log::ERROR);

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -580,23 +580,6 @@ class Preview {
 			$newXsize = (int)$image->width();
 			$newYsize = (int)$image->height();
 
-			//create transparent background layer
-			$backgroundlayer = imagecreatetruecolor($x, $y);
-			$white = imagecolorallocate($backgroundlayer, 255, 255, 255);
-			imagefill($backgroundlayer, 0, 0, $white);
-
-			$image = $image->resource();
-
-			$mergeX = floor(abs($x - $newXsize) * 0.5);
-			$mergeY = floor(abs($y - $newYsize) * 0.5);
-
-			imagecopy($backgroundlayer, $image, $mergeX, $mergeY, 0, 0, $newXsize, $newYsize);
-
-			//$black = imagecolorallocate(0,0,0);
-			//imagecolortransparent($transparentlayer, $black);
-
-			$image = new \OC_Image($backgroundlayer);
-
 			$this->preview = $image;
 			return;
 		}

--- a/lib/private/preview/svg.php
+++ b/lib/private/preview/svg.php
@@ -24,6 +24,7 @@ if (extension_loaded('imagick')) {
 			public function getThumbnail($path,$maxX,$maxY,$scalingup,$fileview) {
 				try{
 					$svg = new Imagick();
+					$svg->setResolution(5,5);
 					$svg->setBackgroundColor(new \ImagickPixel('transparent'));
 
 					$content = stream_get_contents($fileview->fopen($path, 'r'));


### PR DESCRIPTION
please review @PVince81 @bantu 

fixes https://github.com/owncloud/core/issues/7771
