### PR TITLE
[sharing] move the mount point up if the parent folder no longer exists

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -9,6 +9,7 @@ OC::$CLASSPATH['OC\Files\Cache\Shared_Updater'] = 'files_sharing/lib/updater.php
 OC::$CLASSPATH['OC\Files\Cache\Shared_Watcher'] = 'files_sharing/lib/watcher.php';
 OC::$CLASSPATH['OCA\Files\Share\Api'] = 'files_sharing/lib/api.php';
 OC::$CLASSPATH['OCA\Files\Share\Maintainer'] = 'files_sharing/lib/maintainer.php';
+OC::$CLASSPATH['OCA\Files\Share\Proxy'] = 'files_sharing/lib/proxy.php';
 OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
@@ -18,3 +19,5 @@ OCP\Util::addScript('files_sharing', 'share');
 \OC_Hook::connect('OC_Filesystem', 'delete', '\OC\Files\Cache\Shared_Updater', 'deleteHook');
 \OC_Hook::connect('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Shared_Updater', 'renameHook');
 \OC_Hook::connect('OC_Appconfig', 'post_set_value', '\OCA\Files\Share\Maintainer', 'configChangeHook');
+
+OC_FileProxy::register(new OCA\Files\Share\Proxy());

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -180,4 +180,26 @@ class Helper {
 
 		return $relPath;
 	}
+
+	/**
+	 * check if file name already exists and generate unique target
+	 *
+	 * @param string $path
+	 * @param array $excludeList
+	 * @param \OC\Files\View $view
+	 * @return string $path
+	 */
+	public static function generateUniqueTarget($path, $excludeList, $view) {
+		$pathinfo = pathinfo($path);
+		$ext = (isset($pathinfo['extension'])) ? '.'.$pathinfo['extension'] : '';
+		$name = $pathinfo['filename'];
+		$dir = $pathinfo['dirname'];
+		$i = 2;
+		while ($view->file_exists($path) || in_array($path, $excludeList)) {
+			$path = \OC\Files\Filesystem::normalizePath($dir . '/' . $name . ' ('.$i.')' . $ext);
+			$i++;
+		}
+
+		return $path;
+	}
 }

--- a/apps/files_sharing/lib/proxy.php
+++ b/apps/files_sharing/lib/proxy.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Bjoern Schiessle
+ * @copyright 2014 Bjoern Schiessle <schiessle@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files\Share;
+
+class Proxy extends \OC_FileProxy {
+
+	/**
+	 * check if the deleted folder contains share mount points and move them
+	 * up to the parent
+	 *
+	 * @param string $path
+	 */
+	public function preUnlink($path) {
+		$this->moveMountPointsUp($path);
+	}
+
+	/**
+	 * check if the deleted folder contains share mount points and move them
+	 * up to the parent
+	 *
+	 * @param string $path
+	 */
+	public function preRmdir($path) {
+		$this->moveMountPointsUp($path);
+	}
+
+	/**
+	 * move share mount points up to the parent
+	 *
+	 * @param string $path
+	 */
+	private function moveMountPointsUp($path) {
+		$view = new \OC\Files\View('/');
+
+		// find share mount points within $path and move them up to the parent folder
+		// before we delete $path
+		$mountManager = \OC\Files\Filesystem::getMountManager();
+		$mountedShares = $mountManager->findIn($path);
+		foreach ($mountedShares as $mount) {
+			if ($mount->getStorage() instanceof \OC\Files\Storage\Shared) {
+				$mountPoint = $mount->getMountPoint();
+				$mountPointName = $mount->getMountPointName();
+				$target = \OCA\Files_Sharing\Helper::generateUniqueTarget(dirname($path) . '/' . $mountPointName, array(), $view);
+				$view->rename($mountPoint, $target);
+			}
+		}
+	}
+
+}

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -75,16 +75,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 			$excludeList = array_merge($excludeList, $exclude);
 		}
 
