### PR TITLE
Fixed too generic checkbox and link selectors

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -92,8 +92,8 @@ window.FileList = {
 			FileList.breadcrumb.resize(width, false);
 		});
 
-		this.$fileList.on('click','td.filename a', _.bind(this._onClickFile, this));
-		this.$fileList.on('change', 'td.filename input:checkbox', _.bind(this._onClickFileCheckbox, this));
+		this.$fileList.on('click','td.filename>a.name', _.bind(this._onClickFile, this));
+		this.$fileList.on('change', 'td.filename>input:checkbox', _.bind(this._onClickFileCheckbox, this));
 		this.$el.find('#select_all').click(_.bind(this._onClickSelectAll, this));
 		this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
 		this.$el.find('.delete-selected').click(_.bind(this._onClickDeleteSelected, this));
@@ -107,7 +107,7 @@ window.FileList = {
 	 * @param state true to select, false to deselect
 	 */
 	_selectFileEl: function($tr, state) {
-		var $checkbox = $tr.find('input:checkbox');
+		var $checkbox = $tr.find('td.filename>input:checkbox');
 		var oldData = !!this._selectedFiles[$tr.data('id')];
 		var data;
 		$checkbox.prop('checked', state);
@@ -156,7 +156,7 @@ window.FileList = {
 			else {
 				this._lastChecked = $tr;
 			}
-			var $checkbox = $tr.find('input:checkbox');
+			var $checkbox = $tr.find('td.filename>input:checkbox');
 			this._selectFileEl($tr, !$checkbox.prop('checked'));
 			this.updateSelectionSummary();
 		} else {
@@ -191,7 +191,7 @@ window.FileList = {
 	 */
 	_onClickSelectAll: function(e) {
 		var checked = $(e.target).prop('checked');
-		this.$fileList.find('td.filename input:checkbox').prop('checked', checked)
+		this.$fileList.find('td.filename>input:checkbox').prop('checked', checked)
 			.closest('tr').toggleClass('selected', checked);
 		this._selectedFiles = {};
 		this._selectionSummary.clear();


### PR DESCRIPTION
It turns out that the sharing dropdown is embedded into the table row
for some reason.

This fix makes use of a more specific selector for the checkboxes and
file name links to make sure it doesn't spill into any other potential
elements like the sharing dialog.

CC @DeepDiver1975 as discussed
Please review @schiesbn @jancborchardt @MorrisJobke 

Before the fix: the checkboxes from the sharing dropdown cause the whole file to be selected
After the fix: correct isolation between file list checkbox and share dropdown checkbox
