### PR TITLE
function declaration did not match

### DIFF
--- a/tests/lib/contacts/localadressbook.php
+++ b/tests/lib/contacts/localadressbook.php
@@ -17,7 +17,7 @@ class Test_LocalAddressBook extends PHPUnit_Framework_TestCase
 	public function testSearchFN() {
 		$stub = $this->getMockForAbstractClass('\OCP\IUserManager', array('searchDisplayName'));
 
-		$stub->expects($this->any())->method('searchDisplayName')->will($this->return(array(
+		$stub->expects($this->any())->method('searchDisplayName')->will($this->returnValue(array(
 			new SimpleUserForTesting('tom', 'Thomas'),
 			new SimpleUserForTesting('tomtom', 'Thomas T.'),
 		)));
@@ -25,13 +25,13 @@ class Test_LocalAddressBook extends PHPUnit_Framework_TestCase
 		$localAddressBook = new LocalAddressBook($stub);
 
 		$result = $localAddressBook->search('tom', array('FN'), array());
-		$this->assertEqual(2, count($result));
+		$this->assertEquals(2, count($result));
 	}
 
 	public function testSearchId() {
 		$stub = $this->getMockForAbstractClass('\OCP\IUserManager', array('searchDisplayName'));
 
-		$stub->expects($this->any())->method('search')->will($this->return(array(
+		$stub->expects($this->any())->method('search')->will($this->returnValue(array(
 			new SimpleUserForTesting('tom', 'Thomas'),
 			new SimpleUserForTesting('tomtom', 'Thomas T.'),
 		)));
@@ -39,7 +39,7 @@ class Test_LocalAddressBook extends PHPUnit_Framework_TestCase
 		$localAddressBook = new LocalAddressBook($stub);
 
 		$result = $localAddressBook->search('tom', array('id'), array());
-		$this->assertEqual(2, count($result));
+		$this->assertEquals(2, count($result));
 	}
 }
 

--- a/tests/lib/contacts/localadressbook.php
+++ b/tests/lib/contacts/localadressbook.php
@@ -72,7 +72,7 @@ class SimpleUserForTesting implements \OCP\IUser {
 	public function delete() {
 	}
 
-	public function setPassword($password, $recoveryPassword) {
+	public function setPassword($password, $recoveryPassword = null) {
 	}
 
 	public function getHome() {


### PR DESCRIPTION
```
00:12:57.380 PHP Fatal error:  Declaration of SimpleUserForTesting::setPassword() must be compatible with OCP\IUser::setPassword($password, $recoveryPassword = NULL) in /var/lib/jenkins/jobs/pull-request-analyser/workspace/tests/lib/contacts/localadressbook.php on line 47
00:12:57.380 PHP Stack trace:
00:12:57.380 PHP   1. {main}() /usr/bin/phpunit:0
00:12:57.380 PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:46
00:12:57.380 PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php/PHPUnit/TextUI/Command.php:129
00:12:57.380 PHP   4. PHPUnit_TextUI_Command->handleArguments() /usr/share/php/PHPUnit/TextUI/Command.php:138
00:12:57.380 PHP   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration() /usr/share/php/PHPUnit/TextUI/Command.php:657
00:12:57.380 PHP   6. PHPUnit_Util_Configuration->getTestSuite() /usr/share/php/PHPUnit/Util/Configuration.php:789
00:12:57.380 PHP   7. PHPUnit_Framework_TestSuite->addTestFiles() /usr/share/php/PHPUnit/Util/Configuration.php:873
00:12:57.380 PHP   8. PHPUnit_Framework_TestSuite->addTestFile() /usr/share/php/PHPUnit/Framework/TestSuite.php:416
00:12:57.380 PHP   9. PHPUnit_Util_Fileloader::checkAndLoad() /usr/share/php/PHPUnit/Framework/TestSuite.php:355
00:12:57.380 PHP  10. PHPUnit_Util_Fileloader::load() /usr/share/php/PHPUnit/Util/Fileloader.php:76
00:12:57.380 PHP  11. include_once() /usr/share/php/PHPUnit/Util/Fileloader.php:92
```
