### PR TITLE
Return Etag and OC-Fileid after MKCOL call

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -181,21 +181,6 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 	}
 
 	/**
-	 * Returns the ETag for a file
-	 *
-	 * An ETag is a unique identifier representing the current version of the
-	 * file. If the file changes, the ETag MUST change.  The ETag is an
-	 * arbitrary string, but MUST be surrounded by double-quotes.
-	 *
-	 * Return null if the ETag can not effectively be determined
-	 *
-	 * @return mixed
-	 */
-	public function getETag() {
-		return '"' . $this->info->getEtag() . '"';
-	}
-
-	/**
 	 * Returns the mime-type for a file
 	 *
 	 * If null is returned, we'll assume application/octet-stream

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -240,6 +240,21 @@ abstract class OC_Connector_Sabre_Node implements \Sabre\DAV\INode, \Sabre\DAV\I
 	}
 
 	/**
+	 * Returns the ETag for a node
+	 *
+	 * An ETag is a unique identifier representing the current version of the
+	 * file. If the file changes, the ETag MUST change.  The ETag is an
+	 * arbitrary string, but MUST be surrounded by double-quotes.
+	 *
+	 * Return null if the ETag can not effectively be determined
+	 *
+	 * @return mixed
+	 */
+	public function getETag() {
+		return '"' . $this->info->getEtag() . '"';
+	}
+
+	/**
 	 * @return string|null
 	 */
 	public function getDavPermissions() {

--- a/lib/private/connector/sabre/server.php
+++ b/lib/private/connector/sabre/server.php
@@ -96,6 +96,21 @@ class OC_Connector_Sabre_Server extends Sabre\DAV\Server {
 
 	}
 
+	public function createCollection($uri, array $resourceType, array $properties) {
+		parent::createCollection($uri, $resourceType, $properties);
+
+		// FIXME: this logic could be achieved by adding a "afterCreateCollection" event upstream
+
+		// only process if the collection is a directory
+		if (!in_array('{DAV:}collection', $resourceType)) {
+			return;
+		}
+
+		$node = $this->tree->getNodeForPath($uri);
+		$this->httpResponse->setHeader('OC-FileId', $node->getFileId());
+		$this->httpResponse->setHeader('Etag', $node->getEtag());
+	}
+
 	/**
 	 * Small helper to support PROPFIND with DEPTH_INFINITY.
 	 * @param string $path


### PR DESCRIPTION
Moved getEtag() method from File to Node class.
Added override for createCollection() to be able to return the Etag and
OC-Fileid as extra headers after directory creation.

Hopefully the least ugly hack without having to patch SabreDAV upstream.

Please review @DeepDiver1975 @icewind1991 @karlitschek 
