### PR TITLE
use fileinfo object in search results

### DIFF
--- a/lib/private/search/result/file.php
+++ b/lib/private/search/result/file.php
@@ -92,10 +92,9 @@ class File extends \OCP\Search\Result {
 	 * @param string $path
 	 * @return string relative path
 	 */
-	function getRelativePath ($path) {
+	protected function getRelativePath ($path) {
 		$root = \OC::$server->getUserFolder();
 		return $root->getRelativePath($path);
-
 	}
 
 }

--- a/lib/private/search/result/file.php
+++ b/lib/private/search/result/file.php
@@ -18,7 +18,9 @@
  */
 
 namespace OC\Search\Result;
-use \OC\Files\Filesystem;
+use OC\Files\Filesystem;
+use OCP\Files\FileInfo;
+
 /**
  * A found file
  */
@@ -65,20 +67,20 @@ class File extends \OCP\Search\Result {
 	 * Create a new file search result
 	 * @param array $data file data given by provider
 	 */
-	public function __construct(array $data = null) {
-		$info = pathinfo($data['path']);
-		$this->id = $data['fileid'];
+	public function __construct(FileInfo $data) {
+		$info = pathinfo($data->getPath());
+		$this->id = $data->getId();
 		$this->name = $info['basename'];
 		$this->link = \OCP\Util::linkTo(
 			'files',
 			'index.php',
 			array('dir' => $info['dirname'], 'file' => $info['basename'])
 		);
-		$this->permissions = self::get_permissions($data['path']);
-		$this->path = (strpos($data['path'], 'files') === 0) ? substr($data['path'], 5) : $data['path'];
-		$this->size = $data['size'];
-		$this->modified = $data['mtime'];
-		$this->mime_type = $data['mimetype'];
+		$this->permissions = self::get_permissions($data->getPath());
+		$this->path = (strpos($data->getPath(), 'files') === 0) ? substr($data->getPath(), 5) : $data->getPath();
+		$this->size = $data->getSize();
+		$this->modified = $data->getMtime();
+		$this->mime_type = $data->getMimetype();
 	}
 
 	/**

--- a/lib/private/search/result/file.php
+++ b/lib/private/search/result/file.php
@@ -65,10 +65,13 @@ class File extends \OCP\Search\Result {
 
 	/**
 	 * Create a new file search result
-	 * @param array $data file data given by provider
+	 * @param FileInfo $data file data given by provider
 	 */
 	public function __construct(FileInfo $data) {
-		$info = pathinfo($data->getPath());
+
+		$path = $this->getRelativePath($data->getPath());
+
+		$info = pathinfo($path);
 		$this->id = $data->getId();
 		$this->name = $info['basename'];
 		$this->link = \OCP\Util::linkTo(
@@ -76,38 +79,23 @@ class File extends \OCP\Search\Result {
 			'index.php',
 			array('dir' => $info['dirname'], 'file' => $info['basename'])
 		);
-		$this->permissions = self::get_permissions($data->getPath());
-		$this->path = (strpos($data->getPath(), 'files') === 0) ? substr($data->getPath(), 5) : $data->getPath();
+		$this->permissions = $data->getPermissions();
+		$this->path = $path;
 		$this->size = $data->getSize();
 		$this->modified = $data->getMtime();
 		$this->mime_type = $data->getMimetype();
 	}
 
 	/**
-	 * Determine permissions for a given file path
+	 * converts a path relative to the users files folder
+	 * eg /user/files/foo.txt -> /foo.txt
 	 * @param string $path
-	 * @return int
+	 * @return string relative path
 	 */
-	function get_permissions($path) {
-		// add read permissions
-		$permissions = \OCP\PERMISSION_READ;
-		// get directory
-		$fileinfo = pathinfo($path);
-		$dir = $fileinfo['dirname'] . '/';
-		// add update permissions
-		if (Filesystem::isUpdatable($dir)) {
-			$permissions |= \OCP\PERMISSION_UPDATE;
-		}
-		// add delete permissions
-		if (Filesystem::isDeletable($dir)) {
-			$permissions |= \OCP\PERMISSION_DELETE;
-		}
-		// add share permissions
-		if (Filesystem::isSharable($dir)) {
-			$permissions |= \OCP\PERMISSION_SHARE;
-		}
-		// return
-		return $permissions;
+	function getRelativePath ($path) {
+		$root = \OC::$server->getUserFolder();
+		return $root->getRelativePath($path);
+
 	}
-	
+
 }


### PR DESCRIPTION
fixes log entries like:

``` json
{"reqId":"53bd3a9247c78","app":"PHP","message":"Argument 1 passed to OC\\Search\\Result\\File::__construct() must be of the type array, object given, called in \/home\/jfd\/Repositories\/oc\/core\/lib\/private\/
search\/provider\/file.php on line 56 and defined at \/home\/jfd\/Repositories\/oc\/core\/lib\/private\/search\/result\/file.php#68","level":0,"time":"2014-07-09T12:50:26+00:00","method":"GET","url":"\/core\/ind
ex.php\/search\/ajax\/search.php?query=baz"}
```

@icewind1991 @DeepDiver1975 @PVince81 easy to reproduce: just search for a file
