### PR TITLE
Automatically Rotate Avatar based on exif data

### DIFF
--- a/core/avatar/controller.php
+++ b/core/avatar/controller.php
@@ -46,7 +46,12 @@ class Controller {
 		if (isset($_POST['path'])) {
 			$path = stripslashes($_POST['path']);
 			$view = new \OC\Files\View('/'.$user.'/files');
-			$newAvatar = $view->file_get_contents($path);
+			$fileInfo = $view->getFileInfo($path);
+                        if($fileInfo['encrypted'] === true) {
+				$fileName = $view->toTmpFile($path);
+			} else {
+				$fileName = $view->getLocalFile($path);
+			}
 		} elseif (!empty($_FILES)) {
 			$files = $_FILES['files'];
 			if (
@@ -54,7 +59,9 @@ class Controller {
 				is_uploaded_file($files['tmp_name'][0]) &&
 				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
 			) {
-				$newAvatar = file_get_contents($files['tmp_name'][0]);
+				\OC\Cache::set('avatar_upload', file_get_contents($files['tmp_name'][0]), 7200);
+				$view = new \OC\Files\View('/'.$user.'/cache');
+				$fileName = $view->getLocalFile('avatar_upload');
 				unlink($files['tmp_name'][0]);
 			}
 		} else {
@@ -64,11 +71,9 @@ class Controller {
 		}
 
 		try {
-			$avatar = new \OC_Avatar($user);
-			$avatar->set($newAvatar);
-			\OC_JSON::success();
-		} catch (\OC\NotSquareException $e) {
-			$image = new \OC_Image($newAvatar);
+			$image = new \OC_Image();
+			$image->loadFromFile($fileName);
+			$image->fixOrientation();
 
 			if ($image->valid()) {
 				\OC\Cache::set('tmpavatar', $image->data(), 7200);


### PR DESCRIPTION
This commit..
- doesn't check if a local or uploaded file is square which gives a user the option to crop square images
- caches uploaded images to an initial temporary file (needed to fix orientation)
- fixes orientation based on exif data
- check for and works with encrypted local images
