### PR TITLE
Fixed default quota field on user management page

### DIFF
--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -43,15 +43,26 @@
                 var areaSelector = $(button).data('apps-slide-toggle');
                 var area = $(areaSelector);
 
+				function hideArea() {
+					area.slideUp(function() {
+						area.trigger(new $.Event('hide'));
+					});
+				}
+				function showArea() {
+					area.slideDown(function() {
+						area.trigger(new $.Event('show'));
+					});
+				}
+
                 // do nothing if the area is animated
                 if (!area.is(':animated')) {
 
                     // button toggles the area
                     if (button === event.target) {
                         if (area.is(':visible')) {
-                            area.slideUp();
+                            hideArea();
                         } else {
-                            area.slideDown();
+                            showArea();
                         }
 
                     // all other areas that have not been clicked but are open
@@ -59,7 +70,7 @@
                     } else {
                         var closest = $(event.target).closest(areaSelector);
                         if (area.is(':visible') && closest[0] !== area[0]) {
-                            area.slideUp();
+                            hideArea();
                         }
                     }
                 }

--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -10,38 +10,38 @@
 
 (function (document, $, exports) {
 
-    'use strict';
+	'use strict';
 
-    var dynamicSlideToggleEnabled = false;
+	var dynamicSlideToggleEnabled = false;
 
-    exports.Apps = {
-        enableDynamicSlideToggle: function () {
-            dynamicSlideToggleEnabled = true;
-        }
-    };
+	exports.Apps = {
+		enableDynamicSlideToggle: function () {
+			dynamicSlideToggleEnabled = true;
+		}
+	};
 
-    /**
-     * Provides a way to slide down a target area through a button and slide it
-     * up if the user clicks somewhere else. Used for the news app settings and
-     * add new field.
-     *
-     * Usage:
-     * <button data-apps-slide-toggle=".slide-area">slide</button>
-     * <div class=".slide-area" class="hidden">I'm sliding up</div>
-     */
-    var registerAppsSlideToggle = function () {
-        var buttons = $('[data-apps-slide-toggle]');
+	/**
+	 * Provides a way to slide down a target area through a button and slide it
+	 * up if the user clicks somewhere else. Used for the news app settings and
+	 * add new field.
+	 *
+	 * Usage:
+	 * <button data-apps-slide-toggle=".slide-area">slide</button>
+	 * <div class=".slide-area" class="hidden">I'm sliding up</div>
+	 */
+	var registerAppsSlideToggle = function () {
+		var buttons = $('[data-apps-slide-toggle]');
 
-        $(document).click(function (event) {
+		$(document).click(function (event) {
 
-            if (dynamicSlideToggleEnabled) {
-                buttons = $('[data-apps-slide-toggle]');
-            }
+			if (dynamicSlideToggleEnabled) {
+				buttons = $('[data-apps-slide-toggle]');
+			}
 
-            buttons.each(function (index, button) {
+			buttons.each(function (index, button) {
 
-                var areaSelector = $(button).data('apps-slide-toggle');
-                var area = $(areaSelector);
+				var areaSelector = $(button).data('apps-slide-toggle');
+				var area = $(areaSelector);
 
 				function hideArea() {
 					area.slideUp(function() {
@@ -54,34 +54,34 @@
 					});
 				}
 
-                // do nothing if the area is animated
-                if (!area.is(':animated')) {
+				// do nothing if the area is animated
+				if (!area.is(':animated')) {
 
-                    // button toggles the area
-                    if (button === event.target) {
-                        if (area.is(':visible')) {
-                            hideArea();
-                        } else {
-                            showArea();
-                        }
+					// button toggles the area
+					if (button === event.target) {
+						if (area.is(':visible')) {
+							hideArea();
+						} else {
+							showArea();
+						}
 
-                    // all other areas that have not been clicked but are open
-                    // should be slid up
-                    } else {
-                        var closest = $(event.target).closest(areaSelector);
-                        if (area.is(':visible') && closest[0] !== area[0]) {
-                            hideArea();
-                        }
-                    }
-                }
-            });
+					// all other areas that have not been clicked but are open
+					// should be slid up
+					} else {
+						var closest = $(event.target).closest(areaSelector);
+						if (area.is(':visible') && closest[0] !== area[0]) {
+							hideArea();
+						}
+					}
+				}
+			});
 
-        });
-    };
+		});
+	};
 
 
-    $(document).ready(function () {
-        registerAppsSlideToggle();
-    });
+	$(document).ready(function () {
+		registerAppsSlideToggle();
+	});
 
 }(document, jQuery, OC));

