### PR TITLE
mysql setup: if dbuser exists try a different one (owncloud/core#108)

### DIFF
--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -15,12 +15,11 @@ class MySQL extends AbstractDatabase {
 		//user already specified in config
 		$oldUser=\OC_Config::getValue('dbuser', false);
 
-		//we don't have this dbuser specified in config
+		//we don't have a dbuser specified in config
 		if($this->dbuser!=$oldUser) {
 			//add prefix to the admin username to prevent collisions
 			$adminUser=substr('oc_'.$username, 0, 16);
 
-			//endless loop
 			$i = 1;
 			while(true) {
 				//this should be enough to check for admin rights in mysql
@@ -44,7 +43,7 @@ class MySQL extends AbstractDatabase {
 					}
 					else {
 						//repeat with different username
-						$length=ceil(log10($i));
+						$length=strlen((string)$i);
 						$adminUser=substr('oc_'.$username, 0, 16 - $length).$i;
 						$i++;
 					}

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -40,15 +40,13 @@ class MySQL extends AbstractDatabase {
 						$this->createDBUser($connection);
 
 						break;
-					}
-					else {
+					} else {
 						//repeat with different username
 						$length=strlen((string)$i);
 						$adminUser=substr('oc_'.$username, 0, 16 - $length).$i;
 						$i++;
 					}
-				}
-				else {
+				} else {
 					break;
 				}
 			};

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -35,7 +35,7 @@ class MySQL extends AbstractDatabase {
 						//use the admin login data for the new database user
 						$this->dbuser=$adminUser;
 
-						//hash the password so we don't need to store the admin config in the config file
+						//create a random password so we don't need to store the admin password in the config file
 						$this->dbpassword=\OC_Util::generateRandomBytes(30);
 
 						$this->createDBUser($connection);

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -14,35 +14,26 @@ class MySQL extends AbstractDatabase {
 		}
 		$oldUser=\OC_Config::getValue('dbuser', false);
 
-		//this should be enough to check for admin rights in mysql
-		$query="SELECT user FROM mysql.user WHERE user='$this->dbuser'";
-		if(mysql_query($query, $connection)) {
-			//use the admin login data for the new database user
+		if($this->dbuser!=$oldUser) {
+			//this should be enough to check for admin rights in mysql
+			$query="SELECT user FROM mysql.user WHERE user='$this->dbuser'";
+			if(mysql_query($query, $connection)) {
+				//use the admin login data for the new database user
 
-			//add prefix to the mysql user name to prevent collisions
-			$this->dbuser=substr('oc_'.$username, 0, 16);
-			if($this->dbuser!=$oldUser) {
+				//add prefix to the mysql user name to prevent collisions
+				$this->dbuser=substr('oc_'.$username, 0, 16);
 				//hash the password so we don't need to store the admin config in the config file
 				$this->dbpassword=\OC_Util::generateRandomBytes(30);
 
 				$this->createDBUser($connection);
-
-				\OC_Config::setValue('dbuser', $this->dbuser);
-				\OC_Config::setValue('dbpassword', $this->dbpassword);
 			}
 
-			//create the database
-			$this->createDatabase($connection);
+			\OC_Config::setValue('dbuser', $this->dbuser);
+			\OC_Config::setValue('dbpassword', $this->dbpassword);
 		}
-		else {
-			if($this->dbuser!=$oldUser) {
-				\OC_Config::setValue('dbuser', $this->dbuser);
-				\OC_Config::setValue('dbpassword', $this->dbpassword);
-			}
 
-			//create the database
-			$this->createDatabase($connection);
-		}
+		//create the database
+		$this->createDatabase($connection);
 
 		//fill the database if needed
 		$query='select count(*) from information_schema.tables'


### PR DESCRIPTION
Fixing the oldest bug available :)
This seams to be a proper solution for owncloud/core#108.

If dbuser has no admin rights, use it.
If dbuser has admin rights and oc_[admin] does not exist, create oc_[admin].
If dbuser has admin rights and oc_[admin] exists try oc_[admin]1, oc_[admin]2, ...

What do you think?
