### PR TITLE
use icon-confirm instead of text for accepting remote share, works better with translations

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -89,21 +89,39 @@ thead {
 }
 
 /* within #save */
-#remote_address {
-	margin: 0;
-	height: 14px;
-	padding: 6px;
+#save .save-form {
+	position: relative;
 }
 
-#save button {
+#remote_address {
+	margin: 0;
+	width: 130px;
+	height: 14px;
+	padding: 6px;
+	padding-right: 24px;
+}
+
+#save #save-button,
+#save #save-button-confirm {
 	margin: 0 5px;
 	height: 28px;
 	padding-bottom: 4px;
 	line-height: 14px;
 }
 
-#save .save-form [type="submit"] {
-	margin: 0 5px;
-	height: 28px;
-	padding-bottom: 4px;
+#save-button-confirm {
+	position: absolute;
+	background-color: transparent;
+	border: none;
+	margin: 2px 4px !important;
+	right: 0;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+	filter: alpha(opacity=50);
+	opacity: .5;
+}
+#save-button-confirm:hover,
+#save-button-confirm:focus {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	filter: alpha(opacity=100);
+	opacity: 1;
 }

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -101,6 +101,10 @@ thead {
 	padding-right: 24px;
 }
 
+.ie8 #remote_address {
+	padding-right: 30px;
+}
+
 #save #save-button,
 #save #save-button-confirm {
 	margin: 0 5px;
@@ -119,6 +123,11 @@ thead {
 	filter: alpha(opacity=50);
 	opacity: .5;
 }
+
+.ie8 #save-button-confirm {
+	margin: 2px 0 !important;
+}
+
 #save-button-confirm:hover,
 #save-button-confirm:focus {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -163,7 +163,7 @@ OCA.Sharing.PublicApp = {
 			OCA.Sharing.PublicApp._saveToOwnCloud(remote, token, owner, name, isProtected);
 		});
 
-		$('#save > button').click(function () {
+		$('#save #save-button').click(function () {
 			$(this).hide();
 			$('.save-form').css('display', 'inline');
 			$('#remote_address').focus();

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -19,10 +19,10 @@
 		<div class="header-right">
 			<span id="details">
 				<span id="save" data-protected="<?php p($_['protected'])?>" data-owner="<?php p($_['displayName'])?>" data-name="<?php p($_['filename'])?>">
-					<button><?php p($l->t('Add to your ownCloud')) ?></button>
+					<button id="save-button"><?php p($l->t('Add to your ownCloud')) ?></button>
 					<form class="save-form hidden" action="#">
 						<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
-						<input type="submit" value="<?php p($l->t('Save')) ?>"/>
+						<button id="save-button-confirm" class="icon-confirm svg"></button>
 					</form>
 				</span>
 				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">


### PR DESCRIPTION
Ticks another one off #8934 (server-server sharing UX review).

Currently there is a »Save« button when you click the »Add to your ownCloud« function in public sharing. This will cause problems with long strings through translations. Also it’s just ugly and doesn’t seem to belong to the input field.

This fixes that, with a confirm icon which belongs in the input field.

Please test @owncloud/designers 
