### PR TITLE
add link to contribute and promote pages in personal settings

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -19,6 +19,9 @@ input#openid, input#webdav { width:20em; }
 .clientsbox .center {
 	margin-top: 10px;
 }
+.clientsbox a {
+	font-weight: bold;
+}
 
 #passworderror { display:none; }
 #passwordchanged { display:none; }

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -15,6 +15,18 @@
 	<a href="<?php p($_['clients']['ios']); ?>" target="_blank">
 		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'appstore.png')); ?>" />
 	</a>
+
+	<?php if (OC_Util::getEditionString() === ''): ?>
+	<p class="center">
+		<?php print_unescaped($l->t('If you want to support the project
+		<a href="https://owncloud.org/contribute"
+			target="_blank">join development</a>
+		or
+		<a href="https://owncloud.org/contribute/#promote"
+			target="_blank">spread the word</a>!'));?>
+	</p>
+	<?php endif; ?>
+
 	<?php if(OC_APP::isEnabled('firstrunwizard')) {?>
 	<p class="center"><a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a></p>
 	<?php }?>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -22,7 +22,7 @@
 		<a href="https://owncloud.org/contribute"
 			target="_blank">join development</a>
 		or
-		<a href="https://owncloud.org/contribute/#promote"
+		<a href="https://owncloud.org/promote"
 			target="_blank">spread the word</a>!'));?>
 	</p>
 	<?php endif; ?>


### PR DESCRIPTION
This requires a »Promote« section to be added and linkable to the »Contribute« page http://owncloud.org/contribute/#promote cc @tomneedham 

The section will not appear for branded ownClouds.

Please check @karlitschek @jospoortvliet – same thing as for the firstrunwizard at https://github.com/owncloud/firstrunwizard/pull/8
