### PR TITLE
properly cancel a Paginated Results operation in order to avoid protocol...

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1376,7 +1376,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * resets a running Paged Search operation
 	 */
 	private function abandonPagedSearch() {
-		if(count($this->cookies) > 0) {
+		if(!empty($this->lastCookie)) {
 			$cr = $this->connection->getConnectionResource();
 			$this->ldap->controlPagedResult($cr, 0, false, $this->lastCookie);
 			$this->getPagedSearchResultState();
@@ -1475,9 +1475,8 @@ class Access extends LDAPUtility implements user\IUserTools {
 					}
 				}
 				if(!is_null($cookie)) {
-					if($offset > 0) {
-						\OCP\Util::writeLog('user_ldap', 'Cookie '.CRC32($cookie), \OCP\Util::INFO);
-					}
+					//since offset = 0, this is a new search. We abandon other searches that might be ongoing.
+					$this->abandonPagedSearch();
 					$pagedSearchOK = $this->ldap->controlPagedResult(
 						$this->connection->getConnectionResource(), $limit,
 						false, $cookie);

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -95,6 +95,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 		//Cancel possibly running Paged Results operation, otherwise we run in
 		//LDAP protocol errors
 		$this->abandonPagedSearch();
+		// openLDAP requires that we init a new Paged Search. Not needed by AD,
+		// but does not hurt either.
+		$this->initPagedSearch($filter, array($dn), $attr, 1, 0);
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -36,8 +36,16 @@ class Access extends LDAPUtility implements user\IUserTools {
 	//never ever check this var directly, always use getPagedSearchResultState
 	protected $pagedSearchedSuccessful;
 
+	/**
+	 * @var string[] $cookies an array of returned Paged Result cookies
+	 */
 	protected $cookies = array();
 
+	/**
+	 * @var string $lastCookie the last cookie returned from a Paged Results
+	 * operation, defaults to an empty string
+	 */
+	protected $lastCookie = '';
 
 	public function __construct(Connection $connection, ILDAPWrapper $ldap,
 		user\Manager $userManager) {
@@ -84,7 +92,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 			\OCP\Util::writeLog('user_ldap', 'LDAP resource not available.', \OCP\Util::DEBUG);
 			return false;
 		}
-		//all or nothing! otherwise we get in trouble with.
+		//Cancel possibly running Paged Results operation, otherwise we run in
+		//LDAP protocol errors
+		$this->abandonPagedSearch();
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {
@@ -805,9 +815,6 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$linkResources = array_pad(array(), count($base), $cr);
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
 		$error = $this->ldap->errno($cr);
-		if ($pagedSearchOK) {
-			$this->ldap->controlPagedResult($cr, 999999, false, "");
-		}
 		if(!is_array($sr) || $error !== 0) {
 			\OCP\Util::writeLog('user_ldap',
 				'Error when searching: '.$this->ldap->error($cr).
@@ -1366,6 +1373,19 @@ class Access extends LDAPUtility implements user\IUserTools {
 	}
 
 	/**
+	 * resets a running Paged Search operation
+	 */
+	private function abandonPagedSearch() {
+		if(count($this->cookies) > 0) {
+			$cr = $this->connection->getConnectionResource();
+			$this->ldap->controlPagedResult($cr, 0, false, $this->lastCookie);
+			$this->getPagedSearchResultState();
+			$this->lastCookie = '';
+			$this->cookies = array();
+		}
+	}
+
+	/**
 	 * get a cookie for the next LDAP paged search
 	 * @param string $base a string with the base DN for the search
 	 * @param string $filter the search filter to identify the correct search
@@ -1403,6 +1423,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		if(!empty($cookie)) {
 			$cacheKey = 'lc' . crc32($base) . '-' . crc32($filter) . '-' .intval($limit) . '-' . intval($offset);
 			$this->cookies[$cacheKey] = $cookie;
+			$this->lastCookie = $cookie;
 		}
 	}
 

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -97,7 +97,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$this->abandonPagedSearch();
 		// openLDAP requires that we init a new Paged Search. Not needed by AD,
 		// but does not hurt either.
-		$this->initPagedSearch($filter, array($dn), $attr, 1, 0);
+		$this->initPagedSearch($filter, array($dn), array($attr), 1, 0);
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1376,7 +1376,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * resets a running Paged Search operation
 	 */
 	private function abandonPagedSearch() {
-		if(!empty($this->lastCookie)) {
+		if($this->connection->hasPagedResultSupport) {
 			$cr = $this->connection->getConnectionResource();
 			$this->ldap->controlPagedResult($cr, 0, false, $this->lastCookie);
 			$this->getPagedSearchResultState();

--- a/apps/user_ldap/lib/ildapwrapper.php
+++ b/apps/user_ldap/lib/ildapwrapper.php
@@ -51,7 +51,7 @@ interface ILDAPWrapper {
 	 * @param resource $link LDAP link resource
 	 * @param int $pageSize number of results per page
 	 * @param bool $isCritical Indicates whether the pagination is critical of not.
-	 * @param array $cookie structure sent by LDAP server
+	 * @param string $cookie structure sent by LDAP server
 	 * @return bool true on success, false otherwise
 	 */
 	public function controlPagedResult($link, $pageSize, $isCritical, $cookie);


### PR DESCRIPTION
... errors, fixes #10526

This is mostly an issue with OpenLDAP, AD worked with the old approach. But now we are also following the RFC more nicely.

How to test?
1. Have an OpenLDAP ready with more than 20 users
2. Put the test script into  your ownCloud root: https://gist.github.com/blizzz/1b4998422823f7a2d3af
3. Run the test script from command line: `php -f testCancel.php  2> data/owncloud.log`

On master with OpenLDAP it will fail with this output:

```
Step 1: fetching 10 users succeeded
Step 2: reading attribute done
Validation: cancelling Paged Search failed! Users found:  0
```

With AD, or with  OpenLDAP and this fix, it will succeed, output like this:

```
Step 1: fetching 10 users succeeded
Step 2: reading attribute done
Validation: cancelling Paged Search succeeded :) !
```

If possible, please also test with 389 Directory Server, OpenDJ, Oracle Internet Directory, Apache DS.
