### PR TITLE
Compare upload limit against biggest file

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -233,7 +233,8 @@ OC.Upload = {
 						data.originalFiles.selection = {
 							uploads: [],
 							filesToUpload: data.originalFiles.length,
-							totalBytes: 0
+							totalBytes: 0,
+							biggestFileBytes: 0
 						};
 					}
 					var selection = data.originalFiles.selection;
@@ -273,13 +274,15 @@ OC.Upload = {
 
 					// add size
 					selection.totalBytes += file.size;
+					// update size of biggest file
+					selection.biggestFileBytes = Math.max(selection.biggestFileBytes, file.size);
 
-					// check PHP upload limit
-					if (selection.totalBytes > $('#upload_limit').val()) {
+					// check PHP upload limit against biggest file
+					if (selection.biggestFileBytes > $('#upload_limit').val()) {
 						data.textStatus = 'sizeexceedlimit';
 						data.errorThrown = t('files',
 							'Total file size {size1} exceeds upload limit {size2}', {
-							'size1': humanFileSize(selection.totalBytes),
+							'size1': humanFileSize(selection.biggestFileBytes),
 							'size2': humanFileSize($('#upload_limit').val())
 						});
 					}


### PR DESCRIPTION
When uploading multiple files from the web interface, compare the PHP
upload limit against the largest file, not against the sum of all files.

The issue occurs when uploading multiple files which are in total above the upload limit but individually below it.

CC: @jancborchardt
