### PR TITLE
Don't use /Shared as a base for links in share email

### DIFF
--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -100,13 +100,19 @@ class MailNotifications {
 			}
 
 			// Link to folder, or root folder if a file
+
 			if ($itemType === 'folder') {
-				$foldername =  $filename;
+				$args = array(
+					'dir' => $filename,
+				);
 			} else {
-				$foldername = "/";
+				$args = array(
+					'dir' => '/',
+					'scrollto' => $filename,
+				);
 			}
 
-			$link = \OCP\Util::linkToAbsolute('files', 'index.php', array("dir" => $foldername));
+			$link = \OCP\Util::linkToAbsolute('files', 'index.php', $args);
 
 			list($htmlMail, $alttextMail) = $this->createMailBody($filename, $link, $expiration);
 

--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -99,12 +99,11 @@ class MailNotifications {
 				}
 			}
 
+			// Link to folder, or root folder if a file
 			if ($itemType === 'folder') {
-				$foldername = "/Shared/" . $filename;
+				$foldername =  $filename;
 			} else {
-				// if it is a file we can just link to the Shared folder,
-				// that's the place where the user will find the file
-				$foldername = "/Shared";
+				$foldername = "/";
 			}
 
 			$link = \OCP\Util::linkToAbsolute('files', 'index.php', array("dir" => $foldername));


### PR DESCRIPTION
I noticed that all share email notifications base to /Shared.

Added scrollto=$filename to the url, but also noticed this has been commented out for quite a while, can't think why: https://github.com/owncloud/core/commit/9d38e3602b2faf37d861729c52690ce51b8fee97

@PVince81 ^ ?

@karlitschek 
