### PR TITLE
Stable6 fix encryption

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -594,7 +594,7 @@ class Hooks {
 
 			// create destination folder if not exists
 			if (!$view->file_exists(dirname($newShareKeyPath))) {
-				$view->mkdir(dirname($newShareKeyPath), 0750, true);
+				mkdir($view->getLocalFile($newShareKeyPath), 0750, true);
 			}
 
 			$view->rename($oldShareKeyPath, $newShareKeyPath);
@@ -605,7 +605,7 @@ class Hooks {
 
 			// create destination folder if not exists
 			if (!$view->file_exists(dirname($newKeyfilePath))) {
-				$view->mkdir(dirname($newKeyfilePath), 0750, true);
+				mkdir(dirname($view->getLocalFile($newKeyfilePath)), 0750, true);
 			}
 
 			$view->rename($oldKeyfilePath, $newKeyfilePath);

--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -290,19 +290,20 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 			'/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/keyfiles/'
 			. $this->filename . '.key'));
 
-		// make subfolder
+		// make subfolder and sub-subfolder
 		$this->rootView->mkdir('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder);
+		$this->rootView->mkdir('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder . '/' . $this->folder);
 
-		$this->assertTrue($this->rootView->is_dir('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder));
+		$this->assertTrue($this->rootView->is_dir('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder . '/' . $this->folder));
 
 		// move the file out of the shared folder
 		$root = $this->rootView->getRoot();
 		$this->rootView->chroot('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/');
-		$this->rootView->rename($this->filename, '/' . $this->folder . '/' . $this->filename);
+		$this->rootView->rename($this->filename, '/' . $this->folder . '/' . $this->folder . '/' . $this->filename);
 		$this->rootView->chroot($root);
 
 		$this->assertFalse($this->rootView->file_exists('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->filename));
-		$this->assertTrue($this->rootView->file_exists('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder . '/' . $this->filename));
+		$this->assertTrue($this->rootView->file_exists('/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files/' . $this->folder . '/' . $this->folder . '/' . $this->filename));
 
 		// keys should be renamed too
 		$this->assertFalse($this->rootView->file_exists(
@@ -313,10 +314,10 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.key'));
 
 		$this->assertTrue($this->rootView->file_exists(
-			'/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/share-keys/' . $this->folder . '/'
+			'/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/share-keys/' . $this->folder . '/' . $this->folder . '/'
 			. $this->filename . '.' . self::TEST_ENCRYPTION_HOOKS_USER1 . '.shareKey'));
 		$this->assertTrue($this->rootView->file_exists(
-			'/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/keyfiles/' . $this->folder . '/'
+			'/' . self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/keyfiles/' . $this->folder . '/' . $this->folder . '/'
 			. $this->filename . '.key'));
 
 		// cleanup


### PR DESCRIPTION
Should fix rename of encryption keys if sub-subfolder doesn't exists.

see #6411 

Maybe it also fix #8936 
