### PR TITLE
fix japanese lang code

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -39,7 +39,7 @@ $enableDecryptAll = $filesStillEncrypted || $backupKeysExists;
 
 // array of common languages
 $commonlangcodes = array(
-	'en', 'es', 'fr', 'de', 'de_DE', 'ja_JP', 'ar', 'ru', 'nl', 'it', 'pt_BR', 'pt_PT', 'da', 'fi_FI', 'nb_NO', 'sv', 'tr', 'zh_CN', 'ko'
+	'en', 'es', 'fr', 'de', 'de_DE', 'ja', 'ar', 'ru', 'nl', 'it', 'pt_BR', 'pt_PT', 'da', 'fi_FI', 'nb_NO', 'sv', 'tr', 'zh_CN', 'ko'
 );
 
 $languageNames=include 'languageCodes.php';


### PR DESCRIPTION
Similar to https://github.com/owncloud/core/pull/10312

ja_JP has not been updated since March and the reference
to this language should be removed. It also exists as ja
on Transifex. Discussion is here: #10281 
