### PR TITLE
Explicitly make name column use type text for mdb2

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -330,7 +330,7 @@ class OC_DB {
 	 *
 	 * SQL query via MDB2 prepare(), needs to be execute()'d!
 	 */
-	static public function prepare( $query , $limit = null, $offset = null, $isManipulation = null) {
+	static public function prepare( $query , $limit = null, $offset = null, $isManipulation = null, array $types = null) {
 
 		if (!is_null($limit) && $limit != -1) {
 			if (self::$backend == self::BACKEND_MDB2) {
@@ -375,9 +375,9 @@ class OC_DB {
 		if(self::$backend==self::BACKEND_MDB2) {
 			// differentiate between query and manipulation
 			if ($isManipulation) {
-				$result = self::$connection->prepare( $query, null, MDB2_PREPARE_MANIP );
+				$result = self::$connection->prepare( $query, $types, MDB2_PREPARE_MANIP );
 			} else {
-				$result = self::$connection->prepare( $query, null, MDB2_PREPARE_RESULT );
+				$result = self::$connection->prepare( $query, $types, MDB2_PREPARE_RESULT );
 			}
 
 			// Die if we have an error (error means: bad query, not 0 results!)
@@ -446,7 +446,7 @@ class OC_DB {
 						 . ' pass an array with \'limit\' and \'offset\' instead';
 				throw new DatabaseException($message, $stmt);
 			}
-			$stmt = array('sql' => $stmt, 'limit' => null, 'offset' => null);
+			$stmt = array('sql' => $stmt, 'limit' => null, 'offset' => null, 'types' => null);
 		}
 		if (is_array($stmt)){
 			// convert to prepared statement
@@ -456,11 +456,15 @@ class OC_DB {
 			}
 			if ( ! array_key_exists('limit', $stmt) ) {
 				$stmt['limit'] = null;
-			}
-			if ( ! array_key_exists('limit', $stmt) ) {
 				$stmt['offset'] = null;
 			}
-			$stmt = self::prepare($stmt['sql'], $stmt['limit'], $stmt['offset']);
+			if ( ! array_key_exists('offset', $stmt) ) {
+				$stmt['offset'] = null;
+			}
+			if ( ! array_key_exists('types', $stmt) ) {
+				$stmt['types'] = null;
+			}
+			$stmt = self::prepare($stmt['sql'], $stmt['limit'], $stmt['offset'], null, $stmt['types']);
 		}
 		if ($stmt instanceof PDOStatementWrapper || $stmt instanceof MDB2_Statement_Common) {
 			/** @var $stmt PDOStatementWrapper|MDB2_Statement_Common */

--- a/lib/files/cache/cache.php
+++ b/lib/files/cache/cache.php
@@ -262,16 +262,24 @@ class Cache {
 
 			$data['path'] = $file;
 			$data['parent'] = $this->getParentId($file);
-			$data['name'] = basename($file);
 
 			list($queryParts, $params) = $this->buildParts($data);
 			$queryParts[] = '`storage`';
 			$params[] = $this->numericId;
-			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
+			$types = array_fill(0, count($queryParts), null);
+			
+			//add name with explicit type 'text'
+			$data['name'] = basename($file);
+			$queryParts[] = '`name`';
+			$params[] = basename($file);
+			$types[] = 'text';
 
-			\OC_DB::executeAudited('
+			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
+			
+			\OC_DB::executeAudited(array('sql' => '
 				INSERT INTO `*PREFIX*filecache`(' . implode(', ', $queryParts) . ')
 				VALUES(' . implode(', ', $valuesPlaceholder) . ')',
+				'types'=>$types),
 				$params
 			);
 


### PR DESCRIPTION
oracle uses MDB2 for all db queries. The problem is MDB2 tries to guess the type of query variables is the type is not specified explicitly. That causes folders like `2013-04-24` to break the filecache because the name is inserted into the filecache as `2013-04-24 00:00:00`.

well ... only OC5 on oracle is affected. OC6 on oracle is working fine.

@DeepDiver1975 @karlitschek @craigpg @icewind1991 @bartv2  I created the PR here because it makes folders unusable. With this PR rescanning will repair the broken filecache.
