### PR TITLE
Fixed array_combine for PHP 5.3

### DIFF
--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -55,8 +55,13 @@ class ControllerMethodReflector {
 
 		// extract type parameter information
 		preg_match_all('/@param (?<type>\w+) \$(?<var>\w+)/', $docs, $matches);
-		$this->types = array_combine($matches['var'], $matches['type']);
-
+		// this is just a fix for PHP 5.3 (array_combine raises warning if called with
+		// two empty arrays
+		if($matches['var'] === array() && $matches['type'] === array()) {
+			$this->types = array();
+		} else {
+			$this->types = array_combine($matches['var'], $matches['type']);
+		}
 		// get method parameters
 		foreach ($reflection->getParameters() as $param) {
 			if($param->isOptional()) {


### PR DESCRIPTION
@MorrisJobke I picked your fix from https://github.com/owncloud/core/pull/8915/files#diff-70d328f9886bee8f9168251246746875R58 to fix the memory leak in PHP 5.3.

Fixes https://github.com/owncloud/core/issues/8813

Please review @Raydiation @MorrisJobke @icewind1991 
