### PR TITLE
check quota when trying to download a file via new -> web

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -15,7 +15,8 @@ class Helper
 
 		return array('uploadMaxFilesize' => $maxUploadFilesize,
 					 'maxHumanFilesize'  => $maxHumanFilesize,
-					 'usedSpacePercent'  => (int)$storageInfo['relative']);
+					 'usedSpacePercent'  => (int)$storageInfo['relative'],
+					 'freeSpace'		 => (int)$storageInfo['free']);
 	}
 
 	public static function determineIcon($file) {


### PR DESCRIPTION
backport of #10290, fixes #10047 for stable6, also requires the 'freeSpace' in the result of buildFileStorageStatistics()

cc @icewind1991 @DeepDiver1975 @bantu @karlitschek @ser72 
