### PR TITLE
Dont try to execute jobs that no longer exist

### DIFF
--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -96,7 +96,10 @@ class JobList implements IJobList {
 		$query->execute();
 		$jobs = array();
 		while ($row = $query->fetch()) {
-			$jobs[] = $this->buildJob($row);
+			$job = $this->buildJob($row);
+			if ($job) {
+				$jobs[] = $job;
+			}
 		}
 		return $jobs;
 	}


### PR DESCRIPTION
This solves a crash in cron.php where a background job is registered, the app is updated and the background job class no longer exists.

cc @DeepDiver1975 @PVince81 
