### PR TITLE
Fix quota bar width, and indicate almost full storage

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -737,6 +737,7 @@ code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono
 	white-space: nowrap;
 	border-bottom-left-radius: 3px;
 	border-top-left-radius: 3px;
+	min-width: 1%;
 	max-width: 100%;
 }
 #quotatext {padding:.6em 1em;}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -736,7 +736,9 @@ code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono
 	font-weight: normal;
 	white-space: nowrap;
 	border-bottom-left-radius: 3px;
-	border-top-left-radius: 3px; }
+	border-top-left-radius: 3px;
+	max-width: 100%;
+}
 #quotatext {padding:.6em 1em;}
 
 .pager { list-style:none; float:right; display:inline; margin:.7em 13em 0 0; }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -742,6 +742,10 @@ code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono
 }
 #quotatext {padding:.6em 1em;}
 
+#quota div.quota-warning {
+	background-color: #fc4;
+}
+
 .pager { list-style:none; float:right; display:inline; margin:.7em 13em 0 0; }
 .pager li { display:inline-block; }
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -34,7 +34,8 @@
 
 
 <div id="quota" class="section">
-	<div style="width:<?php p($_['usage_relative']);?>%;">
+	<div style="width:<?php p($_['usage_relative']);?>%;
+		<?php if($_['usage_relative'] > 80): ?>background-color:#fc4;<?php endif; ?>">
 		<p id="quotatext">
 			<?php print_unescaped($l->t('You have used <strong>%s</strong> of the available <strong>%s</strong>',
 			array($_['usage'], $_['total_space'])));?>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -34,8 +34,8 @@
 
 
 <div id="quota" class="section">
-	<div style="width:<?php p($_['usage_relative']);?>%;
-		<?php if($_['usage_relative'] > 80): ?>background-color:#fc4;<?php endif; ?>">
+	<div style="width:<?php p($_['usage_relative']);?>%"
+		<?php if($_['usage_relative'] > 80): ?> class="quota-warning" <?php endif; ?>>
 		<p id="quotatext">
 			<?php print_unescaped($l->t('You have used <strong>%s</strong> of the available <strong>%s</strong>',
 			array($_['usage'], $_['total_space'])));?>


### PR DESCRIPTION
When the quota is set by the admin to a value below the used space, the bar extends to make the personal page scroll horizontally. This fixes it.

Also adds a minimum width of 1% so it’s apparent how the quota bar will look. I know it’s incorrect, but otherwise it will look strange because it’s just empty.

Now the quota bar is also colored (in the notification yellow) when storage use is over 90%.

Please review @owncloud/designers 
