### PR TITLE
[sharing] allow admin to set default expire date

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -844,9 +844,20 @@ class Share extends \OC\Share\Constants {
 	 * @return bool True if item was expired, false otherwise.
 	 */
 	protected static function expireItem(array $item) {
+
+		// get default expire settings
+		$defaultSettings = Helper::getDefaultExpireSetting();
+		// calculate expire date
 		if (!empty($item['expiration'])) {
-			$now = new \DateTime();
-			$expires = new \DateTime($item['expiration']);
+			$userDefinedExpire = new \DateTime($item['expiration']);
+			$userDefinedExpireTimestamp = $userDefinedExpire->getTimestamp();
+		} else {
+			$userDefinedExpireTimestamp = null;
+		}
+		$expires = Helper::calculateExpireDate($defaultSettings, $item['stime'], $userDefinedExpireTimestamp);
+
+		if (is_int($expires)) {
+			$now = time();
 			if ($now > $expires) {
 				self::unshareItem($item);
 				return true;

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -45,6 +45,10 @@ $tmpl->assign('backgroundjobs_mode', OC_Appconfig::getValue('core', 'backgroundj
 $tmpl->assign('cron_log', OC_Config::getValue('cron_log', true));
 $tmpl->assign('lastcron', OC_Appconfig::getValue('core', 'lastcron', false));
 $tmpl->assign('shareAPIEnabled', OC_Appconfig::getValue('core', 'shareapi_enabled', 'yes'));
+$tmpl->assign('shareDefaultExpireDateSet', OC_Appconfig::getValue('core', 'shareapi_default_expire_date', 'no'));
+$tmpl->assign('shareExpireAfterNDays', OC_Appconfig::getValue('core', 'shareapi_expire_after_n_days', '7'));
+$tmpl->assign('shareEnforceExpireDate', OC_Appconfig::getValue('core', 'shareapi_enforce_expire_date', 'no'));
+
 
 // Check if connected using HTTPS
 if (OC_Request::serverProtocol() === 'https') {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -132,6 +132,7 @@ table.grid td.date{
 span.securitywarning {color:#C33; font-weight:bold; }
 span.connectionwarning {color:#933; font-weight:bold; }
 table.shareAPI td { padding-bottom: 0.8em; }
+table.shareAPI input#shareapi_expire_after_n_days {width: 25px;}
 
 #mail_settings p label:first-child {
 	display: inline-block;

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -254,6 +254,23 @@ if (!$_['internetconnectionworking']) {
 				<em><?php p($l->t('Allow users to send mail notification for shared files')); ?></em>
 			</td>
 		</tr>
+
+		<tr>
+			<td <?php if ($_['shareAPIEnabled'] == 'no') print_unescaped('class="hidden"');?>>
+				<input type="checkbox" name="shareapi_default_expire_date" id="shareapi_default_expire_date"
+				       value="1" <?php if ($_['shareDefaultExpireDateSet'] == 'yes') print_unescaped('checked="checked"'); ?> />
+				<label for="shareapi_default_expire_date"><?php p($l->t('Set default expire date'));?></label><br/>
+				<?php p($l->t( 'Expire after ' )); ?>
+				<input type="text" name='shareapi_expire_after_n_days' id="shareapi_expire_after_n_days" placeholder="<?php p('7')?>"
+					   value='<?php p($_['shareExpireAfterNDays']) ?>' />
+				<?php p($l->t( 'days' )); ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapi_enforce_expire_date"
+				       value="1" <?php if ($_['shareEnforceExpireDate'] == 'yes') print_unescaped('checked="checked"'); ?> />
+				<label for="shareapi_enforce_expire_date"><?php p($l->t('Enforce expire date'));?></label><br/>
+				<em><?php p($l->t('Expire shares by default after N days')); ?></em>
+			</td>
+		</tr>
+
 	</table>
 </div>
 
@@ -296,7 +313,7 @@ if (!$_['internetconnectionworking']) {
 	<p><?php p($l->t('This is used for sending out notifications.')); ?></p>
 
 	<p>
-		<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label> 
+		<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label>
 		<select name='mail_smtpmode' id='mail_smtpmode'>
 			<?php foreach ($mail_smtpmode as $smtpmode):
 				$selected = '';

--- a/tests/lib/share/helper.php
+++ b/tests/lib/share/helper.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* ownCloud
+*
+* @author Bjoern Schiessle
+* @copyright 2014 Bjoern Schiessle <schiessle@owncloud.com>
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+class Test_Share_Helper extends PHPUnit_Framework_TestCase {
+
+	public function expireDateProvider() {
+		return array(
+			// no default expire date, we take the users expire date
+			array(array('defaultExpireDateSet' => false), 2000000000, 2000010000, 2000010000),
+			// no default expire date and no user defined expire date, return false
+			array(array('defaultExpireDateSet' => false), 2000000000, null, false),
+			// unenforced expire data and no user defined expire date, take default expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => false), 2000000000, null, 2000086400),
+			// enforced expire date and no user defined expire date, take default expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => true), 2000000000, null, 2000086400),
+			// unenforced expire date and user defined date > default expire date, take users expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => false), 2000000000, 2000100000, 2000100000),
+			// unenforced expire date and user expire date < default expire date, take users expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => false), 2000000000, 2000010000, 2000010000),
+			// enforced expire date and user expire date < default expire date, take users expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => true), 2000000000, 2000010000, 2000010000),
+			// enforced expire date and users expire date > default expire date, take default expire date
+			array(array('defaultExpireDateSet' => true, 'expireAfterDays' => 1, 'enforceExpireDate' => true), 2000000000, 2000100000, 2000086400),
+		);
+	}
+
+	/**
+	 * @dataProvider expireDateProvider
+	 */
+	public function testCalculateExpireDate($defaultExpireSettings, $creationTime, $userExpireDate, $expected) {
+		$result = \OC\Share\Helper::calculateExpireDate($defaultExpireSettings, $creationTime, $userExpireDate);
+		$this->assertSame($expected, $result);
+	}
+
+
+}


### PR DESCRIPTION
Allow admin to set default expire date. Default expire date will be defined as "days after the item was shared".

 Options:
- set default expire date, will be used if no user defined expire date exists
- set default expire date and enforce it, use defined date if it is smaller than the default date, otherwise use the default expire date

cc @jancborchardt can you have a look at the additional admin settings. 

At the moment I don't show the default expire date in the share drop-down. The problem, the share dialog can only set one expire date for all shares of one file while the default expire date is always n days after a specific share was created. Maybe you have a idea how to visualize this settings for the user?
