### PR TITLE
Apps styles update

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -57,7 +57,7 @@
 #app-navigation li:hover > a,
 #app-navigation .selected,
 #app-navigation .selected a {
-	background-color: #ccc;
+	background-color: #ddd;
 }
 
 #app-navigation .with-icon a,
@@ -140,7 +140,7 @@
 }
 
 #app-navigation > ul .collapsible.open:hover {
-	box-shadow: inset 0 0 3px #ccc;
+	box-shadow: inset 0 0 3px #ddd;
 }
 
 #app-navigation > ul .collapsible.open ul {

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -429,27 +429,6 @@
 	background-color: transparent;
 }
 
-/* icons */
-.folder-icon, .delete-icon, .edit-icon, .progress-icon {
-	background-repeat: no-repeat;
-	background-position: center;
-}
-.folder-icon { background-image: url('../img/places/folder.svg'); }
-.delete-icon { background-image: url('../img/actions/delete.svg'); }
-.delete-icon:hover, .delete-icon:focus {
-	background-image: url('../img/actions/delete-hover.svg');
-}
-.edit-icon { background-image: url('../img/actions/rename.svg'); }
-.progress-icon {
-	background-image: url('../img/loading.gif');
-	background-size: 16px;
-	/* force show the loading icon, not only on hover */
-	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-	filter:alpha(opacity=100);
-	opacity: 1 !important;
-	display: inline !important;
-}
-
 /* buttons */
 button.loading {
 	background-image: url('../img/loading.gif');


### PR DESCRIPTION
- remove icon styles from apps.css as they are in icons.css
- use same shade of grey for active navigation items and hovering – it’s way simpler and reduces the greyish blandness of ownCloud a bit

Please review @owncloud/designers @Raydiation 
