### PR TITLE
Move BasicAuth check to isLoggedIn

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -780,15 +780,6 @@ class OC {
 				if (isset($_COOKIE['oc_token'])) {
 					OC_Preferences::deleteKey(OC_User::getUser(), 'login_token', $_COOKIE['oc_token']);
 				}
-				if (isset($_SERVER['PHP_AUTH_USER'])) {
-					if (isset($_COOKIE['oc_ignore_php_auth_user'])) {
-						// Ignore HTTP Authentication for 5 more mintues.
-						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], time() + 300, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
-					} elseif ($_SERVER['PHP_AUTH_USER'] === self::$server->getSession()->get('loginname')) {
-						// Ignore HTTP Authentication to allow a different user to log in.
-						setcookie('oc_ignore_php_auth_user', $_SERVER['PHP_AUTH_USER'], 0, OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
-					}
-				}
 				OC_User::logout();
 				// redirect to webroot and add slash if webroot is empty
 				header("Location: " . OC::$WEBROOT.(empty(OC::$WEBROOT) ? '/' : ''));
@@ -833,9 +824,8 @@ class OC {
 		} // remember was checked after last login
 		elseif (OC::tryRememberLogin()) {
 			$error[] = 'invalidcookie';
-		} // logon via web form or WebDAV
-		elseif (OC::tryFormLogin()) {}
-		elseif (OC::tryBasicAuthLogin()) {
+		} // logon via web form
+		elseif (OC::tryFormLogin()) {
 			$error[] = 'invalidpassword';
 		}
 
@@ -953,25 +943,6 @@ class OC {
 		return true;
 	}
 
-	/**
-	 * Try to login a user using HTTP authentication.
-	 * @return bool
-	 */
-	protected static function tryBasicAuthLogin() {
-		if (!isset($_SERVER["PHP_AUTH_USER"])
-			|| !isset($_SERVER["PHP_AUTH_PW"])
-			|| (isset($_COOKIE['oc_ignore_php_auth_user']) && $_COOKIE['oc_ignore_php_auth_user'] === $_SERVER['PHP_AUTH_USER'])
-		) {
-			return false;
-		}
-
-		if (OC_User::login($_SERVER["PHP_AUTH_USER"], $_SERVER["PHP_AUTH_PW"])) {
-			OC_User::unsetMagicInCookie();
-			$_SERVER['HTTP_REQUESTTOKEN'] = OC_Util::callRegister();
-		}
-
-		return true;
-	}
 
 }
 

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -335,15 +335,19 @@ class OC_User {
 	}
 
 	/**
-	 * Check if the user is logged in
+	 * Check if the user is logged in, considers also the HTTP basic credentials
 	 * @return bool
-	 *
-	 * Checks if the user is logged in
 	 */
 	public static function isLoggedIn() {
 		if (\OC::$server->getSession()->get('user_id') !== null && self::$incognitoMode === false) {
 			return self::userExists(\OC::$server->getSession()->get('user_id'));
 		}
+
+		// Check whether the user has authenticated using Basic Authentication
+		if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+			return \OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Ensures that Basic Auth works properly for APIs and removes the need for some even uglier lines of code.

Related to https://github.com/owncloud/core/pull/11155#discussion_r17724967 and needs a backport to stable7.

@PVince81 @DeepDiver1975 @karlitschek Testing welcome. Especially the APIs (e.g. `curl -D - http://admin:admin@localhost/core/index.php/apps/files/api/v1/thumbnail/100/100/welcome.txt`) and https://github.com/owncloud/core/issues/11129
