### PR TITLE
Click to hide the notification

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -594,7 +594,7 @@ OC.Notification={
 					OC.Notification.getDefaultNotificationFunction.call();
 				}
 			}
-			if (callback) {
+			if (jQuery.isFunction(callback)) {
 				callback.call();
 			}
 			$('#notification').empty();
@@ -643,6 +643,12 @@ OC.Notification={
 		return ($("#notification").text() === '');
 	}
 };
+
+// Hide Notification message on click
+$(document).ready(function() {
+	$("#notification").on('click', OC.Notification.hide);
+});
+
 
 /**
  * Breadcrumb class


### PR DESCRIPTION
Sometimes the notification message stays longer than we want
Users can click on it (probably also tap on mobile) to hide
the message as well.

To test, type on console:

`OC.Notification.show("this is a notification message")`

and click on the message
