### PR TITLE
Preserve transparency when loading from a file

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -450,6 +450,9 @@ class OC_Image {
 			case IMAGETYPE_GIF:
 				if (imagetypes() & IMG_GIF) {
 					$this->resource = imagecreatefromgif($imagePath);
+					// Preserve transparency
+					imagealphablending($this->resource, true);
+					imagesavealpha($this->resource, true);
 				} else {
 					OC_Log::write('core',
 						'OC_Image->loadFromFile, GIF images not supported: '.$imagePath,
@@ -468,6 +471,9 @@ class OC_Image {
 			case IMAGETYPE_PNG:
 				if (imagetypes() & IMG_PNG) {
 					$this->resource = imagecreatefrompng($imagePath);
+					// Preserve transparency
+					imagealphablending($this->resource, true);
+					imagesavealpha($this->resource, true);
 				} else {
 					OC_Log::write('core',
 						'OC_Image->loadFromFile, PNG images not supported: '.$imagePath,

--- a/tests/lib/image.php
+++ b/tests/lib/image.php
@@ -115,6 +115,9 @@ class Test_Image extends PHPUnit_Framework_TestCase {
 	public function testData() {
 		$img = new \OC_Image(OC::$SERVERROOT.'/tests/data/testimage.png');
 		$raw = imagecreatefromstring(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.png'));
+		// Preserve transparency
+		imagealphablending($raw, true);
+		imagesavealpha($raw, true);
 		ob_start();
 		imagepng($raw);
 		$expected = ob_get_clean();


### PR DESCRIPTION
Fix #7148 - again :)

Immediately after commiting I've noticed: Is this needed for `IMAGETYPE_GIF` as well?

@karlitschek backport?

cc @georgehrke @blackm @MorrisJobke @PVince81 

Edit: When using the file mentioned in #7148 it's still just black, that's because JCrop doesn't deal with transparency, but shows a black background itself:

My avatar with a transparent corner in jcrop:
![screenshot556](https://cloud.githubusercontent.com/assets/1410802/3888462/60a27fac-2200-11e4-99d5-bc6b21ea3ef8.png)

And when it's cropped:
![screenshot557](https://cloud.githubusercontent.com/assets/1410802/3888461/60a13890-2200-11e4-9163-205f99df832a.png)
