### PR TITLE
Download files inline

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -37,7 +37,7 @@ if(!\OC\Files\Filesystem::file_exists($filename)) {
 $ftype=\OC\Files\Filesystem::getMimeType( $filename );
 
 header('Content-Type:'.$ftype);
-OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');
+OCP\Response::setContentDispositionHeader(basename($filename), 'inline');
 OCP\Response::disableCaching();
 header('Content-Length: '.\OC\Files\Filesystem::filesize($filename));
 


### PR DESCRIPTION
Use content-disposition=inline instead of attachment when clicking on a file. This allows the user to preview/see a supported file directly in the browser while unsupported files by the browser are still presented as a download.

This does not affect the "download" button which uses apps/files/ajax/download.php, so the user can force a download by clicking on the "download" button or right click on the file and select "save as".

This at least fixes #1745 and fixes owncloud/apps#1687, maybe more, and gives the choice back to the user whether to download the file or show it in the browser.

---

Please let me know if I need to sign the Contributor Agreement for this pull request.
