### PR TITLE
DragnDrop Upload text style

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -320,6 +320,10 @@ table td.filename .uploadtext {
 	margin-top: 5px;
 	height: 20px;
 	padding: 10px 0;
+	font-size: 11px;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+	filter: alpha(opacity=50);
+	opacity: .5;
 }
 
 .ie8 input[type="checkbox"]{

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -316,7 +316,10 @@ table td.filename .nametext .innernametext {
 
 table td.filename .uploadtext {
 	font-weight: normal;
-	margin-left: 8px;
+	margin-left: 55px;
+	margin-top: 5px;
+	height: 20px;
+	padding: 10px 0;
 }
 
 .ie8 input[type="checkbox"]{


### PR DESCRIPTION
The 8px margin was ugly.

Replaces https://github.com/owncloud/core/pull/10037 also includes the change pointed out by @MorrisJobke in https://github.com/owncloud/core/pull/10037#issuecomment-50606480

@nstamm @MorrisJobke @jancborchardt @PVince81 
