### PR TITLE
Extends the public user api

### DIFF
--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -10,6 +10,7 @@
 namespace OC\User;
 
 use OC\Hooks\PublicEmitter;
+use OCP\IUserManager;
 
 /**
  * Class Manager
@@ -24,7 +25,7 @@ use OC\Hooks\PublicEmitter;
  *
  * @package OC\User
  */
-class Manager extends PublicEmitter {
+class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * @var \OC_User_Interface[] $backends
 	 */

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -10,6 +10,7 @@
 namespace OC\User;
 
 use OC\Hooks\Emitter;
+use OCP\IUserSession;
 
 /**
  * Class Session
@@ -29,7 +30,7 @@ use OC\Hooks\Emitter;
  *
  * @package OC\User
  */
-class Session implements Emitter, \OCP\IUserSession {
+class Session implements IUserSession, Emitter {
 	/**
 	 * @var \OC\User\Manager $manager
 	 */

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -10,8 +10,9 @@
 namespace OC\User;
 
 use OC\Hooks\Emitter;
+use OCP\IUser;
 
-class User {
+class User implements IUser {
 	/**
 	 * @var string $uid
 	 */

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -93,6 +93,13 @@ interface IServerContainer {
 	function getAppFolder();
 
 	/**
+	 * Returns a user manager
+	 *
+	 * @return \OCP\IUserManager
+	 */
+	function getUserManager();
+
+	/**
 	 * Returns the user session
 	 *
 	 * @return \OCP\IUserSession

--- a/lib/public/iuser.php
+++ b/lib/public/iuser.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP;
+
+interface IUser {
+	/**
+	 * get the user id
+	 *
+	 * @return string
+	 */
+	public function getUID();
+
+	/**
+	 * get the displayname for the user, if no specific displayname is set it will fallback to the user id
+	 *
+	 * @return string
+	 */
+	public function getDisplayName();
+
+	/**
+	 * set the displayname for the user
+	 *
+	 * @param string $displayName
+	 * @return bool
+	 */
+	public function setDisplayName($displayName);
+
+	/**
+	 * returns the timestamp of the user's last login or 0 if the user did never
+	 * login
+	 *
+	 * @return int
+	 */
+	public function getLastLogin();
+
+	/**
+	 * updates the timestamp of the most recent login of this user
+	 */
+	public function updateLastLoginTimestamp();
+
+	/**
+	 * Delete the user
+	 *
+	 * @return bool
+	 */
+	public function delete();
+
+	/**
+	 * Set the password of the user
+	 *
+	 * @param string $password
+	 * @param string $recoveryPassword for the encryption app to reset encryption keys
+	 * @return bool
+	 */
+	public function setPassword($password, $recoveryPassword);
+
+	/**
+	 * get the users home folder to mount
+	 *
+	 * @return string
+	 */
+	public function getHome();
+
+	/**
+	 * check if the backend allows the user to change his avatar on Personal page
+	 *
+	 * @return bool
+	 */
+	public function canChangeAvatar();
+
+	/**
+	 * check if the backend supports changing passwords
+	 *
+	 * @return bool
+	 */
+	public function canChangePassword();
+
+	/**
+	 * check if the backend supports changing display names
+	 *
+	 * @return bool
+	 */
+	public function canChangeDisplayName();
+
+	/**
+	 * check if the user is enabled
+	 *
+	 * @return bool
+	 */
+	public function isEnabled();
+
+	/**
+	 * set the enabled status for the user
+	 *
+	 * @param bool $enabled
+	 */
+	public function setEnabled($enabled);
+}

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP;
+
+
+/**
+ * Class Manager
+ *
+ * Hooks available in scope \OC\User:
+ * - preSetPassword(\OC\User\User $user, string $password, string $recoverPassword)
+ * - postSetPassword(\OC\User\User $user, string $password, string $recoverPassword)
+ * - preDelete(\OC\User\User $user)
+ * - postDelete(\OC\User\User $user)
+ * - preCreateUser(string $uid, string $password)
+ * - postCreateUser(\OC\User\User $user, string $password)
+ *
+ * @package OC\User
+ */
+interface IUserManager {
+		/**
+	 * register a user backend
+	 *
+	 * @param \OCP\UserInterface $backend
+	 */
+	public function registerBackend($backend);
+
+	/**
+	 * remove a user backend
+	 *
+	 * @param \OCP\UserInterface $backend
+	 */
+	public function removeBackend($backend);
+
+	/**
+	 * remove all user backends
+	 */
+	public function clearBackends() ;
+
+	/**
+	 * get a user by user id
+	 *
+	 * @param string $uid
+	 * @return \OCP\IUser
+	 */
+	public function get($uid);
+
+	/**
+	 * check if a user exists
+	 *
+	 * @param string $uid
+	 * @return bool
+	 */
+	public function userExists($uid);
+
+	/**
+	 * Check if the password is valid for the user
+	 *
+	 * @param string $loginname
+	 * @param string $password
+	 * @return mixed the User object on success, false otherwise
+	 */
+	public function checkPassword($loginname, $password);
+
+	/**
+	 * search by user id
+	 *
+	 * @param string $pattern
+	 * @param int $limit
+	 * @param int $offset
+	 * @return \OCP\IUser[]
+	 */
+	public function search($pattern, $limit = null, $offset = null);
+
+	/**
+	 * search by displayName
+	 *
+	 * @param string $pattern
+	 * @param int $limit
+	 * @param int $offset
+	 * @return \OCP\IUser[]
+	 */
+	public function searchDisplayName($pattern, $limit = null, $offset = null);
+
+	/**
+	 * @param string $uid
+	 * @param string $password
+	 * @throws \Exception
+	 * @return bool|\OCP\IUser the created user of false
+	 */
+	public function createUser($uid, $password);
+
+	/**
+	 * returns how many users per backend exist (if supported by backend)
+	 *
+	 * @return array an array of backend class as key and count number as value
+	 */
+	public function countUsers();
+}

--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -49,4 +49,17 @@ interface IUserSession {
 	 */
 	public function logout();
 
+	/**
+	 * set the currently active user
+	 *
+	 * @param \OCP\User|null $user
+	 */
+	public function setUser($user);
+
+	/**
+	 * get the current active user
+	 *
+	 * @return \OCP\User
+	 */
+	public function getUser();
 }


### PR DESCRIPTION
While reviewing owncloud/search_lucene#1 I noticed that the public (object oriented) api for user management is lacking severly.
- Adds public interfaces for User objects and the UserManager
- Extends `IUserSession` with `getUser()` and `setUser()`
- Make the user manager available in the public server container

cc @DeepDiver1975 @PVince81 
