### PR TITLE
allow . in dbname on web install

### DIFF
--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -23,18 +23,21 @@ $(document).ready(function() {
 		$('#use_other_db').slideUp(250);
 		$('#use_oracle_db').slideUp(250);
 		$('#sqliteInformation').show();
+		$('#dbname').attr('pattern','[0-9a-zA-Z$_-]+');
 	});
 
 	$('#mysql,#pgsql,#mssql').click(function() {
 		$('#use_other_db').slideDown(250);
 		$('#use_oracle_db').slideUp(250);
 		$('#sqliteInformation').hide();
+		$('#dbname').attr('pattern','[0-9a-zA-Z$_-]+');
 	});
 
 	$('#oci').click(function() {
 		$('#use_other_db').slideDown(250);
 		$('#use_oracle_db').show(250);
 		$('#sqliteInformation').hide();
+		$('#dbname').attr('pattern','[0-9a-zA-Z$_-.]+');
 	});
 
 	$('input[checked]').trigger('click');


### PR DESCRIPTION
Uses JS to update the dbname input pattern when switching databases in the installer. Removes the autoconfig workaround that is still necessary after merging https://github.com/owncloud/core/pull/10694 

@DeepDiver1975 @ser72 @VicDeo @cdamken @gig13 @craigpg 
