### PR TITLE
file actions improved error handling

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -26,7 +26,7 @@ $success = true;
 
 //Now delete
 foreach ($files as $file) {
-	if (($dir === '' && $file === 'Shared') || !\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
+	if (!\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
 		$filesWithError .= $file . "\n";
 		$success = false;
 	}

--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -26,7 +26,8 @@ $success = true;
 
 //Now delete
 foreach ($files as $file) {
-	if (!\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
+	if (\OC\Files\Filesystem::file_exists($dir . '/' . $file) &&
+			!\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
 		$filesWithError .= $file . "\n";
 		$success = false;
 	}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1322,6 +1322,10 @@
 								if (!result || result.status === 'error') {
 									OC.dialogs.alert(result.data.message, t('core', 'Could not rename file'));
 									fileInfo = oldFileInfo;
+									if (result.data.code === 'sourcenotfound') {
+										self.remove(result.data.newname, {updateSummary: true});
+										return;
+									}
 								}
 								else {
 									fileInfo = result.data;

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -71,15 +71,25 @@ class App {
 			'data'		=> NULL
 		);
 
+		$normalizedOldPath = \OC\Files\Filesystem::normalizePath($dir . '/' . $oldname);
+		$normalizedNewPath = \OC\Files\Filesystem::normalizePath($dir . '/' . $newname);
+
 		// rename to non-existing folder is denied
-		if (!$this->view->file_exists($dir)) {
+		if (!$this->view->file_exists($normalizedOldPath)) {
+			$result['data'] = array(
+				'message'	=> $this->l10n->t('%s could not be renamed as it has been deleted', array($oldname)),
+				'code' => 'sourcenotfound',
+				'oldname' => $oldname,
+				'newname' => $newname,
+			);
+		}else if (!$this->view->file_exists($dir)) {
 			$result['data'] = array('message' => (string)$this->l10n->t(
 					'The target folder has been moved or deleted.',
 					array($dir)),
 					'code' => 'targetnotfound'
 				);
 		// rename to existing file is denied
-		} else if ($this->view->file_exists($dir . '/' . $newname)) {
+		} else if ($this->view->file_exists($normalizedNewPath)) {
 
 			$result['data'] = array(
 				'message'	=> $this->l10n->t(
@@ -90,10 +100,10 @@ class App {
 			// rename to "." is denied
 			$newname !== '.' and
 			// THEN try to rename
-			$this->view->rename($dir . '/' . $oldname, $dir . '/' . $newname)
+			$this->view->rename($normalizedOldPath, $normalizedNewPath)
 		) {
 			// successful rename
-			$meta = $this->view->getFileInfo($dir . '/' . $newname);
+			$meta = $this->view->getFileInfo($normalizedNewPath);
 			$fileinfo = \OCA\Files\Helper::formatFileInfo($meta);
 			$result['success'] = true;
 			$result['data'] = $fileinfo;


### PR DESCRIPTION
- add a error message if the user tries to rename a file which no longer exists and remove the file from his file list
- no special treatment for a folder called "Shared"
- no error on delete if the file/folder doesn't exists

fix #10259
