### PR TITLE
use notification to show error on new via web

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -668,7 +668,11 @@ $(document).ready(function() {
 						});
 						eventSource.listen('error',function(error) {
 							$('#uploadprogressbar').fadeOut();
-							alert(error);
+							OC.Notification.show(error);
+							// hide notification after 10 sec
+							setTimeout(function() {
+								OC.Notification.hide();
+							}, 10000);
 						});
 						break;
 				}


### PR DESCRIPTION
fixes alert dialog showing twice in firefox, see https://github.com/owncloud/core/issues/10047#issuecomment-53468026

@PVince81 @MorrisJobke @DeepDiver1975 @karlitschek -1 +5 quick review for stable6 please. I will forward port after that without PRs.
