### PR TITLE
Enable autowatch for karma

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -167,7 +167,7 @@ module.exports = function(config) {
 		logLevel: config.LOG_INFO,
 
 		// enable / disable watching file and executing tests whenever any file changes
-		autoWatch: false,
+		autoWatch: true,
 
 		// Start these browsers, currently available:
 		// - Chrome


### PR DESCRIPTION
This way unit tests can be run in multiple browsers with the command
line and tests will re-run automatically when files are changed.

@DeepDiver1975 

This shouldn't affect CI, it's only when running "karma" manually at dev time.
