### PR TITLE
Preserve keys when sorting parameters when generatings urls

### DIFF
--- a/lib/private/route/cachingrouter.php
+++ b/lib/private/route/cachingrouter.php
@@ -31,7 +31,7 @@ class CachingRouter extends Router {
 	 * @return string
 	 */
 	public function generate($name, $parameters = array(), $absolute = false) {
-		sort($parameters);
+		asort($parameters);
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . $name . json_encode($parameters) . intval($absolute);
 		if ($this->cache->hasKey($key)) {
 			return $this->cache->get($key);


### PR DESCRIPTION
Otherwise invalid urls will be generated.

~~This fixes #8375 for me but I'm not sure if this is the only issue.~~
After some more testing I still have that issue, PR is still valid though

cc @tanghus @schiesbn @LukasReschke 
