### PR TITLE
Add delete undo styles

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -148,6 +148,41 @@
 }
 
 
+/* Deleted entries with undo button */
+#app-navigation .app-navigation-entry-deleted {
+	display: inline-block;
+	height: 44px;
+	width: 100%;
+}
+
+	#app-navigation .app-navigation-entry-deleted-description {
+		padding-left: 12px;
+		position: relative;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		display: inline-block;
+		width: 201px; /* fallback for IE8 */
+		width: calc(100% - 49px);
+		line-height: 44px;
+		float: left;
+	}
+
+	#app-navigation .app-navigation-entry-deleted-button {
+		margin: 0;
+		height: 44px;
+		width: 44px;
+		line-height: 44px;
+		border: 0;
+		display: inline-block;
+		background-color: transparent;
+		opacity: .5;
+	}
+
+	#app-navigation .app-navigation-entry-deleted-button:hover {
+		opacity: 1;
+	}
+
 /* counter and actions, legacy code */
 #app-navigation .utils {
 	position: absolute;


### PR DESCRIPTION
This is much like Android's undo delete for notifications and mails and allows you to undo a deletion of a menu entry:

![screenshot from 2014-09-13 00 34 36](https://cloud.githubusercontent.com/assets/195053/4258155/0c3cf7f4-3acd-11e4-9e9c-51c63f73ccb5.png)

by using this html:

``` html
<div class="app-navigation-entry-deleted">
    <div class="app-navigation-entry-deleted-description">Deleted feed Bild.de</div>
    <button class="app-navigation-entry-deleted-button icon-history" title="Undo"></button>
</div>
```

The history button undoes the deletion

@jancborchardt @jbtbnl @MorrisJobke @georgehrke @raghunayyar @LEDfan

Please also review the design and workflow.
