### PR TITLE
Adjust renaming of directories with a dot in name

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -572,7 +572,8 @@ window.FileList = {
 		input.focus();
 		//preselect input
 		var len = input.val().lastIndexOf('.');
-		if (len === -1) {
+		if ( len === -1 ||
+			tr.data('type') === 'dir' ) {
 			len = input.val().length;
 		}
 		input.selectRange(0, len);


### PR DESCRIPTION
Directories will not be considered to have an extension, even if a dot is found. This adjusts the logic to pre-select text when an item is to be renamed, and brings it in line with the rest of the code to handle file extensions.

Fixes #8280 
