### PR TITLE
Close session when loading apps

### DIFF
--- a/settings/apps.php
+++ b/settings/apps.php
@@ -22,6 +22,7 @@
 */
 
 OC_Util::checkAdminUser();
+\OC::$server->getSession()->close();
 
 // Load the files we need
 OCP\Util::addStyle('settings', 'settings' );


### PR DESCRIPTION
Otherwise the session is blocked while all remote apps are loaded. This can be very annoying especially when apps.owncloud.com is down or not reachable.

@karlitschek Might be worth backporting to stable7.
