### PR TITLE
remove a left over that uselessly fetches all users

### DIFF
--- a/apps/files_external/settings.php
+++ b/apps/files_external/settings.php
@@ -47,7 +47,6 @@ $tmpl->assign('isAdminPage', true);
 $tmpl->assign('mounts', OC_Mount_Config::getSystemMountPoints());
 $tmpl->assign('backends', $backends);
 $tmpl->assign('personal_backends', $personal_backends);
-$tmpl->assign('userDisplayNames', OC_User::getDisplayNames());
 $tmpl->assign('dependencies', OC_Mount_Config::checkDependencies());
 $tmpl->assign('allowUserMounting', OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes'));
 return $tmpl->fetchPage();


### PR DESCRIPTION
Removing this line slipped in https://github.com/owncloud/core/pull/10558 while it was in the original PR https://github.com/owncloud/core/pull/8507. It causes all users to be fetched upon opening admin page when files_external is enabled. The placeholder they are assigned to has been removed in the mentioned PRs.

@butonic @LukasReschke @PVince81 
