### PR TITLE
p() and print_unescaped() also take arrays as parameter

### DIFF
--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -7,16 +7,17 @@
  */
 
 /**
- * Prints an XSS escaped string
- * @param string $string the string which will be escaped and printed
+ * Prints a sanitized string
+ * @param string|array $string the string which will be escaped and printed
  */
 function p($string) {
 	print(OC_Util::sanitizeHTML($string));
 }
 
 /**
- * Prints an unescaped string
- * @param string $string the string which will be printed as it is
+ * Prints an unsanitized string - usage of this function may result into XSS.
+ * Consider using p() instead.
+ * @param string|array $string the string which will be printed as it is
  */
 function print_unescaped($string) {
 	print($string);


### PR DESCRIPTION
This fixes some scrutinizer issues.
