### PR TITLE
if only one attribute is requested, the returned array has 0 as key inst...

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -379,7 +379,7 @@ class Wizard extends LDAPUtility {
 		do {
 			$result = $this->access->searchGroups($filter, array('cn'), $limit, $offset);
 			foreach($result as $item) {
-				$groupNames[] = $item['cn'];
+				$groupNames[] = $item[0];
 				$groupEntries[] = $item;
 			}
 			$offset += $limit;


### PR DESCRIPTION
...ead of attribute name. fixes #10888 

Due to inconsistent behaviour of in the return values of Access->searchGroups. If want to rework the Access class for 8 and 9 anyway and one part will be taking out search operations. But this needs to go back to stable7, so only a small fix.

See reproduction steps in https://github.com/owncloud/core/issues/10888

The issue was introduced in https://github.com/owncloud/core/commit/441c600c906a2ec55bdab123840be5d1d63bb679 7 days ago

@Xenopathic @MorrisJobke @dupondje @xtruthx or others thx
