### PR TITLE
Avoid unnecessary writing to the DB when prefrences are not changed in fact

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -73,7 +73,6 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 			}
 
 			$user->markLogin();
-			$user->update();
 
 			return $user->getUsername();
 		}

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -183,6 +183,10 @@ class AppConfig implements \OCP\IAppConfig {
 			);
 			$this->conn->insert('*PREFIX*appconfig', $data);
 		} else {
+			$oldValue = $this->getValue($app, $key);
+			if($oldValue === strval($value)) {
+				return true;
+			}
 			$data = array(
 				'configvalue' => $value,
 			);

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -173,11 +173,16 @@ class Preferences {
 	 */
 	public function setValue($user, $app, $key, $value, $preCondition = null) {
 		// Check if the key does exist
-		$query = 'SELECT COUNT(*) FROM `*PREFIX*preferences`'
+		$query = 'SELECT `configvalue` FROM `*PREFIX*preferences`'
 			. ' WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?';
-		$count = $this->conn->fetchColumn($query, array($user, $app, $key));
-		$exists = $count > 0;
+		$oldValue = $this->conn->fetchColumn($query, array($user, $app, $key));
+		$exists = $oldValue !== false;
 
+		if($oldValue === strval($value)) {
+			// no changes
+			return true;
+		}
+		
 		$affectedRows = 0;
 
 		if (!$exists && $preCondition === null) {

--- a/tests/lib/appconfig.php
+++ b/tests/lib/appconfig.php
@@ -95,6 +95,72 @@ class Test_Appconfig extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('somevalue', $value['configvalue']);
 	}
 
+	public function testSetValueUnchanged() {
+		$statementMock = $this->getMock('\Doctrine\DBAL\Statement', array(), array(), '', false);
+		$statementMock->expects($this->once())
+			->method('fetch')
+			->will($this->returnValue(false));
+
+		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
+		$connectionMock->expects($this->once())
+			->method('executeQuery')
+			->with($this->equalTo('SELECT `configvalue`, `configkey` FROM `*PREFIX*appconfig`'
+				.' WHERE `appid` = ?'), $this->equalTo(array('bar')))
+			->will($this->returnValue($statementMock));
+		$connectionMock->expects($this->once())
+			->method('insert')
+			->with($this->equalTo('*PREFIX*appconfig'),
+				$this->equalTo(
+					array(
+						'appid' => 'bar',
+						'configkey' => 'foo',
+						'configvalue' => 'v1',
+					)
+				));
+		$connectionMock->expects($this->never())
+			->method('update');
+
+		$appconfig = new OC\AppConfig($connectionMock);
+		$appconfig->setValue('bar', 'foo', 'v1');
+		$appconfig->setValue('bar', 'foo', 'v1');
+		$appconfig->setValue('bar', 'foo', 'v1');
+	}
+
+	public function testSetValueUnchanged2() {
+		$statementMock = $this->getMock('\Doctrine\DBAL\Statement', array(), array(), '', false);
+		$statementMock->expects($this->once())
+			->method('fetch')
+			->will($this->returnValue(false));
+
+		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
+		$connectionMock->expects($this->once())
+			->method('executeQuery')
+			->with($this->equalTo('SELECT `configvalue`, `configkey` FROM `*PREFIX*appconfig`'
+				.' WHERE `appid` = ?'), $this->equalTo(array('bar')))
+			->will($this->returnValue($statementMock));
+		$connectionMock->expects($this->once())
+			->method('insert')
+			->with($this->equalTo('*PREFIX*appconfig'),
+				$this->equalTo(
+					array(
+						'appid' => 'bar',
+						'configkey' => 'foo',
+						'configvalue' => 'v1',
+					)
+				));
+		$connectionMock->expects($this->once())
+			->method('update')
+			->with($this->equalTo('*PREFIX*appconfig'),
+				$this->equalTo(array('configvalue' => 'v2')),
+				$this->equalTo(array('appid' => 'bar', 'configkey' => 'foo'))
+				);
+
+		$appconfig = new OC\AppConfig($connectionMock);
+		$appconfig->setValue('bar', 'foo', 'v1');
+		$appconfig->setValue('bar', 'foo', 'v2');
+		$appconfig->setValue('bar', 'foo', 'v2');
+	}
+
 	public function testDeleteKey() {
 		\OC_Appconfig::deleteKey('testapp', 'deletethis');
 		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*appconfig` WHERE `appid` = ? AND `configkey` = ?');

--- a/tests/lib/preferences-singleton.php
+++ b/tests/lib/preferences-singleton.php
@@ -7,6 +7,161 @@
  * See the COPYING-README file.
  */
 
+class Test_Preferences extends PHPUnit_Framework_TestCase {
+	public static function setUpBeforeClass() {
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*preferences` VALUES(?, ?, ?, ?)');
+		$query->execute(array("Someuser", "someapp", "somekey", "somevalue"));
+
+		$query->execute(array("Someuser", "getusersapp", "somekey", "somevalue"));
+		$query->execute(array("Anotheruser", "getusersapp", "somekey", "someothervalue"));
+		$query->execute(array("Anuser", "getusersapp", "somekey", "somevalue"));
+
+		$query->execute(array("Someuser", "getappsapp", "somekey", "somevalue"));
+
+		$query->execute(array("Someuser", "getkeysapp", "firstkey", "somevalue"));
+		$query->execute(array("Someuser", "getkeysapp", "anotherkey", "somevalue"));
+		$query->execute(array("Someuser", "getkeysapp", "key-tastic", "somevalue"));
+
+		$query->execute(array("Someuser", "getvalueapp", "key", "a value for a key"));
+
+		$query->execute(array("Deleteuser", "deleteapp", "deletekey", "somevalue"));
+		$query->execute(array("Deleteuser", "deleteapp", "somekey", "somevalue"));
+		$query->execute(array("Deleteuser", "someapp", "somekey", "somevalue"));
+	}
+
+	public static function tearDownAfterClass() {
+		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*preferences` WHERE `userid` = ?');
+		$query->execute(array('Someuser'));
+		$query->execute(array('Anotheruser'));
+		$query->execute(array('Anuser'));
+	}
+
+	public function testGetUsers() {
+		$query = \OC_DB::prepare('SELECT DISTINCT `userid` FROM `*PREFIX*preferences`');
+		$result = $query->execute();
+		$expected = array();
+		while ($row = $result->fetchRow()) {
+			$expected[] = $row['userid'];
+		}
+
+		$this->assertEquals($expected, \OC_Preferences::getUsers());
+	}
+
+	public function testGetApps() {
+		$query = \OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*preferences` WHERE `userid` = ?');
+		$result = $query->execute(array('Someuser'));
+		$expected = array();
+		while ($row = $result->fetchRow()) {
+			$expected[] = $row['appid'];
+		}
+
+		$this->assertEquals($expected, \OC_Preferences::getApps('Someuser'));
+	}
+
+	public function testGetKeys() {
+		$query = \OC_DB::prepare('SELECT DISTINCT `configkey` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ?');
+		$result = $query->execute(array('Someuser', 'getkeysapp'));
+		$expected = array();
+		while ($row = $result->fetchRow()) {
+			$expected[] = $row['configkey'];
+		}
+
+		$this->assertEquals($expected, \OC_Preferences::getKeys('Someuser', 'getkeysapp'));
+	}
+
+	public function testGetValue() {
+		$this->assertNull(\OC_Preferences::getValue('nonexistant', 'nonexistant', 'nonexistant'));
+
+		$this->assertEquals('default', \OC_Preferences::getValue('nonexistant', 'nonexistant', 'nonexistant', 'default'));
+
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'getvalueapp', 'key'));
+		$row = $result->fetchRow();
+		$expected = $row['configvalue'];
+		$this->assertEquals($expected, \OC_Preferences::getValue('Someuser', 'getvalueapp', 'key'));
+	}
+
+	public function testSetValue() {
+		$this->assertTrue(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'newvalue'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$value = $row['configvalue'];
+		$this->assertEquals('newvalue', $value);
+
+		$this->assertTrue(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'othervalue'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$value = $row['configvalue'];
+		$this->assertEquals('othervalue', $value);
+	}
+
+	public function testSetValueWithPreCondition() {
+		// remove existing key
+		$this->assertTrue(\OC_Preferences::deleteKey('Someuser', 'setvalueapp', 'newkey'));
+
+		// add new preference with pre-condition should fails
+		$this->assertFalse(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'newvalue', 'preCondition'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$this->assertFalse($row);
+
+		// add new preference without pre-condition should insert the new value
+		$this->assertTrue(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'newvalue'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$value = $row['configvalue'];
+		$this->assertEquals('newvalue', $value);
+
+		// wrong pre-condition, value should stay the same
+		$this->assertFalse(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'othervalue', 'preCondition'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$value = $row['configvalue'];
+		$this->assertEquals('newvalue', $value);
+
+		// correct pre-condition, value should change
+		$this->assertTrue(\OC_Preferences::setValue('Someuser', 'setvalueapp', 'newkey', 'othervalue', 'newvalue'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Someuser', 'setvalueapp', 'newkey'));
+		$row = $result->fetchRow();
+		$value = $row['configvalue'];
+		$this->assertEquals('othervalue', $value);
+	}
+
+	public function testDeleteKey() {
+		$this->assertTrue(\OC_Preferences::deleteKey('Deleteuser', 'deleteapp', 'deletekey'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?');
+		$result = $query->execute(array('Deleteuser', 'deleteapp', 'deletekey'));
+		$this->assertEquals(0, count($result->fetchAll()));
+	}
+
+	public function testDeleteApp() {
+		$this->assertTrue(\OC_Preferences::deleteApp('Deleteuser', 'deleteapp'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ?');
+		$result = $query->execute(array('Deleteuser', 'deleteapp'));
+		$this->assertEquals(0, count($result->fetchAll()));
+	}
+
+	public function testDeleteUser() {
+		$this->assertTrue(\OC_Preferences::deleteUser('Deleteuser'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?');
+		$result = $query->execute(array('Deleteuser'));
+		$this->assertEquals(0, count($result->fetchAll()));
+	}
+
+	public function testDeleteAppFromAllUsers() {
+		$this->assertTrue(\OC_Preferences::deleteAppFromAllUsers('someapp'));
+		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `appid` = ?');
+		$result = $query->execute(array('someapp'));
+		$this->assertEquals(0, count($result->fetchAll()));
+	}
+}
+
 class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 	public function testGetUsers()
 	{
@@ -30,10 +185,10 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
 		$connectionMock->expects($this->exactly(2))
 			->method('fetchColumn')
-			->with($this->equalTo('SELECT `configvalue` FROM `*PREFIX*preferences`'
+			->with($this->equalTo('SELECT COUNT(*) FROM `*PREFIX*preferences`'
 				.' WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?'),
 				$this->equalTo(array('grg', 'bar', 'foo')))
-			->will($this->onConsecutiveCalls(false, 'v1'));
+			->will($this->onConsecutiveCalls(0, 1));
 		$connectionMock->expects($this->once())
 			->method('insert')
 			->with($this->equalTo('*PREFIX*preferences'),
@@ -59,12 +214,12 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 
 	public function testSetValueUnchanged() {
 		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
-		$connectionMock->expects($this->exactly(3))
+		$connectionMock->expects($this->exactly(2))
 			->method('fetchColumn')
 			->with($this->equalTo('SELECT `configvalue` FROM `*PREFIX*preferences`'
 				.' WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?'),
 				$this->equalTo(array('grg', 'bar', 'foo')))
-			->will($this->onConsecutiveCalls(false, 'v1', 'v1'));
+			->will($this->onConsecutiveCalls(0, 1));
 		$connectionMock->expects($this->once())
 			->method('insert')
 			->with($this->equalTo('*PREFIX*preferences'),
@@ -87,12 +242,12 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 
 	public function testSetValueUnchanged2() {
 		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
-		$connectionMock->expects($this->exactly(3))
+		$connectionMock->expects($this->exactly(2))
 			->method('fetchColumn')
 			->with($this->equalTo('SELECT `configvalue` FROM `*PREFIX*preferences`'
 				.' WHERE `userid` = ? AND `appid` = ? AND `configkey` = ?'),
 				$this->equalTo(array('grg', 'bar', 'foo')))
-			->will($this->onConsecutiveCalls(false, 'v1', 'v2'));
+			->will($this->onConsecutiveCalls(0, 1));
 		$connectionMock->expects($this->once())
 			->method('insert')
 			->with($this->equalTo('*PREFIX*preferences'),


### PR DESCRIPTION
Avoids unnecessary writing to the DB when the value in question is not changed. Small changeset,  with unit tests. Fixes https://github.com/owncloud/core/issues/9475

What happens in general is that ownCloud reads the email from LDAP address for a users every 24hrs at earliest. It is taken over into owncloud i.e. written to the database. Now we write it only, if the value has actually changed. User preferences are read at once so this has no additional read operations but saves a write. It also avoids a double-write when it is triggered from both login and userExists check. userExists is always called prior to the login attempt.

Reviewers/testers please, maybe @Xenopathic @PVince81 @icewind1991 or others?
