### PR TITLE
Fix test mail behaviour

### DIFF
--- a/settings/admin/controller.php
+++ b/settings/admin/controller.php
@@ -86,7 +86,7 @@ class Controller {
 			$defaults = new \OC_Defaults();
 
 			try {
-				\OC_Mail::send($email, $_POST['user'],
+				\OC_Mail::send($email, \OC_User::getDisplayName(),
 					$l->t('test email settings'),
 					$l->t('If you received this email, the settings seem to be correct.'),
 					\OCP\Util::getDefaultEmailAddress('no-reply'), $defaults->getName());

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -123,10 +123,10 @@ $(document).ready(function(){
 		});
 	});
 
-	$('#sendtestemail').click(function(){
+	$('#sendtestemail').click(function(event){
+		event.preventDefault();
 		OC.msg.startAction('#sendtestmail_msg', t('settings', 'Sending...'));
-		var post = $( "#sendtestemail" ).serialize();
-		$.post(OC.generateUrl('/settings/admin/mailtest'), post, function(data){
+		$.post(OC.generateUrl('/settings/admin/mailtest'), '', function(data){
 			OC.msg.finishedAction('#sendtestmail_msg', data);
 		});
 	});


### PR DESCRIPTION
- ref #8854
- prevent default of "send test mail" button
- drop unused form serialization
- use display name of user for test mail

cc @nickvergessen 
