### PR TITLE
Reenable proxies if a test failed to restore it

### DIFF
--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -166,6 +166,8 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 	private function cleanProxies() {
 		$proxies = OC_FileProxy::getProxies();
 		OC_FileProxy::clearProxies();
+		// reenable in case some test failed to reenable them
+		OC_FileProxy::$enabled = true;
 		return count($proxies) > 0;
 	}
 }


### PR DESCRIPTION
This should at least prevent encryption tests to break other tests.

See my analysis here https://github.com/owncloud/core/issues/9646#issuecomment-49091297

Please review @schiesbn 

@MorrisJobke you might want to try this patch on Travis with the encryption tests unskipped
