### PR TITLE
shade color for modified dates again, fix #9363

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -676,7 +676,11 @@
 			tr.append(td);
 
 			// date column
-			var modifiedColor = Math.round((Math.round((new Date()).getTime() / 1000) - mtime)/60/60/24*5);
+			var modifiedColor = Math.round(((Math.round((new Date()).getTime()) - mtime)/60/60/24*5) / 1000);
+			// ensure that the brightest color is still readable
+			if (modifiedColor >= '160') {
+				modifiedColor = 160;
+			}
 			td = $('<td></td>').attr({ "class": "date" });
 			td.append($('<span></span>').attr({
 				"class": "modified",

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -675,8 +675,9 @@
 			}).text(simpleSize);
 			tr.append(td);
 
-			// date column
-			var modifiedColor = Math.round(((Math.round((new Date()).getTime()) - mtime)/60/60/24*5) / 1000);
+			// date column (1000 milliseconds to seconds, 60 seconds, 60 minutes, 24 hours)
+			// difference in days multiplied by 5 - brightest shade for files older than 32 days (160/5)
+			var modifiedColor = Math.round(((new Date()).getTime() - mtime )/1000/60/60/24*5 );
 			// ensure that the brightest color is still readable
 			if (modifiedColor >= '160') {
 				modifiedColor = 160;


### PR DESCRIPTION
This fixes the regression reported at https://github.com/owncloud/core/issues/9363

With this fix, the modified date is visualized by shading the modified date text, much like the file size. More recent changes are displayed darker to emphasize them.

Please review @owncloud/designers 
