### PR TITLE
Debugging the file proxies with encryption

### DIFF
--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -94,6 +94,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		} else {
 			OC_App::disable('files_trashbin');
 		}
+
+		// make sure that proxies have been reenabled
+		$this->assertTrue(\OC_FileProxy::$enabled);
 	}
 
 	public static function tearDownAfterClass() {
@@ -104,7 +107,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testGenerateKey() {
+	function xtestGenerateKey() {
 
 		# TODO: use more accurate (larger) string length for test confirmation
 
@@ -114,7 +117,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
-	function testDecryptPrivateKey() {
+	function xtestDecryptPrivateKey() {
 
 		// test successful decrypt
 		$crypted = Encryption\Crypt::symmetricEncryptFileContent($this->genPrivateKey, 'hat');
@@ -134,7 +137,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricEncryptFileContent() {
+	function xtestSymmetricEncryptFileContent() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
 
@@ -152,7 +155,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricStreamEncryptShortFileContent() {
+	function xtestSymmetricStreamEncryptShortFileContent() {
 
 		$filename = 'tmp-' . uniqid() . '.test';
 
@@ -210,7 +213,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
 	 * reassembly of its data
 	 */
-	function testSymmetricStreamEncryptLongFileContent() {
+	function xtestSymmetricStreamEncryptLongFileContent() {
 
 		// Generate a a random filename
 		$filename = 'tmp-' . uniqid() . '.test';
@@ -294,7 +297,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 * Test that data that is read by the crypto stream wrapper
 	 */
-	function testSymmetricStreamDecryptShortFileContent() {
+	function xtestSymmetricStreamDecryptShortFileContent() {
 
 		$filename = 'tmp-' . uniqid();
 
@@ -324,7 +327,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricStreamDecryptLongFileContent() {
+	function xtestSymmetricStreamDecryptLongFileContent() {
 
 		$filename = 'tmp-' . uniqid();
 
@@ -346,7 +349,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testIsEncryptedContent() {
+	function xtestIsEncryptedContent() {
 
 		$this->assertFalse(Encryption\Crypt::isCatfileContent($this->dataUrl));
 
@@ -361,7 +364,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @large
 	 */
-	function testMultiKeyEncrypt() {
+	function xtestMultiKeyEncrypt() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
 
@@ -388,7 +391,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testRenameFile() {
+	function xtestRenameFile() {
 
 		$filename = 'tmp-' . uniqid();
 
@@ -419,7 +422,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testMoveFileIntoFolder() {
+	function xtestMoveFileIntoFolder() {
 
 		$filename = 'tmp-' . uniqid();
 
@@ -490,7 +493,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testChangePassphrase() {
+	function xtestChangePassphrase() {
 		$filename = 'tmp-' . uniqid();
 
 		// Save long data as encrypted file using stream wrapper
@@ -527,7 +530,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testViewFilePutAndGetContents() {
+	function xtestViewFilePutAndGetContents() {
 
 		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
@@ -561,7 +564,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @large
 	 */
-	function testTouchExistingFile() {
+	function xtestTouchExistingFile() {
 		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
@@ -585,7 +588,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testTouchFile() {
+	function xtestTouchFile() {
 		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
@@ -609,7 +612,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testFopenFile() {
+	function xtestFopenFile() {
 		$filename = '/tmp-' . uniqid();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 


### PR DESCRIPTION
@schiesbn please have a look at `testMoveFolder` which doesn't reenable the file proxies due to an exception.

This PR simply adds an extra check that shows the issue.
