### PR TITLE
Set group usercount to 0, not '', fixes #9782

### DIFF
--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -30,8 +30,10 @@ GroupList = {
 		var $groupLiElement = $(groupLiElement);
 		if (usercount === undefined || usercount === 0 || usercount < 0) {
 			usercount = '';
+			$groupLiElement.data('usercount', 0);
+		} else {
+			$groupLiElement.data('usercount', usercount);
 		}
-		$groupLiElement.data('usercount', usercount);
 		$groupLiElement.find('.usercount').text(usercount);
 	},
 


### PR DESCRIPTION
Fixes an issue with the user count when creating a group, and then a new user.

@MTRichards @blizzz 

To test:
- Go to settings > users
- Add a new group
- Without refreshing page, add a new user with that new group

Previously:
- User count for the new group would show 'NaN'

Now:
- User count for the new group should show '1'

See: https://github.com/owncloud/core/issues/9782#issuecomment-50892350
