### PR TITLE
Do not clear URL hash when no external mount params given

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1411,6 +1411,10 @@ OC.Util.History = {
 		if (pos >= 0) {
 			return hash.substr(pos + 1);
 		}
+		if (hash.length) {
+			// remove hash sign
+			return hash.substr(1);
+		}
 		return '';
 	},
 


### PR DESCRIPTION
Whenever external share parameters were passed through the URL hash, the
URL hash will now be cleared.

In other cases, the hash needs to be left alone because it is used as
workaround for the lack of history API in IE8 / IE9

Removed getParamterByName() and use OC.Util.History.parseUrlQuery() that
does the same, including replacing the "+" with spaces.

Fixes #9184 
- [x] test: make sure that server to server sharing mount confirmation still works
