### PR TITLE
Fixed file actions fallback

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -133,6 +133,8 @@
 		display: function (parent, triggerEvent, fileList) {
 			if (!fileList) {
 				console.warn('FileActions.display() MUST be called with a OCA.Files.FileList instance');
+				// using default list instead, which could be wrong
+				fileList = OCA.Files.App.fileList;
 			}
 			this.currentFile = parent;
 			var self = this;
@@ -162,7 +164,7 @@
 
 				event.data.actionFunc(file, {
 					$file: $tr,
-					fileList: fileList || OCA.Files.App.fileList,
+					fileList: fileList,
 					fileActions: self,
 					dir: $tr.attr('data-path') || fileList.getCurrentDirectory()
 				});


### PR DESCRIPTION
Some apps are calling FileActions.display() directly but omit the new
fileList argument.

This fix makes the fileList argument correctly fall back to the default
file list (the one from the "All files" section)

Note that this only happens randomly with the documents app, whenever its own ajax calls return after the file list has already been rendered.

Fixes #9026 

Please review @VicDeo @MorrisJobke
