### PR TITLE
Load apps in tests, fixes #9666

### DIFF
--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -20,8 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-
 class Test_Mount_Config_Dummy_Storage {
 	public function test() {
 		return true;

--- a/apps/files_external/tests/mountconfig.php
+++ b/apps/files_external/tests/mountconfig.php
@@ -58,7 +58,7 @@ class Test_Mount_Config extends \PHPUnit_Framework_TestCase {
 
 		\OC_User::setUserId(self::TEST_USER1);
 		$this->userHome = \OC_User::getHome(self::TEST_USER1);
-		mkdir($this->userHome);
+		@mkdir($this->userHome);
 
 		$this->dataDir = \OC_Config::getValue(
 			'datadirectory',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,10 @@ if ($configDir) {
 
 require_once __DIR__ . '/../lib/base.php';
 
+// load minimum set of apps
+OC_App::loadApps(array('authentication'));
+OC_App::loadApps(array('filesystem', 'logging'));
+
 if (!class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -49,7 +49,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -71,7 +71,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -98,7 +98,7 @@ class Scanner extends \PHPUnit_Framework_TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
 		$originalPropagator = $scanner->getPropagator();
 		$scanner->setPropagator($propagator);
 		$scanner->addMount($mount);


### PR DESCRIPTION
This adds a small file that can be `require`d instead of lib/base.php, which ensures that a minimum set of apps are loaded. This fixes the regression introduced by ac7fb1b23e40e3075535ed5d4188219580b2386a for apps/files_external/tests/mountconfig.php

Fixes #9666
