### PR TITLE
increase whitespace below headings in settings

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -484,7 +484,7 @@ button.loading {
 }
 .section h2 {
 	font-size: 20px;
-	margin-bottom: 7px;
+	margin-bottom: 12px;
 }
 .section h3 {
 	font-size: 16px;


### PR DESCRIPTION
Before, the content below stuck too much to the header. This fixes that.

Please review @owncloud/designers
