### PR TITLE
[stable5] Added missing var that messes up IE8

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -230,7 +230,8 @@ $(document).ready(function() {
 		var dir=$('#dir').val()||'/';
 		OC.Notification.show(t('files','Your download is being prepared. This might take some time if the files are big.'));
 		// use special download URL if provided, e.g. for public shared files
-		if ( (downloadURL = document.getElementById("downloadURL")) ) {
+		var downloadURL = document.getElementById("downloadURL");
+		if (downloadURL) {
 			window.location=downloadURL.value+"&download&files="+encodeURIComponent(fileslist);
 		} else {
 			window.location=OC.filePath('files', 'ajax', 'download.php') + '?'+ $.param({ dir: dir, files: fileslist });


### PR DESCRIPTION
This is an IE8 issue only.

Steps for the issue:
1. In the public page, select all files
2. Click "Download" in the header

Before the fix: JS error and redirect to main page
After the fix: zip download is initiated

Please review/test in IE8: @felixboehm @icewind1991 @MorrisJobke 
