### PR TITLE
Adapt chosen (css) path

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -15,7 +15,7 @@ OC_Util::addStyle( 'settings', 'settings' );
 OC_Util::addScript( '3rdparty', 'strengthify/jquery.strengthify' );
 OC_Util::addStyle( '3rdparty', 'strengthify/strengthify' );
 OC_Util::addScript( '3rdparty', 'chosen/chosen.jquery.min' );
-OC_Util::addStyle( '3rdparty', 'chosen' );
+OC_Util::addStyle( '3rdparty', 'chosen/chosen' );
 \OC_Util::addScript('files', 'jquery.fileupload');
 if (\OC_Config::getValue('enable_avatars', true) === true) {
 	\OC_Util::addScript('3rdparty/Jcrop', 'jquery.Jcrop.min');


### PR DESCRIPTION
Avoid shipping duplicate files in 3rdparty/css.

3rdparty/css/chosen/ already contains chosen.css and chosen-sprite.png
so its useless to duplicate them in 3rdparty/css.

Taking the same approach as in apps/calendar/appinfo/app.php and
apps/files_external/settings.php.
