### PR TITLE
Fix trashbin when deleting a file over an external share

### DIFF
--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -54,7 +54,6 @@ $server->subscribeEvent('beforeMethod', function () use ($server, $objectTree, $
 	$ownerView = \OC\Files\Filesystem::getView();
 	$path = $ownerView->getPath($fileId);
 
-
 	$view = new \OC\Files\View($ownerView->getAbsolutePath($path));
 	$rootInfo = $view->getFileInfo('');
 

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -22,6 +22,8 @@
 
 namespace OCA\Files_Trashbin;
 
+use OC\Files\Filesystem;
+
 class Trashbin {
 	// how long do we keep files in the trash bin if no other value is defined in the config file (unit: days)
 
@@ -99,7 +101,9 @@ class Trashbin {
 	 * @param string $file_path path to the deleted file/directory relative to the files root directory
 	 */
 	public static function move2trash($file_path) {
-		$user = \OCP\User::getUser();
+		// get the user for which the filesystem is setup
+		$root = Filesystem::getRoot();
+		list(, $user) = explode('/', $root);
 		$size = 0;
 		list($owner, $ownerPath) = self::getUidAndFilename($file_path);
 		self::setUpTrash($user);


### PR DESCRIPTION
files_trashbin needs to access the current logged in user to do it's work.

Fixes #9094

cc @schiesbn @DeepDiver1975 @PVince81 
