### PR TITLE
app settings: display input fields at full width

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -113,10 +113,6 @@
 	bottom: 0;
 }
 
-.app-files #app-settings input {
-	width: 90%;
-}
-
 #filestable tbody tr { background-color:#fff; height:40px; }
 #filestable tbody tr:hover, tbody tr:active {
 	background-color: rgb(240,240,240);

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -190,6 +190,10 @@
 	overflow-y: auto;
 }
 
+
+
+/* APP-SETTINGS ---------------------------------------------------------------*/
+
 /* settings area */
 #app-settings {
 	position: fixed;
@@ -213,6 +217,11 @@
 	/* restrict height of settings and make scrollable */
 	max-height: 300px;
 	overflow-y: auto;
+}
+
+/* display input fields at full width */
+#app-settings-content input {
+	width: 93%;
 }
 
 .settings-button {


### PR DESCRIPTION
Move the rule from Files app to app styles. @PVince81 Fixes it for example in the Activity app @nickvergessen 

@owncloud/designers 
