### PR TITLE
[OC 7] Fix preview animation on uploading

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -707,6 +707,7 @@
 		 * @param options map of attributes:
 		 * - "updateSummary": true to update the summary after adding (default), false otherwise
 		 * - "silent": true to prevent firing events like "fileActionsReady"
+		 * - "animate": true to animate preview loading (defaults to true here)
 		 * @return new tr element (not appended to the table)
 		 */
 		add: function(fileData, options) {
@@ -714,7 +715,7 @@
 			var $tr;
 			var $rows;
 			var $insertionPoint;
-			options = options || {};
+			options = _.extend({animate: true}, options || {});
 
 			// there are three situations to cover:
 			// 1) insertion point is visible on the current page
@@ -772,6 +773,7 @@
 		 * @param options map of attributes:
 		 * - "index" optional index at which to insert the element
 		 * - "updateSummary" true to update the summary after adding (default), false otherwise
+		 * - "animate" true to animate the preview rendering
 		 * @return new tr element (not appended to the table)
 		 */
 		_renderRow: function(fileData, options) {
@@ -813,7 +815,7 @@
 
 			if (fileData.isPreviewAvailable) {
 				// lazy load / newly inserted td ?
-				if (!fileData.icon) {
+				if (options.animate) {
 					this.lazyLoadPreview({
 						path: path + '/' + fileData.name,
 						mime: mime,

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -162,7 +162,6 @@
 					else {
 						file.type = 'file';
 						if (share.isPreviewAvailable) {
-							file.icon = true;
 							file.isPreviewAvailable = true;
 						}
 					}


### PR DESCRIPTION
When adding/uploading files, the preview is now animated.
When loading a list of files directly the preview is displayed directly.

Please review @owncloud/designers 

This is a regression from OC 6, but I think it's fine to have it in 7.0.1.
(discovered through an IE8 bug)

CC @karlitschek @craigpg
