### PR TITLE
Unset the cached active user when using a different session object

### DIFF
--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -91,8 +91,8 @@ class Session implements IUserSession, Emitter {
 		// fetch the deprecated \OC::$session if it changed for backwards compatibility
 		if (isset(\OC::$session) && \OC::$session !== $this->session) {
 			\OC::$server->getLogger()->warning(
-				'One of your installed apps still seems to use the deprecated '.
-				'\OC::$session and has replaced it with a new instance. Please file a bug against it.'.
+				'One of your installed apps still seems to use the deprecated ' .
+				'\OC::$session and has replaced it with a new instance. Please file a bug against it.' .
 				'Closing and replacing session in UserSession instance.'
 			);
 			$this->setSession(\OC::$session);
@@ -110,6 +110,7 @@ class Session implements IUserSession, Emitter {
 			$this->session->close();
 		}
 		$this->session = $session;
+		$this->activeUser = null;
 
 		// maintain deprecated \OC::$session
 		if (\OC::$session !== $this->session) {
@@ -195,7 +196,7 @@ class Session implements IUserSession, Emitter {
 	public function login($uid, $password) {
 		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
 		$user = $this->manager->checkPassword($uid, $password);
-		if($user !== false) {
+		if ($user !== false) {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
 					$this->setUser($user);
@@ -221,7 +222,7 @@ class Session implements IUserSession, Emitter {
 	public function loginWithCookie($uid, $currentToken) {
 		$this->manager->emit('\OC\User', 'preRememberedLogin', array($uid));
 		$user = $this->manager->get($uid);
-		if(is_null($user)) {
+		if (is_null($user)) {
 			// user does not exist
 			return false;
 		}
@@ -229,7 +230,7 @@ class Session implements IUserSession, Emitter {
 		// get stored tokens
 		$tokens = \OC_Preferences::getKeys($uid, 'login_token');
 		// test cookies token against stored tokens
-		if(!in_array($currentToken, $tokens, true)) {
+		if (!in_array($currentToken, $tokens, true)) {
 			return false;
 		}
 		// replace successfully used token with a new one
@@ -275,13 +276,13 @@ class Session implements IUserSession, Emitter {
 		unset($_COOKIE["oc_username"]); //TODO: DI
 		unset($_COOKIE["oc_token"]);
 		unset($_COOKIE["oc_remember_login"]);
-		setcookie('oc_username', '', time()-3600, \OC::$WEBROOT);
-		setcookie('oc_token', '', time()-3600, \OC::$WEBROOT);
-		setcookie('oc_remember_login', '', time()-3600, \OC::$WEBROOT);
+		setcookie('oc_username', '', time() - 3600, \OC::$WEBROOT);
+		setcookie('oc_token', '', time() - 3600, \OC::$WEBROOT);
+		setcookie('oc_remember_login', '', time() - 3600, \OC::$WEBROOT);
 		// old cookies might be stored under /webroot/ instead of /webroot
 		// and Firefox doesn't like it!
-		setcookie('oc_username', '', time()-3600, \OC::$WEBROOT . '/');
-		setcookie('oc_token', '', time()-3600, \OC::$WEBROOT . '/');
-		setcookie('oc_remember_login', '', time()-3600, \OC::$WEBROOT . '/');
+		setcookie('oc_username', '', time() - 3600, \OC::$WEBROOT . '/');
+		setcookie('oc_token', '', time() - 3600, \OC::$WEBROOT . '/');
+		setcookie('oc_remember_login', '', time() - 3600, \OC::$WEBROOT . '/');
 	}
 }

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -9,6 +9,9 @@
 
 namespace Test\User;
 
+use OC\Session\Memory;
+use OC\User\User;
+
 class Session extends \PHPUnit_Framework_TestCase {
 	public function testGetUser() {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
@@ -54,26 +57,26 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
 		$session->expects($this->exactly(2))
 			->method('set')
-			->with($this->callback(function($key) {
-						switch($key) {
-							case 'user_id':
-							case 'loginname':
-								return true;
-								break;
-							default:
-								return false;
-								break;
-						}
-					},
-					'foo'));
+			->with($this->callback(function ($key) {
+					switch ($key) {
+						case 'user_id':
+						case 'loginname':
+							return true;
+							break;
+						default:
+							return false;
+							break;
+					}
+				},
+				'foo'));
 
 		$managerMethods = get_class_methods('\OC\User\Manager');
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -110,9 +113,9 @@ class Session extends \PHPUnit_Framework_TestCase {
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -145,9 +148,9 @@ class Session extends \PHPUnit_Framework_TestCase {
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -192,23 +195,23 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$session = $this->getMock('\OC\Session\Memory', array(), array(''));
 		$session->expects($this->exactly(1))
 			->method('set')
-			->with($this->callback(function($key) {
-						switch($key) {
-							case 'user_id':
-								return true;
-							default:
-								return false;
-						}
-					},
-					'foo'));
+			->with($this->callback(function ($key) {
+					switch ($key) {
+						case 'user_id':
+							return true;
+						default:
+							return false;
+					}
+				},
+				'foo'));
 
 		$managerMethods = get_class_methods('\OC\User\Manager');
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -254,9 +257,9 @@ class Session extends \PHPUnit_Framework_TestCase {
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -296,9 +299,9 @@ class Session extends \PHPUnit_Framework_TestCase {
 		//keep following methods intact in order to ensure hooks are
 		//working
 		$doNotMock = array('__construct', 'emit', 'listen');
-		foreach($doNotMock as $methodName) {
+		foreach ($doNotMock as $methodName) {
 			$i = array_search($methodName, $managerMethods, true);
-			if($i !== false) {
+			if ($i !== false) {
 				unset($managerMethods[$i]);
 			}
 		}
@@ -326,5 +329,32 @@ class Session extends \PHPUnit_Framework_TestCase {
 		$granted = $userSession->loginWithCookie('foo', $token);
 
 		$this->assertSame($granted, false);
+	}
+
+	public function testActiveUserAfterSetSession() {
+		$users = array(
+			'foo' => new User('foo', null),
+			'bar' => new User('bar', null)
+		);
+
+		$manager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$manager->expects($this->any())
+			->method('get')
+			->will($this->returnCallback(function ($uid) use ($users) {
+				return $users[$uid];
+			}));
+
+		$session = new Memory('');
+		$session->set('user_id', 'foo');
+		$userSession = new \OC\User\Session($manager, $session);
+		$this->assertEquals($users['foo'], $userSession->getUser());
+
+		$session2 = new Memory('');
+		$session2->set('user_id', 'bar');
+		$userSession->setSession($session2);
+		$this->assertEquals($users['bar'], $userSession->getUser());
 	}
 }


### PR DESCRIPTION
When changing the current session, the cached active user is no longer valid.

cc @DeepDiver1975 @PVince81 
