### PR TITLE
Use svg mimeicons for empty text files

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -31,7 +31,7 @@ class Helper
 	/**
 	 * Determine icon for a given file
 	 *
-	 * @param \OC\Files\FileInfo $file file info
+	 * @param \OCP\Files\FileInfo $file file info
 	 * @return string icon URL
 	 */
 	public static function determineIcon($file) {
@@ -111,7 +111,7 @@ class Helper
 		$entry['mtime'] = $i['mtime'] * 1000;
 		// only pick out the needed attributes
 		$entry['icon'] = \OCA\Files\Helper::determineIcon($i);
-		if (\OC::$server->getPreviewManager()->isMimeSupported($i['mimetype'])) {
+		if (\OC::$server->getPreviewManager()->isAvailable($i)) {
 			$entry['isPreviewAvailable'] = true;
 		}
 		$entry['name'] = $i->getName();

--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -34,7 +34,8 @@ if ($maxX === 0 || $maxY === 0) {
 
 try {
 	$preview = new \OC\Preview(\OC_User::getUser(), 'files');
-	if (!$always and !$preview->isMimeSupported(\OC\Files\Filesystem::getMimeType($file))) {
+	$info = \OC\Files\Filesystem::getFileInfo($file);
+	if (!$always and !$preview->isAvailable($info)) {
 		\OC_Response::setStatus(404);
 	} else {
 		$preview->setFile($file);

--- a/lib/private/preview/provider.php
+++ b/lib/private/preview/provider.php
@@ -11,6 +11,16 @@ abstract class Provider {
 	abstract public function getMimeType();
 
 	/**
+	 * Check if a preview can be generated for $path
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
+	public function isAvailable($path) {
+		return true;
+	}
+
+	/**
 	 * get thumbnail for file at path $path
 	 * @param string $path Path of file
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image

--- a/lib/private/preview/txt.php
+++ b/lib/private/preview/txt.php
@@ -14,6 +14,16 @@ class TXT extends Provider {
 	}
 
 	/**
+	 * Check if a preview can be generated for $path
+	 *
+	 * @param \OC\Files\FileInfo $file
+	 * @return bool
+	 */
+	public function isAvailable($file) {
+		return $file->getSize() > 5;
+	}
+
+	/**
 	 * @param string $path
 	 * @param int $maxX
 	 * @param int $maxY

--- a/lib/private/previewmanager.php
+++ b/lib/private/previewmanager.php
@@ -14,25 +14,35 @@ use OCP\IPreview;
 class PreviewManager implements IPreview {
 	/**
 	 * return a preview of a file
+	 *
 	 * @param string $file The path to the file where you want a thumbnail from
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param boolean $scaleUp Scale smaller images up to the thumbnail size or not. Might look ugly
 	 * @return \OCP\Image
 	 */
-	function createPreview($file, $maxX = 100, $maxY = 75, $scaleUp = false)
-	{
+	function createPreview($file, $maxX = 100, $maxY = 75, $scaleUp = false) {
 		$preview = new \OC\Preview('', '/', $file, $maxX, $maxY, $scaleUp);
 		return $preview->getPreview();
 	}
 
 	/**
 	 * returns true if the passed mime type is supported
+	 *
 	 * @param string $mimeType
 	 * @return boolean
 	 */
-	function isMimeSupported($mimeType = '*')
-	{
+	function isMimeSupported($mimeType = '*') {
 		return \OC\Preview::isMimeSupported($mimeType);
+	}
+
+	/**
+	 * Check if a preview can be generated for a file
+	 *
+	 * @param \OC\Files\FileInfo $file
+	 * @return bool
+	 */
+	function isAvailable($file) {
+		return \OC\Preview::isAvailable($file);
 	}
 }

--- a/lib/public/ipreview.php
+++ b/lib/public/ipreview.php
@@ -57,4 +57,11 @@ interface IPreview
 	 */
 	function isMimeSupported($mimeType = '*');
 
+	/**
+	 * Check if a preview can be generated for a file
+	 *
+	 * @param \OCP\Files\FileInfo $file
+	 * @return bool
+	 */
+	function isAvailable($file);
 }


### PR DESCRIPTION
This adds a system where the preview system can be queried if a preview is available based on more then just the mimetype. This is useful for backends that can't always generate a proper preview for all files or the supported mimetypes (the text backend for empty text files)

Fix for #10049 

cc @georgehrke @MorrisJobke @DeepDiver1975 
