### PR TITLE
Added check and cleanup for storage/filecache

### DIFF
--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -41,6 +41,12 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 	}
 
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		if ($this->cleanStorages() && $this->isShowSuiteWarning()) {
+			printf("TestSuite '%s': Did not clean up storages\n", $suite->getName());
+		}
+		if ($this->cleanFileCache() && $this->isShowSuiteWarning()) {
+			printf("TestSuite '%s': Did not clean up file cache\n", $suite->getName());
+		}
 		if ($this->cleanStrayDataFiles() && $this->isShowSuiteWarning()) {
 			printf("TestSuite '%s': Did not clean up data dir\n", $suite->getName());
 		}
@@ -111,6 +117,26 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 			return true;
 		}
 
+		return false;
+	}
+
+	private function cleanStorages() {
+		$sql = 'DELETE FROM `*PREFIX*storages`';
+		$query = \OC_DB::prepare( $sql );
+		$result = $query->execute();
+		if ($result > 0) {
+			return true;
+		}
+		return false;
+	}
+
+	private function cleanFileCache() {
+		$sql = 'DELETE FROM `*PREFIX*filecache`';
+		$query = \OC_DB::prepare( $sql );
+		$result = $query->execute();
+		if ($result > 0) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Some tests don't clean up the file cache and sometimes entries are
reused by mistake in subsequent test suites.

This cleans up the file cache and storage after every test suite and
also shows an annoying warning.

Please review @Raydiation @schiesbn @icewind1991 

The warnings should help find out what tests do not clean up properly.
I recently found out that one such test is breaking PHP 5.3 + sqlite tests.
Let's see if they'd pass here.
