### PR TITLE
Add a config option for setting the filesystem watcher policy

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -283,5 +283,14 @@ $CONFIG = array(
  * cache directory and "$user" is the user.
  *
  */
-'cache_path' => ''
+'cache_path' => '',
+
+/*
+ * specifies how often the filesystem is checked for changes made outside owncloud
+ * 0 -> never check the filesystem for outside changes, provides a performance increase when it's certain that no changes are made directly to the filesystem
+ * 1 -> check each file or folder at most once per request, recomended for general use if outside changes might happen
+ * 2 -> check every time the filesystem is used, causes a performance hit when using external storages, not recomended for regular use
+ */
+'filesystem_check_changes' => 1
+
 );

--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -45,7 +45,7 @@ class Watcher {
 	}
 
 	/**
-	 * @param int $policy either \OC\Files\Cache\Watcher::UPDATE_NEVER, \OC\Files\Cache\Watcher::UPDATE_ONCE, \OC\Files\Cache\Watcher::UPDATE_ALWAYS
+	 * @param int $policy either \OC\Files\Cache\Watcher::CHECK_NEVER, \OC\Files\Cache\Watcher::CHECK_ONCE, \OC\Files\Cache\Watcher::CHECK_ALWAYS
 	 */
 	public function setPolicy($policy) {
 		$this->watchPolicy = $policy;

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -7,6 +7,7 @@
  */
 
 namespace OC\Files\Storage;
+use OC\Files\Cache\Watcher;
 
 /**
  * Storage backend class for providing common filesystem operation methods
@@ -276,6 +277,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	public function getWatcher($path = '') {
 		if (!isset($this->watcher)) {
 			$this->watcher = new \OC\Files\Cache\Watcher($this);
+			$this->watcher->setPolicy(\OC::$server->getConfig()->getSystemValue('filesystem_check_changes', Watcher::CHECK_ONCE));
 		}
 		return $this->watcher;
 	}


### PR DESCRIPTION
The watcher policy can be used to disable the checking for outside changes made to the filesystem, an admin can use this option to get a performance increase (particular when using external storages) if he knows no outside changes will be made to the filesystem.

To test:
- set `'filesystem_check_changes' => 0` in config.php
- perform an outside change to the filesystem (rename, delete, create)
- check if the change is not detected by in the files app
- set `'filesystem_check_changes' => 1` and reload the files app
- changes should now be detected

cc @DeepDiver1975 @PVince81
