### PR TITLE
only show message if default expire date is enforced

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -342,12 +342,8 @@ OC.Share={
 				html += '<br />';
 
 				var defaultExpireMessage = '';
-				if ((itemType === 'folder' || itemType === 'file') && oc_appconfig.core.defaultExpireDateEnabled) {
-					if (oc_appconfig.core.defaultExpireDateEnforced) {
-						defaultExpireMessage = t('core', 'The public link will expire no later than {days} days after it is created',  {'days': escapeHTML(oc_appconfig.core.defaultExpireDate)}) + '<br/>';
-					} else {
-						defaultExpireMessage = t('core', 'By default the public link will expire after {days} days', {'days': escapeHTML(oc_appconfig.core.defaultExpireDate)}) + '<br/>';
-					}
+				if ((itemType === 'folder' || itemType === 'file') && oc_appconfig.core.defaultExpireDateEnforced) {
+					defaultExpireMessage = t('core', 'The public link will expire no later than {days} days after it is created',  {'days': escapeHTML(oc_appconfig.core.defaultExpireDate)}) + '<br/>';
 				}
 
 				html += '<input id="linkText" type="text" readonly="readonly" />';


### PR DESCRIPTION
fix for #9354 

I removed the message if the expire date is only a suggestion. In this case the date is set by default and the user can do whatever he wants, change it remove it etc.

If the expire date is enforced I keep the message

I think this makes sense @jancborchardt and @MorrisJobke 

@PVince81 There is still a small issue. If the expire date is enforced and I create a link i set the maxDate, so that the user can only pick a date in the range given by the admin (see: https://github.com/owncloud/core/blob/master/core/js/share.js#L686). But for some reasons the date picker isn't updated. Directly after the link was created you can pick any date. Only if you close the share dialog and open it again the date picker is updated. Maybe you can have a quick look if this can be fixed easily. Thanks!
