### PR TITLE
Better appframework controllers

### DIFF
--- a/lib/private/appframework/app.php
+++ b/lib/private/appframework/app.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/core/api.php
+++ b/lib/private/appframework/core/api.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -85,7 +85,8 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 			return new Dispatcher(
 				$c['Protocol'], 
 				$c['MiddlewareDispatcher'], 
-				$c['ControllerMethodReflector']
+				$c['ControllerMethodReflector'],
+				$c['Request']
 			);
 		});
 

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -33,6 +33,7 @@ use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Middleware\Security\CORSMiddleware;
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\IApi;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Middleware;
@@ -81,7 +82,11 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 		});
 
 		$this['Dispatcher'] = $this->share(function($c) {
-			return new Dispatcher($c['Protocol'], $c['MiddlewareDispatcher']);
+			return new Dispatcher(
+				$c['Protocol'], 
+				$c['MiddlewareDispatcher'], 
+				$c['ControllerMethodReflector']
+			);
 		});
 
 
@@ -90,7 +95,11 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 		 */
 		$app = $this;
 		$this['SecurityMiddleware'] = $this->share(function($c) use ($app){
-			return new SecurityMiddleware($app, $c['Request']);
+			return new SecurityMiddleware(
+				$app, 
+				$c['Request'], 
+				$c['ControllerMethodReflector']
+			);
 		});
 
 		$this['CORSMiddleware'] = $this->share(function($c) {
@@ -118,6 +127,9 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 			return new TimeFactory();
 		});
 
+		$this['ControllerMethodReflector'] = $this->share(function($c) {
+			return new ControllerMethodReflector();
+		});
 
 	}
 

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -104,7 +104,10 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 		});
 
 		$this['CORSMiddleware'] = $this->share(function($c) {
-			return new CORSMiddleware($c['Request']);
+			return new CORSMiddleware(
+				$c['Request'],
+				$c['ControllerMethodReflector']
+			);
 		});
 
 		$middleWares = &$this->middleWares;

