### PR TITLE
Do not filter groups, but therefore update the user counts according to  the filter

### DIFF
--- a/lib/private/group/metadata.php
+++ b/lib/private/group/metadata.php
@@ -39,9 +39,9 @@ class MetaData {
 	protected $sorting = false;
 
 	/**
-	 * @param string the uid of the current user
-	 * @param bool whether the current users is an admin
-	 * @param \OC\Group\Manager
+	 * @param string $user the uid of the current user
+	 * @param bool $isAdmin whether the current users is an admin
+	 * @param \OC\Group\Manager $groupManager
 	 */
 	public function __construct(
 			$user,
@@ -105,9 +105,9 @@ class MetaData {
 	}
 
 	/**
-	 * @brief sets the sort mode, currently 0 (none) and 1 (user entries,
+	 * sets the sort mode, currently 0 (none) and 1 (user entries,
 	 * descending) are supported
-	 * @param int the sortMode (SORT_NONE, SORT_USERCOUNT)
+	 * @param int $sortMode (SORT_NONE, SORT_USERCOUNT)
 	 */
 	public function setSorting($sortMode) {
 		if($sortMode >= 0 && $sortMode <= 1) {
@@ -118,11 +118,11 @@ class MetaData {
 	}
 
 	/**
-	 * @brief adds an group entry to the resulting array
-	 * @param array the resulting array, by reference
-	 * @param array the sort key array, by reference
-	 * @param array the sort key index, by reference
-	 * @param array the group's meta data as returned by generateGroupMetaData()
+	 * adds an group entry to the resulting array
+	 * @param array $entries the resulting array, by reference
+	 * @param array $sortKeys the sort key array, by reference
+	 * @param int $sortIndex the sort key index, by reference
+	 * @param array $data the group's meta data as returned by generateGroupMetaData()
 	 * @return null
 	 */
 	private function addEntry(&$entries, &$sortKeys, &$sortIndex, $data) {
@@ -134,7 +134,7 @@ class MetaData {
 	}
 
 	/**
-	 * @brief creates an array containing the group meta data
+	 * creates an array containing the group meta data
 	 * @param \OC\Group\Group $group
 	 * @param string $userSearch
 	 * @return array with the keys 'id', 'name' and 'usercount'
@@ -148,9 +148,9 @@ class MetaData {
 	}
 
 	/**
-	 * @brief sorts the result array, if applicable
-	 * @param array the result array, by reference
-	 * @param array the array containing the sort keys
+	 * sorts the result array, if applicable
+	 * @param array $entries the result array, by reference
+	 * @param array $sortKeys the array containing the sort keys
 	 * @param return null
 	 */
 	private function sort(&$entries, $sortKeys) {
@@ -160,8 +160,8 @@ class MetaData {
 	}
 
 	/**
-	 * @brief returns the available groups
-	 * @param string a search string
+	 * returns the available groups
+	 * @param string $search a search string
 	 * @return \OC\Group\Group[]
 	 */
 	private function getGroups($search = '') {

--- a/settings/ajax/grouplist.php
+++ b/settings/ajax/grouplist.php
@@ -27,6 +27,12 @@ if (isset($_GET['pattern']) && !empty($_GET['pattern'])) {
 } else {
 	$pattern = '';
 }
+if (isset($_GET['filterGroups']) && !empty($_GET['filterGroups'])) {
+	$filterGroups = intval($_GET['filterGroups']) === 1;
+} else {
+	$filterGroups = false;
+}
+$groupPattern = $filterGroups ? $pattern : '';
 $groups = array();
 $adminGroups = array();
 $groupManager = \OC_Group::getManager();
@@ -36,13 +42,7 @@ $isAdmin = OC_User::isAdminUser(OC_User::getUser());
 //groups will be filtered out later
 $groupsInfo = new \OC\Group\MetaData(OC_User::getUser(), true, $groupManager);
 $groupsInfo->setSorting($groupsInfo::SORT_USERCOUNT);
-list($adminGroups, $groups) = $groupsInfo->get($pattern);
-
-$accessibleGroups = $groupManager->search($pattern);
-if(!$isAdmin) {
-	$subadminGroups = OC_SubAdmin::getSubAdminsGroups(OC_User::getUser());
-	$accessibleGroups = array_intersect($groups, $subadminGroups);
-}
+list($adminGroups, $groups) = $groupsInfo->get($groupPattern, $pattern);
 
 OC_JSON::success(
 	array('data' => array('adminGroups' => $adminGroups, 'groups' => $groups)));

--- a/settings/js/users/filter.js
+++ b/settings/js/users/filter.js
@@ -14,6 +14,7 @@ function UserManagementFilter(filterInput, userList, groupList) {
 	this.filterInput = filterInput;
 	this.userList = userList;
 	this.groupList = groupList;
+	this.filterGroups = false;
 	this.thread = undefined;
 	this.oldval = this.filterInput.val();
 
@@ -55,7 +56,10 @@ UserManagementFilter.prototype.init = function() {
 UserManagementFilter.prototype.run = _.debounce(function() {
 		this.userList.empty();
 		this.userList.update(GroupList.getCurrentGID());
-		this.groupList.empty();
+		if(this.filterGroups) {
+			// user counts are being updated nevertheless
+			this.groupList.empty();
+		}
 		this.groupList.update();
 	},
 	300

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -114,7 +114,10 @@ GroupList = {
 		GroupList.updating = true;
 		$.get(
 			OC.generateUrl('/settings/ajax/grouplist'),
-			{pattern: filter.getPattern()},
+			{
+				pattern: filter.getPattern(),
+				filterGroups: filter.filterGroups ? 1 : 0
+			},
 			function (result) {
 
 				var lis = [];

--- a/tests/lib/group/metadata.php
+++ b/tests/lib/group/metadata.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Arthur Schiwon <blizzz@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Group;
+
+class Test_MetaData extends \PHPUnit_Framework_TestCase {
+	private function getGroupManagerMock() {
+		return $this->getMockBuilder('\OC\Group\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function getGroupMock() {
+		$group = $this->getMockBuilder('\OC\Group\Group')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$group->expects($this->exactly(9))
+			->method('getGID')
+			->will($this->onConsecutiveCalls(
+				'admin', 'admin', 'admin',
+				'g2', 'g2', 'g2',
+				'g3', 'g3', 'g3'));
+
+		$group->expects($this->exactly(3))
+			->method('count')
+			->with('')
+			->will($this->onConsecutiveCalls(2, 3, 5));
+
+		return $group;
+	}
+
+
+	public function testGet() {
+		$groupManager = $this->getGroupManagerMock();
+		$groupMetaData = new \OC\Group\MetaData('foo', true, $groupManager);
+		$group = $this->getGroupMock();
+		$groups = array_fill(0, 3, $group);
+
+		$groupManager->expects($this->once())
+			->method('search')
+			->with('')
+			->will($this->returnValue($groups));
+
+		list($adminGroups, $ordinaryGroups) = $groupMetaData->get();
+
+		$this->assertSame(1, count($adminGroups));
+		$this->assertSame(2, count($ordinaryGroups));
+
+		$this->assertSame('g2', $ordinaryGroups[0]['name']);
+		$this->assertSame(3, $ordinaryGroups[0]['usercount']);
+	}
+
+	public function testGetWithSorting() {
+		$groupManager = $this->getGroupManagerMock();
+		$groupMetaData = new \OC\Group\MetaData('foo', true, $groupManager);
+		$groupMetaData->setSorting($groupMetaData::SORT_USERCOUNT);
+		$group = $this->getGroupMock();
+		$groups = array_fill(0, 3, $group);
+
+		$groupManager->expects($this->once())
+			->method('search')
+			->with('')
+			->will($this->returnValue($groups));
+
+		list($adminGroups, $ordinaryGroups) = $groupMetaData->get();
+
+		$this->assertSame(1, count($adminGroups));
+		$this->assertSame(2, count($ordinaryGroups));
+
+		$this->assertSame('g3', $ordinaryGroups[0]['name']);
+		$this->assertSame(5, $ordinaryGroups[0]['usercount']);
+	}
+
+	public function testGetWithCache() {
+		$groupManager = $this->getGroupManagerMock();
+		$groupMetaData = new \OC\Group\MetaData('foo', true, $groupManager);
+		$group = $this->getGroupMock();
+		$groups = array_fill(0, 3, $group);
+
+		$groupManager->expects($this->once())
+			->method('search')
+			->with('')
+			->will($this->returnValue($groups));
+
+		//two calls, if caching fails call counts for group and groupmanager
+		//are exceeded
+		$groupMetaData->get();
+		$groupMetaData->get();
+	}
+
+	//get() does not need to be tested with search parameters, because they are
+	//solely and only passed to GroupManager and Group.
+
+}


### PR DESCRIPTION
On the users page, the groups are filtered at the moment. However, [we want  to leave them but update the users counts](https://github.com/owncloud/core/issues/9332#issuecomment-48380699).

We can turn on filtering  any time in the future again, the logic did not vanish. 

Fixes #9332 

@jancborchardt @raghunayyar @DeepDiver1975 

There  is not change in the group sorting, would we want this?
