### PR TITLE
Backport of #8183 and #8197

### DIFF
--- a/lib/connector/sabre/file.php
+++ b/lib/connector/sabre/file.php
@@ -164,10 +164,11 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements Sabre_D
 	 */
 	public function getContentType() {
 		if (isset($this->fileinfo_cache['mimetype'])) {
-			return $this->fileinfo_cache['mimetype'];
+			$mimeType = $this->fileinfo_cache['mimetype'];
+		} else {
+			$mimeType = \OC\Files\Filesystem::getMimeType($this->path);
 		}
 
-		return \OC\Files\Filesystem::getMimeType($this->path);
-
+		return \OC_Helper::getSecureMimeType($mimeType);
 	}
 }

--- a/lib/json.php
+++ b/lib/json.php
@@ -104,8 +104,6 @@ class OC_JSON{
 	* Encode and print $data in json format
 	*/
 	public static function encodedPrint($data, $setContentType=true) {
-		// Disable mimesniffing, don't move this to setContentTypeHeader!
-		header( 'X-Content-Type-Options: nosniff' );
 		if($setContentType) {
 			self::setContentTypeHeader();
 		}

--- a/lib/mimetypes.list.php
+++ b/lib/mimetypes.list.php
@@ -1,101 +1,136 @@
 <?php
 /**
-* ownCloud
-*
-* @author Robin Appelman
-* @copyright 2011 Robin Appelman icewind1991@gmail.com
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
-
-/**
- * list of mimetypes by extension
+ * ownCloud
+ *
+ * @author Robin Appelman
+ * @copyright 2011 Robin Appelman icewind1991@gmail.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
+/**
+ * Array mapping file extensions to mimetypes (in alphabetical order).
+ *
+ * The first index in the mime type array is the assumed correct mimetype
+ * and the second is either a secure alternative or null if the correct
+ * is considered secure.
+ */
 return array(
-	'css'=>'text/css',
-	'flac'=>'audio/flac',
-	'gif'=>'image/gif',
-	'gzip'=>'application/x-gzip',
-	'gz'=>'application/x-gzip',
-	'html'=>'text/html',
-	'htm'=>'text/html',
-	'ics'=>'text/calendar',
-	'ical'=>'text/calendar',
-	'jpeg'=>'image/jpeg',
-	'jpg'=>'image/jpeg',
-	'js'=>'application/javascript',
-	'oga'=>'audio/ogg',
-	'ogg'=>'audio/ogg',
-	'ogv'=>'video/ogg',
-	'pdf'=>'application/pdf',
-	'png'=>'image/png',
-	'svg'=>'image/svg+xml',
-	'tar'=>'application/x-tar',
-	'tgz'=>'application/x-compressed',
-	'tar.gz'=>'application/x-compressed',
-	'tif'=>'image/tiff',
-	'tiff'=>'image/tiff',
-	'txt'=>'text/plain',
-	'zip'=>'application/zip',
-	'wav'=>'audio/wav',
-	'odt'=>'application/vnd.oasis.opendocument.text',
-	'ods'=>'application/vnd.oasis.opendocument.spreadsheet',
-	'odg'=>'application/vnd.oasis.opendocument.graphics',
-	'odp'=>'application/vnd.oasis.opendocument.presentation',
-	'pages'=>'application/x-iwork-pages-sffpages',
-	'numbers'=>'application/x-iwork-numbers-sffnumbers',
-	'keynote'=>'application/x-iwork-keynote-sffkey',
-	'kra'=>'application/x-krita',
-	'mp3'=>'audio/mpeg',
-	'doc'=>'application/msword',
-	'docx'=>'application/msword',
-	'xls'=>'application/msexcel',
-	'xlsx'=>'application/msexcel',
-	'php'=>'application/x-php',
-	'exe'=>'application/x-ms-dos-executable',
-	'msi' => 'application/x-msi',
-	'pl'=>'application/x-pearl',
-	'py'=>'application/x-python',
-	'blend'=>'application/x-blender',
-	'xcf'=>'application/x-gimp',
-	'psd'=>'application/x-photoshop',
-	'xml'=>'application/xml',
-	'avi'=>'video/x-msvideo',
-	'dv'=>'video/dv',
-	'm2t'=>'video/mp2t',
-	'mp4'=>'video/mp4',
-	'm4v'=>'video/mp4',
-	'mpg'=>'video/mpeg',
-	'mpeg'=>'video/mpeg',
-	'mov'=>'video/quicktime',
-	'webm'=>'video/webm',
-	'wmv'=>'video/x-ms-asf',
-	'py'=>'text/x-script.phyton',
-	'vcf' => 'text/vcard',
-	'vcard' => 'text/vcard',
-	'doc'=>'application/msword',
-	'docx'=>'application/msword',
-	'xls'=>'application/msexcel',
-	'xlsx'=>'application/msexcel',
-	'ppt'=>'application/mspowerpoint',
-	'pptx'=>'application/mspowerpoint',
-	'sgf' => 'application/sgf',
-	'cdr' => 'application/coreldraw',
-	'impress' => 'text/impress',
-	'ai' => 'application/illustrator',
-	'epub' => 'application/epub+zip',
-	'mobi' => 'application/x-mobipocket-ebook'
+	'7z' => array('application/x-7z-compressed', null),
+	'accdb' => array('application/msaccess', null),
+	'ai' => array('application/illustrator', null),
+	'avi' => array('video/x-msvideo', null),
+	'bash' => array('text/x-shellscript', null),
+	'blend' => array('application/x-blender', null),
+	'bin' => array('application/x-bin', null),
+	'bmp' => array('image/bmp', null),
+	'cb7' => array('application/x-cbr', null),
+	'cba' => array('application/x-cbr', null),
+	'cbr' => array('application/x-cbr', null),
+	'cbt' => array('application/x-cbr', null),
+	'cbtc' => array('application/x-cbr', null),
+	'cbz' => array('application/x-cbr', null),
+	'cc' => array('text/x-c', null),
+	'cdr' => array('application/coreldraw', null),
+	'cpp' => array('text/x-c++src', null),
+	'css' => array('text/css', null),
+	'csv' => array('text/csv', null),
+	'cvbdl' => array('application/x-cbr', null),
+	'c' => array('text/x-c', null),
+	'c++' => array('text/x-c++src', null),
+	'deb' => array('application/x-deb', null),
+	'doc' => array('application/msword', null),
+	'docx' => array('application/vnd.openxmlformats-officedocument.wordprocessingml.document', null),
+	'dot' => array('application/msword', null),
+	'dotx' => array('application/vnd.openxmlformats-officedocument.wordprocessingml.template', null),
+	'dv' => array('video/dv', null),
+	'eot' => array('application/vnd.ms-fontobject', null),
+	'epub' => array('application/epub+zip', null),
+	'exe' => array('application/x-ms-dos-executable', null),
+	'flac' => array('audio/flac', null),
+	'gif' => array('image/gif', null),
+	'gz' => array('application/x-gzip', null),
+	'gzip' => array('application/x-gzip', null),
+	'html' => array('text/html', 'text/plain'),
+	'htm' => array('text/html', 'text/plain'),
+	'ical' => array('text/calendar', null),
+	'ics' => array('text/calendar', null),
+	'impress' => array('text/impress', null),
+	'jpeg' => array('image/jpeg', null),
+	'jpg' => array('image/jpeg', null),
+	'js' => array('application/javascript', 'text/plain'),
+	'json' => array('application/json', 'text/plain'),
+	'keynote' => array('application/x-iwork-keynote-sffkey', null),
+	'kra' => array('application/x-krita', null),
+	'm2t' => array('video/mp2t', null),
+	'm4v' => array('video/mp4', null),
+	'markdown' => array('text/markdown', null),
+	'mdown' => array('text/markdown', null),
+	'md' => array('text/markdown', null),
+	'mdb' => array('application/msaccess', null),
+	'mdwn' => array('text/markdown', null),
+	'mkv' => array('video/x-matroska', null),
+	'mobi' => array('application/x-mobipocket-ebook', null),
+	'mov' => array('video/quicktime', null),
+	'mp3' => array('audio/mpeg', null),
+	'mp4' => array('video/mp4', null),
+	'mpeg' => array('video/mpeg', null),
+	'mpg' => array('video/mpeg', null),
+	'msi' => array('application/x-msi', null),
+	'numbers' => array('application/x-iwork-numbers-sffnumbers', null),
+	'odg' => array('application/vnd.oasis.opendocument.graphics', null),
+	'odp' => array('application/vnd.oasis.opendocument.presentation', null),
+	'ods' => array('application/vnd.oasis.opendocument.spreadsheet', null),
+	'odt' => array('application/vnd.oasis.opendocument.text', null),
+	'oga' => array('audio/ogg', null),
+	'ogg' => array('audio/ogg', null),
+	'ogv' => array('video/ogg', null),
+	'otf' => array('font/opentype', null),
+	'pages' => array('application/x-iwork-pages-sffpages', null),
+	'pdf' => array('application/pdf', null),
+	'php' => array('application/x-php', null),
+	'pl' => array('application/x-perl', null),
+	'png' => array('image/png', null),
+	'ppt' => array('application/mspowerpoint', null),
+	'pptx' => array('application/vnd.openxmlformats-officedocument.presentationml.presentation', null),
+	'psd' => array('application/x-photoshop', null),
+	'py' => array('text/x-python', null),
+	'rar' => array('application/x-rar-compressed', null),
+	'reveal' => array('text/reveal', null),
+	'sgf' => array('application/sgf', null),
+	'sh-lib' => array('text/x-shellscript', null),
+	'sh' => array('text/x-shellscript', null),
+	'svg' => array('image/svg+xml', 'text/plain'),
+	'swf' => array('application/x-shockwave-flash', 'application/octet-stream'),
+	'tar' => array('application/x-tar', null),
+	'tar.gz' => array('application/x-compressed', null),
+	'tex' => array('application/x-tex', null),
+	'tgz' => array('application/x-compressed', null),
+	'tiff' => array('image/tiff', null),
+	'tif' => array('image/tiff', null),
+	'ttf' => array('application/x-font-ttf', null),
+	'txt' => array('text/plain', null),
+	'vcard' => array('text/vcard', null),
+	'vcf' => array('text/vcard', null),
+	'wav' => array('audio/wav', null),
+	'webm' => array('video/webm', null),
+	'woff' => array('application/font-woff', null),
+	'wmv' => array('video/x-ms-asf', null),
+	'xcf' => array('application/x-gimp', null),
+	'xls' => array('application/msexcel', null),
+	'xlsx' => array('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', null),
+	'xml' => array('application/xml', 'text/plain'),
+	'zip' => array('application/zip', null),
 );

--- a/lib/template.php
+++ b/lib/template.php
@@ -185,28 +185,6 @@ class OC_Template{
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$this->l10n = OC_L10N::get($parts[0]);
 
-		// Some headers to enhance security
-		header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
-		header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-
-		// iFrame Restriction Policy
-		$xFramePolicy = OC_Config::getValue('xframe_restriction', true);
-		if($xFramePolicy) {
-			header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
-		}
-		
-		// Content Security Policy
-		// If you change the standard policy, please also change it in config.sample.php
-		$policy = OC_Config::getValue('custom_csp_policy',
-			'default-src \'self\'; '
-			.'script-src \'self\' \'unsafe-eval\'; '
-			.'style-src \'self\' \'unsafe-inline\'; '
-			.'frame-src *; '
-			.'img-src *; '
-			.'font-src \'self\' data:; '
-			.'media-src *');
-		header('Content-Security-Policy:'.$policy); // Standard
-
 		$this->findTemplate($name);
 	}
 


### PR DESCRIPTION
Tested with litmus and manually

To test:
- html files are delivered as `text/plain` over webdav
- `Content-Security-Policy` and other security headers are sent with webdav requests

cc @DeepDiver1975 @LukasReschke 
