### PR TITLE
ldap_ prefix will be added in invokeLDAPMethod(), having it would lead t...

### DIFF
--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -106,7 +106,7 @@ class LDAP implements ILDAPWrapper {
 	 * @link http://www.php.net/manual/en/function.ldap-explode-dn.php
 	 */
 	public function explodeDN($dn, $withAttrib) {
-		return $this->invokeLDAPMethod('ldap_explode_dn', $dn, $withAttrib);
+		return $this->invokeLDAPMethod('explode_dn', $dn, $withAttrib);
 	}
 
 	/**


### PR DESCRIPTION
...o a unexisting function, fixes #9829

This was not  detected by unit tests, because Jenkins does not have LDAP module (and therefore the tests are written to avoid LDAP functions). We should change that.

The fix is less than a  one-liner… The removed ldap_ prefix (see diff) will be added in invokeLDAPMethod(), i.e. it was doubled and thus led to the bug.

How to test:
- have LDAP set up 
- delete User Mappings on Expert tab  (not in production system  of course!!!)
- go to the Users page
- check whether `Invalid argument supplied for foreach() at /var/www/owncloud/apps/user_ldap/lib/access.php#201` appears in the log file (before, bad) or not (now, good).

Please test/review @4lfr3d7115 @xtruthx @prislea or others, thx!
