### PR TITLE
Show less whitespace above publicly shared images

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -44,13 +44,6 @@ p.info a {
 	max-width:100%;
 }
 
-/* some margin for the file type icon */
-#imgframe .publicpreview {
-	margin-top: 10%;
-}
-
-
-
 thead {
 	padding-left: 0 !important; /* fixes multiselect bar offset on shared page */
 }


### PR DESCRIPTION
Dont show a large amount of white space above publicly shared images.

cc @owncloud/designers
