### PR TITLE
show a warning in the personal settings and admin settins if the encyption keys are not initialized

### DIFF
--- a/apps/files_encryption/settings-admin.php
+++ b/apps/files_encryption/settings-admin.php
@@ -12,8 +12,11 @@ $tmpl = new OCP\Template('files_encryption', 'settings-admin');
 
 // Check if an adminRecovery account is enabled for recovering files after lost pwd
 $recoveryAdminEnabled = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryAdminEnabled', '0');
+$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
+$initStatus = $session->getInitialized();
 
 $tmpl->assign('recoveryEnabled', $recoveryAdminEnabled);
+$tmpl->assign('initStatus', $initStatus);
 
 \OCP\Util::addscript('files_encryption', 'settings-admin');
 \OCP\Util::addscript('core', 'multiselect');

--- a/apps/files_encryption/templates/settings-admin.php
+++ b/apps/files_encryption/templates/settings-admin.php
@@ -1,6 +1,9 @@
 <form id="encryption" class="section">
 	<h2><?php p($l->t('Encryption')); ?></h2>
 
+	<?php if($_["initStatus"] === \OCA\Encryption\Session::NOT_INITIALIZED): ?>
+		<?php p($l->t("Encryption App is enabled but your keys are not initialized, please log-out and log-in again")); ?>
+	<?php else: ?>
 	<p>
 		<?php p($l->t("Enable recovery key (allow to recover users files in case of password loss):")); ?>
 		<br/>
@@ -57,4 +60,5 @@
 		</button>
 		<span class="msg"></span>
 	</p>
+	<?php endif; ?>
 </form>

--- a/apps/files_encryption/templates/settings-personal.php
+++ b/apps/files_encryption/templates/settings-personal.php
@@ -1,7 +1,11 @@
 <form id="encryption" class="section">
 	<h2><?php p( $l->t( 'Encryption' ) ); ?></h2>
 
-	<?php if ( $_["initialized"] === '1' ): ?>
+	<?php if ( $_["initialized"] === \OCA\Encryption\Session::NOT_INITIALIZED ): ?>
+
+	<?php p($l->t("Encryption App is enabled but your keys are not initialized, please log-out and log-in again")); ?>
+
+	<?php elseif ( $_["initialized"] === \OCA\Encryption\Session::INIT_EXECUTED ): ?>
 		<p>
 			<a name="changePKPasswd" />
 			<label for="changePrivateKeyPasswd">
@@ -33,9 +37,8 @@
 			</button>
 			<span class="msg"></span>
 		</p>
-	<?php endif; ?>
 
-	<?php if ( $_["recoveryEnabled"] && $_["privateKeySet"] ): ?>
+	<?php elseif ( $_["recoveryEnabled"] && $_["privateKeySet"] &&  $_["initialized"] === \OCA\Encryption\Session::INIT_SUCCESSFUL ): ?>
 		<br />
 		<p>
 			<label for="userEnableRecovery"><?php p( $l->t( "Enable password recovery:" ) ); ?></label>


### PR DESCRIPTION
If the user enabled encryption and switches directly to the personal or admin settings we shouldn't display any settings but instead ask the user to logout and log-in again to initialize the encryption. Small side-issue of #9936
