### PR TITLE
Make skeleton directory configurable.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -222,6 +222,11 @@ $CONFIG = array(
  */
 // "datadirectory" => "",
 
+/* The directory where the skeleton files are located. These files will be copied to the data
+ * directory of new users. Leave empty to not copy any skeleton files.
+ */
+// "skeletondirectory" => "",
+
 /* Enable maintenance mode to disable ownCloud
    If you want to prevent users to login to ownCloud before you start doing some maintenance work,
    you need to set the value of the maintenance parameter to true.

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -208,7 +208,10 @@ class OC_Util {
 	 * @param string $userDirectory
 	 */
 	public static function copySkeleton($userDirectory) {
-		OC_Util::copyr(\OC::$SERVERROOT.'/core/skeleton' , $userDirectory);
+		$skeletonDirectory = OC_Config::getValue('skeletondirectory', \OC::$SERVERROOT.'/core/skeleton');
+		if (!empty($skeletonDirectory)) {
+			OC_Util::copyr($skeletonDirectory , $userDirectory);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This allows to specify a custom skeleton directory. The files in this directoy are copied to the data directory of new users.

Leave the new `skeletondirectory` config variable empty to completely disable this function.
