### PR TITLE
Add an option to disallow sending sharing emails to non-owncloud users

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -120,6 +120,7 @@ $tmpl->assign('usedSpacePercent', (int)$storageInfo['relative']);
 $tmpl->assign('isPublic', false);
 $tmpl->assign("encryptedFiles", \OCP\Util::encryptedFiles());
 $tmpl->assign("mailNotificationEnabled", $config->getAppValue('core', 'shareapi_allow_mail_notification', 'no'));
+$tmpl->assign("mailPublicNotificationEnabled", $config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));
 $tmpl->assign("allowShareWithLink", $config->getAppValue('core', 'shareapi_allow_links', 'yes'));
 $tmpl->assign("encryptionInitStatus", $encryptionInitStatus);
 $tmpl->assign('appNavigation', $nav);

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -15,5 +15,6 @@
 <input type="hidden" name="encryptedFiles" id="encryptedFiles" value="<?php $_['encryptedFiles'] ? p('1') : p('0'); ?>" />
 <input type="hidden" name="encryptedInitStatus" id="encryptionInitStatus" value="<?php p($_['encryptionInitStatus']) ?>" />
 <input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled" value="<?php p($_['mailNotificationEnabled']) ?>" />
+<input type="hidden" name="mailPublicNotificationEnabled" id="mailPublicNotificationEnabled" value="<?php p($_['mailPublicNotificationEnabled']) ?>" />
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />
 <?php endif;

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -410,10 +410,14 @@ OC.Share={
 					html += '<label for="sharingDialogAllowPublicUpload">' + t('core', 'Allow Public Upload') + '</label>';
 					html += '</div>';
 				}
-				html += '</div><form id="emailPrivateLink" >';
-				html += '<input id="email" style="display:none; width:62%;" value="" placeholder="'+t('core', 'Email link to person')+'" type="text" />';
-				html += '<input id="emailButton" style="display:none;" type="submit" value="'+t('core', 'Send')+'" />';
-				html += '</form>';
+				html += '</div>';
+				var mailPublicNotificationEnabled = $('input:hidden[name=mailPublicNotificationEnabled]').val();
+				if (mailPublicNotificationEnabled === 'yes') {
+					html += '<form id="emailPrivateLink">';
+					html += '<input id="email" style="display:none; width:62%;" value="" placeholder="'+t('core', 'Email link to person')+'" type="text" />';
+					html += '<input id="emailButton" style="display:none;" type="submit" value="'+t('core', 'Send')+'" />';
+					html += '</form>';
+				}
 			}
 
 			html += '<div id="expiration">';
@@ -520,7 +524,7 @@ OC.Share={
 					.append( insert )
 					.appendTo( ul );
 			};
-			if (link && linksAllowed) {
+			if (link && linksAllowed && $('#email').length != 0) {
 				$('#email').autocomplete({
 					minLength: 1,
 					source: function (search, response) {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -31,6 +31,7 @@ describe('OC.Share tests', function() {
 			$('#testArea').append($('<div id="shareContainer"></div>'));
 			// horrible parameters
 			$('#testArea').append('<input id="allowShareWithLink" type="hidden" value="yes">');
+			$('#testArea').append('<input id="mailPublicNotificationEnabled" name="mailPublicNotificationEnabled" type="hidden" value="yes">');
 			$container = $('#shareContainer');
 			/* jshint camelcase:false */
 			oldAppConfig = _.extend({}, oc_appconfig.core);
@@ -361,6 +362,16 @@ describe('OC.Share tests', function() {
 					expect($('#dropdown [name=expirationCheckbox]').prop('disabled')).toEqual(true);
 					$('#dropdown [name=expirationCheckbox]').click();
 					expect($('#dropdown [name=expirationCheckbox]').prop('checked')).toEqual(true);
+				});
+				it('displayes email form when sending emails is enabled', function() {
+					$('input[name=mailPublicNotificationEnabled]').val('yes');
+					showDropDown();
+					expect($('#emailPrivateLink').length).toEqual(1);
+				});
+				it('not renders email form when sending emails is disabled', function() {
+					$('input[name=mailPublicNotificationEnabled]').val('no');
+					showDropDown();
+					expect($('#emailPrivateLink').length).toEqual(0);
 				});
 				it('sets picker minDate to today and no maxDate by default', function() {
 					showDropDown();

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -66,6 +66,7 @@ $template->assign('allowLinks', $appConfig->getValue('core', 'shareapi_allow_lin
 $template->assign('enforceLinkPassword', \OCP\Util::isPublicLinkPasswordRequired());
 $template->assign('allowPublicUpload', $appConfig->getValue('core', 'shareapi_allow_public_upload', 'yes'));
 $template->assign('allowResharing', $appConfig->getValue('core', 'shareapi_allow_resharing', 'yes'));
+$template->assign('allowPublicMailNotification', $appConfig->getValue('core', 'shareapi_allow_public_notification', 'no'));
 $template->assign('allowMailNotification', $appConfig->getValue('core', 'shareapi_allow_mail_notification', 'no'));
 $template->assign('onlyShareWithGroupMembers', \OC\Share\Share::shareWithGroupMembersOnly());
 $databaseOverload = (strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !== false);

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -271,9 +271,14 @@ if ($_['suggestedOverwriteWebroot']) {
 				<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword"
 						   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
 				<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
+
 				<input type="checkbox" name="shareapi_allow_public_upload" id="allowPublicUpload"
 				       value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 				<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>
+
+				<input type="checkbox" name="shareapi_allow_public_notification" id="allowPublicMailNotification"
+					value="1" <?php if ($_['allowPublicMailNotification'] == 'yes') print_unescaped('checked="checked"'); ?> />
+				<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
 
 				<input type="checkbox" name="shareapi_default_expire_date" id="shareapiDefaultExpireDate"
 				       value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />
@@ -302,7 +307,7 @@ if ($_['suggestedOverwriteWebroot']) {
 		<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 			<input type="checkbox" name="shareapi_allow_mail_notification" id="allowMailNotification"
 				   value="1" <?php if ($_['allowMailNotification'] === 'yes') print_unescaped('checked="checked"'); ?> />
-			<label for="allowMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
+			<label for="allowMailNotification"><?php p($l->t('Allow users to send mail notification for shared files to other users'));?></label><br/>
 		</p>
 		<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 			<input type="checkbox" name="shareapi_exclude_groups" id="shareapiExcludeGroups"


### PR DESCRIPTION
Fix #10836

@dnel @PVince81 @karlitschek @schiesbn 
