### PR TITLE
fixed session interval calculation

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -57,7 +57,7 @@ $array = array(
 	"firstDay" => json_encode($l->l('firstday', 'firstday')) ,
 	"oc_config" => json_encode(
 		array(
-			'session_lifetime' => \OCP\Config::getSystemValue('session_lifetime', ini_get('session.gc_maxlifetime')),
+			'session_lifetime' => min(\OCP\Config::getSystemValue('session_lifetime', ini_get('session.gc_maxlifetime')), ini_get('session.gc_maxlifetime')),
 			'session_keepalive' => \OCP\Config::getSystemValue('session_keepalive', true)
 		)
 	)


### PR DESCRIPTION
use the minimum of configured session_livetime and session.gc_maxlifetime for session heartbeat interval calculation

If session_livetime is explicit configured and at least 2 times largen that session.gc_maxlifetime a wrong session refresh interval is calculated.
