### PR TITLE
Ensure db connection before changing cache state

### DIFF
--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -417,6 +417,7 @@ class OC_DB {
 	 * @param bool $enabled
 	 */
 	static public function enableCaching($enabled) {
+		self::connect();
 		if ($enabled) {
 			self::$connection->enableQueryStatementCaching();
 		} else {


### PR DESCRIPTION
When trying to upgrade from 7.0.0 to 7.0.2, the manual upgrade path
(e.g. `sudo -u www-data /usr/bin/php5 ./occ upgrade`) exits with the
following fatal error:

```
/var/www/owncloud# php occ upgrade
PHP Fatal error:  Call to a member function
  disableQueryStatementCaching() on a non-object in
  /var/www/owncloud/lib/private/db.php on line 423
```

This is caused by the self::$connection static variable having not
been initialized at the point of call. Adding a self::connect() fixes
the issue.

See https://forum.owncloud.org/viewtopic.php?f=29&t=23398&p=68556#p68556
