### PR TITLE
trusted domains shall not be ignored on autosetup

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -50,6 +50,12 @@ class OC_Setup {
 		$username = htmlspecialchars_decode($options['adminlogin']);
 		$password = htmlspecialchars_decode($options['adminpass']);
 		$datadir = htmlspecialchars_decode($options['directory']);
+		if(    isset($options['trusted_domains'])
+		    && is_array($options['trusted_domains'])) {
+			$trustedDomains = $options['trusted_domains'];
+		} else {
+			$trustedDomains = array(OC_Request::serverHost());
+		}
 
 		if (OC_Util::runningOnWindows()) {
 			$datadir = rtrim(realpath($datadir), '\\');
@@ -65,7 +71,7 @@ class OC_Setup {
 		OC_Config::setValue('passwordsalt', $salt);
 
 		//write the config file
-		OC_Config::setValue('trusted_domains', array(OC_Request::serverHost())); 
+		OC_Config::setValue('trusted_domains', $trustedDomains);
 		OC_Config::setValue('datadirectory', $datadir);
 		OC_Config::setValue('dbtype', $dbtype);
 		OC_Config::setValue('version', implode('.', OC_Util::getVersion()));


### PR DESCRIPTION
We have the mechanism to automatically run setup, when sufficient information is provided in config/autoconfig.php. A $trusted_domains entry however is ignored.

How to test? 
1. Create an autoconfig.php just like a config.php  with specified details on dbtype, dbhost, directory, adminlogin, adminpass, dbuser, dbpass, dbname, trusted_domains. Make sure that the trusted_domains array keeps more information than just the domain/IP under which you will reach your ownCloud :) 
2. Visit the ownCloud web interface, this triggers the autosetup
3.  Check the created config.php. Before applying this, the trusted_domains consists only of the domain you accessed ownCloud with in step 2. After applying this, it trusted_domains will appear as expected.

Needed for UCS, but it is not urgent.

I added the is_array check after testing, i.e. I do another test tomorrow, but it should be fine.

please review @LukasReschke @DeepDiver1975 @PVince81 
