### PR TITLE
Fix upgrade process when apps enabled for specific groups

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -3,6 +3,10 @@ set_time_limit(0);
 require_once '../../lib/base.php';
 
 if (OC::checkUpgrade(false)) {
+	// if a user is currently logged in, their session must be ignored to
+	// avoid side effects
+	\OC_User::setIncognitoMode(true);
+
 	$l = new \OC_L10N('core');
 	$eventSource = new OC_EventSource();
 	$updater = new \OC\Updater(\OC_Log::$object);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1490,9 +1490,11 @@ class OC_Util {
 	}
 
 	/**
-	 * Check whether the instance needs to preform an upgrade
+	 * Check whether the instance needs to perform an upgrade,
+	 * either when the core version is higher or any app requires
+	 * an upgrade.
 	 *
-	 * @return bool
+	 * @return bool whether the core or any app needs an upgrade
 	 */
 	public static function needUpgrade() {
 		if (OC_Config::getValue('installed', false)) {
@@ -1502,14 +1504,16 @@ class OC_Util {
 				return true;
 			}
 
-			// also check for upgrades for apps
-			$apps = \OC_App::getEnabledApps();
+			// also check for upgrades for apps (independently from the user)
+			$apps = \OC_App::getEnabledApps(false, true);
+			$shouldUpgrade = false;
 			foreach ($apps as $app) {
 				if (\OC_App::shouldUpgrade($app)) {
-					return true;
+					$shouldUpgrade = true;
+					break;
 				}
 			}
-			return false;
+			return $shouldUpgrade;
 		} else {
 			return false;
 		}

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -303,6 +303,8 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		\OC::$WEBROOT = '';
 
 		Dummy_OC_App::setEnabledApps($enabledApps);
+		// need to set a user id to make sure enabled apps are read from cache
+		\OC_User::setUserId(uniqid());
 		\OCP\Config::setSystemValue('defaultapp', $defaultAppConfig);
 		$this->assertEquals('http://localhost/' . $expectedPath, \OC_Util::getDefaultPageUrl());
 
@@ -310,6 +312,7 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		\OC::$WEBROOT = $oldWebRoot;
 		Dummy_OC_App::restore();
 		\OCP\Config::setSystemValue('defaultapp', $oldDefaultApps);
+		\OC_User::setUserId(null);
 	}
 
 	function defaultAppsProvider() {

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -344,6 +344,25 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * Test needUpgrade() when the core version is increased
+	 */
+	public function testNeedUpgradeCore() {
+		$oldConfigVersion = OC_Config::getValue('version', '0.0.0');
+		$oldSessionVersion = \OC::$server->getSession()->get('OC_Version');
+
+		$this->assertFalse(\OCP\Util::needUpgrade());
+
+		OC_Config::setValue('version', '7.0.0.0');
+		\OC::$server->getSession()->set('OC_Version', array(7, 0, 0, 1));
+
+		$this->assertTrue(\OCP\Util::needUpgrade());
+
+		OC_Config::setValue('version', $oldConfigVersion);
+		$oldSessionVersion = \OC::$server->getSession()->set('OC_Version', $oldSessionVersion);
+
+		$this->assertFalse(\OCP\Util::needUpgrade());
+	}
 }
 
 /**


### PR DESCRIPTION
Fix issue where the currently logged user was causing side-effects when
upgrading.
Now setting incognito mode (no user) on update to make sure the whole
apps list is taken into account with getEnabledApps() or isEnabled().

Fixes #10762 
Fixes #10650 

TODO:
- [x] unit test for `getEnabledApps()`
- [x] unit test for `needsUpgrade()`
- [x] acceptance test (if possible) to verify whether an app enabled with group correctly appears
