### PR TITLE
Possible fix for sharing a direct link #8180

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,7 +32,7 @@ RewriteRule ^(.*)$ - [ENV=URI:$1]
 RewriteCond %{ENV:BASE} ^$
 RewriteCond %{ENV:URI}::%{REQUEST_URI} ^(.*)::(.*?)\1$
 RewriteRule ^ - [ENV=BASE:%2]
-RewriteRule ^public/(.*)$ %{ENV:BASE}index.php/apps/files_sharing/ajax/publicpreview.php?x=1280&y=899&a=true&t=$1&scalingup=0 [R,L]
+RewriteRule ^public/(.*)$ %{ENV:BASE}index.php/apps/files_sharing/ajax/publicpreview.php?x=99999999&y=99999999&a=true&t=$1&scalingup=0 [R,L]
 
 </IfModule>
 <IfModule mod_mime.c>

--- a/.htaccess
+++ b/.htaccess
@@ -25,7 +25,15 @@ RewriteRule ^\.well-known/caldav /remote.php/caldav/ [R]
 RewriteRule ^apps/calendar/caldav\.php remote.php/caldav/ [QSA,L]
 RewriteRule ^apps/contacts/carddav\.php remote.php/carddav/ [QSA,L]
 RewriteRule ^remote/(.*) remote.php [QSA,L]
-RewriteRule ^test/([^/]*)$ index.php/apps/files_sharing/ajax/publicpreview.php?x=1280&y=899&a=true&t=$1&scalingup=0 [QSA,L]
+
+#Enable short share urls(eg: host.com/public/$1
+RewriteCond %{ENV:URI} ^$
+RewriteRule ^(.*)$ - [ENV=URI:$1]
+RewriteCond %{ENV:BASE} ^$
+RewriteCond %{ENV:URI}::%{REQUEST_URI} ^(.*)::(.*?)\1$
+RewriteRule ^ - [ENV=BASE:%2]
+RewriteRule ^public/(.*)$ %{ENV:BASE}index.php/apps/files_sharing/ajax/publicpreview.php?x=1280&y=899&a=true&t=$1&scalingup=0 [R,L]
+
 </IfModule>
 <IfModule mod_mime.c>
 AddType image/svg+xml svg svgz

--- a/.htaccess
+++ b/.htaccess
@@ -25,6 +25,7 @@ RewriteRule ^\.well-known/caldav /remote.php/caldav/ [R]
 RewriteRule ^apps/calendar/caldav\.php remote.php/caldav/ [QSA,L]
 RewriteRule ^apps/contacts/carddav\.php remote.php/carddav/ [QSA,L]
 RewriteRule ^remote/(.*) remote.php [QSA,L]
+RewriteRule ^test/([^/]*)$ index.php/apps/files_sharing/ajax/publicpreview.php?x=1280&y=899&a=true&t=$1&scalingup=0 [QSA,L]
 </IfModule>
 <IfModule mod_mime.c>
 AddType image/svg+xml svg svgz


### PR DESCRIPTION
More info see https://github.com/owncloud/core/issues/8180#issuecomment-51488885

How to build a test url
- Share an image
- you get an url like
  `https://xxx.xxxx.com/public.php?service=files&t=c6b8bb0f7d87fb4f4635bf47f0ce8c29`
  copy the t value -> `c6b8bb0f7d87fb4f4635bf47f0ce8c29`
  And then go to
  http://domain.com/public/c6b8bb0f7d87fb4f4635bf47f0ce8c29

Expected behaviour:
See the image full size.

Actual behaviour:
Redirect to files app
