### PR TITLE
Fixed Sabre Node implementation to correctly return timestamps as int

### DIFF
--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -139,12 +139,15 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 
 	/**
 	 * @brief Returns the last modification time, as a unix timestamp
-	 * @return int
+	 * @return int timestamp as integer
 	 */
 	public function getLastModified() {
 		$this->getFileinfoCache();
-		return $this->fileinfo_cache['mtime'];
-
+		$timestamp = $this->fileinfo_cache['mtime'];
+		if (!empty($timestamp)) {
+			return (int)$timestamp;
+		}
+		return $timestamp;
 	}
 
 	/**


### PR DESCRIPTION
Replacement PR for #8098 
Fixes #7921

Negative timestamps were returned as string and were confusing other
Sabre API like Sabre_DAV_Property_GetLastModified.
This fix makes sure the timestamp is returned as int when defined.

Please review @DeepDiver1975 @icewind1991 

To test this:
1. Create a file "test.txt" in a local sync folder
2. Wait for it to be uploaded successfully
3. Run `touch -d 1960-11-14 test.txt`
4. Create another file to retrigger sync

Before the fix: error occured while checking if "test.txt" needs syncing
After the fix: no error
