### PR TITLE
Propagate file action changes to the file lists

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -172,7 +172,8 @@
 		 */
 		destroy: function() {
 			// TODO: also unregister other event handlers
-			this.fileActions.removeUpdateListener(this._onFileActionsUpdated);
+			this.fileActions.off('registerAction', this._onFileActionsUpdated);
+			this.fileActions.off('setDefault', this._onFileActionsUpdated);
 		},
 
 		_initFileActions: function(fileActions) {
@@ -182,7 +183,8 @@
 				this.fileActions.registerDefaultActions();
 			}
 			this._onFileActionsUpdated = _.debounce(_.bind(this._onFileActionsUpdated, this), 100);
-			this.fileActions.addUpdateListener(this._onFileActionsUpdated);
+			this.fileActions.on('registerAction', this._onFileActionsUpdated);
+			this.fileActions.on('setDefault', this._onFileActionsUpdated);
 		},
 
 		/**

--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -52,9 +52,7 @@ describe('OCA.Files.App tests', function() {
 		App.initialize();
 	});
 	afterEach(function() {
-		App.navigation = null;
-		App.fileList = null;
-		App.files = null;
+		App.destroy();
 
 		pushStateStub.restore();
 		parseUrlQueryStub.restore();

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -354,7 +354,7 @@ describe('OCA.Files.FileActions tests', function() {
 		it('notifies update event handlers once after multiple changes', function() {
 			var actionStub = sinon.stub();
 			var handler = sinon.stub();
-			FileActions.addUpdateListener(handler);
+			FileActions.on('registerAction', handler);
 			FileActions.register(
 					'all',
 					'Test',
@@ -374,8 +374,8 @@ describe('OCA.Files.FileActions tests', function() {
 		it('does not notifies update event handlers after unregistering', function() {
 			var actionStub = sinon.stub();
 			var handler = sinon.stub();
-			FileActions.addUpdateListener(handler);
-			FileActions.removeUpdateListener(handler);
+			FileActions.on('registerAction', handler);
+			FileActions.off('registerAction', handler);
 			FileActions.register(
 					'all',
 					'Test',

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -45,12 +45,7 @@ describe('OCA.Sharing.App tests', function() {
 		fileListOut = App.initSharingOut($('#app-content-sharingout'));
 	});
 	afterEach(function() {
-		App._inFileList = null;
-		App._outFileList = null;
-		fileListIn.destroy();
-		fileListOut.destroy();
-		fileListIn = null;
-		fileListOut = null;
+		App.destroy();
 	});
 
 	describe('initialization', function() {


### PR DESCRIPTION
Whenever an app needs to register an event late, it does that on the
original file actions object.

Since the file actions that the file list work on is a merged list, not
the original one, the registration event needs to be propagated there as
well.

Fixes https://github.com/owncloud/core/issues/9463

Please review @icewind1991 @MorrisJobke @DeepDiver1975 

I'm not super happy about this approach, but it's the best I can do short term.
