### PR TITLE
fix size and unbold empty content message

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -283,8 +283,7 @@ input[type="submit"].enabled {
 }
 
 #emptycontent {
-	font-size: 1.5em;
-	font-weight: bold;
+	font-size: 16px;
 	color: #888;
 	position: absolute;
 	text-align: center;


### PR DESCRIPTION
Use same size as for app name in header (to not use too many different font sizes).

Also unbold for lighter appeal and less screaming at people.

Please check @owncloud/designers 
