### PR TITLE
keep long file names in one line to not overflow download button on mobile

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -70,13 +70,26 @@ thead {
 	margin: 0;
 }
 
+
 .directDownload,
 .directLink {
 	margin-bottom: 20px;
 }
+
+/* keep long file names in one line to not overflow download button on mobile */
+.directDownload #download {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 90%;
+	display: inline-block;
+	margin-left: auto;
+	margin-right: auto;
+}
 .directDownload .button img {
 	vertical-align: text-bottom;
 }
+
 .directLink label {
 	font-weight: normal;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";


### PR DESCRIPTION
To test, share a file with a long name with a public link and look at the download button on the public page with a small screen.

Please test @owncloud/designers @DeepDiver1975 
