### PR TITLE
force loading of encryption app to show correct error

### DIFF
--- a/apps/files_encryption/files/error.php
+++ b/apps/files_encryption/files/error.php
@@ -4,6 +4,9 @@ if (!isset($_)) { //also provide standalone error page
 	require_once __DIR__ . '/../../../lib/base.php';
 	require_once __DIR__ . '/../lib/crypt.php';
 
+	OC_JSON::checkAppEnabled('files_encryption');
+	OC_App::loadApp('files_encryption');
+
 	$l = \OC::$server->getL10N('files_encryption');
 
 	if (isset($_GET['errorCode'])) {


### PR DESCRIPTION
In some cases (eg encryption not initialized) the encryption redirects to an error page. Unfortunately, if the encryption app.php has not been loaded the Crypt class cannot be found because the classpath for it has not been set up and it does not follow an autoloadable path and you will see a `Class 'OCA\Encryption\Crypt' not found` in the log, related: https://github.com/owncloud/core/issues/9238

This forces loading the 'files_encryption' app when displaying the error page, allowing the correct error to be shown.

@schiesbn @PVince81
