### PR TITLE
content size checks are not valid for LOCK

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -105,7 +105,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		// if content length is sent by client:
 		// double check if the file was fully received
 		// compare expected and actual size
-		if (isset($_SERVER['CONTENT_LENGTH'])) {
+		if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] !== 'LOCK') {
 			$expected = $_SERVER['CONTENT_LENGTH'];
 			$actual = $this->fileView->filesize($partFilePath);
 			if ($actual != $expected) {


### PR DESCRIPTION
refs https://github.com/owncloud/core/issues/9832#issuecomment-55282725

@avoine please test

@icewind1991 @PVince81 @bantu please review

@karlitschek @craigpg should be backported to stable7

How to test:
1. connect with a webdav client (e.g. cadaver)
2. perform a LOCK on an not existing file - in this case the file will be created which causes the original error
