### PR TITLE
Show original path information in trashbin and for shares

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -674,6 +674,12 @@
 			if (extension) {
 				nameSpan.append($('<span></span>').addClass('extension').text(extension));
 			}
+			if (fileData.extraData) {
+				if (fileData.extraData.charAt(0) === '/') {
+					fileData.extraData = fileData.extraData.substr(1);
+				}
+				nameSpan.addClass('extra-data').attr('title', fileData.extraData);
+			}
 			// dirs can show the number of uploaded files
 			if (type === 'dir') {
 				linkElem.append($('<span></span>').attr({

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -138,6 +138,9 @@ class Helper
 			}
 			$entry['mountType'] = $mountType;
 		}
+		if (isset($i['extraData'])) {
+			$entry['extraData'] = $i['extraData'];
+		}
 		return $entry;
 	}
 

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -181,6 +181,9 @@
 						file.name = OC.basename(share.file_target);
 						file.path = OC.dirname(share.file_target);
 						file.permissions = share.permissions;
+						if (file.path) {
+							file.extraData = share.file_target;
+						}
 					}
 					else {
 						if (share.share_type !== OC.Share.SHARE_TYPE_LINK) {
@@ -189,6 +192,9 @@
 						file.name = OC.basename(share.path);
 						file.path = OC.dirname(share.path);
 						file.permissions = OC.PERMISSION_ALL;
+						if (file.path) {
+							file.extraData = share.path;
+						}
 					}
 					return file;
 				})

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -35,6 +35,7 @@ class Helper
 		$absoluteDir = $view->getAbsolutePath($dir);
 
 		if (is_resource($dirContent)) {
+			$originalLocations = \OCA\Files_Trashbin\Trashbin::getLocations($user);
 			while (($entryName = readdir($dirContent)) !== false) {
 				if (!\OC\Files\Filesystem::isIgnoredDir($entryName)) {
 					$id = $entryName;
@@ -47,6 +48,13 @@ class Helper
 						$parts = explode('/', ltrim($dir, '/'));
 						$timestamp = substr(pathinfo($parts[0], PATHINFO_EXTENSION), 1);
 					}
+					$originalPath = '';
+					if (isset($originalLocations[$id][$timestamp])) {
+						$originalPath = $originalLocations[$id][$timestamp];
+						if (substr($originalPath, -1) === '/') {
+							$originalPath = substr($originalPath, 0, -1);
+						}
+					}
 					$i = array(
 						'name' => $id,
 						'mtime' => $timestamp,
@@ -54,6 +62,9 @@ class Helper
 						'type' => $view->is_dir($dir . '/' . $entryName) ? 'dir' : 'file',
 						'directory' => ($dir === '/') ? '' : $dir,
 					);
+					if ($originalPath) {
+						$i['extraData'] = $originalPath.'/'.$id;
+					}
 					$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i);
 				}
 			}

--- a/core/css/jquery-tipsy.css
+++ b/core/css/jquery-tipsy.css
@@ -1,5 +1,5 @@
 .tipsy { font-size:10px; position:absolute; padding:5px; z-index:100000; }
-.tipsy-inner { background-color:#000; color:#FFF; max-width:400px; padding:5px 8px 4px 8px; text-align:center; overflow: hidden; text-overflow: ellipsis; }
+.tipsy-inner { background-color:#000; color:#FFF; max-width:200px; padding:5px 8px 4px 8px; text-align:center; }
 
 /* Rounded corners */
 .tipsy-inner { border-radius:3px; -moz-border-radius:3px; -webkit-border-radius:3px; }

--- a/core/css/jquery-tipsy.css
+++ b/core/css/jquery-tipsy.css
@@ -1,5 +1,5 @@
 .tipsy { font-size:10px; position:absolute; padding:5px; z-index:100000; }
-.tipsy-inner { background-color:#000; color:#FFF; max-width:200px; padding:5px 8px 4px 8px; text-align:center; }
+.tipsy-inner { background-color:#000; color:#FFF; max-width:400px; padding:5px 8px 4px 8px; text-align:center; overflow: hidden; text-overflow: ellipsis; }
 
 /* Rounded corners */
 .tipsy-inner { border-radius:3px; -moz-border-radius:3px; -webkit-border-radius:3px; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -815,6 +815,11 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 .extra-data {
 	padding-right: 5px !important;
 }
+.tipsy-inner {
+	max-width: 400px !important;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
 
 /* ---- TAGS ---- */
 #tagsdialog .content {

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -811,6 +811,11 @@ span.ui-icon {float: left; margin: 3px 7px 30px 0;}
 	height: 16px;
 }
 
+/* ---- TOOLTIPS ---- */
+.extra-data {
+	padding-right: 5px !important;
+}
+
 /* ---- TAGS ---- */
 #tagsdialog .content {
 	width: 100%; height: 280px;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1097,6 +1097,7 @@ function initCore() {
 	$('td .modified').tipsy({gravity:'s', fade:true, live:true});
 	$('td.lastLogin').tipsy({gravity:'s', fade:true, html:true});
 	$('input').tipsy({gravity:'w', fade:true});
+	$('.extra-data').tipsy({gravity:'w', fade:true, live:true});
 
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function(event) {


### PR DESCRIPTION
Hovering over an item in the trashbin or in a sharing overview page will show a tooltip containing the original path of the file in the filesystem

![screenshot - 270814 - 10 48 36](https://cloud.githubusercontent.com/assets/2016878/4057967/5b0da2a8-2dcf-11e4-9448-96cef5506b62.png)
