### PR TITLE
Fix bottom of files list, add proper space to have room for dropdowns

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -472,8 +472,8 @@ a.action>img {
 }
 
 .summary td {
-	padding-top: 8px;
-	padding-bottom: 8px;
+	padding-top: 20px;
+	padding-bottom: 300px;
 	border-bottom: none;
 }
 .summary .info {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -473,7 +473,7 @@ a.action>img {
 
 .summary td {
 	padding-top: 20px;
-	padding-bottom: 300px;
+	padding-bottom: 250px;
 	border-bottom: none;
 }
 .summary .info {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -477,7 +477,7 @@ a.action>img {
 	border-bottom: none;
 }
 .summary .info {
-	margin-left: 55px;
+	margin-left: 40px;
 }
 
 #scanning-message{ top:40%; left:40%; position:absolute; display:none; }

--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -22,6 +22,10 @@ table td.date {
 table td {
 	padding: 0;
 }
+/* and accordingly fix left margin of file list summary on mobile */
+.summary .info {
+	margin-left: 55px;
+}
 
 /* remove shift for multiselect bar to account for missing navigation */
 table.multiselect thead {


### PR DESCRIPTION
- add whitespace to bottom of Files list – more obvious it's the end, and proper space for the dropdowns for the last file
- fix left margin of file list summary

Please review @owncloud/designers @PVince81 (with infinite scrolling)
