### PR TITLE
Move authentication failed logging to checkPassword

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -185,9 +185,6 @@ $CONFIG = array(
  (watch out, this option can increase the size of your log file)*/
 "log_query" => false,
 
-/* Enable or disable the logging of IP addresses in case of webform auth failures */
-"log_authfailip" => false,
-
 /* Whether ownCloud should log the last successfull cron exec */
 "cron_log" => true,
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -856,13 +856,6 @@ class OC {
 		} // logon via web form
 		elseif (OC::tryFormLogin()) {
 			$error[] = 'invalidpassword';
-			if ( OC_Config::getValue('log_authfailip', false) ) {
-				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:'.$_SERVER['REMOTE_ADDR'],
-				OC_Log::WARN);
-			} else {
-				OC_Log::write('core', 'Login failed: user \''.$_POST["user"].'\' , wrong password, IP:set log_authfailip=true in conf',
-                                OC_Log::WARN);
-			}
 		}
 
 		OC_Util::displayLoginPage(array_unique($error));

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -164,6 +164,8 @@ class Manager extends PublicEmitter implements IUserManager {
 				}
 			}
 		}
+
+		\OC::$server->getLogger()->warning('Login failed: \''. $loginname .'\' (Remote IP: \''. $_SERVER['REMOTE_ADDR'] .'\', X-Forwarded-For: \''. $_SERVER['HTTP_X_FORWARDED_FOR'] .'\')', array('app' => 'core'));
 		return false;
 	}
 

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -165,7 +165,10 @@ class Manager extends PublicEmitter implements IUserManager {
 			}
 		}
 
-		\OC::$server->getLogger()->warning('Login failed: \''. $loginname .'\' (Remote IP: \''. $_SERVER['REMOTE_ADDR'] .'\', X-Forwarded-For: \''. $_SERVER['HTTP_X_FORWARDED_FOR'] .'\')', array('app' => 'core'));
+		$remoteAddr = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+		$forwardedFor = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : '';
+
+		\OC::$server->getLogger()->warning('Login failed: \''. $loginname .'\' (Remote IP: \''. $remoteAddr .'\', X-Forwarded-For: \''. $forwardedFor .'\')', array('app' => 'core'));
 		return false;
 	}
 


### PR DESCRIPTION
This PR moves the logging for invalid login attempts to `checkPassword` where it should be called all the time. Not the cleanest solution but does it's job (TM).

Furthermore:
- `log_authfailip` have been removed. This settings is insane and defaulting it to false was even more.
- The `X-Forwarded-For` header is now logged too. What the server admin does with this information and whether he trusts it is not our department ;-)

Testplan:
- [ ] Login via WebDAV with invalid credentials => logged
- [ ] Login via WebDAV with valid credentials => not logged
- [ ] Login via form with invalid credentials => logged
- [ ] Login via form with valid credentials => not logged

Fixes https://github.com/owncloud/core/issues/10366

@karlitschek I'd propose that we backport this to stable7 but not stable6 (logging format has changed a little bit - I don't want to embarrass EE customers but for CE mentioning this prominently in the changelog should be enough). What do you think?
