### PR TITLE
Fix Signiture Does Not Match when mounting Amazon S3 external storage

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -72,6 +72,12 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			sleep($this->timeout);
 		}
 	}
+	private function cleanKey($path) {
+		if ($path === '.') {
+			return '/';
+		}
+		return $path;
+	}
 
 	public function __construct($params) {
 		if (!isset($params['key']) || !isset($params['secret']) || !isset($params['bucket'])) {
@@ -118,11 +124,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				throw new \Exception("Creation of bucket failed.");
 			}
 		}
-
 		if (!$this->file_exists('.')) {
 			$result = $this->connection->putObject(array(
 				'Bucket' => $this->bucket,
-				'Key'    => '.',
+				'Key'    => $this->cleanKey('.'),
 				'Body'   => '',
 				'ContentType' => 'httpd/unix-directory',
 				'ContentLength' => 0
@@ -167,7 +172,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		try {
 			$result = $this->connection->doesObjectExist(
 				$this->bucket,
-				$path
+				$this->cleanKey($path)
 			);
 		} catch (S3Exception $e) {
 			\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
@@ -261,7 +266,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 			$result = $this->connection->headObject(array(
 				'Bucket' => $this->bucket,
-				'Key' => $path
+				'Key' => $this->cleanKey($path)
 			));
 
 			$stat = array();
@@ -291,8 +296,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			if ($path != '.') {
 				$path .= '/';
 			}
-
-			if ($this->connection->doesObjectExist($this->bucket, $path)) {
+			if ($this->connection->doesObjectExist($this->bucket, $this->cleanKey($path))) {
 				return 'dir';
 			}
 		} catch (S3Exception $e) {
@@ -309,7 +313,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		try {
 			$result = $this->connection->deleteObject(array(
 				'Bucket' => $this->bucket,
-				'Key' => $path
+				'Key' => $this->cleanKey($path)
 			));
 			$this->testTimeout();
 		} catch (S3Exception $e) {
@@ -332,7 +336,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				try {
 					$result = $this->connection->getObject(array(
 						'Bucket' => $this->bucket,
-						'Key' => $path,
+						'Key' => $this->cleanKey($path),
 						'SaveAs' => $tmpFile
 					));
 				} catch (S3Exception $e) {
@@ -380,7 +384,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			try {
 				$result = $this->connection->headObject(array(
 					'Bucket' => $this->bucket,
-					'Key' => $path
+					'Key' => $this->cleanKey($path)
 				));
 			} catch (S3Exception $e) {
 				\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
@@ -407,7 +411,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				}
 				$result = $this->connection->copyObject(array(
 					'Bucket' => $this->bucket,
-					'Key' => $path,
+					'Key' => $this->cleanKey($path),
 					'Metadata' => $metadata,
 					'CopySource' => $this->bucket . '/' . $path
 				));
@@ -415,7 +419,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			} else {
 				$result = $this->connection->putObject(array(
 					'Bucket' => $this->bucket,
-					'Key' => $path,
+					'Key' => $this->cleanKey($path),
 					'Metadata' => $metadata
 				));
 				$this->testTimeout();
@@ -436,7 +440,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			try {
 				$result = $this->connection->copyObject(array(
 					'Bucket' => $this->bucket,
-					'Key' => $path2,
+					'Key' => $this->cleanKey($path2),
 					'CopySource' => $this->bucket . '/' . $path1
 				));
 				$this->testTimeout();
@@ -535,7 +539,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		try {
 			$result= $this->connection->putObject(array(
 				'Bucket' => $this->bucket,
-				'Key' => self::$tmpFiles[$tmpFile],
+				'Key' => $this->cleanKey(self::$tmpFiles[$tmpFile]),
 				'SourceFile' => $tmpFile,
 				'ContentType' => \OC_Helper::getMimeType($tmpFile),
 				'ContentLength' => filesize($tmpFile)


### PR DESCRIPTION
For some reason the aws-sdk-php package does not caclulate the
signiture correctly when accessing an object in a bucket with a name of
'.'.

When we are at the top of a S3 bucket there is a need(?) to have a directory
name.  Per standard Unix the name picked was '.' (dot or period).  This
choice exercises the aws-sdk bug.

This fix is to add a field to the method to store the name to use instead of
'.' which at this point is hard coded to '<root>'.  We also add a private
function 'cleanKey()' which will test for the '.' name and replace it with
the variable.  Finally all calls to manipulate objects where the path is
not obviously not '.' are processed through cleanKey().

An example where we don't process through clean key would be
    'Key' => $path.'/',

Use correct relationship operator

Per feed back use === instead of ==

use '/' instead of '<root>'
