### PR TITLE
Do not double decode values

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -111,7 +111,7 @@ if (isset($path)) {
 			\OC::$server->getSession()->close();
 		}
 		if (isset($_GET['files'])) { // download selected files
-			$files = urldecode($_GET['files']);
+			$files = $_GET['files'];
 			$files_list = json_decode($files);
 			// in case we get only a single file
 			if ($files_list === NULL ) {


### PR DESCRIPTION
The values are already decoded by the webserver and we do not need to double decode it.

Testplan:
- [x] Upload a file containing + and another one containing & in the filename, upload it to a folder and share the folder => Downloading both files alone from the sharing page should work
- [x] Upload a file containing + and another one containing & in the filename, upload it to a folder and share the folder => Downloading both files together from the sharing page should work (ZIP download!)
- [x] Do the same test with regular file names

Fixes https://github.com/owncloud/core/issues/11012
