### PR TITLE
return true in isHtaccessWorking when on CLI and no overwrite.cli.url has been configured

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -986,7 +986,9 @@ class OC_Util {
 	 * file in the data directory and trying to access via http
 	 */
 	public static function isHtaccessWorking() {
-		if (!OC::$server->getConfig()->getSystemValue('check_for_working_htaccess', true)) {
+		if (!OC::$server->getConfig()->getSystemValue('check_for_working_htaccess', true)
+			|| (\OC::$CLI && OC::$server->getConfig()->getSystemValue('overwrite.cli.url', false) !== false)
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
fixes cli installation when running travis tests, otherwise an exception like this is thrown

```
#0 /home/jfd/Repositories/oc/core/lib/private/util.php(1161): OC\HTTPHelper-&gt;getUrlContent(&#039;/data/htaccesst...&#039;)
#1 /home/jfd/Repositories/oc/core/lib/private/util.php(1014): OC_Util::getUrlContent(&#039;/data/htaccesst...&#039;)
#2 /home/jfd/Repositories/oc/core/core/setup/controller.php(128): OC_Util::isHtaccessWorking()
#3 /home/jfd/Repositories/oc/core/core/setup/controller.php(15): OC\Core\Setup\Controller-&gt;getSystemInfo()
#4 /home/jfd/Repositories/oc/core/lib/base.php(711): OC\Core\Setup\Controller-&gt;run(Array)
#5 /home/jfd/Repositories/oc/core/index.php(28): OC::handleRequest()
#6 {main}
```

see eg. https://travis-ci.org/owncloud/activity/jobs/37903932#L190

the `overwrite.cli.url` param is only configured after the check is made during installation.

cc @DeepDiver1975 
