### PR TITLE
Quick fix for #9119. Increase preview to keep empty message more centered

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -2,7 +2,7 @@
 	background: #fff;
 	text-align: center;
 	margin: 45px auto 0;
-	min-height: 150px;
+	min-height: 600px;
 }
 
 #preview .notCreatable {


### PR DESCRIPTION
 Increase preview to keep empty message more centered and push footer down.
