### PR TITLE
[WIP] Throw an exception if any of specified app paths are not found

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -179,6 +179,11 @@ class OC {
 		$paths = array();
 		foreach (OC::$APPSROOTS as $path) {
 			$paths[] = $path['path'];
+			if(!file_exists($path['path'])) {
+				throw new Exception(sprintf('App directory %s not found! Please put the ownCloud apps folder in the'
+					. 'ownCloud folder or the folder above. '
+					. 'You can also configure the location in the config.php file.', $path['path']));
+			}
 		}
 
 		// set the right include path

--- a/lib/base.php
+++ b/lib/base.php
@@ -180,7 +180,7 @@ class OC {
 		foreach (OC::$APPSROOTS as $path) {
 			$paths[] = $path['path'];
 			if(!file_exists($path['path'])) {
-				throw new Exception(sprintf('App directory %s not found! Please put the ownCloud apps folder in the'
+				throw new HintException(sprintf('App directory %s not found! Please put the ownCloud apps folder in the'
 					. 'ownCloud folder or the folder above. '
 					. 'You can also configure the location in the config.php file.', $path['path']));
 			}


### PR DESCRIPTION
E.g. when we have app paths in config, but they do not exist,
currently we do not show any exception messages or write into log.

Try:
- Rename apps directory into something else
- refresh OC page.

Expected: A warning message or an entry in log

Actual: Just infinite loop warning by Chromium

This writes an exception to the log
