### PR TITLE
Use non-empty defaults for preview cmd line

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -282,7 +282,7 @@ $CONFIG = array(
 /* custom path for libreoffice / openoffice binary */
 'preview_libreoffice_path' => '/usr/bin/libreoffice',
 /* cl parameters for libreoffice / openoffice */
-'preview_office_cl_parameters' => '',
+'preview_office_cl_parameters' => ' --headless --nologo --nofirststartwizard --invisible --norestore -convert-to pdf -outdir ',
 
 /* whether avatars should be enabled */
 'enable_avatars' => true,


### PR DESCRIPTION
Ref https://github.com/owncloud/core/issues/10284

Copying an empty value from `config.sample.php` to `config.php` may cause non-working previews. 
