### PR TITLE
Fix files list scroll behavior

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -89,7 +89,7 @@
 
 /* fit app list view heights */
 .app-files #app-content>.viewcontainer {
-	height: 100%;
+	min-height: 100%;
 }
 
 /* move Deleted Files to bottom of sidebar */


### PR DESCRIPTION
View container height needs to be accurate and span over the whole
scroll container for infinite scrolling to work properly.

This fixes the bogus scrolling behavior with infinite scrolling.
Before the fix it would load the next page for every pixel when moving down the scroll cursor with the mouse.
After the fix it only loads the next page after reaching the bottom.

This CSS fix fixes the calculation.

Please review @owncloud/designers @MorrisJobke @wakeup 
