### PR TITLE
Re-enable the sabredav browser plugin to fix sync client setup

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -41,6 +41,7 @@ $server->setBaseUri($baseuri);
 $defaults = new OC_Defaults();
 $server->addPlugin(new Sabre_DAV_Auth_Plugin($authBackend, $defaults->getName()));
 $server->addPlugin(new Sabre_DAV_Locks_Plugin($lockBackend));
+$server->addPlugin(new Sabre_DAV_Browser_Plugin(false));
 $server->addPlugin(new OC_Connector_Sabre_FilesPlugin());
 $server->addPlugin(new OC_Connector_Sabre_AbortedUploadDetectionPlugin());
 $server->addPlugin(new OC_Connector_Sabre_QuotaPlugin());


### PR DESCRIPTION
Without the browser plugin it's impossible to setup the sync client (1.5.1)

From what I understand, to check the provided username and password the client makes a GET request to `example.com/owncloud/remote.php/webdav` with the browser plugin disabled sabredav will throw an error and the sync client thinks the credentials are invalid.

cc @DeepDiver1975 @dragotin @PVince81 
