### PR TITLE
shorten userid columns to 64 chars, ref #9186

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -813,7 +813,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>255</length>
+				<length>64</length>
 			</field>
 
 			<!-- Foreign Key share::id or NULL -->
@@ -1226,7 +1226,7 @@
 			<type>text</type>
 			<default></default>
 			<notnull>true</notnull>
-			<length>255</length>
+			<length>64</length>
 		</field>
 
 		<field>

--- a/version.php
+++ b/version.php
@@ -3,7 +3,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(7, 0, 0, 2);
+$OC_Version=array(7, 0, 0, 3);
 
 // The human readable string
 $OC_VersionString='7.0 beta 1';


### PR DESCRIPTION
the user table only uses 64 chars for the user id, no need to create longer columns for `oc_share.uid_owner` and `oc_privatedata.user`. `oc_share.share_with` might also contain emails, so the foreign key comment there might not be correct but that is a different issue. Should solve #9186 by shortening the resulting index `oc_share.file_target_index` to < 1000 chars.
