### PR TITLE
Fix drag and drop in IE8

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -311,7 +311,7 @@ var createDragShadow = function(event) {
 
 	// do not show drag shadow for too many files
 	var selectedFiles = _.first(FileList.getSelectedFiles(), FileList.pageSize);
-	selectedFiles.sort(FileList._fileInfoCompare);
+	selectedFiles = _.sortBy(selectedFiles, FileList._fileInfoCompare);
 
 	if (!isDragSelected && selectedFiles.length === 1) {
 		//revert the selection


### PR DESCRIPTION
For some reason IE8 didn't like the sort function, so using the one from
underscore instead.

To test this, just drag a file from the file list into a folder.
Before the fix: lots of "JScript" errors in the console.
After the fix: works.

Please review @MorrisJobke @icewind1991 
