### PR TITLE
Simplify app navigation look

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -191,7 +191,7 @@
 /* settings area */
 #app-settings {
 	position: fixed;
-	width: 249px;
+	width: 250px; /* change to 100% when layout positions are absolute */
 	bottom: 0;
 }
 #app-settings.opened #app-settings-content {

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -193,7 +193,6 @@
 	position: fixed;
 	width: 249px;
 	bottom: 0;
-	border-top: 1px solid #ccc;
 }
 #app-settings.opened #app-settings-content {
 	display: block;

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -22,8 +22,7 @@
 	height: 100%;
 	float: left;
 	-moz-box-sizing: border-box; box-sizing: border-box;
-	background-color: #f8f8f8;
-	border-right: 1px solid #ccc;
+	background-color: #f5f5f5;
 	padding-bottom: 44px;
 	-webkit-user-select: none;
 	-moz-user-select: none;
@@ -49,11 +48,6 @@
 #app-navigation .selected,
 #app-navigation .selected a {
 	background-color: #ccc;
-}
-
-/* special rules for first-level entries and folders */
-#app-navigation > ul > li {
-	background-color: #f8f8f8;
 }
 
 #app-navigation .with-icon a {


### PR DESCRIPTION
This removes the two unneeded borders from the app navigation. One from the right side of it, and one from the settings entry.

This makes it look more light and distinguishes purely by the background shade.

Please review @owncloud/designers @jbtbnl 
