### PR TITLE
Page size calculation based on real page height

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -49,8 +49,10 @@
 		fileSummary: null,
 		initialized: false,
 
-		// number of files per page
-		pageSize: 20,
+		// number of files per page, calculated dynamically
+		pageSize: function() {
+			return Math.ceil($('#app-content').height() / 50);
+		},
 
 		/**
 		 * Array of files in the current folder.
@@ -496,7 +498,7 @@
 		 */
 		_nextPage: function(animate) {
 			var index = this.$fileList.children().length,
-				count = this.pageSize,
+				count = this.pageSize(),
 				tr,
 				fileData,
 				newTrs = [],
@@ -1189,7 +1191,7 @@
 			// if there are less elements visible than one page
 			// but there are still pending elements in the array,
 			// then directly append the next page
-			if (lastIndex < this.files.length && lastIndex < this.pageSize) {
+			if (lastIndex < this.files.length && lastIndex < this.pageSize()) {
 				this._nextPage(true);
 			}
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -51,7 +51,7 @@
 
 		// number of files per page, calculated dynamically
 		pageSize: function() {
-			return Math.ceil($('#app-content').height() / 50);
+			return Math.ceil(this.$el.height() / 50);
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -51,7 +51,7 @@
 
 		// number of files per page, calculated dynamically
 		pageSize: function() {
-			return Math.ceil(this.$el.parent().height() / 50);
+			return Math.ceil(this.$container.height() / 50);
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -51,7 +51,7 @@
 
 		// number of files per page, calculated dynamically
 		pageSize: function() {
-			return Math.ceil(this.$el.height() / 50);
+			return Math.ceil(this.$el.parent().height() / 50);
 		},
 
 		/**

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -350,7 +350,7 @@ var createDragShadow = function(event) {
 	}
 
 	// do not show drag shadow for too many files
-	var selectedFiles = _.first(FileList.getSelectedFiles(), FileList.pageSize);
+	var selectedFiles = _.first(FileList.getSelectedFiles(), FileList.pageSize());
 	selectedFiles = _.sortBy(selectedFiles, FileList._fileInfoCompare);
 
 	if (!isDragSelected && selectedFiles.length === 1) {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -120,7 +120,7 @@ describe('OCA.Files.FileList tests', function() {
 			size: 250,
 			etag: '456'
 		}];
-		pageSizeStub = sinon.stub(OCA.File.FileList.prototype, 'pageSize').returns(20);
+		pageSizeStub = sinon.stub(OCA.Files.FileList.prototype, 'pageSize').returns(20);
 		fileList = new OCA.Files.FileList($('#app-content-files'));
 	});
 	afterEach(function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -20,7 +20,7 @@
 */
 
 describe('OCA.Files.FileList tests', function() {
-	var testFiles, alertStub, notificationStub, fileList;
+	var testFiles, alertStub, notificationStub, fileList, pageSizeStub;
 	var bcResizeStub;
 
 	/**
@@ -120,7 +120,7 @@ describe('OCA.Files.FileList tests', function() {
 			size: 250,
 			etag: '456'
 		}];
-
+		pageSizeStub = sinon.stub(OCA.File.FileList.prototype, 'pageSize').returns(20);
 		fileList = new OCA.Files.FileList($('#app-content-files'));
 	});
 	afterEach(function() {
@@ -130,6 +130,7 @@ describe('OCA.Files.FileList tests', function() {
 		notificationStub.restore();
 		alertStub.restore();
 		bcResizeStub.restore();
+		pageSizeStub.restore();
 	});
 	describe('Getters', function() {
 		it('Returns the current directory', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -815,7 +815,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.$fileList.on('fileActionsReady', handler);
 			fileList._nextPage();
 			expect(handler.calledOnce).toEqual(true);
-			expect(handler.getCall(0).args[0].$files.length).toEqual(fileList.pageSize);
+			expect(handler.getCall(0).args[0].$files.length).toEqual(fileList.pageSize());
 		});
 		it('does not trigger "fileActionsReady" event after single add with silent argument', function() {
 			var handler = sinon.stub();


### PR DESCRIPTION
This is fix for https://github.com/owncloud/core/issues/10060
Instead of hard coding page size as 20 items, we check real page height, and divide by 50 (height of one row).
This will allow to load fewer items on small screens and enough items on large screens (4k, portrait orientation, etc.).
Also checking page height on every load to respond on browser window resizing,
