### PR TITLE
fix shouldEncrypt() method and improved decryptAll() unit tests

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -53,10 +53,11 @@ class Proxy extends \OC_FileProxy {
 	private static function shouldEncrypt($path, $mode = 'w') {
 
 		$userId = Helper::getUser($path);
+		$session = new Session(new \OC\Files\View());
 
 		// don't call the crypt stream wrapper, if...
 		if (
-				\OCP\App::isEnabled('files_encryption') === false // encryption is disabled
+				$session->getInitialized() !== Session::INIT_SUCCESSFUL // encryption successful initialized
 				|| Crypt::mode() !== 'server'   // we are not in server-side-encryption mode
 				|| strpos($path, '/' . $userId . '/files') !== 0 // path is not in files/
 				|| substr($path, 0, 8) === 'crypt://' // we are already in crypt mode

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -349,10 +349,12 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->view->unlink($this->userId . '/files/' . $filename);
 	}
 
-
 	function testDecryptAll() {
 
 		$filename = "/decryptAll" . uniqid() . ".txt";
+		$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data/');
+		$userdir = $datadir . '/' . $this->userId . '/files/';
+
 		$util = new Encryption\Util($this->view, $this->userId);
 
 		$this->view->file_put_contents($this->userId . '/files/' . $filename, $this->dataShort);
@@ -362,13 +364,47 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($fileInfoEncrypted instanceof \OC\Files\FileInfo);
 		$this->assertEquals($fileInfoEncrypted['encrypted'], 1);
 
-		// decrypt all encrypted files
-		$result = $util->decryptAll('/' . $this->userId . '/' . 'files');
+		$encContent = file_get_contents($userdir . $filename);
 
-		$this->assertTrue($result);
+		\OC_App::disable('files_encryption');
+
+		$user = \OCP\User::getUser();
+		$this->logoutHelper();
+		$this->loginHelper($user, false, false, false);
+
+		$content = file_get_contents($userdir . $filename);
+
+		//content should be encrypted
+		$this->assertSame($encContent, $content);
+
+		// now we load the encryption app again
+		OC_App::loadApp('files_encryption');
+
+		// init encryption app
+		$params = array('uid' => \OCP\User::getUser(),
+			'password' => \OCP\User::getUser());
+
+		$view = new OC_FilesystemView('/');
+		$util = new \OCA\Encryption\Util($view, \OCP\User::getUser());
+
+		$result = $util->initEncryption($params);
+
+		$this->assertTrue($result instanceof \OCA\Encryption\Session);
+
+		$successful = $util->decryptAll();
+
+		$this->assertTrue($successful);
+
+		$this->logoutHelper();
+		$this->loginHelper($user, false, false, false);
+
+		// file should be unencrypted and fileInfo should contain the correct values
+		$content = file_get_contents($userdir . $filename);
+
+		// now we should get the plain data
+		$this->assertSame($this->dataShort, $content);
 
 		$fileInfoUnencrypted = $this->view->getFileInfo($this->userId . '/files/' . $filename);
-
 		$this->assertTrue($fileInfoUnencrypted instanceof \OC\Files\FileInfo);
 
 		// check if mtime and etags unchanged
@@ -377,9 +413,12 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		// file should no longer be encrypted
 		$this->assertEquals(0, $fileInfoUnencrypted['encrypted']);
 
+		// cleanup
 		$this->view->unlink($this->userId . '/files/' . $filename);
+		OC_App::enable('files_encryption');
 
 	}
+
 
 	function testDescryptAllWithBrokenFiles() {
 
@@ -508,7 +547,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	 * @param bool $create
 	 * @param bool $password
 	 */
-	public static function loginHelper($user, $create = false, $password = false) {
+	public static function loginHelper($user, $create = false, $password = false, $loadEncryption = true) {
 		if ($create) {
 			try {
 				\OC_User::createUser($user, $user);
@@ -527,9 +566,11 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
 
-		$params['uid'] = $user;
-		$params['password'] = $password;
-		OCA\Encryption\Hooks::login($params);
+		if ($loadEncryption) {
+			$params['uid'] = $user;
+			$params['password'] = $password;
+			OCA\Encryption\Hooks::login($params);
+		}
 	}
 
 	public static function logoutHelper() {


### PR DESCRIPTION
fix shouldEncrypt() method and improve decryptAll() unit tests. 

\OCP\App::isEnabled() will return false if the app is not enabled, even if it was loaded temporarily, e.g. for the decryptAll() method. Now we will just check if the encryption session was initialized successfully.

This is only a regression in master, releases are not affected.
