### PR TITLE
fix typo in var name

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -638,7 +638,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		if($isUser) {
 			//make sure that email address is retrieved prior to login, so user
 			//will be notified when something is shared with him
-			$this->userManager->get($ocname)->update();
+			$this->userManager->get($ocName)->update();
 		}
 
 		return true;


### PR DESCRIPTION
A typo.

@DeepDiver1975 my IDE is not to blame, it showed correctly that it was not defined. But I was faster :speedboat: 

@PVince81 
