### PR TITLE
Fix #9650 - S3 tests failing

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -445,8 +445,14 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				return false;
 			}
 		} else {
+
+			/**
+			 * If path2 exists we are overwriting something. Directories in S3 are
+			 * virtual, so keys in path2 will not be removed when the directory is
+			 * overwritten. Therefore, remove path2 before continuing.
+			 */
 			if ($this->file_exists($path2)) {
-				return false;
+				$this->unlink($path2);
 			}
 
 			try {
@@ -482,28 +488,13 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$path1 = $this->normalizePath($path1);
 		$path2 = $this->normalizePath($path2);
 
-		if ($this->is_file($path1)) {
-			if ($this->copy($path1, $path2) === false) {
-				return false;
-			}
+		if ($this->copy($path1, $path2) === false) {
+			return false;
+		}
 
-			if ($this->unlink($path1) === false) {
-				$this->unlink($path2);
-				return false;
-			}
-		} else {
-			if ($this->file_exists($path2)) {
-				return false;
-			}
-
-			if ($this->copy($path1, $path2) === false) {
-				return false;
-			}
-
-			if ($this->rmdir($path1) === false) {
-				$this->rmdir($path2);
-				return false;
-			}
+		if ($this->unlink($path1) === false) {
+			$this->unlink($path2);
+			return false;
 		}
 
 		return true;

--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -264,7 +264,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$stat = array();
 			$stat['size'] = $result['ContentLength'] ? $result['ContentLength'] : 0;
 			if ($result['Metadata']['lastmodified']) {
-				$stat['mtime'] = strtotime($result['Metadata']['lastmodified']);
+				$stat['mtime'] = is_numeric($result['Metadata']['lastmodified']) ? intval($result['Metadata']['lastmodified']) : strtotime($result['Metadata']['lastmodified']);
 			} else {
 				$stat['mtime'] = strtotime($result['LastModified']);
 			}

--- a/apps/files_external/tests/amazons3.php
+++ b/apps/files_external/tests/amazons3.php
@@ -28,6 +28,10 @@ class AmazonS3 extends Storage {
 
 	private $config;
 
+	protected function clearBucket() {
+		$this->instance->getConnection()->clearBucket($this->config['amazons3']['bucket']);
+	}
+
 	public function setUp() {
 		$this->config = include('files_external/tests/config.php');
 		if ( ! is_array($this->config) or ! isset($this->config['amazons3']) or ! $this->config['amazons3']['run']) {
@@ -38,29 +42,7 @@ class AmazonS3 extends Storage {
 
 	public function tearDown() {
 		if ($this->instance) {
-			$connection = $this->instance->getConnection();
-
-			try {
-				// NOTE(berendt): clearBucket() is not working with Ceph
-				$iterator = $connection->getIterator('ListObjects', array(
-					'Bucket' => $this->config['amazons3']['bucket']
-				));
-
-				foreach ($iterator as $object) {
-					$connection->deleteObject(array(
-						'Bucket' => $this->config['amazons3']['bucket'],
-						'Key' => $object['Key']
-					));
-				}
-			} catch (S3Exception $e) {
-			}
-
-			$connection->deleteBucket(array(
-				'Bucket' => $this->config['amazons3']['bucket']
-			));
-
-			//wait some seconds for completing the replication
-			sleep(30);
+			$this->clearBucket();
 		}
 	}
 }


### PR DESCRIPTION
The S3-tests extend from Test\Files\Storage\Storage. Some methods in this class test way too much functionality at once (especially testStat), so I split some of the tests into smaller components. I realize changing core tests might be a touchy subject so please review the changes.

Most of the failing S3-tests regarded renaming/overwriting which was fixed by removing some unnecessary return calls. Two tests (both split from testStat) are still failing:

```
1) Test\Files\Storage\AmazonS3::testRootHasUpdatedAfterCreatingFile
Failed asserting that false is true.

/Users/johan/Desktop/OC/tests/lib/files/storage/storage.php:248

2) Test\Files\Storage\AmazonS3::testRootHasUpdatedAfterUnlinkingFile
Failed asserting that false is true.

/Users/johan/Desktop/OC/tests/lib/files/storage/storage.php:257
```

These fail because there is no reliable way (to my knowledge) to find out when a bucket was last modified.
