### PR TITLE
simplify security warning on admin page

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -162,8 +162,10 @@ table.grid td.date{
 }
 
 /* ADMIN */
-span.securitywarning {color:#C33; font-weight:bold; }
-span.connectionwarning {color:#933; font-weight:bold; }
+span.securitywarning, span.connectionwarning {
+	color:#C33;
+	font-weight:bold;
+}
 table.shareAPI td { padding-bottom: 0.8em; }
 table.shareAPI input#shareapiExpireAfterNDays {width: 25px;}
 table.shareAPI .indent { padding-left: 2em; }


### PR DESCRIPTION
Simplifies the CSS rules for different warning.

The "no innternet connection warning" and the "non-HTTPS warning" had different color, what just looks ugly. This fix unifies the rules for both CSS classes to one.

@owncloud/designers @wakeup @PVince81 
