### PR TITLE
Work with MySQL Sockets

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -26,7 +26,7 @@ $CONFIG = array(
 /* Password to access the ownCloud database */
 "dbpassword" => "",
 
-/* Host running the ownCloud database */
+/* Host running the ownCloud database. To specify a port use "HOSTNAME:####"; to specify a unix sockets use "localhost:/path/to/socket". */
 "dbhost" => "",
 
 /* Prefix for the ownCloud tables in the database */

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -67,6 +67,8 @@ class OC_DB {
 			list($host, $port)=explode(':', $host, 2);
 			if(!is_int($port)||$port<1||$port>65535) {
 				$socket=true;
+			} else {
+				$socket=false;
 			}
 		} else {
 			$port=false;

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -65,6 +65,9 @@ class OC_DB {
 		$type = OC_Config::getValue( "dbtype", "sqlite" );
 		if(strpos($host, ':')) {
 			list($host, $port)=explode(':', $host, 2);
+			if(!is_int($port)||$port<1||$port>65535) {
+				$socket=true;
+			}
 		} else {
 			$port=false;
 		}
@@ -89,7 +92,11 @@ class OC_DB {
 				'dbname' => $name,
 			);
 			if (!empty($port)) {
-				$connectionParams['port'] = $port;
+				if ($socket) {
+					$connectionParams['unix_socket'] = $port;
+				} else {
+					$connectionParams['port'] = $port;
+				}
 			}
 		}
 

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -64,14 +64,10 @@ class OC_DB {
 		$pass = OC_Config::getValue( "dbpassword", "" );
 		$type = OC_Config::getValue( "dbtype", "sqlite" );
 		if(strpos($host, ':')) {
-			list($host, $port)=explode(':', $host, 2);
-			if(!is_int($port)||$port<1||$port>65535) {
-				$socket=true;
-			} else {
-				$socket=false;
-			}
+			list($host, $socket)=explode(':', $host, 2);
+			$port = ctype_digit($socket) && $socket<=65535;
 		} else {
-			$port=false;
+			$socket=FALSE;
 		}
 
 		$factory = new \OC\DB\ConnectionFactory();
@@ -93,11 +89,11 @@ class OC_DB {
 				'host' => $host,
 				'dbname' => $name,
 			);
-			if (!empty($port)) {
-				if ($socket) {
-					$connectionParams['unix_socket'] = $port;
+			if ($socket) {
+				if ($port) {
+					$connectionParams['port'] = $socket;
 				} else {
-					$connectionParams['port'] = $port;
+					$connectionParams['unix_socket'] = $socket;
 				}
 			}
 		}

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -65,7 +65,7 @@ class OC_DB {
 		$type = OC_Config::getValue( "dbtype", "sqlite" );
 		if(strpos($host, ':')) {
 			list($host, $socket)=explode(':', $host, 2);
-			$port = ctype_digit($socket) && $socket<=65535;
+			$port = is_numeric($socket);
 		} else {
 			$socket=FALSE;
 		}


### PR DESCRIPTION
This passes anything that is not a valid port (0<int<65535) as a unix socket.
I tested this with unix sockets; this needs to be tested with a non-standard mysql port as well but I don't foresee any issues.

To use a unix socket, even one different than PHP's mysql.default_socket..
- Database Host = localhost:/path/to/socket
