### PR TITLE
Move trusted domain check to init()

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -583,6 +583,21 @@ class OC {
 			);
 			return;
 		}
+
+		$host = OC_Request::insecureServerHost();
+		// if the host passed in headers isn't trusted
+		if (!OC::$CLI
+			// overwritehost is always trusted
+			&& OC_Request::getOverwriteHost() === null
+			&& !OC_Request::isTrustedDomain($host)
+		) {
+			header('HTTP/1.1 400 Bad Request');
+			header('Status: 400 Bad Request');
+			$tmpl = new OCP\Template('core', 'untrustedDomain', 'guest');
+			$tmpl->assign('domain', $_SERVER['SERVER_NAME']);
+			$tmpl->printPage();
+			return;
+		}
 	}
 
 	private static function registerLocalAddressBook() {
@@ -681,21 +696,6 @@ class OC {
 			$controller = new OC\Core\Setup\Controller();
 			$controller->run($_POST);
 			exit();
-		}
-
-		$host = OC_Request::insecureServerHost();
-		// if the host passed in headers isn't trusted
-		if (!OC::$CLI
-			// overwritehost is always trusted
-			&& OC_Request::getOverwriteHost() === null
-			&& !OC_Request::isTrustedDomain($host)
-		) {
-			header('HTTP/1.1 400 Bad Request');
-			header('Status: 400 Bad Request');
-			$tmpl = new OCP\Template('core', 'untrustedDomain', 'guest');
-			$tmpl->assign('domain', $_SERVER['SERVER_NAME']);
-			$tmpl->printPage();
-			return;
 		}
 
 		$request = OC_Request::getPathInfo();


### PR DESCRIPTION
handleRequest() is not called from remote.php or public.php which made these files party available but all included apps in there produced errors.

As the expected behaviour is anyways that a trusted domain warning is shown I moved this to init()

Testplan:
- [x] Open a shared link from an untrusted domain without this patch => Works and gallery error is shown
- [x] Open a shared link from an untrusted domain with this patch => Trusted domain error is shown

Fixes https://github.com/owncloud/core/issues/10064

@MTRichards Please review.
@karlitschek I think we want to backport this to stable7.
