### PR TITLE
Fix search results in root dir & deprecate OC_Search_Provider

### DIFF
--- a/lib/private/legacy/search/provider.php
+++ b/lib/private/legacy/search/provider.php
@@ -17,6 +17,10 @@
  *
  */
 
+/**
+ * Class OC_Search_Provider
+ * @deprecated use \OCP\Search\Provider instead
+ */
 abstract class OC_Search_Provider extends \OCP\Search\Provider {
 
 }

--- a/search/js/result.js
+++ b/search/js/result.js
@@ -72,6 +72,9 @@ OC.search.showResults=function(results){
 					
 					if (type[i].path) {
 						var parent = OC.dirname(type[i].path);
+						if (parent === '') {
+							parent = '/';
+						}
 						var containerName = OC.basename(parent);
 						if (containerName === '') {
 							containerName = '/';


### PR DESCRIPTION
On master clicking on a search result located in the root folder will show you a blank page because the query parameter is `dir=` instead of `dir=/`. Subdirectories work fine. 
0e2f51b fixes this cornercase
b56f5f2 just adds a deprecation warning to the legacy OC_Search_Provider

@PVince81 @schiesbn quick review of 7 LOC?
