### PR TITLE
Urlencode file name before passing it to cURL

### DIFF
--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -101,7 +101,8 @@ class LargeFileHelper {
 	*/
 	public function getFileSizeViaCurl($filename) {
 		if (function_exists('curl_init')) {
-			$ch = curl_init("file://$filename");
+			$fencoded = urlencode($filename);
+			$ch = curl_init("file://$fencoded");
 			curl_setopt($ch, CURLOPT_NOBODY, true);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_HEADER, true);


### PR DESCRIPTION
Large file helper use cURL to determine file sizes. Thus filenames must be
urlencoded in case special symbols like '#' can cause BadRequest errors.

Signed-off-by: Tony Zelenoff antonz@parallels.com
