### PR TITLE
Fix issue when no apps are enabled

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -172,6 +172,7 @@ class OC_App {
 		if (!$forceRefresh && !empty(self::$enabledAppsCache)) {
 			return self::$enabledAppsCache;
 		}
+		$apps = array();
 		$appConfig = \OC::$server->getAppConfig();
 		$appStatus = $appConfig->getValues(false, 'enabled');
 		$user = \OC_User::getUser();


### PR DESCRIPTION
Properly initialize $apps array

Fixes #9770 

Note: this only happens if ZERO app is enabled.

Please review @tomneedham @MorrisJobke @schiesbn @MorrisJobke 
