### PR TITLE
Clear enabled apps cache after loading authentication app

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -93,6 +93,13 @@ class OC_App {
 				throw new \OC\NeedsUpdateException();
 			}
 			require_once $app . '/appinfo/app.php';
+			if (self::isType($app, array('authentication'))) {
+				// since authentication apps affect the "is app enabled for group" check,
+				// the enabled apps cache needs to be cleared to make sure that the
+				// next time getEnableApps() is called it will also include apps that were
+				// enabled for groups
+				self::$enabledAppsCache = array();
+			}
 		}
 	}
 


### PR DESCRIPTION
Since getEnabledApps() depends on an authentication app to be loaded,
especially in the case of LDAP, the cache from getEnabledApps() is now
cleared to make sure that subsequent calls will properly return apps
that were enabled for groups.
This is because getEnabledApps() uses the inGroups() function from the
group manager provided by LDAP or any other authentication app.

Fixes https://github.com/owncloud/core/issues/11484

TODO
- [ ] add unit tests
