### PR TITLE
Remove legacy routing code

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,7 +24,6 @@ RewriteRule ^\.well-known/carddav /remote.php/carddav/ [R]
 RewriteRule ^\.well-known/caldav /remote.php/caldav/ [R]
 RewriteRule ^apps/calendar/caldav\.php remote.php/caldav/ [QSA,L]
 RewriteRule ^apps/contacts/carddav\.php remote.php/carddav/ [QSA,L]
-RewriteRule ^apps/([^/]*)/(.*\.(php))$ index.php?app=$1&getfile=$2 [QSA,L]
 RewriteRule ^remote/(.*) remote.php [QSA,L]
 </IfModule>
 <IfModule mod_mime.c>

--- a/lib/base.php
+++ b/lib/base.php
@@ -715,7 +715,8 @@ class OC {
 				OC_App::loadApps();
 			} else {
 				// For guests: Load only authentication, filesystem and logging
-				OC_App::loadApps(array('authentication', 'filesystem', 'logging'));
+				OC_App::loadApps(array('authentication'));
+				OC_App::loadApps(array('filesystem', 'logging'));
 			}
 		}
 

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -188,8 +188,11 @@ class Router implements IRouter {
 		if (substr($url, 0, 6) === '/apps/') {
 			// empty string / 'apps' / $app / rest of the route
 			list(, , $app,) = explode('/', $url, 4);
+			\OC::$REQUESTEDAPP = $app;
 			$this->loadRoutes($app);
 		} else if (substr($url, 0, 6) === '/core/' or substr($url, 0, 10) === '/settings/') {
+			\OC::$REQUESTEDAPP = $url;
+			\OC_App::loadApps();
 			$this->loadRoutes('core');
 		} else {
 			$this->loadRoutes();

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -767,15 +767,12 @@ class OC_Util {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		if(isset($_REQUEST['redirect_url'])) {
 			$location = urldecode($_REQUEST['redirect_url']);
-		}
-		else if (isset(OC::$REQUESTEDAPP) && !empty(OC::$REQUESTEDAPP)) {
-			$location = $urlGenerator->getAbsoluteURL('/index.php/apps/'.OC::$REQUESTEDAPP.'/index.php');
 		} else {
 			$defaultPage = OC_Appconfig::getValue('core', 'defaultpage');
 			if ($defaultPage) {
 				$location = $urlGenerator->getAbsoluteURL($defaultPage);
 			} else {
-				$location = $urlGenerator->getAbsoluteURL('/index.php/files/index.php');
+				$location = $urlGenerator->getAbsoluteURL('/index.php/apps/files');
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);

--- a/public.php
+++ b/public.php
@@ -24,6 +24,10 @@ try {
 	$parts = explode('/', $file, 2);
 	$app = $parts[0];
 
+	// Load all required applications
+	\OC::$REQUESTEDAPP = $app;
+	OC_App::loadApps(array('authentication', 'filesystem', 'logging'));
+
 	OC_Util::checkAppEnabled($app);
 	OC_App::loadApp($app);
 	OC_User::setIncognitoMode(true);

--- a/public.php
+++ b/public.php
@@ -26,7 +26,8 @@ try {
 
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
-	OC_App::loadApps(array('authentication', 'filesystem', 'logging'));
+	OC_App::loadApps(array('authentication'));
+	OC_App::loadApps(array('filesystem', 'logging'));
 
 	OC_Util::checkAppEnabled($app);
 	OC_App::loadApp($app);

--- a/remote.php
+++ b/remote.php
@@ -26,7 +26,8 @@ try {
 
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
-	OC_App::loadApps(array('authentication', 'filesystem', 'logging'));
+	OC_App::loadApps(array('authentication'));
+	OC_App::loadApps(array('filesystem', 'logging'));
 
 	switch ($app) {
 		case 'core':

--- a/remote.php
+++ b/remote.php
@@ -1,7 +1,6 @@
 <?php
 
 try {
-
 	require_once 'lib/base.php';
 	$path_info = OC_Request::getPathInfo();
 	if ($path_info === false || $path_info === '') {
@@ -24,6 +23,11 @@ try {
 
 	$parts=explode('/', $file, 2);
 	$app=$parts[0];
+
+	// Load all required applications
+	\OC::$REQUESTEDAPP = $app;
+	OC_App::loadApps(array('authentication', 'filesystem', 'logging'));
+
 	switch ($app) {
 		case 'core':
 			$file =  OC::$SERVERROOT .'/'. $file;


### PR DESCRIPTION
The getfile routing code was absolutely legacy and not needed anymore. Additionally \OC::$REQUESTEDAPP was never set to the actually accessed application.

This commit removes the legacy routing code and ensures that $REQUESTEDAPP is always set so that other applications (e.g. the firewall or a two-factor authentication) can intercept the currently accessed app.

<hr/>

Testplan:
- [x] Installation works
- [x] Login with DB works
- [x] Logout works
- [x] Login with alternate backend works (tested with user_webdavauth)
- [x] Other apps are accessible
- [x] Redirect on login works (e.g. index.php?redirect_url=%2Fcore%2Findex.php%2Fsettings%2Fapps%3Finstalled)
- [x] Personal settings are accessible
- [x] Admin settings are accessible
- [x] Sharing files works
- [x] DAV works
- [x] OC::$REQUESTEDAPP contains the requested application and can be intercepted by other applications

@karlitschek @PVince81 Please review. This addresses https://github.com/owncloud/security-tracker/issues/70
