### PR TITLE
[master] Use actual file path on rename/delete

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -255,7 +255,7 @@
 			this.register('all', 'Delete', OC.PERMISSION_DELETE, function () {
 				return OC.imagePath('core', 'actions/delete');
 			}, function (filename, context) {
-				context.fileList.do_delete(filename);
+				context.fileList.do_delete(filename, context.dir);
 				$('.tipsy').remove();
 			});
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1215,7 +1215,7 @@
 						$.ajax({
 							url: OC.filePath('files','ajax','rename.php'),
 							data: {
-								dir : self.getCurrentDirectory(),
+								dir : tr.attr('data-path') || self.getCurrentDirectory(),
 								newname: newName,
 								file: oldname
 							},

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -140,6 +140,7 @@ describe('OCA.Files.FileActions tests', function() {
 			id: 18,
 			type: 'file',
 			name: 'testName.txt',
+			path: '/somepath/dir',
 			mimetype: 'text/plain',
 			size: '1234',
 			etag: 'a01234c',
@@ -151,6 +152,8 @@ describe('OCA.Files.FileActions tests', function() {
 		$tr.find('.action.delete').click();
 
 		expect(deleteStub.calledOnce).toEqual(true);
+		expect(deleteStub.getCall(0).args[0]).toEqual('testName.txt');
+		expect(deleteStub.getCall(0).args[1]).toEqual('/somepath/dir');
 		deleteStub.restore();
 	});
 	it('passes context to action handler', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -485,7 +485,9 @@ describe('OCA.Files.FileList tests', function() {
 			var $input, request;
 
 			for (var i = 0; i < testFiles.length; i++) {
-				fileList.add(testFiles[i], {silent: true});
+				var file = testFiles[i];
+				file.path = '/some/subdir';
+				fileList.add(file, {silent: true});
 			}
 
 			// trigger rename prompt
@@ -498,7 +500,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(1);
 			request = fakeServer.requests[0];
 			expect(request.url.substr(0, request.url.indexOf('?'))).toEqual(OC.webroot + '/index.php/apps/files/ajax/rename.php');
-			expect(OC.parseQueryString(request.url)).toEqual({'dir': '/subdir', newname: 'Tu_after_three.txt', file: 'One.txt'});
+			expect(OC.parseQueryString(request.url)).toEqual({'dir': '/some/subdir', newname: 'Tu_after_three.txt', file: 'One.txt'});
 		}
 		it('Inserts renamed file entry at correct position if rename ajax call suceeded', function() {
 			doRename();


### PR DESCRIPTION
When renaming or deleting a file that is in a subdirectory, performing
the action from the sharing overview or another file list view, the
actual directory of the file must be used instead of the current
directory.

Please review @schiesbn @icewind1991 @karlitschek 
