### PR TITLE
Adding link tag to enable facebook timeline previews

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -1,4 +1,9 @@
 <?php /** @var $l OC_L10N */ ?>
+<?php $thumbSize=1024; ?>
+<?php if ( \OC\Preview::isMimeSupported($_['mimetype'])): /* This enables preview images for links (e.g. on Facebook, Google+, ...)*/?>
+	<link rel="image_src" href="<?php p(OCP\Util::linkToRoute( 'core_ajax_public_preview', array('x' => $thumbSize, 'y' => $thumbSize, 'file' => $_['directory_path'], 't' => $_['dirToken']))); ?>" />
+<?php endif; ?>
+
 <div id="notification-container">
 	<div id="notification" style="display: none;"></div>
 </div>


### PR DESCRIPTION
added tag to make facebook load a preview picture

Update public.php

add check ifMimeSupported and put the thumbsize in a variable

generate preview for all supported mimes
