### PR TITLE
fixing namespace of MapperTestUtility

### DIFF
--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -22,7 +22,7 @@
  */
 
 
-namespace OCP\AppFramework\Db;
+namespace Test\AppFramework\Db;
 
 
 /**


### PR DESCRIPTION
and rename file to be lowercase

fixes #9689 
