### PR TITLE
Changed access mode for Dropbox to 'auto'

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -44,7 +44,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 			$this->id = 'dropbox::'.$params['app_key'] . $params['token']. '/' . $this->root;
 			$oauth = new \Dropbox_OAuth_Curl($params['app_key'], $params['app_secret']);
 			$oauth->setToken($params['token'], $params['token_secret']);
-			$this->dropbox = new \Dropbox_API($oauth, 'dropbox');
+			$this->dropbox = new \Dropbox_API($oauth, 'auto');
 		} else {
 			throw new \Exception('Creating \OC\Files\Storage\Dropbox storage failed');
 		}


### PR DESCRIPTION
The change of the mode will eliminate the need of a hardcoded access mode.
Dropbox currently offers two: dropbox and sandbox

dropbox is used to access the full Dropbox
sandbox is used to access a jailed application area

'auto' will be used to automatically generate API requests urls...
