### PR TITLE
Prevent errors on broken SFTP config

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -166,6 +166,9 @@ class SFTP extends \OC\Files\Storage\Common {
 	public function opendir($path) {
 		try {
 			$list = $this->client->nlist($this->absPath($path));
+			if ($list === false) {
+				return false;
+			}
 
 			$id = md5('sftp:' . $path);
 			$dirStream = array();


### PR DESCRIPTION
Steps to reproduce:
1. Create a valid SFTP config with an invalid root (`~` and `$HOME` were tested)
2. Attempt to view the main Files page
3. Notice 'Unknown error' and errors in owncloud.log
4. Retry with fix, no errors

EDIT: 'Unknown error' may be a red herring, it just happened to me with a completely valid SFTP config (which works for browsing files!)
