### PR TITLE
drastic speedup for nested ldap groups

### DIFF
--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -187,12 +187,6 @@ class OC_Group {
 	public static function getUserGroups($uid) {
 		$user = self::$userManager->get($uid);
 		if ($user) {
-			/*$groups = self::getManager()->getUserGroups($user);
-			$groupIds = array();
-			foreach ($groups as $group) {
-				$groupIds[] = $group->getGID();
-			}
-			return $groupIds;*/
 			return self::getManager()->getUserGroupIds($user);
 		} else {
 			return array();

--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -187,12 +187,13 @@ class OC_Group {
 	public static function getUserGroups($uid) {
 		$user = self::$userManager->get($uid);
 		if ($user) {
-			$groups = self::getManager()->getUserGroups($user);
+			/*$groups = self::getManager()->getUserGroups($user);
 			$groupIds = array();
 			foreach ($groups as $group) {
 				$groupIds[] = $group->getGID();
 			}
-			return $groupIds;
+			return $groupIds;*/
+			return self::getManager()->getUserGroupIds($user);
 		} else {
 			return array();
 		}

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -182,6 +182,18 @@ class Manager extends PublicEmitter {
 		$this->cachedUserGroups[$uid] = array_values($groups);
 		return $this->cachedUserGroups[$uid];
 	}
+	/**
+	 * @param \OC\User\User $user
+	 * @return array with group names
+	 */
+	public function getUserGroupIds($user) {
+		$groupIds = array();
+		foreach ($this->backends as $backend) {
+			$groupIds = array_merge($groupIds,$backend->getUserGroups($user->getUID()));
+			
+		}
+		return $groupIds;
+	}
 
 	/**
 	 * get a list of all display names in a group

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -189,7 +189,7 @@ class Manager extends PublicEmitter {
 	public function getUserGroupIds($user) {
 		$groupIds = array();
 		foreach ($this->backends as $backend) {
-			$groupIds = array_merge($groupIds,$backend->getUserGroups($user->getUID()));
+			$groupIds = array_merge($groupIds, $backend->getUserGroups($user->getUID()));
 			
 		}
 		return $groupIds;


### PR DESCRIPTION
Changes a function call in getUserGroups to only retrieve group ids instead of objects.
this change significantly improves performance when using owncloud with many groups, e.g. nested ldap hierarchy (1.2.840.113556.1.4.1941), since getUserGroups gets called in oc_share::getItems, which is needed for every page request.
in my particular case, it took more than 10s to load the calendar page and more than 6s to load the file page.
this was in an environment with 100 user groups (nested) per user. The performance was bad due to the following call stack:
self::getManager()->getUserGroups($user)
- getGroupObject() (executed for every group!)
  - groupExists() (resulting in many ldap-requests)
    since the groups are loaded from ldap, it is unnecessary to check whether the group exists or not.
    This contribution is under MIT licence.
