### PR TITLE
Allow a config option to affect the scanner's ability to change the cache

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -291,6 +291,9 @@ $CONFIG = array(
  * 1 -> check each file or folder at most once per request, recomended for general use if outside changes might happen
  * 2 -> check every time the filesystem is used, causes a performance hit when using external storages, not recomended for regular use
  */
-'filesystem_check_changes' => 1
+'filesystem_check_changes' => 1,
+
+/* When the filesystem is checked for changes made outside of owncloud, allow those changes to affect internal metadata storage */
+'enable_scan_to_cache' => true,
 
 );

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -138,9 +138,11 @@ class Scanner extends BasicEmitter {
 											$parent = '';
 										}
 										$parentCacheData = $this->cache->get($parent);
-										$this->cache->update($parentCacheData['fileid'], array(
-											'etag' => $this->storage->getETag($parent),
-										));
+										if(Config::getSystemValue('enable_scan_to_cache', true)) {
+											$this->cache->update($parentCacheData['fileid'], array(
+												'etag' => $this->storage->getETag($parent),
+											));
+										}
 									}
 								}
 							}
@@ -299,7 +301,9 @@ class Scanner extends BasicEmitter {
 		$lastPath = null;
 		while (($path = $this->cache->getIncomplete()) !== false && $path !== $lastPath) {
 			$this->scan($path, self::SCAN_RECURSIVE, self::REUSE_ETAG);
-			$this->cache->correctFolderSize($path);
+			if(Config::getSystemValue('enable_scan_to_cache', true)) {
+				$this->cache->correctFolderSize($path);
+			}
 			$lastPath = $path;
 		}
 	}

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -10,6 +10,7 @@ namespace OC\Files\Cache;
 
 use OC\Files\Filesystem;
 use OC\Hooks\BasicEmitter;
+use OCP\Config;
 
 /**
  * Class Scanner
@@ -156,12 +157,16 @@ class Scanner extends BasicEmitter {
 					}
 				}
 				if (!empty($newData)) {
-					$data['fileid'] = $this->cache->put($file, $newData);
+					if(Config::getSystemValue('enable_scan_to_cache', true)) {
+						$data['fileid'] = $this->cache->put($file, $newData);
+					}
 					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
 					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
 				}
 			} else {
-				$this->cache->remove($file);
+				if(Config::getSystemValue('enable_scan_to_cache', true)) {
+					$this->cache->remove($file);
+				}
 			}
 			return $data;
 		}
@@ -244,7 +249,9 @@ class Scanner extends BasicEmitter {
 			$removedChildren = \array_diff($existingChildren, $newChildren);
 			foreach ($removedChildren as $childName) {
 				$child = ($path) ? $path . '/' . $childName : $childName;
-				$this->cache->remove($child);
+				if(Config::getSystemValue('enable_scan_to_cache', true)) {
+					$this->cache->remove($child);
+				}
 			}
 			\OC_DB::commit();
 			if ($exceptionOccurred){
@@ -263,7 +270,9 @@ class Scanner extends BasicEmitter {
 					$size += $childSize;
 				}
 			}
-			$this->cache->put($path, array('size' => $size));
+			if(Config::getSystemValue('enable_scan_to_cache', true)) {
+				$this->cache->put($path, array('size' => $size));
+			}
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'postScanFolder', array($path, $this->storageId));
 		return $size;


### PR DESCRIPTION
This is different from the newly added "filesystem_check_changes" option, in that it still goes through all of the motions of the scan, but it does not alter the cache.  This allows apps that hook into the system (either via hooks or via a `Wrapper` class) to observe the scan when it is executed and act accordingly.
