### PR TITLE
Issue/8131 Fix emitting of filesystem related hooks

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -119,6 +119,22 @@ class Filesystem {
 	const signal_post_write = 'post_write';
 
 	/**
+	 * signal emitted before file/dir update
+	 *
+	 * @param string $path
+	 * @param bool $run changing this flag to false in hook handler will cancel event
+	 */
+	const signal_update = 'update';
+
+	/**
+	 * signal emitted after file/dir update
+	 *
+	 * @param string $path
+	 * @param bool $run changing this flag to false in hook handler will cancel event
+	 */
+	const signal_post_update = 'post_update';
+
+	/**
 	 * signal emits when reading file/dir
 	 *
 	 * @param string $path

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -291,6 +291,15 @@ class View {
 								Filesystem::signal_param_run => &$run
 							)
 						);
+					} else {
+						\OC_Hook::emit(
+							Filesystem::CLASSNAME,
+							Filesystem::signal_update,
+							array(
+								Filesystem::signal_param_path => $this->getHookPath($path),
+								Filesystem::signal_param_run => &$run,
+							)
+						);
 					}
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
@@ -319,6 +328,12 @@ class View {
 								Filesystem::signal_post_create,
 								array(Filesystem::signal_param_path => $this->getHookPath($path))
 							);
+						} else {
+							\OC_Hook::emit(
+								Filesystem::CLASSNAME,
+								Filesystem::signal_post_update,
+								array(Filesystem::signal_param_path => $this->getHookPath($path))
+							);
 						}
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
@@ -335,7 +350,7 @@ class View {
 				return false;
 			}
 		} else {
-			$hooks = ($this->file_exists($path)) ? array('write') : array('create', 'write');
+			$hooks = ($this->file_exists($path)) ? array('update', 'write') : array('create', 'write');
 			return $this->basicOperation('file_put_contents', $path, $hooks, $data);
 		}
 	}
@@ -516,6 +531,15 @@ class View {
 							Filesystem::signal_param_run => &$run
 						)
 					);
+				} elseif ($run) {
+					\OC_Hook::emit(
+						Filesystem::CLASSNAME,
+						Filesystem::signal_update,
+						array(
+							Filesystem::signal_param_path => $this->getHookPath($path2),
+							Filesystem::signal_param_run => &$run,
+						)
+					);
 				}
 				if ($run) {
 					\OC_Hook::emit(
@@ -570,6 +594,12 @@ class View {
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
 							Filesystem::signal_post_create,
+							array(Filesystem::signal_param_path => $this->getHookPath($path2))
+						);
+					} else {
+						\OC_Hook::emit(
+							Filesystem::CLASSNAME,
+							Filesystem::signal_post_update,
 							array(Filesystem::signal_param_path => $this->getHookPath($path2))
 						);
 					}

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -393,8 +393,6 @@ class View extends \PHPUnit_Framework_TestCase {
 		$rootView->file_put_contents('/foo.txt', 'asd');
 		$this->assertNull($this->hookPath);
 
-		$this->hookWritePath = $this->hookUpdatePath = $this->hookCreatePath = null;
-
 		$subView->file_put_contents('/foo.txt', 'asd');
 		$this->assertEquals('/substorage/foo.txt', $this->hookPath);
 	}


### PR DESCRIPTION
- [x] Create hook is not emitted when a large file is created after it has been uploaded in chunks
- [x] Emit a new hook when a file is written to update a file

Fix #8131 

@schiesbn @DeepDiver1975 @PVince81 
