### PR TITLE
Only load personal external storages for allowed backends

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -238,17 +238,21 @@ class OC_Mount_Config {
 			}
 		}
 
+		$personalBackends = self::getPersonalBackends();
+
 		// Load personal mount points
 		$mountConfig = self::readData($user);
 		if (isset($mountConfig[self::MOUNT_TYPE_USER][$user])) {
 			foreach ($mountConfig[self::MOUNT_TYPE_USER][$user] as $mountPoint => $options) {
-				$options['personal'] = true;
-				$options['options'] = self::decryptPasswords($options['options']);
+				if (isset($personalBackends[$options['class']])) {
+					$options['personal'] = true;
+					$options['options'] = self::decryptPasswords($options['options']);
 
-				// Always override previous config
-				$options['priority_type'] = self::MOUNT_TYPE_PERSONAL;
-				$options['backend'] = $backends[$options['class']]['backend'];
-				$mountPoints[$mountPoint] = $options;
+					// Always override previous config
+					$options['priority_type'] = self::MOUNT_TYPE_PERSONAL;
+					$options['backend'] = $backends[$options['class']]['backend'];
+					$mountPoints[$mountPoint] = $options;
+				}
 			}
 		}
 


### PR DESCRIPTION
To test:
- Add an SMB (or other) mount using the personal mount config
- Verify the mount shows up in the ui
- Disable the SMB external storage backend for personal mount config from the admin panel
- Verify the mount is gone
- Re-enable the backend
  -Verify the mount is back

cc @DeepDiver1975 
