### PR TITLE
[WIP] Introduce public calendar api

### DIFF
--- a/lib/private/calendarmanager.php
+++ b/lib/private/calendarmanager.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Thomas Müller
+ * @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC {
+
+	class CalendarManager implements \OCP\Calendar\IManager {
+
+		/**
+		 * @var \OCP\ICalendar[]
+		 */
+		private $calendars = [];
+
+		/**
+		 * @var \Closure[] to call to load/register calendars
+		 */
+		private $calendarLoaders = [];
+
+		public function search($pattern, $searchProperties = array(), $options = array()) {
+			$this->loadCalendars();
+			$result = array();
+			foreach($this->calendars as $cal) {
+				$r = $cal->search($pattern, $searchProperties, $options);
+				$contacts = array();
+				foreach($r as $c){
+					$c['calendar-key'] = $cal->getKey();
+					$contacts[] = $c;
+				}
+				$result = array_merge($result, $contacts);
+			}
+
+			return $result;
+		}
+
+		/**
+		 * This function can be used to delete the contact identified by the given id
+		 *
+		 * @param object $id the unique identifier to an event/task
+		 * @param string $calendarKey identifier of the calendar in which the task/event shall be deleted
+		 * @return bool successful or not
+		 */
+		public function delete($id, $calendarKey) {
+			$cal = $this->getCalendar($calendarKey);
+			if (!$cal) {
+				return null;
+			}
+
+			if ($cal->getPermissions() & \OCP\Constants::PERMISSION_DELETE) {
+				return $cal->delete($id);
+			}
+
+			return null;
+		}
+
+		/**
+		 * @param array $properties this array if key-value-pairs defines a task/event
+		 * @param string $calendarKey identifier of the calendar in which the task/event shall be created or updated
+		 * @return array an array representing the task/event just created or updated
+		 */
+		public function createOrUpdate($properties, $calendarKey) {
+			$cal = $this->getCalendar($calendarKey);
+			if (!$cal) {
+				return null;
+			}
+
+			if ($cal->getPermissions() & \OCP\Constants::PERMISSION_CREATE) {
+				return $cal->createOrUpdate($properties);
+			}
+
+			return null;
+		}
+
+		/**
+		 * @return bool true if enabled, false if not
+		 */
+		public function isEnabled() {
+			return !empty($this->calendars) || !empty($this->calendarLoaders);
+		}
+
+		/**
+		 * @param \OCP\ICalendar $calendar
+		 */
+		public function registerCalendar(\OCP\ICalendar $calendar) {
+			$this->calendars[$calendar->getKey()] = $calendar;
+		}
+
+		/**
+		 * @param \OCP\ICalendar $calendar
+		 */
+		public function unregisterCalendar(\OCP\ICalendar $calendar) {
+			unset($this->calendars[$calendar->getKey()]);
+		}
+
+		/**
+		 * @return \OCP\ICalendar[]
+		 */
+		public function getCalendars() {
+			$this->loadCalendars();
+			$result = array();
+			foreach($this->calendars as $cal) {
+				$result[$cal->getKey()] = $cal->getDisplayName();
+			}
+
+			return $result;
+		}
+
+		public function clear() {
+			$this->calendars = array();
+			$this->calendarLoaders = array();
+		}
+
+		/**
+		 * @param \Closure $callable
+		 */
+		public function register(\Closure $callable)
+		{
+			$this->calendarLoaders[] = $callable;
+		}
+
+		/**
+		 * @param string $calendarKey
+		 * @return \OCP\ICalendar
+		 */
+		protected function getCalendar($calendarKey)
+		{
+			$this->loadCalendars();
+			if (!array_key_exists($calendarKey, $this->calendars)) {
+				return null;
+			}
+
+			return $this->calendars[$calendarKey];
+		}
+
+		protected function loadCalendars()
+		{
+			foreach($this->calendarLoaders as $callable) {
+				$callable($this);
+			}
+			$this->calendarLoaders = array();
+		}
+
+	}
+}

