### PR TITLE
Hide the size in the trashbin summary row

### DIFF
--- a/apps/files_trashbin/css/trash.css
+++ b/apps/files_trashbin/css/trash.css
@@ -15,3 +15,6 @@
 #app-content-trashbin .summary :last-child {
 	padding: 0;
 }
+#app-content-trashbin #filestable .summary .filesize {
+	display: none;
+}


### PR DESCRIPTION
This also fixes the extra spacing that appearing on the right of the
table.

Please review @owncloud/designers 
