### PR TITLE
always regenerate etag when writing back file to objectstore

### DIFF
--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -385,7 +385,6 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if (empty($stat)) {
 			// create new file
 			$stat = array(
-				'etag' => $this->getETag($path),
 				'permissions' => \OCP\PERMISSION_ALL,
 			);
 		}
@@ -395,6 +394,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		$stat['mtime'] = $mTime;
 		$stat['storage_mtime'] = $mTime;
 		$stat['mimetype'] = \OC_Helper::getMimeType($tmpFile);
+		$stat['etag'] = $this->getETag($path);
 
 		$fileId = $this->getCache()->put($path, $stat);
 		try {


### PR DESCRIPTION
@karlitschek @PVince81 @icewind1991 fixes preview regeneration and most likely synchronization when using objectstore
