### PR TITLE
Fix template rendering for 'blank' templates

### DIFF
--- a/lib/public/appframework/http/templateresponse.php
+++ b/lib/public/appframework/http/templateresponse.php
@@ -134,8 +134,10 @@ class TemplateResponse extends Response {
 	 * @return string the rendered html
 	 */
 	public function render(){
+		// \OCP\Template needs an empty string instead of 'blank' for an unwrapped response
+		$renderAs = $this->renderAs === 'blank' ? '' : $this->renderAs;
 
-		$template = new \OCP\Template($this->appName, $this->templateName, $this->renderAs);
+		$template = new \OCP\Template($this->appName, $this->templateName, $renderAs);
 
 		foreach($this->params as $key => $value){
 			$template->assign($key, $value);


### PR DESCRIPTION
See http://api.owncloud.org/classes/OCP.AppFramework.Http.TemplateResponse.html `setRenderAs`

> $renderAs     string      admin, user or blank. 
> Admin also prints the admin settings header and footer, user renders the normal normal page including footer and header and blank just renders the plain template

This was previously done in a helper class  https://github.com/owncloud/music/blob/stable5/appframework/http/templateresponse.php#L118 -> https://github.com/owncloud/music/blob/stable5/appframework/core/api.php#L385:L389

cc @Raydiation @DeepDiver1975 @PVince81 @karlitschek 
This needs backport to stable7 because it's a broken behaviour of the public API.
