### PR TITLE
Change type of `objid` to text in table `vcategory_to_object`

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1140,11 +1140,11 @@
 
 		<field>
 			<name>objid</name>
-			<type>integer</type>
+			<type>text</type>
 			<default>0</default>
 			<notnull>true</notnull>
 			<unsigned>true</unsigned>
-			<length>4</length>
+			<length>255</length>
 		</field>
 
 		<!-- Foreign Key vcategory::id -->

--- a/lib/private/tags.php
+++ b/lib/private/tags.php
@@ -203,7 +203,7 @@ class Tags implements \OCP\ITags {
 
 		if(!is_null($result)) {
 			while( $row = $result->fetchRow()) {
-				$ids[] = (int)$row['objid'];
+				$ids[] = $row['objid'];
 			}
 		}
 


### PR DESCRIPTION
For the `LocalUsers` (#8951) backend it must be possible to add strings to the `objid` column of the `vcategory_to_object` table. Refs 

I'm okay with merging this after oC7 is released since #8951 will also be merged after that, but can you tell me whether this change is okay?
