### PR TITLE
for whitelabeled edition, show branding name (e.g. 'ownCloud') instead of appname in header bar

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -53,7 +53,13 @@
 			</a>
 			<a href="#" class="menutoggle">
 				<div class="header-appname">
-					<?php p(!empty($_['application'])?$_['application']: $l->t('Apps')); ?>
+					<?php
+						if(OC_Util::getEditionString() === '') {
+							p(!empty($_['application'])?$_['application']: $l->t('Apps'));
+						} else {
+							p($theme->getName());
+						}
+					?>
 				</div>
 				<div class="icon-caret svg"></div>
 			</a>


### PR DESCRIPTION
@MTRichards @karlitschek please check if that’s good. Works well on desktop and on mobile without having too much stuff in the header.

![enterprise-owncloud](https://cloud.githubusercontent.com/assets/925062/4421366/5115e122-4583-11e4-9dc7-d9cb65800fb8.png)
