### PR TITLE
Do not rename primary key index when renaming table

### DIFF
--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -128,7 +128,13 @@ class Migrator {
 		$indexes = $table->getIndexes();
 		$newIndexes = array();
 		foreach ($indexes as $index) {
-			$indexName = 'oc_' . uniqid(); // avoid conflicts in index names
+			if ($index->isPrimary()) {
+				// do not rename primary key
+				$indexName = $index->getName();
+			} else {
+				// avoid conflicts in index names
+				$indexName = 'oc_' . uniqid();
+			}
 			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}
 

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -119,4 +119,25 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 			$this->assertTrue(true);
 		}
 	}
+
+	public function testAddingPrimaryKeyWithAutoIncrement() {
+		$startSchema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $startSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer');
+		$table->addColumn('name', 'string');
+
+		$endSchema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $endSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer', array('autoincrement' => true));
+		$table->addColumn('name', 'string');
+		$table->setPrimaryKey(array('id'));
+
+		$migrator = $this->getMigrator();
+		$migrator->migrate($startSchema);
+
+		$migrator->checkMigrate($endSchema);
+		$migrator->migrate($endSchema);
+
+		$this->assertTrue(true);
+	}
 }


### PR DESCRIPTION
When the migrator renames a table, for example for upgrade simulation,
it should not rename the primary key to avoid messing up with the diff
because the MySQL Doctrine code expects that index to always be called
"primary".

FYI @icewind1991 

TODO:
- [x] test with Mysql
- [x] test with PostgreSQL
- [x] test with SQLite
- [x] add unit tests
