### PR TITLE
Remove old upgrade routines

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -165,19 +165,6 @@ class Updater extends BasicEmitter {
 		// (in case it didn't exist before)
 		file_put_contents(\OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/.ocdata', '');
 
-		/*
-		 * START CONFIG CHANGES FOR OLDER VERSIONS
-		 */
-		if (!\OC::$CLI && version_compare($installedVersion, '6.90.1', '<')) {
-			// Add the trusted_domains config if it is not existant
-			// This is added to prevent host header poisoning
-			\OC_Config::setValue('trusted_domains', \OC_Config::getValue('trusted_domains', array(\OC_Request::serverHost())));
-		}
-
-		/*
-		 * STOP CONFIG CHANGES FOR OLDER VERSIONS
-		 */
-
 		// pre-upgrade repairs
 		$repair = new \OC\Repair(\OC\Repair::getBeforeUpgradeRepairSteps());
 		$repair->run();
@@ -189,13 +176,6 @@ class Updater extends BasicEmitter {
 			// simulate apps DB upgrade
 			$this->checkAppUpgrade($currentVersion);
 
-		}
-
-		// upgrade from OC6 to OC7
-		// TODO removed it again for OC8
-		$sharePolicy = \OC_Appconfig::getValue('core', 'shareapi_share_policy', 'global');
-		if ($sharePolicy === 'groups_only') {
-			\OC_Appconfig::setValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		}
 
 		if ($this->updateStepEnabled) {


### PR DESCRIPTION
We do not support updates from 6 to 8 directly, therefore we can remove those upgrade routines.
