### PR TITLE
LDAP Active Directory Primary Groups support depends on bcmath module

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1298,6 +1298,12 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 */
 	public function convertSID2Str($sid) {
 		try {
+			if(!function_exists('bcadd')) {
+				\OCP\Util::writeLog('user_ldap',
+					'You need to install bcmath module for PHP to have support ' .
+					'for AD primary groups', \OCP\Util::WARN);
+				throw new \Excpetion('missing bcmath module');
+			}
 			$srl = ord($sid[0]);
 			$numberSubID = ord($sid[1]);
 			$x = substr($sid, 2, 6);

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1302,7 +1302,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 				\OCP\Util::writeLog('user_ldap',
 					'You need to install bcmath module for PHP to have support ' .
 					'for AD primary groups', \OCP\Util::WARN);
-				throw new \Excpetion('missing bcmath module');
+				throw new \Exception('missing bcmath module');
 			}
 			$srl = ord($sid[0]);
 			$numberSubID = ord($sid[1]);

--- a/apps/user_ldap/tests/access.php
+++ b/apps/user_ldap/tests/access.php
@@ -82,6 +82,10 @@ class Test_Access extends \PHPUnit_Framework_TestCase {
 		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
 		$access = new Access($con, $lw, $um);
 
+		if(!function_exists('\bcadd')) {
+			$this->markTestSkipped('bcmath not available');
+		}
+
 		$sidBinary = file_get_contents(__DIR__ . '/data/sid.dat');
 		$sidExpected = 'S-1-5-21-249921958-728525901-1594176202';
 
@@ -92,10 +96,35 @@ class Test_Access extends \PHPUnit_Framework_TestCase {
 		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
 		$access = new Access($con, $lw, $um);
 
+		if(!function_exists('\bcadd')) {
+			$this->markTestSkipped('bcmath not available');
+		}
+
 		$sidIllegal = 'foobar';
 		$sidExpected = '';
 
 		$this->assertSame($sidExpected, $access->convertSID2Str($sidIllegal));
+	}
+
+	public function testConvertSID2StrNoBCMath() {
+		if(function_exists('\bcadd')) {
+			$removed = false;
+			if(function_exists('runkit_function_remove')) {
+				$removed = !runkit_function_remove('\bcadd');
+			}
+			if(!$removed) {
+				$this->markTestSkipped('bcadd could not be removed for ' .
+					'testing without bcmath');
+			}
+		}
+
+		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
+		$access = new Access($con, $lw, $um);
+
+		$sidBinary = file_get_contents(__DIR__ . '/data/sid.dat');
+		$sidExpected = '';
+
+		$this->assertSame($sidExpected, $access->convertSID2Str($sidBinary));
 	}
 
 	public function testGetDomainDNFromDNSuccess() {


### PR DESCRIPTION
At least in Debian based distributions (Ubuntu) it is compiled into PHP, but it is a dedicated package on OpenSuse for instance. Before using bc math functions a check is done, if they are not present a log message is written, beside this ownCloud continues to work, only this feature does not.

i need to test it further myself, but others are welcome of course, too. 
