### PR TITLE
Database code cleanup

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -95,19 +95,6 @@ class MDB2SchemaManager {
 	}
 
 	/**
-	 * drop a table
-	 * @param string $tableName the table to drop
-	 */
-	public function dropTable($tableName) {
-		$sm = $this->conn->getSchemaManager();
-		$fromSchema = $sm->createSchema();
-		$toSchema = clone $fromSchema;
-		$toSchema->dropTable($tableName);
-		$sql = $fromSchema->getMigrateToSql($toSchema, $this->conn->getDatabasePlatform());
-		$this->conn->executeQuery($sql);
-	}
-
-	/**
 	 * remove all tables defined in a database structure xml file
 	 * @param string $file the xml file describing the tables
 	 */
@@ -122,27 +109,6 @@ class MDB2SchemaManager {
 		$comparator = new \Doctrine\DBAL\Schema\Comparator();
 		$schemaDiff = $comparator->compare($fromSchema, $toSchema);
 		$this->executeSchemaChange($schemaDiff);
-	}
-
-	/**
-	 * replaces the ownCloud tables with a new set
-	 * @param string $file path to the MDB2 xml db export file
-	 */
-	public function replaceDB( $file ) {
-		$apps = \OC_App::getAllApps();
-		$this->conn->beginTransaction();
-		// Delete the old tables
-		$this->removeDBStructure( \OC::$SERVERROOT . '/db_structure.xml' );
-
-		foreach($apps as $app) {
-			$path = \OC_App::getAppPath($app).'/appinfo/database.xml';
-			if(file_exists($path)) {
-				$this->removeDBStructure( $path );
-			}
-		}
-
-		// Create new tables
-		$this->conn->commit();
 	}
 
 	/**

--- a/lib/private/db/statementwrapper.php
+++ b/lib/private/db/statementwrapper.php
@@ -13,6 +13,7 @@
  * @method string errorCode();
  * @method array errorInfo();
  * @method integer rowCount();
+ * @method array fetchAll(integer $fetchMode = null);
  */
 class OC_DB_StatementWrapper {
 	/**

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -24,10 +24,8 @@ class Test_DBSchema extends PHPUnit_Framework_TestCase {
 		$content = str_replace( '*dbprefix*', '*dbprefix*'.$r, $content );
 		file_put_contents( $this->schema_file2, $content );
 
-		$prefix = OC_Config::getValue( "dbtableprefix", "oc_" );
-		
-		$this->table1 = $prefix.$r.'cntcts_addrsbks';
-		$this->table2 = $prefix.$r.'cntcts_cards';
+		$this->table1 = $r.'cntcts_addrsbks';
+		$this->table2 = $r.'cntcts_cards';
 	}
 
 	public function tearDown() {
@@ -74,51 +72,8 @@ class Test_DBSchema extends PHPUnit_Framework_TestCase {
 	/**
 	 * @param string $table
 	 */
-	public function tableExist($table) {
-
-		switch (OC_Config::getValue( 'dbtype', 'sqlite' )) {
-			case 'sqlite':
-			case 'sqlite3':
-				$sql = "SELECT name FROM sqlite_master "
-					.  "WHERE type = 'table' AND name = ? "
-					.  "UNION ALL SELECT name FROM sqlite_temp_master "
-					.  "WHERE type = 'table' AND name = ?";
-				$result = \OC_DB::executeAudited($sql, array($table, $table));
-				break;
-			case 'mysql':
-				$sql = 'SHOW TABLES LIKE ?';
-				$result = \OC_DB::executeAudited($sql, array($table));
-				break;
-			case 'pgsql':
-				$sql = 'SELECT tablename AS table_name, schemaname AS schema_name '
-					.  'FROM pg_tables WHERE schemaname NOT LIKE \'pg_%\' '
-					.  'AND schemaname != \'information_schema\' '
-					.  'AND tablename = ?';
-				$result = \OC_DB::executeAudited($sql, array($table));
-				break;
-			case 'oci':
-				$sql = 'SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME = ?';
-				$result = \OC_DB::executeAudited($sql, array($table));
-				break;
-			case 'mssql':
-				$sql = 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?';
-				$result = \OC_DB::executeAudited($sql, array($table));
-				break;
-		}
-		
-		$name = $result->fetchOne();
-		if ($name === $table) {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	/**
-	 * @param string $table
-	 */
 	public function assertTableExist($table) {
-		$this->assertTrue($this->tableExist($table), 'Table ' . $table . ' does not exist');
+		$this->assertTrue(OC_DB::tableExists($table), 'Table ' . $table . ' does not exist');
 	}
 
 	/**
@@ -128,8 +83,9 @@ class Test_DBSchema extends PHPUnit_Framework_TestCase {
 		$type=OC_Config::getValue( "dbtype", "sqlite" );
 		if( $type == 'sqlite' || $type == 'sqlite3' ) {
 			// sqlite removes the tables after closing the DB
+			$this->assertTrue(true);
 		} else {
-			$this->assertFalse($this->tableExist($table), 'Table ' . $table . ' exists.');
+			$this->assertFalse(OC_DB::tableExists($table), 'Table ' . $table . ' exists.');
 		}
 	}
 }


### PR DESCRIPTION
- fix dropTable() and introduce tableExists()
- kill replaceDB() - this function is unused and it's implementation obviously wrong
- add method annotation OC_DB_StatementWrapper::fetchAll
- remove duplicate code in Test_DBSchema and reuse OC_DB::tableExists

https://github.com/owncloud/core/pull/8483 requires these changes - these code fragments have been extracted to reduce the change set in #8483 in order to get the failing unit tests sorted out
