### PR TITLE
max icon size for app menu

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -190,6 +190,8 @@
 #navigation .app-icon {
 	margin: 0 auto;
 	padding: 0;
+	max-height: 32px;
+	max-width: 32px;
 }
 
 /* Apps management */


### PR DESCRIPTION
Prevent size overflow of app icons in app menu.
Suggested by @DeepDiver1975 in https://github.com/owncloud/apps/pull/1857.
