### PR TITLE
Expose permission via WebDAV

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -27,20 +27,11 @@ class Helper
 	 */
 	public static function determineIcon($file) {
 		if($file['type'] === 'dir') {
-			$dir = $file['directory'];
 			$icon = \OC_Helper::mimetypeIcon('dir');
-			$absPath = $file->getPath();
-			$mount = \OC\Files\Filesystem::getMountManager()->find($absPath);
-			if (!is_null($mount)) {
-				$sid = $mount->getStorageId();
-				if (!is_null($sid)) {
-					$sid = explode(':', $sid);
-					if ($sid[0] === 'shared') {
-						$icon = \OC_Helper::mimetypeIcon('dir-shared');
-					} elseif ($sid[0] !== 'local' and $sid[0] !== 'home') {
-						$icon = \OC_Helper::mimetypeIcon('dir-external');
-					}
-				}
+			if ($file->isShared()) {
+				$icon = \OC_Helper::mimetypeIcon('dir-shared');
+			} elseif ($file->isMounted()) {
+				$icon = \OC_Helper::mimetypeIcon('dir-external');
 			}
 		}else{
 			$icon = \OC_Helper::mimetypeIcon($file->getMimetype());

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -24,6 +24,16 @@
 class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 	private static $user;
 
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $viewMock;
+
+	/**
+	 * @var \OCA\Files\App
+	 */
+	private $files;
+
 	function setUp() {
 		// mock OC_L10n
 		if (!self::$user) {
@@ -72,7 +82,7 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 			->method('getFileInfo')
 			->will($this->returnValue(new \OC\Files\FileInfo(
 				'/',
-				null,
+				new \OC\Files\Storage\Local(array('datadir' => '/')),
 				'/',
 				array(
 				'fileid' => 123,

--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -37,7 +37,7 @@ class OC_Connector_Sabre_FilesPlugin extends Sabre_DAV_ServerPlugin
 
 		$server->xmlNamespaces[self::NS_OWNCLOUD] = 'oc';
 		$server->protectedProperties[] = '{' . self::NS_OWNCLOUD . '}id';
-		$server->protectedProperties[] = '{' . self::NS_OWNCLOUD . '}permissions';
+		$server->protectedProperties[] = '{' . self::NS_OWNCLOUD . '}perm';
 
 		$this->server = $server;
 		$this->server->subscribeEvent('beforeGetProperties', array($this, 'beforeGetProperties'));

--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -37,6 +37,7 @@ class OC_Connector_Sabre_FilesPlugin extends Sabre_DAV_ServerPlugin
 
 		$server->xmlNamespaces[self::NS_OWNCLOUD] = 'oc';
 		$server->protectedProperties[] = '{' . self::NS_OWNCLOUD . '}id';
+		$server->protectedProperties[] = '{' . self::NS_OWNCLOUD . '}permissions';
 
 		$this->server = $server;
 		$this->server->subscribeEvent('beforeGetProperties', array($this, 'beforeGetProperties'));
@@ -57,15 +58,24 @@ class OC_Connector_Sabre_FilesPlugin extends Sabre_DAV_ServerPlugin
 
 		if ($node instanceof OC_Connector_Sabre_Node) {
 
-			$fileid_propertyname = '{' . self::NS_OWNCLOUD . '}id';
-			if (array_search($fileid_propertyname, $requestedProperties)) {
-				unset($requestedProperties[array_search($fileid_propertyname, $requestedProperties)]);
+			$fileIdPropertyName = '{' . self::NS_OWNCLOUD . '}id';
+			$permissionsPropertyName = '{' . self::NS_OWNCLOUD . '}permissions';
+			if (array_search($fileIdPropertyName, $requestedProperties)) {
+				unset($requestedProperties[array_search($fileIdPropertyName, $requestedProperties)]);
+			}
+			if (array_search($permissionsPropertyName, $requestedProperties)) {
+				unset($requestedProperties[array_search($permissionsPropertyName, $requestedProperties)]);
 			}
 
 			/** @var $node OC_Connector_Sabre_Node */
 			$fileId = $node->getFileId();
 			if (!is_null($fileId)) {
-				$returnedProperties[200][$fileid_propertyname] = $fileId;
+				$returnedProperties[200][$fileIdPropertyName] = $fileId;
+			}
+
+			$permissions = $node->getDavPermissions();
+			if (!is_null($fileId)) {
+				$returnedProperties[200][$permissionsPropertyName] = $permissions;
 			}
 
 		}

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -252,14 +252,17 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 		if ($this->info->isMounted()) {
 			$p .= 'M';
 		}
+		if ($this->info->isDeletable()) {
+			$p .= 'D';
+		}
+		if ($this->info->isDeletable()) {
+			$p .= 'N';
+		}
 		if ($this->info->getType() === \OCP\Files\FileInfo::TYPE_FILE) {
 			if ($this->info->isUpdateable()) {
 				$p .= 'W';
 			}
 		} else {
-			if ($this->info->isDeletable()) {
-				$p .= 'D';
-			}
 			if ($this->info->isUpdateable()) {
 				$p .= 'CK';
 			}

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -237,4 +237,33 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 
 		return null;
 	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getDavPermissions() {
+		$p ='';
+		if ($this->info->isShared()) {
+			$p .= 'S';
+		}
+		if ($this->info->isShareable()) {
+			$p .= 'R';
+		}
+		if ($this->info->isMounted()) {
+			$p .= 'M';
+		}
+		if ($this->info->getType() === \OCP\Files\FileInfo::TYPE_FILE) {
+			if ($this->info->isUpdateable()) {
+				$p .= 'W';
+			}
+		} else {
+			if ($this->info->isDeletable()) {
+				$p .= 'D';
+			}
+			if ($this->info->isUpdateable()) {
+				$p .= 'CK';
+			}
+		}
+		return $p;
+	}
 }

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -196,4 +196,28 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	public function isShareable() {
 		return $this->checkPermissions(\OCP\PERMISSION_SHARE);
 	}
+
+	/**
+	 * Check if a file or folder is shared
+	 * @return bool
+	 */
+	public function isShared() {
+		$sid = $this->getStorage()->getId();
+		if (!is_null($sid)) {
+			$sid = explode(':', $sid);
+			return ($sid[0] === 'shared');
+		}
+
+		return false;
+	}
+
+	public function isMounted() {
+		$sid = $this->getStorage()->getId();
+		if (!is_null($sid)) {
+			$sid = explode(':', $sid);
+			return ($sid[0] !== 'local' and $sid[0] !== 'home');
+		}
+
+		return false;
+	}
 }

--- a/lib/public/files/fileinfo.php
+++ b/lib/public/files/fileinfo.php
@@ -135,4 +135,18 @@ interface FileInfo {
 	 * @return bool
 	 */
 	public function isShareable();
+
+	/**
+	 * Check if a file or folder is shared
+	 *
+	 * @return bool
+	 */
+	public function isShared();
+
+	/**
+	 * Check if a file or folder is mounted
+	 *
+	 * @return bool
+	 */
+	public function isMounted();
 }


### PR DESCRIPTION
- Introduce isShared() and isMounted() on FileInfo class
- Reuse these methods on determineIcon()
- Generate permission string for the desktop client
- expose {http://owncloud.org/ns}perm as additional WebDAV property containing the permission string

FYI:
@danimo @dragotin @icewind1991 @karlitschek 

I will work on the detailed list of permission with @dragotin next week

refs https://github.com/owncloud/core/issues/8322
