### PR TITLE
Add ability to theme iOS and Android client URLs just like desktop URLs.

### DIFF
--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -186,7 +186,7 @@ class OC_Defaults {
 		if ($this->themeExist('getShortFooter')) {
 			$footer = $this->theme->getShortFooter();
 		} else {
-			$footer = '<a href=\"'. $this->getBaseUrl() . '\" target=\"_blank\">' .$this->getEntity() . '</a>'.
+			$footer = '<a href="'. $this->getBaseUrl() . '" target="_blank">' .$this->getEntity() . '</a>'.
 				' – ' . $this->getSlogan();
 		}
 

--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -18,6 +18,8 @@ class OC_Defaults {
 	private $defaultTitle;
 	private $defaultBaseUrl;
 	private $defaultSyncClientUrl;
+	private $defaultiOSClientURL;
+	private $defaultAndroidClientURL;
 	private $defaultDocBaseUrl;
 	private $defaultDocVersion;
 	private $defaultSlogan;
@@ -28,18 +30,20 @@ class OC_Defaults {
 		$this->l = OC_L10N::get('lib');
 		$version = OC_Util::getVersion();
 
-		$this->defaultEntity = "ownCloud"; /* e.g. company name, used for footers and copyright notices */
-		$this->defaultName = "ownCloud"; /* short name, used when referring to the software */
-		$this->defaultTitle = "ownCloud"; /* can be a longer name, for titles */
-		$this->defaultBaseUrl = "https://owncloud.org";
-		$this->defaultSyncClientUrl = "https://owncloud.org/sync-clients/";
-		$this->defaultDocBaseUrl = "http://doc.owncloud.org";
-		$this->defaultDocVersion = $version[0] . ".0"; // used to generate doc links
-		$this->defaultSlogan = $this->l->t("web services under your control");
-		$this->defaultLogoClaim = "";
-		$this->defaultMailHeaderColor = "#1d2d44"; /* header color of mail notifications */
+		$this->defaultEntity = 'ownCloud'; /* e.g. company name, used for footers and copyright notices */
+		$this->defaultName = 'ownCloud'; /* short name, used when referring to the software */
+		$this->defaultTitle = 'ownCloud'; /* can be a longer name, for titles */
+		$this->defaultBaseUrl = 'https://owncloud.org';
+		$this->defaultSyncClientUrl = 'https://owncloud.org/sync-clients/';
+		$this->defaultiOSClientURL = 'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8';
+		$this->defaultAndroidClientURL = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
+		$this->defaultDocBaseUrl = 'http://doc.owncloud.org';
+		$this->defaultDocVersion = $version[0] . '.0'; // used to generate doc links
+		$this->defaultSlogan = $this->l->t('web services under your control');
+		$this->defaultLogoClaim = '';
+		$this->defaultMailHeaderColor = '#1d2d44'; /* header color of mail notifications */
 
-		if (class_exists("OC_Theme")) {
+		if (class_exists('OC_Theme')) {
 			$this->theme = new OC_Theme();
 		}
 	}
@@ -75,6 +79,30 @@ class OC_Defaults {
 			return $this->theme->getSyncClientUrl();
 		} else {
 			return $this->defaultSyncClientUrl;
+		}
+	}
+
+	/**
+	 * Returns the URL to the App Store for the iOS Client
+	 * @return string URL
+	 */
+	public function getiOSClientUrl() {
+		if ($this->themeExist('getiOSClientUrl')) {
+			return $this->theme->getiOSClientUrl();
+		} else {
+			return $this->defaultiOSClientUrl;
+		}
+	}
+
+	/**
+	 * Returns the URL to Google Play for the Android Client
+	 * @return string URL
+	 */
+	public function getAndroidClientUrl() {
+		if ($this->themeExist('getAndroidClientUrl')) {
+			return $this->theme->getAndroidClientUrl();
+		} else {
+			return $this->defaultAndroidClientUrl;
 		}
 	}
 
@@ -158,7 +186,7 @@ class OC_Defaults {
 		if ($this->themeExist('getShortFooter')) {
 			$footer = $this->theme->getShortFooter();
 		} else {
-			$footer = "<a href=\"". $this->getBaseUrl() . "\" target=\"_blank\">" .$this->getEntity() . "</a>".
+			$footer = '<a href=\"'. $this->getBaseUrl() . '\" target=\"_blank\">' .$this->getEntity() . '</a>'.
 				' – ' . $this->getSlogan();
 		}
 

--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -18,8 +18,8 @@ class OC_Defaults {
 	private $defaultTitle;
 	private $defaultBaseUrl;
 	private $defaultSyncClientUrl;
-	private $defaultiOSClientURL;
-	private $defaultAndroidClientURL;
+	private $defaultiOSClientUrl;
+	private $defaultAndroidClientUrl;
 	private $defaultDocBaseUrl;
 	private $defaultDocVersion;
 	private $defaultSlogan;
@@ -35,8 +35,8 @@ class OC_Defaults {
 		$this->defaultTitle = 'ownCloud'; /* can be a longer name, for titles */
 		$this->defaultBaseUrl = 'https://owncloud.org';
 		$this->defaultSyncClientUrl = 'https://owncloud.org/sync-clients/';
-		$this->defaultiOSClientURL = 'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8';
-		$this->defaultAndroidClientURL = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
+		$this->defaultiOSClientUrl = 'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8';
+		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
 		$this->defaultDocBaseUrl = 'http://doc.owncloud.org';
 		$this->defaultDocVersion = $version[0] . '.0'; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('web services under your control');

--- a/lib/public/defaults.php
+++ b/lib/public/defaults.php
@@ -66,6 +66,22 @@ class Defaults {
 	}
 
 	/**
+	 * link to the iOS client
+	 * @return string
+	 */
+	public function getiOSClientUrl() {
+		return $this->defaults->getiOSClientUrl();
+	}
+
+	/**
+	 * link to the Android client
+	 * @return string
+	 */
+	public function getAndroidClientUrl() {
+		return $this->defaults->getAndroidClientUrl();
+	}
+
+	/**
 	 * base URL to the documentation of your ownCloud instance
 	 * @return string
 	 */

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -76,8 +76,8 @@ usort( $languages, function ($a, $b) {
 //links to clients
 $clients = array(
 	'desktop' => OC_Config::getValue('customclient_desktop', $defaults->getSyncClientUrl()),
-	'android' => OC_Config::getValue('customclient_android', 'https://play.google.com/store/apps/details?id=com.owncloud.android'),
-	'ios'     => OC_Config::getValue('customclient_ios', 'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8')
+	'android' => OC_Config::getValue('customclient_android', $defaults->getAndroidClientUrl()),
+	'ios'     => OC_Config::getValue('customclient_ios', $defaults->getiOSClientUrl())
 );
 
 // Return template


### PR DESCRIPTION
Desktop client download URLs can be themed, but not mobile clients. This little patch adds this capability to the defaults system. No impact to existing themes that do not have the necessary methods. In that case, current default URLs are returned.
