### PR TITLE
Repair broken parent link in the scanner

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -100,45 +100,47 @@ class Scanner extends BasicEmitter {
 			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
 			$data = $this->getData($file);
 			if ($data) {
-				if ($file and !$parentExistsInCache) {
-					$parent = dirname($file);
-					if ($parent === '.' or $parent === '/') {
-						$parent = '';
-					}
-					if (!$this->cache->inCache($parent)) {
-						$this->scanFile($parent);
-					}
+				$parent = dirname($file);
+				if ($parent === '.' or $parent === '/') {
+					$parent = '';
 				}
-				$newData = $data;
+				$parentId = $this->cache->getId($parent);
+				if ($file and $parentId === -1) {
+					$parentData = $this->scanFile($parent);
+					$parentId = $parentData['fileid'];
+				}
+				if ($parent) {
+					$data['parent'] = $parentId;
+				}
 				$cacheData = $this->cache->get($file);
-				if ($cacheData) {
-					if ($reuseExisting) {
-						// prevent empty etag
-						if (empty($cacheData['etag'])) {
-							$etag = $data['etag'];
-						} else {
-							$etag = $cacheData['etag'];
+				if ($cacheData and $reuseExisting) {
+					// prevent empty etag
+					if (empty($cacheData['etag'])) {
+						$etag = $data['etag'];
+					} else {
+						$etag = $cacheData['etag'];
+					}
+					// only reuse data if the file hasn't explicitly changed
+					if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
+						$data['mtime'] = $cacheData['mtime'];
+						if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
+							$data['size'] = $cacheData['size'];
 						}
-						// only reuse data if the file hasn't explicitly changed
-						if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
-							$data['mtime'] = $cacheData['mtime'];
-							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
-								$data['size'] = $cacheData['size'];
-							}
-							if ($reuseExisting & self::REUSE_ETAG) {
-								$data['etag'] = $etag;
-							}
-						}
-						// Only update metadata that has changed
-						$newData = array_diff_assoc($data, $cacheData);
-						if (isset($newData['etag'])) {
-							$cacheDataString = print_r($cacheData, true);
-							$dataString = print_r($data, true);
-							\OCP\Util::writeLog('OC\Files\Cache\Scanner',
-								"!!! No reuse of etag for '$file' !!! \ncache: $cacheDataString \ndata: $dataString",
-								\OCP\Util::DEBUG);
+						if ($reuseExisting & self::REUSE_ETAG) {
+							$data['etag'] = $etag;
 						}
 					}
+					// Only update metadata that has changed
+					$newData = array_diff_assoc($data, $cacheData);
+					if (isset($newData['etag'])) {
+						$cacheDataString = print_r($cacheData, true);
+						$dataString = print_r($data, true);
+						\OCP\Util::writeLog('OC\Files\Cache\Scanner',
+							"!!! No reuse of etag for '$file' !!! \ncache: $cacheDataString \ndata: $dataString",
+							\OCP\Util::DEBUG);
+					}
+				} else {
+					$newData = $data;
 				}
 				if (!empty($newData)) {
 					$data['fileid'] = $this->addToCache($file, $newData);

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -89,10 +89,9 @@ class Scanner extends BasicEmitter {
 	 *
 	 * @param string $file
 	 * @param int $reuseExisting
-	 * @param bool $parentExistsInCache
 	 * @return array an array of metadata of the scanned file
 	 */
-	public function scanFile($file, $reuseExisting = 0, $parentExistsInCache = false) {
+	public function scanFile($file, $reuseExisting = 0) {
 		if (!self::isPartialFile($file)
 			and !Filesystem::isFileBlacklisted($file)
 		) {
@@ -242,7 +241,7 @@ class Scanner extends BasicEmitter {
 					if (!Filesystem::isIgnoredDir($file)) {
 						$newChildren[] = $file;
 						try {
-							$data = $this->scanFile($child, $reuse, true);
+							$data = $this->scanFile($child, $reuse);
 							if ($data) {
 								if ($data['mimetype'] === 'httpd/unix-directory' and $recursive === self::SCAN_RECURSIVE) {
 									$childQueue[] = $child;

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -105,6 +105,8 @@ class Scanner extends BasicEmitter {
 					$parent = '';
 				}
 				$parentId = $this->cache->getId($parent);
+
+				// scan the parent if it's not in the cache (id -1) and the current file is not the root folder
 				if ($file and $parentId === -1) {
 					$parentData = $this->scanFile($parent);
 					$parentId = $parentData['fileid'];

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -32,7 +32,6 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 
 	function tearDown() {
 		if ($this->cache) {
-			$ids = $this->cache->getAll();
 			$this->cache->clear();
 		}
 	}
@@ -199,7 +198,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($this->cache->inCache('folder/bar.txt'));
 	}
 
-	public function testScanRemovedFile(){
+	public function testScanRemovedFile() {
 		$this->fillTestFolders();
 
 		$this->scanner->scan('');
@@ -232,5 +231,53 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$newData0 = $this->cache->get('folder/bar.txt');
 		$this->assertInternalType('string', $newData0['etag']);
 		$this->assertNotEmpty($newData0['etag']);
+	}
+
+	public function testRepairParent() {
+		$this->fillTestFolders();
+		$this->scanner->scan('');
+		$this->assertTrue($this->cache->inCache('folder/bar.txt'));
+		$oldFolderId = $this->cache->getId('folder');
+
+		// delete the folder without removing the childs
+		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+		\OC_DB::executeAudited($sql, array($oldFolderId));
+
+		$cachedData = $this->cache->get('folder/bar.txt');
+		$this->assertEquals($oldFolderId, $cachedData['parent']);
+		$this->assertFalse($this->cache->inCache('folder'));
+
+		$this->scanner->scan('');
+
+		$this->assertTrue($this->cache->inCache('folder'));
+		$newFolderId = $this->cache->getId('folder');
+		$this->assertNotEquals($oldFolderId, $newFolderId);
+
+		$cachedData = $this->cache->get('folder/bar.txt');
+		$this->assertEquals($newFolderId, $cachedData['parent']);
+	}
+
+	public function testRepairParentShallow() {
+		$this->fillTestFolders();
+		$this->scanner->scan('');
+		$this->assertTrue($this->cache->inCache('folder/bar.txt'));
+		$oldFolderId = $this->cache->getId('folder');
+
+		// delete the folder without removing the childs
+		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+		\OC_DB::executeAudited($sql, array($oldFolderId));
+
+		$cachedData = $this->cache->get('folder/bar.txt');
+		$this->assertEquals($oldFolderId, $cachedData['parent']);
+		$this->assertFalse($this->cache->inCache('folder'));
+
+		$this->scanner->scan('folder', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
+
+		$this->assertTrue($this->cache->inCache('folder'));
+		$newFolderId = $this->cache->getId('folder');
+		$this->assertNotEquals($oldFolderId, $newFolderId);
+
+		$cachedData = $this->cache->get('folder/bar.txt');
+		$this->assertEquals($newFolderId, $cachedData['parent']);
 	}
 }


### PR DESCRIPTION
Make sure the `parent` row is set correctly in the database to prevent ghost files in the cache.

Possible fix for #8118 

cc @PVince81 
