### PR TITLE
Make PHPUnit_Framework_TestListener implementations compatible to 4.0.

### DIFF
--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -20,6 +20,9 @@ class StartSessionListener implements PHPUnit_Framework_TestListener {
 	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
 	}
 
+	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	}
+
 	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
 	}
 

--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -25,6 +25,9 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
     }
 
+	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	}
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
     }
 

--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -16,31 +16,31 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 		$this->verbosity = $verbosity;
 	}
 
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {
-    }
+	public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	}
 
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {
-    }
+	public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {
+	}
 
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
-    }
+	public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	}
 
 	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
 	}
 
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
-    }
+	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+	}
 
-    public function startTest(PHPUnit_Framework_Test $test) {
-    }
+	public function startTest(PHPUnit_Framework_Test $test) {
+	}
 
-    public function endTest(PHPUnit_Framework_Test $test, $time) {
-    }
+	public function endTest(PHPUnit_Framework_Test $test, $time) {
+	}
 
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
-    }
+	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
+	}
 
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
 		if ($this->cleanStrayDataFiles() && $this->isShowSuiteWarning()) {
 			printf("TestSuite '%s': Did not clean up data dir\n", $suite->getName());
 		}
@@ -50,7 +50,7 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 		if ($this->cleanProxies() && $this->isShowSuiteWarning()) {
 			printf("TestSuite '%s': Did not clean up proxies\n", $suite->getName());
 		}
-    }
+	}
 
 	private function isShowSuiteWarning() {
 		return $this->verbosity === 'suite' || $this->verbosity === 'detail';
@@ -143,4 +143,3 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 		return count($proxies) > 0;
 	}
 }
-?>


### PR DESCRIPTION
@DeepDiver1975 @schiesbn @icewind1991 et al.

Fixes

```
PHP Fatal error:  Class StartSessionListener contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (PHPUnit_Framework_TestListener::addRiskyTest) in /home/www-data/projects/owncloud/core/tests/startsessionlistener.php on line 44
```

http://phpunit.de/manual/4.0/en/extending-phpunit.html
