### PR TITLE
Add flock to config

### DIFF
--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -6,32 +6,9 @@
  * @author Jakob Sack
  * @copyright 2012 Frank Karlitschek frank@owncloud.org
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-/*
- *
- * An example of config.php
- *
- * <?php
- * $CONFIG = array(
- *     "database" => "mysql",
- *     "firstrun" => false,
- *     "pi" => 3.14
- * );
- * ?>
- *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
  */
 
 /**
@@ -42,11 +19,13 @@
  */
 class OC_Config {
 
-	/**
-	 * @var \OC\Config
-	 */
+	/** @var \OC\Config */
 	public static $object;
 
+	/**
+	 * Returns the config instance
+	 * @return \OC\Config
+	 */
 	public static function getObject() {
 		return self::$object;
 	}
@@ -92,7 +71,6 @@ class OC_Config {
 	 * @param string $key key
 	 *
 	 * This function removes a key from the config.php.
-	 *
 	 */
 	public static function deleteKey($key) {
 		self::$object->deleteKey($key);

--- a/tests/lib/config.php
+++ b/tests/lib/config.php
@@ -7,82 +7,134 @@
  */
 
 class Test_Config extends PHPUnit_Framework_TestCase {
-	const CONFIG_FILE = 'static://config.php';
-	const CONFIG_DIR = 'static://';
-	const TESTCONTENT = '<?php $CONFIG=array("foo"=>"bar");';
+	const TESTCONTENT = '<?php $CONFIG=array("foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
 
-	/**
-	 * @var \OC\Config
-	 */
+	/** @var array */
+	private $initialConfig = array('foo' => 'bar', 'beers' => array('Appenzeller', 'Guinness', 'Kölsch'), 'alcohol_free' => false);
+	/** @var string */
+	private $configFile;
+	/** @var \OC\Config */
 	private $config;
+	/** @var string */
+	private $randomTmpDir;
 
 	function setUp() {
-		file_put_contents(self::CONFIG_FILE, self::TESTCONTENT);
-		$this->config = new OC\Config(self::CONFIG_DIR);
+		$this->randomTmpDir = \OC_Helper::tmpFolder();
+		$this->configFile = $this->randomTmpDir.'testconfig.php';
+		file_put_contents($this->configFile, self::TESTCONTENT);
+		$this->config = new OC\Config($this->randomTmpDir, 'testconfig.php');
 	}
 
-	public function testReadData() {
-		$config = new OC\Config('/non-existing');
-		$this->assertAttributeEquals(array(), 'cache', $config);
-
-		$this->assertAttributeEquals(array('foo' => 'bar'), 'cache', $this->config);
+	public function tearDown() {
+		unlink($this->configFile);
 	}
 
 	public function testGetKeys() {
-		$this->assertEquals(array('foo'), $this->config->getKeys());
+		$expectedConfig = array('foo', 'beers', 'alcohol_free');
+		$this->assertSame($expectedConfig, $this->config->getKeys());
 	}
 
 	public function testGetValue() {
-		$this->assertEquals('bar', $this->config->getValue('foo'));
-		$this->assertEquals(null, $this->config->getValue('bar'));
-		$this->assertEquals('moo', $this->config->getValue('bar', 'moo'));
+		$this->assertSame('bar', $this->config->getValue('foo'));
+		$this->assertSame(null, $this->config->getValue('bar'));
+		$this->assertSame('moo', $this->config->getValue('bar', 'moo'));
+		$this->assertSame(false, $this->config->getValue('alcohol_free', 'someBogusValue'));
+		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers', 'someBogusValue'));
+		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers'));
 	}
 
 	public function testSetValue() {
 		$this->config->setDebugMode(false);
 		$this->config->setValue('foo', 'moo');
-		$this->assertAttributeEquals(array('foo' => 'moo'), 'cache', $this->config);
-		$content = file_get_contents(self::CONFIG_FILE);
+		$expectedConfig = $this->initialConfig;
+		$expectedConfig['foo'] = 'moo';
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n);\n";
+		$content = file_get_contents($this->configFile);
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
-		$this->config->setValue('bar', 'red');
-		$this->assertAttributeEquals(array('foo' => 'moo', 'bar' => 'red'), 'cache', $this->config);
-		$content = file_get_contents(self::CONFIG_FILE);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'bar' => 'red',\n);\n";
+		$this->config->setValue('bar', 'red');
+		$this->config->setValue('apps', array('files', 'gallery'));
+		$expectedConfig['bar'] = 'red';
+		$expectedConfig['apps'] = array('files', 'gallery');
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+
+		$content = file_get_contents($this->configFile);
+
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'bar' => 'red',\n  'apps' => \n " .
+			" array (\n    0 => 'files',\n    1 => 'gallery',\n  ),\n);\n";
 		$this->assertEquals($expected, $content);
 	}
 
 	public function testDeleteKey() {
 		$this->config->setDebugMode(false);
 		$this->config->deleteKey('foo');
-		$this->assertAttributeEquals(array(), 'cache', $this->config);
-		$content = file_get_contents(self::CONFIG_FILE);
+		$expectedConfig = $this->initialConfig;
+		unset($expectedConfig['foo']);
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$content = file_get_contents($this->configFile);
 
-		$expected = "<?php\n\$CONFIG = array (\n);\n";
+		$expected = "<?php\n\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
 	}
 
-	public function testSavingDebugMode() {
+	public function testSetDebugMode() {
 		$this->config->setDebugMode(true);
-		$this->config->deleteKey('foo'); // change something so we save to the config file
-		$this->assertAttributeEquals(array(), 'cache', $this->config);
+		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
 		$this->assertAttributeEquals(true, 'debugMode', $this->config);
-		$content = file_get_contents(self::CONFIG_FILE);
+		$content = file_get_contents($this->configFile);
+		$expected = "<?php\ndefine('DEBUG',true);\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
+		$this->assertEquals($expected, $content);
 
-		$expected = "<?php\ndefine('DEBUG',true);\n\$CONFIG = array (\n);\n";
+		$this->config->setDebugMode(false);
+		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
+		$this->assertAttributeEquals(false, 'debugMode', $this->config);
+		$content = file_get_contents($this->configFile);
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertEquals($expected, $content);
 	}
 
-	/**
-	 * @expectedException \OC\HintException
-	 */
-	public function testWriteData() {
-		if (\OC_Util::runningOnWindows()) {
-			throw new \OC\HintException('this is ireelevent for windows');
-		}
-		$config = new OC\Config('/non-writable');
-		$config->setValue('foo', 'bar');
+	public function testIsDebugMode() {
+		// Default
+		$this->assertFalse($this->config->isDebugMode());
+
+		// Manually set to false
+		$this->config->setDebugMode(false);
+		$this->assertFalse($this->config->isDebugMode());
+
+		// Manually set to true
+		$this->config->setDebugMode(true);
+		$this->assertTrue($this->config->isDebugMode());
 	}
+
+	public function testConfigMerge() {
+		// Create additional config
+		$additionalConfig = '<?php $CONFIG=array("php53"=>"totallyOutdated");';
+		$additionalConfigPath = $this->randomTmpDir.'additionalConfig.testconfig.php';
+		file_put_contents($additionalConfigPath, $additionalConfig);
+
+		// Reinstantiate the config to force a read-in of the additional configs
+		$this->config = new \OC\Config($this->randomTmpDir, 'testconfig.php');
+
+		// Ensure that the config value can be read and the config has not been modified
+		$this->assertSame('totallyOutdated', $this->config->getValue('php53', 'bogusValue'));
+		$this->assertEquals(self::TESTCONTENT, file_get_contents($this->configFile));
+
+		// Write a new value to the config
+		$this->config->setValue('CoolWebsites', array('demo.owncloud.org', 'owncloud.org', 'owncloud.com'));
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'php53' => 'totallyOutdated',\n  'CoolWebsites' => \n  array (\n  " .
+			"  0 => 'demo.owncloud.org',\n    1 => 'owncloud.org',\n    2 => 'owncloud.com',\n  ),\n);\n";
+		$this->assertEquals($expected, file_get_contents($this->configFile));
+
+		// Cleanup
+		unlink($additionalConfigPath);
+	}
+
 }


### PR DESCRIPTION
This adds a file lock to the config in hope that this prevents race conditions as reported in https://github.com/owncloud/core/issues/11070

Testplan:
- [ ] Delete config.php and make it read-only => Error is thrown that it is not writeable
- [ ] Installation still works
- [ ] Changing config settings works (i.e. using the SMTP config switches in the administration menu)
- [ ] Your PC didn't blow up
- [ ] Installing the news app and the "Disable AppCode checker" app did not destroy your installation

@bantu Please review. Much appreciated, thanks!
@PVince81 Your feedback would also be very welcome!
