### PR TITLE
Remove ability to trigger DEBUG mode via cookie

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -491,13 +491,6 @@ class OC {
 			require_once $vendorAutoLoad;
 		}
 
-		// set debug mode if an xdebug session is active
-		if (!defined('DEBUG') || !DEBUG) {
-			if (isset($_COOKIE['XDEBUG_SESSION'])) {
-				define('DEBUG', true);
-			}
-		}
-
 		if (!defined('PHPUNIT_RUN')) {
 			OC\Log\ErrorHandler::setLogger(OC_Log::$object);
 			if (defined('DEBUG') and DEBUG) {


### PR DESCRIPTION
Users should not be able to enable debug mode on their own by setting a cookie. Using debug mode might leak too much information about the environment or have other unexpected behaviour.

We should backport this. 

@karlitschek 
