### PR TITLE
apps/files_sharing: fix path resolution

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -404,10 +404,10 @@ class Shared_Cache extends Cache {
 	public function getPathById($id, $pathEnd = '') {
 		// direct shares are easy
 		$path = $this->getShareById($id);
-		if (is_string($path)) {
+		if (is_string($path) && $this->storage->getSourceId() == $id) {
 			return ltrim($pathEnd, '/');
 		} else {
-			// if the item is a direct share we try and get the path of the parent and append the name of the item to it
+			// if the item is not a direct share we try and get the path of the parent and append the name of the item to it
 			list($parent, $name) = $this->getParentInfo($id);
 			if ($parent > 0) {
 				return $this->getPathById($parent, '/' . $name . $pathEnd);


### PR DESCRIPTION
Currently, the documments app failes to edit files on a share.
This is due to \OCS\Files\View::getPathById to return an invalid
path for any fileid on a share.
This is due to Shared_Cache::getPathById to always return a local
path, even if the requested file is not present on this share.
This happens because the recursion using getParentInfo happens until
a shared folder (parent to the fileid requested) is found, and then
the local path relativ to that is used. If this Cache belonged to
a different share than the one found, the returned path is incorrect.

Further, this does not even handle the case when there are multiple
shares, with one shared folder is nested within another shared folder,
as the recursion will stop once the inner share is visited.

This patch fixes this by checking that the share found actually is
the one this cache and its backend storage belongs to.

This fixes the document app for me.
