### PR TITLE
Fix blurring of invalid file name on rename

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1195,9 +1195,20 @@
 				return true;
 			};
 
+			function restore() {
+				input.tipsy('hide');
+				tr.data('renaming',false);
+				form.remove();
+				td.children('a.name').show();
+			}
+
 			form.submit(function(event) {
 				event.stopPropagation();
 				event.preventDefault();
+				if (input.hasClass('error')) {
+					return;
+				}
+
 				try {
 					var newName = input.val();
 					input.tipsy('hide');
@@ -1267,10 +1278,7 @@
 					input.addClass('error');
 				}
 				if (event.keyCode === 27) {
-					input.tipsy('hide');
-					tr.data('renaming',false);
-					form.remove();
-					td.children('a.name').show();
+					restore();
 				}
 			});
 			input.click(function(event) {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -595,6 +595,47 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileList.$fileList.find('input.filename').length).toEqual(0);
 			expect(fileList.$fileList.find('form').length).toEqual(0);
 		});
+		it('Validates the file name', function() {
+			var $input, $tr;
+
+			for (var i = 0; i < testFiles.length; i++) {
+				fileList.add(testFiles[i], {silent: true});
+			}
+
+			// trigger rename prompt
+			fileList.rename('One.txt');
+			$input = fileList.$fileList.find('input.filename');
+			$input.val('Two.jpg');
+
+			// simulate key to trigger validation
+			$input.trigger(new $.Event('keyup', {keyCode: 97}));
+
+			// input is still there with error
+			expect(fileList.$fileList.find('input.filename').length).toEqual(1);
+			expect(fileList.$fileList.find('input.filename').hasClass('error')).toEqual(true);
+
+			// trigger submit does not send server request
+			$input.closest('form').trigger('submit');
+			expect(fakeServer.requests.length).toEqual(0);
+
+			// simulate escape key
+			$input.trigger(new $.Event('keyup', {keyCode: 27}));
+
+			// element is added back with the correct name
+			$tr = fileList.findFileEl('One.txt');
+			expect($tr.length).toEqual(1);
+			expect($tr.find('a .nametext').text().trim()).toEqual('One.txt');
+			expect($tr.find('a.name').is(':visible')).toEqual(true);
+
+			$tr = fileList.findFileEl('Two.jpg');
+			expect($tr.length).toEqual(1);
+			expect($tr.find('a .nametext').text().trim()).toEqual('Two.jpg');
+			expect($tr.find('a.name').is(':visible')).toEqual(true);
+
+			// input and form are gone
+			expect(fileList.$fileList.find('input.filename').length).toEqual(0);
+			expect(fileList.$fileList.find('form').length).toEqual(0);
+		});
 	});
 	describe('Moving files', function() {
 		beforeEach(function() {


### PR DESCRIPTION
When renaming to an existing file name, blurring the field should not
remove it.

This fix keeps the field until escape is pressed instead of replacing it
with a broken empty space.

Fixes https://github.com/owncloud/core/issues/8747 (see steps there)

Please review @icewind1991 @MorrisJobke 
