### PR TITLE
[sharing] fix mail notification

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -107,7 +107,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$mailNotification = new OC\Share\MailNotifications();
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
 
-			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, true);
+			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
 
 			if (empty($result)) {
 				OCP\JSON::success();
@@ -126,7 +126,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$shareType = $_POST['shareType'];
 			$itemType = $_POST['itemType'];
 			$recipient = $_POST['recipient'];
-			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, false);
+			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, false);
 			OCP\JSON::success();
 			break;
 

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -820,17 +820,18 @@ class Share extends \OC\Share\Constants {
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
+	 * @param string $recipient with whom was the file shared
 	 * @param boolean $status
 	 */
-	public static function setSendMailStatus($itemType, $itemSource, $shareType, $status) {
+	public static function setSendMailStatus($itemType, $itemSource, $shareType, $recipient, $status) {
 		$status = $status ? 1 : 0;
 
 		$query = \OC_DB::prepare(
 				'UPDATE `*PREFIX*share`
 					SET `mail_send` = ?
-					WHERE `item_type` = ? AND `item_source` = ? AND `share_type` = ?');
+					WHERE `item_type` = ? AND `item_source` = ? AND `share_type` = ? AND `share_with` = ?');
 
-		$result = $query->execute(array($status, $itemType, $itemSource, $shareType));
+		$result = $query->execute(array($status, $itemType, $itemSource, $shareType, $recipient));
 
 		if($result === false) {
 			\OC_Log::write('OCP\Share', 'Couldn\'t set send mail status', \OC_Log::ERROR);

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -274,10 +274,11 @@ class Share extends \OC\Share\Constants {
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
+	 * @param string $recipient with whom was the item shared
 	 * @param bool $status
 	 */
-	public static function setSendMailStatus($itemType, $itemSource, $shareType, $status) {
-		return \OC\Share\Share::setSendMailStatus($itemType, $itemSource, $shareType, $status);
+	public static function setSendMailStatus($itemType, $itemSource, $shareType, $recipient, $status) {
+		return \OC\Share\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, $status);
 	}
 
 	/**


### PR DESCRIPTION
we need the recipient as a additional parameter to know for which share the notification was send.

This affects master, stable7 and stable6

fix #10393
