### PR TITLE
Only cache enabled apps when logged in

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -174,6 +174,7 @@ class OC_App {
 		}
 		$appConfig = \OC::$server->getAppConfig();
 		$appStatus = $appConfig->getValues(false, 'enabled');
+		$user = \OC_User::getUser();
 		foreach ($appStatus as $app => $enabled) {
 			if ($app === 'files') {
 				continue;
@@ -181,7 +182,6 @@ class OC_App {
 			if ($enabled === 'yes') {
 				$apps[] = $app;
 			} else if ($enabled !== 'no') {
-				$user = \OC_User::getUser();
 				$groups = json_decode($enabled);
 				if (is_array($groups)) {
 					foreach ($groups as $group) {
@@ -195,7 +195,9 @@ class OC_App {
 		}
 		sort($apps);
 		array_unshift($apps, 'files');
-		self::$enabledAppsCache = $apps;
+		if ($user) {
+			self::$enabledAppsCache = $apps;
+		}
 		return $apps;
 	}
 

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -195,6 +195,9 @@ class OC_App {
 		}
 		sort($apps);
 		array_unshift($apps, 'files');
+		// Only cache the app list, when the user is logged in.
+		// Otherwise we cache the list with disabled apps, although
+		// the apps are enabled for the user after he logged in.
 		if ($user) {
 			self::$enabledAppsCache = $apps;
 		}


### PR DESCRIPTION
This prevents the enabled apps being cached before the user apps are loaded and the groups of the user are known.

Fixes #9154 

cc @DeepDiver1975 @nickvergessen 
