### PR TITLE
Do not load extra user backends when an upgrade is due

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -554,7 +554,9 @@ class OC {
 		OC_Group::useBackend(new OC_Group_Database());
 
 		//setup extra user backends
-		OC_User::setupBackends();
+		if (!self::checkUpgrade(false)) {
+			OC_User::setupBackends();
+		}
 
 		self::registerCacheHooks();
 		self::registerFilesystemHooks();


### PR DESCRIPTION
Whenever an upgrade is due, do not load extra user backends

Fixes https://github.com/owncloud/core/issues/10762

Steps:
1) Setup OC 6.0.4
2) Enable user_external (do not configure it)
3) Upgrade to this PR's branch

Before the fix: exception
After the fix: upgrade works

Please review/test @adamwill @icewind1991 @blizzz 
