### PR TITLE
LDAP: Wizard email attribute detection

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -61,6 +61,7 @@ $wizard = new \OCA\user_ldap\lib\Wizard($configuration, $ldapWrapper, $access);
 switch($action) {
 	case 'guessPortAndTLS':
 	case 'guessBaseDN':
+	case 'detectEmailAttribute':
 	case 'determineGroupMemberAssoc':
 	case 'determineUserObjectClasses':
 	case 'determineGroupObjectClasses':

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -39,9 +39,24 @@ if(!isset($_POST['ldap_serverconfig_chooser'])) {
 }
 $prefix = $_POST['ldap_serverconfig_chooser'];
 
-$ldapWrapper = new OCA\user_ldap\lib\LDAP();
+$ldapWrapper = new \OCA\user_ldap\lib\LDAP();
 $configuration = new \OCA\user_ldap\lib\Configuration($prefix);
-$wizard = new \OCA\user_ldap\lib\Wizard($configuration, $ldapWrapper);
+
+$con = new \OCA\user_ldap\lib\Connection($ldapWrapper, '', null);
+$con->setConfiguration($configuration->getConfiguration());
+$con->ldapConfigurationActive = true;
+$con->setIgnoreValidation(true);
+
+$userManager = new \OCA\user_ldap\lib\user\Manager(
+	\OC::$server->getConfig(),
+	new \OCA\user_ldap\lib\FilesystemHelper(),
+	new \OCA\user_ldap\lib\LogWrapper(),
+	\OC::$server->getAvatarManager(),
+	new \OCP\Image());
+
+$access = new \OCA\user_ldap\lib\Access($con, $ldapWrapper, $userManager);
+
+$wizard = new \OCA\user_ldap\lib\Wizard($configuration, $ldapWrapper, $access);
 
 switch($action) {
 	case 'guessPortAndTLS':

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -14,7 +14,7 @@ function LdapFilter(target)  {
 	}
 }
 
-LdapFilter.prototype.compose = function() {
+LdapFilter.prototype.compose = function(callback) {
 	var action;
 
 	if(this.locked) {
@@ -49,6 +49,9 @@ LdapFilter.prototype.compose = function() {
 			} else if(filter.target === 'Group') {
 				LdapWizard.countGroups();
 				LdapWizard.detectGroupMemberAssoc();
+			}
+			if(typeof callback !== 'undefined') {
+				callback();
 			}
 		},
 		function () {

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -340,6 +340,14 @@ var LdapWizard = {
 		LdapWizard._countThings('countUsers');
 	},
 
+	detectEmailAttribute: function() {
+		param = 'action=detectEmailAttribute'+
+				'&ldap_serverconfig_chooser='+
+				encodeURIComponent($('#ldap_serverconfig_chooser').val());
+		//runs in the background, no callbacks necessary
+		LdapWizard.ajax(param, LdapWizard.applyChanges, function(){});
+	},
+
 	detectGroupMemberAssoc: function() {
 		param = 'action=determineGroupMemberAssoc'+
 				'&ldap_serverconfig_chooser='+
@@ -577,7 +585,7 @@ var LdapWizard = {
 	postInitUserFilter: function() {
 		if(LdapWizard.userFilterObjectClassesHasRun &&
 			LdapWizard.userFilterAvailableGroupsHasRun) {
-			LdapWizard.userFilter.compose();
+			LdapWizard.userFilter.compose(LdapWizard.detectEmailAttribute);
 			LdapWizard.countUsers();
 		}
 	},
@@ -619,6 +627,7 @@ var LdapWizard = {
 
 		if(triggerObj.id == 'ldap_userlist_filter') {
 			LdapWizard.countUsers();
+			LdapWizard.detectEmailAttribute();
 		} else if(triggerObj.id == 'ldap_group_filter') {
 			LdapWizard.countGroups();
 			LdapWizard.detectGroupMemberAssoc();
@@ -656,9 +665,12 @@ var LdapWizard = {
 		LdapWizard._save($('#'+originalObj)[0], $.trim(values));
 		if(originalObj == 'ldap_userfilter_objectclass'
 		   || originalObj == 'ldap_userfilter_groups') {
-			LdapWizard.userFilter.compose();
+			LdapWizard.userFilter.compose(LdapWizard.detectEmailAttribute);
 			//when user filter is changed afterwards, login filter needs to
 			//be adjusted, too
+			if(!LdapWizard.loginFilter) {
+				LdapWizard.initLoginFilter();
+			}
 			LdapWizard.loginFilter.compose();
 		} else if(originalObj == 'ldap_loginfilter_attributes') {
 			LdapWizard.loginFilter.compose();
@@ -720,7 +732,7 @@ var LdapWizard = {
 			LdapWizard._save({ id: modeKey }, LdapWizard.filterModeAssisted);
 			if(moc.indexOf('user') >= 0) {
 				LdapWizard.blacklistRemove('ldap_userlist_filter');
-				LdapWizard.userFilter.compose();
+				LdapWizard.userFilter.compose(LdapWizard.detectEmailAttribute);
 			} else {
 				LdapWizard.blacklistRemove('ldap_group_filter');
 				LdapWizard.groupFilter.compose();

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -155,7 +155,7 @@ class Wizard extends LDAPUtility {
 	 * detects the most often used email attribute for users applying to the
 	 * user list filter. If a setting is already present that returns at least
 	 * one hit, the detection will be canceled.
-	 * @return bool|string
+	 * @return WizardResult|bool
 	 */
 	public function detectEmailAttribute() {
 		if(!$this->checkRequirements(array('ldapHost',
@@ -197,7 +197,7 @@ class Wizard extends LDAPUtility {
 			}
 		}
 
-		return $winner;
+		return $this->result;
 	}
 
 	/**
@@ -820,7 +820,6 @@ class Wizard extends LDAPUtility {
 				if(empty($filter)) {
 					$filter = '(objectclass=*)';
 				}
-				$this->detectEmailAttribute();
 				break;
 
 			case self::LFILTER_GROUP_LIST:

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -172,6 +172,9 @@ class Wizard extends LDAPUtility {
 			if($count > 0) {
 				return false;
 			}
+			$writeLog = true;
+		} else {
+			$writeLog = false;
 		}
 
 		$emailAttributes = array('mail', 'mailPrimaryAddress');
@@ -187,6 +190,11 @@ class Wizard extends LDAPUtility {
 
 		if($winner !== '') {
 			$this->result->addChange('ldap_email_attr', $winner);
+			if($writeLog) {
+				\OCP\Util::writeLog('user_ldap', 'The mail attribute has ' .
+					'automatically been reset, because the original value ' .
+					'did not return any results.', \OCP\Util::INFO);
+			}
 		}
 
 		return $winner;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -155,7 +155,7 @@ class Wizard extends LDAPUtility {
 	 * detects the most often used email attribute for users applying to the
 	 * user list filter. If a setting is already present that returns at least
 	 * one hit, the detection will be canceled.
-	 * @return bool
+	 * @return bool|string
 	 */
 	public function detectEmailAttribute() {
 		if(!$this->checkRequirements(array('ldapHost',
@@ -189,6 +189,7 @@ class Wizard extends LDAPUtility {
 			$this->result->addChange('ldap_email_attr', $winner);
 		}
 
+		return $winner;
 	}
 
 	/**

--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -274,8 +274,9 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 				var_dump($filter);
 			}));
 
-		$resultAttribute = $wizard->detectEmailAttribute();
-		$this->assertSame('mailPrimaryAddress', $resultAttribute);
+		$result = $wizard->detectEmailAttribute()->getResultArray();
+		$this->assertSame('mailPrimaryAddress',
+			$result['changes']['ldap_email_attr']);
 	}
 
 	public function testDetectEmailAttributeFind() {
@@ -312,8 +313,9 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 				var_dump($filter);
 			}));
 
-		$resultAttribute = $wizard->detectEmailAttribute();
-		$this->assertSame('mailPrimaryAddress', $resultAttribute);
+		$result = $wizard->detectEmailAttribute()->getResultArray();
+		$this->assertSame('mailPrimaryAddress',
+			$result['changes']['ldap_email_attr']);
 	}
 
 	public function testDetectEmailAttributeFindNothing() {
@@ -350,8 +352,8 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 				var_dump($filter);
 			}));
 
-		$resultAttribute = $wizard->detectEmailAttribute();
-		$this->assertSame('', $resultAttribute);
+		$result = $wizard->detectEmailAttribute();
+		$this->assertSame(false, $result->hasChanges());
 	}
 
 	public function testCumulativeSearchOnAttributeSkipReadDN() {

--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -43,9 +43,11 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function getWizardAndMocks() {
-		static $conMethods;
+		static $confMethods;
+		static $connMethods;
+		static $accMethods;
 
-		if(is_null($conMethods)) {
+		if(is_null($confMethods)) {
 			$confMethods = get_class_methods('\OCA\user_ldap\lib\Configuration');
 			$connMethods = get_class_methods('\OCA\user_ldap\lib\Connection');
 			$accMethods  = get_class_methods('\OCA\user_ldap\lib\Access');

--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -46,13 +46,24 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 		static $conMethods;
 
 		if(is_null($conMethods)) {
-			$conMethods = get_class_methods('\OCA\user_ldap\lib\Configuration');
+			$confMethods = get_class_methods('\OCA\user_ldap\lib\Configuration');
+			$connMethods = get_class_methods('\OCA\user_ldap\lib\Connection');
+			$accMethods  = get_class_methods('\OCA\user_ldap\lib\Access');
 		}
 		$lw   = $this->getMock('\OCA\user_ldap\lib\ILDAPWrapper');
 		$conf = $this->getMock('\OCA\user_ldap\lib\Configuration',
-							   $conMethods,
+							   $confMethods,
 							   array($lw, null, null));
-		return array(new Wizard($conf, $lw), $conf, $lw);
+
+		$connector = $this->getMock('\OCA\user_ldap\lib\Connection',
+			$connMethods, array($lw, null, null));
+		$um = $this->getMockBuilder('\OCA\user_ldap\lib\user\Manager')
+					->disableOriginalConstructor()
+					->getMock();
+		$access = $this->getMock('\OCA\user_ldap\lib\Access',
+			$accMethods, array($connector, $lw, $um));
+
+		return array(new Wizard($conf, $lw, $access), $conf, $lw);
 	}
 
 	private function prepareLdapWrapperForConnections(&$ldap) {

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -85,7 +85,7 @@ class OC_Log_Owncloud {
 			}
 			$entry = json_encode($entry);
 			$handle = @fopen(self::$logFile, 'a');
-// 			@chmod(self::$logFile, 0640);
+			@chmod(self::$logFile, 0640);
 			if ($handle) {
 				fwrite($handle, $entry."\n");
 				fclose($handle);

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -85,7 +85,7 @@ class OC_Log_Owncloud {
 			}
 			$entry = json_encode($entry);
 			$handle = @fopen(self::$logFile, 'a');
-			@chmod(self::$logFile, 0640);
+// 			@chmod(self::$logFile, 0640);
 			if ($handle) {
 				fwrite($handle, $entry."\n");
 				fclose($handle);


### PR DESCRIPTION
This PR introduces auto-detection of the mail  attribute. #7895 

How to test?
1. Have an LDAP with mail or mailPrimaryAddress set for at least one user
2. Go to the wizard, configure the first tab, then go to the next tab
3. Upon automatically creating the user list filter the email attribute will be detected. You can see it in the Advanced tab or via ./occ ldap:show-config [configPrefix]

Trigger: user list filter created/changed
Condition: email attribute is not configured OR (it is configured, but the search results in 0 findings)

How does the detection work? 
- Define email attributes (mail, mailPrimaryAddress)
- AND-combine user list filter with ($attrname=*)
- Count results for each attribute
- Take the one with most results

Other criteria:
- If a set attribute is replaced, drop a log message

Q: Can admin still configure it manually?
A: Configuration field stays in Advanced tab. Custom setting will override wizard detection, as long as it is valid, i.e. returns at least one result. OTOH it means that if you have an email field in LDAP it will not be possible to live without set email attribute.

Please test/review @PVince81 @Xenopathic @MorrisJobke, cc @MTRichards 
