### PR TITLE
trigger lazy loading earlier, fix #9823

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -400,7 +400,7 @@
 		 * This appends/renders the next page of entries when reaching the bottom.
 		 */
 		_onScroll: function(e) {
-			if (this.$container.scrollTop() + this.$container.height() > this.$el.height() - 100) {
+			if (this.$container.scrollTop() + this.$container.height() > this.$el.height() - 300) {
 				this._nextPage(true);
 			}
 		},


### PR DESCRIPTION
Currently lazy loading is triggered a bit too late. When you scroll down, you already see the footer of the file list and a bit more whitespace before the next set of files loads. This triggers it well before the end of the list is reached.

 fix #9823 

Please review @PVince81 @owncloud/designers
