### PR TITLE
Fallback to window height when positioning dialogs

### DIFF
--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -66,9 +66,10 @@
 			$(window).resize(function() {
 				self.parent = self.$dialog.parent().length > 0 ? self.$dialog.parent() : $('body');
 				var pos = self.parent.position();
+				var parentHeight = (self.parent.height()) ? self.parent.height() : $(window).height();
 				self.$dialog.css({
 					left: pos.left + (self.parent.width() - self.$dialog.outerWidth())/2,
-					top: pos.top + (self.parent.height() - self.$dialog.outerHeight())/2
+					top: pos.top + (parentHeight - self.$dialog.outerHeight())/2
 				});
 			});
 


### PR DESCRIPTION
This prevents dialogs from being half hidden at the top of the screen.

![](https://i.imgur.com/YIUj0gg.png)

cc @PVince81 @DeepDiver1975 @karlitschek 
