### PR TITLE
move Help section from controls bar to sidebar

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -975,15 +975,6 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .arrow.left { left:-13px; bottom:1.2em; -webkit-transform:rotate(270deg); -moz-transform:rotate(270deg); -o-transform:rotate(270deg); -ms-transform:rotate(270deg); transform:rotate(270deg); }
 .arrow.up { top:-8px; right:6px; }
 .arrow.down { -webkit-transform:rotate(180deg); -moz-transform:rotate(180deg); -o-transform:rotate(180deg); -ms-transform:rotate(180deg); transform:rotate(180deg); }
-.help-includes {
-	overflow: hidden;
-	width: 100%;
-	height: 100%;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-	padding-top: 44px;
-}
-.help-iframe {width: 100%; height: 100%; margin: 0;padding: 0; border: 0; overflow: auto;}
 
 
 /* ---- BREADCRUMB ---- */

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -180,8 +180,6 @@ span.error {
         background: #ce3702;
 }
 
-/* HELP */
-.pressed {background-color:#DDD;}
 
 /* PASSWORD */
 .strengthify-wrapper {
@@ -195,4 +193,23 @@ span.error {
 doesnotexist:-o-prefocus, .strengthify-wrapper {
 	left: 185px;
 	width: 129px;
+}
+
+
+
+
+
+/* HELP */
+
+.help-includes {
+	overflow: hidden !important;
+}
+
+.help-iframe {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	overflow: auto;
 }

--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -17,12 +17,12 @@
 
 		<li>
 			<a href="http://owncloud.org/support" target="_blank">
-				<?php p($l->t( 'Online Documentation' )); ?>
+				<?php p($l->t( 'Online Documentation' )); ?> ↗
 			</a>
 		</li>
 		<li>
 			<a href="https://forum.owncloud.org" target="_blank">
-				<?php p($l->t( 'Forum' )); ?>
+				<?php p($l->t( 'Forum' )); ?> ↗
 			</a>
 		</li>
 
@@ -30,14 +30,14 @@
 		<li>
 			<a href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md"
 				target="_blank">
-				<?php p($l->t( 'Bugtracker' )); ?>
+				<?php p($l->t( 'Bugtracker' )); ?> ↗
 			</a>
 		</li>
 	<?php } ?>
 
 	<li>
 		<a href="https://owncloud.com" target="_blank">
-			<?php p($l->t( 'Commercial Support' )); ?>
+			<?php p($l->t( 'Commercial Support' )); ?> ↗
 		</a>
 	</li>
 </div>

--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -1,21 +1,48 @@
-<div id="controls">
+<div id="app-navigation">
+	<ul>
 	<?php if($_['admin']) { ?>
-		<a class="button newquestion <?php p($_['style1']); ?>"
-			href="<?php print_unescaped($_['url1']); ?>"><?php p($l->t( 'User Documentation' )); ?></a>
-		<a class="button newquestion <?php p($_['style2']); ?>"
-			href="<?php print_unescaped($_['url2']); ?>"><?php p($l->t( 'Administrator Documentation' )); ?></a>
+		<li>
+			<a class="<?php p($_['style1']); ?>"
+				href="<?php print_unescaped($_['url1']); ?>">
+				<?php p($l->t( 'User Documentation' )); ?>
+			</a>
+		</li>
+		<li>
+			<a class="<?php p($_['style2']); ?>"
+				href="<?php print_unescaped($_['url2']); ?>">
+				<?php p($l->t( 'Administrator Documentation' )); ?>
+			</a>
+		</li>
 	<?php } ?>
-	<a class="button newquestion" href="http://owncloud.org/support" target="_blank"><?php
-		p($l->t( 'Online Documentation' )); ?></a>
-	<a class="button newquestion" href="http://forum.owncloud.org" target="_blank"><?php
-		p($l->t( 'Forum' )); ?></a>
+
+		<li>
+			<a href="http://owncloud.org/support" target="_blank">
+				<?php p($l->t( 'Online Documentation' )); ?>
+			</a>
+		</li>
+		<li>
+			<a href="https://forum.owncloud.org" target="_blank">
+				<?php p($l->t( 'Forum' )); ?>
+			</a>
+		</li>
+
 	<?php if($_['admin']) { ?>
-		<a class="button newquestion" href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md" target="_blank"><?php
-			p($l->t( 'Bugtracker' )); ?></a>
+		<li>
+			<a href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md"
+				target="_blank">
+				<?php p($l->t( 'Bugtracker' )); ?>
+			</a>
+		</li>
 	<?php } ?>
-	<a class="button newquestion" href="http://owncloud.com" target="_blank"><?php
-		p($l->t( 'Commercial Support' )); ?></a>
+
+	<li>
+		<a href="https://owncloud.com" target="_blank">
+			<?php p($l->t( 'Commercial Support' )); ?>
+		</a>
+	</li>
 </div>
-<div class="help-includes">
-	<iframe src="<?php print_unescaped($_['url']); ?>" class="help-iframe">abc</iframe>
+
+<div id="app-content" class="help-includes">
+	<iframe src="<?php print_unescaped($_['url']); ?>" class="help-iframe">
+	</iframe>
 </div>


### PR DESCRIPTION
(The horizontal iFrame scrollbar is the same on current master – this is simply a move from controls to the new app style.)

Possible future enhancements (not blocking for this PR):
- [x] either iframe the Bugtracker, Forum as well or mark them as external links with an icon
- [ ] mark the active navigation entry in the navigation

Please review @karlitschek @owncloud/designers 
