### PR TITLE
Return 503 in  public.php and OCS API when upgrade is due

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -301,7 +301,7 @@ class OC_API {
 	 * @param OC_OCS_Result $result
 	 * @param string $format the format xml|json
 	 */
-	private static function respond($result, $format='xml') {
+	public static function respond($result, $format='xml') {
 		// Send 401 headers if unauthorised
 		if($result->getStatusCode() === self::RESPOND_UNAUTHORISED) {
 			header('WWW-Authenticate: Basic realm="Authorisation Required"');

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -23,6 +23,14 @@
 
 require_once '../lib/base.php';
 
+if (\OCP\Util::needUpgrade()) {
+	// since the behavior of apps or remotes are unpredictable during
+	// an upgrade, return a 503 directly
+	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+	OC_Template::printErrorPage('Service unavailable');
+	exit;
+}
+
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -27,7 +27,8 @@ if (\OCP\Util::needUpgrade()) {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-	OC_Template::printErrorPage('Service unavailable');
+	$response = new OC_OCS_Result(null, OC_Response::STATUS_SERVICE_UNAVAILABLE, 'Service unavailable');
+	OC_API::respond($response, OC_API::requestedFormat());
 	exit;
 }
 

--- a/public.php
+++ b/public.php
@@ -3,6 +3,14 @@
 try {
 
 	require_once 'lib/base.php';
+	if (\OCP\Util::needUpgrade()) {
+		// since the behavior of apps or remotes are unpredictable during
+		// an upgrade, return a 503 directly
+		OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+		OC_Template::printErrorPage('Service unavailable');
+		exit;
+	}
+
 	OC::checkMaintenanceMode();
 	OC::checkSingleUserMode();
 	$pathInfo = OC_Request::getPathInfo();


### PR DESCRIPTION
To prevent unexpected behavior, public.php and the OCS API calls will
return 503 Service Unavailable when an upgrade is due.

Hopefully fixes cases like https://github.com/owncloud/core/issues/9295

Please review @jancborchardt @DeepDiver1975 @karlitschek @icewind1991 
