### PR TITLE
Add unit tests for arrays and quotationmark

### DIFF
--- a/tests/lib/template.php
+++ b/tests/lib/template.php
@@ -28,13 +28,23 @@ class Test_TemplateFunctions extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testP() {
-		// FIXME: do we need more testcases?
-		$htmlString = "<script>alert('xss');</script>";
+		$badString = '<img onload="alert(1)" />';
 		ob_start();
-		p($htmlString);
+		p($badString);
 		$result = ob_get_clean();
+		$this->assertEquals('&lt;img onload=&quot;alert(1)&quot; /&gt;', $result);
 
-		$this->assertEquals("&lt;script&gt;alert(&#039;xss&#039;);&lt;/script&gt;", $result);
+		$badString = "<script>alert('Hacked!');</script>";
+		ob_start();
+		p($badString);
+		$result = ob_get_clean();
+		$this->assertEquals('&lt;script&gt;alert(&#039;Hacked!&#039;);&lt;/script&gt;', $result);
+
+		$goodString = 'This is a good string without HTML.';
+		ob_start();
+		p($goodString);
+		$result = ob_get_clean();
+		$this->assertEquals('This is a good string without HTML.', $result);
 	}
 
 	public function testPNormalString() {

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -69,7 +69,6 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('This is a good string without HTML.', $result);
 	}
 
-
 	function testEncodePath(){
 		$component = '/§#@test%&^ä/-child';
 		$result = OC_Util::encodePath($component);

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -67,7 +67,7 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$goodString = 'This is a good string without HTML.';
 		$result = OC_Util::sanitizeHTML($goodString);
 		$this->assertEquals('This is a good string without HTML.', $result);
-}
+	}
 
 
 	function testEncodePath(){

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -43,15 +43,33 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 	}
 
 	function testSanitizeHTML() {
+		$badArray = array(
+			'While it is unusual to pass an array',
+			'this function actually <blink>supports</blink> it.',
+			'And therefore there needs to be a <script>alert("Unit"+\'test\')</script> for it!'
+		);
+		$goodArray = array(
+			'While it is unusual to pass an array',
+			'this function actually &lt;blink&gt;supports&lt;/blink&gt; it.',
+			'And therefore there needs to be a &lt;script&gt;alert(&quot;Unit&quot;+&#039;test&#039;)&lt;/script&gt; for it!'
+		);
+		$result = OC_Util::sanitizeHTML($badArray);
+		$this->assertEquals($goodArray, $result);
+
+		$badString = '<img onload="alert(1)" />';
+		$result = OC_Util::sanitizeHTML($badString);
+		$this->assertEquals('&lt;img onload=&quot;alert(1)&quot; /&gt;', $result);
+
 		$badString = "<script>alert('Hacked!');</script>";
 		$result = OC_Util::sanitizeHTML($badString);
-		$this->assertEquals("&lt;script&gt;alert(&#039;Hacked!&#039;);&lt;/script&gt;", $result);
+		$this->assertEquals('&lt;script&gt;alert(&#039;Hacked!&#039;);&lt;/script&gt;', $result);
 
-		$goodString = "This is an harmless string.";
+		$goodString = 'This is a good string without HTML.';
 		$result = OC_Util::sanitizeHTML($goodString);
-		$this->assertEquals("This is an harmless string.", $result);
-	}
-	
+		$this->assertEquals('This is a good string without HTML.', $result);
+}
+
+
 	function testEncodePath(){
 		$component = '/§#@test%&^ä/-child';
 		$result = OC_Util::encodePath($component);


### PR DESCRIPTION
OC_Util::sanitizeHTML() also supports array but we actually had no unit test for it. Additionally this commit introduces a test for escaping " into `&quot;`

Second try due to my missing git skills ;-)
