### PR TITLE
Delete bogus cached previews while updating

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -82,11 +82,21 @@ class Repair extends BasicEmitter {
 	 * @return array of RepairStep instances
 	 */
 	public static function getBeforeUpgradeRepairSteps() {
-		return array(
+		$steps = array(
 			new \OC\Repair\InnoDB(),
 			new \OC\Repair\Collation(\OC::$server->getConfig(), \OC_DB::getConnection()),
 			new \OC\Repair\SearchLuceneTables()
 		);
+
+		//There is no need to delete all previews on every single update
+		//only 7.0.0 thru 7.0.2 generated broken previews
+		$currentVersion = \OC_Config::getValue('version');
+		if (version_compare($currentVersion, '7.0.0.0', '>=') &&
+			version_compare($currentVersion, '7.0.2.2', '<=')) {
+			$steps[] = new \OC\Repair\Preview();
+		}
+
+		return $steps;
 	}
 
 	/**

--- a/lib/repair/preview.php
+++ b/lib/repair/preview.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2014 Georg Ehrke <georg@ownCloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OC\Repair;
+
+use OC\Files\View;
+use OC\Hooks\BasicEmitter;
+
+class Preview extends BasicEmitter implements \OC\RepairStep {
+
+	public function getName() {
+		return 'Cleaning-up broken previews';
+	}
+
+	public function run() {
+		$view = new View('/');
+		$children = $view->getDirectoryContent('/');
+
+		foreach ($children as $child) {
+			if ($view->is_dir($child->getPath())) {
+				$thumbnailsFolder = $child->getPath() . '/thumbnails';
+				if ($view->is_dir($thumbnailsFolder)) {
+					$view->rmdir($thumbnailsFolder);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/10521

To test this:
- checkout ownCloud 7
- make sure your config.php's `version` is bigger (or equal) than `7.0.0.0` and smaller (or equal) than `7.0.2.2`
- create users
- upload files and make sure /userdir/thumbnails contains smth
- upgrade
- check if all /userdir/thumbnails folders were deleted

please review @MorrisJobke @PVince81 
