### PR TITLE
Don't update the mtime if the storage mtime hasn't changed

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -129,6 +129,7 @@ class Scanner extends BasicEmitter {
 						}
 						// only reuse data if the file hasn't explicitly changed
 						if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
+							$data['mtime'] = $cacheData['mtime'];
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
 								$data['size'] = $cacheData['size'];
 							}

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -112,7 +112,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('/foo', '/foo/folder', '/foo/folder/bar.txt', '/foo/foo.txt'), $changes);
 		$this->assertEquals(array('/', '/foo', '/foo/folder'), $parents);
 
-		$cache->put('foo.txt', array('mtime' => time() - 50));
+		$cache->put('foo.txt', array('storage_mtime' => time() - 50));
 
 		$propagator = $this->getMock('\OC\Files\Cache\ChangePropagator', array('propagateChanges'), array(), '', false);
 		$scanner->setPropagator($propagator);
@@ -128,7 +128,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$scanner->setPropagator($originalPropagator);
 
 		$oldInfo = $cache->get('');
-		$cache->put('foo.txt', array('mtime' => time() - 70));
+		$cache->put('foo.txt', array('storage_mtime' => time() - 70));
 		$storage->file_put_contents('foo.txt', 'asdasd');
 
 		$scanner->scan('');


### PR DESCRIPTION
Fixed `testReuseExistingRoot`

When the cache propagator updated the folder mtimes at a next second then actual scan ran, the change in mtime of 1 seccond was seen as a change which triggered the propagator again.

cc @PVince81 @DeepDiver1975 
