### PR TITLE
Set version AFTER a successful update

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -212,8 +212,6 @@ class Updater extends BasicEmitter {
 			\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 			$this->emit('\OC\Updater', 'dbUpgrade');
 
-			// TODO: why not do this at the end ?
-			\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
 			$disabledApps = \OC_App::checkAppsRequirements();
 			if (!empty($disabledApps)) {
 				$this->emit('\OC\Updater', 'disabledApps', array($disabledApps));
@@ -227,6 +225,9 @@ class Updater extends BasicEmitter {
 
 			//Invalidate update feed
 			\OC_Appconfig::setValue('core', 'lastupdatedat', 0);
+
+			// only set the final version if everything went well
+			\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
 		}
 	}
 }


### PR DESCRIPTION
If an app upgrade failed, the core version will not be increased either
in the database. This will re-display the update page and make it
possible to redo the apps upgrade.

Note that any core repair routine must take into account that an update
might need to be redone again even though the core's DB state is already
the one of the new version.

This is the first part of the fix for https://github.com/owncloud/core/issues/9817
Second part will be to really prevent apps to update from remote.php, public.php or cron.php, just in case... or for people who are already in the broken state.

Please review @icewind1991 @DeepDiver1975 @karlitschek 
Any idea why the core version wasn't set at the end in past versions ?
