### PR TITLE
[encryption] support aes 256

### DIFF
--- a/apps/files_encryption/ajax/changeRecoveryPassword.php
+++ b/apps/files_encryption/ajax/changeRecoveryPassword.php
@@ -35,11 +35,12 @@ $encryptedRecoveryKey = $view->file_get_contents($keyPath);
 $decryptedRecoveryKey = \OCA\Encryption\Crypt::decryptPrivateKey($encryptedRecoveryKey, $oldPassword);
 
 if ($decryptedRecoveryKey) {
-
-	$encryptedRecoveryKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($decryptedRecoveryKey, $newPassword);
-	$view->file_put_contents($keyPath, $encryptedRecoveryKey);
-
-	$return = true;
+	$cipher = \OCA\Encryption\Helper::getCipher();
+	$encryptedKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($decryptedRecoveryKey, $newPassword, $cipher);
+	if ($encryptedKey) {
+		\OCA\Encryption\Keymanager::setPrivateSystemKey($encryptedKey, $keyId . '.private.key');
+		$return = true;
+	}
 }
 
 \OC_FileProxy::$enabled = $proxyStatus;

--- a/apps/files_encryption/ajax/updatePrivateKeyPassword.php
+++ b/apps/files_encryption/ajax/updatePrivateKeyPassword.php
@@ -35,13 +35,13 @@ $encryptedKey = $view->file_get_contents($keyPath);
 $decryptedKey = \OCA\Encryption\Crypt::decryptPrivateKey($encryptedKey, $oldPassword);
 
 if ($decryptedKey) {
-
-	$encryptedKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($decryptedKey, $newPassword);
-	$view->file_put_contents($keyPath, $encryptedKey);
-
-	$session->setPrivateKey($decryptedKey);
-
-	$return = true;
+	$cipher = \OCA\Encryption\Helper::getCipher();
+	$encryptedKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($decryptedKey, $newPassword, $cipher);
+	if ($encryptedKey) {
+		\OCA\Encryption\Keymanager::setPrivateKey($encryptedKey, $user);
+		$session->setPrivateKey($decryptedKey);
+		$return = true;
+	}
 }
 
 \OC_FileProxy::$enabled = $proxyStatus;

