### PR TITLE
Return whole file if range request cannot be granted due to encryption

### DIFF
--- a/lib/private/connector/sabre/server.php
+++ b/lib/private/connector/sabre/server.php
@@ -33,6 +33,11 @@ class OC_Connector_Sabre_Server extends Sabre\DAV\Server {
 	 */
 	private $overLoadedUri = null;
 
+	/**
+	 * @var boolean
+	 */
+	private $ignoreRangeHeader = false;
+
 	public function getRequestUri() {
 
 		if (!is_null($this->overLoadedUri)) {
@@ -57,6 +62,23 @@ class OC_Connector_Sabre_Server extends Sabre\DAV\Server {
 		$result = parent::checkPreconditions($handleAsGET);
 		$this->overLoadedUri = null;
 		return $result;
+	}
+
+	public function getHTTPRange() {
+		if ($this->ignoreRangeHeader) {
+			return null;
+		}
+		return parent::getHTTPRange();
+	}
+
+	protected function httpGet($uri) {
+		$range = $this->getHTTPRange();
+
+		if (OC_App::isEnabled('files_encryption') && $range) {
+			// encryption does not support range requests
+			$this->ignoreRangeHeader = true;	
+		}
+		return parent::httpGet($uri);
 	}
 
 	/**


### PR DESCRIPTION
Whenenver range headers are set and encryption is enabled, it is not
possible to automatically fseek() to the proper position.

To avoid returning corrupt/invalid data or causing a decryption error,
the range headers are stripped so that the SabreDAV code in httpGet()
returns the whole file.

Fixes https://github.com/owncloud/core/issues/10383

Please review @DeepDiver1975 @icewind1991 @schiesbn @guruz 
