### PR TITLE
Fixes for filepicker

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -152,6 +152,15 @@ table.multiselect thead {
 }
 
 
+/* do not show dates in filepicker */
+#oc-dialog-filepicker-content .filelist .date {
+	display: none;
+}
+#oc-dialog-filepicker-content .filelist .filename {
+	max-width: 80%;
+}
+
+
 /* fix controls bar jumping when navigation is slid out */
 .snapjs-left #app-navigation-toggle,
 .snapjs-left #controls {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -767,6 +767,10 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 #oc-dialog-filepicker-content .filelist .filename {
 	position: absolute;
 	top: 8px;
+	max-width: 60%;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 #oc-dialog-filepicker-content .filelist img {
 	margin: 2px 1em 0 4px;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -777,8 +777,9 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 }
 #oc-dialog-filepicker-content .filelist .date {
 	float: right;
-	margin-right: 1em;
-	margin-top: 8px;
+	margin-right: 10px;
+	margin-top: 0;
+	padding-top: 9px;
 }
 #oc-dialog-filepicker-content .filepicker_element_selected { background-color:lightblue;}
 .ui-dialog {position:fixed !important;}

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -206,7 +206,7 @@ var OCdialogs = {
 
 			self.$filePicker.ocdialog({
 				closeOnEscape: true,
-				width: (4/9)*$(document).width(),
+				width: (4/5)*$(document).width(),
 				height: 420,
 				modal: modal,
 				buttons: buttonlist,


### PR DESCRIPTION
Previously long filenames were wrapped endlessly in the filepicker. Now they ellipsize.

You can test this with the profile image selector in the personal settings.

Please review @DeepDiver1975 @owncloud/designers 
