### PR TITLE
Add a trusted domain wizard

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -611,6 +611,10 @@ label.infield {
 	margin-left: -200px !important;
 }
 
+.error-wide .button {
+	color: black !important;
+}
+
 /* Fixes for log in page, TODO should be removed some time */
 #body-login .update,
 #body-login .error {

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -1,0 +1,19 @@
+<?php /** @var $_ array */ ?>
+
+<ul class="error-wide">
+	<li class='error'>
+		<?php p($l->t('You are accessing the server from an untrusted domain.')); ?><br/>
+
+		<p class='hint'>
+			<?php p($l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domain" setting in config/config.php. An example configuration is provided in config/config.sample.php.')); ?>
+			<br/>
+			<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
+			<br/><br/>
+			<p style="text-align:center;">
+				<a href="<?php print_unescaped(OC_Helper::makeURLAbsolute(\OCP\Util::linkToRoute('settings_admin'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
+					<?php p($l->t('Add "%s" as trusted domain', array($_['domain']))); ?>
+				</a>
+			</p>
+		</p>
+	</li>
+</ul>

--- a/lib/base.php
+++ b/lib/base.php
@@ -689,10 +689,9 @@ class OC {
 		) {
 			header('HTTP/1.1 400 Bad Request');
 			header('Status: 400 Bad Request');
-			OC_Template::printErrorPage(
-				$l->t('You are accessing the server from an untrusted domain.'),
-				$l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domain" setting in config/config.php. An example configuration is provided in config/config.sample.php.')
-			);
+			$tmpl = new OCP\Template('core', 'untrustedDomain', 'guest');
+			$tmpl->assign('domain', $_SERVER['SERVER_NAME']);
+			$tmpl->printPage();
 			return;
 		}
 

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -18,11 +18,10 @@ class AllConfig implements \OCP\IConfig {
 	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param mixed $value the value that should be stored
-	 * @todo need a use case for this
 	 */
-// 	public function setSystemValue($key, $value) {
-// 		\OCP\Config::setSystemValue($key, $value);
-// 	}
+ 	public function setSystemValue($key, $value) {
+ 		\OCP\Config::setSystemValue($key, $value);
+	}
 
 	/**
 	 * Looks up a system wide defined value

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -39,9 +39,8 @@ interface IConfig {
 	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param mixed $value the value that should be stored
-	 * @todo need a use case for this
 	 */
-// 	public function setSystemValue($key, $value);
+	public function setSystemValue($key, $value);
 
 	/**
 	 * Looks up a system wide defined value

--- a/settings/ajax/setsecurity.php
+++ b/settings/ajax/setsecurity.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2013, Lukas Reschke <lukas@statuscode.ch>
+ * Copyright (c) 2013-2014, Lukas Reschke <lukas@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  */
@@ -8,6 +8,14 @@
 OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
-OC_Config::setValue( 'forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
+if(isset($_POST['enforceHTTPS'])) {
+	OC_Config::setValue( 'forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
+}
+
+if(isset($_POST['trustedDomain'])) {
+	$trustedDomains = OC_Config::getValue('trusted_domains');
+	$trustedDomains[] = $_POST['trustedDomain'];
+	OC_Config::setValue('trusted_domains', $trustedDomains);
+}
 
 echo 'true';

--- a/settings/ajax/setsecurity.php
+++ b/settings/ajax/setsecurity.php
@@ -9,13 +9,13 @@ OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
 if(isset($_POST['enforceHTTPS'])) {
-	OC_Config::setValue( 'forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
+	 \OC::$server->getConfig()->setSystemValue('forcessl', filter_var($_POST['enforceHTTPS'], FILTER_VALIDATE_BOOLEAN));
 }
 
 if(isset($_POST['trustedDomain'])) {
-	$trustedDomains = OC_Config::getValue('trusted_domains');
+	$trustedDomains = \OC::$server->getConfig()->getSystemValue('trusted_domains');
 	$trustedDomains[] = $_POST['trustedDomain'];
-	OC_Config::setValue('trusted_domains', $trustedDomains);
+	\OC::$server->getConfig()->setSystemValue('trusted_domains', $trustedDomains);
 }
 
 echo 'true';

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -48,7 +48,9 @@ $(document).ready(function(){
 					$.ajax({
 						type: 'POST',
 						url: OC.generateUrl('settings/ajax/setsecurity.php'),
-						data: { trustedDomain: params.trustDomain}
+						data: { trustedDomain: params.trustDomain }
+					}).done(function() {
+						window.location.replace(OC.generateUrl('settings/admin'));
 					});
 				}
 			});

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -38,6 +38,22 @@ var SharingGroupList = {
 };
 
 $(document).ready(function(){
+	var params = OC.Util.History.parseUrlQuery();
+
+	// Hack to add a trusted domain
+	if (params.trustDomain) {
+		OC.dialogs.confirm(t('core', 'Are you really sure you want add "{domain}" as trusted domain?', {domain: params.trustDomain}),
+			t('core', 'Add trusted domain'), function(answer) {
+				if(answer) {
+					$.ajax({
+						type: 'POST',
+						url: OC.generateUrl('settings/ajax/setsecurity.php'),
+						data: { trustedDomain: params.trustDomain}
+					});
+				}
+			});
+	}
+
 
 	$('select#excludedGroups[multiple]').each(function (index, element) {
 		SharingGroupList.applyMultipleSelect($(element));


### PR DESCRIPTION
Adds a little button to the trusted domain warning, if an admin clicks on the warning he will be redirected to ownCloud and asked whether he want to trust this domain.

By far not the cleanest code, or clean at all, but does the job and I don't see a reason to make a lot of changes for this little improvement. I think there is no need in making "yet another" admin setting, automagic is at least preferred by myself ;-)

A check on the wording would be much appreciated.

How it looks:
![screen shot 2014-08-21 at 22 22 56](https://cloud.githubusercontent.com/assets/878997/4002902/69387dec-2971-11e4-9a7f-1fc01e76f99b.png)
![screen shot 2014-08-21 at 22 23 06](https://cloud.githubusercontent.com/assets/878997/4002911/76fc453a-2971-11e4-937d-afd9695e45e7.png)

@MTRichards @craigpg @karlitschek 
