### PR TITLE
Return and use isPreviewAvailable for share previews

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -166,11 +166,10 @@
 					}
 					else {
 						file.type = 'file';
-						// force preview retrieval as we don't have mime types,
-						// the preview endpoint will fall back to the mime type
-						// icon if no preview exists
-						file.isPreviewAvailable = true;
-						file.icon = true;
+						if (share.isPreviewAvailable) {
+							file.icon = true;
+							file.isPreviewAvailable = true;
+						}
 					}
 					file.share = {
 						id: share.id,

--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -60,6 +60,9 @@ class Api {
 			foreach ($shares as &$share) {
 				if ($share['item_type'] === 'file' && isset($share['path'])) {
 					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['path']);
+					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
+						$share['isPreviewAvailable'] = true;
+					}
 				}
 				$newShares[] = $share;
 			}
@@ -214,6 +217,9 @@ class Api {
 			foreach ($shares as &$share) {
 				if ($share['item_type'] === 'file') {
 					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['file_target']);
+					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
+						$share['isPreviewAvailable'] = true;
+					}
 				}
 			}
 			$result = new \OC_OCS_Result($shares);


### PR DESCRIPTION
Since the mime type is known, now isPreviewAvailable is returned as well
and used by the JS side to properly render mime icon and previews.

Fixes https://github.com/owncloud/core/issues/9428
Or at least it prevents loading the preview when there is none.

Please review @schiesbn @MorrisJobke @icewind1991 
