### PR TITLE
Filesystem handlers

### DIFF
--- a/apps/files_trashbin/lib/hooks.php
+++ b/apps/files_trashbin/lib/hooks.php
@@ -29,17 +29,14 @@ namespace OCA\Files_Trashbin;
 class Hooks {
 
 	/**
-	 * Copy files to trash bin
+	 * Set trashbin as unlink handler for filesystem
 	 * @param array $params
-	 *
-	 * This function is connected to the delete signal of OC_Filesystem
-	 * to copy the file to the trash bin
 	 */
-	public static function remove_hook($params) {
-
+	public static function setup_hook($params) {
 		if ( \OCP\App::isEnabled('files_trashbin') ) {
-			$path = $params['path'];
-			Trashbin::move2trash($path);
+			$trashbin = new Trashbin();
+			\OC\Files\Filesystem::setHandler('unlink', $trashbin);
+			\OC\Files\Filesystem::setHandler('rmdir', $trashbin);
 		}
 	}
 

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -793,4 +793,25 @@ class Filesystem {
 	static public function getETag($path) {
 		return self::$defaultInstance->getETag($path);
 	}
+
+	/**
+	 * return the handler object for an operation on the default view
+	 *
+	 * @param string $operation
+	 * @return object|null
+	 */
+	static public function getHandler($operation) {
+		return self::$defaultInstance->getHandler($operation);
+	}
+
+	/**
+	 * set the handler object for an operation on the default view
+	 *
+	 * @param string $operation
+	 * @param object|null $handler
+	 * @throws \OCP\Files\InvalidHandlerException
+	 */
+	static public function setHandler($operation, $handler) {
+		return self::$defaultInstance->setHandler($operation, $handler);
+	}
 }

--- a/lib/public/files/invalidhandlerexception.php
+++ b/lib/public/files/invalidhandlerexception.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Robin McCorkell
+ * @copyright 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Files/InvalidHandlerException class
+ */
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\Files;
+
+/**
+ * Exception for invalid filesystem action handlers
+ */
+class InvalidHandlerException extends \Exception {}


### PR DESCRIPTION
This PR introduces the concept of filesystem handlers - objects that can be called instead of a storage to perform certain tasks. Apps can install their handlers by calling `\OC\Files\Filesystem::setHandler()` (after the filesystem is set up), which will then only apply for the default view - all other views will still call the storage. Handlers are covered by three unit tests.

This PR also rewrites files_trashbin to use filesystem handlers instead of hooks. That means no copying then deletion, just a straight up rename! Fixes #10915 

@PVince81 @icewind1991 @DeepDiver1975 
