### PR TITLE
[sharing] return the new name if a mount point was renamed

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -85,7 +85,8 @@ class Shared_Cache extends Cache {
 	 */
 	public function get($file) {
 		if (is_string($file)) {
-			if ($cache = $this->getSourceCache($file)) {
+			$cache = $this->getSourceCache($file);
+			if ($cache) {
 				$data = $cache->get($this->files[$file]);
 				$data['displayname_owner'] = \OC_User::getDisplayName($this->storage->getSharedFrom());
 				$data['path'] = $file;
@@ -96,16 +97,17 @@ class Shared_Cache extends Cache {
 				return $data;
 			}
 		} else {
+			$sourceId = $file;
 			// if we are at the root of the mount point we want to return the
 			// cache information for the source item
-			if (!is_int($file) || $file === 0) {
-				$file = $this->storage->getSourceId();
+			if (!is_int($sourceId) || $sourceId === 0) {
+				$sourceId = $this->storage->getSourceId();
 			}
 			$query = \OC_DB::prepare(
 				'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`,'
 				. ' `size`, `mtime`, `encrypted`, `unencrypted_size`, `storage_mtime`, `etag`'
 				. ' FROM `*PREFIX*filecache` WHERE `fileid` = ?');
-			$result = $query->execute(array($file));
+			$result = $query->execute(array($sourceId));
 			$data = $result->fetchRow();
 			$data['fileid'] = (int)$data['fileid'];
 			$data['mtime'] = (int)$data['mtime'];
@@ -124,6 +126,7 @@ class Shared_Cache extends Cache {
 			}
 			if (!is_int($file) || $file === 0) {
 				$data['path'] = '';
+				$data['name'] = basename($this->storage->getMountPoint());
 				$data['is_share_mount_point'] = true;
 			}
 			return $data;


### PR DESCRIPTION
we should update the "name" of the file/folder to reflect the current mount point. Otherwise the filename will always fall back to the owners filename if a user renames a shared file/folder.

Steps to test:
- user1 shares a folder "folder" with user2
- user2 renames "folder" to "folder2"
- without this pr: after the rename was finished successfully the name in the web interface will still be "folder" until you reload the page
- with this pr: you will see the new name immediately

cc @icewind1991 please also have a look because this touches the file cache behavior.  
