### PR TITLE
storage: do not check file mode on rename

### DIFF
--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -172,10 +172,19 @@ if (\OC_Util::runningOnWindows()) {
 		}
 
 		public function rename($path1, $path2) {
-			if (!$this->isUpdatable($path1)) {
-				\OC_Log::write('core', 'unable to rename, file is not writable : ' . $path1, \OC_Log::ERROR);
+			$srcParent = dirname($path1);
+			$dstParent = dirname($path2);
+
+			if (!$this->isUpdatable($srcParent)) {
+				\OC_Log::write('core', 'unable to rename, source directory is not writable : ' . $srcParent, \OC_Log::ERROR);
 				return false;
 			}
+
+			if (!$this->isUpdatable($dstParent)) {
+				\OC_Log::write('core', 'unable to rename, destination directory is not writable : ' . $dstParent, \OC_Log::ERROR);
+				return false;
+			}
+
 			if (!$this->file_exists($path1)) {
 				\OC_Log::write('core', 'unable to rename, file does not exists : ' . $path1, \OC_Log::ERROR);
 				return false;

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -184,10 +184,19 @@ class MappedLocal extends \OC\Files\Storage\Common {
 	}
 
 	public function rename($path1, $path2) {
-		if (!$this->isUpdatable($path1)) {
-			\OC_Log::write('core', 'unable to rename, file is not writable : ' . $path1, \OC_Log::ERROR);
+		$srcParent = dirname($path1);
+		$dstParent = dirname($path2);
+
+		if (!$this->isUpdatable($srcParent)) {
+			\OC_Log::write('core', 'unable to rename, source directory is not writable : ' . $srcParent, \OC_Log::ERROR);
 			return false;
 		}
+
+		if (!$this->isUpdatable($dstParent)) {
+			\OC_Log::write('core', 'unable to rename, destination directory is not writable : ' . $dstParent, \OC_Log::ERROR);
+			return false;
+		}
+
 		if (!$this->file_exists($path1)) {
 			\OC_Log::write('core', 'unable to rename, file does not exists : ' . $path1, \OC_Log::ERROR);
 			return false;


### PR DESCRIPTION
At DESY (www.desy.de) we deploying ownCloud on top of dCache (www.dcache.org).
dCache provides a huge managed space, but has a limitation - all files are immutable.
This means, that as soon as upload of a file is complete, you  can't modify it.. But it's
absolutely valid to remove and create a new one with the same name. This is what
ownCloud internally does - rename on the filesystem. Nevertheless, it uses php's
is_writable() function which based  on access system call. dCache will tell
caller thet file modifications are not allowed. The following patch modifies ownCloud
to provide dcache friendly behavior, but still keep the same file safety level.

MIT licensed.

split check into two steps:
- is it allowed to update directory
- is it allowed to update file.

Technically, on rename we have to check remove and
create permissions on a parent directory.

If directory does not allow updates, then we will check the file.
This behavior complaint with ACLs (at least NFS4 acls).

For PATCH method, this will work as well, as we allow to
modify file if it's writable or we allow to modify file
as parent directory permissions are allow to replace file
with a new one.

Signed-off-by: Tigran Mkrtchyan tigran.mkrtchyan@desy.de
