### PR TITLE
fix size of breadcrumb separator

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -812,6 +812,7 @@ div.crumb {
 	display: block;
 	background: url('../img/breadcrumb.svg') no-repeat right center;
 	height: 44px;
+	background-size: auto 24px;
 }
 div.crumb.hidden {
 	display: none;


### PR DESCRIPTION
cc @icewind1991 @owncloud/designers @PVince81 

Before
![breadcrumb-before](https://cloud.githubusercontent.com/assets/245432/3483629/7f019140-0392-11e4-8800-fbc55c6108bf.png)
After
![breadcrumb-after](https://cloud.githubusercontent.com/assets/245432/3483630/83784c1e-0392-11e4-93f1-5667a8f2a0a5.png)
