### PR TITLE
update attributes for share-with-user view

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -59,6 +59,9 @@
 			$tr.attr('data-share-id', _.pluck(fileData.shares, 'id').join(','));
 			if (this._sharedWithUser) {
 				$tr.attr('data-share-owner', fileData.shareOwner);
+				$tr.attr('data-mounttype', 'shared-root');
+				var permission = parseInt($tr.attr('data-permissions')) | OC.PERMISSION_DELETE;
+				$tr.attr('data-permissions', permission);
 			}
 			return $tr;
 		},


### PR DESCRIPTION
 file should always have delete permissions, this means unshare in this context, and the overview page is always a root view.

fix #9971 
