### PR TITLE
Fix update cleanup to only affect file and folders

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -204,8 +204,8 @@ class Shared_Updater {
 	static public function fixBrokenSharesOnAppUpdate() {
 		// delete all shares where the original file no longer exists
 		$findAndRemoveShares = \OC_DB::prepare('DELETE FROM `*PREFIX*share` ' .
-			'WHERE `file_source` NOT IN ( ' .
-				'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `item_type` IN (\'file\', \'folder\'))'
+			'WHERE `item_type` IN (\'file\', \'folder\') ' .
+			'AND `file_source` NOT IN (SELECT `fileid` FROM `*PREFIX*filecache`)'
 		);
 		$findAndRemoveShares->execute(array());
 	}


### PR DESCRIPTION
Fix bug in the SQL query that cleans up stray shares for removed
files/folders, which is now correctly limited to that item type instead
of also removing all other share types.

Related to https://github.com/owncloud/core/pull/7293

Please review @MorrisJobke @schiesbn @DeepDiver1975 @icewind1991 

Something to keep in mind: when writing test it's always better to add a few extra cases to simulate unrelated data, and assert that the data still exists.
