### PR TITLE
Return "application/octet-stream" as hardocded mimetype

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -197,19 +197,15 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 	}
 
 	/**
-	 * Returns the mime-type for a file
-	 *
-	 * If null is returned, we'll assume application/octet-stream
-	 *
-	 * @return mixed
+	 * Returns "application/octet-stream" as hardcoded mimetype
+	 * while this has some disadvantages (e.g. Nautilus won't show
+	 * applications that can open the filetype) it is the only
+	 * reliable method to prevent a CSP bypass.
+	 *  
+	 * @return "application/octet-stream" 
 	 */
 	public function getContentType() {
-		if (isset($this->fileinfo_cache['mimetype'])) {
-			return $this->fileinfo_cache['mimetype'];
-		}
-
-		return \OC\Files\Filesystem::getMimeType($this->path);
-
+		return "application/octet-stream";
 	}
 
 	/**


### PR DESCRIPTION
While this has some disadvantages (e.g. Nautilus won't show applications that can open the filetype) it is the only reliable way to prevent a CSP bypass. A `Content-Disposition` header forcing the browser to download the filetype will prevent potential XSS but not the CSP bypass.

According to @danimo the client does not use the returned `Content-Type`.

Please review @DeepDiver1975 @karlitschek 
