### PR TITLE
remove legacy OC_Filesystem being used in a hook callback

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -637,8 +637,8 @@ class OC {
 	 */
 	public static function registerFilesystemHooks() {
 		// Check for blacklisted files
-		OC_Hook::connect('OC_Filesystem', 'write', 'OC_Filesystem', 'isBlacklisted');
-		OC_Hook::connect('OC_Filesystem', 'rename', 'OC_Filesystem', 'isBlacklisted');
+		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isBlacklisted');
+		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isBlacklisted');
 	}
 
 	/**


### PR DESCRIPTION
fixes #8737 

@karlitschek @icewind1991 @PVince81 THX
