### PR TITLE
Fix getPath for storage roots

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1154,10 +1154,10 @@ class View {
 			 * @var \OC\Files\Mount\Mount $mount
 			 */
 			$cache = $mount->getStorage()->getCache();
-			if ($internalPath = $cache->getPathById($id)) {
+			if (!is_null($internalPath = $cache->getPathById($id))) {
 				$fullPath = $mount->getMountPoint() . $internalPath;
 				if (!is_null($path = $this->getRelativePath($fullPath))) {
-					return $path;
+					return rtrim($path, '/');
 				}
 			}
 		}

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -152,6 +152,22 @@ class View extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
+	function testGetPathStorageRoot() {
+		$storage1 = $this->getTestStorage();
+		$storage2 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, array(), '/');
+		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
+
+		$rootView = new \OC\Files\View('');
+
+		$cachedData = $rootView->getFileInfo('/substorage');
+		$id1 = $cachedData['fileid'];
+		$this->assertEquals('/substorage', $rootView->getPath($id1));
+	}
+
+	/**
+	 * @medium
+	 */
 	function testMountPointOverwrite() {
 		$storage1 = $this->getTestStorage(false);
 		$storage2 = $this->getTestStorage();


### PR DESCRIPTION
Needed for sharing filesystem mounts, without this patch sharing a mounted filesystem fails because sharing thinks the file doesn't exist

cc @DeepDiver1975 @schiesbn
