### PR TITLE
Remove bottom: 0 from app-navigation-entry-utils to prevent the utils form overlapping the whole element....

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -189,7 +189,6 @@
 	position: absolute;
 	top: 0;
 	right: 0;
-	bottom: 0;
 	z-index: 105;
 }
 
@@ -335,7 +334,8 @@
 	#app-navigation .app-navigation-entry-edit input {
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
-		width: 204px;
+		width: 190px;
+		width: calc(100% - 36px);
 		padding: 5px;
 		margin-right: 0;
 		height: 38px;

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -334,7 +334,7 @@
 	#app-navigation .app-navigation-entry-edit input {
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
-		width: 190px;
+		width: 204px; /* fallback for IE8 */
 		width: calc(100% - 36px);
 		padding: 5px;
 		margin-right: 0;

--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -105,3 +105,7 @@ select {
 	overflow-y: auto;
 }
 
+.ie8 #app-navigation .app-navigation-entry-edit input {
+	line-height: 38px;
+}
+


### PR DESCRIPTION
... This happens for instance if a folder has entries -> the menu expands to the very bottom and overlaps all entries and makes them impossible to click. Without the bottom: 0 it just uses its normal height which is fine.

@jancborchardt @raghunayyar @MorrisJobke @jbtbnl @georgehrke 
