### PR TITLE
Default app fix

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -74,7 +74,11 @@ $CONFIG = array(
 /* URL to the parent directory of the 3rdparty directory, as seen by the browser */
 "3rdpartyurl" => "",
 
-/* Default app to load on login */
+/* Default app to open on login.
+ * This can be a comma-separated list of app ids.
+ * If the first app is not enabled for the current user,
+ * it will try with the second one and so on. If no enabled app could be found,
+ * the "files" app will be displayed instead. */
 "defaultapp" => "files",
 
 /* Enable the help menu item in the settings */

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -163,7 +163,7 @@ class OC_App {
 	/**
 	 * get all enabled apps
 	 */
-	private static $enabledAppsCache = array();
+	protected static $enabledAppsCache = array();
 
 	public static function getEnabledApps($forceRefresh = false) {
 		if (!OC_Config::getValue('installed', false)) {

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -815,10 +815,13 @@ class OC_Util {
 	}
 
 	/**
-	 * Redirect to the user default page
-	 * @return void
+	 * Returns the URL of the default page
+	 * based on the system configuration and
+	 * the apps visible for the current user
+	 *
+	 * @return string URL
 	 */
-	public static function redirectToDefaultPage() {
+	public static function getDefaultPageUrl() {
 		$urlGenerator = \OC::$server->getURLGenerator();
 		if(isset($_REQUEST['redirect_url'])) {
 			$location = urldecode($_REQUEST['redirect_url']);
@@ -837,11 +840,20 @@ class OC_Util {
 						break;
 					}
 				}
-				$location = $urlGenerator->linkTo($appId, 'index.php');
+				$location = $urlGenerator->getAbsoluteURL('/index.php/apps/' . $appId . '/');
 			}
 		}
+		return $location;
+	}
+
+	/**
+	 * Redirect to the user default page
+	 * @return void
+	 */
+	public static function redirectToDefaultPage() {
+		$location = self::getDefaultPageUrl();
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);
-		header( 'Location: '.$location );
+		header('Location: '.$location);
 		exit();
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -827,7 +827,9 @@ class OC_Util {
 			if ($defaultPage) {
 				$location = $urlGenerator->getAbsoluteURL($defaultPage);
 			} else {
-				$location = $urlGenerator->getAbsoluteURL('/index.php/apps/files');
+				$defaultApp = \OCP\Config::getSystemValue('defaultapp', 'files');
+				$defaultApp = OC_App::cleanAppId(strip_tags($defaultApp));
+				$location = $urlGenerator->getAbsoluteURL('/index.php/apps/' . $defaultApp);
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -827,9 +827,17 @@ class OC_Util {
 			if ($defaultPage) {
 				$location = $urlGenerator->getAbsoluteURL($defaultPage);
 			} else {
-				$defaultApp = \OCP\Config::getSystemValue('defaultapp', 'files');
-				$defaultApp = OC_App::cleanAppId(strip_tags($defaultApp));
-				$location = $urlGenerator->getAbsoluteURL('/index.php/apps/' . $defaultApp);
+				$appId = 'files';
+				$defaultApps = explode(',', \OCP\Config::getSystemValue('defaultapp', 'files'));
+				// find the first app that is enabled for the current user
+				foreach ($defaultApps as $defaultApp) {
+					$defaultApp = OC_App::cleanAppId(strip_tags($defaultApp));
+					if (OC_App::isEnabled($defaultApp)) {
+						$appId = $defaultApp;
+						break;
+					}
+				}
+				$location = $urlGenerator->linkTo($appId, 'index.php');
 			}
 		}
 		OC_Log::write('core', 'redirectToDefaultPage: '.$location, OC_Log::DEBUG);


### PR DESCRIPTION
Adds back the defaultapp setting with some extras.
Since it's now possible to disable apps for some groups, we need fallbacks.

It is now possible to specify multiple apps separated by commas.

Note that the current code doesn't work for all apps.

For some reason the "contacts" app is giving the wrong route, needs research.
We need a better way for creating the route.

@LukasReschke @bantu @icewind1991 
