### PR TITLE
Only mount the storages for the user once

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -45,6 +45,7 @@ class Filesystem {
 	 */
 	static private $defaultInstance;
 
+	static private $usersSetup = array();
 
 	/**
 	 * classname which used for hooks handling
@@ -321,7 +322,10 @@ class Filesystem {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
-		$parser = new \OC\ArrayParser();
+		if (isset(self::$usersSetup[$user])) {
+			return;
+		}
+		self::$usersSetup[$user] = true;
 
 		$root = \OC_User::getHome($user);
 

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -431,6 +431,7 @@ class Filesystem {
 	 */
 	public static function clearMounts() {
 		if (self::$mounts) {
+			self::$usersSetup = array();
 			self::$mounts->clear();
 		}
 	}


### PR DESCRIPTION
`Filesystem::initMountPoints()` is called in various places to get the filesystem loaded for sharing.

Currently every time the method is called the mount for the user will be overwritten by new instances of the storage which causes an overhead in case of external storage (having to re-initialize the connection), messes with the locking wrapper(a new instance will be created and the old one, holding any open locks is thrown away) and probably breaks some more assumptions regarding storages and storage wrappers.

This adds a basic check to make sure we only setup the mount points for each user once

cc @DeepDiver1975 @PVince81 @th3fallen 
