### PR TITLE
Re-add missing sftp:// stream wrapper

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -7,6 +7,10 @@
  */
 namespace OC\Files\Storage;
 
+/**
+* Uses phpseclib's Net_SFTP class and the Net_SFTP_Stream stream wrapper to
+* provide access to SFTP servers.
+*/
 class SFTP extends \OC\Files\Storage\Common {
 	private $host;
 	private $user;

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -18,6 +18,17 @@ class SFTP extends \OC\Files\Storage\Common {
 	private static $tempFiles = array();
 
 	public function __construct($params) {
+		// The sftp:// scheme has to be manually registered via inclusion of
+		// the 'Net/SFTP/Stream.php' file which registers the Net_SFTP_Stream
+		// stream wrapper as a side effect.
+		// A slightly better way to register the stream wrapper is available
+		// since phpseclib 0.3.7 in the form of a static call to
+		// Net_SFTP_Stream::register() which will trigger autoloading if
+		// necessary.
+		// TODO: Call Net_SFTP_Stream::register() instead when phpseclib is
+		//       updated to 0.3.7 or higher.
+		require_once 'Net/SFTP/Stream.php';
+
 		$this->host = $params['host'];
 		$proto = strpos($this->host, '://');
 		if ($proto != false) {


### PR DESCRIPTION
Fixes #9320
Regression from #8729 (entirely my fault apparently)

Without this patch, SFTP external storage is not fully usable. As such this should be backported to stable7. stable6 (and possibly earlier) is not affected.

File inclusion has been added to the constructor such that this is not yet another side effect.

The following manual tests have been performed via the webinterface:
- Deletion of existing file in subfolder
- Deletion of existing empty directory
- Deletion of existing directory containing files
- Mass deletion of directories containing files
- Upload of a file
- Download of a file
- Detection of file details (filesize etc.)

Futhermore upload and download of files via WebDAV has been tested.

@PVince81 @DeepDiver1975 
