### PR TITLE
Dynamically update stored credentials in mount config

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -28,7 +28,7 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 
 // connecting hooks
 OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
-OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_OC', 'login');
+OCP\Util::connectHook('OC_User', 'post_login', '\OC_Mount_Config', 'updateDynamicMountPoints');
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Local', array(
 	'backend' => (string)$l->t('Local'),

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -28,7 +28,7 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 
 // connecting hooks
 OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
-OCP\Util::connectHook('OC_User', 'post_login', '\OC_Mount_Config', 'updateDynamicMountPoints');
+OCP\Util::connectHook('OC_User', 'post_login', '\OC_Mount_Config', 'updateMountPointCredentials');
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Local', array(
 	'backend' => (string)$l->t('Local'),

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -114,17 +114,17 @@ class OC_Mount_Config {
 	}
 
 	/**
-	 * Hook that updates credentials in dynamic mount points
+	 * Hook that updates credentials in mount points when needed
 	 * @param array $params
 	 */
-	public static function updateDynamicMountPoints($credentials) {
+	public static function updateMountPointCredentials($credentials) {
 		$username = \OC_User::getUserSession()->getLoginName();
 
 		$mountPoints = self::getAbsoluteMountPoints($credentials['uid']);
 		foreach ($mountPoints as $mountPoint => $options) {
 			try {
 				$storage = new $options['class']($options['options']);
-				if ($storage->isDynamic()) {
+				if ($storage->needCredentialsUpdate()) {
 					$options['options']['user'] = $username;
 					$options['options']['password'] = $credentials['password'];
 					// Remove '/uid/files/' from mount point [strlen(...) + 8]

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -118,7 +118,7 @@ class OC_Mount_Config {
 	 * @param array $params
 	 */
 	public static function updateDynamicMountPoints($credentials) {
-		$username = \OC::$session->get('loginname');
+		$username = \OC_User::getUserSession()->getLoginName();
 
 		$mountPoints = self::getAbsoluteMountPoints($credentials['uid']);
 		foreach ($mountPoints as $mountPoint => $options) {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -124,10 +124,12 @@ class OC_Mount_Config {
 		foreach ($mountPoints as $mountPoint => $options) {
 			try {
 				$storage = new $options['class']($options['options']);
-				// Create/update personal mountpoint with username and password if dynamic
 				if ($storage->isDynamic()) {
 					$options['options']['user'] = $username;
 					$options['options']['password'] = $credentials['password'];
+					// Remove '/uid/files/' from mount point [strlen(...) + 8]
+					// and create/update personal mountpoint with username and
+					// password from existing system mount configuration
 					self::addMountPoint(substr($mountPoint, strlen($credentials['uid']) + 8),
 					                    $options['class'],
 					                    $options['options'],

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -74,7 +74,7 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 		}
 	}
 
-	public function isDynamic() {
+	public function needCredentialsUpdate() {
 		return true;
 	}
 }

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -14,13 +14,12 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 	private $username_as_share;
 
 	public function __construct($params) {
-		if (isset($params['host']) && \OC::$session->exists('smb-credentials')) {
+		if (isset($params['host'])) {
 			$host=$params['host'];
 			$this->username_as_share = ($params['username_as_share'] === 'true');
 
-			$params_auth = \OC::$session->get('smb-credentials');
-			$user = \OC::$session->get('loginname');
-			$password = $params_auth['password'];
+			$user = isset($params['user']) ? $params['user'] : 'unset';
+			$password = isset($params['password']) ? $params['password'] : 'unset';
 
 			$root=isset($params['root'])?$params['root']:'/';
 			$share = '';
@@ -44,50 +43,39 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 		}
 	}
 
-	public static function login( $params ) {
-		\OC::$session->set('smb-credentials', $params);
-	}
+	public function test() {
+		$smb = new \smb();
+		$pu = $smb->parse_url($this->constructUrl(''));
 
-	public function isSharable($path) {
-		return false;
-	}
+		// Attempt to connect anonymously
+		$pu['user'] = '';
+		$pu['pass'] = '';
 
-	public function test($isPersonal = true) {
-		if ($isPersonal) {
-			if ($this->stat('')) {
-				return true;
-			}
-			return false;
-		} else {
-			$smb = new \smb();
-			$pu = $smb->parse_url($this->constructUrl(''));
-
-			// Attempt to connect anonymously
-			$pu['user'] = '';
-			$pu['pass'] = '';
-
-			// Share cannot be checked if dynamic
-			if ($this->username_as_share) {
-				if ($smb->look($pu)) {
-					return true;
-				} else {
-					return false;
-				}
-			}
-			if (!$pu['share']) {
-				return false;
-			}
-
-			// The following error messages are expected due to anonymous login
-			$regexp = array(
-				'(NT_STATUS_ACCESS_DENIED)' => 'skip'
-			) + $smb->getRegexp();
-
-			if ($smb->client("-d 0 " . escapeshellarg('//' . $pu['host'] . '/' . $pu['share']) . " -c exit", $pu, $regexp)) {
+		// Share cannot be checked if username as share
+		if ($this->username_as_share) {
+			if ($smb->look($pu)) {
 				return true;
 			} else {
 				return false;
 			}
 		}
+		if (!$pu['share']) {
+			return false;
+		}
+
+		// The following error messages are expected due to anonymous login
+		$regexp = array(
+			'(NT_STATUS_ACCESS_DENIED)' => 'skip'
+		) + $smb->getRegexp();
+
+		if ($smb->client("-d 0 " . escapeshellarg('//' . $pu['host'] . '/' . $pu['share']) . " -c exit", $pu, $regexp)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public function isDynamic() {
+		return true;
 	}
 }

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -22,7 +22,6 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 			$password = isset($params['password']) ? $params['password'] : 'unset';
 
 			$root=isset($params['root'])?$params['root']:'/';
-			$share = '';
 
 			if ($this->username_as_share) {
 				$share = '/'.$user;

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -640,9 +640,9 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 	}
 
 	/*
-	 * Test non-dynamic mount point for original behaviour
+	 * Test mount point without credentials update for original behaviour
 	 */
-	public function testNonDynamicMountPoint() {
+	public function testMountPointNoCredentialsUpdate() {
 		$this->assertTrue(
 			OC_Mount_Config::addMountPoint(
 				'/ext',
@@ -661,7 +661,7 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		);
 
 		// simulate login
-		\OC_Mount_Config::updateDynamicMountPoints(
+		\OC_Mount_Config::updateMountPointCredentials(
 			array('uid' => self::TEST_USER1, 'password' => self::TEST_USER1)
 		);
 
@@ -676,9 +676,9 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 	}
 
 	/*
-	 * Test dynamic mount point for credential updating
+	 * Test mount point for credentials updating
 	 */
-	public function testDynamicMountPoint() {
+	public function testMountPointCredentialsUpdate() {
 		$this->assertTrue(
 			OC_Mount_Config::addMountPoint(
 				'/ext',
@@ -698,7 +698,7 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		);
 
 		// simulate login
-		\OC_Mount_Config::updateDynamicMountPoints(
+		\OC_Mount_Config::updateMountPointCredentials(
 			array('uid' => self::TEST_USER1, 'password' => self::TEST_USER1)
 		);
 

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -55,6 +55,7 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		\OC_Group::addToGroup(self::TEST_USER2, self::TEST_GROUP2);
 
 		\OC_User::setUserId(self::TEST_USER1);
+		\OC_User::getUserSession()->setLoginName(self::TEST_USER1);
 		$this->userHome = \OC_User::getHome(self::TEST_USER1);
 		mkdir($this->userHome);
 
@@ -636,5 +637,78 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('\OC\Files\Storage\SMB', $config[1]['class']);
 		$this->assertEquals('ext', $config[1]['mountpoint']);
 		$this->assertEquals($options2, $config[1]['options']);
+	}
+
+	/*
+	 * Test non-dynamic mount point for original behaviour
+	 */
+	public function testNonDynamicMountPoint() {
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				'\OC\Files\Storage\SMB',
+				array(
+					'host' => 'smbhost',
+					'user' => 'smbuser',
+					'password' => 'smbpass',
+					'share' => 'smbshare',
+					'root' => 'smbroot'
+				),
+				OC_Mount_Config::MOUNT_TYPE_USER,
+				self::TEST_USER1,
+				false
+			)
+		);
+
+		// simulate login
+		\OC_Mount_Config::updateDynamicMountPoints(
+			array('uid' => self::TEST_USER1, 'password' => self::TEST_USER1)
+		);
+
+		// ensure user and password are unchanged
+		$mountPoints = OC_Mount_Config::getAbsoluteMountPoints(self::TEST_USER1);
+		$this->assertEquals('smbuser',
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['user']
+		);
+		$this->assertEquals('smbpass',
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['password']
+		);
+	}
+
+	/*
+	 * Test dynamic mount point for credential updating
+	 */
+	public function testDynamicMountPoint() {
+		$this->assertTrue(
+			OC_Mount_Config::addMountPoint(
+				'/ext',
+				'\OC\Files\Storage\SMB_OC',
+				array(
+					'host' => 'smbhost',
+					'username_as_share' => false,
+					'user' => 'smbuser',
+					'password' => 'smbpass',
+					'share' => 'smbshare',
+					'root' => 'smbroot'
+				),
+				OC_Mount_Config::MOUNT_TYPE_USER,
+				self::TEST_USER1,
+				false
+			)
+		);
+
+		// simulate login
+		\OC_Mount_Config::updateDynamicMountPoints(
+			array('uid' => self::TEST_USER1, 'password' => self::TEST_USER1)
+		);
+
+		// ensure user and password are changed
+		$mountPoints = OC_Mount_Config::getAbsoluteMountPoints(self::TEST_USER1);
+		$this->assertEquals(self::TEST_USER1,
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['user']
+		);
+		$this->assertEquals(self::TEST_USER1,
+			$mountPoints['/'.self::TEST_USER1.'/files/ext']['options']['password']
+		);
 	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -349,7 +349,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 *
 	 * @return bool
 	 */
-	public function isDynamic() {
+	public function needCredentialsUpdate() {
 		return false;
 	}
 

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -344,6 +344,11 @@ abstract class Common implements \OC\Files\Storage\Storage {
 		return false;
 	}
 
+	/**
+	 * check if storage requires updating of credentials on owner login
+	 *
+	 * @return bool
+	 */
 	public function isDynamic() {
 		return false;
 	}

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -344,6 +344,10 @@ abstract class Common implements \OC\Files\Storage\Storage {
 		return false;
 	}
 
+	public function isDynamic() {
+		return false;
+	}
+
 	/**
 	 * get the free space in the storage
 	 *


### PR DESCRIPTION
Instead of storing credentials in a session variable, on login the credentials are used to update any dynamic personal mount points (or create them if system-wide ones are encountered) with the new credentials.

Sharing for `SMB_OC` has been enabled.

The following needs testing:
- [x] iRODS
- [x] Sharing support ~~(this is a little broken at the moment)~~ ~~Separate bug affecting SMB~~ This was a separate issue, fixed in #8293 
- [x] Non-dynamic mount points are working as expected

**21/04/2014** WIP status removed

@PVince81 @icewind1991 @DeepDiver1975
