### PR TITLE
Show login again instead of JSON if CSRF check fails

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -921,7 +921,9 @@ class OC {
 			return false;
 		}
 
-		OC_JSON::callCheck();
+		if(!OC_Util::isCallRegistered()) {
+			return false;
+		}
 		OC_App::loadApps();
 
 		//setup extra user backends


### PR DESCRIPTION
Previously a JSON error page was shown to the user in-case the CSRF token was not valid. This was confusing and prevented people from login.

With this at least the login page is shown again and not a JSON error message. I consider this as sufficient since adding a new error page just for this sake would uneededly make lib/base.php even more cluttered and this is a edge-case which optimally should anyways not happen that often.

This can be tested by opening the login page, then clearing the cookies, and trying to login.

@PVince81 As discussed.
@karlitschek Might be worth backporting to stable7.
