### PR TITLE
Fixed getAbsolutePath case when path is "0"

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -37,7 +37,7 @@ class View {
 	}
 
 	public function getAbsolutePath($path = '/') {
-		if (!$path) {
+		if ($path === '') {
 			$path = '/';
 		}
 		if ($path[0] !== '/') {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -585,4 +585,22 @@ class View extends \PHPUnit_Framework_TestCase {
 		$info2 = $view->getFileInfo('/test/test');
 		$this->assertSame($info['etag'], $info2['etag']);
 	}
+
+	/**
+	 * @dataProvider absolutePathProvider
+	 */
+	public function testGetAbsolutePath($expectedPath, $relativePath) {
+		$view = new \OC\Files\View('/files');
+		$this->assertEquals($expectedPath, $view->getAbsolutePath($relativePath));
+	}
+
+	function absolutePathProvider() {
+		return array(
+			array('/files/', ''),
+			array('/files/0', '0'),
+			array('/files/', '/'),
+			array('/files/test', 'test'),
+			array('/files/test', '/test'),
+		);
+	}
 }


### PR DESCRIPTION
Make sure to correctly check for string emptiness when the passed path
is "0".

Fixes #8564 

Please review @icewind1991 @schiesbn @LukasReschke 
