### PR TITLE
Don't automatically setup the filesystem the moment we load OC\Files\Filesystem

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -35,22 +35,6 @@ if (!OC_Config::getValue('maintenance', false)) {
 	if(!in_array('crypt', stream_get_wrappers())) {
 		stream_wrapper_register('crypt', 'OCA\Encryption\Stream');
 	}
-
-	// check if we are logged in
-	if (OCP\User::isLoggedIn()) {
-
-		// ensure filesystem is loaded
-		if (!\OC\Files\Filesystem::$loaded) {
-			\OC_Util::setupFS();
-		}
-
-		$view = new OC\Files\View('/');
-
-		$sessionReady = OCA\Encryption\Helper::checkRequirements();
-		if($sessionReady) {
-			$session = new \OCA\Encryption\Session($view);
-		}
-	}
 } else {
 	// logout user if we are in maintenance to force re-login
 	OCP\User::logout();

--- a/lib/base.php
+++ b/lib/base.php
@@ -721,6 +721,7 @@ class OC {
 					OC_App::loadApps();
 				}
 				self::checkSingleUserMode();
+				OC_Util::setupFS();
 				OC::$server->getRouter()->match(OC_Request::getRawPathInfo());
 				return;
 			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -776,6 +776,7 @@ class OC {
 		if (OC_User::isLoggedIn()) {
 			OC_App::loadApps();
 			OC_User::setupBackends();
+			OC_Util::setupFS();
 			if (isset($_GET["logout"]) and ($_GET["logout"])) {
 				OC_JSON::callCheck();
 				if (isset($_COOKIE['oc_token'])) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -794,5 +794,3 @@ class Filesystem {
 		return self::$defaultInstance->getETag($path);
 	}
 }
-
-\OC_Util::setupFS();

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -232,7 +232,11 @@ class OC_User {
 	 */
 	public static function login($uid, $password) {
 		session_regenerate_id(true);
-		return self::getUserSession()->login($uid, $password);
+		$result = self::getUserSession()->login($uid, $password);
+		if ($result) {
+			OC_Util::setupFS($uid);
+		}
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
Currently the filesystem is setup the moment `OC\Files\Filesystem` is first mentioned, this can leads to an unpredictable state since the order of initializing owncloud is dependent on apps that might or might not accidentally setup the filesystem (i.e. using one of the `Filesystem::` constants while setting up hooks).

This PR changes it to explicitly setup the filesystem either after loading all apps or after a successful login and ensures we load our components in the order we expect.

cc @DeepDiver1975 @PVince81 @butonic 
