### PR TITLE
add template functions for html imports

### DIFF
--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -42,6 +42,16 @@ function style($app, $file) {
 }
 
 /**
+ * Shortcut for HTML imports
+ * @param string $app the appname
+ * @param string $file the path relative to the app's component folder
+ */
+function component($app, $file) {
+	$url = link_to($app, 'component/' . $file);
+	OC_Util::addHeader('link', array('rel' => 'import', 'href' => $url));
+}
+
+/**
  * make OC_Helper::linkTo available as a simple function
  * @param string $app app
  * @param string $file file

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -47,7 +47,7 @@ function style($app, $file) {
  * @param string $file the path relative to the app's component folder
  */
 function component($app, $file) {
-	$url = link_to($app, 'component/' . $file);
+	$url = link_to($app, 'component/' . $file . '.html');
 	OC_Util::addHeader('link', array('rel' => 'import', 'href' => $url));
 }
 


### PR DESCRIPTION
Adds HTML imports to the header:

``` php
<?php
component('news', 'test');
?>
```

inside a template will add a header that includes **$app/component/test.html**:

``` html
<link rel="import" href="owncloud.home/apps/news/components/test.html" >
```
