### PR TITLE
Fix OC Dialog non-localized strings in file replace dialog

### DIFF
--- a/apps/files/templates/fileexists.html
+++ b/apps/files/templates/fileexists.html
@@ -3,8 +3,8 @@
 	<span class="what">{what}<!-- If you select both versions, the copied file will have a number added to its name. --></span><br/>
 	<br/>
 	<table>
-		<th><label><input class="allnewfiles" type="checkbox" />New Files<span class="count"></span></label></th>
-		<th><label><input class="allexistingfiles" type="checkbox" />Already existing files<span class="count"></span></label></th>
+		<th><label><input class="allnewfiles" type="checkbox" /><?php p($l->t('New Files')); ?><span class="count"></span></label></th>
+		<th><label><input class="allexistingfiles" type="checkbox" /><?php p($l->t('Already existing files')); ?><span class="count"></span></label></th>
 	</table>
 	<div class="conflicts">
 		<div class="template">

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -343,7 +343,7 @@ var OCdialogs = {
 				addConflict(conflicts, original, replacement);
 
 				var count = $(dialog_id+ ' .conflict').length;
-				var title = n('files',
+				var title = n('core',
 								'{count} file conflict',
 								'{count} file conflicts',
 								count,
@@ -358,14 +358,14 @@ var OCdialogs = {
 				//create dialog
 				this._fileexistsshown = true;
 				$.when(this._getFileExistsTemplate()).then(function($tmpl) {
-					var title = t('files','One file conflict');
+					var title = t('core','One file conflict');
 					var $dlg = $tmpl.octemplate({
 						dialog_name: dialog_name,
 						title: title,
 						type: 'fileexists',
 
-						why: t('files','Which files do you want to keep?'),
-						what: t('files','If you select both versions, the copied file will have a number added to its name.')
+						why: t('core','Which files do you want to keep?'),
+						what: t('core','If you select both versions, the copied file will have a number added to its name.')
 					});
 					$('body').append($dlg);
 
@@ -430,10 +430,10 @@ var OCdialogs = {
 						var count = $(dialog_id).find('.conflict .replacement input[type="checkbox"]:checked').length;
 						if (count === $(dialog_id+ ' .conflict').length) {
 							$(dialog_id).find('.allnewfiles').prop('checked', true);
-							$(dialog_id).find('.allnewfiles + .count').text(t('files','(all selected)'));
+							$(dialog_id).find('.allnewfiles + .count').text(t('core','(all selected)'));
 						} else if (count > 0) {
 							$(dialog_id).find('.allnewfiles').prop('checked', false);
-							$(dialog_id).find('.allnewfiles + .count').text(t('files','({count} selected)',{count:count}));
+							$(dialog_id).find('.allnewfiles + .count').text(t('core','({count} selected)',{count:count}));
 						} else {
 							$(dialog_id).find('.allnewfiles').prop('checked', false);
 							$(dialog_id).find('.allnewfiles + .count').text('');
@@ -443,10 +443,10 @@ var OCdialogs = {
 						var count = $(dialog_id).find('.conflict .original input[type="checkbox"]:checked').length;
 						if (count === $(dialog_id+ ' .conflict').length) {
 							$(dialog_id).find('.allexistingfiles').prop('checked', true);
-							$(dialog_id).find('.allexistingfiles + .count').text(t('files','(all selected)'));
+							$(dialog_id).find('.allexistingfiles + .count').text(t('core','(all selected)'));
 						} else if (count > 0) {
 							$(dialog_id).find('.allexistingfiles').prop('checked', false);
-							$(dialog_id).find('.allexistingfiles + .count').text(t('files','({count} selected)',{count:count}));
+							$(dialog_id).find('.allexistingfiles + .count').text(t('core','({count} selected)',{count:count}));
 						} else {
 							$(dialog_id).find('.allexistingfiles').prop('checked', false);
 							$(dialog_id).find('.allexistingfiles + .count').text('');


### PR DESCRIPTION
There are still some issues with the html file. @MorrisJobke Any idea why it is still not localized?

The core/js/oc-dialogs.js is just fine.
