### PR TITLE
Use body element when animating scroll in public page

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1919,7 +1919,13 @@
 
 			// Animation
 			var _this = this;
-			this.$container.animate({
+			var $scrollContainer = this.$container;
+			if ($scrollContainer[0] === window) {
+				// need to use "body" to animate scrolling
+				// when the scroll container is the window
+				$scrollContainer = $('body');
+			}
+			$scrollContainer.animate({
 				// Scrolling to the top of the new element
 				scrollTop: currentOffset + $fileRow.offset().top - $fileRow.height() * 2 - additionalOffset
 			}, {


### PR DESCRIPTION
In the public page the scroll container is the window instead of a div.
The $(window) object doesn't support animating the scroll property, so
the $('body') element is used instead.

Fixes https://github.com/owncloud/core/issues/11589

Please review @icewind1991 @MorrisJobke @schiesbn @jancborchardt 
