### PR TITLE
Allow separate templates for internal and external share notifications

### DIFF
--- a/core/templates/internalaltmail.php
+++ b/core/templates/internalaltmail.php
@@ -1,0 +1,13 @@
+<?php
+print_unescaped($l->t("Hey there,\n\njust letting you know that %s shared %s with you.\nView it: %s\n\n", array($_['user_displayname'], $_['filename'], $_['link'])));
+if ( isset($_['expiration']) ) {
+	print_unescaped($l->t("The share will expire on %s.", array($_['expiration'])));
+	print_unescaped("\n\n");
+}
+// TRANSLATORS term at the end of a mail
+p($l->t("Cheers!"));
+?>
+
+--
+<?php p($theme->getName() . ' - ' . $theme->getSlogan()); ?>
+<?php print_unescaped("\n".$theme->getBaseUrl());

--- a/core/templates/internalmail.php
+++ b/core/templates/internalmail.php
@@ -1,0 +1,39 @@
+<table cellspacing="0" cellpadding="0" border="0" width="100%">
+<tr><td>
+<table cellspacing="0" cellpadding="0" border="0" width="600px">
+<tr>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
+<img src="<?php p(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+</td>
+</tr>
+<tr><td colspan="2">&nbsp;</td></tr>
+<tr>
+<td width="20px">&nbsp;</td>
+<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+<?php
+print_unescaped($l->t('Hey there,<br><br>just letting you know that %s shared <strong>%s</strong> with you.<br><a href="%s">View it!</a><br><br>', array($_['user_displayname'], $_['filename'], $_['link'])));
+if ( isset($_['expiration']) ) {
+	p($l->t("The share will expire on %s.", array($_['expiration'])));
+	print_unescaped('<br><br>');
+}
+// TRANSLATORS term at the end of a mail
+p($l->t('Cheers!'));
+?>
+</td>
+</tr>
+<tr><td colspan="2">&nbsp;</td></tr>
+<tr>
+<td width="20px">&nbsp;</td>
+<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
+<?php p($theme->getName()); ?> -
+<?php p($theme->getSlogan()); ?>
+<br><a href="<?php p($theme->getBaseUrl()); ?>"><?php p($theme->getBaseUrl());?></a>
+</td>
+</tr>
+<tr>
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+</td></tr>
+</table>

--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -136,7 +136,7 @@ class MailNotifications {
 
 			$link = \OCP\Util::linkToAbsolute('files', 'index.php', $args);
 
-			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration);
+			list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, 'internal');
 
 			// send it out now
 			try {
@@ -210,20 +210,20 @@ class MailNotifications {
 	 * @param string $filename the shared file
 	 * @param string $link link to the shared file
 	 * @param int $expiration expiration date (timestamp)
+	 * @param bool $prefix prefix of mail template files
 	 * @return array an array of the html mail body and the plain text mail body
 	 */
-	private function createMailBody($filename, $link, $expiration) {
-
+	private function createMailBody($filename, $link, $expiration, $prefix = '') {
 		$formattedDate = $expiration ? $this->l->l('date', $expiration) : null;
 
-		$html = new \OC_Template("core", "mail", "");
+		$html = new \OC_Template('core', $prefix . 'mail', '');
 		$html->assign ('link', $link);
 		$html->assign ('user_displayname', $this->senderDisplayName);
 		$html->assign ('filename', $filename);
 		$html->assign('expiration',  $formattedDate);
 		$htmlMail = $html->fetchPage();
 
-		$plainText = new \OC_Template("core", "altmail", "");
+		$plainText = new \OC_Template('core', $prefix . 'altmail', '');
 		$plainText->assign ('link', $link);
 		$plainText->assign ('user_displayname', $this->senderDisplayName);
 		$plainText->assign ('filename', $filename);


### PR DESCRIPTION
This pr adds the ability to have separate templates for internal and external share notification emails. The templates are just duplicates of the existing mail.php and altmail.php templates at this stage so as to avoid altering the functionality of existing deployments. But they can be customised by themes.

In our test implementation we have set the text for internal notifications to direct users to their local ownCloud folder instead of a hyperlink. We found the link caused confusion resulting in the belief that shared content wasn't syncing locally. It was syncing, just so well that they didn't notice.