--- a/lib/private/appframework/http.php
+++ b/lib/private/appframework/http.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt, Thomas Tanghus, Bart Visscher
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -138,7 +138,7 @@ class Dispatcher {
 				(
 					$this->request->method === 'GET' ||
 					strpos($this->request->getHeader('Content-Type'), 
-						'application/x-www-form-urlencoded') !== false)
+						'application/x-www-form-urlencoded') !== false
 				)
 			) {
 				$value = false;

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -116,6 +116,8 @@ class Dispatcher {
 	/**
 	 * Uses the reflected parameters, types and request parameters to execute
 	 * the controller
+	 * @param Controller $controller the controller to be executed
+	 * @param string $methodName the method on the controller that should be executed
 	 * @return Response
 	 */
 	private function executeController($controller, $methodName) {

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -171,7 +171,7 @@ class Dispatcher {
 				}
 			}
 
-			$response = $controller->formatResponse($response, $format);
+			$response = $controller->buildResponse($response, $format);
 		}
 
 		return $response;

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt, Thomas Tanghus, Bart Visscher
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -137,11 +137,8 @@ class Dispatcher {
 				$value === 'false' && 
 				(
 					$this->request->method === 'GET' ||
-					(
-						$this->request->method === 'POST' &&
-						strpos($this->request->getHeader('Content-Type'), 
-								'application/x-www-form-urlencoded') !== false
-					)
+					strpos($this->request->getHeader('Content-Type'), 
+						'application/x-www-form-urlencoded') !== false)
 				)
 			) {
 				$value = false;

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -3,7 +3,9 @@
  * ownCloud - Request
  *
  * @author Thomas Tanghus
+ * @author Bernhard Posselt
  * @copyright 2013 Thomas Tanghus (thomas@tanghus.net)
+ * @copyright 2014 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/middleware/middlewaredispatcher.php
+++ b/lib/private/appframework/middleware/middlewaredispatcher.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/middleware/security/corsmiddleware.php
+++ b/lib/private/appframework/middleware/security/corsmiddleware.php
@@ -11,7 +11,7 @@
 
 namespace OC\AppFramework\Middleware\Security;
 
-use OC\AppFramework\Utility\MethodAnnotationReader;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\IRequest;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
@@ -25,12 +25,16 @@ use OCP\AppFramework\Middleware;
 class CORSMiddleware extends Middleware {
 
 	private $request;
+	private $reflector;
 
 	/**
 	 * @param IRequest $request
+	 * @param ControllerMethodReflector $reflector
 	 */
-	public function __construct(IRequest $request) {
+	public function __construct(IRequest $request, 
+	                            ControllerMethodReflector $reflector) {
 		$this->request = $request;
+		$this->reflector = $reflector;
 	}
 
 
@@ -46,10 +50,9 @@ class CORSMiddleware extends Middleware {
 	 */
 	public function afterController($controller, $methodName, Response $response){
 		// only react if its a CORS request and if the request sends origin and
-		$reflector = new MethodAnnotationReader($controller, $methodName);
 
 		if(isset($this->request->server['HTTP_ORIGIN']) &&
-			$reflector->hasAnnotation('CORS')) {
+			$this->reflector->hasAnnotation('CORS')) {
 
 			// allow credentials headers must not be true or CSRF is possible 
 			// otherwise
@@ -57,7 +60,7 @@ class CORSMiddleware extends Middleware {
 				if(strtolower($header) === 'access-control-allow-credentials' &&
 				   strtolower(trim($value)) === 'true') {
 					$msg = 'Access-Control-Allow-Credentials must not be '.
-					       'set to true in order to prevent CSRF';
+						   'set to true in order to prevent CSRF';
 					throw new SecurityException($msg);
 				}
 			}

--- a/lib/private/appframework/middleware/security/securityexception.php
+++ b/lib/private/appframework/middleware/security/securityexception.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -25,7 +25,7 @@
 namespace OC\AppFramework\Middleware\Security;
 
 use OC\AppFramework\Http;
-use OC\AppFramework\Utility\MethodAnnotationReader;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\Response;
@@ -55,10 +55,13 @@ class SecurityMiddleware extends Middleware {
 	/**
 	 * @param IAppContainer $app
 	 * @param IRequest $request
+	 * @param ControllerMethodReflector $reflector
 	 */
-	public function __construct(IAppContainer $app, IRequest $request){
+	public function __construct(IAppContainer $app, IRequest $request,
+	                            ControllerMethodReflector $reflector){
 		$this->app = $app;
 		$this->request = $request;
+		$this->reflector = $reflector;
 	}
 
 
@@ -72,28 +75,25 @@ class SecurityMiddleware extends Middleware {
 	 */
 	public function beforeController($controller, $methodName){
 
-		// get annotations from comments
-		$annotationReader = new MethodAnnotationReader($controller, $methodName);
-
 		// this will set the current navigation entry of the app, use this only
 		// for normal HTML requests and not for AJAX requests
 		$this->app->getServer()->getNavigationManager()->setActiveEntry($this->app->getAppName());
 
 		// security checks
-		$isPublicPage = $annotationReader->hasAnnotation('PublicPage');
+		$isPublicPage = $this->reflector->hasAnnotation('PublicPage');
 		if(!$isPublicPage) {
 			if(!$this->app->isLoggedIn()) {
 				throw new SecurityException('Current user is not logged in', Http::STATUS_UNAUTHORIZED);
 			}
 
-			if(!$annotationReader->hasAnnotation('NoAdminRequired')) {
+			if(!$this->reflector->hasAnnotation('NoAdminRequired')) {
 				if(!$this->app->isAdminUser()) {
 					throw new SecurityException('Logged in user must be an admin', Http::STATUS_FORBIDDEN);
 				}
 			}
 		}
 
-		if(!$annotationReader->hasAnnotation('NoCSRFRequired')) {
+		if(!$this->reflector->hasAnnotation('NoCSRFRequired')) {
 			if(!$this->request->passesCSRFCheck()) {
 				throw new SecurityException('CSRF check failed', Http::STATUS_PRECONDITION_FAILED);
 			}

--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -53,6 +53,11 @@ class SecurityMiddleware extends Middleware {
 	private $request;
 
 	/**
+	 * @var OC\AppFramework\Utility\ControllerMethodReflector
+	 */
+	private $reflector;
+
+	/**
 	 * @param IAppContainer $app
 	 * @param IRequest $request
 	 * @param ControllerMethodReflector $reflector

--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2014 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -28,23 +28,59 @@ namespace OC\AppFramework\Utility;
 /**
  * Reads and parses annotations from doc comments
  */
-class MethodAnnotationReader {
+class ControllerMethodReflector {
 
 	private $annotations;
+	private $types;
+	private $parameters;
+
+	public function __construct() {
+		$this->types = array();
+		$this->parameters = array();
+		$this->annotations = array();
+	}
+
 
 	/**
 	 * @param object $object an object or classname
-	 * @param string $method the method which we want to inspect for annotations
+	 * @param string $method the method which we want to inspect
 	 */
-	public function __construct($object, $method){
-		$this->annotations = array();
-
+	public function reflect($object, $method){
 		$reflection = new \ReflectionMethod($object, $method);
 		$docs = $reflection->getDocComment();
 
 		// extract everything prefixed by @ and first letter uppercase
 		preg_match_all('/@([A-Z]\w+)/', $docs, $matches);
 		$this->annotations = $matches[1];
+
+		// extract type parameter information
+		preg_match_all('/@param (?<type>\w+) \$(?<var>\w+)/', $docs, $matches);
+		$this->types = array_combine($matches['var'], $matches['type']);
+
+		// get method parameters
+		foreach ($reflection->getParameters() as $param) {
+			$this->parameters[] = $param->name;
+		}
+	}
+
+
+	/**
+	 * Inspects the PHPDoc parameters for types
+	 * @param strint $parameter the parameter whose type comments should be 
+	 * parsed
+	 * @return string type in the type parameters (@param int $something) would
+	 * return int
+	 */
+	public function getType($parameter) {
+		return $this->types[$parameter];
+	}
+
+
+	/**
+	 * @return array the arguments of the method
+	 */
+	public function getParameters() {
+		return $this->parameters;
 	}
 
 

--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -66,7 +66,7 @@ class ControllerMethodReflector {
 
 	/**
 	 * Inspects the PHPDoc parameters for types
-	 * @param strint $parameter the parameter whose type comments should be 
+	 * @param string $parameter the parameter whose type comments should be 
 	 * parsed
 	 * @return string|null type in the type parameters (@param int $something) 
 	 * would return int or null if not existing

--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -68,11 +68,15 @@ class ControllerMethodReflector {
 	 * Inspects the PHPDoc parameters for types
 	 * @param strint $parameter the parameter whose type comments should be 
 	 * parsed
-	 * @return string type in the type parameters (@param int $something) would
-	 * return int
+	 * @return string|null type in the type parameters (@param int $something) 
+	 * would return int or null if not existing
 	 */
 	public function getType($parameter) {
-		return $this->types[$parameter];
+		if(array_key_exists($parameter, $this->types)) {
+			return $this->types[$parameter];
+		} else {
+			return null;
+		}
 	}
 
 

--- a/lib/private/appframework/utility/timefactory.php
+++ b/lib/private/appframework/utility/timefactory.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/controller.php
+++ b/lib/public/appframework/controller.php
@@ -51,7 +51,7 @@ abstract class Controller {
 	protected $request;
 
 	private $serializer;
-	private $formatters;
+	private $responders;
 
 	/**
 	 * constructor of the controller
@@ -71,8 +71,8 @@ abstract class Controller {
 		$this->appName = $appName;
 		$this->request = $request;
 
-		// default formatters
-		$this->formatters = array(
+		// default responders
+		$this->responders = array(
 			'json' => function ($response) {
 				return new JSONResponse($response);
 			}
@@ -94,34 +94,34 @@ abstract class Controller {
 	/**
 	 * Registers a formatter for a type
 	 * @param string $format
-	 * @param \Closure $closure
+	 * @param \Closure $responder
 	 */
-	protected function registerFormatter($format, \Closure $formatter) {
-		$this->formatters[$format] = $formatter;
+	protected function registerResponder($format, \Closure $responder) {
+		$this->responders[$format] = $responder;
 	}
 
 
 	/**
 	 * Serializes and formats a response
-	 * @param mixed response the value that was returned from a controller and
+	 * @param mixed $response the value that was returned from a controller and
 	 * is not a Response instance
 	 * @param string $format the format for which a formatter has been registered
 	 * @throws \DomainException if format does not match a registered formatter
 	 * @return Response
 	 */
-	public function formatResponse($response, $format='json') {
-		if(array_key_exists($format, $this->formatters)) {
+	public function buildResponse($response, $format='json') {
+		if(array_key_exists($format, $this->responders)) {
 
 			if ($this->serializer) {
 				$response = $this->serializer->serialize($response);
 			}
 
-			$formatter = $this->formatters[$format];
+			$responder = $this->responders[$format];
 			
-			return $formatter($response);
+			return $responder($response);
 
 		} else {
-			throw new \DomainException('No formatter registered for format ' . 
+			throw new \DomainException('No responder registered for format ' . 
 				$format . '!');
 		}
 	}

--- a/lib/public/appframework/controller.php
+++ b/lib/public/appframework/controller.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012, 2014 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http.php
+++ b/lib/public/appframework/http.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt, Thomas Tanghus, Bart Visscher
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/downloadresponse.php
+++ b/lib/public/appframework/http/downloadresponse.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/iresponseserializer.php
+++ b/lib/public/appframework/http/iresponseserializer.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ownCloud - App Framework
  *
@@ -21,35 +20,8 @@
  *
  */
 
+namespace OCP\AppFramework\Http;
 
-namespace OC\AppFramework\Utility;
-
-
-class MethodAnnotationReaderTest extends \PHPUnit_Framework_TestCase {
-
-
-	/**
-	 * @Annotation
-	 */
-	public function testReadAnnotation(){
-		$reader = new MethodAnnotationReader('\OC\AppFramework\Utility\MethodAnnotationReaderTest',
-				'testReadAnnotation');
-
-		$this->assertTrue($reader->hasAnnotation('Annotation'));
-	}
-
-
-	/**
-	 * @Annotation
-	 * @param test
-	 */
-	public function testReadAnnotationNoLowercase(){
-		$reader = new MethodAnnotationReader('\OC\AppFramework\Utility\MethodAnnotationReaderTest',
-				'testReadAnnotationNoLowercase');
-
-		$this->assertTrue($reader->hasAnnotation('Annotation'));
-		$this->assertFalse($reader->hasAnnotation('param'));
-	}
-
-
+interface IResponseSerializer {
+    function serialize($response);
 }

--- a/lib/public/appframework/http/iresponseserializer.php
+++ b/lib/public/appframework/http/iresponseserializer.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/redirectresponse.php
+++ b/lib/public/appframework/http/redirectresponse.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/response.php
+++ b/lib/public/appframework/http/response.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt, Thomas Tanghus, Bart Visscher
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/templateresponse.php
+++ b/lib/public/appframework/http/templateresponse.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/http/templateresponse.php
+++ b/lib/public/appframework/http/templateresponse.php
@@ -61,12 +61,16 @@ class TemplateResponse extends Response {
 	 * constructor of TemplateResponse
 	 * @param string $appName the name of the app to load the template from
 	 * @param string $templateName the name of the template
+	 * @param array $params an array of parameters which should be passed to the
+	 * template
+	 * @param string $renderAs how the page should be rendered, defaults to user
 	 */
-	public function __construct($appName, $templateName) {
+	public function __construct($appName, $templateName, array $params=array(),
+	                            $renderAs='user') {
 		$this->templateName = $templateName;
 		$this->appName = $appName;
-		$this->params = array();
-		$this->renderAs = 'user';
+		$this->params = $params;
+		$this->renderAs = $renderAs;
 	}
 
 

--- a/lib/public/appframework/iapi.php
+++ b/lib/public/appframework/iapi.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/lib/public/appframework/middleware.php
+++ b/lib/public/appframework/middleware.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2012 Bernhard Posselt <nukeawhale@gmail.com>
+ * Copyright (c) 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.

--- a/tests/lib/appframework/AppTest.php
+++ b/tests/lib/appframework/AppTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -26,9 +26,31 @@ namespace OCP\AppFramework;
 
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\IResponseSerializer;
 
 
-class ChildController extends Controller {};
+class ToUpperCaseSerializer implements IResponseSerializer {
+	public function serialize($response) {
+		return array(strtoupper($response));
+	}
+}
+
+class ChildController extends Controller {
+	public function custom($in) {
+		$this->registerFormatter('json', function ($response) {
+			return new JSONResponse(array(strlen($response)));
+		});
+
+		return $in;
+	}
+
+	public function serializer($in) {
+		$this->registerSerializer(new ToUpperCaseSerializer());
+
+		return $in;
+	}
+};
 
 class ControllerTest extends \PHPUnit_Framework_TestCase {
 
@@ -126,6 +148,37 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetEnvVariable(){
 		$this->assertEquals('daheim', $this->controller->env('PATH'));
+	}
+
+
+	/**
+	 * @expectedException \DomainException
+	 */
+	public function testFormatResonseInvalidFormat() {
+		$this->controller->formatResponse(null, 'test');
+	}
+
+
+	public function testFormat() {
+		$response = $this->controller->formatResponse(array('hi'), 'json');
+
+		$this->assertEquals(array('hi'), $response->getData());
+	}
+
+
+	public function testCustomFormatter() {
+		$response = $this->controller->custom('hi');
+		$response = $this->controller->formatResponse($response, 'json');
+
+		$this->assertEquals(array(2), $response->getData());		
+	}
+
+
+	public function testCustomSerializer() {
+		$response = $this->controller->serializer('hi');
+		$response = $this->controller->formatResponse($response, 'json');
+
+		$this->assertEquals(array('HI'), $response->getData());	
 	}
 
 

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -38,7 +38,7 @@ class ToUpperCaseSerializer implements IResponseSerializer {
 
 class ChildController extends Controller {
 	public function custom($in) {
-		$this->registerFormatter('json', function ($response) {
+		$this->registerResponder('json', function ($response) {
 			return new JSONResponse(array(strlen($response)));
 		});
 
@@ -155,12 +155,12 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
 	 * @expectedException \DomainException
 	 */
 	public function testFormatResonseInvalidFormat() {
-		$this->controller->formatResponse(null, 'test');
+		$this->controller->buildResponse(null, 'test');
 	}
 
 
 	public function testFormat() {
-		$response = $this->controller->formatResponse(array('hi'), 'json');
+		$response = $this->controller->buildResponse(array('hi'), 'json');
 
 		$this->assertEquals(array('hi'), $response->getData());
 	}
@@ -168,7 +168,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCustomFormatter() {
 		$response = $this->controller->custom('hi');
-		$response = $this->controller->formatResponse($response, 'json');
+		$response = $this->controller->buildResponse($response, 'json');
 
 		$this->assertEquals(array(2), $response->getData());		
 	}
@@ -176,7 +176,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCustomSerializer() {
 		$response = $this->controller->serializer('hi');
-		$response = $this->controller->formatResponse($response, 'json');
+		$response = $this->controller->buildResponse($response, 'json');
 
 		$this->assertEquals(array('HI'), $response->getData());	
 	}

--- a/tests/lib/appframework/dependencyinjection/DIContainerTest.php
+++ b/tests/lib/appframework/dependencyinjection/DIContainerTest.php
@@ -5,8 +5,8 @@
  *
  * @author Bernhard Posselt
  * @author Morris Jobke
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
- * @copyright 2013 Morris Jobke morris.jobke@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
+ * @copyright 2013 Morris Jobke <morris.jobke@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -41,7 +41,7 @@ class TestController extends Controller {
 	 * @param bool $bool
 	 */
 	public function exec($int, $bool) {
-		$this->registerFormatter('text', function($in) {
+		$this->registerResponder('text', function($in) {
 			return new JSONResponse(array('text' => $in));
 		});
 		return array($int, $bool);

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -25,8 +25,28 @@
 namespace OC\AppFramework\Http;
 
 use OC\AppFramework\Middleware\MiddlewareDispatcher;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Http;
-//require_once(__DIR__ . "/../classloader.php");
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Controller;
+
+
+class TestController extends Controller {
+	public function __construct($appName, $request) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @param int $int
+	 * @param bool $bool
+	 */
+	public function exec($int, $bool) {
+		$this->registerFormatter('text', function($in) {
+			return new JSONResponse(array('text' => $in));
+		});
+		return array($int, $bool);
+	}
+}
 
 
 class DispatcherTest extends \PHPUnit_Framework_TestCase {
@@ -39,6 +59,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 	private $lastModified;
 	private $etag;
 	private $http;
+	private $reflector;
 
 	protected function setUp() {
 		$this->controllerMethod = 'test';
@@ -64,8 +85,17 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 			'\OCP\AppFramework\Controller',
 			array($this->controllerMethod), array($app, $request));
 		
+		$this->request = $this->getMockBuilder(
+			'\OC\AppFramework\Http\Request')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->reflector = new ControllerMethodReflector();
+
 		$this->dispatcher = new Dispatcher(
-			$this->http, $this->middlewareDispatcher);
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
 		
 		$this->response = $this->getMockBuilder(
 			'\OCP\AppFramework\Http\Response')
@@ -81,7 +111,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 	 * @param string $out
 	 * @param string $httpHeaders
 	 */
-	private function setMiddlewareExpections($out=null, 
+	private function setMiddlewareExpectations($out=null, 
 		$httpHeaders=null, $responseHeaders=array(),
 		$ex=false, $catchEx=true) {
 
@@ -159,14 +189,12 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 			->with($this->equalTo($this->controller), 
 				$this->equalTo($this->controllerMethod),
 				$this->equalTo($out))
-			->will($this->returnValue($out));
-
-		
+			->will($this->returnValue($out));		
 	}
 
 
 	public function testDispatcherReturnsArrayWith2Entries() {
-		$this->setMiddlewareExpections();
+		$this->setMiddlewareExpectations();
 
 		$response = $this->dispatcher->dispatch($this->controller, 
 			$this->controllerMethod);
@@ -180,7 +208,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$out = 'yo';
 		$httpHeaders = 'Http';
 		$responseHeaders = array('hell' => 'yeah');
-		$this->setMiddlewareExpections($out, $httpHeaders, $responseHeaders);
+		$this->setMiddlewareExpectations($out, $httpHeaders, $responseHeaders);
 
 		$response = $this->dispatcher->dispatch($this->controller, 
 			$this->controllerMethod);
@@ -195,7 +223,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$out = 'yo';
 		$httpHeaders = 'Http';
 		$responseHeaders = array('hell' => 'yeah');
-		$this->setMiddlewareExpections($out, $httpHeaders, $responseHeaders, true);		
+		$this->setMiddlewareExpectations($out, $httpHeaders, $responseHeaders, true);		
 
 		$response = $this->dispatcher->dispatch($this->controller, 
 			$this->controllerMethod);
@@ -210,12 +238,128 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$out = 'yo';
 		$httpHeaders = 'Http';
 		$responseHeaders = array('hell' => 'yeah');
-		$this->setMiddlewareExpections($out, $httpHeaders, $responseHeaders, true, false);
+		$this->setMiddlewareExpectations($out, $httpHeaders, $responseHeaders, true, false);
 
 		$this->setExpectedException('\Exception');
 		$response = $this->dispatcher->dispatch($this->controller, 
 			$this->controllerMethod);
 
+	}
+
+
+	private function dispatcherPassthrough() {
+		$this->middlewareDispatcher->expects($this->once())
+				->method('beforeController');
+		$this->middlewareDispatcher->expects($this->once())
+			->method('afterController')
+			->will($this->returnCallback(function($a, $b, $in) {
+				return $in;
+			}));
+		$this->middlewareDispatcher->expects($this->once())
+			->method('beforeOutput')
+			->will($this->returnCallback(function($a, $b, $in) {
+				return $in;
+			}));
+	}
+
+	public function testControllerParametersInjected() {
+		$this->request = new Request(array(
+			'post' => array(
+				'int' => '3',
+				'bool' => 'false'
+			),
+			'method' => 'POST'
+		));
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('[3,true]', $response[2]);
+	}
+
+
+	public function testResponseTransformedByUrlFormat() {
+		$this->request = new Request(array(
+			'post' => array(
+				'int' => '3',
+				'bool' => 'false'
+			),
+			'urlParams' => array(
+				'format' => 'text'
+			),
+			'method' => 'GET'
+		));
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('{"text":[3,false]}', $response[2]);
+	}
+
+
+	public function testResponseTransformedByAcceptHeader() {
+		$this->request = new Request(array(
+			'post' => array(
+				'int' => '3',
+				'bool' => 'false'
+			),
+			'server' => array(
+				'HTTP_ACCEPT' => 'application/text, test',
+				'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+			),
+			'method' => 'POST'
+		));
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('{"text":[3,false]}', $response[2]);
+	}
+
+
+	public function testResponsePrimarilyTransformedByParameterFormat() {
+		$this->request = new Request(array(
+			'post' => array(
+				'int' => '3',
+				'bool' => 'false'
+			),
+			'get' => array(
+				'format' => 'text'
+			),
+			'server' => array(
+				'HTTP_ACCEPT' => 'application/json, test'
+			),
+			'method' => 'POST'
+		));
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('{"text":[3,true]}', $response[2]);
 	}
 
 }

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -319,7 +319,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 				'HTTP_ACCEPT' => 'application/text, test',
 				'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded'
 			),
-			'method' => 'POST'
+			'method' => 'PUT'
 		));
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,

--- a/tests/lib/appframework/http/DownloadResponseTest.php
+++ b/tests/lib/appframework/http/DownloadResponseTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/HttpTest.php
+++ b/tests/lib/appframework/http/HttpTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -5,8 +5,8 @@
  *
  * @author Bernhard Posselt
  * @author Morris Jobke
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
- * @copyright 2013 Morris Jobke morris.jobke@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
+ * @copyright 2013 Morris Jobke <morris.jobke@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/RedirectResponseTest.php
+++ b/tests/lib/appframework/http/RedirectResponseTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/ResponseTest.php
+++ b/tests/lib/appframework/http/ResponseTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/TemplateResponseTest.php
+++ b/tests/lib/appframework/http/TemplateResponseTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/http/TemplateResponseTest.php
+++ b/tests/lib/appframework/http/TemplateResponseTest.php
@@ -51,6 +51,22 @@ class TemplateResponseTest extends \PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSetParamsConstructor(){
+		$params = array('hi' => 'yo');
+		$this->tpl = new TemplateResponse($this->api, 'home', $params);
+
+		$this->assertEquals(array('hi' => 'yo'), $this->tpl->getParams());
+	}
+
+
+	public function testSetRenderAsConstructor(){
+		$renderAs = 'myrender';
+		$this->tpl = new TemplateResponse($this->api, 'home', array(), $renderAs);
+
+		$this->assertEquals($renderAs, $this->tpl->getRenderAs());
+	}
+
+
 	public function testSetParams(){
 		$params = array('hi' => 'yo');
 		$this->tpl->setParams($params);
@@ -62,36 +78,6 @@ class TemplateResponseTest extends \PHPUnit_Framework_TestCase {
 	public function testGetTemplateName(){
 		$this->assertEquals('home', $this->tpl->getTemplateName());
 	}
-
-
-//	public function testRender(){
-//		$ocTpl = $this->getMock('Template', array('fetchPage'));
-//		$ocTpl->expects($this->once())
-//				->method('fetchPage');
-//
-//		$tpl = new TemplateResponse('core', 'error');
-//
-//		$tpl->render();
-//	}
-//
-//
-//	public function testRenderAssignsParams(){
-//		$params = array('john' => 'doe');
-//
-//		$tpl = new TemplateResponse('app', 'home');
-//		$tpl->setParams($params);
-//
-//		$tpl->render();
-//	}
-//
-//
-//	public function testRenderDifferentApp(){
-//
-//		$tpl = new TemplateResponse('app', 'home', 'app2');
-//
-//		$tpl->render();
-//	}
-
 
 	public function testGetRenderAs(){
 		$render = 'myrender';

--- a/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/middleware/MiddlewareTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
@@ -13,10 +13,18 @@
 namespace OC\AppFramework\Middleware\Security;
 
 use OC\AppFramework\Http\Request;
+use OC\AppFramework\Utility\ControllerMethodReflector;
+
 use OCP\AppFramework\Http\Response;
 
 
 class CORSMiddlewareTest extends \PHPUnit_Framework_TestCase {
+
+	private $reflector;
+
+	protected function setUp() {
+		$this->reflector = new ControllerMethodReflector();
+	}
 
 	/**
 	 * @CORS
@@ -25,11 +33,11 @@ class CORSMiddlewareTest extends \PHPUnit_Framework_TestCase {
 		$request = new Request(
 			array('server' => array('HTTP_ORIGIN' => 'test'))
 		);
+		$this->reflector->reflect($this, __FUNCTION__);
+		$middleware = new CORSMiddleware($request, $this->reflector);
 
-		$middleware = new CORSMiddleware($request);
 		$response = $middleware->afterController($this, __FUNCTION__, new Response());
 		$headers = $response->getHeaders();
-
 		$this->assertEquals('test', $headers['Access-Control-Allow-Origin']);
 	}
 
@@ -38,7 +46,7 @@ class CORSMiddlewareTest extends \PHPUnit_Framework_TestCase {
 		$request = new Request(
 			array('server' => array('HTTP_ORIGIN' => 'test'))
 		);
-		$middleware = new CORSMiddleware($request);
+		$middleware = new CORSMiddleware($request, $this->reflector);
 
 		$response = $middleware->afterController($this, __FUNCTION__, new Response());
 		$headers = $response->getHeaders();
@@ -51,8 +59,9 @@ class CORSMiddlewareTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testNoOriginHeaderNoCORSHEADER() {
 		$request = new Request();
+		$this->reflector->reflect($this, __FUNCTION__);
+		$middleware = new CORSMiddleware($request, $this->reflector);
 
-		$middleware = new CORSMiddleware($request);
 		$response = $middleware->afterController($this, __FUNCTION__, new Response());
 		$headers = $response->getHeaders();
 		$this->assertFalse(array_key_exists('Access-Control-Allow-Origin', $headers));
@@ -67,7 +76,8 @@ class CORSMiddlewareTest extends \PHPUnit_Framework_TestCase {
 		$request = new Request(
 			array('server' => array('HTTP_ORIGIN' => 'test'))
 		);
-		$middleware = new CORSMiddleware($request);
+		$this->reflector->reflect($this, __FUNCTION__);
+		$middleware = new CORSMiddleware($request, $this->reflector);
 
 		$response = new Response();
 		$response->addHeader('AcCess-control-Allow-Credentials ', 'TRUE');

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -26,6 +26,7 @@ namespace OC\AppFramework\Middleware\Security;
 
 use OC\AppFramework\Http;
 use OC\AppFramework\Http\Request;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\JSONResponse;
 
@@ -37,14 +38,16 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 	private $secException;
 	private $secAjaxException;
 	private $request;
+	private $reader;
 
 	public function setUp() {
 		$api = $this->getMock('OC\AppFramework\DependencyInjection\DIContainer', array(), array('test'));
 		$this->controller = $this->getMock('OCP\AppFramework\Controller',
 				array(), array($api, new Request()));
+		$this->reader = new ControllerMethodReflector();
 
 		$this->request = new Request();
-		$this->middleware = new SecurityMiddleware($api, $this->request);
+		$this->middleware = new SecurityMiddleware($api, $this->request, $this->reader);
 		$this->secException = new SecurityException('hey', false);
 		$this->secAjaxException = new SecurityException('hey', true);
 	}
@@ -68,7 +71,8 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 		$api->expects($this->any())->method('getServer')
 			->will($this->returnValue($serverMock));
 
-		$sec = new SecurityMiddleware($api, $this->request);
+		$sec = new SecurityMiddleware($api, $this->request, $this->reader);
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', $method);
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', $method);
 	}
 
@@ -99,11 +103,12 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 				->will($this->returnValue(true));
 		}
 
-		$sec = new SecurityMiddleware($api, $this->request);
+		$sec = new SecurityMiddleware($api, $this->request, $this->reader);
 
 		try {
-			$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest',
-					$method);
+			$controller = '\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest';
+			$this->reader->reflect($controller, $method);
+			$sec->beforeController($controller,	$method);
 		} catch (SecurityException $ex){
 			$this->assertEquals($status, $ex->getCode());
 		}
@@ -184,7 +189,9 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 				->method('isLoggedIn')
 				->will($this->returnValue(true));
 
-		$sec = new SecurityMiddleware($api, $this->request);
+		$sec = new SecurityMiddleware($api, $this->request, $this->reader);
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest',
+				'testNoChecks');
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest',
 				'testNoChecks');
 	}
@@ -207,7 +214,7 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 				->will($this->returnValue(true));
 		}
 
-		$sec = new SecurityMiddleware($api, $this->request);
+		$sec = new SecurityMiddleware($api, $this->request, $this->reader);
 
 		if($shouldFail){
 			$this->setExpectedException('\OC\AppFramework\Middleware\Security\SecurityException');
@@ -215,6 +222,7 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 			$this->setExpectedException(null);
 		}
 
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', $method);
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', $method);
 	}
 
@@ -230,7 +238,8 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 			->method('passesCSRFCheck')
 			->will($this->returnValue(false));
 
-		$sec = new SecurityMiddleware($api, $request);
+		$sec = new SecurityMiddleware($api, $request, $this->reader);
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testCsrfCheck');
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testCsrfCheck');
 	}
 
@@ -246,7 +255,8 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 			->method('passesCSRFCheck')
 			->will($this->returnValue(false));
 
-		$sec = new SecurityMiddleware($api, $request);
+		$sec = new SecurityMiddleware($api, $request, $this->reader);
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testNoCsrfCheck');
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testNoCsrfCheck');
 	}
 
@@ -261,7 +271,8 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 			->method('passesCSRFCheck')
 			->will($this->returnValue(true));
 
-		$sec = new SecurityMiddleware($api, $request);
+		$sec = new SecurityMiddleware($api, $request, $this->reader);
+		$this->reader->reflect('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testFailCsrfCheck');
 		$sec->beforeController('\OC\AppFramework\Middleware\Security\SecurityMiddlewareTest', 'testFailCsrfCheck');
 	}
 
@@ -318,7 +329,7 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 
 		$this->request = new Request(
 			array('server' => array('HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')));
-		$this->middleware = new SecurityMiddleware($api, $this->request);
+		$this->middleware = new SecurityMiddleware($api, $this->request, $this->reader);
 		$response = $this->middleware->afterException($this->controller, 'test',
 				$this->secException);
 

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -75,7 +75,7 @@ class ControllerMethodReflectorTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @Annotation
-	 * @param double $test
+	 * @param double $test something special
 	 */
 	public function testReadTypeDoubleAnnotations(){
 		$reader = new ControllerMethodReflector();

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\AppFramework\Utility;
+
+
+class ControllerMethodReflectorTest extends \PHPUnit_Framework_TestCase {
+
+
+	/**
+	 * @Annotation
+	 */
+	public function testReadAnnotation(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadAnnotation'
+		);
+
+		$this->assertTrue($reader->hasAnnotation('Annotation'));
+	}
+
+
+	/**
+	 * @Annotation
+	 * @param test
+	 */
+	public function testReadAnnotationNoLowercase(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadAnnotationNoLowercase'
+		);
+
+		$this->assertTrue($reader->hasAnnotation('Annotation'));
+		$this->assertFalse($reader->hasAnnotation('param'));
+	}
+
+
+	/**
+	 * @Annotation
+	 * @param int $test
+	 */
+	public function testReadTypeIntAnnotations(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadTypeIntAnnotations'
+		);
+
+		$this->assertEquals('int', $reader->getType('test'));
+	}
+
+
+	/**
+	 * @Annotation
+	 * @param double $test
+	 */
+	public function testReadTypeDoubleAnnotations(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadTypeDoubleAnnotations'
+		);
+
+		$this->assertEquals('double', $reader->getType('test'));
+	}
+
+
+	public function arguments($arg, $arg2) {}
+	public function testReflectParameters() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'arguments'
+		);
+
+		$this->assertEquals(array('arg', 'arg2'), $reader->getParameters());	
+	}
+
+
+	public function arguments2($arg) {}
+	public function testReflectParameters2() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'arguments2'
+		);
+
+		$this->assertEquals(array('arg',), $reader->getParameters());	
+	}
+
+
+}

--- a/tests/lib/group.php
+++ b/tests/lib/group.php
@@ -4,8 +4,8 @@
  *
  * @author Robin Appelman
  * @author Bernhard Posselt
- * @copyright 2012 Robin Appelman icewind@owncloud.com
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Robin Appelman <icewind@owncloud.com>
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/template.php
+++ b/tests/lib/template.php
@@ -3,7 +3,7 @@
 * ownCloud
 *
 * @author Bernhard Posselt
-* @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+* @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE


### PR DESCRIPTION
implement most of the basic stuff that was suggested in #8290

Further Changes
- MethodAnnotationReader has been renamed to ControllerMethodReflector and will always be run before any middleware. You can inject that into your middlewares to prevent multiple expensive parsing of annotations and comments in your code
- I've adjusted the template response constructor to be easier to use
- I've deprecated all the previous methods in the controller base class since stuff is injected anyways now and for everything else theres the protected $request object. Also TemplateResponse is easier to use which should get rid of the render method
- The formatter is now choosen by the **format** parameter (does not matter what kind of request, so you can use /url/items.{format} or ?format=json. If theres no parameter it checks the first parameter in the Accept header, and if everything fails, default to json

I'll add a nice description of what exactly it does later on ;)

Usecases:
## Return JSON from a controller

``` php
<?php
class JSONController extends Controller {
    public function authors () {
        return array('id' => 1, 'test' => 'hi');
    }
}
```
## Return XML from a controller
- **Route**: /my/app/authors.{format}
- **GET** /my/app/authors.xml

or
- **Route**: /my/app/authors
- **GET** /my/app/authors?format=xml OR
- **Accept**: application/xml

``` php
<?php
class XMLController extends Controller {
    public function authors () {
        // response does not yet exist but if you want you can create a PR
        $this->registerResponder('xml', function($response) {
            return new XMLResponse($response);
        });

        return array('id' => 1, 'test' => 'hi');
    }
}
```
## Transform any data to a PHP array that can be formatted with a responder

``` php
<?php
class ItemApiSerializer implements IResponseSerializer {

    public function serialize($response) {
        $result = array('items' => array());

        // wrap response in an array if its just a single item
        if(!is_array($response)) {
            $response = array($response);
        }

        foreach($response as $item) {
            $result['items'][] = $item->toApi();    
        }
    }

}

class JSONController extends Controller {
    public function authors () {
        $this->registerSerializer(new ItemApiSerializer());

        return array(new SomeClass(), new SomeClass());
    }
}
```
## Inject and cast parameters
- **GET** /my/app/authors/3?published=false
- **Route**: /my/app/authors/{authorId}

``` php
<?php
class AuthorController extends Controller {
    /**
     * @param int $authorId
     * @param bool $published
     */
    public function index ($authorId, $published) {
        // return {"id":3,"published":false}
        return array('id' => $authorId, 'test' => $published);
    }
}
```
