### PR TITLE
do not show menu toggle on public share links as there is no menu

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -7,6 +7,11 @@
 	background-position: right 26px;
 	padding-right: 16px !important;
 }
+/* do not show menu toggle on public share links as there is no menu */
+#body-public #owncloud.menutoggle {
+	background-image: none;
+	padding-right: 0 !important;
+}
 
 /* compress search box on mobile, expand when focused */
 .searchbox input[type="search"] {


### PR DESCRIPTION
Previously the menu toggle caret was shown on public share links. This was misleading because there is no menu to toggle on mobile.

Please review @owncloud/designers 
