### PR TITLE
don't clean up the test environment if a data provider was finished

### DIFF
--- a/tests/testcleanuplistener.php
+++ b/tests/testcleanuplistener.php
@@ -41,20 +41,23 @@ class TestCleanupListener implements PHPUnit_Framework_TestListener {
 	}
 
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
-		if ($this->cleanStorages() && $this->isShowSuiteWarning()) {
-			printf("TestSuite '%s': Did not clean up storages\n", $suite->getName());
-		}
-		if ($this->cleanFileCache() && $this->isShowSuiteWarning()) {
-			printf("TestSuite '%s': Did not clean up file cache\n", $suite->getName());
-		}
-		if ($this->cleanStrayDataFiles() && $this->isShowSuiteWarning()) {
-			printf("TestSuite '%s': Did not clean up data dir\n", $suite->getName());
-		}
-		if ($this->cleanStrayHooks() && $this->isShowSuiteWarning()) {
-			printf("TestSuite '%s': Did not clean up hooks\n", $suite->getName());
-		}
-		if ($this->cleanProxies() && $this->isShowSuiteWarning()) {
-			printf("TestSuite '%s': Did not clean up proxies\n", $suite->getName());
+		// don't clean up the test environment if a data provider finished
+		if (!($suite instanceof PHPUnit_Framework_TestSuite_DataProvider)) {
+			if ($this->cleanStorages() && $this->isShowSuiteWarning()) {
+				printf("TestSuite '%s': Did not clean up storages\n", $suite->getName());
+			}
+			if ($this->cleanFileCache() && $this->isShowSuiteWarning()) {
+				printf("TestSuite '%s': Did not clean up file cache\n", $suite->getName());
+			}
+			if ($this->cleanStrayDataFiles() && $this->isShowSuiteWarning()) {
+				printf("TestSuite '%s': Did not clean up data dir\n", $suite->getName());
+			}
+			if ($this->cleanStrayHooks() && $this->isShowSuiteWarning()) {
+				printf("TestSuite '%s': Did not clean up hooks\n", $suite->getName());
+			}
+			if ($this->cleanProxies() && $this->isShowSuiteWarning()) {
+				printf("TestSuite '%s': Did not clean up proxies\n", $suite->getName());
+			}
 		}
 	}
 


### PR DESCRIPTION
endTestSuite() also gets called if a data provider was processed successfully. But in this case we shouldn't clean up the test environment, otherwise all following tests will fail. 

That's just a quick fix, in the long run we should move away from the listeners to a base class for all tests to handle the clean-up and other stuff.

see: https://github.com/owncloud/core/issues/9963

cc @DeepDiver1975 @PVince81 
