### PR TITLE
Dont throw an error when calling $server->getUserFolder when logged out

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -255,7 +255,11 @@ class Server extends SimpleContainer implements IServerContainer {
 	 * @return \OCP\Files\Folder
 	 */
 	function getUserFolder() {
-		$dir = '/' . $this->getUserSession()->getUser()->getUID();
+		$user = $this->getUserSession()->getUser();
+		if (!$user) {
+			return null;
+		}
+		$dir = '/' . $user->getUID();
 		$root = $this->getRootFolder();
 		$folder = null;
 


### PR DESCRIPTION
Returning `null` is a lot better then dying.

This also fixed owncloud/music#254 for me.

cc @DeepDiver1975 @PVince81 @MorrisJobke 