--- a/lib/public/calendar/imanager.php
+++ b/lib/public/calendar/imanager.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Thomas Müller
+ * @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Calendar {
+
+	/**
+	 * This class provides access to any calendar source within ownCloud.
+	 * Use this class exclusively if you want to access tasks/events.
+	 *
+	 */
+	interface IManager {
+
+		/**
+		 * @param string $pattern which should match within the $searchProperties
+		 * @param array $searchProperties defines the properties within the query pattern should match
+		 * @param array $options
+		 * 		'from' 	: defines the starting point in time for the query
+		 * 		'to'	: defines the end
+		 *
+		 * @return array of events/tasks which are arrays of key-value-pairs
+		 */
+		public function search($pattern, $searchProperties, $options);
+
+
+		/**
+		 * This function can be used to delete the task/event identified by the given id
+		 *
+		 * @param object $id the unique identifier to an event/task
+		 * @param string $calendarKey identifier of the calendar in which the task/event shall be deleted
+		 * @return bool successful or not
+		 */
+		function delete($id, $calendarKey);
+
+		/**
+		 * This function is used to create a new task/event if 'id' is not given or not present.
+		 * Otherwise the task/event will be updated by replacing the entire data set.
+		 *
+		 * @param array $properties this array if key-value-pairs defines a task/event
+		 * @param string $calendarKey identifier of the calendar in which the task/event shall be created or updated
+		 * @return array an array representing the task/event just created or updated
+		 */
+		function createOrUpdate($properties, $calendarKey);
+
+		/**
+		 * Check if task/events are available (e.g. task/events app enabled)
+		 *
+		 * @return bool true if enabled, false if not
+		 */
+		function isEnabled();
+
+		/**
+		 * Registers a calendar
+		 *
+		 * @param \OCP\ICalendar $calendar
+		 * @return void
+		 */
+		function registerCalendar(\OCP\ICalendar $calendar);
+
+		/**
+		 * Unregisters an calendar
+		 *
+		 * @param \OCP\ICalendar $calendar
+		 * @return void
+		 */
+		function unregisterCalendar(\OCP\ICalendar $calendar);
+
+		/**
+		 * In order to improve lazy loading a closure can be registered which will be called in case
+		 * calendars are actually requested
+		 *
+		 * @param \Closure $callable
+		 * @return void
+		 */
+		function register(\Closure $callable);
+
+		/**
+		 * @return \OCP\ICalendar[]
+		 */
+		function getCalendars();
+
+		/**
+		 * removes all registered calendars
+		 * @return void
+		 */
+		function clear();
+	}
+}

--- a/lib/public/icalendar.php
+++ b/lib/public/icalendar.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Thomas Müller
+ * @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP {
+
+	interface ICalendar {
+
+		/**
+		 * @param string $pattern which should match within the $searchProperties
+		 * @param array $searchProperties defines the properties within the query pattern should match
+		 * @param array $options
+		 * 		'from' 	: defines the starting point in time for the query
+		 * 		'to'	: defines the end
+		 *
+		 * @return array of events/journals/tasks which are arrays of key-value-pairs
+		 */
+		public function search($pattern, $searchProperties, $options);
+
+		/**
+		 * @return string defining the technical unique key
+		 */
+		public function getKey();
+
+		/**
+		 * In comparison to getKey() this function returns a human readable (maybe translated) name
+		 * @return string
+		 */
+		public function getDisplayName();
+
+		/**
+		 * @param array $properties this array if key-value-pairs defines a event/task
+		 * @return array an array representing the event/task just created or updated
+		 */
+		public function createOrUpdate($properties);
+
+		/**
+		 * @return mixed
+		 */
+		public function getPermissions();
+
+		/**
+		 * @param object $id the unique identifier to an event/task
+		 * @return bool successful or not
+		 */
+		public function delete($id);
+	}
+}

