### PR TITLE
Handle return values better from Filesystem::getMountBy*

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -54,7 +54,7 @@ class Shared_Cache extends Cache {
 		if (isset($source['path']) && isset($source['fileOwner'])) {
 			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
 			$mounts = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
-			if (is_array($mounts) and count($mounts)) {
+			if (is_array($mounts) and !empty($mounts)) {
 				$fullPath = $mounts[0]->getMountPoint() . $source['path'];
 				list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($fullPath);
 				if ($storage) {

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -87,10 +87,11 @@ class Shared extends \OC\Files\Storage\Common {
 			if (!isset($source['fullPath'])) {
 				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
 				$mount = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
-				if (is_array($mount)) {
+				if (is_array($mount) && !empty($mount)) {
 					$this->files[$target]['fullPath'] = $mount[key($mount)]->getMountPoint() . $source['path'];
 				} else {
 					$this->files[$target]['fullPath'] = false;
+					\OCP\Util::writeLog('files_sharing', "Unable to get mount for shared storage '" . $source['storage'] . "' user '" . $source['fileOwner'] . "'", \OCP\Util::ERROR);
 				}
 			}
 			return $this->files[$target]['fullPath'];

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1228,7 +1228,7 @@ class Share extends \OC\Share\Constants {
 				} else {
 					if (!isset($mounts[$row['storage']])) {
 						$mountPoints = \OC\Files\Filesystem::getMountByNumericId($row['storage']);
-						if (is_array($mountPoints)) {
+						if (is_array($mountPoints) && !empty($mountPoints)) {
 							$mounts[$row['storage']] = current($mountPoints);
 						}
 					}


### PR DESCRIPTION
`getMountByStorageId` and `getMountByNumericId` return an empty array on error, which should be detected to avoid possible errors. This PR also adds in some new logging points and throws to aid debugging
