### PR TITLE
Remove wrong whitespace from URL and use HTTPS

### DIFF
--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -30,7 +30,7 @@ class OC_Defaults {
 		$this->defaultName = "ownCloud"; /* short name, used when referring to the software */
 		$this->defaultTitle = "ownCloud"; /* can be a longer name, for titles */
 		$this->defaultBaseUrl = "http://owncloud.org";
-		$this->defaultSyncClientUrl = " http://owncloud.org/sync-clients/";
+		$this->defaultSyncClientUrl = "https://owncloud.org/sync-clients/";
 		$this->defaultDocBaseUrl = "http://doc.owncloud.org";
 		$this->defaultSlogan = $this->l->t("web services under your control");
 		$this->defaultLogoClaim = "";

--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -29,7 +29,7 @@ class OC_Defaults {
 		$this->defaultEntity = "ownCloud"; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = "ownCloud"; /* short name, used when referring to the software */
 		$this->defaultTitle = "ownCloud"; /* can be a longer name, for titles */
-		$this->defaultBaseUrl = "http://owncloud.org";
+		$this->defaultBaseUrl = "https://owncloud.org";
 		$this->defaultSyncClientUrl = "https://owncloud.org/sync-clients/";
 		$this->defaultDocBaseUrl = "http://doc.owncloud.org";
 		$this->defaultSlogan = $this->l->t("web services under your control");


### PR DESCRIPTION
The whitespace caused the generated links to begin with a whitespace (e.g. `<a href=" http://owncloud.org/sync-clients/" target="_blank">`)

Additionally I switched the link to HTTPS.
