### PR TITLE
kill OC::$session

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -2,7 +2,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 
 // Get data

--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -23,7 +23,7 @@
 
 // Check if we are a user
 OCP\User::checkLoggedIn();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 $files = $_GET["files"];
 $dir = $_GET["dir"];

--- a/apps/files/ajax/getstoragestats.php
+++ b/apps/files/ajax/getstoragestats.php
@@ -7,7 +7,7 @@ if (isset($_GET['dir'])) {
 }
 
 OCP\JSON::checkLoggedIn();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 // send back json
 OCP\JSON::success(array('data' => \OCA\Files\Helper::buildFileStorageStatistics($dir)));

--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -1,7 +1,7 @@
 <?php
 
 OCP\JSON::checkLoggedIn();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 $l = OC_L10N::get('files');
 
 // Load the files

--- a/apps/files/ajax/mimeicon.php
+++ b/apps/files/ajax/mimeicon.php
@@ -1,4 +1,4 @@
 <?php
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 print OC_Helper::mimetypeIcon($_GET['mime']);

--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -2,7 +2,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 // Get data
 $dir = stripslashes($_POST["dir"]);

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -7,7 +7,7 @@ if(!OC_User::isLoggedIn()) {
 	exit;
 }
 
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 // Get the params
 $dir = isset( $_REQUEST['dir'] ) ? '/'.trim($_REQUEST['dir'], '/\\') : '';

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -5,7 +5,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 // Get the params
 $dir = isset( $_POST['dir'] ) ? stripslashes($_POST['dir']) : '';

