### PR TITLE
[encryption] make sure that we always detect the system wide mount point

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1769,10 +1769,11 @@ class Util {
 	 * @return boolean
 	 */
 	public function isSystemWideMountPoint($path) {
+		$normalizedPath = ltrim($path, '/');
 		if (\OCP\App::isEnabled("files_external")) {
 			$mount = \OC_Mount_Config::getSystemMountPoints();
 			foreach ($mount as $mountPoint => $data) {
-				if ($mountPoint == substr($path, 1, strlen($mountPoint))) {
+				if ($mountPoint == substr($normalizedPath, 0, strlen($mountPoint))) {
 					return true;
 				}
 			}


### PR DESCRIPTION
normalize path before comparison to make sure that we always detect the system wide mount points

fix for #8397
