### PR TITLE
[share api] add OCS api call to set expire date for link shares

### DIFF
--- a/apps/files_sharing/lib/api.php
+++ b/apps/files_sharing/lib/api.php
@@ -411,7 +411,7 @@ class Api {
 
 		if ($share['item_type'] !== 'folder' ||
 				(int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK ) {
-			return new \OC_OCS_Result(null, 404, "public upload is only possible for public shared folders");
+			return new \OC_OCS_Result(null, 400, "public upload is only possible for public shared folders");
 		}
 
 		// read, create, update (7) if public upload is enabled or
@@ -431,7 +431,7 @@ class Api {
 	private static function updateExpireDate($share, $params) {
 		// only public links can have a expire date
 		if ((int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK ) {
-			return new \OC_OCS_Result(null, 404, "expire date only exists for public link shares");
+			return new \OC_OCS_Result(null, 400, "expire date only exists for public link shares");
 		}
 
 		try {

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -80,18 +80,12 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			break;
 		case 'setExpirationDate':
 			if (isset($_POST['date'])) {
-				$l = OC_L10N::get('core');
-				$date = new \DateTime($_POST['date']);
-				$today = new \DateTime('now');
-
-				
-
-				if ($date < $today) {
-					OC_JSON::error(array('data' => array('message' => $l->t('Expiration date is in the past.'))));
-					return;
+				try {
+					$return = OCP\Share::setExpirationDate($_POST['itemType'], $_POST['itemSource'], $_POST['date']);
+					($return) ? OC_JSON::success() : OC_JSON::error();
+				} catch (\Exception $e) {
+					OC_JSON::error(array('data' => array('message' => $e->getMessage())));
 				}
-				$return = OCP\Share::setExpirationDate($_POST['itemType'], $_POST['itemSource'], $_POST['date']);
-				($return) ? OC_JSON::success() : OC_JSON::error();
 			}
 			break;
 		case 'informRecipients':

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -22,7 +22,7 @@ class OC_Util {
 			self::$rootMounted = true;
 		}
 	}
-	
+
 	/**
 	 * mounting an object storage as the root fs will in essence remove the
 	 * necessity of a data folder being present.
@@ -50,7 +50,7 @@ class OC_Util {
 			self::$rootMounted = true;
 		}
 	}
-	
+
 	/**
 	 * Can be set up
 	 * @param string $user
@@ -168,6 +168,21 @@ class OC_Util {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * check if share API enforces a default expire date
+	 * @return boolean
+	 */
+	public static function isDefaultExpireDateEnforced() {
+		$isDefaultExpireDateEnabled = \OCP\Config::getAppValue('core', 'shareapi_default_expire_date', 'no');
+		$enforceDefaultExpireDate = false;
+		if ($isDefaultExpireDateEnabled === 'yes') {
+			$value = \OCP\Config::getAppValue('core', 'shareapi_enforce_expire_date', 'no');
+			$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
+		}
+
+		return $enforceDefaultExpireDate;
 	}
 
 	/**

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -298,10 +298,11 @@ class Share extends \OC\Share\Constants {
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $date expiration date
+	 * @param int $shareTime timestamp from when the file was shared
 	 * @return boolean
 	 */
-	public static function setExpirationDate($itemType, $itemSource, $date) {
-		return \OC\Share\Share::setExpirationDate($itemType, $itemSource, $date);
+	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null) {
+		return \OC\Share\Share::setExpirationDate($itemType, $itemSource, $date, $shareTime);
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -519,6 +519,15 @@ class Util {
 	}
 
 	/**
+	 * check if share API enforces a default expire date
+	 * @return boolean
+	 */
+	public static function isDefaultExpireDateEnforced() {
+		return \OC_Util::isDefaultExpireDateEnforced();
+	}
+
+
+	/**
 	 * Checks whether the current version needs upgrade.
 	 *
 	 * @return bool true if upgrade is needed, false otherwise

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -326,15 +326,37 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->shareUserOneTestFileWithUserTwo();
 		$this->shareUserTestFileAsLink();
 
-		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInPast),
-			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
-		);
+		// manipulate share table and set expire date to the past
+		$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `expiration` = ? WHERE `item_type` = ? AND `item_source` = ?  AND `uid_owner` = ? AND `share_type` = ?');
+		$query->bindValue(1, new \DateTime($this->dateInPast), 'datetime');
+		$query->bindValue(2, 'test');
+		$query->bindValue(3, 'test.txt');
+		$query->bindValue(4, $this->user1);
+		$query->bindValue(5, \OCP\Share::SHARE_TYPE_LINK);
+		$query->execute();
 
 		$shares = OCP\Share::getItemsShared('test');
 		$this->assertSame(1, count($shares));
 		$share = reset($shares);
 		$this->assertSame(\OCP\Share::SHARE_TYPE_USER, $share['share_type']);
+	}
+
+	public function testSetExpireDateInPast() {
+		OC_User::setUserId($this->user1);
+		$this->shareUserOneTestFileWithUserTwo();
+		$this->shareUserTestFileAsLink();
+
+		$setExpireDateFailed = false;
+		try {
+			$this->assertTrue(
+					OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInPast, ''),
+					'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
+			);
+		} catch (\Exception $e) {
+			$setExpireDateFailed = true;
+		}
+
+		$this->assertTrue($setExpireDateFailed);
 	}
 
 	public function testShareWithUserExpirationValid() {
@@ -344,7 +366,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInFuture),
+			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInFuture, ''),
 			'Failed asserting that user 1 successfully set an expiration date for the test.txt share.'
 		);
 
@@ -552,7 +574,7 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 
 		// testGetShareByTokenExpirationValid
 		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInFuture),
+			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInFuture, ''),
 			'Failed asserting that user 1 successfully set a future expiration date for the test.txt share.'
 		);
 		$row = $this->getShareByValidToken($token);
@@ -561,11 +583,15 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 			'Failed asserting that the returned row has an expiration date.'
 		);
 
-		// testGetShareByTokenExpirationExpired
-		$this->assertTrue(
-			OCP\Share::setExpirationDate('test', 'test.txt', $this->dateInPast),
-			'Failed asserting that user 1 successfully set a past expiration date for the test.txt share.'
-		);
+		// manipulate share table and set expire date to the past
+		$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `expiration` = ? WHERE `item_type` = ? AND `item_source` = ?  AND `uid_owner` = ? AND `share_type` = ?');
+		$query->bindValue(1, new \DateTime($this->dateInPast), 'datetime');
+		$query->bindValue(2, 'test');
+		$query->bindValue(3, 'test.txt');
+		$query->bindValue(4, $this->user1);
+		$query->bindValue(5, \OCP\Share::SHARE_TYPE_LINK);
+		$query->execute();
+
 		$this->assertFalse(
 			OCP\Share::getShareByToken($token),
 			'Failed asserting that an expired share could not be found.'


### PR DESCRIPTION
Long standing bug https://github.com/owncloud/core/issues/5835 can now be fixes because from OC7 on the expire date is only used for link shares.

This PR add a OCS share api call to set a expire date.

Set expire date:

```
curl -X PUT -u schiesbn:schiesbn http://localhost/owncloud/ocs/v1.php/apps/files_sharing/api/v1/shares/<shareId> -d expireDate="31-07-2014"
```

expire date need to be a well formate date, e.g. 'YYYY-MM-DD' works too.
