### PR TITLE
Dont overwrite OCA.Sharing

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -10,7 +10,9 @@
 
 /* global FileActions, Files */
 /* global dragOptions, folderDropOptions */
-OCA.Sharing = {};
+if (!OCA.Sharing) {
+	OCA.Sharing = {};
+}
 if (!OCA.Files) {
 	OCA.Files = {};
 }


### PR DESCRIPTION
Prevents a js error

cc @schiesbn @PVince81 
