### PR TITLE
Make the session available as early as possible

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -419,6 +419,8 @@ class OC {
 		self::$loader->registerPrefix('Pimple', '3rdparty/Pimple');
 		spl_autoload_register(array(self::$loader, 'load'));
 
+		self::$session = new \OC\Session\Memory('');
+
 		// set some stuff
 		//ob_start();
 		error_reporting(E_ALL | E_STRICT);

--- a/lib/base.php
+++ b/lib/base.php
@@ -419,6 +419,7 @@ class OC {
 		self::$loader->registerPrefix('Pimple', '3rdparty/Pimple');
 		spl_autoload_register(array(self::$loader, 'load'));
 
+		// make a dummy session available as early as possible since error pages need it
 		self::$session = new \OC\Session\Memory('');
 
 		// set some stuff


### PR DESCRIPTION
The session object needs to be available as early as possible in case an error is thrown before the correct session can be setup since the session object is used for displaying the error page.

cc @DeepDiver1975 @PVince81 
