### PR TITLE
Fix remote.php routes for apps that are enabled for specific groups

### DIFF
--- a/lib/private/connector/sabre/appenabledplugin.php
+++ b/lib/private/connector/sabre/appenabledplugin.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Connector\Sabre;
+
+use OCP\App\IManager;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\ServerPlugin;
+
+/**
+ * Plugin to check if an app is enabled for the current user
+ */
+class AppEnabledPlugin extends ServerPlugin {
+
+	/**
+	 * Reference to main server object
+	 *
+	 * @var \Sabre\DAV\Server
+	 */
+	private $server;
+
+	/**
+	 * @var string
+	 */
+	private $app;
+
+	/**
+	 * @var \OCP\App\IManager
+	 */
+	private $appManager;
+
+	/**
+	 * @param string $app
+	 * @param \OCP\App\IManager $appManager
+	 */
+	public function __construct($app, IManager $appManager) {
+		$this->app = $app;
+		$this->appManager = $appManager;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by \Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param \Sabre\DAV\Server $server
+	 * @return void
+	 */
+	public function initialize(\Sabre\DAV\Server $server) {
+
+		$this->server = $server;
+		$this->server->subscribeEvent('beforeMethod', array($this, 'checkAppEnabled'), 30);
+	}
+
+	/**
+	 * This method is called before any HTTP after auth and checks if the user has access to the app
+	 *
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @return bool
+	 */
+	public function checkAppEnabled() {
+		if (!$this->appManager->isEnabledForUser($this->app)) {
+			throw new Forbidden();
+		}
+	}
+}

--- a/public.php
+++ b/public.php
@@ -37,7 +37,9 @@ try {
 	OC_App::loadApps(array('authentication'));
 	OC_App::loadApps(array('filesystem', 'logging'));
 
-	OC_Util::checkAppEnabled($app);
+	if (!\OC::$server->getAppManager()->isInstalled($app)) {
+		throw new Exception('App not installed: ' . $app);
+	}
 	OC_App::loadApp($app);
 	OC_User::setIncognitoMode(true);
 

--- a/remote.php
+++ b/remote.php
@@ -43,7 +43,9 @@ try {
 			$file =  OC::$SERVERROOT .'/'. $file;
 			break;
 		default:
-			OC_Util::checkAppEnabled($app);
+			if (!\OC::$server->getAppManager()->isInstalled($app)) {
+				throw new Exception('App not installed: ' . $app);
+			}
 			OC_App::loadApp($app);
 			$file = OC_App::getAppPath($app) .'/'. $parts[1];
 			break;


### PR DESCRIPTION
Since checking if an app is enabled requires a user to be logged in we need to postpone those checks until after the *DAV auth is handled, to achieve this a sabre/dav plugin is provided for apps

See owncloud/contacts#563 and owncloud/calendar#502 for the app parts of this

cc @DeepDiver1975 
