### PR TITLE
Use afterBind to send fileId header for files and directories

### DIFF
--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -41,7 +41,7 @@ class OC_Connector_Sabre_FilesPlugin extends \Sabre\DAV\ServerPlugin
 
 		$this->server = $server;
 		$this->server->subscribeEvent('beforeGetProperties', array($this, 'beforeGetProperties'));
-		$this->server->subscribeEvent('afterCreateFile', array($this, 'sendFileIdHeader'));
+		$this->server->subscribeEvent('afterBind', array($this, 'sendFileIdHeader'));
 		$this->server->subscribeEvent('afterWriteContent', array($this, 'sendFileIdHeader'));
 	}
 


### PR DESCRIPTION
afterBind is called for both files and directories and is now used to
send the OC-FileId headers.

Fixes https://github.com/owncloud/core/issues/9000

Final version I hope, doesn't need any patching :smile: 

Please review @DeepDiver1975 @icewind1991 @th3fallen 
