### PR TITLE
get permissions directly from share storage to avoid additional db calls

### DIFF
--- a/apps/files_sharing/lib/permissions.php
+++ b/apps/files_sharing/lib/permissions.php
@@ -63,9 +63,7 @@ class Shared_Permissions extends Permissions {
 	 * @return int[]
 	 */
 	public function getMultiple($fileIds, $user) {
-		if (count($fileIds) === 0) {
-			return array();
-		}
+		$filePermissions = array();
 		foreach ($fileIds as $fileId) {
 			$filePermissions[$fileId] = $this->get($fileId, $user);
 		}

--- a/apps/files_sharing/lib/permissions.php
+++ b/apps/files_sharing/lib/permissions.php
@@ -79,7 +79,11 @@ class Shared_Permissions extends Permissions {
 	 */
 	public function getDirectoryPermissions($parentId, $user) {
 
-		$fileCacheId = ($parentId === -1) ? $this->storage->getSourceId() : $parentId;
+		if ($parentId === -1 && $this->storage->instanceOfStorage('\OC\Files\Storage\Shared')) {
+			$fileCacheId =  $this->storage->getSourceId();
+		} else {
+			$fileCacheId = $parentId;
+		}
 
 		$query = \OC_DB::prepare('SELECT `fileid` FROM `*PREFIX*filecache` WHERE `parent` = ?');
 		$result = $query->execute(array($fileCacheId));

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -102,7 +102,7 @@ class Shared extends \OC\Files\Storage\Common {
 	 * @param string $target Shared target file path
 	 * @return int CRUDS permissions granted
 	 */
-	public function getPermissions($target) {
+	public function getPermissions($target = '') {
 		$permissions = $this->share['permissions'];
 		// part file are always have delete permissions
 		if (pathinfo($target, PATHINFO_EXTENSION) === 'part') {

--- a/lib/private/files/cache/permissions.php
+++ b/lib/private/files/cache/permissions.php
@@ -15,14 +15,28 @@ class Permissions {
 	private $storageId;
 
 	/**
+	 * @var \OC\Files\Storage\Storage $storage
+	 */
+	protected $storage;
+
+	/**
 	 * @param \OC\Files\Storage\Storage|string $storage
 	 */
 	public function __construct($storage) {
 		if ($storage instanceof \OC\Files\Storage\Storage) {
 			$this->storageId = $storage->getId();
+			$this->storage = $storage;
 		} else {
 			$this->storageId = $storage;
+			$mountManager = \OC\Files\Filesystem::getMountManager();
+			$mount = $mountManager->findByStorageId($this->storageId);
+			$firstMountPoint = reset($mount);
+			if ($firstMountPoint instanceof \OC\Files\Storage\Storage) {
+				$storage = $firstMountPoint->getStorage();
+				$this->storage = $storage;
+			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
This saves quite a lot of db queries. All files within a share always have the permission given by the owner, no need to do expensive db calls.

@icewind1991 please have a look at it, especially to my changes to OC\Files\Cache\Permissions

cc @PVince81 
