### PR TITLE
Make MySQL affected row count consistent with other DBMSes 

### DIFF
--- a/lib/private/db/connectionfactory.php
+++ b/lib/private/db/connectionfactory.php
@@ -61,6 +61,8 @@ class ConnectionFactory {
 			throw new \InvalidArgumentException("Unsupported type: $type");
 		}
 		$result = $this->defaultConnectionParams[$normalizedType];
+		// \PDO::MYSQL_ATTR_FOUND_ROWS may not be defined, e.g. when the MySQL
+		// driver is missing. In this case, we won't be able to connect anyway.
 		if ($normalizedType === 'mysql' && defined('\PDO::MYSQL_ATTR_FOUND_ROWS')) {
 			$result['driverOptions'] = array(
 				\PDO::MYSQL_ATTR_FOUND_ROWS => true,

--- a/lib/private/db/connectionfactory.php
+++ b/lib/private/db/connectionfactory.php
@@ -60,7 +60,13 @@ class ConnectionFactory {
 		if (!isset($this->defaultConnectionParams[$normalizedType])) {
 			throw new \InvalidArgumentException("Unsupported type: $type");
 		}
-		return $this->defaultConnectionParams[$normalizedType];
+		$result = $this->defaultConnectionParams[$normalizedType];
+		if ($normalizedType === 'mysql' && defined('\PDO::MYSQL_ATTR_FOUND_ROWS')) {
+			$result['driverOptions'] = array(
+				\PDO::MYSQL_ATTR_FOUND_ROWS => true,
+			);
+		}
+		return $result;
 	}
 
 	/**

--- a/tests/lib/ocs/privatedata.php
+++ b/tests/lib/ocs/privatedata.php
@@ -79,6 +79,31 @@ class Test_OC_OCS_Privatedata extends PHPUnit_Framework_TestCase
 		$this->assertEquals('updated', $data['value']);
 	}
 
+	public function testSetSameValue() {
+		$_POST = array('value' => 123456789);
+		$params = array('app' => $this->appKey, 'key' => 'k-10');
+		$result = OC_OCS_Privatedata::set($params);
+		$this->assertEquals(100, $result->getStatusCode());
+
+		$result = OC_OCS_Privatedata::get($params);
+		$this->assertOcsResult(1, $result);
+		$data = $result->getData();
+		$data = $data[0];
+		$this->assertEquals('123456789', $data['value']);
+
+		// set the same value again
+		$_POST = array('value' => 123456789);
+		$params = array('app' => $this->appKey, 'key' => 'k-10');
+		$result = OC_OCS_Privatedata::set($params);
+		$this->assertEquals(100, $result->getStatusCode());
+
+		$result = OC_OCS_Privatedata::get($params);
+		$this->assertOcsResult(1, $result);
+		$data = $result->getData();
+		$data = $data[0];
+		$this->assertEquals('123456789', $data['value']);
+	}
+
 	public function testSetMany() {
 		$_POST = array('value' => 123456789);
 


### PR DESCRIPTION
"UPDATE t SET a = 1" now returns the number of rows that have a = 1 after the update instead of the number of rows that have been updated to a = 1.

Inspired by https://github.com/phpbb/phpbb/pull/2492
Largely replaces #8432 (the tests should probably be kept)

Please note that the PDO::MYSQL_ATTR_FOUND_ROWS constant might be undefined when the MySQL PDO driver is not available. This results in a bit of ugliness in code.

@butonic @nickvergessen @PVince81 @DeepDiver1975 @icewind1991 
