### PR TITLE
Fix Tar support for php >=5.5

### DIFF
--- a/tests/lib/archive/tar.php
+++ b/tests/lib/archive/tar.php
@@ -10,12 +10,6 @@ require_once 'archive.php';
 
 if (!OC_Util::runningOnWindows()) {
 class Test_Archive_TAR extends Test_Archive {
-	public function setUp() {
-		if (floatval(phpversion())>=5.5) {
-			$this->markTestSkipped('php 5.5 changed unpack function.');
-			return;
-		}
-	}
 	protected function getExisting() {
 		$dir = OC::$SERVERROOT . '/tests/data';
 		return new OC_Archive_TAR($dir . '/data.tar.gz');


### PR DESCRIPTION
Updater Archive_Tar to fix tar support for php 5.5 and higher.

See owncloud/3rdparty#111

cc @DeepDiver1975 @PVince81 
