### PR TITLE
Don't do app upgrades in the background

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -18,6 +18,12 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Checked database schema update'));
 	});
+	$updater->listen('\OC\Updater', 'appUpgradeCheck', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Checked database schema update for apps'));
+	});
+	$updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Updated "%s" to %s', array($app, $version)));
+	});
 	$updater->listen('\OC\Updater', 'disabledApps', function ($appList) use ($eventSource, $l) {
 		$list = array();
 		foreach ($appList as $appId) {

--- a/index.php
+++ b/index.php
@@ -27,6 +27,12 @@ try {
 
 	OC::handleRequest();
 
+} catch(\OC\ServiceUnavailableException $ex) {
+	\OCP\Util::logException('index', $ex);
+
+	//show the user a detailed error page
+	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+	OC_Template::printExceptionErrorPage($ex);
 } catch (Exception $ex) {
 	\OCP\Util::logException('index', $ex);
 

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -62,6 +62,9 @@ class OC_App {
 	 * if $types is set, only apps of those types will be loaded
 	 */
 	public static function loadApps($types = null) {
+		if (OC_Config::getValue('maintenance', false)) {
+			return false;
+		}
 		// Load the enabled apps here
 		$apps = self::getEnabledApps();
 		// prevent app.php from printing output
@@ -81,11 +84,12 @@ class OC_App {
 	 * load a single app
 	 *
 	 * @param string $app
+	 * @param bool $checkUpgrade whether an upgrade check should be done
 	 * @throws \OC\NeedsUpdateException
 	 */
-	public static function loadApp($app) {
+	public static function loadApp($app, $checkUpgrade = true) {
 		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
-			if (self::shouldUpgrade($app)) {
+			if ($checkUpgrade and self::shouldUpgrade($app)) {
 				throw new \OC\NeedsUpdateException();
 			}
 			require_once $app . '/appinfo/app.php';
@@ -1135,7 +1139,7 @@ class OC_App {
 	 */
 	public static function updateApp($appId) {
 		if (file_exists(self::getAppPath($appId) . '/appinfo/preupdate.php')) {
-			self::loadApp($appId);
+			self::loadApp($appId, false);
 			include self::getAppPath($appId) . '/appinfo/preupdate.php';
 		}
 		if (file_exists(self::getAppPath($appId) . '/appinfo/database.xml')) {
@@ -1145,7 +1149,7 @@ class OC_App {
 			return false;
 		}
 		if (file_exists(self::getAppPath($appId) . '/appinfo/update.php')) {
-			self::loadApp($appId);
+			self::loadApp($appId, false);
 			include self::getAppPath($appId) . '/appinfo/update.php';
 		}
 

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1167,6 +1167,9 @@ class OC_App {
 
 		self::setAppTypes($appId);
 
+		$version = \OC_App::getAppVersion($appId);
+		\OC_Appconfig::setValue($appId, 'installed_version', $version);
+
 		return true;
 	}
 

--- a/lib/private/needsupdateexception.php
+++ b/lib/private/needsupdateexception.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+class NeedsUpdateException extends ServiceUnavailableException {
+}

--- a/lib/private/serviceunavailableexception.php
+++ b/lib/private/serviceunavailableexception.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+class ServiceUnavailableException extends \Exception {
+}

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -265,7 +265,7 @@ class Updater extends BasicEmitter {
 		foreach ($apps as $appId) {
 			if (\OC_App::shouldUpgrade($appId)) {
 				\OC_App::updateApp($appId);
-				$this->emit('\OC\Updater', 'appUpgrade', array($appId, $version));
+				$this->emit('\OC\Updater', 'appUpgrade', array($appId, \OC_App::getAppVersion($appId)));
 			}
 		}
 	}

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -228,8 +228,6 @@ class Updater extends BasicEmitter {
 	}
 
 	protected function doCoreUpgrade() {
-		\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
-
 		// do the real upgrade
 		\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -7,6 +7,7 @@
  */
 
 namespace OC;
+
 use OC\Hooks\BasicEmitter;
 
 /**
@@ -61,6 +62,7 @@ class Updater extends BasicEmitter {
 
 	/**
 	 * Check if a new version is available
+	 *
 	 * @param string $updaterUrl the url to check, i.e. 'http://apps.owncloud.com/updater.php'
 	 * @return array|bool
 	 */
@@ -161,7 +163,7 @@ class Updater extends BasicEmitter {
 		// create empty file in data dir, so we can later find
 		// out that this is indeed an ownCloud data directory
 		// (in case it didn't exist before)
-		file_put_contents(\OC_Config::getValue('datadirectory', \OC::$SERVERROOT.'/data').'/.ocdata', '');
+		file_put_contents(\OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/.ocdata', '');
 
 		/*
 		 * START CONFIG CHANGES FOR OLDER VERSIONS
@@ -182,22 +184,11 @@ class Updater extends BasicEmitter {
 
 		// simulate DB upgrade
 		if ($this->simulateStepEnabled) {
-			// simulate core DB upgrade
-			\OC_DB::simulateUpdateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
+			$this->checkCoreUpgrade();
 
 			// simulate apps DB upgrade
-			$version = \OC_Util::getVersion();
-			$apps = \OC_App::getEnabledApps();
-			foreach ($apps as $appId) {
-				$info = \OC_App::getAppInfo($appId);
-				if (\OC_App::isAppCompatible($version, $info) && \OC_App::shouldUpgrade($appId)) {
-					if (file_exists(\OC_App::getAppPath($appId) . '/appinfo/database.xml')) {
-						\OC_DB::simulateUpdateDbFromStructure(\OC_App::getAppPath($appId) . '/appinfo/database.xml');
-					}
-				}
-			}
+			$this->checkAppUpgrade($currentVersion);
 
-			$this->emit('\OC\Updater', 'dbSimulateUpgrade');
 		}
 
 		// upgrade from OC6 to OC7
@@ -208,16 +199,14 @@ class Updater extends BasicEmitter {
 		}
 
 		if ($this->updateStepEnabled) {
-			// do the real upgrade
-			\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
-			$this->emit('\OC\Updater', 'dbUpgrade');
+			$this->doCoreUpgrade();
 
 			$disabledApps = \OC_App::checkAppsRequirements();
 			if (!empty($disabledApps)) {
 				$this->emit('\OC\Updater', 'disabledApps', array($disabledApps));
 			}
-			// load all apps to also upgrade enabled apps
-			\OC_App::loadApps();
+
+			$this->doAppUpgrade();
 
 			// post-upgrade repairs
 			$repair = new \OC\Repair(\OC\Repair::getRepairSteps());
@@ -228,6 +217,60 @@ class Updater extends BasicEmitter {
 
 			// only set the final version if everything went well
 			\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
+		}
+	}
+
+	protected function checkCoreUpgrade() {
+		// simulate core DB upgrade
+		\OC_DB::simulateUpdateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
+
+		$this->emit('\OC\Updater', 'dbSimulateUpgrade');
+	}
+
+	protected function doCoreUpgrade() {
+		\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
+
+		// do the real upgrade
+		\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
+
+		$this->emit('\OC\Updater', 'dbUpgrade');
+	}
+
+	/**
+	 * @param string $version the oc version to check app compatibilty with
+	 */
+	protected function checkAppUpgrade($version) {
+		$apps = \OC_App::getEnabledApps();
+
+
+		foreach ($apps as $appId) {
+			if ($version) {
+				$info = \OC_App::getAppInfo($appId);
+				$compatible = \OC_App::isAppCompatible($version, $info);
+			} else {
+				$compatible = true;
+			}
+
+			if ($compatible && \OC_App::shouldUpgrade($appId)) {
+				if (file_exists(\OC_App::getAppPath($appId) . '/appinfo/database.xml')) {
+					\OC_DB::simulateUpdateDbFromStructure(\OC_App::getAppPath($appId) . '/appinfo/database.xml');
+				}
+			}
+		}
+
+		$this->emit('\OC\Updater', 'appUpgradeCheck');
+	}
+
+	protected function doAppUpgrade() {
+		$apps = \OC_App::getEnabledApps();
+
+		foreach ($apps as $appId) {
+			if (\OC_App::shouldUpgrade($appId)) {
+				\OC_App::updateApp($appId);
+				$version = \OC_App::getAppVersion($appId);
+				\OC_Appconfig::setValue($appId, 'installed_version', $version);
+				$this->emit('\OC\Updater', 'appUpgrade', array($appId, $version));
+			}
 		}
 	}
 }

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -267,8 +267,6 @@ class Updater extends BasicEmitter {
 		foreach ($apps as $appId) {
 			if (\OC_App::shouldUpgrade($appId)) {
 				\OC_App::updateApp($appId);
-				$version = \OC_App::getAppVersion($appId);
-				\OC_Appconfig::setValue($appId, 'installed_version', $version);
 				$this->emit('\OC\Updater', 'appUpgrade', array($appId, $version));
 			}
 		}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1462,7 +1462,18 @@ class OC_Util {
 		if (OC_Config::getValue('installed', false)) {
 			$installedVersion = OC_Config::getValue('version', '0.0.0');
 			$currentVersion = implode('.', OC_Util::getVersion());
-			return version_compare($currentVersion, $installedVersion, '>');
+			if (version_compare($currentVersion, $installedVersion, '>')) {
+				return true;
+			}
+
+			// also check for upgrades for apps
+			$apps = \OC_App::getEnabledApps();
+			foreach ($apps as $app) {
+				if (\OC_App::shouldUpgrade($app)) {
+					return true;
+				}
+			}
+			return false;
 		} else {
 			return false;
 		}

--- a/public.php
+++ b/public.php
@@ -45,6 +45,11 @@ try {
 
 	require_once OC_App::getAppPath($app) . '/' . $parts[1];
 
+} catch (\OC\ServiceUnavailableException $ex) {
+	//show the user a detailed error page
+	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	OC_Template::printExceptionErrorPage($ex);
 } catch (Exception $ex) {
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);

--- a/remote.php
+++ b/remote.php
@@ -51,6 +51,10 @@ try {
 	$baseuri = OC::$WEBROOT . '/remote.php/'.$service.'/';
 	require_once $file;
 
+} catch (\OC\ServiceUnavailableException $ex) {
+	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);
+	OC_Template::printExceptionErrorPage($ex);
 } catch (Exception $ex) {
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	\OCP\Util::writeLog('remote', $ex->getMessage(), \OCP\Util::FATAL);

--- a/settings/ajax/updateapp.php
+++ b/settings/ajax/updateapp.php
@@ -33,7 +33,10 @@ if (!is_numeric($appId)) {
 
 $appId = OC_App::cleanAppId($appId);
 
+\OC_Config::setValue('maintenance', true);
 $result = OC_Installer::updateAppByOCSId($appId, $isShipped);
+\OC_Config::setValue('maintenance', false);
+
 if($result !== false) {
 	OC_JSON::success(array('data' => array('appid' => $appId)));
 } else {


### PR DESCRIPTION
This removes the logic for transparently upgrading apps and moves it to the same system we use for core upgrades.
Transparent app upgrades can leave the instance in a broken state when requests are being processed in parallel.

Only doing the upgrades in the foreground prevents this and provide a way for users to know when an upgrade failed.

cc @DeepDiver1975 @PVince81 
