### PR TITLE
Lazy loading of fileinfo

### DIFF
--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -12,26 +12,28 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	/**
 	 * @var array $data
 	 */
-	private $data;
+	protected $data;
 
 	/**
 	 * @var string $path
 	 */
-	private $path;
+	protected $path;
 
 	/**
 	 * @var \OC\Files\Storage\Storage $storage
 	 */
-	private $storage;
+	protected $storage;
 
 	/**
 	 * @var string $internalPath
 	 */
-	private $internalPath;
+	protected $internalPath;
 
 	/**
-	 * @param string|boolean $path
-	 * @param Storage\Storage $storage
+	 * @param string $path
+	 * @param \OC\Files\Storage\Storage $storage
+	 * @param string $internalPath
+	 * @param array $data
 	 */
 	public function __construct($path, $storage, $internalPath, $data) {
 		$this->path = $path;

--- a/lib/private/files/lazyfileinfo.php
+++ b/lib/private/files/lazyfileinfo.php
@@ -102,10 +102,10 @@ class LazyFileInfo extends FileInfo {
 	protected function loadPermissions() {
 		if (is_null($this->permissions)) {
 			$permissionsCache = $this->storage->getPermissionsCache($this->internalPath);
-			$permissions = $permissionsCache->get($this->getId(), $this->user->getUID());
-			if ($permissions === -1) {
+			$this->permissions = $permissionsCache->get($this->getId(), $this->user->getUID());
+			if ($this->permissions === -1) {
 				$this->permissions = $this->storage->getPermissions($this->internalPath);
-				$permissionsCache->set($this->getId(), $this->user->getUID(), $permissions);
+				$permissionsCache->set($this->getId(), $this->user->getUID(), $this->permissions);
 			}
 		}
 	}

--- a/lib/private/files/lazyfileinfo.php
+++ b/lib/private/files/lazyfileinfo.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files;
+
+class LazyFileInfo extends FileInfo {
+	/**
+	 * @var bool
+	 */
+	protected $includeMountPoints;
+
+	/**
+	 * @var \OC\User\User
+	 */
+	protected $user;
+
+	/**
+	 * @var int
+	 */
+	protected $permissions;
+
+	/**
+	 * @param string $path
+	 * @param \OC\Files\Storage\Storage $storage
+	 * @param string $internalPath
+	 * @param \OC\User\User $user
+	 * @param bool $includeMountPoints
+	 */
+	public function __construct($path, $storage, $internalPath, $user, $includeMountPoints = true) {
+		$this->path = $path;
+		$this->storage = $storage;
+		$this->internalPath = $internalPath;
+		$this->includeMountPoints = $includeMountPoints;
+		$this->user = $user;
+		$this->data = null;
+		$this->permissions = null;
+	}
+
+	public function offsetSet($offset, $value) {
+		$this->load();
+		parent::offsetSet($offset, $value);
+	}
+
+	public function offsetExists($offset) {
+		$this->load();
+		return parent::offsetExists($offset);
+	}
+
+	public function offsetUnset($offset) {
+		$this->load();
+		parent::offsetUnset($offset);
+	}
+
+	public function offsetGet($offset) {
+		$this->load();
+		if ($offset === 'permissions') {
+			return $this->getPermissions();
+		}
+		return parent::offsetGet($offset);
+	}
+
+	protected function load() {
+		if (is_null($this->data)) {
+			$data = null;
+			$cache = $this->storage->getCache($this->internalPath);
+
+			if (!$cache->inCache($this->internalPath)) {
+				$scanner = $this->storage->getScanner($this->internalPath);
+				$scanner->scan($this->internalPath, Cache\Scanner::SCAN_SHALLOW);
+			} else {
+				$watcher = $this->storage->getWatcher($this->internalPath);
+				$data = $watcher->checkUpdate($this->internalPath);
+			}
+
+			if (!is_array($data)) {
+				$data = $cache->get($this->internalPath);
+			}
+
+			if ($data and isset($data['fileid'])) {
+				if ($this->includeMountPoints and $data['mimetype'] === 'httpd/unix-directory') {
+					//add the sizes of other mountpoints to the folder
+					$mountManager = Filesystem::getMountManager();
+					$mounts = $mountManager->findIn($this->path);
+					foreach ($mounts as $mount) {
+						$subStorage = $mount->getStorage();
+						$subCache = $subStorage->getCache('');
+						$rootEntry = $subCache->get('');
+						$data['size'] += isset($rootEntry['size']) ? $rootEntry['size'] : 0;
+					}
+				}
+			}
+			$data = \OC_FileProxy::runPostProxies('getFileInfo', $this->path, $data);
+			$this->data = $data;
+		}
+	}
+
+	protected function loadPermissions() {
+		if (is_null($this->permissions)) {
+			$permissionsCache = $this->storage->getPermissionsCache($this->internalPath);
+			$permissions = $permissionsCache->get($this->getId(), $this->user->getUID());
+			if ($permissions === -1) {
+				$this->permissions = $this->storage->getPermissions($this->internalPath);
+				$permissionsCache->set($this->getId(), $this->user->getUID(), $permissions);
+			}
+		}
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPath() {
+		return $this->path;
+	}
+
+	/**
+	 * @return \OCP\Files\Storage
+	 */
+	public function getStorage() {
+		return $this->storage;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getInternalPath() {
+		return $this->internalPath;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId() {
+		$this->load();
+		return parent::getId();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMimetype() {
+		$this->load();
+		return parent::getMimetype();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMimePart() {
+		$this->load();
+		return parent::getMimePart();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		$this->load();
+		return parent::getName();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEtag() {
+		$this->load();
+		return parent::getEtag();
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getSize() {
+		$this->load();
+		return parent::getSize();
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getMTime() {
+		$this->load();
+		return parent::getMTime();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isEncrypted() {
+		$this->load();
+		return parent::isEncrypted();
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPermissions() {
+		$this->loadPermissions();
+		return $this->permissions;
+	}
+
+	/**
+	 * @return \OCP\Files\FileInfo::TYPE_FILE | \OCP\Files\FileInfo::TYPE_FOLDER
+	 */
+	public function getType() {
+		$this->load();
+		return parent::getType();
+	}
+
+	public function getData() {
+		$this->load();
+		$data = parent::getData();
+		$data['permissions'] = $this->getPermissions();
+		return $data;
+	}
+
+	/**
+	 * @param int $permissions
+	 * @return bool
+	 */
+	protected function checkPermissions($permissions) {
+		return parent::checkPermissions($permissions);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isReadable() {
+		return parent::isReadable();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isUpdateable() {
+		return parent::isUpdateable();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isDeletable() {
+		return parent::isDeletable();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isShareable() {
+		return parent::isShareable();
+	}
+}

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -361,6 +361,7 @@ class View extends \PHPUnit_Framework_TestCase {
 
 		$rootView = new \OC\Files\View('');
 		$oldCachedData = $rootView->getFileInfo('foo.txt');
+		$oldMTime = $oldCachedData['mtime'];
 
 		$rootView->touch('foo.txt', 500);
 
@@ -371,7 +372,7 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView->putFileInfo('foo.txt', array('storage_mtime' => 1000)); //make sure the watcher detects the change
 		$rootView->file_put_contents('foo.txt', 'asd');
 		$cachedData = $rootView->getFileInfo('foo.txt');
-		$this->assertGreaterThanOrEqual($cachedData['mtime'], $oldCachedData['mtime']);
+		$this->assertGreaterThanOrEqual($cachedData['mtime'], $oldMTime);
 		$this->assertEquals($cachedData['storage_mtime'], $cachedData['mtime']);
 	}
 


### PR DESCRIPTION
Only make the calls to the filecache when the data is actually needed.

This allows us to, in the future, pass the fileinfo in filesystem hooks without hitting a performance penalty if it isn't used.

Short term, the main advantage this gives is not having to load the permissions data every time.

cc @DeepDiver1975 @PVince81 @karlitschek 
