### PR TITLE
fixes the layout for error messages on the update page

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -622,6 +622,12 @@ label.infield {
 	cursor: pointer;
 }
 
+/* fixes for update page TODO should be fixed some time in a proper way */
+/* this is just for an error while updating the ownCloud instance */
+#body-login .updateProgress .error {
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
 
 /* Alternative Logins */
 #alternative-logins legend { margin-bottom:10px; }


### PR DESCRIPTION
Before:
![error-on-update-page-before](https://cloud.githubusercontent.com/assets/245432/3367863/9d214f7e-fb6a-11e3-9812-c188a03694fb.png)

After:
![error-on-update-page-after](https://cloud.githubusercontent.com/assets/245432/3367862/9a865bc4-fb6a-11e3-8984-488479fe41e0.png)

cc @owncloud/designers 
