### PR TITLE
add logout hook to remove keys from session

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -123,6 +123,14 @@ class Hooks {
 	}
 
 	/**
+	 * remove keys from session during logout
+	 */
+	public static function logout() {
+		$session = new \OCA\Encryption\Session(new \OC\Files\View());
+		$session->removeKeys();
+	}
+
+	/**
 	 * setup encryption backend upon user created
 	 * @note This method should never be called for users using client side encryption
 	 */
@@ -173,7 +181,6 @@ class Hooks {
 	 * @param array $params keys: uid, password
 	 */
 	public static function setPassphrase($params) {
-
 		if (\OCP\App::isEnabled('files_encryption') === false) {
 			return true;
 		}

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -49,6 +49,7 @@ class Helper {
 	public static function registerUserHooks() {
 
 		\OCP\Util::connectHook('OC_User', 'post_login', 'OCA\Encryption\Hooks', 'login');
+		\OCP\Util::connectHook('OC_User', 'logout', 'OCA\Encryption\Hooks', 'logout');
 		\OCP\Util::connectHook('OC_User', 'post_setPassword', 'OCA\Encryption\Hooks', 'setPassphrase');
 		\OCP\Util::connectHook('OC_User', 'pre_setPassword', 'OCA\Encryption\Hooks', 'preSetPassphrase');
 		\OCP\Util::connectHook('OC_User', 'post_createUser', 'OCA\Encryption\Hooks', 'postCreateUser');

--- a/apps/files_encryption/lib/session.php
+++ b/apps/files_encryption/lib/session.php
@@ -122,6 +122,14 @@ class Session {
 	}
 
 	/**
+	 * remove keys from session
+	 */
+	public function removeKeys() {
+		\OC::$session->remove('publicSharePrivateKey');
+		\OC::$session->remove('privateKey');
+	}
+
+	/**
 	 * Sets status of encryption app
 	 * @param string $init INIT_SUCCESSFUL, INIT_EXECUTED, NOT_INITIALIZED
 	 * @return bool

--- a/apps/files_encryption/templates/settings-personal.php
+++ b/apps/files_encryption/templates/settings-personal.php
@@ -9,14 +9,13 @@
 		<p>
 			<a name="changePKPasswd" />
 			<label for="changePrivateKeyPasswd">
-				<?php p( $l->t( "Your private key password no longer match your log-in password:" ) ); ?>
+				<em><?php p( $l->t( "Your private key password no longer match your log-in password." ) ); ?></em>
 			</label>
 			<br />
-			<em><?php p( $l->t( "Set your old private key password to your current log-in password." ) ); ?>
+			<?php p( $l->t( "Set your old private key password to your current log-in password:" ) ); ?>
 			<?php if (  $_["recoveryEnabledForUser"] ):
 					p( $l->t( " If you don't remember your old password you can ask your administrator to recover your files." ) );
 			endif; ?>
-			</em>
 			<br />
 			<input
 				type="password"


### PR DESCRIPTION
fix #10232 

we reuse the old session if you logout and directly login again. The old session still contains the unencrypted keys even if the password changed in the meantime. This PR removes the keys from the session during logout. This also guarantees that we don't store the unencrypted keys longer as necessary in the session.

cc @DeepDiver1975 @icewind1991 @MorrisJobke please review it. Thanks!
