### PR TITLE
make encryption stream wrapper seekable

### DIFF
--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -161,10 +161,15 @@ class Stream {
 			$this->size = $this->rootView->filesize($this->rawPath);
 
 			// calculate unencrypted size
-			// the next block is a hack that only works on seekable encrypted streams
-			// it should be replace by something that works on all streams
-			fseek($this->handle,floor($this->size/8192)*8192,SEEK_SET);
-			$data=fread($this->handle,8192);
+			if (fseek($this->handle,floor($this->size/8192)*8192,SEEK_SET) === 0) {
+				$data=fread($this->handle,8192);
+			} else {
+				$count=8192;
+				while ($count==8192) {
+					$data=fread($this->handle,8192);
+					$count=strlen($data);
+				}
+			}
 			$result='';
 			if(strlen($data)) {
 				if (!$this->getKey()) {

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -178,8 +178,16 @@ class Stream {
 					$result = Crypt::symmetricDecryptFileContent($data, $this->plainKey);
 				}
 			}
-			rewind($this->handle);
 			$this->unencryptedSize = floor($this->size/8192)*6126 + strlen($result);
+			if (rewind($this->handle) === false) {
+				fclose($this->handle);
+				if ($this->isLocalTmpFile) {
+					$this->handle = fopen($this->localTmpFile, $mode);
+				} else {
+					$this->handle = $this->rootView->fopen($this->rawPath, $mode);
+				}
+				
+			}
 
 		}
 

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -501,27 +501,14 @@ class Util {
 			$stream = fopen('crypt://' . $path, "r");
 
 			if (is_resource($stream)) {
-				// calculate last chunk position
-				$lastChunckPos = ($lastChunkNr * 8192);
+				// calculate last chunk position in the unencrypted stream
+				$lastChunckPos = ($lastChunkNr * 6126);
 
 				// seek to end
-				if (@fseek($stream, $lastChunckPos) === -1) {
-					// storage doesn't support fseek, we need a local copy
-					fclose($stream);
-					$localFile = $this->view->getLocalFile($path);
-					Helper::addTmpFileToMapper($localFile, $path);
-					$stream = fopen('crypt://' . $localFile, "r");
-					if (fseek($stream, $lastChunckPos) === -1) {
-						// if fseek also fails on the local storage, than
-						// there is nothing we can do
-						fclose($stream);
-						\OCP\Util::writeLog('Encryption library', 'couldn\'t determine size of "' . $path, \OCP\Util::ERROR);
-						return $result;
-					}
-				}
+				fseek($stream, $lastChunckPos)
 
-				// get the content of the last chunk
-				$lastChunkContent = fread($stream, $lastChunkSize);
+				// get the content of the last chunk (it won't read past the end, which is never more than 6126 away)
+				$lastChunkContent = fread($stream,6126);
 
 				// calc the real file size with the size of the last chunk
 				$realSize = (($lastChunkNr * 6126) + strlen($lastChunkContent));


### PR DESCRIPTION
I refactored the encryption stream wrapper to make it seekable. This is necessary to handle http range requests efficiently. With the old code the Sabre webdav server would set the beginning of the range by applying fseek on the unencrypted stream, which resulted in the pointer of the encrypted streem set in the middle of a block and subsequently an error in decrypting the subsequent part of the stream. After making the stream seekable (with fseek applying on the unencrypted rather than the encrypted string) the dav server can much more efficiently handle http get operations on parts of large files.

The general concept is to add a position variable as a pointer for the unencrypted stream. This pointer can be moved around. To read from the stream the current block is stored in cache. Writing is also done on the cache. If necessary, read and write spill over in the next block(s). When moving to another block the cash is always flushed (with a writeflag determining if write is necessary).

The getFileSize function is updated along (making use of the seekable nature of the stream).
