### PR TITLE
WebDAV now throws 403 when deletion did not work

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -192,7 +192,10 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
-		$this->fileView->rmdir($this->path);
+		if (!$this->fileView->rmdir($this->path)) {
+			// assume it wasn't possible to remove due to permission issue
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
 
 	}
 

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -167,7 +167,11 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		if (!$this->info->isDeletable()) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
-		$this->fileView->unlink($this->path);
+
+		if (!$this->fileView->unlink($this->path)) {
+			// assume it wasn't possible to delete due to permissions
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
 
 		// remove properties
 		$this->removeProperties();

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -143,4 +143,67 @@ class Test_OC_Connector_Sabre_File extends PHPUnit_Framework_TestCase {
 		// action
 		$file->put('test data');
 	}
+
+	/**
+	 *
+	 */
+	public function testDeleteWhenAllowed() {
+		// setup
+		$view = $this->getMock('\OC\Files\View',
+			array());
+
+		$view->expects($this->once())
+			->method('unlink')
+			->will($this->returnValue(true));
+
+		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
+			'permissions' => \OCP\PERMISSION_ALL
+		));
+
+		$file = new OC_Connector_Sabre_File($view, $info);
+
+		// action
+		$file->delete();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDeleteThrowsWhenDeletionNotAllowed() {
+		// setup
+		$view = $this->getMock('\OC\Files\View',
+			array());
+
+		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
+			'permissions' => 0
+		));
+
+		$file = new OC_Connector_Sabre_File($view, $info);
+
+		// action
+		$file->delete();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDeleteThrowsWhenDeletionFailed() {
+		// setup
+		$view = $this->getMock('\OC\Files\View',
+			array());
+
+		// but fails
+		$view->expects($this->once())
+			->method('unlink')
+			->will($this->returnValue(false));
+
+		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
+			'permissions' => \OCP\PERMISSION_ALL
+		));
+
+		$file = new OC_Connector_Sabre_File($view, $info);
+
+		// action
+		$file->delete();
+	}
 }


### PR DESCRIPTION
Assume a permission issue whenever a file could not be deleted.

This is because some storages are not able to return permissions, so a
permission denied situation can only be triggered during direct
deletion.

@fernandoruiz @davivel @icewind1991 
