### PR TITLE
allow horizontal scrollbar for personal and admin settings

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -302,6 +302,10 @@ input[type="submit"].enabled {
 	-moz-box-sizing:border-box;
 	box-sizing:border-box;
 }
+/* allow horizontal scrollbar for personal and admin settings */
+#body-settings:not(.snapjs-left) .app-settings {
+	overflow-x: auto;
+}
 
 #emptycontent {
 	font-size: 16px;


### PR DESCRIPTION
This fixes the external storage settings not being accessible with narrower screens. It just shows a horizontal scrollbar. (Fixes it both for Personal and Admin settings)

@jnfrmarks @rperezb @owncloud/designers please test.
