### PR TITLE
fix shift of icons in 'New' menu in IE8/9, fix #7987

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -51,7 +51,7 @@
 	margin: 5px;
 	padding-left: 42px;
 	padding-bottom: 2px;
-	background-position: initial;
+	background-position: left center;
 	cursor: pointer;
 }
 #new > ul > li > p {


### PR DESCRIPTION
Please review @owncloud/designers, this fixes #7987.
