### PR TITLE
throw exception if file is to large for trash bin

### DIFF
--- a/apps/files_trashbin/appinfo/app.php
+++ b/apps/files_trashbin/appinfo/app.php
@@ -2,6 +2,8 @@
 
 //OC::$CLASSPATH['OCA\Files_Trashbin\Hooks'] = 'files_trashbin/lib/hooks.php';
 //OC::$CLASSPATH['OCA\Files_Trashbin\Trashbin'] = 'files_trashbin/lib/trash.php';
+OC::$CLASSPATH['OCA\Files_Trashbin\Exceptions\CopyRecursiveException'] = 'files_trashbin/lib/exceptions.php';
+
 
 // register hooks
 \OCA\Files_Trashbin\Trashbin::registerHooks();

--- a/apps/files_trashbin/lib/exceptions.php
+++ b/apps/files_trashbin/lib/exceptions.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * ownCloud - trash bin
+ *
+ * @author Bjoern Schiessle
+ * @copyright 2014 Bjoern Schiessle schiessle@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Trashbin\Exceptions;
+
+class CopyRecursiveException extends \Exception {
+}


### PR DESCRIPTION
fix for #8345 

not the perfect solution because we prevent ownCloud from adding the new file to the trash bin instead of first expiring the existing files. But it fixes the described issue without introducing to much changes.
