### PR TITLE
Fixed drag and drop from external files, added tests

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -91,6 +91,11 @@
 	position: relative;
 }
 
+/* fit app list view heights */
+.app-files #app-content>.viewcontainer {
+	height: 100%;
+}
+
 /**
  * Override global #controls styles
  * to be more flexible / relative

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1517,10 +1517,9 @@
 			fileUploadStart.on('fileuploaddrop', function(e, data) {
 				OC.Upload.log('filelist handle fileuploaddrop', e, data);
 
-
 				var dropTarget = $(e.originalEvent.target);
-				// check if dropped inside this list and not another one
-				if (dropTarget.length && !self.$el.has(dropTarget).length) {
+				// check if dropped inside this container and not another one
+				if (dropTarget.length && !self.$el.is(dropTarget) && !self.$el.has(dropTarget).length) {
 					return false;
 				}
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1517,13 +1517,19 @@
 			fileUploadStart.on('fileuploaddrop', function(e, data) {
 				OC.Upload.log('filelist handle fileuploaddrop', e, data);
 
-				var dropTarget = $(e.originalEvent.target).closest('tr, .crumb');
-				// check if dropped inside this list at all
-				if (dropTarget && !self.$el.has(dropTarget).length) {
+
+				var dropTarget = $(e.originalEvent.target);
+				// check if dropped inside this list and not another one
+				if (dropTarget.length && !self.$el.has(dropTarget).length) {
 					return false;
 				}
 
-				if (dropTarget && (dropTarget.data('type') === 'dir' || dropTarget.hasClass('crumb'))) { // drag&drop upload to folder
+				// find the closest tr or crumb to use as target
+				dropTarget = dropTarget.closest('tr, .crumb');
+
+				// if dropping on tr or crumb, drag&drop upload to folder
+				if (dropTarget && (dropTarget.data('type') === 'dir' ||
+					dropTarget.hasClass('crumb'))) {
 
 					// remember as context
 					data.context = dropTarget;
@@ -1543,7 +1549,7 @@
 					}
 
 					// update folder in form
-					data.formData = function(form) {
+					data.formData = function() {
 						return [
 							{name: 'dir', value: dir},
 							{name: 'requesttoken', value: oc_requesttoken},
@@ -1551,6 +1557,9 @@
 						];
 					};
 				} else {
+					// we are dropping somewhere inside the file list, which will
+					// upload the file to the current directory
+
 					// cancel uploads to current dir if no permission
 					var isCreatable = (self.getDirectoryPermissions() & OC.PERMISSION_CREATE) !== 0;
 					if (!isCreatable) {

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -2,7 +2,7 @@
 <?php $_['appNavigation']->printPage(); ?>
 <div id="app-content">
 	<?php foreach ($_['appContents'] as $content) { ?>
-	<div id="app-content-<?php p($content['id']) ?>" class="hidden">
+	<div id="app-content-<?php p($content['id']) ?>" class="hidden viewcontainer">
 	<?php print_unescaped($content['content']) ?>
 	</div>
 	<?php } ?>

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1730,7 +1730,7 @@ describe('OCA.Files.FileList tests', function() {
 				ev = dropOn($anotherTable.find('.crumb'));
 				expect(ev.result).toEqual(false);
 			});
-			it('drop on an element outside file list does not trigger upload', function() {
+			it('drop on an element outside file list container does not trigger upload', function() {
 				var $anotherEl = $('<div>outside</div>');
 				var ev;
 				$('#testArea').append($anotherEl);
@@ -1741,6 +1741,12 @@ describe('OCA.Files.FileList tests', function() {
 			it('drop on an element inside the table triggers upload', function() {
 				var ev;
 				ev = dropOn(fileList.$fileList.find('th:first'), uploadData);
+
+				expect(ev.result).not.toEqual(false);
+			});
+			it('drop on an element on the table container triggers upload', function() {
+				var ev;
+				ev = dropOn($('#app-content-files'), uploadData);
 
 				expect(ev.result).not.toEqual(false);
 			});


### PR DESCRIPTION
- Fixed detection whether the drop zone is inside the currently visible
  table
- Now dragging outside the table does nothing instead of uploading,
  because the user might drop on the sidebar
- Added unit tests for the drop handler

It took me some time to figure out how to simulate the drop event but it was worth it, now it's possible to test those drop event handlers :smile: 

Fixes #8660 

Please review @DeepDiver1975 @schiesbn @icewind1991 @MorrisJobke 
