### PR TITLE
Add a CLI command that deletes an LDAP config

### DIFF
--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -10,3 +10,4 @@ $application->add(new OCA\user_ldap\Command\ShowConfig());
 $application->add(new OCA\user_ldap\Command\SetConfig());
 $application->add(new OCA\user_ldap\Command\TestConfig());
 $application->add(new OCA\user_ldap\Command\CreateEmptyConfig());
+$application->add(new OCA\user_ldap\Command\DeleteConfig());

--- a/apps/user_ldap/command/deleteconfig.php
+++ b/apps/user_ldap/command/deleteconfig.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2014 Martin Konrad <info@martin-konrad.net>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\user_ldap\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use \OCA\user_ldap\lib\Helper;
+
+class DeleteConfig extends Command {
+
+	protected function configure() {
+		$this
+			->setName('ldap:delete-config')
+			->setDescription('deletes an existing LDAP configuration')
+			->addArgument(
+					'configID',
+					InputArgument::REQUIRED,
+					'the configuration ID'
+				     )
+		;
+	}
+
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$configPrefix = $input->getArgument('configID');;
+
+		$success = Helper::deleteServerConfiguration($configPrefix);
+
+		if($success) {
+			$output->writeln("Deleted configuration with configID '{$configPrefix}'");
+		} else {
+			$output->writeln("Cannot delete configuration with configID '{$configPrefix}'");
+		}
+	}
+}

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -111,9 +111,6 @@ class Helper {
 	 * @return bool true on success, false otherwise
 	 */
 	static public function deleteServerConfiguration($prefix) {
-		//just to be on the safe side
-		\OCP\User::checkAdminUser();
-
 		if(!in_array($prefix, self::getServerConfigurationPrefixes())) {
 			return false;
 		}


### PR DESCRIPTION
With this change LDAP configurations can be managed completely from
the command line.

This PR is related to #11347.

@blizzz: Note that I had to remove the checkAdminUser() call from deleteServerConfiguration() to make this work. Is this a relevant security feature? I'm open to suggestions here...
