### PR TITLE
allow prefilling login

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -760,8 +760,8 @@ class OC_Util {
 		foreach ($errors as $value) {
 			$parameters[$value] = true;
 		}
-		if (!empty($_POST['user'])) {
-			$parameters["username"] = $_POST['user'];
+		if (!empty($_REQUEST['user'])) {
+			$parameters["username"] = $_REQUEST['user'];
 			$parameters['user_autofocus'] = false;
 		} else {
 			$parameters["username"] = '';


### PR DESCRIPTION
I want to be able to send deep links into the gallery, that also prefill the username if the user is not logged in, sth like http://localhost/core/index.php?redirect_url=%2Findex.php%2Fapps%2Fgallery&user=guest

The guest account has quota zero and can only access the files and pictures apps.

@LukasReschke security nightmare?
@jancborchardt usability improvement?
