### PR TITLE
Return OC-Fileid after MKCOL call (alternative fix with SabreDAV patch)

### DIFF
--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -42,6 +42,7 @@ class OC_Connector_Sabre_FilesPlugin extends \Sabre\DAV\ServerPlugin
 		$this->server = $server;
 		$this->server->subscribeEvent('beforeGetProperties', array($this, 'beforeGetProperties'));
 		$this->server->subscribeEvent('afterCreateFile', array($this, 'sendFileIdHeader'));
+		$this->server->subscribeEvent('afterCreateCollection', array($this, 'sendFileIdHeader'));
 		$this->server->subscribeEvent('afterWriteContent', array($this, 'sendFileIdHeader'));
 	}
 


### PR DESCRIPTION
Alternative fix for https://github.com/owncloud/core/issues/9000 that only returns OC-Fileid (no Etag) but uses a simpler approach.

Requires SabreDAV patch: https://github.com/fruux/sabre-dav/pull/504
Temporary patch for 3rdparty: https://github.com/owncloud/3rdparty/pull/115

@DeepDiver1975 @icewind1991 @th3fallen 
