### PR TITLE
CRON call ends in null exception

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -122,8 +122,11 @@ try {
 			// Work and success :-)
 			$jobList = \OC::$server->getJobList();
 			$job = $jobList->getNext();
-			$job->execute($jobList, $logger);
-			$jobList->setLastJob($job);
+			if ($job != null)
+			{
+				$job->execute($jobList, $logger);
+				$jobList->setLastJob($job);
+			}
 			OC_JSON::success();
 		}
 	}

--- a/cron.php
+++ b/cron.php
@@ -122,8 +122,7 @@ try {
 			// Work and success :-)
 			$jobList = \OC::$server->getJobList();
 			$job = $jobList->getNext();
-			if ($job != null)
-			{
+			if ($job != null) {
 				$job->execute($jobList, $logger);
 				$jobList->setLastJob($job);
 			}


### PR DESCRIPTION
[error] 4461#0: *186285 FastCGI sent in stderr: "PHP message
: PHP Fatal error:  Call to a member function execute() on null in /var/www/ownc
loud/cron.php on line 125" while reading response header from upstream, client:
217.13.183.252, server: cloud.mycloud.com, request: "GET /cron.php HTTP/1.1", upstre
am: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "cloud.mycloud.com", referrer: "
https://cloud.mycloud.com/"
