### PR TITLE
Allow specifying the item source in unshareFromSelf().

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -718,23 +718,24 @@ class Share extends \OC\Share\Constants {
 	/**
 	 * Unshare an item shared with the current user
 	 * @param string $itemType
-	 * @param string $itemTarget
+	 * @param string $itemOrigin Item target or source
+	 * @param boolean $originIsSource true if $itemOrigin is the source, false if $itemOrigin is the target (optional)
 	 * @return boolean true on success or false on failure
 	 *
 	 * Unsharing from self is not allowed for items inside collections
 	 */
-	public static function unshareFromSelf($itemType, $itemTarget) {
-
+	public static function unshareFromSelf($itemType, $itemOrigin, $originIsSource = false) {
+		$originType = ($originIsSource) ? 'source' : 'target';
 		$uid = \OCP\User::getUser();
 
 		if ($itemType === 'file' || $itemType === 'folder') {
-			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `file_target` = ?';
+			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `file_' . $originType . '` = ?';
 		} else {
-			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `item_target` = ?';
+			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `item_' . $originType . '` = ?';
 		}
 
 		$query = \OCP\DB::prepare($statement);
-		$result = $query->execute(array($itemType, $itemTarget));
+		$result = $query->execute(array($itemType, $itemOrigin));
 
 		$shares = $result->fetchAll();
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -265,8 +265,8 @@ class Share extends \OC\Share\Constants {
 	 *
 	 * Unsharing from self is not allowed for items inside collections
 	 */
-	public static function unshareFromSelf($itemType, $itemTarget) {
-		return \OC\Share\Share::unshareFromSelf($itemType, $itemTarget);
+	public static function unshareFromSelf($itemType, $itemOrigin, $originIsSource = false) {
+		return \OC\Share\Share::unshareFromSelf($itemType, $itemOrigin, $originIsSource);
 	}
 
 	/**

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -314,6 +314,25 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(in_array('test.txt', $to_test));
 		$this->assertTrue(in_array('test1.txt', $to_test));
 
+		// Unshare from self
+		$this->assertTrue(OCP\Share::unshareFromSelf('test', 'test.txt'));
+		$this->assertEquals(array('test1.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
+
+		// Unshare from self via source
+		$this->assertTrue(OCP\Share::unshareFromSelf('test', 'share.txt', true));
+		$this->assertEquals(array(), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
+
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		OC_User::setUserId($this->user3);
+		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+
+		OC_User::setUserId($this->user2);
+		$to_test = OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET);
+		$this->assertEquals(2, count($to_test));
+		$this->assertTrue(in_array('test.txt', $to_test));
+		$this->assertTrue(in_array('test1.txt', $to_test));
+
 		// Remove user
 		OC_User::setUserId($this->user1);
 		OC_User::deleteUser($this->user1);
@@ -512,6 +531,11 @@ class Test_Share extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 		OC_User::setUserId($this->user2);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
+
+		// Unshare from self via source
+		OC_User::setUserId($this->user1);
+		$this->assertTrue(OCP\Share::unshareFromSelf('test', 'share.txt', true));
+		$this->assertEquals(array(), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 
 		// Remove group
 		OC_Group::deleteGroup($this->group1);


### PR DESCRIPTION
This pull request allows unshareFromSelf() to be performed using an item source instead of an item target.
The new behavior is useful if the item source is readily available but the item target is not; the change does not modify the default behavior.

This is needed by owncloud/calendar#495.
