### PR TITLE
Added error check to lib/private/image.php

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -648,6 +648,12 @@ class OC_Image {
 		}
 		// create gd image
 		$im = imagecreatetruecolor($meta['width'], $meta['height']);
+		if ($im == FALSE) {
+			fclose($fh);
+			trigger_error('imagecreatefrombmp(): imagecreatetruecolor failed for file "' . $fileName . '" with dimensions ' . $meta['width'] . 'x' . $meta['height'], E_USER_WARNING);
+			return FALSE;
+		}
+
 		$data = fread($fh, $meta['imagesize']);
 		$p = 0;
 		$vide = chr(0);


### PR DESCRIPTION
This checks that imagecreatetruecolor actually creates an image, rather than returning FALSE.
Without this check, subsequent loop might create billions of ERROR-level log messages.

Signed-off-by: Byron Marohn combustible@live.com
