### PR TITLE
Fix display of checkboxes in Pale Moon

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -354,8 +354,6 @@ table td.filename .uploadtext {
 	z-index: 5;
 }
 #fileList tr td.filename>input[type="checkbox"]{
-	/* sometimes checkbox height is bigger (KDE/Qt), so setting to absolute
-	 * to prevent it to increase the height */
 	position: relative;
 	z-index: 4;
 }

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -349,14 +349,15 @@ table td.filename .uploadtext {
 #fileList tr td.filename>input[type="checkbox"] + label,
 .select-all + label {
 	height: 50px;
-	position: absolute;
+	position: relative;
 	width: 50px;
 	z-index: 5;
 }
 #fileList tr td.filename>input[type="checkbox"]{
 	/* sometimes checkbox height is bigger (KDE/Qt), so setting to absolute
 	 * to prevent it to increase the height */
-	position: absolute;
+	position: relative;
+	z-index: 4;
 }
 #fileList tr td.filename>input[type="checkbox"] + label {
 	left: 0;


### PR DESCRIPTION
In Pale Moon (24.7.1) the checkboxes in the file list are not in the responding line on the icon but all of them are next to the "select all" checkbox.
This fix should not change anything in Firefox and chromium (on windows) but as the comment states it has to be checked on KDE/Qt.
BTW why is position absolute naccessary? For my understanding relative is exactly what you want to use in such a case...
