### PR TITLE
[sharing] respect "sharing allowed" setting in the share dialog

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -83,6 +83,7 @@ $array = array(
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
+				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
 				)
 			)
 	),

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -488,7 +488,7 @@ OC.Share={
 				if (possiblePermissions & OC.PERMISSION_DELETE) {
 					permissions = permissions | OC.PERMISSION_DELETE;
 				}
-				if (possiblePermissions & OC.PERMISSION_SHARE) {
+				if (oc_appconfig.core.resharingAllowed && (possiblePermissions & OC.PERMISSION_SHARE)) {
 					permissions = permissions | OC.PERMISSION_SHARE;
 				}
 
@@ -620,7 +620,7 @@ OC.Share={
 				}
 				html += '<label><input type="checkbox" name="mailNotification" class="mailNotification" ' + checked + ' />'+t('core', 'notify by email')+'</label> ';
 			}
-			if (possiblePermissions & OC.PERMISSION_SHARE) {
+			if (oc_appconfig.core.resharingAllowed && (possiblePermissions & OC.PERMISSION_SHARE)) {
 				html += '<label><input type="checkbox" name="share" class="permissions" '+shareChecked+' data-permissions="'+OC.PERMISSION_SHARE+'" />'+t('core', 'can share')+'</label>';
 			}
 			if (possiblePermissions & OC.PERMISSION_CREATE || possiblePermissions & OC.PERMISSION_UPDATE || possiblePermissions & OC.PERMISSION_DELETE) {

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1114,7 +1114,7 @@ class Share extends \OC\Share\Constants {
 	 *
 	 * Resharing is allowed by default if not configured
 	 */
-	private static function isResharingAllowed() {
+	public static function isResharingAllowed() {
 		if (!isset(self::$isResharingAllowed)) {
 			if (\OC_Appconfig::getValue('core', 'shareapi_allow_resharing', 'yes') == 'yes') {
 				self::$isResharingAllowed = true;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -330,6 +330,15 @@ class Share extends \OC\Share\Constants {
 	public static function checkPasswordProtectedShare(array $linkItem) {
 		return \OC\Share\Share::checkPasswordProtectedShare($linkItem);
 	}
+
+	/**
+	 * Check if resharing is allowed
+	 *
+	 * @return boolean true if allowed or false
+	 */
+	public static function isResharingAllowed() {
+		return \OC\Share\Share::isResharingAllowed();
+	}
 }
 
 /**


### PR DESCRIPTION
don't display a checkbox to allow resharing if it was disabled by the admin

fix #2824 

cc @nickvergessen  @jancborchardt @MorrisJobke 
