### PR TITLE
Layout fixes

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -220,7 +220,7 @@
 }
 
 /* display input fields at full width */
-#app-settings-content input {
+#app-settings-content input[type='text'] {
 	width: 93%;
 }
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -305,7 +305,7 @@ input[type="submit"].enabled {
 	color: #888;
 	position: absolute;
 	text-align: center;
-	top: 50%;
+	top: 30%;
 	width: 100%;
 }
 


### PR DESCRIPTION
- app settings: only display text fields at full width, not buttons
- display empty content message a bit higher up so it's easier to see

Check it @owncloud/designers 
