### PR TITLE
Add ability to enable/disable maintenance mode from cli.

### DIFF
--- a/core/command/maintenance/mmode.php
+++ b/core/command/maintenance/mmode.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
+ * and Stephen Colebrook <scolebrook@mac.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Core\Command\Maintenance;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MMode extends Command {
+
+	protected function configure() {
+		$this
+			->setName('maintenance:mmode')
+			->setDescription('set maintenance mode')
+			->addOption(
+				'on',
+				null,
+				InputOption::VALUE_NONE,
+				'enable maintenance mode'
+			)
+			->addOption(
+				'off',
+				null,
+				InputOption::VALUE_NONE,
+				'disable maintenance mode'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ($input->getOption('on')) {
+			\OC_Config::setValue('maintenance', true);
+			$output->writeln('Maintenance mode enabled');
+		} elseif ($input->getOption('off')) {
+			\OC_Config::setValue('maintenance', false);
+			$output->writeln('Maintenance mode disabled');
+		} else {
+			if (\OC_Config::getValue('maintenance', false)) {
+				$output->writeln('Maintenance mode is currently enabled');
+			} else {
+				$output->writeln('Maintenance mode is currently disabled');
+			}
+		}
+	}
+}

--- a/core/command/maintenance/mode.php
+++ b/core/command/maintenance/mode.php
@@ -14,11 +14,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MMode extends Command {
+class Mode extends Command {
 
 	protected function configure() {
 		$this
-			->setName('maintenance:mmode')
+			->setName('maintenance:mode')
 			->setDescription('set maintenance mode')
 			->addOption(
 				'on',

--- a/core/command/maintenance/mode.php
+++ b/core/command/maintenance/mode.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com>
- * and Stephen Colebrook <scolebrook@mac.com>
+ * Copyright (c) 2013 Robin Appelman <icewind@owncloud.com> and
+ * Copyright (c) 2014 Stephen Colebrook <scolebrook@mac.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -9,12 +9,21 @@
 
 namespace OC\Core\Command\Maintenance;
 
+use OC\Config;
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Mode extends Command {
+
+	protected $config;
+
+	public function __construct(Config $config) {
+		$this->config = $config;
+		parent::__construct();
+	}
 
 	protected function configure() {
 		$this
@@ -36,13 +45,13 @@ class Mode extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if ($input->getOption('on')) {
-			\OC_Config::setValue('maintenance', true);
+			$this->config->setValue('maintenance', true);
 			$output->writeln('Maintenance mode enabled');
 		} elseif ($input->getOption('off')) {
-			\OC_Config::setValue('maintenance', false);
+			$this->config->setValue('maintenance', false);
 			$output->writeln('Maintenance mode disabled');
 		} else {
-			if (\OC_Config::getValue('maintenance', false)) {
+			if ($this->config->getValue('maintenance', false)) {
 				$output->writeln('Maintenance mode is currently enabled');
 			} else {
 				$output->writeln('Maintenance mode is currently disabled');

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -12,7 +12,7 @@ $application->add(new OC\Core\Command\Db\GenerateChangeScript());
 $application->add(new OC\Core\Command\Db\ConvertType(OC_Config::getObject(), new \OC\DB\ConnectionFactory()));
 $application->add(new OC\Core\Command\Upgrade());
 $application->add(new OC\Core\Command\Maintenance\SingleUser());
-$application->add(new OC\Core\Command\Maintenance\MMode());
+$application->add(new OC\Core\Command\Maintenance\Mode());
 $application->add(new OC\Core\Command\App\Disable());
 $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -12,6 +12,7 @@ $application->add(new OC\Core\Command\Db\GenerateChangeScript());
 $application->add(new OC\Core\Command\Db\ConvertType(OC_Config::getObject(), new \OC\DB\ConnectionFactory()));
 $application->add(new OC\Core\Command\Upgrade());
 $application->add(new OC\Core\Command\Maintenance\SingleUser());
+$application->add(new OC\Core\Command\Maintenance\MMode());
 $application->add(new OC\Core\Command\App\Disable());
 $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -12,7 +12,7 @@ $application->add(new OC\Core\Command\Db\GenerateChangeScript());
 $application->add(new OC\Core\Command\Db\ConvertType(OC_Config::getObject(), new \OC\DB\ConnectionFactory()));
 $application->add(new OC\Core\Command\Upgrade());
 $application->add(new OC\Core\Command\Maintenance\SingleUser());
-$application->add(new OC\Core\Command\Maintenance\Mode());
+$application->add(new OC\Core\Command\Maintenance\Mode(OC_Config::getObject()));
 $application->add(new OC\Core\Command\App\Disable());
 $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());


### PR DESCRIPTION
Simple addition to the capabilities of console.php to turn maintenance mode on or off. Basically a dupe of the singleuser.php script by Robin Appelman. Useful for backup scripts so that database and data directory snapshots can be taken with no changes from users. If these two things are not perfectly in sync when backed up, restore will be a major headache.
