### PR TITLE
Setup the external share manager in a hook

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -14,15 +14,8 @@ OC::$CLASSPATH['OCA\Files\Share\Proxy'] = 'files_sharing/lib/proxy.php';
 
 \OCP\App::registerAdmin('files_sharing', 'settings-admin');
 
-$externalManager = new \OCA\Files_Sharing\External\Manager(
-	\OC::$server->getDatabaseConnection(),
-	\OC\Files\Filesystem::getMountManager(),
-	\OC\Files\Filesystem::getLoader(),
-	\OC::$server->getUserSession()
-);
-$externalManager->setup();
-
 OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
+OCP\Util::connectHook('OC_Filesystem', 'setup', '\OCA\Files_Sharing\External\Manager', 'setup');
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
 

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -67,7 +67,7 @@ class Manager {
 		}
 	}
 
-	public function setup() {
+	private function setupMounts() {
 		// don't setup server-to-server shares if the file_external app is disabled
 		// FIXME no longer needed if we use the webdav implementation from  core
 		if (\OC_App::isEnabled('files_external') === false) {
@@ -86,6 +86,16 @@ class Manager {
 				$this->mountShare($row);
 			}
 		}
+	}
+
+	public static function setup() {
+		$externalManager = new \OCA\Files_Sharing\External\Manager(
+			\OC::$server->getDatabaseConnection(),
+			\OC\Files\Filesystem::getMountManager(),
+			\OC\Files\Filesystem::getLoader(),
+			\OC::$server->getUserSession()
+		);
+		$externalManager->setupMounts();
 	}
 
 	protected function stripPath($path) {


### PR DESCRIPTION
To make sure the external shares are initialized in the right order and
make sure the session is correctly initialized before, the external
share manager is now set up in a filesystem setup hook.

Fixes #9149 

Please review @schiesbn @icewind1991 
