### PR TITLE
requesttoken has now a length of 30 chars

### DIFF
--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -39,7 +39,7 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 
 	function testCallRegister() {
 		$result = strlen(OC_Util::callRegister());
-		$this->assertEquals(20, $result);
+		$this->assertEquals(30, $result);
 	}
 
 	function testSanitizeHTML() {


### PR DESCRIPTION
@LukasReschke 

fixes the unit test:

```
Test_Util::testCallRegister
Failed asserting that 30 matches expected 20.

/var/lib/jenkins/jobs/server-master-linux-tomtom/workspace/database/sqlite/label/master/tests/lib/util.php:42

```
