### PR TITLE
allow resharing of files with only share permissions

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -522,12 +522,6 @@
 				mime = mime || 'httpd/unix-directory';
 			}
 
-			// user should always be able to rename a share mount point
-			var allowRename = 0;
-			if (fileData.isShareMountPoint) {
-				allowRename = OC.PERMISSION_UPDATE;
-			}
-
 			//containing tr
 			var tr = $('<tr></tr>').attr({
 				"data-id" : fileData.id,
@@ -537,7 +531,7 @@
 				"data-mime": mime,
 				"data-mtime": mtime,
 				"data-etag": fileData.etag,
-				"data-permissions": fileData.permissions | allowRename || this.getDirectoryPermissions()
+				"data-permissions": fileData.permissions || this.getDirectoryPermissions()
 			});
 
 			if (type === 'dir') {
@@ -936,7 +930,7 @@
 
 		/**
 		 * Lazy load a file's preview.
-		 * 
+		 *
 		 * @param path path of the file
 		 * @param mime mime type
 		 * @param callback callback function to call when the image was loaded
@@ -1639,7 +1633,7 @@
 							if (fileDirectory.length === 1) {
 								fileDirectory = fileDirectory[0];
 
-								// Get the directory 
+								// Get the directory
 								var fd = self.findFileEl(fileDirectory);
 								if (fd.length === 0) {
 									var dir = {
@@ -1655,7 +1649,7 @@
 							} else {
 								fileDirectory = fileDirectory[0];
 							}
-							
+
 							fileDirectory = self.findFileEl(fileDirectory);
 
 							// update folder size

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -21,6 +21,11 @@ $(document).ready(function() {
 				var tr = oldCreateRow.apply(this, arguments);
 				if (fileData.shareOwner) {
 					tr.attr('data-share-owner', fileData.shareOwner);
+					// user should always be able to rename a mount point
+					if (fileData.isShareMountPoint) {
+						tr.attr('data-permissions', fileData.permissions | OC.PERMISSION_UPDATE);
+						tr.attr('data-reshare-permissions', fileData.permissions);
+					}
 				}
 				return tr;
 			};
@@ -78,7 +83,11 @@ $(document).ready(function() {
 			if ($(tr).data('type') == 'dir') {
 				itemType = 'folder';
 			}
-			var possiblePermissions = $(tr).data('permissions');
+			var possiblePermissions = $(tr).data('reshare-permissions');
+			if (_.isUndefined(possiblePermissions)) {
+				possiblePermissions = $(tr).data('permissions');
+			}
+
 			var appendTo = $(tr).find('td.filename');
 			// Check if drop down is already visible for a different file
 			if (OC.Share.droppedDown) {


### PR DESCRIPTION
allow resharing of files with only share permissions

How to test it:
- user1 shares a file with user2 with only share permissions
- user2 tries to reshare the file with user3

Without this PR reshare should not work, with this PR reshare should work.

cc @PVince81 
