### PR TITLE
Priority on external storage mounts

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -32,11 +32,13 @@ OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_OC', 'login
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Local', array(
 	'backend' => (string)$l->t('Local'),
+	'priority' => 150,
 	'configuration' => array(
 		'datadir' => (string)$l->t('Location'))));
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\AmazonS3', array(
 	'backend' => (string)$l->t('Amazon S3'),
+	'priority' => 100,
 	'configuration' => array(
 		'key' => (string)$l->t('Key'),
 		'secret' => '*'.$l->t('Secret'),
@@ -45,6 +47,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\AmazonS3', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\AmazonS3', array(
 	'backend' => (string)$l->t('Amazon S3 and compliant'),
+	'priority' => 100,
 	'configuration' => array(
 		'key' => (string)$l->t('Access Key'),
 		'secret' => '*'.$l->t('Secret Key'),
@@ -58,6 +61,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\AmazonS3', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Dropbox', array(
 	'backend' => 'Dropbox',
+	'priority' => 100,
 	'configuration' => array(
 		'configured' => '#configured',
 		'app_key' => (string)$l->t('App key'),
@@ -69,6 +73,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\Dropbox', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\FTP', array(
 	'backend' => 'FTP',
+	'priority' => 100,
 	'configuration' => array(
 		'host' => (string)$l->t('Host'),
 		'user' => (string)$l->t('Username'),
@@ -79,6 +84,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\FTP', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Google', array(
 	'backend' => 'Google Drive',
+	'priority' => 100,
 	'configuration' => array(
 		'configured' => '#configured',
 		'client_id' => (string)$l->t('Client ID'),
@@ -90,6 +96,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\Google', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Swift', array(
 	'backend' => (string)$l->t('OpenStack Object Storage'),
+	'priority' => 100,
 	'configuration' => array(
 		'user' => (string)$l->t('Username (required)'),
 		'bucket' => (string)$l->t('Bucket (required)'),
@@ -107,6 +114,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\Swift', array(
 if (!OC_Util::runningOnWindows()) {
 	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB', array(
 		'backend' => 'SMB / CIFS',
+		'priority' => 100,
 		'configuration' => array(
 			'host' => (string)$l->t('Host'),
 			'user' => (string)$l->t('Username'),
@@ -117,6 +125,7 @@ if (!OC_Util::runningOnWindows()) {
 
 	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB_OC', array(
 			'backend' => (string)$l->t('SMB / CIFS using OC login'),
+			'priority' => 90,
 			'configuration' => array(
 				'host' => (string)$l->t('Host'),
 				'username_as_share' => '!'.$l->t('Username as share'),
@@ -127,6 +136,7 @@ if (!OC_Util::runningOnWindows()) {
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\DAV', array(
 	'backend' => 'WebDAV',
+	'priority' => 100,
 	'configuration' => array(
 		'host' => (string)$l->t('URL'),
 		'user' => (string)$l->t('Username'),
@@ -137,6 +147,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\DAV', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\OwnCloud', array(
 	'backend' => 'ownCloud',
+	'priority' => 100,
 	'configuration' => array(
 		'host' => (string)$l->t('URL'),
 		'user' => (string)$l->t('Username'),
@@ -147,6 +158,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\OwnCloud', array(
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP', array(
 	'backend' => 'SFTP',
+	'priority' => 100,
 	'configuration' => array(
 		'host' => (string)$l->t('Host'),
 		'user' => (string)$l->t('Username'),

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -756,6 +756,11 @@ class OC_Mount_Config {
 		$applicable = key($mountPoint);
 		if (isset($data[$mountType])) {
 			if (isset($data[$mountType][$applicable])) {
+				if (isset($mountPoints[$mountType][$applicable][$mountPoint])
+					&& isset($mountPoints[$mountType][$applicable][$mountPoint]['priority'])) {
+					$mount[$applicable][$mountPoint]['priority']
+						= $mountPoints[$mountType][$applicable][$mountPoint]['priority'];
+				}
 				$data[$mountType][$applicable]
 					= array_merge($data[$mountType][$applicable], $mountPoint[$applicable]);
 			} else {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -479,8 +479,13 @@ class OC_Mount_Config {
 
 		// Set default priority if none set
 		if (!isset($mountPoints[$mountType][$applicable][$mountPoint]['priority'])) {
-			$mountPoints[$mountType][$applicable][$mountPoint]['priority']
-				= $backends[$class]['priority'];
+			if (isset($backends[$class]['priority'])) {
+				$mountPoints[$mountType][$applicable][$mountPoint]['priority']
+					= $backends[$class]['priority'];
+			} else {
+				$mountPoints[$mountType][$applicable][$mountPoint]['priority']
+					= 100;
+			}
 		}
 
 		self::writeData($isPersonal ? OCP\User::getUser() : NULL, $mountPoints);

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -145,6 +145,7 @@ class OC_Mount_Config {
 					$options['priority'] = $backends[$options['class']]['priority'];
 				}
 
+				// Override if priority greater
 				if ( (!isset($mountPoints[$mountPoint]))
 					|| ($options['priority'] >= $mountPoints[$mountPoint]['priority']) ) {
 					$options['priority_type'] = self::MOUNT_TYPE_GLOBAL;
@@ -165,6 +166,7 @@ class OC_Mount_Config {
 					$options['priority'] = $backends[$options['class']]['priority'];
 				}
 
+				// Override if priority greater
 				if ( (!isset($mountPoints[$mountPoint]))
 					|| ($options['priority'] >= $mountPoints[$mountPoint]['priority']) ) {
 					$options['priority_type'] = self::MOUNT_TYPE_GLOBAL;
@@ -186,6 +188,7 @@ class OC_Mount_Config {
 							$options['priority'] = $backends[$options['class']]['priority'];
 						}
 
+						// Override if priority greater or if priority type different
 						if ( (!isset($mountPoints[$mountPoint]))
 							|| ($options['priority'] >= $mountPoints[$mountPoint]['priority'])
 							|| ($mountPoints[$mountPoint]['priority_type'] !== self::MOUNT_TYPE_GROUP) ) {
@@ -210,6 +213,7 @@ class OC_Mount_Config {
 							$options['priority'] = $backends[$options['class']]['priority'];
 						}
 
+						// Override if priority greater or if priority type different
 						if ( (!isset($mountPoints[$mountPoint]))
 							|| ($options['priority'] >= $mountPoints[$mountPoint]['priority'])
 							|| ($mountPoints[$mountPoint]['priority_type'] !== self::MOUNT_TYPE_USER) ) {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -163,7 +163,7 @@ class OC_Mount_Config {
 
 				if ( (!isset($mountPoints[$mountPoint]))
 					|| ($options['priority'] >= $mountPoints[$mountPoint]['priority'])
-					|| ($mountPoints[$mountPoint]['priority_type'] != 'global') ) {
+					|| ($mountPoints[$mountPoint]['priority_type'] !== 'global') ) {
 					$options['priority_type'] = 'global';
 					$mountPoints[$mountPoint] = $options;
 				}
@@ -184,7 +184,7 @@ class OC_Mount_Config {
 
 						if ( (!isset($mountPoints[$mountPoint]))
 							|| ($options['priority'] >= $mountPoints[$mountPoint]['priority'])
-							|| ($mountPoints[$mountPoint]['priority_type'] != 'group') ) {
+							|| ($mountPoints[$mountPoint]['priority_type'] !== 'group') ) {
 							$options['priority_type'] = 'group';
 							$mountPoints[$mountPoint] = $options;
 						}
@@ -207,7 +207,7 @@ class OC_Mount_Config {
 
 						if ( (!isset($mountPoints[$mountPoint]))
 							|| ($options['priority'] >= $mountPoints[$mountPoint]['priority'])
-							|| ($mountPoints[$mountPoint]['priority_type'] != 'user') ) {
+							|| ($mountPoints[$mountPoint]['priority_type'] !== 'user') ) {
 							$options['priority_type'] = 'user';
 							$mountPoints[$mountPoint] = $options;
 						}
@@ -223,7 +223,7 @@ class OC_Mount_Config {
 				$options['options'] = self::decryptPasswords($options['options']);
 
 				if ( (!isset($mountPoints[$mountPoint]))
-					|| ($mountPoints[$mountPoint]['priority_type'] != 'personal') ) {
+					|| ($mountPoints[$mountPoint]['priority_type'] !== 'personal') ) {
 					$options['priority_type'] = 'personal';
 					$mountPoints[$mountPoint] = $options;
 				}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -769,6 +769,13 @@ class OC_Mount_Config {
 		$mountPath = key($mountPoint[$applicable]);
 		if (isset($data[$mountType])) {
 			if (isset($data[$mountType][$applicable])) {
+				// Merge priorities
+				if (isset($data[$mountType][$applicable][$mountPath])
+					&& isset($data[$mountType][$applicable][$mountPath]['priority'])
+					&& !isset($mountPoint[$applicable][$mountPath]['priority'])) {
+					$mountPoint[$applicable][$mountPath]['priority']
+						= $data[$mountType][$applicable][$mountPath]['priority'];
+				}
 				$data[$mountType][$applicable]
 					= array_merge($data[$mountType][$applicable], $mountPoint[$applicable]);
 			} else {

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -41,16 +41,22 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 	const TEST_USER1 = 'user1';
 	const TEST_USER2 = 'user2';
 	const TEST_GROUP1 = 'group1';
+	const TEST_GROUP1B = 'group1b';
 	const TEST_GROUP2 = 'group2';
+	const TEST_GROUP2B = 'group2b';
 
 	public function setUp() {
 		\OC_User::createUser(self::TEST_USER1, self::TEST_USER1);
 		\OC_User::createUser(self::TEST_USER2, self::TEST_USER2);
 
 		\OC_Group::createGroup(self::TEST_GROUP1);
+		\OC_Group::createGroup(self::TEST_GROUP1B);
 		\OC_Group::addToGroup(self::TEST_USER1, self::TEST_GROUP1);
+		\OC_Group::addToGroup(self::TEST_USER1, self::TEST_GROUP1B);
 		\OC_Group::createGroup(self::TEST_GROUP2);
+		\OC_Group::createGroup(self::TEST_GROUP2B);
 		\OC_Group::addToGroup(self::TEST_USER2, self::TEST_GROUP2);
+		\OC_Group::addToGroup(self::TEST_USER2, self::TEST_GROUP2B);
 
 		\OC_User::setUserId(self::TEST_USER1);
 		$this->userHome = \OC_User::getHome(self::TEST_USER1);
@@ -81,7 +87,9 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		\OC_User::deleteUser(self::TEST_USER2);
 		\OC_User::deleteUser(self::TEST_USER1);
 		\OC_Group::deleteGroup(self::TEST_GROUP1);
+		\OC_Group::deleteGroup(self::TEST_GROUP1B);
 		\OC_Group::deleteGroup(self::TEST_GROUP2);
+		\OC_Group::deleteGroup(self::TEST_GROUP2B);
 
 		@unlink($this->dataDir . '/mount.json');
 
@@ -634,5 +642,114 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('\OC\Files\Storage\SMB', $config[1]['class']);
 		$this->assertEquals('ext', $config[1]['mountpoint']);
 		$this->assertEquals($options2, $config[1]['options']);
+	}
+
+	public function priorityDataProvider() {
+		return array(
+
+		// test 1 - group vs group
+		array(
+			array(
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_GROUP,
+					'applicable' => self::TEST_GROUP1,
+					'priority' => 50
+				),
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_GROUP,
+					'applicable' => self::TEST_GROUP1B,
+					'priority' => 60
+				)
+			),
+			1
+		),
+		// test 2 - user vs personal
+		array(
+			array(
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_USER,
+					'applicable' => self::TEST_USER1,
+					'priority' => 2000
+				),
+				array(
+					'isPersonal' => true,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_USER,
+					'applicable' => self::TEST_USER1,
+					'priority' => null
+				)
+			),
+			1
+		),
+		// test 3 - all vs group vs user
+		array(
+			array(
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_USER,
+					'applicable' => 'all',
+					'priority' => 70
+				),
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_GROUP,
+					'applicable' => self::TEST_GROUP1,
+					'priority' => 60
+				),
+				array(
+					'isPersonal' => false,
+					'mountType' => OC_Mount_Config::MOUNT_TYPE_USER,
+					'applicable' => self::TEST_USER1,
+					'priority' => 50
+				)
+			),
+			2
+		)
+
+		);
+	}
+
+	/**
+	 * Ensure priorities are being respected
+	 * Test user is self::TEST_USER1
+	 *
+	 * @dataProvider priorityDataProvider
+	 * @param array[] $mounts array of associative array of mount parameters:
+	 *	bool $isPersonal
+	 *	string $mountType
+	 *	string $applicable
+	 *	int|null $priority null for personal
+	 * @param int $expected index of expected visible mount
+	 */
+	public function testPriority($mounts, $expected) {
+		$mountConfig = array(
+			'host' => 'somehost',
+			'user' => 'someuser',
+			'password' => 'somepassword',
+			'root' => 'someroot'
+		);
+
+		// Add mount points
+		foreach($mounts as $i => $mount) {
+			$this->assertTrue(
+				OC_Mount_Config::addMountPoint(
+					'/ext',
+					'\OC\Files\Storage\SMB',
+					$mountConfig + array('id' => $i),
+					$mount['mountType'],
+					$mount['applicable'],
+					$mount['isPersonal'],
+					$mount['priority']
+				)
+			);
+		}
+
+		// Get mount points for user
+		$mountPoints = OC_Mount_Config::getAbsoluteMountPoints(self::TEST_USER1);
+
+		$this->assertEquals(1, count($mountPoints));
+		$this->assertEquals($expected, $mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['id']);
 	}
 }

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -752,4 +752,52 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, count($mountPoints));
 		$this->assertEquals($expected, $mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['id']);
 	}
+
+	/**
+	 * Test for persistence of priority when changing mount options
+	 */
+	public function testPriorityPersistence() {
+		$class = '\OC\Files\Storage\SMB';
+		$priority = 123;
+		$mountConfig = array(
+			'host' => 'somehost',
+			'user' => 'someuser',
+			'password' => 'somepassword',
+			'root' => 'someroot'
+		);
+
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				$class,
+				$mountConfig,
+				OC_Mount_Config::MOUNT_TYPE_USER,
+				self::TEST_USER1,
+				false,
+				$priority
+			)
+		);
+
+		// Check for correct priority
+		$mountPoints = OC_Mount_Config::getAbsoluteMountPoints(self::TEST_USER1);
+		$this->assertEquals($priority,
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['priority']);
+
+		// Simulate changed mount options (without priority set)
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				$class,
+				$mountConfig,
+				OC_Mount_Config::MOUNT_TYPE_USER,
+				self::TEST_USER1,
+				false
+			)
+		);
+
+		// Check for correct priority
+		$mountPoints = OC_Mount_Config::getAbsoluteMountPoints(self::TEST_USER1);
+		$this->assertEquals($priority,
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['priority']);
+	}
 }


### PR DESCRIPTION
These changes implement the ability to set priorities on mount points. Currently `mount.json` needs to be edited manually, since I couldn't think of a decent interface on the web view (it probably needs some kind of 'advanced' section).

The idea for this is so that the administrator, who may be auto-generating `mount.json` for a large number of users, might want to put priority on the mounts used by a user who is part of multiple groups. For example, a user 'ismith' may be part of groups 'staff' and 'officestaff', as they are a member of the office staff, but a home mount for 'officestaff' should take priority over the one for 'staff', so the administrator just bumps up the priority.

This should work with existing mount configurations, and shouldn't affect the logic of setups where priorities are ignored, _with one exception_: I noticed `MOUNT_TYPE_GLOBAL` being used in `getAbsoluteMountPoints`, but couldn't find any reference to that mount type anywhere else, so in 0641266 I moved the logic for 'All Users' to be considered as part of `MOUNT_TYPE_GLOBAL`.

The default priorities, found in the backend registration, are defined as follows:
- Local - 150
- Remote mounts - 100
- Remote wrapper mounts (SMB_OC only) - 90
