### PR TITLE
Make email, display name change translatable again

### DIFF
--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -4,7 +4,7 @@
 OCP\JSON::callCheck();
 OC_JSON::checkLoggedIn();
 
-$l=OC_L10N::get('core');
+$l=OC_L10N::get('settings');
 
 $username = isset($_POST["username"]) ? $_POST["username"] : OC_User::getUser();
 $displayName = $_POST["displayName"];

--- a/settings/ajax/lostpassword.php
+++ b/settings/ajax/lostpassword.php
@@ -3,7 +3,7 @@
 OC_JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
-$l=OC_L10N::get('core');
+$l=OC_L10N::get('settings');
 
 // Get data
 if( isset( $_POST['email'] ) && OC_Mail::validateAddress($_POST['email']) ) {


### PR DESCRIPTION
Those two files were using 'core' translations. However, should have used 'settings'.
