### PR TITLE
LDAP: optimize retrieval of displaynames, fixes #8135

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -483,10 +483,16 @@ class Access extends LDAPUtility {
 			$ocname = $this->dn2ocname($ldapObject['dn'], $nameByLDAP, $isUsers);
 			if($ocname) {
 				$ownCloudNames[] = $ocname;
+				$this->cacheDisplayName($ocname, $nameByLDAP);
 			}
 			continue;
 		}
 		return $ownCloudNames;
+	}
+
+	public function cacheDisplayName($uid, $displayName) {
+		$cacheKeyTrunk = 'getDisplayName';
+		$this->connection->writeToCache($cacheKeyTrunk.$uid,$displayName);
 	}
 
 	/**

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -483,16 +483,25 @@ class Access extends LDAPUtility {
 			$ocname = $this->dn2ocname($ldapObject['dn'], $nameByLDAP, $isUsers);
 			if($ocname) {
 				$ownCloudNames[] = $ocname;
-				$this->cacheDisplayName($ocname, $nameByLDAP);
+				if($isUsers) {
+					//cache the user names so it does not need to be retrieved
+					//again later (e.g. sharing dialogue).
+					$this->cacheUserDisplayName($ocname, $nameByLDAP);
+				}
 			}
 			continue;
 		}
 		return $ownCloudNames;
 	}
 
-	public function cacheDisplayName($uid, $displayName) {
+	/**
+	 * @brief caches the user display name
+	 * @param string the internal owncloud username
+	 * @param string the display name
+	 */
+	public function cacheUserDisplayName($ocname, $displayName) {
 		$cacheKeyTrunk = 'getDisplayName';
-		$this->connection->writeToCache($cacheKeyTrunk.$uid,$displayName);
+		$this->connection->writeToCache($cacheKeyTrunk.$ocname, $displayName);
 	}
 
 	/**


### PR DESCRIPTION
Problem: determining the display name per users takes time if it is not cached, because it requires a query per user.

Solution: get the display name immediately when searching for the users and cache it. 

Funfact: half of the solution was already there, only the caching part was not.

TODOs left:
- [x] test (does it really work)?
- [x] PHP Doc

How to test:
1. Open the search dialog and enter 2 characters
2. Note the ajax response time and compare it to a run without this PR. Make sure the cache is emptied inbetween the runs (e.g. set cache TTL to a low value in LDAP settings, e.g. 10 seconds. Don't set it to 0, which disables the cache).
