### PR TITLE
Show spinner for all files when deleting all

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1087,6 +1087,8 @@ window.FileList = {
 		else {
 			// no files passed, delete all in current dir
 			params.allfiles = true;
+			// show spinner for all files
+			this.$fileList.find('tr>td.date .action.delete').removeClass('delete-icon').addClass('progress-icon');
 		}
 
 		$.post(OC.filePath('files', 'ajax', 'delete.php'),
@@ -1106,6 +1108,7 @@ window.FileList = {
 								FileList.fileSummary.remove({type: fileEl.attr('data-type'), size: fileEl.attr('data-size')});
 							});
 						}
+						// TODO: this info should be returned by the ajax call!
 						checkTrashStatus();
 						FileList.updateEmptyContent();
 						FileList.fileSummary.update();

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -413,6 +413,20 @@ describe('FileList tests', function() {
 
 			expect(notificationStub.notCalled).toEqual(true);
 		});
+		it('shows spinner on files to be deleted', function() {
+			FileList.setFiles(testFiles);
+			doDelete();
+
+			expect(FileList.findFileEl('One.txt').find('.progress-icon:not(.delete-icon)').length).toEqual(1);
+			expect(FileList.findFileEl('Three.pdf').find('.delete-icon:not(.progress-icon)').length).toEqual(1);
+		});
+		it('shows spinner on all files when deleting all', function() {
+			FileList.setFiles(testFiles);
+
+			FileList.do_delete();
+
+			expect(FileList.$fileList.find('tr .progress-icon:not(.delete-icon)').length).toEqual(4);
+		});
 		it('updates summary when deleting last file', function() {
 			FileList.setFiles([testFiles[0], testFiles[1]]);
 			doDelete();


### PR DESCRIPTION
Regression introduced by code changes related to "select all" feature.

To test:
1. Open folder containing many files
2. Click "select all" checkbox
3. Delete: spinner appears for all files
4. Go to trashbin
5. Click "select all" checkbox.
6. Delete: spinner appears for all files

Please review @schiesbn @jancborchardt @MorrisJobke 
