### PR TITLE
LDAP: fix possible infinite loop, that causes hanging wizard, fixes #8457

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -909,6 +909,7 @@ class Wizard extends LDAPUtility {
 					if(!$this->ldap->isResource($entry)) {
 						continue 2;
 					}
+					$rr = $entry; //will be expected by nextEntry next round
 					$attributes = $this->ldap->getAttributes($cr, $entry);
 					$dn = $this->ldap->getDN($cr, $entry);
 					if($dn === false || in_array($dn, $dnRead)) {
@@ -922,7 +923,6 @@ class Wizard extends LDAPUtility {
 					$foundItems = array_merge($foundItems, $newItems);
 					$this->resultCache[$dn][$attr] = $newItems;
 					$dnRead[] = $dn;
-					$rr = $entry; //will be expected by nextEntry next round
 				} while(($state === self::LRESULT_PROCESSED_SKIP
 						|| $this->ldap->isResource($entry))
 						&& ($dnReadLimit === 0 || $dnReadCount < $dnReadLimit));


### PR DESCRIPTION
Under certain circumstances,  usually with small user bases, but not necessarily so, the LDAP wizard can appear "hanging" while looking for object classes. It happens when an LDAP entry that has been analyzed before and returned again by a different filter shall be skipped. The search offset however did not change so the same result is returned again. 

The solution is to adjust the search offset when necessary :) Unit test included. 

Please test / review @ser72 @Elethiomel @tps800 @Xenopathic @PVince81 or others
