### PR TITLE
improve logo flexibility to fix wide custom logo alignment, fix #9339

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -42,8 +42,7 @@
 }
 
 #header .logo {
-	background-image: url(../img/logo.svg);
-	background-repeat: no-repeat;
+	background: url(../img/logo.svg) no-repeat center;
 	width: 252px;
 	height: 120px;
 	margin: 0 auto;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -657,7 +657,6 @@ label.infield {
 #body-login .wrapper {
 	min-height: 100%;
 	margin: 0 auto -70px;
-	width: 300px;
 }
 #body-login footer, #body-login .push {
 	height: 70px;


### PR DESCRIPTION
Fixes #9339. This removed the 300px width restriction on custom logos as well as centers the background div. These changes are MIT licensed.
