### PR TITLE
Use getRemoteAddress which supports reverse proxies

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -68,7 +68,7 @@ if($linkedItem['item_type'] === 'folder') {
 	$isValid = \OC\Files\Filesystem::isValidPath($file);
 	if(!$isValid) {
 		\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
-		\OC_Log::write('core-preview', 'Passed filename is not valid, might be malicious (file:"' . $file . '";ip:"' . $_SERVER['REMOTE_ADDR'] . '")', \OC_Log::WARN);
+		\OC_Log::write('core-preview', 'Passed filename is not valid, might be malicious (file:"' . $file . '";ip:"' . \OC::$server->getRequest()->getRemoteAddress() . '")', \OC_Log::WARN);
 		exit;
 	}
 	$sharedFile = \OC\Files\Filesystem::normalizePath($file);

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -181,10 +181,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			}
 		}
 
-		$remoteAddr = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
-		$forwardedFor = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : '';
-
-		\OC::$server->getLogger()->warning('Login failed: \''. $loginname .'\' (Remote IP: \''. $remoteAddr .'\', X-Forwarded-For: \''. $forwardedFor .'\')', array('app' => 'core'));
+		\OC::$server->getLogger()->warning('Login failed: \''. $loginname .'\' (Remote IP: \''. \OC::$server->getRequest()->getRemoteAddress(). ')', ['app' => 'core']);
 		return false;
 	}
 


### PR DESCRIPTION
Breaking change for 8.1 wiki (Security > Administrators):

The log format for failed logins has changed and uses now the remote address and is considering reverse proxies for such scenarios when configured correctly.
