### PR TITLE
Fix isDeletable

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -204,6 +204,9 @@ class Google extends \OC\Files\Storage\Common {
 	}
 
 	public function rmdir($path) {
+		if (!$this->isDeletable($path)) {
+			return false;
+		}
 		if (trim($path, '/') === '') {
 			$dir = $this->opendir($path);
 			if(is_resource($dir)) {

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -21,7 +21,7 @@ abstract class StreamWrapper extends Common {
 	}
 
 	public function rmdir($path) {
-		if ($this->file_exists($path) and $this->isDeletable($path)) {
+		if ($this->file_exists($path) && $this->isDeletable($path)) {
 			$dh = $this->opendir($path);
 			while (($file = readdir($dh)) !== false) {
 				if ($this->is_dir($path . '/' . $file)) {

--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -21,7 +21,7 @@ abstract class StreamWrapper extends Common {
 	}
 
 	public function rmdir($path) {
-		if ($this->file_exists($path)) {
+		if ($this->file_exists($path) and $this->isDeletable($path)) {
 			$dh = $this->opendir($path);
 			while (($file = readdir($dh)) !== false) {
 				if ($this->is_dir($path . '/' . $file)) {

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -187,7 +187,7 @@ class Swift extends \OC\Files\Storage\Common {
 	public function rmdir($path) {
 		$path = $this->normalizePath($path);
 
-		if (!$this->is_dir($path) or !$this->isDeletable($path)) {
+		if (!$this->is_dir($path) || !$this->isDeletable($path)) {
 			return false;
 		}
 

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -187,7 +187,7 @@ class Swift extends \OC\Files\Storage\Common {
 	public function rmdir($path) {
 		$path = $this->normalizePath($path);
 
-		if (!$this->is_dir($path)) {
+		if (!$this->is_dir($path) or !$this->isDeletable($path)) {
 			return false;
 		}
 

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -95,7 +95,11 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	public function isDeletable($path) {
-		return $this->isUpdatable($path);
+		if ($path === '' or $path === '/') {
+			return false;
+		}
+		$parent = dirname($path);
+		return $this->isUpdatable($parent);
 	}
 
 	public function isSharable($path) {

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -95,11 +95,11 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	}
 
 	public function isDeletable($path) {
-		if ($path === '' or $path === '/') {
+		if ($path === '' || $path === '/') {
 			return false;
 		}
 		$parent = dirname($path);
-		return $this->isUpdatable($parent);
+		return $this->isUpdatable($parent) and $this->isUpdatable($path);
 	}
 
 	public function isSharable($path) {

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -99,7 +99,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 			return false;
 		}
 		$parent = dirname($path);
-		return $this->isUpdatable($parent) and $this->isUpdatable($path);
+		return $this->isUpdatable($parent) && $this->isUpdatable($path);
 	}
 
 	public function isSharable($path) {

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -39,6 +39,9 @@ if (\OC_Util::runningOnWindows()) {
 		}
 
 		public function rmdir($path) {
+			if (!$this->isDeletable($path)) {
+				return false;
+			}
 			try {
 				$it = new \RecursiveIteratorIterator(
 					new \RecursiveDirectoryIterator($this->datadir . $path),

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -38,6 +38,9 @@ class MappedLocal extends \OC\Files\Storage\Common {
 	}
 
 	public function rmdir($path) {
+		if (!$this->isDeletable($path)) {
+			return false;
+		}
 		try {
 			$it = new \RecursiveIteratorIterator(
 				new \RecursiveDirectoryIterator($this->buildPath($path)),


### PR DESCRIPTION
- Fixes default `isDeletable` to check if the parent is writable
- Don't start recursing into a directory when it's not deletable

To test:
- on master:
- Create a folder and put some files in there
- Outside oc, change the owner of the folder so the web server no longer has write access to it (only the folder, not the files inside)
- rescan the filesystem
- Try to delete one of the files inside the read-only folder (which are shown as deletable in the web-uid)
- Switch to this PR
- Rescan the filesystem
- The files inside the read-only folder should now show as non-deletable

cc @PVince81 @DeepDiver1975 
