### PR TITLE
LDAP Wizard: get correct total no of users, groups and complete list of groups on big setups

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1028,11 +1028,11 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @brief combines the input filters with AND
+	 * combines the input filters with OR
 	 * @param $filters array, the filters to connect
 	 * @returns the combined filter
 	 *
-	 * Combines Filter arguments with AND
+	 * Combines Filter arguments with OR
 	 */
 	public function combineFilterWithOr($filters) {
 		return $this->combineFilter($filters, '|');

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -724,6 +724,18 @@ class Access extends LDAPUtility {
 	}
 
 	/**
+	 * returns the number of available groups
+	 * @param string $filter the LDAP search filter
+	 * @param string[] $attr optional
+	 * @param int|null $limit
+	 * @param int|null $offset
+	 * @return int|bool
+	 */
+	public function countGroups($filter, $attr = array('dn'), $limit = null, $offset = null) {
+		return $this->count($filter, $this->connection->ldapBaseGroups, $attr, $limit, $offset);
+	}
+
+	/**
 	 * @brief prepares and executes an LDAP search operation
 	 * @param $filter the LDAP filter for the search
 	 * @param $base an array containing the LDAP subtree(s) that shall be searched

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -43,8 +43,9 @@ class Connection extends LDAPUtility {
 
 	/**
 	 * @brief Constructor
-	 * @param $configPrefix a string with the prefix for the configkey column (appconfig table)
-	 * @param $configID a string with the value for the appid column (appconfig table) or null for on-the-fly connections
+	 * @param \OCA\user_ldap\lib\ILDAPWrapper $ldap
+	 * @param string $configPrefix a string with the prefix for the configkey column (appconfig table)
+	 * @param string|null $configID a string with the value for the appid column (appconfig table) or null for on-the-fly connections
 	 */
 	public function __construct(ILDAPWrapper $ldap, $configPrefix = '', $configID = 'user_ldap') {
 		parent::__construct($ldap);

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -41,6 +41,8 @@ class Connection extends LDAPUtility {
 
 	protected $doNotValidate = false;
 
+	protected $ignoreValidation = false;
+
 	/**
 	 * @brief Constructor
 	 * @param \OCA\user_ldap\lib\ILDAPWrapper $ldap
@@ -106,6 +108,16 @@ class Connection extends LDAPUtility {
 			}
 			$this->validateConfiguration();
 		}
+	}
+
+	/**
+	 * sets whether the result of the configuration validation shall
+	 * be ignored when establishing the connection. Used by the Wizard
+	 * in early configuration state.
+	 * @param bool $state
+	 */
+	public function setIgnoreValidation($state) {
+		$this->ignoreValidation = (bool)$state;
 	}
 
 	/**
@@ -441,7 +453,7 @@ class Connection extends LDAPUtility {
 		if(!$phpLDAPinstalled) {
 			return false;
 		}
-		if(!$this->configured) {
+		if(!$this->ignoreValidation && !$this->configured) {
 			\OCP\Util::writeLog('user_ldap',
 								'Configuration is invalid, cannot connect',
 								\OCP\Util::WARN);

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -904,14 +904,12 @@ class Wizard extends LDAPUtility {
 	 * specified attribute
 	 * @param $filters array, the filters that shall be used in the search
 	 * @param $attr the attribute of which a list of values shall be returned
-	 * @param $lfw bool, whether the last filter is a wildcard which shall not
-	 * be processed if there were already findings, defaults to true
 	 * @param $maxF string. if not null, this variable will have the filter that
 	 * yields most result entries
 	 * @return mixed, an array with the values on success, false otherwise
 	 *
 	 */
-	public function cumulativeSearchOnAttribute($filters, $attr, $lfw = true, $dnReadLimit = 3, &$maxF = null) {
+	public function cumulativeSearchOnAttribute($filters, $attr, $dnReadLimit = 3, &$maxF = null) {
 		$dnRead = array();
 		$foundItems = array();
 		$maxEntries = 0;
@@ -929,7 +927,7 @@ class Wizard extends LDAPUtility {
 			$lastFilter = $filters[count($filters)-1];
 		}
 		foreach($filters as $filter) {
-			if($lfw && $lastFilter === $filter && count($foundItems) > 0) {
+			if($lastFilter === $filter && count($foundItems) > 0) {
 				//skip when the filter is a wildcard and results were found
 				continue;
 			}
@@ -998,16 +996,11 @@ class Wizard extends LDAPUtility {
 
 		//how deep to dig?
 		//When looking for objectclasses, testing few entries is sufficient,
-		//when looking for group we need to get all names, though.
-		if(strtolower($attr) === 'objectclass') {
-			$dig = 3;
-		} else {
-			$dig = 0;
-		}
+		$dig = 3;
 
 		$availableFeatures =
 			$this->cumulativeSearchOnAttribute($objectclasses, $attr,
-											   true, $dig, $maxEntryObjC);
+											   $dig, $maxEntryObjC);
 		if(is_array($availableFeatures)
 		   && count($availableFeatures) > 0) {
 			natcasesort($availableFeatures);

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -91,7 +91,6 @@ class Wizard extends LDAPUtility {
 	}
 
 	public function countGroups() {
-		$base = $this->configuration->ldapBase[0];
 		$filter = $this->configuration->ldapGroupFilter;
 
 		if(empty($filter)) {
@@ -116,7 +115,6 @@ class Wizard extends LDAPUtility {
 	}
 
 	public function countUsers() {
-		$base = $this->configuration->ldapBase[0];
 		$filter = $this->configuration->ldapUserFilter;
 
 		$usersTotal = $this->countEntries($filter, 'users');
@@ -277,6 +275,7 @@ class Wizard extends LDAPUtility {
 		$obclasses = array('posixGroup', 'group', 'zimbraDistributionList', 'groupOfNames');
 		$ldapAccess = $this->getAccess();
 
+		$filterParts = array();
 		foreach($obclasses as $obclass) {
 			$filterParts[] = 'objectclass='.$obclass;
 		}

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -1072,6 +1072,8 @@ class Wizard extends LDAPUtility {
 	private function getAccess() {
 		$con = new Connection($this->ldap, '', null);
 		$con->setConfiguration($this->configuration->getConfiguration());
+		$con->ldapConfigurationActive = true;
+		$con->setIgnoreValidation(true);
 		$ldapAccess = new Access($con, $this->ldap);
 		return $ldapAccess;
 	}

--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -127,7 +127,7 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 
 		# The following expectations are the real test #
 		$filters = array('f1', 'f2', '*');
-		$wizard->cumulativeSearchOnAttribute($filters, 'cn', true, 5);
+		$wizard->cumulativeSearchOnAttribute($filters, 'cn', 5);
 		unset($uidnumber);
 	}
 
@@ -203,7 +203,7 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 
 		# The following expectations are the real test #
 		$filters = array('f1', 'f2', '*');
-		$wizard->cumulativeSearchOnAttribute($filters, 'cn', true, 0);
+		$wizard->cumulativeSearchOnAttribute($filters, 'cn', 0);
 		unset($uidnumber);
 	}
 


### PR DESCRIPTION
How to test: 
- have an OpenLDAP with a soft sizeLimit of 500 and a hard sizeLimit of 2000. (works for AD, too, only it does not have a hard limit by default). 
- have 1700 of both users and groups
- use the wizard to configure the LDAP server
- on the User Filter tab the amount of found users is shown in the lower left
  - before: 500
  - now: 1700
- on the Group Filter tab select the proper object class. The amount of found users is shown in the lower left
  - before: 500
  - now: 1700
- on the Group Filter Tab the Group multiselect box shows
  - before:  500 groups
  - now all: 1700 groups

It also fixes what is resolved in #8975 and thus replaces that PR.

Please test/review @PVince81 @ser72 @bboule @Xenopathic  @icewind1991 or others
