### PR TITLE
Don't keep the full info of all children in memory

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -224,6 +224,17 @@ class Scanner extends BasicEmitter {
 		return $data;
 	}
 
+	protected function getExistingChildren($path) {
+		$existingChildren = array();
+		if ($this->cache->inCache($path)) {
+			$children = $this->cache->getFolderContents($path);
+			foreach ($children as $child) {
+				$existingChildren[] = $child['name'];
+			}
+		}
+		return $existingChildren;
+	}
+
 	/**
 	 * scan all the files and folders in a folder
 	 *
@@ -239,13 +250,7 @@ class Scanner extends BasicEmitter {
 		$this->emit('\OC\Files\Cache\Scanner', 'scanFolder', array($path, $this->storageId));
 		$size = 0;
 		$childQueue = array();
-		$existingChildren = array();
-		if ($this->cache->inCache($path)) {
-			$children = $this->cache->getFolderContents($path);
-			foreach ($children as $child) {
-				$existingChildren[] = $child['name'];
-			}
-		}
+		$existingChildren = $this->getExistingChildren($path);
 		$newChildren = array();
 		if ($this->storage->is_dir($path) && ($dh = $this->storage->opendir($path))) {
 			$exceptionOccurred = false;


### PR DESCRIPTION
Improves the memory footprint for the file scanner (30MB -> 5MB for my local test)

Fixes #10954 for the most part

Note, I'm working on additional (less significant) improvements for this issue but those require larger changes and depend on #10993 and are thus not suited for backporting to stable7

cc @DeepDiver1975 @PVince81 @th3fallen 
