### PR TITLE
Check result of storage wrappers

### DIFF
--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -99,6 +99,9 @@ class StorageFactory implements IStorageFactory {
 		}, $wrappers);
 		foreach ($wrappers as $wrapper) {
 			$storage = $wrapper($mountPoint->getMountPoint(), $storage, $mountPoint);
+			if (!($storage instanceof \OCP\Files\Storage)) {
+				throw new \Exception('Invalid result from storage wrapper');
+			}
 		}
 		return $storage;
 	}


### PR DESCRIPTION
Currently if a storage wrapper doesn't return a storage object it will break the filesystem, this adds a simple check to verify that the returned value is indeed a storage.

Possibly related to owncloud/documents#283

cc @DeepDiver1975 @karlitschek 
