### PR TITLE
Add a warning to the configuration file

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * This configuration file is only provided to document the different configuration options and their usage.
+ * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK YOUR INSTANCE.
+ * Instead copy configurations switches that you consider important for your instance manually to your configuration.
+ */
+
 /* Only enable this for local development and not in productive environments */
 /* This will disable the minifier and outputs some additional debug informations */
 define("DEBUG", true);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -3,7 +3,7 @@
 /**
  * This configuration file is only provided to document the different configuration options and their usage.
  * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK YOUR INSTANCE.
- * Instead copy configurations switches that you consider important for your instance manually to your configuration.
+ * Instead, manually copy configurations' switches that you consider important for your instance to your configuration.
  */
 
 /* Only enable this for local development and not in productive environments */


### PR DESCRIPTION
Some people believe that they should copy the sample config to the "real" config. I noticed this several times in IRC and on the bugtracker.

I guess this warning should be enough to avoid this in the future.
