### PR TITLE
Rotate thumbnail when encryption is enabled

### DIFF
--- a/lib/private/preview/image.php
+++ b/lib/private/preview/image.php
@@ -22,12 +22,13 @@ class Image extends Provider {
 		}
 
 		$image = new \OC_Image();
-		//check if file is encrypted
+
 		if($fileInfo['encrypted'] === true) {
-			$image->loadFromData(stream_get_contents($fileview->fopen($path, 'r')));
-		}else{
-			$image->loadFromFile($fileview->getLocalFile($path));
+			$fileName = $fileview->toTmpFile($path);
+		} else {
+			$fileName = $fileview->getLocalFile($path);
 		}
+		$image->loadFromFile($fileName);
 
 		return $image->valid() ? $image : false;
 	}


### PR DESCRIPTION
When a picture is encrypted, save it to a temporary file first so that
the PHP function for rotation can access it as file.

refs: https://github.com/owncloud/gallery/pull/36

@PVince81 @schiesbn @icewind1991 @georgehrke THX
