### PR TITLE
make sure that the users file system is initialized before we emit the post hook

### DIFF
--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -263,6 +263,13 @@ class Manager extends PublicEmitter implements IUserManager {
 			if ($backend->implementsActions(\OC_USER_BACKEND_CREATE_USER)) {
 				$backend->createUser($uid, $password);
 				$user = $this->getUserObject($uid, $backend);
+
+				// make sure that the users file system is initialized before we
+				// emit the post hook
+				if (!\OC_User::isLoggedIn()) {
+					\OC_Util::setupFS($uid);
+				}
+
 				$this->emit('\OC\User', 'postCreateUser', array($user, $password));
 				return $user;
 			}

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -150,6 +150,8 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		OC_Preferences::setValue($user1, 'files', 'quota', '1024');
 		\OC_User::setUserId($user1);
 
+		// make sure that we set up the file system again after the quota was set
+		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($user1);
 
 		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');


### PR DESCRIPTION
Because I don't can reproduce issue https://github.com/owncloud/core/issues/11289, that's just an idea.

This PR probably introduced the problem https://github.com/owncloud/core/pull/10697/files. As you can see we added a explicit setupFS() to the delete user operation. We probably need something similar for the create user operation to make sure that the filesystem is initialized if a app wants to react on the event and for example place some data to the users data directory.

cc @DeepDiver1975  @icewind1991  what do you think? Does it makes sense?
