### PR TITLE
fix position of rename function, and text size

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -325,6 +325,7 @@ table td.filename .uploadtext {
 	filter: alpha(opacity=0);
 	opacity: 0;
 	float: left;
+	top: 0;
 	margin: 32px 0 4px 32px; /* bigger clickable area doesn’t work in FF width:2.8em; height:2.4em;*/
 }
 /* Show checkbox when hovering, checked, or selected */
@@ -355,6 +356,7 @@ table td.filename .uploadtext {
 }
 #fileList tr td.filename>input[type="checkbox"] + label {
 	left: 0;
+	top: 0;
 }
 .select-all + label {
 	top: 0;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -230,10 +230,9 @@ table td.filename a.name {
 }
 table tr[data-type="dir"] td.filename a.name span.nametext {font-weight:bold; }
 table td.filename input.filename {
-	width: 80%;
-	font-size: 14px;
-	margin-top: 0;
-	margin-left: 2px;
+	width: 70%;
+	margin-top: 1px;
+	margin-left: 48px;
 	cursor: text;
 }
 table td.filename a, table td.login, table td.logout, table td.download, table td.upload, table td.create, table td.delete { padding:3px 8px 8px 3px; }


### PR DESCRIPTION
The rename box position was off …
Now it’s aligned perfectly with the original text.

Please review @owncloud/designers
