### PR TITLE
also expire file if timestamp = limit, happens if trashbin_retention_obl...

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -799,7 +799,7 @@ class Trashbin {
 		foreach ($files as $file) {
 			$timestamp = $file['mtime'];
 			$filename = $file['name'];
-			if ($timestamp < $limit) {
+			if ($timestamp <= $limit) {
 				$count++;
 				$size += self::delete($filename, $user, $timestamp);
 				\OC_Log::write('files_trashbin', 'remove "' . $filename . '" from trash bin because it is older than ' . $retention_obligation, \OC_log::INFO);


### PR DESCRIPTION
also expire file if timestamp = limit, happens if trashbin_retention_obligation is set to zero.

cc @jnfrmarks should fix the problem which you pointed out to me by mail.
