### PR TITLE
Dont' use mountpoint permissions as share permissions for external storages

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -19,6 +19,10 @@
 				OCA.Files.FileList.prototype._createRow = function(fileData) {
 					var tr = oldCreateRow.apply(this, arguments);
 					var sharePermissions = fileData.permissions;
+					if (fileData.mountType && fileData.mountType === "external-root"){
+						// for external storages we cant use the permissions of the mountpoint
+						sharePermissions = OC.PERMISSION_ALL;
+					}
 					if (fileData.type === 'file') {
 						// files can't be shared with delete permissions
 						sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -21,7 +21,8 @@
 					var sharePermissions = fileData.permissions;
 					if (fileData.mountType && fileData.mountType === "external-root"){
 						// for external storages we cant use the permissions of the mountpoint
-						sharePermissions = OC.PERMISSION_ALL;
+						// instead we show all permissions and only use the share permissions from the mountpoint to handle resharing
+						sharePermissions = sharePermissions | (OC.PERMISSION_ALL & ~OC.PERMISSION_SHARE);
 					}
 					if (fileData.type === 'file') {
 						// files can't be shared with delete permissions

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -551,4 +551,89 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.find('.nametext').text().trim()).toEqual('local name.txt');
 		});
 	});
+	describe('setting share permissions for files', function () {
+		beforeEach(function () {
+
+			var $content = $('<div id="content"></div>');
+			$('#testArea').append($content);
+			// dummy file list
+			var $div = $(
+				'<div>' +
+				'<table id="filestable">' +
+				'<thead></thead>' +
+				'<tbody id="fileList"></tbody>' +
+				'</table>' +
+				'</div>');
+			$('#content').append($div);
+
+			fileList = new OCA.Files.FileList(
+				$div, {
+					fileActions: fileActions
+				}
+			);
+		});
+
+		it('external storage root folder', function () {
+			var $tr;
+			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
+			fileList.setFiles([{
+				id: 1,
+				type: 'dir',
+				name: 'One.txt',
+				path: '/subdir',
+				mimetype: 'text/plain',
+				size: 12,
+				permissions: OC.PERMISSION_READ,
+				etag: 'abc',
+				shareOwner: 'User One',
+				recipients: 'User Two',
+				mountType: 'external-root'
+			}]);
+			$tr = fileList.$el.find('tr:first');
+
+			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE);
+		});
+
+		it('external storage root folder reshare', function () {
+			var $tr;
+			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
+			fileList.setFiles([{
+				id: 1,
+				type: 'dir',
+				name: 'One.txt',
+				path: '/subdir',
+				mimetype: 'text/plain',
+				size: 12,
+				permissions: OC.PERMISSION_READ + OC.PERMISSION_SHARE,
+				etag: 'abc',
+				shareOwner: 'User One',
+				recipients: 'User Two',
+				mountType: 'external-root'
+			}]);
+			$tr = fileList.$el.find('tr:first');
+
+			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL);
+		});
+
+		it('external storage root folder file', function () {
+			var $tr;
+			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
+			fileList.setFiles([{
+				id: 1,
+				type: 'file',
+				name: 'One.txt',
+				path: '/subdir',
+				mimetype: 'text/plain',
+				size: 12,
+				permissions: OC.PERMISSION_READ,
+				etag: 'abc',
+				shareOwner: 'User One',
+				recipients: 'User Two',
+				mountType: 'external-root'
+			}]);
+			$tr = fileList.$el.find('tr:first');
+
+			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE);
+		});
+	});
 });


### PR DESCRIPTION
Since the permissions of a storage mountpoint says nothing of the permissions of the files inside we can't take the permissions as the possible sharing permissions

Fixes #8503

cc @PVince81 @DeepDiver1975 
