### PR TITLE
Cache factory needs to use globalPrefix in createLowLatency()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -478,8 +478,6 @@ class OC {
 
 		self::initPaths();
 		if (OC_Config::getValue('instanceid', false)) {
-			// \OC\Memcache\Cache has a hidden dependency on
-			// OC_Util::getInstanceId() for namespacing. See #5409.
 			try {
 				self::$loader->setMemoryCache(\OC\Memcache\Factory::createLowLatency('Autoloader'));
 			} catch (\Exception $ex) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -475,23 +475,9 @@ class OC {
 		@ini_set('file_uploads', '50');
 
 		self::handleAuthHeaders();
-
 		self::initPaths();
+		self::registerAutoloaderCache();
 
-		// The class loader takes an optional low-latency cache, which MUST be
-		// namespaced. The instanceid is used for namespacing, but might be
-		// unavailable at this point. Futhermore, it might not be possible to
-		// generate an instanceid via \OC_Util::getInstanceId() because the
-		// config file may not be writable. As such, we only register a class
-		// loader cache if instanceid is available without trying to create one.
-		$instanceId = OC_Config::getValue('instanceid', null);
-		if ($instanceId) {
-			try {
-				$memcacheFactory = new \OC\Memcache\Factory($instanceId);
-				self::$loader->setMemoryCache($memcacheFactory->createLowLatency('Autoloader'));
-			} catch (\Exception $ex) {
-			}
-		}
 		OC_Util::isSetLocaleWorking();
 
 		// setup 3rdparty autoloader
@@ -648,6 +634,23 @@ class OC {
 			OC_Hook::connect('OC_User', 'post_addToGroup', 'OC\Share\Hooks', 'post_addToGroup');
 			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OC\Share\Hooks', 'post_removeFromGroup');
 			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC\Share\Hooks', 'post_deleteGroup');
+		}
+	}
+
+	protected static function registerAutoloaderCache() {
+		// The class loader takes an optional low-latency cache, which MUST be
+		// namespaced. The instanceid is used for namespacing, but might be
+		// unavailable at this point. Futhermore, it might not be possible to
+		// generate an instanceid via \OC_Util::getInstanceId() because the
+		// config file may not be writable. As such, we only register a class
+		// loader cache if instanceid is available without trying to create one.
+		$instanceId = OC_Config::getValue('instanceid', null);
+		if ($instanceId) {
+			try {
+				$memcacheFactory = new \OC\Memcache\Factory($instanceId);
+				self::$loader->setMemoryCache($memcacheFactory->createLowLatency('Autoloader'));
+			} catch (\Exception $ex) {
+			}
 		}
 	}
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -477,9 +477,18 @@ class OC {
 		self::handleAuthHeaders();
 
 		self::initPaths();
-		if (OC_Config::getValue('instanceid', false)) {
+
+		// The class loader takes an optional low-latency cache, which MUST be
+		// namespaced. The instanceid is used for namespacing, but might be
+		// unavailable at this point. Futhermore, it might not be possible to
+		// generate an instanceid via \OC_Util::getInstanceId() because the
+		// config file may not be writable. As such, we only register a class
+		// loader cache if instanceid is available without trying to create one.
+		$instanceId = OC_Config::getValue('instanceid', null);
+		if ($instanceId) {
 			try {
-				self::$loader->setMemoryCache(\OC\Memcache\Factory::createLowLatency('Autoloader'));
+				$memcacheFactory = new \OC\Memcache\Factory($instanceId);
+				self::$loader->setMemoryCache($memcacheFactory->createLowLatency('Autoloader'));
 			} catch (\Exception $ex) {
 			}
 		}

--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -59,7 +59,8 @@ class Factory implements ICacheFactory {
 	 * @param string $prefix
 	 * @return null|Cache
 	 */
-	public static function createLowLatency($prefix = '') {
+	public function createLowLatency($prefix = '') {
+		$prefix = $this->globalPrefix . '/' . $prefix;
 		if (XCache::isAvailable()) {
 			return new XCache($prefix);
 		} elseif (APCu::isAvailable()) {
@@ -76,7 +77,7 @@ class Factory implements ICacheFactory {
 	 *
 	 * @return bool
 	 */
-	public static function isAvailableLowLatency() {
+	public function isAvailableLowLatency() {
 		return XCache::isAvailable() || APCu::isAvailable() || APC::isAvailable();
 	}
 


### PR DESCRIPTION
Fixes #9991 

This is to avoid conflicts when running multiple instances in the same hosting environment. Without this patch multiple instances on the same server sharing the same memory cache will not work correctly.
