### PR TITLE
Confirm password field.

### DIFF
--- a/core/lostpassword/controller.php
+++ b/core/lostpassword/controller.php
@@ -84,7 +84,7 @@ class Controller {
 
 	public static function resetPassword($args) {
 		if (self::checkToken($args['user'], $args['token'])) {
-			if (isset($_POST['password'])) {
+			if (isset($_POST['password']) && isset($_POST['confirm-password']) && $_POST['password'] === $_POST['confirm-password']) {
 				if (\OC_User::setPassword($args['user'], $_POST['password'])) {
 					\OC_Preferences::deleteKey($args['user'], 'owncloud', 'lostpassword');
 					\OC_User::unsetMagicInCookie();

--- a/core/lostpassword/templates/resetpassword.php
+++ b/core/lostpassword/templates/resetpassword.php
@@ -8,6 +8,10 @@
 				<label for="password" class="infield"><?php echo $l->t( 'New password' ); ?></label>
 				<input type="password" name="password" id="password" value="" required />
 			</p>
+			<p class="infield">
+				<label for="confirm-password" class="infield"><?php echo $l->t( 'Confirm password' ); ?></label>
+				<input type="password" name="confirm-password" id="confirm-password" value="" required />
+			</p>
 			<input type="submit" id="submit" value="<?php echo $l->t('Reset password'); ?>" />
 		<?php endif; ?>
 	</fieldset>

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -12,15 +12,28 @@ class Controller {
 		\OC_App::loadApps();
 
 		$username = \OC_User::getUser();
+		$confirmpassword = isset($_POST['confirm-password']) ? $_POST['confirm-password'] : null;
 		$password = isset($_POST['personal-password']) ? $_POST['personal-password'] : null;
 		$oldPassword = isset($_POST['oldpassword']) ? $_POST['oldpassword'] : '';
 
+		if (	is_null($confirmpassword) || empty($confirmpassword) ||
+			is_null($password) || empty($password) ||
+			is_null($oldPassword) || empty($oldPassword)) {
+			$l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("Please fill every field")) ));
+			exit();
+		}
+		if ($confirmpassword !== $password) {
+			$l = new \OC_L10n('settings');
+			\OC_JSON::error(array("data" => array("message" => $l->t("Password and Confirm Password must be equal")) ));
+			exit();
+		}
 		if (!\OC_User::checkPassword($username, $oldPassword)) {
 			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+		if (\OC_User::setPassword($username, $password)) {
 			\OC_JSON::success();
 		} else {
 			\OC_JSON::error();

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -123,7 +123,7 @@ function avatarResponseHandler(data) {
 
 $(document).ready(function(){
 	$("#passwordbutton").click( function(){
-		if ($('#pass1').val() !== '' && $('#pass2').val() !== '') {
+		if ($('#pass1').val() !== '' && $('#pass2').val() !== '' && $('#pass3').val() !== '') {
 			// Serialize the data
 			var post = $( "#passwordform" ).serialize();
 			$('#passwordchanged').hide();
@@ -133,12 +133,13 @@ $(document).ready(function(){
 				if( data.status === "success" ){
 					$('#pass1').val('');
 					$('#pass2').val('');
+					$('#pass3').val('');
 					$('#passwordchanged').show();
 				} else{
 					if (typeof(data.data) !== "undefined") {
 						$('#passworderror').html(data.data.message);
 					} else {
-						$('#passworderror').html(t('Unable to change password'));
+						$('#passworderror').html(t('settings', 'Unable to change password'));
 					}
 					$('#passworderror').show();
 				}
@@ -146,6 +147,7 @@ $(document).ready(function(){
 			return false;
 		} else {
 			$('#passwordchanged').hide();
+			$('#passworderror').html(t('settings', 'Please fill every field'));
 			$('#passworderror').show();
 			return false;
 		}


### PR DESCRIPTION
I am not an usability expert, but from my point of view _every_ time someone could change the password should insert the password two times to be sure that the user doesn't write something wrong.

The commit adds a confirm-password field in change-password box in personal area and in the lostpassword area.

This pull request is for version 6.
