### PR TITLE
get mount point from mount manager

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -320,14 +320,9 @@ class Hooks {
 
 			$sharingEnabled = \OCP\Share::isEnabled();
 
-			// get the path including mount point only if not a shared folder
-			list($storage, ) = \OC\Files\Filesystem::resolvePath('/' . $userId . '/files' . $path);
-
-			if (!($storage instanceof \OC\Files\Storage\Local)) {
-				$mountPoint = 'files' . $storage->getMountPoint();
-			} else {
-				$mountPoint = '';
-			}
+			$mountManager = \OC\Files\Filesystem::getMountManager();
+			$mount = $mountManager->find('/' . $userId . '/files' . $path);
+			$mountPoint = $mount->getMountPoint();
 
 			// if a folder was shared, get a list of all (sub-)folders
 			if ($params['itemType'] === 'folder') {
@@ -370,14 +365,9 @@ class Hooks {
 				}
 			}
 
-			// get the path including mount point only if not a shared folder
-			list($storage, ) = \OC\Files\Filesystem::resolvePath('/' . $userId . '/files' . $path);
-
-			if (!($storage instanceof \OC\Files\Storage\Local)) {
-				$mountPoint = 'files' . $storage->getMountPoint();
-			} else {
-				$mountPoint = '';
-			}
+			$mountManager = \OC\Files\Filesystem::getMountManager();
+			$mount = $mountManager->find('/' . $userId . '/files' . $path);
+			$mountPoint = $mount->getMountPoint();
 
 			// if we unshare a folder we need a list of all (sub-)files
 			if ($params['itemType'] === 'folder') {

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1384,10 +1384,11 @@ class Util {
 				// getDirectoryContent() returns the paths relative to the mount points, so we need
 				// to re-construct the complete path
 				$path = ($mountPoint !== '') ? $mountPoint . '/' .  $c['path'] : $c['path'];
+				$path = \OC\Files\Filesystem::normalizePath($path);
 				if ($c['type'] === 'dir') {
-					$dirList[] = substr($path, strlen("files"));
+					$dirList[] = substr($path, strlen('/' . \OCP\User::getUser() . "/files"));
 				} else {
-					$result[] = substr($path, strlen("files"));
+					$result[] = substr($path, strlen('/' . \OCP\User::getUser() . "/files"));
 				}
 			}
 


### PR DESCRIPTION
relying on the storage to get the mount point doesn't work for external storages. Use the mount manager to get the mount point.
