### PR TITLE
no top border for first settings item, detail enhancement

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -274,6 +274,10 @@ button.loading {
 	color: #555;
 	border-top: 1px solid #ddd;
 }
+/* no top border for first settings item */
+.section:first-child {
+	border-top: none;
+}
 .section h2 {
 	font-size: 20px;
 	margin-bottom: 7px;


### PR DESCRIPTION
This removes the first line directly below the header when you are for example in the Admin settings.

Please review @owncloud/designers 
