### PR TITLE
Add group management to the public api

### DIFF
--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -34,26 +34,19 @@
  *   post_removeFromGroup(uid, gid)
  */
 class OC_Group {
-	/**
-	 * @var \OC\Group\Manager $manager
-	 */
-	private static $manager;
-
-	/**
-	 * @var \OC\User\Manager
-	 */
-	private static $userManager;
 
 	/**
 	 * @return \OC\Group\Manager
 	 */
 	public static function getManager() {
-		if (self::$manager) {
-			return self::$manager;
-		}
-		self::$userManager = \OC_User::getManager();
-		self::$manager = new \OC\Group\Manager(self::$userManager);
-		return self::$manager;
+		return \OC::$server->getGroupManager();
+	}
+
+	/**
+	 * @return \OC\User\Manager
+	 */
+	private static function getUserManager() {
+		return \OC::$server->getUserManager();
 	}
 
 	/**
@@ -127,7 +120,7 @@ class OC_Group {
 	 */
 	public static function inGroup($uid, $gid) {
 		$group = self::getManager()->get($gid);
-		$user = self::$userManager->get($uid);
+		$user = self::getUserManager()->get($uid);
 		if ($group and $user) {
 			return $group->inGroup($user);
 		}
@@ -144,7 +137,7 @@ class OC_Group {
 	 */
 	public static function addToGroup($uid, $gid) {
 		$group = self::getManager()->get($gid);
-		$user = self::$userManager->get($uid);
+		$user = self::getUserManager()->get($uid);
 		if ($group and $user) {
 			OC_Hook::emit("OC_Group", "pre_addToGroup", array("run" => true, "uid" => $uid, "gid" => $gid));
 			$group->addUser($user);
@@ -165,7 +158,7 @@ class OC_Group {
 	 */
 	public static function removeFromGroup($uid, $gid) {
 		$group = self::getManager()->get($gid);
-		$user = self::$userManager->get($uid);
+		$user = self::getUserManager()->get($uid);
 		if ($group and $user) {
 			OC_Hook::emit("OC_Group", "pre_removeFromGroup", array("run" => true, "uid" => $uid, "gid" => $gid));
 			$group->removeUser($user);
@@ -185,7 +178,7 @@ class OC_Group {
 	 * if the user exists at all.
 	 */
 	public static function getUserGroups($uid) {
-		$user = self::$userManager->get($uid);
+		$user = self::getUserManager()->get($uid);
 		if ($user) {
 			return self::getManager()->getUserGroupIds($user);
 		} else {

--- a/lib/private/group/group.php
+++ b/lib/private/group/group.php
@@ -9,7 +9,9 @@
 
 namespace OC\Group;
 
-class Group {
+use OCP\IGroup;
+
+class Group implements IGroup {
 	/**
 	 * @var string $id
 	 */

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -10,6 +10,7 @@
 namespace OC\Group;
 
 use OC\Hooks\PublicEmitter;
+use OCP\IGroupManager;
 
 /**
  * Class Manager
@@ -26,7 +27,7 @@ use OC\Hooks\PublicEmitter;
  *
  * @package OC\Group
  */
-class Manager extends PublicEmitter {
+class Manager extends PublicEmitter implements IGroupManager {
 	/**
 	 * @var \OC_Group_Backend[]|\OC_Group_Database[] $backends
 	 */

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -13,6 +13,7 @@ use OCP\IServerContainer;
 
 /**
  * Class Server
+ *
  * @package OC
  *
  * TODO: hookup all manager classes
@@ -20,10 +21,10 @@ use OCP\IServerContainer;
 class Server extends SimpleContainer implements IServerContainer {
 
 	function __construct() {
-		$this->registerService('ContactsManager', function($c) {
+		$this->registerService('ContactsManager', function ($c) {
 			return new ContactsManager();
 		});
-		$this->registerService('Request', function($c) {
+		$this->registerService('Request', function ($c) {
 			if (isset($c['urlParams'])) {
 				$urlParams = $c['urlParams'];
 			} else {
@@ -37,7 +38,8 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 
 			if (defined('PHPUNIT_RUN') && PHPUNIT_RUN
-			&& in_array('fakeinput', stream_get_wrappers())) {
+				&& in_array('fakeinput', stream_get_wrappers())
+			) {
 				$stream = 'fakeinput://data';
 			} else {
 				$stream = 'php://input';
@@ -52,21 +54,21 @@ class Server extends SimpleContainer implements IServerContainer {
 					'env' => $_ENV,
 					'cookies' => $_COOKIE,
 					'method' => (isset($_SERVER) && isset($_SERVER['REQUEST_METHOD']))
-						? $_SERVER['REQUEST_METHOD']
-						: null,
+							? $_SERVER['REQUEST_METHOD']
+							: null,
 					'urlParams' => $urlParams,
 					'requesttoken' => $requestToken,
 				), $stream
 			);
 		});
-		$this->registerService('PreviewManager', function($c) {
+		$this->registerService('PreviewManager', function ($c) {
 			return new PreviewManager();
 		});
-		$this->registerService('TagManager', function($c) {
+		$this->registerService('TagManager', function ($c) {
 			$user = \OC_User::getUser();
 			return new TagManager($user);
 		});
-		$this->registerService('RootFolder', function($c) {
+		$this->registerService('RootFolder', function ($c) {
 			// TODO: get user and user manager from container as well
 			$user = \OC_User::getUser();
 			/** @var $c SimpleContainer */
@@ -76,7 +78,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			$view = new View();
 			return new Root($manager, $view, $user);
 		});
-		$this->registerService('UserManager', function($c) {
+		$this->registerService('UserManager', function ($c) {
 			/**
 			 * @var SimpleContainer $c
 			 * @var \OC\AllConfig $config
@@ -84,7 +86,15 @@ class Server extends SimpleContainer implements IServerContainer {
 			$config = $c->query('AllConfig');
 			return new \OC\User\Manager($config);
 		});
-		$this->registerService('UserSession', function($c) {
+		$this->registerService('GroupManager', function ($c) {
+			/**
+			 * @var SimpleContainer $c
+			 * @var \OC\User\Manager $userManager
+			 */
+			$userManager = $c->query('UserManager');
+			return new \OC\Group\Manager($userManager);
+		});
+		$this->registerService('UserSession', function ($c) {
 			/**
 			 * @var SimpleContainer $c
 			 * @var \OC\User\Manager $manager
@@ -126,40 +136,40 @@ class Server extends SimpleContainer implements IServerContainer {
 			});
 			return $userSession;
 		});
-		$this->registerService('NavigationManager', function($c) {
+		$this->registerService('NavigationManager', function ($c) {
 			return new \OC\NavigationManager();
 		});
-		$this->registerService('AllConfig', function($c) {
+		$this->registerService('AllConfig', function ($c) {
 			return new \OC\AllConfig();
 		});
 		$this->registerService('AppConfig', function ($c) {
 			return new \OC\AppConfig(\OC_DB::getConnection());
 		});
-		$this->registerService('L10NFactory', function($c) {
+		$this->registerService('L10NFactory', function ($c) {
 			return new \OC\L10N\Factory();
 		});
-		$this->registerService('URLGenerator', function($c) {
+		$this->registerService('URLGenerator', function ($c) {
 			/** @var $c SimpleContainer */
 			$config = $c->query('AllConfig');
 			return new \OC\URLGenerator($config);
 		});
-		$this->registerService('AppHelper', function($c) {
+		$this->registerService('AppHelper', function ($c) {
 			return new \OC\AppHelper();
 		});
-		$this->registerService('UserCache', function($c) {
+		$this->registerService('UserCache', function ($c) {
 			return new UserCache();
 		});
 		$this->registerService('MemCacheFactory', function ($c) {
 			$instanceId = \OC_Util::getInstanceId();
 			return new \OC\Memcache\Factory($instanceId);
 		});
-		$this->registerService('ActivityManager', function($c) {
+		$this->registerService('ActivityManager', function ($c) {
 			return new ActivityManager();
 		});
-		$this->registerService('AvatarManager', function($c) {
+		$this->registerService('AvatarManager', function ($c) {
 			return new AvatarManager();
 		});
-		$this->registerService('Logger', function($c) {
+		$this->registerService('Logger', function ($c) {
 			/** @var $c SimpleContainer */
 			$logClass = $c->query('AllConfig')->getSystemValue('log_type', 'owncloud');
 			$logger = 'OC_Log_' . ucfirst($logClass);
@@ -174,7 +184,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			$config = $c->getConfig();
 			return new \OC\BackgroundJob\JobList($c->getDatabaseConnection(), $config);
 		});
-		$this->registerService('Router', function ($c){
+		$this->registerService('Router', function ($c) {
 			/**
 			 * @var Server $c
 			 */
@@ -186,10 +196,10 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 			return $router;
 		});
-		$this->registerService('Search', function($c){
+		$this->registerService('Search', function ($c) {
 			return new Search();
 		});
-		$this->registerService('Db', function($c){
+		$this->registerService('Db', function ($c) {
 			return new Db();
 		});
 	}
@@ -259,14 +269,14 @@ class Server extends SimpleContainer implements IServerContainer {
 		$root = $this->getRootFolder();
 		$folder = null;
 
-		if(!$root->nodeExists($dir)) {
+		if (!$root->nodeExists($dir)) {
 			$folder = $root->newFolder($dir);
 		} else {
 			$folder = $root->get($dir);
 		}
 
 		$dir = '/files';
-		if(!$folder->nodeExists($dir)) {
+		if (!$folder->nodeExists($dir)) {
 			$folder = $folder->newFolder($dir);
 		} else {
 			$folder = $folder->get($dir);
@@ -285,7 +295,7 @@ class Server extends SimpleContainer implements IServerContainer {
 		$dir = '/' . \OC_App::getCurrentApp();
 		$root = $this->getRootFolder();
 		$folder = null;
-		if(!$root->nodeExists($dir)) {
+		if (!$root->nodeExists($dir)) {
 			$folder = $root->newFolder($dir);
 		} else {
 			$folder = $root->get($dir);
@@ -298,6 +308,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	function getUserManager() {
 		return $this->query('UserManager');
+	}
+
+	/**
+	 * @return \OC\Group\Manager
+	 */
+	function getGroupManager() {
+		return $this->query('GroupManager');
 	}
 
 	/**
@@ -326,12 +343,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 *
 	 * @return \OCP\IAppConfig
 	 */
-	function getAppConfig(){
+	function getAppConfig() {
 		return $this->query('AppConfig');
 	}
 
 	/**
 	 * get an L10N instance
+	 *
 	 * @param string $app appid
 	 * @return \OC_L10N
 	 */
@@ -403,7 +421,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	 *
 	 * @return \OCP\BackgroundJob\IJobList
 	 */
-	function getJobList(){
+	function getJobList() {
 		return $this->query('JobList');
 	}
 
@@ -421,12 +439,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 *
 	 * @return \OCP\Route\IRouter
 	 */
-	function getRouter(){
+	function getRouter() {
 		return $this->query('Router');
 	}
 
 	/**
 	 * Returns a search instance
+	 *
 	 * @return \OCP\ISearch
 	 */
 	function getSearch() {
@@ -435,6 +454,7 @@ class Server extends SimpleContainer implements IServerContainer {
 
 	/**
 	 * Returns an instance of the db facade
+	 *
 	 * @return \OCP\IDb
 	 */
 	function getDb() {

--- a/lib/public/igroup.php
+++ b/lib/public/igroup.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP;
+
+interface IGroup {
+	/**
+	 * @return string
+	 */
+	public function getGID();
+
+	/**
+	 * get all users in the group
+	 *
+	 * @return \OCP\IUser[]
+	 */
+	public function getUsers();
+
+	/**
+	 * check if a user is in the group
+	 *
+	 * @param \OCP\IUser $user
+	 * @return bool
+	 */
+	public function inGroup($user);
+
+	/**
+	 * add a user to the group
+	 *
+	 * @param \OCP\IUser $user
+	 */
+	public function addUser($user);
+
+	/**
+	 * remove a user from the group
+	 *
+	 * @param \OCP\IUser $user
+	 */
+	public function removeUser($user);
+
+	/**
+	 * search for users in the group by userid
+	 *
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return \OCP\IUser[]
+	 */
+	public function searchUsers($search, $limit = null, $offset = null);
+
+	/**
+	 * returns the number of users matching the search string
+	 *
+	 * @param string $search
+	 * @return int|bool
+	 */
+	public function count($search = '');
+
+	/**
+	 * search for users in the group by displayname
+	 *
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return \OCP\IUser[]
+	 */
+	public function searchDisplayName($search, $limit = null, $offset = null);
+
+	/**
+	 * delete the group
+	 *
+	 * @return bool
+	 */
+	public function delete();
+}

--- a/lib/public/igroupmanager.php
+++ b/lib/public/igroupmanager.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP;
+
+/**
+ * Class Manager
+ *
+ * Hooks available in scope \OC\Group:
+ * - preAddUser(\OC\Group\Group $group, \OC\User\User $user)
+ * - postAddUser(\OC\Group\Group $group, \OC\User\User $user)
+ * - preRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
+ * - postRemoveUser(\OC\Group\Group $group, \OC\User\User $user)
+ * - preDelete(\OC\Group\Group $group)
+ * - postDelete(\OC\Group\Group $group)
+ * - preCreate(string $groupId)
+ * - postCreate(\OC\Group\Group $group)
+ *
+ * @package OC\Group
+ */
+interface IGroupManager {
+	/**
+	 * @param \OCP\UserInterface $backend
+	 */
+	public function addBackend($backend);
+
+	public function clearBackends();
+
+	/**
+	 * @param string $gid
+	 * @return \OCP\IGroup
+	 */
+	public function get($gid);
+
+	/**
+	 * @param string $gid
+	 * @return bool
+	 */
+	public function groupExists($gid);
+
+	/**
+	 * @param string $gid
+	 * @return \OCP\IGroup
+	 */
+	public function createGroup($gid);
+
+	/**
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return \OCP\IGroup[]
+	 */
+	public function search($search, $limit = null, $offset = null);
+
+	/**
+	 * @param \OCP\IUser $user
+	 * @return \OCP\IGroup[]
+	 */
+	public function getUserGroups($user);
+
+	/**
+	 * @param \OCP\IUser $user
+	 * @return array with group names
+	 */
+	public function getUserGroupIds($user);
+
+	/**
+	 * get a list of all display names in a group
+	 *
+	 * @param string $gid
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of display names (value) and user ids (key)
+	 */
+	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0);
+}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -100,6 +100,13 @@ interface IServerContainer {
 	function getUserManager();
 
 	/**
+	 * Returns a group manager
+	 *
+	 * @return \OCP\IGroupManager
+	 */
+	function getGroupManager();
+
+	/**
 	 * Returns the user session
 	 *
 	 * @return \OCP\IUserSession


### PR DESCRIPTION
Adds public interfaces `\OCP\IGroup` and `\OCP\IGroupManager` and exposes the group manager in the server container.

cc @DeepDiver1975 @PVince81 
