### PR TITLE
use correct app-icon class for new apps as well, fix icon size

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -283,7 +283,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					if(container.children('li[data-id="'+entry.id+'"]').length === 0){
 						var li=$('<li></li>');
 						li.attr('data-id', entry.id);
-						var img= $('<img class="icon"/>').attr({ src: entry.icon});
+						var img= $('<img class="app-icon"/>').attr({ src: entry.icon});
 						var a=$('<a></a>').attr('href', entry.href);
 						var filename=$('<span></span>');
 						filename.text(entry.name);


### PR DESCRIPTION
This makes the JS use the same app-icon class for the app icon as the PHP does. This makes sure that the max-icon-size works for apps you just enabled (as introduced by @visit1985 in https://github.com/owncloud/core/pull/9922).

Please review @visit1985 @owncloud/designers 
