### PR TITLE
Fixed array detection on public download

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -114,7 +114,7 @@ if (isset($path)) {
 			$files = $_GET['files'];
 			$files_list = json_decode($files);
 			// in case we get only a single file
-			if ($files_list === NULL ) {
+			if (!is_array($files_list)) {
 				$files_list = array($files);
 			}
 			OC_Files::get($path, $files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD');


### PR DESCRIPTION
When downloading a folder called "0001" PHP should fallback to parsing
it as string and properly detect that it is not a JSON array.

Fixes https://github.com/owncloud/core/issues/11425

Please review @schiesbn @MorrisJobke @zlydk @icewind1991 
