### PR TITLE
Sharing fix permissions

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -95,9 +95,9 @@ class Shared_Cache extends Cache {
 				}
 				$data['uid_owner'] = $this->storage->getOwner($file);
 				if (isset($data['permissions'])) {
-					$data['permissions'] &= $this->storage->getPermissions('');
+					$data['permissions'] &= $this->storage->getPermissions($file);
 				} else {
-					$data['permissions'] = $this->storage->getPermissions('');
+					$data['permissions'] = $this->storage->getPermissions($file);
 				}
 				return $data;
 			}
@@ -163,7 +163,7 @@ class Shared_Cache extends Cache {
 				$sourceFolderContent[$key]['path'] = $dir . $c['name'];
 				$sourceFolderContent[$key]['uid_owner'] = $parent['uid_owner'];
 				$sourceFolderContent[$key]['displayname_owner'] = $parent['uid_owner'];
-				$sourceFolderContent[$key]['permissions'] = $sourceFolderContent[$key]['permissions'] & $this->storage->getPermissions('');
+				$sourceFolderContent[$key]['permissions'] = $sourceFolderContent[$key]['permissions'] & $this->storage->getPermissions($dir . $c['name']);
 			}
 
 			return $sourceFolderContent;

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -145,10 +145,9 @@ class Test_Files_Sharing_Permissions extends Test_Files_Sharing_Base {
 		$this->assertEquals(27, $contents[1]['permissions']);
 		$contents = $this->secondView->getDirectoryContent('files/shareddirrestricted');
 		$this->assertEquals('subdir', $contents[0]['name']);
-		$this->assertEquals(7 | \OCP\PERMISSION_DELETE, $contents[0]['permissions']);
+		$this->assertEquals(7, $contents[0]['permissions']);
 		$this->assertEquals('textfile1.txt', $contents[1]['name']);
 		// 3 is correct because create is reserved to folders only
-		// delete permissions are added since mount points can always be deleted
-		$this->assertEquals(3 | \OCP\PERMISSION_DELETE, $contents[1]['permissions']);
+		$this->assertEquals(3, $contents[1]['permissions']);
 	}
 }

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -166,4 +166,35 @@ class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
 		$this->assertTrue($result);
 	}
 
+	function testGetPermissions() {
+		$fileinfoFolder = $this->view->getFileInfo($this->folder);
+
+		$result = \OCP\Share::shareItem('folder', $fileinfoFolder['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 1);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$this->assertTrue(\OC\Files\Filesystem::is_dir($this->folder));
+
+		// for the share root we expect:
+		// the shared permissions (1)
+		// the delete permission (8), to enable unshare
+		// the update permission (2), to allow renaming of the mount point
+		$rootInfo = \OC\Files\Filesystem::getFileInfo($this->folder);
+		$this->assertSame(11, $rootInfo->getPermissions());
+
+		// for the file within the shared folder we expect:
+		// the shared permissions (1)
+		$subfileInfo = \OC\Files\Filesystem::getFileInfo($this->folder . $this->filename);
+		$this->assertSame(1, $subfileInfo->getPermissions());
+
+
+		//cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileinfoFolder['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+	}
+
 }

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -884,8 +884,8 @@ class View {
 							if ($extOnly && $subStorage instanceof \OC\Files\Storage\Shared) {
 								continue;
 							}
-							$subCache = $subStorage->getCache('');
-							$rootEntry = $subCache->get('');
+							$subCache = $subStorage->getCache($internalPath);
+							$rootEntry = $subCache->get($internalPath);
 							$data['size'] += isset($rootEntry['size']) ? $rootEntry['size'] : 0;
 						}
 					}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -884,7 +884,7 @@ class View {
 							if ($extOnly && $subStorage instanceof \OC\Files\Storage\Shared) {
 								continue;
 							}
-							$subCache = $subStorage->getCache($internalPath);
+							$subCache = $subStorage->getCache('');
 							$rootEntry = $subCache->get($internalPath);
 							$data['size'] += isset($rootEntry['size']) ? $rootEntry['size'] : 0;
 						}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -885,7 +885,7 @@ class View {
 								continue;
 							}
 							$subCache = $subStorage->getCache('');
-							$rootEntry = $subCache->get($internalPath);
+							$rootEntry = $subCache->get('');
 							$data['size'] += isset($rootEntry['size']) ? $rootEntry['size'] : 0;
 						}
 					}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -896,7 +896,7 @@ class View {
 			return false;
 		}
 
-		if ($mount instanceof MoveableMount) {
+		if ($mount instanceof MoveableMount && $internalPath === '') {
 			$data['permissions'] |= \OCP\PERMISSION_DELETE | \OCP\PERMISSION_UPDATE;
 		}
 


### PR DESCRIPTION
make sure that we always return the correct permissions.

How to test:
- Create a folder "folder"
- Upload a file to "folder", e.g. "test.txt"
- share the folder with user2, remove all permissions
- login as user2
- the folder should have permissions to delete (unshare) and rename
- navigate to the folder
- file in the folder should only have read permissions (without this patch the file will also have delete and rename permissions)

@icewind1991 please have a look, since this also touches the oc filesystem.
