### PR TITLE
[6.0.5] Fix merging of external storage configurations

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -294,18 +294,23 @@ class OC_Mount_Config {
 					$mount['options'] = self::decryptPasswords($mount['options']);
 					// Remove '/$user/files/' from mount point
 					$mountPoint = substr($mountPoint, 13);
-					// Merge the mount point into the current mount points
-					if (isset($system[$mountPoint]) && $system[$mountPoint]['configuration'] == $mount['options']) {
-						$system[$mountPoint]['applicable']['groups']
-							= array_merge($system[$mountPoint]['applicable']['groups'], array($group));
+
+					$config = array(
+						'class' => $mount['class'],
+						'mountpoint' => $mountPoint,
+						'backend' => $backends[$mount['class']]['backend'],
+						'options' => $mount['options'],
+						'applicable' => array('groups' => array($group), 'users' => array()),
+						'status' => self::getBackendStatus($mount['class'], $mount['options'])
+					);
+					$hash = self::makeConfigHash($config);
+					// If an existing config exists (with same class, mountpoint and options)
+					if (isset($system[$hash])) {
+						// add the groups into that config
+						$system[$hash]['applicable']['groups']
+							= array_merge($system[$hash]['applicable']['groups'], array($group));
 					} else {
-						$system[$mountPoint] = array(
-							'class' => $mount['class'],
-							'backend' => $backends[$mount['class']]['backend'],
-							'configuration' => $mount['options'],
-							'applicable' => array('groups' => array($group), 'users' => array()),
-							'status' => self::getBackendStatus($mount['class'], $mount['options'])
-						);
+						$system[$hash] = $config;
 					}
 				}
 			}
@@ -320,23 +325,27 @@ class OC_Mount_Config {
 					$mount['options'] = self::decryptPasswords($mount['options']);
 					// Remove '/$user/files/' from mount point
 					$mountPoint = substr($mountPoint, 13);
-					// Merge the mount point into the current mount points
-					if (isset($system[$mountPoint]) && $system[$mountPoint]['configuration'] == $mount['options']) {
-						$system[$mountPoint]['applicable']['users']
-							= array_merge($system[$mountPoint]['applicable']['users'], array($user));
+					$config = array(
+						'class' => $mount['class'],
+						'mountpoint' => $mountPoint,
+						'backend' => $backends[$mount['class']]['backend'],
+						'options' => $mount['options'],
+						'applicable' => array('groups' => array(), 'users' => array($user)),
+						'status' => self::getBackendStatus($mount['class'], $mount['options'])
+					);
+					$hash = self::makeConfigHash($config);
+					// If an existing config exists (with same class, mountpoint and options)
+					if (isset($system[$hash])) {
+						// add the users into that config
+						$system[$hash]['applicable']['users']
+							= array_merge($system[$hash]['applicable']['users'], array($user));
 					} else {
-						$system[$mountPoint] = array(
-							'class' => $mount['class'],
-							'backend' => $backends[$mount['class']]['backend'],
-							'configuration' => $mount['options'],
-							'applicable' => array('groups' => array(), 'users' => array($user)),
-							'status' => self::getBackendStatus($mount['class'], $mount['options'])
-						);
+						$system[$hash] = $config;
 					}
 				}
 			}
 		}
