### PR TITLE
Keep fileid on move in objectstore, fixes #10848

### DIFF
--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -82,7 +82,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			$parentExists = true;
 
 			// we are done when the root folder was meant to be created
-			if  ($dirName === $path) {
+			if ($dirName === $path) {
 				return true;
 			}
 		}
@@ -290,38 +290,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function rename($source, $target) {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
-		$stat1 = $this->stat($source);
-		if (isset($stat1['mimetype']) && $stat1['mimetype'] === 'httpd/unix-directory') {
-			$this->remove($target);
-			$dir = $this->opendir($source);
-			$this->mkdir($target);
-			while ($file = readdir($dir)) {
-				if (!Filesystem::isIgnoredDir($file)) {
-					if (!$this->rename($source . '/' . $file, $target . '/' . $file)) {
-						return false;
-					}
-				}
-			}
-			closedir($dir);
-			$this->remove($source);
-			return true;
-		} else {
-			if (is_array($stat1)) {
-				$parent = $this->stat(dirname($target));
-				if (is_array($parent)) {
-					$this->remove($target);
-					$stat1['parent'] = $parent['fileid'];
-					$stat1['path'] = $target;
-					$stat1['path_hash'] = md5($target);
-					$stat1['name'] = \OC_Util::basename($target);
-					$stat1['mtime'] = time();
-					$stat1['etag'] = $this->getETag($target);
-					$this->getCache()->update($stat1['fileid'], $stat1);
-					return true;
-				}
-			}
-		}
-		return false;
+		$this->remove($target);
+		$this->getCache()->move($source, $target);
+		$this->touch(dirname($target));
+		return true;
 	}
 
 	public function getMimeType($path) {

--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -111,4 +111,87 @@ class Swift extends \Test\Files\Storage\Storage {
 		}
 	}
 
+	/**
+	 * @dataProvider copyAndMoveProvider
+	 */
+	public function testMove($source, $target) {
+		$this->initSourceAndTarget($source);
+		$sourceId = $this->instance->getCache()->getId(ltrim('/',$source));
+		$this->assertNotEquals(-1, $sourceId);
+
+		$this->instance->rename($source, $target);
+
+		$this->assertTrue($this->instance->file_exists($target), $target.' was not created');
+		$this->assertFalse($this->instance->file_exists($source), $source.' still exists');
+		$this->assertSameAsLorem($target);
+
+		$targetId = $this->instance->getCache()->getId(ltrim('/',$target));
+		$this->assertSame($sourceId, $targetId, 'fileid must be stable on move or shares will break');
+	}
+
+	public function testRenameDirectory() {
+		$this->instance->mkdir('source');
+		$this->instance->file_put_contents('source/test1.txt', 'foo');
+		$this->instance->file_put_contents('source/test2.txt', 'qwerty');
+		$this->instance->mkdir('source/subfolder');
+		$this->instance->file_put_contents('source/subfolder/test.txt', 'bar');
+		$sourceId = $this->instance->getCache()->getId('source');
+		$this->assertNotEquals(-1, $sourceId);
+		$this->instance->rename('source', 'target');
+
+		$this->assertFalse($this->instance->file_exists('source'));
+		$this->assertFalse($this->instance->file_exists('source/test1.txt'));
+		$this->assertFalse($this->instance->file_exists('source/test2.txt'));
+		$this->assertFalse($this->instance->file_exists('source/subfolder'));
+		$this->assertFalse($this->instance->file_exists('source/subfolder/test.txt'));
+
+		$this->assertTrue($this->instance->file_exists('target'));
+		$this->assertTrue($this->instance->file_exists('target/test1.txt'));
+		$this->assertTrue($this->instance->file_exists('target/test2.txt'));
+		$this->assertTrue($this->instance->file_exists('target/subfolder'));
+		$this->assertTrue($this->instance->file_exists('target/subfolder/test.txt'));
+
+		$this->assertEquals('foo', $this->instance->file_get_contents('target/test1.txt'));
+		$this->assertEquals('qwerty', $this->instance->file_get_contents('target/test2.txt'));
+		$this->assertEquals('bar', $this->instance->file_get_contents('target/subfolder/test.txt'));
+		$targetId = $this->instance->getCache()->getId('target');
+		$this->assertSame($sourceId, $targetId, 'fileid must be stable on move or shares will break');
+	}
+
+	public function testRenameOverWriteDirectory() {
+		$this->instance->mkdir('source');
+		$this->instance->file_put_contents('source/test1.txt', 'foo');
+		$sourceId = $this->instance->getCache()->getId('source');
+		$this->assertNotEquals(-1, $sourceId);
+
+		$this->instance->mkdir('target');
+		$this->instance->file_put_contents('target/test1.txt', 'bar');
+		$this->instance->file_put_contents('target/test2.txt', 'bar');
+
+		$this->instance->rename('source', 'target');
+
+		$this->assertFalse($this->instance->file_exists('source'));
+		$this->assertFalse($this->instance->file_exists('source/test1.txt'));
+		$this->assertFalse($this->instance->file_exists('target/test2.txt'));
+		$this->assertEquals('foo', $this->instance->file_get_contents('target/test1.txt'));
+		$targetId = $this->instance->getCache()->getId('target');
+		$this->assertSame($sourceId, $targetId, 'fileid must be stable on move or shares will break');
+	}
+
+	public function testRenameOverWriteDirectoryOverFile() {
+		$this->instance->mkdir('source');
+		$this->instance->file_put_contents('source/test1.txt', 'foo');
+		$sourceId = $this->instance->getCache()->getId('source');
+		$this->assertNotEquals(-1, $sourceId);
+
+		$this->instance->file_put_contents('target', 'bar');
+
+		$this->instance->rename('source', 'target');
+
+		$this->assertFalse($this->instance->file_exists('source'));
+		$this->assertFalse($this->instance->file_exists('source/test1.txt'));
+		$this->assertEquals('foo', $this->instance->file_get_contents('target/test1.txt'));
+		$targetId = $this->instance->getCache()->getId('target');
+		$this->assertSame($sourceId, $targetId, 'fileid must be stable on move or shares will break');
+	}
 }


### PR DESCRIPTION
fixes #10848 @labkode @schiesbn @PVince81 @karlitschek @MTRichards 

@icewind1991 I manually update the mtime of the targets parent folder. Should maybe Cache::move() do that itself?
