### PR TITLE
Use the cached fileinfo to get creatable permissions

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -84,7 +84,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node
 	 * @return void
 	 */
 	public function createDirectory($name) {
-		if (!$this->fileView->isCreatable($this->path)) {
+		if (!$this->info->isCreatable()) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 


### PR DESCRIPTION
Saves having to get the info from the storage backend.

cc @DeepDiver1975 @PVince81 
