### PR TITLE
Conceal or display SabreDAV version number.

### DIFF
--- a/lib/private/connector/sabre/server.php
+++ b/lib/private/connector/sabre/server.php
@@ -38,6 +38,14 @@ class OC_Connector_Sabre_Server extends Sabre\DAV\Server {
 	 */
 	private $ignoreRangeHeader = false;
 
+	/**
+	 * @see \Sabre\DAV\Server
+	 */
+	public function __construct($treeOrNode = null) {
+		parent::__construct($treeOrNode);
+		self::$exposeVersion = false;
+	}
+
 	public function getRequestUri() {
 
 		if (!is_null($this->overLoadedUri)) {


### PR DESCRIPTION
Conceal or display SabreDAV version number in browser and http response headers. Of benefit for the same reason as obscuring web server or php version number.
