### PR TITLE
in case $_POST['itemSourceName'] does not exist we simply default it to ...

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -31,6 +31,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				try {
 					$shareType = (int)$_POST['shareType'];
 					$shareWith = $_POST['shareWith'];
+					$itemSourceName = isset($_POST['itemSourceName']) ? $_POST['itemSourceName'] : null;
 					if ($shareType === OCP\Share::SHARE_TYPE_LINK && $shareWith == '') {
 						$shareWith = null;
 					}
@@ -41,7 +42,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$shareType,
 						$shareWith,
 						$_POST['permissions'],
-						$_POST['itemSourceName'],
+						$itemSourceName,
 						(!empty($_POST['expirationDate']) ? new \DateTime($_POST['expirationDate']) : null)
 					);
 


### PR DESCRIPTION
...null

fixes #6971 

@butonic @schiesbn @SunboX @escservices please review and test - THX
