### PR TITLE
Easier use for other Apps working with Global Sharing API 

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -34,6 +34,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					if ($shareType === OCP\Share::SHARE_TYPE_LINK && $shareWith == '') {
 						$shareWith = null;
 					}
+					
+					$itemSourceName=(isset($_POST['itemSourceName']))?$_POST['itemSourceName']:'';
 
 					$token = OCP\Share::shareItem(
 						$_POST['itemType'],
@@ -41,7 +43,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$shareType,
 						$shareWith,
 						$_POST['permissions'],
-						$_POST['itemSourceName'],
+						$itemSourceName,
 						(!empty($_POST['expirationDate']) ? new \DateTime($_POST['expirationDate']) : null)
 					);
 

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -34,6 +34,9 @@ if ($defaultExpireDateEnabled) {
 	$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
 }
 
+$mailNotificationEnabled = \OCP\Config::getAppValue('core', 'shareapi_allow_mail_notification', 'yes');
+$allowShareWithLink= \OCP\Config::getAppValue('core', 'shareapi_allow_links', 'yes');
+
 $array = array(
 	"oc_debug" => (defined('DEBUG') && DEBUG) ? 'true' : 'false',
 	"oc_isadmin" => OC_User::isAdminUser(OC_User::getUser()) ? 'true' : 'false',
@@ -83,6 +86,8 @@ $array = array(
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
+				'mailNotificationEnabled' => $mailNotificationEnabled,
+				'allowShareWithLink' => $allowShareWithLink,
 				)
 			)
 	),

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -1032,7 +1032,8 @@ $(document).ready(function() {
 		var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
 		
 		if(itemType !== 'file' || itemType !== 'folder'){
-		   file = $('a.share').filterAttr('data-item',String(itemSource)).data('title');
+			//data-title contains the itemtitle e.g. the calender name or event title
+			file = $('a.share').filterAttr('data-item',String(itemSource)).data('title');
 		}
 		
 		var email = $('#email').val();

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -93,7 +93,7 @@ OC.Share={
 		}
 		// TODO: iterating over the files might be more efficient
 		for (item in OC.Share.statuses){
-			var image = OC.imagePath('core', 'actions/share');
+			var image = OC.imagePath('core', 'actions/shared');
 			var data = OC.Share.statuses[item];
 			var hasLink = data.link;
 			// Links override shared in terms of icon display
@@ -1029,6 +1029,11 @@ $(document).ready(function() {
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
 		var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
+		
+		if(itemType !='file' || itemType !='folder'){
+		   file = $('a.share[data-item="'+itemSource+'"]').data('title');
+		}
+		
 		var email = $('#email').val();
 		var expirationDate = '';
 		if ( $('#expirationCheckbox').is(':checked') === true ) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -93,7 +93,7 @@ OC.Share={
 		}
 		// TODO: iterating over the files might be more efficient
 		for (item in OC.Share.statuses){
-			var image = OC.imagePath('core', 'actions/shared');
+			var image = OC.imagePath('core', 'actions/share');
 			var data = OC.Share.statuses[item];
 			var hasLink = data.link;
 			// Links override shared in terms of icon display
@@ -383,7 +383,8 @@ OC.Share={
 			html += '<input id="shareWith" type="text" placeholder="'+t('core', 'Share with user or group …')+'" />';
 			html += '<ul id="shareWithList">';
 			html += '</ul>';
-			var linksAllowed = $('#allowShareWithLink').val() === 'yes';
+		        var linksAllowed = OC.appConfig.core.allowShareWithLink === 'yes';
+			
 			if (link && linksAllowed) {
 				html += '<div id="link">';
 				html += '<input type="checkbox" name="linkCheckbox" id="linkCheckbox" value="1" /><label for="linkCheckbox">'+t('core', 'Share link')+'</label>';
@@ -612,7 +613,7 @@ OC.Share={
 			var showCrudsButton;
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
 			html += '<span class="username">' + escapeHTML(shareWithDisplayName) + '</span>';
-			var mailNotificationEnabled = $('input:hidden[name=mailNotificationEnabled]').val();
+			var mailNotificationEnabled = OC.appConfig.core.mailNotificationEnabled;
 			if (mailNotificationEnabled === 'yes') {
 				var checked = '';
 				if (mailSend === '1') {
@@ -1030,8 +1031,8 @@ $(document).ready(function() {
 		var itemSource = $('#dropdown').data('item-source');
 		var file = $('tr').filterAttr('data-id', String(itemSource)).data('file');
 		
-		if(itemType !='file' || itemType !='folder'){
-		   file = $('a.share[data-item="'+itemSource+'"]').data('title');
+		if(itemType !== 'file' || itemType !== 'folder'){
+		   file = $('a.share').filterAttr('data-item',String(itemSource)).data('title');
 		}
 		
 		var email = $('#email').val();

--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -109,6 +109,19 @@ class MailNotifications {
 
 			$link = \OCP\Util::linkToAbsolute('files', 'index.php', array("dir" => $foldername));
 
+                        $hookParams = array(
+				'language'      => $this->l,
+				'senderDisplayName'      => $this->senderDisplayName,
+				'itemSource'      => $itemSource,
+				'itemType'      => $itemType,
+				'itemTarget'      => $items[0]['item_target'],
+				'itemLink'    => &$link,
+				'filename'    => &$filename,
+				'subject'    => &$subject,
+		         );
+		         
+                        \OC_Hook::emit('OCP\Share', 'share_internal_mail',$hookParams);
+
 			list($htmlMail, $alttextMail) = $this->createMailBody($filename, $link, $expiration);
 
 			// send it out now

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -296,7 +296,7 @@ class Share extends \OC\Share\Constants {
 
 		// first check if there is a db entry for the specific user
 		$query = \OC_DB::prepare(
-				'SELECT `file_target`, `permissions`, `expiration`
+				'SELECT `file_target`,`item_target`, `permissions`, `expiration`
 					FROM
 					`*PREFIX*share`
 					WHERE
@@ -314,7 +314,7 @@ class Share extends \OC\Share\Constants {
 			$groups = \OC_Group::getUserGroups($user);
 
 			$query = \OC_DB::prepare(
-					'SELECT `file_target`, `permissions`, `expiration`
+					'SELECT `file_target`,`item_target`, `permissions`, `expiration`
 						FROM
 						`*PREFIX*share`
 						WHERE

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1877,6 +1877,9 @@ class Share extends \OC\Share\Constants {
 		if (isset($row['file_source'])) {
 			$row['file_source'] = (int) $row['file_source'];
 		}
+		if (isset($row['item_source'])) {
+			$row['item_source'] = (int) $row['item_source'];
+		}
 		if (isset($row['permissions'])) {
 			$row['permissions'] = (int) $row['permissions'];
 		}


### PR DESCRIPTION
Now if you would like to use the global share api so it's much easier to work with!
No additional share js code for an app is needed!
For example e.g. calendar
init share calendar we need:

I. Checking global rights of the share Api

```
$tmpl->assign("mailNotificationEnabled", \OC_Appconfig::getValue('core', 'shareapi_allow_mail_notification', 'yes'));
$tmpl->assign("allowShareWithLink", \OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
```

II. we need the global input fields

```
<input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled" value="<?php p($_['mailNotificationEnabled']) ?>" />
<input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />
```

III. we need the share link e.g. sharing Calendar

```
<?php if ($_['calendar']['permissions'] & OCP\PERMISSION_SHARE) { ?>
        <a href="#" class="share permanent" 
        data-title="<?php p($_['calendar']['displayname']) ?>"
        data-item-type="calendar" 
        data-item="<?php p($_['calendar']['id']); ?>"
        data-link="true"
        data-possible-permissions="<?php p($_['calendar']['permissions']) ?>"
        title="<?php p($l->t('Share Calendar')) ?>"
        style="background:url(<?php print_unescaped(OCP\Util::imagePath('core', 'actions/share.svg')) ?>) no-repeat center;"
           ></a>
    <?php } ?>
```

```
data-title="<?php p($_['calendar']['displayname']) ?>"
```

is new and needed if we would like to send an email to an external!

IV. need init the Icons

```
OC.Share.loadIcons('calendar');
```

That's all!
Now you can manage your shares with the global share api, automatically you can define Share via Link, Send E-Mail internal or send E-Mail for external User!