--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -193,10 +193,14 @@ class Hooks {
 				$privateKey = $session->getPrivateKey();
 
 				// Encrypt private key with new user pwd as passphrase
-				$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($privateKey, $params['password']);
+				$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($privateKey, $params['password'], Helper::getCipher());
 
 				// Save private key
-				Keymanager::setPrivateKey($encryptedPrivateKey);
+				if ($encryptedPrivateKey) {
+					Keymanager::setPrivateKey($encryptedPrivateKey, \OCP\User::getUser());
+				} else {
+					\OCP\Util::writeLog('files_encryption', 'Could not update users encryption password', \OCP\Util::ERROR);
+				}
 
 				// NOTE: Session does not need to be updated as the
 				// private key has not changed, only the passphrase
@@ -231,16 +235,17 @@ class Hooks {
 					// Save public key
 					$view->file_put_contents('/public-keys/' . $user . '.public.key', $keypair['publicKey']);
 
-					// Encrypt private key empty passphrase
-					$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], $newUserPassword);
+					// Encrypt private key with new password
+					$encryptedKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($keypair['privateKey'], $newUserPassword, Helper::getCipher());
+					if ($encryptedKey) {
+						Keymanager::setPrivateKey($encryptedKey, $user);
 
-					// Save private key
-					$view->file_put_contents(
-							'/' . $user . '/files_encryption/' . $user . '.private.key', $encryptedPrivateKey);
-
-					if ($recoveryPassword) { // if recovery key is set we can re-encrypt the key files
-						$util = new Util($view, $user);
-						$util->recoverUsersFiles($recoveryPassword);
+						if ($recoveryPassword) { // if recovery key is set we can re-encrypt the key files
+							$util = new Util($view, $user);
+							$util->recoverUsersFiles($recoveryPassword);
+						}
+					} else {
+						\OCP\Util::writeLog('files_encryption', 'Could not update users encryption password', \OCP\Util::ERROR);
 					}
 
 					\OC_FileProxy::$enabled = $proxyStatus;

--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -312,7 +312,7 @@ class Crypt {
 	 *
 	 * This function decrypts a file
 	 */
-	public static function symmetricDecryptFileContent($keyfileContent, $passphrase = '', $cipher = 'AES-128-CFB') {
+	public static function symmetricDecryptFileContent($keyfileContent, $passphrase = '', $cipher = Crypt::DEFAULT_CIPHER) {
 
 		if (!$keyfileContent) {
 

--- a/apps/files_encryption/lib/exceptions.php
+++ b/apps/files_encryption/lib/exceptions.php
@@ -22,6 +22,15 @@
 
 namespace OCA\Encryption\Exceptions;
 
+/**
+ * General encryption exception
+ * Possible Error Codes:
+ * 10 - unexpected end of encryption header
+ * 20 - unexpected blog size
+ * 30 - encryption header to large
+ * 40 - unknown cipher
+ * 50 - encryption failed
+ */
 class EncryptionException extends \Exception {
 }
 

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -258,9 +258,13 @@ class Keymanager {
 	 * @note Encryption of the private key must be performed by client code
 	 * as no encryption takes place here
 	 */
-	public static function setPrivateKey($key) {
+	public static function setPrivateKey($key, $user = '') {
 
-		$user = \OCP\User::getUser();
+		if ($user === '') {
+			$user = \OCP\User::getUser();
+		}
+
+		$header = Crypt::generateHeader();
 
 		$view = new \OC\Files\View('/' . $user . '/files_encryption');
 
@@ -271,12 +275,39 @@ class Keymanager {
 			$view->mkdir('');
 		}
 
-		$result = $view->file_put_contents($user . '.private.key', $key);
+		$result = $view->file_put_contents($user . '.private.key', $header . $key);
 
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		return $result;
 
+	}
+
+	/**
+	 * write private system key (recovery and public share key) to disk
+	 *
+	 * @param string $key encrypted key
+	 * @param string $keyName name of the key file
+	 * @return boolean
+	 */
+	public static function setPrivateSystemKey($key, $keyName) {
+
+		$header = Crypt::generateHeader();
+
+		$view = new \OC\Files\View('/owncloud_private_key');
+
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
+
+		if (!$view->file_exists('')) {
+			$view->mkdir('');
+		}
+
+		$result = $view->file_put_contents($keyName, $header . $key);
+
+		\OC_FileProxy::$enabled = $proxyStatus;
+
+		return $result;
 	}
 
 	/**

--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -80,11 +80,13 @@ class Session {
 			$this->view->file_put_contents('/public-keys/' . $publicShareKeyId . '.public.key', $keypair['publicKey']);
 
 			// Encrypt private key empty passphrase
-			$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], '');
-
-			// Save private key
-			$this->view->file_put_contents(
-				'/owncloud_private_key/' . $publicShareKeyId . '.private.key', $encryptedPrivateKey);
+			$cipher = \OCA\Encryption\Helper::getCipher();
+			$encryptedKey = \OCA\Encryption\Crypt::symmetricEncryptFileContent($keypair['privateKey'], '', $cipher);
+			if ($encryptedKey) {
+				Keymanager::setPrivateSystemKey($encryptedKey, $publicShareKeyId . '.private.key');
+			} else {
+				\OCP\Util::writeLog('files_encryption', 'Could not create public share keys', \OCP\Util::ERROR);
+			}
 
 			\OC_FileProxy::$enabled = $proxyStatus;
 

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -167,11 +167,12 @@ class Util {
 				\OC_FileProxy::$enabled = false;
 
 				// Encrypt private key with user pwd as passphrase
-				$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], $passphrase);
+				$encryptedPrivateKey = Crypt::symmetricEncryptFileContent($keypair['privateKey'], $passphrase, Helper::getCipher());
 
 				// Save key-pair
 				if ($encryptedPrivateKey) {
-					$this->view->file_put_contents($this->privateKeyPath, $encryptedPrivateKey);
+					$header = crypt::generateHeader();
+					$this->view->file_put_contents($this->privateKeyPath, $header . $encryptedPrivateKey);
 					$this->view->file_put_contents($this->publicKeyPath, $keypair['publicKey']);
 				}
 
@@ -384,8 +385,14 @@ class Util {
 			&& $this->isEncryptedPath($path)
 		) {
 
-			// get the size from filesystem
-			$size = $this->view->filesize($path);
+			$offset = 0;
+			if ($this->containHeader($path)) {
+				$offset = Crypt::BLOCKSIZE;
+			}
+
+			// get the size from filesystem if the file contains a encryption header we
+			// we substract it
+			$size = $this->view->filesize($path) - $offset;
 
 			// fast path, else the calculation for $lastChunkNr is bogus
 			if ($size === 0) {
@@ -396,15 +403,15 @@ class Util {
 			// calculate last chunk nr
 			// next highest is end of chunks, one subtracted is last one
 			// we have to read the last chunk, we can't just calculate it (because of padding etc)
-			$lastChunkNr = ceil($size/ 8192) - 1;
-			$lastChunkSize = $size - ($lastChunkNr * 8192);
+			$lastChunkNr = ceil($size/ Crypt::BLOCKSIZE) - 1;
+			$lastChunkSize = $size - ($lastChunkNr * Crypt::BLOCKSIZE);
 
 			// open stream
 			$stream = fopen('crypt://' . $path, "r");
 
 			if (is_resource($stream)) {
 				// calculate last chunk position
-				$lastChunckPos = ($lastChunkNr * 8192);
+				$lastChunckPos = ($lastChunkNr * Crypt::BLOCKSIZE);
 
 				// seek to end
 				if (@fseek($stream, $lastChunckPos) === -1) {
@@ -436,6 +443,30 @@ class Util {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		return $result;
+	}
+
+	/**
+	 * check if encrypted file contain a encryption header
+	 *
+	 * @param string $path
+	 * @return boolean
+	 */
+	private function containHeader($path) {
+		// Disable encryption proxy to read the raw data
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
+
+		$isHeader = false;
+		$handle = $this->view->fopen($path, 'r');
+
+		if (is_resource($handle)) {
+			$firstBlock = fread($handle, Crypt::BLOCKSIZE);
+			$isHeader =  Crypt::isHeader($firstBlock);
+		}
+
+		\OC_FileProxy::$enabled = $proxyStatus;
+
+		return $isHeader;
 	}
 
 	/**

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -96,6 +96,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->assertTrue(\OC_FileProxy::$enabled);
+		\OCP\Config::deleteSystemValue('cipher');
 	}
 
 	public static function tearDownAfterClass() {
@@ -156,6 +157,24 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
+	function testSymmetricEncryptFileContentAes128() {
+
+		# TODO: search in keyfile for actual content as IV will ensure this test always passes
+
+		$crypted = Encryption\Crypt::symmetricEncryptFileContent($this->dataShort, 'hat', 'AES-128-CFB');
+
+		$this->assertNotEquals($this->dataShort, $crypted);
+
+
+		$decrypt = Encryption\Crypt::symmetricDecryptFileContent($crypted, 'hat', 'AES-128-CFB');
+
+		$this->assertEquals($this->dataShort, $decrypt);
+
+	}
+
+	/**
+	 * @medium
+	 */
 	function testSymmetricStreamEncryptShortFileContent() {
 
 		$filename = 'tmp-' . uniqid() . '.test';
@@ -164,6 +183,47 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		// Test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile));
+
+		// Disable encryption proxy to prevent recursive calls
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
+
+		// Get file contents without using any wrapper to get it's actual contents on disk
+		$retreivedCryptedFile = $this->view->file_get_contents($this->userId . '/files/' . $filename);
+
+		// Re-enable proxy - our work is done
+		\OC_FileProxy::$enabled = $proxyStatus;
+
+		// Check that the file was encrypted before being written to disk
+		$this->assertNotEquals($this->dataShort, $retreivedCryptedFile);
+
+		// Get file contents with the encryption wrapper
+		$decrypted = file_get_contents('crypt:///' . $this->userId . '/files/'. $filename);
+
+		// Check that decrypted data matches
+		$this->assertEquals($this->dataShort, $decrypted);
+
+		// Teardown
+		$this->view->unlink($this->userId . '/files/' . $filename);
+
+		Encryption\Keymanager::deleteFileKey($this->view, $filename);
+	}
+
+	/**
+	 * @medium
+	 */
+	function testSymmetricStreamEncryptShortFileContentAes128() {
+
+		$filename = 'tmp-' . uniqid() . '.test';
+
+		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+
+		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/'. $filename, $this->dataShort);
+
+		// Test that data was successfully written
+		$this->assertTrue(is_int($cryptedFile));
+
+		\OCP\Config::deleteSystemValue('cipher');
 
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -221,6 +281,106 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		// Check that the file was encrypted before being written to disk
 		$this->assertNotEquals($this->dataLong . $this->dataLong, $retreivedCryptedFile);
+
+		$decrypted = file_get_contents('crypt:///' . $this->userId . '/files/'. $filename);
+
+		$this->assertEquals($this->dataLong . $this->dataLong, $decrypted);
+
+		// Teardown
+
+		$this->view->unlink($this->userId . '/files/' . $filename);
+
+		Encryption\Keymanager::deleteFileKey($this->view, $filename);
+
+	}
+
+	/**
+	 * @medium
+	 * Test that data that is written by the crypto stream wrapper with AES 128
+	 * @note Encrypted data is manually prepared and decrypted here to avoid dependency on success of stream_read
+	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
+	 * reassembly of its data
+	 */
+	function testSymmetricStreamEncryptLongFileContentAes128() {
+
+		// Generate a a random filename
+		$filename = 'tmp-' . uniqid() . '.test';
+
+		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+
+		// Save long data as encrypted file using stream wrapper
+		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong . $this->dataLong);
+
+		// Test that data was successfully written
+		$this->assertTrue(is_int($cryptedFile));
+
+		// Disable encryption proxy to prevent recursive calls
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
+
+		\OCP\Config::deleteSystemValue('cipher');
+
+		// Get file contents without using any wrapper to get it's actual contents on disk
+		$retreivedCryptedFile = $this->view->file_get_contents($this->userId . '/files/' . $filename);
+
+		// Re-enable proxy - our work is done
+		\OC_FileProxy::$enabled = $proxyStatus;
+
+
+		// Check that the file was encrypted before being written to disk
+		$this->assertNotEquals($this->dataLong . $this->dataLong, $retreivedCryptedFile);
+
+		$decrypted = file_get_contents('crypt:///' . $this->userId . '/files/'. $filename);
+
+		$this->assertEquals($this->dataLong . $this->dataLong, $decrypted);
+
+		// Teardown
+
+		$this->view->unlink($this->userId . '/files/' . $filename);
+
+		Encryption\Keymanager::deleteFileKey($this->view, $filename);
+
+	}
+
+	/**
+	 * @medium
+	 * Test that data that is written by the crypto stream wrapper with AES 128
+	 * @note Encrypted data is manually prepared and decrypted here to avoid dependency on success of stream_read
+	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
+	 * reassembly of its data
+	 */
+	function testStreamDecryptLongFileContentWithoutHeader() {
+
+		// Generate a a random filename
+		$filename = 'tmp-' . uniqid() . '.test';
+
+		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+
+		// Save long data as encrypted file using stream wrapper
+		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong . $this->dataLong);
+
+		\OCP\Config::deleteSystemValue('cipher');
+
+		// Test that data was successfully written
+		$this->assertTrue(is_int($cryptedFile));
+
+		// Disable encryption proxy to prevent recursive calls
+		$proxyStatus = \OC_FileProxy::$enabled;
+		\OC_FileProxy::$enabled = false;
+
+		// Get file contents without using any wrapper to get it's actual contents on disk
+		$retreivedCryptedFile = $this->view->file_get_contents($this->userId . '/files/' . $filename);
+
+		// Check that the file was encrypted before being written to disk
+		$this->assertNotEquals($this->dataLong . $this->dataLong, $retreivedCryptedFile);
+
+		// remove the header to check if we can also decrypt old files without a header,
+		//  this files should fall back to AES-128
+		$cryptedWithoutHeader = substr($retreivedCryptedFile, Encryption\Crypt::BLOCKSIZE);
+		$this->view->file_put_contents($this->userId . '/files/' . $filename, $cryptedWithoutHeader);
+
+		// Re-enable proxy - our work is done
+		\OC_FileProxy::$enabled = $proxyStatus;
 
 		$decrypted = file_get_contents('crypt:///' . $this->userId . '/files/'. $filename);
 

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -177,6 +177,38 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
+	function testSetPrivateKey() {
+
+		$key = "dummy key";
+
+		Encryption\Keymanager::setPrivateKey($key, 'dummyUser');
+
+		$this->assertTrue($this->view->file_exists('/dummyUser/files_encryption/dummyUser.private.key'));
+
+		//clean up
+		$this->view->deleteAll('/dummyUser');
+	}
+
+	/**
+	 * @medium
+	 */
+	function testSetPrivateSystemKey() {
+
+		$key = "dummy key";
+		$keyName = "myDummyKey.private.key";
+
+		Encryption\Keymanager::setPrivateSystemKey($key, $keyName);
+
+		$this->assertTrue($this->view->file_exists('/owncloud_private_key/' . $keyName));
+
+		// clean up
+		$this->view->unlink('/owncloud_private_key/' . $keyName);
+	}
+
+
+	/**
+	 * @medium
+	 */
 	function testGetUserKeys() {
 
 		$keys = Encryption\Keymanager::getUserKeys($this->view, $this->userId);

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -107,7 +107,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		$key = Encryption\Keymanager::getPrivateKey($this->view, $this->userId);
 
-		$privateKey = Encryption\Crypt::symmetricDecryptFileContent($key, $this->pass);
+		$privateKey = Encryption\Crypt::decryptPrivateKey($key, $this->pass);
 
 		$res = openssl_pkey_get_private($privateKey);
 
@@ -189,7 +189,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		$this->assertArrayHasKey('key', $sslInfoPublic);
 
-		$privateKey = Encryption\Crypt::symmetricDecryptFileContent($keys['privateKey'], $this->pass);
+		$privateKey = Encryption\Crypt::decryptPrivateKey($keys['privateKey'], $this->pass);
 
 		$resPrivate = openssl_pkey_get_private($privateKey);
 

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -540,9 +540,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . $publicShareKeyId . '.shareKey'));
 
 		// some hacking to simulate public link
-		$GLOBALS['app'] = 'files_sharing';
-		$GLOBALS['fileOwner'] = \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1;
-		\OC_User::setUserId(false);
+		//$GLOBALS['app'] = 'files_sharing';
+		//$GLOBALS['fileOwner'] = \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1;
+		\Test_Encryption_Util::logoutHelper();
 
 		// get file contents
 		$retrievedCryptedFile = file_get_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->filename);

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -490,7 +490,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	public static function logoutHelper() {
 		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
+		\OC_User::setUserId(false);
 		\OC\Files\Filesystem::tearDown();
 	}
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -277,6 +277,9 @@ $CONFIG = array(
 	//'config' => '/absolute/location/of/openssl.cnf',
 ),
 
+// default cipher used for file encryption, currently we support AES-128-CFB and AES-256-CFB
+'cipher' => 'AES-256-CFB',
+
 /* whether usage of the instance should be restricted to admin users only */
 'singleuser' => false,
 


### PR DESCRIPTION
Basic AES-256 support for the files encryption app.

~~That's an early version. I did some random tests and it worked quite nicely. But I still need to add some unit test and of course some more testing would be really useful.~~ Feel free to give it a try and report your experience back here.

Some information on how it works:
- With this patch we support AES128 and AES256
- The administrator can set the cipher he want to use in the config.php, see config.sample.php. By default we will use AES-256-CFB
- Every time we encrypt a file we use the first block as header. The header looks something like `HBEGIN:cipher:AES-256-CFB:HEND-------` where the ending '-' are used as padding so that the payload always begin with the second block.
- When we read a file we check for the header. If the header exists we use the cipher defined in the header, if not we fall back to AES-128-CFB.

FYI @karlitschek @MTRichards 

Known issues:
- [x] encrypt() and decrypt() is also used for the private key, we also need to introduce a header for it
- [x] need to write unit tests
