### PR TITLE
Proper support for removing and moving storages for specific backends

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -217,6 +217,9 @@ class Shared_Cache extends Cache {
 	 */
 	public function remove($file) {
 		$file = ($file === false) ? '' : $file;
+		if ($file === '' or $file === '/') {
+			return;
+		}
 		if ($cache = $this->getSourceCache($file)) {
 			$cache->remove($this->files[$file]);
 		}

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -22,11 +22,13 @@
  */
 
 namespace OC\Files\Storage;
+use OCP\Files\IMovableStorage;
+use OCP\Files\IRemovableStorage;
 
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
  */
-class Shared extends \OC\Files\Storage\Common implements \OCP\Files\IMovableStorage {
+class Shared extends \OC\Files\Storage\Common implements IMovableStorage, IRemovableStorage {
 
 	private $share;   // the shared resource
 	private $files = array();
@@ -583,4 +585,7 @@ class Shared extends \OC\Files\Storage\Common implements \OCP\Files\IMovableStor
 		return null;
 	}
 
+	public function removeMount($mountPoint) {
+		return \OCP\Share::unshareFromSelf($this->share['item_type'], $this->share['file_target']);
+	}
 }

--- a/lib/public/files/imovablestorage.php
+++ b/lib/public/files/imovablestorage.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OCP\Files;
+
+interface IMovableStorage {
+	/**
+	 * Change the mountpoint of the storage
+	 *
+	 * @param string $source
+	 * @param string $target
+	 * @return bool
+	 */
+	public function moveMountPoint($source, $target);
+}

--- a/lib/public/files/iremovablestorage.php
+++ b/lib/public/files/iremovablestorage.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OCP\Files;
+
+interface IRemovableStorage {
+	/**
+	 * Remove the mount
+	 *
+	 * @param string $mountPoint
+	 * @return bool
+	 */
+	public function removeMount($mountPoint);
+}


### PR DESCRIPTION
This adds the interfaces `IMovableStorage` and `IRemovableStorage` to denote storage backends which are able to rename or remove the mountpoint for the storage (currently only shared storage, external shared storage and archive storage can use the same interfaces)

This removes the dependency on a class defined by an app (`\OC\Files\Storage\Shared`) from the core filesystem logic and generalizes the special shared logic.

Also this patch fixes the behavior when deleting the "root" shared item where previously the source item was removed from the filecache for the original owner. With the new login the file or folder is just unshared and the source file stays intact.

cc @schiesbn @DeepDiver1975 @PVince81 
