### PR TITLE
Add clickable labels to encryption recovery radios

### DIFF
--- a/apps/files_encryption/templates/settings-admin.php
+++ b/apps/files_encryption/templates/settings-admin.php
@@ -16,18 +16,20 @@
 		<br/>
 		<input
 			type='radio'
+			id='adminEnableRecovery'
 			name='adminEnableRecovery'
 			value='1'
 			<?php echo($_["recoveryEnabled"] === '1' ? 'checked="checked"' : 'disabled'); ?> />
-		<?php p($l->t("Enabled")); ?>
+		<label for="adminEnableRecovery"><?php p($l->t("Enabled")); ?></label>
 		<br/>
 
 		<input
 			type='radio'
+			id='adminDisableRecovery'
 			name='adminEnableRecovery'
 			value='0'
 			<?php echo($_["recoveryEnabled"] === '0' ? 'checked="checked"' : 'disabled'); ?> />
-		<?php p($l->t("Disabled")); ?>
+		<label for="adminDisableRecovery"><?php p($l->t("Disabled")); ?></label>
 	</p>
 	<br/><br/>
 

--- a/apps/files_encryption/templates/settings-personal.php
+++ b/apps/files_encryption/templates/settings-personal.php
@@ -46,18 +46,20 @@
 			<br />
 			<input
 			type='radio'
+			id='userEnableRecovery'
 			name='userEnableRecovery'
 			value='1'
 			<?php echo ( $_["recoveryEnabledForUser"] ? 'checked="checked"' : '' ); ?> />
-			<?php p( $l->t( "Enabled" ) ); ?>
+			<label for="userEnableRecovery"><?php p( $l->t( "Enabled" ) ); ?></label>
 			<br />
 
 			<input
 			type='radio'
+			id='userDisableRecovery'
 			name='userEnableRecovery'
 			value='0'
 			<?php echo ( $_["recoveryEnabledForUser"] === false ? 'checked="checked"' : '' ); ?> />
-			<?php p( $l->t( "Disabled" ) ); ?>
+			<label for="userDisableRecovery"><?php p( $l->t( "Disabled" ) ); ?></label>
 			<div id="recoveryEnabledSuccess"><?php p( $l->t( 'File recovery settings updated' ) ); ?></div>
 			<div id="recoveryEnabledError"><?php p( $l->t( 'Could not update file recovery' ) ); ?></div>
 		</p>


### PR DESCRIPTION
This is a fix for Issue: #11174.
### Possible Changes
- Instead of applying a new `id` attribute to the radio buttons, we could instead wrap the radio button `input` tag inside of a `<label>`.

---

Add clickable radio button labels to the encryption recovery settings pages:
- `settings-admin.php`
- `settings-personal.php`

Pressing on the radio button text now toggles the state of the radio button.

---

Let me know if you have any suggestions or improvements.

**Edit:** This contribution is MIT licensed.
