### PR TITLE
LDAP: fix background job, fixes #8995

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -469,7 +469,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		}
 
 		//if group really still exists, we will be able to read its objectclass
-		$objcs = $this->access->readAttribute($dn, 'objectclass');
+		$objcs = $this->access->readAttribute($dn, '');
 		if(!$objcs || empty($objcs)) {
 			$this->access->connection->writeToCache('groupExists'.$gid, false);
 			return false;

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -469,8 +469,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		}
 
 		//if group really still exists, we will be able to read its objectclass
-		$objcs = $this->access->readAttribute($dn, '');
-		if(!$objcs || empty($objcs)) {
+		if(!is_array($this->access->readAttribute($dn, ''))) {
 			$this->access->connection->writeToCache('groupExists'.$gid, false);
 			return false;
 		}

--- a/apps/user_ldap/lib/jobs.php
+++ b/apps/user_ldap/lib/jobs.php
@@ -160,8 +160,14 @@ class Jobs extends \OC\BackgroundJob\TimedJob {
 		$ldapWrapper = new LDAP();
 		if(count($configPrefixes) === 1) {
 			//avoid the proxy when there is only one LDAP server configured
+			$userManager = new user\Manager(
+				\OC::$server->getConfig(),
+				new FilesystemHelper(),
+				new LogWrapper(),
+				\OC::$server->getAvatarManager(),
+				new \OCP\Image());
 			$connector = new Connection($ldapWrapper, $configPrefixes[0]);
-			$ldapAccess = new Access($connector, $ldapWrapper);
+			$ldapAccess = new Access($connector, $ldapWrapper, $userManager);
 			self::$groupBE = new \OCA\user_ldap\GROUP_LDAP($ldapAccess);
 		} else {
 			self::$groupBE = new \OCA\user_ldap\Group_Proxy($configPrefixes, $ldapWrapper);


### PR DESCRIPTION
A parameter was missing to instantiate Access in the background job. 

To test:
- have LDAP configured, but with only one active server configuration!
- run cron.php (mind interval  check, temporarily set it to  0 in https://github.com/owncloud/core/blob/61f6ca25a8f1430a4bc881388caa091a4de040c0/apps/user_ldap/lib/jobs.php#L68)
  - before: error as described in https://github.com/owncloud/core/issues/8995
  - after: works 

Please test/review @paszczus @PVince81 @Xenopathic or others, ty
