### PR TITLE
Fix user api

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -255,7 +255,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	 * @return \OCP\Files\Folder
 	 */
 	function getUserFolder() {
-		$dir = '/' . \OCP\User::getUser();
+		$dir = '/' . $this->getUserSession()->getUser()->getUID();
 		$root = $this->getRootFolder();
 		$folder = null;
 

--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -52,14 +52,14 @@ interface IUserSession {
 	/**
 	 * set the currently active user
 	 *
-	 * @param \OCP\User|null $user
+	 * @param \OCP\IUser|null $user
 	 */
 	public function setUser($user);
 
 	/**
 	 * get the current active user
 	 *
-	 * @return \OCP\User
+	 * @return \OCP\IUser
 	 */
 	public function getUser();
 }


### PR DESCRIPTION
Still working on making search_lucene use more of the appframework...

b3106c3 is self-explanatory and was overlooked in https://github.com/owncloud/core/pull/9546
8189292 is a little trickier. Without it the getUserFolder will try to look up the userid via OC::$session which (at least here was somehow replaced with an empty `OC\Session\Memory` instance) The commit changes the lookup to use the UserSession service that has bee ninitialized in the servercontainers constructor.

cc @DeepDiver1975 @icewind1991 
