### PR TITLE
show loading feedback also when clicking 'Apps' entry in app list

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -113,6 +113,7 @@
 						<a href="<?php print_unescaped(OC_Helper::linkToRoute('settings_apps').'?installed'); ?>" title=""
 							<?php if( $_['appsmanagement_active'] ): ?> class="active"<?php endif; ?>>
 							<img class="app-icon svg" alt="" src="<?php print_unescaped(OC_Helper::imagePath('settings', 'apps.svg')); ?>"/>
+							<div class="icon-loading-dark" style="display:none;"></div>
 							<span>
 								<?php p($l->t('Apps')); ?>
 							</span>


### PR DESCRIPTION
Previously the »Apps« entry didn’t show feedback when clicked – unlike the other apps.

This is now fixed – review please @owncloud/designers 
