### PR TITLE
Fixed folder icon update routine when share owner exists

### DIFF
--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -938,16 +938,6 @@ describe('OCA.Files.FileList tests', function() {
 	describe('file previews', function() {
 		var previewLoadStub;
 
-		function getImageUrl($el) {
-			// might be slightly different cross-browser
-			var url = $el.css('background-image');
-			var r = url.match(/url\(['"]?([^'")]*)['"]?\)/);
-			if (!r) {
-				return url;
-			}
-			return r[1];
-		}
-
 		beforeEach(function() {
 			previewLoadStub = sinon.stub(OCA.Files.FileList.prototype, 'lazyLoadPreview');
 		});
@@ -961,7 +951,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('renders default icon for dir when none provided and no preview is available', function() {
@@ -971,7 +961,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('renders provided icon for file when provided', function() {
@@ -982,7 +972,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('renders preview when no icon was provided and preview is available', function() {
@@ -993,11 +983,11 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
 			expect(previewLoadStub.calledOnce).toEqual(true);
 			// third argument is callback
 			previewLoadStub.getCall(0).args[0].callback(OC.webroot + '/somepath.png');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/somepath.png');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/somepath.png');
 		});
 		it('renders default file type icon when no icon was provided and no preview is available', function() {
 			var fileData = {
@@ -1007,7 +997,7 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+			expect(OC.TestUtil.getImageUrl($td)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 	});

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -231,7 +231,7 @@ OC.Share={
 		var shareFolderIcon;
 		var image = OC.imagePath('core', 'actions/share');
 		// update folder icon
-		if (type === 'dir' && (hasShares || hasLink)) {
+		if (type === 'dir' && (hasShares || hasLink || owner)) {
 			if (hasLink) {
 				shareFolderIcon = OC.imagePath('core', 'filetypes/folder-public');
 			}

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -82,6 +82,26 @@ window.Snap.prototype = {
 	var fakeServer = null,
 		$testArea = null;
 
+	/**
+	 * Utility functions for testing
+	 */
+	var TestUtil = {
+		/**
+		 * Returns the image URL set on the given element
+		 * @param $el element
+		 * @return {String} image URL
+		 */
+		getImageUrl: function($el) {
+			// might be slightly different cross-browser
+			var url = $el.css('background-image');
+			var r = url.match(/url\(['"]?([^'")]*)['"]?\)/);
+			if (!r) {
+				return url;
+			}
+			return r[1];
+		}
+	};
+
 	beforeEach(function() {
 		// test area for elements that need absolute selector access or measure widths/heights
 		// which wouldn't work for detached or hidden elements
@@ -103,6 +123,10 @@ window.Snap.prototype = {
 		// make it globally available, so that other tests can define
 		// custom responses
 		window.fakeServer = fakeServer;
+
+		if (!OC.TestUtil) {
+			OC.TestUtil = TestUtil;
+		}
 	});
 
 	afterEach(function() {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -562,7 +562,52 @@ describe('OC.Share tests', function() {
 			});
 		});
 
-		// TODO: add unit tests for folder icons
+		describe('displaying the folder icon', function() {
+			function checkIcon(expectedImage) {
+				var imageUrl = OC.TestUtil.getImageUrl($file.find('.filename'));
+				expectedIcon = OC.imagePath('core', expectedImage);
+				expect(imageUrl).toEqual(expectedIcon);
+			}
+
+			it('shows a plain folder icon for non-shared folders', function() {
+				$file.attr('data-type', 'dir');
+				OC.Share.markFileAsShared($file);
+
+				checkIcon('filetypes/folder');
+			});
+			it('shows a shared folder icon for folders shared with another user', function() {
+				$file.attr('data-type', 'dir');
+				OC.Share.markFileAsShared($file, true);
+
+				checkIcon('filetypes/folder-shared');
+			});
+			it('shows a shared folder icon for folders shared with the current user', function() {
+				$file.attr('data-type', 'dir');
+				$file.attr('data-share-owner', 'someoneelse');
+				OC.Share.markFileAsShared($file);
+
+				checkIcon('filetypes/folder-shared');
+			});
+			it('shows a link folder icon for folders shared with link', function() {
+				$file.attr('data-type', 'dir');
+				OC.Share.markFileAsShared($file, false, true);
+
+				checkIcon('filetypes/folder-public');
+			});
+			it('shows a link folder icon for folders shared with both link and another user', function() {
+				$file.attr('data-type', 'dir');
+				OC.Share.markFileAsShared($file, true, true);
+
+				checkIcon('filetypes/folder-public');
+			});
+			it('shows a link folder icon for folders reshared with link', function() {
+				$file.attr('data-type', 'dir');
+				$file.attr('data-share-owner', 'someoneelse');
+				OC.Share.markFileAsShared($file, false, true);
+
+				checkIcon('filetypes/folder-public');
+			});
+		});
 		// TODO: add unit tests for share recipients
 	});
 });


### PR DESCRIPTION
Whenever a folder has a "data-share-owner" attribute, the icon is now
properly updated to a shared folder icon.

Fixes https://github.com/owncloud/core/issues/9352

Note: the actual fix is on one line, everything else is just unit tests :smile: 

Please review @icewind1991 @schiesbn @purigarcia @MorrisJobke 
