### PR TITLE
file size on non-(Linux/BSD/Windows)-installations

### DIFF
--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -147,7 +147,7 @@ class LargeFileHelper {
 		if (\OC_Helper::is_function_enabled('exec')) {
 			$os = strtolower(php_uname('s'));
 			$arg = escapeshellarg($filename);
-			$result = '';
+			$result = null;
 			if (strpos($os, 'linux') !== false) {
 				$result = $this->exec("stat -c %s $arg");
 			} else if (strpos($os, 'bsd') !== false) {


### PR DESCRIPTION
Determining the file size using the exec() method is implemented for Linux, BSD, and Windows. However, on systems matching neither platform name (like SunOS), the fall-through path will return a file size result constituting a zero size instead of an invalid null return value.
