### PR TITLE
Log warning when no uid was found for user

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -283,6 +283,10 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$uid = $userDN;
 		} else if(strtolower($this->access->connection->ldapGroupMemberAssocAttr) === 'memberuid') {
 			$result = $this->access->readAttribute($userDN, 'uid');
+			if ($result === false) {
+				\OCP\Util::writeLog('user_ldap', 'No uid attribute found for DN ' . $userDN . ' on '.
+					$this->access->connection->ldapHost, \OCP\Util::DEBUG);
+			}
 			$uid = $result[0];
 		} else {
 			// just in case


### PR DESCRIPTION
In some incomplete setups (like mine) it can happen that the uid
attribute of users is missing.

To be able to find out that something is wrong, a debug message is now
logged when it has not been found.

To test:
1) Create a user but omit the "uid" attribute (I had "cn" set and did not know I had to set "uid" as well)
2) Add that user in a LDAP group and make sure the group memberships are visible in OC
3) Go to the admin page
4) Exclude the user's group from sharing
5) Refresh the page

Before this PR: no warnings message
After this PR: a warning message appears in the log (debug level)

Note that "exclude user group from sharing" does not work when uid is not set, but this is not ownCloud's fault.

@blizzz 
