### PR TITLE
Resolves cache tests failing if the directory length is longer than 64

### DIFF
--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -336,6 +336,10 @@ class Cache extends \PHPUnit_Framework_TestCase {
 		$storageId = $this->storage->getId();
 		$data = array('size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file');
 		$id = $this->cache->put('foo', $data);
+
+		if (strlen($storageId) > 64) {
+			$storageId = md5($storageId);
+		}
 		$this->assertEquals(array($storageId, 'foo'), \OC\Files\Cache\Cache::getById($id));
 	}
 


### PR DESCRIPTION
...ers

Partially resolves https://github.com/owncloud/core/issues/10991 failure 2
