### PR TITLE
[issues/9490] \OC::$WEBROOT is invalid when called from cron.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -41,16 +41,16 @@ $CONFIG = array(
 /* Blacklist a specific file and disallow the upload of files with this name - WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING. */
 "blacklisted_files" => array('.htaccess'),
 
-/* The automatic hostname detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the automatic detection. You can also add a port. For example "www.example.com:88" */
+/* The automatic hostname detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the automatic detection. You can also add a port. For example "www.example.com:88" */
 "overwritehost" => "",
 
-/* The automatic protocol detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the protocol detection. For example "https" */
+/* The automatic protocol detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the protocol detection. For example "https" */
 "overwriteprotocol" => "",
 
-/* The automatic webroot detection of ownCloud can fail in certain reverse proxy situations. This option allows to manually override the automatic detection. For example "/domain.tld/ownCloud". The value "/" can be used to remove the root. */
+/* The automatic webroot detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the automatic detection. For example "/domain.tld/ownCloud". The value "/" can be used to remove the root. */
 "overwritewebroot" => "",
 
-/* The automatic detection of ownCloud can fail in certain reverse proxy situations. This option allows to define a manually override condition as regular expression for the remote ip address. For example "^10\.0\.0\.[1-3]$" */
+/* The automatic detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to define a manually override condition as regular expression for the remote ip address. For example "^10\.0\.0\.[1-3]$" */
 "overwritecondaddr" => "",
 
 /* A proxy to use to connect to the internet. For example "myproxy.org:88" */

--- a/lib/base.php
+++ b/lib/base.php
@@ -117,10 +117,18 @@ class OC {
 			}
 		}
 
-		OC::$WEBROOT = substr($scriptName, 0, strlen($scriptName) - strlen(OC::$SUBURI));
+		if (substr($scriptName, 0 - strlen(OC::$SUBURI)) === OC::$SUBURI) {
+			OC::$WEBROOT = substr($scriptName, 0, 0 - strlen(OC::$SUBURI));
 
-		if (OC::$WEBROOT != '' and OC::$WEBROOT[0] !== '/') {
-			OC::$WEBROOT = '/' . OC::$WEBROOT;
+			if (OC::$WEBROOT != '' && OC::$WEBROOT[0] !== '/') {
+				OC::$WEBROOT = '/' . OC::$WEBROOT;
+			}
+		} else {
+			// The scriptName is not ending with OC::$SUBURI
+			// This most likely means that we are calling from CLI.
+			// However some cron jobs still need to generate
+			// a web URL, so we use overwritewebroot as a fallback.
+			OC::$WEBROOT = OC_Config::getValue('overwritewebroot', '');
 		}
 
 		// search the 3rdparty folder

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -95,7 +95,7 @@ class OC_Request {
 	 * reverse proxies
 	 */
 	public static function serverHost() {
-		if(OC::$CLI) {
+		if (OC::$CLI && defined('PHPUNIT_RUN')) {
 			return 'localhost';
 		}
 


### PR DESCRIPTION
Fix #9490, owncloud/activity#87

@icewind1991 you added the hack into lib/private/request.php 12f7cb87679453fa96c796df857b7e7193d4ee09
@PVince81 @DeepDiver1975 @MorrisJobke @karlitschek @butonic @LukasReschke 
