### PR TITLE
skip objectstore tests on travis, trystack too unreliable for CI

### DIFF
--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -31,6 +31,10 @@ class Swift extends \Test\Files\Storage\Storage {
 	private $objectStorage;
 
 	public function setUp() {
+		// TODO travis: objectstore tests with trystack are not very reliable. We need separate infrastructure for this
+		if (getenv('TRAVIS')) {
+ 			$this->markTestSkipped('objectstore tests are unreliable on travis');
+		}
 
 		\OC_App::disable('files_sharing');
 		\OC_App::disable('files_versions');


### PR DESCRIPTION
trystack is too unreliable for CI.

@karlitschek @DeepDiver1975 we can reenable this when we have our own swift service infrastructure in place

needs port to master
