### PR TITLE
add y to with-aspect naming schema

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -322,7 +322,7 @@ class Preview {
 		if($fileInfo !== null && $fileInfo !== false) {
 			$fileId = $fileInfo->getId();
 
-			$previewPath = $this->getThumbnailsFolder() . '/' . $fileId . '/';
+			$previewPath = $this->getPreviewPath($fileId);
 			$this->userView->deleteAll($previewPath);
 			return $this->userView->rmdir($previewPath);
 		}
@@ -392,7 +392,7 @@ class Preview {
 			return array();
 		}
 
-		$previewPath = $this->getThumbnailsFolder() . '/' . $fileId . '/';
+		$previewPath = $this->getPreviewPath($fileId);
 
 		$wantedAspectRatio = (float) ($this->getMaxX() / $this->getMaxY());
 
@@ -509,7 +509,7 @@ class Preview {
 				$this->preview = $preview;
 				$this->resizeAndCrop();
 
-				$previewPath = $this->getThumbnailsFolder() . '/' . $fileId . '/';
+				$previewPath = $this->getPreviewPath($fileId);
 				$cachePath = $this->buildCachePath($fileId);
 
 				if ($this->userView->is_dir($this->getThumbnailsFolder() . '/') === false) {
@@ -797,12 +797,18 @@ class Preview {
 		$maxX = $this->getMaxX();
 		$maxY = $this->getMaxY();
 
-		$previewPath = $this->getThumbnailsFolder() . '/' . $fileId . '/';
-		$preview = $previewPath . $maxX . '-' . $maxY . '.png';
+		$previewPath = $this->getPreviewPath($fileId);
+		$preview = $previewPath . strval($maxX) . '-' . strval($maxY);
 		if ($this->keepAspect) {
-			$preview = $previewPath . $maxX . '-with-aspect.png';
-			return $preview;
+			$preview .= '-with-aspect';
 		}
+		$preview .= '.png';
+
 		return $preview;
+	}
+
+
+	private function getPreviewPath($fileId) {
+		return $this->getThumbnailsFolder() . '/' . $fileId . '/';
 	}
 }

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -808,6 +808,10 @@ class Preview {
 	}
 
 
+	/**
+	 * @param int $fileId
+	 * @return string
+	 */
 	private function getPreviewPath($fileId) {
 		return $this->getThumbnailsFolder() . '/' . $fileId . '/';
 	}


### PR DESCRIPTION
please review @icewind1991 @MorrisJobke 

@icewind1991 I am not sure how to properly cleanup the existing cached previews that already have this {x}-with-aspect naming schema. Is there some good way to get all files where the filename matches a regex?

partial fix for https://github.com/owncloud/core/issues/10570
