### PR TITLE
Sharing improvements

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -40,8 +40,13 @@ $(document).ready(function() {
 				$(allShared).find('.fileactions').append(function() {
 					var owner = $(this).closest('tr').attr('data-share-owner');
 					var shareBy = t('files_sharing', 'Shared by {owner}', {owner: owner});
-					return shareNotification + '<span> ' + shareBy + '</span></span>';
+					var $result = $(shareNotification + '<span> ' + shareBy + '</span></span>');
+					$result.on('click', function() {
+						return false;
+					});
+					return $result;
 				});
+
 			} else {
 				allShared = $fileList.find('[data-share-owner] [data-Action="Share"]');
 				allShared.addClass('permanent');

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -31,8 +31,8 @@ $(document).ready(function() {
 			// we create a share notification action to inform the user about files
 			// shared with him otherwise we just update the existing share action.
 			var allShared;
+			var $fileList = $(this);
 			if (oc_appconfig.core.sharingDisabledForUser) {
-				var $fileList = $(this);
 				allShared = $fileList.find('[data-share-owner]');
 				var shareNotification = '<a class="action action-share-notification permanent"' +
 						' data-action="Share-Notification" href="#" original-title="">' +

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -517,14 +517,14 @@ class Shared extends \OC\Files\Storage\Common {
 			$parent = dirname($parent);
 		}
 
-		$newMountPoint = \OC\Files\Filesystem::normalizePath($parent . '/' . $mountPoint);
+		$newMountPoint = \OCA\Files_Sharing\Helper::generateUniqueTarget(
+				\OC\Files\Filesystem::normalizePath($parent . '/' . $mountPoint),
+				array(),
+				new \OC\Files\View('/' . \OCP\User::getUser() . '/files')
+				);
 
 		if($newMountPoint !== $share['file_target']) {
-			$newMountPoint = \OCA\Files_Sharing\Helper::generateUniqueTarget(
-					$newMountPoint,
-					array(),
-					new \OC\Files\View('/' . \OCP\User::getUser() . '/files')
-					);
+
 			self::updateFileTarget($newMountPoint, $share);
 			$share['file_target'] = $newMountPoint;
 


### PR DESCRIPTION
- `$fileList` needs to be declared before the if-statement
- always check for a unique filename, fix #8673 
- prevent default action when clicking on the share notification

cc @PVince81 
