### PR TITLE
Sharing ux improvements

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -11,7 +11,7 @@
 	margin-right:112px;
 	position:absolute;
 	right:0;
-	width:380px;
+	width:420px;
 	z-index:500;
 	padding:16px;
 }

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -11,7 +11,7 @@
 	margin-right:112px;
 	position:absolute;
 	right:0;
-	width:320px;
+	width:380px;
 	z-index:500;
 	padding:16px;
 }

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -25,6 +25,13 @@ foreach(OC_App::getEnabledApps() as $app) {
 	$apps_paths[$app] = OC_App::getAppWebPath($app);
 }
 
+$defaultExpireDateEnabled = \OCP\Config::getAppValue('core', 'shareapi_default_expire_date', 'no');
+$defaultExpireDate = $enforceDefaultExpireDate = null;
+if ($defaultExpireDateEnabled === 'yes') {
+	$defaultExpireDate = \OCP\Config::getAppValue('core', 'shareapi_expire_after_n_days', '7');
+	$enforceDefaultExpireDate = \OCP\Config::getAppValue('core', 'shareapi_enforce_expire_date', 'no');
+}
+
 $array = array(
 	"oc_debug" => (defined('DEBUG') && DEBUG) ? 'true' : 'false',
 	"oc_isadmin" => OC_User::isAdminUser(OC_User::getUser()) ? 'true' : 'false',
@@ -66,6 +73,14 @@ $array = array(
 			'version'			=> implode('.', OC_Util::getVersion()),
 			'versionstring'		=> OC_Util::getVersionString(),
 		)
+	),
+	"oc_appconfig" => json_encode(
+			array("core" => array(
+				'defaultExpireDateEnabled' => $defaultExpireDateEnabled,
+				'defaultExpireDate' => $defaultExpireDate,
+				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
+				)
+			)
 	),
 	"oc_defaults" => json_encode(
 		array(

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -219,7 +219,18 @@ OC.Share={
 				html += '<div id="link">';
 				html += '<input type="checkbox" name="linkCheckbox" id="linkCheckbox" value="1" /><label for="linkCheckbox">'+t('core', 'Share link')+'</label>';
 				html += '<br />';
+
+				var defaultExpireMessage = '';
+				if ((itemType === 'folder' || itemType === 'file') && oc_appconfig.core.defaultExpireDateEnabled === 'yes') {
+					if (oc_appconfig.core.defaultExpireDateEnforced === 'yes') {
+						defaultExpireMessage = t('core', 'The public link will expire no later than {days} days after it is created',  {'days': oc_appconfig.core.defaultExpireDate}) + '<br/>';
+					} else {
+						defaultExpireMessage = t('core', 'By default the public link will expire after {days} days', {'days': oc_appconfig.core.defaultExpireDate}) + '<br/>';
+					}
+				}
+				html += '<div id="defaultExpireMessage">'+defaultExpireMessage+'</div>';
 				html += '<input id="linkText" type="text" readonly="readonly" />';
+
 				html += '<input type="checkbox" name="showPassword" id="showPassword" value="1" style="display:none;" /><label for="showPassword" style="display:none;">'+t('core', 'Password protect')+'</label>';
 				html += '<div id="linkPass">';
 				html += '<input id="linkPassText" type="password" placeholder="'+t('core', 'Password')+'" />';
@@ -490,19 +501,20 @@ OC.Share={
 			$('#linkPassText').attr('placeholder', '**********');
 		}
 		$('#expiration').show();
+		$('#defaultExpireMessage').show();
 		$('#emailPrivateLink #email').show();
 		$('#emailPrivateLink #emailButton').show();
 		$('#allowPublicUploadWrapper').show();
 	},
 	hideLink:function() {
 		$('#linkText').hide('blind');
+		$('#defaultExpireMessage').hide();
 		$('#showPassword').hide();
 		$('#showPassword+label').hide();
 		$('#linkPass').hide();
 		$('#emailPrivateLink #email').hide();
 		$('#emailPrivateLink #emailButton').hide();
 		$('#allowPublicUploadWrapper').hide();
-		$('#expirationDate').hide();
 	},
 	dirname:function(path) {
 		return path.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -746,6 +746,9 @@ $(document).ready(function() {
 					OC.dialogs.alert(t('core', 'Error unsetting expiration date'), t('core', 'Error'));
 				}
 				$('#expirationDate').hide('blind');
+				if (oc_appconfig.core.defaultExpireDateEnforced === 'no') {
+					$('#defaultExpireMessage'). show('blind');
+				}
 			});
 		}
 	});
