### PR TITLE
fix nametext height, was higher than the row

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -256,6 +256,7 @@ table td.filename .nametext {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	max-width: 800px;
+	height: 100%;
 }
 
 table td.filename .nametext .innernametext {


### PR DESCRIPTION
Please review @owncloud/designers 

This is mostly a cosmetical improvement, it doesn’t seem to have caused any issues. Still it could in the future.
