### PR TITLE
reduce bottom padding in filelist, fix perceived glitching, fix #11213

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -492,7 +492,7 @@ a.action>img {
 
 .summary td {
 	padding-top: 20px;
-	padding-bottom: 250px;
+	padding-bottom: 150px;
 	border-bottom: none;
 }
 .summary .info {


### PR DESCRIPTION
Reducing the bottom padding of the file list from a bit much 250px to a more normal 150px. This fixes #11213

Please test @PVince81 @owncloud/designers 
