### PR TITLE
Add another example to the trusted_domains config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -54,7 +54,7 @@ $CONFIG = array(
 "proxyuserpwd" => "",
 
 /* List of trusted domains, to prevent host header poisoning ownCloud is only using these Host headers */
-'trusted_domains' => array('demo.owncloud.org'),
+'trusted_domains' => array('demo.owncloud.org', 'otherdomain.owncloud.org'),
 
 /* Theme to use for ownCloud */
 "theme" => "",


### PR DESCRIPTION
Users often ask in IRC or the forum how to add another domain to the configuration.
Hopefully they will be able to find it out on their own if we have an example with two domains.
