### PR TITLE
Remove warning when deleting all entries

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -7,10 +7,11 @@ OCP\JSON::callCheck();
 
 // Get data
 $dir = stripslashes($_POST["dir"]);
-$files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
 $allFiles = isset($_POST["allfiles"]) ? $_POST["allfiles"] : false;
 if ($allFiles === 'true') {
 	$allFiles = true;
+} else {
+	$files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
 }
 
 // delete all files in dir ?

--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -8,20 +8,16 @@ OCP\JSON::callCheck();
 // Get data
 $dir = stripslashes($_POST["dir"]);
 $allFiles = isset($_POST["allfiles"]) ? $_POST["allfiles"] : false;
-if ($allFiles === 'true') {
-	$allFiles = true;
-} else {
-	$files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
-}
 
 // delete all files in dir ?
-if ($allFiles) {
+if ($allFiles === 'true') {
 	$files = array();
 	$fileList = \OC\Files\Filesystem::getDirectoryContent($dir);
 	foreach ($fileList as $fileInfo) {
 		$files[] = $fileInfo['name'];
 	}
 } else {
+	$files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
 	$files = json_decode($files);
 }
 $filesWithError = '';


### PR DESCRIPTION
When deleting all entries, only "allfiles" is defined but not "file" or
"files", which caused a PHP warning to be logged.
