### PR TITLE
user/backed: use pow of two for backed action constants

### DIFF
--- a/lib/private/user/backend.php
+++ b/lib/private/user/backend.php
@@ -31,15 +31,14 @@ define('OC_USER_BACKEND_NOT_IMPLEMENTED',   -501);
 /**
  * actions that user backends can define
  */
-define('OC_USER_BACKEND_CREATE_USER',       0x00000001);
-define('OC_USER_BACKEND_SET_PASSWORD',      0x00000010);
-define('OC_USER_BACKEND_CHECK_PASSWORD',    0x00000100);
-define('OC_USER_BACKEND_GET_HOME',			0x00001000);
-define('OC_USER_BACKEND_GET_DISPLAYNAME',	0x00010000);
-define('OC_USER_BACKEND_SET_DISPLAYNAME',	0x00100000);
-define('OC_USER_BACKEND_PROVIDE_AVATAR',	0x01000000);
-define('OC_USER_BACKEND_COUNT_USERS',		0x10000000);
-//more actions cannot be defined without breaking 32bit platforms!
+define('OC_USER_BACKEND_CREATE_USER',       1 << 0);
+define('OC_USER_BACKEND_SET_PASSWORD',      1 << 4);
+define('OC_USER_BACKEND_CHECK_PASSWORD',    1 << 8);
+define('OC_USER_BACKEND_GET_HOME',          1 << 12);
+define('OC_USER_BACKEND_GET_DISPLAYNAME',   1 << 16);
+define('OC_USER_BACKEND_SET_DISPLAYNAME',   1 << 20);
+define('OC_USER_BACKEND_PROVIDE_AVATAR',    1 << 24);
+define('OC_USER_BACKEND_COUNT_USERS',       1 << 28);
 
 /**
  * Abstract base class for user management. Provides methods for querying backend


### PR DESCRIPTION
the current implementation limits number of possible backed actions
to 8 as it uses pow of 16 for constants. This change introduces pow
of two and allows up-to 32 actions to be defined.
