### PR TITLE
command line tools to see, modify and test existing LDAP configurations

### DIFF
--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+$application->add(new OCA\user_ldap\Command\showConfig());
+$application->add(new OCA\user_ldap\Command\setConfig());
+$application->add(new OCA\user_ldap\Command\testConfig());

--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -6,6 +6,6 @@
  * See the COPYING-README file.
  */
 
-$application->add(new OCA\user_ldap\Command\showConfig());
-$application->add(new OCA\user_ldap\Command\setConfig());
-$application->add(new OCA\user_ldap\Command\testConfig());
+$application->add(new OCA\user_ldap\Command\ShowConfig());
+$application->add(new OCA\user_ldap\Command\SetConfig());
+$application->add(new OCA\user_ldap\Command\TestConfig());

--- a/apps/user_ldap/command/setconfig.php
+++ b/apps/user_ldap/command/setconfig.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\user_ldap\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use \OCA\user_ldap\lib\Helper;
+use \OCA\user_ldap\lib\Configuration;
+
+class SetConfig extends Command {
+
+	protected function configure() {
+		$this
+			->setName('ldap:set-config')
+			->setDescription('shows the LDAP configuration')
+			->addArgument(
+					'configID',
+					InputArgument::REQUIRED,
+					'the configuration ID'
+				     )
+			->addArgument(
+					'configKey',
+					InputArgument::REQUIRED,
+					'the configuration key'
+				     )
+			->addArgument(
+					'configValue',
+					InputArgument::REQUIRED,
+					'the new configuration value'
+				     )
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$availableConfigs = Helper::getServerConfigurationPrefixes();
+		$configID = $input->getArgument('configID');
+		if(!in_array($configID, $availableConfigs)) {
+			$output->writeln("Invalid configID");
+			return;
+		}
+
+		$this->setValue(
+			$configID,
+			$input->getArgument('configKey'),
+			$input->getArgument('configValue')
+		);
+	}
+
+	/**
+	 * save the configuration value as provided
+	 * @param string configID
+	 * @param string configKey
+	 * @param string configValue
+	 */
+	protected function setValue($configID, $key, $value) {
+		$configHolder = new Configuration($configID);
+		$configHolder->$key = $value;
+		$configHolder->saveConfiguration();
+	}
+}

