### PR TITLE
fix multiselect bar offset on shared page

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -28,8 +28,9 @@
 	max-width:100%;
 }
 
+/* fix multiselect bar offset on shared page */
 thead {
-	padding-left: 0 !important; /* fixes multiselect bar offset on shared page */
+	left: 0 !important;
 }
 
 #data-upload-form {


### PR DESCRIPTION
Fixes a regression where the multiselect bar on a public link shared page is shifted to the right.

Please review @owncloud/designers 
