### PR TITLE
Added extra check to avoid deleting key folders

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -142,6 +142,12 @@ class Trashbin {
 		$user = \OCP\User::getUser();
 		$size = 0;
 		list($owner, $ownerPath) = self::getUidAndFilename($file_path);
+
+		// file has been deleted in between
+		if (empty($ownerPath)) {
+			return false;
+		}
+
 		self::setUpTrash($user);
 
 		$view = new \OC\Files\View('/' . $user);
@@ -219,6 +225,10 @@ class Trashbin {
 			$rootView = new \OC\Files\View('/');
 
 			list($owner, $ownerPath) = self::getUidAndFilename($file_path);
+			// file has been deleted in between
+			if (empty($ownerPath)) {
+				return 0;
+			}
 
 			if ($rootView->is_dir($owner . '/files_versions/' . $ownerPath)) {
 				$size += self::calculateSize(new \OC\Files\View('/' . $owner . '/files_versions/' . $ownerPath));
@@ -261,6 +271,11 @@ class Trashbin {
 			$rootView = new \OC\Files\View('/');
 
 			list($owner, $ownerPath) = self::getUidAndFilename($file_path);
+
+			// file has been deleted in between
+			if (empty($ownerPath)) {
+				return 0;
+			}
 
 			$util = new \OCA\Encryption\Util(new \OC\Files\View('/'), $user);
 
@@ -440,6 +455,12 @@ class Trashbin {
 
 			list($owner, $ownerPath) = self::getUidAndFilename($target);
 
+			// file has been deleted in between
+			if (empty($ownerPath)) {
+				\OC_FileProxy::$enabled = $proxyStatus;
+				return false;
+			}
+
 			if ($timestamp) {
 				$versionedFile = $filename;
 			} else {
@@ -483,6 +504,11 @@ class Trashbin {
 			$target = \OC\Files\Filesystem::normalizePath('/' . $location . '/' . $uniqueFilename);
 
 			list($owner, $ownerPath) = self::getUidAndFilename($target);
+
+			// file has been deleted in between
+			if (empty($ownerPath)) {
+				return false;
+			}
 
 			$util = new \OCA\Encryption\Util(new \OC\Files\View('/'), $user);
 


### PR DESCRIPTION
Whenever a delete operation is called twice in a row, it could happen
that the first call already deleted the file.

The second call would return an empty $ownerPath because the file does
not exist. That empty $ownerPath would run the key deletion operation on
the wrong path.

This fix adds checks in many places to make sure we don't use $ownerPath
when it's empty or null.

Fixes https://github.com/owncloud/core/issues/11183

Please review @schiesbn @LukasReschke @icewind1991 

Regression testing needed:
- [ ] reproduce original issue (see steps in ticket)
- [ ] versions delete + restore
- [ ] encryption share-keys delete + restore
