### PR TITLE
Use Doctrine Platform to generate SQL query for table truncation.

### DIFF
--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -172,7 +172,7 @@ class Helper {
 	}
 
 	/**
-	 * extractsthe domain from a given URL
+	 * extracts the domain from a given URL
 	 * @param string $url the URL
 	 * @return string|false domain as string on success, false otherwise
 	 */

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -159,14 +159,9 @@ class Helper {
 			return false;
 		}
 
-		$dbtype = \OCP\Config::getSystemValue('dbtype');
-		if(strpos($dbtype, 'sqlite') !== false || $dbtype === 'oci') {
-			$query = \OCP\DB::prepare('DELETE FROM '.$table);
-		} else {
-			$query = \OCP\DB::prepare('TRUNCATE '.$table);
-		}
-
-
+		$connection = \OC_DB::getConnection();
+		$sql = $connection->getDatabasePlatform()->getTruncateTableSQL($table);
+		$query = \OCP\DB::prepare($sql);
 		$res = $query->execute();
 
 		if(\OCP\DB::isError($res)) {

--- a/apps/user_ldap/tests/helper.php
+++ b/apps/user_ldap/tests/helper.php
@@ -1,0 +1,31 @@
+<?php
+/**
+* ownCloud
+*
+* @author Thomas Müller
+* @copyright 2014 Thomas Müller deepdiver@owncloud.com
+*
+*/
+
+namespace OCA\user_ldap\tests;
+
+use OCA\user_ldap\lib\Helper;
+
+class Test_Helper extends \PHPUnit_Framework_TestCase {
+
+	public function testTableTruncate() {
+
+		$statement = \OCP\DB::prepare('INSERT INTO `*PREFIX*ldap_user_mapping` (`ldap_dn`, `owncloud_name`, `directory_uuid`) VALUES (?, ?, ?)');
+		$statement->execute(array('db01', 'oc1', '000-0000-0000'));
+		$statement->execute(array('db02', 'oc2', '000-0000-0001'));
+
+		$statement = \OCP\DB::prepare('SELECT count(*) FROM `*PREFIX*ldap_user_mapping`');
+		$result = $statement->execute();
+		$this->assertEquals(2, $result->fetchOne());
+
+		Helper::clearMapping('user');
+
+		$result = $statement->execute();
+		$this->assertEquals(0, $result->fetchOne());
+	}
+}


### PR DESCRIPTION
Possible replacement for #10720 (and as a result hopefully fixes #10708).

In contrast to #10720 this does not introduce further DB switching, but instead removes DB switching completely.

The new expected behaviour is as follows (also see https://github.com/owncloud/core/pull/10720#issuecomment-53894567):
MySQL uses TRUNCATE (as before)
Sqlite uses DELETE FROM (as before)
MSSQL uses TRUNCATE TABLE (as in #10720)
Oracle uses TRUNCATE TABLE (previously used DELETE FROM, so this needs testing)

I have not done any testing, I will leave that to people with LDAP setup or unit tests.

@blizzz @DeepDiver1975 @butonic @gig13 
