### PR TITLE
Improve share settings

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -236,7 +236,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			break;
 		case 'getShareWith':
 			if (isset($_GET['search'])) {
-				$sharePolicy = OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global');
+				$shareWithinGroupOnly = OC\Share\Share::shareWithGroupMembersOnly();
 				$shareWith = array();
 // 				if (OC_App::isEnabled('contacts')) {
 // 					// TODO Add function to contacts to only get the 'fullname' column to improve performance
@@ -256,7 +256,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 // 					}
 // 				}
 				$groups = OC_Group::getGroups($_GET['search']);
-				if ($sharePolicy == 'groups_only') {
+				if ($shareWithinGroupOnly) {
 					$usergroups = OC_Group::getUserGroups(OC_User::getUser());
 					$groups = array_intersect($groups, $usergroups);
 				}
@@ -266,7 +266,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$offset = 0;
 				while ($count < 15 && count($users) == $limit) {
 					$limit = 15 - $count;
-					if ($sharePolicy == 'groups_only') {
+					if ($shareWithinGroupOnly) {
 						$users = OC_Group::DisplayNamesInGroups($usergroups, $_GET['search'], $limit, $offset);
 					} else {
 						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -478,7 +478,7 @@ class Share extends \OC\Share\Constants {
 	 */
 	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, \DateTime $expirationDate = null) {
 		$uidOwner = \OC_User::getUser();
-		$sharingPolicy = \OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global');
+		$shareWithinGroupOnly = self::shareWithGroupMembersOnly();
 		$l = \OC_L10N::get('lib');
 
 		if (is_null($itemSourceName)) {
@@ -533,7 +533,7 @@ class Share extends \OC\Share\Constants {
 				\OC_Log::write('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OC_Log::ERROR);
 				throw new \Exception($message_t);
 			}
-			if ($sharingPolicy == 'groups_only') {
+			if ($shareWithinGroupOnly) {
 				$inGroup = array_intersect(\OC_Group::getUserGroups($uidOwner), \OC_Group::getUserGroups($shareWith));
 				if (empty($inGroup)) {
 					$message = 'Sharing %s failed, because the user '
@@ -563,7 +563,7 @@ class Share extends \OC\Share\Constants {
 				\OC_Log::write('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OC_Log::ERROR);
 				throw new \Exception($message_t);
 			}
-			if ($sharingPolicy == 'groups_only' && !\OC_Group::inGroup($uidOwner, $shareWith)) {
+			if ($shareWithinGroupOnly && !\OC_Group::inGroup($uidOwner, $shareWith)) {
 				$message = 'Sharing %s failed, because '
 					.'%s is not a member of the group %s';
 				$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', array($itemSourceName, $uidOwner, $shareWith));
@@ -1829,4 +1829,14 @@ class Share extends \OC\Share\Constants {
 			return $backend->formatItems($items, $format, $parameters);
 		}
 	}
+
+	/**
+	 * check if user can only share with group members
+	 * @return bool
+	 */
+	public static function shareWithGroupMembersOnly() {
+		$value = \OC_Appconfig::getValue('core', 'shareapi_only_share_with_group_members', 'no');
+		return ($value === 'yes') ? true : false;
+	}
+
 }

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -53,7 +53,7 @@ class Updater extends BasicEmitter {
 		$version = \OC_Util::getVersion();
 		$version['installed'] = \OC_Appconfig::getValue('core', 'installedat');
 		$version['updated'] = \OC_Appconfig::getValue('core', 'lastupdatedat');
-		$version['updatechannel'] = \OC_Util::getChannel(); 
+		$version['updatechannel'] = \OC_Util::getChannel();
 		$version['edition'] = \OC_Util::getEditionString();
 		$version['build'] = \OC_Util::getBuild();
 		$versionString = implode('x', $version);
@@ -119,7 +119,7 @@ class Updater extends BasicEmitter {
 		if (!\OC::$CLI && version_compare($installedVersion, '6.90.1', '<')) {
 			// Add the trusted_domains config if it is not existant
 			// This is added to prevent host header poisoning
-			\OC_Config::setValue('trusted_domains', \OC_Config::getValue('trusted_domains', array(\OC_Request::serverHost()))); 
+			\OC_Config::setValue('trusted_domains', \OC_Config::getValue('trusted_domains', array(\OC_Request::serverHost())));
 		}
 		/*
 		 * STOP CONFIG CHANGES FOR OLDER VERSIONS
@@ -149,6 +149,13 @@ class Updater extends BasicEmitter {
 			$canUpgrade = true;
 		} catch (\Exception $exception) {
 			$this->emit('\OC\Updater', 'failure', array($exception->getMessage()));
+		}
+
+		// upgrade from OC6 to OC7
+		// TODO removed it again for OC8
+		$sharePolicy = \OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global');
+		if ($sharePolicy === 'groups_only') {
+			\OC_Appconfig::setValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		}
 
 		if ($canUpgrade) {

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -83,7 +83,7 @@ $tmpl->assign('enforceLinkPassword', \OCP\Util::isPublicLinkPasswordRequired());
 $tmpl->assign('allowPublicUpload', OC_Appconfig::getValue('core', 'shareapi_allow_public_upload', 'yes'));
 $tmpl->assign('allowResharing', OC_Appconfig::getValue('core', 'shareapi_allow_resharing', 'yes'));
 $tmpl->assign('allowMailNotification', OC_Appconfig::getValue('core', 'shareapi_allow_mail_notification', 'no'));
-$tmpl->assign('sharePolicy', OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global'));
+$tmpl->assign('onlyShareWithGroupMembers', \OC\Share\Share::shareWithGroupMembersOnly());
 $tmpl->assign('forms', array());
 foreach($forms as $form) {
 	$tmpl->append('forms', $form);

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -83,9 +83,6 @@ $(document).ready(function(){
 	$('#allowLinks').change(function() {
 		$("#publicLinkSettings").toggleClass('hidden', !this.checked);
 	});
-	$('#allowResharing').change(function() {
-		$("#resharingSettings").toggleClass('hidden', !this.checked);
-	});
 
 	$('#security').change(function(){
 		$.post(OC.filePath('settings','ajax','setsecurity.php'), { enforceHTTPS: $('#forcessl').val() },function(){} );

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -278,12 +278,9 @@ if (!$_['internetconnectionworking']) {
 		</tr>
 		<tr>
 			<td <?php if ($_['shareAPIEnabled'] === 'no') print_unescaped('class="hidden"');?>>
-				<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
-					   value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />
-				<label for="sharePolicyGlobal"><?php p($l->t('Allow users to share with anyone')); ?></label><br/>
-				<input type="radio" name="shareapi_share_policy" id="sharePolicyGroupsOnly"
-					   value="groups_only" <?php if ($_['sharePolicy'] === 'groups_only') print_unescaped('checked="checked"'); ?> />
-				<label for="sharePolicyGroupsOnly"><?php p($l->t('Allow users to only share with users in their groups'));?></label><br/>
+				<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers"
+					   value="1" <?php if ($_['onlyShareWithGroupMembers']) print_unescaped('checked="checked"'); ?> />
+				<label for="onlyShareWithGroupMembers"><?php p($l->t('Restrict users to only share with users in their groups'));?></label><br/>
 			</td>
 		</tr>
 		<tr>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -274,14 +274,16 @@ if (!$_['internetconnectionworking']) {
 				<input type="checkbox" name="shareapi_allow_resharing" id="allowResharing"
 					   value="1" <?php if ($_['allowResharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowResharing"><?php p($l->t('Allow resharing'));?></label><br/>
-				<div id="resharingSettings" <?php ($_['allowResharing'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?>>
-					<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
-						    value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />
-					<label for="sharePolicyGlobal"><?php p($l->t('Allow users to share with anyone')); ?></label><br/>
-					<input type="radio" name="shareapi_share_policy" id="sharePolicyGroupsOnly"
-						    value="groups_only" <?php if ($_['sharePolicy'] === 'groups_only') print_unescaped('checked="checked"'); ?> />
-					<label for="sharePolicyGroupsOnly"><?php p($l->t('Allow users to only share with users in their groups'));?></label><br/>
-				</div>
+			</td>
+		</tr>
+		<tr>
+			<td <?php if ($_['shareAPIEnabled'] === 'no') print_unescaped('class="hidden"');?>>
+				<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
+					   value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />
+				<label for="sharePolicyGlobal"><?php p($l->t('Allow users to share with anyone')); ?></label><br/>
+				<input type="radio" name="shareapi_share_policy" id="sharePolicyGroupsOnly"
+					   value="groups_only" <?php if ($_['sharePolicy'] === 'groups_only') print_unescaped('checked="checked"'); ?> />
+				<label for="sharePolicyGroupsOnly"><?php p($l->t('Allow users to only share with users in their groups'));?></label><br/>
 			</td>
 		</tr>
 		<tr>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -237,15 +237,14 @@ if (!$_['internetconnectionworking']) {
 			<td id="enable">
 				<input type="checkbox" name="shareapi_enabled" id="shareAPIEnabled"
 					   value="1" <?php if ($_['shareAPIEnabled'] === 'yes') print_unescaped('checked="checked"'); ?> />
-				<label for="shareAPIEnabled"><?php p($l->t('Enable Share API'));?></label><br/>
-				<em><?php p($l->t('Allow apps to use the Share API')); ?></em>
+				<label for="shareAPIEnabled"><?php p($l->t('Allow apps to use the Share API'));?></label><br/>
 			</td>
 		</tr>
 		<tr>
 			<td <?php if ($_['shareAPIEnabled'] === 'no') print_unescaped('class="hidden"');?>>
 				<input type="checkbox" name="shareapi_allow_links" id="allowLinks"
 					   value="1" <?php if ($_['allowLinks'] === 'yes') print_unescaped('checked="checked"'); ?> />
-				<label for="allowLinks"><?php p($l->t('Allow links'));?></label><br/>
+				<label for="allowLinks"><?php p($l->t('Allow users to share via link'));?></label><br/>
 				<div <?php ($_['allowLinks'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?> id="publicLinkSettings">
 				<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword"
 						   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
@@ -268,7 +267,6 @@ if (!$_['internetconnectionworking']) {
 				</div>
 
 				</div>
-				<em><?php p($l->t('Allow users to share items to the public with links')); ?></em>
 			</td>
 		</tr>
 		<tr>
@@ -276,7 +274,6 @@ if (!$_['internetconnectionworking']) {
 				<input type="checkbox" name="shareapi_allow_resharing" id="allowResharing"
 					   value="1" <?php if ($_['allowResharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowResharing"><?php p($l->t('Allow resharing'));?></label><br/>
-				<em><?php p($l->t('Allow users to share items shared with them again')); ?></em>
 				<div id="resharingSettings" <?php ($_['allowResharing'] === 'yes') ? print_unescaped('class="indent"') : print_unescaped('class="hidden indent"');?>>
 					<input type="radio" name="shareapi_share_policy" id="sharePolicyGlobal"
 						    value="global" <?php if ($_['sharePolicy'] === 'global') print_unescaped('checked="checked"'); ?> />

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -384,8 +384,8 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
-		$policy = OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global');
-		OC_Appconfig::setValue('core', 'shareapi_share_policy', 'groups_only');
+		$policy = OC_Appconfig::getValue('core', 'shareapi_only_share_with_group_members', 'no');
+		OC_Appconfig::setValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		$message = 'Sharing test.txt failed, because '.$this->user1.' is not a member of the group '.$this->group2;
 		try {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group2, OCP\PERMISSION_READ);
@@ -393,7 +393,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
-		OC_Appconfig::setValue('core', 'shareapi_share_policy', $policy);
+		OC_Appconfig::setValue('core', 'shareapi_only_share_with_group_members', $policy);
 
 		// Valid share
 		$this->shareUserOneTestFileWithGroupOne();


### PR DESCRIPTION
Improve wording of share settings. And changed two radio buttons to one checkbox.

How to test it:
- Go to the admin settings
- Toggle the 'Allow users to only share with users in their groups' button
- check if user can only share with other users in the same group if the checkbox is activates

cc @jancborchardt 
