### PR TITLE
silently discard the response body, needed for apache/mod_dav and maybe ...

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -281,6 +281,7 @@ class DAV extends \OC\Files\Storage\Common {
 		curl_setopt($curl, CURLOPT_INFILE, $source); // file pointer
 		curl_setopt($curl, CURLOPT_INFILESIZE, filesize($path));
 		curl_setopt($curl, CURLOPT_PUT, true);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		if ($this->secure === true) {
 			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
 			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);


### PR DESCRIPTION
...other dav servers which return an html body

See https://github.com/owncloud/core/issues/5771
