### PR TITLE
Add optional user ID parameter for getUseFolder

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -209,10 +209,17 @@ class Server extends SimpleContainer implements IServerContainer {
 	/**
 	 * Returns a view to ownCloud's files folder
 	 *
+	 * @param string $userId user ID
 	 * @return \OCP\Files\Folder
 	 */
-	function getUserFolder() {
-		$dir = '/' . \OCP\User::getUser();
+	function getUserFolder($userId = null) {
+		if($userId === null) {
+			$userId = \OCP\User::getUser();
+			if (!$userId) {
+				return null;
+			}
+		}
+		$dir = '/' . $userId;
 		$root = $this->getRootFolder();
 		$folder = null;
 


### PR DESCRIPTION
Backport of #10770 

This is required because the user session hasn't the method `getUser()` so I need to use the static method call `\OCP\User`

cc @icewind1991 @tomneedham 
