### PR TITLE
Obviously have to pass the hostname as is when there is no ':' in the hostname

### DIFF
--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -78,12 +78,12 @@ class OC_DB {
 				// Host variable may carry a port or socket.
 				list($host, $portOrSocket) = explode(':', $host, 2);
 				if (ctype_digit($portOrSocket)) {
-					$connectionParams['host'] = $host;
 					$connectionParams['port'] = $portOrSocket;
 				} else {
 					$connectionParams['unix_socket'] = $portOrSocket;
 				}
 			}
+			$connectionParams['host'] = $host;
 			$connectionParams['dbname'] = $name;
 		}
 


### PR DESCRIPTION
When there is no colon in the database hostname, we currently do not pass the hostname on.

Fixes #9066
Regression from #9018
Reverts 73062040e68212ac6e92d36211ca0bef91777589
