### PR TITLE
Bugfix for issue #9583

### DIFF
--- a/lib/private/group/metadata.php
+++ b/lib/private/group/metadata.php
@@ -168,7 +168,19 @@ class MetaData {
 		if($this->isAdmin) {
 			return $this->groupManager->search($search);
 		} else {
-			return \OC_SubAdmin::getSubAdminsGroups($this->user);
+            $groupIds = \OC_SubAdmin::getSubAdminsGroups($this->user);
+
+            /* \OC_SubAdmin::getSubAdminsGroups() returns an array of GIDs, but this
+             * method is expected to return an array with the GIDs as keys and group objects as
+             * values, so we need to convert this information.
+             */
+			$this->groups = array();
+            foreach($groupIds as $gid) {
+                $grp = $this->groupManager->get($gid);
+                if (!empty($grp)) {
+                    $this->groups[$gid] = $grp;
+                }
+            }
 		}
 	}
 }

--- a/lib/private/group/metadata.php
+++ b/lib/private/group/metadata.php
@@ -174,13 +174,15 @@ class MetaData {
 			* method is expected to return an array with the GIDs as keys and group objects as
 			* values, so we need to convert this information.
 			*/
-			$this->groups = array();
+			$groups = array();
 			foreach($groupIds as $gid) {
 				$group = $this->groupManager->get($gid);
 				if (!is_null($group)) {
-					$this->groups[$gid] = $group;
+					$groups[$gid] = $group;
 				}
 			}
+
+			return $groups;
 		}
 	}
 }

--- a/lib/private/group/metadata.php
+++ b/lib/private/group/metadata.php
@@ -176,9 +176,9 @@ class MetaData {
 			*/
 			$this->groups = array();
 			foreach($groupIds as $gid) {
-				$grp = $this->groupManager->get($gid);
-				if (!empty($grp)) {
-					$this->groups[$gid] = $grp;
+				$group = $this->groupManager->get($gid);
+				if (!is_null($group)) {
+					$this->groups[$gid] = $group;
 				}
 			}
 		}

--- a/lib/private/group/metadata.php
+++ b/lib/private/group/metadata.php
@@ -168,19 +168,19 @@ class MetaData {
 		if($this->isAdmin) {
 			return $this->groupManager->search($search);
 		} else {
-            $groupIds = \OC_SubAdmin::getSubAdminsGroups($this->user);
+			$groupIds = \OC_SubAdmin::getSubAdminsGroups($this->user);
 
-            /* \OC_SubAdmin::getSubAdminsGroups() returns an array of GIDs, but this
-             * method is expected to return an array with the GIDs as keys and group objects as
-             * values, so we need to convert this information.
-             */
+			/* \OC_SubAdmin::getSubAdminsGroups() returns an array of GIDs, but this
+			* method is expected to return an array with the GIDs as keys and group objects as
+			* values, so we need to convert this information.
+			*/
 			$this->groups = array();
-            foreach($groupIds as $gid) {
-                $grp = $this->groupManager->get($gid);
-                if (!empty($grp)) {
-                    $this->groups[$gid] = $grp;
-                }
-            }
+			foreach($groupIds as $gid) {
+				$grp = $this->groupManager->get($gid);
+				if (!empty($grp)) {
+					$this->groups[$gid] = $grp;
+				}
+			}
 		}
 	}
 }

--- a/settings/users.php
+++ b/settings/users.php
@@ -37,9 +37,9 @@ if($isAdmin) {
 }else{
 	/* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
 	$gids = array();
-	foreach($groups as $grp) {
-		if (isset($grp['id'])) {
-			$gids[] = $grp['id'];
+	foreach($groups as $group) {
+		if (isset($group['id'])) {
+			$gids[] = $group['id'];
 		}
 	}
 	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 30);

--- a/settings/users.php
+++ b/settings/users.php
@@ -35,13 +35,13 @@ if($isAdmin) {
 	$accessibleUsers = OC_User::getDisplayNames('', 30);
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
-    /* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
-    $gids = array();
-    foreach($groups as $grp) {
-        if (isset($grp['id'])) {
-            $gids[] = $grp['id'];
-        }
-    }
+	/* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
+	$gids = array();
+	foreach($groups as $grp) {
+		if (isset($grp['id'])) {
+			$gids[] = $grp['id'];
+		}
+	}
 	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 30);
 	$subadmins = false;
 }

--- a/settings/users.php
+++ b/settings/users.php
@@ -35,7 +35,14 @@ if($isAdmin) {
 	$accessibleUsers = OC_User::getDisplayNames('', 30);
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
-	$accessibleUsers = OC_Group::displayNamesInGroups($groups, '', 30);
+    /* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
+    $gids = array();
+    foreach($groups as $grp) {
+        if (isset($grp['id'])) {
+            $gids[] = $grp['id'];
+        }
+    }
+	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 30);
 	$subadmins = false;
 }
 


### PR DESCRIPTION
lib/private/group/metadata.php: For subadmins also return an array of groups, indexed by their GIDs.
settings/users.php: Convert array of arrays to array of GIDs before calling into OC_Group::displayNamesInGroups.

Signed-off-by: Stephan Peijnik speijnik@anexia-it.com
