### PR TITLE
Remove loadAppScriptFile

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -6,6 +6,33 @@
  * See the COPYING-README file.
  */
 
+/** @var $this OC\Route\Router */
+
+$this->create('files_index', '/')
+	->actionInclude('files/index.php');
+$this->create('files_ajax_delete', 'ajax/delete.php')
+	->actionInclude('files/ajax/delete.php');
+$this->create('files_ajax_download', 'ajax/download.php')
+	->actionInclude('files/ajax/download.php');
+$this->create('files_ajax_getstoragestats', 'ajax/getstoragestats.php')
+	->actionInclude('files/ajax/getstoragestats.php');
+$this->create('files_ajax_list', 'ajax/list.php')
+	->actionInclude('files/ajax/list.php');
+$this->create('files_ajax_mimeicon', 'ajax/mimeicon.php')
+	->actionInclude('files/ajax/mimeicon.php');
+$this->create('files_ajax_move', 'ajax/move.php')
+	->actionInclude('files/ajax/move.php');
+$this->create('files_ajax_newfile', 'ajax/newfile.php')
+	->actionInclude('files/ajax/newfile.php');
+$this->create('files_ajax_newfolder', 'ajax/newfolder.php')
+	->actionInclude('files/ajax/newfolder.php');
+$this->create('files_ajax_rename', 'ajax/rename.php')
+	->actionInclude('files/ajax/rename.php');
+$this->create('files_ajax_scan', 'ajax/scan.php')
+	->actionInclude('files/ajax/scan.php');
+$this->create('files_ajax_upload', 'ajax/upload.php')
+	->actionInclude('files/ajax/upload.php');
+
 $this->create('download', 'download{file}')
 	->requirements(array('file' => '.*'))
 	->actionInclude('files/download.php');

--- a/apps/files_encryption/appinfo/routes.php
+++ b/apps/files_encryption/appinfo/routes.php
@@ -5,5 +5,18 @@
  * See the COPYING-README file.
  */
 
+/** @var $this \OCP\Route\IRouter */
+
+$this->create('files_encryption_ajax_adminrecovery', 'ajax/adminrecovery.php')
+	->actionInclude('files_encryption/ajax/adminrecovery.php');
+$this->create('files_encryption_ajax_changeRecoveryPassword', 'ajax/changeRecoveryPassword.php')
+	->actionInclude('files_encryption/ajax/changeRecoveryPassword.php');
+$this->create('files_encryption_ajax_getMigrationStatus', 'ajax/getMigrationStatus.php')
+	->actionInclude('files_encryption/ajax/getMigrationStatus.php');
+$this->create('files_encryption_ajax_updatePrivateKeyPassword', 'ajax/updatePrivateKeyPassword.php')
+	->actionInclude('files_encryption/ajax/updatePrivateKeyPassword.php');
+$this->create('files_encryption_ajax_userrecovery', 'ajax/userrecovery.php')
+	->actionInclude('files_encryption/ajax/userrecovery.php');
+
 // Register with the capabilities API
 OC_API::register('get', '/cloud/capabilities', array('OCA\Encryption\Capabilities', 'getCapabilities'), 'files_encryption', OC_API::USER_AUTH);

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -5,10 +5,14 @@ $this->create('core_ajax_public_preview', '/publicpreview')->action(
 		require_once __DIR__ . '/../ajax/publicpreview.php';
 	});
 
-$this->create('sharing_external_shareinfo', '/shareinfo')->actionInclude('files_sharing/ajax/shareinfo.php');
-$this->create('sharing_external_add', '/external')->actionInclude('files_sharing/ajax/external.php');
-$this->create('sharing_external_test_remote', '/testremote')->actionInclude('files_sharing/ajax/testremote.php');
-
+$this->create('files_sharing_ajax_list', 'ajax/list.php')
+	->actionInclude('files_sharing/ajax/list.php');
+$this->create('sharing_external_shareinfo', '/shareinfo')
+	->actionInclude('files_sharing/ajax/shareinfo.php');
+$this->create('sharing_external_add', '/external')
+	->actionInclude('files_sharing/ajax/external.php');
+$this->create('sharing_external_test_remote', '/testremote')
+	->actionInclude('files_sharing/ajax/testremote.php');
 // OCS API
 
 //TODO: SET: mail notification, waiting for PR #4689 to be accepted

--- a/apps/files_trashbin/appinfo/routes.php
+++ b/apps/files_trashbin/appinfo/routes.php
@@ -4,3 +4,12 @@ $this->create('core_ajax_trashbin_preview', '/preview')->action(
 function() {
 	require_once __DIR__ . '/../ajax/preview.php';
 });
+
+$this->create('files_trashbin_ajax_delete', 'ajax/delete.php')
+	->actionInclude('files_trashbin/ajax/delete.php');
+$this->create('files_trashbin_ajax_isEmpty', 'ajax/isEmpty.php')
+	->actionInclude('files_trashbin/ajax/isEmpty.php');
+$this->create('files_trashbin_ajax_list', 'ajax/list.php')
+	->actionInclude('files_trashbin/ajax/list.php');
+$this->create('files_trashbin_ajax_undelete', 'ajax/undelete.php')
+	->actionInclude('files_trashbin/ajax/undelete.php');

--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -11,5 +11,10 @@ function() {
 	require_once __DIR__ . '/../ajax/preview.php';
 });
 
