### PR TITLE
don't typecast null values inside dispatcher.php

### DIFF
--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -145,7 +145,7 @@ class Dispatcher {
 			) {
 				$value = false;
 
-			} elseif(in_array($type, $types)) {
+			} elseif($value !== null && in_array($type, $types)) {
 				settype($value, $type);
 			}
 


### PR DESCRIPTION
please review @DeepDiver1975 @Raydiation 

Example code:

``` php
    /**
     * @param int $limit
     * @param int $offset
     * @return Response
     *
     * @NoAdminRequired
     * @NoCSRFRequired
     */
    public function index($limit=null, $offset=null) {
        try {
            var_dump(func_get_args());exit;
```

Output master:

```
array (size=2)
  0 => 0
  1 => 0
```

This branch: 

``` text
array (size=2)
  0 => null
  1 => null
```
