### PR TITLE
Fix mobile share view glitches

### DIFF
--- a/apps/files/js/filesummary.js
+++ b/apps/files/js/filesummary.js
@@ -181,7 +181,7 @@
 
 			var info = t('files', '{dirs} and {files}', infoVars);
 
-			var $summary = $('<td><span class="info">'+info+'</span></td>'+fileSize+'<td></td>');
+			var $summary = $('<td><span class="info">'+info+'</span></td>'+fileSize+'<td class="date"></td>');
 
 			if (!this.summary.totalFiles && !this.summary.totalDirs) {
 				this.$el.addClass('hidden');

--- a/apps/files_sharing/css/mobile.css
+++ b/apps/files_sharing/css/mobile.css
@@ -5,6 +5,11 @@
 	position: absolute !important;
 }
 
+/* hide text of download button, only show icon */
+#download-text {
+	display: none;
+}
+
 /* hide size and date columns */
 table th#headerSize,
 table td.filesize,

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -11,8 +11,10 @@
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <header><div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>">
-		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud"><img class="svg"
-		                                                                                          src="<?php print_unescaped(image_path('', 'logo-wide.svg')); ?>" alt="<?php p($theme->getName()); ?>" /></a>
+		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
+			title="" id="owncloud">
+			<div class="logo-icon svg"></div>
+		</a>
 		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 		<div class="header-right">
 			<span id="details">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -25,7 +25,7 @@
 				</span>
 				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
 					<img class="svg" alt="" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>"/>
-					<?php p($l->t('Download'))?>
+					<span id="download-text"><?php p($l->t('Download'))?></span>
 				</a>
 			</span>
 		</div>

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -230,8 +230,10 @@
 	padding: 7px 5px;
 	color: #fff;
 	height: 100%;
-	max-width: 40%;
+	max-width: 80%;
 	white-space: nowrap;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 /* Profile picture in header */


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/9360
- fix position of shared file buttons
- remove whitespace glitch on right of files table
- hide text of download button, only show icon
- use same logo as for when logged in

Please review @owncloud/designers 
