### PR TITLE
Reenable file proxy when renaming between mount points

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -484,6 +484,7 @@ class Hooks {
 			unset(self::$renamedFiles[$params['oldpath']]);
 		} else {
 			\OCP\Util::writeLog('Encryption library', "can't get path and owner from the file before it was renamed", \OCP\Util::DEBUG);
+			\OC_FileProxy::$enabled = $proxyStatus;
 			return false;
 		}
 


### PR DESCRIPTION
When moving a folder into another mount point, $renamedFiles is empty
because that goes over a different mechanism.

In such case, this fix makes sure that the file proxy is reenable to
avoid breaking the subsequent files that are being moved.

Fixes https://github.com/owncloud/core/issues/11162

Note: I did not remove the warnings, they are logged as debug anyway.

Please review @schiesbn @LukasReschke @th3fallen 

To test, use the steps from #11162 but have at least TWO files inside the folder. One of them will be broken before this fix.
