### PR TITLE
Remove special case for css in OC.filePath

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -258,7 +258,7 @@ var OC={
 	filePath:function(app,type,file){
 		var isCore=OC.coreApps.indexOf(app)!==-1,
 			link=OC.webroot;
-		if((file.substring(file.length-3) === 'php' || file.substring(file.length-3) === 'css') && !isCore){
+		if(file.substring(file.length-3) === 'php' && !isCore){
 			link+='/index.php/apps/' + app;
 			if (file != 'index.php') {
 				link+='/';

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -134,6 +134,24 @@ describe('Core base tests', function() {
 			expect(escapeHTML('This is a good string without HTML.')).toEqual('This is a good string without HTML.');
 		});
 	});
+	describe('filePath', function() {
+		it('Uses a direct link for css and images,' , function() {
+			OC.webroot = 'http://localhost';
+			OC.appswebroots['files'] = OC.webroot + '/apps3/files';
+
+			expect(OC.filePath('core', 'css', 'style.css')).toEqual('http://localhost/core/css/style.css');
+			expect(OC.filePath('files', 'css', 'style.css')).toEqual('http://localhost/apps3/files/css/style.css');
+			expect(OC.filePath('core', 'img', 'image.png')).toEqual('http://localhost/core/img/image.png');
+			expect(OC.filePath('files', 'img', 'image.png')).toEqual('http://localhost/apps3/files/img/image.png');
+		});
+		it('Routes PHP files via index.php,' , function() {
+			OC.webroot = 'http://localhost';
+			OC.appswebroots['files'] = OC.webroot + '/apps3/files';
+
+			expect(OC.filePath('core', 'ajax', 'test.php')).toEqual('http://localhost/index.php/core/ajax/test.php');
+			expect(OC.filePath('files', 'ajax', 'test.php')).toEqual('http://localhost/index.php/apps/files/ajax/test.php');
+		});
+	});
 	describe('Link functions', function() {
 		var TESTAPP = 'testapp';
 		var TESTAPP_ROOT = OC.webroot + '/appsx/testapp';

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -135,19 +135,21 @@ describe('Core base tests', function() {
 		});
 	});
 	describe('filePath', function() {
-		it('Uses a direct link for css and images,' , function() {
+		beforeEach(function() {
 			OC.webroot = 'http://localhost';
 			OC.appswebroots['files'] = OC.webroot + '/apps3/files';
+		});
+		afterEach(function() {
+			delete OC.appswebroots['files'];
+		});
 
+		it('Uses a direct link for css and images,' , function() {
 			expect(OC.filePath('core', 'css', 'style.css')).toEqual('http://localhost/core/css/style.css');
 			expect(OC.filePath('files', 'css', 'style.css')).toEqual('http://localhost/apps3/files/css/style.css');
 			expect(OC.filePath('core', 'img', 'image.png')).toEqual('http://localhost/core/img/image.png');
 			expect(OC.filePath('files', 'img', 'image.png')).toEqual('http://localhost/apps3/files/img/image.png');
 		});
 		it('Routes PHP files via index.php,' , function() {
-			OC.webroot = 'http://localhost';
-			OC.appswebroots['files'] = OC.webroot + '/apps3/files';
-
 			expect(OC.filePath('core', 'ajax', 'test.php')).toEqual('http://localhost/index.php/core/ajax/test.php');
 			expect(OC.filePath('files', 'ajax', 'test.php')).toEqual('http://localhost/index.php/apps/files/ajax/test.php');
 		});


### PR DESCRIPTION
Fixes the returned path from `OC.filePath` when trying to get the path to a css file, i.e.

`OC.filePath('files','css','foo.css')`

before:
`"/owncloud/index.php/apps/files/css/foo.css"`
after:
`"/owncloud/apps/files/css/foo.css"`

The special case was previously needed when css files were served with php

Note that this bug breaks apps who are using `OC.addScript`

cc @DeepDiver1975 @PVince81 
