### PR TITLE
Redirect after session expiry to the previous loaded page

### DIFF
--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -143,6 +143,8 @@ class SecurityMiddleware extends Middleware {
 
 				// TODO: replace with link to route
 				$url = $this->urlGenerator->getAbsoluteURL('index.php');
+				// add redirect URL to redirect to the previous page after login
+				$url .= '?redirect_url=' . urlencode($this->request->server['REQUEST_URI']);
 				$response = new RedirectResponse($url);
 				$this->logger->debug($exception->getMessage());
 			}

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -313,7 +313,8 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 	public function testAfterExceptionReturnsRedirect(){
 		$this->request = new Request(
 			array('server' =>
-				array('HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+				array('HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+					'REQUEST_URI' => 'owncloud/index.php/apps/specialapp')
 			)
 		);
 		$this->middleware = $this->getMiddleware(true, true);
@@ -321,6 +322,7 @@ class SecurityMiddlewareTest extends \PHPUnit_Framework_TestCase {
 				$this->secException);
 
 		$this->assertTrue($response instanceof RedirectResponse);
+		$this->assertEquals('?redirect_url=owncloud%2Findex.php%2Fapps%2Fspecialapp', $response->getRedirectURL());
 	}
 
 


### PR DESCRIPTION
- fixes #6945 

This fixes the most annoying thing I noticed on my own production instance.

cc @owncloud/designers @Raydiation @PVince81 @cosenal 
