### PR TITLE
better check whether string resembles a DN, fixes #9887

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -141,6 +141,18 @@ class Access extends LDAPUtility implements user\IUserTools {
 	}
 
 	/**
+	 * checks whether the given string is probably a DN
+	 * @param string $string
+	 * @return boolean
+	 */
+	public function stringResemblesDN($string) {
+		$r = $this->ldap->explodeDN($string, 0);
+		// if exploding a DN succeeds and does not end up in
+		// an empty array except for $r[count] being 0.
+		return (is_array($r) && count($r) > 1);
+	}
+
+	/**
 	 * sanitizes a DN received from the LDAP server
 	 * @param array $dn the DN in question
 	 * @return array the sanitized DN

--- a/apps/user_ldap/lib/user/iusertools.php
+++ b/apps/user_ldap/lib/user/iusertools.php
@@ -33,6 +33,8 @@ interface IUserTools {
 
 	public function readAttribute($dn, $attr, $filter = 'objectClass=*');
 
+	public function stringResemblesDN($string);
+
 	public function dn2username($dn, $ldapname = null);
 
 	public function username2dn($name);

--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -143,8 +143,7 @@ class Manager {
 			return $this->users['byUid'][$id];
 		}
 
-		if(strpos(mb_strtolower($id, 'UTF-8'), 'dc=') === false
-		   && strpos(mb_strtolower($id, 'UTF-8'), 'uid=') === false ) {
+		if(!$this->access->stringResemblesDN($id) ) {
 			//most likely a uid
 			$dn = $this->access->username2dn($id);
 			if($dn !== false) {

--- a/apps/user_ldap/tests/access.php
+++ b/apps/user_ldap/tests/access.php
@@ -156,4 +156,80 @@ class Test_Access extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame($expected, $access->getDomainDNFromDN($inputDN));
 	}
+
+	public function stringResemblesDNYes() {
+		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
+		$access = new Access($con, $lw, $um);
+
+		$input = 'foo=bar,bar=foo,dc=foobar';
+		$interResult = array(
+			'count' => 3,
+			0 => 'foo=bar',
+			1 => 'bar=foo',
+			2 => 'dc=foobar'
+		);
+
+		$lw->expects($this->once())
+			->method('explodeDN')
+			->will($this->returnValue($interResult));
+
+		$this->assertTrue($access->stringResemblesDN($input));
+	}
+
+	public function stringResemblesDNYesLDAPmod() {
+		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
+		$lw = new \OCA\user_ldap\lib\LDAP();
+		$access = new Access($con, $lw, $um);
+
+		if(!function_exists('ldap_explode_dn')) {
+			$this->markTestSkipped('LDAP Module not available');
+		}
+
+		$input = 'foo=bar,bar=foo,dc=foobar';
+		$interResult = array(
+			'count' => 3,
+			0 => 'foo=bar',
+			1 => 'bar=foo',
+			2 => 'dc=foobar'
+		);
+
+		$lw->expects($this->once())
+			->method('explodeDN')
+			->will($this->returnValue($interResult));
+
+		$this->assertTrue($access->stringResemblesDN($input));
+	}
+
+	public function stringResemblesDNNo() {
+		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
+		$access = new Access($con, $lw, $um);
+
+		$input = 'foobarbarfoodcfoobar';
+		$interResult = false;
+
+		$lw->expects($this->once())
+			->method('explodeDN')
+			->will($this->returnValue($interResult));
+
+		$this->assertFalse($access->stringResemblesDN($input));
+	}
+
+	public function stringResemblesDNNoLDAPMod() {
+		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
+		$lw = new \OCA\user_ldap\lib\LDAP();
+		$access = new Access($con, $lw, $um);
+
+		if(!function_exists('ldap_explode_dn')) {
+			$this->markTestSkipped('LDAP Module not available');
+		}
+
+		$input = 'foobarbarfoodcfoobar';
+		$interResult = false;
+
+		$lw->expects($this->once())
+			->method('explodeDN')
+			->will($this->returnValue($interResult));
+
+		$this->assertFalse($access->stringResemblesDN($input));
+	}
 }

--- a/apps/user_ldap/tests/access.php
+++ b/apps/user_ldap/tests/access.php
@@ -157,26 +157,48 @@ class Test_Access extends \PHPUnit_Framework_TestCase {
 		$this->assertSame($expected, $access->getDomainDNFromDN($inputDN));
 	}
 
-	public function stringResemblesDNYes() {
+	private function getResemblesDNInputData() {
+		return  $cases = array(
+			array(
+				'input' => 'foo=bar,bar=foo,dc=foobar',
+				'interResult' => array(
+					'count' => 3,
+					0 => 'foo=bar',
+					1 => 'bar=foo',
+					2 => 'dc=foobar'
+				),
+				'expectedResult' => true
+			),
+			array(
+				'input' => 'foobarbarfoodcfoobar',
+				'interResult' => false,
+				'expectedResult' => false
+			)
+		);
+	}
+
+	public function testStringResemblesDN() {
 		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
 		$access = new Access($con, $lw, $um);
 
-		$input = 'foo=bar,bar=foo,dc=foobar';
-		$interResult = array(
-			'count' => 3,
-			0 => 'foo=bar',
-			1 => 'bar=foo',
-			2 => 'dc=foobar'
-		);
+		$cases = $this->getResemblesDNInputData();
 
-		$lw->expects($this->once())
+		$lw->expects($this->exactly(2))
 			->method('explodeDN')
-			->will($this->returnValue($interResult));
+			->will($this->returnCallback(function ($dn) use ($cases) {
+				foreach($cases as $case) {
+					if($dn === $case['input']) {
+						return $case['interResult'];
+					}
+				}
+			}));
 
-		$this->assertTrue($access->stringResemblesDN($input));
+		foreach($cases as $case) {
+			$this->assertSame($case['expectedResult'], $access->stringResemblesDN($case['input']));
+		}
 	}
 
-	public function stringResemblesDNYesLDAPmod() {
+	public function testStringResemblesDNLDAPmod() {
 		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
 		$lw = new \OCA\user_ldap\lib\LDAP();
 		$access = new Access($con, $lw, $um);
@@ -185,51 +207,10 @@ class Test_Access extends \PHPUnit_Framework_TestCase {
 			$this->markTestSkipped('LDAP Module not available');
 		}
 
-		$input = 'foo=bar,bar=foo,dc=foobar';
-		$interResult = array(
-			'count' => 3,
-			0 => 'foo=bar',
-			1 => 'bar=foo',
-			2 => 'dc=foobar'
-		);
+		$cases = $this->getResemblesDNInputData();
 
-		$lw->expects($this->once())
-			->method('explodeDN')
-			->will($this->returnValue($interResult));
-
-		$this->assertTrue($access->stringResemblesDN($input));
-	}
-
-	public function stringResemblesDNNo() {
-		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
-		$access = new Access($con, $lw, $um);
-
-		$input = 'foobarbarfoodcfoobar';
-		$interResult = false;
-
-		$lw->expects($this->once())
-			->method('explodeDN')
-			->will($this->returnValue($interResult));
-
-		$this->assertFalse($access->stringResemblesDN($input));
-	}
-
-	public function stringResemblesDNNoLDAPMod() {
-		list($lw, $con, $um) = $this->getConnecterAndLdapMock();
-		$lw = new \OCA\user_ldap\lib\LDAP();
-		$access = new Access($con, $lw, $um);
-
-		if(!function_exists('ldap_explode_dn')) {
-			$this->markTestSkipped('LDAP Module not available');
+		foreach($cases as $case) {
+			$this->assertSame($case['expectedResult'], $access->stringResemblesDN($case['input']));
 		}
-
-		$input = 'foobarbarfoodcfoobar';
-		$interResult = false;
-
-		$lw->expects($this->once())
-			->method('explodeDN')
-			->will($this->returnValue($interResult));
-
-		$this->assertFalse($access->stringResemblesDN($input));
 	}
 }

--- a/apps/user_ldap/tests/user/manager.php
+++ b/apps/user_ldap/tests/user/manager.php
@@ -44,6 +44,11 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
         $inputDN = 'cn=foo,dc=foobar,dc=bar';
         $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
+		$access->expects($this->once())
+            ->method('stringResemblesDN')
+            ->with($this->equalTo($inputDN))
+            ->will($this->returnValue(true));
+
         $access->expects($this->once())
             ->method('dn2username')
             ->with($this->equalTo($inputDN))
@@ -66,6 +71,38 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
         $inputDN = 'uid=foo,o=foobar,c=bar';
         $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
+		$access->expects($this->once())
+            ->method('stringResemblesDN')
+            ->with($this->equalTo($inputDN))
+            ->will($this->returnValue(true));
+
+        $access->expects($this->once())
+            ->method('dn2username')
+            ->with($this->equalTo($inputDN))
+            ->will($this->returnValue($uid));
+
+        $access->expects($this->never())
+            ->method('username2dn');
+
+        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+        $manager->setLdapAccess($access);
+        $user = $manager->get($inputDN);
+
+        $this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
+    }
+
+    public function testGetByExoticDN() {
+        list($access, $config, $filesys, $image, $log, $avaMgr) =
+            $this->getTestInstances();
+
+        $inputDN = 'ab=cde,f=ghei,mno=pq';
+        $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
+
+		$access->expects($this->once())
+            ->method('stringResemblesDN')
+            ->with($this->equalTo($inputDN))
+            ->will($this->returnValue(true));
+
         $access->expects($this->once())
             ->method('dn2username')
             ->with($this->equalTo($inputDN))
@@ -86,6 +123,11 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
             $this->getTestInstances();
 
         $inputDN = 'cn=gone,dc=foobar,dc=bar';
+
+		$access->expects($this->once())
+            ->method('stringResemblesDN')
+            ->with($this->equalTo($inputDN))
+            ->will($this->returnValue(true));
 
         $access->expects($this->once())
             ->method('dn2username')
@@ -118,6 +160,11 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
             ->method('username2dn')
             ->with($this->equalTo($uid))
             ->will($this->returnValue($dn));
+
+        $access->expects($this->once())
+            ->method('stringResemblesDN')
+            ->with($this->equalTo($uid))
+            ->will($this->returnValue(false));
 
         $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
         $manager->setLdapAccess($access);

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -131,6 +131,11 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 			   ->will($this->returnValue('gunslinger'));
 
 		$access->expects($this->any())
+			   ->method('stringResemblesDN')
+			   ->with($this->equalTo('dnOfRoland,dc=test'))
+			   ->will($this->returnValue(true));
+
+		$access->expects($this->any())
 			   ->method('areCredentialsValid')
 			   ->will($this->returnCallback(function($dn, $pwd) {
 					if($pwd === 'dt19') {


### PR DESCRIPTION
We have a check in place that tries to guess whether a provided user id is a DN or a username. Unfortunately this was not sufficient and resulted in errors when a provided DN  did not meet our expectations :( This PR is supposed to fix this.

Please test and review @ksteinb @ostraaten @Xenopathic