-		return $system;
+		return array_values($system);
 	}
 
 	/**
@@ -356,11 +365,12 @@ class OC_Mount_Config {
 					$mount['class'] = '\OC\Files\Storage\\'.substr($mount['class'], 15);
 				}
 				$mount['options'] = self::decryptPasswords($mount['options']);
-				// Remove '/uid/files/' from mount point
-				$personal[substr($mountPoint, strlen($uid) + 8)] = array(
+				$personal[] = array(
 					'class' => $mount['class'],
+					// Remove '/uid/files/' from mount point
+					'mountpoint' => substr($mountPoint, strlen($uid) + 8),
 					'backend' => $backends[$mount['class']]['backend'],
-					'configuration' => $mount['options'],
+					'options' => $mount['options'],
 					'status' => self::getBackendStatus($mount['class'], $mount['options'])
 				);
 			}
@@ -694,5 +704,21 @@ class OC_Mount_Config {
 		$cipher = new Crypt_AES(CRYPT_AES_MODE_CBC);
 		$cipher->setKey(\OCP\Config::getSystemValue('passwordsalt'));
 		return $cipher;
+	}
+
+	/**
+	 * Computes a hash based on the given configuration.
+	 * This is mostly used to find out whether configurations
+	 * are the same.
+	 */
+	private static function makeConfigHash($config) {
+		$data = json_encode(
+			array(
+				'c' => $config['class'],
+				'm' => $config['mountpoint'],
+				'o' => $config['options']
+			)
+		);
+		return hash('md5', $data);
 	}
 }

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -16,17 +16,17 @@
 			</thead>
 			<tbody width="100%">
 			<?php $_['mounts'] = array_merge($_['mounts'], array('' => array())); ?>
-			<?php foreach ($_['mounts'] as $mountPoint => $mount): ?>
-				<tr <?php print_unescaped(($mountPoint != '') ? 'class="'.OC_Util::sanitizeHTML($mount['class']).'"' : 'id="addMountPoint"'); ?>>
+			<?php foreach ($_['mounts'] as $mount): ?>
+				<tr <?php print_unescaped(($mount['mountpoint'] !== '') ? 'class="'.OC_Util::sanitizeHTML($mount['class']).'"' : 'id="addMountPoint"'); ?>>
 					<td class="status">
 					<?php if (isset($mount['status'])): ?>
 						<span class="<?php p(($mount['status']) ? 'success' : 'error'); ?>"></span>
 					<?php endif; ?>
 					</td>
 					<td class="mountPoint"><input type="text" name="mountPoint"
-												  value="<?php p($mountPoint); ?>"
+												  value="<?php p($mount['mountpoint']); ?>"
 												  placeholder="<?php p($l->t('Folder name')); ?>" /></td>
-					<?php if ($mountPoint == ''): ?>
+					<?php if ($mount['mountpoint'] == ''): ?>
 						<td class="backend">
 							<select id="selectBackend" data-configurations='<?php print_unescaped(json_encode($_['backends'])); ?>'>
 								<option value="" disabled selected
@@ -41,8 +41,8 @@
 							data-class="<?php p($mount['class']); ?>"><?php p($mount['backend']); ?></td>
 					<?php endif; ?>
 					<td class ="configuration" width="100%">
-						<?php if (isset($mount['configuration'])): ?>
-							<?php foreach ($mount['configuration'] as $parameter => $value): ?>
+						<?php if (isset($mount['options'])): ?>
+							<?php foreach ($mount['options'] as $parameter => $value): ?>
 								<?php if (isset($_['backends'][$mount['class']]['configuration'][$parameter])): ?>
 									<?php $placeholder = $_['backends'][$mount['class']]['configuration'][$parameter]; ?>
 									<?php if (strpos($placeholder, '*') !== false): ?>
@@ -108,7 +108,7 @@
 							</select>
 						</td>
 					<?php endif; ?>
-					<td <?php if ($mountPoint != ''): ?>class="remove"
+					<td <?php if ($mount['mountpoint'] != ''): ?>class="remove"
 						<?php else: ?>style="visibility:hidden;"
 						<?php endif ?>><img alt="<?php p($l->t('Delete')); ?>"
 											title="<?php p($l->t('Delete')); ?>"


### PR DESCRIPTION
This is a backport of https://github.com/owncloud/core/pull/7888

Merging of configurations is whenever the same config is available for
multiple users/groups, in which case the config is considered as a
single one by the UI, and shows multiple users/groups selected.

Fixed merging logic to make sure that class, mount point and options are
the same before merging them.

Fixed merging to work correctly when the same mount point path is used
for separate users and configs. These are now correctly shows in the UI
as separate entries.
