### PR TITLE
Use secure mimetype for content delivery

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -34,7 +34,7 @@ if(!\OC\Files\Filesystem::file_exists($filename)) {
 	exit;
 }
 
-$ftype=\OC\Files\Filesystem::getMimeType( $filename );
+$ftype=\OC_Helper::getSecureMimeType(\OC\Files\Filesystem::getMimeType( $filename ));
 
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -49,7 +49,7 @@ class OC_Files {
 			header('Content-Type: application/zip');
 		} else {
 			$filesize = \OC\Files\Filesystem::filesize($filename);
-			header('Content-Type: '.\OC\Files\Filesystem::getMimeType($filename));
+			header('Content-Type: '.\OC_Helper::getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename)));
 			if ($filesize > -1) {
 				header("Content-Length: ".$filesize);
 			}


### PR DESCRIPTION
Adds some hardening against potential CSP bypasses. Without this our CSP protection might be bypassed by an authenticated user.

Testplan:
- [ ] Upload a "test.js" file and download it via the web interface. Mimetype while downloading should be `text/plain`
- [ ] Upload a `test.odt` file and download it via the web interface. Mimetype while downloading should be `application/vnd.oasis.opendocument.text`

@karlitschek This might be worthwhile backporting to stable7. - I don't think this is something for stable6 though.
@icewind1991 as discussed
