### PR TITLE
Pass the correct root to the preview on post_write

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -640,7 +640,7 @@ class Preview {
 	}
 
 	public static function post_write($args) {
-		self::post_delete($args);
+		self::post_delete($args, 'files/');
 	}
 
 	public static function prepare_delete_files($args) {


### PR DESCRIPTION
Without this the Preview object created is for `/$user/foo` instead `/$user/files/foo`

cc @georgehrke @DeepDiver1975 @PVince81 
