### PR TITLE
Improved scanner error message

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -67,7 +67,7 @@ class Scanner extends BasicEmitter {
 	public function getData($path) {
 		if (!$this->storage->isReadable($path)) {
 			//cant read, nothing we can do
-			\OCP\Util::writeLog('OC\Files\Cache\Scanner', "!!! Path '$path' is not readable !!!", \OCP\Util::DEBUG);
+			\OCP\Util::writeLog('OC\Files\Cache\Scanner', "!!! Path '$path' is not accessible or present !!!", \OCP\Util::DEBUG);
 			return null;
 		}
 		$data = array();


### PR DESCRIPTION
This is a small improvement of a scanner message.

As described in https://github.com/owncloud/gallery/issues/43 it will help identifying problems better.
In particular when a graphical mime type can not be processed because the necessary code has not been implemeted. Happens when a thumb should be created out of a eg. tiff file which is right now not supported. The correspondent folder gets created but not the thumbnail, by that the error message from scanner is triggered. The current message tells file is "not readble" but in reality it is missing - therefore this change.

Old Scanner message  ..."is not readable !!!"
New Scanner message ..."is not accessible or present !!!"
(because access may not be a permission but a precence problem)
