### PR TITLE
dn needs to be fetched to be able to detect memberOf support

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -377,9 +377,11 @@ class Wizard extends LDAPUtility {
 		$limit = 400;
 		$offset = 0;
 		do {
-			$result = $this->access->searchGroups($filter, array('cn'), $limit, $offset);
+			// we need to request dn additionally here, otherwise memberOf
+			// detection will fail later
+			$result = $this->access->searchGroups($filter, array('cn', 'dn'), $limit, $offset);
 			foreach($result as $item) {
-				$groupNames[] = $item[0];
+				$groupNames[] = $item['cn'];
 				$groupEntries[] = $item;
 			}
 			$offset += $limit;


### PR DESCRIPTION
To test:
1. Have an AD instance
2. Create a new LDAP configuration and complete the first tab
3. In the second tab, the "only from those groups" multiselect should be enabled and filled with groups. Prior to this fix, it is disabled. 
4. The groups in the multiselect in the groups tab should still be visible, too :)

Fixes a possible regression compared to to 7.0.2

Please test and review @jnfrmarks @Xenopathic @tps800 or others

cc @craigpg @cdamken 
