### PR TITLE
fix BadRequest error if CONTENT_LENGTH not set

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -102,13 +102,16 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			throw new OC_Connector_Sabre_Exception_FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 
+		// if content length is sent by client:
 		// double check if the file was fully received
 		// compare expected and actual size
-		$expected = $_SERVER['CONTENT_LENGTH'];
-		$actual = $this->fileView->filesize($partFilePath);
-		if ($actual != $expected) {
-			$this->fileView->unlink($partFilePath);
-			throw new \Sabre\DAV\Exception\BadRequest('expected filesize ' . $expected . ' got ' . $actual);
+		if (isset($_SERVER['CONTENT_LENGTH'])) {
+			$expected = $_SERVER['CONTENT_LENGTH'];
+			$actual = $this->fileView->filesize($partFilePath);
+			if ($actual != $expected) {
+				$this->fileView->unlink($partFilePath);
+				throw new \Sabre\DAV\Exception\BadRequest('expected filesize ' . $expected . ' got ' . $actual);
+			}
 		}
 
 		// rename to correct path


### PR DESCRIPTION
fixes issue #10843
If client does not send content length header on webdav upload (e.g. because the content comes from a stream and its length is not predictable) the put() method should not try to compare the content length value with the actually amount of received data, because this will always fail and results in a BadRequest exception. So the check will only be performed if $_SERVER['CONTENT_LENGTH'] is set.

This contribution is MIT licensed.
