### PR TITLE
Routing: Dont strip the s from the resource id to prevent possible weird behavior with irregular english plural nouns

### DIFF
--- a/lib/private/appframework/routing/routeconfig.php
+++ b/lib/private/appframework/routing/routeconfig.php
@@ -122,14 +122,13 @@ class RouteConfig {
 		foreach ($resources as $resource => $config) {
 
 			// the url parameter used as id to the resource
-			$resourceId = $this->buildResourceId($resource);
 			foreach($actions as $action) {
 				$url = $config['url'];
 				$method = $action['name'];
 				$verb = isset($action['verb']) ? strtoupper($action['verb']) : 'GET';
 				$collectionAction = isset($action['on-collection']) ? $action['on-collection'] : false;
 				if (!$collectionAction) {
-					$url = $url . '/' . $resourceId;
+					$url = $url . '/{id}';
 				}
 				if (isset($action['url-postfix'])) {
 					$url = $url . '/' . $action['url-postfix'];
@@ -166,15 +165,6 @@ class RouteConfig {
 	 */
 	private function buildActionName($action) {
 		return $this->underScoreToCamelCase($action);
-	}
-
-	/**
-	 * Generates the id used in the url part o the route url
-	 * @param string $resource
-	 * @return string
-	 */
-	private function buildResourceId($resource) {
-		return '{' . $this->underScoreToCamelCase($resource) . 'Id}';
 	}
 
 	/**

--- a/lib/private/appframework/routing/routeconfig.php
+++ b/lib/private/appframework/routing/routeconfig.php
@@ -88,7 +88,7 @@ class RouteConfig {
 							->method($verb)
 							->action($handler);
 
-			// optionally register requirements for route. This is used to 
+			// optionally register requirements for route. This is used to
 			// tell the route parser how url parameters should be matched
 			if(array_key_exists('requirements', $simpleRoute)) {
 				$router->requirements($simpleRoute['requirements']);
@@ -174,7 +174,7 @@ class RouteConfig {
 	 * @return string
 	 */
 	private function buildResourceId($resource) {
-		return '{'.$this->underScoreToCamelCase(rtrim($resource, 's')).'Id}';
+		return '{' . $this->underScoreToCamelCase($resource) . 'Id}';
 	}
 
 	/**

--- a/tests/lib/appframework/routing/RoutingTest.php
+++ b/tests/lib/appframework/routing/RoutingTest.php
@@ -6,7 +6,7 @@ use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\routing\RouteConfig;
 
 
-class RouteConfigTest extends \PHPUnit_Framework_TestCase
+class RoutingTest extends \PHPUnit_Framework_TestCase
 {
 
 	public function testSimpleRoute()
@@ -76,16 +76,16 @@ class RouteConfigTest extends \PHPUnit_Framework_TestCase
 
 	public function testResource()
 	{
-		$routes = array('resources' => array('accounts' => array('url' => '/accounts')));
+		$routes = array('resources' => array('account' => array('url' => '/accounts')));
 
-		$this->assertResource($routes, 'accounts', '/accounts', 'AccountsController', 'accountId');
+		$this->assertResource($routes, 'account', '/accounts', 'AccountController', 'accountId');
 	}
 
 	public function testResourceWithUnderScoreName()
 	{
 		$routes = array('resources' => array('admin_accounts' => array('url' => '/admin/accounts')));
 
-		$this->assertResource($routes, 'admin_accounts', '/admin/accounts', 'AdminAccountsController', 'adminAccountId');
+		$this->assertResource($routes, 'admin_accounts', '/admin/accounts', 'AdminAccountsController', 'adminAccountsId');
 	}
 
 	/**

--- a/tests/lib/appframework/routing/RoutingTest.php
+++ b/tests/lib/appframework/routing/RoutingTest.php
@@ -78,14 +78,14 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
 	{
 		$routes = array('resources' => array('account' => array('url' => '/accounts')));
 
-		$this->assertResource($routes, 'account', '/accounts', 'AccountController', 'accountId');
+		$this->assertResource($routes, 'account', '/accounts', 'AccountController', 'id');
 	}
 
 	public function testResourceWithUnderScoreName()
 	{
 		$routes = array('resources' => array('admin_accounts' => array('url' => '/admin/accounts')));
 
-		$this->assertResource($routes, 'admin_accounts', '/admin/accounts', 'AdminAccountsController', 'adminAccountsId');
+		$this->assertResource($routes, 'admin_accounts', '/admin/accounts', 'AdminAccountsController', 'id');
 	}
 
 	/**


### PR DESCRIPTION
# Addresses the following problem:

If a user creates a resource **accounts** for instance, the **s** at the end is stripped for the id paramter so the id would become **{accountId}** in the url. This can lead to a number of various weird behaviors if the plural is not regular: e.g.:
- **knives** -> **kniveId** (instead of **knifeId**)
- **series** -> **serieId** (instead of **seriesId**)
- **species** -> **specieId** (instead of **speciesId**)
- etc. 

Rails solves this by shipping a dictionary containing those exceptions but I think it's out of scope to ship exceptions for the english language. 

Therefore I think its better to get rid of that behaviour alltogether and use **{id}** as the key (a resource has only one id anyways) e.g.:

```
 'resources' => array(
    array('author' => array('url' => '/authors'))
),
```

will turn into:

```
'routes' => array(
    array('name' => 'author#index', 'url' => '/authors', 'verb' => 'GET'),
    array('name' => 'author#show', 'url' => '/authors/{id}', 'verb' => 'GET'),
    array('name' => 'author#create', 'url' => '/authors', 'verb' => 'POST'),
    array('name' => 'author#update', 'url' => '/authors/{id}', 'verb' => 'PUT'),
    array('name' => 'author#destroy', 'url' => '/authors/{id}', 'verb' => 'DELETE'),
)
```

instead of

```
'routes' => array(
    array('name' => 'author#index', 'url' => '/authors', 'verb' => 'GET'),
    array('name' => 'author#show', 'url' => '/authors/{authorId}', 'verb' => 'GET'),
    array('name' => 'author#create', 'url' => '/authors', 'verb' => 'POST'),
    array('name' => 'author#update', 'url' => '/authors/{authorId}', 'verb' => 'PUT'),
    array('name' => 'author#destroy', 'url' => '/authors/{authorId}', 'verb' => 'DELETE'),
)
```

This may break backwards compability though which is why I'd prefer to get this into 7 before it is released.

@MorrisJobke @DeepDiver1975 @Kondou-ger @LEDfan
