### PR TITLE
add max-width to directLink input to prevent overflow

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -115,4 +115,5 @@ thead {
 .directLink input {
 	margin-left: 5px;
 	width: 300px;
+	max-width: 90%;
 }


### PR DESCRIPTION
Really small thing: Just prevent the directlink input box to overflow on really small displays. Please review quickly @owncloud/designers 
