### PR TITLE
Fix service warning

### DIFF
--- a/public.php
+++ b/public.php
@@ -17,7 +17,7 @@ try {
 	if (!$pathInfo && !isset($_GET['service'])) {
 		header('HTTP/1.0 404 Not Found');
 		exit;
-	} elseif ($_GET['service']) {
+	} elseif (isset($_GET['service'])) {
 		$service = $_GET['service'];
 	} else {
 		$pathInfo = trim($pathInfo, '/');


### PR DESCRIPTION
Got these on the remote server when testing server to server sharing with the sync client:

```
{"app":"PHP","message":"Undefined index: service at \/var\/www\/owncloud\/public.php#20","level":3,"time":"2014-06-30T15:27:58+00:00"}
{"app":"PHP","message":"Undefined index: service at \/var\/www\/owncloud\/public.php#20","level":3,"time":"2014-06-30T15:27:58+00:00"}
{"app":"PHP","message":"Undefined index: service at \/var\/www\/owncloud\/public.php#20","level":3,"time":"2014-06-30T15:27:58+00:00"}
{"app":"PHP","message":"Undefined index: service at \/var\/www\/owncloud\/public.php#20","level":3,"time":"2014-06-30T15:27:58+00:00"}
```

This PR fixes that.

Please review @icewind1991 @schiesbn 

We should pay more attention to warnings in our PRs. :smile: 
