### PR TITLE
change order of registering api and capabilities to fix file version previews

### DIFF
--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -5,11 +5,11 @@
  * See the COPYING-README file.
  */
 
-// Register with the capabilities API
-OC_API::register('get', '/cloud/capabilities', array('OCA\Files_Versions\Capabilities', 'getCapabilities'), 'files_versions', OC_API::USER_AUTH);
-
 /** @var $this \OCP\Route\IRouter */
 $this->create('core_ajax_versions_preview', '/preview')->action(
 function() {
 	require_once __DIR__ . '/../ajax/preview.php';
 });
+
+// Register with the capabilities API
+OC_API::register('get', '/cloud/capabilities', array('OCA\Files_Versions\Capabilities', 'getCapabilities'), 'files_versions', OC_API::USER_AUTH);

--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -72,6 +72,7 @@ class OC_API {
 				->requirements($requirements)
 				->action('OC_API', 'call');
 			self::$actions[$name] = array();
+			OC::$server->getRouter()->useCollection('root');
 		}
 		self::$actions[$name][] = array('app' => $app, 'action' => $action, 'authlevel' => $authLevel);
 	}

--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -65,6 +65,7 @@ class OC_API {
 		$name = strtolower($method).$url;
 		$name = str_replace(array('/', '{', '}'), '_', $name);
 		if(!isset(self::$actions[$name])) {
+			$oldCollection = OC::$server->getRouter()->getCurrentCollection();
 			OC::$server->getRouter()->useCollection('ocs');
 			OC::$server->getRouter()->create($name, $url)
 				->method($method)
@@ -72,7 +73,7 @@ class OC_API {
 				->requirements($requirements)
 				->action('OC_API', 'call');
 			self::$actions[$name] = array();
-			OC::$server->getRouter()->useCollection('root');
+			OC::$server->getRouter()->useCollection($oldCollection);
 		}
 		self::$actions[$name][] = array('app' => $app, 'action' => $action, 'authlevel' => $authLevel);
 	}

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -26,6 +26,11 @@ class Router implements IRouter {
 	protected $collection = null;
 
 	/**
+	 * @var string
+	 */
+	protected $collectionName = null;
+
+	/**
 	 * @var \Symfony\Component\Routing\RouteCollection
 	 */
 	protected $root = null;
@@ -160,7 +165,18 @@ class Router implements IRouter {
 	 */
 	public function useCollection($name) {
 		$this->collection = $this->getCollection($name);
+		$this->collectionName = $name;
 	}
+
+	/**
+	 * returns the current collection name in use for adding routes
+	 *
+	 * @return string the collection name
+	 */
+	public function getCurrentCollection() {
+		return $this->collectionName;
+	}
+
 
 	/**
 	 * Create a \OC\Route\Route.

--- a/lib/public/route/irouter.php
+++ b/lib/public/route/irouter.php
@@ -37,6 +37,13 @@ interface IRouter {
 	public function useCollection($name);
 
 	/**
+	 * returns the current collection name in use for adding routes
+	 *
+	 * @return string the collection name
+	 */
+	public function getCurrentCollection();
+
+	/**
 	 * Create a \OCP\Route\IRoute.
 	 *
 	 * @param string $name Name of the route to create.


### PR DESCRIPTION
When registering an api call the collection gets set to

``` php
            OC::$server->getRouter()->useCollection('ocs');
```

My guess is it does not get reverted so when the next create rout call is executed is goes into the wrong collection. Fixes 

@PVince81 @icewind1991 @schiesbn a quick review please.
