### PR TITLE
fix old Japanese language code redirection

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -39,7 +39,7 @@ $enableDecryptAll = $filesStillEncrypted || $backupKeysExists;
 
 // array of common languages
 $commonlangcodes = array(
-	'en', 'es', 'fr', 'de', 'de_DE', 'ja_JP', 'ar', 'ru', 'nl', 'it', 'pt_BR', 'pt_PT', 'da', 'fi_FI', 'nb_NO', 'sv', 'tr', 'zh_CN', 'ko'
+	'en', 'es', 'fr', 'de', 'de_DE', 'ja', 'ar', 'ru', 'nl', 'it', 'pt_BR', 'pt_PT', 'da', 'fi_FI', 'nb_NO', 'sv', 'tr', 'zh_CN', 'ko'
 );
 
 $languageNames=include 'languageCodes.php';


### PR DESCRIPTION
ja_JP has not been updated since March and the reference
to this language should be removed. It also exists as _ja_
on Transifex. Discussion is here: #10281 

@DeepDiver1975 @MorrisJobke 

This should be backported to stable7 and stable6 as well.

Later on, we will remove all obsolete ja_JP.php files.