--- a/apps/user_ldap/command/setconfig.php
+++ b/apps/user_ldap/command/setconfig.php
@@ -21,7 +21,7 @@ class SetConfig extends Command {
 	protected function configure() {
 		$this
 			->setName('ldap:set-config')
-			->setDescription('shows the LDAP configuration')
+			->setDescription('modifies an LDAP configuration')
 			->addArgument(
 					'configID',
 					InputArgument::REQUIRED,

--- a/apps/user_ldap/command/setconfig.php
+++ b/apps/user_ldap/command/setconfig.php
@@ -57,9 +57,9 @@ class SetConfig extends Command {
 
 	/**
 	 * save the configuration value as provided
-	 * @param string configID
-	 * @param string configKey
-	 * @param string configValue
+	 * @param string $configID
+	 * @param string $configKey
+	 * @param string $configValue
 	 */
 	protected function setValue($configID, $key, $value) {
 		$configHolder = new Configuration($configID);

--- a/apps/user_ldap/command/showconfig.php
+++ b/apps/user_ldap/command/showconfig.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\user_ldap\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use \OCA\user_ldap\lib\Helper;
+use \OCA\user_ldap\lib\Configuration;
+
+class ShowConfig extends Command {
+
+	protected function configure() {
+		$this
+			->setName('ldap:show-config')
+			->setDescription('shows the LDAP configuration')
+			->addArgument(
+					'configID',
+					InputArgument::OPTIONAL,
+					'will show the configuration of the specified id'
+				     )
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$availableConfigs = Helper::getServerConfigurationPrefixes();
+		$configID = $input->getArgument('configID');
+		if(!is_null($configID)) {
+			$configIDs[] = $configID;
+			if(!in_array($configIDs[0], $availableConfigs)) {
+				$output->writeln("Invalid configID");
+				return;
+			}
+		} else {
+			$configIDs = $availableConfigs;
+		}
+
+		$this->renderConfigs($configIDs, $output);
+	}
+
+	/**
+	 * prints the LDAP configuration(s)
+	 * @param string[] configID(s)
+	 * @param OutputInterface $output
+	 */
+	protected function renderConfigs($configIDs, $output) {
+		$ldapWrapper = new \OCA\user_ldap\lib\LDAP();
+		foreach($configIDs as $id) {
+			$configHolder = new Configuration($id);
+			$configuration = $configHolder->getConfiguration();
+			ksort($configuration);
+
+			$table = $this->getHelperSet()->get('table');
+			$table->setHeaders(array('Configuration', $id));
+			$rows = array();
+			foreach($configuration as $key => $value) {
+				if($key === 'ldapAgentPassword') {
+					$value = '***';
+				}
+				if(is_array($value)) {
+					$value = implode(';', $value);
+				}
+				$rows[] = array($key, $value);
+			}
+			$table->setRows($rows);
+			$table->render($output);
+		}
+	}
+}

--- a/apps/user_ldap/command/showconfig.php
+++ b/apps/user_ldap/command/showconfig.php
@@ -52,7 +52,6 @@ class ShowConfig extends Command {
 	 * @param OutputInterface $output
 	 */
 	protected function renderConfigs($configIDs, $output) {
-		$ldapWrapper = new \OCA\user_ldap\lib\LDAP();
 		foreach($configIDs as $id) {
 			$configHolder = new Configuration($id);
 			$configuration = $configHolder->getConfiguration();

--- a/apps/user_ldap/command/testconfig.php
+++ b/apps/user_ldap/command/testconfig.php
@@ -52,7 +52,7 @@ class TestConfig extends Command {
 
 	/**
 	 * tests the specified connection
-	 * @param string configID
+	 * @param string $configID
 	 * @return int
 	 */
 	protected function testConfig($configID) {

--- a/apps/user_ldap/command/testconfig.php
+++ b/apps/user_ldap/command/testconfig.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\user_ldap\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use \OCA\user_ldap\lib\Helper;
+use \OCA\user_ldap\lib\Connection;
+
+class TestConfig extends Command {
+
+	protected function configure() {
+		$this
+			->setName('ldap:test-config')
+			->setDescription('shows the LDAP configuration')
+			->addArgument(
+					'configID',
+					InputArgument::REQUIRED,
+					'the configuration ID'
+				     )
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$availableConfigs = Helper::getServerConfigurationPrefixes();
+		$configID = $input->getArgument('configID');
+		if(!in_array($configID, $availableConfigs)) {
+			$output->writeln("Invalid configID");
+			return;
+		}
+
+		$result = $this->testConfig($configID);
+		if($result === 0) {
+			$output->writeln('The configuration is valid and the connection could be established!');
+		} else if($result === 1) {
+			$output->writeln('The configuration is invalid. Please have a look at the logs for further details.');
+		} else if($result === 2) {
+			$output->writeln('The configuration is valid, but the Bind failed. Please check the server settings and credentials.');
+		} else {
+			$output->writeln('Your LDAP server was kidnapped by aliens.');
+		}
+	}
+
+	/**
+	 * tests the specified connection
+	 * @param string configID
+	 * @return int
+	 */
+	protected function testConfig($configID) {
+		$lw = new \OCA\user_ldap\lib\LDAP();
+		$connection = new Connection($lw, $configID);
+
+		//ensure validation is run before we attempt the bind
+		$connection->getConfiguration();
+
+		if(!$connection->setConfiguration(array(
+			'ldap_configuration_active' => 1,
+		))) {
+			return 1;
+		}
+		if($connection->bind()) {
+			return 0;
+		}
+		return 2;
+	}
+}

--- a/apps/user_ldap/command/testconfig.php
+++ b/apps/user_ldap/command/testconfig.php
@@ -21,7 +21,7 @@ class TestConfig extends Command {
 	protected function configure() {
 		$this
 			->setName('ldap:test-config')
-			->setDescription('shows the LDAP configuration')
+			->setDescription('tests an LDAP configuration')
 			->addArgument(
 					'configID',
 					InputArgument::REQUIRED,

--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -272,7 +272,7 @@ class Configuration {
 		if(empty($value)) {
 			$value = '';
 		} else if (!is_array($value)) {
-			$value = preg_split('/\r\n|\r|\n/', $value);
+			$value = preg_split('/\r\n|\r|\n|;/', $value);
 			if($value === false) {
 				$value = '';
 			}


### PR DESCRIPTION
Registers following command line tools:

```
ldap
  ldap:set-config             modifies an LDAP configuration
  ldap:show-config            shows the LDAP configuration
  ldap:test-config            tests an LDAP configuration
```

Example usages (/wo output):

```
./occ ldap:set-config s02 ldapUserDisplayName displayname    # sets displayname on configuration "s02"
```

```
./occ ldap:show-config        # shows all configurations
./occ ldap:show-config ""     # shows the (by default) first configuration
./occ ldap:show-config s02    # shows the configuration with the id s02
```

```
./occ ldap:test-config s02    # tests the configuration like the button on Advanced tab in LDAP settings
```

Please review/test @PVince81 @icewind1991 or others thx
