### PR TITLE
 	Remove limit and offset manipulation when getting users or groups, be… 

### DIFF
--- a/lib/private/group/group.php
+++ b/lib/private/group/group.php
@@ -172,12 +172,6 @@ class Group {
 		$users = array();
 		foreach ($this->backends as $backend) {
 			$userIds = $backend->usersInGroup($this->gid, $search, $limit, $offset);
-			if (!is_null($limit)) {
-				$limit -= count($userIds);
-			}
-			if (!is_null($offset)) {
-				$offset -= count($userIds);
-			}
 			$users += $this->getVerifiedUsers($userIds);
 			if (!is_null($limit) and $limit <= 0) {
 				return array_values($users);
@@ -222,12 +216,6 @@ class Group {
 				$userIds = array_keys($backend->displayNamesInGroup($this->gid, $search, $limit, $offset));
 			} else {
 				$userIds = $backend->usersInGroup($this->gid, $search, $limit, $offset);
-			}
-			if (!is_null($limit)) {
-				$limit -= count($userIds);
-			}
-			if (!is_null($offset)) {
-				$offset -= count($userIds);
 			}
 			$users = $this->getVerifiedUsers($userIds);
 			if (!is_null($limit) and $limit <= 0) {

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -134,12 +134,6 @@ class Manager extends PublicEmitter {
 		$groups = array();
 		foreach ($this->backends as $backend) {
 			$groupIds = $backend->getGroups($search, $limit, $offset);
-			if (!is_null($limit)) {
-				$limit -= count($groupIds);
-			}
-			if (!is_null($offset)) {
-				$offset -= count($groupIds);
-			}
 			foreach ($groupIds as $groupId) {
 				$groups[$groupId] = $this->getGroupObject($groupId);
 			}

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -175,13 +175,6 @@ class Manager extends PublicEmitter {
 			if (is_array($backendUsers)) {
 				foreach ($backendUsers as $uid) {
 					$users[] = $this->getUserObject($uid, $backend);
-					if (!is_null($limit)) {
-						$limit--;
-					}
-					if (!is_null($offset) and $offset > 0) {
-						$offset--;
-					}
-
 				}
 			}
 		}
@@ -211,13 +204,6 @@ class Manager extends PublicEmitter {
 			if (is_array($backendUsers)) {
 				foreach ($backendUsers as $uid => $displayName) {
 					$users[] = $this->getUserObject($uid, $backend);
-					if (!is_null($limit)) {
-						$limit--;
-					}
-					if (!is_null($offset) and $offset > 0) {
-						$offset--;
-					}
-
 				}
 			}
 		}

--- a/tests/lib/group/group.php
+++ b/tests/lib/group/group.php
@@ -287,7 +287,7 @@ class Group extends \PHPUnit_Framework_TestCase {
 			->will($this->returnValue(array('user2')));
 		$backend2->expects($this->once())
 			->method('usersInGroup')
-			->with('group1', 'user', 1, 0)
+			->with('group1', 'user', 2, 1)
 			->will($this->returnValue(array('user1')));
 
 		$users = $group->searchUsers('user', 2, 1);

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -254,7 +254,7 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$backend2 = $this->getMock('\OC_Group_Database');
 		$backend2->expects($this->once())
 			->method('getGroups')
-			->with('1', 1, 0)
+			->with('1', 2, 1)
 			->will($this->returnValue(array('group12')));
 		$backend2->expects($this->any())
 			->method('groupExists')

--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -210,7 +210,7 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$backend2 = $this->getMock('\OC_User_Dummy');
 		$backend2->expects($this->once())
 			->method('getUsers')
-			->with($this->equalTo('fo'), $this->equalTo(1), $this->equalTo(0))
+			->with($this->equalTo('fo'), $this->equalTo(3), $this->equalTo(1))
 			->will($this->returnValue(array('foo3')));
 
 		$manager = new \OC\User\Manager();


### PR DESCRIPTION
…cause it does not work when more than one user or group backend. Fixing it would be too costly performance wise, so we switch back to the model used in OC 5: limit and offset are effective per backend, and not a general constraint.

What happens currently when fetching users: users from the first registered backend are read first correctly. Then the users are read from the second registered backend, but with an incorrectly computed offset. As a consquence not every user is loaded.

To fix it to work as intentend we would need to compute all users in the backends that are already progressed. With the search string in mind it can be costly process, so we refrain.

What happens with this PR when fetchung users: users from all backends are fetched the same time. Limit/Offset does not need to be manipulated any more. I.e. more than 30 users (if existent) are loaded upon first opening the users page.

As discussed with @icewind1991 priorly on IRC.

Reviewers please @DeepDiver1975 @bantu or others.
