### PR TITLE
Fix silent crash if 3rdparty dir is not available

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -132,20 +132,25 @@ class OC {
 		}
 
 		// search the 3rdparty folder
-		if (OC_Config::getValue('3rdpartyroot', '') <> '' and OC_Config::getValue('3rdpartyurl', '') <> '') {
-			OC::$THIRDPARTYROOT = OC_Config::getValue('3rdpartyroot', '');
-			OC::$THIRDPARTYWEBROOT = OC_Config::getValue('3rdpartyurl', '');
-		} elseif (file_exists(OC::$SERVERROOT . '/3rdparty')) {
-			OC::$THIRDPARTYROOT = OC::$SERVERROOT;
-			OC::$THIRDPARTYWEBROOT = OC::$WEBROOT;
-		} elseif (file_exists(OC::$SERVERROOT . '/../3rdparty')) {
-			OC::$THIRDPARTYWEBROOT = rtrim(dirname(OC::$WEBROOT), '/');
-			OC::$THIRDPARTYROOT = rtrim(dirname(OC::$SERVERROOT), '/');
-		} else {
-			throw new Exception('3rdparty directory not found! Please put the ownCloud 3rdparty'
+		OC::$THIRDPARTYROOT = OC_Config::getValue('3rdpartyroot', null);
+		OC::$THIRDPARTYWEBROOT = OC_Config::getValue('3rdpartyurl', null);
+		
+		if (is_null(OC::$THIRDPARTYROOT) && is_null(OC::$THIRDPARTYWEBROOT)) {
+			if (file_exists(OC::$SERVERROOT . '/3rdparty')) {
+				OC::$THIRDPARTYROOT = OC::$SERVERROOT;
+				OC::$THIRDPARTYWEBROOT = OC::$WEBROOT;
+			} elseif (file_exists(OC::$SERVERROOT . '/../3rdparty')) {
+				OC::$THIRDPARTYWEBROOT = rtrim(dirname(OC::$WEBROOT), '/');
+				OC::$THIRDPARTYROOT = rtrim(dirname(OC::$SERVERROOT), '/');
+			}
+		}
+		if (is_null(OC::$THIRDPARTYROOT) || !file_exists(OC::$THIRDPARTYROOT)) {
+			echo('3rdparty directory not found! Please put the ownCloud 3rdparty'
 				. ' folder in the ownCloud folder or the folder above.'
 				. ' You can also configure the location in the config.php file.');
+			exit();
 		}
+		
 		// search the apps folder
 		$config_paths = OC_Config::getValue('apps_paths', array());
 		if (!empty($config_paths)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -148,7 +148,7 @@ class OC {
 			echo('3rdparty directory not found! Please put the ownCloud 3rdparty'
 				. ' folder in the ownCloud folder or the folder above.'
 				. ' You can also configure the location in the config.php file.');
-			exit();
+			return;
 		}
 		
 		// search the apps folder


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/9975

Regression.
Unfortunately `OC_Template::printExceptionErrorPage` would not work without 3rdparty dir.
