### PR TITLE
Fix Folder::getById

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -405,7 +405,7 @@ class Shared_Cache extends Cache {
 	public function getPathById($id, $pathEnd = '') {
 		// direct shares are easy
 		if ($id === $this->storage->getSourceId()) {
-			return $pathEnd;
+			return ltrim($pathEnd, '/');
 		} else {
 			// if the item is a direct share we try and get the path of the parent and append the name of the item to it
 			list($parent, $name) = $this->getParentInfo($id);

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -43,6 +43,7 @@ class Shared_Cache extends Cache {
 
 	/**
 	 * Get the source cache of a shared file or folder
+	 *
 	 * @param string $target Shared target file path
 	 * @return \OC\Files\Cache\Cache
 	 */
@@ -275,7 +276,7 @@ class Shared_Cache extends Cache {
 	 */
 	public function search($pattern) {
 
-		$pattern = trim($pattern,'%');
+		$pattern = trim($pattern, '%');
 
 		$normalizedPattern = $this->normalize($pattern);
 
@@ -403,9 +404,8 @@ class Shared_Cache extends Cache {
 	 */
 	public function getPathById($id, $pathEnd = '') {
 		// direct shares are easy
-		$path = $this->getShareById($id);
-		if (is_string($path)) {
-			return ltrim($pathEnd, '/');
+		if ($id === $this->storage->getSourceId()) {
+			return $pathEnd;
 		} else {
 			// if the item is a direct share we try and get the path of the parent and append the name of the item to it
 			list($parent, $name) = $this->getParentInfo($id);
@@ -419,28 +419,14 @@ class Shared_Cache extends Cache {
 
 	/**
 	 * @param integer $id
-	 */
-	private function getShareById($id) {
-		$item = \OCP\Share::getItemSharedWithBySource('file', $id);
-		if ($item) {
-			return trim($item['file_target'], '/');
-		}
-		$item = \OCP\Share::getItemSharedWithBySource('folder', $id);
-		if ($item) {
-			return trim($item['file_target'], '/');
-		}
-		return null;
-	}
-
-	/**
-	 * @param integer $id
+	 * @return array
 	 */
 	private function getParentInfo($id) {
 		$sql = 'SELECT `parent`, `name` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
 		$query = \OC_DB::prepare($sql);
 		$result = $query->execute(array($id));
 		if ($row = $result->fetchRow()) {
-			return array($row['parent'], $row['name']);
+			return array((int)$row['parent'], $row['name']);
 		} else {
 			return array(-1, '');
 		}

--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -27,7 +27,6 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 	/**
 	 * @param string $path
-	 * @throws \OCP\Files\NotFoundException
 	 * @return string
 	 */
 	public function getRelativePath($path) {
@@ -37,7 +36,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		if ($path === $this->path) {
 			return '/';
 		} else if (strpos($path, $this->path . '/') !== 0) {
-			throw new NotFoundException();
+			return null;
 		} else {
 			$path = substr($path, strlen($this->path));
 			return $this->normalizePath($path);

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -169,32 +169,6 @@ class Root extends Folder implements Emitter {
 		}
 	}
 
-	/**
-	 * search file by id
-	 *
-	 * An array is returned because in the case where a single storage is mounted in different places the same file
-	 * can exist in different places
-	 *
-	 * @param int $id
-	 * @throws \OCP\Files\NotFoundException
-	 * @return Node[]
-	 */
-	public function getById($id) {
-		$result = Cache::getById($id);
-		if (is_null($result)) {
-			throw new NotFoundException();
-		} else {
-			list($storageId, $internalPath) = $result;
-			$nodes = array();
-			$mounts = $this->mountManager->findByStorageId($storageId);
-			foreach ($mounts as $mount) {
-				$nodes[] = $this->get($mount->getMountPoint() . $internalPath);
-			}
-			return $nodes;
-		}
-
-	}
-
 	//most operations cant be done on the root
 
 	/**

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -162,7 +162,7 @@ class Root extends Folder implements Emitter {
 			if ($this->view->file_exists($fullPath)) {
 				return $this->createNode($fullPath);
 			} else {
-				throw new NotFoundException();
+				throw new NotFoundException($path);
 			}
 		} else {
 			throw new NotPermittedException();

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -513,9 +513,6 @@ class Folder extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
 	}
 
-	/**
-	 * @expectedException \OCP\Files\NotFoundException
-	 */
 	public function testGetByIdOutsideFolder() {
 		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**
@@ -550,7 +547,8 @@ class Folder extends \PHPUnit_Framework_TestCase {
 			->will($this->returnValue($mount));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
-		$node->getById(1);
+		$result = $node->getById(1);
+		$this->assertCount(0, $result);
 	}
 
 	public function testGetByIdMultipleStorages() {

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -9,6 +9,7 @@
 namespace Test\Files\Node;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Mount\Mount;
 use OC\Files\Node\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -467,5 +468,133 @@ class Folder extends \PHPUnit_Framework_TestCase {
 
 		$file = new Node(null, null, '/foobar');
 		$this->assertFalse($folder->isSubNode($file));
+	}
+
+	public function testGetById() {
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		/**
+		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 */
+		$view = $this->getMock('\OC\Files\View');
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($this->user));
+		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$mount = new Mount($storage, '/bar');
+		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+
+		$view->expects($this->once())
+			->method('file_exists')
+			->will($this->returnValue(true));
+
+		$storage->expects($this->once())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$cache->expects($this->once())
+			->method('getPathById')
+			->with('1')
+			->will($this->returnValue('foo/qwerty'));
+
+		$root->expects($this->once())
+			->method('getMountsIn')
+			->with('/bar/foo')
+			->will($this->returnValue(array()));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->with('/bar/foo')
+			->will($this->returnValue($mount));
+
+		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
+		$result = $node->getById(1);
+		$this->assertEquals(1, count($result));
+		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotFoundException
+	 */
+	public function testGetByIdOutsideFolder() {
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		/**
+		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 */
+		$view = $this->getMock('\OC\Files\View');
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($this->user));
+		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$mount = new Mount($storage, '/bar');
+		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+
+		$storage->expects($this->once())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$cache->expects($this->once())
+			->method('getPathById')
+			->with('1')
+			->will($this->returnValue('foobar'));
+
+		$root->expects($this->once())
+			->method('getMountsIn')
+			->with('/bar/foo')
+			->will($this->returnValue(array()));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->with('/bar/foo')
+			->will($this->returnValue($mount));
+
+		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
+		$node->getById(1);
+	}
+
+	public function testGetByIdMultipleStorages() {
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		/**
+		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 */
+		$view = $this->getMock('\OC\Files\View');
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($this->user));
+		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$mount1 = new Mount($storage, '/bar');
+		$mount2 = new Mount($storage, '/bar/foo/asd');
+		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+
+		$view->expects($this->any())
+			->method('file_exists')
+			->will($this->returnValue(true));
+
+		$storage->expects($this->any())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$cache->expects($this->any())
+			->method('getPathById')
+			->with('1')
+			->will($this->returnValue('foo/qwerty'));
+
+		$root->expects($this->any())
+			->method('getMountsIn')
+			->with('/bar/foo')
+			->will($this->returnValue(array($mount2)));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->with('/bar/foo')
+			->will($this->returnValue($mount1));
+
+		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
+		$result = $node->getById(1);
+		$this->assertEquals(2, count($result));
+		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
+		$this->assertEquals('/bar/foo/asd/foo/qwerty', $result[1]->getPath());
 	}
 }


### PR DESCRIPTION
Fixes #10173

With the removal of the Shared folder the logic for `View::getPath($id)` was updated but `Folder::getById($id)` was forgotten.

cc @MorrisJobke @DeepDiver1975 
