### PR TITLE
Prevent loading apps in remote when an upgrade is due

### DIFF
--- a/remote.php
+++ b/remote.php
@@ -2,6 +2,15 @@
 
 try {
 	require_once 'lib/base.php';
+
+	if (\OCP\Util::needUpgrade()) {
+		// since the behavior of apps or remotes are unpredictable during
+		// an upgrade, return a 503 directly
+		OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+		OC_Template::printErrorPage('Service unavailable');
+		exit;
+	}
+
 	$path_info = OC_Request::getPathInfo();
 	if ($path_info === false || $path_info === '') {
 		OC_Response::setStatus(OC_Response::STATUS_NOT_FOUND);


### PR DESCRIPTION
remote.php is loading apps here https://github.com/owncloud/core/blob/master/remote.php#L29

If an update is due for these apps, then accessing any remote will automatically update these apps, which is wrong.

This fix makes it return a 503 error code (Service unavailable) in such cases.

In the past such code might have been returned by the WebDAV plugin of the files app, but the behavior can be unpredictable if we let the app auto-update or init itself when an update is due, so it's better to catch this case earlier.

Please review @karlitschek @icewind1991 @LukasReschke @blizzz 
