### PR TITLE
Remove passing by reference to allow for proper GC

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -247,7 +247,7 @@ class Proxy extends \OC_FileProxy {
 	 * @param resource $result
 	 * @return resource
 	 */
-	public function postFopen($path, &$result) {
+	public function postFopen($path, $result) {
 
 		$path = \OC\Files\Filesystem::normalizePath($path);
 


### PR DESCRIPTION
The garbage collector in PHP 5.3.10 does not properly release the file
handle when calling fclose() due to the fact that it is passed by
reference.
This has the side-effect of preventing file locks to be released as well
when the files_locking app is enabled.

This fix removes the useless passing by reference and now the file
handle and file lock are freed properly.

:one: day of research for :one: byte fix

To test:
1) Setup OC with PHP 5.3.10 (best is Ubuntu 12.04.5 LTS)
2) Enable encryption
3) Enable files_locking app
4) Try and upload a file

Before the fix: error message that lock cannot be freed
After the fix: upload works

Please review @icewind1991 @schiesbn @DeepDiver1975 @LukasReschke 
