### PR TITLE
Drop the connection check from the admin page

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1150,39 +1150,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Check if the ownCloud server can connect to the internet
-	 *
-	 * @return bool
-	 */
-	public static function isInternetConnectionWorking() {
-		// in case there is no internet connection on purpose return false
-		if (self::isInternetConnectionEnabled() === false) {
-			return false;
-		}
-
-		// in case the connection is via proxy return true to avoid connecting to owncloud.org
-		if (OC_Config::getValue('proxy', '') != '') {
-			return true;
-		}
-
-		// try to connect to owncloud.org to see if http connections to the internet are possible.
-		$connected = @fsockopen("www.owncloud.org", 80);
-		if ($connected) {
-			fclose($connected);
-			return true;
-		} else {
-			// second try in case one server is down
-			$connected = @fsockopen("apps.owncloud.com", 80);
-			if ($connected) {
-				fclose($connected);
-				return true;
-			} else {
-				return false;
-			}
-		}
-	}
-
-	/**
 	 * Check if the connection to the internet is disabled on purpose
 	 *
 	 * @return string

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1150,15 +1150,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Check if the connection to the internet is disabled on purpose
-	 *
-	 * @return string
-	 */
-	public static function isInternetConnectionEnabled() {
-		return \OC_Config::getValue("has_internet_connection", true);
-	}
-
-	/**
 	 * clear all levels of output buffering
 	 *
 	 * @return void

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -38,7 +38,6 @@ $tmpl->assign('mail_smtppassword', OC_Config::getValue( "mail_smtppassword", '' 
 $tmpl->assign('entries', $entries);
 $tmpl->assign('entriesremain', $entriesremain);
 $tmpl->assign('htaccessworking', $htaccessworking);
-$tmpl->assign('internetconnectionworking', OC_Util::isInternetConnectionEnabled() ? OC_Util::isInternetConnectionWorking() : false);
 $tmpl->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
 $tmpl->assign('isPhpCharSetUtf8', OC_Util::isPhpCharSetUtf8());
 $tmpl->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -180,23 +180,9 @@ if (!$_['isLocaleWorking']) {
 	</span>
 
 </div>
+
 <?php
 }
-
-// is internet connection working ?
-if (!$_['internetconnectionworking']) {
-	?>
-	<div class="section">
-		<h2><?php p($l->t('Internet connection not working'));?></h2>
-
-		<span class="connectionwarning">
-		<?php p($l->t('This server has no working internet connection. This means that some of the features like mounting of external storage, notifications about updates or installation of 3rd party apps don´t work. Accessing files from remote and sending of notification emails might also not work. We suggest to enable internet connection for this server if you want to have all features.')); ?>
-	</span>
-
-	</div>
-<?php
-}
-
 if ($_['suggestedOverwriteWebroot']) {
 	?>
 	<div class="section">

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -80,14 +80,6 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, \OC_Util::fileInfoLoaded());
 	}
 
-	public function testIsInternetConnectionEnabled() {
-		\OC_Config::setValue("has_internet_connection", false);
-		$this->assertFalse(\OC_Util::isInternetConnectionEnabled());
-
-		\OC_Config::setValue("has_internet_connection", true);
-		$this->assertTrue(\OC_Util::isInternetConnectionEnabled());
-	}
-
 	function testGenerateRandomBytes() {
 		$result = strlen(OC_Util::generateRandomBytes(59));
 		$this->assertEquals(59, $result);


### PR DESCRIPTION
It increases the loading time of the admin page, creates a privacy concern by "calling home", relies on the oc web servers to be alive, needlessly increases the load on the oc servers and is generally a useless thing to check.

cc @DeepDiver1975 @PVince81