--- a/core/js/singleselect.js
+++ b/core/js/singleselect.js
@@ -2,9 +2,13 @@
 	$.fn.singleSelect = function () {
 		return this.each(function (i, select) {
 			var input = $('<input/>'),
+				gravity = $(select).attr('data-gravity'),
 				inputTooltip = $(select).attr('data-inputtitle');
 			if (inputTooltip){
 				input.attr('title', inputTooltip);
+			}
+			if (typeof gravity === 'undefined') {
+				gravity = 'n'
 			}
 			select = $(select);
 			input.css('position', 'absolute');
@@ -35,7 +39,7 @@
 					input.css(select.offset());
 					input.show();
 					if ($.fn.tipsy){
-						input.tipsy({gravity: 'n', trigger: 'manual'});
+						input.tipsy({gravity: gravity, trigger: 'manual'});
 						input.tipsy('show');
 					}
 					select.css('background-color', 'white');

--- a/core/js/singleselect.js
+++ b/core/js/singleselect.js
@@ -87,6 +87,10 @@
 					$(this).tipsy('hide');
 				}
 			});
+			input.click(function(ev) {
+				// prevent clicks to close any container
+				ev.stopPropagation();
+			});
 		});
 	};
 })(jQuery);

--- a/core/js/singleselect.js
+++ b/core/js/singleselect.js
@@ -2,7 +2,7 @@
 	$.fn.singleSelect = function () {
 		return this.each(function (i, select) {
 			var input = $('<input/>'),
-				gravity = $(select).attr('data-gravity'),
+				gravity = $(select).attr('data-tipsy-gravity'),
 				inputTooltip = $(select).attr('data-inputtitle');
 			if (inputTooltip){
 				input.attr('title', inputTooltip);

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -289,28 +289,4 @@ $(document).ready( function () {
 	$userGroupList.on('click', '.isgroup', function () {
 		GroupList.showGroup(GroupList.getElementGID(this));
 	});
-
-	// Implements Quota Settings Toggle.
-	var $appSettings = $('#app-settings');
-	$('#app-settings-header').on('click keydown',function(event) {
-		if(wrongKey(event)) {
-			return;
-		}
-		if($appSettings.hasClass('open')) {
-			$appSettings.switchClass('open', '');
-		} else {
-			$appSettings.switchClass('', 'open');
-		}
-	});
-	$('body').on('click', function(event){
-		if($appSettings.find(event.target).length === 0) {
-			$appSettings.switchClass('open', '');
-		}
-	});
-
 });
-
-var wrongKey = function(event) {
-	return ((event.type === 'keydown' || event.type === 'keypress') &&
-		(event.keyCode !== 32 && event.keyCode !== 13));
-};

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -6,7 +6,7 @@
 		<!-- Default storage -->
 		<span><?php p($l->t('Default Quota'));?></span>
 		<?php if((bool) $_['isAdmin']): ?>
-			<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-gravity="s">
+			<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-tipsy-gravity="s">
 				<option <?php if($_['default_quota'] === 'none') print_unescaped('selected="selected"');?> value='none'>
 					<?php p($l->t('Unlimited'));?>
 				</option>

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -1,5 +1,5 @@
 <div id="app-settings-header">
-	<button class="settings-button" tabindex="0"></button>
+	<button class="settings-button" tabindex="0" data-apps-slide-toggle="#app-settings-content"></button>
 </div>
 <div id="app-settings-content">
 	<div class="quota">

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -6,7 +6,7 @@
 		<!-- Default storage -->
 		<span><?php p($l->t('Default Quota'));?></span>
 		<?php if((bool) $_['isAdmin']): ?>
-			<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>">
+			<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-gravity="s">
 				<option <?php if($_['default_quota'] === 'none') print_unescaped('selected="selected"');?> value='none'>
 					<?php p($l->t('Unlimited'));?>
 				</option>


### PR DESCRIPTION
Fix default quota settings field

The default quota settings field is initially hidden which makes it impossible for singleSelect() to make its width measurements.

This fix uses the app navigation slide "show" event to defer the singleSelect() initialization on the default quota field.

To make this work, the app slide toggle was changed to trigger "show" and "hide" events when slid.

Fixes #10178 

Please review @blizzz @MorrisJobke @raghunayyar @jancborchardt 
