### PR TITLE
Clear up confusion of log_rotate_size config value

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -207,8 +207,9 @@ $CONFIG = array(
  * will stay limited and older entries are available for a while longer. The
  * total disk usage is twice the configured size.
  * WARNING: When you use this, the log entries will eventually be lost.
+ * Example: To set this to 100 MiB, use the value: 104857600 (1024*1024*100 bytes).
  */
-'log_rotate_size' => false, // 104857600, // 100 MiB
+'log_rotate_size' => false,
 
 /* Lifetime of the remember login cookie, default is 15 days */
 "remember_login_cookie_lifetime" => 60*60*24*15,


### PR DESCRIPTION
This is a fix for Issue #10776.

Remove the second comment which could be confused with suggesting an invalid value: `// 100 MiB`.

To keep the easily readable example value, it has been moved into the comment header for the config item.

**Edit:** Forgot to mention that if you think other examples need to be added or the wording is a little strange, just let me know - I appreciate the feedback. 
