### PR TITLE
Disable snapper init for IE <= 9

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1140,7 +1140,7 @@ function initCore() {
 	setupMainMenu();
 
 	// just add snapper for logged in users
-	if($('#app-navigation').length) {
+	if($('#app-navigation').length && !$('html').hasClass('lte9')) {
 
 		// App sidebar on mobile
 		var snapper = new Snap({


### PR DESCRIPTION
Snapper doesn't work at all for IE8 and IE9 and messes up with the main
container layout when enabled.

This commits disables snapper for these browsers.

Fixes https://github.com/owncloud/core/issues/8944

Please review @MorrisJobke @owncloud/designers 

@icewind1991 did you check snapper on your tablet ?