--- a/tests/lib/public/calendars.php
+++ b/tests/lib/public/calendars.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Thomas Müller
+ * @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class Test_Calendars extends \Test\TestCase {
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	public function testDisabledIfEmpty() {
+		$calendarManager = new \OC\CalendarManager();
+		// pretty simple
+		$this->assertFalse($calendarManager->isEnabled());
+	}
+
+	public function testEnabledAfterRegister() {
+		// create mock for the calendar
+		$stub = $this->getMockForAbstractClass("OCP\ICalendar", array('getKey'));
+
+		// we expect getKey to be called twice:
+		// first time on register
+		// second time on un-register
+		$stub->expects($this->exactly(2))
+			->method('getKey');
+
+		$calendarManager = new \OC\CalendarManager();
+
+		// not enabled before register
+		$this->assertFalse($calendarManager->isEnabled());
+
+		// register the address book
+		$calendarManager->registerCalendar($stub);
+
+		// contacts api shall be enabled
+		$this->assertTrue($calendarManager->isEnabled());
+
+		// unregister the address book
+		$calendarManager->unregisterCalendar($stub);
+
+		// not enabled after register
+		$this->assertFalse($calendarManager->isEnabled());
+	}
+
+	public function testCalendarEnumeration() {
+		// create mock for the calendar
+		$stub = $this->getMockForAbstractClass("OCP\ICalendar", array('getKey', 'getDisplayName'));
+
+		// setup return for method calls
+		$stub->expects($this->any())
+			->method('getKey')
+			->will($this->returnValue('SIMPLE_CALENDAR'));
+		$stub->expects($this->any())
+			->method('getDisplayName')
+			->will($this->returnValue('A very simple calendar'));
+
+		$calendarManager = new \OC\CalendarManager();
+
+		// register the calendar
+		$calendarManager->registerCalendar($stub);
+		$all_books = $calendarManager->getCalendars();
+
+		$this->assertEquals(1, count($all_books));
+		$this->assertEquals('A very simple calendar', $all_books['SIMPLE_CALENDAR']);
+	}
+
+	public function testSearchInAddressBook() {
+		// create mock for the addressbook
+		$stub1 = $this->getMockForAbstractClass("OCP\ICalendar", array('getKey', 'getDisplayName', 'search'));
+		$stub2 = $this->getMockForAbstractClass("OCP\ICalendar", array('getKey', 'getDisplayName', 'search'));
+
+		$searchResult1 = array(
+			array('id' => 0, 'SUMMARY' => 'Meeting 1'),
+			array('id' => 5, 'SUMMARY' => 'Meeting 2'),
+		);
+		$searchResult2 = array(
+			array('id' => 0, 'SUMMARY' => 'Hack-Week Berlin'),
+			array('id' => 5, 'SUMMARY' => 'Hack-Week Stuttgart'),
+		);
+
+		// setup return for method calls for $stub1
+		$stub1->expects($this->any())->method('getKey')->will($this->returnValue('SIMPLE_CALENDAR1'));
+		$stub1->expects($this->any())->method('getDisplayName')->will($this->returnValue('Calendar of ownCloud Inc'));
+		$stub1->expects($this->any())->method('search')->will($this->returnValue($searchResult1));
+
+		// setup return for method calls for $stub2
+		$stub2->expects($this->any())->method('getKey')->will($this->returnValue('SIMPLE_CALENDAR2'));
+		$stub2->expects($this->any())->method('getDisplayName')->will($this->returnValue('Calendar of ownCloud Community'));
+		$stub2->expects($this->any())->method('search')->will($this->returnValue($searchResult2));
+
+		// register the calendars
+		$calendarManager = new \OC\CalendarManager();
+		$calendarManager->registerCalendar($stub1);
+		$calendarManager->registerCalendar($stub2);
+		$allCals = $calendarManager->getCalendars();
+
+		// assert the count - doesn't hurt
+		$this->assertEquals(2, count($allCals));
+
+		// perform the search
+		$result = $calendarManager->search('x', array());
+
+		// we expect 4 hits
+		$this->assertEquals(4, count($result));
+
+	}
+}


### PR DESCRIPTION
We need a public api in ownCloud core to access available calendars.

The basic design of the api follows the contacts manager approach which is in place for quite some time now.

There are basically 3 pieces involved:
- the manager - holding all calendars
- the calendar - holding events and tasks
- the event/task

Please review the api design! THX

@karlitschek @MorrisJobke @georgehrke @Raydiation @PVince81 @schiesbn @butonic THX
