### PR TITLE
Setting same value to OCS privatedata API on MySQL causes row duplication

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1187,6 +1187,7 @@ class Util {
 		$query = \OCP\DB::prepare($sql);
 		$manipulatedRows = $query->execute($args);
 
+		// FIXME: this will return 0 if the migration status already was $status
 		if ($manipulatedRows === 1) {
 			$result = true;
 			\OCP\Util::writeLog('Encryption library', "Migration status set to " . self::MIGRATION_OPEN, \OCP\Util::INFO);

--- a/lib/private/ocs/privatedata.php
+++ b/lib/private/ocs/privatedata.php
@@ -69,14 +69,18 @@ class OC_OCS_Privatedata {
 		$key = addslashes(strip_tags($parameters['key']));
 		$value = OC_OCS::readData('post', 'value', 'text');
 
-		// update in DB
-		$query = \OCP\DB::prepare('UPDATE `*PREFIX*privatedata` SET `value` = ?  WHERE `user` = ? AND `app` = ? AND `key` = ?');
-		$numRows = $query->execute(array($value, $user, $app, $key));
-                
-		if ($numRows === false || $numRows === 0) {
+		// check if key is already set
+		$query = \OCP\DB::prepare('SELECT `value`  FROM `*PREFIX*privatedata` WHERE `user` = ? AND `app` = ? AND `key` = ? ');
+		$result = $query->execute(array($user, $app, $key));
+
+		if ($result->numRows() == 0) {
 			// store in DB
-			$query = \OCP\DB::prepare('INSERT INTO `*PREFIX*privatedata` (`user`, `app`, `key`, `value`)' . ' VALUES(?, ?, ?, ?)');
+			$query = \OCP\DB::prepare('INSERT INTO `*PREFIX*privatedata` (`user`, `app`, `key`, `value`) VALUES(?, ?, ?, ?)');
 			$query->execute(array($user, $app, $key, $value));
+		} else {
+			// update in DB
+			$query = \OCP\DB::prepare('UPDATE `*PREFIX*privatedata` SET `value` = ?  WHERE `user` = ? AND `app` = ? AND `key` = ? ');
+			$query->execute(array($value, $user, $app, $key ));
 		}
 
 		return new OC_OCS_Result(null, 100);

--- a/tests/lib/ocs/privatedata.php
+++ b/tests/lib/ocs/privatedata.php
@@ -79,6 +79,31 @@ class Test_OC_OCS_Privatedata extends PHPUnit_Framework_TestCase
 		$this->assertEquals('updated', $data['value']);
 	}
 
+	public function testSetSameValue() {
+		$_POST = array('value' => 123456789);
+		$params = array('app' => $this->appKey, 'key' => 'k-10');
+		$result = OC_OCS_Privatedata::set($params);
+		$this->assertEquals(100, $result->getStatusCode());
+
+		$result = OC_OCS_Privatedata::get($params);
+		$this->assertOcsResult(1, $result);
+		$data = $result->getData();
+		$data = $data[0];
+		$this->assertEquals('123456789', $data['value']);
+
+		// set the same value again
+		$_POST = array('value' => 123456789);
+		$params = array('app' => $this->appKey, 'key' => 'k-10');
+		$result = OC_OCS_Privatedata::set($params);
+		$this->assertEquals(100, $result->getStatusCode());
+
+		$result = OC_OCS_Privatedata::get($params);
+		$this->assertOcsResult(1, $result);
+		$data = $result->getData();
+		$data = $data[0];
+		$this->assertEquals('123456789', $data['value']);
+	}
+
 	public function testSetMany() {
 		$_POST = array('value' => 123456789);
 


### PR DESCRIPTION
When doing the following:
1) Try a SQL UPDATE to change a value
2) If zero rows were updated, try an INSERT

The trouble with this logic is that MySQL returns "zero rows updated" if the passed values are the same as the existing ones in the DB.

This is potentially harmful. I grepped the code and there is only one other location (in encryption migration) that seem to rely on this.

I don't have a good fix yet but wanted to discuss this here.
The PR brings a unit test that will trigger the error (curious to see what other DBs will fail)

I'd rather expect from Doctrine that the "num_rows" returned is consistent between DBs.

@DeepDiver1975 @karlitschek @schiesbn @icewind1991 @bartv2 
