### PR TITLE
Prevent updates between multiple major versions

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -146,15 +146,37 @@ class Updater extends BasicEmitter {
 	}
 
 	/**
+	 * Whether an upgrade to a specified version is possible
+	 * @param string $oldVersion
+	 * @param string $newVersion
+	 * @return bool
+	 */
+	public function isUpgradePossible($oldVersion, $newVersion) {
+		$oldVersion = explode('.', $oldVersion);
+		$newVersion = explode('.', $newVersion);
+
+		if($newVersion[0] > ($oldVersion[0] + 1) || $oldVersion[0] > $newVersion[0]) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * runs the update actions in maintenance mode, does not upgrade the source files
 	 * except the main .htaccess file
 	 *
 	 * @param string $currentVersion current version to upgrade to
 	 * @param string $installedVersion previous version from which to upgrade from
 	 *
+	 * @throws \Exception
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
 	private function doUpgrade($currentVersion, $installedVersion) {
+		// Stop update if the update is over several major versions
+		if (!self::isUpgradePossible($installedVersion, $currentVersion)) {
+			throw new \Exception('Updates between multiple major versions are unsupported.');
+		}
+
 		// Update htaccess files for apache hosts
 		if (isset($_SERVER['SERVER_SOFTWARE']) && strstr($_SERVER['SERVER_SOFTWARE'], 'Apache')) {
 			\OC_Setup::updateHtaccess();
@@ -235,7 +257,7 @@ class Updater extends BasicEmitter {
 	}
 
 	/**
-	 * @param string $version the oc version to check app compatibilty with
+	 * @param string $version the oc version to check app compatibility with
 	 */
 	protected function checkAppUpgrade($version) {
 		$apps = \OC_App::getEnabledApps();

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) 2014 Lukas Reschke <lukas@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+class UpdaterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testVersionCompatbility() {
+		return array(
+			array('1.0.0.0', '2.2.0', true),
+			array('1.1.1.1', '2.0.0', true),
+			array('5.0.3', '4.0.3', false),
+			array('12.0.3', '13.4.5', true),
+			array('1', '2', true),
+			array('2', '2', true),
+			array('6.0.5', '6.0.6', true),
+			array('5.0.6', '7.0.4', false)
+		);
+	}
+
+	/**
+	 * @dataProvider testVersionCompatbility
+	 */
+	function testIsUpgradePossible($oldVersion, $newVersion, $result) {
+		$updater = new Updater();
+		$this->assertSame($result, $updater->isUpgradePossible($oldVersion, $newVersion));
+	}
+
+}


### PR DESCRIPTION
Testplan:
- [x] Increment version in version.php for 1 major release => Update works
- [x] Increment version in version.php for 2 major releases => Update does not work

Ref https://github.com/owncloud/core/issues/11078
