### PR TITLE
Record login timestamp per user. Required for new user managament.

### DIFF
--- a/core/command/user/lastseen.php
+++ b/core/command/user/lastseen.php
@@ -41,7 +41,7 @@ class LastSeen extends Command {
 			$date = new \DateTime();
 			$date->setTimestamp($lastLogin);
 			$output->writeln($user->getUID() .
-				'`s last login: ' . $date->format('d.m.Y h:i'));
+				'`s last login: ' . $date->format('d.m.Y H:i'));
 		}
 	}
 }

--- a/core/command/user/lastseen.php
+++ b/core/command/user/lastseen.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Command\User;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class LastSeen extends Command {
+	protected function configure() {
+		$this
+			->setName('user:lastseen')
+			->setDescription('shows when the user was logged it last time')
+			->addArgument(
+				'uid',
+				InputArgument::REQUIRED,
+				'the username'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$userManager = \OC::$server->getUserManager();
+		$user = $userManager->get($input->getArgument('uid'));
+		if(is_null($user)) {
+			$output->writeln('User does not exist');
+			return;
+		}
+
+		$lastLogin = $user->getLastLogin();
+		if($lastLogin === 0) {
+			$output->writeln('User ' . $user->getUID() .
+				' has never logged in, yet.');
+		} else {
+			$date = new \DateTime();
+			$date->setTimestamp($lastLogin);
+			$output->writeln($user->getUID() . '`s ' .
+				' last login: ' . $date->format('d.m.Y h:i'));
+		}
+	}
+}

--- a/core/command/user/lastseen.php
+++ b/core/command/user/lastseen.php
@@ -40,8 +40,8 @@ class LastSeen extends Command {
 		} else {
 			$date = new \DateTime();
 			$date->setTimestamp($lastLogin);
-			$output->writeln($user->getUID() . '`s ' .
-				' last login: ' . $date->format('d.m.Y h:i'));
+			$output->writeln($user->getUID() .
+				'`s last login: ' . $date->format('d.m.Y h:i'));
 		}
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -17,3 +17,4 @@ $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());
 $application->add(new OC\Core\Command\Maintenance\Repair(new \OC\Repair()));
 $application->add(new OC\Core\Command\User\Report());
+$application->add(new OC\Core\Command\User\LastSeen());

