### PR TITLE
[WIP] Fix share + version dropdown conflicts

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -85,19 +85,18 @@
 				}
 
 				var appendTo = $tr.find('td.filename');
+				var $dropdown;
 				// Check if drop down is already visible for a different file
 				if (OC.Share.droppedDown) {
 					if ($tr.attr('data-id') !== $('#dropdown').attr('data-item-source')) {
 						OC.Share.hideDropDown(function () {
-							$tr.addClass('mouseOver');
 							OC.Share.showDropDown(itemType, $tr.data('id'), appendTo, true, possiblePermissions, filename);
 						});
 					} else {
 						OC.Share.hideDropDown();
 					}
 				} else {
-					$tr.addClass('mouseOver');
-					OC.Share.showDropDown(itemType, $tr.data('id'), appendTo, true, possiblePermissions, filename);
+					$dropdown = OC.Share.showDropDown(itemType, $tr.data('id'), appendTo, true, possiblePermissions, filename);
 				}
 				$('#dropdown').on('sharesChanged', function(ev) {
 					// files app current cannot show recipients on load, so we don't update the

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -534,20 +534,7 @@ var OC={
 	registerMenu: function($toggle, $menuEl) {
 		$menuEl.addClass('menu');
 		$toggle.on('click.menu', function(event) {
-			if ($menuEl.is(OC._currentMenu)) {
-				$menuEl.slideUp(OC.menuSpeed);
-				OC._currentMenu = null;
-				OC._currentMenuToggle = null;
-				return false;
-			}
-			// another menu was open?
-			else if (OC._currentMenu) {
-				// close it
-				OC._currentMenu.hide();
-			}
-			$menuEl.slideToggle(OC.menuSpeed);
-			OC._currentMenu = $menuEl;
-			OC._currentMenuToggle = $toggle;
+			OC.showMenu($menuEl, $toggle);
 			return false;
 		});
 	},
@@ -564,6 +551,52 @@ var OC={
 		}
 		$toggle.off('click.menu').removeClass('menutoggle');
 		$menuEl.removeClass('menu');
+	},
+
+	/**
+	 * Displays the given menu (even if not registered)
+	 * Triggers a "show" event on the menu element after the animation.
+	 * @param $menuEl menu element
+	 * @param [$toggle] optional toggle element
+	 */
+	showMenu: function($menuEl, $toggle) {
+		console.log('showMenu: ', $menuEl);
+		// this class makes it possible to click inside
+		$menuEl.addClass('menu');
+		if ($menuEl.is(OC._currentMenu)) {
+			OC.hideMenu($menuEl);
+			return;
+		}
+		// another menu was open?
+		else if (OC._currentMenu) {
+			// close it
+			OC._currentMenu.hide();
+		}
+		$menuEl.slideDown(OC.menuSpeed, function() {
+			$menuEl.trigger(new $.Event('show'));
+		});
+		OC._currentMenu = $menuEl;
+		OC._currentMenuToggle = $toggle;
+	},
+
+	/**
+	 * Hides the given menu.
+	 * Triggers a "hide" event on the menu element after the animation.
+	 * @param [$menuEl] menu element, defaults to the current menu
+	 */
+	hideMenu: function($menuEl, callback) {
+		console.log('hideMenu: ', $menuEl);
+		if (!$menuEl) {
+			$menuEl = OC._currentMenu;
+		}
+		if (!$menuEl) {
+			return;
+		}
+		$menuEl.slideUp(OC.menuSpeed, function() {
+			$menuEl.trigger(new $.Event('hide'));
+		});
+		OC._currentMenu = null;
+		OC._currentMenuToggle = null;
 	},
 
 	/**
@@ -1104,15 +1137,11 @@ function initCore() {
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function(event) {
 		var $el = $(event.target);
-		if ($el.closest('.menu').length || $el.closest('.menutoggle').length) {
+		if ($el.closest('.menu').length || $el.closest('.menutoggle').length || $el.closest('.ui-autocomplete').length) {
 			// don't close when clicking on the menu directly or a menu toggle
 			return false;
 		}
-		if (OC._currentMenu) {
-			OC._currentMenu.slideUp(OC.menuSpeed);
-		}
-		OC._currentMenu = null;
-		OC._currentMenuToggle = null;
+		OC.hideMenu();
 	});
 
 

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -351,7 +351,7 @@ OC.Share={
 	showDropDown:function(itemType, itemSource, appendTo, link, possiblePermissions, filename) {
 		var data = OC.Share.loadItem(itemType, itemSource);
 		var dropDownEl;
-		var html = '<div id="dropdown" class="drop" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
+		var html = '<div id="dropdown" class="drop drop-shares" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
 		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
 			if (data.reshare.share_type == OC.Share.SHARE_TYPE_GROUP) {
 				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: escapeHTML(data.reshare.share_with), owner: escapeHTML(data.reshare.displayname_owner)})+'</span>';
@@ -532,26 +532,30 @@ OC.Share={
 			dropDownEl.appendTo(appendTo);
 		}
 		dropDownEl.attr('data-item-source-name', filename);
-		$('#dropdown').show('blind', function() {
-			OC.Share.droppedDown = true;
-		});
 		if ($('html').hasClass('lte9')){
-			$('#dropdown input[placeholder]').placeholder();
+			dropDownEl.find('input[placeholder]').placeholder();
 		}
+		OC.showMenu(dropDownEl);
+		OC.Share.droppedDown = true;
+		// TODO: move this to the files' app share action
+		dropDownEl.closest('tr').addClass('mouseOver');
+		dropDownEl.one('hide', function() {
+			OC.Share.currentShares = null;
+			OC.Share.droppedDown = false;
+			if (typeof FileActions !== 'undefined') {
+				dropDownEl.closest('tr').removeClass('mouseOver');
+			}
+			dropDownEl.remove();
+		});
 		$('#shareWith').focus();
+		return dropDownEl;
 	},
 	hideDropDown:function(callback) {
-		OC.Share.currentShares = null;
-		$('#dropdown').hide('blind', function() {
-			OC.Share.droppedDown = false;
-			$('#dropdown').remove();
-			if (typeof FileActions !== 'undefined') {
-				$('tr').removeClass('mouseOver');
-			}
-			if (callback) {
-				callback.call();
-			}
-		});
+		// TODO: deprecated
+		OC.hideMenu();
+		if (callback) {
+			callback.call();
+		}
 	},
 	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, mailSend, collection) {
 		var shareItem = {
@@ -773,26 +777,11 @@ $(document).ready(function() {
 			if ($(this).data('link') !== undefined && $(this).data('link') == true) {
 				link = true;
 			}
-			if (OC.Share.droppedDown) {
-				if (itemSource != $('#dropdown').data('item')) {
-					OC.Share.hideDropDown(function () {
-						OC.Share.showDropDown(itemType, itemSource, appendTo, link, possiblePermissions);
-					});
-				} else {
-					OC.Share.hideDropDown();
-				}
+			if (OC.Share.droppedDown && itemSource === $('#dropdown').data('item')) {
+				OC.Share.hideDropDown();
 			} else {
 				OC.Share.showDropDown(itemType, itemSource, appendTo, link, possiblePermissions);
 			}
-		}
-	});
-
-	$(this).click(function(event) {
-		var target = $(event.target);
-		var isMatched = !target.is('.drop, .ui-datepicker-next, .ui-datepicker-prev, .ui-icon')
-			&& !target.closest('#ui-datepicker-div').length && !target.closest('.ui-autocomplete').length;
-		if (OC.Share.droppedDown && isMatched && $('#dropdown').has(event.target).length === 0) {
-			OC.Share.hideDropDown();
 		}
 	});
 


### PR DESCRIPTION
Added more unified dropdown handling for share and versions

Now using showMenu/hideMenu for the share and versions dropdown.
This makes them exclude each other and the clicking outside is handled in a single location.

TODOs:
- [ ] BUG: calendar dropdown doesn't reclose when clicking on toggle
- [ ] BUG: "mouseOver" class doesn't stay when switching directly between share and versions dropdowns
