### PR TITLE
mountType attribute + delete hint fix

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -291,14 +291,20 @@
 			if (actions['Delete']) {
 				var img = self.icons['Delete'];
 				var html;
+				var mountType = $tr.attr('data-mounttype');
+				var deleteTitle = t('files', 'Delete');
+				if (mountType === 'external-root') {
+					deleteTitle = t('files', 'Disconnect storage');
+				} else if (mountType === 'shared-root') {
+					deleteTitle = t('files', 'Unshare');
+				} else if (fileList.id === 'trashbin') {
+					deleteTitle = t('files', 'Delete permanently');
+				}
+
 				if (img.call) {
 					img = img(file);
 				}
-				if (typeof trashBinApp !== 'undefined' && trashBinApp) {
-					html = '<a href="#" original-title="' + t('files', 'Delete permanently') + '" class="action delete delete-icon" />';
-				} else {
-					html = '<a href="#" original-title="' + t('files', 'Delete') + '" class="action delete delete-icon" />';
-				}
+				html = '<a href="#" original-title="' + escapeHTML(deleteTitle) + '" class="action delete delete-icon" />';
 				var element = $(html);
 				element.data('action', actions['Delete']);
 				element.on('click', {a: null, elem: parent, actionFunc: actions['Delete'].action}, actionHandler);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -600,6 +600,10 @@
 				"data-permissions": fileData.permissions || this.getDirectoryPermissions()
 			});
 
+			if (fileData.mountType) {
+				tr.attr('data-mounttype', fileData.mountType);
+			}
+
 			if (!_.isUndefined(path)) {
 				tr.attr('data-path', path);
 			}

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -37,6 +37,7 @@ class Helper
 	public static function determineIcon($file) {
 		if($file['type'] === 'dir') {
 			$icon = \OC_Helper::mimetypeIcon('dir');
+			// TODO: move this part to the client side, using mountType
 			if ($file->isShared()) {
 				$icon = \OC_Helper::mimetypeIcon('dir-shared');
 			} elseif ($file->isMounted()) {
@@ -124,6 +125,18 @@ class Helper
 		}
 		if (isset($i['is_share_mount_point'])) {
 			$entry['isShareMountPoint'] = $i['is_share_mount_point'];
+		}
+		$mountType = null;
+		if ($i->isShared()) {
+			$mountType = 'shared';
+		} else if ($i->isMounted()) {
+			$mountType = 'external';
+		}
+		if ($mountType !== null) {
+			if ($i->getInternalPath() === '') {
+				$mountType .= '-root';
+			}
+			$entry['mountType'] = $mountType;
 		}
 		return $entry;
 	}

--- a/apps/files_external/js/mountsfilelist.js
+++ b/apps/files_external/js/mountsfilelist.js
@@ -104,6 +104,7 @@
 		_makeFiles: function(data) {
 			var files = _.map(data, function(fileData) {
 				fileData.icon = OC.imagePath('core', 'filetypes/folder-external');
+				fileData.mountType = 'external';
 				return fileData;
 			});
 

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -233,6 +233,7 @@
 				.each(function(data) {
 					// convert the recipients map to a flat
 					// array of sorted names
+					data.mountType = 'shared';
 					data.recipients = _.keys(data.recipients);
 					data.recipientsDisplayName = OCA.Sharing.Util.formatRecipients(
 						data.recipients,


### PR DESCRIPTION
Added mountType attribute for files/folder to indicated whether they are regular, external or shared.

The client side then adapts the "Delete" action hint text based on this information.

Please review @icewind1991 @schiesbn @MorrisJobke @jancborchardt 

Fixes https://github.com/owncloud/core/issues/9348
