### PR TITLE
Add a note about overwritewebroot when using system cron

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -19,6 +19,7 @@ $htaccessworking=OC_Util::isHtaccessWorking();
 
 $entries=OC_Log_Owncloud::getEntries(3);
 $entriesremain = count(OC_Log_Owncloud::getEntries(4)) > 3;
+$config = \OC::$server->getConfig();
 
 // Should we display sendmail as an option?
 $tmpl->assign('sendmail_is_available', (bool) findBinaryPath('sendmail'));
@@ -71,13 +72,15 @@ $tmpl->assign('groups', $groups);
 
 
 // Check if connected using HTTPS
-if (OC_Request::serverProtocol() === 'https') {
-	$connectedHTTPS = true;
-} else {
-	$connectedHTTPS = false;
-}
-$tmpl->assign('isConnectedViaHTTPS', $connectedHTTPS);
+$tmpl->assign('isConnectedViaHTTPS', OC_Request::serverProtocol() === 'https');
 $tmpl->assign('enforceHTTPSEnabled', OC_Config::getValue( "forcessl", false));
+
+// If the current webroot is non-empty but the webroot from the config is,
+// and system cron is used, the URL generator fails to build valid URLs.
+$shouldSuggestOverwriteWebroot = $config->getAppValue('core', 'backgroundjobs_mode', 'ajax') === 'cron' &&
+	\OC::$WEBROOT && \OC::$WEBROOT !== '/' &&
+	!$config->getSystemValue('overwritewebroot', '');
+$tmpl->assign('suggestedOverwriteWebroot', ($shouldSuggestOverwriteWebroot) ? \OC::$WEBROOT : '');
 
 $tmpl->assign('allowLinks', OC_Appconfig::getValue('core', 'shareapi_allow_links', 'yes'));
 $tmpl->assign('enforceLinkPassword', \OCP\Util::isPublicLinkPasswordRequired());

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -1,7 +1,11 @@
-<?php /**
+<?php
+/**
  * Copyright (c) 2011, Robin Appelman <icewind1991@gmail.com>
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
+ */
+/**
+ * @var array $_
  */
 $levels = array('Debug', 'Info', 'Warning', 'Error', 'Fatal');
 $levelLabels = array(
@@ -187,6 +191,19 @@ if (!$_['internetconnectionworking']) {
 
 		<span class="connectionwarning">
 		<?php p($l->t('This server has no working internet connection. This means that some of the features like mounting of external storage, notifications about updates or installation of 3rd party apps don´t work. Accessing files from remote and sending of notification emails might also not work. We suggest to enable internet connection for this server if you want to have all features.')); ?>
+	</span>
+
+	</div>
+<?php
+}
+
+if ($_['suggestedOverwriteWebroot']) {
+	?>
+	<div class="section">
+		<h2><?php p($l->t('URL generation in notification emails'));?></h2>
+
+		<span class="connectionwarning">
+		<?php p($l->t('If your installation is not installed in the root of the domain and uses system cron, there can be issues with the URL generation. To avoid these problems, please set the "overwritewebroot" option in your config.php file to the webroot path of your installation (Suggested: "%s")', $_['suggestedOverwriteWebroot'])); ?>
 	</span>
 
 	</div>


### PR DESCRIPTION
If the current webroot is non-empty but the webroot from the config is,
and system cron is used, the URL generator fails to build valid URLs.
So we notify the admin to set it up correctly.

Fix #9995 

@DeepDiver1975 @PVince81  @MorrisJobke 

Related to #9494
