### PR TITLE
Fix warnings when personal is not set

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -111,7 +111,7 @@ class OC_Mount_Config {
 				$objectClass = $options['options']['objectstore']['class'];
 				$options['options']['objectstore'] = new $objectClass($options['options']['objectstore']);
 			}
-			if ($options['personal']){
+			if (isset($options['personal']) && $options['personal']) {
 				$mount = new \OCA\Files_External\PersonalMount($options['class'], $mountPoint, $options['options'], $loader);
 			} else{
 				$mount = new \OC\Files\Mount\Mount($options['class'], $mountPoint, $options['options'], $loader);


### PR DESCRIPTION
Fixes log pollution with:

```
{"reqId":"53b29c26104f8","app":"PHP","message":"Undefined index: personal at \/srv\/www\/htdocs\/owncloud\/apps\/files_external\/lib\/config.php#114","level":0,"time":"2014-07-01T11:31:50+00:00","method":"GET","url":"\/owncloud\/index.php\/apps\/files\/ajax\/getstoragestats.php?dir=%2F"}
```

Please review @icewind1991 @Xenopathic @schiesbn 
