### PR TITLE
More sugar for including lists of files in templates

### DIFF
--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -26,29 +26,51 @@ function print_unescaped($string) {
 /**
  * Shortcut for adding scripts to a page
  * @param string $app the appname
- * @param string $file the filename
+ * @param string|string[] $file the filename,
+ * if an array is given it will add all scripts
  */
 function script($app, $file) {
-	OC_Util::addScript($app, $file);
+	if(is_array($file)) {
+		foreach($file as $f) {
+			OC_Util::addScript($app, $f);
+		}
+	} else {
+		OC_Util::addScript($app, $file);
+	}
 }
 
 /**
  * Shortcut for adding styles to a page
  * @param string $app the appname
- * @param string $file the filename
+ * @param string|string[] $file the filename,
+ * if an array is given it will add all styles
  */
 function style($app, $file) {
-	OC_Util::addStyle($app, $file);
+	if(is_array($file)) {
+		foreach($file as $f) {
+			OC_Util::addStyle($app, $f);
+		}
+	} else {
+		OC_Util::addStyle($app, $file);
+	}
 }
 
 /**
  * Shortcut for HTML imports
  * @param string $app the appname
- * @param string $file the path relative to the app's component folder
+ * @param string|string[] $file the path relative to the app's component folder,
+ * if an array is given it will add all components
  */
 function component($app, $file) {
-	$url = link_to($app, 'component/' . $file . '.html');
-	OC_Util::addHeader('link', array('rel' => 'import', 'href' => $url));
+	if(is_array($file)) {
+		foreach($file as $f) {
+			$url = link_to($app, 'component/' . $f . '.html');
+			OC_Util::addHeader('link', array('rel' => 'import', 'href' => $url));
+		}
+	} else {
+		$url = link_to($app, 'component/' . $file . '.html');
+		OC_Util::addHeader('link', array('rel' => 'import', 'href' => $url));
+	}
 }
 
 /**


### PR DESCRIPTION
Most of the time you want to include a list of js/css/component files in the same app. This PR allows you to pass a a file or array of files to those functions:

``` php
<?php

// include one file
script('news', 'vendor/traceur-runtime/traceur-runtime.min');
script('news', 'vendor/angular/angular.min');
script('news', 'vendor/angular-route/angular-route.min');
script('news', 'vendor/angular-sanitize/angular-sanitize.min');
script('news', 'vendor/angular-animate/angular-animate.min');
script('news', 'vendor/momentjs/min/moment-with-locales.min');
script('news', 'build/app.min');

// include multiple files of the same app
script('news', [
    'vendor/traceur-runtime/traceur-runtime.min',
    'vendor/angular/angular.min',
    'vendor/angular-route/angular-route.min',
    'vendor/angular-sanitize/angular-sanitize.min',
    'vendor/angular-animate/angular-animate.min',
    'vendor/momentjs/min/moment-with-locales.min',
    'build/app.min',
]);
```

@georgehrke @raghunayyar @jancborchardt @icewind1991 @MorrisJobke @th3fallen @jbtbnl @LEDfan 
