### PR TITLE
don't move a share mount point into a different mount point

### DIFF
--- a/apps/files_sharing/lib/external/mount.php
+++ b/apps/files_sharing/lib/external/mount.php
@@ -38,6 +38,7 @@ class Mount extends \OC\Files\Mount\Mount implements MoveableMount {
 	public function moveMount($target) {
 		$result = $this->manager->setMountPoint($this->mountPoint, $target);
 		$this->setMountPoint($target);
+
 		return $result;
 	}
 

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -236,4 +236,5 @@ class Helper {
 		$result = $appConfig->getValue('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 		return ($result === 'yes') ? true : false;
 	}
+
 }

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -8,10 +8,8 @@
 
 namespace OCA\Files_Sharing;
 
-use OC\Files\Filesystem;
 use OC\Files\Mount\Mount;
 use OC\Files\Mount\MoveableMount;
-use OC\Files\Storage\Shared;
 
 /**
  * Shared mount points can be moved by the user
@@ -119,14 +117,6 @@ class SharedMount extends Mount implements MoveableMount {
 	 * @return bool
 	 */
 	public function moveMount($target) {
-		// it shouldn't be possible to move a Shared storage into another one
-		list($targetStorage,) = Filesystem::resolvePath($target);
-		if ($targetStorage instanceof Shared) {
-			\OCP\Util::writeLog('file sharing',
-				'It is not allowed to move one mount point into another one',
-				\OCP\Util::DEBUG);
-			return false;
-		}
 
 		$relTargetPath = $this->stripUserFilesPath($target);
 		$share = $this->storage->getShare();

--- a/lib/private/files/objectstore/homeobjectstorestorage.php
+++ b/lib/private/files/objectstore/homeobjectstorestorage.php
@@ -22,7 +22,7 @@ namespace OC\Files\ObjectStore;
 
 use OC\User\User;
 
-class HomeObjectStoreStorage extends ObjectStoreStorage {
+class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IHomeStorage {
 
 	/**
 	 * The home user storage requires a user object to create a unique storage id

--- a/lib/private/files/storage/home.php
+++ b/lib/private/files/storage/home.php
@@ -11,7 +11,7 @@ namespace OC\Files\Storage;
 /**
  * Specialized version of Local storage for home directory usage
  */
-class Home extends Local {
+class Home extends Local implements \OCP\Files\IHomeStorage {
 	/**
 	 * @var string
 	 */

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -336,3 +336,7 @@ interface Storage {
 	 */
 	public function instanceOfStorage($class);
 }
+
+interface IHomeStorage {
+
+}


### PR DESCRIPTION
fix for #8429 

Don't move a share mount point into another mount point.

cc @PVince81 @icewind1991 
