### PR TITLE
fix wizard test, adjust to changed parameters of the tested method, intr...

### DIFF
--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -280,7 +280,7 @@ class Test_Wizard extends \PHPUnit_Framework_TestCase {
 
 		# The following expectations are the real test #
 		$filters = array('f1', 'f2', '*');
-		$resultArray = $wizard->cumulativeSearchOnAttribute($filters, 'cn', true, 0);
+		$resultArray = $wizard->cumulativeSearchOnAttribute($filters, 'cn', 0);
 		$this->assertSame(6, count($resultArray));
 		unset($mark);
 	}


### PR DESCRIPTION
...oduced by 9caa354cfc1f73159f335646ca89be4db72b125e

Due to simplification of the method, one parameter was removed in its declaration. The test method should not send it now, obviously.

Affects stable6 only (because i missed to port https://github.com/owncloud/core/pull/8623 -.-)

To test, run test apps/user_ldap/tests/wizard.php

Before it will fail, now it full succeed.

@craigpg @Xenopathic @DeepDiver1975 

@karlitschek: Needs to be ported to stable7 and master together with #8623 subsequently.
