### PR TITLE
make reshare settings foldable

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -83,6 +83,9 @@ $(document).ready(function(){
 	$('#allowLinks').change(function() {
 		$("#publicLinkSettings").toggleClass('hidden', !this.checked);
 	});
+	$('#allowResharing').change(function() {
+		$("#resharingSettings").toggleClass('hidden', !this.checked);
+	});
 
 	$('#security').change(function(){
 		$.post(OC.filePath('settings','ajax','setsecurity.php'), { enforceHTTPS: $('#forcessl').val() },function(){} );

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -248,16 +248,14 @@ if (!$_['internetconnectionworking']) {
 					   value="1" <?php if ($_['allowResharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowResharing"><?php p($l->t('Allow resharing'));?></label><br/>
 				<em><?php p($l->t('Allow users to share items shared with them again')); ?></em>
-			</td>
-		</tr>
-		<tr>
-			<td <?php if ($_['shareAPIEnabled'] === 'no') print_unescaped('class="hidden"');?>>
-				<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
-					   value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />
-				<label for="sharePolicyGlobal"><?php p($l->t('Allow users to share with anyone')); ?></label><br/>
-				<input type="radio" name="shareapi_share_policy" id="sharePolicyGroupsOnly"
-					   value="groups_only" <?php if ($_['sharePolicy'] === 'groups_only') print_unescaped('checked="checked"'); ?> />
-				<label for="sharePolicyGroupsOnly"><?php p($l->t('Allow users to only share with users in their groups'));?></label><br/>
+				<div id="resharingSettings" <?php ($_['allowResharing'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?>>
+					<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
+						    value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />
+					<label for="sharePolicyGlobal"><?php p($l->t('Allow users to share with anyone')); ?></label><br/>
+					<input type="radio" name="shareapi_share_policy" id="sharePolicyGroupsOnly"
+						    value="groups_only" <?php if ($_['sharePolicy'] === 'groups_only') print_unescaped('checked="checked"'); ?> />
+					<label for="sharePolicyGroupsOnly"><?php p($l->t('Allow users to only share with users in their groups'));?></label><br/>
+				</div>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
Unchecking "Allow reshare" setting will hide unnecessary settings.
