### PR TITLE
[server2server-sharing] no longer check if the external storage app is enabled

### DIFF
--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -13,10 +13,7 @@ OCP\JSON::checkAppEnabled('files_sharing');
 $l = OC_L10N::get('files_sharing');
 
 // check if server admin allows to mount public links from other servers
-// check if files_external is enabled
-// FIXME file_external check no longer needed if we use the webdav implementation from core
-if (OCA\Files_Sharing\Helper::isIncomingServer2serverShareEnabled() === false ||
-		\OC_App::isEnabled('files_external') === false) {
+if (OCA\Files_Sharing\Helper::isIncomingServer2serverShareEnabled() === false) {
 	\OCP\JSON::error(array('data' => array('message' => $l->t('Server to server sharing is not enabled on this server'))));
 	exit();
 }

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -68,9 +68,8 @@ class Manager {
 	}
 
 	private function setupMounts() {
-		// don't setup server-to-server shares if the file_external app is disabled
-		// FIXME no longer needed if we use the webdav implementation from  core
-		if (\OC_App::isEnabled('files_external') === false) {
+		// don't setup server-to-server shares if the admin disabled it
+		if (\OCA\Files_Sharing\Helper::isIncomingServer2serverShareEnabled() === false) {
 			return false;
 		}
 


### PR DESCRIPTION
no longer check if the external storage app is enabled, we use no the webdav implementation from core

fix #9293 

Please test it... At the moment I can't create a server-to-server share so I couldn't test it.

cc @icewind1991 @PVince81 
