### PR TITLE
reduce multiselect max-width from 400 to 200px to not take too much space

### DIFF
--- a/core/css/multiselect.css
+++ b/core/css/multiselect.css
@@ -50,7 +50,7 @@ ul.multiselectoptions > li input[type='checkbox']:checked+label {
 
 div.multiselect, select.multiselect {
 	display: inline-block;
-	max-width: 400px;
+	max-width: 200px;
 	min-width: 150px;
 	padding-right: 10px;
 	min-height: 20px;


### PR DESCRIPTION
Test this in the user management with some users who are in lots of groups. Currently this leads to a very wide table, which can result in a horizontal scrollbar and not being able to delete a specific user because the name is on the far left (out of viewport) when the delete icon is visible on the right.

This is a quick fix for that, please review @owncloud/designers @msrex 

(Note to self: We should also backport this to stable6.)
