### PR TITLE
Tentative fix for legacy file actions unit test side effect

### DIFF
--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -23,6 +23,7 @@ describe('OCA.Files.App tests', function() {
 	var App = OCA.Files.App;
 	var pushStateStub;
 	var parseUrlQueryStub;
+	var oldLegacyFileActions;
 
 	beforeEach(function() {
 		$('#testArea').append(
@@ -41,6 +42,7 @@ describe('OCA.Files.App tests', function() {
 			'</div>'
 		);
 
+		oldLegacyFileActions = window.FileActions;
 		window.FileActions = new OCA.Files.FileActions();
 		OCA.Files.legacyFileActions = window.FileActions;
 		OCA.Files.fileActions = new OCA.Files.FileActions();
@@ -53,6 +55,8 @@ describe('OCA.Files.App tests', function() {
 	});
 	afterEach(function() {
 		App.destroy();
+
+		window.FileActions = oldLegacyFileActions;
 
 		pushStateStub.restore();
 		parseUrlQueryStub.restore();

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -57,6 +57,16 @@ describe('OCA.Sharing.App tests', function() {
 		});
 	});
 	describe('file actions', function() {
+		var oldLegacyFileActions;
+
+		beforeEach(function() {
+			oldLegacyFileActions = window.FileActions;
+			window.FileActions = new OCA.Files.FileActions();
+		});
+
+		afterEach(function() {
+			window.FileActions = oldLegacyFileActions;
+		});
 		it('provides default file actions', function() {
 			_.each([fileListIn, fileListOut], function(fileList) {
 				var fileActions = fileList.fileActions;


### PR DESCRIPTION
Sometimes the JS unit test with legacy file actions fail.

This fix runs the legacy file actions tests on a dummy instead of the
real one.

I hope this fixes https://github.com/owncloud/core/issues/11052

We should run Jenkins a few times on this PR as the original issue happens randomly @DeepDiver1975 
