### PR TITLE
Test if delete request orginates in enterprise provisioning api.

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -245,7 +245,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	* Deletes a user
 	*/
 	public function deleteUser($uid) {
-		if ((OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
+		if (OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
 			// request to delete user has come from provisioning api
 			// assume the script that is making the api call is in the act of deleting the user from the directory
 			// return true to run clean up code in OC_User::deleteUser and fire hooks in OC\User\User::delete

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -245,7 +245,14 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	* Deletes a user
 	*/
 	public function deleteUser($uid) {
-		return false;
+		if ((OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
+			// request to delete user has come from provisioning api
+			// assume the script that is making the api call is in the act of deleting the user from the directory
+			// return true to run clean up code in OC_User::deleteUser and fire hooks in OC\User\User::delete
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/apps/user_ldap/user_proxy.php
+++ b/apps/user_ldap/user_proxy.php
@@ -209,7 +209,14 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	 * Deletes a user
 	 */
 	public function deleteUser($uid) {
-		return false;
+		if ((OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
+			// request to delete user has come from provisioning api
+			// assume the script that is making the api call is in the act of deleting the user from the directory
+			// return true to run clean up code in OC_User::deleteUser and fire hooks in OC\User\User::delete
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/apps/user_ldap/user_proxy.php
+++ b/apps/user_ldap/user_proxy.php
@@ -209,7 +209,7 @@ class User_Proxy extends lib\Proxy implements \OCP\UserInterface {
 	 * Deletes a user
 	 */
 	public function deleteUser($uid) {
-		if ((OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
+		if (OCP\App::isEnabled('enterprise_key') && preg_match('/^/ocs/v1\.php/cloud/users/.+/', $_SERVER['REQUEST_URI']) && $_SERVER['REQUEST_METHOD'] === 'DELETE') {
 			// request to delete user has come from provisioning api
 			// assume the script that is making the api call is in the act of deleting the user from the directory
 			// return true to run clean up code in OC_User::deleteUser and fire hooks in OC\User\User::delete


### PR DESCRIPTION
Test if delete request orginates in enterprise provisioning api. If so, assume script making the api call is in the act of removing the user from the backend directory and return true so all clean up code is executed and hooks fired.

Deleting a directory user in the users list in the oc web interface will continue to do nothing (return false). This will only affect calls from the provisioning api and allow delete integration in corporate environments.
