### PR TITLE
Clear file selection when list is repopulated

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -512,6 +512,8 @@
 
 			this.fileSummary.calculate(filesArray);
 
+			this._selectedFiles = {};
+			this._selectionSummary.clear();
 			this.updateSelectionSummary();
 			$(window).scrollTop(0);
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1368,7 +1368,8 @@ describe('OCA.Files.FileList tests', function() {
 						"Content-Type": "application/json"
 					},
 					JSON.stringify(data)
-			]);
+				]
+			);
 			fileList.changeDirectory('/');
 			fakeServer.respond();
 			expect($('.select-all').prop('checked')).toEqual(false);
@@ -1385,6 +1386,37 @@ describe('OCA.Files.FileList tests', function() {
 			selectedFiles = _.pluck(fileList.getSelectedFiles(), 'name');
 
 			expect(selectedFiles.length).toEqual(41);
+		});
+		describe('clearing the selection', function() {
+			it('clears selected files selected individually calling setFiles()', function() {
+				var selectedFiles;
+
+				fileList.setFiles(generateFiles(0, 41));
+				fileList.$fileList.find('tr:eq(5) input:checkbox:first').click();
+				fileList.$fileList.find('tr:eq(7) input:checkbox:first').click();
+
+				selectedFiles = _.pluck(fileList.getSelectedFiles(), 'name');
+				expect(selectedFiles.length).toEqual(2);
+
+				fileList.setFiles(generateFiles(0, 2));
+
+				selectedFiles = _.pluck(fileList.getSelectedFiles(), 'name');
+				expect(selectedFiles.length).toEqual(0);
+			});
+			it('clears selected files selected with select all when calling setFiles()', function() {
+				var selectedFiles;
+
+				fileList.setFiles(generateFiles(0, 41));
+				$('.select-all').click();
+
+				selectedFiles = _.pluck(fileList.getSelectedFiles(), 'name');
+				expect(selectedFiles.length).toEqual(42);
+
+				fileList.setFiles(generateFiles(0, 2));
+
+				selectedFiles = _.pluck(fileList.getSelectedFiles(), 'name');
+				expect(selectedFiles.length).toEqual(0);
+			});
 		});
 		describe('Selection overlay', function() {
 			it('show delete action according to directory permissions', function() {


### PR DESCRIPTION
When calling FileList.setFiles() the current selection needs to be
cleared.

Fixes #9111 

Please review @MorrisJobke @schiesbn @icewind1991 
