### PR TITLE
properly encode groups as json, not ',' separated

### DIFF
--- a/settings/ajax/userlist.php
+++ b/settings/ajax/userlist.php
@@ -58,8 +58,8 @@ if (OC_User::isAdminUser(OC_User::getUser())) {
 		$users[] = array(
 			'name' => $uid,
 			'displayname' => $displayname,
-			'groups' => join(', ', OC_Group::getUserGroups($uid)),
-			'subadmin' => join(', ', OC_SubAdmin::getSubAdminsGroups($uid)),
+			'groups' => OC_Group::getUserGroups($uid),
+			'subadmin' => OC_SubAdmin::getSubAdminsGroups($uid),
 			'quota' => OC_Preferences::getValue($uid, 'files', 'quota', 'default'),
 			'storageLocation' => $user->getHome(),
 			'lastLogin' => $user->getLastLogin(),
@@ -82,7 +82,7 @@ if (OC_User::isAdminUser(OC_User::getUser())) {
 		$users[] = array(
 			'name' => $uid,
 			'displayname' => $user->getDisplayName(),
-			'groups' => join(', ', $userGroups),
+			'groups' => $userGroups,
 			'quota' => OC_Preferences::getValue($uid, 'files', 'quota', 'default'),
 			'storageLocation' => $user->getHome(),
 			'lastLogin' => $user->getLastLogin(),


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/9774 for master.

Multiselect expects the groups to be an array, not a comma separated string.

@blizzz @nickvergessen @PVince81 It seems this ajax file is only used by users.json.

@karlitschek @craigpg will backport to stable7 and stable6 when reviewed.
