### PR TITLE
don't show share dialog and navigation entry if sharing was disabled for the user

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -33,21 +33,25 @@ OC_FileProxy::register(new OCA\Files\Share\Proxy());
 		"name" => $l->t('Shared with you')
 	)
 );
-\OCA\Files\App::getNavigationManager()->add(
-	array(
-		"id" => 'sharingout',
-		"appname" => 'files_sharing',
-		"script" => 'list.php',
-		"order" => 15,
-		"name" => $l->t('Shared with others')
-	)
-);
-\OCA\Files\App::getNavigationManager()->add(
-	array(
-		"id" => 'sharinglinks',
-		"appname" => 'files_sharing',
-		"script" => 'list.php',
-		"order" => 20,
-		"name" => $l->t('Shared by link')
-	)
-);
+
+if (\OCP\Util::isSharingDisabledForUser() === false) {
+
+	\OCA\Files\App::getNavigationManager()->add(
+			array(
+				"id" => 'sharingout',
+				"appname" => 'files_sharing',
+				"script" => 'list.php',
+				"order" => 15,
+				"name" => $l->t('Shared with others')
+			)
+	);
+	\OCA\Files\App::getNavigationManager()->add(
+			array(
+				"id" => 'sharinglinks',
+				"appname" => 'files_sharing',
+				"script" => 'list.php',
+				"order" => 20,
+				"name" => $l->t('Shared by link')
+			)
+	);
+}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -960,6 +960,10 @@ class View {
 					$content['permissions'] = $storage->getPermissions($content['path']);
 					$cache->update($content['fileid'], array('permissions' => $content['permissions']));
 				}
+				// if sharing was disabled for the user we remove the share permissions
+				if (\OCP\Util::isSharingDisabledForUser()) {
+					$content['permissions'] = $content['permissions'] & ~\OCP\PERMISSION_SHARE;
+				}
 				$files[] = new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content);
 			}
 
@@ -1008,6 +1012,12 @@ class View {
 								}
 							}
 							$rootEntry['path'] = substr($path . '/' . $rootEntry['name'], strlen($user) + 2); // full path without /$user/
+
+							// if sharing was disabled for the user we remove the share permissions
+							if (\OCP\Util::isSharingDisabledForUser()) {
+								$content['permissions'] = $content['permissions'] & ~\OCP\PERMISSION_SHARE;
+							}
+
 							$files[] = new FileInfo($path . '/' . $rootEntry['name'], $subStorage, '', $rootEntry);
 						}
 					}


### PR DESCRIPTION
don't show share dialog and navigation entry if sharing was disabled for the user, fix #10273 

cc @icewind1991 please have a look at it, thanks!
