### PR TITLE
Catch exceptions when moving files

### DIFF
--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -19,10 +19,16 @@ if(\OC\Files\Filesystem::file_exists($target . '/' . $file)) {
 if ($target != '' || strtolower($file) != 'shared') {
 	$targetFile = \OC\Files\Filesystem::normalizePath($target . '/' . $file);
 	$sourceFile = \OC\Files\Filesystem::normalizePath($dir . '/' . $file);
-	if(\OC\Files\Filesystem::rename($sourceFile, $targetFile)) {
-		OCP\JSON::success(array("data" => array( "dir" => $dir, "files" => $file )));
-	} else {
-		OCP\JSON::error(array("data" => array( "message" => $l->t("Could not move %s", array($file)) )));
+	try {
+		if(\OC\Files\Filesystem::rename($sourceFile, $targetFile)) {
+			OCP\JSON::success(array("data" => array( "dir" => $dir, "files" => $file )));
+		} else {
+			OCP\JSON::error(array("data" => array( "message" => $l->t("Could not move %s", array($file)) )));
+		}
+	} catch (\OCP\Files\NotPermittedException $e) {
+		OCP\JSON::error(array("data" => array( "message" => $l->t("Permission denied") )));
+	} catch (\Exception $e) {
+		OCP\JSON::error(array("data" => array( "message" => $e->getMessage())));
 	}
 }else{
 	OCP\JSON::error(array("data" => array( "message" => $l->t("Could not move %s", array($file)) )));


### PR DESCRIPTION
When moving files on storages that don't expose permissions, the storage
itself might throw an exception when the permission is denied.

This fix ensures that exceptions are caught and forwarded to the client
instead of just hanging.

Fixes https://github.com/owncloud/core/issues/10876

I tested it as follows:
1) Enable ext storage app
2) Enable SFTP storage
3) Edit `apps/files_external/lib/sftp.php`. In the `rename` function: add `throw new \OCP\Files\NotPermittedException("message");`
4) In the web UI, move a file inside a subdir of the storage
5) Change the exception to `\Exception("Test message")` to test the second case to catch any exception
6) Move a file again

Please review @th3fallen @icewind1991 @jmaciasportela 
