### PR TITLE
Improvment in opcode cache clear

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -180,7 +180,7 @@ class Config {
 		}
 		// Prevent others not to read the config
 		@chmod($this->configFilename, 0640);
-		\OC_Util::clearOpcodeCache();
+		\OC_Util::clearOpcodeCache($this->configFilename);
 	}
 }
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1350,8 +1350,8 @@ class OC_Util {
 	 * @return void
 	 */
 	public static function clearOpcodeCache($path=NULL) {
-		// APC
-		if (function_exists('apc_clear_cache')) {
+		// APC, !APCu
+		if (function_exists('apc_clear_cache') && !function_exists('apcu_clear_cache')) {
 			apc_clear_cache();
 		}
 		// Zend Opcache

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1354,10 +1354,6 @@ class OC_Util {
 		if (function_exists('apc_clear_cache') && !function_exists('apcu_clear_cache')) {
 			apc_clear_cache();
 		}
-		// Zend Opcache
-		if (function_exists('accelerator_reset')) {
-			accelerator_reset();
-		}
 		// XCache
 		if (function_exists('xcache_clear_cache')) {
 			if (ini_get('xcache.admin.enable_auth')) {
@@ -1366,12 +1362,17 @@ class OC_Util {
 				xcache_clear_cache(XC_TYPE_PHP, 0);
 			}
 		}
-		// Opcache (PHP >= 5.5)
+		// Zend Opcache (>= 7.0.2, PHP >= 5.5)
 		if ($path && function_exists('opcache_invalidate')) {
 			opcache_invalidate($path);
 
+		// Zend Opcache (= 7.0.1)
 		} else if (function_exists('opcache_reset')) {
 			opcache_reset();
+
+		// Zend Opcache (version <= 7.0.0)
+		} else if (function_exists('accelerator_reset')) {
+			accelerator_reset();
 		}
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1346,9 +1346,10 @@ class OC_Util {
 	 * Clear the opcode cache if one exists
 	 * This is necessary for writing to the config file
 	 * in case the opcode cache does not re-validate files
+	 * @param string $path of the configuration file
 	 * @return void
 	 */
-	public static function clearOpcodeCache() {
+	public static function clearOpcodeCache($path=NULL) {
 		// APC
 		if (function_exists('apc_clear_cache')) {
 			apc_clear_cache();
@@ -1366,7 +1367,10 @@ class OC_Util {
 			}
 		}
 		// Opcache (PHP >= 5.5)
-		if (function_exists('opcache_reset')) {
+		if ($path && function_exists('opcache_invalidate')) {
+			opcache_invalidate($path);
+
+		} else if (function_exists('opcache_reset')) {
 			opcache_reset();
 		}
 	}


### PR DESCRIPTION
Of course the "opcache_reset + opcache.fast_shutdown=1" which cause segfault is a PHP bug (https://bugs.php.net/67687) and have to be fixed there.

So 3974de2 is mostly a workaround to this issue, but it's also a improvement as resetting "all" the cache is bad for perf. (Of course most admin will have to reset it after code update, but only once, and atomic deployment is another problem)
