### PR TITLE
[stable6] Fix public download link when zip download is disabled

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -163,13 +163,18 @@ var FileActions = {
 };
 
 $(document).ready(function () {
+	var hasDownloadAction = false;
+	var downloadScope;
 	if ($('#allowZipDownload').val() == 1) {
-		var downloadScope = 'all';
+		downloadScope = 'all';
 	} else {
-		var downloadScope = 'file';
+		downloadScope = 'file';
 	}
 
-	if (typeof disableDownloadActions == 'undefined' || !disableDownloadActions) {
+	hasDownloadAction = FileActions.actions[downloadScope] && FileActions.actions[downloadScope].Download;
+
+	// do not override download action if it exists (might have been registered by an app already)
+	if ((typeof disableDownloadActions == 'undefined' || !disableDownloadActions) && !hasDownloadAction) {
 		FileActions.register(downloadScope, 'Download', OC.PERMISSION_READ, function () {
 			return OC.imagePath('core', 'actions/download');
 		}, function (filename) {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -25,13 +25,17 @@ $(document).ready(function() {
 				window.location = $(tr).find('a.name').attr('href');
 			}
 		});
-		FileActions.register('file', 'Download', OC.PERMISSION_READ, '', function(filename) {
+		FileActions.register('file', 'Download', OC.PERMISSION_READ, function() {
+			return OC.imagePath('core', 'actions/download');
+		}, function(filename) {
 			var tr = FileList.findFileEl(filename);
 			if (tr.length > 0) {
 				window.location = $(tr).find('a.name').attr('href');
 			}
 		});
-		FileActions.register('dir', 'Download', OC.PERMISSION_READ, '', function(filename) {
+		FileActions.register('dir', 'Download', OC.PERMISSION_READ, function() {
+			return OC.imagePath('core', 'actions/download');
+		}, function(filename) {
 			var tr = FileList.findFileEl(filename);
 			if (tr.length > 0) {
 				window.location = $(tr).find('a.name').attr('href')+'&download';


### PR DESCRIPTION
Fix public download link when zip download is disabled

Fixes #8590 

When zip download is disabled, the public download action defined in public.js is overridden by the one in fileactions.js because of the JS loading order.

This quick fix prevents the override to happen when a download action is already defined.

There are additional changes that were required to make the download action icon work when registered from the public page.

Please review @MorrisJobke @icewind1991 

@Tie-fighter @ghiamar @enoch85 can you help testing this ?