--- a/lib/base.php
+++ b/lib/base.php
@@ -886,7 +886,7 @@ class OC {
 
 		if(OC_User::userExists($_COOKIE['oc_username'])) {
 			self::cleanupLoginTokens($_COOKIE['oc_username']);
-			// confirm credentials in cookie
+			// verify whether the supplied "remember me" token was valid
 			$granted = OC_User::loginWithCookie(
 				$_COOKIE['oc_username'], $_COOKIE['oc_token']);
 			if($granted === true) {

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -236,6 +236,17 @@ class OC_User {
 	}
 
 	/**
+	 * Try to login a user using the magic cookie (remember login)
+	 *
+	 * @param string $uid The username of the user to log in
+	 * @param string $token
+	 * @return bool
+	 */
+	public static function loginWithCookie($uid, $token) {
+		return self::getUserSession()->loginWithCookie($uid, $token);
+	}
+
+	/**
 	 * Try to login a user, assuming authentication
 	 * has already happened (e.g. via Single Sign On).
 	 *

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -52,7 +52,7 @@ class Manager extends PublicEmitter {
 				unset($cachedUsers[$i]);
 			}
 		});
-		$this->listen('\OC\User', 'postLogin', function ($user, $pw) {
+		$this->listen('\OC\User', 'postLogin', function ($user) {
 			$user->updateLastLoginTimestamp();
 		});
 		$this->listen('\OC\User', 'postRememberedLogin', function ($user) {

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -52,6 +52,12 @@ class Manager extends PublicEmitter {
 				unset($cachedUsers[$i]);
 			}
 		});
+		$this->listen('\OC\User', 'postLogin', function ($user, $pw) {
+			$user->updateLastLoginTimestamp();
+		});
+		$this->listen('\OC\User', 'postRememberedLogin', function ($user) {
+			$user->updateLastLoginTimestamp();
+		});
 	}
 
 	/**

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -22,7 +22,9 @@ use OC\Hooks\Emitter;
  * - preCreateUser(string $uid, string $password)
  * - postCreateUser(\OC\User\User $user)
  * - preLogin(string $user, string $password)
- * - postLogin(\OC\User\User $user)
+ * - postLogin(\OC\User\User $user, string $password)
+ * - preRememberedLogin(string $uid)
+ * - postRememberedLogin(\OC\User\User $user)
  * - logout()
  *
  * @package OC\User
@@ -178,6 +180,7 @@ class Session implements Emitter, \OCP\IUserSession {
 	 * @return bool
 	 */
 	public function loginWithCookie($uid, $currentToken) {
+		$this->manager->emit('\OC\User', 'preRememberedLogin', array($uid));
 		$user = $this->manager->get($uid);
 		if(is_null($user)) {
 			// user does not exist

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -171,6 +171,38 @@ class Session implements Emitter, \OCP\IUserSession {
 	}
 
 	/**
+	 * perform login using the magic cookie (remember login)
+	 *
+	 * @param string $uid the username
+	 * @param string $currentToken
+	 * @return bool
+	 */
+	public function loginWithCookie($uid, $currentToken) {
+		$user = $this->manager->get($uid);
+		if(is_null($user)) {
+			// user does not exist
+			return false;
+		}
+
+		// get stored tokens
+		$tokens = \OC_Preferences::getKeys($uid, 'login_token');
+		// test cookies token against stored tokens
+		if(!in_array($currentToken, $tokens, true)) {
+			return false;
+		}
+		// replace successfully used token with a new one
+		\OC_Preferences::deleteKey($uid, 'login_token', $currentToken);
+		$newToken = \OC_Util::generateRandomBytes(32);
+		\OC_Preferences::setValue($uid, 'login_token', $newToken, time());
+		$this->setMagicInCookie($user->getUID(), $newToken);
+
+		//login
+		$this->setUser($user);
+		$this->manager->emit('\OC\User', 'postRememberedLogin', array($user));
+		return true;
+	}
+
+	/**
 	 * logout the user from the session
 	 */
 	public function logout() {

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -125,8 +125,6 @@ class User {
 
 	/**
 	 * updates the timestamp of the most recent login of this user
-	 *
-	 * @return null
 	 */
 	public function updateLastLoginTimestamp() {
 		$this->lastLogin = time();

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -43,6 +43,11 @@ class User {
 	private $home;
 
 	/**
+	 * @var int $lastLogin
+	 */
+	private $lastLogin;
+
+	/**
 	 * @var \OC\AllConfig $config
 	 */
 	private $config;
@@ -64,6 +69,7 @@ class User {
 		} else {
 			$this->enabled = true;
 		}
+		$this->lastLogin = \OC_Preferences::getValue($uid, 'login', 'lastLogin', 0);
 	}
 
 	/**
@@ -105,6 +111,27 @@ class User {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * returns the timestamp of the user's last login or 0 if the user did never
+	 * login
+	 *
+	 * @return int
+	 */
+	public function getLastLogin() {
+		return $this->lastLogin;
+	}
+
+	/**
+	 * updates the timestamp of the most recent login of this user
+	 *
+	 * @return null
+	 */
+	public function updateLastLoginTimestamp() {
+		$this->lastLogin = time();
+		\OC_Preferences::setValue(
+			$this->uid, 'login', 'lastLogin', $this->lastLogin);
 	}
 
 	/**

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -243,8 +243,6 @@ class Session extends \PHPUnit_Framework_TestCase {
 			array($manager, $session));
 
 		$granted = $userSession->loginWithCookie('foo', $token);
-		//clean up token
-		\OC_Preferences::deleteKey('foo', 'login_token', $token);
 
 		$this->assertSame($granted, true);
 	}
@@ -287,8 +285,6 @@ class Session extends \PHPUnit_Framework_TestCase {
 
 		$userSession = new \OC\User\Session($manager, $session);
 		$granted = $userSession->loginWithCookie('foo', 'badToken');
-		//clean up token
-		\OC_Preferences::deleteKey('foo', 'login_token', $token);
 
 		$this->assertSame($granted, false);
 	}
@@ -330,8 +326,6 @@ class Session extends \PHPUnit_Framework_TestCase {
 
 		$userSession = new \OC\User\Session($manager, $session);
 		$granted = $userSession->loginWithCookie('foo', $token);
-		//clean up token
-		\OC_Preferences::deleteKey('foo', 'login_token', $token);
 
 		$this->assertSame($granted, false);
 	}

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -196,10 +196,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 						switch($key) {
 							case 'user_id':
 								return true;
-								break;
 							default:
 								return false;
-								break;
 						}
 					},
 					'foo'));

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -168,7 +168,17 @@ class Session extends \PHPUnit_Framework_TestCase {
 					},
 					'foo'));
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
@@ -177,6 +187,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('foo'));
+		$user->expects($this->once())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('get')
@@ -206,7 +218,17 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session->expects($this->never())
 			->method('set');
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
@@ -215,6 +237,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('foo'));
+		$user->expects($this->never())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('get')
@@ -238,7 +262,17 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session->expects($this->never())
 			->method('set');
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
@@ -246,6 +280,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 
 		$user->expects($this->never())
 			->method('getUID');
+		$user->expects($this->never())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('get')
@@ -262,7 +298,5 @@ class Session extends \PHPUnit_Framework_TestCase {
 		\OC_Preferences::deleteKey('foo', 'login_token', $token);
 
 		$this->assertSame($granted, false);
-
-
 	}
 }

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -67,7 +67,17 @@ class Session extends \PHPUnit_Framework_TestCase {
 					},
 					'foo'));
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
@@ -78,6 +88,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('foo'));
+		$user->expects($this->once())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('checkPassword')
@@ -94,7 +106,17 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session->expects($this->never())
 			->method('set');
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
@@ -102,6 +124,8 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$user->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(false));
+		$user->expects($this->never())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('checkPassword')
@@ -117,13 +141,25 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session->expects($this->never())
 			->method('set');
 
-		$manager = $this->getMock('\OC\User\Manager');
+		$managerMethods = get_class_methods('\OC\User\Manager');
+		//keep following methods intact in order to ensure hooks are
+		//working
+		$doNotMock = array('__construct', 'emit', 'listen');
+		foreach($doNotMock as $methodName) {
+			$i = array_search($methodName, $managerMethods, true);
+			if($i !== false) {
+				unset($managerMethods[$i]);
+			}
+		}
+		$manager = $this->getMock('\OC\User\Manager', $managerMethods, array());
 
 		$backend = $this->getMock('OC_User_Dummy');
 
 		$user = $this->getMock('\OC\User\User', array(), array('foo', $backend));
 		$user->expects($this->never())
 			->method('isEnabled');
+		$user->expects($this->never())
+			->method('updateLastLoginTimestamp');
 
 		$manager->expects($this->once())
 			->method('checkPassword')


### PR DESCRIPTION
This PR  cleans up the tryRememberLogin method first, moves the core part to the user session and also adds tests for it. This is  necessary, because we need to record the timestamp as well, when a magic cookie (remember checkbox active) is used. The \OC\User\User object gets method to update and return the login timestamp. Updating the timestamp is triggered by postLogin and postRememberedLogin (new!) events. I tested it for login via web interface, remember cookie and desktop client.

There is also a command line tool to get the last login of a specific user. Example:

```
$ ./occ user:lastseen master
master`s last login: 23.05.2014 08:48
```

This PR is required for new user management in #7151.

Please test/review @LukasReschke @icewind1991 @DeepDiver1975 
