### PR TITLE
Adjust logic for deciding if trashbin empty

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -921,13 +921,11 @@ class Trashbin {
 	public static function isEmpty($user) {
 
 		$view = new \OC\Files\View('/' . $user . '/files_trashbin');
-		$dh = $view->opendir('/files');
-		if (!$dh) {
-			return false;
-		}
-		while ($file = readdir($dh)) {
-			if ($file !== '.' and $file !== '..') {
-				return false;
+		if ($view->is_dir('/files') && $dh = $view->opendir('/files')) {
+			while ($file = readdir($dh)) {
+				if ($file !== '.' and $file !== '..') {
+					return false;
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
Any error in opening the trashbin directory returns 'true' for `isEmpty`. An error is prevented by checking if the directory exists before trying to open it.
