### PR TITLE
fix mail settings save function - ref #8854

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -344,7 +344,7 @@ if (!$_['internetconnectionworking']) {
 	</table>
 </div>
 
-<div id="mail_settings" class="section">
+<div class="section"><form  id="mail_settings">
 	<h2><?php p($l->t('Email Server'));?></h2>
 
 	<p><?php p($l->t('This is used for sending out notifications.')); ?> <span id="mail_settings_msg" class="msg"></span></p>
@@ -424,7 +424,7 @@ if (!$_['internetconnectionworking']) {
 	<em><?php p($l->t( 'Test email settings' )); ?></em>
 	<input type="submit" name="sendtestemail" id="sendtestemail" value="<?php p($l->t( 'Send email' )); ?>"/>
 	<span id="sendtestmail_msg" class="msg"></span>
-</div>
+</form></div>
 
 <div class="section">
 	<h2><?php p($l->t('Log'));?></h2>


### PR DESCRIPTION
Regression. It is not possible to call serialize() on a non form elment. Therefore the serialize of the mail settings just return an empty string and this got saved. This change fixes that.

partial fix of #8854 

Steps to test:
- go to mail settings in admin settings
- change them - wait for the green succes notification
- refresh page -> settings should be saved (not the case for master)

cc @nickvergessen @PVince81 
