### PR TITLE
[DEBUG] Test case for debugging the last index ID bug from Doctrine/MySQL

### DIFF
--- a/apps/files_encryption/tests/migration.php
+++ b/apps/files_encryption/tests/migration.php
@@ -50,10 +50,44 @@ class Test_Migration extends PHPUnit_Framework_TestCase {
 
 	}
 
-	public function testDataMigration() {
+	public function checkLastIndexId() {
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` ('
+			.' `item_type`, `item_source`, `item_target`, `share_type`,'
+			.' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
+			.' `file_target`, `token`, `parent`, `expiration`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)');
+		$query->bindValue(1, 'file');
+		$query->bindValue(2, 949);
+		$query->bindValue(3, '/949');
+		$query->bindValue(4, 0);
+		$query->bindValue(5, 'migrate-test-user');
+		$query->bindValue(6, 'migrate-test-owner');
+		$query->bindValue(7, 23);
+		$query->bindValue(8, 1402493312);
+		$query->bindValue(9, 0);
+		$query->bindValue(10, '/migration.txt');
+		$query->bindValue(11, null);
+		$query->bindValue(12, null);
+		$query->bindValue(13, null);
+		$this->assertEquals(1, $query->execute());
 
-		//FIXME fix this test so that we can enable it again
-		$this->markTestIncomplete('Disabled, because of this tests a lot of other tests fail at the moment');
+		$this->assertNotEquals('0', \OC_DB::insertid('*PREFIX*share'));
+
+		// cleanup
+		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share` WHERE `file_target` = ?');
+		$query->bindValue(1, '/migration.txt');
+		$this->assertEquals(1, $query->execute());
+
+	}
+
+	public function testBrokenLastIndexId() {
+
+		// create test table
+		$this->checkLastIndexId();
+		OC_DB::createDbFromStructure(__DIR__ . '/encryption_table.xml');
+		$this->checkLastIndexId();
+	}
+
+	public function testDataMigration() {
 
 		$this->assertTableNotExist('encryption_test');
 
@@ -79,9 +113,6 @@ class Test_Migration extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testDuplicateDataMigration() {
-
-		//FIXME fix this test so that we can enable it again
-		$this->markTestIncomplete('Disabled, because of this tests a lot of other tests fail at the moment');
 
 		// create test table
 		OC_DB::createDbFromStructure(__DIR__ . '/encryption_table.xml');

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -106,6 +106,16 @@ class OC_DB {
 	}
 
 	/**
+	 * The existing database connection is closed and connected again
+	 */
+	public static function reconnect() {
+		if(self::$connection) {
+			self::$connection->close();
+			self::$connection->connect();
+		}
+	}
+
+	/**
 	 * @return \OC\DB\Connection
 	 */
 	static public function getConnection() {

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -24,8 +24,6 @@ class MDB2SchemaManager {
 	 */
 	public function __construct($conn) {
 		$this->conn = $conn;
-		$this->conn->close();
-		$this->conn->connect();
 	}
 
 	/**
@@ -150,6 +148,10 @@ class MDB2SchemaManager {
 			$this->conn->query($sql);
 		}
 		$this->conn->commit();
+
+		if ($this->conn->getDatabasePlatform() instanceof SqlitePlatform) {
+			\OC_DB::reconnect();
+		}
 		return true;
 	}
 }


### PR DESCRIPTION
See https://github.com/owncloud/core/issues/8946#issuecomment-45751508

This commit adds a test case that proves that the last index ID is always returning `0` after an insert whenever `OC_DB::createDbFromStructure()` is called.

You can run the test locally using this command:
`./autotest.sh mysql ../apps/files_encryption/tests/migration.php`

Then you can make it work by commenting out `$this->conn->close()` in the constructor of the `lib/private/db/mdb2schemamanager.php` class.
I think that class probably closes the connection to force transaction closing and make sure we get a clean connection. This has the side effect of breaking the subsequent "last index ID" requests.

This all doesn't make much sense. But this branch can be used to investigate the problem further.

Note that it was the main cause of the failing tests on master.

@icewind1991 @bantu @schiesbn @nickvergessen @bartv2 @DeepDiver1975 
