### PR TITLE
Allow setting of controller default method values through normal PHP default values

### DIFF
--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -126,11 +126,11 @@ class Dispatcher {
 		// valid types that will be casted
 		$types = array('int', 'integer', 'bool', 'boolean', 'float');
 
-		foreach($this->reflector->getParameters() as $param) {
+		foreach($this->reflector->getParameters() as $param => $default) {
 
 			// try to get the parameter from the request object and cast
 			// it to the type annotated in the @param annotation
-			$value = $this->request->getParam($param);
+			$value = $this->request->getParam($param, $default);
 			$type = $this->reflector->getType($param);
 			
 			// if this is submitted using GET or a POST form, 'false' should be 

--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -59,7 +59,12 @@ class ControllerMethodReflector {
 
 		// get method parameters
 		foreach ($reflection->getParameters() as $param) {
-			$this->parameters[] = $param->name;
+			if($param->isOptional()) {
+				$default = $param->getDefaultValue();
+			} else {
+				$default = null;
+			}
+			$this->parameters[$param->name] = $default;
 		}
 	}
 
@@ -81,7 +86,7 @@ class ControllerMethodReflector {
 
 
 	/**
-	 * @return array the arguments of the method
+	 * @return array the arguments of the method with key => default value
 	 */
 	public function getParameters() {
 		return $this->parameters;

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -40,11 +40,11 @@ class TestController extends Controller {
 	 * @param int $int
 	 * @param bool $bool
 	 */
-	public function exec($int, $bool) {
+	public function exec($int, $bool, $test=4, $test2=1) {
 		$this->registerResponder('text', function($in) {
 			return new JSONResponse(array('text' => $in));
 		});
-		return array($int, $bool);
+		return array($int, $bool, $test, $test2);
 	}
 }
 
@@ -262,6 +262,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 			}));
 	}
 
+
 	public function testControllerParametersInjected() {
 		$this->request = new Request(array(
 			'post' => array(
@@ -280,8 +281,32 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('[3,true]', $response[2]);
+		$this->assertEquals('[3,true,4,1]', $response[2]);
 	}
+
+
+	public function testControllerParametersInjectedDefaultOverwritten() {
+		$this->request = new Request(array(
+			'post' => array(
+				'int' => '3',
+				'bool' => 'false',
+				'test2' => 7
+			),
+			'method' => 'POST'
+		));
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('[3,true,4,7]', $response[2]);
+	}
+
 
 
 	public function testResponseTransformedByUrlFormat() {
@@ -305,7 +330,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('{"text":[3,false]}', $response[2]);
+		$this->assertEquals('{"text":[3,false,4,1]}', $response[2]);
 	}
 
 
@@ -331,7 +356,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('{"text":[3,false]}', $response[2]);
+		$this->assertEquals('{"text":[3,false,4,1]}', $response[2]);
 	}
 
 
@@ -359,7 +384,10 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('{"text":[3,true]}', $response[2]);
+		$this->assertEquals('{"text":[3,true,4,1]}', $response[2]);
 	}
+
+
+
 
 }

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -88,7 +88,7 @@ class ControllerMethodReflectorTest extends \PHPUnit_Framework_TestCase {
 	}
 
 
-	public function arguments($arg, $arg2) {}
+	public function arguments($arg, $arg2='hi') {}
 	public function testReflectParameters() {
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
@@ -96,7 +96,7 @@ class ControllerMethodReflectorTest extends \PHPUnit_Framework_TestCase {
 			'arguments'
 		);
 
-		$this->assertEquals(array('arg', 'arg2'), $reader->getParameters());	
+		$this->assertEquals(array('arg' => null, 'arg2' => 'hi'), $reader->getParameters());	
 	}
 
 
@@ -108,7 +108,7 @@ class ControllerMethodReflectorTest extends \PHPUnit_Framework_TestCase {
 			'arguments2'
 		);
 
-		$this->assertEquals(array('arg',), $reader->getParameters());	
+		$this->assertEquals(array('arg' => null), $reader->getParameters());	
 	}
 
 


### PR DESCRIPTION
While trying to start porting yesterday I ran into the problem I ran into the problem that I wanted to get rid of 

``` php
public function index() {
    $batchSize = (int) $this->params('batchSize', 20);
}
```

where 20 is the default parameter if nothing is passed. This pull request lets you set the default parameter in the method signature:

``` php
public function index($batchSize=20) {
}
```

The nice thing is that it works by key and not by position, so the following is possble:
**GET /url?param1=hi&param4=2**

``` php
public function index($param1, $param2 $param3=20, $param4=5) {
    // $param1 = 'hi'
    // $param2 = null
    // $param3 = 20
    // $param4 = 2
}
```

@DeepDiver1975 @LEDfan @Kondou-ger @MorrisJobke @DeepDiver1975 
