### PR TITLE
Preview large TXT files fix

### DIFF
--- a/lib/private/preview/txt.php
+++ b/lib/private/preview/txt.php
@@ -34,7 +34,7 @@ class TXT extends Provider {
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
 
 		$content = $fileview->fopen($path, 'r');
-		$content = stream_get_contents($content);
+		$content = stream_get_contents($content,3000);
 
 		//don't create previews of empty text files
 		if(trim($content) === '') {


### PR DESCRIPTION
Limit the size of the string generating the preview image for TXT files
