### PR TITLE
Scroll to file on search or add

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -24,6 +24,7 @@
 		initialize: function() {
 			this.navigation = new OCA.Files.Navigation($('#app-navigation'));
 
+			var urlParams = OC.Util.History.parseUrlQuery();
 			var fileActions = new OCA.Files.FileActions();
 			// default actions
 			fileActions.registerDefaultActions();
@@ -47,7 +48,8 @@
 					dragOptions: dragOptions,
 					folderDropOptions: folderDropOptions,
 					fileActions: fileActions,
-					allowLegacyActions: true
+					allowLegacyActions: true,
+					scrollTo: urlParams.scrollto
 				}
 			);
 			this.files.initialize();
@@ -58,7 +60,7 @@
 
 			this._setupEvents();
 			// trigger URL change event handlers
-			this._onPopState(OC.Util.History.parseUrlQuery());
+			this._onPopState(urlParams);
 		},
 
 		/**

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -629,7 +629,7 @@ OC.Upload = {
 								},
 								function(result) {
 									if (result.status === 'success') {
-										FileList.add(result.data, {hidden: hidden, animate: true});
+										FileList.add(result.data, {hidden: hidden, animate: true, scrollTo: true});
 									} else {
 										OC.dialogs.alert(result.data.message, t('core', 'Could not create file'));
 									}
@@ -645,7 +645,7 @@ OC.Upload = {
 								},
 								function(result) {
 									if (result.status === 'success') {
-										FileList.add(result.data, {hidden: hidden, animate: true});
+										FileList.add(result.data, {hidden: hidden, animate: true, scrollTo: true});
 									} else {
 										OC.dialogs.alert(result.data.message, t('core', 'Could not create folder'));
 									}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -722,9 +722,10 @@
 		 *
 		 * @param fileData map of file attributes
 		 * @param options map of attributes:
-		 * - "updateSummary": true to update the summary after adding (default), false otherwise
-		 * - "silent": true to prevent firing events like "fileActionsReady"
-		 * - "animate": true to animate preview loading (defaults to true here)
+		 * @param options.updateSummary true to update the summary after adding (default), false otherwise
+		 * @param options.silent true to prevent firing events like "fileActionsReady"
+		 * @param options.animate true to animate preview loading (defaults to true here)
+		 * @param options.scrollTo true to automatically scroll to the file's location
 		 * @return new tr element (not appended to the table)
 		 */
 		add: function(fileData, options) {
@@ -771,6 +772,10 @@
 				window.setTimeout(function() {
 					$tr.removeClass('transparent');
 				});
+			}
+
+			if (options.scrollTo) {
+				this.scrollTo(fileData.name);
 			}
 
 			// defaults to true if not defined

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -110,9 +110,10 @@
 		 * @param $el container element with existing markup for the #controls
 		 * and a table
 		 * @param options map of options, see other parameters
-		 * @param scrollContainer scrollable container, defaults to $(window)
-		 * @param dragOptions drag options, disabled by default
-		 * @param folderDropOptions folder drop options, disabled by default
+		 * @param options.scrollContainer scrollable container, defaults to $(window)
+		 * @param options.dragOptions drag options, disabled by default
+		 * @param options.folderDropOptions folder drop options, disabled by default
+		 * @param options.scrollTo name of file to scroll to after the first load
 		 */
 		initialize: function($el, options) {
 			var self = this;
@@ -172,6 +173,12 @@
 			this.setupUploadEvents();
 
 			this.$container.on('scroll', _.bind(this._onScroll, this));
+
+			if (options.scrollTo) {
+				this.$fileList.one('updated', function() {
+					self.scrollTo(options.scrollTo);
+				});
+			}
 		},
 
 		/**
@@ -1523,16 +1530,15 @@
 			this.$table.removeClass('hidden');
 		},
 		scrollTo:function(file) {
-			//scroll to and highlight preselected file
-			var $scrollToRow = this.findFileEl(file);
-			if ($scrollToRow.exists()) {
-				$scrollToRow.addClass('searchresult');
-				$(window).scrollTop($scrollToRow.position().top);
-				//remove highlight when hovered over
-				$scrollToRow.one('hover', function() {
-					$scrollToRow.removeClass('searchresult');
-				});
+			if (!_.isArray(file)) {
+				file = [file];
 			}
+			this.highlightFiles(file, function($tr) {
+				$tr.addClass('searchresult');
+				$tr.one('hover', function() {
+					$tr.removeClass('searchresult');
+				});
+			});
 		},
 		filter:function(query) {
 			this.$fileList.find('tr').each(function(i,e) {
@@ -1861,9 +1867,11 @@
 		/**
 		 * Scroll to the last file of the given list
 		 * Highlight the list of files
-		 * @param files array of filenames
+		 * @param files array of filenames,
+		 * @param {Function} [highlightFunction] optional function
+		 * to be called after the scrolling is finished
 		 */
-		highlightFiles: function(files) {
+		highlightFiles: function(files, highlightFunction) {
 			// Detection of the uploaded element
 			var filename = files[files.length - 1];
 			var $fileRow = this.findFileEl(filename);
@@ -1888,12 +1896,16 @@
 				duration: 500,
 				complete: function() {
 					// Highlighting function
-					var highlightRow = function($fileRow) {
-						$fileRow.addClass("highlightUploaded");
-						setTimeout(function() {
-							$fileRow.removeClass("highlightUploaded");
-						}, 2500);
-					};
+					var highlightRow = highlightFunction;
+
+					if (!highlightRow) {
+						highlightRow = function($fileRow) {
+							$fileRow.addClass("highlightUploaded");
+							setTimeout(function() {
+								$fileRow.removeClass("highlightUploaded");
+							}, 2500);
+						};
+					}
 
 					// Loop over uploaded files
 					for(var i=0; i<files.length; i++) {

--- a/search/js/result.js
+++ b/search/js/result.js
@@ -80,7 +80,7 @@ OC.search.showResults=function(results){
 							containerName = '/';
 						}
 						var containerLink = OC.linkTo('files', 'index.php')
-							+'?dir='+encodeURIComponent(parent)
+							+'/?dir='+encodeURIComponent(parent)
 							+'&scrollto='+encodeURIComponent(type[i].name);
 						row.find('td.result a')
 							.attr('href', containerLink)


### PR DESCRIPTION
Fixes the following cases:
1) Type a file name in the search box, click on the result in the dropdown (the file must be in a different dir). It will open the matching directory and scroll there.

2) Activity app, when clicking on a file, it will go to the files app and scroll to it.

3) Create a new file or folder with the menu, it will scroll to that file.

Note that the search and activity apps simply use the "scrollto" URL argument which is what triggers the scrolling.

Please review and test @th3fallen @butonic @icewind1991 @owncloud/designers 

Fixes https://github.com/owncloud/core/issues/10737
