### PR TITLE
Added migrator test for reserved keyword

### DIFF
--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -58,7 +58,7 @@ class MDB2SchemaManager {
 	/**
 	 * @return \OC\DB\Migrator
 	 */
-	protected function getMigrator() {
+	public function getMigrator() {
 		$platform = $this->conn->getDatabasePlatform();
 		if ($platform instanceof SqlitePlatform) {
 			return new SQLiteMigrator($this->conn);

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -138,4 +138,26 @@ class Migrator extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(true);
 	}
+
+	public function testReservedKeywords() {
+		$startSchema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $startSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer', array('autoincrement' => true));
+		$table->addColumn('user', 'string', array('length' => 255));
+		$table->setPrimaryKey(array('id'));
+
+		$endSchema = new Schema(array(), array(), $this->getSchemaConfig());
+		$table = $endSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer', array('autoincrement' => true));
+		$table->addColumn('user', 'string', array('length' => 64));
+		$table->setPrimaryKey(array('id'));
+
+		$migrator = $this->manager->getMigrator();
+		$migrator->migrate($startSchema);
+
+		$migrator->checkMigrate($endSchema);
+		$migrator->migrate($endSchema);
+
+		$this->assertTrue(true);
+	}
 }


### PR DESCRIPTION
This is a unit test for https://github.com/owncloud/core/issues/9318

It also fixes the fact that it wasn't always using the migrator subclasses when testing.

The test will fail until the upstream patch is in.
