### PR TITLE
reduce share action text to the user name only

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -143,7 +143,7 @@
 							' data-action="Share-Notification" href="#" original-title="">' +
 							' <img class="svg" src="' + OC.imagePath('core', 'actions/share') + '"></img>';
 					$tr.find('.fileactions').append(function() {
-						var shareBy = t('files_sharing', 'Shared by {owner}', {owner: escapeHTML($tr.attr('data-share-owner'))});
+						var shareBy = escapeHTML($tr.attr('data-share-owner'));
 						var $result = $(shareNotification + '<span> ' + shareBy + '</span></span>');
 						$result.on('click', function() {
 							return false;

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -165,7 +165,7 @@ describe('OCA.Sharing.Util tests', function() {
 			$tr = fileList.$el.find('tbody tr:first');
 			$action = $tr.find('.action-share');
 			expect($action.hasClass('permanent')).toEqual(true);
-			expect($action.find('>span').text()).toEqual('Shared by User One');
+			expect($action.find('>span').text()).toEqual('User One');
 			expect(OC.basename($action.find('img').attr('src'))).toEqual('share.svg');
 			expect(OC.basename(getImageUrl($tr.find('.filename')))).toEqual('folder-shared.svg');
 		});
@@ -207,7 +207,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect($tr.find('.action-share').length).toEqual(0);
 			$action = $tr.find('.action-share-notification');
 			expect($action.hasClass('permanent')).toEqual(true);
-			expect($action.find('>span').text().trim()).toEqual('Shared by User One');
+			expect($action.find('>span').text().trim()).toEqual('User One');
 			expect(OC.basename($action.find('img').attr('src'))).toEqual('share.svg');
 			expect(OC.basename(getImageUrl($tr.find('.filename')))).toEqual('folder-shared.svg');
 			expect($action.find('img').length).toEqual(1);
@@ -369,7 +369,7 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.updateIcon('file', 1);
 
 			expect($action.hasClass('permanent')).toEqual(true);
-			expect($action.find('>span').text()).toEqual('Shared by User One');
+			expect($action.find('>span').text()).toEqual('User One');
 			expect(OC.basename($action.find('img').attr('src'))).toEqual('share.svg');
 		});
 		it('keep share text after unsharing reshare', function() {
@@ -405,7 +405,7 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.updateIcon('file', 1);
 
 			expect($action.hasClass('permanent')).toEqual(true);
-			expect($action.find('>span').text()).toEqual('Shared by User One');
+			expect($action.find('>span').text()).toEqual('User One');
 			expect(OC.basename($action.find('img').attr('src'))).toEqual('share.svg');
 		});
 	});

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -191,7 +191,7 @@ OC.Share={
 		var parts = this._REMOTE_OWNER_REGEXP.exec(owner);
 		if (!parts) {
 			// display as is, most likely to be a simple owner name
-			return t('files_sharing', 'Shared by {owner}', {owner: escapeHTML(owner)});
+			return escapeHTML(owner);
 		}
 
 		var userName = parts[1];
@@ -211,7 +211,7 @@ OC.Share={
 			html += '<span class="userDomain">@' + escapeHTML(userDomain) + '</span>';
 		}
 		html += '</span>';
-		return t('files_sharing', 'Shared by {owner}', {owner: html});
+		return html;
 	},
 	/**
 	 * Marks/unmarks a given file as shared by changing its action icon

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -403,39 +403,39 @@ describe('OC.Share tests', function() {
 			}
 
 			it('displays the local share owner as is', function() {
-				checkOwner('User One', 'Shared by User One', null);
+				checkOwner('User One', 'User One', null);
 			});
 			it('displays the user name part of a remote share owner', function() {
 				checkOwner(
 					'User One@someserver.com',
-					'Shared by User One',
+					'User One',
 					'User One@someserver.com'
 				);
 				checkOwner(
 					'User One@someserver.com/',
-					'Shared by User One',
+					'User One',
 					'User One@someserver.com'
 				);
 				checkOwner(
 					'User One@someserver.com/root/of/owncloud',
-					'Shared by User One',
+					'User One',
 					'User One@someserver.com'
 				);
 			});
 			it('displays the user name part with domain of a remote share owner', function() {
 				checkOwner(
 					'User One@example.com@someserver.com',
-					'Shared by User One@example.com',
+					'User One@example.com',
 					'User One@example.com@someserver.com'
 				);
 				checkOwner(
 					'User One@example.com@someserver.com/',
-					'Shared by User One@example.com',
+					'User One@example.com',
 					'User One@example.com@someserver.com'
 				);
 				checkOwner(
 					'User One@example.com@someserver.com/root/of/owncloud',
-					'Shared by User One@example.com',
+					'User One@example.com',
 					'User One@example.com@someserver.com'
 				);
 			});


### PR DESCRIPTION
Short description: This removes the »Shared by« prefix. So just shows the share icon and the username of the person it was shared by. @PVince81 would be interested in what you think as well.

fixes #9503 
