### PR TITLE
[stable6] Fix trashbin warnings in logs

### DIFF
--- a/apps/files_trashbin/js/trash.js
+++ b/apps/files_trashbin/js/trash.js
@@ -1,6 +1,11 @@
 
 $(document).ready(function() {
 
+	Files.updateStorageStatistics = function() {
+		// no op because the trashbin doesn't have
+		// storage info like free space / used space
+	};
+
 	if (typeof FileActions !== 'undefined') {
 		FileActions.register('all', 'Restore', OC.PERMISSION_READ, OC.imagePath('core', 'actions/history'), function(filename) {
 			var tr = FileList.findFileEl(filename);

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -51,6 +51,7 @@ class Helper
 			$i['name'] = $r['id'];
 			$i['date'] = \OCP\Util::formatDate($r['timestamp']);
 			$i['timestamp'] = $r['timestamp'];
+			$i['etag'] = $i['timestamp']; // dummy etag
 			$i['mimetype'] = $r['mime'];
 			$i['type'] = $r['type'];
 			if ($i['type'] === 'file') {


### PR DESCRIPTION
This fixes two things:
1) etag warnings in logs: https://github.com/owncloud/core/issues/6400
2) Backports https://github.com/owncloud/core/pull/7872 to avoid yet another warning about `disk_free_space`

@enoch85 can you help testing both cases ? :smile: 
See the referenced links for reproduction steps.

@karlitschek fixes for stable6 only, master is ok as the code is very different there.
