### PR TITLE
Kill insecure random number generation

### DIFF
--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -29,7 +29,7 @@ require_once __DIR__.'/template/functions.php';
 class OC_Template extends \OC\Template\Base {
 	private $renderas; // Create a full page?
 	private $path; // The path to the template
-	private $headers=array(); //custom headers
+	private $headers = array(); //custom headers
 	protected $app; // app id
 
 	/**
@@ -37,6 +37,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @param string $app app providing the template
 	 * @param string $name of the template file (without suffix)
 	 * @param string $renderas = ""; produce a full page
+	 * @param bool $registerCall = true
 	 * @return OC_Template object
 	 *
 	 * This function creates an OC_Template object.
@@ -45,14 +46,14 @@ class OC_Template extends \OC\Template\Base {
 	 * according layout. For now, renderas can be set to "guest", "user" or
 	 * "admin".
 	 */
-	public function __construct( $app, $name, $renderas = "" ) {
+	public function __construct( $app, $name, $renderas = "", $registerCall = true ) {
 		// Read the selected theme from the config file
 		$theme = OC_Util::getTheme();
 
 		// Read the detected formfactor and use the right file name.
 		$fext = self::getFormFactorExtension();
 
-		$requesttoken = OC::$server->getSession() ? OC_Util::callRegister() : '';
+		$requesttoken = (OC::$server->getSession() and $registerCall) ? OC_Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = OC_L10N::get($parts[0]);
@@ -253,7 +254,7 @@ class OC_Template extends \OC\Template\Base {
 		* Warning: All data passed to $hint needs to get sanitized using OC_Util::sanitizeHTML
 		*/
 	public static function printErrorPage( $error_msg, $hint = '' ) {
-		$content = new OC_Template( '', 'error', 'error' );
+		$content = new \OC_Template( '', 'error', 'error', false );
 		$errors = array(array('error' => $error_msg, 'hint' => $hint));
 		$content->assign( 'errors', $errors );
 		$content->printPage();

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -59,7 +59,9 @@ class OC_TemplateLayout extends OC_Template {
 			$this->assign( 'user_uid', OC_User::getUser() );
 			$this->assign( 'appsmanagement_active', strpos(OC_Request::requestUri(), OC_Helper::linkToRoute('settings_apps')) === 0 );
 			$this->assign('enableAvatars', \OC_Config::getValue('enable_avatars', true));
-		} else if ($renderas == 'guest' || $renderas == 'error') {
+		} else if ($renderas == 'error') {
+			parent::__construct('core', 'layout.guest', '', false);
+		} else if ($renderas == 'guest') {
 			parent::__construct('core', 'layout.guest');
 		} else {
 			parent::__construct('core', 'layout.base');

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1208,6 +1208,7 @@ class OC_Util {
 	 *
 	 * @param int $length of the random string
 	 * @return string
+	 * @throws Exception when no secure RNG source is available
 	 * Please also update secureRNGAvailable if you change something here
 	 */
 	public static function generateRandomBytes($length = 30) {
@@ -1228,17 +1229,8 @@ class OC_Util {
 			}
 		}
 
-		// Fallback to mt_rand()
-		$characters = '0123456789';
-		$characters .= 'abcdefghijklmnopqrstuvwxyz';
-		$charactersLength = strlen($characters) - 1;
-		$pseudoByte = "";
-
-		// Select some random characters
-		for ($i = 0; $i < $length; $i++) {
-			$pseudoByte .= $characters[mt_rand(0, $charactersLength)];
-		}
-		return $pseudoByte;
+		// No random numbers are better then bad random numbers
+		throw new \Exception('No secure random number generator available, please install the php-openssl extension');
 	}
 
 	/**


### PR DESCRIPTION
Bad random numbers are in fact **not** better than no random numbers.

Also fixes a problem where when `registerCall` gives an exception we would fail to render a proper error page

cc @PVince81 @DeepDiver1975 @LukasReschke 
