### PR TITLE
Do not load apps in console.php when an upgrade is due

### DIFF
--- a/console.php
+++ b/console.php
@@ -22,16 +22,22 @@ try {
 		exit(0);
 	}
 
-	// load all apps to get all api routes properly setup
-	OC_App::loadApps();
+	// only load apps if no update is due,
+	// else only core commands will be available
+	if (!\OCP\Util::needUpgrade()) {
+		// load all apps to get all api routes properly setup
+		OC_App::loadApps();
+	}
 
 	$defaults = new OC_Defaults;
 	$application = new Application($defaults->getName(), \OC_Util::getVersionString());
 	require_once 'core/register_command.php';
-	foreach(OC_App::getAllApps() as $app) {
-		$file = OC_App::getAppPath($app).'/appinfo/register_command.php';
-		if(file_exists($file)) {
-			require $file;
+	if (!\OCP\Util::needUpgrade()) {
+		foreach(OC_App::getAllApps() as $app) {
+			$file = OC_App::getAppPath($app).'/appinfo/register_command.php';
+			if(file_exists($file)) {
+				require $file;
+			}
 		}
 	}
 	$application->run();


### PR DESCRIPTION
This makes it still possible to update from the command line, but
disables custom commands from apps

This fixes app updates happening too early when triggering a CLI update.

Please review @icewind1991 @DeepDiver1975 @bantu 

Note: you can simulate an app update.php fail by increasing the app's version number and adding `throw new \Exception("simulated exception");` in the app's `update.php` file.
