### PR TITLE
modify tests/enable_app.php to pass additional apps from the commandline

### DIFF
--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -22,3 +22,7 @@ enableApp('files_external');
 enableApp('user_ldap');
 enableApp('files_versions');
 
+// also enable apps passed like php -f enable_all.php news notes
+foreach($argv as $arg) {
+    enableApp($arg);
+}


### PR DESCRIPTION
Used like:

```
php -f tests/enable_apps.php news notes music
```

can be used to enable your app for acceptance/system testing.

@bantu @DeepDiver1975 @MorrisJobke @LEDfan
