### PR TITLE
setting and checking default_charset in php.ini to be UTF-8

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -472,9 +472,6 @@ class OC {
 		@ini_set('post_max_size', '10G');
 		@ini_set('file_uploads', '50');
 
-		// setting charset to UTF8
-		@ini_set('default_charset', 'UTF-8');
-
 		self::handleAuthHeaders();
 
 		self::initPaths();

--- a/lib/base.php
+++ b/lib/base.php
@@ -472,6 +472,9 @@ class OC {
 		@ini_set('post_max_size', '10G');
 		@ini_set('file_uploads', '50');
 
+		// setting charset to UTF8
+		@ini_set('default_charset', 'UTF-8');
+
 		self::handleAuthHeaders();
 
 		self::initPaths();

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1447,4 +1447,11 @@ class OC_Util {
 			return false;
 		}
 	}
+
+	/**
+	 * @return string
+	 */
+	public static function isPhpCharSetUtf8() {
+		return ini_get('default_charset') === 'UTF-8';
+	}
 }

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -39,6 +39,7 @@ $tmpl->assign('entriesremain', $entriesremain);
 $tmpl->assign('htaccessworking', $htaccessworking);
 $tmpl->assign('internetconnectionworking', OC_Util::isInternetConnectionEnabled() ? OC_Util::isInternetConnectionWorking() : false);
 $tmpl->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
+$tmpl->assign('isPhpCharSetUtf8', OC_Util::isPhpCharSetUtf8());
 $tmpl->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());
 $tmpl->assign('isWebDavWorking', OC_Util::isWebDAVWorking());
 $tmpl->assign('has_fileinfo', OC_Util::fileInfoLoaded());

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -129,14 +129,28 @@ if (!$_['has_fileinfo']) {
 // is PHP at least at 5.3.8?
 if ($_['old_php']) {
 	?>
-<div class="section">
-	<h2><?php p($l->t('Your PHP version is outdated'));?></h2>
+	<div class="section">
+		<h2><?php p($l->t('Your PHP version is outdated'));?></h2>
 
 		<span class="connectionwarning">
 		<?php p($l->t('Your PHP version is outdated. We strongly recommend to update to 5.3.8 or newer because older versions are known to be broken. It is possible that this installation is not working correctly.')); ?>
 	</span>
 
-</div>
+	</div>
+<?php
+}
+
+// is PHP charset set to UTF8?
+if (!$_['isPhpCharSetUtf8']) {
+	?>
+	<div class="section">
+		<h2><?php p($l->t('PHP charset is not set to UTF-8'));?></h2>
+
+		<span class="connectionwarning">
+		<?php p($l->t("PHP charset is not set to UTF-8. This can cause major issues with non-acsii characters in file names. We highly recommend to change the value of 'default_charset' php.ini to 'UTF-8'.")); ?>
+	</span>
+
+	</div>
 <?php
 }
 
@@ -168,14 +182,14 @@ if (!$_['isLocaleWorking']) {
 // is internet connection working ?
 if (!$_['internetconnectionworking']) {
 	?>
-<div class="section">
-	<h2><?php p($l->t('Internet connection not working'));?></h2>
+	<div class="section">
+		<h2><?php p($l->t('Internet connection not working'));?></h2>
 
 		<span class="connectionwarning">
 		<?php p($l->t('This server has no working internet connection. This means that some of the features like mounting of external storage, notifications about updates or installation of 3rd party apps don´t work. Accessing files from remote and sending of notification emails might also not work. We suggest to enable internet connection for this server if you want to have all features.')); ?>
 	</span>
 
-</div>
+	</div>
 <?php
 }
 ?>


### PR DESCRIPTION
as discussed in https://github.com/owncloud/core/issues/9764#issuecomment-50031774

@bantu @PVince81 @butonic @schiesbn please review

@karlitschek @craigpg I suggest to keep this in master for now - in case this issue pops up again in the future we could still backport this. In addition the fix in such a case is simple: set 'default_charset' to 'UTF-8' in php.ini
