### PR TITLE
Enforce Minimum Password Strength

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -359,4 +359,16 @@ $CONFIG = array(
  */
 'share_folder' => '/',
 
+/**
+ * Minimum password strength for changing of passwords via a user profile from: 0-5.
+ * Correlates to the following messages when changing:
+ * -1: Disabled
+ * 0: Very weak password
+ * 1: Weak password
+ * 2: So-so password
+ * 3: Good password
+ * 4: Strong password
+ */
+'min_password_strength' => '-1',
+
 );

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -2,6 +2,9 @@
 
 namespace OC\Settings\ChangePassword;
 
+use ZxcvbnPhp\Zxcvbn;
+
+
 class Controller {
 	public static function changePersonalPassword($args) {
 		// Check if we are an user
@@ -17,6 +20,16 @@ class Controller {
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
+
+		$zxcvbn = new Zxcvbn();
+		$strength = $zxcvbn->passwordStrength($password);
+
+		if($strength['score'] < \OC_Config::getValue("min_password_strength", "-1") ) {
+			$l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("Password is not strong enough.")) ));
+			exit();	
+		}
+
 		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
 			\OC_JSON::success();
 		} else {


### PR DESCRIPTION
Hey guys,

This is a little PoC for enforcing password strength in a user profile.  This enables a config option to be set to enforce the minimum password being changed.

You will also need to edit `3rdparty` to include the following in `composer.json`:

```
        "require": {
                ......
                "bjeavons/zxcvbn-php": "*"
        }
```

And run `composer update`

My question is, is there a more modular way of doing this?

As in rather than changing core, overwrite the **ChangePassword** controller within a module/app somehow.
