### PR TITLE
traverse folders in php to search in shared files

### DIFF
--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -95,6 +95,80 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 		parent::tearDown();
 	}
 
+	function searchDataProvider() {
+		return array(
+			array('%another%',
+				array(
+					array('name' => 'another too.txt', 'path' => 'subdir/another too.txt'),
+					array('name' => 'another.txt', 'path' => 'subdir/another.txt'),
+				)
+			),
+			array('%Another%',
+				array(
+					array('name' => 'another too.txt', 'path' => 'subdir/another too.txt'),
+					array('name' => 'another.txt', 'path' => 'subdir/another.txt'),
+				)
+			),
+			array('%dir%',
+				array(
+					array('name' => 'emptydir', 'path' => 'emptydir'),
+					array('name' => 'subdir', 'path' => 'subdir'),
+					array('name' => 'shareddir', 'path' => ''),
+				)
+			),
+			array('%Dir%',
+				array(
+					array('name' => 'emptydir', 'path' => 'emptydir'),
+					array('name' => 'subdir', 'path' => 'subdir'),
+					array('name' => 'shareddir', 'path' => ''),
+				)
+			),
+			array('%txt%',
+				array(
+					array('name' => 'bar.txt', 'path' => 'bar.txt'),
+					array('name' => 'another too.txt', 'path' => 'subdir/another too.txt'),
+					array('name' => 'another.txt', 'path' => 'subdir/another.txt'),
+				)
+			),
+			array('%Txt%',
+				array(
+					array('name' => 'bar.txt', 'path' => 'bar.txt'),
+					array('name' => 'another too.txt', 'path' => 'subdir/another too.txt'),
+					array('name' => 'another.txt', 'path' => 'subdir/another.txt'),
+				)
+			),
+			array('%',
+				array(
+					array('name' => 'bar.txt', 'path' => 'bar.txt'),
+					array('name' => 'emptydir', 'path' => 'emptydir'),
+					array('name' => 'subdir', 'path' => 'subdir'),
+					array('name' => 'another too.txt', 'path' => 'subdir/another too.txt'),
+					array('name' => 'another.txt', 'path' => 'subdir/another.txt'),
+					array('name' => 'not a text file.xml', 'path' => 'subdir/not a text file.xml'),
+					array('name' => 'shareddir', 'path' => ''),
+				)
+			),
+			array('%nonexistant%',
+				array(
+				)
+			),
+		);
+	}
+
+	/**
+	 * we cannot use a dataProvider because that would cause the stray hook detection to remove the hooks
+	 * that were added in setUpBeforeClass.
+	 */
+	function testSearch() {
+		foreach ($this->searchDataProvider() as $data) {
+			list($pattern, $expectedFiles) = $data;
+
+			$results = $this->sharedStorage->getCache()->search($pattern);
+
+			$this->verifyFiles($expectedFiles, $results);
+		}
+
+	}
 	/**
 	 * Test searching by mime type
 	 */
@@ -114,8 +188,6 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 					'path' => 'subdir/another.txt'
 				),
 			);
-		$this->verifyFiles($check, $results);
-
 		$this->verifyFiles($check, $results);
 	}
 
@@ -245,7 +317,7 @@ class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
 				}
 			}
 		}
-		$this->assertTrue(empty($results));
+		$this->assertEquals(array(), $results);
 	}
 
 	/**


### PR DESCRIPTION
makeshift fix for https://github.com/owncloud/core/issues/10009 

@karlitschek @DeepDiver1975 @craigpg needed for 7.0.1

Why makeshift, you ask? The solution uses the same directory traversing as searchByMime ... which is a performance nightmare and ugly. But it works.

@icewind1991 @PVince81 @schiesbn We definitely need to come up with a better solution... I still vote for a n:m relation table between share and files. Yes it takes longer to share hundreds of files ... but it is a much cleaner solution and allows us to use joins and let the db do it's magic.
