### PR TITLE
Fix error when viewing expired link

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -374,6 +374,9 @@ class Filesystem {
 	 * Returns path like /admin/files
 	 */
 	static public function getRoot() {
+		if (!self::$defaultInstance) {
+			return null;
+		}
 		return self::$defaultInstance->getRoot();
 	}
 


### PR DESCRIPTION
Fixes #8243

To test:
- create a public link and set the expiry date
- move the expiry date to the past by editing the entry in the database.
- try to view the now expired public link 

@autrui can check if this solves the problem for you?

cc @DeepDiver1975 @karlitschek 
