### PR TITLE
Allow specifying protocol in ext storage OC config

### DIFF
--- a/apps/files_external/lib/owncloud.php
+++ b/apps/files_external/lib/owncloud.php
@@ -22,6 +22,14 @@ class OwnCloud extends \OC\Files\Storage\DAV{
 		// extract context path from host if specified
 		// (owncloud install path on host)
 		$host = $params['host'];
+		// strip protocol
+		if (substr($host, 0, 8) == "https://") {
+			$host = substr($host, 8);
+			$params['secure'] = true;
+		} else if (substr($host, 0, 7) == "http://") {
+			$host = substr($host, 7);
+			$params['secure'] = false;
+		}
 		$contextPath = '';
 		$hostSlashPos = strpos($host, '/');
 		if ($hostSlashPos !== false){

--- a/apps/files_external/tests/owncloudfunctions.php
+++ b/apps/files_external/tests/owncloudfunctions.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Files\Storage;
+
+class OwnCloudFunctions extends \PHPUnit_Framework_TestCase {
+
+	function configUrlProvider() {
+		return array(
+			array(
+				array(
+					'host' => 'testhost',
+					'root' => 'testroot',
+					'secure' => false
+				),
+				'http://testhost/remote.php/webdav/testroot/',
+			),
+			array(
+				array(
+					'host' => 'testhost',
+					'root' => 'testroot',
+					'secure' => true
+				),
+				'https://testhost/remote.php/webdav/testroot/',
+			),
+			array(
+				array(
+					'host' => 'http://testhost',
+					'root' => 'testroot',
+					'secure' => false
+				),
+				'http://testhost/remote.php/webdav/testroot/',
+			),
+			array(
+				array(
+					'host' => 'https://testhost',
+					'root' => 'testroot',
+					'secure' => false
+				),
+				'https://testhost/remote.php/webdav/testroot/',
+			),
+			array(
+				array(
+					'host' => 'https://testhost/testroot',
+					'root' => '',
+					'secure' => false
+				),
+				'https://testhost/testroot/remote.php/webdav/',
+			),
+			array(
+				array(
+					'host' => 'https://testhost/testroot',
+					'root' => 'subdir',
+					'secure' => false
+				),
+				'https://testhost/testroot/remote.php/webdav/subdir/',
+			),
+			array(
+				array(
+					'host' => 'http://testhost/testroot',
+					'root' => 'subdir',
+					'secure' => true
+				),
+				'http://testhost/testroot/remote.php/webdav/subdir/',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider configUrlProvider
+	 */
+	public function testConfig($config, $expectedUri) {
+		$config['user'] = 'someuser';
+		$config['password'] = 'somepassword';
+		$instance = new \OC\Files\Storage\OwnCloud($config);
+		$this->assertEquals($expectedUri, $instance->createBaseUri());
+	}
+}

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -58,7 +58,7 @@ class DAV extends \OC\Files\Storage\Common {
 				$this->root .= '/';
 			}
 		} else {
-			throw new \Exception();
+			throw new \Exception('Invalid webdav storage configuration');
 		}
 	}
 
@@ -85,7 +85,7 @@ class DAV extends \OC\Files\Storage\Common {
 		return 'webdav::' . $this->user . '@' . $this->host . '/' . $this->root;
 	}
 
-	protected function createBaseUri() {
+	public function createBaseUri() {
 		$baseUri = 'http';
 		if ($this->secure) {
 			$baseUri .= 's';


### PR DESCRIPTION
Allow specifying a protocol in the host field when mounting another
ownCloud instance. Note that this was already possible with the WebDAV
config but this bug made it inconsistent.

Fixes https://github.com/owncloud/core/issues/11360

Please review @jnfrmarks @icewind1991 @MorrisJobke @DeepDiver1975 
