### PR TITLE
[regression] Fixed trashbin to use correct class

### DIFF
--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -20,7 +20,7 @@ class Helper
 		$timestamp = null;
 		$user = \OCP\User::getUser();
 
-		$view = new \OC_Filesystemview('/' . $user . '/files_trashbin/files');
+		$view = new \OC\Files\View('/' . $user . '/files_trashbin/files');
 
 		if (ltrim($dir, '/') !== '' && !$view->is_dir($dir)) {
 			throw new \Exception('Directory does not exists');


### PR DESCRIPTION
It seems that \OC_Filesystemview has been removed.
Now using the correct class \OC\Files\View()

Please review this super quick one: @icewind1991 @schiesbn 
