### PR TITLE
Remove annoying karma 404 warnings for images

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -121,6 +121,9 @@ module.exports = function(config) {
 		files.push('apps/' + appsToTest[i] + '/tests/js/*.js');
 	}
 
+	// serve images to avoid warnings
+	files.push({pattern: 'core/img/**/*', watched: false, included: false, served: true});
+
 	config.set({
 
 		// base path, that will be used to resolve files and exclude
@@ -136,6 +139,11 @@ module.exports = function(config) {
 		exclude: [
 
 		],
+
+		proxies: {
+			// prevent warnings for images
+			'/context.html//core/img/': 'http://localhost:9876/base/core/img/'
+		},
 
 		// test results reporter to use
 		// possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'


### PR DESCRIPTION
Karma now serves images from core to avoid polluting the logs with a lot
of 404 warnings.

This also makes it easier to read the test errors during development.

@DeepDiver1975 
