### PR TITLE
Set email input field to type=email for better UX

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -86,7 +86,7 @@ if($_['passwordChangeSupported']) {
 ?>
 <form id="lostpassword" class="section">
 	<h2><?php p($l->t('Email'));?></h2>
-	<input type="text" name="email" id="email" value="<?php p($_['email']); ?>"
+	<input type="email" name="email" id="email" value="<?php p($_['email']); ?>"
 		placeholder="<?php p($l->t('Your email address'));?>"
 		autocomplete="on" autocapitalize="off" autocorrect="off" />
 	<span class="msg"></span><br />


### PR DESCRIPTION
Setting `<input type="email" ...>` instead of `<input type="text" ...>` makes for an awesome user experience.

There are some additional niceties on Desktop (address book integration, validation, etc.), but the big win is on Mobile, where browsers can show users a virtual keyboard tailored to entering email addresses.
## Before & After Screenshots:

![FxOS 2.0 Virtual Keyboards](https://cloud.githubusercontent.com/assets/24193/4047965/fdba0442-2d3e-11e4-92a6-671389ec69f7.png)

![iOS 7 Virtual Keyboards](https://cloud.githubusercontent.com/assets/24193/4047971/08a9e4c6-2d3f-11e4-969f-1df5c6a93491.png)
