### PR TITLE
Fix Undefined index: storage in share.php

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1523,7 +1523,7 @@ class Share extends \OC\Share\Constants {
 		$select = '*';
 		if ($format == self::FORMAT_STATUSES) {
 			if ($fileDependent) {
-				$select = '`*PREFIX*share`.`id`, `*PREFIX*share`.`parent`, `share_type`, `path`, `share_with`, `uid_owner` , `file_source`';
+				$select = '`*PREFIX*share`.`id`, `*PREFIX*share`.`parent`, `share_type`, `path`, `storage`, `share_with`, `uid_owner` , `file_source`';
 			} else {
 				$select = '`id`, `parent`, `share_type`, `share_with`, `uid_owner`, `item_source`';
 			}


### PR DESCRIPTION
There parameter was removed when the code was cleaned up:
`{"app":"PHP","message":"Undefined index: storage at
E:\\ownCloud\\owncloud\\lib\\private\\share\\share.php#1160",
"level":0,"time":"2014-04-09T12:56:23+00:00"}`

@schiesbn @PVince81 @DeepDiver1975 
