### PR TITLE
Implementation of generic abortable hooks

### DIFF
--- a/lib/private/hooks/basicemitter.php
+++ b/lib/private/hooks/basicemitter.php
@@ -77,13 +77,24 @@ abstract class BasicEmitter implements Emitter {
 	 * @param string $scope
 	 * @param string $method
 	 * @param array $arguments optional
+	 * @param bool $abortable optional Defines whether the hook is abortable or not
+	 * @return bool true if not aborted, false otherwise
 	 */
-	protected function emit($scope, $method, $arguments = array()) {
+	protected function emit($scope, $method, $arguments = array(), $abortable = false) {
 		$eventName = $scope . '::' . $method;
 		if (isset($this->listeners[$eventName])) {
 			foreach ($this->listeners[$eventName] as $callback) {
-				call_user_func_array($callback, $arguments);
+				$result = call_user_func_array($callback, $arguments);
+				if ($abortable && $result === false) {
+					/* If the hook is abortable and the result was false we do not want the execution to carry on
+					 * and return immediately
+					 */
+					return $result;
+				}
 			}
 		}
+
+		/* Not aborted or not abortable. For non-abortable calls to emit() this return value can safely be ignored. */
+		return true;
 	}
 }

--- a/lib/private/hooks/legacyemitter.php
+++ b/lib/private/hooks/legacyemitter.php
@@ -9,8 +9,8 @@
 namespace OC\Hooks;
 
 abstract class LegacyEmitter extends BasicEmitter {
-	protected function emit($scope, $method, $arguments = array()) {
+	protected function emit($scope, $method, $arguments = array(), $abortable=false) {
 		\OC_Hook::emit($scope, $method, $arguments);
-		parent::emit($scope, $method, $arguments);
+		return parent::emit($scope, $method, $arguments, $abortable);
 	}
 }

--- a/lib/private/hooks/publicemitter.php
+++ b/lib/private/hooks/publicemitter.php
@@ -13,8 +13,10 @@ class PublicEmitter extends BasicEmitter {
 	 * @param string $scope
 	 * @param string $method
 	 * @param array $arguments optional
+	 * @param bool $abortable optional Defines whether the hook is abortable or not
+	 * @return bool true if not aborted, false otherwise
 	 */
-	public function emit($scope, $method, $arguments = array()) {
-		parent::emit($scope, $method, $arguments);
+	public function emit($scope, $method, $arguments = array(), $abortable = false) {
+		return parent::emit($scope, $method, $arguments, $abortable);
 	}
 }


### PR DESCRIPTION
BasicEmitter::emit now allows an additional, optional argument "$abortable"
to be specified. This defaults to false, in order to preserve the original
behaviour.
If $abortable is true, the return value of each function invoked by emit
is checked for a return value of false. As soon as one function returns
false, running the hook handlers is stopped and false is returned by
BasicEmitter::emit.

Signed-off-by: Stephan Peijnik speijnik@anexia-it.com
