### PR TITLE
[encryption] create backup from all keys before recovery

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -228,6 +228,9 @@ class Hooks {
 						|| !$util->userKeysExists()
 						|| !$view->file_exists($user . '/files')) {
 
+					// backup old keys
+					$util->backupAllKeys('recovery');
+
 					$newUserPassword = $params['password'];
 
 					// make sure that the users home is mounted

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -54,7 +54,7 @@ class Proxy extends \OC_FileProxy {
 		$view = new \OC\Files\View();
 
 		// files outside of the files-folder are excluded
-		if(strpos($path, '/' . $uid . '/files') !== 0) {
+		if(strpos($path, '/' . $uid . '/files/') !== 0) {
 			return true;
 		}
 

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1478,6 +1478,22 @@ class Util {
 	}
 
 	/**
+	 * create a backup of all keys from the user
+	 *
+	 * @param string $purpose (optional) define the purpose of the backup, will be part of the backup folder
+	 */
+	public function backupAllKeys($purpose = '') {
+		$this->userId;
+		$backupDir = $this->encryptionDir . '/backup.';
+		$backupDir .= ($purpose === '') ? date("Y-m-d_H-i-s") . '/' : $purpose . '.' . date("Y-m-d_H-i-s") . '/';
+		$this->view->mkdir($backupDir);
+		$this->view->copy($this->shareKeysPath, $backupDir . 'share-keys/');
+		$this->view->copy($this->keyfilesPath, $backupDir . 'keyfiles/');
+		$this->view->copy($this->privateKeyPath, $backupDir . $this->userId . '.private.key');
+		$this->view->copy($this->publicKeyPath, $backupDir . $this->userId . '.public.key');
+	}
+
+	/**
 	 * check if the file is stored on a system wide mount point
 	 * @param string $path relative to /data/user with leading '/'
 	 * @return boolean

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -398,6 +398,48 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	}
 
+	/**
+	 * test if all keys get moved to the backup folder correctly
+	 */
+	function testBackupAllKeys() {
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER1);
+
+		// create some dummy key files
+		$encPath = '/' . self::TEST_ENCRYPTION_UTIL_USER1 . '/files_encryption';
+		$this->view->file_put_contents($encPath . '/keyfiles/foo.key', 'key');
+		$this->view->file_put_contents($encPath . '/share-keys/foo.user1.shareKey', 'share key');
+
+		$util = new \OCA\Encryption\Util($this->view, self::TEST_ENCRYPTION_UTIL_USER1);
+
+		$util->backupAllKeys('testing');
+
+		$encFolderContent = $this->view->getDirectoryContent($encPath);
+
+		$backupPath = '';
+		foreach ($encFolderContent as $c) {
+			$name = $c['name'];
+			if (substr($name, 0, strlen('backup'))  === 'backup') {
+				$backupPath = $encPath . '/'. $c['name'];
+				break;
+			}
+		}
+
+		$this->assertTrue($backupPath !== '');
+
+		// check backupDir Content
+		$this->assertTrue($this->view->is_dir($backupPath . '/keyfiles'));
+		$this->assertTrue($this->view->is_dir($backupPath . '/share-keys'));
+		$this->assertTrue($this->view->file_exists($backupPath . '/keyfiles/foo.key'));
+		$this->assertTrue($this->view->file_exists($backupPath . '/share-keys/foo.user1.shareKey'));
+		$this->assertTrue($this->view->file_exists($backupPath . '/' . self::TEST_ENCRYPTION_UTIL_USER1 . '.private.key'));
+		$this->assertTrue($this->view->file_exists($backupPath . '/' . self::TEST_ENCRYPTION_UTIL_USER1 . '.public.key'));
+
+		//cleanup
+		$this->view->deleteAll($backupPath);
+		$this->view->unlink($encPath . '/keyfiles/foo.key', 'key');
+		$this->view->unlink($encPath . '/share-keys/foo.user1.shareKey', 'share key');
+	}
+
 
 	function testDescryptAllWithBrokenFiles() {
 


### PR DESCRIPTION
Steps to test:
1. create two users "admin" and "user"
2. "admin" enables encryption
3. "admin" enabled the recovery key in the admin settings
4. "user" enables recovery key in the personal settings
5. "user" uploads some files
6. "admin" changes the password from "user" in the user settings with the recovery pasword
7. look at `/data/user/files_encryption`, you should find a `backup.recovery.<date>` folder which contains all file keys, share keys and the users public key.
8. login as "user", you should be able to read the files with the new key -> logout again
9. copy filekeys, share-keys and the private-key from the backup folder back to `data/user2/files_encryption` and the public key from the backup to `data/public-keys`
10. login again as "user" -> you should get a warning that login password doesn't match key password
    11 follow the instruction and update the private key in the personal settings by providing the old login password (before recovery) and the new login password (set by the admin during recovery)
11. Now you should be able to read the files again with the backup keys.

cc @PVince81 

fix #11061
