### PR TITLE
remove obsolete 'Download preparing' message for zip downloads, fix #3755

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -345,7 +345,6 @@
 			else {
 				files = _.pluck(this.getSelectedFiles(), 'name');
 			}
-			OC.Notification.show(t('files','Your download is being prepared. This might take some time if the files are big.'));
 			OC.redirect(this.getDownloadUrl(files, dir));
 			return false;
 		},


### PR DESCRIPTION
Fix #3755, please review @owncloud/designers 
