### PR TITLE
Fix file size comparator return value

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -93,7 +93,7 @@ class Helper
 	public static function compareSize($a, $b) {
 		$aSize = $a->getSize();
 		$bSize = $b->getSize();
-		return $aSize - $bSize;
+		return ($aSize < $bSize) ? -1 : 1;
 	}
 
 	/**


### PR DESCRIPTION
With OC 7.0.2, sorting files and directories by size gives unpredictable results, as you can see [here](https://cloud.githubusercontent.com/assets/264472/4551756/53dccc9e-4e76-11e4-8d09-fc46fda697ac.png) and [here](https://cloud.githubusercontent.com/assets/264472/4551757/53dcfaca-4e76-11e4-958f-a8c321c89197.png).
This is due to the file size comparator function not doing what its documentation says ("return int -1 if $a must come before $b, 1 otherwise") - instead, it subtracts the two file sizes and returns the result.

After applying this simple, one-line change, sorting by file size works as expected for me.
