### PR TITLE
Return the proper owner for home storages

### DIFF
--- a/lib/private/files/storage/home.php
+++ b/lib/private/files/storage/home.php
@@ -66,4 +66,14 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 	public function getUser() {
 		return $this->user;
 	}
+
+	/**
+	 * get the owner of a path
+	 *
+	 * @param string $path The path to get the owner
+	 * @return string uid or false
+	 */
+	public function getOwner($path) {
+		return $this->user->getUID();
+	}
 }

--- a/tests/lib/files/storage/home.php
+++ b/tests/lib/files/storage/home.php
@@ -53,6 +53,8 @@ class Home extends Storage {
 	 */
 	private $tmpDir;
 
+	private $userId;
+
 	/**
 	 * @var \OC\User\User $user
 	 */
@@ -96,5 +98,9 @@ class Home extends Storage {
 	 */
 	public function testGetCacheReturnsHomeCache() {
 		$this->assertInstanceOf('\OC\Files\Cache\HomeCache', $this->instance->getCache());
+	}
+
+	public function testGetOwner() {
+		$this->assertEquals($this->userId, $this->instance->getOwner(''));
 	}
 }


### PR DESCRIPTION
Since we pass the owner of the home storage when mounting we might as well use it

This fixes the returned owner when called from public pages (and cron job and simular, non-loggedin situations)

Partial fix for #9759 

Note that this only fixes the owner for the home storage in those cases, any other mounted storage will still return the incorrect owner, fixing that will require a lot more work

cc @nickvergessen @DeepDiver1975 @PVince81 
