### PR TITLE
[WIP] Use stream wrapper that allows to seek HTTP files

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -522,6 +522,7 @@ class OC {
 		stream_wrapper_register('close', 'OC\Files\Stream\Close');
 		stream_wrapper_register('quota', 'OC\Files\Stream\Quota');
 		stream_wrapper_register('oc', 'OC\Files\Stream\OC');
+		stream_wrapper_register('seekablehttp', 'OC\Files\Stream\SeekableHttp');
 
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
 		OC_App::loadApps(array('session'));

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -170,31 +170,28 @@ class DAV extends \OC\Files\Storage\Common {
 				if (!$this->file_exists($path)) {
 					return false;
 				}
-				//straight up curl instead of sabredav here, sabredav put's the entire get result in memory
-				$curl = curl_init();
-				$fp = fopen('php://temp', 'r+');
-				curl_setopt($curl, CURLOPT_USERPWD, $this->user . ':' . $this->password);
-				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri() . $this->encodePath($path));
-				curl_setopt($curl, CURLOPT_FILE, $fp);
-				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-				curl_setopt($curl, CURLOPT_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
-				curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
+
+				$url = 'seekablehttp://';
+
+				$options = array();
+				
+				$options['userpwd'] = $this->user . ':' . $this->password;
+				$options['url'] = $this->createBaseUri() . $this->encodePath($path);
+
 				if ($this->secure === true) {
-					curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
-					curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+						
+					$options['secure'] = true;
+
 					if ($this->certPath) {
-						curl_setopt($curl, CURLOPT_CAINFO, $this->certPath);
+						$options['capath'] = $this->certPath;
 					}
 				}
 
-				curl_exec($curl);
-				$statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-				if ($statusCode !== 200) {
-					\OCP\Util::writeLog("webdav client", 'curl GET ' . curl_getinfo($curl, CURLINFO_EFFECTIVE_URL) . ' returned status code ' . $statusCode, \OCP\Util::ERROR);
-				}
-				curl_close($curl);
-				rewind($fp);
-				return $fp;
+				$params = array( 'seekablehttp' => $options );
+
+				$context = stream_context_create( $params );
+
+				return fopen($url, 'r', false, $context);
 			case 'w':
 			case 'wb':
 			case 'a':

--- a/lib/private/files/stream/seekablehttp.php
+++ b/lib/private/files/stream/seekablehttp.php
@@ -118,7 +118,7 @@ class SeekableHttp {
             return FALSE;
         }
 
-        $available_count = min( $this->read_bytes - $this->position, $count); 
+	$this->wait_for_position($this->position + $count)
 
         fseek($this->temp_file, $this->position);
 

--- a/lib/private/files/stream/seekablehttp.php
+++ b/lib/private/files/stream/seekablehttp.php
@@ -118,7 +118,7 @@ class SeekableHttp {
             return FALSE;
         }
 
-	$this->waitForPosition($this->position + $count)
+	$this->waitForPosition($this->position + $count);
 
         fseek($this->tempFile, $this->position);
 

--- a/lib/private/files/stream/seekablehttp.php
+++ b/lib/private/files/stream/seekablehttp.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Copyright (c) 2014 Lorenzo Keller <lorenzo.keller@gmail.com>
+ * This file is public domain.
+
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Stream;
+
+class SeekableHttp {
+
+    public $context;
+
+    // keeps track of the number of bytes written to the temporary file
+    var $read_bytes = 0;
+
+    // context used to download the file
+    var $curl;
+    var $multi_curl;
+
+    // a file resource pointing to a temporary file where we store the download 
+    var $temp_file;
+
+    // different than null as long as we are downloading from the remote server
+    var $active;
+
+    // position at which our client (the person that opened the stream with our)
+    // protocol wants the next read to happen 
+    var $position = 0;
+
+    function write_to_temp($res, $data) {
+
+        // write the newly received data at the end of the temporary file
+        fseek($this->temp_file, $this->read_bytes);
+        $written = fwrite($this->temp_file, $data);
+        $this->read_bytes += $written;
+        return $written;
+
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path) {
+
+        // open the temporary file that will store the partial download
+        $this->temp_file = fopen('php://temp', 'rwb');
+
+        // setup the download
+        $this->curl = curl_init();
+
+        $args = stream_context_get_options($this->context)['seekablehttp'];
+
+        curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($this->curl, CURLOPT_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        curl_setopt($this->curl, CURLOPT_REDIR_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
+
+        curl_setopt($this->curl, CURLOPT_HEADER, 0);
+        curl_setopt($this->curl, CURLOPT_URL, $args['url']);
+        curl_setopt($this->curl, CURLOPT_USERPWD, $args['userpwd']);
+
+
+        if ( array_key_exists('secure', $args) && $args['secure'] ) {
+
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+
+            if ( array_key_exists('capath', $args) ) {
+                curl_setopt($curl, CURLOPT_CAINFO, $args['capath']);
+            }
+
+        }
+
+        // set a callback that will be called when new data comes in
+        curl_setopt($this->curl, CURLOPT_WRITEFUNCTION, 
+                        array($this, 'write_to_temp'));
+
+        $this->multi_curl = curl_multi_init();
+
+        curl_multi_add_handle($this->multi_curl,$this->curl);
+
+        $this->active = null;
+
+        // start the download
+        do {
+            $mrc = curl_multi_exec($this->multi_curl, $this->active);
+        } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+
+        if ( $mrc != CURLM_OK ) {
+            $this->stream_close();
+        }
+
+        return true;
+    }
+
+    public function stream_close() {
+        // clean up when closing the download
+        $active = null;
+
+        $statusCode = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
+
+        if ($statusCode !== 200) {
+
+            $effective_url = curl_getinfo($this->curl, CURLINFO_EFFECTIVE_URL);
+            \OCP\Util::writeLog('webdav client', 
+                'curl GET ' . $effective_url .
+                ' returned status code ' . $statusCode, \OCP\Util::ERROR);
+
+        }
+
+        curl_multi_remove_handle($this->multi_curl, $this->curl);
+        curl_multi_close($this->multi_curl);
+
+    }
+
+
+    public function stream_read($count) {
+
+        if ( $this->stream_eof()) {
+            return FALSE;
+        }
+
+        $available_count = min( $this->read_bytes - $this->position, $count); 
+
+        fseek($this->temp_file, $this->position);
+
+        $data = fread($this->temp_file, $available_count);
+
+        $this->position += strlen($data);
+
+        return $data;
+
+    }
+
+    public function stream_tell() {
+        return $this->position;
+    }
+
+    function wait_data() {
+        // wait for incoming data
+        if (curl_multi_select($this->multi_curl) != -1) {
+
+            // read the data
+            do {
+                $mrc = curl_multi_exec($this->multi_curl, $this->active);
+            } while ($mrc == CURLM_CALL_MULTI_PERFORM);
+
+
+            if ( $mrc != CURLM_OK) {
+                $this->stream_close();
+            }
+
+        } else {
+            $this->stream_close();
+        }
+    }
+
+    function wait_for_end() {
+        // wait until the download is over
+        while ( $this->active) {
+            $this->wait_data();
+        }
+    }
+
+    function wait_for_position($position) {
+        // wait until we read past the position or the download is over
+        while ( $position >= $this->read_bytes && $this->active) {
+            $this->wait_data();
+        }
+    }
+
+    public function stream_eof() {
+
+        // here we could rely on the Content-Lenght field of the header
+        $this->wait_for_position($this->position);
+
+        // return FALSE if the request is past the end of the file
+        return $this->position >= $this->read_bytes ;
+    }
+
+    public function stream_set_option($option, $arg1, $arg2) {
+        return false;
+    }
+
+    public function url_stat($path) {
+        return false;
+    }
+
+    public function stream_stat() {
+        return false;
+    }
+
+    public function stream_seek($offset, $whence) {
+
+        switch ($whence) {
+            case SEEK_SET:
+
+                $this->wait_for_position($offset);
+
+                if ($this->read_bytes > $offset) {
+                    $this->position = $offset;
+                    return TRUE;
+                } else {
+                    return FALSE;
+                }
+
+                break;
+
+            case SEEK_CUR:
+
+                return $this->stream_seek($this->position + $offset, SEEK_SET);
+
+            case SEEK_END:
+
+                // here we could rely on the Content-Lenght field of the header
+                $this->wait_for_end();
+                return $this->stream_seek($this->position + $offset, SEEK_SET);
+
+            default:
+                return false;
+        }
+    }
+
+}


### PR DESCRIPTION
We want to start pushing to client connecting to owncloud the content of files stored on a remote DAV server while we are still downloading 
it from the remote server without waiting to first fully download the file on the owncloud server. We cannot directly use fopen('http://...') because
we want to be able to seek the resource, instead we use the stream wrapper implemented here.

Some things on which feedback would be very useful: 
- is the wrapper implementing enough functions or some are missing?
- what is the best way to create unit tests for this code?
