### PR TITLE
Disable login button until the timezone is set

### DIFF
--- a/core/js/visitortimezone.js
+++ b/core/js/visitortimezone.js
@@ -1,4 +1,10 @@
 $(document).ready(function () {
 		var visitortimezone = (-new Date().getTimezoneOffset() / 60);
 		$('#timezone-offset').val(visitortimezone);
+
+		// only enable the submit button once we are sure that the timezone is set
+		var $loginForm = $('form[name="login"]');
+		if ($loginForm.length) {
+			$loginForm.find('input#submit').prop('disabled', false);
+		}
 });

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -51,7 +51,7 @@
 		<label for="remember_login"><?php p($l->t('remember')); ?></label>
 		<?php endif; ?>
 		<input type="hidden" name="timezone-offset" id="timezone-offset"/>
-		<input type="submit" id="submit" class="login primary" value="<?php p($l->t('Log in')); ?>"/>
+		<input type="submit" id="submit" class="login primary" value="<?php p($l->t('Log in')); ?>" disabled="disabled"/>
 	</fieldset>
 </form>
 <?php if (!empty($_['alt_login'])) { ?>


### PR DESCRIPTION
On slow computers it might happen that the user manages to login before
the timezone code has a chance to run, which then causes dates to appear
wrong in the UI.

This fix makes sure the login cannot happen until the timezone field is
set.

Note that it's not possible to run the timezone code outside of
document.ready() because at that time the DOM element doesn't exist yet.

Fixes #8206, but only the case where the user logs in before the page has finished loading. The SSO code doesn't go through the login page so will be fixed separately.

Please review @ser72 @DeepDiver1975 @icewind1991 @schiesbn 
