### PR TITLE
app manager forgets the documentation links workaround for #8081

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -45,15 +45,30 @@ OC.Settings.Apps = OC.Settings.Apps || {
 				page.find('span.userDocumentation').html("<a id='userDocumentation' href='" + app.documentation.user + "'>" + t('settings', 'User Documentation') + "</a>");
 				page.find('p.documentation').show();
 			}
+			else {
+				page.find('span.userDocumentation').empty();
+				userDocumentation = false;
+			}
 			if (typeof(app.documentation.admin) !== 'undefined') {
 				adminDocumentation = true;
 				page.find('span.adminDocumentation').html("<a id='adminDocumentation' href='" + app.documentation.admin + "'>" + t('settings', 'Admin Documentation') + "</a>");
 				page.find('p.documentation').show();
 			}
+			else {
+				page.find('span.adminDocumentation').empty();
+				adminDocumentation = false;
+			}
 
 			if(userDocumentation && adminDocumentation) {
-				page.find('span.userDocumentation').after(', ');
+				page.find('span.comma').remove();
+				page.find('span.userDocumentation').after('<span class="comma">, </span>');
 			}
+			else {
+				page.find('span.comma').remove();
+			}
+		}
+		else {
+			page.find('p.documentation').hide();
 		}
 
 		if (typeof(app.website) !== 'undefined') {


### PR DESCRIPTION
But could not manage how to remove the "," between two documents, though.

Workaround for #8081
