### PR TITLE
Added permission check for drag and drop

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1632,6 +1632,18 @@
 		},
 
 		/**
+		 * Shows a "permission denied" notification
+		 */
+		_showPermissionDeniedNotification: function() {
+			var message = t('core', 'You don’t have permission to upload or create files here');
+			OC.Notification.show(message);
+			//hide notification after 10 sec
+			setTimeout(function() {
+				OC.Notification.hide();
+			}, 5000);
+		},
+
+		/**
 		 * Setup file upload events related to the file-upload plugin
 		 */
 		setupUploadEvents: function() {
@@ -1662,6 +1674,12 @@
 					// remember as context
 					data.context = dropTarget;
 
+					// if permissions are specified, only allow if create permission is there
+					var permissions = dropTarget.data('permissions');
+					if (!_.isUndefined(permissions) && (permissions & OC.PERMISSION_CREATE) === 0) {
+						self._showPermissionDeniedNotification();
+						return false;
+					}
 					var dir = dropTarget.data('file');
 					// if from file list, need to prepend parent dir
 					if (dir) {
@@ -1686,6 +1704,7 @@
 					// cancel uploads to current dir if no permission
 					var isCreatable = (self.getDirectoryPermissions() & OC.PERMISSION_CREATE) !== 0;
 					if (!isCreatable) {
+						self._showPermissionDeniedNotification();
 						return false;
 					}
 				}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -433,7 +433,12 @@ var folderDropOptions = {
 			return false;
 		}
 
-		var targetPath = FileList.getCurrentDirectory() + '/' + $(this).closest('tr').data('file');
+		var $tr = $(this).closest('tr');
+		if (($tr.data('permissions') & OC.PERMISSION_CREATE) === 0) {
+			FileList._showPermissionDeniedNotification();
+			return false;
+		}
+		var targetPath = FileList.getCurrentDirectory() + '/' + $tr.data('file');
 
 		var files = FileList.getSelectedFiles();
 		if (files.length === 0) {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1835,7 +1835,6 @@ describe('OCA.Files.FileList tests', function() {
 			// but it makes it possible to simulate the event triggering to
 			// test the response of the handlers
 			$uploader = $('#file_upload_start');
-			fileList.setupUploadEvents();
 			fileList.setFiles(testFiles);
 		});
 
@@ -1912,6 +1911,16 @@ describe('OCA.Files.FileList tests', function() {
 				ev = dropOn(fileList.$fileList.find('th:first'));
 
 				expect(ev.result).toEqual(false);
+				expect(notificationStub.calledOnce).toEqual(true);
+			});
+			it('drop on an folder does not trigger upload if no upload permission on that folder', function() {
+				var $tr = fileList.findFileEl('somedir');
+				var ev;
+				$tr.data('permissions', OC.PERMISSION_READ);
+				ev = dropOn($tr);
+
+				expect(ev.result).toEqual(false);
+				expect(notificationStub.calledOnce).toEqual(true);
 			});
 			it('drop on a file row inside the table triggers upload to current folder', function() {
 				var ev;


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/10846

When dropping files onto a read-only folder, a notification
is now shown instead of attempting to upload.

This for both the drag for upload and drag from inside the file list
cases.

To test:
1) Share a folder with another user and uncheck "can edit"
2) Login as the second user
3) Try uploading files into that read-only folder with drag and drop
4) Try dragging other files from within the file list into that read-only folder
5) You should see an error notification related to permissions instead of "Target was renamed or moved ..."

Please review @th3fallen @icewind1991 @MorrisJobke 

CC @jancborchardt for the extra notification. I tried to reuse the existing text so that it can reuse the translation.
