### PR TITLE
Add app version to JS and CSS

### DIFF
--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -14,6 +14,8 @@ use Assetic\Filter\CssImportFilter;
 
 class OC_TemplateLayout extends OC_Template {
 
+	private static $versionHash = '';
+
 	/**
 	 * @param string $renderas
 	 * @param string $appid application id
@@ -70,26 +72,25 @@ class OC_TemplateLayout extends OC_Template {
 			parent::__construct('core', 'layout.base');
 		}
 
-		$versionParameter = '?v=' . md5(implode(OC_Util::getVersion()));
+		if(empty(self::$versionHash)) {
+			self::$versionHash = md5(implode(',', OC_App::getAppVersions()));
+		}
+		
 		$useAssetPipeline = $this->isAssetPipelineEnabled();
 		if ($useAssetPipeline) {
-
-			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config') . $versionParameter);
-
+			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config', array('v' => self::$versionHash)));
 			$this->generateAssets();
-
 		} else {
-
 			// Add the js files
 			$jsfiles = self::findJavascriptFiles(OC_Util::$scripts);
 			$this->assign('jsfiles', array(), false);
 			if (OC_Config::getValue('installed', false) && $renderas!='error') {
-				$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config') . $versionParameter);
+				$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config', array('v' => self::$versionHash)));
 			}
 			foreach($jsfiles as $info) {
 				$web = $info[1];
 				$file = $info[2];
-				$this->append( 'jsfiles', $web.'/'.$file . $versionParameter);
+				$this->append( 'jsfiles', $web.'/'.$file . '?v=' . self::$versionHash);
 			}
 
 			// Add the css files
@@ -99,7 +100,7 @@ class OC_TemplateLayout extends OC_Template {
 				$web = $info[1];
 				$file = $info[2];
 
-				$this->append( 'cssfiles', $web.'/'.$file . $versionParameter);
+				$this->append( 'cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
 			}
 		}
 	}

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -203,6 +203,8 @@ class OC_TemplateLayout extends OC_Template {
 		}, $files);
 
 		sort($files);
+		// include the apps' versions hash to invalidate the cached assets
+		$files[]= self::$versionHash;
 		return hash('md5', implode('', $files));
 	}
 


### PR DESCRIPTION
This leads to the regeneration of the hash in case a single application is updated. - This does not touch the Assetic Pipeline because I don't know how it works.

Fixes https://github.com/owncloud/core/issues/11374

@karlitschek Shall we backport this?
