### PR TITLE
Allow apps to control via a hook skipping add/remove a file during filescan

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -291,6 +291,9 @@ $CONFIG = array(
  * 1 -> check each file or folder at most once per request, recomended for general use if outside changes might happen
  * 2 -> check every time the filesystem is used, causes a performance hit when using external storages, not recomended for regular use
  */
-'filesystem_check_changes' => 1
+'filesystem_check_changes' => 1,
+
+/* specifies whether changes in the filesystem outside of owncloud affect cached data about those files */
+'filesystem_check_enable' => 1,
 
 );

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -293,7 +293,7 @@ $CONFIG = array(
  */
 'filesystem_check_changes' => 1,
 
-/* specifies whether changes in the filesystem outside of owncloud affect cached data about those files */
-'filesystem_check_enable' => 1,
+/* If true, prevent owncloud from changing the cache due to changes in the filesystem for all storage */
+'filesystem_cache_readonly' => false,
 
 );

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -167,7 +167,7 @@ class Scanner extends BasicEmitter {
 				}
 				if (!empty($newData)) {
 					\OC_Hook::emit('Scanner', 'addToCache', array('file' => $file, 'data' => $newData));
-					if(!Config::getSystemValue('filesystem_cache_readonly', false)) {
+					if($this->cacheActive) {
 						$data['fileid'] = $this->cache->put($file, $newData);
 					}
 					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -157,7 +157,7 @@ class Scanner extends BasicEmitter {
 					}
 				}
 				if (!empty($newData)) {
-					$addToCache = Config::getSystemValue('allow_scanner_to_affect_cache', true);
+					$addToCache = Config::getSystemValue('filesystem_check_enable', true);
 					\OC_Hook::emit('Scanner', 'addToCache', array('file' => $file, 'addToCache' => &$addToCache, 'data' => &$newData));
 					if($addToCache) {
 						$data['fileid'] = $this->cache->put($file, $newData);
@@ -166,7 +166,7 @@ class Scanner extends BasicEmitter {
 					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
 				}
 			} else {
-				$removeFromCache = Config::getSystemValue('allow_scanner_to_affect_cache', true);
+				$removeFromCache = Config::getSystemValue('filesystem_check_enable', true);
 				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $file, 'removeFromCache' => &$removeFromCache));
 				if($removeFromCache) {
 					$this->cache->remove($file);
@@ -253,7 +253,7 @@ class Scanner extends BasicEmitter {
 			$removedChildren = \array_diff($existingChildren, $newChildren);
 			foreach ($removedChildren as $childName) {
 				$child = ($path) ? $path . '/' . $childName : $childName;
-				$removeFromCache = Config::getSystemValue('allow_scanner_to_affect_cache', true);
+				$removeFromCache = Config::getSystemValue('filesystem_check_enable', true);
 				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $child, 'removeFromCache' => &$removeFromCache));
 				if($removeFromCache) {
 					$this->cache->remove($child);
@@ -277,7 +277,7 @@ class Scanner extends BasicEmitter {
 				}
 			}
 			$newData = array('size' => $size);
-			$addToCache = Config::getSystemValue('allow_scanner_to_affect_cache', true);
+			$addToCache = Config::getSystemValue('filesystem_check_enable', true);
 			\OC_Hook::emit('Scanner', 'addToCache', array('file' => $child, 'addToCache' => &$addToCache, 'data' => &$newData));
 			if($addToCache) {
 				$this->cache->put($path, $newData);

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -161,7 +161,11 @@ class Scanner extends BasicEmitter {
 					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
 				}
 			} else {
-				$this->cache->remove($file);
+				$removeFromCache = true;
+				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $file, 'removeFromCache' => &$removeFromCache));
+				if($removeFromCache) {
+					$this->cache->remove($file);
+				}
 			}
 			return $data;
 		}
@@ -244,7 +248,11 @@ class Scanner extends BasicEmitter {
 			$removedChildren = \array_diff($existingChildren, $newChildren);
 			foreach ($removedChildren as $childName) {
 				$child = ($path) ? $path . '/' . $childName : $childName;
-				$this->cache->remove($child);
+				$addToCache = true;
+				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $child, 'removeFromCache' => &$addToCache));
+				if($addToCache) {
+					$this->cache->remove($child);
+				}
 			}
 			\OC_DB::commit();
 			if ($exceptionOccurred){
@@ -263,7 +271,11 @@ class Scanner extends BasicEmitter {
 					$size += $childSize;
 				}
 			}
-			$this->cache->put($path, array('size' => $size));
+			$addToCache = true;
+			\OC_Hook::emit('Scanner', 'addToCache', array('file' => $path, 'addToCache' => &$addToCache, 'size' => &$size));
+			if($addToCache) {
+				$this->cache->put($path, array('size' => $size));
+			}
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'postScanFolder', array($path, $this->storageId));
 		return $size;

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -248,9 +248,9 @@ class Scanner extends BasicEmitter {
 			$removedChildren = \array_diff($existingChildren, $newChildren);
 			foreach ($removedChildren as $childName) {
 				$child = ($path) ? $path . '/' . $childName : $childName;
-				$addToCache = true;
-				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $child, 'removeFromCache' => &$addToCache));
-				if($addToCache) {
+				$removeFromCache = true;
+				\OC_Hook::emit('Scanner', 'removeFromCache', array('file' => $child, 'removeFromCache' => &$removeFromCache));
+				if($removeFromCache) {
 					$this->cache->remove($child);
 				}
 			}


### PR DESCRIPTION
Rare environment-specific scenarios exist that can leave either the cache data or file stranded to be deleted when it should be maintained or archived for review.

This PR attempts to provide a tool for an app developer to affect the behavior of the filescan operation so that files and/or data that would otherwise be deleted by the filescan can optionally be retained or moved.

Very basic sample code for use (app.php):

``` php
<?php

namespace OCA;

class LostAndFound {
    public function removeFromCache($params) {
        extract($params);
        $removeFromCache = false;
        echo "Not removed: {$file}\n";
    }

    public function addToCache($params) {
        extract($params);
        $addToCache = false;
        echo "Not added: {$file}\n";
    }
}

\OCP\Util::connectHook('Scanner', 'removeFromCache', 'OCA\LostAndFound', 'removeFromCache');
\OCP\Util::connectHook('Scanner', 'addToCache', 'OCA\LostAndFound', 'addToCache');

```

Intent for use being something like this during a recovery period:

``` bash
occ app:enable lost_and_found
occ files:scan --all
occ app:disable lost_and_found
```
