### PR TITLE
Disable sharing in trashbin app

### DIFF
--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -6,6 +6,7 @@
 <div id="emptycontent" class="hidden"><?php p($l->t('Nothing in here. Your trash bin is empty!'))?></div>
 
 <input type="hidden" id="permissions" value="0"></input>
+<input type="hidden" id="disableSharing" data-status="<?php p($_['disableSharing']); ?>"></input>
 <input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 
 <table id="filestable">


### PR DESCRIPTION
Regression from ajaxification branch: sharing still needs to be disabled through "disableSharing" attribute in the trashbin app.

Please review @schiesbn @MorrisJobke @icewind1991 
