### PR TITLE
Make the password changed msg inline to fix #10242

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -20,6 +20,10 @@ select {
 	background-image: url('../img/actions/delete-hover.png');
 }
 
+.ie8 .icon-checkmark {
+	background-image: url('../img/actions/checkmark.png');
+}
+
 .lte9 .icon-triangle-e {
 	background-image: url('../img/actions/triangle-e.png');
 }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -25,8 +25,6 @@ input#openid, input#webdav { width:20em; }
 	font-weight: bold;
 }
 
-#passworderror { display:none; }
-#passwordchanged { display:none; }
 #displaynameerror { display:none; }
 #displaynamechanged { display:none; }
 input#identity { width:20em; }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -182,20 +182,25 @@ $(document).ready(function () {
 				if (data.status === "success") {
 					$('#pass1').val('');
 					$('#pass2').val('');
-					$('#passwordchanged').show();
+					// Hide a possible errormsg and show successmsg
+					$('#password-changed').removeClass('hidden').addClass('inlineblock');
+					$('#password-error').removeClass('inlineblock').addClass('hidden');
 				} else {
 					if (typeof(data.data) !== "undefined") {
 						$('#passworderror').html(data.data.message);
 					} else {
 						$('#passworderror').html(t('Unable to change password'));
 					}
-					$('#passworderror').show();
+					// Hide a possible successmsg and show errormsg
+					$('#password-changed').removeClass('inlineblock').addClass('hidden');
+					$('#password-error').removeClass('hidden').addClass('inlineblock');
 				}
 			});
 			return false;
 		} else {
-			$('#passwordchanged').hide();
-			$('#passworderror').show();
+			// Hide a possible successmsg and show errormsg
+			$('#password-changed').removeClass('inlineblock').addClass('hidden');
+			$('#password-error').removeClass('hidden').addClass('inlineblock');
 			return false;
 		}
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -69,9 +69,10 @@ if($_['passwordChangeSupported']) {
 	script('jquery-showpassword');
 ?>
 <form id="passwordform" class="section">
-	<h2><?php p($l->t('Password'));?></h2>
-	<div id="passwordchanged"><?php echo $l->t('Your password was changed');?></div>
-	<div id="passworderror"><?php echo $l->t('Unable to change your password');?></div>
+	<h2 class="inlineblock"><?php p($l->t('Password'));?></h2>
+	<div class="hidden icon-checkmark" id="password-changed"></div>
+	<div class="hidden" id="password-error"><?php p($l->t('Unable to change your password'));?></div>
+	<br>
 	<input type="password" id="pass1" name="oldpassword"
 		placeholder="<?php echo $l->t('Current password');?>"
 		autocomplete="off" autocapitalize="off" autocorrect="off" />


### PR DESCRIPTION
@MorrisJobke this is your plugin … Prior to this I decided to work around this, by removing the tipsy, but this seemed pretty hacky to me, so I did this instead.

![screenshot560](https://cloud.githubusercontent.com/assets/1410802/4012260/31005652-2a0c-11e4-8bda-81da88bdd819.png)

Should I add a margin between the message and the `h2`?

cc @ser72 @LukasReschke @owncloud/designers 
