### PR TITLE
Load fundamental apps, before any possible customizing app may follow

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -696,6 +696,8 @@ class OC {
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
 				if (!OC_Config::getValue('maintenance', false) && !self::needUpgrade()) {
+					OC_App::loadApps(array('authentication'));
+					OC_App::loadApps(array('filesystem', 'logging'));
 					OC_App::loadApps();
 				}
 				self::checkSingleUserMode();


### PR DESCRIPTION
ac7fb1b2 brought a regression that fundamental apps are not loaded anymore in some circumstances.

Examples:
- LDAP user logs in, but cannot use text editor
- LDAP user logs in first time, First Time Wizard does not show up
  (both described in https://github.com/owncloud/core/issues/8963#issuecomment-46088834)

My fix is just to load the fundamental app types – authentication, then filesystem and logging –  before anything else (as it properly happens in other places, i guess it was just overseen).

@PVince81 @LukasReschke @DeepDiver1975 
