### PR TITLE
Restore autotest config on SIGINT or SIGTERM

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -63,6 +63,16 @@ if [ -f config/config.php ]; then
 	mv config/config.php config/config-autotest-backup.php
 fi
 
+function restore_config {
+	# Restore existing config
+	if [ -f config/config-autotest-backup.php ]; then
+		mv config/config-autotest-backup.php config/config.php
+	fi
+}
+
+# restore config on exit, even when killed
+trap restore_config SIGINT SIGTERM
+
 # use tmpfs for datadir - should speedup unit test execution
 if [ -d /dev/shm ]; then
   DATADIR=/dev/shm/data-autotest$EXECUTOR_NUMBER
@@ -220,11 +230,7 @@ fi
 
 cd $BASEDIR
 
-# Restore existing config
-if [ -f config/config-autotest-backup.php ]; then
-	mv config/config-autotest-backup.php config/config.php
-fi
-
+restore_config
 #
 # NOTES on mysql:
 #  - CREATE DATABASE oc_autotest;


### PR DESCRIPTION
When hitting Ctrl+C to interrupt unit test running, the old
configuration was not restored properly.

This fix traps the signal to properly restore the configuration after an
interruption.

Note: this is for people like me who run their unit tests on the command line :smile: 

Please review @DeepDiver1975 @th3fallen @schiesbn 
