### PR TITLE
Revert 'hides table header while users load.'

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -282,7 +282,6 @@ var UserList = {
 		if (UserList.updating) {
 			return;
 		}
-		$userList.css('display', 'none');
 		$userList.siblings('.loading').css('visibility', 'visible');
 		UserList.updating = true;
 		if(gid === undefined) {
@@ -311,7 +310,6 @@ var UserList = {
 					});
 					if (result.data.length > 0) {
 						UserList.doSort();
-						$userList.css('display', 'block');
 						$userList.siblings('.loading').css('visibility', 'hidden');
 					}
 					else {


### PR DESCRIPTION
This reverts commit 0dc12a3737127aad28be12f9417d2a63601a88ff.

Reverts https://github.com/owncloud/core/pull/9330 because it caused https://github.com/owncloud/core/issues/9368

https://github.com/owncloud/core/issues/8873 needs to be reopened after merging.

@jancborchardt @raghunayyar @MorrisJobke
