### PR TITLE
Improved external share dialog

### DIFF
--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -42,12 +42,39 @@
 			}
 		};
 		if (!passwordProtected) {
-			OC.dialogs.confirm(t('files_sharing', 'Add {name} from {owner}@{remote}', {name: name, owner: owner, remote: remoteClean})
-				, t('files_sharing','Add Share'), callback, true);
+			OC.dialogs.confirm(
+				t(
+					'files_sharing',
+					'Do you want to add the remote share {name} from {owner}@{remote}?',
+					{name: name, owner: owner, remote: remoteClean}
+				),
+				t('files_sharing','Remote share'),
+				callback,
+				true
+			).then(this._adjustDialog);
 		} else {
-			OC.dialogs.prompt(t('files_sharing', 'Add {name} from {owner}@{remote}', {name: name, owner: owner, remote: remoteClean})
-				, t('files_sharing','Add Share'), callback, true, t('files_sharing','Password'), true);
+			OC.dialogs.prompt(
+				t(
+					'files_sharing',
+					'Do you want to add the remote share {name} from {owner}@{remote}?',
+					{name: name, owner: owner, remote: remoteClean}
+				),
+				t('files_sharing','Remote share'),
+				callback,
+				true,
+				t('files_sharing','Remote share password'),
+				true
+			).then(this._adjustDialog);
 		}
+	};
+
+	OCA.Sharing._adjustDialog = function() {
+		var $dialog = $('.oc-dialog:visible');
+		var $buttons = $dialog.find('button');
+		// hack the buttons
+		$dialog.find('.ui-icon').remove();
+		$buttons.eq(0).text(t('core', 'Cancel'));
+		$buttons.eq(1).text(t('core', 'Add remote share'));
 	};
 })();
 

--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -31,6 +31,17 @@
 	margin-top: 10px;
 	width: 100%;
 }
+/* align primary button to right, other buttons to left */
+.oc-dialog-buttonrow.twobuttons button:nth-child(1) {
+	float: left;
+}
+.oc-dialog-buttonrow.twobuttons button:nth-child(2) {
+	float: right;
+}
+
+.oc-dialog-buttonrow.onebutton button {
+	float: right;
+}
 
 .oc-dialog-close {
 	position:absolute;

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -111,6 +111,13 @@
 						var $buttonrow = $('<div class="oc-dialog-buttonrow" />');
 						this.$buttonrow = $buttonrow.appendTo(this.$dialog);
 					}
+					if (value.length === 1) {
+						this.$buttonrow.addClass('onebutton');
+					} else if (value.length === 2) {
+						this.$buttonrow.addClass('twobuttons');
+					} else if (value.length === 3) {
+						this.$buttonrow.addClass('threebuttons');
+					}
 					$.each(value, function(idx, val) {
 						var $button = $('<button>').text(val.text);
 						if (val.classes) {

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -19,7 +19,7 @@
  *
  */
 
-/* global OC, t, alert, $ */
+/* global alert */
 
 /**
  * this class to ease the usage of jquery dialogs
@@ -66,7 +66,7 @@ var OCdialogs = {
 	* @param modal make the dialog modal
 	*/
 	confirm:function(text, title, callback, modal) {
-		this.message(
+		return this.message(
 			text,
 			title,
 			'notice',
@@ -86,7 +86,7 @@ var OCdialogs = {
 	 * @param password whether the input should be a password input
 	 */
 	prompt: function (text, title, callback, modal, name, password) {
-		$.when(this._getMessageTemplate()).then(function ($tmpl) {
+		return $.when(this._getMessageTemplate()).then(function ($tmpl) {
 			var dialogName = 'oc-dialog-' + OCdialogs.dialogsCounter + '-content';
 			var dialogId = '#' + dialogName;
 			var $dlg = $tmpl.octemplate({
@@ -104,8 +104,15 @@ var OCdialogs = {
 				modal = false;
 			}
 			$('body').append($dlg);
-			var buttonlist = [
-				{
+			var buttonlist = [{
+					text : t('core', 'No'),
+					click: function () {
+						if (callback !== undefined) {
+							callback(false, input.val());
+						}
+						$(dialogId).ocdialog('close');
+					}
+				}, {
 					text         : t('core', 'Yes'),
 					click        : function () {
 						if (callback !== undefined) {
@@ -114,15 +121,6 @@ var OCdialogs = {
 						$(dialogId).ocdialog('close');
 					},
 					defaultButton: true
-				},
-				{
-					text : t('core', 'No'),
-					click: function () {
-						if (callback !== undefined) {
-							callback(false, input.val());
-						}
-						$(dialogId).ocdialog('close');
-					}
 				}
 			];
 
@@ -237,7 +235,7 @@ var OCdialogs = {
 	 * You better use a wrapper instead ...
 	*/
 	message:function(content, title, dialogType, buttons, callback, modal) {
-		$.when(this._getMessageTemplate()).then(function($tmpl) {
+		return $.when(this._getMessageTemplate()).then(function($tmpl) {
 			var dialogName = 'oc-dialog-' + OCdialogs.dialogsCounter + '-content';
 			var dialogId = '#' + dialogName;
 			var $dlg = $tmpl.octemplate({
@@ -254,6 +252,15 @@ var OCdialogs = {
 			switch (buttons) {
 			case OCdialogs.YES_NO_BUTTONS:
 				buttonlist = [{
+					text: t('core', 'No'),
+					click: function(){
+						if (callback !== undefined) {
+							callback(false);
+						}
+						$(dialogId).ocdialog('close');
+					}
+				},
+				{
 					text: t('core', 'Yes'),
 					click: function(){
 						if (callback !== undefined) {
@@ -262,15 +269,6 @@ var OCdialogs = {
 						$(dialogId).ocdialog('close');
 					},
 					defaultButton: true
-				},
-				{
-					text: t('core', 'No'),
-					click: function(){
-						if (callback !== undefined) {
-							callback(false);
-						}
-						$(dialogId).ocdialog('close');
-					}
 				}];
 				break;
 			case OCdialogs.OK_BUTTON:


### PR DESCRIPTION
OC.dialogs now returns the promise to make it possible for the called to
do additional operations after the promise is resolved.

Changed title, label and buttons.
Removed icon.

Please review @owncloud/designers @icewind1991 @schiesbn 

:warning: protect your eyes, hacking involved!

Feel free to push if you want to change the wording.
The best way to test it is to comment out the line with `location.href` in `external.js` to force the dialog appearing every time on refresh. (convenient for testing)

Edit: removed wrong screenshot
