### PR TITLE
Redeclared as public to allow invocation from within the closure in php ...

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -13,7 +13,7 @@ use OC\Hooks\Emitter;
 
 class Repair extends BasicEmitter {
 	/**
-	 * @var array
+	 * @var RepairStep[]
 	 **/
 	private $repairSteps;
 
@@ -79,5 +79,14 @@ class Repair extends BasicEmitter {
 	 */
 	public static function getBeforeUpgradeRepairSteps() {
 		return array();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Redeclared as public to allow invocation from within the closure above in php 5.3
+	 */
+	public function emit($scope, $method, $arguments = array()) {
+		parent::emit($scope, $method, $arguments);
 	}
 }


### PR DESCRIPTION
...5.3

@PVince81 @karlitschek @craigpg 

fixes php 5.3 execution issue:

```
00:12:14.570 .....PHP Fatal error:  Call to protected method OC\Hooks\BasicEmitter::emit() from context '' in /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/lib/private/repair.php on line 47
00:12:14.582 PHP Stack trace:
00:12:14.582 PHP   1. {main}() /usr/bin/php53/phpunit:0
00:12:14.582 PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/php53/phpunit:46
00:12:14.582 PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php53/lib/php/PHPUnit/TextUI/Command.php:129
00:12:14.582 PHP   4. PHPUnit_TextUI_TestRunner->doRun() /usr/share/php53/lib/php/PHPUnit/TextUI/Command.php:176
00:12:14.582 PHP   5. PHPUnit_Framework_TestSuite->run() /usr/share/php53/lib/php/PHPUnit/TextUI/TestRunner.php:349
00:12:14.582 PHP   6. PHPUnit_Framework_TestSuite->run() /usr/share/php53/lib/php/PHPUnit/Framework/TestSuite.php:705
00:12:14.582 PHP   7. PHPUnit_Framework_TestSuite->runTest() /usr/share/php53/lib/php/PHPUnit/Framework/TestSuite.php:745
00:12:14.582 PHP   8. PHPUnit_Framework_TestCase->run() /usr/share/php53/lib/php/PHPUnit/Framework/TestSuite.php:775
00:12:14.582 PHP   9. PHPUnit_Framework_TestResult->run() /usr/share/php53/lib/php/PHPUnit/Framework/TestCase.php:783
00:12:14.582 PHP  10. PHPUnit_Framework_TestCase->runBare() /usr/share/php53/lib/php/PHPUnit/Framework/TestResult.php:648
00:12:14.582 PHP  11. PHPUnit_Framework_TestCase->runTest() /usr/share/php53/lib/php/PHPUnit/Framework/TestCase.php:838
00:12:14.582 PHP  12. ReflectionMethod->invokeArgs() /usr/share/php53/lib/php/PHPUnit/Framework/TestCase.php:983
00:12:14.582 PHP  13. Test_Repair->testRunRepairStep() /usr/share/php53/lib/php/PHPUnit/Framework/TestCase.php:983
00:12:14.582 PHP  14. OC\Repair->run() /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/tests/lib/repair.php:49
00:12:14.582 PHP  15. TestRepairStep->run() /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/lib/private/repair.php:51
00:12:14.582 PHP  16. OC\Hooks\BasicEmitter->emit() /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/tests/lib/repair.php:27
00:12:14.582 PHP  17. call_user_func_array() /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/lib/private/hooks/basicemitter.php:85
00:12:14.582 PHP  18. OC\{closure}() /var/lib/jenkins/jobs/server-master-linux-php533/workspace/database/sqlite/label/master/lib/private/hooks/basicemitter.php:85
```
