### PR TITLE
add indie.json for Indie App Store listing

### DIFF
--- a/indie.json
+++ b/indie.json
@@ -1,0 +1,92 @@
+{
+    "name": "ownCloud",
+    "icons": [
+        {
+            "src": "https://raw.githubusercontent.com/owncloud/www/master/assets/img/common/owncloud-square-logo.png",
+            "sizes": "500x500",
+            "type": "image/png",
+            "density": "1"
+        },
+        {
+            "src": "core/img/favicon-touch.png",
+            "sizes": "128x128",
+            "type": "image/png",
+            "density": "1"
+        },
+        {
+            "src": "core/img/favicon.png",
+            "sizes": "32x32",
+            "type": "image/png",
+            "density": "1"
+        }
+    ],
+    "start_url": "/",
+    "display": "fullscreen",
+    "orientation": "landscape",
+    "short_description": "sync & share your stuff",
+    "description": "ownCloud gives you web services under your control. It is a self-hosted open source platform with file sync & sharing at its core and available clients for desktop and mobile. The web frontend has apps for Pictures, Calendar, Contacts, News/RSS, Bookmarks, Notes, Music and much more via an open app platform.",
+    "license": "AGPLv3",
+    "license_url": "https://raw.githubusercontent.com/owncloud/core/master/COPYING-AGPL",
+    "source_url": "https://github.com/owncloud/core",
+    "version": "7.0.0",
+    "developer": {
+        "name": "ownCloud Inc.",
+        "url": "https://owncloud.org"
+    },
+    "wikipedia_url": "https://wikipedia.org/wiki/ownCloud",
+    "default_locale": "en",
+    "protocols": [
+        "SSL/TLS",
+        "WebDAV",
+        "CalDAV",
+        "CardDAV",
+        "Ampache",
+        "RSS"
+    ],
+    "categories": [
+        {
+            "name": "BSD",
+            "subcategories": [
+                "Files",
+                "Sync",
+                "Calendar",
+                "Contacts",
+                "News",
+                "Notes"
+            ]
+        },
+        {
+            "name": "GNU/Linux",
+            "subcategories": [
+                "Files",
+                "Sync",
+                "Calendar",
+                "Contacts",
+                "News",
+                "Notes"
+            ]
+        },
+        {
+            "name": "OS X",
+            "subcategories": [
+                "Files",
+                "Sync",
+                "Calendar",
+                "Contacts",
+                "News",
+                "Notes"
+            ]
+        },
+        {
+            "name": "Windows",
+            "subcategories": [
+                "Files",
+                "Sync",
+                "Calendar",
+                "Contacts",
+                "News",
+                "Notes"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
indie.json aims for an open standard for installing indie web apps on platforms. It’s based off the W3C spec for a web app manifest: https://w3c.github.io/manifest/

This file has all the info which allows ownCloud to be listed in app stores which use that standard. Several platforms have voiced interest in working towards a shared app data format & perhaps installer store experience. For example Indie Box, ArkOS, IndiePhone, Cozy and more.

cc @karlitschek @brennannovak @DeepDiver1975 

More info about the work on this common format is at https://indiewebcamp.com/store and soon a first »Indie App Store« will be running at http://indietech.org
