### PR TITLE
Preventing access to the config folder

### DIFF
--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,0 +1,12 @@
+# line below if for Apache 2.4
+<ifModule mod_authz_core>
+Require all denied
+</ifModule>
+
+# line below if for Apache 2.2
+<ifModule !mod_authz_core>
+deny from all
+</ifModule>
+
+# section for Apache 2.2 and 2.4
+IndexIgnore *


### PR DESCRIPTION
It isn't uncommon that admins create a backup file of the config (i.e. `config.php.bak`) before performing any changes. This would allow everybody to read the backup of the configuration file which contain several secret and critical values.

I don't believe this is worth a backport or getting added to the installer. It's just a nice to have. People that create public readable backups of their configuration are the one to blame, not us :-)

\ccing @dragotin since he brought this to my attention on Jan. 28
