### PR TITLE
add function to invalidate one opcache file, use it if possible #9885

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -207,8 +207,11 @@ class Config {
 		flock($filePointer, LOCK_UN);
 		fclose($filePointer);
 
-		// Clear the opcode cache
-		\OC_Util::clearOpcodeCache();
+		// Try invalidating the opcache just for the file we wrote...
+		if (!\OC_Util::deleteFromOpcodeCache($this->configFilename)) {
+			// But if that doesn't work, clear the whole cache.
+			\OC_Util::clearOpcodeCache();
+		}
 	}
 }
 

--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -208,7 +208,7 @@ class Config {
 		fclose($filePointer);
 
 		// Try invalidating the opcache just for the file we wrote...
-		if (!\OC_Util::deleteFromOpcodeCache($this->configFilename)) {
+		if (!\OC_Util::deleteFromOpcodeCache($this->configFilePath)) {
 			// But if that doesn't work, clear the whole cache.
 			\OC_Util::clearOpcodeCache();
 		}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1257,9 +1257,10 @@ class OC_Util {
 	 * caller should fall back on clearing the entire cache
 	 * with clearOpcodeCache() if unsuccessful
 	 *
+	 * @param string $path the path of the file to clear from the cache
 	 * @return bool true if underlying function returns true, otherwise false
 	 */
-	public static function deleteFromOpcodeCache($path=NULL) {
+	public static function deleteFromOpcodeCache($path) {
 		$ret = false;
 		if ($path) {
 			// APC >= 3.1.1

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1250,6 +1250,31 @@ class OC_Util {
 	}
 
 	/**
+	 * Clear a single file from the opcode cache
+	 * This is useful for writing to the config file
+	 * in case the opcode cache does not re-validate files
+	 * Returns true if successful, false if unsuccessful:
+	 * caller should fall back on clearing the entire cache
+	 * with clearOpcodeCache() if unsuccessful
+	 *
+	 * @return bool true if underlying function returns true, otherwise false
+	 */
+	public static function deleteFromOpcodeCache($path=NULL) {
+		$ret = false;
+		if ($path) {
+			// APC >= 3.1.1
+			if (function_exists('apc_delete_file')) {
+				$ret = @apc_delete_file($path);
+			}
+			// Zend OpCache >= 7.0.0, PHP >= 5.5.0
+			if (function_exists('opcache_invalidate')) {
+				$ret = opcache_invalidate($path);
+			}
+		}
+		return $ret;
+	}
+
+	/**
 	 * Clear the opcode cache if one exists
 	 * This is necessary for writing to the config file
 	 * in case the opcode cache does not re-validate files


### PR DESCRIPTION
Issue #9885 appears to be triggered by ownCloud invalidating the entire
PHP opcache. Testing indicates it can be avoided by only invalidating the
single file that was written from the opcache, instead of clearing the
whole thing. In general it is more efficient to invalidate only the single
file that was changed, rather than the whole cache.

This adds a deleteFromOpcodeCache() function which invalidates a single
file from the opcache if possible, returning true if the underlying
function returns true (which may mean 'success', or 'file does not exist',
or 'file exists but is not in opcache', all of which are OK to treat as
good for our purposes). It also changes writeData() in config.php to try
using deleteFromOpcodeCache() and only fall back on clearOpcodeCache() if
that fails.
