### PR TITLE
Fix dav permissions for folders

### DIFF
--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -264,7 +264,7 @@ abstract class OC_Connector_Sabre_Node implements \Sabre\DAV\INode, \Sabre\DAV\I
 				$p .= 'W';
 			}
 		} else {
-			if ($this->info->isUpdateable()) {
+			if ($this->info->isCreatable()) {
 				$p .= 'CK';
 			}
 		}

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -184,6 +184,15 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
+	 * Check whether new files or folders can be created inside this folder
+	 *
+	 * @return bool
+	 */
+	public function isCreatable() {
+		return $this->checkPermissions(\OCP\PERMISSION_CREATE);
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function isDeletable() {

--- a/lib/public/files/fileinfo.php
+++ b/lib/public/files/fileinfo.php
@@ -136,6 +136,13 @@ interface FileInfo {
 	public function isUpdateable();
 
 	/**
+	 * Check whether new files or folders can be created inside this folder
+	 *
+	 * @return bool
+	 */
+	public function isCreatable();
+
+	/**
 	 * Check if a file or folder can be deleted
 	 *
 	 * @return bool

--- a/tests/lib/connector/sabre/node.php
+++ b/tests/lib/connector/sabre/node.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright (c) 2014 Thomas Müller <thomas.mueller@tmit.eu>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Connector\Sabre;
+
+use OC\Files\FileInfo;
+use OC\Files\View;
+
+class Node extends \PHPUnit_Framework_TestCase {
+	public function davPermissionsProvider() {
+		return array(
+			array(\OCP\PERMISSION_ALL, 'file', false, false, 'RDNVW'),
+			array(\OCP\PERMISSION_ALL, 'dir', false, false, 'RDNVCK'),
+			array(\OCP\PERMISSION_ALL, 'file', true, false, 'SRDNVW'),
+			array(\OCP\PERMISSION_ALL, 'file', true, true, 'SRMDNVW'),
+			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_SHARE, 'file', true, false, 'SDNVW'),
+			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_UPDATE, 'file', false, false, 'RDNV'),
+			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_DELETE, 'file', false, false, 'RW'),
+			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_CREATE, 'file', false, false, 'RDNVW'),
+			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_CREATE, 'dir', false, false, 'RDNV'),
+		);
+	}
+
+	/**
+	 * @dataProvider davPermissionsProvider
+	 */
+	public function testDavPermissions($permissions, $type, $shared, $mounted, $expected) {
+		$info = $this->getMockBuilder('\OC\Files\FileInfo')
+			->disableOriginalConstructor()
+			->setMethods(array('getPermissions', 'isShared', 'isMounted', 'getType'))
+			->getMock();
+		$info->expects($this->any())
+			->method('getPermissions')
+			->will($this->returnValue($permissions));
+		$info->expects($this->any())
+			->method('isShared')
+			->will($this->returnValue($shared));
+		$info->expects($this->any())
+			->method('isMounted')
+			->will($this->returnValue($mounted));
+		$info->expects($this->any())
+			->method('getType')
+			->will($this->returnValue($type));
+		$view = $this->getMock('\OC\Files\View');
+
+		$node = new \OC_Connector_Sabre_File($view, $info);
+		$this->assertEquals($expected, $node->getDavPermissions());
+	}
+}


### PR DESCRIPTION
Fixes #11284 by properly using `isCreatable` instead of `isWritable` which do in fact mean different things

cc @dragotin @PVince81 @DeepDiver1975 
