### PR TITLE
Fix slideshow buttons being invisible

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -109,7 +109,7 @@ input[type="button"],
 	margin: 3px 3px 3px 0;
 	padding: 7px 6px 5px;
 	font-size: 13px;
-	background: #fff;
+	background-color: #fff;
 	color: #333;
 	border: 1px solid #ddd;
 	outline: none;


### PR DESCRIPTION
Setting `background-color` instead of `background` allows other stylesheets to overwrite the background color without "messing" with other background properties

Fixes https://github.com/owncloud/gallery/issues/21

cc @jancborchardt @PVince81 
