### PR TITLE
Throw error in showPreview instead the constructor

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -111,11 +111,6 @@ class Preview {
 			\OC_Log::write('core', 'No preview providers exist', \OC_Log::ERROR);
 			throw new \Exception('No preview providers');
 		}
-
-		// Check if file is valid
-		if($this->isFileValid() === false) {
-			throw new NotFoundException('File not found.');
-		}
 	}
 
 	/**
@@ -540,10 +535,15 @@ class Preview {
 	}
 
 	/**
-	 * show preview
-	 * @return void
+	 * @param null|string $mimeType
+	 * @throws NotFoundException
 	 */
 	public function showPreview($mimeType = null) {
+		// Check if file is valid
+		if($this->isFileValid() === false) {
+			throw new NotFoundException('File not found.');
+		}
+
 		\OCP\Response::enableCaching(3600 * 24); // 24 hours
 		if (is_null($this->preview)) {
 			$this->getPreview();


### PR DESCRIPTION
This function is also used in a way such as:

```
    $preview = new \OC\Preview(\OC_User::getUser(), 'files');
    $info = \OC\Files\Filesystem::getFileInfo($file);
    if (!$always and !$preview->isAvailable($info)) {
        \OC_Response::setStatus(404);
    } else {
        $preview->setFile($file);
        $preview->setMaxX($maxX);
        $preview->setMaxY($maxY);
        $preview->setScalingUp($scalingUp);
        $preview->setKeepAspect($keepAspect);
    }
```

Which won't work anymore since `setFile` is used instead of passing the file in the constructor. Fixes a regression in master. 

@PVince81 @th3fallen
