### PR TITLE
Only encode dangerous dangerous characters

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -805,7 +805,7 @@ class OC_Util {
 			array_walk_recursive($value, 'OC_Util::sanitizeHTML');
 		} else {
 			//Specify encoding for PHP<5.4
-			$value = htmlentities((string)$value, ENT_QUOTES, 'UTF-8');
+			$value = htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
 		}
 		return $value;
 	}


### PR DESCRIPTION
There is no need to encode all characters into HTML entities, only potential dangerous characters as &, ", ', < and > should get encoded.

This may fix issues like https://github.com/owncloud/calendar/pull/394

@georgehrke 
