### PR TITLE
Dont create borders around previews when scaling up is disabled

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -615,7 +615,7 @@ class Preview {
 			return;
 		}
 
-		if ($newXSize < $x || $newYSize < $y) {
+		if (($newXSize < $x || $newYSize < $y) && $scalingUp) {
 			if ($newXSize > $x) {
 				$cropX = floor(($newXSize - $x) * 0.5);
 				$image->crop($cropX, 0, $x, $newYSize);


### PR DESCRIPTION
Previously, when requesting a preview that is larger than the source image a border added to the preview to create an image of the requested size even if scaling up is disabled.

This leads to white borders being shown around images in the slideshow (since using previews for slideshows was introduced) and wastes bandwith and disk space with previews that are larger then the original image.

To test: `owncloud/index.php/core/preview.png?file=/path/to/small/image&x=3000&a=true&scalingup=0`
(dont forget to clear the cached thumbnail after switching branches)

cc @DeepDiver1975 @PVince81 @georgehrke  
