### PR TITLE
Support having legacy `OC_Cache_FileGlobalGC` background jobs

### DIFF
--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -149,6 +149,9 @@ class JobList implements IJobList {
 		/**
 		 * @var Job $job
 		 */
+		if ($class === 'OC_Cache_FileGlobalGC') {
+			$class = '\OC\Cache\FileGlobalGC';
+		}
 		$job = new $class();
 		$job->setId($row['id']);
 		$job->setLastRun($row['last_run']);


### PR DESCRIPTION
`OC_Cache_FileGlobalGC` was renamed to `\OC\Cache\FileGlobalGC` recently but users can still have the old classname in the backgroundjob database

@PVince81 I believe you ran into this one
