### PR TITLE
define min height/width for icon classes to make sure they show

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -1,6 +1,8 @@
 [class^="icon-"], [class*=" icon-"] {
 	background-repeat: no-repeat;
 	background-position: center;
+	min-width: 16px;
+	min-height: 16px;
 }
 
 


### PR DESCRIPTION
Otherwise elements like span and a which have no height/width by default do not show icons.

Please review @Gomez @owncloud/designers 
