### PR TITLE
Redirect only to absolute URL

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -847,8 +847,10 @@ class OC_Util {
 	 */
 	public static function getDefaultPageUrl() {
 		$urlGenerator = \OC::$server->getURLGenerator();
-		if (isset($_REQUEST['redirect_url'])) {
-			$location = urldecode($_REQUEST['redirect_url']);
+		// Deny the redirect if the URL contains a @
+		// This prevents unvalidated redirects like ?redirect_url=:user@domain.com
+		if (isset($_REQUEST['redirect_url']) && strpos($_REQUEST['redirect_url'], '@') === false) {
+			$location = $urlGenerator->getAbsoluteURL(urldecode($_REQUEST['redirect_url']));
 		} else {
 			$defaultPage = OC_Appconfig::getValue('core', 'defaultpage');
 			if ($defaultPage) {


### PR DESCRIPTION
We do not want to redirect to other domains using the "?redirect_url=" feature. Please notice, that the ownCloud project does not consider open redirectors as security issue.

To test:
- [ ] http://localhost/core/index.php?redirect_url=%2Fcore%2Findex.php%2Fsettings%2Fadmin redirects to admin page
- [ ] http://localhost/core/index.php?redirect_url=https://www.owncloud.com redirects to invalid page on same domain

Fixes https://github.com/owncloud/security-tracker/issues/73
