### PR TITLE
fix double closing </a> for filenames

### DIFF
--- a/apps/files/templates/part.list.php
+++ b/apps/files/templates/part.list.php
@@ -34,17 +34,15 @@ $totalsize = 0; ?>
 				<span class="nametext">
 					<?php print_unescaped(htmlspecialchars($file['name']));?>
 				</span>
+				<span class="uploadtext" currentUploads="0">
+				</span>
+			</a>
 		<?php else: ?>
 			<a class="name" href="<?php p(rtrim($_['downloadURL'],'/').'/'.trim($directory,'/').'/'.$name); ?>">
 				<label class="filetext" title="" for="select-<?php p($file['fileid']); ?>"></label>
 				<span class="nametext"><?php print_unescaped(htmlspecialchars($file['basename']));?><span class='extension'><?php p($file['extension']);?></span></span>
 			</a>
 		<?php endif; ?>
-			<?php if($file['type'] == 'dir'):?>
-				<span class="uploadtext" currentUploads="0">
-				</span>
-			<?php endif;?>
-			</a>
 		</td>
 		<td class="filesize"
 			style="color:rgb(<?php p($simple_size_color.','.$simple_size_color.','.$simple_size_color) ?>)">


### PR DESCRIPTION
The current filelist rendering in stable6 is broken. It renders the closing `</a>` tag twice for files. Furthermore ,the second `if($file['type'] == 'dir')` check can be merged into the first.

@DeepDiver1975 @MorrisJobke @VicDeo dunno if it breaks anything, but interestingly IE11 was picky enough to tell me about it. Not needed for master.
