### PR TITLE
Fixes #8326: deletion of directories on S3

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -192,10 +192,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 		// Since there are no real directories on S3, we need
 		// to delete all objects prefixed with the path.
-		$objects = $this->connection->listObjects([
+		$objects = $this->connection->listObjects(array(
 			'Bucket' => $this->bucket,
 			'Prefix' => $path . '/'
-		]);
+		));
 
 		try {
 			$result = $this->connection->deleteObjects(array(


### PR DESCRIPTION
Since there are no real directories on S3 the previous OC\Files\Storage\AmazonS3::unlink did not work as expected. The method now determines if the supplied path is a directory and then executes OC\Files\Storage\AmazonS3::rmdir. rmdir has been improved to use native sdk-methods, which means that recursion is no longer necessary.
