### PR TITLE
for shared links, use wide logo on desktop and icon on mobile

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -13,7 +13,7 @@
 <header><div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
 			title="" id="owncloud">
-			<div class="logo-icon svg"></div>
+			<div class="logo-wide svg"></div>
 		</a>
 		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 		<div class="header-right">

--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -21,6 +21,14 @@
 	box-align: center;
 }
 
+/* on mobile, show logo-icon instead of logo-wide */
+#header .logo-wide {
+	background-image: url(../img/logo-icon.svg);
+	background-repeat: no-repeat;
+	width: 62px;
+	height: 34px;
+}
+
 /* compress search box on mobile, expand when focused */
 .searchbox input[type="search"] {
 	width: 15%;


### PR DESCRIPTION
Previously only the small icon was shown on desktop for shared links. This fixes that.

Please review @owncloud/designers 
