### PR TITLE
Create .user.ini for PHP-FPM

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,0 +1,4 @@
+upload_max_filesize=513M
+post_max_size=513M
+memory_limit=512M
+mbstring.func_overload=0


### PR DESCRIPTION
PHP-FPM can't read .htaccess PHP settings unless a PECL extension is installed.
From version 5.3+ of PHP, settings can be set in .user.ini files

This is a .user.ini file mirroring what is included in the .htaccess file
TODO: Update the documentation if there are sections documenting how to change some PHP limits
