### PR TITLE
Move security headers

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -214,11 +214,9 @@ class OC {
 	}
 
 	/*
-	* This function adds some security related headers to all requests 
-	* served via base.php
-	* The implementation of this function as to happen here to ensure that
-	* all third-party components (e.g. SabreDAV) also benefit from this
-	* headers
+	* This function adds some security related headers to all requests served via base.php
+	* The implementation of this function as hto happen here to ensure that all third-party 
+	* components (e.g. SabreDAV) also benefit from this headers.
 	*/
 	public static function addSecurityHeaders() {
 		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters

--- a/lib/base.php
+++ b/lib/base.php
@@ -213,6 +213,36 @@ class OC {
 		}
 	}
 
+	/*
+	* This function adds some security related headers to all requests 
+	* served via base.php
+	* The implementation of this function as to happen here to ensure that
+	* all third-party components (e.g. SabreDAV) also benefit from this
+	* headers
+	*/
+	public static function addSecurityHeaders() {
+		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
+		header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
+
+		// iFrame Restriction Policy
+		$xFramePolicy = OC_Config::getValue('xframe_restriction', true);
+		if($xFramePolicy) {
+			header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
+		}
+
+		// Content Security Policy
+		// If you change the standard policy, please also change it in config.sample.php
+		$policy = OC_Config::getValue('custom_csp_policy',
+			'default-src \'self\'; '
+			.'script-src \'self\' \'unsafe-eval\'; '
+			.'style-src \'self\' \'unsafe-inline\'; '
+			.'frame-src *; '
+			.'img-src *; '
+			.'font-src \'self\' data:; '
+			.'media-src *');
+		header('Content-Security-Policy:'.$policy);
+	}
+
 	public static function checkSSL() {
 		// redirect to https site if configured
 		if (OC_Config::getValue("forcessl", false)) {
@@ -512,6 +542,7 @@ class OC {
 		self::checkConfig();
 		self::checkInstalled();
 		self::checkSSL();
+		self::addSecurityHeaders();
 
 		$errors = OC_Util::checkServer();
 		if (count($errors) > 0) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -215,7 +215,7 @@ class OC {
 
 	/*
 	* This function adds some security related headers to all requests served via base.php
-	* The implementation of this function as hto happen here to ensure that all third-party 
+	* The implementation of this function has to happen here to ensure that all third-party 
 	* components (e.g. SabreDAV) also benefit from this headers.
 	*/
 	public static function addSecurityHeaders() {

--- a/lib/private/json.php
+++ b/lib/private/json.php
@@ -119,8 +119,6 @@ class OC_JSON{
 	* Encode and print $data in json format
 	*/
 	public static function encodedPrint($data, $setContentType=true) {
-		// Disable mimesniffing, don't move this to setContentTypeHeader!
-		header( 'X-Content-Type-Options: nosniff' );
 		if($setContentType) {
 			self::setContentTypeHeader();
 		}

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -64,7 +64,8 @@ class OC_Template extends \OC\Template\Base {
 		$this->path = $path;
 
 		parent::__construct($template, $requesttoken, $l10n, $themeDefaults);
-}
+	}
+
 	/**
 	 * autodetect the formfactor of the used device
 	 * default -> the normal desktop browser interface

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -64,31 +64,7 @@ class OC_Template extends \OC\Template\Base {
 		$this->path = $path;
 
 		parent::__construct($template, $requesttoken, $l10n, $themeDefaults);
-
-		// Some headers to enhance security
-		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
-		header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-
-		// iFrame Restriction Policy
-		$xFramePolicy = OC_Config::getValue('xframe_restriction', true);
-		if($xFramePolicy) {
-			header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
-		}
-		
-		// Content Security Policy
-		// If you change the standard policy, please also change it in config.sample.php
-		$policy = OC_Config::getValue('custom_csp_policy',
-			'default-src \'self\'; '
-			.'script-src \'self\' \'unsafe-eval\'; '
-			.'style-src \'self\' \'unsafe-inline\'; '
-			.'frame-src *; '
-			.'img-src *; '
-			.'font-src \'self\' data:; '
-			.'media-src *');
-		header('Content-Security-Policy:'.$policy); // Standard
-
-	}
-
+}
 	/**
 	 * autodetect the formfactor of the used device
 	 * default -> the normal desktop browser interface

--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -49,7 +49,6 @@ class JSONResponse extends Response {
 	public function __construct($data=array(), $statusCode=Http::STATUS_OK) {
 		$this->data = $data;
 		$this->setStatus($statusCode);
-		$this->addHeader('X-Content-Type-Options', 'nosniff');
 		$this->addHeader('Content-type', 'application/json; charset=utf-8');
 	}
 

--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -79,13 +79,6 @@ class JSONResponseTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, $this->json->render());
 	}
 
-
-	public function testShouldHaveXContentHeaderByDefault() {
-		$headers = $this->json->getHeaders();
-		$this->assertEquals('nosniff', $headers['X-Content-Type-Options']);
-	}
-
-
 	public function testConstructorAllowsToSetData() {
 		$data = array('hi');
 		$code = 300;


### PR DESCRIPTION
Some headers were currently only added to the templates but not to other components (e.g. SabreDAV / JSON / etc...)
The migration to base.php ensures that the headers are served to all requests passing base.php
