### PR TITLE
use case insensitive linguistic sort and compare when connecting to oracle

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -458,9 +458,27 @@ class Cache {
 		// normalize pattern
 		$pattern = $this->normalize($pattern);
 
-		$sql = 'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `encrypted`, `unencrypted_size`, `etag`, `permissions`
-				FROM `*PREFIX*filecache` WHERE `name` LIKE ? AND `storage` = ?';
-		$result = \OC_DB::executeAudited($sql, array($pattern, $this->getNumericStorageId()));
+
+		$sql = '
+			SELECT `fileid`, `storage`, `path`, `parent`, `name`,
+				`mimetype`, `mimepart`, `size`, `mtime`, `encrypted`,
+				`unencrypted_size`, `etag`, `permissions`
+			FROM `*PREFIX*filecache`
+			WHERE `storage` = ? AND ';
+		$dbtype = \OC_Config::getValue( 'dbtype', 'sqlite' );
+		if($dbtype === 'oci') {
+			//remove starting and ending % from the pattern
+			$pattern = '^'.str_replace('%', '.*', $pattern).'$';
+			$sql .= 'REGEXP_LIKE(`name`, ?, \'i\')';
+		} else if($dbtype === 'pgsql') {
+			$sql .= '`name` ILIKE ?';
+		} else {
+			$sql .= '`name` LIKE ?';
+		}
+		$result = \OC_DB::executeAudited($sql,
+			array($this->getNumericStorageId(), $pattern)
+		);
+
 		$files = array();
 		while ($row = $result->fetchRow()) {
 			$row['mimetype'] = $this->getMimetype($row['mimetype']);

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -239,6 +239,12 @@ class Cache extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, count($this->cache->search('folder%')));
 		$this->assertEquals(3, count($this->cache->search('%')));
 
+		// case insensitive search should match the same files
+		$this->assertEquals(2, count($this->cache->search('%Foo%')));
+		$this->assertEquals(1, count($this->cache->search('Foo')));
+		$this->assertEquals(1, count($this->cache->search('%Folder%')));
+		$this->assertEquals(1, count($this->cache->search('Folder%')));
+
 		$this->assertEquals(3, count($this->cache->searchByMime('foo')));
 		$this->assertEquals(2, count($this->cache->searchByMime('foo/file')));
 	}


### PR DESCRIPTION
was a cherry pick of https://github.com/owncloud/core/pull/8307 to master, forward port of https://github.com/owncloud/core/pull/8306

now switched to setting the the sort and compare session params when opening the connection.

cc @DeepDiver1975 @icewind1991 @PVince81 @karlitschek
