### PR TITLE
Be more strict in checking the resultCode of memcached hasKey function

### DIFF
--- a/lib/private/memcache/memcached.php
+++ b/lib/private/memcache/memcached.php
@@ -57,7 +57,7 @@ class Memcached extends Cache {
 
 	public function hasKey($key) {
 		self::$cache->get($this->getNamespace() . $key);
-		return self::$cache->getResultCode() !== \Memcached::RES_NOTFOUND;
+		return self::$cache->getResultCode() === \Memcached::RES_SUCCESS;
 	}
 
 	public function remove($key) {


### PR DESCRIPTION
Memcached hasKey should test for success, the `get` can fail for other reasons.

One of the other failures is no running server.
