### PR TITLE
Add storage->instanceOfStorage() to handle instanceof with storage wrappers

### DIFF
--- a/apps/files_sharing/lib/proxy.php
+++ b/apps/files_sharing/lib/proxy.php
@@ -57,7 +57,7 @@ class Proxy extends \OC_FileProxy {
 		$mountManager = \OC\Files\Filesystem::getMountManager();
 		$mountedShares = $mountManager->findIn($path);
 		foreach ($mountedShares as $mount) {
-			if ($mount->getStorage() instanceof \OC\Files\Storage\Shared) {
+			if ($mount->getStorage()->instanceOfStorage('\OC\Files\Storage\Shared')) {
 				$mountPoint = $mount->getMountPoint();
 				$mountPointName = $mount->getMountPointName();
 				$target = \OCA\Files_Sharing\Helper::generateUniqueTarget(dirname($path) . '/' . $mountPointName, array(), $view);

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -300,7 +300,7 @@ class Shared extends \OC\Files\Storage\Common {
 
 		// it shouldn't be possible to move a Shared storage into another one
 		list($targetStorage, ) = \OC\Files\Filesystem::resolvePath($targetPath);
-		if ($targetStorage instanceof \OC\Files\Storage\Shared) {
+		if ($targetStorage->instanceOfStorage('\OC\Files\Storage\Shared')) {
 			\OCP\Util::writeLog('file sharing',
 					'It is not allowed to move one mount point into another one',
 					\OCP\Util::DEBUG);

--- a/lib/private/files/mount/mount.php
+++ b/lib/private/files/mount/mount.php
@@ -161,6 +161,6 @@ class Mount {
 	 * @param callable $wrapper
 	 */
 	public function wrapStorage($wrapper) {
-		$this->storage = $wrapper($this->mountPoint, $this->storage);
+		$this->storage = $wrapper($this->mountPoint, $this->getStorage());
 	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -7,6 +7,7 @@
  */
 
 namespace OC\Files\Storage;
+
 use OC\Files\Filesystem;
 use OC\Files\Cache\Watcher;
 
@@ -21,7 +22,6 @@ use OC\Files\Cache\Watcher;
  * Some \OC\Files\Storage\Common methods call functions which are first defined
  * in classes which extend it, e.g. $this->stat() .
  */
-
 abstract class Common implements \OC\Files\Storage\Storage {
 	protected $cache;
 	protected $scanner;
@@ -46,7 +46,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	protected function remove($path) {
 		if ($this->is_dir($path)) {
 			return $this->rmdir($path);
-		} else if($this->is_file($path)) {
+		} else if ($this->is_file($path)) {
 			return $this->unlink($path);
 		} else {
 			return false;
@@ -411,5 +411,15 @@ abstract class Common implements \OC\Files\Storage\Storage {
 
 	protected function removeCachedFile($path) {
 		unset($this->cachedFiles[$path]);
+	}
+
+	/**
+	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
+	 *
+	 * @param string $class
+	 * @return bool
+	 */
+	public function instanceOfStorage($class) {
+		return is_a($this, $class);
 	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -440,4 +440,14 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	public function isLocal() {
 		return $this->storage->isLocal();
 	}
+
+	/**
+	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
+	 *
+	 * @param string $class
+	 * @return bool
+	 */
+	public function instanceOfStorage($class) {
+		return is_a($this, $class) or $this->storage->instanceOfStorage($class);
+	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -450,4 +450,15 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	public function instanceOfStorage($class) {
 		return is_a($this, $class) or $this->storage->instanceOfStorage($class);
 	}
+
+	/**
+	 * Pass any methods custom to specific storage implementations to the wrapped storage
+	 *
+	 * @param string $method
+	 * @param array $args
+	 * @return mixed
+	 */
+	public function __call($method, $args) {
+		return call_user_func_array(array($this->storage, $method), $args);
+	}
 }

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -57,7 +57,10 @@ class OC_Util {
 				// set up quota for home storages, even for other users
 				// which can happen when using sharing
 
-				if ($storage instanceof \OC\Files\Storage\Home) {
+				/**
+				 * @var \OC\Files\Storage\Storage $storage
+				 */
+				if ($storage->instanceOfStorage('\OC\Files\Storage\Home')) {
 					$user = $storage->getUser()->getUID();
 					$quota = OC_Util::getUserQuota($user);
 					if ($quota !== \OC\Files\SPACE_UNLIMITED) {

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -327,4 +327,12 @@ interface Storage {
 	 * @return bool true if the files are stored locally, false otherwise
 	 */
 	public function isLocal();
+
+	/**
+	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
+	 *
+	 * @param string $class
+	 * @return bool
+	 */
+	public function instanceOfStorage($class);
 }

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -464,4 +464,10 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('foo', $this->instance->file_get_contents('target/test1.txt'));
 	}
+
+	public function testInstanceOfStorage() {
+		$this->assertTrue($this->instance->instanceOfStorage('\OCP\Files\Storage'));
+		$this->assertTrue($this->instance->instanceOfStorage(get_class($this->instance)));
+		$this->assertFalse($this->instance->instanceOfStorage('\OC'));
+	}
 }

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -155,4 +155,10 @@ class Quota extends \Test\Files\Storage\Storage {
 
 		$this->assertEquals(1024 - 50, $instance->free_space(''));
 	}
+
+	public function testInstanceOfStorageWrapper() {
+		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Local'));
+		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Wrapper'));
+		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota'));
+	}
 }

--- a/tests/lib/files/storage/wrapper/wrapper.php
+++ b/tests/lib/files/storage/wrapper/wrapper.php
@@ -23,4 +23,9 @@ class Wrapper extends \Test\Files\Storage\Storage {
 	public function tearDown() {
 		\OC_Helper::rmdirr($this->tmpDir);
 	}
+
+	public function testInstanceOfStorageWrapper() {
+		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Local'));
+		$this->assertTrue($this->instance->instanceOfStorage('\OC\Files\Storage\Wrapper\Wrapper'));
+	}
 }


### PR DESCRIPTION
When using storagewrappers `$storage instanceof \OC\Files\Storage\Local` can't be used to reliably check for a specific type of storage since the storage object might be a storage wrapper.
Instead `$storage->instanceOfStorage('\OC\Files\Storage\Local')` can be used which also checks `instanceof` with an wrapped storage.

This PR also replaces some of the existing usages of instanceof with the new function, usages of instanceof that are left are in the process of being removed (#8771, #8666)

cc @schiesbn @ringmaster @DeepDiver1975 @PVince81 
