### PR TITLE
fix oc dialog because the body isn't 100% x 100% in dimensions anymore

### DIFF
--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -24,11 +24,12 @@
 }
 .oc-dialog-buttonrow {
 	background: white;
-	position: absolute;
-	bottom: 15px;
-	right: 15px;
+	float: right;
+	position: relative;
+	bottom: 0;
 	display: block;
 	margin-top: 10px;
+	width: 100%;
 }
 
 .oc-dialog-close {

--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -24,12 +24,11 @@
 }
 .oc-dialog-buttonrow {
 	background: white;
-	float: right;
-	position: relative;
-	bottom: 0;
+	position: absolute;
+	bottom: 15px;
+	right: 15px;
 	display: block;
 	margin-top: 10px;
-	width: 100%;
 }
 
 .oc-dialog-close {

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -160,10 +160,16 @@
 			}
 			this.parent = this.$dialog.parent().length > 0 ? this.$dialog.parent() : $('body');
 			content_height = Math.min(content_height, this.parent.height()-20);
-			this.element.css({
-				height: content_height + 'px',
-				width: this.$dialog.innerWidth()-20 + 'px'
-			});
+			if (content_height> 0) {
+				this.element.css({
+					height: content_height + 'px',
+					width: this.$dialog.innerWidth()-20 + 'px'
+				});
+			} else {
+				this.element.css({
+					width : this.$dialog.innerWidth() - 20 + 'px'
+				});
+			}
 		},
 		_createOverlay: function() {
 			if(!this.options.modal) {

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -67,8 +67,8 @@
 				self.parent = self.$dialog.parent().length > 0 ? self.$dialog.parent() : $('body');
 				var pos = self.parent.position();
 				self.$dialog.css({
-					left: pos.left + (self.parent.width() - self.$dialog.outerWidth())/2,
-					top: pos.top + (self.parent.height() - self.$dialog.outerHeight())/2
+					left: pos.left + (window.innerWidth - self.$dialog.outerWidth())/2,
+					top: pos.top + (window.innerHeight - self.$dialog.outerHeight())/2
 				});
 			});
 

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -67,8 +67,8 @@
 				self.parent = self.$dialog.parent().length > 0 ? self.$dialog.parent() : $('body');
 				var pos = self.parent.position();
 				self.$dialog.css({
-					left: pos.left + (window.innerWidth - self.$dialog.outerWidth())/2,
-					top: pos.top + (window.innerHeight - self.$dialog.outerHeight())/2
+					left: pos.left + ($(window).innerWidth() - self.$dialog.outerWidth())/2,
+					top: pos.top + ($(window).innerHeight() - self.$dialog.outerHeight())/2
 				});
 			});
 


### PR DESCRIPTION
Seems to be caused by a CSS change where the body get the width and height (100%) property removed.

cc @jancborchardt 

Tested with Chrom, Firefox and IE8 (9-11 are downloading). For IE8 the innerWidth/height doesn't work and the popup therefore is placed on the top left corner but is fully usable. I don't want to but further code into this to support IE8. Opinions? @DeepDiver1975 @karlitschek @PVince81 ?
