### PR TITLE
Config sample cleanup

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -5,8 +5,17 @@
  * configuration options and their usage.
  *
  * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK
- * YOUR INSTANCE. Instead, manually copy configurations' switches that you
+ * YOUR INSTANCE. Instead, manually copy configurations switches that you
  * consider important for your instance to your configuration.
+ *
+ * This file is used to generate the config documentation. Please consider
+ * following requirements of the current parser:
+ *  * all comments need to start with `/**` and end with ` *\/` - each on their
+ *    own line
+ *  * add a `@see CONFIG_INDEX` to copy a previously described config option
+ *    also to this line
+ *  * everything between the ` *\/` and the next `/**` will be treated as the
+ *    config option
  */
 
 /**
@@ -45,7 +54,7 @@ $CONFIG = array(
 'trusted_domains' => array('demo.example.org', 'otherdomain.example.org:8080'),
 
 /**
- * The directory where the user data is stored, default to data in the owncloud
+ * The directory where the user data is stored, default to data in the ownCloud
  * directory. The sqlite database is also stored here, when sqlite is used.
  */
 'datadirectory' => '',
@@ -117,12 +126,12 @@ $CONFIG = array(
 'knowledgebaseenabled' => true,
 
 /**
- * whether avatars should be enabled
+ * Specifies whether avatars should be enabled
  */
 'enable_avatars' => true,
 
 /**
- * allow user to change his display name, if it is supported by the back-end
+ * Allow user to change his display name, if it is supported by the back-end
  */
 'allow_user_to_change_display_name' => true,
 
@@ -217,13 +226,13 @@ $CONFIG = array(
 'mail_smtpsecure' => '',
 
 /**
- * authentication needed to send mail, depends on mail_smtpmode if this is used
+ * Authentication needed to send mail, depends on mail_smtpmode if this is used
  * (false = disable authentication)
  */
 'mail_smtpauth' => false,
 
 /**
- * authentication type needed to send mail, depends on mail_smtpmode if this is
+ * Authentication type needed to send mail, depends on mail_smtpmode if this is
  * used Can be LOGIN (default), PLAIN or NTLM
  */
 'mail_smtpauthtype' => 'LOGIN',
@@ -312,7 +321,8 @@ $CONFIG = array(
 'appcodechecker' => true,
 
 /**
- * Check if ownCloud is up to date
+ * Check if ownCloud is up to date and shows a notification if a new version is
+ * available
  */
 'updatechecker' => true,
 
@@ -345,10 +355,10 @@ $CONFIG = array(
 'log_type' => 'owncloud',
 
 /**
- * File for the owncloud logger to log to, (default is ownloud.log in the data
+ * File for the ownCloud logger to log to, (default is owncloud.log in the data
  * dir)
  */
-'logfile' => '',
+'logfile' => 'owncloud.log',
 
 /**
  * Loglevel to start logging at. 0 = DEBUG, 1 = INFO, 2 = WARN, 3 = ERROR
@@ -356,10 +366,14 @@ $CONFIG = array(
  */
 'loglevel' => 2,
 
-/* date format to be used while writing to the owncloud logfile */
+/**
+ * date format to be used while writing to the ownCloud logfile
+ */
 'logdateformat' => 'F d, Y H:i:s',
 
-/* timezone used while writing to the owncloud logfile (default: UTC) */
+/**
+ * timezone used while writing to the ownCloud logfile (default: UTC)
+ */
 'logtimezone' => 'Europe/Berlin',
 
 /**
@@ -375,7 +389,7 @@ $CONFIG = array(
 
 /**
  * Configure the size in bytes log rotation should happen, 0 or false disables
- * the rotation. This rotates the current owncloud logfile to a new name, this
+ * the rotation. This rotates the current ownCloud logfile to a new name, this
  * way the total log usage will stay limited and older entries are available for
  * a while longer. The total disk usage is twice the configured size.
  *
@@ -490,6 +504,7 @@ $CONFIG = array(
  * Only register providers that have been explicitly enabled
  *
  * The following providers are enabled by default:
+ *
  *  - OC\Preview\Image
  *  - OC\Preview\MarkDown
  *  - OC\Preview\MP3
@@ -497,6 +512,7 @@ $CONFIG = array(
  *
  * The following providers are disabled by default due to performance or privacy
  * concerns:
+ *
  *  - OC\Preview\Illustrator
  *  - OC\Preview\Movies
  *  - OC\Preview\MSOffice2003
@@ -602,7 +618,7 @@ $CONFIG = array(
 	//array('other.host.local', 11211),
 ),
 
-/*
+/**
  * Location of the cache folder, defaults to 'data/$user/cache' where '$user' is
  * the current user.
  *
@@ -619,7 +635,7 @@ $CONFIG = array(
 
 /**
  * specifies how often the filesystem is checked for changes made outside
- * owncloud
+ * ownCloud
  *
  * 0 -> never check the filesystem for outside changes, provides a performance
  * increase when it's certain that no changes are made directly to the
@@ -639,7 +655,7 @@ $CONFIG = array(
 'mount_file' => 'data/mount.json',
 
 /**
- * If true, prevent owncloud from changing the cache due to changes in the
+ * If true, prevent ownCloud from changing the cache due to changes in the
  * filesystem for all storage
  */
 'filesystem_cache_readonly' => false,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1,149 +1,260 @@
 <?php
 
 /**
- * This configuration file is only provided to document the different configuration options and their usage.
- * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK YOUR INSTANCE.
- * Instead, manually copy configurations' switches that you consider important for your instance to your configuration.
+ * This configuration file is only provided to document the different
+ * configuration options and their usage.
+ *
+ * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK
+ * YOUR INSTANCE. Instead, manually copy configurations' switches that you
+ * consider important for your instance to your configuration.
  */
 
-/* Only enable this for local development and not in productive environments */
-/* This will disable the minifier and outputs some additional debug informations */
-define("DEBUG", true);
+/**
+ * Only enable this for local development and not in productive environments
+ * This will disable the minifier and outputs some additional debug informations
+ */
+define('DEBUG', true);
 
 $CONFIG = array(
-/* Flag to indicate ownCloud is successfully installed (true = installed) */
-"installed" => false,
+/**
+ * Flag to indicate ownCloud is successfully installed (true = installed)
+ */
+'installed' => false,
 
-/* Type of database, can be sqlite, mysql or pgsql */
-"dbtype" => "sqlite",
+/**
+ * Type of database, can be sqlite, mysql or pgsql
+ */
+'dbtype' => 'sqlite',
 
-/* Name of the ownCloud database */
-"dbname" => "owncloud",
+/**
+ * Name of the ownCloud database
+ */
+'dbname' => 'owncloud',
 
-/* User to access the ownCloud database */
-"dbuser" => "",
+/**
+ * User to access the ownCloud database
+ */
+'dbuser' => '',
 
-/* Password to access the ownCloud database */
-"dbpassword" => "",
+/**
+ * Password to access the ownCloud database
+ */
+'dbpassword' => '',
 
-/* Host running the ownCloud database. To specify a port use "HOSTNAME:####"; to specify a unix sockets use "localhost:/path/to/socket". */
-"dbhost" => "",
+/**
+ * Host running the ownCloud database. To specify a port use 'HOSTNAME:####'; to
+ * specify a unix sockets use 'localhost:/path/to/socket'.
+ */
+'dbhost' => '',
 
-/* Prefix for the ownCloud tables in the database */
-"dbtableprefix" => "",
+/**
+ * Prefix for the ownCloud tables in the database
+ */
+'dbtableprefix' => '',
 
-/* Define the salt used to hash the user passwords. All your user passwords are lost if you lose this string. */
-"passwordsalt" => "",
+/**
+ * Define the salt used to hash the user passwords. All your user passwords are
+ * lost if you lose this string.
+ */
+'passwordsalt' => '',
 
-/* Secret used by ownCloud for various purposes, e.g. to encrypt data. If you lose this string there will be data corruption. */
-"secret" => "",
+/**
+ * Secret used by ownCloud for various purposes, e.g. to encrypt data. If you
+ * lose this string there will be data corruption.
+ */
+'secret' => '',
 
-/* Force use of HTTPS connection (true = use HTTPS) */
-"forcessl" => false,
+/**
+ * Force use of HTTPS connection (true = use HTTPS)
+ */
+'forcessl' => false,
 
-/* Blacklist a specific file and disallow the upload of files with this name - WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING. */
-"blacklisted_files" => array('.htaccess'),
+/**
+ * Blacklist a specific file and disallow the upload of files with this name
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'blacklisted_files' => array('.htaccess'),
 
-/* The automatic hostname detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the automatic detection. You can also add a port. For example "www.example.com:88" */
-"overwritehost" => "",
+/**
+ * The automatic hostname detection of ownCloud can fail in certain reverse
+ * proxy and CLI/cron situations. This option allows to manually override the
+ * automatic detection. You can also add a port. For example
+ * 'www.example.com:88'
+ */
+'overwritehost' => '',
 
-/* The automatic protocol detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the protocol detection. For example "https" */
-"overwriteprotocol" => "",
+/**
+ * The automatic protocol detection of ownCloud can fail in certain reverse
+ * proxy and CLI/cron situations. This option allows to manually override the
+ * protocol detection. For example 'https'
+ */
+'overwriteprotocol' => '',
 
-/* The automatic webroot detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to manually override the automatic detection. For example "/domain.tld/ownCloud". The value "/" can be used to remove the root. */
-"overwritewebroot" => "",
+/**
+ * The automatic webroot detection of ownCloud can fail in certain reverse proxy
+ * and CLI/cron situations. This option allows to manually override the
+ * automatic detection. For example '/domain.tld/ownCloud'. The value '/' can be
+ * used to remove the root.
+ */
+'overwritewebroot' => '',
 
-/* The automatic detection of ownCloud can fail in certain reverse proxy and CLI/cron situations. This option allows to define a manually override condition as regular expression for the remote ip address. For example "^10\.0\.0\.[1-3]$" */
-"overwritecondaddr" => "",
+/**
+ * The automatic detection of ownCloud can fail in certain reverse proxy and
+ * CLI/cron situations. This option allows to define a manually override
+ * condition as regular expression for the remote ip address. For example
+ * '^10\.0\.0\.[1-3]$'
+ */
+'overwritecondaddr' => '',
 
-/* A proxy to use to connect to the internet. For example "myproxy.org:88" */
-"proxy" => "",
+/**
+ * A proxy to use to connect to the internet. For example 'myproxy.org:88'
+ */
+'proxy' => '',
 
-/* The optional authentication for the proxy to use to connect to the internet. The format is: [username]:[password] */
-"proxyuserpwd" => "",
+/**
+ * The optional authentication for the proxy to use to connect to the internet.
+ * The format is: [username]:[password]
+ */
+'proxyuserpwd' => '',
 
-/* List of trusted domains, to prevent host header poisoning ownCloud is only using these Host headers */
-'trusted_domains' => array('demo.owncloud.org', 'otherdomain.owncloud.org:8080'),
+/**
+ * List of trusted domains, to prevent host header poisoning ownCloud is only
+ * using these Host headers
+ */
+'trusted_domains' => array('demo.example.org', 'otherdomain.example.org:8080'),
 
-/* List of trusted proxy servers */
+/**
+ * List of trusted proxy servers
+ */
 'trusted_proxies' => array('203.0.113.45', '198.51.100.128'),
 
-/* Headers that should be trusted as client IP address in combination with `trusted_proxies` */
+/**
+ * Headers that should be trusted as client IP address in combination with
+ * `trusted_proxies`
+ */
 'forwarded_for_headers' => array('HTTP_X_FORWARDED', 'HTTP_FORWARDED_FOR'),
 
-/* Theme to use for ownCloud */
-"theme" => "",
+/**
+ * Theme to use for ownCloud
+ */
+'theme' => '',
 
-/* Optional ownCloud default language - overrides automatic language detection on public pages like login or shared items. This has no effect on the user's language preference configured under "personal -> language" once they have logged in */
-"default_language" => "en",
+/**
+ * Optional ownCloud default language - overrides automatic language detection
+ * on public pages like login or shared items. This has no effect on the user's
+ * language preference configured under 'personal -> language' once they have
+ * logged in
+ */
+'default_language' => 'en',
 
-/* Path to the parent directory of the 3rdparty directory */
-"3rdpartyroot" => "",
+/**
+ * Path to the parent directory of the 3rdparty directory
+ */
+'3rdpartyroot' => '',
 
-/* URL to the parent directory of the 3rdparty directory, as seen by the browser */
-"3rdpartyurl" => "",
+/**
+ * URL to the parent directory of the 3rdparty directory, as seen by the browser
+ */
+'3rdpartyurl' => '',
 
-/* Default app to open on login.
- * This can be a comma-separated list of app ids.
- * If the first app is not enabled for the current user,
- * it will try with the second one and so on. If no enabled app could be found,
- * the "files" app will be displayed instead. */
-"defaultapp" => "files",
+/**
+ * Default app to open on login.
+ *
+ * This can be a comma-separated list of app ids. If the first app is not
+ * enabled for the current user, it will try with the second one and so on. If
+ * no enabled app could be found, the 'files' app will be displayed instead.
+ */
+'defaultapp' => 'files',
 
-/* Enable the help menu item in the settings */
-"knowledgebaseenabled" => true,
+/**
+ * Enable the help menu item in the settings
+ */
+'knowledgebaseenabled' => true,
 
-/* Enable installing apps from the appstore */
-"appstoreenabled" => true,
+/**
+ * Enable installing apps from the appstore
+ */
+'appstoreenabled' => true,
 
-/* URL of the appstore to use, server should understand OCS */
-"appstoreurl" => "https://api.owncloud.com/v1",
+/**
+ * URL of the appstore to use, server should understand OCS
+ */
+'appstoreurl' => 'https://api.owncloud.com/v1',
 
-/* Domain name used by ownCloud for the sender mail address, e.g. no-reply@example.com */
-"mail_domain" => "example.com",
+/**
+ * Domain name used by ownCloud for the sender mail address, e.g.
+ * no-reply@example.com
+ */
+'mail_domain' => 'example.com',
 
-/* FROM address used by ownCloud for the sender mail address, e.g. owncloud@example.com
-   This setting overwrites the built in 'sharing-noreply' and 'lostpassword-noreply'
-   FROM addresses, that ownCloud uses
-*/
-"mail_from_address" => "owncloud",
+/**
+ * FROM address used by ownCloud for the sender mail address, e.g.
+ * owncloud@example.com
+ *
+ * This setting overwrites the built in 'sharing-noreply' and
+ * 'lostpassword-noreply' FROM addresses, that ownCloud uses
+ */
+'mail_from_address' => 'owncloud',
 
-/* Enable SMTP class debugging */
-"mail_smtpdebug" => false,
+/**
+ * Enable SMTP class debugging
+ */
+'mail_smtpdebug' => false,
 
-/* Mode to use for sending mail, can be sendmail, smtp, qmail or php, see PHPMailer docs */
-"mail_smtpmode" => "sendmail",
+/**
+ * Mode to use for sending mail, can be sendmail, smtp, qmail or php, see
+ * PHPMailer docs
+ */
+'mail_smtpmode' => 'sendmail',
 
-/* Host to use for sending mail, depends on mail_smtpmode if this is used */
-"mail_smtphost" => "127.0.0.1",
+/**
+ * Host to use for sending mail, depends on mail_smtpmode if this is used
+ */
+'mail_smtphost' => '127.0.0.1',
 
-/* Port to use for sending mail, depends on mail_smtpmode if this is used */
-"mail_smtpport" => 25,
+/**
+ * Port to use for sending mail, depends on mail_smtpmode if this is used
+ */
+'mail_smtpport' => 25,
 
-/* SMTP server timeout in seconds for sending mail, depends on mail_smtpmode if this is used */
-"mail_smtptimeout" => 10,
+/**
+ * SMTP server timeout in seconds for sending mail, depends on mail_smtpmode if
+ * this is used
+ */
+'mail_smtptimeout' => 10,
 
-/* SMTP connection prefix or sending mail, depends on mail_smtpmode if this is used.
-   Can be '', ssl or tls */
-"mail_smtpsecure" => "",
+/**
+ * SMTP connection prefix or sending mail, depends on mail_smtpmode if this is
+ * used. Can be '', 'ssl' or 'tls'
+ */
+'mail_smtpsecure' => '',
 
-/* authentication needed to send mail, depends on mail_smtpmode if this is used
+/**
+ * authentication needed to send mail, depends on mail_smtpmode if this is used
  * (false = disable authentication)
  */
-"mail_smtpauth" => false,
+'mail_smtpauth' => false,
 
-/* authentication type needed to send mail, depends on mail_smtpmode if this is used
- * Can be LOGIN (default), PLAIN or NTLM */
-"mail_smtpauthtype" => "LOGIN",
+/**
+ * authentication type needed to send mail, depends on mail_smtpmode if this is
+ * used Can be LOGIN (default), PLAIN or NTLM
+ */
+'mail_smtpauthtype' => 'LOGIN',
 
-/* Username to use for sendmail mail, depends on mail_smtpauth if this is used */
-"mail_smtpname" => "",
+/**
+ * Username to use for sendmail mail, depends on mail_smtpauth if this is used
+ */
+'mail_smtpname' => '',
 
-/* Password to use for sendmail mail, depends on mail_smtpauth if this is used */
-"mail_smtppassword" => "",
+/**
+ * Password to use for sendmail mail, depends on mail_smtpauth if this is used
+ */
+'mail_smtppassword' => '',
 
-/* memcached servers (Only used when xCache, APC and APCu are absent.) */
-"memcached_servers" => array(
+/**
+ * memcached servers (Only used when xCache, APC and APCu are absent.)
+ */
+'memcached_servers' => array(
 	// hostname, port and optional weight. Also see:
 	// http://www.php.net/manual/en/memcached.addservers.php
 	// http://www.php.net/manual/en/memcached.addserver.php
@@ -151,42 +262,76 @@ $CONFIG = array(
 	//array('other.host.local', 11211),
 ),
 
-/* How long should ownCloud keep deleted files in the trash bin, default value:  30 days */
+/**
+ * How long should ownCloud keep deleted files in the trash bin, default value:
+ * 30 days
+ */
 'trashbin_retention_obligation' => 30,
 
-/* Disable/Enable auto expire for the trash bin, by default auto expire is enabled */
+/**
+ * Disable/Enable auto expire for the trash bin, by default auto expire is
+ * enabled
+ */
 'trashbin_auto_expire' => true,
 
-/* allow user to change his display name, if it is supported by the back-end */
+/**
+ * allow user to change his display name, if it is supported by the back-end
+ */
 'allow_user_to_change_display_name' => true,
 
-/* Ensure that 3rdparty applications follows coding guidelines */
-"appcodechecker" => true,
+/**
+ * Ensure that 3rdparty applications follows coding guidelines
+ */
+'appcodechecker' => true,
 
-/* Check if ownCloud is up to date */
-"updatechecker" => true,
+/**
+ * Check if ownCloud is up to date
+ */
+'updatechecker' => true,
 
-/* Are we connected to the internet or are we running in a closed network? */
-"has_internet_connection" => true,
+/**
+ * Are we connected to the internet or are we running in a closed network?
+ */
+'has_internet_connection' => true,
 
-/* Check if the ownCloud WebDAV server is working correctly. Can be disabled if not needed in special situations*/
-"check_for_working_webdav" => true,
+/**
+ * Check if the ownCloud WebDAV server is working correctly. Can be disabled if
+ * not needed in special situations
+ */
+'check_for_working_webdav' => true,
 
-/* Check if .htaccess protection of data is working correctly. Can be disabled if not needed in special situations*/
-"check_for_working_htaccess" => true,
+/**
+ * Check if .htaccess protection of data is working correctly. Can be disabled
+ * if not needed in special situations
+ */
+'check_for_working_htaccess' => true,
 
-/* Place to log to, can be owncloud and syslog (owncloud is log menu item in admin menu) */
-"log_type" => "owncloud",
+/**
+ * Place to log to, can be 'owncloud' and 'syslog' (owncloud is log menu item in
+ * admin menu)
+ */
+'log_type' => 'owncloud',
 
-/* File for the owncloud logger to log to, (default is ownloud.log in the data dir) */
-"logfile" => "",
+/**
+ * File for the owncloud logger to log to, (default is ownloud.log in the data
+ * dir)
+ */
+'logfile' => '',
 
-/* This entry is just here to show a warning in case somebody copied the sample configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!  */
-/* If you, brave person, have read until here be aware that you should not modify *ANY* settings in this file without reading the documentation */
-"copied_sample_config" => true,
+/**
+ * This entry is just here to show a warning in case somebody copied the sample
+ * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
+ *
+ * If you, brave person, have read until here be aware that you should not
+ * modify *ANY* settings in this file without reading the documentation
+ */
+'copied_sample_config' => true,
 
-/* Loglevel to start logging at. 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (default is WARN) */
-"loglevel" => "",
+/**
+ * Loglevel to start logging at. 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (default is
+ * WARN)
+ */
+'loglevel' => 2,
 
 /* date format to be used while writing to the owncloud logfile */
 'logdateformat' => 'F d, Y H:i:s',
@@ -194,119 +339,172 @@ $CONFIG = array(
 /* timezone used while writing to the owncloud logfile (default: UTC) */
 'logtimezone' => 'Europe/Berlin',
 
-/* Append all database queries and parameters to the log file.
- (watch out, this option can increase the size of your log file)*/
-"log_query" => false,
+/**
+ * Append all database queries and parameters to the log file. (watch out, this
+ * option can increase the size of your log file)
+ */
+'log_query' => false,
 
-/* Whether ownCloud should log the last successfull cron exec */
-"cron_log" => true,
+/**
+ * Whether ownCloud should log the last successfull cron exec
+ */
+'cron_log' => true,
 
-/*
- * Configure the size in bytes log rotation should happen, 0 or false disables the rotation.
- * This rotates the current owncloud logfile to a new name, this way the total log usage
- * will stay limited and older entries are available for a while longer. The
- * total disk usage is twice the configured size.
+/**
+ * Configure the size in bytes log rotation should happen, 0 or false disables
+ * the rotation. This rotates the current owncloud logfile to a new name, this
+ * way the total log usage will stay limited and older entries are available for
+ * a while longer. The total disk usage is twice the configured size.
+ *
  * WARNING: When you use this, the log entries will eventually be lost.
- * Example: To set this to 100 MiB, use the value: 104857600 (1024*1024*100 bytes).
+ *
+ * Example: To set this to 100 MiB, use the value: 104857600 (1024*1024*100
+ * bytes).
  */
 'log_rotate_size' => false,
 
-/* Lifetime of the remember login cookie, default is 15 days */
-"remember_login_cookie_lifetime" => 60*60*24*15,
-
-/* Life time of a session after inactivity */
-"session_lifetime" => 60 * 60 * 24,
-
-/*
- * Enable/disable session keep alive when a user is logged in in the Web UI.
- * This is achieved by sending a "heartbeat" to the server to prevent
- * the session timing out.
+/**
+ * Lifetime of the remember login cookie, default is 15 days
  */
-"session_keepalive" => true,
+'remember_login_cookie_lifetime' => 60*60*24*15,
 
-/* Custom CSP policy, changing this will overwrite the standard policy */
-"custom_csp_policy" => "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src *; img-src *; font-src 'self' data:; media-src *",
+/**
+ * Life time of a session after inactivity
+ */
+'session_lifetime' => 60 * 60 * 24,
 
-/* Enable/disable X-Frame-Restriction */
-/* HIGH SECURITY RISK IF DISABLED*/
-"xframe_restriction" => true,
+/**
+ * Enable/disable session keep alive when a user is logged in in the Web UI.
+ * This is achieved by sending a 'heartbeat' to the server to prevent the
+ * session timing out.
+ */
+'session_keepalive' => true,
 
-/* The directory where the user data is stored, default to data in the owncloud
+/**
+ * Custom CSP policy, changing this will overwrite the standard policy
+ */
+'custom_csp_policy' =>
+	"default-src 'self'; script-src 'self' 'unsafe-eval'; ".
+	"style-src 'self' 'unsafe-inline'; frame-src *; img-src *; ".
+	"font-src 'self' data:; media-src *",
+
+/**
+ * Enable/disable X-Frame-Restriction
+ *
+ * HIGH SECURITY RISK IF DISABLED
+ */
+'xframe_restriction' => true,
+
+/**
+ * The directory where the user data is stored, default to data in the owncloud
  * directory. The sqlite database is also stored here, when sqlite is used.
  */
-// "datadirectory" => "",
+'datadirectory' => '',
 
-/* The directory where the skeleton files are located. These files will be copied to the data
- * directory of new users. Leave empty to not copy any skeleton files.
+/**
+ * The directory where the skeleton files are located. These files will be
+ * copied to the data directory of new users. Leave empty to not copy any
+ * skeleton files.
  */
-// "skeletondirectory" => "",
+'skeletondirectory' => '',
 
-/* Enable maintenance mode to disable ownCloud
-   If you want to prevent users to login to ownCloud before you start doing some maintenance work,
-   you need to set the value of the maintenance parameter to true.
-   Please keep in mind that users who are already logged-in are kicked out of ownCloud instantly.
-*/
-"maintenance" => false,
+/**
+ * Enable maintenance mode to disable ownCloud
+ *
+ * If you want to prevent users to login to ownCloud before you start doing some
+ * maintenance work, you need to set the value of the maintenance parameter to
+ * true. Please keep in mind that users who are already logged-in are kicked out
+ * of ownCloud instantly.
+ */
+'maintenance' => false,
 
-"apps_paths" => array(
+/**
+ * Set an array of path for your apps directories
+ *
+ * key 'path' is for the fs path and the key 'url' is for the http path to your
+ * applications paths. 'writable' indicates whether the user can install apps in
+ * this folder. You must have at least 1 app folder writable or you must set the
+ * parameter 'appstoreenabled' to false
+ */
+'apps_paths' => array(
 
-/* Set an array of path for your apps directories
- key 'path' is for the fs path and the key 'url' is for the http path to your
- applications paths. 'writable' indicates whether the user can install apps in this folder.
- You must have at least 1 app folder writable or you must set the parameter 'appstoreenabled' to false
-*/
 	array(
 		'path'=> '/var/www/owncloud/apps',
 		'url' => '/apps',
 		'writable' => true,
 	),
 ),
-'user_backends'=>array(
+
+/**
+ * TODO
+ */
+'user_backends' => array(
 	array(
-		'class'=>'OC_User_IMAP',
-		'arguments'=>array('{imap.gmail.com:993/imap/ssl}INBOX')
+		'class' => 'OC_User_IMAP',
+		'arguments' => array('{imap.gmail.com:993/imap/ssl}INBOX')
 	)
 ),
-//links to custom clients
-'customclient_desktop' => '', //http://owncloud.org/sync-clients/
-'customclient_android' => '', //https://play.google.com/store/apps/details?id=com.owncloud.android
-'customclient_ios' => '', //https://itunes.apple.com/us/app/owncloud/id543672169?mt=8
 
-// PREVIEW
+/**
+ * links to custom clients
+ */
+'customclient_desktop' =>
+	'http://owncloud.org/sync-clients/',
+'customclient_android' =>
+	'https://play.google.com/store/apps/details?id=com.owncloud.android',
+'customclient_ios' =>
+	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
+
+/**
+ * PREVIEW
+ */
 'enable_previews' => true,
-/* the max width of a generated preview, if value is null, there is no limit */
+/**
+ * the max width of a generated preview, if value is null, there is no limit
+ */
 'preview_max_x' => null,
-/* the max height of a generated preview, if value is null, there is no limit */
+/**
+ * the max height of a generated preview, if value is null, there is no limit
+ */
 'preview_max_y' => null,
-/* the max factor to scale a preview, default is set to 10 */
+/**
+ * the max factor to scale a preview, default is set to 10
+ */
 'preview_max_scale_factor' => 10,
-/* custom path for libreoffice / openoffice binary */
+/**
+ * custom path for libreoffice / openoffice binary
+ */
 'preview_libreoffice_path' => '/usr/bin/libreoffice',
-/* cl parameters for libreoffice / openoffice */
-'preview_office_cl_parameters' => ' --headless --nologo --nofirststartwizard --invisible --norestore -convert-to pdf -outdir ',
+/**
+ * cl parameters for libreoffice / openoffice
+ */
+'preview_office_cl_parameters' =>
+	' --headless --nologo --nofirststartwizard --invisible --norestore '.
+	'-convert-to pdf -outdir ',
 
 /**
  * Only register providers that have been explicitly enabled
  *
  * The following providers are enabled by default:
  *  - OC\Preview\Image
+ *  - OC\Preview\MarkDown
  *  - OC\Preview\MP3
  *  - OC\Preview\TXT
- *  - OC\Preview\MarkDown
  *
- * The following providers are disabled by default due to performance or privacy concerns:
- *  - OC\Preview\MSOfficeDoc
+ * The following providers are disabled by default due to performance or privacy
+ * concerns:
+ *  - OC\Preview\Illustrator
+ *  - OC\Preview\Movies
  *  - OC\Preview\MSOffice2003
  *  - OC\Preview\MSOffice2007
+ *  - OC\Preview\MSOfficeDoc
  *  - OC\Preview\OpenDocument
+ *  - OC\Preview\PDF
+ *  - OC\Preview\Photoshop
+ *  - OC\Preview\Postscript
  *  - OC\Preview\StarOffice
  *  - OC\Preview\SVG
- *  - OC\Preview\Movies
- *  - OC\Preview\PDF
  *  - OC\Preview\TIFF
- *  - OC\Preview\Illustrator
- *  - OC\Preview\Postscript
- *  - OC\Preview\Photoshop
  */
 'enabledPreviewProviders' => array(
 	'OC\Preview\Image',
@@ -315,73 +513,115 @@ $CONFIG = array(
 	'OC\Preview\MarkDown'
 ),
 
-/* whether avatars should be enabled */
+/**
+ * whether avatars should be enabled
+ */
 'enable_avatars' => true,
 
-// Extra SSL options to be used for configuration
+/**
+ * Extra SSL options to be used for configuration
+ */
 'openssl' => array(
-	//'config' => '/absolute/location/of/openssl.cnf',
+	'config' => '/absolute/location/of/openssl.cnf',
 ),
 
-// default cipher used for file encryption, currently we support AES-128-CFB and AES-256-CFB
+/**
+ * default cipher used for file encryption, currently we support AES-128-CFB and
+ * AES-256-CFB
+ */
 'cipher' => 'AES-256-CFB',
 
-/* whether usage of the instance should be restricted to admin users only */
+/**
+ * whether usage of the instance should be restricted to admin users only
+ */
 'singleuser' => false,
 
-/* all css and js files will be served by the web server statically in one js file and ons css file*/
+/**
+ * all css and js files will be served by the web server statically in one js
+ * file and ons css file
+ */
 'asset-pipeline.enabled' => false,
 
-/* where mount.json file should be stored, defaults to data/mount.json */
-// 'mount_file' => 'data/mount.json',
+/**
+ * where mount.json file should be stored
+ */
+'mount_file' => 'data/mount.json',
 
 /*
- * Location of the cache folder, defaults to "data/$user/cache" where "$user" is the current user.
+ * Location of the cache folder, defaults to 'data/$user/cache' where '$user' is
+ * the current user.
  *
- * When specified, the format will change to "$cache_path/$user" where "$cache_path" is the configured
- * cache directory and "$user" is the user.
- *
+ * When specified, the format will change to '$cache_path/$user' where
+ * '$cache_path' is the configured cache directory and '$user' is the user.
  */
 'cache_path' => '',
 
-/* EXPERIMENTAL: option whether to include external storage in quota calculation, defaults to false */
+/**
+ * EXPERIMENTAL: option whether to include external storage in quota
+ * calculation, defaults to false
+ */
 'quota_include_external_storage' => false,
 
-/*
- * specifies how often the filesystem is checked for changes made outside owncloud
- * 0 -> never check the filesystem for outside changes, provides a performance increase when it's certain that no changes are made directly to the filesystem
- * 1 -> check each file or folder at most once per request, recomended for general use if outside changes might happen
- * 2 -> check every time the filesystem is used, causes a performance hit when using external storages, not recomended for regular use
+/**
+ * specifies how often the filesystem is checked for changes made outside
+ * owncloud
+ *
+ * 0 -> never check the filesystem for outside changes, provides a performance
+ * increase when it's certain that no changes are made directly to the
+ * filesystem
+ *
+ * 1 -> check each file or folder at most once per request, recommended for
+ * general use if outside changes might happen
+ *
+ * 2 -> check every time the filesystem is used, causes a performance hit when
+ * using external storages, not recommended for regular use
  */
 'filesystem_check_changes' => 1,
 
-/* If true, prevent owncloud from changing the cache due to changes in the filesystem for all storage */
+/**
+ * If true, prevent owncloud from changing the cache due to changes in the
+ * filesystem for all storage
+ */
 'filesystem_cache_readonly' => false,
 
-/*
- * The example below shows how to configure ownCloud to store all files in a swift object storage
+/**
+ * The example below shows how to configure ownCloud to store all files in a
+ * swift object storage
  *
- * It is important to note that ownCloud in object store mode will expect exclusive access
- * to the object store container because it only stores the binary data for each file. The
- * metadata is currently kept in the local database for performance reasons.
+ * It is important to note that ownCloud in object store mode will expect
+ * exclusive access to the object store container because it only stores the
+ * binary data for each file. The metadata is currently kept in the local
+ * database for performance reasons.
  *
- * WARNING: The current implementation is incompatible with any app that uses direct file IO and circumvents our
- * virtual filesystem. That includes Encryption and Gallery. Gallery will store thumbnails directly in the filesystem
- * and encryption will cause severe overhead because key files need to be fetched in addition to any requested file.
+ * WARNING: The current implementation is incompatible with any app that uses
+ * direct file IO and circumvents our virtual filesystem. That includes
+ * Encryption and Gallery. Gallery will store thumbnails directly in the
+ * filesystem and encryption will cause severe overhead because key files need
+ * to be fetched in addition to any requested file.
  *
  * One way to test is applying for a trystack account at http://trystack.org/
  */
 'objectstore' => array(
 	'class' => 'OC\\Files\\ObjectStore\\Swift',
 	'arguments' => array(
-		'username' => 'facebook100000123456789', // trystack will user your facebook id as the user name
-		'password' => 'Secr3tPaSSWoRdt7', // in the trystack dashboard go to user -> settings -> API Password to generate a password
-		'container' => 'owncloud', // must already exist in the objectstore, name can be different
-		'autocreate' => true, // create the container if it does not exist. default is false
-		'region' => 'RegionOne', //required, dev-/trystack defaults to 'RegionOne'
-		'url' => 'http://8.21.28.222:5000/v2.0', // The Identity / Keystone endpoint
-		'tenantName' => 'facebook100000123456789', // required on dev-/trystack
-		'serviceName' => 'swift', //dev-/trystack uses swift by default, the lib defaults to 'cloudFiles' if omitted
+		// trystack will user your facebook id as the user name
+		'username' => 'facebook100000123456789',
+		// in the trystack dashboard go to user -> settings -> API Password to
+		// generate a password
+		'password' => 'Secr3tPaSSWoRdt7',
+		// must already exist in the objectstore, name can be different
+		'container' => 'owncloud',
+		// create the container if it does not exist. default is false
+		'autocreate' => true,
+		// required, dev-/trystack defaults to 'RegionOne'
+		'region' => 'RegionOne',
+		// The Identity / Keystone endpoint
+		'url' => 'http://8.21.28.222:5000/v2.0',
+		// required on dev-/trystack
+		'tenantName' => 'facebook100000123456789',
+		// dev-/trystack uses swift by default, the lib defaults to 'cloudFiles'
+		// if omitted
+		'serviceName' => 'swift',
 	),
 ),
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -16,15 +16,50 @@
 define('DEBUG', true);
 
 $CONFIG = array(
+
+
 /**
- * Flag to indicate ownCloud is successfully installed (true = installed)
+ * Default Parameters
+ *
+ * These parameters are configured by the ownCloud installer, and are required
+ * for your ownCloud server to operate.
  */
-'installed' => false,
+
+
+/**
+ * This is a unique identifier for your ownCloud installation, created
+ * automatically by the installer.
+ */
+'instanceid' => '',
+
+/**
+ * Define the salt used to hash the user passwords. All your user passwords are
+ * lost if you lose this string.
+ */
+'passwordsalt' => '',
+
+/**
+ * List of trusted domains, to prevent host header poisoning ownCloud is only
+ * using these Host headers
+ */
+'trusted_domains' => array('demo.example.org', 'otherdomain.example.org:8080'),
+
+/**
+ * The directory where the user data is stored, default to data in the owncloud
+ * directory. The sqlite database is also stored here, when sqlite is used.
+ */
+'datadirectory' => '',
 
 /**
  * Type of database, can be sqlite, mysql or pgsql
  */
 'dbtype' => 'sqlite',
+
+/**
+ * Host running the ownCloud database. To specify a port use 'HOSTNAME:####'; to
+ * specify a unix sockets use 'localhost:/path/to/socket'.
+ */
+'dbhost' => '',
 
 /**
  * Name of the ownCloud database
@@ -42,102 +77,22 @@ $CONFIG = array(
 'dbpassword' => '',
 
 /**
- * Host running the ownCloud database. To specify a port use 'HOSTNAME:####'; to
- * specify a unix sockets use 'localhost:/path/to/socket'.
- */
-'dbhost' => '',
-
-/**
  * Prefix for the ownCloud tables in the database
  */
 'dbtableprefix' => '',
 
 /**
- * Define the salt used to hash the user passwords. All your user passwords are
- * lost if you lose this string.
+ * Flag to indicate ownCloud is successfully installed (true = installed)
  */
-'passwordsalt' => '',
+'installed' => false,
+
 
 /**
- * Secret used by ownCloud for various purposes, e.g. to encrypt data. If you
- * lose this string there will be data corruption.
+ * User Experience
+ *
+ * These optional parameters control some aspects of the user interface. Default
+ * values, where present, are shown.
  */
-'secret' => '',
-
-/**
- * Force use of HTTPS connection (true = use HTTPS)
- */
-'forcessl' => false,
-
-/**
- * Blacklist a specific file and disallow the upload of files with this name
- * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
- */
-'blacklisted_files' => array('.htaccess'),
-
-/**
- * The automatic hostname detection of ownCloud can fail in certain reverse
- * proxy and CLI/cron situations. This option allows to manually override the
- * automatic detection. You can also add a port. For example
- * 'www.example.com:88'
- */
-'overwritehost' => '',
-
-/**
- * The automatic protocol detection of ownCloud can fail in certain reverse
- * proxy and CLI/cron situations. This option allows to manually override the
- * protocol detection. For example 'https'
- */
-'overwriteprotocol' => '',
-
-/**
- * The automatic webroot detection of ownCloud can fail in certain reverse proxy
- * and CLI/cron situations. This option allows to manually override the
- * automatic detection. For example '/domain.tld/ownCloud'. The value '/' can be
- * used to remove the root.
- */
-'overwritewebroot' => '',
-
-/**
- * The automatic detection of ownCloud can fail in certain reverse proxy and
- * CLI/cron situations. This option allows to define a manually override
- * condition as regular expression for the remote ip address. For example
- * '^10\.0\.0\.[1-3]$'
- */
-'overwritecondaddr' => '',
-
-/**
- * A proxy to use to connect to the internet. For example 'myproxy.org:88'
- */
-'proxy' => '',
-
-/**
- * The optional authentication for the proxy to use to connect to the internet.
- * The format is: [username]:[password]
- */
-'proxyuserpwd' => '',
-
-/**
- * List of trusted domains, to prevent host header poisoning ownCloud is only
- * using these Host headers
- */
-'trusted_domains' => array('demo.example.org', 'otherdomain.example.org:8080'),
-
-/**
- * List of trusted proxy servers
- */
-'trusted_proxies' => array('203.0.113.45', '198.51.100.128'),
-
-/**
- * Headers that should be trusted as client IP address in combination with
- * `trusted_proxies`
- */
-'forwarded_for_headers' => array('HTTP_X_FORWARDED', 'HTTP_FORWARDED_FOR'),
-
-/**
- * Theme to use for ownCloud
- */
-'theme' => '',
 
 /**
  * Optional ownCloud default language - overrides automatic language detection
@@ -146,16 +101,6 @@ $CONFIG = array(
  * logged in
  */
 'default_language' => 'en',
-
-/**
- * Path to the parent directory of the 3rdparty directory
- */
-'3rdpartyroot' => '',
-
-/**
- * URL to the parent directory of the 3rdparty directory, as seen by the browser
- */
-'3rdpartyurl' => '',
 
 /**
  * Default app to open on login.
@@ -172,14 +117,56 @@ $CONFIG = array(
 'knowledgebaseenabled' => true,
 
 /**
- * Enable installing apps from the appstore
+ * whether avatars should be enabled
  */
-'appstoreenabled' => true,
+'enable_avatars' => true,
 
 /**
- * URL of the appstore to use, server should understand OCS
+ * allow user to change his display name, if it is supported by the back-end
  */
-'appstoreurl' => 'https://api.owncloud.com/v1',
+'allow_user_to_change_display_name' => true,
+
+/**
+ * Lifetime of the remember login cookie, default is 15 days
+ */
+'remember_login_cookie_lifetime' => 60*60*24*15,
+
+/**
+ * Life time of a session after inactivity
+ */
+'session_lifetime' => 60 * 60 * 24,
+
+/**
+ * Enable/disable session keep alive when a user is logged in in the Web UI.
+ * This is achieved by sending a 'heartbeat' to the server to prevent the
+ * session timing out.
+ */
+'session_keepalive' => true,
+
+/**
+ * The directory where the skeleton files are located. These files will be
+ * copied to the data directory of new users. Leave empty to not copy any
+ * skeleton files.
+ */
+'skeletondirectory' => '',
+
+/**
+ * TODO
+ */
+'user_backends' => array(
+	array(
+		'class' => 'OC_User_IMAP',
+		'arguments' => array('{imap.gmail.com:993/imap/ssl}INBOX')
+	)
+),
+
+
+/**
+ * Mail Parameters
+ *
+ * These configure the email settings for ownCloud notifications and password
+ * resets.
+ */
 
 /**
  * Domain name used by ownCloud for the sender mail address, e.g.
@@ -251,16 +238,53 @@ $CONFIG = array(
  */
 'mail_smtppassword' => '',
 
+
 /**
- * memcached servers (Only used when xCache, APC and APCu are absent.)
+ * Proxy Configurations
  */
-'memcached_servers' => array(
-	// hostname, port and optional weight. Also see:
-	// http://www.php.net/manual/en/memcached.addservers.php
-	// http://www.php.net/manual/en/memcached.addserver.php
-	array('localhost', 11211),
-	//array('other.host.local', 11211),
-),
+
+/**
+ * The automatic hostname detection of ownCloud can fail in certain reverse
+ * proxy and CLI/cron situations. This option allows to manually override the
+ * automatic detection. You can also add a port. For example
+ * 'www.example.com:88'
+ */
+'overwritehost' => '',
+
+/**
+ * The automatic protocol detection of ownCloud can fail in certain reverse
+ * proxy and CLI/cron situations. This option allows to manually override the
+ * protocol detection. For example 'https'
+ */
+'overwriteprotocol' => '',
+
+/**
+ * The automatic webroot detection of ownCloud can fail in certain reverse proxy
+ * and CLI/cron situations. This option allows to manually override the
+ * automatic detection. For example '/domain.tld/ownCloud'. The value '/' can be
+ * used to remove the root.
+ */
+'overwritewebroot' => '',
+
+/**
+ * The automatic detection of ownCloud can fail in certain reverse proxy and
+ * CLI/cron situations. This option allows to define a manually override
+ * condition as regular expression for the remote ip address. For example
+ * '^10\.0\.0\.[1-3]$'
+ */
+'overwritecondaddr' => '',
+
+/**
+ * A proxy to use to connect to the internet. For example 'myproxy.org:88'
+ */
+'proxy' => '',
+
+
+/**
+ * Deleted Items
+ *
+ * These parameters control the Deleted files app.
+ */
 
 /**
  * How long should ownCloud keep deleted files in the trash bin, default value:
@@ -274,10 +298,13 @@ $CONFIG = array(
  */
 'trashbin_auto_expire' => true,
 
+
 /**
- * allow user to change his display name, if it is supported by the back-end
+ * ownCloud Verifications
+ *
+ * ownCloud performs several verification checks. There are two options, 'true'
+ * and 'false'.
  */
-'allow_user_to_change_display_name' => true,
 
 /**
  * Ensure that 3rdparty applications follows coding guidelines
@@ -306,6 +333,11 @@ $CONFIG = array(
  */
 'check_for_working_htaccess' => true,
 
+
+/**
+ * Logging
+ */
+
 /**
  * Place to log to, can be 'owncloud' and 'syslog' (owncloud is log menu item in
  * admin menu)
@@ -319,17 +351,8 @@ $CONFIG = array(
 'logfile' => '',
 
 /**
- * This entry is just here to show a warning in case somebody copied the sample
- * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
- *
- * If you, brave person, have read until here be aware that you should not
- * modify *ANY* settings in this file without reading the documentation
- */
-'copied_sample_config' => true,
-
-/**
- * Loglevel to start logging at. 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (default is
- * WARN)
+ * Loglevel to start logging at. 0 = DEBUG, 1 = INFO, 2 = WARN, 3 = ERROR
+ * (default is WARN)
  */
 'loglevel' => 2,
 
@@ -363,60 +386,48 @@ $CONFIG = array(
  */
 'log_rotate_size' => false,
 
-/**
- * Lifetime of the remember login cookie, default is 15 days
- */
-'remember_login_cookie_lifetime' => 60*60*24*15,
 
 /**
- * Life time of a session after inactivity
- */
-'session_lifetime' => 60 * 60 * 24,
-
-/**
- * Enable/disable session keep alive when a user is logged in in the Web UI.
- * This is achieved by sending a 'heartbeat' to the server to prevent the
- * session timing out.
- */
-'session_keepalive' => true,
-
-/**
- * Custom CSP policy, changing this will overwrite the standard policy
- */
-'custom_csp_policy' =>
-	"default-src 'self'; script-src 'self' 'unsafe-eval'; ".
-	"style-src 'self' 'unsafe-inline'; frame-src *; img-src *; ".
-	"font-src 'self' data:; media-src *",
-
-/**
- * Enable/disable X-Frame-Restriction
+ * Alternate Code Locations
  *
- * HIGH SECURITY RISK IF DISABLED
+ * Some of the ownCloud code may be stored in alternate locations.
  */
-'xframe_restriction' => true,
 
 /**
- * The directory where the user data is stored, default to data in the owncloud
- * directory. The sqlite database is also stored here, when sqlite is used.
+ * Path to the parent directory of the 3rdparty directory
  */
-'datadirectory' => '',
+'3rdpartyroot' => '',
 
 /**
- * The directory where the skeleton files are located. These files will be
- * copied to the data directory of new users. Leave empty to not copy any
- * skeleton files.
+ * URL to the parent directory of the 3rdparty directory, as seen by the browser
  */
-'skeletondirectory' => '',
+'3rdpartyurl' => '',
 
 /**
- * Enable maintenance mode to disable ownCloud
+ * links to custom clients
+ */
+'customclient_desktop' =>
+	'http://owncloud.org/sync-clients/',
+'customclient_android' =>
+	'https://play.google.com/store/apps/details?id=com.owncloud.android',
+'customclient_ios' =>
+	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
+
+/**
+ * Apps
  *
- * If you want to prevent users to login to ownCloud before you start doing some
- * maintenance work, you need to set the value of the maintenance parameter to
- * true. Please keep in mind that users who are already logged-in are kicked out
- * of ownCloud instantly.
+ * Options for the Apps folder, Apps store, and App code checker.
  */
-'maintenance' => false,
+
+/**
+ * Enable installing apps from the appstore
+ */
+'appstoreenabled' => true,
+
+/**
+ * URL of the appstore to use, server should understand OCS
+ */
+'appstoreurl' => 'https://api.owncloud.com/v1',
 
 /**
  * Set an array of path for your apps directories
@@ -436,27 +447,20 @@ $CONFIG = array(
 ),
 
 /**
+ * @see appcodechecker
+ */
+
+
+/**
+ * Previews
+ *
+ * ownCloud supports previews of image files, the covers of MP3 files, and text
+ * files. These options control enabling and disabling previews, and thumbnail
+ * size.
+ */
+
+/**
  * TODO
- */
-'user_backends' => array(
-	array(
-		'class' => 'OC_User_IMAP',
-		'arguments' => array('{imap.gmail.com:993/imap/ssl}INBOX')
-	)
-),
-
-/**
- * links to custom clients
- */
-'customclient_desktop' =>
-	'http://owncloud.org/sync-clients/',
-'customclient_android' =>
-	'https://play.google.com/store/apps/details?id=com.owncloud.android',
-'customclient_ios' =>
-	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
-
-/**
- * PREVIEW
  */
 'enable_previews' => true,
 /**
@@ -513,10 +517,38 @@ $CONFIG = array(
 	'OC\Preview\MarkDown'
 ),
 
+
 /**
- * whether avatars should be enabled
+ * Maintenance
+ *
+ * These options are for halting user activity when you are performing server
+ * maintenance.
  */
-'enable_avatars' => true,
+
+/**
+ * Enable maintenance mode to disable ownCloud
+ *
+ * If you want to prevent users to login to ownCloud before you start doing some
+ * maintenance work, you need to set the value of the maintenance parameter to
+ * true. Please keep in mind that users who are already logged-in are kicked out
+ * of ownCloud instantly.
+ */
+'maintenance' => false,
+
+/**
+ * whether usage of the instance should be restricted to admin users only
+ */
+'singleuser' => false,
+
+
+/**
+ * SSL
+ */
+
+/**
+ * Force use of HTTPS connection (true = use HTTPS)
+ */
+'forcessl' => false,
 
 /**
  * Extra SSL options to be used for configuration
@@ -525,6 +557,34 @@ $CONFIG = array(
 	'config' => '/absolute/location/of/openssl.cnf',
 ),
 
+
+/**
+ * Miscellaneous
+ */
+
+/**
+ * Blacklist a specific file and disallow the upload of files with this name
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'blacklisted_files' => array('.htaccess'),
+
+/**
+ * define default folder for shared files and folders
+ */
+'share_folder' => '/',
+
+/**
+ * Theme to use for ownCloud
+ */
+'theme' => '',
+
+/**
+ * Enable/disable X-Frame-Restriction
+ *
+ * HIGH SECURITY RISK IF DISABLED
+ */
+'xframe_restriction' => true,
+
 /**
  * default cipher used for file encryption, currently we support AES-128-CFB and
  * AES-256-CFB
@@ -532,20 +592,15 @@ $CONFIG = array(
 'cipher' => 'AES-256-CFB',
 
 /**
- * whether usage of the instance should be restricted to admin users only
+ * memcached servers (Only used when xCache, APC and APCu are absent.)
  */
-'singleuser' => false,
-
-/**
- * all css and js files will be served by the web server statically in one js
- * file and ons css file
- */
-'asset-pipeline.enabled' => false,
-
-/**
- * where mount.json file should be stored
- */
-'mount_file' => 'data/mount.json',
+'memcached_servers' => array(
+	// hostname, port and optional weight. Also see:
+	// http://www.php.net/manual/en/memcached.addservers.php
+	// http://www.php.net/manual/en/memcached.addserver.php
+	array('localhost', 11211),
+	//array('other.host.local', 11211),
+),
 
 /*
  * Location of the cache folder, defaults to 'data/$user/cache' where '$user' is
@@ -577,6 +632,11 @@ $CONFIG = array(
  * using external storages, not recommended for regular use
  */
 'filesystem_check_changes' => 1,
+
+/**
+ * where mount.json file should be stored
+ */
+'mount_file' => 'data/mount.json',
 
 /**
  * If true, prevent owncloud from changing the cache due to changes in the
@@ -626,8 +686,54 @@ $CONFIG = array(
 ),
 
 /**
- * define default folder for shared files and folders
+ * Custom CSP policy, changing this will overwrite the standard policy
  */
-'share_folder' => '/',
+'custom_csp_policy' =>
+	"default-src 'self'; script-src 'self' 'unsafe-eval'; ".
+	"style-src 'self' 'unsafe-inline'; frame-src *; img-src *; ".
+	"font-src 'self' data:; media-src *",
+
+
+/**
+ * Forgotten ones
+ */
+
+/**
+ * Secret used by ownCloud for various purposes, e.g. to encrypt data. If you
+ * lose this string there will be data corruption.
+ */
+'secret' => '',
+
+/**
+ * The optional authentication for the proxy to use to connect to the internet.
+ * The format is: [username]:[password]
+ */
+'proxyuserpwd' => '',
+
+/**
+ * List of trusted proxy servers
+ */
+'trusted_proxies' => array('203.0.113.45', '198.51.100.128'),
+
+/**
+ * Headers that should be trusted as client IP address in combination with
+ * `trusted_proxies`
+ */
+'forwarded_for_headers' => array('HTTP_X_FORWARDED', 'HTTP_FORWARDED_FOR'),
+
+/**
+ * This entry is just here to show a warning in case somebody copied the sample
+ * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
+ *
+ * If you, brave person, have read until here be aware that you should not
+ * modify *ANY* settings in this file without reading the documentation
+ */
+'copied_sample_config' => true,
+
+/**
+ * all css and js files will be served by the web server statically in one js
+ * file and ons css file
+ */
+'asset-pipeline.enabled' => false,
 
 );


### PR DESCRIPTION
With this PR I want to enhance the quality of the documentation.

The idea was to generate the "What config options are available and what do they do" documentation page from the `config.sample.php`, because it's hard to keep both in sync. @carlaschroder did a great job at the documentation part and we should work together as this means less repeating work for ourselves. We also push the developers to document new config options in the config.sample.php, so why don't we reuse that effort and generate documentation right from this.

I wrote a little script that parses the config.sample.php and generates a RST file. https://github.com/MorrisJobke/ownCloud-config-converter

Output: https://gist.github.com/MorrisJobke/31aad4fff99d97b0fc1c

You maybe think: "OMG! This is a huge PR, which changes nearly everything!" Yes. But I splitted it into some commits. The first introduces proper comments (starting with `/**` and ending with `*/`) which has no more than 80 characters per line. The second one moves everything around and I was inspired (I used exactly the same order) by @carlaschroder 's PR (owncloud/documentation#594). The last one ist just a cleanup of all of this stuff.

What do you think? Is this a good idea? Could this work? I also can try to write a test case for a valid (parse-able by my script) config.sample.php?

cc @karlitschek @craigpg @DeepDiver1975 @danimo @wakeup 
