### PR TITLE
Close the session for preview generation

### DIFF
--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -6,6 +6,7 @@
  * See the COPYING-README file.
  */
 \OC_Util::checkLoggedIn();
+\OC::$server->getSession()->close();
 
 $file = array_key_exists('file', $_GET) ? (string)$_GET['file'] : '';
 $maxX = array_key_exists('x', $_GET) ? (int)$_GET['x'] : '36';


### PR DESCRIPTION
Without closing the session every preview image generation is locking the session which makes the webinterface unresponsive.
