### PR TITLE
use $search parameter to search for users within a group

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -191,7 +191,6 @@ class Manager extends PublicEmitter implements IGroupManager {
 		$groupIds = array();
 		foreach ($this->backends as $backend) {
 			$groupIds = array_merge($groupIds, $backend->getUserGroups($user->getUID()));
-			
 		}
 		return $groupIds;
 	}
@@ -210,7 +209,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 			return array();
 		}
 		// only user backends have the capability to do a complex search for users
-		$groupUsers  = $group->searchUsers('', $limit, $offset);
+		$groupUsers  = $group->searchUsers($search, $limit, $offset);
 		$search = trim($search);
 		if(!empty($search)) {
 			//TODO: for OC 7 earliest: user backend should get a method to check selected users against a pattern

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -365,7 +365,7 @@ class Manager extends \PHPUnit_Framework_TestCase {
 
 		$backend->expects($this->once())
 			->method('usersInGroup')
-			->with('testgroup', '', -1, 0)
+			->with('testgroup', 'user3', -1, 0)
 			->will($this->returnValue(array('user2', 'user33')));
 
 		/**


### PR DESCRIPTION
use $search parameter to search for users within a group

This works with the ownCloud user and group backend. @blizzz does this also works with LDAP?
fix #10513
fix #8899
