### PR TITLE
Add darwin to if block

### DIFF
--- a/lib/private/largefilehelper.php
+++ b/lib/private/largefilehelper.php
@@ -151,7 +151,7 @@ class LargeFileHelper {
 			$result = null;
 			if (strpos($os, 'linux') !== false) {
 				$result = $this->exec("stat -c %s $arg");
-			} else if (strpos($os, 'bsd') !== false) {
+			} else if (strpos($os, 'bsd') !== false || strpos($os, 'darwin') !== false) {
 				$result = $this->exec("stat -f %z $arg");
 			} else if (strpos($os, 'win') !== false) {
 				$result = $this->exec("for %F in ($arg) do @echo %~zF");


### PR DESCRIPTION
Otherwise it would fall into the 'win' else block because strpos($os, 'win') does also match 'darwin' which is the `php_uname` for OS X.

@georgehrke @th3fallen @tomneedham To test just run the `largefilehelpergetfilesize.php` tests.

@bantu FYI
