### PR TITLE
Make Entity properties ```protected``` as in docs

### DIFF
--- a/tests/lib/appframework/db/EntityTest.php
+++ b/tests/lib/appframework/db/EntityTest.php
@@ -37,10 +37,10 @@ namespace OCP\AppFramework\Db;
  * @method void setPreName(string $preName)
  */
 class TestEntity extends Entity {
-	public $name;
-	public $email;
-	public $testId;
-	public $preName;
+	protected $name;
+	protected $email;
+	protected $testId;
+	protected $preName;
 
 	public function __construct($name=null){
 		$this->addType('testId', 'integer');		

--- a/tests/lib/appframework/db/mappertest.php
+++ b/tests/lib/appframework/db/mappertest.php
@@ -36,8 +36,8 @@ use Test\AppFramework\Db\MapperTestUtility;
  * @method void setPreName(string $preName)
  */
 class Example extends Entity {
-	public $preName;
-	public $email;
+	protected $preName;
+	protected $email;
 };
 
 


### PR DESCRIPTION
Entity properties are marked as `protected` in appframework tests to correctly reflect the
documentation, after discussion with @Raydiation.

See also owncloud/documentation@644f2eedac8e912c3019366b29ecdfbd9a15c5d9
