### PR TITLE
Add require_once to update.php due to routing

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -1,5 +1,6 @@
 <?php
 set_time_limit(0);
+require_once '../../lib/base.php';
 
 if (OC::checkUpgrade(false)) {
 	$l = new \OC_L10N('core');


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/10585
Partially reverts 52d5429768acdb87b2dc2efedc89eb4ad0d29139
## Testplan
1. Setup OC on stable7
2. Switch to the "fix-10585" branch
3. Run the upgrade

@PVince81 