+$this->create('files_versions_ajax_getVersions', 'ajax/getVersions.php')
+	->actionInclude('files_versions/ajax/getVersions.php');
+$this->create('files_versions_ajax_rollbackVersion', 'ajax/rollbackVersion.php')
+	->actionInclude('files_versions/ajax/rollbackVersion.php');
+
 // Register with the capabilities API
 OC_API::register('get', '/cloud/capabilities', array('OCA\Files_Versions\Capabilities', 'getCapabilities'), 'files_versions', OC_API::USER_AUTH);

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) 2014, Lukas Reschke <lukas@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or later.
+ * See the COPYING-README file.
+ */
+
+/** @var $this \OCP\Route\IRouter */
+$this->create('user_ldap_ajax_clearMappings', 'ajax/clearMappings.php')
+	->actionInclude('user_ldap/ajax/clearMappings.php');
+$this->create('user_ldap_ajax_deleteConfiguration', 'ajax/deleteConfiguration.php')
+	->actionInclude('user_ldap/ajax/deleteConfiguration.php');
+$this->create('user_ldap_ajax_getConfiguration', 'ajax/getConfiguration.php')
+	->actionInclude('user_ldap/ajax/getConfiguration.php');
+$this->create('user_ldap_ajax_getNewServerConfigPrefix', 'ajax/getNewServerConfigPrefix.php')
+	->actionInclude('user_ldap/ajax/getNewServerConfigPrefix.php');
+$this->create('user_ldap_ajax_setConfiguration', 'ajax/setConfiguration.php')
+	->actionInclude('user_ldap/ajax/setConfiguration.php');
+$this->create('user_ldap_ajax_testConfiguration', 'ajax/testConfiguration.php')
+	->actionInclude('user_ldap/ajax/testConfiguration.php');
+$this->create('user_ldap_ajax_wizard', 'ajax/wizard.php')
+	->actionInclude('user_ldap/ajax/wizard.php');

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -1,6 +1,5 @@
 <?php
 set_time_limit(0);
-require_once '../../lib/base.php';
 
 if (OC::checkUpgrade(false)) {
 	$l = new \OC_L10N('core');

--- a/core/routes.php
+++ b/core/routes.php
@@ -80,7 +80,8 @@ $this->create('core_ajax_preview', '/core/preview')
 	->actionInclude('core/ajax/preview.php');
 $this->create('core_ajax_preview', '/core/preview.png')
 	->actionInclude('core/ajax/preview.php');
-
+$this->create('core_ajax_update', '/core/ajax/update.php')
+	->actionInclude('core/ajax/update.php');
 // Avatar routes
 $this->create('core_avatar_get_tmp', '/avatar/tmp')
 	->get()

--- a/core/routes.php
+++ b/core/routes.php
@@ -98,16 +98,6 @@ $this->create('core_avatar_post_cropped', '/avatar/cropped')
 	->post()
 	->action('OC\Core\Avatar\Controller', 'postCroppedAvatar');
 
-// Not specifically routed
-$this->create('app_index_script', '/apps/{app}/')
-	->defaults(array('file' => 'index.php'))
-	//->requirements(array('file' => '.*.php'))
-	->action('OC', 'loadAppScriptFile');
-$this->create('app_script', '/apps/{app}/{file}')
-	->defaults(array('file' => 'index.php'))
-	->requirements(array('file' => '.*.php'))
-	->action('OC', 'loadAppScriptFile');
-
 // used for heartbeat
 $this->create('heartbeat', '/heartbeat')->action(function(){
 	// do nothing

--- a/lib/base.php
+++ b/lib/base.php
@@ -789,32 +789,6 @@ class OC {
 		}
 	}
 
-	/**
-	 * Load a PHP file belonging to the specified application
-	 * @param array $param The application and file to load
-	 * @return bool Whether the file has been found (will return 404 and false if not)
-	 * @deprecated This function will be removed in ownCloud 8 - use proper routing instead
-	 * @param $param
-	 * @return bool Whether the file has been found (will return 404 and false if not)
-	 */
-	public static function loadAppScriptFile($param) {
-		OC_App::loadApps();
-		$app = $param['app'];
-		$file = $param['file'];
-		$app_path = OC_App::getAppPath($app);
-		$file = $app_path . '/' . $file;
-
-		if (OC_App::isEnabled($app) && $app_path !== false && OC_Helper::issubdirectory($file, $app_path)) {
-			unset($app, $app_path);
-			if (file_exists($file)) {
-				require_once $file;
-				return true;
-			}
-		}
-		header('HTTP/1.0 404 Not Found');
-		return false;
-	}
-
 	protected static function handleAuthHeaders() {
 		//copy http auth headers for apache+php-fcgid work around
 		if (isset($_SERVER['HTTP_XAUTHORIZATION']) && !isset($_SERVER['HTTP_AUTHORIZATION'])) {


### PR DESCRIPTION
This removes `loadAppScriptFile` and enforces the usage of proper routing.

Fixes https://github.com/owncloud/core/issues/9060
# Todo
- [x] core
- [x] files
- [x] files_encryption
- [x] files_sharing
- [x] files_trashbin
- [x] files_versions
- [x] user_ldap
- [x] user_webdavauth
- [x] Create PR for some apps in the apps directory  (some examples: https://github.com/owncloud/apps/pull/1894)
- [x] Send mail to developer ML
# Script to generate routes

``` php
<?php

$app =  $argv[1];

$routableFolders = array(
    'ajax'
);

foreach($routableFolders as $folder) {
    $scannedDirectory = scandir('./'.$app.'/'.$folder);
    $scannedDirectory = array_diff($scannedDirectory, array('.', '..'));

    foreach($scannedDirectory as $file) {
        $fileWithoutExtension = substr($file, 0, -4);
        echo('$this->create(\''.$app.'_'.$folder.'_'.$fileWithoutExtension.'\', \''.$folder.'/'.$file.'\')'."\n");
        echo("\t".'->actionInclude(\''.$app.'/'.$folder.'/'.$file.'\');');
        echo("\n");
    }
}
```
