### PR TITLE
Fix STORAGE_* constants usage by moving those constants into \OC\Files\Filesystem

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -286,7 +286,7 @@ class Google extends \OC\Files\Storage\Common {
 				// Check if this is a Google Doc
 				if ($this->getMimeType($path) !== $file->getMimeType()) {
 					// Return unknown file size
-					$stat['size'] = \OC\Files\SPACE_UNKNOWN;
+					$stat['size'] = \OC\Files\Filesystem::SPACE_UNKNOWN;
 				} else {
 					$stat['size'] = $file->getFileSize();
 				}

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -377,7 +377,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 			list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($source);
 			return $storage->free_space($internalPath);
 		}
-		return \OC\Files\SPACE_UNKNOWN;
+		return \OC\Files\Filesystem::SPACE_UNKNOWN;
 	}
 
 	public function getLocalFile($path) {

--- a/lib/private/connector/sabre/quotaplugin.php
+++ b/lib/private/connector/sabre/quotaplugin.php
@@ -72,7 +72,7 @@ class OC_Connector_Sabre_QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 				$length -= $chunkHandler->getCurrentSize();
 			}
 			$freeSpace = $this->getFreeSpace($parentUri);
-			if ($freeSpace !== \OC\Files\SPACE_UNKNOWN && $length > $freeSpace) {
+			if ($freeSpace !== \OC\Files\Filesystem::SPACE_UNKNOWN && $length > $freeSpace) {
 				if (isset($chunkHandler)) {
 					$chunkHandler->cleanup();
 				}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -33,9 +33,9 @@ namespace OC\Files;
 use OC\Files\Storage\Loader;
 
 class Filesystem {
-    const SPACE_NOT_COMPUTED = -1;
-    const SPACE_UNKNOWN = -2;
-    const SPACE_UNLIMITED = -3;
+	const SPACE_NOT_COMPUTED = -1;
+	const SPACE_UNKNOWN = -2;
+	const SPACE_UNLIMITED = -3;
 
 	/**
 	 * @var Mount\Manager $mounts

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -31,11 +31,12 @@
 namespace OC\Files;
 
 use OC\Files\Storage\Loader;
-const SPACE_NOT_COMPUTED = -1;
-const SPACE_UNKNOWN = -2;
-const SPACE_UNLIMITED = -3;
 
 class Filesystem {
+    const SPACE_NOT_COMPUTED = -1;
+    const SPACE_UNKNOWN = -2;
+    const SPACE_UNLIMITED = -3;
+
 	/**
 	 * @var Mount\Manager $mounts
 	 */

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -397,7 +397,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 * @return int
 	 */
 	public function free_space($path) {
-		return \OC\Files\SPACE_UNKNOWN;
+		return \OC\Files\Filesystem::SPACE_UNKNOWN;
 	}
 
 	/**

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -243,10 +243,10 @@ class DAV extends \OC\Files\Storage\Common {
 			if (isset($response['{DAV:}quota-available-bytes'])) {
 				return (int)$response['{DAV:}quota-available-bytes'];
 			} else {
-				return \OC\Files\SPACE_UNKNOWN;
+				return \OC\Files\Filesystem::SPACE_UNKNOWN;
 			}
 		} catch (\Exception $e) {
-			return \OC\Files\SPACE_UNKNOWN;
+			return \OC\Files\Filesystem::SPACE_UNKNOWN;
 		}
 	}
 

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -224,7 +224,7 @@ if (\OC_Util::runningOnWindows()) {
 		public function free_space($path) {
 			$space = @disk_free_space($this->datadir . $path);
 			if ($space === false || is_null($space)) {
-				return \OC\Files\SPACE_UNKNOWN;
+				return \OC\Files\Filesystem::SPACE_UNKNOWN;
 			}
 			return $space;
 		}

--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -50,7 +50,7 @@ class Quota extends Wrapper {
 			}
 			return $data['size'];
 		} else {
-			return \OC\Files\SPACE_NOT_COMPUTED;
+			return \OC\Files\Filesystem::SPACE_NOT_COMPUTED;
 		}
 	}
 
@@ -66,7 +66,7 @@ class Quota extends Wrapper {
 		} else {
 			$used = $this->getSize($this->sizeRoot);
 			if ($used < 0) {
-				return \OC\Files\SPACE_NOT_COMPUTED;
+				return \OC\Files\Filesystem::SPACE_NOT_COMPUTED;
 			} else {
 				$free = $this->storage->free_space($path);
 				$quotaFree = max($this->quota - $used, 0);

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -886,7 +886,7 @@ class OC_Helper {
 	 */
 	public static function freeSpace($dir) {
 		$freeSpace = \OC\Files\Filesystem::free_space($dir);
-		if ($freeSpace !== \OC\Files\SPACE_UNKNOWN) {
+		if ($freeSpace !== \OC\Files\Filesystem::SPACE_UNKNOWN) {
 			$freeSpace = max($freeSpace, 0);
 			return $freeSpace;
 		} else {
@@ -959,7 +959,7 @@ class OC_Helper {
 		}
 		if ($includeExtStorage) {
 			$quota = OC_Util::getUserQuota(\OCP\User::getUser());
-			if ($quota !== \OC\Files\SPACE_UNLIMITED) {
+			if ($quota !== \OC\Files\Filesystem::SPACE_UNLIMITED) {
 				// always get free space / total space from root + mount points
 				$path = '';
 				return self::getGlobalStorageInfo();

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -105,7 +105,7 @@ class OC_Util {
 					if (is_object($storage->getUser())) {
 						$user = $storage->getUser()->getUID();
 						$quota = OC_Util::getUserQuota($user);
-						if ($quota !== \OC\Files\SPACE_UNLIMITED) {
+						if ($quota !== \OC\Files\Filesystem::SPACE_UNLIMITED) {
 							return new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => $quota, 'root' => 'files'));
 						}
 					}
@@ -182,7 +182,7 @@ class OC_Util {
 			$userQuota = $config->getAppValue('files', 'default_quota', 'none');
 		}
 		if($userQuota === 'none') {
-			return \OC\Files\SPACE_UNLIMITED;
+			return \OC\Files\Filesystem::SPACE_UNLIMITED;
 		}else{
 			return OC_Helper::computerFileSize($userQuota);
 		}


### PR DESCRIPTION
As constants not defined within a class cannot be automatically found by the
autoloader moving those constants into a class makes them accessible to
code which uses them.

Signed-off-by: Stephan Peijnik speijnik@anexia-it.com
