### PR TITLE
Fix many issues with drag and drop upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -346,7 +346,7 @@ OC.Upload = {
 						// noone set update parameters, we set the minimum
 						data.formData = {
 							requesttoken: oc_requesttoken,
-							dir: FileList.getCurrentDirectory(),
+							dir: data.targetDir || FileList.getCurrentDirectory(),
 							file_directory: fileDirectory
 						};
 					}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1649,15 +1649,34 @@
 						data.context.find('td.filesize').text(humanFileSize(size));
 					} else {
 						// only append new file if uploaded into the current folder
-						if (file.directory !== '/' && file.directory !== self.getCurrentDirectory()) {
+						if (file.directory !== self.getCurrentDirectory()) {
+							// Uploading folders actually uploads a list of files
+							// for which the target directory (file.directory) might lie deeper
+							// than the current directory
 
-							var fileDirectory = file.directory.replace('/','').replace(/\/$/, "").split('/');
+							var fileDirectory = file.directory.replace('/','').replace(/\/$/, "");
+							var currentDirectory = self.getCurrentDirectory().replace('/','').replace(/\/$/, "") + '/';
 
-							if (fileDirectory.length === 1) {
+							if (currentDirectory !== '/') {
+								// abort if fileDirectory does not start with current one
+								if (fileDirectory.indexOf(currentDirectory) !== 0) {
+									return;
+								}
+
+								// remove the current directory part
+								fileDirectory = fileDirectory.substr(currentDirectory.length);
+							}
+
+							// only take the first section of the path
+							fileDirectory = fileDirectory.split('/');
+
+							var fd;
+							// if the first section exists / is a subdir
+							if (fileDirectory.length) {
 								fileDirectory = fileDirectory[0];
 
-								// Get the directory
-								var fd = self.findFileEl(fileDirectory);
+								// See whether it is already in the list
+								fd = self.findFileEl(fileDirectory);
 								if (fd.length === 0) {
 									var dir = {
 										name: fileDirectory,
@@ -1667,19 +1686,15 @@
 										size: 0,
 										id: file.parentId
 									};
-									self.add(dir, {insert: true});
+									fd = self.add(dir, {insert: true});
 								}
-							} else {
-								fileDirectory = fileDirectory[0];
+
+								// update folder size
+								size = parseInt(fd.attr('data-size'), 10);
+								size += parseInt(file.size, 10);
+								fd.attr('data-size', size);
+								fd.find('td.filesize').text(OC.Util.humanFileSize(size));
 							}
-
-							fileDirectory = self.findFileEl(fileDirectory);
-
-							// update folder size
-							size = parseInt(fileDirectory.attr('data-size'), 10);
-							size += parseInt(file.size, 10);
-							fileDirectory.attr('data-size', size);
-							fileDirectory.find('td.filesize').text(humanFileSize(size));
 
 							return;
 						}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1561,17 +1561,12 @@
 						dir = dropTarget.data('dir') || '/';
 					}
 
-					// update folder in form
-					data.formData = function() {
-						return [
-							{name: 'dir', value: dir},
-							{name: 'requesttoken', value: oc_requesttoken},
-							{name: 'file_directory', value: data.files[0].relativePath}
-						];
-					};
+					// add target dir
+					data.targetDir = dir;
 				} else {
 					// we are dropping somewhere inside the file list, which will
 					// upload the file to the current directory
+					data.targetDir = self.getCurrentDirectory();
 
 					// cancel uploads to current dir if no permission
 					var isCreatable = (self.getDirectoryPermissions() & OC.PERMISSION_CREATE) !== 0;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1730,20 +1730,6 @@ describe('OCA.Files.FileList tests', function() {
 				return ev;
 			}
 
-			/**
-			 * Convert form data to a flat list
-			 * 
-			 * @param formData form data array as used by jquery.upload
-			 * @return map based on the array's key values
-			 */
-			function decodeFormData(data) {
-				var map = {};
-				_.each(data.formData(), function(entry) {
-					map[entry.name] = entry.value;
-				});
-				return map;
-			}
-
 			beforeEach(function() {
 				// simulate data structure from jquery.upload
 				uploadData = {
@@ -1803,11 +1789,7 @@ describe('OCA.Files.FileList tests', function() {
 				ev = dropOn(fileList.findFileEl('somedir').find('td:eq(2)'), uploadData);
 
 				expect(ev.result).not.toEqual(false);
-				expect(uploadData.formData).toBeDefined();
-				formData = decodeFormData(uploadData);
-				expect(formData.dir).toEqual('/subdir/somedir');
-				expect(formData.file_directory).toEqual('fileToUpload.txt');
-				expect(formData.requesttoken).toBeDefined();
+				expect(uploadData.targetDir).toEqual('/subdir/somedir');
 			});
 			it('drop on a breadcrumb inside the table triggers upload to target folder', function() {
 				var ev, formData;
@@ -1815,11 +1797,7 @@ describe('OCA.Files.FileList tests', function() {
 				ev = dropOn(fileList.$el.find('.crumb:eq(2)'), uploadData);
 
 				expect(ev.result).not.toEqual(false);
-				expect(uploadData.formData).toBeDefined();
-				formData = decodeFormData(uploadData);
-				expect(formData.dir).toEqual('/a/b');
-				expect(formData.file_directory).toEqual('fileToUpload.txt');
-				expect(formData.requesttoken).toBeDefined();
+				expect(uploadData.targetDir).toEqual('/a/b');
 			});
 		});
 	});

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -128,7 +128,7 @@ OCA.Sharing.PublicApp = {
 				data.formData = {
 					requesttoken: $('#publicUploadRequestToken').val(),
 					dirToken: $('#dirToken').val(),
-					subdir: self.fileList.getCurrentDirectory(),
+					subdir: data.targetDir || self.fileList.getCurrentDirectory(),
 					file_directory: fileDirectory
 				};
 			});


### PR DESCRIPTION
Fixes upload.php to return the correct folder to the UI on upload.
Fixes logic to append/update the entry when visible and ignore it when not visible, for both file and folder uploads.

Fixes #8669 Drag external file, drop on breadcrumb when file exists
Fixes #8990 Drag and Drop of a file onto a folder in the file list creates "undefined" subfolder

Please review @nickvergessen @MorrisJobke @DeepDiver1975 @icewind1991 @schiesbn 
