### PR TITLE
Make the recursive delete more robust

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -407,7 +407,7 @@ class OC_Helper {
 		if (is_dir($dir)) {
 			$files = scandir($dir);
 			foreach ($files as $file) {
-				if ($file != "." && $file != "..") {
+				if ($file !== '' && $file !== "." && $file !== "..") {
 					self::rmdirr("$dir/$file");
 				}
 			}


### PR DESCRIPTION
The current smb backend uses `OC_Helper::rmdirr` for recursive delete but it sometimes returns empty filename from `scandir` which can cause an infinite loop.

cc @DeepDiver1975 @PVince81 
