### PR TITLE
Fix oc stream seek

### DIFF
--- a/lib/private/files/stream/close.php
+++ b/lib/private/files/stream/close.php
@@ -29,7 +29,7 @@ class Close {
 	}
 
 	public function stream_seek($offset, $whence = SEEK_SET) {
-		fseek($this->source, $offset, $whence);
+		return fseek($this->source, $offset, $whence) === 0;
 	}
 
 	public function stream_tell() {

--- a/lib/private/files/stream/oc.php
+++ b/lib/private/files/stream/oc.php
@@ -48,7 +48,7 @@ class OC {
 	}
 
 	public function stream_seek($offset, $whence = SEEK_SET) {
-		fseek($this->fileSource, $offset, $whence);
+		return fseek($this->fileSource, $offset, $whence) === 0;
 	}
 
 	public function stream_tell() {

--- a/lib/private/files/stream/quota.php
+++ b/lib/private/files/stream/quota.php
@@ -83,7 +83,7 @@ class Quota {
 		}
 		// this wrapper needs to return "true" for success.
 		// the fseek call itself returns 0 on succeess
-		return !fseek($this->source, $offset, $whence);
+		return fseek($this->source, $offset, $whence) === 0;
 	}
 
 	public function stream_tell() {

--- a/tests/lib/streamwrappers.php
+++ b/tests/lib/streamwrappers.php
@@ -79,6 +79,16 @@ class Test_StreamWrappers extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('.', '..', 'bar.txt', 'foo.txt'), scandir('oc:///'));
 		$this->assertEquals('qwerty', file_get_contents('oc:///bar.txt'));
 
+		$fh = fopen('oc:///bar.txt', 'rb');
+		$this->assertSame(0, ftell($fh));
+		$content = fread($fh, 4);
+		$this->assertSame(4, ftell($fh));
+		$this->assertSame('qwer', $content);
+		$content = fread($fh, 1);
+		$this->assertSame(5, ftell($fh));
+		$this->assertSame(0, fseek($fh, 0));
+		$this->assertSame(0, ftell($fh));
+
 		unlink('oc:///foo.txt');
 		$this->assertEquals(array('.', '..', 'bar.txt'), scandir('oc:///'));
 	}


### PR DESCRIPTION
I was debugging a strange bug for fun in my vacation: https://github.com/owncloud/music/issues/212

In short fseek end ftell are broken when using the OC stream wrapper. The stream_seek implementation needs to return true or false, depending on the result of fseek, see http://de1.php.net/manual/de/streamwrapper.stream-seek.php#115111

test in ef6db5e
fix in 01e61bf

cc @icewind1991 @MorrisJobke 

@karlitschek I recommend backporting unless we want to hunt obscure problems in the enterprise edition
