### PR TITLE
the share action should only be added for shareable files

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
 			}
 		});
 
-		FileActions.register('all', 'Share', OC.PERMISSION_READ, OC.imagePath('core', 'actions/share'), function(filename) {
+		FileActions.register('all', 'Share', OC.PERMISSION_SHARE, OC.imagePath('core', 'actions/share'), function(filename) {
 			if ($('#dir').val() == '/') {
 				var item = $('#dir').val() + filename;
 			} else {


### PR DESCRIPTION
IMHO this file action should only be registered for shareable files.

The "shared by xyz" is registered in a different place. 

@DeepDiver1975 @VicDeo @icewind1991 @schiesbn needs port to master.
