### PR TITLE
set logger before registrate to an error handler

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -515,13 +515,13 @@ class OC {
 		}
 
 		if (!defined('PHPUNIT_RUN')) {
+			OC\Log\ErrorHandler::setLogger(OC_Log::$object);
 			if (defined('DEBUG') and DEBUG) {
 				OC\Log\ErrorHandler::register(true);
 				set_exception_handler(array('OC_Template', 'printExceptionErrorPage'));
 			} else {
 				OC\Log\ErrorHandler::register();
 			}
-			OC\Log\ErrorHandler::setLogger(OC_Log::$object);
 		}
 
 		// register the stream wrappers


### PR DESCRIPTION
This has the potential to fix the white screen of death.

The logger was set after the registration to an error handler. Therefore "PHP Fatal"s like this

```
PHP Fatal error:  Call to a member function debug() on a non-object in lib/private/log/errorhandler.php on line 71
Stack trace:
  1. {main}()                                       index.php:0
  2. require_once()                                 index.php:26
  3. OC::init()                                     lib/base.php:985
  4. spl_autoload_call()                            lib/base.php:524
  5. OC\\Autoloader->load()                         lib/base.php:0
  6. require_once()                                 lib/autoloader.php:143
  7. OC\\Log->__construct()                         lib/private/legacy/log.php:16
  8. call_user_func:{lib/private/log.php:34}()      lib/private/log.php:34
  9. OC_Log_Owncloud::init()                        lib/private/log.php:34
 10. file_exists()                                  lib/private/log/owncloud.php:49
 11. OC\\Log\\ErrorHandler->onAll()                 lib/private/log/owncloud.php:49
```

where caused.

This change first sets a log handler and then registers the error handler.

cc @icewind1991 @karlitschek @butonic @PVince81 
