### PR TITLE
[WIP] Only show the storage full warning when the folder is writable

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -63,7 +63,10 @@
 				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('original-title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
-				Files.displayStorageWarnings();
+				if (response.data.permissions & OC.PERMISSION_CREATE) {
+					console.log(response.data);
+					Files.displayStorageWarnings();
+				}
 			}
 			if (response[0] === undefined) {
 				return;
@@ -72,7 +75,9 @@
 				$('#max_upload').val(response[0].uploadMaxFilesize);
 				$('#upload.button').attr('original-title', response[0].maxHumanFilesize);
 				$('#usedSpacePercent').val(response[0].usedSpacePercent);
-				Files.displayStorageWarnings();
+				if (response.data.permissions & OC.PERMISSION_CREATE) {
+					Files.displayStorageWarnings();
+				}
 			}
 
 		},

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -14,8 +14,10 @@ namespace OCA\Files;
 class Helper
 {
 	public static function buildFileStorageStatistics($dir) {
+		$info = \OC\Files\Filesystem::getFileInfo($dir, false);
+
 		// information about storage capacities
-		$storageInfo = \OC_Helper::getStorageInfo($dir);
+		$storageInfo = \OC_Helper::getStorageInfo($dir, $info);
 
 		$l = new \OC_L10N('files');
 		$maxUploadFileSize = \OCP\Util::maxUploadFilesize($dir, $storageInfo['free']);
@@ -24,8 +26,9 @@ class Helper
 
 		return array('uploadMaxFilesize' => $maxUploadFileSize,
 					 'maxHumanFilesize'  => $maxHumanFileSize,
-					 'freeSpace' => $storageInfo['free'],
-					 'usedSpacePercent'  => (int)$storageInfo['relative']);
+					 'freeSpace'         => $storageInfo['free'],
+					 'usedSpacePercent'  => (int)$storageInfo['relative'],
+					 'permissions'       => $info->getPermissions());
 	}
 
 	/**


### PR DESCRIPTION
In read-only folders this message this message only adds clutter since nothing can be uploaded anyway

Can be tested with owncloud/apps#1756

cc @DeepDiver1975 @PVince81 @jancborchardt 
