### PR TITLE
Better detecting of remote changes for external shares

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -111,7 +111,8 @@ class Storage extends DAV implements ISharedStorage {
 	 * @return bool
 	 */
 	public function hasUpdated($path, $time) {
-		// since we check updates for the entire storage at once, we only need to check once per request
+		// since for owncloud webdav servers we can rely on etag propagation we only need to check the root of the storage
+		// because of that we only do one check for the entire storage per request
 		if ($this->updateChecked) {
 			return false;
 		}

--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -33,6 +33,8 @@ class Storage extends DAV implements ISharedStorage {
 	 */
 	private $token;
 
+	private $updateChecked = false;
+
 	public function __construct($options) {
 		$this->remote = $options['remote'];
 		$this->remoteUser = $options['owner'];
@@ -99,5 +101,21 @@ class Storage extends DAV implements ISharedStorage {
 			$this->scanner = new Scanner($storage);
 		}
 		return $this->scanner;
+	}
+
+	/**
+	 * check if a file or folder has been updated since $time
+	 *
+	 * @param string $path
+	 * @param int $time
+	 * @return bool
+	 */
+	public function hasUpdated($path, $time) {
+		// since we check updates for the entire storage at once, we only need to check once per request
+		if ($this->updateChecked) {
+			return false;
+		}
+		$this->updateChecked = true;
+		return parent::hasUpdated('', $time);
 	}
 }

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -451,8 +451,9 @@ class DAV extends \OC\Files\Storage\Common {
 		if (strpos($permissionsString, 'W') !== false) {
 			$permissions |= \OCP\PERMISSION_UPDATE;
 		}
-		if (strpos($permissionsString, 'C') !== false) {
+		if (strpos($permissionsString, 'CK') !== false) {
 			$permissions |= \OCP\PERMISSION_CREATE;
+			$permissions |= \OCP\PERMISSION_UPDATE;
 		}
 		return $permissions;
 	}

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -449,5 +449,24 @@ class DAV extends \OC\Files\Storage\Common {
 			return 0;
 		}
 	}
+
+	/**
+	 * check if a file or folder has been updated since $time
+	 *
+	 * @param string $path
+	 * @param int $time
+	 * @return bool
+	 */
+	public function hasUpdated($path, $time) {
+		$this->init();
+		$response = $this->client->propfind($this->encodePath($path), array('{DAV:}getlastmodified', '{DAV:}getetag'));
+		if (isset($response['{DAV:}getetag'])) {
+			$cachedData = $this->getCache()->get($path);
+			return $cachedData['etag'] !== $response['{DAV:}getetag'];
+		} else {
+			$remoteMtime = strtotime($response['{DAV:}getlastmodified']);
+			return $remoteMtime > $time;
+		}
+	}
 }
 


### PR DESCRIPTION
- Use the etag to detect changes instead of the less reliable mtime
- Detect changes to permissions of the share
- Only check the root of the storage since we can rely on etag propagation

Fixes #9086

cc @PVince81 @DeepDiver1975 @schiesbn 
