### PR TITLE
Fix sharing of ext storage mount points

### DIFF
--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -33,10 +33,12 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	private $path;
 
 	public function isValidSource($itemSource, $uidOwner) {
-		$query = \OC_DB::prepare('SELECT `name` FROM `*PREFIX*filecache` WHERE `fileid` = ?');
-		$result = $query->execute(array($itemSource));
-		if ($row = $result->fetchRow()) {
-			$this->path = $row['name'];
+		$path = \OC\Files\Filesystem::getPath($itemSource);
+		if ($path) {
+			// FIXME: attributes should not be set here,
+			// keeping this pattern for now to avoid unexpected
+			// regressions
+			$this->path = basename($path);
 			return true;
 		}
 		return false;

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -29,10 +29,14 @@ use OCA\Files\Share;
  */
 class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
+	const TEST_FOLDER_NAME = '/folder_share_api_test';
+
+	private static $tempStorage;
+
 	function setUp() {
 		parent::setUp();
 
-		$this->folder = '/folder_share_api_test';
+		$this->folder = self::TEST_FOLDER_NAME;
 		$this->subfolder  = '/subfolder_share_api_test';
 		$this->subsubfolder = '/subsubfolder_share_api_test';
 
@@ -50,6 +54,8 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	function tearDown() {
 		$this->view->unlink($this->filename);
 		$this->view->deleteAll($this->folder);
+
+		self::$tempStorage = null;
 
 		parent::tearDown();
 	}
@@ -929,6 +935,54 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
+	 * Post init mount points hook for mounting simulated ext storage
+	 */
+	public static function initTestMountPointsHook($data) {
+		if ($data['user'] === \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1) {
+			\OC\Files\Filesystem::mount(self::$tempStorage, array(), '/' . \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1 . '/files' . self::TEST_FOLDER_NAME);
+		}
+	}
+
+	/**
+	 * Tests mounting a folder that is an external storage mount point.
+	 */
+	public function testShareStorageMountPoint() {
+		self::$tempStorage = new \OC\Files\Storage\Temporary(array());
+		self::$tempStorage->file_put_contents('test.txt', 'abcdef');
+		self::$tempStorage->getScanner()->scan('');
+
+		// needed because the sharing code sometimes switches the user internally and mounts the user's
+		// storages. In our case the temp storage isn't mounted automatically, so doing it in the post hook
+		// (similar to how ext storage works)
+		OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\Test_Files_Sharing_Api', 'initTestMountPointsHook');
+
+		// logging in will auto-mount the temp storage for user1 as well
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo = $this->view->getFileInfo($this->folder);
+
+		// user 1 shares the mount point folder with user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
+
+		$this->assertTrue($result);
+
+		// user2: check that mount point name appears correctly
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+
+		$view = new \OC\Files\View('/' . \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2 . '/files');
+
+		$this->assertTrue($view->file_exists($this->folder));
+		$this->assertTrue($view->file_exists($this->folder . '/test.txt'));
+
+		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+
+		\OC_Hook::clear('OC_Filesystem', 'post_initMountPoints', '\Test_Files_Sharing_Api', 'initTestMountPointsHook');
+	}
+	/**
 	 * @expectedException \Exception
 	 */
 	public function testShareNonExisting() {
@@ -950,5 +1004,4 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 
 		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);
 	}
-
 }

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -603,6 +603,10 @@ class Cache {
 		$sql = 'SELECT `path` FROM `*PREFIX*filecache` WHERE `fileid` = ? AND `storage` = ?';
 		$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 		if ($row = $result->fetchRow()) {
+			// Oracle stores empty strings as null...
+			if ($row['path'] === null) {
+				return '';
+			}
 			return $row['path'];
 		} else {
 			return null;


### PR DESCRIPTION
When sharing an ext storage mount point, it will now use the name of the
mount point instead of an empty string for the target path.

Fixes #5347 
This fix is compatible with stable6 as long as #8431 gets fixed there.

There is an additional issue: when navigating into the folder the user doesn't have rename or delete permissions. Needs further research.

@schiesbn @icewind1991 
