### PR TITLE
Use relative, human readable dates in OC.filePickers - Fixes #8802

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -635,7 +635,7 @@ var OCdialogs = {
 					type: entry.type,
 					dir: dir,
 					filename: entry.name,
-					date: OC.mtime2date(Math.floor(entry.mtime / 1000))
+					date: relative_modified_date(entry.mtime/1000)
 				});
 				if (entry.isPreviewAvailable) {
 					var urlSpec = {


### PR DESCRIPTION
See: https://github.com/owncloud/core/issues/8802

To test, you can install the Music app, go to Personal settings, click the box to choose your music location. 

All date elements should be at least 2 digits long. Yeah should be 4 digits.

@jancborchardt @wakeup 
