### PR TITLE
fix logger implementation

### DIFF
--- a/lib/private/log.php
+++ b/lib/private/log.php
@@ -154,6 +154,6 @@ class Log implements ILogger {
 		$message = strtr($message, $replace);
 
 		$logger = $this->logger;
-		$logger::write($app, $message, $level);
+		call_user_func(array($logger, 'write'), $app, $message, $level);
 	}
 }

--- a/tests/lib/logger.php
+++ b/tests/lib/logger.php
@@ -19,7 +19,7 @@ class Logger extends \PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		self::$logs = array();
-		$this->logger = new Log($this);
+		$this->logger = new Log('Test\Logger');
 	}
 
 	public function testInterpolation() {


### PR DESCRIPTION
I was trying to use the Logger implementation returned by `\OC::$server->getLogger()`. It dies horribly whenever trying to log anything because it instantiates the `$logger` member as a string `'OC_Log_Owncloud'` in init() and then tries to call a method on it with `$this->logger::write(...)`. I assume the idea of the current constructor is to allow passing in an `ILogger` instance or maybe even a `Psr\Log\LoggerInterface` which is why I made log()  assume $logger to be an object first and only then make a `call_user_func(...)`
