### PR TITLE
Also skip tar tests on stable 5 when running php >=5.5

### DIFF
--- a/tests/lib/archive/tar.php
+++ b/tests/lib/archive/tar.php
@@ -10,6 +10,13 @@ require_once 'archive.php';
 
 if (!OC_Util::runningOnWindows()) {
 class Test_Archive_TAR extends Test_Archive {
+	public function setUp() {
+		if (floatval(phpversion()) >= 5.5) {
+			$this->markTestSkipped('php 5.5 changed unpack function.');
+			return;
+		}
+	}
+
 	protected function getExisting() {
 		$dir = OC::$SERVERROOT . '/tests/data';
 		return new OC_Archive_TAR($dir . '/data.tar.gz');


### PR DESCRIPTION
Tar support is broken for php >=5.5 for versions lower than stable7

cc @DeepDiver1975 
