### PR TITLE
Remove all occurences of @brief and @returns from PHPDoc

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -66,7 +66,7 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief test rename of file/folder
+	 * test rename of file/folder
 	 */
 	function testRenameFolder() {
 		$dir = '/';

--- a/apps/files_encryption/ajax/adminrecovery.php
+++ b/apps/files_encryption/ajax/adminrecovery.php
@@ -5,7 +5,7 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  *
- * @brief Script to handle admin settings for encrypted key recovery
+ * Script to handle admin settings for encrypted key recovery
  */
 use OCA\Encryption;
 

--- a/apps/files_encryption/ajax/changeRecoveryPassword.php
+++ b/apps/files_encryption/ajax/changeRecoveryPassword.php
@@ -5,7 +5,7 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  *
- * @brief Script to change recovery key password
+ * Script to change recovery key password
  *
  */
 

--- a/apps/files_encryption/ajax/getMigrationStatus.php
+++ b/apps/files_encryption/ajax/getMigrationStatus.php
@@ -4,7 +4,7 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  *
- * @brief check migration status
+ * check migration status
  */
 use OCA\Encryption\Util;
 

--- a/apps/files_encryption/ajax/updatePrivateKeyPassword.php
+++ b/apps/files_encryption/ajax/updatePrivateKeyPassword.php
@@ -5,7 +5,7 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  *
- * @brief Script to change recovery key password
+ * Script to change recovery key password
  *
  */
 

--- a/apps/files_encryption/ajax/userrecovery.php
+++ b/apps/files_encryption/ajax/userrecovery.php
@@ -4,7 +4,7 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  *
- * @brief Script to handle admin settings for encrypted key recovery
+ * Script to handle admin settings for encrypted key recovery
  */
 
 use OCA\Encryption;

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -36,7 +36,7 @@ class Hooks {
 	private static $deleteFiles = array();
 
 	/**
-	 * @brief Startup encryption backend upon user login
+	 * Startup encryption backend upon user login
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function login($params) {
@@ -136,7 +136,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief setup encryption backend upon user created
+	 * setup encryption backend upon user created
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function postCreateUser($params) {
@@ -149,7 +149,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief cleanup encryption backend upon user deleted
+	 * cleanup encryption backend upon user deleted
 	 * @note This method should never be called for users using client side encryption
 	 */
 	public static function postDeleteUser($params) {
@@ -171,7 +171,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief If the password can't be changed within ownCloud, than update the key password in advance.
+	 * If the password can't be changed within ownCloud, than update the key password in advance.
 	 */
 	public static function preSetPassphrase($params) {
 		if (\OCP\App::isEnabled('files_encryption')) {
@@ -182,7 +182,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief Change a user's encryption passphrase
+	 * Change a user's encryption passphrase
 	 * @param array $params keys: uid, password
 	 */
 	public static function setPassphrase($params) {
@@ -259,7 +259,7 @@ class Hooks {
 	}
 
 	/*
-	 * @brief check if files can be encrypted to every user.
+	 * check if files can be encrypted to every user.
 	 */
 	/**
 	 * @param array $params
@@ -398,7 +398,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief mark file as renamed so that we know the original source after the file was renamed
+	 * mark file as renamed so that we know the original source after the file was renamed
 	 * @param array $params with the old path and the new path
 	 */
 	public static function preRename($params) {
@@ -421,7 +421,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief after a file is renamed, rename its keyfile and share-keys also fix the file size and fix also the sharing
+	 * after a file is renamed, rename its keyfile and share-keys also fix the file size and fix also the sharing
 	 * @param array $params array with oldpath and newpath
 	 *
 	 * This function is connected to the rename signal of OC_Filesystem and adjust the name and location
@@ -557,7 +557,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief if the file was really deleted we remove the encryption keys
+	 * if the file was really deleted we remove the encryption keys
 	 * @param array $params
 	 * @return boolean|null
 	 */
@@ -597,7 +597,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief remember the file which should be deleted and it's owner
+	 * remember the file which should be deleted and it's owner
 	 * @param array $params
 	 * @return boolean|null
 	 */

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -40,7 +40,7 @@ class Crypt {
 
 
 	/**
-	 * @brief return encryption mode client or server side encryption
+	 * return encryption mode client or server side encryption
 	 * @param string $user name (use system wide setting if name=null)
 	 * @return string 'client' or 'server'
 	 */
@@ -51,7 +51,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Create a new encryption keypair
+	 * Create a new encryption keypair
 	 * @return array publicKey, privatekey
 	 */
 	public static function createKeypair() {
@@ -85,7 +85,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Add arbitrary padding to encrypted data
+	 * Add arbitrary padding to encrypted data
 	 * @param string $data data to be padded
 	 * @return string padded data
 	 * @note In order to end up with data exactly 8192 bytes long we must
@@ -102,7 +102,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Remove arbitrary padding to encrypted data
+	 * Remove arbitrary padding to encrypted data
 	 * @param string $padded padded data to remove padding from
 	 * @return string unpadded data on success, false on error
 	 */
@@ -124,7 +124,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Check if a file's contents contains an IV and is symmetrically encrypted
+	 * Check if a file's contents contains an IV and is symmetrically encrypted
 	 * @param string $content
 	 * @return boolean
 	 * @note see also OCA\Encryption\Util->isEncryptedPath()
@@ -178,7 +178,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Check if a file is encrypted via legacy system
+	 * Check if a file is encrypted via legacy system
 	 * @param boolean $isCatFileContent
 	 * @param string $relPath The path of the file, relative to user/data;
 	 *        e.g. filename or /Docs/filename, NOT admin/files/filename
@@ -208,7 +208,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Symmetrically encrypt a string
+	 * Symmetrically encrypt a string
 	 * @param string $plainContent
 	 * @param string $iv
 	 * @param string $passphrase
@@ -228,7 +228,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Symmetrically decrypt a string
+	 * Symmetrically decrypt a string
 	 * @param string $encryptedContent
 	 * @param string $iv
 	 * @param string $passphrase
@@ -250,7 +250,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Concatenate encrypted data with its IV and padding
+	 * Concatenate encrypted data with its IV and padding
 	 * @param string $content content to be concatenated
 	 * @param string $iv IV to be concatenated
 	 * @return string concatenated content
@@ -264,7 +264,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Split concatenated data and IV into respective parts
+	 * Split concatenated data and IV into respective parts
 	 * @param string $catFile concatenated data to be split
 	 * @return array keys: encrypted, iv
 	 */
@@ -289,7 +289,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Symmetrically encrypts a string and returns keyfile content
+	 * Symmetrically encrypts a string and returns keyfile content
 	 * @param string $plainContent content to be encrypted in keyfile
 	 * @param string $passphrase
 	 * @return false|string encrypted content combined with IV
@@ -321,7 +321,7 @@ class Crypt {
 
 
 	/**
-	 * @brief Symmetrically decrypts keyfile content
+	 * Symmetrically decrypts keyfile content
 	 * @param string $keyfileContent
 	 * @param string $passphrase
 	 * @throws \Exception
@@ -358,7 +358,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Decrypt private key and check if the result is a valid keyfile
+	 * Decrypt private key and check if the result is a valid keyfile
 	 * @param string $encryptedKey encrypted keyfile
 	 * @param string $passphrase to decrypt keyfile
 	 * @return string|false encrypted private key or false
@@ -385,7 +385,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Create asymmetrically encrypted keyfile content using a generated key
+	 * Create asymmetrically encrypted keyfile content using a generated key
 	 * @param string $plainContent content to be encrypted
 	 * @param array $publicKeys array keys must be the userId of corresponding user
 	 * @return array keys: keys (array, key = userId), data
@@ -433,7 +433,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Asymmetrically encrypt a file using multiple public keys
+	 * Asymmetrically encrypt a file using multiple public keys
 	 * @param string $encryptedContent
 	 * @param string $shareKey
 	 * @param mixed $privateKey
@@ -467,7 +467,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Generates a pseudo random initialisation vector
+	 * Generates a pseudo random initialisation vector
 	 * @return String $iv generated IV
 	 */
 	private static function generateIv() {
@@ -496,7 +496,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Generate a pseudo random 256-bit ASCII key, used as file key
+	 * Generate a pseudo random 256-bit ASCII key, used as file key
 	 * @return string|false Generated key
 	 */
 	public static function generateKey() {
@@ -522,7 +522,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief Get the blowfish encryption handler for a key
+	 * Get the blowfish encryption handler for a key
 	 * @param string $key (optional)
 	 * @return \Crypt_Blowfish blowfish object
 	 *
@@ -543,7 +543,7 @@ class Crypt {
 	}
 
 	/**
-	 * @brief decrypts content using legacy blowfish system
+	 * decrypts content using legacy blowfish system
 	 * @param string $content the cleartext message you want to decrypt
 	 * @param string $passphrase
 	 * @return string cleartext content

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -24,7 +24,7 @@
 namespace OCA\Encryption;
 
 /**
- * @brief Class to manage registration of hooks an various helper methods
+ * Class to manage registration of hooks an various helper methods
  * @package OCA\Encryption
  */
 class Helper {
@@ -32,7 +32,7 @@ class Helper {
 	private static $tmpFileMapping; // Map tmp files to files in data/user/files
 
 	/**
-	 * @brief register share related hooks
+	 * register share related hooks
 	 *
 	 */
 	public static function registerShareHooks() {
@@ -43,7 +43,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief register user related hooks
+	 * register user related hooks
 	 *
 	 */
 	public static function registerUserHooks() {
@@ -56,7 +56,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief register filesystem related hooks
+	 * register filesystem related hooks
 	 *
 	 */
 	public static function registerFilesystemHooks() {
@@ -68,7 +68,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief register app management related hooks
+	 * register app management related hooks
 	 *
 	 */
 	public static function registerAppHooks() {
@@ -78,7 +78,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief setup user for files_encryption
+	 * setup user for files_encryption
 	 *
 	 * @param Util $util
 	 * @param string $password
@@ -100,7 +100,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief enable recovery
+	 * enable recovery
 	 *
 	 * @param string $recoveryKeyId
 	 * @param string $recoveryPassword
@@ -164,7 +164,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief Check if a path is a .part file
+	 * Check if a path is a .part file
 	 * @param string $path Path that may identify a .part file
 	 * @return bool
 	 */
@@ -181,7 +181,7 @@ class Helper {
 
 
 	/**
-	 * @brief Remove .path extension from a file path
+	 * Remove .path extension from a file path
 	 * @param string $path Path that may identify a .part file
 	 * @return string File path without .part extension
 	 * @note this is needed for reusing keys
@@ -208,7 +208,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief disable recovery
+	 * disable recovery
 	 *
 	 * @param string $recoveryPassword
 	 * @return bool
@@ -227,7 +227,7 @@ class Helper {
 
 
 	/**
-	 * @brief checks if access is public/anonymous user
+	 * checks if access is public/anonymous user
 	 * @return bool
 	 */
 	public static function isPublicAccess() {
@@ -239,7 +239,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief Format a path to be relative to the /user/files/ directory
+	 * Format a path to be relative to the /user/files/ directory
 	 * @param string $path the absolute path
 	 * @return string e.g. turns '/admin/files/test.txt' into 'test.txt'
 	 */
@@ -259,7 +259,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief try to get the user from the path if no user is logged in
+	 * try to get the user from the path if no user is logged in
 	 * @param string $path
 	 * @return mixed user or false if we couldn't determine a user
 	 */
@@ -294,7 +294,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief get path to the corresponding file in data/user/files if path points
+	 * get path to the corresponding file in data/user/files if path points
 	 *        to a version or to a file in cache
 	 * @param string $path path to a version or a file in the trash
 	 * @return string path to corresponding file relative to data/user/files
@@ -327,7 +327,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief create directory recursively
+	 * create directory recursively
 	 * @param string $path
 	 * @param \OC\Files\View $view
 	 */
@@ -344,7 +344,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief redirect to a error page
+	 * redirect to a error page
 	 * @param Session $session
 	 */
 	public static function redirectToErrorPage($session, $errorCode = null) {
@@ -428,7 +428,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief glob uses different pattern than regular expressions, escape glob pattern only
+	 * glob uses different pattern than regular expressions, escape glob pattern only
 	 * @param string $path unescaped path
 	 * @return string path
 	 */
@@ -437,7 +437,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief remember from which file the tmp file (getLocalFile() call) was created
+	 * remember from which file the tmp file (getLocalFile() call) was created
 	 * @param string $tmpFile path of tmp file
 	 * @param string $originalFile path of the original file relative to data/
 	 */
@@ -446,7 +446,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief get the path of the original file
+	 * get the path of the original file
 	 * @param string $tmpFile path of the tmp file
 	 * @return string|false path of the original file or false
 	 */

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -24,13 +24,13 @@
 namespace OCA\Encryption;
 
 /**
- * @brief Class to manage storage and retrieval of encryption keys
+ * Class to manage storage and retrieval of encryption keys
  * @note Where a method requires a view object, it's root must be '/'
  */
 class Keymanager {
 
 	/**
-	 * @brief retrieve the ENCRYPTED private key from a user
+	 * retrieve the ENCRYPTED private key from a user
 	 *
 	 * @param \OC\Files\View $view
 	 * @param string $user
@@ -55,7 +55,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief retrieve public key for a specified user
+	 * retrieve public key for a specified user
 	 * @param \OC\Files\View $view
 	 * @param string $userId
 	 * @return string public key or false
@@ -74,7 +74,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Retrieve a user's public and private key
+	 * Retrieve a user's public and private key
 	 * @param \OC\Files\View $view
 	 * @param string $userId
 	 * @return array keys: privateKey, publicKey
@@ -89,7 +89,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Retrieve public keys for given users
+	 * Retrieve public keys for given users
 	 * @param \OC\Files\View $view
 	 * @param array $userIds
 	 * @return array of public keys for the specified users
@@ -109,7 +109,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief store file encryption key
+	 * store file encryption key
 	 *
 	 * @param \OC\Files\View $view
 	 * @param \OCA\Encryption\Util $util
@@ -167,7 +167,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief retrieve keyfile for an encrypted file
+	 * retrieve keyfile for an encrypted file
 	 * @param \OC\Files\View $view
 	 * @param \OCA\Encryption\Util $util
 	 * @param string|false $filePath
@@ -210,7 +210,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Delete a keyfile
+	 * Delete a keyfile
 	 *
 	 * @param \OC\Files\View $view
 	 * @param string $path path of the file the key belongs to
@@ -266,7 +266,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief store private key from the user
+	 * store private key from the user
 	 * @param string $key
 	 * @return bool
 	 * @note Encryption of the private key must be performed by client code
@@ -293,7 +293,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief store share key
+	 * store share key
 	 *
 	 * @param \OC\Files\View $view
 	 * @param string $path where the share key is stored
@@ -319,7 +319,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief store multiple share keys for a single file
+	 * store multiple share keys for a single file
 	 * @param \OC\Files\View $view
 	 * @param \OCA\Encryption\Util $util
 	 * @param string $path
@@ -365,7 +365,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief retrieve shareKey for an encrypted file
+	 * retrieve shareKey for an encrypted file
 	 * @param \OC\Files\View $view
 	 * @param string $userId
 	 * @param \OCA\Encryption\Util $util
@@ -406,7 +406,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief delete all share keys of a given file
+	 * delete all share keys of a given file
 	 * @param \OC\Files\View $view
 	 * @param string $userId owner of the file
 	 * @param string $filePath path to the file, relative to the owners file dir
@@ -445,7 +445,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Delete a single user's shareKey for a single file
+	 * Delete a single user's shareKey for a single file
 	 */
 	public static function delShareKey(\OC\Files\View $view, $userIds, $filePath) {
 
@@ -486,7 +486,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief recursively delete share keys from given users
+	 * recursively delete share keys from given users
 	 *
 	 * @param string $dir directory
 	 * @param array $userIds user ids for which the share keys should be deleted
@@ -512,7 +512,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief Make preparations to vars and filesystem for saving a keyfile
+	 * Make preparations to vars and filesystem for saving a keyfile
 	 * @param string|boolean $path
 	 * @param string $basePath
 	 */
@@ -542,7 +542,7 @@ class Keymanager {
 	}
 
 	/**
-	 * @brief extract filename from share key name
+	 * extract filename from share key name
 	 * @param string $shareKey (filename.userid.sharekey)
 	 * @return string|false filename or false
 	 */

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -24,7 +24,7 @@
  */
 
 /**
- * @brief Encryption proxy which handles filesystem operations before and after
+ * Encryption proxy which handles filesystem operations before and after
  *        execution and encrypts, and handles keyfiles accordingly. Used for
  *        webui.
  */
@@ -144,7 +144,7 @@ class Proxy extends \OC_FileProxy {
 	}
 
 	/**
-	 * @brief update file cache with the new unencrypted size after file was written
+	 * update file cache with the new unencrypted size after file was written
 	 * @param string $path
 	 * @param mixed $result
 	 * @return mixed
@@ -212,7 +212,7 @@ class Proxy extends \OC_FileProxy {
 	}
 
 	/**
-	 * @brief remember initial fopen mode because sometimes it gets changed during the request
+	 * remember initial fopen mode because sometimes it gets changed during the request
 	 * @param string $path path
 	 * @param string $mode type of access
 	 */

--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -36,7 +36,7 @@ class Session {
 
 
 	/**
-	 * @brief if session is started, check if ownCloud key pair is set up, if not create it
+	 * if session is started, check if ownCloud key pair is set up, if not create it
 	 * @param \OC\Files\View $view
 	 *
 	 * @note The ownCloud key pair is used to allow public link sharing even if encryption is enabled
@@ -105,7 +105,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Sets user private key to session
+	 * Sets user private key to session
 	 * @param string $privateKey
 	 * @return bool
 	 *
@@ -120,7 +120,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Sets status of encryption app
+	 * Sets status of encryption app
 	 * @param string $init INIT_SUCCESSFUL, INIT_EXECUTED, NOT_INITIALIZED
 	 * @return bool
 	 *
@@ -135,7 +135,7 @@ class Session {
 	}
 
 	/**
-	 * @brief remove encryption keys and init status from session
+	 * remove encryption keys and init status from session
 	 */
 	public function closeSession() {
 		\OC::$session->remove('encryptionInitialized');
@@ -144,7 +144,7 @@ class Session {
 
 
 	/**
-	 * @brief Gets status if we already tried to initialize the encryption app
+	 * Gets status if we already tried to initialize the encryption app
 	 * @return string init status INIT_SUCCESSFUL, INIT_EXECUTED, NOT_INITIALIZED
 	 *
 	 * @note this doesn not indicate of the init was successful, we just remeber the try!
@@ -158,7 +158,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Gets user or public share private key from session
+	 * Gets user or public share private key from session
 	 * @return string $privateKey The user's plaintext private key
 	 *
 	 */
@@ -176,7 +176,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Sets public user private key to session
+	 * Sets public user private key to session
 	 * @param string $privateKey
 	 * @return bool
 	 */
@@ -189,7 +189,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Gets public share private key from session
+	 * Gets public share private key from session
 	 * @return string $privateKey
 	 *
 	 */
@@ -204,7 +204,7 @@ class Session {
 
 
 	/**
-	 * @brief Sets user legacy key to session
+	 * Sets user legacy key to session
 	 * @param string $legacyKey
 	 * @return bool
 	 */
@@ -216,7 +216,7 @@ class Session {
 	}
 
 	/**
-	 * @brief Gets user legacy key from session
+	 * Gets user legacy key from session
 	 * @return string $legacyKey The user's plaintext legacy key
 	 *
 	 */

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -31,7 +31,7 @@
 namespace OCA\Encryption;
 
 /**
- * @brief Provides 'crypt://' stream wrapper protocol.
+ * Provides 'crypt://' stream wrapper protocol.
  * @note We use a stream wrapper because it is the most secure way to handle
  * decrypted content transfers. There is no safe way to decrypt the entire file
  * somewhere on the server, so we have to encrypt and decrypt blocks on the fly.
@@ -179,7 +179,7 @@ class Stream {
 	}
 
 	/**
-	 * @brief Returns the current position of the file pointer
+	 * Returns the current position of the file pointer
 	 * @return int position of the file pointer
 	 */
 	public function stream_tell() {
@@ -246,7 +246,7 @@ class Stream {
 	}
 
 	/**
-	 * @brief Encrypt and pad data ready for writing to disk
+	 * Encrypt and pad data ready for writing to disk
 	 * @param string $plainData data to be encrypted
 	 * @param string $key key to use for encryption
 	 * @return string encrypted data on success, false on failure
@@ -267,7 +267,7 @@ class Stream {
 	}
 
 	/**
-	 * @brief Fetch the plain encryption key for the file and set it as plainKey property
+	 * Fetch the plain encryption key for the file and set it as plainKey property
 	 * @internal param bool $generate if true, a new key will be generated if none can be found
 	 * @return bool true on key found and set, false on key not found and new key generated and set
 	 */
@@ -318,7 +318,7 @@ class Stream {
 	}
 
 	/**
-	 * @brief Handle plain data from the stream, and write it in 8192 byte blocks
+	 * Handle plain data from the stream, and write it in 8192 byte blocks
 	 * @param string $data data to be written to disk
 	 * @note the data will be written to the path stored in the stream handle, set in stream_open()
 	 * @note $data is only ever be a maximum of 8192 bytes long. This is set by PHP internally. stream_write() is called multiple times in a loop on data larger than 8192 bytes

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -25,7 +25,7 @@
 namespace OCA\Encryption;
 
 /**
- * @brief Class for utilities relating to encrypted file storage system
+ * Class for utilities relating to encrypted file storage system
  * @param \OC\Files\View $view expected to have OC '/' as root path
  * @param string $userId ID of the logged in user
  * @param int $client indicating status of client side encryption. Currently
@@ -111,7 +111,7 @@ class Util {
 	}
 
 	/**
-	 * @brief check if the users private & public key exists
+	 * check if the users private & public key exists
 	 * @return boolean
 	 */
 	public function userKeysExists() {
@@ -125,7 +125,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Sets up user folders and keys for serverside encryption
+	 * Sets up user folders and keys for serverside encryption
 	 *
 	 * @param string $passphrase to encrypt server-stored private key with
 	 * @return bool
@@ -222,7 +222,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Check whether pwd recovery is enabled for a given user
+	 * Check whether pwd recovery is enabled for a given user
 	 * @return bool 1 = yes, 0 = no, false = no record
 	 *
 	 * @note If records are not being returned, check for a hidden space
@@ -264,7 +264,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Enable / disable pwd recovery for a given user
+	 * Enable / disable pwd recovery for a given user
 	 * @param bool $enabled Whether to enable or disable recovery
 	 * @return bool
 	 */
@@ -300,7 +300,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Find all files and their encryption status within a directory
+	 * Find all files and their encryption status within a directory
 	 * @param string $directory The path of the parent directory to search
 	 * @param bool $found the founded files if called again
 	 * @return mixed false if 0 found, array on success. Keys: name, path
@@ -421,7 +421,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Check if a given path identifies an encrypted file
+	 * Check if a given path identifies an encrypted file
 	 * @param string $path
 	 * @return boolean
 	 */
@@ -463,7 +463,7 @@ class Util {
 	}
 
 	/**
-	 * @brief get the file size of the unencrypted file
+	 * get the file size of the unencrypted file
 	 * @param string $path absolute path
 	 * @return bool
 	 */
@@ -537,7 +537,7 @@ class Util {
 	}
 
 	/**
-	 * @brief fix the file size of the encrypted file
+	 * fix the file size of the encrypted file
 	 * @param string $path absolute path
 	 * @return boolean true / false if file is encrypted
 	 */
@@ -594,7 +594,7 @@ class Util {
 	}
 
 	/**
-	 * @brief encrypt versions from given file
+	 * encrypt versions from given file
 	 * @param array $filelist list of encrypted files, relative to data/user/files
 	 * @return boolean
 	 */
@@ -640,7 +640,7 @@ class Util {
 	}
 
 	/**
-	 * @brief decrypt versions from given file
+	 * decrypt versions from given file
 	 * @param string $filelist list of decrypted files, relative to data/user/files
 	 * @return boolean
 	 */
@@ -686,7 +686,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Decrypt all files
+	 * Decrypt all files
 	 * @return bool
 	 */
 	public function decryptAll() {
@@ -799,7 +799,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Encrypt all files in a directory
+	 * Encrypt all files in a directory
 	 * @param string $dirPath the directory whose files will be encrypted
 	 * @param null $legacyPassphrase
 	 * @param null $newPassphrase
@@ -926,7 +926,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Return important encryption related paths
+	 * Return important encryption related paths
 	 * @param string $pathName Name of the directory to return the path of
 	 * @return string path
 	 */
@@ -970,7 +970,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Filter an array of UIDs to return only ones ready for sharing
+	 * Filter an array of UIDs to return only ones ready for sharing
 	 * @param array $unfilteredUsers users to be checked for sharing readiness
 	 * @return array as multi-dimensional array. keys: ready, unready
 	 */
@@ -1017,7 +1017,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Decrypt a keyfile
+	 * Decrypt a keyfile
 	 * @param string $filePath
 	 * @param string $privateKey
 	 * @return false|string
@@ -1036,7 +1036,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Encrypt keyfile to multiple users
+	 * Encrypt keyfile to multiple users
 	 * @param Session $session
 	 * @param array $users list of users which should be able to access the file
 	 * @param string $filePath path of the file to be shared
@@ -1097,7 +1097,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Find, sanitise and format users sharing a file
+	 * Find, sanitise and format users sharing a file
 	 * @note This wraps other methods into a portable bundle
 	 * @param boolean $sharingEnabled
 	 * @param string $filePath path relativ to current users files folder
@@ -1176,7 +1176,7 @@ class Util {
 	}
 
 	/**
-	 * @brief set migration status
+	 * set migration status
 	 * @param int $status
 	 * @return boolean
 	 */
@@ -1199,7 +1199,7 @@ class Util {
 	}
 
 	/**
-	 * @brief start migration mode to initially encrypt users data
+	 * start migration mode to initially encrypt users data
 	 * @return boolean
 	 */
 	public function beginMigration() {
@@ -1221,7 +1221,7 @@ class Util {
 	}
 
 	/**
-	 * @brief close migration mode after users data has been encrypted successfully
+	 * close migration mode after users data has been encrypted successfully
 	 * @return boolean
 	 */
 	public function finishMigration() {
@@ -1237,7 +1237,7 @@ class Util {
 	}
 
 	/**
-	 * @brief check if files are already migrated to the encryption system
+	 * check if files are already migrated to the encryption system
 	 * @return int|false migration status, false = in case of no record
 	 * @note If records are not being returned, check for a hidden space
 	 *       at the start of the uid in db
@@ -1288,7 +1288,7 @@ class Util {
 	}
 
 	/**
-	 * @brief get uid of the owners of the file and the path to the file
+	 * get uid of the owners of the file and the path to the file
 	 * @param string $path Path of the file to check
 	 * @throws \Exception
 	 * @note $shareFilePath must be relative to data/UID/files. Files
@@ -1367,7 +1367,7 @@ class Util {
 	}
 
 	/**
-	 * @brief go recursively through a dir and collect all files and sub files.
+	 * go recursively through a dir and collect all files and sub files.
 	 * @param string $dir relative to the users files folder
 	 * @return array with list of files relative to the users files folder
 	 */
@@ -1397,7 +1397,7 @@ class Util {
 	}
 
 	/**
-	 * @brief get owner of the shared files.
+	 * get owner of the shared files.
 	 * @param int $id ID of a share
 	 * @return string owner
 	 */
@@ -1511,7 +1511,7 @@ class Util {
 	}
 
 	/**
-	 * @brief add recovery key to all encrypted files
+	 * add recovery key to all encrypted files
 	 */
 	public function addRecoveryKeys($path = '/') {
 		$dirContent = $this->view->getDirectoryContent($this->keyfilesPath . $path);
@@ -1532,7 +1532,7 @@ class Util {
 	}
 
 	/**
-	 * @brief remove recovery key to all encrypted files
+	 * remove recovery key to all encrypted files
 	 */
 	public function removeRecoveryKeys($path = '/') {
 		$dirContent = $this->view->getDirectoryContent($this->keyfilesPath . $path);
@@ -1550,7 +1550,7 @@ class Util {
 	}
 
 	/**
-	 * @brief decrypt given file with recovery key and encrypt it again to the owner and his new key
+	 * decrypt given file with recovery key and encrypt it again to the owner and his new key
 	 * @param string $file
 	 * @param string $privateKey recovery key to decrypt the file
 	 */
@@ -1598,7 +1598,7 @@ class Util {
 	}
 
 	/**
-	 * @brief collect all files and recover them one by one
+	 * collect all files and recover them one by one
 	 * @param string $path to look for files keys
 	 * @param string $privateKey private recovery key which is used to decrypt the files
 	 */
@@ -1618,7 +1618,7 @@ class Util {
 	}
 
 	/**
-	 * @brief recover users files in case of password lost
+	 * recover users files in case of password lost
 	 * @param string $recoveryPassword
 	 */
 	public function recoverUsersFiles($recoveryPassword) {
@@ -1637,7 +1637,7 @@ class Util {
 	}
 
 	/**
-	 * @brief check if the file is stored on a system wide mount point
+	 * check if the file is stored on a system wide mount point
 	 * @param string $path relative to /data/user with leading '/'
 	 * @return boolean
 	 */
@@ -1654,7 +1654,7 @@ class Util {
 	}
 
 	/**
-	 * @brief decrypt private key and add it to the current session
+	 * decrypt private key and add it to the current session
 	 * @param array $params with 'uid' and 'password'
 	 * @return mixed session or false
 	 */
@@ -1682,7 +1682,7 @@ class Util {
 	}
 
 	/*
-	 * @brief remove encryption related keys from the session
+	 * remove encryption related keys from the session
 	 */
 	public function closeEncryptionSession() {
 		$session = new \OCA\Encryption\Session($this->view);

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -206,7 +206,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief Test that data that is written by the crypto stream wrapper
+	 * Test that data that is written by the crypto stream wrapper
 	 * @note Encrypted data is manually prepared and decrypted here to avoid dependency on success of stream_read
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
 	 * reassembly of its data
@@ -293,7 +293,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief Test that data that is read by the crypto stream wrapper
+	 * Test that data that is read by the crypto stream wrapper
 	 */
 	function testSymmetricStreamDecryptShortFileContent() {
 
@@ -388,7 +388,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test decryption using legacy blowfish method
+	 * test decryption using legacy blowfish method
 	 */
 	function testLegacyDecryptShort() {
 
@@ -402,7 +402,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test decryption using legacy blowfish method
+	 * test decryption using legacy blowfish method
 	 */
 	function testLegacyDecryptLong() {
 
@@ -660,7 +660,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @brief encryption using legacy blowfish method
+	 * encryption using legacy blowfish method
 	 * @param string $data data to encrypt
 	 * @param string $passwd password
 	 * @return string

--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -32,7 +32,7 @@ use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Hooks
- * @brief this class provide basic hook app tests
+ * this class provide basic hook app tests
  */
 class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
@@ -259,7 +259,7 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief test rename operation
+	 * test rename operation
 	 */
 	function testRenameHook() {
 

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -33,7 +33,7 @@ use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Proxy
- * @brief this class provide basic proxy app tests
+ * this class provide basic proxy app tests
  */
 class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 
@@ -91,7 +91,7 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test if postFileSize returns the unencrypted file size
+	 * test if postFileSize returns the unencrypted file size
 	 */
 	function testPostFileSize() {
 

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -959,7 +959,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @brief test moving a shared file out of the Shared folder
+	 * test moving a shared file out of the Shared folder
 	 */
 	function testRename() {
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -33,7 +33,7 @@ use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Stream
- * @brief this class provide basic stream tests
+ * this class provide basic stream tests
  */
 class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 
@@ -183,7 +183,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test if stream wrapper can read files outside from the data folder
+	 * test if stream wrapper can read files outside from the data folder
 	 */
 	function testStreamFromLocalFile() {
 

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -34,7 +34,7 @@ use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Trashbin
- * @brief this class provide basic trashbin app tests
+ * this class provide basic trashbin app tests
  */
 class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
@@ -114,7 +114,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test delete file
+	 * test delete file
 	 */
 	function testDeleteFile() {
 
@@ -186,7 +186,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test restore file
+	 * test restore file
 	 *
 	 * @depends testDeleteFile
 	 */
@@ -218,7 +218,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test delete file forever
+	 * test delete file forever
 	 */
 	function testPermanentDeleteFile() {
 

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -121,7 +121,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test that paths set during User construction are correct
+	 * test that paths set during User construction are correct
 	 */
 	function testKeyPaths() {
 		$util = new Encryption\Util($this->view, $this->userId);
@@ -136,7 +136,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test detection of encrypted files
+	 * test detection of encrypted files
 	 */
 	function testIsEncryptedPath() {
 
@@ -171,7 +171,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test setup of encryption directories
+	 * test setup of encryption directories
 	 */
 	function testSetupServerSide() {
 		$this->assertEquals(true, $this->util->setupServerSide($this->pass));
@@ -179,14 +179,14 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test checking whether account is ready for encryption,
+	 * test checking whether account is ready for encryption,
 	 */
 	function testUserIsReady() {
 		$this->assertEquals(true, $this->util->ready());
 	}
 
 	/**
-	 * @brief test checking whether account is not ready for encryption,
+	 * test checking whether account is not ready for encryption,
 	 */
 //	function testUserIsNotReady() {
 //		$this->view->unlink($this->publicKeyDir);
@@ -200,7 +200,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @medium
-	 * @brief test checking whether account is not ready for encryption,
+	 * test checking whether account is not ready for encryption,
 	 */
 	function testIsLegacyUser() {
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
@@ -279,7 +279,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-<	 * @brief Test that data that is read by the crypto stream wrapper
+<	 * Test that data that is read by the crypto stream wrapper
 	 */
 	function testGetFileSize() {
 		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -34,7 +34,7 @@ use OCA\Encryption;
 /**
  * Class Test_Encryption_Webdav
  *
- * @brief this class provide basic webdav tests for PUT,GET and DELETE
+ * this class provide basic webdav tests for PUT,GET and DELETE
  */
 class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 
@@ -112,7 +112,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief test webdav put random file
+	 * test webdav put random file
 	 */
 	function testWebdavPUT() {
 
@@ -167,7 +167,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief test webdav get random file
+	 * test webdav get random file
 	 *
 	 * @depends testWebdavPUT
 	 */
@@ -190,7 +190,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief test webdav delete random file
+	 * test webdav delete random file
 	 * @depends testWebdavGET
 	 */
 	function testWebdavDELETE($filename) {
@@ -216,7 +216,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief handle webdav request
+	 * handle webdav request
 	 *
 	 * @param bool $body
 	 *

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -63,7 +63,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief Returns the path's metadata
+	 * Returns the path's metadata
 	 * @param string $path path for which to return the metadata
 	 * @param bool $list if true, also return the directory's contents
 	 * @return mixed directory contents if $list is true, file metadata if $list is

--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -25,7 +25,7 @@ namespace OCA\Files\Share;
 class Api {
 
 	/**
-	 * @brief get all shares
+	 * get all shares
 	 *
 	 * @param array $params option 'file' to limit the result to a specific file/folder
 	 * @return \OC_OCS_Result share information
@@ -60,7 +60,7 @@ class Api {
 	}
 
 	/**
-	 * @brief get share information for a given share
+	 * get share information for a given share
 	 *
 	 * @param array $params which contains a 'id'
 	 * @return \OC_OCS_Result share information
@@ -76,7 +76,7 @@ class Api {
 	}
 
 	/**
-	 * @brief collect all share information, either of a specific share or all
+	 * collect all share information, either of a specific share or all
 	 *        shares for a given path
 	 * @param array $params
 	 * @return \OC_OCS_Result
@@ -130,7 +130,7 @@ class Api {
 	}
 
 	/**
-	 * @brief add reshares to a array of shares
+	 * add reshares to a array of shares
 	 * @param array $shares array of shares
 	 * @param int $itemSource item source ID
 	 * @return array new shares array which includes reshares
@@ -161,7 +161,7 @@ class Api {
 	}
 
 	/**
-	 * @brief get share from all files in a given folder (non-recursive)
+	 * get share from all files in a given folder (non-recursive)
 	 * @param array $params contains 'path' to the folder
 	 * @return \OC_OCS_Result
 	 */
@@ -196,7 +196,7 @@ class Api {
 	}
 
 	/**
-	 * @brief create a new share
+	 * create a new share
 	 * @param array $params
 	 * @return \OC_OCS_Result
 	 */
@@ -313,7 +313,7 @@ class Api {
 	}
 
 	/**
-	 * @brief update permissions for a share
+	 * update permissions for a share
 	 * @param array $share information about the share
 	 * @param array $params contains 'permissions'
 	 * @return \OC_OCS_Result
@@ -358,7 +358,7 @@ class Api {
 	}
 
 	/**
-	 * @brief enable/disable public upload
+	 * enable/disable public upload
 	 * @param array $share information about the share
 	 * @param array $params contains 'publicUpload' which can be 'yes' or 'no'
 	 * @return \OC_OCS_Result
@@ -384,7 +384,7 @@ class Api {
 	}
 
 	/**
-	 * @brief update password for public link share
+	 * update password for public link share
 	 * @param array $share information about the share
 	 * @param array $params 'password'
 	 * @return \OC_OCS_Result
@@ -438,7 +438,7 @@ class Api {
 	}
 
 	/**
-	 * @brief unshare a file/folder
+	 * unshare a file/folder
 	 * @param array $params contains the shareID 'id' which should be unshared
 	 * @return \OC_OCS_Result
 	 */
@@ -478,7 +478,7 @@ class Api {
 	}
 
 	/**
-	 * @brief get file ID from a given path
+	 * get file ID from a given path
 	 * @param string $path
 	 * @return string fileID or null
 	 */
@@ -495,7 +495,7 @@ class Api {
 	}
 
 	/**
-	 * @brief get itemType
+	 * get itemType
 	 * @param string $path
 	 * @return string type 'file', 'folder' or null of file/folder doesn't exists
 	 */
@@ -513,7 +513,7 @@ class Api {
 	}
 
 	/**
-	 * @brief get some information from a given share
+	 * get some information from a given share
 	 * @param int $shareID
 	 * @return array with: item_source, share_type, share_with, item_type, permissions
 	 */

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -42,7 +42,7 @@ class Shared_Cache extends Cache {
 	}
 
 	/**
-	 * @brief Get the source cache of a shared file or folder
+	 * Get the source cache of a shared file or folder
 	 * @param string $target Shared target file path
 	 * @return \OC\Files\Cache\Cache
 	 */

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -162,7 +162,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief Format a path to be relative to the /user/files/ directory
+	 * Format a path to be relative to the /user/files/ directory
 	 * @param string $path the absolute path
 	 * @return string e.g. turns '/admin/files/test.txt' into 'test.txt'
 	 */

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -54,7 +54,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	}
 
 	/**
-	 * @brief create unique target
+	 * create unique target
 	 * @param string $filePath
 	 * @param string $shareWith
 	 * @param string $exclude
@@ -154,7 +154,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	}
 
 	/**
-	 * @brief resolve reshares to return the correct source item
+	 * resolve reshares to return the correct source item
 	 * @param array $source
 	 * @return array source item
 	 */

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -36,7 +36,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief get id of the mount point
+	 * get id of the mount point
 	 * @return string
 	 */
 	public function getId() {
@@ -44,7 +44,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief get file cache of the shared item source
+	 * get file cache of the shared item source
 	 * @return string
 	 */
 	public function getSourceId() {
@@ -52,7 +52,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief Get the source file path, permissions, and owner for a shared file
+	 * Get the source file path, permissions, and owner for a shared file
 	 * @param string $target Shared target file path
 	 * @return Returns array with the keys path, permissions, and owner or false if not found
 	 */
@@ -75,7 +75,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief Get the source file path for a shared file
+	 * Get the source file path for a shared file
 	 * @param string $target Shared target file path
 	 * @return string source file path or false if not found
 	 */
@@ -98,7 +98,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief Get the permissions granted for a shared file
+	 * Get the permissions granted for a shared file
 	 * @param string $target Shared target file path
 	 * @return int CRUDS permissions granted
 	 */
@@ -263,7 +263,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief Format a path to be relative to the /user/files/ directory
+	 * Format a path to be relative to the /user/files/ directory
 	 * @param string $path the absolute path
 	 * @return string e.g. turns '/admin/files/test.txt' into '/test.txt'
 	 */
@@ -287,7 +287,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief rename a shared folder/file
+	 * rename a shared folder/file
 	 * @param string $sourcePath
 	 * @param string $targetPath
 	 * @return bool
@@ -481,7 +481,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief return mount point of share, relative to data/user/files
+	 * return mount point of share, relative to data/user/files
 	 * @return string
 	 */
 	public function getMountPoint() {
@@ -489,7 +489,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief get share type
+	 * get share type
 	 * @return integer can be single user share (0) group share (1), unique group share name (2)
 	 */
 	private function getShareType() {
@@ -501,7 +501,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief does the group share already has a user specific unique name
+	 * does the group share already has a user specific unique name
 	 * @return bool
 	 */
 	private function uniqueNameSet() {
@@ -509,14 +509,14 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief the share now uses a unique name of this user
+	 * the share now uses a unique name of this user
 	 */
 	private function setUniqueName() {
 		$this->share['unique_name'] = true;
 	}
 
 	/**
-	 * @brief get share ID
+	 * get share ID
 	 * @return integer unique share ID
 	 */
 	private function getShareId() {
@@ -524,7 +524,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief get the user who shared the file
+	 * get the user who shared the file
 	 * @return string
 	 */
 	public function getSharedFrom() {
@@ -532,7 +532,7 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @brief return share type, can be "file" or "folder"
+	 * return share type, can be "file" or "folder"
 	 * @return string
 	 */
 	public function getItemType() {

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -27,7 +27,7 @@ class Shared_Updater {
 	static private $toRemove = array();
 
 	/**
-	 * @brief walk up the users file tree and update the etags
+	 * walk up the users file tree and update the etags
 	 * @param string $user
 	 * @param string $path
 	 */
@@ -78,7 +78,7 @@ class Shared_Updater {
 	}
 
 	/**
-	 * @brief remove all shares for a given file if the file was deleted
+	 * remove all shares for a given file if the file was deleted
 	 *
 	 * @param string $path
 	 */

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -352,7 +352,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief share a folder, than reshare a file within the shared folder and check if we construct the correct path
+	 * share a folder, than reshare a file within the shared folder and check if we construct the correct path
 	 * @medium
 	 */
 	function testGetShareFromFolderReshares() {
@@ -417,7 +417,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief reshare a sub folder and check if we get the correct path
+	 * reshare a sub folder and check if we get the correct path
 	 * @medium
 	 */
 	function testGetShareFromSubFolderReShares() {
@@ -470,7 +470,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief test re-re-share of folder if the path gets constructed correctly
+	 * test re-re-share of folder if the path gets constructed correctly
 	 * @medium
 	 */
 	function testGetShareFromFolderReReShares() {
@@ -538,7 +538,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief test multiple shared folder if the path gets constructed correctly
+	 * test multiple shared folder if the path gets constructed correctly
 	 * @medium
 	 */
 	function testGetShareMultipleSharedFolder() {
@@ -621,7 +621,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief test re-re-share of folder if the path gets constructed correctly
+	 * test re-re-share of folder if the path gets constructed correctly
 	 * @medium
 	 */
 	function testGetShareFromFileReReShares() {
@@ -895,7 +895,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief test unshare of a reshared file
+	 * test unshare of a reshared file
 	 */
 	function testDeleteReshare() {
 
@@ -939,7 +939,7 @@ class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief share a folder which contains a share mount point, should be forbidden
+	 * share a folder which contains a share mount point, should be forbidden
 	 */
 	public function testShareFolderWithAMountPoint() {
 		// user 1 shares a folder with user2

--- a/apps/files_sharing/tests/base.php
+++ b/apps/files_sharing/tests/base.php
@@ -119,7 +119,7 @@ abstract class Test_Files_Sharing_Base extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief get some information from a given share
+	 * get some information from a given share
 	 * @param int $shareID
 	 * @return array with: item_source, share_type, share_with, item_type, permissions
 	 */

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -230,7 +230,7 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 	}
 
 	/**
-	 * @brief verify if each value from the result matches the expected result
+	 * verify if each value from the result matches the expected result
 	 * @param array $example array with the expected results
 	 * @param array $result array with the results
 	 */

--- a/apps/files_trashbin/lib/hooks.php
+++ b/apps/files_trashbin/lib/hooks.php
@@ -29,7 +29,7 @@ namespace OCA\Files_Trashbin;
 class Hooks {
 
 	/**
-	 * @brief Copy files to trash bin
+	 * Copy files to trash bin
 	 * @param array $params
 	 *
 	 * This function is connected to the delete signal of OC_Filesystem
@@ -44,7 +44,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief clean up user specific settings if user gets deleted
+	 * clean up user specific settings if user gets deleted
 	 * @param array $params array with uid
 	 *
 	 * This function is connected to the pre_deleteUser signal of OC_Users
@@ -56,7 +56,7 @@ class Hooks {
 			Trashbin::deleteUser($uid);
 			}
 	}
-	
+
 	public static function post_write_hook($params) {
 		Trashbin::resizeTrash(\OCP\User::getUser());
 	}

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -62,7 +62,7 @@ class Trashbin {
 
 
 	/**
-	 * @brief copy file to owners trash
+	 * copy file to owners trash
 	 * @param string $sourcePath
 	 * @param string $owner
 	 * @param string $ownerPath
@@ -373,7 +373,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief restore versions from trash bin
+	 * restore versions from trash bin
 	 *
 	 * @param \OC\Files\View $view file view
 	 * @param string $file complete path to file
@@ -421,7 +421,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief restore encryption keys from trash bin
+	 * restore encryption keys from trash bin
 	 *
 	 * @param \OC\Files\View $view
 	 * @param string $file complete path to file
@@ -523,7 +523,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief delete all files from the trash
+	 * delete all files from the trash
 	 */
 	public static function deleteAll() {
 		$user = \OCP\User::getUser();
@@ -537,7 +537,7 @@ class Trashbin {
 
 
 	/**
-	 * @brief delete file from trash bin permanently
+	 * delete file from trash bin permanently
 	 *
 	 * @param string $filename path to the file
 	 * @param int $timestamp of deletion time
@@ -653,7 +653,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief deletes used space for trash bin in db if user was deleted
+	 * deletes used space for trash bin in db if user was deleted
 	 *
 	 * @param type $uid id of deleted user
 	 * @return bool result of db delete operation
@@ -707,7 +707,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief resize trash bin if necessary after a new file was added to ownCloud
+	 * resize trash bin if necessary after a new file was added to ownCloud
 	 * @param string $user user id
 	 */
 	public static function resizeTrash($user) {
@@ -871,7 +871,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief get the size from a given root folder
+	 * get the size from a given root folder
 	 * @param \OC\Files\View $view file view on the root folder
 	 * @return integer size of the folder
 	 */
@@ -925,7 +925,7 @@ class Trashbin {
 	}
 
 	/**
-	 * @brief check if trash bin is empty for a given user
+	 * check if trash bin is empty for a given user
 	 * @param string $user
 	 */
 	public static function isEmpty($user) {

--- a/apps/files_versions/lib/hooks.php
+++ b/apps/files_versions/lib/hooks.php
@@ -29,7 +29,7 @@ class Hooks {
 
 
 	/**
-	 * @brief Erase versions of deleted file
+	 * Erase versions of deleted file
 	 * @param array $params
 	 *
 	 * This function is connected to the delete signal of OC_Filesystem
@@ -46,7 +46,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief mark file as "deleted" so that we can clean up the versions if the file is gone
+	 * mark file as "deleted" so that we can clean up the versions if the file is gone
 	 * @param array $params
 	 */
 	public static function pre_remove_hook($params) {
@@ -57,7 +57,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief rename/move versions of renamed/moved files
+	 * rename/move versions of renamed/moved files
 	 * @param array $params array with oldpath and newpath
 	 *
 	 * This function is connected to the rename signal of OC_Filesystem and adjust the name and location
@@ -75,7 +75,7 @@ class Hooks {
 	}
 
 	/**
-	 * @brief clean up user specific settings if user gets deleted
+	 * clean up user specific settings if user gets deleted
 	 * @param array $params array with uid
 	 *
 	 * This function is connected to the pre_deleteUser signal of OC_Users

--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -147,7 +147,7 @@ class Storage {
 
 
 	/**
-	 * @brief mark file as deleted so that we can remove the versions if the file is gone
+	 * mark file as deleted so that we can remove the versions if the file is gone
 	 * @param string $path
 	 */
 	public static function markDeletedFile($path) {
@@ -261,7 +261,7 @@ class Storage {
 
 
 	/**
-	 * @brief get a list of all available versions of a file in descending chronological order
+	 * get a list of all available versions of a file in descending chronological order
 	 * @param string $uid user id from the owner of the file
 	 * @param string $filename file to find versions of, relative to the user files dir
 	 * @param string $userFullPath
@@ -307,7 +307,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief translate a timestamp into a string like "5 days ago"
+	 * translate a timestamp into a string like "5 days ago"
 	 * @param int $timestamp
 	 * @return string for example "5 days ago"
 	 */
@@ -334,7 +334,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief deletes used space for files versions in db if user was deleted
+	 * deletes used space for files versions in db if user was deleted
 	 *
 	 * @param string $uid id of deleted user
 	 * @return \OC_DB_StatementWrapper of db delete operation
@@ -345,7 +345,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief get the size of all stored versions from a given user
+	 * get the size of all stored versions from a given user
 	 * @param string $uid id from the user
 	 * @return int size of versions
 	 */
@@ -372,7 +372,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief returns all stored file versions from a given user
+	 * returns all stored file versions from a given user
 	 * @param string $uid id of the user
 	 * @return array with contains two arrays 'all' which contains all versions sorted by age and 'by_file' which contains all versions sorted by filename
 	 */
@@ -420,7 +420,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief get list of files we want to expire
+	 * get list of files we want to expire
 	 * @param array $versions list of versions
 	 * @param integer $time
 	 * @return array containing the list of to deleted versions and the size of them
@@ -477,7 +477,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief Erase a file's versions which exceed the set quota
+	 * Erase a file's versions which exceed the set quota
 	 */
 	private static function expire($filename, $versionsSize = null, $offset = 0) {
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
@@ -574,7 +574,7 @@ class Storage {
 	}
 
 	/**
-	 * @brief create recursively missing directories
+	 * create recursively missing directories
 	 * @param string $filename $path to a file
 	 * @param \OC\Files\View $view view on data/user/
 	 */

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -24,14 +24,14 @@ require_once __DIR__ . '/../lib/versions.php';
 
 /**
  * Class Test_Files_versions
- * @brief this class provide basic files versions test
+ * this class provide basic files versions test
  */
 class Test_Files_Versioning extends \PHPUnit_Framework_TestCase {
 
 
 	/**
 	 * @medium
-	 * @brief test expire logic
+	 * test expire logic
 	 * @dataProvider versionsProvider
 	 */
 	function testGetExpireList($versions, $sizeOfAllDeletedFiles) {

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -39,7 +39,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -126,7 +126,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array with group names
 	 *
@@ -204,7 +204,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @return array with user ids
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
@@ -285,7 +285,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief returns the number of users in a group, who match the search term
+	 * returns the number of users in a group, who match the search term
 	 * @param string $gid the internal group name
 	 * @param string $search optional, a search string
 	 * @return int|bool
@@ -363,7 +363,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @return array with group names
 	 *
 	 * Returns a list with all groups (used by getGroups)
@@ -402,7 +402,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief get a list of all groups using a paged search
+	 * get a list of all groups using a paged search
 	 * @return array with group names
 	 *
 	 * Returns a list with all groups
@@ -480,7 +480,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	}
 
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param int $actions bitwise-or'ed actions
 	* @return boolean
 	*

--- a/apps/user_ldap/group_proxy.php
+++ b/apps/user_ldap/group_proxy.php
@@ -30,7 +30,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	private $refBackend = null;
 
 	/**
-	 * @brief Constructor
+	 * Constructor
 	 * @param string[] $serverConfigPrefixes array containing the config Prefixes
 	 */
 	public function __construct($serverConfigPrefixes, ILDAPWrapper $ldap) {
@@ -45,7 +45,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief Tries the backends one after the other until a positive result is returned from the specified method
+	 * Tries the backends one after the other until a positive result is returned from the specified method
 	 * @param string $gid the gid connected to the request
 	 * @param string $method the method of the group backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
@@ -63,7 +63,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief Asks the backend connected to the server that supposely takes care of the gid from the request.
+	 * Asks the backend connected to the server that supposely takes care of the gid from the request.
 	 * @param string $gid the gid connected to the request
 	 * @param string $method the method of the group backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
@@ -95,7 +95,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -107,7 +107,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return string[] with group names
 	 *
@@ -128,7 +128,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @return string[] with user ids
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
@@ -145,7 +145,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief returns the number of users in a group, who match the search term
+	 * returns the number of users in a group, who match the search term
 	 * @param string $gid the internal group name
 	 * @param string $search optional, a search string
 	 * @return int|bool
@@ -156,7 +156,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @return string[] with group names
 	 *
 	 * Returns a list with all groups
@@ -184,7 +184,7 @@ class Group_Proxy extends lib\Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * @brief Check if backend implements actions
+	 * Check if backend implements actions
 	 * @param int $actions bitwise-or'ed actions
 	 * @return boolean
 	 *

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -51,7 +51,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief reads a given attribute for an LDAP record identified by a DN
+	 * reads a given attribute for an LDAP record identified by a DN
 	 * @param string $dn the record in question
 	 * @param string $attr the attribute that shall be retrieved
 	 *        if empty, just check the record's existence
@@ -115,7 +115,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief checks whether the given attributes value is probably a DN
+	 * checks whether the given attributes value is probably a DN
 	 * @param string $attr the attribute in question
 	 * @return boolean if so true, otherwise false
 	 */
@@ -129,7 +129,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief sanitizes a DN received from the LDAP server
+	 * sanitizes a DN received from the LDAP server
 	 * @param array $dn the DN in question
 	 * @return array the sanitized DN
 	 */
@@ -185,7 +185,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns the LDAP DN for the given internal ownCloud name of the group
+	 * returns the LDAP DN for the given internal ownCloud name of the group
 	 * @param string $name the ownCloud name in question
 	 * @return string with the LDAP DN on success, otherwise false
 	 */
@@ -200,7 +200,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns the LDAP DN for the given internal ownCloud name of the user
+	 * returns the LDAP DN for the given internal ownCloud name of the user
 	 * @param string $name the ownCloud name in question
 	 * @return string with the LDAP DN on success, otherwise false
 	 */
@@ -216,7 +216,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns the LDAP DN for the given internal ownCloud name
+	 * returns the LDAP DN for the given internal ownCloud name
 	 * @param string $name the ownCloud name in question
 	 * @param boolean $isUser is it a user? otherwise group
 	 * @return string with the LDAP DN on success, otherwise false
@@ -235,7 +235,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns the internal ownCloud name for the given LDAP DN of the group, false on DN outside of search DN or failure
+	 * returns the internal ownCloud name for the given LDAP DN of the group, false on DN outside of search DN or failure
 	 * @param string $dn the dn of the group object
 	 * @param string $ldapName optional, the display name of the object
 	 * @return string with the name to use in ownCloud, false on DN outside of search DN
@@ -252,7 +252,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns the internal ownCloud name for the given LDAP DN of the user, false on DN outside of search DN or failure
+	 * returns the internal ownCloud name for the given LDAP DN of the user, false on DN outside of search DN or failure
 	 * @param string $dn the dn of the user object
 	 * @param string $ldapName optional, the display name of the object
 	 * @return string with with the name to use in ownCloud
@@ -269,7 +269,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief returns an internal ownCloud name for the given LDAP DN, false on DN outside of search DN
+	 * returns an internal ownCloud name for the given LDAP DN, false on DN outside of search DN
 	 * @param string $dn the dn of the user object
 	 * @param string $ldapName optional, the display name of the object
 	 * @param bool $isUser optional, whether it is a user object (otherwise group assumed)
@@ -361,7 +361,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief gives back the user names as they are used ownClod internally
+	 * gives back the user names as they are used ownClod internally
 	 * @param array $ldapUsers an array with the ldap Users result in style of array ( array ('dn' => foo, 'uid' => bar), ... )
 	 * @return array an array with the user names to use in ownCloud
 	 *
@@ -372,7 +372,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief gives back the group names as they are used ownClod internally
+	 * gives back the group names as they are used ownClod internally
 	 * @param array $ldapGroups an array with the ldap Groups result in style of array ( array ('dn' => foo, 'cn' => bar), ... )
 	 * @return array an array with the group names to use in ownCloud
 	 *
@@ -452,7 +452,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief caches the user display name
+	 * caches the user display name
 	 * @param string $ocName the internal ownCloud username
 	 * @param string $displayName the display name
 	 */
@@ -462,7 +462,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a unique name for internal ownCloud use for users. Don't call it directly.
+	 * creates a unique name for internal ownCloud use for users. Don't call it directly.
 	 * @param string $name the display name of the object
 	 * @return string with with the name to use in ownCloud or false if unsuccessful
 	 *
@@ -484,7 +484,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a unique name for internal ownCloud use for groups. Don't call it directly.
+	 * creates a unique name for internal ownCloud use for groups. Don't call it directly.
 	 * @param string $name the display name of the object
 	 * @return string with with the name to use in ownCloud or false if unsuccessful.
 	 *
@@ -532,7 +532,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a unique name for internal ownCloud use.
+	 * creates a unique name for internal ownCloud use.
 	 * @param string $name the display name of the object
 	 * @param boolean $isUser whether name should be created for a user (true) or a group (false)
 	 * @return string with with the name to use in ownCloud or false if unsuccessful
@@ -551,7 +551,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief retrieves all known groups from the mappings table
+	 * retrieves all known groups from the mappings table
 	 * @return array with the results
 	 *
 	 * retrieves all known groups from the mappings table
@@ -561,7 +561,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief retrieves all known users from the mappings table
+	 * retrieves all known users from the mappings table
 	 * @return array with the results
 	 *
 	 * retrieves all known users from the mappings table
@@ -585,7 +585,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief inserts a new user or group into the mappings table
+	 * inserts a new user or group into the mappings table
 	 * @param string $dn the record in question
 	 * @param string $ocName the name to use in ownCloud
 	 * @param bool $isUser is it a user or a group?
@@ -670,7 +670,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief executes an LDAP search, optimized for Users
+	 * executes an LDAP search, optimized for Users
 	 * @param string $filter the LDAP filter for the search
 	 * @param string|string[] $attr optional, when a certain attribute shall be filtered out
 	 * @param integer $limit
@@ -695,7 +695,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief executes an LDAP search, optimized for Groups
+	 * executes an LDAP search, optimized for Groups
 	 * @param string $filter the LDAP filter for the search
 	 * @param string|string[] $attr optional, when a certain attribute shall be filtered out
 	 * @param integer $limit
@@ -709,7 +709,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief prepares and executes an LDAP search operation
+	 * prepares and executes an LDAP search operation
 	 * @param string $filter the LDAP filter for the search
 	 * @param array $base an array containing the LDAP subtree(s) that shall be searched
 	 * @param string|string[] $attr optional, array, one or more attributes that shall be
@@ -755,7 +755,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief processes an LDAP paged search operation
+	 * processes an LDAP paged search operation
 	 * @param array $sr the array containing the LDAP search resources
 	 * @param string $filter the LDAP filter for the search
 	 * @param array $base an array containing the LDAP subtree(s) that shall be searched
@@ -796,7 +796,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief executes an LDAP search, but counts the results only
+	 * executes an LDAP search, but counts the results only
 	 * @param string $filter the LDAP filter for the search
 	 * @param array $base an array containing the LDAP subtree(s) that shall be searched
 	 * @param string|string[] $attr optional, array, one or more attributes that shall be
@@ -861,7 +861,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Executes an LDAP search
+	 * Executes an LDAP search
 	 * @param string $filter the LDAP filter for the search
 	 * @param array $base an array containing the LDAP subtree(s) that shall be searched
 	 * @param string|string[] $attr optional, array, one or more attributes that shall be
@@ -991,7 +991,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	* @brief escapes (user provided) parts for LDAP filter
+	* escapes (user provided) parts for LDAP filter
 	* @param string $input, the provided value
 	* @return string the escaped string
 	*/
@@ -1002,7 +1002,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief combines the input filters with AND
+	 * combines the input filters with AND
 	 * @param string[] $filters the filters to connect
 	 * @return string the combined filter
 	 */
@@ -1011,7 +1011,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief combines the input filters with AND
+	 * combines the input filters with AND
 	 * @param string[] $filters the filters to connect
 	 * @return string the combined filter
 	 */
@@ -1020,7 +1020,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief combines the input filters with given operator
+	 * combines the input filters with given operator
 	 * @param string[] $filters the filters to connect
 	 * @param string $operator either & or |
 	 * @return string the combined filter
@@ -1038,7 +1038,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a filter part for to perform search for users
+	 * creates a filter part for to perform search for users
 	 * @param string $search the search term
 	 * @return string the final filter part to use in LDAP searches
 	 */
@@ -1049,7 +1049,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a filter part for to perform search for groups
+	 * creates a filter part for to perform search for groups
 	 * @param string $search the search term
 	 * @return string the final filter part to use in LDAP searches
 	 */
@@ -1060,7 +1060,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates a filter part for searches
+	 * creates a filter part for searches
 	 * @param string $search the search term
 	 * @param string[]|null $searchAttributes
 	 * @param string $fallbackAttribute a fallback attribute in case the user
@@ -1107,7 +1107,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief auto-detects the directory's UUID attribute
+	 * auto-detects the directory's UUID attribute
 	 * @param string $dn a known DN used to check against
 	 * @param bool $isUser
 	 * @param bool $force the detection should be run, even if it is not set to auto
@@ -1183,7 +1183,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief converts a binary ObjectGUID into a string representation
+	 * converts a binary ObjectGUID into a string representation
 	 * @param string $oguid the ObjectGUID in it's binary form as retrieved from AD
 	 * @return string
 	 * @link http://www.php.net/manual/en/function.ldap-get-values-len.php#73198
@@ -1209,7 +1209,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief converts a stored DN so it can be used as base parameter for LDAP queries, internally we store them for usage in LDAP filters
+	 * converts a stored DN so it can be used as base parameter for LDAP queries, internally we store them for usage in LDAP filters
 	 * @param string $dn the DN
 	 * @return string
 	 */
@@ -1218,7 +1218,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief checks if the given DN is part of the given base DN(s)
+	 * checks if the given DN is part of the given base DN(s)
 	 * @param string $dn the DN
 	 * @param string[] $bases array containing the allowed base DN or DNs
 	 * @return bool
@@ -1240,7 +1240,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief get a cookie for the next LDAP paged search
+	 * get a cookie for the next LDAP paged search
 	 * @param string $base a string with the base DN for the search
 	 * @param string $filter the search filter to identify the correct search
 	 * @param int $limit the limit (or 'pageSize'), to identify the correct search well
@@ -1265,7 +1265,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief set a cookie for LDAP paged search run
+	 * set a cookie for LDAP paged search run
 	 * @param string $base a string with the base DN for the search
 	 * @param string $filter the search filter to identify the correct search
 	 * @param int $limit the limit (or 'pageSize'), to identify the correct search well
@@ -1281,7 +1281,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Check whether the most recent paged search was successful. It flushed the state var. Use it always after a possible paged search.
+	 * Check whether the most recent paged search was successful. It flushed the state var. Use it always after a possible paged search.
 	 * @return boolean|null true on success, null or false otherwise
 	 */
 	public function getPagedSearchResultState() {
@@ -1291,7 +1291,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Prepares a paged search, if possible
+	 * Prepares a paged search, if possible
 	 * @param string $filter the LDAP filter for the search
 	 * @param string[] $bases an array containing the LDAP subtree(s) that shall be searched
 	 * @param string[] $attr optional, when a certain attribute shall be filtered outside

--- a/apps/user_ldap/lib/backendutility.php
+++ b/apps/user_ldap/lib/backendutility.php
@@ -29,7 +29,7 @@ abstract class BackendUtility {
 	protected $access;
 
 	/**
-	 * @brief constructor, make sure the subclasses call this one!
+	 * constructor, make sure the subclasses call this one!
 	 * @param Access $access an instance of Access for LDAP interaction
 	 */
 	public function __construct(Access $access) {

--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -117,7 +117,7 @@ class Configuration {
 	}
 
 	/**
-	 * @brief set LDAP configuration with values delivered by an array, not read
+	 * set LDAP configuration with values delivered by an array, not read
 	 * from configuration. It does not save the configuration! To do so, you
 	 * must call saveConfiguration afterwards.
 	 * @param array $config array that holds the config parameters in an associated
@@ -212,7 +212,7 @@ class Configuration {
 	}
 
 	/**
-	 * @brief saves the current Configuration in the database
+	 * saves the current Configuration in the database
 	 */
 	public function saveConfiguration() {
 		$cta = array_flip($this->getConfigTranslationArray());

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -42,7 +42,7 @@ class Connection extends LDAPUtility {
 	protected $doNotValidate = false;
 
 	/**
-	 * @brief Constructor
+	 * Constructor
 	 * @param ILDAPWrapper $ldap
 	 * @param string $configPrefix a string with the prefix for the configkey column (appconfig table)
 	 * @param string $configID a string with the value for the appid column (appconfig table) or null for on-the-fly connections
@@ -73,7 +73,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief defines behaviour when the instance is cloned
+	 * defines behaviour when the instance is cloned
 	 */
 	public function __clone() {
 		//a cloned instance inherits the connection resource. It may use it,
@@ -117,7 +117,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief initializes the LDAP backend
+	 * initializes the LDAP backend
 	 * @param bool $force read the config settings no matter what
 	 */
 	public function init($force = false) {
@@ -126,7 +126,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Returns the LDAP handler
+	 * Returns the LDAP handler
 	 */
 	public function getConnectionResource() {
 		if(!$this->ldapConnectionRes) {
@@ -210,7 +210,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Caches the general LDAP configuration.
+	 * Caches the general LDAP configuration.
 	 * @param bool $force optional. true, if the re-read should be forced. defaults
 	 * to false.
 	 * @return null
@@ -223,7 +223,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief set LDAP configuration with values delivered by an array, not read from configuration
+	 * set LDAP configuration with values delivered by an array, not read from configuration
 	 * @param array $config array that holds the config parameters in an associated array
 	 * @param array &$setParameters optional; array where the set fields will be given to
 	 * @return boolean true if config validates, false otherwise. Check with $setParameters for detailed success on single parameters
@@ -243,7 +243,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief saves the current Configuration in the database and empties the
+	 * saves the current Configuration in the database and empties the
 	 * cache
 	 * @return null
 	 */
@@ -253,7 +253,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief get the current LDAP configuration
+	 * get the current LDAP configuration
 	 * @return array
 	 */
 	public function getConfiguration() {
@@ -433,7 +433,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Validates the user specified configuration
+	 * Validates the user specified configuration
 	 * @return bool true if configuration seems OK, false otherwise
 	 */
 	private function validateConfiguration() {

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -26,7 +26,7 @@ namespace OCA\user_ldap\lib;
 class Helper {
 
 	/**
-	 * @brief returns prefixes for each saved LDAP/AD server configuration.
+	 * returns prefixes for each saved LDAP/AD server configuration.
 	 * @param bool $activeConfigurations optional, whether only active configuration shall be
 	 * retrieved, defaults to false
 	 * @return array with a list of the available prefixes
@@ -79,7 +79,7 @@ class Helper {
 
 	/**
 	 *
-	 * @brief determines the host for every configured connection
+	 * determines the host for every configured connection
 	 * @return array an array with configprefix as keys
 	 *
 	 */
@@ -106,7 +106,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief deletes a given saved LDAP/AD server configuration.
+	 * deletes a given saved LDAP/AD server configuration.
 	 * @param string $prefix the configuration prefix of the config to delete
 	 * @return bool true on success, false otherwise
 	 */
@@ -176,7 +176,7 @@ class Helper {
 	}
 
 	/**
-	 * @brief extractsthe domain from a given URL
+	 * extractsthe domain from a given URL
 	 * @param string $url the URL
 	 * @return string|false domain as string on success, false otherwise
 	 */

--- a/apps/user_ldap/lib/ildapwrapper.php
+++ b/apps/user_ldap/lib/ildapwrapper.php
@@ -28,7 +28,7 @@ interface ILDAPWrapper {
 	//LDAP functions in use
 
 	/**
-	 * @brief Bind to LDAP directory
+	 * Bind to LDAP directory
 	 * @param resource $link LDAP link resource
 	 * @param string $dn an RDN to log in with
 	 * @param string $password the password
@@ -39,7 +39,7 @@ interface ILDAPWrapper {
 	public function bind($link, $dn, $password);
 
 	/**
-	 * @brief connect to an LDAP server
+	 * connect to an LDAP server
 	 * @param string $host The host to connect to
 	 * @param string $port The port to connect to
 	 * @return mixed a link resource on success, otherwise false
@@ -47,7 +47,7 @@ interface ILDAPWrapper {
 	public function connect($host, $port);
 
 	/**
-	 * @brief Send LDAP pagination control
+	 * Send LDAP pagination control
 	 * @param resource $link LDAP link resource
 	 * @param int $pageSize number of results per page
 	 * @param bool $isCritical Indicates whether the pagination is critical of not.
@@ -57,7 +57,7 @@ interface ILDAPWrapper {
 	public function controlPagedResult($link, $pageSize, $isCritical, $cookie);
 
 	/**
-	 * @brief Retrieve the LDAP pagination cookie
+	 * Retrieve the LDAP pagination cookie
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @param string $cookie structure sent by LDAP server
@@ -68,7 +68,7 @@ interface ILDAPWrapper {
 	public function controlPagedResultResponse($link, $result, &$cookie);
 
 	/**
-	 * @brief Count the number of entries in a search
+	 * Count the number of entries in a search
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @return int|false number of results on success, false otherwise
@@ -76,21 +76,21 @@ interface ILDAPWrapper {
 	public function countEntries($link, $result);
 
 	/**
-	 * @brief Return the LDAP error number of the last LDAP command
+	 * Return the LDAP error number of the last LDAP command
 	 * @param resource $link LDAP link resource
 	 * @return string error message as string
 	 */
 	public function errno($link);
 
 	/**
-	 * @brief Return the LDAP error message of the last LDAP command
+	 * Return the LDAP error message of the last LDAP command
 	 * @param resource $link LDAP link resource
 	 * @return int error code as integer
 	 */
 	public function error($link);
 
 	/**
-	 * @brief Return first result id
+	 * Return first result id
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @return Resource an LDAP search result resource
@@ -98,7 +98,7 @@ interface ILDAPWrapper {
 	public function firstEntry($link, $result);
 
 	/**
-	 * @brief Get attributes from a search result entry
+	 * Get attributes from a search result entry
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @return array containing the results, false on error
@@ -106,7 +106,7 @@ interface ILDAPWrapper {
 	public function getAttributes($link, $result);
 
 	/**
-	 * @brief Get the DN of a result entry
+	 * Get the DN of a result entry
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @return string containing the DN, false on error
@@ -114,7 +114,7 @@ interface ILDAPWrapper {
 	public function getDN($link, $result);
 
 	/**
-	 * @brief Get all result entries
+	 * Get all result entries
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @return array containing the results, false on error
@@ -122,7 +122,7 @@ interface ILDAPWrapper {
 	public function getEntries($link, $result);
 
 	/**
-	 * @brief Return next result id
+	 * Return next result id
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP entry result resource
 	 * @return resource an LDAP search result resource
@@ -130,7 +130,7 @@ interface ILDAPWrapper {
 	public function nextEntry($link, $result);
 
 	/**
-	 * @brief Read an entry
+	 * Read an entry
 	 * @param resource $link LDAP link resource
 	 * @param array $baseDN The DN of the entry to read from
 	 * @param string $filter An LDAP filter
@@ -140,7 +140,7 @@ interface ILDAPWrapper {
 	public function read($link, $baseDN, $filter, $attr);
 
 	/**
-	 * @brief Search LDAP tree
+	 * Search LDAP tree
 	 * @param resource $link LDAP link resource
 	 * @param string $baseDN The DN of the entry to read from
 	 * @param string $filter An LDAP filter
@@ -152,7 +152,7 @@ interface ILDAPWrapper {
 	public function search($link, $baseDN, $filter, $attr, $attrsOnly = 0, $limit = 0);
 
 	/**
-	 * @brief Sets the value of the specified option to be $value
+	 * Sets the value of the specified option to be $value
 	 * @param resource $link LDAP link resource
 	 * @param string $option a defined LDAP Server option
 	 * @param int $value the new value for the option
@@ -161,14 +161,14 @@ interface ILDAPWrapper {
 	public function setOption($link, $option, $value);
 
 	/**
-	 * @brief establish Start TLS
+	 * establish Start TLS
 	 * @param resource $link LDAP link resource
 	 * @return bool true on success, false otherwise
 	 */
 	public function startTls($link);
 
 	/**
-	 * @brief Sort the result of a LDAP search
+	 * Sort the result of a LDAP search
 	 * @param resource $link LDAP link resource
 	 * @param resource $result LDAP result resource
 	 * @param string $sortFilter attribute to use a key in sort
@@ -176,7 +176,7 @@ interface ILDAPWrapper {
 	public function sort($link, $result, $sortFilter);
 
 	/**
-	 * @brief Unbind from LDAP directory
+	 * Unbind from LDAP directory
 	 * @param resource $link LDAP link resource
 	 * @return bool true on success, false otherwise
 	 */
@@ -185,19 +185,19 @@ interface ILDAPWrapper {
 	//additional required methods in ownCloud
 
 	/**
-	 * @brief Checks whether the server supports LDAP
+	 * Checks whether the server supports LDAP
 	 * @return bool true if it the case, false otherwise
 	 * */
 	public function areLDAPFunctionsAvailable();
 
 	/**
-	 * @brief Checks whether PHP supports LDAP Paged Results
+	 * Checks whether PHP supports LDAP Paged Results
 	 * @return bool true if it the case, false otherwise
 	 * */
 	public function hasPagedResultSupport();
 
 	/**
-	 * @brief Checks whether the submitted parameter is a resource
+	 * Checks whether the submitted parameter is a resource
 	 * @param resource $resource the resource variable to check
 	 * @return bool true if it is a resource, false otherwise
 	 */

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -204,7 +204,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	/**
-	 * @brief Checks whether the server supports LDAP
+	 * Checks whether the server supports LDAP
 	 * @return boolean if it the case, false otherwise
 	 * */
 	public function areLDAPFunctionsAvailable() {
@@ -212,7 +212,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	/**
-	 * @brief Checks whether PHP supports LDAP Paged Results
+	 * Checks whether PHP supports LDAP Paged Results
 	 * @return boolean if it the case, false otherwise
 	 * */
 	public function hasPagedResultSupport() {
@@ -222,7 +222,7 @@ class LDAP implements ILDAPWrapper {
 	}
 
 	/**
-	 * @brief Checks whether the submitted parameter is a resource
+	 * Checks whether the submitted parameter is a resource
 	 * @param Resource $resource the resource variable to check
 	 * @return bool true if it is a resource, false otherwise
 	 */

--- a/apps/user_ldap/lib/ldaputility.php
+++ b/apps/user_ldap/lib/ldaputility.php
@@ -27,7 +27,7 @@ abstract class LDAPUtility {
 	protected $ldap;
 
 	/**
-	 * @brief constructor, make sure the subclasses call this one!
+	 * constructor, make sure the subclasses call this one!
 	 * @param ILDAPWrapper $ldapWrapper an instance of an ILDAPWrapper
 	 */
 	public function __construct(ILDAPWrapper $ldapWrapper) {

--- a/apps/user_ldap/lib/proxy.php
+++ b/apps/user_ldap/lib/proxy.php
@@ -90,7 +90,7 @@ abstract class Proxy {
 	abstract protected function walkBackends($id, $method, $parameters);
 
 	/**
-	 * @brief Takes care of the request to the User backend
+	 * Takes care of the request to the User backend
 	 * @param string $id
 	 * @param string $method string, the method of the user backend that shall be called
 	 * @param array $parameters an array of parameters to be passed

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -44,7 +44,7 @@ class Wizard extends LDAPUtility {
 	const LDAP_NW_TIMEOUT = 4;
 
 	/**
-	 * @brief Constructor
+	 * Constructor
 	 * @param Configuration $configuration an instance of Configuration
 	 * @param ILDAPWrapper $ldap an instance of ILDAPWrapper
 	 */
@@ -162,7 +162,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief return the state of the Group Filter Mode
+	 * return the state of the Group Filter Mode
 	 * @return WizardResult
 	 */
 	public function getGroupFilterMode() {
@@ -171,7 +171,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief return the state of the Login Filter Mode
+	 * return the state of the Login Filter Mode
 	 * @return WizardResult
 	 */
 	public function getLoginFilterMode() {
@@ -180,7 +180,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief return the state of the User Filter Mode
+	 * return the state of the User Filter Mode
 	 * @return WizardResult
 	 */
 	public function getUserFilterMode() {
@@ -189,7 +189,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief return the state of the mode of the specified filter
+	 * return the state of the mode of the specified filter
 	 * @param string $confKey contains the access key of the Configuration
 	 */
 	private function getFilterMode($confKey) {
@@ -201,7 +201,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief detects the available LDAP attributes
+	 * detects the available LDAP attributes
 	 * @return array The instance's WizardResult instance
 	 * @throws \Exception
 	 */
@@ -235,7 +235,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief detects the available LDAP groups
+	 * detects the available LDAP groups
 	 * @return WizardResult the instance's WizardResult instance
 	 */
 	public function determineGroupsForGroups() {
@@ -245,7 +245,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief detects the available LDAP groups
+	 * detects the available LDAP groups
 	 * @return WizardResult the instance's WizardResult instance
 	 */
 	public function determineGroupsForUsers() {
@@ -254,7 +254,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief detects the available LDAP groups
+	 * detects the available LDAP groups
 	 * @param string $dbKey
 	 * @param string $confKey
 	 * @param bool $testMemberOf
@@ -310,7 +310,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Detects the available object classes
+	 * Detects the available object classes
 	 * @return WizardResult the instance's WizardResult instance
 	 * @throws \Exception
 	 */
@@ -337,7 +337,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief detects the available object classes
+	 * detects the available object classes
 	 * @return WizardResult
 	 * @throws \Exception
 	 */
@@ -479,7 +479,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief tries to determine a base dn from User DN or LDAP Host
+	 * tries to determine a base dn from User DN or LDAP Host
 	 * @return WizardResult|false WizardResult on success, false otherwise
 	 */
 	public function guessBaseDN() {
@@ -519,7 +519,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief sets the found value for the configuration key in the WizardResult
+	 * sets the found value for the configuration key in the WizardResult
 	 * as well as in the Configuration instance
 	 * @param string $key the configuration key
 	 * @param string $value the (detected) value
@@ -531,7 +531,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Checks, whether a port was entered in the Host configuration
+	 * Checks, whether a port was entered in the Host configuration
 	 * field. In this case the port will be stripped off, but also stored as
 	 * setting.
 	 */
@@ -549,7 +549,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief tries to detect the group member association attribute which is
+	 * tries to detect the group member association attribute which is
 	 * one of 'uniqueMember', 'memberUid', 'member'
 	 * @return string|false, string with the attribute name, false on error
 	 * @throws \Exception
@@ -591,7 +591,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Checks whether for a given BaseDN results will be returned
+	 * Checks whether for a given BaseDN results will be returned
 	 * @param string $base the BaseDN to test
 	 * @return bool true on success, false otherwise
 	 * @throws \Exception
@@ -617,7 +617,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief Checks whether the server supports memberOf in LDAP Filter.
+	 * Checks whether the server supports memberOf in LDAP Filter.
 	 * Requires that groups are determined, thus internally called from within
 	 * determineGroups()
 	 * @return bool true if it does, false otherwise
@@ -658,7 +658,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief creates an LDAP Filter from given configuration
+	 * creates an LDAP Filter from given configuration
 	 * @param integer $filterType int, for which use case the filter shall be created
 	 * can be any of self::LFILTER_USER_LIST, self::LFILTER_LOGIN or
 	 * self::LFILTER_GROUP_LIST
@@ -877,7 +877,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief checks whether a valid combination of agent and password has been
+	 * checks whether a valid combination of agent and password has been
 	 * provided (either two values or nothing for anonymous connect)
 	 * @return bool, true if everything is fine, false otherwise
 	 */
@@ -905,7 +905,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief does a cumulativeSearch on LDAP to get different values of a
+	 * does a cumulativeSearch on LDAP to get different values of a
 	 * specified attribute
 	 * @param string[] $filters array, the filters that shall be used in the search
 	 * @param string $attr the attribute of which a list of values shall be returned
@@ -981,7 +981,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief determines if and which $attr are available on the LDAP server
+	 * determines if and which $attr are available on the LDAP server
 	 * @param string[] $objectclasses the objectclasses to use as search filter
 	 * @param string $attr the attribute to look for
 	 * @param string $dbkey the dbkey of the setting the feature is connected to
@@ -1040,7 +1040,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @brief appends a list of values fr
+	 * appends a list of values fr
 	 * @param resource $result the return value from ldap_get_attributes
 	 * @param string $attribute the attribute values to look for
 	 * @param array &$known new values will be appended here

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -78,7 +78,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief Prepares the Access mock for checkPassword tests
+	 * Prepares the Access mock for checkPassword tests
 	 * @param \OCA\user_ldap\lib\Access $access mock
 	 * @return void
 	 */
@@ -186,7 +186,7 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief Prepares the Access mock for getUsers tests
+	 * Prepares the Access mock for getUsers tests
 	 * @param \OCA\user_ldap\lib\Access $access mock
 	 * @return void
 	 */

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -69,7 +69,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief reads jpegPhoto and set is as avatar if available
+	 * reads jpegPhoto and set is as avatar if available
 	 * @param string $uid ownCloud user name
 	 * @param string $dn the user's LDAP DN
 	 * @return void
@@ -117,7 +117,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief checks whether the user is allowed to change his avatar in ownCloud
+	 * checks whether the user is allowed to change his avatar in ownCloud
 	 * @param string $uid the ownCloud user name
 	 * @return boolean either the user can or cannot
 	 */
@@ -135,7 +135,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief reads the image from LDAP that shall be used as Avatar
+	 * reads the image from LDAP that shall be used as Avatar
 	 * @param string $uid the ownCloud user name
 	 * @param string $dn the user DN
 	 * @return string data (provided by LDAP) | false
@@ -155,7 +155,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return boolean
@@ -199,7 +199,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Get a list of all users
+	 * Get a list of all users
 	 * @return string[] with all uids
 	 *
 	 * Get a list of all users.
@@ -240,7 +240,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -271,7 +271,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	* @brief delete a user
+	* delete a user
 	* @param string $uid The username of the user to delete
 	* @return bool
 	*
@@ -282,7 +282,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	* @brief get the user's home directory
+	* get the user's home directory
 	* @param string $uid the username
 	* @return boolean
 	*/
@@ -325,7 +325,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief get display name of the user
+	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
@@ -352,7 +352,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Get a list of all display names
+	 * Get a list of all display names
 	 * @return array with all displayNames (value) and the correspondig uids (key)
 	 *
 	 * Get a list of all display names and user ids.
@@ -373,7 +373,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	}
 
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param int $actions bitwise-or'ed actions
 	* @return boolean
 	*

--- a/apps/user_ldap/user_proxy.php
+++ b/apps/user_ldap/user_proxy.php
@@ -30,7 +30,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	private $refBackend = null;
 
 	/**
-	 * @brief Constructor
+	 * Constructor
 	 * @param array $serverConfigPrefixes array containing the config Prefixes
 	 */
 	public function __construct($serverConfigPrefixes, ILDAPWrapper $ldap) {
@@ -45,7 +45,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Tries the backends one after the other until a positive result is returned from the specified method
+	 * Tries the backends one after the other until a positive result is returned from the specified method
 	 * @param string $uid the uid connected to the request
 	 * @param string $method the method of the user backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
@@ -68,7 +68,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Asks the backend connected to the server that supposely takes care of the uid from the request.
+	 * Asks the backend connected to the server that supposely takes care of the uid from the request.
 	 * @param string $uid the uid connected to the request
 	 * @param string $method the method of the user backend that shall be called
 	 * @param array $parameters an array of parameters to be passed
@@ -105,7 +105,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Check if backend implements actions
+	 * Check if backend implements actions
 	 * @param int $actions bitwise-or'ed actions
 	 * @return boolean
 	 *
@@ -118,7 +118,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Get a list of all users
+	 * Get a list of all users
 	 * @return string[] with all uids
 	 *
 	 * Get a list of all users.
@@ -136,7 +136,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -145,7 +145,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return bool
@@ -157,7 +157,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief get the user's home directory
+	 * get the user's home directory
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -166,7 +166,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief get display name of the user
+	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
@@ -175,7 +175,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief checks whether the user is allowed to change his avatar in ownCloud
+	 * checks whether the user is allowed to change his avatar in ownCloud
 	 * @param string $uid the ownCloud user name
 	 * @return boolean either the user can or cannot
 	 */
@@ -184,7 +184,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Get a list of all display names
+	 * Get a list of all display names
 	 * @return array with all displayNames (value) and the corresponding uids (key)
 	 *
 	 * Get a list of all display names and user ids.
@@ -202,7 +202,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief delete a user
+	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -220,7 +220,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	}
 
 	/**
-	 * @brief Count the number of users
+	 * Count the number of users
 	 * @return int|bool
 	 */
 	public function countUsers() {

--- a/build/build.xml
+++ b/build/build.xml
@@ -40,6 +40,26 @@
    </fileset>
 
   </apply>
+
+  <!-- this looks for @brief and @returns annotation in PHP files and fails if it found some -->
+  <apply executable="egrep" failonerror="false" resultproperty="grepReturnCode">
+    <arg value="-rsHn" />
+    <arg value="@brief|@returns" />
+
+    <fileset dir="${basedir}/build">
+      <include name="**/*.php" />
+      <exclude name="**/3rdparty/**" />
+      <exclude name="**/l10n/**" />
+    </fileset>
+  </apply>
+
+  <!-- fail if grep has found something -->
+  <fail message="Please remove @returns and @brief annotations for PHPDoc (listed above)">
+    <condition>
+      <equals arg1="0" arg2="${grepReturnCode}"/>
+    </condition>
+  </fail>
+
  </target>
 
  <!-- javascript lint -->

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -147,7 +147,7 @@ class Autoloader {
 	}
 
 	/**
-	 * @brief Sets the optional low-latency cache for class to path mapping.
+	 * Sets the optional low-latency cache for class to path mapping.
 	 * @param \OC\Memcache\Cache $memoryCache Instance of memory cache.
 	 */
 	public function setMemoryCache(\OC\Memcache\Cache $memoryCache = null) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -666,7 +666,7 @@ class OC {
 	}
 
 	/**
-	 * @brief Handle the request
+	 * Handle the request
 	 */
 	public static function handleRequest() {
 		$l = \OC_L10N::get('lib');

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -37,7 +37,7 @@ class OC_App{
 	static private $altLogin = array();
 
 	/**
-	 * @brief clean the appid
+	 * clean the appid
 	 * @param string|boolean $app Appid that needs to be cleaned
 	 * @return string
 	 */
@@ -46,7 +46,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief loads all apps
+	 * loads all apps
 	 * @param array $types
 	 * @return bool
 	 *
@@ -187,7 +187,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief checks whether or not an app is enabled
+	 * checks whether or not an app is enabled
 	 * @param string $app app
 	 * @return bool
 	 *
@@ -202,7 +202,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief enables an app
+	 * enables an app
 	 * @param mixed $app app
 	 * @throws \Exception
 	 * @return void
@@ -250,7 +250,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief disables an app
+	 * disables an app
 	 * @param string $app app
 	 * @return boolean|null
 	 *
@@ -269,7 +269,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief adds an entry to the navigation
+	 * adds an entry to the navigation
 	 * @param array $data array containing the data
 	 * @return bool
 	 *
@@ -291,7 +291,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief marks a navigation entry as active
+	 * marks a navigation entry as active
 	 * @param string $id id of the entry
 	 * @return bool
 	 *
@@ -305,7 +305,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief Get the navigation entries for the $app
+	 * Get the navigation entries for the $app
 	 * @param string $app app
 	 * @return array an array of the $data added with addNavigationEntry
 	 *
@@ -321,7 +321,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief gets the active Menu entry
+	 * gets the active Menu entry
 	 * @return string id or empty string
 	 *
 	 * This function returns the id of the active navigation entry (set by
@@ -332,7 +332,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief Returns the Settings Navigation
+	 * Returns the Settings Navigation
 	 * @return string
 	 *
 	 * This function returns an array containing all settings pages added. The
@@ -500,7 +500,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief Read all app metadata from the info.xml file
+	 * Read all app metadata from the info.xml file
 	 * @param string $appid id of the app or the path of the info.xml file
 	 * @param boolean $path (optional)
 	 * @return array
@@ -567,7 +567,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief Returns the navigation
+	 * Returns the navigation
 	 * @return array
 	 *
 	 * This function returns an array containing all entries added. The
@@ -659,7 +659,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief: get a list of all apps in the apps folder
+	 * get a list of all apps in the apps folder
 	 * @return array an array of app names (string IDs)
 	 * @todo: change the name of this method to getInstalledApps, which is more accurate
 	 */
@@ -692,7 +692,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief: Lists all apps, this is used in apps.php
+	 * Lists all apps, this is used in apps.php
 	 * @return array
 	 */
 	public static function listAllApps() {
@@ -766,7 +766,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief: Internal custom sort funtion to bring the app into the right order. Should only be called by listAllApps
+	 * Internal custom sort funtion to bring the app into the right order. Should only be called by listAllApps
 	 * @return array
 	 */
 	private static function customSort($a, $b) {
@@ -796,7 +796,7 @@ class OC_App{
 	}
 
 	/**
-	 * @brief: get a list of all apps on apps.owncloud.com
+	 * get a list of all apps on apps.owncloud.com
 	 * @return array, multi-dimensional array of apps.
 	 *     Keys: id, name, type, typename, personid, license, detailpage, preview, changed, description
 	 */

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -89,7 +89,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief Get all apps using the config
+	 * Get all apps using the config
 	 * @return array an array of app ids
 	 *
 	 * This function returns a list of all apps that have at least one
@@ -107,7 +107,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief Get the available keys for an app
+	 * Get the available keys for an app
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
 	 *
@@ -122,7 +122,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief Gets the config value
+	 * Gets the config value
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
@@ -141,7 +141,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief check if a key is set in the appconfig
+	 * check if a key is set in the appconfig
 	 * @param string $app
 	 * @param string $key
 	 * @return bool
@@ -152,7 +152,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief sets a value in the appconfig
+	 * sets a value in the appconfig
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $value value
@@ -185,7 +185,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief Deletes a key
+	 * Deletes a key
 	 * @param string $app app
 	 * @param string $key key
 	 * @return boolean|null
@@ -202,7 +202,7 @@ class AppConfig implements \OCP\IAppConfig {
 	}
 
 	/**
-	 * @brief Remove app from appconfig
+	 * Remove app from appconfig
 	 * @param string $app app
 	 * @return boolean|null
 	 *

--- a/lib/private/appframework/core/api.php
+++ b/lib/private/appframework/core/api.php
@@ -119,7 +119,7 @@ class API implements IApi{
 	}
 
 	/**
-	 * @brief connects a function to a hook
+	 * connects a function to a hook
 	 * @param string $signalClass class name of emitter
 	 * @param string $signalName name of signal
 	 * @param string $slotClass class name of slot
@@ -133,7 +133,7 @@ class API implements IApi{
 	}
 
 	/**
-	 * @brief Emits a signal. To get data from the slot use references!
+	 * Emits a signal. To get data from the slot use references!
 	 * @param string $signalClass class name of emitter
 	 * @param string $signalName name of signal
 	 * @param array $params default: array() array with additional data
@@ -144,7 +144,7 @@ class API implements IApi{
 	}
 
 	/**
-	 * @brief clear hooks
+	 * clear hooks
 	 * @param string $signalClass
 	 * @param string $signalName
 	 */

--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -15,7 +15,7 @@ class OC_Avatar implements \OCP\IAvatar {
 	private $view;
 
 	/**
-	 * @brief constructor
+	 * constructor
 	 * @param string $user user to do avatar-management with
 	*/
 	public function __construct ($user) {
@@ -23,7 +23,7 @@ class OC_Avatar implements \OCP\IAvatar {
 	}
 
 	/**
-	 * @brief get the users avatar
+	 * get the users avatar
 	 * @param int $size size in px of the avatar, avatars are square, defaults to 64
 	 * @return boolean|\OC_Image containing the avatar or false if there's no image
 	*/
@@ -43,7 +43,7 @@ class OC_Avatar implements \OCP\IAvatar {
 	}
 
 	/**
-	 * @brief sets the users avatar
+	 * sets the users avatar
 	 * @param \OC_Image|resource|string $data OC_Image, imagedata or path to set a new avatar
 	 * @throws Exception if the provided file is not a jpg or png image
 	 * @throws Exception if the provided image is not valid
@@ -81,7 +81,7 @@ class OC_Avatar implements \OCP\IAvatar {
 	}
 
 	/**
-	 * @brief remove the users avatar
+	 * remove the users avatar
 	 * @return void
 	*/
 	public function remove () {

--- a/lib/private/avatarmanager.php
+++ b/lib/private/avatarmanager.php
@@ -15,7 +15,7 @@ use OCP\IAvatarManager;
 class AvatarManager implements IAvatarManager {
 
 	/**
-	 * @brief return a user specific instance of \OCP\IAvatar
+	 * return a user specific instance of \OCP\IAvatar
 	 * @see \OCP\IAvatar
 	 * @param string $user the ownCloud user id
 	 * @return \OCP\IAvatar

--- a/lib/private/backgroundjob.php
+++ b/lib/private/backgroundjob.php
@@ -25,7 +25,7 @@
  */
 class OC_BackgroundJob{
 	/**
-	 * @brief get the execution type of background jobs
+	 * get the execution type of background jobs
 	 * @return string
 	 *
 	 * This method returns the type how background jobs are executed. If the user
@@ -36,7 +36,7 @@ class OC_BackgroundJob{
 	}
 
 	/**
-	 * @brief sets the background jobs execution type
+	 * sets the background jobs execution type
 	 * @param string $type execution type
 	 * @return false|null
 	 *

--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -64,7 +64,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Lists all available config keys
+	 * Lists all available config keys
 	 * @return array an array of key names
 	 *
 	 * This function returns all keys saved in config.php. Please note that it
@@ -75,7 +75,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Gets a value from config.php
+	 * Gets a value from config.php
 	 * @param string $key key
 	 * @param mixed $default = null default value
 	 * @return mixed the value or $default
@@ -92,7 +92,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Sets a value
+	 * Sets a value
 	 * @param string $key key
 	 * @param mixed $value value
 	 *
@@ -108,7 +108,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Removes a key from the config
+	 * Removes a key from the config
 	 * @param string $key key
 	 *
 	 * This function removes a key from the config.php.
@@ -125,7 +125,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Loads the config file
+	 * Loads the config file
 	 *
 	 * Reads the config file and saves it to the cache
 	 */
@@ -153,7 +153,7 @@ class Config {
 	}
 
 	/**
-	 * @brief Writes the config file
+	 * Writes the config file
 	 *
 	 * Saves the config to the config file.
 	 *

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -56,7 +56,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	protected $info;
 
 	/**
-	 * @brief Sets up the node, expects a full path name
+	 * Sets up the node, expects a full path name
 	 * @param \OC\Files\View $view
 	 * @param \OCP\Files\FileInfo $info
 	 */
@@ -71,7 +71,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	}
 
 	/**
-	 * @brief  Returns the name of the node
+	 *  Returns the name of the node
 	 * @return string
 	 */
 	public function getName() {
@@ -79,7 +79,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	}
 
 	/**
-	 * @brief Renames the node
+	 * Renames the node
 	 * @param string $name The new name
 	 * @throws Sabre_DAV_Exception_BadRequest
 	 * @throws Sabre_DAV_Exception_Forbidden
@@ -116,7 +116,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	}
 
 	/**
-	 * @brief Returns the last modification time, as a unix timestamp
+	 * Returns the last modification time, as a unix timestamp
 	 * @return int timestamp as integer
 	 */
 	public function getLastModified() {
@@ -138,7 +138,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	}
 
 	/**
-	 * @brief Updates properties on this node,
+	 * Updates properties on this node,
 	 * @see Sabre_DAV_IProperties::updateProperties
 	 * @param array $properties
 	 * @return boolean
@@ -188,7 +188,7 @@ abstract class OC_Connector_Sabre_Node implements Sabre_DAV_INode, Sabre_DAV_IPr
 	}
 
 	/**
-	 * @brief Returns a list of properties for this nodes.;
+	 * Returns a list of properties for this nodes.;
 	 * @param array $properties
 	 * @return array
 	 * @note The properties list is a list of propertynames the client

--- a/lib/private/davclient.php
+++ b/lib/private/davclient.php
@@ -32,7 +32,7 @@ class OC_DAVClient extends \Sabre_DAV_Client {
 	protected $verifyHost;
 
 	/**
-	 * @brief Sets the request timeout or 0 to disable timeout.
+	 * Sets the request timeout or 0 to disable timeout.
 	 * @param integer $timeout in seconds or 0 to disable
 	 */
 	public function setRequestTimeout($timeout) {
@@ -40,7 +40,7 @@ class OC_DAVClient extends \Sabre_DAV_Client {
 	}
 
 	/**
-	 * @brief Sets the CURLOPT_SSL_VERIFYHOST setting
+	 * Sets the CURLOPT_SSL_VERIFYHOST setting
 	 * @param integer $value value to set CURLOPT_SSL_VERIFYHOST to
 	*/
 	public function setVerifyHost($value) {

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -50,7 +50,7 @@ class OC_DB {
 	static private $type=null;
 
 	/**
-	 * @brief connects to the database
+	 * connects to the database
 	 * @return boolean|null true if connection can be established or false on error
 	 *
 	 * Connects to the database as specified in config.php
@@ -190,7 +190,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief Prepare a SQL query
+	 * Prepare a SQL query
 	 * @param string $query Query string
 	 * @param int $limit
 	 * @param int $offset
@@ -202,12 +202,12 @@ class OC_DB {
 	 */
 	static public function prepare( $query , $limit = null, $offset = null, $isManipulation = null) {
 		self::connect();
-		
+
 		if ($isManipulation === null) {
 			//try to guess, so we return the number of rows on manipulations
 			$isManipulation = self::isManipulation($query);
 		}
-		
+
 		// return the result
 		try {
 			$result = self::$connection->prepare($query, $limit, $offset);
@@ -222,7 +222,7 @@ class OC_DB {
 	/**
 	 * tries to guess the type of statement based on the first 10 characters
 	 * the current check allows some whitespace but does not work with IF EXISTS or other more complex statements
-	 * 
+	 *
 	 * @param string $sql
 	 * @return bool
 	 */
@@ -245,9 +245,9 @@ class OC_DB {
 		}
 		return false;
 	}
-	
+
 	/**
-	 * @brief execute a prepared statement, on error write log and throw exception
+	 * execute a prepared statement, on error write log and throw exception
 	 * @param mixed $stmt OC_DB_StatementWrapper,
 	 *					  an array with 'sql' and optionally 'limit' and 'offset' keys
 	 *					.. or a simple sql query string
@@ -296,7 +296,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief gets last value of autoincrement
+	 * gets last value of autoincrement
 	 * @param string $table The optional table name (will replace *PREFIX*) and add sequence suffix
 	 * @return string id
 	 * @throws DatabaseException
@@ -312,7 +312,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief Insert a row if a matching row doesn't exists.
+	 * Insert a row if a matching row doesn't exists.
 	 * @param string $table The table to insert into in the form '*PREFIX*tableName'
 	 * @param array $input An array of fieldname/value pairs
 	 * @return boolean number of updated rows
@@ -339,7 +339,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief saves database schema to xml file
+	 * saves database schema to xml file
 	 * @param string $file name of file
 	 * @param int $mode
 	 * @return bool
@@ -352,7 +352,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief Creates tables from XML file
+	 * Creates tables from XML file
 	 * @param string $file file to read structure from
 	 * @return bool
 	 *
@@ -365,7 +365,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief update the database schema
+	 * update the database schema
 	 * @param string $file file to read structure from
 	 * @throws Exception
 	 * @return string|boolean
@@ -382,7 +382,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief drop a table
+	 * drop a table
 	 * @param string $tableName the table to drop
 	 */
 	public static function dropTable($tableName) {
@@ -400,7 +400,7 @@ class OC_DB {
 	}
 
 	/**
-	 * @brief replaces the ownCloud tables with a new set
+	 * replaces the ownCloud tables with a new set
 	 * @param string $file path to the MDB2 xml db export file
 	 */
 	public static function replaceDB( $file ) {

--- a/lib/private/db/adapter.php
+++ b/lib/private/db/adapter.php
@@ -40,7 +40,7 @@ class Adapter {
 	}
 
 	/**
-	 * @brief insert the @input values when they do not exist yet
+	 * insert the @input values when they do not exist yet
 	 * @param string $table name
 	 * @param array $input key->value pairs
 	 * @return int count of inserted rows

--- a/lib/private/db/connection.php
+++ b/lib/private/db/connection.php
@@ -152,7 +152,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 	}
 
 	/**
-	 * @brief Insert a row if a matching row doesn't exists.
+	 * Insert a row if a matching row doesn't exists.
 	 * @param string $table. The table to insert into in the form '*PREFIX*tableName'
 	 * @param array $input. An array of fieldname/value pairs
 	 * @return bool The return value from execute()

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -24,7 +24,7 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * @brief saves database scheme to xml file
+	 * saves database scheme to xml file
 	 * @param string $file name of file
 	 * @param int|string $mode
 	 * @return bool
@@ -38,7 +38,7 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * @brief Creates tables from XML file
+	 * Creates tables from XML file
 	 * @param string $file file to read structure from
 	 * @return bool
 	 *
@@ -51,7 +51,7 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * @brief update the database scheme
+	 * update the database scheme
 	 * @param string $file file to read structure from
 	 * @return string|boolean
 	 */
@@ -86,7 +86,7 @@ class MDB2SchemaManager {
 				$column->oldColumnName = $platform->quoteIdentifier($column->oldColumnName);
 			}
 		}
-		
+
 		if ($generateSql) {
 			return $this->generateChangeScript($schemaDiff);
 		}
@@ -95,7 +95,7 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * @brief drop a table
+	 * drop a table
 	 * @param string $tableName the table to drop
 	 */
 	public function dropTable($tableName) {
@@ -125,7 +125,7 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * @brief replaces the ownCloud tables with a new set
+	 * replaces the ownCloud tables with a new set
 	 * @param string $file path to the MDB2 xml db export file
 	 */
 	public function replaceDB( $file ) {

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -270,7 +270,7 @@ class Scanner extends BasicEmitter {
 	}
 
 	/**
-	 * @brief check if the file should be ignored when scanning
+	 * check if the file should be ignored when scanning
 	 * NOTE: files with a '.part' extension are ignored as well!
 	 *       prevents unfinished put requests to be scanned
 	 * @param string $file

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -108,7 +108,7 @@ class Updater {
 	}
 
 	/**
-	 * @brief get file owner and path
+	 * get file owner and path
 	 * @param string $filename
 	 * @return string[] with the oweners uid and the owners path
 	 */

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -384,7 +384,7 @@ class Filesystem {
 	}
 
 	/**
-	 * @brief get the relative path of the root data directory for the current user
+	 * get the relative path of the root data directory for the current user
 	 * @return string
 	 *
 	 * Returns path like /admin/files
@@ -502,7 +502,7 @@ class Filesystem {
 	}
 
 	/**
-	 * @brief check if the directory should be ignored when scanning
+	 * check if the directory should be ignored when scanning
 	 * NOTE: the special directories . and .. would cause never ending recursion
 	 * @param String $dir
 	 * @return boolean
@@ -662,7 +662,7 @@ class Filesystem {
 	}
 
 	/**
-	 * @brief Fix common problems with a file path
+	 * Fix common problems with a file path
 	 * @param string $path
 	 * @param bool $stripTrailingSlash
 	 * @return string

--- a/lib/private/files/storage/home.php
+++ b/lib/private/files/storage/home.php
@@ -23,7 +23,7 @@ class Home extends Local {
 	protected $user;
 
 	/**
-	 * @brief Construct a Home storage instance
+	 * Construct a Home storage instance
 	 * @param array $arguments array with "user" containing the
 	 * storage owner and "legacy" containing "true" if the storage is
 	 * a legacy storage with "local::" URL instead of the new "home::" one.
@@ -57,7 +57,7 @@ class Home extends Local {
 	}
 
 	/**
-	 * @brief Returns the owner of this home storage
+	 * Returns the owner of this home storage
 	 * @return \OC\User\User owner of this home storage
 	 */
 	public function getUser() {

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -673,7 +673,7 @@ class View {
 	}
 
 	/**
-	 * @brief abstraction layer for basic filesystem functions: wrapper for \OC\Files\Storage\Storage
+	 * abstraction layer for basic filesystem functions: wrapper for \OC\Files\Storage\Storage
 	 * @param string $operation
 	 * @param string $path
 	 * @param array $hooks (optional)

--- a/lib/private/geo.php
+++ b/lib/private/geo.php
@@ -7,7 +7,7 @@
  */
 class OC_Geo{
 	/**
-	 * @brief returns the closest timezone to coordinates
+	 * returns the closest timezone to coordinates
 	 * @param float $latitude
 	 * @param float $longitude
 	 * @return mixed Closest timezone

--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -57,7 +57,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief set the group backend
+	 * set the group backend
 	 * @param \OC_Group_Backend $backend  The backend to use for user managment
 	 * @return bool
 	 */
@@ -74,7 +74,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief Try to create a new group
+	 * Try to create a new group
 	 * @param string $gid The name of the group to create
 	 * @return bool
 	 *
@@ -93,7 +93,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief delete a group
+	 * delete a group
 	 * @param string $gid gid of the group to delete
 	 * @return bool
 	 *
@@ -118,7 +118,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -135,7 +135,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief Add a user to a group
+	 * Add a user to a group
 	 * @param string $uid Name of the user to add to group
 	 * @param string $gid Name of the group in which add the user
 	 * @return bool
@@ -156,7 +156,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief Removes a user from a group
+	 * Removes a user from a group
 	 * @param string $uid Name of the user to remove from group
 	 * @param string $gid Name of the group from which remove the user
 	 * @return bool
@@ -177,7 +177,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -199,7 +199,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @param string $search
 	 * @param int|null $limit
 	 * @param int|null $offset
@@ -227,7 +227,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
@@ -249,7 +249,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief get a list of all users in several groups
+	 * get a list of all users in several groups
 	 * @param string[] $gids
 	 * @param string $search
 	 * @param int $limit
@@ -266,7 +266,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief get a list of all display names in a group
+	 * get a list of all display names in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
@@ -278,7 +278,7 @@ class OC_Group {
 	}
 
 	/**
-	 * @brief get a list of all display names in several groups
+	 * get a list of all display names in several groups
 	 * @param array $gids
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/group/backend.php
+++ b/lib/private/group/backend.php
@@ -49,7 +49,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	);
 
 	/**
-	* @brief Get all supported actions
+	* Get all supported actions
 	* @return int bitwise-or'ed actions
 	*
 	* Returns the supported actions as int to be
@@ -67,7 +67,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	}
 
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param int $actions bitwise-or'ed actions
 	* @return bool
 	*
@@ -79,7 +79,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -91,7 +91,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -103,7 +103,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	}
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -126,7 +126,7 @@ abstract class OC_Group_Backend implements OC_Group_Interface {
 	}
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/group/database.php
+++ b/lib/private/group/database.php
@@ -43,7 +43,7 @@
 class OC_Group_Database extends OC_Group_Backend {
 
 	/**
-	 * @brief Try to create a new group
+	 * Try to create a new group
 	 * @param string $gid The name of the group to create
 	 * @return bool
 	 *
@@ -69,7 +69,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief delete a group
+	 * delete a group
 	 * @param string $gid gid of the group to delete
 	 * @return bool
 	 *
@@ -88,7 +88,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -104,7 +104,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Add a user to a group
+	 * Add a user to a group
 	 * @param string $uid Name of the user to add to group
 	 * @param string $gid Name of the group in which add the user
 	 * @return bool
@@ -123,7 +123,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Removes a user from a group
+	 * Removes a user from a group
 	 * @param string $uid Name of the user to remove from group
 	 * @param string $gid Name of the group from which remove the user
 	 * @return bool
@@ -138,7 +138,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -159,7 +159,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -192,7 +192,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
@@ -212,7 +212,7 @@ class OC_Group_Database extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief get the number of all users matching the search string in a group
+	 * get the number of all users matching the search string in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @return int|false

--- a/lib/private/group/dummy.php
+++ b/lib/private/group/dummy.php
@@ -27,7 +27,7 @@
 class OC_Group_Dummy extends OC_Group_Backend {
 	private $groups=array();
 	/**
-	 * @brief Try to create a new group
+	 * Try to create a new group
 	 * @param string $gid The name of the group to create
 	 * @return bool
 	 *
@@ -44,7 +44,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief delete a group
+	 * delete a group
 	 * @param string $gid gid of the group to delete
 	 * @return bool
 	 *
@@ -60,7 +60,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -76,7 +76,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Add a user to a group
+	 * Add a user to a group
 	 * @param string $uid Name of the user to add to group
 	 * @param string $gid Name of the group in which add the user
 	 * @return bool
@@ -97,7 +97,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Removes a user from a group
+	 * Removes a user from a group
 	 * @param string $uid Name of the user to remove from group
 	 * @param string $gid Name of the group from which remove the user
 	 * @return bool
@@ -117,7 +117,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -136,7 +136,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Get a list of all groups
+	 * Get a list of all groups
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -147,7 +147,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief Get a list of all users in a group
+	 * Get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
@@ -163,7 +163,7 @@ class OC_Group_Dummy extends OC_Group_Backend {
 	}
 
 	/**
-	 * @brief get the number of all users in a group
+	 * get the number of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/group/example.php
+++ b/lib/private/group/example.php
@@ -27,7 +27,7 @@
  */
 abstract class OC_Group_Example {
 	/**
-	 * @brief Try to create a new group
+	 * Try to create a new group
 	 * @param string $gid The name of the group to create
 	 * @return bool
 	 *
@@ -37,7 +37,7 @@ abstract class OC_Group_Example {
 	abstract public static function createGroup($gid);
 
 	/**
-	 * @brief delete a group
+	 * delete a group
 	 * @param string $gid gid of the group to delete
 	 * @return bool
 	 *
@@ -46,7 +46,7 @@ abstract class OC_Group_Example {
 	abstract public static function deleteGroup($gid);
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -56,7 +56,7 @@ abstract class OC_Group_Example {
 	abstract public static function inGroup($uid, $gid);
 
 	/**
-	 * @brief Add a user to a group
+	 * Add a user to a group
 	 * @param string $uid Name of the user to add to group
 	 * @param string $gid Name of the group in which add the user
 	 * @return bool
@@ -66,7 +66,7 @@ abstract class OC_Group_Example {
 	abstract public static function addToGroup($uid, $gid);
 
 	/**
-	 * @brief Removes a user from a group
+	 * Removes a user from a group
 	 * @param string $uid Name of the user to remove from group
 	 * @param string $gid Name of the group from which remove the user
 	 * @return bool
@@ -76,7 +76,7 @@ abstract class OC_Group_Example {
 	abstract public static function removeFromGroup($uid, $gid);
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -86,7 +86,7 @@ abstract class OC_Group_Example {
 	abstract public static function getUserGroups($uid);
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -95,14 +95,14 @@ abstract class OC_Group_Example {
 	abstract public static function getGroups($search = '', $limit = -1, $offset = 0);
 
 	/**
-	 * @brief Check if a group exists
+	 * Check if a group exists
 	 * @param string $gid
 	 * @return bool
 	 */
 	abstract public function groupExists($gid);
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/group/group.php
+++ b/lib/private/group/group.php
@@ -244,7 +244,7 @@ class Group {
 	}
 
 	/**
-	 * @brief returns all the Users from an array that really exists
+	 * returns all the Users from an array that really exists
 	 * @param string[] $userIds an array containing user IDs
 	 * @return \OC\User\User[] an Array with the userId as Key and \OC\User\User as value
 	 */

--- a/lib/private/group/interface.php
+++ b/lib/private/group/interface.php
@@ -23,7 +23,7 @@
 
 interface OC_Group_Interface {
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param int $actions bitwise-or'ed actions
 	* @return boolean
 	*
@@ -33,7 +33,7 @@ interface OC_Group_Interface {
 	public function implementsActions($actions);
 
 	/**
-	 * @brief is user in group?
+	 * is user in group?
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -43,7 +43,7 @@ interface OC_Group_Interface {
 	public function inGroup($uid, $gid);
 
 	/**
-	 * @brief Get all groups a user belongs to
+	 * Get all groups a user belongs to
 	 * @param string $uid Name of the user
 	 * @return array an array of group names
 	 *
@@ -53,7 +53,7 @@ interface OC_Group_Interface {
 	public function getUserGroups($uid);
 
 	/**
-	 * @brief get a list of all groups
+	 * get a list of all groups
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -71,7 +71,7 @@ interface OC_Group_Interface {
 	public function groupExists($gid);
 
 	/**
-	 * @brief get a list of all users in a group
+	 * get a list of all users in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -184,7 +184,7 @@ class Manager extends PublicEmitter {
 	}
 
 	/**
-	 * @brief get a list of all display names in a group
+	 * get a list of all display names in a group
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -31,7 +31,7 @@ class OC_Helper {
 	private static $templateManager;
 
 	/**
-	 * @brief Creates an url using a defined route
+	 * Creates an url using a defined route
 	 * @param string $route
 	 * @param array $parameters
 	 * @return
@@ -45,7 +45,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates an url
+	 * Creates an url
 	 * @param string $app app
 	 * @param string $file file
 	 * @param array $args array with param=>value, will be appended to the returned url
@@ -68,7 +68,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates an absolute url
+	 * Creates an absolute url
 	 * @param string $app app
 	 * @param string $file file
 	 * @param array $args array with param=>value, will be appended to the returned url
@@ -84,7 +84,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Makes an $url absolute
+	 * Makes an $url absolute
 	 * @param string $url the url
 	 * @return string the absolute url
 	 *
@@ -95,7 +95,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates an url for remote use
+	 * Creates an url for remote use
 	 * @param string $service id
 	 * @return string the url
 	 *
@@ -106,7 +106,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates an absolute url for remote use
+	 * Creates an absolute url for remote use
 	 * @param string $service id
 	 * @param bool $add_slash
 	 * @return string the url
@@ -121,7 +121,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates an absolute url for public use
+	 * Creates an absolute url for public use
 	 * @param string $service id
 	 * @param bool $add_slash
 	 * @return string the url
@@ -138,7 +138,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Creates path to an image
+	 * Creates path to an image
 	 * @param string $app app
 	 * @param string $image image name
 	 * @return string the url
@@ -150,7 +150,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief get path to icon of file type
+	 * get path to icon of file type
 	 * @param string $mimetype mimetype
 	 * @return string the url
 	 *
@@ -264,7 +264,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief get path to preview of file
+	 * get path to preview of file
 	 * @param string $path path
 	 * @return string the url
 	 *
@@ -279,7 +279,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Make a human file size
+	 * Make a human file size
 	 * @param int $bytes file size in bytes
 	 * @return string a human readable file size
 	 *
@@ -314,7 +314,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Make a php file size
+	 * Make a php file size
 	 * @param int $bytes file size in bytes
 	 * @return string a php parseable file size
 	 *
@@ -340,7 +340,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Make a computer file size
+	 * Make a computer file size
 	 * @param string $str file size in human readable format
 	 * @return int a file size in bytes
 	 *
@@ -377,7 +377,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Recursive copying of folders
+	 * Recursive copying of folders
 	 * @param string $src source folder
 	 * @param string $dest target folder
 	 *
@@ -399,7 +399,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Recursive deletion of folders
+	 * Recursive deletion of folders
 	 * @param string $dir path to the folder
 	 * @return bool
 	 */
@@ -485,7 +485,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Checks $_REQUEST contains a var for the $s key. If so, returns the html-escaped value of this var; otherwise returns the default value provided by $d.
+	 * Checks $_REQUEST contains a var for the $s key. If so, returns the html-escaped value of this var; otherwise returns the default value provided by $d.
 	 * @param string $s name of the var to escape, if set.
 	 * @param string $d default value.
 	 * @return string the print-safe value.
@@ -726,7 +726,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Checks if $sub is a subdirectory of $parent
+	 * Checks if $sub is a subdirectory of $parent
 	 *
 	 * @param string $sub
 	 * @param string $parent
@@ -752,7 +752,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Returns an array with all keys from input lowercased or uppercased. Numbered indices are left as is.
+	 * Returns an array with all keys from input lowercased or uppercased. Numbered indices are left as is.
 	 *
 	 * @param array $input The array to work on
 	 * @param int $case Either MB_CASE_UPPER or MB_CASE_LOWER (default)
@@ -773,7 +773,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief replaces a copy of string delimited by the start and (optionally) length parameters with the string given in replacement.
+	 * replaces a copy of string delimited by the start and (optionally) length parameters with the string given in replacement.
 	 *
 	 * @param string $string
 	 * @param string $replacement The replacement string.
@@ -794,7 +794,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief Replace all occurrences of the search string with the replacement string
+	 * Replace all occurrences of the search string with the replacement string
 	 *
 	 * @param string $search The value being searched for, otherwise known as the needle.
 	 * @param string $replace The replacement
@@ -816,7 +816,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief performs a search in a nested array
+	 * performs a search in a nested array
 	 * @param array $haystack the array to be searched
 	 * @param string $needle the search string
 	 * @param string $index optional, only search this key name
@@ -858,7 +858,7 @@ class OC_Helper {
 	}
 
 	/**
-	 * @brief calculates the maximum upload size respecting system settings, free space and user quota
+	 * calculates the maximum upload size respecting system settings, free space and user quota
 	 *
 	 * @param string $dir the current folder where the user currently operates
 	 * @param int $freeSpace the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
@@ -873,7 +873,7 @@ class OC_Helper {
 
 	/**
 	 * Calculate free space left within user quota
-	 * 
+	 *
 	 * @param string $dir the current folder where the user currently operates
 	 * @return int number of bytes representing
 	 */

--- a/lib/private/hook.php
+++ b/lib/private/hook.php
@@ -8,7 +8,7 @@ class OC_Hook{
 	static private $registered = array();
 
 	/**
-	 * @brief connects a function to a hook
+	 * connects a function to a hook
 	 * @param string $signalclass class name of emitter
 	 * @param string $signalname name of signal
 	 * @param string $slotclass class name of slot
@@ -42,7 +42,7 @@ class OC_Hook{
 	}
 
 	/**
-	 * @brief emits a signal
+	 * emits a signal
 	 * @param string $signalclass class name of emitter
 	 * @param string $signalname name of signal
 	 * @param mixed $params default: array() array with additional data

--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -33,7 +33,7 @@ class OC_Image {
 	private $fileInfo;
 
 	/**
-	* @brief Get mime type for an image file.
+	* Get mime type for an image file.
 	* @param string|null $filePath The path to a local image file.
 	* @return string The mime type if the it could be determined, otherwise an empty string.
 	*/
@@ -48,7 +48,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Constructor.
+	 * Constructor.
 	 * @param resource|string $imageRef The path to a local file, a base64 encoded string or a resource created by
 	 * an imagecreate* function.
 	 * @return \OC_Image False on error
@@ -70,7 +70,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Determine whether the object contains an image resource.
+	* Determine whether the object contains an image resource.
 	* @return bool
 	*/
 	public function valid() { // apparently you can't name a method 'empty'...
@@ -78,7 +78,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Returns the MIME type of the image or an empty string if no image is loaded.
+	* Returns the MIME type of the image or an empty string if no image is loaded.
 	* @return string
 	*/
 	public function mimeType() {
@@ -86,7 +86,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Returns the width of the image or -1 if no image is loaded.
+	* Returns the width of the image or -1 if no image is loaded.
 	* @return int
 	*/
 	public function width() {
@@ -94,7 +94,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Returns the height of the image or -1 if no image is loaded.
+	* Returns the height of the image or -1 if no image is loaded.
 	* @return int
 	*/
 	public function height() {
@@ -102,7 +102,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Returns the width when the image orientation is top-left.
+	* Returns the width when the image orientation is top-left.
 	* @return int
 	*/
 	public function widthTopLeft() {
@@ -125,7 +125,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Returns the height when the image orientation is top-left.
+	* Returns the height when the image orientation is top-left.
 	* @return int
 	*/
 	public function heightTopLeft() {
@@ -148,7 +148,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Outputs the image.
+	 * Outputs the image.
 	 * @param string $mimeType
 	 * @return bool
 	 */
@@ -161,7 +161,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Saves the image.
+	 * Saves the image.
 	 * @param string $filePath
 	 * @param string $mimeType
 	 * @return bool
@@ -181,7 +181,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Outputs/saves the image.
+	 * Outputs/saves the image.
 	 * @param string $filePath
 	 * @param string $mimeType
 	 * @return bool
@@ -259,7 +259,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Prints the image when called as $image().
+	* Prints the image when called as $image().
 	*/
 	public function __invoke() {
 		return $this->show();
@@ -307,7 +307,7 @@ class OC_Image {
 
 	/**
 	* (I'm open for suggestions on better method name ;)
-	* @brief Get the orientation based on EXIF data.
+	* Get the orientation based on EXIF data.
 	* @return int The orientation or -1 if no EXIF data is available.
 	*/
 	public function getOrientation() {
@@ -335,7 +335,7 @@ class OC_Image {
 
 	/**
 	* (I'm open for suggestions on better method name ;)
-	* @brief Fixes orientation based on EXIF data.
+	* Fixes orientation based on EXIF data.
 	* @return bool.
 	*/
 	public function fixOrientation() {
@@ -396,7 +396,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Loads an image from a local file, a base64 encoded string or a resource created by an imagecreate* function.
+	 * Loads an image from a local file, a base64 encoded string or a resource created by an imagecreate* function.
 	 * @param resource|string $imageRef The path to a local file, a base64 encoded string or a resource created by an imagecreate* function or a file resource (file handle    ).
 	 * @return resource|false An image resource or false on error
 	 */
@@ -421,7 +421,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Loads an image from an open file handle.
+	* Loads an image from an open file handle.
 	* It is the responsibility of the caller to position the pointer at the correct place and to close the handle again.
 	* @param resource $handle
 	* @return resource|false An image resource or false on error
@@ -435,7 +435,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Loads an image from a local file.
+	* Loads an image from a local file.
 	* @param bool|string $imagePath The path to a local file.
 	* @return bool|resource An image resource or false on error
 	*/
@@ -536,7 +536,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Loads an image from a string of data.
+	* Loads an image from a string of data.
 	* @param string $str A string of image data as read from a file.
 	* @return bool|resource An image resource or false on error
 	*/
@@ -561,7 +561,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Loads an image from a base64 encoded string.
+	* Loads an image from a base64 encoded string.
 	* @param string $str A string base64 encoded string of image data.
 	* @return bool|resource An image resource or false on error
 	*/
@@ -729,7 +729,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Resizes the image preserving ratio.
+	* Resizes the image preserving ratio.
 	* @param integer $maxSize The maximum size of either the width or height.
 	* @return bool
 	*/
@@ -793,7 +793,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Crops the image to the middle square. If the image is already square it just returns.
+	* Crops the image to the middle square. If the image is already square it just returns.
 	* @param int $size maximum size for the result (optional)
 	* @return bool for success or failure
 	*/
@@ -852,7 +852,7 @@ class OC_Image {
 	}
 
 	/**
-	* @brief Crops the image from point $x$y with dimension $wx$h.
+	* Crops the image from point $x$y with dimension $wx$h.
 	* @param int $x Horizontal position
 	* @param int $y Vertical position
 	* @param int $w Width
@@ -882,7 +882,7 @@ class OC_Image {
 	}
 
 	/**
-	 * @brief Resizes the image to fit within a boundry while preserving ratio.
+	 * Resizes the image to fit within a boundry while preserving ratio.
 	 * @param integer $maxWidth
 	 * @param integer $maxHeight
 	 * @return bool

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -52,7 +52,7 @@ class OC_Installer{
 	 * It is the task of oc_app_install to create the tables and do whatever is
 	 * needed to get the app working.
 	 *
-	 * @brief Installs an app
+	 * Installs an app
 	 * @param array $data with all information
 	 * @throws \Exception
 	 * @return integer
@@ -219,7 +219,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief checks whether or not an app is installed
+	 * checks whether or not an app is installed
 	 * @param string $app app
 	 * @return bool
 	 *
@@ -235,7 +235,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief Update an application
+	 * Update an application
 	 *
 	 * This function installs an app. All information needed are passed in the
 	 * associative array $data.
@@ -268,7 +268,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief Check if an update for the app is available
+	 * Check if an update for the app is available
 	 * @return string|false false or the version number of the update
 	 *
 	 * The function will check if an update for a version is available
@@ -295,7 +295,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief Check if app is already downloaded
+	 * Check if app is already downloaded
 	 * @param string $name name of the application to remove
 	 * @return boolean
 	 *
@@ -311,7 +311,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief Removes an app
+	 * Removes an app
 	 * @param string $name name of the application to remove
 	 * @param array $options options
 	 * @return boolean|null
@@ -364,7 +364,7 @@ class OC_Installer{
 	}
 
 	/**
-	 * @brief Installs shipped apps
+	 * Installs shipped apps
 	 *
 	 * This function installs all apps found in the 'apps' directory that should be enabled by default;
 	 */

--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -86,7 +86,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief The constructor
+	 * The constructor
 	 * @param string $app app requesting l10n
 	 * @param string $lang default: null Language
 	 *
@@ -176,7 +176,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief Creates a function that The constructor
+	 * Creates a function that The constructor
 	 *
 	 * If language is not set, the constructor tries to find the right
 	 * language.
@@ -235,7 +235,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief Translating
+	 * Translating
 	 * @param string $text The text we need a translation for
 	 * @param array $parameters default:array() Parameters for sprintf
 	 * @return \OC_L10N_String Translation or the same text
@@ -248,7 +248,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief Translating
+	 * Translating
 	 * @param string $text_singular the string to translate for exactly one object
 	 * @param string $text_plural the string to translate for n objects
 	 * @param integer $count Number of objects
@@ -277,7 +277,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief getTranslations
+	 * getTranslations
 	 * @return array Fetch all translations
 	 *
 	 * Returns an associative array with all translations
@@ -288,7 +288,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief getPluralFormString
+	 * getPluralFormString
 	 * @return string containing the gettext "Plural-Forms"-string
 	 *
 	 * Returns a string like "nplurals=2; plural=(n != 1);"
@@ -299,7 +299,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief getPluralFormFunction
+	 * getPluralFormFunction
 	 * @return string the plural form function
 	 *
 	 * returned function accepts the argument $n
@@ -313,7 +313,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief get localizations
+	 * get localizations
 	 * @return array Fetch all localizations
 	 *
 	 * Returns an associative array with all localizations
@@ -324,7 +324,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief Localization
+	 * Localization
 	 * @param string $type Type of localization
 	 * @param array|int|string $data parameters for this localization
 	 * @return String or false
@@ -379,7 +379,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief Choose a language
+	 * Choose a language
 	 * @param array $text Associative Array with possible strings
 	 * @return String
 	 *
@@ -403,9 +403,9 @@ class OC_L10N implements \OCP\IL10N {
 
 
 	/**
-	 * @brief find the best language
+	 * find the best language
 	 * @param array|string $app details below
-	 * @returns string language
+	 * string language
 	 *
 	 * If $app is an array, ownCloud assumes that these are the available
 	 * languages. Otherwise ownCloud tries to find the files in the l10n
@@ -416,10 +416,10 @@ class OC_L10N implements \OCP\IL10N {
 	public function getLanguageCode($app=null) {
 		return self::findLanguage($app);
 	}
-	
+
 
 	/**
-	 * @brief find the best language
+	 * find the best language
 	 * @param array|string $app details below
 	 * @return string language
 	 *
@@ -492,7 +492,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief find the l10n directory
+	 * find the l10n directory
 	 * @param string $app App that needs to be translated
 	 * @return directory
 	 */
@@ -512,7 +512,7 @@ class OC_L10N implements \OCP\IL10N {
 	}
 
 	/**
-	 * @brief find all available languages for an app
+	 * find all available languages for an app
 	 * @param string $app App that needs to be translated
 	 * @return array an array of available languages
 	 */

--- a/lib/private/legacy/appconfig.php
+++ b/lib/private/legacy/appconfig.php
@@ -34,7 +34,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief Get all apps using the config
+	 * Get all apps using the config
 	 * @return array an array of app ids
 	 *
 	 * This function returns a list of all apps that have at least one
@@ -45,7 +45,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief Get the available keys for an app
+	 * Get the available keys for an app
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
 	 *
@@ -57,7 +57,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief Gets the config value
+	 * Gets the config value
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
@@ -71,7 +71,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief check if a key is set in the appconfig
+	 * check if a key is set in the appconfig
 	 * @param string $app
 	 * @param string $key
 	 * @return bool
@@ -81,7 +81,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief sets a value in the appconfig
+	 * sets a value in the appconfig
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $value value
@@ -93,7 +93,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief Deletes a key
+	 * Deletes a key
 	 * @param string $app app
 	 * @param string $key key
 	 *
@@ -104,7 +104,7 @@ class OC_Appconfig {
 	}
 
 	/**
-	 * @brief Remove app from appconfig
+	 * Remove app from appconfig
 	 * @param string $app app
 	 *
 	 * Removes all keys in appconfig belonging to the app.

--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -50,7 +50,7 @@ class OC_Config {
 	}
 
 	/**
-	 * @brief Lists all available config keys
+	 * Lists all available config keys
 	 * @return array an array of key names
 	 *
 	 * This function returns all keys saved in config.php. Please note that it
@@ -61,7 +61,7 @@ class OC_Config {
 	}
 
 	/**
-	 * @brief Gets a value from config.php
+	 * Gets a value from config.php
 	 * @param string $key key
 	 * @param mixed $default = null default value
 	 * @return mixed the value or $default
@@ -74,7 +74,7 @@ class OC_Config {
 	}
 
 	/**
-	 * @brief Sets a value
+	 * Sets a value
 	 * @param string $key key
 	 * @param mixed $value value
 	 *
@@ -86,7 +86,7 @@ class OC_Config {
 	}
 
 	/**
-	 * @brief Removes a key from the config
+	 * Removes a key from the config
 	 * @param string $key key
 	 *
 	 * This function removes a key from the config.php.

--- a/lib/private/legacy/preferences.php
+++ b/lib/private/legacy/preferences.php
@@ -28,7 +28,7 @@ OC_Preferences::$object = new \OC\Preferences(OC_DB::getConnection());
 class OC_Preferences{
 	public static $object;
 	/**
-	 * @brief Get all users using the preferences
+	 * Get all users using the preferences
 	 * @return array an array of user ids
 	 *
 	 * This function returns a list of all users that have at least one entry
@@ -39,7 +39,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Get all apps of a user
+	 * Get all apps of a user
 	 * @param string $user user
 	 * @return integer[] with app ids
 	 *
@@ -51,7 +51,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Get the available keys for an app
+	 * Get the available keys for an app
 	 * @param string $user user
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
@@ -64,7 +64,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Gets the preference
+	 * Gets the preference
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -79,7 +79,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief sets a value in the preferences
+	 * sets a value in the preferences
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -95,7 +95,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Deletes a key
+	 * Deletes a key
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -108,7 +108,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Remove app of user from preferences
+	 * Remove app of user from preferences
 	 * @param string $user user
 	 * @param string $app app
 	 * @return bool
@@ -121,7 +121,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Remove user from preferences
+	 * Remove user from preferences
 	 * @param string $user user
 	 * @return bool
 	 *
@@ -133,7 +133,7 @@ class OC_Preferences{
 	}
 
 	/**
-	 * @brief Remove app from all users
+	 * Remove app from all users
 	 * @param string $app app
 	 * @return bool
 	 *

--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -15,7 +15,7 @@ class ErrorHandler {
 	private static $logger;
 
 	/**
-	 * @brief remove password in URLs
+	 * remove password in URLs
 	 * @param string $msg
 	 * @return string
 	 */

--- a/lib/private/migrate.php
+++ b/lib/private/migrate.php
@@ -53,7 +53,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief finds and loads the providers
+	* finds and loads the providers
 	*/
 	static private function findProviders() {
 		// Find the providers
@@ -68,7 +68,7 @@ class OC_Migrate{
 	}
 
 	/**
-	 * @brief exports a user, or owncloud instance
+	 * exports a user, or owncloud instance
 	 * @param string $uid user id of user to export if export type is user, defaults to current
 	 * @param string $type type of export, defualts to user
 	 * @param string $path path to zip output folder
@@ -192,7 +192,7 @@ class OC_Migrate{
 	}
 
 	/**
-	 * @brief imports a user, or owncloud instance
+	 * imports a user, or owncloud instance
 	 * @param string $path path to zip
 	 * @param string $type type of import (user or instance)
 	 * @param string|null|int $uid userid of new user
@@ -307,7 +307,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief recursively deletes a directory
+	* recursively deletes a directory
 	* @param string $dir path of dir to delete
 	* @param bool $deleteRootToo delete the root directory
 	* @return bool
@@ -332,7 +332,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief tries to extract the import zip
+	* tries to extract the import zip
 	* @param string $path path to the zip
 	* @return string path to extract location (with a trailing slash) or false on failure
 	*/
@@ -356,7 +356,7 @@ class OC_Migrate{
 	}
 
 	/**
-	 * @brief creates a migration.db in the users data dir with their app data in
+	 * creates a migration.db in the users data dir with their app data in
 	 * @return bool whether operation was successfull
 	 */
 	private static function exportAppData( ) {
@@ -406,7 +406,7 @@ class OC_Migrate{
 
 
 	/**
-	 * @brief generates json containing export info, and merges any data supplied
+	 * generates json containing export info, and merges any data supplied
 	 * @param array $array of data to include in the returned json
 	 * @return string
 	 */
@@ -430,7 +430,7 @@ class OC_Migrate{
 	}
 
 	/**
-	 * @brief connects to migration.db, or creates if not found
+	 * connects to migration.db, or creates if not found
 	 * @param string $path to migration.db, defaults to user data dir
 	 * @return bool whether the operation was successful
 	 */
@@ -460,7 +460,7 @@ class OC_Migrate{
 	}
 
 	/**
-	 * @brief creates the tables in migration.db from an apps database.xml
+	 * creates the tables in migration.db from an apps database.xml
 	 * @param string $appid id of the app
 	 * @return bool whether the operation was successful
 	 */
@@ -498,7 +498,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief tries to create the zip
+	* tries to create the zip
 	* @return bool
 	*/
 	static private function createZip() {
@@ -519,7 +519,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief returns an array of apps that support migration
+	* returns an array of apps that support migration
 	* @return array
 	*/
 	static public function getApps() {
@@ -534,7 +534,7 @@ class OC_Migrate{
 	}
 
 	/**
-	* @brief imports a new user
+	* imports a new user
 	* @param string $db string path to migration.db
 	* @param object $info object of migration info
 	* @param string|null|int $uid uid to use

--- a/lib/private/migration/content.php
+++ b/lib/private/migration/content.php
@@ -33,7 +33,7 @@ class OC_Migration_Content{
 	private $tmpfiles=array();
 
 	/**
-	* @brief sets up the
+	* sets up the
 	* @param ZipArchive $zip ZipArchive object
 	* @param object $db a database object (required for exporttype user)
 	* @return bool|null
@@ -46,7 +46,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	 * @brief prepares the db
+	 * prepares the db
 	 * @param string $query the sql query to prepare
 	 */
 	public function prepare( $query ) {
@@ -71,7 +71,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief processes the db query
+	* processes the db query
 	* @param string $query the query to process
 	* @return string of processed query
 	*/
@@ -85,7 +85,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief copys rows to migration.db from the main database
+	* copys rows to migration.db from the main database
 	* @param array $options array of options.
 	* @return bool
 	*/
@@ -127,7 +127,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief saves a sql data set into migration.db
+	* saves a sql data set into migration.db
 	* @param OC_DB_StatementWrapper $data a sql data set returned from self::prepare()->query()
 	* @param array $options array of copyRows options
 	* @return void
@@ -166,7 +166,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief adds a directory to the zip object
+	* adds a directory to the zip object
 	* @param boolean|string $dir string path of the directory to add
 	* @param bool $recursive
 	* @param string $internaldir path of folder to add dir to in zip
@@ -201,7 +201,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief adds a file to the zip from a given string
+	* adds a file to the zip from a given string
 	* @param string $data string of data to add
 	* @param string $path the relative path inside of the zip to save the file to
 	* @return bool
@@ -220,7 +220,7 @@ class OC_Migration_Content{
 	}
 
 	/**
-	* @brief closes the zip, removes temp files
+	* closes the zip, removes temp files
 	* @return bool
 	*/
 	public function finish() {
@@ -235,7 +235,7 @@ class OC_Migration_Content{
 	}
 
 		/**
-	* @brief cleans up after the zip
+	* cleans up after the zip
 	*/
 	private function cleanup() {
 		// Delete tmp files

--- a/lib/private/migration/provider.php
+++ b/lib/private/migration/provider.php
@@ -17,19 +17,19 @@ abstract class OC_Migration_Provider{
 	}
 
 	/**
-	 * @brief exports data for apps
+	 * exports data for apps
 	 * @return array appdata to be exported
 	 */
 	abstract function export( );
 
 	/**
-	 * @brief imports data for the app
+	 * imports data for the app
 	 * @return void
 	 */
 	abstract function import( );
 
 	/**
-	* @brief sets the OC_Migration_Content object to $this->content
+	* sets the OC_Migration_Content object to $this->content
 	* @param OC_Migration_Content $content a OC_Migration_Content object
 	*/
 	public function setData( $uid, $content, $info=null ) {
@@ -43,7 +43,7 @@ abstract class OC_Migration_Provider{
 	}
 
 	/**
-	* @brief returns the appid of the provider
+	* returns the appid of the provider
 	* @return string
 	*/
 	public function getID() {

--- a/lib/private/navigationmanager.php
+++ b/lib/private/navigationmanager.php
@@ -29,7 +29,7 @@ class NavigationManager implements \OCP\INavigationManager {
 	}
 
 	/**
-	 * @brief returns all the added Menu entries
+	 * returns all the added Menu entries
 	 * @return array an array of the added entries
 	 */
 	public function getAll() {
@@ -37,7 +37,7 @@ class NavigationManager implements \OCP\INavigationManager {
 	}
 
 	/**
-	 * @brief removes all the entries
+	 * removes all the entries
 	 */
 	public function clear() {
 		$this->entries = array();
@@ -52,7 +52,7 @@ class NavigationManager implements \OCP\INavigationManager {
 	}
 
 	/**
-	 * @brief gets the active Menu entry
+	 * gets the active Menu entry
 	 * @return string id or empty string
 	 *
 	 * This function returns the id of the active navigation entry (set by

--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -29,7 +29,7 @@
 class OC_OCSClient{
 
 	/**
-	 * @brief Get the url of the OCS AppStore server.
+	 * Get the url of the OCS AppStore server.
 	 * @return string of the AppStore server
 	 *
 	 * This function returns the url of the OCS AppStore server. It´s possible
@@ -47,7 +47,7 @@ class OC_OCSClient{
 
 
 	/**
-	 * @brief Get the content of an OCS url call.
+	 * Get the content of an OCS url call.
 	 * @return string of the response
 	 * This function calls an OCS server and returns the response. It also sets a sane timeout
 	* @param string $url
@@ -58,7 +58,7 @@ class OC_OCSClient{
 	}
 
 	/**
-	 * @brief Get all the categories from the OCS server
+	 * Get all the categories from the OCS server
 	 * @return array an array of category ids
 	 * @note returns NULL if config value appstoreenabled is set to false
 	 * This function returns a list of all the application categories on the OCS server
@@ -91,7 +91,7 @@ class OC_OCSClient{
 	}
 
 	/**
-	 * @brief Get all the applications from the OCS server
+	 * Get all the applications from the OCS server
 	 * @return array an array of application data
 	 *
 	 * This function returns a list of all the applications on the OCS server
@@ -148,7 +148,7 @@ class OC_OCSClient{
 
 
 	/**
-	 * @brief Get an the applications from the OCS server
+	 * Get an the applications from the OCS server
 	 * @param string $id
 	 * @return array an array of application data
 	 *
@@ -191,7 +191,7 @@ class OC_OCSClient{
 	}
 
 	/**
-	 * @brief Get the download url for an application from the OCS server
+	 * Get the download url for an application from the OCS server
 	 * @return array an array of application data
 	 *
 	 * This function returns an download url for an applications from the OCS server

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -68,7 +68,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Get all users using the preferences
+	 * Get all users using the preferences
 	 * @return array an array of user ids
 	 *
 	 * This function returns a list of all users that have at least one entry
@@ -109,7 +109,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Get all apps of an user
+	 * Get all apps of an user
 	 * @param string $user user
 	 * @return integer[] with app ids
 	 *
@@ -122,7 +122,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Get the available keys for an app
+	 * Get the available keys for an app
 	 * @param string $user user
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
@@ -140,7 +140,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Gets the preference
+	 * Gets the preference
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -160,7 +160,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief sets a value in the preferences
+	 * sets a value in the preferences
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -206,7 +206,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Deletes a key
+	 * Deletes a key
 	 * @param string $user user
 	 * @param string $app app
 	 * @param string $key key
@@ -227,7 +227,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Remove app of user from preferences
+	 * Remove app of user from preferences
 	 * @param string $user user
 	 * @param string $app app
 	 *
@@ -246,7 +246,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Remove user from preferences
+	 * Remove user from preferences
 	 * @param string $user user
 	 *
 	 * Removes all keys in preferences belonging to the user.
@@ -261,7 +261,7 @@ class Preferences {
 	}
 
 	/**
-	 * @brief Remove app from all users
+	 * Remove app from all users
 	 * @param string $app app
 	 *
 	 * Removes all keys in preferences belonging to the app.

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -66,7 +66,7 @@ class Preview {
 	protected $info;
 
 	/**
-	 * @brief check if thumbnail or bigger version of thumbnail of file is cached
+	 * check if thumbnail or bigger version of thumbnail of file is cached
 	 * @param string $user userid - if no user is given, OC_User::getUser will be used
 	 * @param string $root path of root
 	 * @param string $file The path to the file where you want a thumbnail from
@@ -111,7 +111,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the path of the file you want a thumbnail from
+	 * returns the path of the file you want a thumbnail from
 	 * @return string
 	 */
 	public function getFile() {
@@ -119,7 +119,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the max width of the preview
+	 * returns the max width of the preview
 	 * @return integer
 	 */
 	public function getMaxX() {
@@ -127,7 +127,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the max height of the preview
+	 * returns the max height of the preview
 	 * @return integer
 	 */
 	public function getMaxY() {
@@ -135,7 +135,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns whether or not scalingup is enabled
+	 * returns whether or not scalingup is enabled
 	 * @return bool
 	 */
 	public function getScalingUp() {
@@ -143,7 +143,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the name of the thumbnailfolder
+	 * returns the name of the thumbnailfolder
 	 * @return string
 	 */
 	public function getThumbnailsFolder() {
@@ -151,7 +151,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the max scale factor
+	 * returns the max scale factor
 	 * @return string
 	 */
 	public function getMaxScaleFactor() {
@@ -159,7 +159,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the max width set in ownCloud's config
+	 * returns the max width set in ownCloud's config
 	 * @return string
 	 */
 	public function getConfigMaxX() {
@@ -167,7 +167,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief returns the max height set in ownCloud's config
+	 * returns the max height set in ownCloud's config
 	 * @return string
 	 */
 	public function getConfigMaxY() {
@@ -189,7 +189,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief set the path of the file you want a thumbnail from
+	 * set the path of the file you want a thumbnail from
 	 * @param string $file
 	 * @return \OC\Preview $this
 	 */
@@ -206,7 +206,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief set mime type explicitly
+	 * set mime type explicitly
 	 * @param string $mimeType
 	 */
 	public function setMimetype($mimeType) {
@@ -214,7 +214,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief set the the max width of the preview
+	 * set the the max width of the preview
 	 * @param int $maxX
 	 * @throws \Exception
 	 * @return \OC\Preview $this
@@ -235,7 +235,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief set the the max height of the preview
+	 * set the the max height of the preview
 	 * @param int $maxY
 	 * @throws \Exception
 	 * @return \OC\Preview $this
@@ -256,7 +256,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief set whether or not scalingup is enabled
+	 * set whether or not scalingup is enabled
 	 * @param bool $scalingUp
 	 * @return \OC\Preview $this
 	 */
@@ -274,7 +274,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief check if all parameters are valid
+	 * check if all parameters are valid
 	 * @return bool
 	 */
 	public function isFileValid() {
@@ -293,7 +293,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief deletes previews of a file with specific x and y
+	 * deletes previews of a file with specific x and y
 	 * @return bool
 	 */
 	public function deletePreview() {
@@ -310,7 +310,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief deletes all previews of a file
+	 * deletes all previews of a file
 	 * @return bool
 	 */
 	public function deleteAllPreviews() {
@@ -328,7 +328,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief check if thumbnail or bigger version of thumbnail of file is cached
+	 * check if thumbnail or bigger version of thumbnail of file is cached
 	 * @param int $fileId fileId of the original image
 	 * @return string|false path to thumbnail if it exists or false
 	 */
@@ -348,7 +348,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief check if a bigger version of thumbnail of file is cached
+	 * check if a bigger version of thumbnail of file is cached
 	 * @param int $fileId fileId of the original image
 	 * @return string|false path to bigger thumbnail if it exists or false
 	*/
@@ -380,7 +380,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief get possible bigger thumbnails of the given image
+	 * get possible bigger thumbnails of the given image
 	 * @param int $fileId fileId of the original image
 	 * @return array an array of paths to bigger thumbnails
 	*/
@@ -433,12 +433,12 @@ class Preview {
 	 * @return bool
 	 */
 	private function unscalable($x, $y) {
-		
+
 		$maxX = $this->getMaxX();
 		$maxY = $this->getMaxY();
 		$scalingUp = $this->getScalingUp();
 		$maxScaleFactor = $this->getMaxScaleFactor();
-		
+
 		if ($x < $maxX || $y < $maxY) {
 			if ($scalingUp) {
 				$scalefactor = $maxX / $x;
@@ -453,7 +453,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief return a preview of a file
+	 * return a preview of a file
 	 * @return \OC_Image
 	 */
 	public function getPreview() {
@@ -529,7 +529,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief show preview
+	 * show preview
 	 * @return void
 	 */
 	public function showPreview($mimeType = null) {
@@ -541,7 +541,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief resize, crop and fix orientation
+	 * resize, crop and fix orientation
 	 * @return void
 	 */
 	private function resizeAndCrop() {
@@ -652,7 +652,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief register a new preview provider to be used
+	 * register a new preview provider to be used
 	 * @param array $options
 	 * @return void
 	 */
@@ -661,7 +661,7 @@ class Preview {
 	}
 
 	/**
-	 * @brief create instances of all the registered preview providers
+	 * create instances of all the registered preview providers
 	 * @return void
 	 */
 	private static function initProviders() {

--- a/lib/private/previewmanager.php
+++ b/lib/private/previewmanager.php
@@ -13,7 +13,7 @@ use OCP\IPreview;
 
 class PreviewManager implements IPreview {
 	/**
-	 * @brief return a preview of a file
+	 * return a preview of a file
 	 * @param string $file The path to the file where you want a thumbnail from
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
@@ -27,7 +27,7 @@ class PreviewManager implements IPreview {
 	}
 
 	/**
-	 * @brief returns true if the passed mime type is supported
+	 * returns true if the passed mime type is supported
 	 * @param string $mimeType
 	 * @return boolean
 	 */

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -16,7 +16,7 @@ class OC_Request {
 	const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost)(:[0-9]+|)$/';
 
 	/**
-	 * @brief Check overwrite condition
+	 * Check overwrite condition
 	 * @param string $type
 	 * @return bool
 	 */
@@ -27,7 +27,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Checks whether a domain is considered as trusted from the list
+	 * Checks whether a domain is considered as trusted from the list
 	 * of trusted domains. If no trusted domains have been configured, returns
 	 * true.
 	 * This is used to prevent Host Header Poisoning.
@@ -47,7 +47,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Returns the unverified server host from the headers without checking
+	 * Returns the unverified server host from the headers without checking
 	 * whether it is a trusted domain
 	 * @return string the server host
 	 *
@@ -87,7 +87,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Returns the server host from the headers, or the first configured
+	 * Returns the server host from the headers, or the first configured
 	 * trusted domain if the host isn't in the trusted list
 	 * @return string the server host
 	 *
@@ -120,7 +120,7 @@ class OC_Request {
 	}
 
 	/**
-	* @brief Returns the server protocol
+	* Returns the server protocol
 	* @return string the server protocol
 	*
 	* Returns the server protocol. It respects reverse proxy servers and load balancers
@@ -142,7 +142,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Returns the request uri
+	 * Returns the request uri
 	 * @return string the request uri
 	 *
 	 * Returns the request uri, even if the website uses one or more
@@ -158,7 +158,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Returns the script name
+	 * Returns the script name
 	 * @return string the script name
 	 *
 	 * Returns the script name, even if the website uses one or more
@@ -176,7 +176,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief get Path info from request
+	 * get Path info from request
 	 * @return string Path info or false when not found
 	 */
 	public static function getPathInfo() {
@@ -200,7 +200,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief get Path info from request, not urldecoded
+	 * get Path info from request, not urldecoded
 	 * @throws Exception
 	 * @return string Path info or false when not found
 	 */
@@ -242,7 +242,7 @@ class OC_Request {
 	}
 
 	/**
-	 * @brief Check if the requester sent along an mtime
+	 * Check if the requester sent along an mtime
 	 * @return false or an mtime
 	 */
 	static public function hasModificationTime () {

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -15,7 +15,7 @@ class OC_Response {
 	const STATUS_SERVICE_UNAVAILABLE = 503;
 
 	/**
-	* @brief Enable response caching by sending correct HTTP headers
+	* Enable response caching by sending correct HTTP headers
 	* @param integer $cache_time time to cache the response
 	*  >0		cache time in seconds
 	*  0 and <0	enable default browser caching
@@ -41,7 +41,7 @@ class OC_Response {
 	}
 
 	/**
-	* @brief disable browser caching
+	* disable browser caching
 	* @see enableCaching with cache_time = 0
 	*/
 	static public function disableCaching() {
@@ -49,7 +49,7 @@ class OC_Response {
 	}
 
 	/**
-	* @brief Set response status
+	* Set response status
 	* @param int $status a HTTP status code, see also the STATUS constants
 	*/
 	static public function setStatus($status) {
@@ -83,7 +83,7 @@ class OC_Response {
 	}
 
 	/**
-	* @brief Send redirect response
+	* Send redirect response
 	* @param string $location to redirect to
 	*/
 	static public function redirect($location) {
@@ -92,7 +92,7 @@ class OC_Response {
 	}
 
 	/**
-	* @brief Set reponse expire time
+	* Set reponse expire time
 	* @param string|DateTime $expires date-time when the response expires
 	*  string for DateInterval from now
 	*  DateTime object when to expire response
@@ -170,7 +170,7 @@ class OC_Response {
 	}
 
 	/**
-	* @brief Send file as response, checking and setting caching headers
+	* Send file as response, checking and setting caching headers
 	* @param string $filepath of file to send
 	*/
 	static public function sendFile($filepath) {

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -152,7 +152,7 @@ class OC_Setup {
 	}
 
 	/**
-	 * @brief Post installation checks
+	 * Post installation checks
 	 */
 	public static function postSetupCheck($params) {
 		// setup was successful -> webdav testing now

--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -202,7 +202,7 @@ class Helper extends \OC\Share\Constants {
 	}
 
 	/**
-	 * @brief get default expire settings defined by the admin
+	 * get default expire settings defined by the admin
 	 * @return array contains 'defaultExpireDateSet', 'enforceExpireDate', 'expireAfterDays'
 	 */
 	public static function getDefaultExpireSetting() {
@@ -222,7 +222,7 @@ class Helper extends \OC\Share\Constants {
 	}
 
 	/**
-	 * @brief calculate expire date
+	 * calculate expire date
 	 * @param array $defaultExpireSettings contains 'defaultExpireDateSet', 'enforceExpireDate', 'expireAfterDays'
 	 * @param int $creationTime timestamp when the share was created
 	 * @param int $userExpireDate expire timestamp set by the user

--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -66,7 +66,7 @@ class MailNotifications {
 	}
 
 	/**
-	 * @brief inform users if a file was shared with them
+	 * inform users if a file was shared with them
 	 *
 	 * @param array $recipientList list of recipients
 	 * @param string $itemSource shared item source
@@ -125,7 +125,7 @@ class MailNotifications {
 	}
 
 	/**
-	 * @brief inform recipient about public link share
+	 * inform recipient about public link share
 	 *
 	 * @param string $recipient recipient email address
 	 * @param string $filename the shared file
@@ -150,7 +150,7 @@ class MailNotifications {
 	}
 
 	/**
-	 * @brief create mail body for plain text and html mail
+	 * create mail body for plain text and html mail
 	 *
 	 * @param string $filename the shared file
 	 * @param string $link link to the shared file

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1718,7 +1718,7 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
-	 * @brief construct select statement
+	 * construct select statement
 	 * @param int $format
 	 * @param boolean $fileDependent ist it a file/folder share or a generla share
 	 * @param string $uidOwner
@@ -1762,7 +1762,7 @@ class Share extends \OC\Share\Constants {
 
 
 	/**
-	 * @brief transform db results
+	 * transform db results
 	 * @param array $row result
 	 */
 	private static function transformDBResults(&$row) {
@@ -1793,7 +1793,7 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
-	 * @brief format result
+	 * format result
 	 * @param array $items result
 	 * @param string $column is it a file share or a general share ('file_target' or 'item_target')
 	 * @param \OCP\Share_Backend $backend sharing backend

--- a/lib/private/subadmin.php
+++ b/lib/private/subadmin.php
@@ -31,7 +31,7 @@ OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC_SubAdmin', 'post_deleteGroup
 class OC_SubAdmin{
 
 	/**
-	 * @brief add a SubAdmin
+	 * add a SubAdmin
 	 * @param string $uid uid of the SubAdmin
 	 * @param string $gid gid of the group
 	 * @return boolean
@@ -44,7 +44,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief delete a SubAdmin
+	 * delete a SubAdmin
 	 * @param string $uid uid of the SubAdmin
 	 * @param string $gid gid of the group
 	 * @return boolean
@@ -57,7 +57,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief get groups of a SubAdmin
+	 * get groups of a SubAdmin
 	 * @param string $uid uid of the SubAdmin
 	 * @return array
 	 */
@@ -72,7 +72,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief get SubAdmins of a group
+	 * get SubAdmins of a group
 	 * @param string $gid gid of the group
 	 * @return array
 	 */
@@ -87,7 +87,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief get all SubAdmins
+	 * get all SubAdmins
 	 * @return array
 	 */
 	public static function getAllSubAdmins() {
@@ -101,7 +101,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief checks if a user is a SubAdmin of a group
+	 * checks if a user is a SubAdmin of a group
 	 * @param string $uid uid of the subadmin
 	 * @param string $gid gid of the group
 	 * @return bool
@@ -117,7 +117,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief checks if a user is a SubAdmin
+	 * checks if a user is a SubAdmin
 	 * @param string $uid uid of the subadmin
 	 * @return bool
 	 */
@@ -137,7 +137,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief checks if a user is a accessible by a subadmin
+	 * checks if a user is a accessible by a subadmin
 	 * @param string $subadmin uid of the subadmin
 	 * @param string $user uid of the user
 	 * @return bool
@@ -159,14 +159,14 @@ class OC_SubAdmin{
 	}
 
 	/*
-	 * @brief alias for self::isSubAdminofGroup()
+	 * alias for self::isSubAdminofGroup()
 	 */
 	public static function isGroupAccessible($subadmin, $group) {
 		return self::isSubAdminofGroup($subadmin, $group);
 	}
 
 	/**
-	 * @brief delete all SubAdmins by uid
+	 * delete all SubAdmins by uid
 	 * @param array $parameters
 	 * @return boolean
 	 */
@@ -177,7 +177,7 @@ class OC_SubAdmin{
 	}
 
 	/**
-	 * @brief delete all SubAdmins by gid
+	 * delete all SubAdmins by gid
 	 * @param array $parameters
 	 * @return boolean
 	 */

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -33,7 +33,7 @@ class OC_Template extends \OC\Template\Base {
 	protected $app; // app id
 
 	/**
-	 * @brief Constructor
+	 * Constructor
 	 * @param string $app app providing the template
 	 * @param string $name of the template file (without suffix)
 	 * @param string $renderas = ""; produce a full page
@@ -97,7 +97,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Returns the formfactor extension for current formfactor
+	 * Returns the formfactor extension for current formfactor
 	 */
 	static public function getFormFactorExtension()
 	{
@@ -130,7 +130,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief find the template with the given name
+	 * find the template with the given name
 	 * @param string $name of the template file (without suffix)
 	 *
 	 * Will select the template file for the selected theme and formfactor.
@@ -154,7 +154,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Add a custom element to the header
+	 * Add a custom element to the header
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
@@ -164,7 +164,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Process the template
+	 * Process the template
 	 * @return boolean|string
 	 *
 	 * This function process the template. If $this->renderas is set, it
@@ -191,7 +191,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Include template
+	 * Include template
 	 * @return string returns content of included template
 	 *
 	 * Includes another template. use <?php echo $this->inc('template'); ?> to
@@ -202,7 +202,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Shortcut to print a simple page for users
+	 * Shortcut to print a simple page for users
 	 * @param string $application The application we render the template for
 	 * @param string $name Name of the template
 	 * @param array $parameters Parameters for the template
@@ -217,7 +217,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Shortcut to print a simple page for admins
+	 * Shortcut to print a simple page for admins
 	 * @param string $application The application we render the template for
 	 * @param string $name Name of the template
 	 * @param array $parameters Parameters for the template
@@ -232,7 +232,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * @brief Shortcut to print a simple page for guests
+	 * Shortcut to print a simple page for guests
 	 * @param string $application The application we render the template for
 	 * @param string $name Name of the template
 	 * @param array|string $parameters Parameters for the template
@@ -247,7 +247,7 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-		* @brief Print a fatal error page and terminates the script
+		* Print a fatal error page and terminates the script
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message
 		* Warning: All data passed to $hint needs to get sanitized using OC_Util::sanitizeHTML
@@ -259,7 +259,7 @@ class OC_Template extends \OC\Template\Base {
 		$content->printPage();
 		die();
 	}
-	
+
 	/**
 	 * print error page using Exception details
 	 * @param Exception $exception

--- a/lib/private/template/base.php
+++ b/lib/private/template/base.php
@@ -59,7 +59,7 @@ class Base {
 	}
 
 	/**
-	 * @brief Assign variables
+	 * Assign variables
 	 * @param string $key key
 	 * @param array|bool|integer|string $value value
 	 * @return bool
@@ -75,7 +75,7 @@ class Base {
 	}
 
 	/**
-	 * @brief Appends a variable
+	 * Appends a variable
 	 * @param string $key key
 	 * @param mixed $value value
 	 * @return boolean|null
@@ -94,7 +94,7 @@ class Base {
 	}
 
 	/**
-	 * @brief Prints the proceeded template
+	 * Prints the proceeded template
 	 * @return bool
 	 *
 	 * This function proceeds the template and prints its output.
@@ -111,7 +111,7 @@ class Base {
 	}
 
 	/**
-	 * @brief Process the template
+	 * Process the template
 	 * @return string
 	 *
 	 * This function processes the template.
@@ -121,7 +121,7 @@ class Base {
 	}
 
 	/**
-	 * @brief doing the actual work
+	 * doing the actual work
 	 * @param string $file
 	 * @return string content
 	 *

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -24,7 +24,7 @@ function print_unescaped($string) {
 }
 
 /**
- * @brief make OC_Helper::linkTo available as a simple function
+ * make OC_Helper::linkTo available as a simple function
  * @param string $app app
  * @param string $file file
  * @param array $args array with param=>value, will be appended to the returned url
@@ -45,7 +45,7 @@ function link_to_docs($key) {
 }
 
 /**
- * @brief make OC_Helper::imagePath available as a simple function
+ * make OC_Helper::imagePath available as a simple function
  * @param string $app app
  * @param string $image image
  * @return string link to the image
@@ -57,7 +57,7 @@ function image_path( $app, $image ) {
 }
 
 /**
- * @brief make OC_Helper::mimetypeIcon available as a simple function
+ * make OC_Helper::mimetypeIcon available as a simple function
  * @param string $mimetype mimetype
  * @return string link to the image
  *
@@ -68,7 +68,7 @@ function mimetype_icon( $mimetype ) {
 }
 
 /**
- * @brief make preview_icon available as a simple function
+ * make preview_icon available as a simple function
  * Returns the path to the preview of the image.
  * @param string $path path of file
  * @return link to the preview
@@ -87,7 +87,7 @@ function publicPreview_icon ( $path, $token ) {
 }
 
 /**
- * @brief make OC_Helper::humanFileSize available as a simple function
+ * make OC_Helper::humanFileSize available as a simple function
  * @param int $bytes size in bytes
  * @return string size as string
  *
@@ -98,7 +98,7 @@ function human_file_size( $bytes ) {
 }
 
 /**
- * @brief Strips the timestamp of its time value
+ * Strips the timestamp of its time value
  * @param int $timestamp UNIX timestamp to strip
  * @return $timestamp without time value
  */
@@ -109,7 +109,7 @@ function strip_time($timestamp){
 }
 
 /**
- * @brief Formats timestamp relatively to the current time using
+ * Formats timestamp relatively to the current time using
  * a human-friendly format like "x minutes ago" or "yesterday"
  * @param int $timestamp timestamp to format
  * @param int $fromTime timestamp to compare from, defaults to current time

--- a/lib/private/template/resourcelocator.php
+++ b/lib/private/template/resourcelocator.php
@@ -52,7 +52,7 @@ abstract class ResourceLocator {
 	}
 
 	/*
-	 * @brief append the $file resource if exist at $root
+	 * append the $file resource if exist at $root
 	 * @param string $root path to check
 	 * @param string $file the filename
 	 * @param string|null $webroot base for path, default map $root to $webroot

--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -29,7 +29,7 @@ class URLGenerator implements IURLGenerator {
 	}
 
 	/**
-	 * @brief Creates an url using a defined route
+	 * Creates an url using a defined route
 	 * @param string $route
 	 * @param array $parameters
 	 * @internal param array $args with param=>value, will be appended to the returned url
@@ -43,7 +43,7 @@ class URLGenerator implements IURLGenerator {
 	}
 
 	/**
-	 * @brief Creates an url
+	 * Creates an url
 	 * @param string $app app
 	 * @param string $file file
 	 * @param array $args array with param=>value, will be appended to the returned url
@@ -92,7 +92,7 @@ class URLGenerator implements IURLGenerator {
 	}
 
 	/**
-	 * @brief Creates path to an image
+	 * Creates path to an image
 	 * @param string $app app
 	 * @param string $image image name
 	 * @throws \RuntimeException If the image does not exist

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -62,7 +62,7 @@ class OC_User {
 	private static $incognitoMode = false;
 
 	/**
-	 * @brief registers backend
+	 * registers backend
 	 * @param string $backend name of the backend
 	 * @deprecated Add classes by calling useBackend with a class instance instead
 	 * @return bool
@@ -75,7 +75,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief gets available backends
+	 * gets available backends
 	 * @deprecated
 	 * @return array an array of backends
 	 *
@@ -86,7 +86,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief gets used backends
+	 * gets used backends
 	 * @deprecated
 	 * @return array an array of backends
 	 *
@@ -97,7 +97,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Adds the backend to the list of used backends
+	 * Adds the backend to the list of used backends
 	 * @param string|OC_User_Interface $backend default: database The backend to use for user management
 	 * @return bool
 	 *
@@ -169,7 +169,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Create a new user
+	 * Create a new user
 	 * @param string $uid The username of the user to create
 	 * @param string $password The password of the new user
 	 * @throws Exception
@@ -185,7 +185,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief delete a user
+	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -223,7 +223,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Try to login a user
+	 * Try to login a user
 	 * @param string $uid The username of the user to log in
 	 * @param string $password The password of the user
 	 * @return boolean|null
@@ -236,7 +236,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Try to login a user, assuming authentication
+	 * Try to login a user, assuming authentication
 	 * has already happened (e.g. via Single Sign On).
 	 *
 	 * Log in a user and regenerate a new session.
@@ -262,7 +262,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Verify with Apache whether user is authenticated.
+	 * Verify with Apache whether user is authenticated.
 	 *
 	 * @return boolean|null
 	 *          true: authenticated
@@ -286,14 +286,14 @@ class OC_User {
 
 
 	/**
-	 * @brief Sets user id for session and triggers emit
+	 * Sets user id for session and triggers emit
 	 */
 	public static function setUserId($uid) {
 		OC::$session->set('user_id', $uid);
 	}
 
 	/**
-	 * @brief Sets user display name for session
+	 * Sets user display name for session
 	 * @param string $uid
 	 * @param null $displayName
 	 * @return bool Whether the display name could get set
@@ -311,7 +311,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Logs the current user out and kills all the session data
+	 * Logs the current user out and kills all the session data
 	 *
 	 * Logout, destroys session
 	 */
@@ -320,7 +320,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check if the user is logged in
+	 * Check if the user is logged in
 	 * @return bool
 	 *
 	 * Checks if the user is logged in
@@ -333,7 +333,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief set incognito mode, e.g. if a user wants to open a public link
+	 * set incognito mode, e.g. if a user wants to open a public link
 	 * @param bool $status
 	 */
 	public static function setIncognitoMode($status) {
@@ -358,7 +358,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check if the user is an admin user
+	 * Check if the user is an admin user
 	 * @param string $uid uid of the admin
 	 * @return bool
 	 */
@@ -371,7 +371,7 @@ class OC_User {
 
 
 	/**
-	 * @brief get the user id of the user currently logged in.
+	 * get the user id of the user currently logged in.
 	 * @return string uid or false
 	 */
 	public static function getUser() {
@@ -384,7 +384,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief get the display name of the user currently logged in.
+	 * get the display name of the user currently logged in.
 	 * @param string $uid
 	 * @return string uid or false
 	 */
@@ -407,7 +407,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Autogenerate a password
+	 * Autogenerate a password
 	 * @return string
 	 *
 	 * generates a password
@@ -417,7 +417,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Set password
+	 * Set password
 	 * @param string $uid The username
 	 * @param string $password The new password
 	 * @param string $recoveryPassword for the encryption app to reset encryption keys
@@ -435,7 +435,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check whether user can change his avatar
+	 * Check whether user can change his avatar
 	 * @param string $uid The username
 	 * @return bool
 	 *
@@ -451,7 +451,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check whether user can change his password
+	 * Check whether user can change his password
 	 * @param string $uid The username
 	 * @return bool
 	 *
@@ -467,7 +467,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check whether user can change his display name
+	 * Check whether user can change his display name
 	 * @param string $uid The username
 	 * @return bool
 	 *
@@ -483,7 +483,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return string|false user id a string on success, false otherwise
@@ -516,7 +516,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Get a list of all users
+	 * Get a list of all users
 	 * @return array an array of all uids
 	 *
 	 * Get a list of all users.
@@ -534,7 +534,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Get a list of all users display name
+	 * Get a list of all users display name
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -552,7 +552,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -600,7 +600,7 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Set cookie value to use in next page load
+	 * Set cookie value to use in next page load
 	 * @param string $username username to be set
 	 * @param string $token
 	 */
@@ -609,14 +609,14 @@ class OC_User {
 	}
 
 	/**
-	 * @brief Remove cookie for "remember username"
+	 * Remove cookie for "remember username"
 	 */
 	public static function unsetMagicInCookie() {
 		self::getUserSession()->unsetMagicInCookie();
 	}
 
 	/**
-	 * @brief Returns the first active backend from self::$_usedBackends.
+	 * Returns the first active backend from self::$_usedBackends.
 	 * @return OCP\Authentication\IApacheBackend|null if no backend active, otherwise OCP\Authentication\IApacheBackend
 	 */
 	private static function findFirstActiveUsedBackend() {

--- a/lib/private/user/backend.php
+++ b/lib/private/user/backend.php
@@ -61,7 +61,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	);
 
 	/**
-	* @brief Get all supported actions
+	* Get all supported actions
 	* @return int bitwise-or'ed actions
 	*
 	* Returns the supported actions as int to be
@@ -79,7 +79,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param int $actions bitwise-or'ed actions
 	* @return boolean
 	*
@@ -91,7 +91,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	 * @brief delete a user
+	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -102,7 +102,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	* @brief Get a list of all users
+	* Get a list of all users
 	* @return array an array of all uids
 	*
 	* Get a list of all users.
@@ -112,7 +112,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	* @brief check if a user exists
+	* check if a user exists
 	* @param string $uid the username
 	* @return boolean
 	*/
@@ -121,7 +121,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	* @brief get the user's home directory
+	* get the user's home directory
 	* @param string $uid the username
 	* @return boolean
 	*/
@@ -130,7 +130,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	 * @brief get display name of the user
+	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
@@ -139,7 +139,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	 * @brief Get a list of all display names
+	 * Get a list of all display names
 	 * @return array an array of  all displayNames (value) and the corresponding uids (key)
 	 *
 	 * Get a list of all display names and user ids.
@@ -154,7 +154,7 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
-	 * @brief Check if a user list is available or not
+	 * Check if a user list is available or not
 	 * @return boolean if users can be listed or not
 	 */
 	public function hasUserListings() {

--- a/lib/private/user/database.php
+++ b/lib/private/user/database.php
@@ -56,7 +56,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Create a new user
+	 * Create a new user
 	 * @param string $uid The username of the user to create
 	 * @param string $password The password of the new user
 	 * @return bool
@@ -78,7 +78,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief delete a user
+	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -97,7 +97,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Set password
+	 * Set password
 	 * @param string $uid The username
 	 * @param string $password The new password
 	 * @return bool
@@ -118,7 +118,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Set display name
+	 * Set display name
 	 * @param string $uid The username
 	 * @param string $displayName The new display name
 	 * @return bool
@@ -138,7 +138,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief get display name of the user
+	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
@@ -148,7 +148,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Get a list of all display names
+	 * Get a list of all display names
 	 * @return array an array of  all displayNames (value) and the correspondig uids (key)
 	 *
 	 * Get a list of all display names and user ids.
@@ -168,7 +168,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return string
@@ -201,7 +201,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Load an user in the cache
+	 * Load an user in the cache
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -225,7 +225,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Get a list of all users
+	 * Get a list of all users
 	 * @return array an array of all uids
 	 *
 	 * Get a list of all users.
@@ -241,7 +241,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -251,7 +251,7 @@ class OC_User_Database extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief get the user's home directory
+	 * get the user's home directory
 	 * @param string $uid the username
 	 * @return string|false
 	 */

--- a/lib/private/user/dummy.php
+++ b/lib/private/user/dummy.php
@@ -28,7 +28,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	private $users = array();
 
 	/**
-	 * @brief Create a new user
+	 * Create a new user
 	 * @param string $uid The username of the user to create
 	 * @param string $password The password of the new user
 	 * @return bool
@@ -46,7 +46,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief delete a user
+	 * delete a user
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -62,7 +62,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Set password
+	 * Set password
 	 * @param string $uid The username
 	 * @param string $password The new password
 	 * @return bool
@@ -79,7 +79,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return string
@@ -96,7 +96,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Get a list of all users
+	 * Get a list of all users
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -109,7 +109,7 @@ class OC_User_Dummy extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */

--- a/lib/private/user/example.php
+++ b/lib/private/user/example.php
@@ -27,7 +27,7 @@
  */
 abstract class OC_User_Example extends OC_User_Backend {
 	/**
-		* @brief Create a new user
+		* Create a new user
 		* @param string $uid The username of the user to create
 		* @param string $password The password of the new user
 		* @return bool
@@ -38,7 +38,7 @@ abstract class OC_User_Example extends OC_User_Backend {
 	abstract public function createUser($uid, $password);
 
 	/**
-		* @brief Set password
+		* Set password
 		* @param string $uid The username
 		* @param string $password The new password
 		* @return bool
@@ -48,7 +48,7 @@ abstract class OC_User_Example extends OC_User_Backend {
 	abstract public function setPassword($uid, $password);
 
 	/**
-		* @brief Check if the password is correct
+		* Check if the password is correct
 		* @param string $uid The username
 		* @param string $password The password
 		* @return string
@@ -59,7 +59,7 @@ abstract class OC_User_Example extends OC_User_Backend {
 	abstract public function checkPassword($uid, $password);
 
 	/**
-		* @brief get the user's home directory
+		* get the user's home directory
 		* @param string $uid The username
 		* @return string
 		*

--- a/lib/private/user/http.php
+++ b/lib/private/user/http.php
@@ -54,7 +54,7 @@ class OC_User_HTTP extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief Check if the password is correct
+	 * Check if the password is correct
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return string
@@ -87,7 +87,7 @@ class OC_User_HTTP extends OC_User_Backend {
 	}
 
 	/**
-	 * @brief check if a user exists
+	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -96,7 +96,7 @@ class OC_User_HTTP extends OC_User_Backend {
 	}
 
 	/**
-	* @brief get the user's home directory
+	* get the user's home directory
 	* @param string $uid the username
 	* @return string|false
 	*/

--- a/lib/private/user/interface.php
+++ b/lib/private/user/interface.php
@@ -24,7 +24,7 @@
 interface OC_User_Interface {
 
 	/**
-	* @brief Check if backend implements actions
+	* Check if backend implements actions
 	* @param $actions bitwise-or'ed actions
 	* @return boolean
 	*
@@ -34,14 +34,14 @@ interface OC_User_Interface {
 	public function implementsActions($actions);
 
 	/**
-	* @brief delete a user
+	* delete a user
 	* @param string $uid The username of the user to delete
 	* @return bool
 	*/
 	public function deleteUser($uid);
 
 	/**
-	* @brief Get a list of all users
+	* Get a list of all users
 	* @return array an array of all uids
 	*
 	* Get a list of all users.
@@ -49,21 +49,21 @@ interface OC_User_Interface {
 	public function getUsers($search = '', $limit = null, $offset = null);
 
 	/**
-	* @brief check if a user exists
+	* check if a user exists
 	* @param string $uid the username
 	* @return boolean
 	*/
 	public function userExists($uid);
 
 	/**
-	 * @brief get display name of the user
+	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
 	 */
 	public function getDisplayName($uid);
 
 	/**
-	 * @brief Get a list of all display names
+	 * Get a list of all display names
 	 * @return array an array of  all displayNames (value) and the corresponding uids (key)
 	 *
 	 * Get a list of all display names and user ids.
@@ -71,7 +71,7 @@ interface OC_User_Interface {
 	public function getDisplayNames($search = '', $limit = null, $offset = null);
 
 	/**
-	 * @brief Check if a user list is available or not
+	 * Check if a user list is available or not
 	 * @return boolean if users can be listed or not
 	 */
 	public function hasUserListings();

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -13,7 +13,7 @@ class OC_Util {
 	private static $fsSetup=false;
 
 	/**
-	 * @brief Can be set up
+	 * Can be set up
 	 * @param string $user
 	 * @return boolean
 	 * @description configure the initial filesystem based on the configuration
@@ -87,7 +87,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief check if a password is required for each public link
+	 * check if a password is required for each public link
 	 * @return boolean
 	 */
 	public static function isPublicLinkPasswordRequired() {
@@ -115,7 +115,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief copies the user skeleton files into the fresh user home files
+	 * copies the user skeleton files into the fresh user home files
 	 * @param string $userDirectory
 	 */
 	public static function copySkeleton($userDirectory) {
@@ -123,7 +123,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief copies a directory recursively
+	 * copies a directory recursively
 	 * @param string $source
 	 * @param string $target
 	 * @return void
@@ -153,7 +153,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief get the current installed version of ownCloud
+	 * get the current installed version of ownCloud
 	 * @return array
 	 */
 	public static function getVersion() {
@@ -162,7 +162,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief get the current installed version string of ownCloud
+	 * get the current installed version string of ownCloud
 	 * @return string
 	 */
 	public static function getVersionString() {
@@ -223,7 +223,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief add a javascript file
+	 * add a javascript file
 	 *
 	 * @param string $application
 	 * @param string|null $file filename
@@ -242,7 +242,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief add a css file
+	 * add a css file
 	 *
 	 * @param string $application
 	 * @param string|null $file filename
@@ -261,7 +261,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Add a custom element to the header
+	 * Add a custom element to the header
 	 * @param string $tag tag name of the element
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
@@ -276,7 +276,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief formats a timestamp in the "right" way
+	 * formats a timestamp in the "right" way
 	 *
 	 * @param int $timestamp
 	 * @param bool $dateOnly option to omit time from the result
@@ -296,7 +296,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief check if the current server configuration is suitable for ownCloud
+	 * check if the current server configuration is suitable for ownCloud
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkServer() {
@@ -540,7 +540,7 @@ class OC_Util {
 
 
 	/**
-	 * @brief check if there are still some encrypted files stored
+	 * check if there are still some encrypted files stored
 	 * @return boolean
 	 */
 	public static function encryptedFiles() {
@@ -561,7 +561,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief check if a backup from the encryption keys exists
+	 * check if a backup from the encryption keys exists
 	 * @return boolean
 	 */
 	public static function backupKeysExists() {
@@ -582,7 +582,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check for correct file permissions of data directory
+	 * Check for correct file permissions of data directory
 	 * @param string $dataDirectory
 	 * @return array arrays with error messages and hints
 	 */
@@ -655,7 +655,7 @@ class OC_Util {
 
 
 	/**
-	 * @brief Check if the app is enabled, redirects to home if not
+	 * Check if the app is enabled, redirects to home if not
 	 * @param string $app
 	 * @return void
 	 */
@@ -682,7 +682,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the user is a admin, redirects to home if not
+	 * Check if the user is a admin, redirects to home if not
 	 * @return void
 	 */
 	public static function checkAdminUser() {
@@ -715,7 +715,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the user is a subadmin, redirects to home if not
+	 * Check if the user is a subadmin, redirects to home if not
 	 * @return null|boolean $groups where the current user is subadmin
 	 */
 	public static function checkSubAdminUser() {
@@ -728,7 +728,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Redirect to the user default page
+	 * Redirect to the user default page
 	 * @return void
 	 */
 	public static function redirectToDefaultPage() {
@@ -752,7 +752,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief get an id unique for this instance
+	 * get an id unique for this instance
 	 * @return string
 	 */
 	public static function getInstanceId() {
@@ -766,7 +766,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Static lifespan (in seconds) when a request token expires.
+	 * Static lifespan (in seconds) when a request token expires.
 	 * @see OC_Util::callRegister()
 	 * @see OC_Util::isCallRegistered()
 	 * @description
@@ -777,7 +777,7 @@ class OC_Util {
 	public static $callLifespan = 3600; // 3600 secs = 1 hour
 
 	/**
-	 * @brief Register an get/post call. Important to prevent CSRF attacks.
+	 * Register an get/post call. Important to prevent CSRF attacks.
 	 * @todo Write howto: CSRF protection guide
 	 * @return string Generated token.
 	 * @description
@@ -802,7 +802,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check an ajax get/post call if the request token is valid.
+	 * Check an ajax get/post call if the request token is valid.
 	 * @return boolean False if request token is not set or is invalid.
 	 * @see OC_Util::$callLifespan
 	 * @see OC_Util::callRegister()
@@ -812,7 +812,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check an ajax get/post call if the request token is valid. Exit if not.
+	 * Check an ajax get/post call if the request token is valid. Exit if not.
 	 * @todo Write howto
 	 * @return void
 	 */
@@ -823,7 +823,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Public function to sanitize HTML
+	 * Public function to sanitize HTML
 	 *
 	 * This function is used to sanitize HTML and should be applied on any
 	 * string or array of strings before displaying it on a web page.
@@ -842,7 +842,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Public function to encode url parameters
+	 * Public function to encode url parameters
 	 *
 	 * This function is used to encode path to file before output.
 	 * Encoding is done according to RFC 3986 with one exception:
@@ -858,7 +858,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the .htaccess file is working
+	 * Check if the .htaccess file is working
 	 * @throws OC\HintException If the testfile can't get written.
 	 * @return bool
 	 * @description Check if the .htaccess file is working by creating a test
@@ -906,7 +906,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief test if webDAV is working properly
+	 * test if webDAV is working properly
 	 * @return bool
 	 * @description
 	 * The basic assumption is that if the server returns 401/Not Authenticated for an unauthenticated PROPFIND
@@ -970,7 +970,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the PHP module fileinfo is loaded.
+	 * Check if the PHP module fileinfo is loaded.
 	 * @return bool
 	 */
 	public static function fileInfoLoaded() {
@@ -978,7 +978,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if a PHP version older then 5.3.8 is installed.
+	 * Check if a PHP version older then 5.3.8 is installed.
 	 * @return bool
 	 */
 	public static function isPHPoutdated() {
@@ -986,7 +986,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the ownCloud server can connect to the internet
+	 * Check if the ownCloud server can connect to the internet
 	 * @return bool
 	 */
 	public static function isInternetConnectionWorking() {
@@ -1018,7 +1018,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Check if the connection to the internet is disabled on purpose
+	 * Check if the connection to the internet is disabled on purpose
 	 * @return string
 	 */
 	public static function isInternetConnectionEnabled(){
@@ -1026,7 +1026,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief clear all levels of output buffering
+	 * clear all levels of output buffering
 	 * @return void
 	 */
 	public static function obEnd(){
@@ -1037,7 +1037,7 @@ class OC_Util {
 
 
 	/**
-	 * @brief Generates a cryptographic secure pseudo-random string
+	 * Generates a cryptographic secure pseudo-random string
 	 * @param int $length of the random string
 	 * @return string
 	 * Please also update secureRNGAvailable if you change something here
@@ -1074,7 +1074,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Checks if a secure random number generator is available
+	 * Checks if a secure random number generator is available
 	 * @return bool
 	 */
 	public static function secureRNGAvailable() {
@@ -1226,7 +1226,7 @@ class OC_Util {
 	}
 
 	/**
-	 * @brief Clear the opcode cache if one exists
+	 * Clear the opcode cache if one exists
 	 * This is necessary for writing to the config file
 	 * in case the opcode cache does not re-validate files
 	 * @return void

--- a/lib/private/vobject.php
+++ b/lib/private/vobject.php
@@ -35,7 +35,7 @@ class OC_VObject{
 	}
 
 	/**
-	 * @brief Parses the VObject
+	 * Parses the VObject
 	 * @param string $data VObject as string
 	 * @return Sabre\VObject\Reader|null
 	 */
@@ -54,7 +54,7 @@ class OC_VObject{
 	}
 
 	/**
-	 * @brief Escapes semicolons
+	 * Escapes semicolons
 	 * @param array $value
 	 * @return string
 	 */
@@ -66,7 +66,7 @@ class OC_VObject{
 	}
 
 	/**
-	 * @brief Creates an array out of a multivalue property
+	 * Creates an array out of a multivalue property
 	 * @param string $value
 	 * @return array
 	 */
@@ -112,7 +112,7 @@ class OC_VObject{
 	}
 
 	/**
-	 * @brief Add property to vobject
+	 * Add property to vobject
 	 * @param object $name of property
 	 * @param object $value of property
 	 * @param array|object $parameters of property

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -13,7 +13,7 @@ namespace OCP;
  */
 interface IAppConfig {
 	/**
-	 * @brief check if a key is set in the appconfig
+	 * check if a key is set in the appconfig
 	 * @param string $app
 	 * @param string $key
 	 * @return bool
@@ -21,7 +21,7 @@ interface IAppConfig {
 	public function hasKey($app, $key);
 
 	/**
-	 * @brief Gets the config value
+	 * Gets the config value
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
@@ -33,7 +33,7 @@ interface IAppConfig {
 	public function getValue($app, $key, $default = null);
 
 	/**
-	 * @brief Deletes a key
+	 * Deletes a key
 	 * @param string $app app
 	 * @param string $key key
 	 * @return bool
@@ -43,7 +43,7 @@ interface IAppConfig {
 	public function deleteKey($app, $key);
 
 	/**
-	 * @brief Get the available keys for an app
+	 * Get the available keys for an app
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
 	 *
@@ -62,7 +62,7 @@ interface IAppConfig {
 	public function getValues($app, $key);
 
 	/**
-	 * @brief sets a value in the appconfig
+	 * sets a value in the appconfig
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $value value
@@ -73,7 +73,7 @@ interface IAppConfig {
 	public function setValue($app, $key, $value);
 
 	/**
-	 * @brief Get all apps using the config
+	 * Get all apps using the config
 	 * @return array an array of app ids
 	 *
 	 * This function returns a list of all apps that have at least one
@@ -82,7 +82,7 @@ interface IAppConfig {
 	public function getApps();
 
 	/**
-	 * @brief Remove app from appconfig
+	 * Remove app from appconfig
 	 * @param string $app app
 	 * @return bool
 	 *

--- a/lib/public/iavatar.php
+++ b/lib/public/iavatar.php
@@ -14,14 +14,14 @@ namespace OCP;
 interface IAvatar {
 
 	/**
-	 * @brief get the users avatar
+	 * get the users avatar
 	 * @param int $size size in px of the avatar, avatars are square, defaults to 64
 	 * @return boolean|\OC_Image containing the avatar or false if there's no image
 	 */
 	function get($size = 64);
 
 	/**
-	 * @brief sets the users avatar
+	 * sets the users avatar
 	 * @param Image $data mixed imagedata or path to set a new avatar
 	 * @throws Exception if the provided file is not a jpg or png image
 	 * @throws Exception if the provided image is not valid
@@ -31,7 +31,7 @@ interface IAvatar {
 	function set($data);
 
 	/**
-	 * @brief remove the users avatar
+	 * remove the users avatar
 	 * @return void
 	 */
 	function remove();

--- a/lib/public/iavatarmanager.php
+++ b/lib/public/iavatarmanager.php
@@ -14,7 +14,7 @@ namespace OCP;
 interface IAvatarManager {
 
 	/**
-	 * @brief return a user specific instance of \OCP\IAvatar
+	 * return a user specific instance of \OCP\IAvatar
 	 * @see \OCP\IAvatar
 	 * @param string $user the ownCloud user id
 	 * @return \OCP\IAvatar

--- a/lib/public/il10n.php
+++ b/lib/public/il10n.php
@@ -75,9 +75,9 @@ interface IL10N {
 
 
 	/**
-	 * @brief find the best language
+	 * find the best language
 	 * @param array|string $app details below
-	 * @returns string language
+	 * @return string language
 	 *
 	 * If $app is an array, ownCloud assumes that these are the available
 	 * languages. Otherwise ownCloud tries to find the files in the l10n

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -492,7 +492,7 @@ class Util {
 	}
 
 	/**
-	 * @brief Generates a cryptographic secure pseudo-random string
+	 * Generates a cryptographic secure pseudo-random string
 	 * @param int $length of the random string
 	 * @return string
 	 */
@@ -501,7 +501,7 @@ class Util {
 	}
 
 	/**
-	 * @brief check if a password is required for each public link
+	 * check if a password is required for each public link
 	 * @return boolean
 	 */
 	public static function isPublicLinkPasswordRequired() {

--- a/tests/lib/errorHandler.php
+++ b/tests/lib/errorHandler.php
@@ -23,7 +23,7 @@
 class Test_ErrorHandler extends \PHPUnit_Framework_TestCase {
 
 	/**
-	 * @brief provide username, password combinations for testRemovePassword
+	 * provide username, password combinations for testRemovePassword
 	 * @return array
 	 */
 	function passwordProvider() {
@@ -53,7 +53,7 @@ class Test_ErrorHandler extends \PHPUnit_Framework_TestCase {
 }
 
 /**
- * @brief dummy class to access protected methods of \OC\Log\ErrorHandler
+ * dummy class to access protected methods of \OC\Log\ErrorHandler
  */
 class TestableErrorHandler extends \OC\Log\ErrorHandler {
 

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -343,7 +343,7 @@ class Cache extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief this test show the bug resulting if we have no normalizer installed
+	 * this test show the bug resulting if we have no normalizer installed
 	 */
 	public function testWithoutNormalizer() {
 		// folder name "Schön" with U+00F6 (normalized)
@@ -386,7 +386,7 @@ class Cache extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief this test shows that there is no bug if we use the normalizer
+	 * this test shows that there is no bug if we use the normalizer
 	 */
 	public function testWithNormalizer() {
 

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -156,7 +156,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 			);
 		$result = OC_Helper::mb_array_change_key_case($arrayStart, MB_CASE_UPPER);
 		$expected = $arrayResult;
-		$this->assertEquals($result, $expected);	
+		$this->assertEquals($result, $expected);
 	}
 
 	function testMb_substr_replace() {
@@ -284,7 +284,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test absolute URL construction
+	 * test absolute URL construction
 	 * @dataProvider provideDocRootURLs
 	 */
 	function testMakeAbsoluteURLDocRoot($url, $expectedResult) {
@@ -296,7 +296,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test absolute URL construction
+	 * test absolute URL construction
 	 * @dataProvider provideSubDirURLs
 	 */
 	function testMakeAbsoluteURLSubDir($url, $expectedResult) {
@@ -326,7 +326,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkTo URL construction
+	 * test linkTo URL construction
 	 * @dataProvider provideDocRootAppUrlParts
 	 */
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
@@ -338,7 +338,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkTo URL construction in sub directory
+	 * test linkTo URL construction in sub directory
 	 * @dataProvider provideSubDirAppUrlParts
 	 */
 	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
@@ -366,7 +366,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkToAbsolute URL construction
+	 * test linkToAbsolute URL construction
 	 * @dataProvider provideDocRootAppAbsoluteUrlParts
 	 */
 	public function testLinkToAbsoluteDocRoot($app, $file, $args, $expectedResult) {
@@ -378,7 +378,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkToAbsolute URL construction in sub directory
+	 * test linkToAbsolute URL construction in sub directory
 	 * @dataProvider provideSubDirAppAbsoluteUrlParts
 	 */
 	public function testLinkToAbsoluteSubDir($app, $file, $args, $expectedResult) {
@@ -406,7 +406,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkToRemoteBase URL construction
+	 * test linkToRemoteBase URL construction
 	 */
 	public function testLinkToRemoteBase() {
 		\OC::$WEBROOT = '';
@@ -420,7 +420,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkToRemote URL construction
+	 * test linkToRemote URL construction
 	 */
 	public function testLinkToRemote() {
 		\OC::$WEBROOT = '';
@@ -438,7 +438,7 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkToPublic URL construction
+	 * test linkToPublic URL construction
 	 */
 	public function testLinkToPublic() {
 		\OC::$WEBROOT = '';

--- a/tests/lib/migrate.php
+++ b/tests/lib/migrate.php
@@ -12,7 +12,7 @@ class Test_Migrate extends PHPUnit_Framework_TestCase {
 	public $tmpfiles = array();
 
 	/**
-	 * @brief Generates a test user and sets up their file system
+	 * Generates a test user and sets up their file system
 	 * @return string the test users id
 	 */
 	public function generateUser() {
@@ -27,8 +27,8 @@ class Test_Migrate extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @brief validates an export for a user
-	 * @brief checks for existence of export_info.json and file folder
+	 * validates an export for a user
+	 * checks for existence of export_info.json and file folder
 	 * @param string $exportedUser the user that was exported
 	 * @param string $path the path to the .zip export
 	 * @param string $exportedBy

--- a/tests/lib/urlgenerator.php
+++ b/tests/lib/urlgenerator.php
@@ -10,7 +10,7 @@ class Test_Urlgenerator extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkTo URL construction
+	 * test linkTo URL construction
 	 * @dataProvider provideDocRootAppUrlParts
 	 */
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
@@ -24,7 +24,7 @@ class Test_Urlgenerator extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test linkTo URL construction in sub directory
+	 * test linkTo URL construction in sub directory
 	 * @dataProvider provideSubDirAppUrlParts
 	 */
 	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
@@ -54,7 +54,7 @@ class Test_Urlgenerator extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test absolute URL construction
+	 * test absolute URL construction
 	 * @dataProvider provideDocRootURLs
 	 */
 	function testGetAbsoluteURLDocRoot($url, $expectedResult) {
@@ -68,7 +68,7 @@ class Test_Urlgenerator extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @small
-	 * @brief test absolute URL construction
+	 * test absolute URL construction
 	 * @dataProvider provideSubDirURLs
 	 */
 	function testGetAbsoluteURLSubDir($url, $expectedResult) {


### PR DESCRIPTION
- test case added to avoid adding them later

@ringmaster Aaaand here it is.... Removed over 800 occurences of @brief (and some @returns) and added a test case to avoid a later regression for those.

This also will improve the text snippet in the generated API - ref #4883

cc @PVince @Xenopathic @DeepDiver1975 @butonic 
