### PR TITLE
Added ORDER BY to enforce share entry order

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1211,6 +1211,7 @@ class Share extends \OC\Share\Constants {
 			}
 		} else {
 			$queryLimit = null;
+			$where .= ' ORDER BY `*PREFIX*share`.`id` ASC';
 		}
 		$select = self::createSelectStatement($format, $fileDependent, $uidOwner);
 		$root = strlen($root);


### PR DESCRIPTION
Sometimes MySQL decides to return the shares in the wrong order, but
some parts of the code seem to require the order to be known, at least
so that the parent shares come before the children shares.

This fix adds an ORDER BY clause to force the order by id.

This should reduce the probability of having randomly failing sharing tests, but doesn't seem to fix the main issue yet. This is a step forward.

Please review @schiesbn @icewind1991 
