### PR TITLE
don't lose file size during rename

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -177,13 +177,9 @@ class Shared extends \OC\Files\Storage\Common {
 	}
 
 	public function filesize($path) {
-		if ($path == '' || $path == '/' || $this->is_dir($path)) {
-			return 0;
-		} else if ($source = $this->getSourcePath($path)) {
-			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
-			return $storage->filesize($internalPath);
-		}
-		return false;
+		$source = $this->getSourcePath($path);
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
+		return $storage->filesize($internalPath);
 	}
 
 	public function isCreatable($path) {

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -36,12 +36,17 @@ class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
 
 		$this->filename = '/share-api-storage.txt';
 
-		// save file with content
+
 		$this->view->mkdir($this->folder);
+
+		// save file with content
+		$this->view->file_put_contents($this->filename, "root file");
+		$this->view->file_put_contents($this->folder . $this->filename, "file in subfolder");
 	}
 
 	function tearDown() {
-		$this->view->deleteAll($this->folder);
+		$this->view->unlink($this->folder);
+		$this->view->unlink($this->filename);
 
 		parent::tearDown();
 	}
@@ -123,7 +128,42 @@ class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
 		$this->assertTrue($this->view->file_exists( $this->folder. '/foo.txt'));
 
 		//cleanup
-		$this->view->unlink($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+	}
+
+	public function testFilesize() {
+
+		$fileinfoFolder = $this->view->getFileInfo($this->folder);
+		$fileinfoFile = $this->view->getFileInfo($this->filename);
+
+		$folderSize = $this->view->filesize($this->folder);
+		$file1Size = $this->view->filesize($this->folder. $this->filename);
+		$file2Size = $this->view->filesize($this->filename);
+
+		$result = \OCP\Share::shareItem('folder', $fileinfoFolder['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->assertTrue($result);
+
+		$result = \OCP\Share::shareItem('file', $fileinfoFile['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// compare file size between user1 and user2, should always be the same
+		$this->assertSame($folderSize, \OC\Files\Filesystem::filesize($this->folder));
+		$this->assertSame($file1Size, \OC\Files\Filesystem::filesize($this->folder . $this->filename));
+		$this->assertSame($file2Size, \OC\Files\Filesystem::filesize($this->filename));
+
+		//cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileinfoFolder['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+		$result = \OCP\Share::unshare('file', $fileinfoFile['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
 	}
 
 }


### PR DESCRIPTION
Don't set filesize to "0" during rename of shared files.

fix #8428 

cc @PVince81 
