### PR TITLE
Fix mime type returning for shared with others files

### DIFF
--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -58,10 +58,8 @@ class Api {
 			return new \OC_OCS_Result(null, 404, 'could not get shares');
 		} else {
 			foreach ($shares as &$share) {
-				// file_target might not be set if the target user hasn't mounted
-				// the filesystem yet
-				if ($share['item_type'] === 'file' && isset($share['file_target'])) {
-					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['file_target']);
+				if ($share['item_type'] === 'file' && isset($share['path'])) {
+					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['path']);
 				}
 				$newShares[] = $share;
 			}


### PR DESCRIPTION
Use "path" instead of "file_target", as the latter is not always set /
reliable.

Please review @icewind1991 @schiesbn 
