### PR TITLE
Prevent undefined index error loading external storages

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -169,6 +169,7 @@ class OC_Mount_Config {
 				foreach ($options as &$option) {
 					$option = self::setUserVars($user, $option);
 				}
+				$options['personal'] = false;
 				$options['options'] = self::decryptPasswords($options['options']);
 				if (!isset($options['priority'])) {
 					$options['priority'] = $backends[$options['class']]['priority'];


### PR DESCRIPTION
In the case of an external mount configuration for all users, the 'personal' config option wasn't being set to false in `getAbsoluteMountPoints()`, causing an error where that option was accessed.

Although it currently doesn't break anything, it would be good to backport this to stable7 @karlitschek 

Please review @PVince81 @icewind1991 
