### PR TITLE
Retrieve storage numeric id earlier when still available

### DIFF
--- a/lib/private/files/cache/storage.php
+++ b/lib/private/files/cache/storage.php
@@ -105,10 +105,10 @@ class Storage {
 	 */
 	public static function remove($storageId) {
 		$storageId = self::adjustStorageId($storageId);
+		$numericId = self::getNumericStorageId($storageId);
 		$sql = 'DELETE FROM `*PREFIX*storages` WHERE `id` = ?';
 		\OC_DB::executeAudited($sql, array($storageId));
 
-		$numericId = self::getNumericStorageId($storageId);
 		if (!is_null($numericId)) {
 			$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?';
 			\OC_DB::executeAudited($sql, array($numericId));


### PR DESCRIPTION
The numeric id is only available before the storage entry is deleted, so
get it at that time.

Fixes https://github.com/owncloud/core/issues/11545

Please review @icewind1991 @MorrisJobke @LukasReschke 
