### PR TITLE
fix variable name

### DIFF
--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -100,7 +100,7 @@ $(document).ready(function() {
 			var dirlisting=getSelectedFiles('dirlisting')[0];
 
 			for (var i=0; i<files.length; i++) {
-				var undeleteAction = $FileList.findFileEl(files[i]).children("td.date");
+				var undeleteAction = FileList.findFileEl(files[i]).children("td.date");
 				undeleteAction[0].innerHTML = undeleteAction[0].innerHTML+spinner;
 			}
 


### PR DESCRIPTION
Obvious, in JS we don't have a '$' in front of a variable name.

fix #8193 

cc @ser72 can you verify that this fixes the issue? Thanks!