--- a/apps/files/ajax/rename.php
+++ b/apps/files/ajax/rename.php
@@ -23,7 +23,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 $files = new \OCA\Files\App(
 	\OC\Files\Filesystem::getView(),

--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -1,6 +1,6 @@
 <?php
 set_time_limit(0); //scanning can take ages
-\OC::$session->close();
+\OC::$server->getSession()->close();
 
 $force = (isset($_GET['force']) and ($_GET['force'] === 'true'));
 $dir = isset($_GET['dir']) ? $_GET['dir'] : '';

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -68,7 +68,7 @@ if (empty($_POST['dirToken'])) {
 OCP\JSON::callCheck();
 if (!\OCP\App::isEnabled('files_encryption')) {
 	// encryption app need to create keys later, so can't close too early
-	\OC::$session->close();
+	\OC::$server->getSession()->close();
 }
 
 

--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -117,7 +117,7 @@ class Session {
 	 */
 	public function setPrivateKey($privateKey) {
 
-		\OC::$session->set('privateKey', $privateKey);
+		\OC::$server->getSession()->set('privateKey', $privateKey);
 
 		return true;
 
@@ -140,7 +140,7 @@ class Session {
 	 */
 	public function setInitialized($init) {
 
-		\OC::$session->set('encryptionInitialized', $init);
+		\OC::$server->getSession()->set('encryptionInitialized', $init);
 
 		return true;
 
@@ -150,8 +150,8 @@ class Session {
 	 * remove encryption keys and init status from session
 	 */
 	public function closeSession() {
-		\OC::$session->remove('encryptionInitialized');
-		\OC::$session->remove('privateKey');
+		\OC::$server->getSession()->remove('encryptionInitialized');
+		\OC::$server->getSession()->remove('privateKey');
 	}
 
 
@@ -162,8 +162,8 @@ class Session {
 	 * @note this doesn not indicate of the init was successful, we just remeber the try!
 	 */
 	public function getInitialized() {
-		if (!is_null(\OC::$session->get('encryptionInitialized'))) {
-			return \OC::$session->get('encryptionInitialized');
+		if (!is_null(\OC::$server->getSession()->get('encryptionInitialized'))) {
+			return \OC::$server->getSession()->get('encryptionInitialized');
 		} else {
 			return self::NOT_INITIALIZED;
 		}
@@ -179,8 +179,8 @@ class Session {
 		if (\OCA\Encryption\Helper::isPublicAccess()) {
 			return $this->getPublicSharePrivateKey();
 		} else {
-			if (!is_null(\OC::$session->get('privateKey'))) {
-				return \OC::$session->get('privateKey');
+			if (!is_null(\OC::$server->getSession()->get('privateKey'))) {
+				return \OC::$server->getSession()->get('privateKey');
 			} else {
 				return false;
 			}
@@ -194,7 +194,7 @@ class Session {
 	 */
 	public function setPublicSharePrivateKey($privateKey) {
 
-		\OC::$session->set('publicSharePrivateKey', $privateKey);
+		\OC::$server->getSession()->set('publicSharePrivateKey', $privateKey);
 
 		return true;
 
@@ -207,8 +207,8 @@ class Session {
 	 */
 	public function getPublicSharePrivateKey() {
 
-		if (!is_null(\OC::$session->get('publicSharePrivateKey'))) {
-			return \OC::$session->get('publicSharePrivateKey');
+		if (!is_null(\OC::$server->getSession()->get('publicSharePrivateKey'))) {
+			return \OC::$server->getSession()->get('publicSharePrivateKey');
 		} else {
 			return false;
 		}

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -14,12 +14,12 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 	private $username_as_share;
 
 	public function __construct($params) {
-		if (isset($params['host']) && \OC::$session->exists('smb-credentials')) {
+		if (isset($params['host']) && \OC::$server->getSession()->exists('smb-credentials')) {
 			$host=$params['host'];
 			$this->username_as_share = ($params['username_as_share'] === 'true');
 
-			$params_auth = \OC::$session->get('smb-credentials');
-			$user = \OC::$session->get('loginname');
+			$params_auth = \OC::$server->getSession()->get('smb-credentials');
+			$user = \OC::$server->getSession()->get('loginname');
 			$password = $params_auth['password'];
 
 			$root=isset($params['root'])?$params['root']:'/';
@@ -45,7 +45,7 @@ class SMB_OC extends \OC\Files\Storage\SMB {
 	}
 
 	public static function login( $params ) {
-		\OC::$session->set('smb-credentials', $params);
+		\OC::$server->getSession()->set('smb-credentials', $params);
 	}
 
 	public function isSharable($path) {

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -106,7 +106,7 @@ class Helper {
 					return false;
 				} else {
 					// Save item id in session for future requests
-					\OC::$session->set('public_link_authenticated', $linkItem['id']);
+					\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);
 				}
 			} else {
 				\OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type']
@@ -117,8 +117,8 @@ class Helper {
 		}
 		else {
 			// not authenticated ?
-			if ( ! \OC::$session->exists('public_link_authenticated')
-				|| \OC::$session->get('public_link_authenticated') !== $linkItem['id']) {
+			if ( ! \OC::$server->getSession()->exists('public_link_authenticated')
+				|| \OC::$server->getSession()->get('public_link_authenticated') !== $linkItem['id']) {
 				return false;
 			}
 		}

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -63,7 +63,7 @@ if (isset($path)) {
 					exit();
 				} else {
 					// Save item id in session for future requests
-					\OC::$session->set('public_link_authenticated', $linkItem['id']);
+					\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);
 				}
 			} else {
 				OCP\Util::writeLog('share', 'Unknown share type '.$linkItem['share_type']
@@ -76,8 +76,8 @@ if (isset($path)) {
 
 		} else {
 			// Check if item id is set in session
-			if ( ! \OC::$session->exists('public_link_authenticated')
-				|| \OC::$session->get('public_link_authenticated') !== $linkItem['id']
+			if ( ! \OC::$server->getSession()->exists('public_link_authenticated')
+				|| \OC::$server->getSession()->get('public_link_authenticated') !== $linkItem['id']
 			) {
 				// Prompt for password
 				OCP\Util::addStyle('files_sharing', 'authenticate');

--- a/cron.php
+++ b/cron.php
@@ -56,10 +56,10 @@ try {
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 
-	\OC::$session->close();
+	\OC::$server->getSession()->close();
 
 	// initialize a dummy memory session
-	\OC::$session = new \OC\Session\Memory('');
+	\OC::$server->setSession(new \OC\Session\Memory(''));
 
 	$logger = \OC_Log::$object;
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -71,7 +71,7 @@ class OC {
 	public static $CLI = false;
 
 	/**
-	 * @deprecated use \OC::$session->getSession() instead
+	 * @deprecated use \OC::$server->getSession() instead
 	 * @var \OC\Session\Session
 	 */
 	public static $session = null;

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -191,7 +191,7 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 	}
 
 	private function getUserId() {
-		return \OC::$session->get('user_id');
+		return \OC::$server->getSession()->get('user_id');
 	}
 
 	/**

--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -78,7 +78,7 @@ class OC_Connector_Sabre_Auth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 		$result = $this->auth($server, $realm);
 
 		// close the session - right after authentication there is not need to write to the session any more
-		\OC::$session->close();
+		\OC::$server->getSession()->close();
 
 		return $result;
     }

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -10,6 +10,7 @@ use OC\DB\ConnectionWrapper;
 use OC\Files\Node\Root;
 use OC\Files\View;
 use OCP\IServerContainer;
+use OCP\ISession;
 
 /**
  * Class Server
@@ -31,8 +32,8 @@ class Server extends SimpleContainer implements IServerContainer {
 				$urlParams = array();
 			}
 
-			if (\OC::$session->exists('requesttoken')) {
-				$requestToken = \OC::$session->get('requesttoken');
+			if (\OC::$server->getSession()->exists('requesttoken')) {
+				$requestToken = \OC::$server->getSession()->get('requesttoken');
 			} else {
 				$requestToken = false;
 			}
@@ -100,7 +101,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			 * @var \OC\User\Manager $manager
 			 */
 			$manager = $c->query('UserManager');
-			$userSession = new \OC\User\Session($manager, \OC::$session);
+			$userSession = new \OC\User\Session($manager, new \OC\Session\Memory(''));
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', array('run' => true, 'uid' => $uid, 'password' => $password));
 			});
@@ -328,6 +329,20 @@ class Server extends SimpleContainer implements IServerContainer {
 	}
 
 	/**
+	 * @return \OCP\ISession
+	 */
+	function getSession() {
+		return $this->query('UserSession')->getSession();
+	}
+
+	/**
+	 * @param \OCP\ISession $session
+	 */
+	function setSession(\OCP\ISession $session) {
+		return $this->query('UserSession')->setSession($session);
+	}
+
+	/**
 	 * @return \OC\NavigationManager
 	 */
 	function getNavigationManager() {
@@ -390,15 +405,6 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	function getMemCacheFactory() {
 		return $this->query('MemCacheFactory');
-	}
-
-	/**
-	 * Returns the current session
-	 *
-	 * @return \OCP\ISession
-	 */
-	function getSession() {
-		return \OC::$session;
 	}
 
 	/**

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1855,8 +1855,8 @@ class Share extends \OC\Share\Constants {
 			return true;
 		}
 
-		if ( \OC::$session->exists('public_link_authenticated')
-			&& \OC::$session->get('public_link_authenticated') === $linkItem['id'] ) {
+		if ( \OC::$server->getSession()->exists('public_link_authenticated')
+			&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id'] ) {
 			return true;
 		}
 

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -52,7 +52,7 @@ class OC_Template extends \OC\Template\Base {
 		// Read the detected formfactor and use the right file name.
 		$fext = self::getFormFactorExtension();
 
-		$requesttoken = OC::$session ? OC_Util::callRegister() : '';
+		$requesttoken = OC::$server->getSession() ? OC_Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = OC_L10N::get($parts[0]);
@@ -101,20 +101,20 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	static public function getFormFactorExtension()
 	{
-		if (!\OC::$session) {
+		if (!\OC::$server->getSession()) {
 			return '';
 		}
 		// if the formfactor is not yet autodetected do the
 		// autodetection now. For possible formfactors check the
 		// detectFormfactor documentation
-		if (!\OC::$session->exists('formfactor')) {
-			\OC::$session->set('formfactor', self::detectFormfactor());
+		if (!\OC::$server->getSession()->exists('formfactor')) {
+			\OC::$server->getSession()->set('formfactor', self::detectFormfactor());
 		}
 		// allow manual override via GET parameter
 		if(isset($_GET['formfactor'])) {
-			\OC::$session->set('formfactor', $_GET['formfactor']);
+			\OC::$server->getSession()->set('formfactor', $_GET['formfactor']);
 		}
-		$formfactor = \OC::$session->get('formfactor');
+		$formfactor = \OC::$server->getSession()->get('formfactor');
 		if($formfactor==='default') {
 			$fext='';
 		}elseif($formfactor==='mobile') {

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -300,7 +300,7 @@ class OC_User {
 	 * Sets user id for session and triggers emit
 	 */
 	public static function setUserId($uid) {
-		OC::$session->set('user_id', $uid);
+		\OC::$server->getSession()->set('user_id', $uid);
 	}
 
 	/**
@@ -337,8 +337,8 @@ class OC_User {
 	 * Checks if the user is logged in
 	 */
 	public static function isLoggedIn() {
-		if (\OC::$session->get('user_id') !== null && self::$incognitoMode === false) {
-			return self::userExists(\OC::$session->get('user_id'));
+		if (\OC::$server->getSession()->get('user_id') !== null && self::$incognitoMode === false) {
+			return self::userExists(\OC::$server->getSession()->get('user_id'));
 		}
 		return false;
 	}
@@ -386,7 +386,7 @@ class OC_User {
 	 * @return string uid or false
 	 */
 	public static function getUser() {
-		$uid = OC::$session ? OC::$session->get('user_id') : null;
+		$uid = \OC::$server->getSession() ? \OC::$server->getSession()->get('user_id') : null;
 		if (!is_null($uid) && self::$incognitoMode === false) {
 			return $uid;
 		} else {

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -384,11 +384,11 @@ class OC_Util {
 	 * @return string timestamp
 	 * @description adjust to clients timezone if we know it
 	 */
-	public static function formatDate($timestamp, $dateOnly = false) {
-		if (\OC::$session->exists('timezone')) {
+	public static function formatDate( $timestamp, $dateOnly = false) {
+		if(\OC::$server->getSession()->exists('timezone')) {
 			$systemTimeZone = intval(date('O'));
 			$systemTimeZone = (round($systemTimeZone / 100, 0) * 60) + ($systemTimeZone % 100);
-			$clientTimeZone = \OC::$session->get('timezone') * 60;
+			$clientTimeZone = \OC::$server->getSession()->get('timezone') * 60;
 			$offset = $clientTimeZone - $systemTimeZone;
 			$timestamp = $timestamp + $offset * 60;
 		}
@@ -412,7 +412,7 @@ class OC_Util {
 		}
 
 		// Assume that if checkServer() succeeded before in this session, then all is fine.
-		if (\OC::$session->exists('checkServer_succeeded') && \OC::$session->get('checkServer_succeeded')) {
+		if (\OC::$server->getSession()->exists('checkServer_succeeded') && \OC::$server->getSession()->get('checkServer_succeeded')) {
 			return $errors;
 		}
 
@@ -615,7 +615,7 @@ class OC_Util {
 		$errors = array_merge($errors, self::checkDatabaseVersion());
 
 		// Cache the result of this function
-		\OC::$session->set('checkServer_succeeded', count($errors) == 0);
+		\OC::$server->getSession()->set('checkServer_succeeded', count($errors) == 0);
 
 		return $errors;
 	}
@@ -938,13 +938,13 @@ class OC_Util {
 	 */
 	public static function callRegister() {
 		// Check if a token exists
-		if (!\OC::$session->exists('requesttoken')) {
+		if (!\OC::$server->getSession()->exists('requesttoken')) {
 			// No valid token found, generate a new one.
 			$requestToken = self::generateRandomBytes(20);
-			\OC::$session->set('requesttoken', $requestToken);
+			\OC::$server->getSession()->set('requesttoken', $requestToken);
 		} else {
 			// Valid token already exists, send it
-			$requestToken = \OC::$session->get('requesttoken');
+			$requestToken = \OC::$server->getSession()->get('requesttoken');
 		}
 		return ($requestToken);
 	}

--- a/tests/lib/ocs/privatedata.php
+++ b/tests/lib/ocs/privatedata.php
@@ -26,7 +26,7 @@ class Test_OC_OCS_Privatedata extends PHPUnit_Framework_TestCase
 	private $appKey;
 
 	public function setUp() {
-		\OC::$session->set('user_id', 'user1');
+		\OC::$server->getSession()->set('user_id', 'user1');
 		$this->appKey = uniqid('app');
 	}
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -740,7 +740,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 	 * @param $item
 	 */
 	public function testCheckPasswordProtectedShare($expected, $item) {
-		\OC::$session->set('public_link_authenticated', 100);
+		\OC::$server->getSession()->set('public_link_authenticated', 100);
 		$result = \OCP\Share::checkPasswordProtectedShare($item);
 		$this->assertEquals($expected, $result);
 	}
@@ -767,8 +767,8 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			return true;
 		}
 
-		if ( \OC::$session->exists('public_link_authenticated')
-			&& \OC::$session->get('public_link_authenticated') === $linkItem['id'] ) {
+		if ( \OC::$server->getSession()->exists('public_link_authenticated')
+			&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id'] ) {
 			return true;
 		}
 		 * */

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -31,9 +31,9 @@ class StartSessionListener implements PHPUnit_Framework_TestListener {
 
 	public function endTest(PHPUnit_Framework_Test $test, $time) {
 		// reopen the session - only allowed for memory session
-		if (\OC::$session instanceof \OC\Session\Memory) {
+		if (\OC::$server->getSession() instanceof \OC\Session\Memory) {
 			/** @var $session \OC\Session\Memory */
-			$session = \OC::$session;
+			$session = \OC::$server->getSession();
 			$session->reopen();
 		}
 	}


### PR DESCRIPTION
TL;DR: having two places where the session is stored is a bad idea

Currently OC::$session is initialized before setting up the OC::$server container. Unfortunately, the container stores the session itself and as a result will get out of sync when OC::$session is replaced directly. An example is cron.php.

This PR makes the UserSession object contain the one and only session reference. the server container delegates getSession and setSession to the UserSession. Setting a session will close the previous session.  This seems to change a lot in core but actually only replaces occurences of `\OC::$session` with `\OC::$server->getSession()` and of course handles setting a new session and initializing it in lib/base.php

Notifying @owncloud/core-developers to spread the word.

Personally, I need to be able to set the userid in the session available in cron.php to set up the filesystem for a user when indexing files in search_lucene. Currently, core is broken in this regard and prevents me using the appframework (parts that are available in core).

@karlitschek @craigpg I _really_ want this in OC7 but we should postpone it to 7.0.1 for stability reasons. I'll defer the new search lucene to 7.0.1 then as well.
