### PR TITLE
Propagate etag changes when the watcher finds a changed file

### DIFF
--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -30,6 +30,11 @@ class Updater {
 		$this->propagator = new ChangePropagator($view);
 	}
 
+	public function propagate($path, $time = null) {
+		$this->propagator->addChange($path);
+		$this->propagator->propagateChanges($time);
+	}
+
 	/**
 	 * Update the cache for $path
 	 *

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -903,6 +903,7 @@ class View {
 				$scanner->scan($internalPath, Cache\Scanner::SCAN_SHALLOW);
 				$data = $cache->get($internalPath);
 			} else if ($watcher->checkUpdate($internalPath, $data)) {
+				$this->updater->propagate($path);
 				$data = $cache->get($internalPath);
 			}
 
@@ -974,6 +975,7 @@ class View {
 				$scanner->scan($internalPath, Cache\Scanner::SCAN_SHALLOW);
 				$data = $cache->get($internalPath);
 			} else if ($watcher->checkUpdate($internalPath, $data)) {
+				$this->updater->propagate($path);
 				$data = $cache->get($internalPath);
 			}
 


### PR DESCRIPTION
Depends on #11409 

Currently when a file is changed directly on an external filesystem and the change is detected, the etag isn't properly propagated to the root.

cc @PVince81 @DeepDiver1975 
