### PR TITLE
adding 'smallint unsigned' to type mapping for sqlite

### DIFF
--- a/lib/private/db/sqlitemigrator.php
+++ b/lib/private/db/sqlitemigrator.php
@@ -71,6 +71,7 @@ class SQLiteMigrator extends Migrator {
 	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
 		$platform = $connection->getDatabasePlatform();
 		$platform->registerDoctrineTypeMapping('tinyint unsigned', 'integer');
+		$platform->registerDoctrineTypeMapping('smallint unsigned', 'integer');
 
 		return parent::getDiff($targetSchema, $connection);
 	}


### PR DESCRIPTION
smallint unsigned type mapping was missing on the migration of core master today

@bantu @PVince81 @icewind1991 

@karlitschek we might want to consider this for stable7 as well
