### PR TITLE
fix sticky footer on log in page

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -352,9 +352,9 @@ input[type="submit"].enabled {
 #body-login #header {
 	padding-top: 100px;
 }
-/* Fix background gradient */
 #body-login {
-	background-attachment: fixed;
+	background-attachment: fixed; /* fix background gradient */
+	height: 100%; /* fix sticky footer */
 }
 
 /* Dark subtle label text */


### PR DESCRIPTION
The ownCloud link and slogan wasn’t sticky to the bottom anymore but rather directly below the log in box and button. This fixes that regression.

Please review @owncloud/designers 
