### PR TITLE
[WIP] Make the files mapper recursively

### DIFF
--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -149,6 +149,9 @@ class Mapper
 				}
 				array_pop($pathArray);
 			} else {
+				if (substr($pathElement, -2) === '\\.') {
+					$pathElement = substr($pathElement, 0, -2);
+				}
 				array_push($pathArray, $pathElement);
 			}
 		}
@@ -168,9 +171,10 @@ class Mapper
 		$logicPath = $this->resolveRelativePath($logicPath);
 
 		if ($logicPath === $this->unchangedPhysicalRoot ||
-			$logicPath . '/' === $this->unchangedPhysicalRoot) {
+			$logicPath . '/' === $this->unchangedPhysicalRoot ||
+			$logicPath . '\\' === $this->unchangedPhysicalRoot) {
 			// If the path is the physical root, we are done with the recursion
-			return rtrim($logicPath, '/');
+			return $logicPath;
 		}
 
 		$resolvedLogicPath = $this->resolveLogicPath($logicPath);

--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -243,24 +243,25 @@ class Mapper
 	 */
 	private function slugify($text) {
 		$originalText = $text;
-		// replace non letter or digits or dots by -
+
+		// Replace non letter or digits or dots by -
 		$text = preg_replace('~[^\\pL\d\.]+~u', '-', $text);
 
-		// trim
+		// Trim trailing and leading dashes
 		$text = trim($text, '-');
 
-		// transliterate
+		// Transliterate (replaces utf8 with their ascii brothers, eg. öäü => oau)
 		if (function_exists('iconv')) {
 			$text = iconv('utf-8', 'us-ascii//TRANSLIT//IGNORE', $text);
 		}
 
-		// lowercase
+		// Lowercase the string
 		$text = strtolower($text);
 
-		// remove unwanted characters
+		// Remove unwanted characters (everything apart from a-z 0-9 - (dash) and . (dot) )
 		$text = preg_replace('~[^-\w\.]+~', '', $text);
-		
-		// trim ending dots (for security reasons and win compatibility)
+
+		// Trim ending dots (for security reasons and win compatibility)
 		$text = preg_replace('~\.+$~', '', $text);
 
 		if (empty($text)) {

--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -262,7 +262,7 @@ class Mapper
 		$text = preg_replace('~[^-\w\.]+~', '', $text);
 
 		// Trim ending dots (for security reasons and win compatibility)
-		$text = preg_replace('~\.+$~', '', $text);
+		$text = rtrim($text, '.');
 
 		if (empty($text)) {
 			/**

--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -7,10 +7,15 @@ namespace OC\Files;
  */
 class Mapper
 {
+	/** @var string Unchanged root path as has been given to the constructor */
 	private $unchangedPhysicalRoot;
+	/** @var string Cleaned root path without relative path segments */
+	private $resolvePhysicalRoot;
 
 	public function __construct($rootDir) {
 		$this->unchangedPhysicalRoot = $rootDir;
+		// Resolve ./, ../ and // so we can compare it to the resolved links we get alter on.
+		$this->resolvePhysicalRoot = $this->resolveRelativePath($rootDir);
 	}
 
 	/**
@@ -170,9 +175,9 @@ class Mapper
 	private function create($logicPath, $store) {
 		$logicPath = $this->resolveRelativePath($logicPath);
 
-		if ($logicPath === $this->unchangedPhysicalRoot ||
-			$logicPath . '/' === $this->unchangedPhysicalRoot ||
-			$logicPath . '\\' === $this->unchangedPhysicalRoot) {
+		if ($logicPath === $this->resolvePhysicalRoot ||
+			$logicPath . '/' === $this->resolvePhysicalRoot ||
+			$logicPath . '\\' === $this->resolvePhysicalRoot) {
 			// If the path is the physical root, we are done with the recursion
 			return $logicPath;
 		}

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -16,7 +16,7 @@ class MappedLocal extends \OC\Files\Storage\Common {
 
 	public function __construct($arguments) {
 		$this->datadir = $arguments['datadir'];
-		if (substr($this->datadir, -1) !== '/') {
+		if (substr($this->datadir, -1) !== '/' && substr($this->datadir, -1) !== '\\') {
 			$this->datadir .= '/';
 		}
 

--- a/tests/lib/files/mapper.php
+++ b/tests/lib/files/mapper.php
@@ -34,47 +34,46 @@ class Mapper extends \Test\TestCase {
 		$this->mapper = new \OC\Files\Mapper('D:/');
 	}
 
-	public function slugifyPathData() {
+	public function slugifyData() {
 		return array(
-			// with extension
-			array('D:/text.txt', 'D:/text.txt'),
-			array('D:/text-2.txt', 'D:/text.txt', 2),
-			array('D:/a/b/text.txt', 'D:/a/b/text.txt'),
-
-			// without extension
-			array('D:/text', 'D:/text'),
-			array('D:/text-2', 'D:/text', 2),
-			array('D:/a/b/text', 'D:/a/b/text'),
-
-			// with double dot
-			array('D:/text.text.txt', 'D:/text.text.txt'),
-			array('D:/text.text-2.txt', 'D:/text.text.txt', 2),
-			array('D:/a/b/text.text.txt', 'D:/a/b/text.text.txt'),
-
-			// foldername and filename with periods
-			array('D:/folder.name.with.periods', 'D:/folder.name.with.periods'),
-			array('D:/folder.name.with.periods/test-2.txt', 'D:/folder.name.with.periods/test.txt', 2),
-			array('D:/folder.name.with.periods/test.txt', 'D:/folder.name.with.periods/test.txt'),
-
-			// foldername and filename with periods and spaces
-			array('D:/folder.name.with.peri-ods', 'D:/folder.name.with.peri ods'),
-			array('D:/folder.name.with.peri-ods/te-st-2.t-x-t', 'D:/folder.name.with.peri ods/te st.t x t', 2),
-			array('D:/folder.name.with.peri-ods/te-st.t-x-t', 'D:/folder.name.with.peri ods/te st.t x t'),
-
-			/**
-			 * If a foldername is empty, after we stripped out some unicode and other characters,
-			 * the resulting name must be reproducable otherwise uploading a file into that folder
-			 * will not write the file into the same folder.
-			 */
-			array('D:/' . md5('ありがとう'), 'D:/ありがとう'),
-			array('D:/' . md5('ありがとう') . '/issue6722.txt', 'D:/ありがとう/issue6722.txt'),
+			array('text.txt', 'text.txt'),
+			array('folder.name.with.peri ods', 'folder.name.with.peri-ods'),
+			array('te st.t x t', 'te-st.t-x-t'),
+			array('ありがとう', md5('ありがとう')),
 		);
 	}
 
 	/**
-	 * @dataProvider slugifyPathData
+	 * @dataProvider slugifyData
 	 */
-	public function testSlugifyPath($slug, $path, $index = null) {
-		$this->assertEquals($slug, $this->mapper->slugifyPath($path, $index));
+	public function testSlugify($fileName, $expected) {
+		$this->assertEquals($expected, \Test_Helper::invokePrivate($this->mapper, 'slugify', array($fileName)));
+	}
+
+	public function addIndexToFilenameData() {
+		return array(
+			// with extension
+			array('text.txt', null, 'text.txt'),
+			array('text.txt', 0, 'text.txt'),
+			array('text.txt', 2, 'text-2.txt'),
+
+			// without extension
+			array('text', null, 'text'),
+			array('text', 0, 'text'),
+			array('text', 2, 'text-2'),
+
+			// with multiple dots
+			array('text.text.txt', null, 'text.text.txt'),
+			array('text.text.txt', 0, 'text.text.txt'),
+			array('text.text.txt', 2, 'text.text-2.txt'),
+			array('text.text.text.txt', 2, 'text.text.text-2.txt'),
+		);
+	}
+
+	/**
+	 * @dataProvider addIndexToFilenameData
+	 */
+	public function testAddIndexToFilename($fileName, $index, $expected) {
+		$this->assertEquals($expected, \Test_Helper::invokePrivate($this->mapper, 'addIndexToFilename', array($fileName, $index)));
 	}
 }

--- a/tests/lib/files/mapper.php
+++ b/tests/lib/files/mapper.php
@@ -40,6 +40,10 @@ class Mapper extends \Test\TestCase {
 			array('folder.name.with.peri ods', 'folder.name.with.peri-ods'),
 			array('te st.t x t', 'te-st.t-x-t'),
 			array('ありがとう', md5('ありがとう')),
+			array('text.txt.', 'text.txt'),
+			array('.text.txt', '.text.txt'),
+			array('text.txt..', 'text.txt'),
+			array('text.txt . .', 'text.txt-.-'),
 		);
 	}
 

--- a/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
+++ b/tests/lib/files/storage/mappedlocalwithdotteddatadir.php
@@ -41,5 +41,15 @@ class MappedLocalWithDottedDataDir extends Storage {
 		unset($this->instance);
 		parent::tearDown();
 	}
+
+	/**
+	 * @dataProvider directoryProvider
+	 */
+	public function testDirectories($directory) {
+		if ($directory !== 'folder') {
+			$this->markTestSkipped('[Windows] Folder names "' . $directory . '" is renamed by the file mapper and can not be tested.');
+		}
+		parent::testDirectories($directory);
+	}
 }
 


### PR DESCRIPTION
This resolves issues on windows, when a parent folder had an index in the past
but the conflicting folder has been removed. Previous to this patch this would
cause a mess on the MappedStorage, since new children are not added to the
correct folder anymore.

Now the method is build recursively, so it correctly uses the parent physical
path instead of trying to recalculate it.

Fix #3499
Fix #9076
Fix #11103
Fix #11558

@th3fallen @DeepDiver1975 @rperezb @icewind1991 @jnfrmarks