@@ -768,6 +771,10 @@ $(document).ready(function() {
 				expirationDateField.tipsy({gravity: 'n', fade: true});
 				expirationDateField.tipsy('show');
 				expirationDateField.addClass('error');
+			} else {
+				if (oc_appconfig.core.defaultExpireDateEnforced === 'no') {
+					$('#defaultExpireMessage'). hide('blind');
+				}
 			}
 		});
 	});

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -228,7 +228,7 @@ OC.Share={
 						defaultExpireMessage = t('core', 'By default the public link will expire after {days} days', {'days': oc_appconfig.core.defaultExpireDate}) + '<br/>';
 					}
 				}
-				html += '<div id="defaultExpireMessage">'+defaultExpireMessage+'</div>';
+
 				html += '<input id="linkText" type="text" readonly="readonly" />';
 
 				html += '<input type="checkbox" name="showPassword" id="showPassword" value="1" style="display:none;" /><label for="showPassword" style="display:none;">'+t('core', 'Password protect')+'</label>';
@@ -250,6 +250,7 @@ OC.Share={
 			html += '<div id="expiration">';
 			html += '<input type="checkbox" name="expirationCheckbox" id="expirationCheckbox" value="1" /><label for="expirationCheckbox">'+t('core', 'Set expiration date')+'</label>';
 			html += '<input id="expirationDate" type="text" placeholder="'+t('core', 'Expiration date')+'" style="display:none; width:90%;" />';
+			html += '<div id="defaultExpireMessage">'+defaultExpireMessage+'</div>';
 			html += '</div>';
 			dropDownEl = $(html);
 			dropDownEl = dropDownEl.appendTo(appendTo);

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -132,7 +132,8 @@ table.grid td.date{
 span.securitywarning {color:#C33; font-weight:bold; }
 span.connectionwarning {color:#933; font-weight:bold; }
 table.shareAPI td { padding-bottom: 0.8em; }
-table.shareAPI input#shareapi_expire_after_n_days {width: 25px;}
+table.shareAPI input#shareapiExpireAfterNDays {width: 25px;}
+table.shareAPI .indent { padding-left: 2em; }
 
 #mail_settings p label:first-child {
 	display: inline-block;

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -31,6 +31,14 @@ $(document).ready(function(){
 		OC.AppConfig.setValue('core', $(this).attr('name'), value);
 	});
 
+	$('#shareapiDefaultExpireDate').change(function() {
+		$("#setDefaultExpireDate").toggleClass('hidden', !this.checked);
+	});
+
+	$('#allowLinks').change(function() {
+		$("#publicLinkSettings").toggleClass('hidden', !this.checked);
+	});
+
 	$('#security').change(function(){
 		$.post(OC.filePath('settings','ajax','setsecurity.php'), { enforceHTTPS: $('#forcessl').val() },function(){} );
 	});

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -217,15 +217,31 @@ if (!$_['internetconnectionworking']) {
 				<input type="checkbox" name="shareapi_allow_links" id="allowLinks"
 					   value="1" <?php if ($_['allowLinks'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowLinks"><?php p($l->t('Allow links'));?></label><br/>
-				<em><?php p($l->t('Allow users to share items to the public with links')); ?></em>
-			</td>
-		</tr>
-		<tr>
-			<td <?php if ($_['shareAPIEnabled'] == 'no') print_unescaped('class="hidden"');?>>
+
+				<div <?php ($_['allowLinks'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?> id="publicLinkSettings">
+
 				<input type="checkbox" name="shareapi_allow_public_upload" id="allowPublicUpload"
 				       value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>
-				<em><?php p($l->t('Allow users to enable others to upload into their publicly shared folders')); ?></em>
+
+				<input type="checkbox" name="shareapi_default_expire_date" id="shareapiDefaultExpireDate"
+				       value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />
+				<label for="shareapiDefaultExpireDate"><?php p($l->t('Set default expiration date'));?></label><br/>
+				<div id="setDefaultExpireDate" <?php ($_['shareDefaultExpireDateSet'] === 'no') ? print_unescaped('class="hidden indent"') : print_unescaped('class="indent"');?>>
+					<?php p($l->t( 'Expire after ' )); ?>
+					<input type="text" name='shareapi_expire_after_n_days' id="shareapiExpireAfterNDays" placeholder="<?php p('7')?>"
+						   value='<?php p($_['shareExpireAfterNDays']) ?>' />
+					<?php p($l->t( 'days' )); ?>
+					<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapiEnforceExpireDate"
+						   value="1" <?php if ($_['shareEnforceExpireDate'] == 'yes') print_unescaped('checked="checked"'); ?> />
+					<label for="shareapiEnforceExpireDate"><?php p($l->t('Enforce expiration date'));?></label><br/>
+				</div>
+
+				</div>
+				<em><?php p($l->t('Allow users to share items to the public with links')); ?></em>
+
+
+
 			</td>
 		</tr>
 		<tr>
@@ -252,22 +268,6 @@ if (!$_['internetconnectionworking']) {
 					   value="1" <?php if ($_['allowMailNotification'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowMailNotification"><?php p($l->t('Allow mail notification'));?></label><br/>
 				<em><?php p($l->t('Allow users to send mail notification for shared files')); ?></em>
-			</td>
-		</tr>
-
-		<tr>
-			<td <?php if ($_['shareAPIEnabled'] == 'no') print_unescaped('class="hidden"');?>>
-				<input type="checkbox" name="shareapi_default_expire_date" id="shareapi_default_expire_date"
-				       value="1" <?php if ($_['shareDefaultExpireDateSet'] == 'yes') print_unescaped('checked="checked"'); ?> />
-				<label for="shareapi_default_expire_date"><?php p($l->t('Set default expiration date'));?></label><br/>
-				<?php p($l->t( 'Expire after ' )); ?>
-				<input type="text" name='shareapi_expire_after_n_days' id="shareapi_expire_after_n_days" placeholder="<?php p('7')?>"
-					   value='<?php p($_['shareExpireAfterNDays']) ?>' />
-				<?php p($l->t( 'days' )); ?>
-				<input type="checkbox" name="shareapi_enforce_expire_date" id="shareapi_enforce_expire_date"
-				       value="1" <?php if ($_['shareEnforceExpireDate'] == 'yes') print_unescaped('checked="checked"'); ?> />
-				<label for="shareapi_enforce_expire_date"><?php p($l->t('Enforce expiration date'));?></label><br/>
-				<em><?php p($l->t('Expire shares by default after N days')); ?></em>
 			</td>
 		</tr>
 


### PR DESCRIPTION
As discussed here https://github.com/owncloud/core/issues/8344
- The admin settings now only show "Set default expiration date", if it is checked we will show the input field and the "enforce expire date" checkbox.
- If you hover over the "set expire date" checkbox or the date-picker you will get following messages: If default expire date is set "By default shares will expire after 7 days" and if it is also enforced "Shares will expire not later than 7 days after they were shared".

cc @jancborchardt please have a look. Thanks!
