### PR TITLE
allow admin to enforce passwords for public link shares

### DIFF
--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -418,13 +418,18 @@ class Api {
 			return  new \OC_OCS_Result(null, 404, "share doesn't exists, can't change password");
 		}
 
-		$result = \OCP\Share::shareItem(
-				$itemType,
-				$itemSource,
-				\OCP\Share::SHARE_TYPE_LINK,
-				$shareWith,
-				$permissions
-				);
+		try {
+			$result = \OCP\Share::shareItem(
+					$itemType,
+					$itemSource,
+					\OCP\Share::SHARE_TYPE_LINK,
+					$shareWith,
+					$permissions
+					);
+		} catch (\Exception $e) {
+			return new \OC_OCS_Result(null, 403, $e->getMessage());
+		}
+
 		if($result) {
 			return new \OC_OCS_Result();
 		}

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -79,6 +79,7 @@ $array = array(
 				'defaultExpireDateEnabled' => $defaultExpireDateEnabled,
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
+				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				)
 			)
 	),

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -87,6 +87,16 @@ class OC_Util {
 	}
 
 	/**
+	 * @brief check if a password is required for each public link
+	 * @return boolean
+	 */
+	public static function isPublicLinkPasswordRequired() {
+		$appConfig = \OC::$server->getAppConfig();
+		$enforcePassword = $appConfig->getValue('core', 'shareapi_enforce_links_password', 'no');
+		return ($enforcePassword === 'yes') ? true : false;
+	}
+
+	/**
 	 * Get the quota of a user
 	 * @param string $user
 	 * @return int Quota bytes

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -499,4 +499,12 @@ class Util {
 	public static function generateRandomBytes($length = 30) {
 		return \OC_Util::generateRandomBytes($length);
 	}
+
+	/**
+	 * @brief check if a password is required for each public link
+	 * @return boolean
+	 */
+	public static function isPublicLinkPasswordRequired() {
+		return \OC_Util::isPublicLinkPasswordRequired();
+	}
 }

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -60,6 +60,7 @@ $tmpl->assign('isConnectedViaHTTPS', $connectedHTTPS);
 $tmpl->assign('enforceHTTPSEnabled', OC_Config::getValue( "forcessl", false));
 
 $tmpl->assign('allowLinks', OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
+$tmpl->assign('enforceLinkPassword', \OCP\Util::isPublicLinkPasswordRequired());
 $tmpl->assign('allowPublicUpload', OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes'));
 $tmpl->assign('allowResharing', OC_Appconfig::getValue('core', 'shareapi_allow_resharing', 'yes'));
 $tmpl->assign('allowMailNotification', OC_Appconfig::getValue('core', 'shareapi_allow_mail_notification', 'yes'));

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -217,9 +217,10 @@ if (!$_['internetconnectionworking']) {
 				<input type="checkbox" name="shareapi_allow_links" id="allowLinks"
 					   value="1" <?php if ($_['allowLinks'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowLinks"><?php p($l->t('Allow links'));?></label><br/>
-
 				<div <?php ($_['allowLinks'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?> id="publicLinkSettings">
-
+				<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword"
+						   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
+				<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
 				<input type="checkbox" name="shareapi_allow_public_upload" id="allowPublicUpload"
 				       value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>


### PR DESCRIPTION
allow admin to enforce a password for every public link. If this setting is enabled the share dialog will first ask for a password and then create/display the link.

cc @jancborchardt probably again something you want to have a look at :smile: 
