### PR TITLE
Libreoffice config folder needs to be set

### DIFF
--- a/lib/private/preview/office-cl.php
+++ b/lib/private/preview/office-cl.php
@@ -29,10 +29,10 @@ if (!\OC_Util::runningOnWindows()) {
 
 			$tmpDir = get_temp_dir();
 
-			$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir) . ' --headless --nologo --nofirststartwizard --invisible --norestore -convert-to pdf -outdir ';
+			$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir . '/owncloud-' . \OC_Util::getInstanceId().'/') . ' --headless --nologo --nofirststartwizard --invisible --norestore -convert-to pdf -outdir ';
 			$clParameters = \OCP\Config::getSystemValue('preview_office_cl_parameters', $defaultParameters);
 
-			$exec = $this->cmd . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath) . ' -env:UserInstallation=file://' . escapeshellarg(get_temp_dir() . '/owncloud-' . \OC_Util::getInstanceId().'/');
+			$exec = $this->cmd . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath);
 
 			shell_exec($exec);
 

--- a/lib/private/preview/office-cl.php
+++ b/lib/private/preview/office-cl.php
@@ -32,7 +32,7 @@ if (!\OC_Util::runningOnWindows()) {
 			$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir) . ' --headless --nologo --nofirststartwizard --invisible --norestore -convert-to pdf -outdir ';
 			$clParameters = \OCP\Config::getSystemValue('preview_office_cl_parameters', $defaultParameters);
 
-			$exec = $this->cmd . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath);
+			$exec = $this->cmd . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath) . ' -env:UserInstallation=file://' . escapeshellarg(get_temp_dir() . '/owncloud-' . \OC_Util::getInstanceId().'/');
 
 			shell_exec($exec);
 


### PR DESCRIPTION
In order to avoid conflicts between multiple instances installed on one server, it's required to define a LibreOffice configuration folder per instance.

Just like with my PR for the documents app (https://github.com/owncloud/documents/pull/353), I propose to use `/tmp/owncloud-<instanceid>`
