### PR TITLE
change 'Cancel upload' text to x icon for more space in breadcrumbs bar

### DIFF
--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -38,9 +38,8 @@
 			</div>
 			<div id="uploadprogresswrapper">
 				<div id="uploadprogressbar"></div>
-				<input type="button" class="stop" style="display:none"
-					value="<?php p($l->t('Cancel upload'));?>"
-				/>
+				<input type="button" class="stop icon-close"
+					style="display:none" value="" />
 			</div>
 		</div>
 		<div id="file_action_panel"></div>


### PR DESCRIPTION
Please review @owncloud/designers 

@PVince81 probably the threshold for ellipsizing stuff in the breadcrumbs bar can be reduced a bit since the button is now way narrower. :)
