### PR TITLE
Handling long paths properly in \OC\Files\View

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -257,7 +257,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>false</notnull>
-				<length>512</length>
+				<length>4000</length>
 			</field>
 
 			<field>

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -29,14 +29,13 @@ use OC\Files\Cache\Updater;
 
 class View {
 	private $fakeRoot = '';
-	private $internal_path_cache = array();
-	private $storage_cache = array();
 
 	public function __construct($root = '') {
 		$this->fakeRoot = $root;
 	}
 
 	public function getAbsolutePath($path = '/') {
+		$this->assertPathLength($path);
 		if ($path === '') {
 			$path = '/';
 		}
@@ -77,6 +76,7 @@ class View {
 	 * @return string
 	 */
 	public function getRelativePath($path) {
+		$this->assertPathLength($path);
 		if ($this->fakeRoot == '') {
 			return $path;
 		}
@@ -208,6 +208,7 @@ class View {
 	}
 
 	public function readfile($path) {
+		$this->assertPathLength($path);
 		@ob_end_clean();
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
@@ -595,6 +596,7 @@ class View {
 	}
 
 	public function toTmpFile($path) {
+		$this->assertPathLength($path);
 		if (Filesystem::isValidPath($path)) {
 			$source = $this->fopen($path, 'r');
 			if ($source) {
@@ -611,7 +613,7 @@ class View {
 	}
 
 	public function fromTmpFile($tmpFile, $path) {
-
+		$this->assertPathLength($path);
 		if (Filesystem::isValidPath($path)) {
 
 			// Get directory that the file is going into
@@ -640,6 +642,7 @@ class View {
 	}
 
 	public function getMimeType($path) {
+		$this->assertPathLength($path);
 		return $this->basicOperation('getMimeType', $path);
 	}
 
@@ -669,6 +672,7 @@ class View {
 	}
 
 	public function free_space($path = '/') {
+		$this->assertPathLength($path);
 		return $this->basicOperation('free_space', $path);
 	}
 
@@ -808,6 +812,7 @@ class View {
 	 * @return \OC\Files\FileInfo|false
 	 */
 	public function getFileInfo($path, $includeMountPoints = true) {
+		$this->assertPathLength($path);
 		$data = array();
 		if (!Filesystem::isValidPath($path)) {
 			return $data;
@@ -878,6 +883,7 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function getDirectoryContent($directory, $mimetype_filter = '') {
+		$this->assertPathLength($directory);
 		$result = array();
 		if (!Filesystem::isValidPath($directory)) {
 			return $result;
@@ -1006,6 +1012,7 @@ class View {
 	 * returns the fileid of the updated file
 	 */
 	public function putFileInfo($path, $data) {
+		$this->assertPathLength($path);
 		if ($data instanceof FileInfo) {
 			$data = $data->getData();
 		}
@@ -1152,5 +1159,13 @@ class View {
 			}
 		}
 		return null;
+	}
+
+	private function assertPathLength($path) {
+		$maxLen = min(PHP_MAXPATHLEN, 4000);
+		$pathLen = strlen($path);
+		if ($pathLen > $maxLen) {
+			throw new \OCP\Files\InvalidPathException("Path length($pathLen) exceeds max path length($maxLen): $path");
+		}
 	}
 }

--- a/version.php
+++ b/version.php
@@ -3,7 +3,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(6, 90, 0, 2);
+$OC_Version=array(6, 90, 0, 3);
 
 // The human readable string
 $OC_VersionString='7.0 pre alpha';


### PR DESCRIPTION
We now support a maximum path of 4000 characters.

Php is limiting us to 4096 (260 chars on Windows :dancers:).
Due to maximum column length on Oracle for a varchar columns being 4000 - this is our new max path length. (I don't want to summon this migration horror on us)

@karlitschek @craigpg @icewind1991 @PVince81 @schiesbn 

This is no the end of the road - more to come .....

further tasks https://github.com/owncloud/core/issues/8571
