### PR TITLE
Added ext storage app in autotest unit test run

### DIFF
--- a/apps/files_external/tests/config.php
+++ b/apps/files_external/tests/config.php
@@ -28,7 +28,7 @@ return array(
 		'wait'=> 0
 	),
 	'owncloud'=>array(
-		'run'=>true,
+		'run'=>false,
 		'host'=>'localhost/owncloud',
 		'user'=>'test',
 		'password'=>'test',

--- a/apps/files_external/tests/dynamicmountconfig.php
+++ b/apps/files_external/tests/dynamicmountconfig.php
@@ -22,8 +22,6 @@
 
 require_once __DIR__ . '/../../../lib/base.php';
 
-require __DIR__ . '/../lib/config.php';
-
 /**
  * Class Test_Mount_Config_Dummy_Backend
  */

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -22,8 +22,6 @@
 
 require_once __DIR__ . '/../../../lib/base.php';
 
-require __DIR__ . '/../lib/config.php';
-
 class Test_Mount_Config_Dummy_Storage {
 	public function test() {
 		return true;

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -18,7 +18,7 @@ function enableApp($app) {
 
 enableApp('files_sharing');
 enableApp('files_encryption');
-//enableApp('files_external');
+enableApp('files_external');
 enableApp('user_ldap');
 enableApp('files_versions');
 


### PR DESCRIPTION
To make sure that the dynamic mount config and config classes from
external storages are tested, these are now added into the autotest.sh
test run by enabling the app.

@DeepDiver1975 before that the config classes weren't tested and were failing!

@Xenopathic it looks like this PR fixes the test errors you got, maybe because I had to remove the extra `require` on top.
