### PR TITLE
[WIP] Cleanup filesystem setup code

### DIFF
--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -24,7 +24,7 @@ $listener = new ScanListener($eventSource);
 
 foreach ($users as $user) {
 	$eventSource->send('user', $user);
-	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection());
+	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection(), \OC::$server->getUserFolder($user));
 	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', array($listener, 'file'));
 	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', array($listener, 'folder'));
 	if ($force) {

--- a/apps/files/command/scan.php
+++ b/apps/files/command/scan.php
@@ -58,7 +58,7 @@ class Scan extends Command {
 	}
 
 	protected function scanFiles($user, $path, $quiet, OutputInterface $output) {
-		$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection());
+		$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection(), \OC::$server->getUserFolder($user));
 		if (!$quiet) {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
 				$output->writeln("Scanning file   <info>$path</info>");

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -48,7 +48,7 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		\OC_User::createUser(self::$user, 'password');
 		\OC_User::setUserId(self::$user);
 
-		\OC\Files\Filesystem::init(self::$user, '/' . self::$user . '/files');
+		\OC_Util::setupFS(self::$user);
 
 		$l10nMock = $this->getMock('\OC_L10N', array('t'), array(), '', false);
 		$l10nMock->expects($this->any())

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -73,6 +73,10 @@ class Helper {
 		\OCP\Util::connectHook('\OC\Core\LostPassword\Controller\LostController', 'post_passwordReset', 'OCA\Files_Encryption\Hooks', 'postPasswordReset');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_umount', 'OCA\Files_Encryption\Hooks', 'postUnmount');
 		\OCP\Util::connectHook('OC_Filesystem', 'umount', 'OCA\Files_Encryption\Hooks', 'preUnmount');
+
+		$factory = \OC::$server->getFilesystemFactory();
+		$factory->listen('\OC\Files', 'preCopySkeleton', array('OCA\Encryption\Hooks', 'preCopySkeleton'));
+		$factory->listen('\OC\Files', 'postCopySkeleton', array('OCA\Encryption\Hooks', 'postCopySkeleton'));
 	}
 
 	/**

--- a/apps/files_encryption/lib/hooks.php
+++ b/apps/files_encryption/lib/hooks.php
@@ -37,6 +37,8 @@ class Hooks {
 	// file for which we want to delete the keys after the delete operation was successful
 	private static $unmountedFiles = array();
 
+	private static $proxyStatus;
+
 	/**
 	 * Startup encryption backend upon user login
 	 * @note This method should never be called for users using client side encryption
@@ -222,7 +224,7 @@ class Hooks {
 					$newUserPassword = $params['password'];
 
 					// make sure that the users home is mounted
-					\OC\Files\Filesystem::initMountPoints($user);
+					\OC::$server->setupFilesystem($user);
 
 					$keypair = Crypt::createKeypair();
 
@@ -625,4 +627,15 @@ class Hooks {
 		}
 	}
 
+	/**
+	 * disable encryption while copying the skeleton
+	 */
+	public static function preCopySkeleton(){
+		self::$proxyStatus = \OC_FileProxy::$enabled;
+		self::$proxyStatus = false;
+	}
+
+	public static function postCopySkeleton() {
+		\OC_FileProxy::$enabled = self::$proxyStatus;
+	}
 }

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -136,7 +136,7 @@ class Util {
 		$this->privateKeyPath =
 				$this->encryptionDir . '/' . $this->userId . '.privateKey'; // e.g. data/admin/admin.privateKey
 		// make sure that the owners home is mounted
-		\OC\Files\Filesystem::initMountPoints($userId);
+		\OC::$server->setupFilesystem($userId);
 
 		if (Helper::isPublicAccess()) {
 			$this->keyId = $this->publicShareKeyId;
@@ -1276,7 +1276,7 @@ class Util {
 			}
 
 			// NOTE: Bah, this dependency should be elsewhere
-			\OC\Files\Filesystem::initMountPoints($fileOwnerUid);
+			\OC::$server->setupFilesystem($fileOwnerUid);
 
 			// If the file owner is the currently logged in user
 			if ($fileOwnerUid === $this->userId) {

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -41,7 +41,6 @@ $userId = $rootLinkItem['uid_owner'];
 
 OCP\JSON::checkUserExists($rootLinkItem['uid_owner']);
 \OC_Util::setupFS($userId);
-\OC\Files\Filesystem::initMountPoints($userId);
 $view = new \OC\Files\View('/' . $userId . '/files');
 
 $pathId = $linkedItem['file_source'];

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -53,7 +53,7 @@ class Shared_Cache extends Cache {
 		}
 		$source = \OC_Share_Backend_File::getSource($target, $this->storage->getMountPoint(), $this->storage->getItemType());
 		if (isset($source['path']) && isset($source['fileOwner'])) {
-			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+			\OC::$server->setupFilesystem($source['fileOwner']);
 			$mounts = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
 			if (is_array($mounts) and !empty($mounts)) {
 				$fullPath = $mounts[0]->getMountPoint() . $source['path'];

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -141,7 +141,7 @@ class Helper {
 	public static function getSharesFromItem($target) {
 		$result = array();
 		$owner = \OC\Files\Filesystem::getOwner($target);
-		\OC\Files\Filesystem::initMountPoints($owner);
+		\OC::$server->setupFilesystem($owner);
 		$info = \OC\Files\Filesystem::getFileInfo($target);
 		$ownerView = new \OC\Files\View('/'.$owner.'/files');
 		if ( $owner != \OCP\User::getUser() ) {
@@ -179,7 +179,7 @@ class Helper {
 
 	public static function getUidAndFilename($filename) {
 		$uid = \OC\Files\Filesystem::getOwner($filename);
-		\OC\Files\Filesystem::initMountPoints($uid);
+		\OC::$server->setupFilesystem($uid);
 		if ( $uid != \OCP\User::getUser() ) {
 			$info = \OC\Files\Filesystem::getFileInfo($filename);
 			$ownerView = new \OC\Files\View('/'.$uid.'/files');

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -74,7 +74,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 			return $target;
 		}
 
-		\OC\Files\Filesystem::initMountPoints($shareWith);
+		\OC::$server->setupFilesystem($shareWith);
 		$view = new \OC\Files\View('/' . $shareWith . '/files');
 
 		if (!$view->is_dir($shareFolder)) {

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -86,7 +86,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$source = $this->getFile($target);
 		if ($source) {
 			if (!isset($source['fullPath'])) {
-				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+				\OC::$server->setupFilesystem($source['fileOwner']);
 				$mount = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
 				if (is_array($mount) && !empty($mount)) {
 					$this->files[$target]['fullPath'] = $mount[key($mount)]->getMountPoint() . $source['path'];

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -35,7 +35,7 @@ class Shared_Updater {
 		// $path points to the mount point which is a virtual folder, so we start with
 		// the parent
 		$path = '/files' . dirname($path);
-		\OC\Files\Filesystem::initMountPoints($user);
+		\OC::$server->setupFilesystem($user);
 		$view = new \OC\Files\View('/' . $user);
 		if ($view->file_exists($path)) {
 			while ($path !== dirname($path)) {

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -42,7 +42,7 @@ class Trashbin {
 
 	public static function getUidAndFilename($filename) {
 		$uid = \OC\Files\Filesystem::getOwner($filename);
-		\OC\Files\Filesystem::initMountPoints($uid);
+		\OC::$server->setupFilesystem($uid);
 		if ($uid != \OCP\User::getUser()) {
 			$info = \OC\Files\Filesystem::getFileInfo($filename);
 			$ownerView = new \OC\Files\View('/' . $uid . '/files');

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -43,7 +43,7 @@ class Storage {
 
 	public static function getUidAndFilename($filename) {
 		$uid = \OC\Files\Filesystem::getOwner($filename);
-		\OC\Files\Filesystem::initMountPoints($uid);
+		\OC::$server->setupFilesystem($uid);
 		if ( $uid != \OCP\User::getUser() ) {
 			$info = \OC\Files\Filesystem::getFileInfo($filename);
 			$ownerView = new \OC\Files\View('/'.$uid.'/files');

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -46,9 +46,10 @@ class Test_Files_Versioning extends \Test\TestCase {
 		\OCA\Files_Versions\Hooks::connectHooks();
 		\OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 
-		// create test user
-		self::loginHelper(self::TEST_VERSIONS_USER2, true);
-		self::loginHelper(self::TEST_VERSIONS_USER, true);
+		$backend = new OC_User_Dummy();
+		\OC_User::useBackend($backend);
+		$backend->createUser(self::TEST_VERSIONS_USER, self::TEST_VERSIONS_USER);
+		$backend->createUser(self::TEST_VERSIONS_USER2, self::TEST_VERSIONS_USER2);
 	}
 
 	public static function tearDownAfterClass() {

--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -27,7 +27,7 @@ class File {
 		if (\OC_User::isLoggedIn()) {
 			$rootView = new View();
 			$user = \OC::$server->getUserSession()->getUser();
-			Filesystem::initMountPoints($user->getUID());
+			\OC::$server->setupFilesystem(\OC_User::getUser());
 			if (!$rootView->file_exists('/' . $user->getUID() . '/cache')) {
 				$rootView->mkdir('/' . $user->getUID() . '/cache');
 			}

--- a/lib/private/files/factory.php
+++ b/lib/private/files/factory.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files;
+
+use OC\Files\Mount\Manager;
+use OC\Files\Node\Root;
+use OC\Files\Storage\StorageFactory as Loader;
+use OC\Files\Storage\Wrapper\Quota;
+use OC\Hooks\BasicEmitter;
+use OCP\Files\FileInfo;
+
+class Factory extends BasicEmitter {
+	/**
+	 * @var \OCP\IConfig
+	 */
+	protected $config;
+
+	/**
+	 * @var \OC\Files\Node\Root
+	 */
+	protected $root;
+
+	/**
+	 * @var \OCP\Files\Folder[]
+	 */
+	protected $userFolders = array();
+
+	/**
+	 * @param \OCP\IConfig $config
+	 */
+	public function __construct($config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Mount the data dir as root storage
+	 *
+	 * @param \OC\Files\Mount\Manager $mountManager
+	 * @param \OC\Files\Storage\StorageFactory $storageLoader
+	 */
+	protected function mountRoot($mountManager, $storageLoader) {
+		// mount local file backend as root
+		$configDataDirectory = $this->config->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data");
+		//first set up the local "root" storage
+		$mount = new Mount\MountPoint('\OC\Files\Storage\Local', '/', array('datadir' => $configDataDirectory), $storageLoader);
+		$mountManager->addMount($mount);
+	}
+
+	/**
+	 * @param \OC\Files\Mount\Manager $mountManager
+	 * @param \OC\Files\Storage\StorageFactory $storageLoader
+	 * @param \OCP\IUser $user
+	 */
+	protected function mountUserFolder($mountManager, $storageLoader, $user) {
+		// check for legacy home id (<= 5.0.12)
+		$legacy = \OC\Files\Cache\Storage::exists('local::' . $user->getHome() . '/');
+		$mount = new Mount\MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), array(
+			'datadir' => $user->getHome(),
+			'user' => $user,
+			'legacy' => $legacy
+		), $storageLoader);
+		$mountManager->addMount($mount);
+
+		// Chance to mount for other storages
+		$mountConfigManager = \OC::$server->getMountProviderCollection();
+		$mounts = $mountConfigManager->getMountsForUser($user);
+		array_walk($mounts, array($mountManager, 'addMount'));
+	}
+
+	/**
+	 * Mount the cache storage if configured and create the cache dir if needed
+	 *
+	 * @param \OC\Files\Mount\Manager $mountManager
+	 * @param \OC\Files\Storage\StorageFactory $storageLoader
+	 * @param \OCP\IUser $user
+	 */
+	protected function setupCacheDir($mountManager, $storageLoader, $user) {
+		$cacheBaseDir = $this->config->getSystemValue('cache_path', '');
+		if ($cacheBaseDir === '') {
+			// use local cache dir relative to the user's home
+			$mount = $mountManager->find('/' . $user->getUID());
+			$userStorage = $mount->getStorage();
+			if (!$userStorage->file_exists('cache')) {
+				$userStorage->mkdir('cache');
+			}
+		} else {
+			$cacheDir = rtrim($cacheBaseDir, '/') . '/' . $user->getUID();
+			if (!file_exists($cacheDir)) {
+				mkdir($cacheDir, 0770, true);
+			}
+			$mount = new Mount\MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', array('datadir' => $cacheDir), $storageLoader);
+			$mountManager->addMount($mount);
+		}
+	}
+
+	/**
+	 * @param \OCP\IUser $user
+	 */
+	protected function copySkeleton($user) {
+		$root = $this->getRoot();
+		$path = '/' . $user->getUID() . '/files';
+		if (!$root->nodeExists($path)) {
+			$this->emit('\OC\Files', 'preCopySkeleton', array($user));
+			$userDirectory = $root->newFolder($path);
+			$skeletonDirectory = $this->config->getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+			if (!empty($skeletonDirectory)) {
+				\OC_Util::copyr($skeletonDirectory, $userDirectory);
+			}
+			$userDirectory->getStorage()->getScanner()->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
+			$this->emit('\OC\Files', 'postCopySkeleton', array($user));
+		}
+	}
+
+	/**
+	 * Create the root filesystem
+	 *
+	 * @return \OC\Files\Node\Root
+	 */
+	public function getRoot() {
+		if ($this->root) {
+			return $this->root;
+		}
+		$mountManager = new Manager();
+		$storageLoader = new Loader();
+		\OC::$server->getEventLogger()->start('setup_fs_root', 'Setup filesystem root');
+
+		$storageLoader->addStorageWrapper('oc_quota', function ($mountPoint, $storage) {
+			/**
+			 * @var \OC\Files\Storage\Storage $storage
+			 */
+			if ($storage->instanceOfStorage('\OCP\Files\IHomeStorage')) {
+				/**
+				 * @var \OCP\Files\IHomeStorage $storage
+				 */
+				if (is_object($storage->getUser())) {
+					$user = $storage->getUser()->getUID();
+					$quota = \OC_Util::getUserQuota($user);
+					if ($quota !== FileInfo::SPACE_UNLIMITED) {
+						return new Quota(array('storage' => $storage, 'quota' => $quota, 'root' => 'files'));
+					}
+				}
+			}
+			return $storage;
+		});
+
+		$this->mountRoot($mountManager, $storageLoader);
+		\OC::$server->getEventLogger()->end('setup_fs_root');
+		$this->root = new Root($mountManager, $storageLoader, new View(''));
+		return $this->root;
+	}
+
+	/**
+	 * Mount the storages for a user
+	 *
+	 * @param \OCP\IUser $user
+	 * @return \OCP\Files\Folder
+	 */
+	public function getUserFolder($user) {
+		if (isset($this->userFolders[$user->getUID()])) {
+			return $this->userFolders[$user->getUID()];
+		}
+		$root = $this->getRoot();
+		$mountManager = $root->getMountManager();
+		$storageLoader = $root->getStorageLoader();
+		if (is_null($mountManager->getMount('/' . $user->getUID()))) {
+			\OC::$server->getEventLogger()->start('setup_fs_' . $user->getUID(), 'Setup filesystem for ' . $user->getUID());
+			$this->mountUserFolder($mountManager, $storageLoader, $user);
+			$this->setupCacheDir($mountManager, $storageLoader, $user);
+			$this->copySkeleton($user);
+			\OC_Hook::emit('OC_Filesystem', 'post_initMountPoints', array('user' => $user->getUID(), 'user_dir' => $user->getHome()));
+
+			\OC_Hook::emit('OC_Filesystem', 'setup', array('user' => $user->getUID(), 'user_dir' => $user->getHome() . '/files'));
+			\OC::$server->getEventLogger()->end('setup_fs_' . $user->getUID());
+		}
+		$this->userFolders[$user->getUID()] = $root->get('/' . $user->getUID());
+		return $this->userFolders[$user->getUID()];
+	}
+
+	/**
+	 * Clear all mounts in the filesystem
+	 *
+	 * @param bool $preserveRoot whether or not to keep the root storage
+	 */
+	public function clear($preserveRoot = false) {
+		if ($this->root) {
+			$this->userFolders = array();
+			$this->root->getMountManager()->clear($preserveRoot);
+		}
+	}
+}

--- a/lib/private/files/fileinfomanager.php
+++ b/lib/private/files/fileinfomanager.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files;
+
+class FileInfoManager {
+	/**
+	 * @var \OC\Files\FileInfo[]
+	 */
+	protected $entries = array();
+
+	/**
+	 * @var \OC\Files\View
+	 */
+	protected $view;
+
+	public function __construct(View $view) {
+		$this->view = $view;
+	}
+
+	public function register(FileInfo $entry) {
+		$this->entries[$entry->getPath()] = $entry;
+	}
+
+	public function getFileInfo($path) {
+		if (isset($this->entries[$path])) {
+			return $this->entries[$path];
+		} else {
+			return null;
+		}
+	}
+}

--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -255,10 +255,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 	private function searchCommon($method, $args) {
 		$files = array();
 		$rootLength = strlen($this->path);
-		/**
-		 * @var \OC\Files\Storage\Storage $storage
-		 */
-		list($storage, $internalPath) = $this->view->resolvePath($this->path);
+		$mount = $this->root->getMount($this->path);
+		$storage = $mount->getStorage();
+		$internalPath=$mount->getInternalPath($this->path);
 		$internalPath = rtrim($internalPath, '/') . '/';
 		$internalRootLength = strlen($internalPath);
 

--- a/lib/private/files/node/node.php
+++ b/lib/private/files/node/node.php
@@ -286,6 +286,15 @@ class Node implements \OCP\Files\Node {
 	}
 
 	/**
+	 * Get the root folder of the filesystem
+	 *
+	 * @return \OCP\Files\Folder
+	 */
+	public function getRoot() {
+		return $this->root;
+	}
+
+	/**
 	 * check if the requested path is valid
 	 *
 	 * @param string $path

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -45,34 +45,39 @@ class Root extends Folder implements IRootFolder {
 	private $mountManager;
 
 	/**
+	 * @var \OC\Files\Storage\StorageFactory
+	 */
+	private $loader;
+
+	/**
 	 * @var \OC\Hooks\PublicEmitter
 	 */
 	private $emitter;
 
 	/**
-	 * @var \OC\User\User $user
-	 */
-	private $user;
-
-	/**
 	 * @param \OC\Files\Mount\Manager $manager
+	 * @param \OC\Files\Storage\StorageFactory $loader
 	 * @param \OC\Files\View $view
-	 * @param \OC\User\User $user
 	 */
-	public function __construct($manager, $view, $user) {
+	public function __construct($manager, $loader, $view) {
 		parent::__construct($this, $view, '');
+		$this->loader = $loader;
 		$this->mountManager = $manager;
-		$this->user = $user;
 		$this->emitter = new PublicEmitter();
 	}
 
 	/**
-	 * Get the user for which the filesystem is setup
-	 *
-	 * @return \OC\User\User
+	 * @return \OC\Files\Mount\Manager
 	 */
-	public function getUser() {
-		return $this->user;
+	public function getMountManager() {
+		return $this->mountManager;
+	}
+
+	/**
+	 * @return \OC\Files\Storage\StorageFactory
+	 */
+	public function getStorageLoader() {
+		return $this->loader;
 	}
 
 	/**
@@ -308,5 +313,14 @@ class Root extends Folder implements IRootFolder {
 	 */
 	public function getName() {
 		return '';
+	}
+
+	/**
+	 * Get the root folder of the filesystem
+	 *
+	 * @return \OCP\Files\Folder
+	 */
+	public function getRoot() {
+		return $this;
 	}
 }

--- a/lib/private/files/objectstorefactory.php
+++ b/lib/private/files/objectstorefactory.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files;
+
+class ObjectStoreFactory extends Factory {
+	/**
+	 * @param \OC\Files\Mount\Manager $mountManager
+	 * @param \OC\Files\Storage\Loader $storageLoader
+	 */
+	protected function mountRoot($mountManager, $storageLoader) {
+		$config = $this->config->getSystemValue('objectstore');
+		// check misconfiguration
+		if (empty($config['class'])) {
+			\OCP\Util::writeLog('files', 'No class given for objectstore', \OCP\Util::ERROR);
+		}
+		if (!isset($config['arguments'])) {
+			$config['arguments'] = array();
+		}
+
+		// instantiate object store implementation
+		$config['arguments']['objectstore'] = new $config['class']($config['arguments']);
+		// mount with plain / root object store implementation
+		$config['class'] = '\OC\Files\ObjectStore\ObjectStoreStorage';
+
+		$mount = new Mount\MountPoint('\OC\Files\ObjectStore\ObjectStoreStorage', '/', $config['arguments'], $storageLoader);
+		$mountManager->addMount($mount);
+	}
+
+	/**
+	 * @param \OC\Files\Mount\Manager $mountManager
+	 * @param \OC\Files\Storage\StorageFactory $storageLoader
+	 * @param \OCP\IUser $user
+	 */
+	protected function mountUserFolder($mountManager, $storageLoader, $user) {
+		$config = $this->config->getSystemValue('objectstore');
+		// sanity checks
+		if (empty($config['class'])) {
+			\OCP\Util::writeLog('files', 'No class given for objectstore', \OCP\Util::ERROR);
+		}
+		if (!isset($config['arguments'])) {
+			$config['arguments'] = array();
+		}
+		// instantiate object store implementation
+		$config['arguments']['objectstore'] = new $config['class']($config['arguments']);
+
+		$mount = new Mount\MountPoint('\OC\Files\ObjectStore\HomeObjectStoreStorage', '/' . $user->getUID(), $config['arguments'], $storageLoader);
+		$mountManager->addMount($mount);
+	}
+}

--- a/lib/private/files/objectstorefactory.php
+++ b/lib/private/files/objectstorefactory.php
@@ -11,7 +11,7 @@ namespace OC\Files;
 class ObjectStoreFactory extends Factory {
 	/**
 	 * @param \OC\Files\Mount\Manager $mountManager
-	 * @param \OC\Files\Storage\Loader $storageLoader
+	 * @param \OC\Files\Storage\StorageFactory $storageLoader
 	 */
 	protected function mountRoot($mountManager, $storageLoader) {
 		$config = $this->config->getSystemValue('objectstore');

--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -40,13 +40,20 @@ class Scanner extends PublicEmitter {
 	protected $db;
 
 	/**
+	 * @var \OCP\Files\Folder
+	 */
+	protected $userFolder;
+
+	/**
 	 * @param string $user
 	 * @param \OCP\IDBConnection $db
+	 * @param \OCP\Files\Folder $userFolder
 	 */
-	public function __construct($user, $db) {
+	public function __construct($user, $db, $userFolder) {
 		$this->user = $user;
 		$this->propagator = new ChangePropagator(new View(''));
 		$this->db = $db;
+		$this->userFolder = $userFolder;
 	}
 
 	/**
@@ -56,12 +63,11 @@ class Scanner extends PublicEmitter {
 	 * @return \OC\Files\Mount\MountPoint[]
 	 */
 	protected function getMounts($dir) {
-		//TODO: move to the node based fileapi once that's done
-		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($this->user);
-		$absolutePath = Filesystem::getView()->getAbsolutePath($dir);
+		/** @var \OC\Files\Node\Root $root */
+		$root = $this->userFolder->getRoot();
+		$mountManager = $root->getMountManager();
+		$absolutePath=$this->userFolder->getFullPath($dir);
 
-		$mountManager = Filesystem::getMountManager();
 		$mounts = $mountManager->findIn($absolutePath);
 		$mounts[] = $mountManager->find($absolutePath);
 		$mounts = array_reverse($mounts); //start with the mount of $dir

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1001,9 +1001,6 @@ class View {
 		if ($path && Cache\Scanner::isPartialFile($path)) {
 			return false;
 		}
-		if (!Filesystem::$loaded) {
-			return false;
-		}
 		$defaultRoot = Filesystem::getRoot();
 		if ($defaultRoot === null) {
 			return false;

--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -545,7 +545,7 @@ class OC_Image {
 			default:
 
 				// this is mostly file created from encrypted file
-				$this->resource = imagecreatefromstring(\OC\Files\Filesystem::file_get_contents(\OC\Files\Filesystem::getLocalPath($imagePath)));
+				$this->resource = imagecreatefromstring(\OC\Files\Filesystem::file_get_contents($imagePath));
 				$iType = IMAGETYPE_PNG;
 				$this->logger->debug('OC_Image->loadFromFile, Default', array('app' => 'core'));
 				break;

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -55,15 +55,22 @@ class Server extends SimpleContainer implements IServerContainer {
 			$tagMapper = $c->query('TagMapper');
 			return new TagManager($tagMapper, $c->getUserSession());
 		});
+		$this->registerService('FilesystemFactory', function (Server $c) {
+			\OC_App::loadApps(array('filesystem'));
+			$config = $c->getConfig();
+			if ($config->getSystemValue('objectstore', false)) {
+				return new \OC\Files\ObjectStoreFactory($config);
+			} else {
+				return new \OC\Files\Factory($config);
+			}
+		});
 		$this->registerService('RootFolder', function (Server $c) {
-			// TODO: get user and user manager from container as well
-			$user = \OC_User::getUser();
-			/** @var $c SimpleContainer */
-			$userManager = $c->query('UserManager');
-			$user = $userManager->get($user);
-			$manager = \OC\Files\Filesystem::getMountManager();
-			$view = new View();
-			return new Root($manager, $view, $user);
+			$userSession = $c->getUserSession();
+			$user = $userSession->getUser();
+			$factory = $c->getFilesystemFactory();
+			\OC\Files\Filesystem::$activeUser = $user;
+			\OC\Files\Filesystem::$loaded = true;
+			return $factory->getRoot();
 		});
 		$this->registerService('UserManager', function (Server $c) {
 			$config = $c->getConfig();
@@ -387,12 +394,36 @@ class Server extends SimpleContainer implements IServerContainer {
 	}
 
 	/**
+	 * Returns filesystem factory
+	 *
+	 * @return \OC\Files\Factory
+	 */
+	function getFilesystemFactory() {
+		return $this->query('FilesystemFactory');
+	}
+
+	/**
 	 * Returns the root folder of ownCloud's data directory
 	 *
 	 * @return \OCP\Files\Folder
 	 */
 	function getRootFolder() {
 		return $this->query('RootFolder');
+	}
+
+	/**
+	 * Setup the filesystem for a user
+	 *
+	 * @param string $userId
+	 */
+	function setupFilesystem($userId) {
+		/** @var \OC\Files\Node\Root $root */
+		$this->getRootFolder();
+		$user = $this->getUserManager()->get($userId);
+		if ($user) {
+			$factory = \OC::$server->getFilesystemFactory();
+			$factory->getUserFolder($user);
+		}
 	}
 
 	/**
@@ -407,42 +438,13 @@ class Server extends SimpleContainer implements IServerContainer {
 			if (!$user) {
 				return null;
 			}
-			$userId = $user->getUID();
 		} else {
 			$user = $this->getUserManager()->get($userId);
 		}
-		\OC\Files\Filesystem::initMountPoints($userId);
-		$dir = '/' . $userId;
-		$root = $this->getRootFolder();
-		$folder = null;
+		$factory = $this->getFilesystemFactory();
 
-		if (!$root->nodeExists($dir)) {
-			$folder = $root->newFolder($dir);
-		} else {
-			$folder = $root->get($dir);
-		}
-
-		$dir = '/files';
-		if (!$folder->nodeExists($dir)) {
-			$folder = $folder->newFolder($dir);
-
-			if (\OCP\App::isEnabled('files_encryption')) {
-				// disable encryption proxy to prevent recursive calls
-				$proxyStatus = \OC_FileProxy::$enabled;
-				\OC_FileProxy::$enabled = false;
-			}
-
-			\OC_Util::copySkeleton($user, $folder);
-
-			if (\OCP\App::isEnabled('files_encryption')) {
-				// re-enable proxy - our work is done
-				\OC_FileProxy::$enabled = $proxyStatus;
-			}
-		} else {
-			$folder = $folder->get($dir);
-		}
-
-		return $folder;
+		$userFolder = $factory->getUserFolder($user);
+		return $userFolder->get('/files');
 	}
 
 	/**

--- a/lib/public/files/ihomestorage.php
+++ b/lib/public/files/ihomestorage.php
@@ -20,5 +20,10 @@
 namespace OCP\Files;
 
 interface IHomeStorage {
-
+	/**
+	 * Get the user to which the home storage belongs
+	 *
+	 * @return \OCP\IUser
+	 */
+	public function getUser();
 }

--- a/lib/public/files/node.php
+++ b/lib/public/files/node.php
@@ -197,4 +197,11 @@ interface Node extends FileInfo {
 	 * @return string
 	 */
 	public function getName();
+
+	/**
+	 * Get the root folder of the filesystem
+	 *
+	 * @return \OCP\Files\Folder
+	 */
+	public function getRoot();
 }

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -298,6 +298,7 @@ interface Storage {
 	 * @return string|false
 	 */
 	public function getLocalFolder($path);
+
 	/**
 	 * check if a file or folder has been updated since $time
 	 *

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -79,6 +79,13 @@ interface IServerContainer {
 	function getRootFolder();
 
 	/**
+	 * Setup the filesystem for a user
+	 *
+	 * @param string $userId
+	 */
+	function setupFilesystem($userId);
+
+	/**
 	 * Returns a view to ownCloud's files folder
 	 *
 	 * @param string $userId user ID

--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -47,14 +47,7 @@ class FileCache extends \Test_Cache {
 		//	OC_FileProxy::register(new OC_FileProxy_Encryption());
 		//}
 
-		//set up temporary storage
-		$this->storage = \OC\Files\Filesystem::getStorage('/');
-		\OC\Files\Filesystem::clearMounts();
-		$storage = new \OC\Files\Storage\Temporary(array());
-		\OC\Files\Filesystem::mount($storage,array(),'/');
-		$datadir = str_replace('local::', '', $storage->getId());
-		$this->datadir = \OC_Config::getValue('cachedirectory', \OC::$SERVERROOT.'/data/cache');
-		\OC_Config::setValue('cachedirectory', $datadir);
+		$this->clearFileSystem();
 
 		\OC_User::clearBackends();
 		\OC_User::useBackend(new \OC_User_Dummy());
@@ -74,11 +67,6 @@ class FileCache extends \Test_Cache {
 
 	protected function tearDown() {
 		\OC_User::setUserId($this->user);
-		\OC_Config::setValue('cachedirectory', $this->datadir);
-
-		// Restore the original mount point
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->storage, array(), '/');
 
 		parent::tearDown();
 	}

--- a/tests/lib/cache/usercache.php
+++ b/tests/lib/cache/usercache.php
@@ -44,13 +44,7 @@ class UserCache extends \Test_Cache {
 		//}
 
 		//set up temporary storage
-		$this->storage = \OC\Files\Filesystem::getStorage('/');
-		\OC\Files\Filesystem::clearMounts();
-		$storage = new \OC\Files\Storage\Temporary(array());
-		\OC\Files\Filesystem::mount($storage,array(),'/');
-		$datadir = str_replace('local::', '', $storage->getId());
-		$this->datadir = \OC_Config::getValue('cachedirectory', \OC::$SERVERROOT.'/data/cache');
-		\OC_Config::setValue('cachedirectory', $datadir);
+		$this->clearFileSystem();
 
 		\OC_User::clearBackends();
 		\OC_User::useBackend(new \OC_User_Dummy());
@@ -70,12 +64,6 @@ class UserCache extends \Test_Cache {
 
 	protected function tearDown() {
 		\OC_User::setUserId($this->user);
-		\OC_Config::setValue('cachedirectory', $this->datadir);
-
-		// Restore the original mount point
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->storage, array(), '/');
-
 		parent::tearDown();
 	}
 }

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -34,7 +34,9 @@ class UpdaterLegacy extends \Test\TestCase {
 
 	private static $user;
 
-	protected function setUp() {
+	private $userBackend;
+
+	public function setUp() {
 		parent::setUp();
 
 		// remember files_encryption state
@@ -61,10 +63,14 @@ class UpdaterLegacy extends \Test\TestCase {
 			self::$user = $this->getUniqueID();
 		}
 
-		\OC_User::createUser(self::$user, 'password');
+		if (!$this->userBackend) {
+			$this->userBackend = new \OC_User_Dummy();
+			$this->userBackend->createUser(self::$user, 'foo');
+		}
+		\OC_User::useBackend($this->userBackend);
 		\OC_User::setUserId(self::$user);
 
-		Filesystem::init(self::$user, '/' . self::$user . '/files');
+		\OC_Util::setupFS(self::$user);
 
 		Filesystem::clearMounts();
 		Filesystem::mount($this->storage, array(), '/' . self::$user . '/files');

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -12,9 +12,6 @@ use OC\Files\Filesystem;
 use OCP\Share;
 
 class EtagTest extends \Test\TestCase {
-	private $datadir;
-
-	private $tmpDir;
 
 	private $uid;
 
@@ -22,9 +19,6 @@ class EtagTest extends \Test\TestCase {
 	 * @var \OC_User_Dummy $userBackend
 	 */
 	private $userBackend;
-
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
 
 	protected function setUp() {
 		parent::setUp();
@@ -34,47 +28,29 @@ class EtagTest extends \Test\TestCase {
 		\OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 		\OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
 
-		$this->datadir = \OC_Config::getValue('datadirectory');
-		$this->tmpDir = \OC_Helper::tmpFolder();
-		\OC_Config::setValue('datadirectory', $this->tmpDir);
-		$this->uid = \OC_User::getUser();
-		\OC_User::setUserId(null);
-
 		$this->userBackend = new \OC_User_Dummy();
 		\OC_User::useBackend($this->userBackend);
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC_Util::tearDownFS();
-	}
-
-	protected function tearDown() {
-		\OC_Config::setValue('datadirectory', $this->datadir);
-		\OC_User::setUserId($this->uid);
-		\OC_Util::setupFS($this->uid);
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
-
-		parent::tearDown();
 	}
 
 	public function testNewUser() {
 		$user1 = $this->getUniqueID('user_');
 		$this->userBackend->createUser($user1, '');
 
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId($user1);
-		\OC_Util::setupFS($user1);
-		Filesystem::mkdir('/folder');
-		Filesystem::mkdir('/folder/subfolder');
-		Filesystem::file_put_contents('/foo.txt', 'asd');
-		Filesystem::file_put_contents('/folder/bar.txt', 'fgh');
-		Filesystem::file_put_contents('/folder/subfolder/qwerty.txt', 'jkl');
+		Filesystem::mount('\OC\Files\Storage\Temporary', array(), '/' . $user1);
+		$folder = \OC::$server->getUserFolder($user1);
+		$folder->newFolder('/folder');
+		$folder->newFolder('/folder/subfolder');
+		$folder->newFile('/foo.txt')->putContent('asd');
+		$folder->newFile('/folder/bar.txt')->putContent('fgh');
+		$folder->newFile('/folder/subfolder/qwerty.txt')->putContent('jkl');
 
 		$files = array('/foo.txt', '/folder/bar.txt', '/folder/subfolder', '/folder/subfolder/qwerty.txt');
-		$originalEtags = $this->getEtags($files);
+		$originalEtags = $this->getEtags($folder, $files);
 
-		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection());
+		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection(), \OC::$server->getUserFolder($user1));
 		$scanner->backgroundScan('/');
 
-		$newEtags = $this->getEtags($files);
+		$newEtags = $this->getEtags($folder, $files);
 		// loop over array and use assertSame over assertEquals to prevent false positives
 		foreach ($originalEtags as $file => $originalEtag) {
 			$this->assertSame($originalEtag, $newEtags[$file]);
@@ -82,13 +58,15 @@ class EtagTest extends \Test\TestCase {
 	}
 
 	/**
+	 * @param \OCP\Files\Folder $folder
 	 * @param string[] $files
+	 * @return string[]
 	 */
-	private function getEtags($files) {
+	private function getEtags($folder, $files) {
 		$etags = array();
 		foreach ($files as $file) {
-			$info = Filesystem::getFileInfo($file);
-			$etags[$file] = $info['etag'];
+			$node = $folder->get($file);
+			$etags[$file] = $node->getEtag();
 		}
 		return $etags;
 	}

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -245,7 +245,7 @@ class Filesystem extends \Test\TestCase {
 			$user = \OC_User::getUser();
 		} else {
 			$user = $this->getUniqueID();
-			\OC\Files\Filesystem::init($user, '/' . $user . '/files');
+			\OC_Util::setupFS($user);
 		}
 		\OC_Hook::clear('OC_Filesystem');
 		\OC_Hook::connect('OC_Filesystem', 'post_write', $this, 'dummyHook');
@@ -267,22 +267,6 @@ class Filesystem extends \Test\TestCase {
 	}
 
 	/**
-	 * Tests that a local storage mount is used when passed user
-	 * does not exist.
-	 */
-	public function testLocalMountWhenUserDoesNotExist() {
-		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
-		$userId = $this->getUniqueID('user_');
-
-		\OC\Files\Filesystem::initMountPoints($userId);
-
-		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
-
-		$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\Storage\Local'));
-		$this->assertEquals('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
-	}
-
-	/**
 	 * Tests that the home storage is used for the user's mount point
 	 */
 	public function testHomeMount() {
@@ -290,7 +274,7 @@ class Filesystem extends \Test\TestCase {
 
 		\OC_User::createUser($userId, $userId);
 
-		\OC\Files\Filesystem::initMountPoints($userId);
+		\OC::$server->setupFilesystem($userId);
 
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
@@ -315,7 +299,7 @@ class Filesystem extends \Test\TestCase {
 		$cache = $localStorage->getCache();
 
 		\OC_User::createUser($userId, $userId);
-		\OC\Files\Filesystem::initMountPoints($userId);
+		\OC::$server->setupFilesystem($userId);
 
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
@@ -342,7 +326,7 @@ class Filesystem extends \Test\TestCase {
 		\OC_Config::setValue('cache_path', '');
 
 		\OC_User::createUser($userId, $userId);
-		\OC\Files\Filesystem::initMountPoints($userId);
+		\OC::$server->setupFilesystem($userId);
 
 		$this->assertEquals(
 			'/' . $userId . '/',
@@ -369,7 +353,7 @@ class Filesystem extends \Test\TestCase {
 		\OC_Config::setValue('cache_path', $cachePath);
 
 		\OC_User::createUser($userId, $userId);
-		\OC\Files\Filesystem::initMountPoints($userId);
+		\OC::$server->setupFilesystem($userId);
 
 		$this->assertEquals(
 			'/' . $userId . '/cache/',

--- a/tests/lib/files/node/file.php
+++ b/tests/lib/files/node/file.php
@@ -8,10 +8,9 @@
 
 namespace Test\Files\Node;
 
+use OC\Files\Storage\StorageFactory as Loader;
 use OC\Files\FileInfo;
 use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
-use OC\Files\View;
 
 class File extends \Test\TestCase {
 	private $user;
@@ -87,7 +86,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 		$root->listen('\OC\Files', 'preDelete', $preListener);
 		$root->listen('\OC\Files', 'postDelete', $postListener);
 
@@ -144,7 +143,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hook = function ($file) {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -267,7 +266,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hook = function ($file) {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -303,7 +302,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, new $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hooksCalled = 0;
 		$hook = function ($file) use (&$hooksCalled) {
@@ -344,7 +343,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hook = function ($file) {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -371,7 +370,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hook = function () {
 			throw new \Exception('Hooks are not supposed to be called');
@@ -398,7 +397,7 @@ class File extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, new $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$hook = function () {
 			throw new \Exception('Hooks are not supposed to be called');

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -12,10 +12,8 @@ use OC\Files\Cache\Cache;
 use OC\Files\FileInfo;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Node;
-use OC\Files\Storage\Loader;
+use OC\Files\Storage\StorageFactory as Loader;
 use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
-use OC\Files\View;
 
 class Folder extends \Test\TestCase {
 	private $user;
@@ -396,9 +394,21 @@ class Folder extends \Test\TestCase {
 			->with('/bar/foo')
 			->will($this->returnValue(array()));
 
-		$view->expects($this->once())
-			->method('resolvePath')
-			->will($this->returnValue(array($storage, 'foo')));
+		$mount = $this->getMockBuilder('\OC\Files\Mount\MountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mount->expects($this->once())
+			->method('getStorage')
+			->will($this->returnValue($storage));
+
+		$mount->expects($this->once())
+			->method('getInternalPath')
+			->will($this->returnValue('foo'));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->will($this->returnValue($mount));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$result = $node->search('qw');
@@ -412,7 +422,7 @@ class Folder extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn'), array($manager, $view, $this->user));
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -436,9 +446,21 @@ class Folder extends \Test\TestCase {
 			->with('')
 			->will($this->returnValue(array()));
 
-		$view->expects($this->once())
-			->method('resolvePath')
-			->will($this->returnValue(array($storage, 'files')));
+		$mount = $this->getMockBuilder('\OC\Files\Mount\MountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mount->expects($this->once())
+			->method('getStorage')
+			->will($this->returnValue($storage));
+
+		$mount->expects($this->once())
+			->method('getInternalPath')
+			->will($this->returnValue('files'));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->will($this->returnValue($mount));
 
 		$result = $root->search('qw');
 		$this->assertEquals(1, count($result));
@@ -474,9 +496,21 @@ class Folder extends \Test\TestCase {
 			->with('/bar/foo')
 			->will($this->returnValue(array()));
 
-		$view->expects($this->once())
-			->method('resolvePath')
-			->will($this->returnValue(array($storage, 'foo')));
+		$mount = $this->getMockBuilder('\OC\Files\Mount\MountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mount->expects($this->once())
+			->method('getStorage')
+			->will($this->returnValue($storage));
+
+		$mount->expects($this->once())
+			->method('getInternalPath')
+			->will($this->returnValue('foo'));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->will($this->returnValue($mount));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$result = $node->searchByTag('tag1', 'user1');
@@ -535,9 +569,21 @@ class Folder extends \Test\TestCase {
 			->with('/bar/foo')
 			->will($this->returnValue(array($subMount)));
 
-		$view->expects($this->once())
-			->method('resolvePath')
-			->will($this->returnValue(array($storage, 'foo')));
+		$mount = $this->getMockBuilder('\OC\Files\Mount\MountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mount->expects($this->once())
+			->method('getStorage')
+			->will($this->returnValue($storage));
+
+		$mount->expects($this->once())
+			->method('getInternalPath')
+			->will($this->returnValue('foo'));
+
+		$root->expects($this->once())
+			->method('getMount')
+			->will($this->returnValue($mount));
 
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -12,6 +12,7 @@ use OC\Files\Cache\Cache;
 use OC\Files\FileInfo;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Node;
+use OC\Files\Storage\Loader;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OC\Files\View;
@@ -86,7 +87,7 @@ class Folder extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 		$root->listen('\OC\Files', 'preDelete', $preListener);
 		$root->listen('\OC\Files', 'postDelete', $postListener);
 
@@ -560,7 +561,7 @@ class Folder extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, new Loader(), $view));
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -603,7 +604,7 @@ class Folder extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, new Loader(), $view));
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
@@ -641,7 +642,7 @@ class Folder extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, $view, $this->user));
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn', 'getMount'), array($manager, new Loader(), $view));
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -10,6 +10,7 @@ namespace Test\Files\Node;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Node\Root;
+use OC\Files\Storage\Loader;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\User\User;
@@ -37,7 +38,7 @@ class IntegrationTests extends \Test\TestCase {
 		parent::setUp();
 
 		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC\Files\Filesystem::init('', '');
+		\OC_Util::setupFS();
 		\OC\Files\Filesystem::clearMounts();
 		$manager = \OC\Files\Filesystem::getMountManager();
 
@@ -51,7 +52,7 @@ class IntegrationTests extends \Test\TestCase {
 		$user = new User($this->getUniqueID('user'), new \OC_User_Dummy);
 		\OC_User::setUserId($user->getUID());
 		$this->view = new View();
-		$this->root = new Root($manager, $this->view, $user);
+		$this->root = new \OC\Files\Node\Root($manager, new Loader(), $this->view);
 		$storage = new Temporary(array());
 		$subStorage = new Temporary(array());
 		$this->storages[] = $storage;

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -8,9 +8,7 @@
 
 namespace Test\Files\Node;
 
-use OC\Files\Cache\Cache;
-use OC\Files\Node\Root;
-use OC\Files\Storage\Loader;
+use OC\Files\Storage\StorageFactory as Loader;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\User\User;

--- a/tests/lib/files/node/node.php
+++ b/tests/lib/files/node/node.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Node;
 
+use OC\Files\Storage\StorageFactory as Loader;
 use OC\Files\FileInfo;
 
 class Node extends \Test\TestCase {
@@ -294,7 +295,7 @@ class Node extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 		$root->listen('\OC\Files', 'preTouch', $preListener);
 		$root->listen('\OC\Files', 'postTouch', $postListener);
 

--- a/tests/lib/files/node/root.php
+++ b/tests/lib/files/node/root.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Node;
 
+use OC\Files\Storage\StorageFactory as Loader;
 use OC\Files\FileInfo;
 use OCP\Files\NotPermittedException;
 use OC\Files\Mount\Manager;
@@ -34,7 +35,7 @@ class Root extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$view->expects($this->once())
 			->method('getFileInfo')
@@ -70,7 +71,7 @@ class Root extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$view->expects($this->once())
 			->method('file_exists')
@@ -90,7 +91,7 @@ class Root extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$root->get('/../foo');
 	}
@@ -104,7 +105,7 @@ class Root extends \Test\TestCase {
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
 		$view = $this->getMock('\OC\Files\View');
-		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
+		$root = new \OC\Files\Node\Root($manager, new Loader(), $view);
 
 		$root->get('/bar/foo');
 	}

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -64,7 +64,8 @@ class Scanner extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
+		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), $userFolder);
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -86,7 +87,8 @@ class Scanner extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
+		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), $userFolder);
 		$scanner->addMount($mount);
 
 		$scanner->scan('');
@@ -113,7 +115,8 @@ class Scanner extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection());
+		$userFolder = $this->getMock('\OCP\Files\Folder');
+		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), $userFolder);
 		$originalPropagator = $scanner->getPropagator();
 		$scanner->setPropagator($propagator);
 		$scanner->addMount($mount);

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -27,7 +27,7 @@ class Test_Helper_Storage extends \Test\TestCase {
 		$this->storage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($this->user);
-		\OC\Files\Filesystem::init($this->user, '/' . $this->user . '/files');
+		\OC_Util::setupFS($this->user);
 		\OC\Files\Filesystem::clearMounts();
 
 		$this->storageMock = null;

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -32,9 +32,7 @@ class Preview extends TestCase {
 		// this gets called by each test in this test class
 		$this->user = $this->getUniqueID();
 		\OC_User::setUserId($this->user);
-		\OC\Files\Filesystem::init($this->user, '/' . $this->user . '/files');
-
-		\OC\Files\Filesystem::mount('OC\Files\Storage\Temporary', array(), '/');
+		$this->clearFileSystem();
 
 		$this->rootView = new \OC\Files\View('');
 		$this->rootView->mkdir('/'.$this->user);

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -54,6 +54,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * Setup a clean filesystem
+	 */
+	protected function clearFileSystem() {
+		\OC\Files\Filesystem::clearMounts();
+		$storage = new \OC\Files\Storage\Temporary(array());
+		\OC\Files\Filesystem::mount($storage, array(), '/');
+	}
+
 	public static function tearDownAfterClass() {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 


### PR DESCRIPTION
- Move the logic of setting up the filesystem from "all over the place" to `\OC\Files\Factory`
- Seperate out logic of setting up the filesystem for object storage based systems (cc @butonic)
- Remove filesystem state from `\OC\Files\Filesystem`
- Let the server container keep track of the state instead

cc @DeepDiver1975 @PVince81 @th3fallen 
