### PR TITLE
Use git checkout on directory as some files may not be in git resulting ...

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -139,7 +139,7 @@ function execute_tests {
 	cd $BASEDIR
 
 	# revert changes to tests/data
-	git checkout tests/data/*
+	git checkout tests/data
 
 	# reset data directory
 	rm -rf $DATADIR


### PR DESCRIPTION
...in, e.g.:

error: pathspec 'tests/data/lorem-copy.txt' did not match any file(s) known to git.
error: pathspec 'tests/data/testimage-copy.png' did not match any file(s) known to git.
