### PR TITLE
fix lineheight of server2server share

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -92,7 +92,6 @@ thead {
 #remote_address {
 	margin: 0;
 	height: 14px;
-	line-height: 16px;
 	padding: 6px;
 }
 

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -19,7 +19,7 @@
 				<span id="save" data-protected="<?php p($_['protected'])?>" data-owner="<?php p($_['displayName'])?>" data-name="<?php p($_['filename'])?>">
 					<button><?php p($l->t('Add to your ownCloud')) ?></button>
 					<form class="save-form hidden" action="#">
-						<input type="text" id="remote_address" placeholder="<?php p($l->t('example.com/owncloud')) ?>"/>
+						<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
 						<input type="submit" value="<?php p($l->t('Save')) ?>"/>
 					</form>
 				</span>


### PR DESCRIPTION
Also as suggested by @DeepDiver1975, we should leave "example.com" strings untranslated as they are reserved for this purpose.

Tested with Chrome/Firefox

Before:

![image](https://cloud.githubusercontent.com/assets/231068/3460499/db42db70-0217-11e4-9b92-50267f1bdf4e.png)

After:

![image](https://cloud.githubusercontent.com/assets/231068/3460492/d06d42ee-0217-11e4-8fa9-15510922d840.png)
