### PR TITLE
Design detail fixes

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -5,6 +5,11 @@
 	border: 0;
 }
 
+/* fix height of select boxes for OS X */
+select {
+	min-height: 29px;
+}
+
 .lte8 .delete-icon { background-image: url('../img/actions/delete.png'); }
 .lte8 .delete-icon:hover, .delete-icon:focus {
 	background-image: url('../img/actions/delete-hover.png');

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -205,9 +205,15 @@ input img, button img, .button img {
 
 
 /* SCROLLING */
-::-webkit-scrollbar { width:8px; }
-::-webkit-scrollbar-track-piece { background-color:transparent; }
-::-webkit-scrollbar-thumb { background:#ddd; }
+::-webkit-scrollbar {
+	width: 8px;
+}
+::-webkit-scrollbar-track-piece {
+	background-color: transparent;
+}
+::-webkit-scrollbar-thumb {
+	background: #ccc;
+}
 
 
 /* BUTTONS */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -204,6 +204,16 @@ input img, button img, .button img {
 }
 
 
+/* prevent ugly selection effect on accidental selection */
+#header,
+#navigation,
+#expanddiv {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+}
+
+
 /* SCROLLING */
 ::-webkit-scrollbar {
 	width: 8px;
@@ -709,8 +719,6 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	overflow-y: auto;
 	overflow-x: hidden;
 	-moz-box-sizing:border-box; box-sizing:border-box;
-	/* prevent ugly selection effect on accidental selection */
-	-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;
 }
 #apps {
 	height: 100%;
@@ -801,8 +809,6 @@ label.infield { cursor:text !important; top:1.05em; left:.85em; }
 	border-bottom-left-radius:7px; border-bottom:1px #333 solid; border-left:1px #333 solid;
 	box-shadow:0 0 7px rgb(29,45,68);
 	-moz-box-sizing: border-box; box-sizing: border-box;
-	/* prevent ugly selection effect on accidental selection */
-	-webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;
 }
 	#expanddiv a {
 		display: block;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -103,8 +103,8 @@ select.quota.active { background: #fff; }
 #app-navigation.appwarning:hover {
 	background: #fbb;
 }
-small.externalapp { color:#FFF; background-color:#BBB; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 4px;}
-small.recommendedapp { color:#FFF; background-color:#888; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 4px;}
+small.externalapp { color:#FFF; background-color:#BBB; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 3px;}
+small.recommendedapp { color:#FFF; background-color:#888; font-weight:bold; font-size: 0.6em; margin: 0; padding: 0.1em 0.2em; border-radius: 3px;}
 small.externalapp.list, small.recommendedapp.list { position: absolute; right: 10px; top: 12px; }
 span.version { margin-left:1em; margin-right:1em; color:#555; }
 
@@ -169,7 +169,7 @@ table.shareAPI .indent { padding-left: 2em; }
 
 span.success {
         background: #37ce02;
-        border-radius: 8px;
+        border-radius: 3px;
 }
 
 span.error {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -118,7 +118,7 @@ $(document).ready(function(){
 		OC.msg.startSaving('#mail_settings_msg');
 		var post = $( "#mail_settings" ).serialize();
 		$.post(OC.generateUrl('/settings/admin/mailsettings'), post, function(data){
-			OC.msg.finishedSaving('#mail_settings .msg', data);
+			OC.msg.finishedSaving('#mail_settings_msg', data);
 		});
 	});
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -323,9 +323,9 @@ if (!$_['internetconnectionworking']) {
 </div>
 
 <div id="mail_settings" class="section">
-	<h2><?php p($l->t('Email Server'));?> <span id="mail_settings_msg" class="msg"></span></h2>
+	<h2><?php p($l->t('Email Server'));?></h2>
 
-	<p><?php p($l->t('This is used for sending out notifications.')); ?></p>
+	<p><?php p($l->t('This is used for sending out notifications.')); ?> <span id="mail_settings_msg" class="msg"></span></p>
 
 	<p>
 		<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label>


### PR DESCRIPTION
- darken scrollbar to distinguish from selected sidebar items
- use user-select: none; on header, navigation and user menu
- fix height of select boxes for OS X
- fix border-radius in settings to 3px
- move saved notification for mail server, so it's smaller cc @nickvergessen 

Please review @owncloud/designers @karlitschek 
