### PR TITLE
files_extern: remove empty Body and ContentLength in Amazon S3 mount

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -128,9 +128,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$result = $this->connection->putObject(array(
 				'Bucket' => $this->bucket,
 				'Key'    => $this->cleanKey('.'),
-				'Body'   => '',
-				'ContentType' => 'httpd/unix-directory',
-				'ContentLength' => 0
+				'ContentType' => 'httpd/unix-directory'
 			));
 			$this->testTimeout();
 		}
@@ -147,9 +145,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$result = $this->connection->putObject(array(
 				'Bucket' => $this->bucket,
 				'Key'    => $path . '/',
-				'Body'   => '',
-				'ContentType' => 'httpd/unix-directory',
-				'ContentLength' => 0
+				'ContentType' => 'httpd/unix-directory'
 			));
 			$this->testTimeout();
 		} catch (S3Exception $e) {


### PR DESCRIPTION
fixes #10501
