### PR TITLE
fix sharing update, add proper escaping (oc7 backport)

### DIFF
--- a/apps/files_sharing/appinfo/update.php
+++ b/apps/files_sharing/appinfo/update.php
@@ -32,6 +32,7 @@ function updateFilePermissions($chunkSize = 99) {
 		}
 	}
 
+	$connection = \OC_DB::getConnection();
 	$chunkedPermissionList = array_chunk($updatedRows, $chunkSize, true);
 
 	foreach ($chunkedPermissionList as $subList) {
@@ -39,7 +40,7 @@ function updateFilePermissions($chunkSize = 99) {
 		//update share table
 		$ids = implode(',', array_keys($subList));
 		foreach ($subList as $id => $permission) {
-			$statement .= "WHEN " . $id . " THEN " . $permission . " ";
+			$statement .= "WHEN " . $connection->quote($id, \PDO::PARAM_INT) . " THEN " . $permission . " ";
 		}
 		$statement .= ' END WHERE `id` IN (' . $ids . ')';
 
@@ -95,6 +96,7 @@ function removeSharedFolder($mkdirs = true, $chunkSize = 99) {
 		}
 
 		$chunkedShareList = array_chunk($shares, $chunkSize, true);
+		$connection = \OC_DB::getConnection();
 
 		foreach ($chunkedShareList as $subList) {
 
@@ -102,7 +104,7 @@ function removeSharedFolder($mkdirs = true, $chunkSize = 99) {
 			//update share table
 			$ids = implode(',', array_keys($subList));
 			foreach ($subList as $id => $target) {
-				$statement .= "WHEN " . $id . " THEN '/Shared" . $target . "' ";
+				$statement .= "WHEN " . $connection->quote($id, \PDO::PARAM_INT) . " THEN " . $connection->quote('/Shared' . $target, \PDO::PARAM_STR);
 			}
 			$statement .= ' END WHERE `id` IN (' . $ids . ')';
 

--- a/apps/files_sharing/tests/update.php
+++ b/apps/files_sharing/tests/update.php
@@ -176,6 +176,7 @@ class Test_Files_Sharing_Update_Routine extends Test_Files_Sharing_Base {
 			array(\OCP\Share::SHARE_TYPE_USER, 'folder', 'user2', 'admin', '/foo2'),
 			array(\OCP\Share::SHARE_TYPE_USER, 'file', 'user3', 'admin', '/foo3'),
 			array(\OCP\Share::SHARE_TYPE_USER, 'folder', 'user4', 'admin', '/foo4'),
+			array(\OCP\Share::SHARE_TYPE_USER, 'folder', 'user4', 'admin', "/foo'4"),
 			array(\OCP\Share::SHARE_TYPE_LINK, 'file', 'user1', 'admin', '/ShouldNotChange'),
 			array(\OCP\Share::SHARE_TYPE_CONTACT, 'contact', 'admin', 'user1', '/ShouldNotChange'),
 


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/9867

I just want to give Jenkins the chance to test it once more on stable7
