### PR TITLE
do not show selected groups twice after user creation

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -654,9 +654,11 @@ $(document).ready(function () {
 				} else {
 					if (result.data.groups) {
 						var addedGroups = result.data.groups;
-						UserList.availableGroups = $.unique($.merge(UserList.availableGroups, addedGroups));
 						for (var i in result.data.groups) {
 							var gid = result.data.groups[i];
+							if(UserList.availableGroups.indexOf(gid) === -1) {
+								UserList.availableGroups.push(gid);
+							}
 							$li = GroupList.getGroupLI(gid);
 							userCount = GroupList.getUserCount($li);
 							GroupList.setUserCount($li, userCount + 1);


### PR DESCRIPTION
Fixes #9716: upon user creation the selected groups have been shown twice in the multiselect.

Please test/review @brozkeff @PVince81 @VicDeo or others

@karlitschek papercut – OC 7 CE or not?
