### PR TITLE
close the session for all DAV calls right after authentication - no need...

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -76,7 +76,7 @@ class OC_Connector_Sabre_Auth extends Sabre_DAV_Auth_Backend_AbstractBasic {
 		$result = $this->auth($server, $realm);
 
 		// close the session - right after authentication there is not need to write to the session any more
-		\OC::$session->close();
+		session_write_close();
 
 		return $result;
     }

--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -73,6 +73,20 @@ class OC_Connector_Sabre_Auth extends Sabre_DAV_Auth_Backend_AbstractBasic {
 	  */
 	public function authenticate(Sabre_DAV_Server $server, $realm) {
 
+		$result = $this->auth($server, $realm);
+
+		// close the session - right after authentication there is not need to write to the session any more
+		\OC::$session->close();
+
+		return $result;
+    }
+
+	/**
+	 * @param Sabre_DAV_Server $server
+	 * @param $realm
+	 * @return bool
+	 */
+	private function auth(Sabre_DAV_Server $server, $realm) {
 		if (OC_User::handleApacheAuth() || OC_User::isLoggedIn()) {
 			$user = OC_User::getUser();
 			OC_Util::setupFS($user);
@@ -81,5 +95,5 @@ class OC_Connector_Sabre_Auth extends Sabre_DAV_Auth_Backend_AbstractBasic {
 		}
 
 		return parent::authenticate($server, $realm);
-    }
+	}
 }


### PR DESCRIPTION
... to write to the session afterwards
