### PR TITLE
content size checks are not valid for LOCK

### DIFF
--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -55,6 +55,7 @@ class Test_OC_Connector_Sabre_File extends PHPUnit_Framework_TestCase {
 			->will($this->returnValue(123456));
 
 		$_SERVER['CONTENT_LENGTH'] = 123456;
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\PERMISSION_ALL
@@ -131,6 +132,7 @@ class Test_OC_Connector_Sabre_File extends PHPUnit_Framework_TestCase {
 			->will($this->returnValue(123456));
 
 		$_SERVER['CONTENT_LENGTH'] = 12345;
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\PERMISSION_ALL


### PR DESCRIPTION
fixes 

```
00:09:55.905 There were 2 failures:
00:09:55.905 
00:09:55.905 1) Test_OC_Connector_Sabre_File::testSimplePutFailsOnRename
00:09:55.905 Failed asserting that exception of type "PHPUnit_Framework_Error_Notice" matches expected exception "\Sabre\DAV\Exception". Message was: "Undefined index: REQUEST_METHOD".
00:09:55.905 
00:09:55.905 
00:09:55.905 2) Test_OC_Connector_Sabre_File::testUploadAbort
00:09:55.908 Failed asserting that exception of type "PHPUnit_Framework_Error_Notice" matches expected exception "\Sabre\DAV\Exception\BadRequest". Message was: "Undefined index: REQUEST_METHOD".
00:09:55.908 
```
