### PR TITLE
Also keep maxY into account when scaling a preview while preserving aspect ratio

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -70,10 +70,6 @@ if(substr($path, 0, 1) === '/') {
 	$path = substr($path, 1);
 }
 
-if ($keepAspect === true) {
-	$maxY = $maxX;
-}
-
 if($maxX === 0 || $maxY === 0) {
 	\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
 	\OC_Log::write('core-preview', 'x and/or y set to 0', \OC_Log::DEBUG);

--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -21,10 +21,6 @@ if ($file === '') {
 	exit;
 }
 
-if ($keepAspect === true) {
-	$maxY = $maxX;
-}
-
 if ($maxX === 0 || $maxY === 0) {
 	//400 Bad Request
 	\OC_Response::setStatus(400);

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -561,9 +561,15 @@ class Preview {
 		$realX = (int)$image->width();
 		$realY = (int)$image->height();
 
-		// compute $maxY using the aspect of the generated preview
+		// compute $maxY and $maxX using the aspect of the generated preview
 		if ($this->keepAspect) {
-			$y = $x / ($realX / $realY);
+			$ratio = $realX / $realY;
+			if($x / $ratio < $y) {
+				// width restricted
+				$y = $x / $ratio;
+			} else {
+				$x = $y * $ratio;
+			}
 		}
 
 		if ($x === $realX && $y === $realY) {


### PR DESCRIPTION
The gallery app requires thumbnails with a fixed height while keeping the aspect ratio

cc @DeepDiver1975 @georgehrke 
