### PR TITLE
Ldap wizard group detection

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -254,7 +254,7 @@ class Wizard extends LDAPUtility {
 			throw new \Exception('Could not connect to LDAP');
 		}
 
-		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList');
+		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList', 'groupOfNames');
 		$this->determineFeature($obclasses, 'cn', $dbkey, $confkey);
 
 		if($testMemberOf) {

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -254,7 +254,7 @@ class Wizard extends LDAPUtility {
 			throw new \Exception('Could not connect to LDAP');
 		}
 
-		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList', '*');
+		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList');
 		$this->determineFeature($obclasses, 'cn', $dbkey, $confkey);
 
 		if($testMemberOf) {
@@ -948,6 +948,7 @@ class Wizard extends LDAPUtility {
 		if(!$cr) {
 			throw new \Exception('Could not connect to LDAP');
 		}
+		$lastFilterIsWildcard = ($objectclasses[count($objectclasses)-1] === '*');
 		$p = 'objectclass=';
 		foreach($objectclasses as $key => $value) {
 			$objectclasses[$key] = $p.$value;
@@ -963,9 +964,8 @@ class Wizard extends LDAPUtility {
 			$dig = 0;
 		}
 
-		$availableFeatures =
-			$this->cumulativeSearchOnAttribute($objectclasses, $attr,
-											   true, $dig, $maxEntryObjC);
+		$availableFeatures = $this->cumulativeSearchOnAttribute
+			($objectclasses, $attr, $lastFilterIsWildcard, $dig, $maxEntryObjC);
 		if(is_array($availableFeatures)
 		   && count($availableFeatures) > 0) {
 			natcasesort($availableFeatures);


### PR DESCRIPTION
This fixes two issues:

1.) support for "groupOfNames" objectclass (i.e. adding it to the array of objectClasses that are known to identify groups).

2.) disabling wildcard search for groups. If your groups do not belong to any known objectClass, ownCloud wants still to be helpful and offers any available object as group. This is terrible, because on big setups it runs half an eternity and the results will hot help much anyway (rather contrary).

The changes are pretty small. 

To test it:

about 1st) create a group in LDAP and make sure it has an objectclass value of "groupOfNames" but none of 'posixGroup', 'group' or 'zimbraDistributionList'. Run the wizard and make sure you find your group in the second drop down in the Groups tab (priorly it won't be there).

about 2nd) remove all groups having  'posixGroup', 'group', 'zimbraDistributionList or 'groupOfNames' as objectClass. Make sure you have any other entries (like users) in LDAP. Run the wizard, the second drop down in the Groups tab shall be empty (priorly full with everything that has an cn attribute, spinner can take a terribly long time depending on the setup).

@karlitschek  I would love to get it into 6.0.4. cc @ser72 

Reviewers please @PVince81 @MorrisJobke @icewind1991 or others
