### PR TITLE
Fix loading of getid3 library

### DIFF
--- a/lib/private/preview/mp3.php
+++ b/lib/private/preview/mp3.php
@@ -14,8 +14,8 @@ class MP3 extends Provider {
 	}
 
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
-		// if an app also loads getid3 then this will avoid a PHP error when it's loaded
-		// afterwards
+		// if an app also loads getid3 then this will avoid a PHP error when
+		// this method is called
 		if(!class_exists('getid3_exception')) {
 			require_once('getid3/getid3.php');
 		}

--- a/lib/private/preview/mp3.php
+++ b/lib/private/preview/mp3.php
@@ -14,7 +14,11 @@ class MP3 extends Provider {
 	}
 
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
-		require_once('getid3/getid3.php');
+		// if an app also loads getid3 then this will avoid a PHP error when it's loaded
+		// afterwards
+		if(!class_exists('getid3_exception')) {
+			require_once('getid3/getid3.php');
+		}
 
 		$getID3 = new \getID3();
 


### PR DESCRIPTION
- fix issues with music app when app is loaded before the preview generation

Reproduce:
- enable music app (then getid3 library is loaded on app setup)
- upload a mp3 file to invoke the preview generation
- before this fix: no preview shown right after upload
- after this fix: preview is shown right after upload

cc @georgehrke @PVince81 