-		$pathinfo = pathinfo($target);
-		$ext = (isset($pathinfo['extension'])) ? '.'.$pathinfo['extension'] : '';
-		$name = $pathinfo['filename'];
-		$i = 2;
-		while ($view->file_exists($target) || in_array($target, $excludeList)) {
-			$target = '/' . $name . ' ('.$i.')' . $ext;
-			$i++;
-		}
-
-		return $target;
+		return \OCA\Files_Sharing\Helper::generateUniqueTarget($target, $excludeList, $view);
 	}
 
 	public function formatItems($items, $format, $parameters = null) {

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -115,11 +115,14 @@ class Shared_Updater {
 	 * @param array $params
 	 */
 	static public function deleteHook($params) {
-		self::correctFolders($params['path']);
-		$fileInfo = \OC\Files\Filesystem::getFileInfo($params['path']);
+		$path = $params['path'];
+		self::correctFolders($path);
+
+		$fileInfo = \OC\Files\Filesystem::getFileInfo($path);
+
 		// mark file as deleted so that we can clean up the share table if
 		// the file was deleted successfully
-		self::$toRemove[$params['path']] =  $fileInfo['fileid'];
+		self::$toRemove[$path] =  $fileInfo['fileid'];
 	}
 
 	/**

--- a/apps/files_sharing/tests/proxy.php
+++ b/apps/files_sharing/tests/proxy.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Bjoern Schiessle
+ * @copyright 2014 Bjoern Schiessle <schiessle@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require_once __DIR__ . '/base.php';
+
+use OCA\Files\Share;
+
+/**
+ * Class Test_Files_Sharing_Api
+ */
+class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
+
+	const TEST_FOLDER_NAME = '/folder_share_api_test';
+
+	private static $tempStorage;
+
+	function setUp() {
+		parent::setUp();
+
+		// load proxies
+		OC::$CLASSPATH['OCA\Files\Share\Proxy'] = 'files_sharing/lib/proxy.php';
+		OC_FileProxy::register(new OCA\Files\Share\Proxy());
+
+		$this->folder = self::TEST_FOLDER_NAME;
+		$this->subfolder  = '/subfolder_share_api_test';
+		$this->subsubfolder = '/subsubfolder_share_api_test';
+
+		$this->filename = '/share-api-test';
+
+		// save file with content
+		$this->view->file_put_contents($this->filename, $this->data);
+		$this->view->mkdir($this->folder);
+		$this->view->mkdir($this->folder . $this->subfolder);
+		$this->view->mkdir($this->folder . $this->subfolder . $this->subsubfolder);
+		$this->view->file_put_contents($this->folder.$this->filename, $this->data);
+		$this->view->file_put_contents($this->folder . $this->subfolder . $this->filename, $this->data);
+	}
+
+	function tearDown() {
+		$this->view->unlink($this->filename);
+		$this->view->deleteAll($this->folder);
+
+		self::$tempStorage = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @medium
+	 */
+	function testpreUnlink() {
+
+		$fileInfo1 = \OC\Files\Filesystem::getFileInfo($this->filename);
+		$fileInfo2 = \OC\Files\Filesystem::getFileInfo($this->folder);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo1->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->assertTrue($result);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// move shared folder to 'localDir' and rename it, so that it uses the same
+		// name as the shared file
+		\OC\Files\Filesystem::mkdir('localDir');
+		$result = \OC\Files\Filesystem::rename($this->folder, '/localDir/' . $this->filename);
+		$this->assertTrue($result);
+
+		\OC\Files\Filesystem::unlink('localDir');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// after we deleted 'localDir' the share should be moved up to the root and be
+		// renamed to "filename (2)"
+		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename . ' (2)' ));
+	}
+}

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -49,6 +49,48 @@ class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
 	/**
 	 * @medium
 	 */
+	function testDeleteParentOfMountPoint() {
+
+		// share to user
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		$result = \OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$this->assertTrue($user2View->file_exists($this->folder));
+
+		// create a local folder
+		$result = $user2View->mkdir('localfolder');
+		$this->assertTrue($result);
+
+		// move mount point to local folder
+		$result = $user2View->rename($this->folder, '/localfolder/' . $this->folder);
+		$this->assertTrue($result);
+
+		// mount point in the root folder should no longer exist
+		$this->assertFalse($user2View->is_dir($this->folder));
+
+		// delete the local folder
+		$result = $user2View->unlink('/localfolder');
+		$this->assertTrue($result);
+
+		//enforce reload of the mount points
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		//mount point should be back at the root
+		$this->assertTrue($user2View->is_dir($this->folder));
+
+		//cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$this->view->unlink($this->folder);
+	}
+
+	/**
+	 * @medium
+	 */
 	function testRenamePartFile() {
 
 		// share to user
@@ -79,5 +121,9 @@ class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		$this->assertTrue($this->view->file_exists( $this->folder. '/foo.txt'));
+
+		//cleanup
+		$this->view->unlink($this->folder);
 	}
+
 }

--- a/lib/private/files/mount/mount.php
+++ b/lib/private/files/mount/mount.php
@@ -59,10 +59,21 @@ class Mount {
 	}
 
 	/**
+	 * get complete path to the mount point, relative to data/
+	 *
 	 * @return string
 	 */
 	public function getMountPoint() {
 		return $this->mountPoint;
+	}
+
+	/**
+	 * get name of the mount point
+	 *
+	 * @return string
+	 */
+	public function getMountPointName() {
+		return basename(rtrim($this->mountPoint, '/'));
 	}
 
 	/**


### PR DESCRIPTION
The user will no longer be able to access a shared file/folder if he moved it to a sub-folder and later deletes the sub-folder. This pull request makes sure that the share mount point will be moved up to a parent folder which exists so that the user can still access the shared file/folder

cc @PVince81 
