### PR TITLE
fix to allow multiple S3 buckets to be used

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -84,7 +84,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			throw new \Exception("Access Key, Secret and Bucket have to be configured.");
 		}
 
-		$this->id = 'amazon::' . $params['key'] . md5($params['secret']);
+		$this->id = 'amazon::' . $params['key'] . md5($params['secret']) . $params['bucket'];
 
 		$this->bucket = $params['bucket'];
 		$scheme = ($params['use_ssl'] === 'false') ? 'http' : 'https';


### PR DESCRIPTION
The "id" should include the bucket name since the "Key ID" and "Secret Key" remain the same within AWS Identities.  In fact, since all S3 buckets must have unique names across all of AWS, the keys could be omitted altogether.

This is only a proposal for an issue I discovered and, as I'm not a PHP developer, I'm not sure what other elements would need to be addressed along with this change.
