### PR TITLE
Fixed shared list sorting

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -238,12 +238,11 @@
 					);
 					delete data.recipientsCount;
 				})
-				// Sort by expected sort comparator
-				.sortBy(this._sortComparator)
 				// Finish the chain by getting the result
 				.value();
 
-			return files;
+			// Sort by expected sort comparator
+			return files.sort(this._sortComparator);
 		}
 	});
 


### PR DESCRIPTION
Use Array.sort instead of underscore's sortBy() as they don't use the
same method/function signature.

Fixes #9462 

Please review @MorrisJobke @icewind1991 
