### PR TITLE
[stable6] Added max heartbeat interval to prevent integer overflow

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -741,6 +741,8 @@ function initCore() {
 	 * time out
 	 */
 	function initSessionHeartBeat(){
+		// max interval in seconds set to 24 hours
+		var maxInterval = 24 * 3600;
 		// interval in seconds
 		var interval = 900;
 		if (oc_config.session_lifetime) {
@@ -749,6 +751,9 @@ function initCore() {
 		// minimum one minute
 		if (interval < 60) {
 			interval = 60;
+		}
+		if (interval > maxInterval) {
+			interval = maxInterval;
 		}
 		OC.Router.registerLoadedCallback(function(){
 			var url = OC.Router.generate('heartbeat');


### PR DESCRIPTION
When using big session timeout values, the interval value might overflow and cause the setInterval() call to ping the server in a loop without any delay.

This fix adds a maximum ping interval of 24 hours.

Please review @schiesbn @icewind1991 @MorrisJobke 

@ser72 please test this patch
