### PR TITLE
show share action of shared items darker to distinguish from non-shared,...

### DIFF
--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -40,6 +40,12 @@ table td.filename .nametext {
 	opacity: .2 !important;
 	display: inline !important;
 }
+/* show share action of shared items darker to distinguish from non-shared */
+#fileList a.action.permanent {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)" !important;
+	filter: alpha(opacity=70) !important;
+	opacity: .7 !important;
+}
 /* do not show Rename or Versions on mobile */
 #fileList .action.action-rename,
 #fileList .action.action-versions {


### PR DESCRIPTION
Fix #8898

> Since the share icon is shown permanently on mobile, it’s not apparent which files are actually shared and which not.
> To make that clear, we should have the share action icons of files/folders which are shared at more opacity.

Please review @owncloud/designers 
