### PR TITLE
Fix enforced share expiration date to be based on share time

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1353,6 +1353,18 @@ OC.Util = {
 				}
 			});
 		});
+	},
+
+	/**
+	 * Remove the time component from a given date
+	 *
+	 * @param {Date} date date
+	 * @return {Date} date with stripped time
+	 */
+	stripTime: function(date) {
+		// FIXME: likely to break when crossing DST
+		// would be better to use a library like momentJS
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 	}
 };
 

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -436,7 +436,7 @@ OC.Share={
 						}
 					}
 					if (share.expiration != null) {
-						OC.Share.showExpirationDate(share.expiration);
+						OC.Share.showExpirationDate(share.expiration, share.stime);
 					}
 				});
 			}
@@ -716,7 +716,24 @@ OC.Share={
 	dirname:function(path) {
 		return path.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');
 	},
-	showExpirationDate:function(date) {
+	/**
+	 * Displays the expiration date field
+	 *
+	 * @param {Date} date current expiration date
+	 * @param {int} [shareTime] share timestamp in seconds, defaults to now
+	 */
+	showExpirationDate:function(date, shareTime) {
+		var now = new Date();
+		var datePickerOptions = {
+			minDate: now,
+			maxDate: null
+		};
+		if (_.isNumber(shareTime)) {
+			shareTime = new Date(shareTime * 1000);
+		}
+		if (!shareTime) {
+			shareTime = now;
+		}
 		$('#expirationCheckbox').attr('checked', true);
 		$('#expirationDate').val(date);
 		$('#expirationDate').show('blind');
@@ -726,13 +743,14 @@ OC.Share={
 		});
 		if (oc_appconfig.core.defaultExpireDateEnforced) {
 			$('#expirationCheckbox').attr('disabled', true);
-			$.datepicker.setDefaults({
-				maxDate : new Date(date.replace(' 00:00:00', ''))
-			});
+			shareTime = OC.Util.stripTime(shareTime).getTime();
+			// max date is share date + X days
+			datePickerOptions.maxDate = new Date(shareTime + oc_appconfig.core.defaultExpireDate * 24 * 3600 * 1000);
 		}
 		if(oc_appconfig.core.defaultExpireDateEnabled) {
 			$('#defaultExpireMessage').show('blind');
 		}
+		$.datepicker.setDefaults(datePickerOptions);
 	}
 };
 

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -466,6 +466,12 @@ describe('Core base tests', function() {
 				}
 			});
 		});
+		describe('stripTime', function() {
+			it('strips time from dates', function() {
+				expect(OC.Util.stripTime(new Date(2014, 2, 24, 15, 4, 45, 24)))
+					.toEqual(new Date(2014, 2, 24, 0, 0, 0, 0));
+			});
+		});
 	});
 });
 


### PR DESCRIPTION
To test:
#### Enable "set expiration date"
- [x] Date picker shows correct range for new shares (min = today, max = not set)
- [x] Date picker shows correct range for existing shares  (min = today, max = not set)
#### Force expiration date
- [x] Date picker shows correct range for new shares (min = today, max = today + 7 days)
- [x] Create share, set its "stime" to 2 days before, date picker shows correct range (min = today - 2 days, max = today + 5 days)

Please review @schiesbn @icewind1991 @DeepDiver1975 @nickvergessen 
