### PR TITLE
Reload the page when the files app encounters an authentication error

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -945,6 +945,13 @@
 			this.hideMask();
 
 			if (!result || result.status === 'error') {
+				// if the error is not related to folder we're trying to load, reload the page to handle logout etc
+				if (result.data.error === 'authentication_error' ||
+					result.data.error === 'token_expired' ||
+					result.data.error === 'application_not_enabled'
+				) {
+					OC.redirect(OC.generateUrl('apps/files'));
+				}
 				OC.Notification.show(result.data.message);
 				return false;
 			}
@@ -968,7 +975,7 @@
 			}
 
 			this.setFiles(result.data.files);
-			return true
+			return true;
 		},
 
 		updateStorageStatistics: function(force) {
@@ -1566,7 +1573,7 @@
 				numMatch=base.match(/\((\d+)\)/);
 				var num=2;
 				if (numMatch && numMatch.length>0) {
-					num=parseInt(numMatch[numMatch.length-1])+1;
+					num=parseInt(numMatch[numMatch.length-1], 10)+1;
 					base=base.split('(');
 					base.pop();
 					base=$.trim(base.join('('));

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1933,4 +1933,30 @@ describe('OCA.Files.FileList tests', function() {
 			});
 		});
 	});
+	describe('Handeling errors', function () {
+		beforeEach(function () {
+			redirectStub = sinon.stub(OC, 'redirect');
+
+			fileList = new OCA.Files.FileList($('#app-content-files'));
+		});
+		afterEach(function () {
+			fileList = undefined;
+
+			redirectStub.restore();
+		});
+		it('reloads the page on authentication errors', function () {
+			fileList.reload();
+			fakeServer.requests[0].respond(
+				200,
+				{ 'Content-Type': 'application/json' },
+				JSON.stringify({
+					status: 'error',
+					data: {
+						'error': 'authentication_error'
+					}
+				})
+			);
+			expect(redirectStub.calledWith(OC.generateUrl('apps/files'))).toEqual(true);
+		});
+	});
 });

--- a/lib/private/json.php
+++ b/lib/private/json.php
@@ -26,7 +26,7 @@ class OC_JSON{
 	public static function checkAppEnabled($app) {
 		if( !OC_App::isEnabled($app)) {
 			$l = OC_L10N::get('lib');
-			self::error(array( 'data' => array( 'message' => $l->t('Application is not enabled') )));
+			self::error(array( 'data' => array( 'message' => $l->t('Application is not enabled'), 'error' => 'application_not_enabled' )));
 			exit();
 		}
 	}
@@ -37,7 +37,7 @@ class OC_JSON{
 	public static function checkLoggedIn() {
 		if( !OC_User::isLoggedIn()) {
 			$l = OC_L10N::get('lib');
-			self::error(array( 'data' => array( 'message' => $l->t('Authentication error') )));
+			self::error(array( 'data' => array( 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' )));
 			exit();
 		}
 	}
@@ -48,7 +48,7 @@ class OC_JSON{
 	public static function callCheck() {
 		if( !OC_Util::isCallRegistered()) {
 			$l = OC_L10N::get('lib');
-			self::error(array( 'data' => array( 'message' => $l->t('Token expired. Please reload page.') )));
+			self::error(array( 'data' => array( 'message' => $l->t('Token expired. Please reload page.'), 'error' => 'token_expired' )));
 			exit();
 		}
 	}
@@ -59,7 +59,7 @@ class OC_JSON{
 	public static function checkAdminUser() {
 		if( !OC_User::isAdminUser(OC_User::getUser())) {
 			$l = OC_L10N::get('lib');
-			self::error(array( 'data' => array( 'message' => $l->t('Authentication error') )));
+			self::error(array( 'data' => array( 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' )));
 			exit();
 		}
 	}
@@ -71,7 +71,7 @@ class OC_JSON{
 	public static function checkUserExists($user) {
 		if (!OCP\User::userExists($user)) {
 			$l = OC_L10N::get('lib');
-			OCP\JSON::error(array('data' => array('message' => $l->t('Unknown user'))));
+			OCP\JSON::error(array('data' => array('message' => $l->t('Unknown user'), 'error' => 'unknown_user' )));
 			exit;
 		}
 	}
@@ -84,7 +84,7 @@ class OC_JSON{
 	public static function checkSubAdminUser() {
 		if(!OC_SubAdmin::isSubAdmin(OC_User::getUser())) {
 			$l = OC_L10N::get('lib');
-			self::error(array( 'data' => array( 'message' => $l->t('Authentication error') )));
+			self::error(array( 'data' => array( 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' )));
 			exit();
 		}
 	}


### PR DESCRIPTION
This adds machine readable (non translated) error messages to `OC\JSON` and adds handeling of those error messages to the files app by reloading the page.
Reloading the page will handle authentication and token expired errors and shows a proper error messages in case the app is unavailable.

Fixes #9442 

cc @PVince81 @MorrisJobke 
