### PR TITLE
Fix issue with personal mount points and sharing

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -132,7 +132,7 @@ class OC_Mount_Config {
 		}
 
 		// Load system mount points
-		$mountConfig = self::readData(false);
+		$mountConfig = self::readData();
 		if (isset($mountConfig[self::MOUNT_TYPE_GLOBAL])) {
 			foreach ($mountConfig[self::MOUNT_TYPE_GLOBAL] as $mountPoint => $options) {
 				$options['options'] = self::decryptPasswords($options['options']);
@@ -169,7 +169,7 @@ class OC_Mount_Config {
 		}
 
 		// Load personal mount points
-		$mountConfig = self::readData(true);
+		$mountConfig = self::readData($user);
 		if (isset($mountConfig[self::MOUNT_TYPE_USER][$user])) {
 			foreach ($mountConfig[self::MOUNT_TYPE_USER][$user] as $mountPoint => $options) {
 				$options['options'] = self::decryptPasswords($options['options']);
@@ -233,7 +233,7 @@ class OC_Mount_Config {
 	* @return array
 	*/
 	public static function getSystemMountPoints() {
-		$mountPoints = self::readData(false);
+		$mountPoints = self::readData();
 		$backends = self::getBackends();
 		$system = array();
 		if (isset($mountPoints[self::MOUNT_TYPE_GROUP])) {
@@ -306,7 +306,7 @@ class OC_Mount_Config {
 	* @return array
 	*/
 	public static function getPersonalMountPoints() {
-		$mountPoints = self::readData(true);
+		$mountPoints = self::readData(OCP\User::getUser());
 		$backEnds = self::getBackends();
 		$uid = OCP\User::getUser();
 		$personal = array();
@@ -400,7 +400,7 @@ class OC_Mount_Config {
 				'options' => self::encryptPasswords($classOptions))
 			)
 		);
-		$mountPoints = self::readData($isPersonal);
+		$mountPoints = self::readData($isPersonal ? OCP\User::getUser() : NULL);
 		// Merge the new mount point into the current mount points
 		if (isset($mountPoints[$mountType])) {
 			if (isset($mountPoints[$mountType][$applicable])) {
@@ -412,7 +412,7 @@ class OC_Mount_Config {
 		} else {
 			$mountPoints[$mountType] = $mount;
 		}
-		self::writeData($isPersonal, $mountPoints);
+		self::writeData($isPersonal ? OCP\User::getUser() : NULL, $mountPoints);
 		return self::getBackendStatus($class, $classOptions, $isPersonal);
 	}
 
@@ -434,7 +434,7 @@ class OC_Mount_Config {
 		} else {
 			$mountPoint = '/$user/files/'.ltrim($mountPoint, '/');
 		}
-		$mountPoints = self::readData($isPersonal);
+		$mountPoints = self::readData($isPersonal ? OCP\User::getUser() : NULL);
 		// Remove mount point
 		unset($mountPoints[$mountType][$applicable][$mountPoint]);
 		// Unset parent arrays if empty
@@ -444,20 +444,20 @@ class OC_Mount_Config {
 				unset($mountPoints[$mountType]);
 			}
 		}
-		self::writeData($isPersonal, $mountPoints);
+		self::writeData($isPersonal ? OCP\User::getUser() : NULL, $mountPoints);
 		return true;
 	}
 
 	/**
 	* Read the mount points in the config file into an array
-	* @param boolean $isPersonal Personal or system config file
+	* @param string|null $user If not null, personal for $user, otherwise system
 	* @return array
 	*/
-	private static function readData($isPersonal) {
+	private static function readData($user = NULL) {
 		$parser = new \OC\ArrayParser();
-		if ($isPersonal) {
-			$phpFile = OC_User::getHome(OCP\User::getUser()).'/mount.php';
-			$jsonFile = OC_User::getHome(OCP\User::getUser()).'/mount.json';
+		if (isset($user)) {
+			$phpFile = OC_User::getHome($user).'/mount.php';
+			$jsonFile = OC_User::getHome($user).'/mount.json';
 		} else {
 			$phpFile = OC::$SERVERROOT.'/config/mount.php';
 			$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data/');
@@ -479,13 +479,12 @@ class OC_Mount_Config {
 
 	/**
 	* Write the mount points to the config file
-	* @param bool Personal or system config file
-	* @param array Mount points
-	* @param boolean $isPersonal
+	* @param string|null $user If not null, personal for $user, otherwise system
+	* @param array $data Mount points
 	*/
-	private static function writeData($isPersonal, $data) {
-		if ($isPersonal) {
-			$file = OC_User::getHome(OCP\User::getUser()).'/mount.json';
+	private static function writeData($user, $data) {
+		if (isset($user)) {
+			$file = OC_User::getHome($user).'/mount.json';
 		} else {
 			$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data/');
 			$file = \OC_Config::getValue('mount_file', $datadir . '/mount.json');


### PR DESCRIPTION
An issue existed where `readData` used `OCP\User::getUser()` to get the user for personal mount points, which worked in all situations apart from when a personal mount point was used for sharing, so the return from `getUser()` is not the user that owns the share. As such, any personal mount points would not work correctly when shared.

`readData` and `writeData` have been changed from using a `$isPersonal` boolean to using a `$user` string|null. `$isPersonal = false` can now be written as `$user = NULL` (or left out in the case of `readData`), and `$isPersonal = true` can be written as `$user = OCP\User::getUser()`.

This PR fixes the sharing issues encountered in #8167.
