### PR TITLE
Refer to relative path instead of absolute path

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -245,7 +245,7 @@ class OC_Request {
 	 * @return string Path info or false when not found
 	 */
 	public static function getRawPathInfo() {
-		$requestUri = $_SERVER['REQUEST_URI'];
+		$requestUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
 		// remove too many leading slashes - can be caused by reverse proxy configuration
 		if (strpos($requestUri, '/') === 0) {
 			$requestUri = '/' . ltrim($requestUri, '/');

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -157,7 +157,7 @@ class OC_TemplateLayout extends OC_Template {
 
 	public function generateAssets() {
 		$jsFiles = self::findJavascriptFiles(OC_Util::$scripts);
-		$jsHash = self::hashScriptNames($jsFiles);
+		$jsHash = self::hashFileNames($jsFiles);
 
 		if (!file_exists("assets/$jsHash.js")) {
 			$jsFiles = array_map(function ($item) {
@@ -179,7 +179,7 @@ class OC_TemplateLayout extends OC_Template {
 		}
 
 		$cssFiles = self::findStylesheetFiles(OC_Util::$styles);
-		$cssHash = self::hashScriptNames($cssFiles);
+		$cssHash = self::hashFileNames($cssFiles);
 
 		if (!file_exists("assets/$cssHash.css")) {
 			$cssFiles = array_map(function ($item) {
@@ -211,16 +211,29 @@ class OC_TemplateLayout extends OC_Template {
 	}
 
 	/**
+	 * Converts the absolute filepath to a relative path from \OC::$SERVERROOT
+	 * @param string $filePath Absolute path
+	 * @return string Relative path
+	 * @throws Exception If $filePath is not under \OC::$SERVERROOT
+	 */
+	public static function convertToRelativePath($filePath) {
+		$relativePath = explode(\OC::$SERVERROOT, $filePath);
+		if(count($relativePath) !== 2) {
+			throw new \Exception('$filePath is not under the \OC::$SERVERROOT');
+		}
+
+		return $relativePath[1];
+	}
+
+	/**
 	 * @param array $files
 	 * @return string
 	 */
-	private static function hashScriptNames($files) {
 
-		$files = array_map(function ($item) {
-			$root = $item[0];
-			$file = $item[2];
-			return $root . '/' . $file;
-		}, $files);
+	private static function hashFileNames($files) {
+		foreach($files as $i => $file) {
+			$files[$i] = self::convertToRelativePath($file[0]).'/'.$file[2];
+		}
 
 		sort($files);
 		// include the apps' versions hash to invalidate the cached assets

--- a/tests/lib/templatelayout.php
+++ b/tests/lib/templatelayout.php
@@ -30,6 +30,9 @@ class OC_TemplateLayout extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider validFilePathProvider
 	 */
 	public function testConvertToRelativePath($absolutePath, $expected) {
+		$_SERVER['REQUEST_URI'] = $expected;
+		$_SERVER['SCRIPT_NAME'] = '/';
+
 		$relativePath = \Test_Helper::invokePrivate(new \OC_TemplateLayout('user'), 'convertToRelativePath', array($absolutePath));
 		$this->assertEquals($expected, $relativePath);
 	}
@@ -39,6 +42,10 @@ class OC_TemplateLayout extends \PHPUnit_Framework_TestCase {
 	 * @expectedExceptionMessage $filePath is not under the \OC::$SERVERROOT
 	 */
 	public function testInvalidConvertToRelativePath() {
-		\Test_Helper::invokePrivate(new \OC_TemplateLayout('user'), 'convertToRelativePath', array('/this/file/is/invalid'));
+		$invalidFile = '/this/file/is/invalid';
+		$_SERVER['REQUEST_URI'] = $invalidFile;
+		$_SERVER['SCRIPT_NAME'] = '/';
+
+		\Test_Helper::invokePrivate(new \OC_TemplateLayout('user'), 'convertToRelativePath', array($invalidFile));
 	}
 }

--- a/tests/lib/templatelayout.php
+++ b/tests/lib/templatelayout.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2014 Lukas Reschke <lukas@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Test;
+
+/**
+ * @package OC\Test
+ */
+class OC_TemplateLayout extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Contains valid file paths in the scheme array($absolutePath, $expectedPath)
+	 * @return array
+	 */
+	public function validFilePathProvider() {
+		return array(
+			array(\OC::$SERVERROOT . '/apps/files/js/fancyJS.js', '/apps/files/js/fancyJS.js'),
+			array(\OC::$SERVERROOT. '/test.js', '/test.js'),
+			array(\OC::$SERVERROOT . '/core/test.js', '/core/test.js'),
+			array(\OC::$SERVERROOT, ''),
+		);
+	}
+
+	/**
+	 * @dataProvider validFilePathProvider
+	 */
+	public function testConvertToRelativePath($absolutePath, $expected) {
+		$relativePath = \Test_Helper::invokePrivate(new \OC_TemplateLayout('user'), 'convertToRelativePath', array($absolutePath));
+		$this->assertEquals($expected, $relativePath);
+	}
+
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage $filePath is not under the \OC::$SERVERROOT
+	 */
+	public function testInvalidConvertToRelativePath() {
+		\Test_Helper::invokePrivate(new \OC_TemplateLayout('user'), 'convertToRelativePath', array('/this/file/is/invalid'));
+	}
+}

--- a/tests/lib/templatelayout.php
+++ b/tests/lib/templatelayout.php
@@ -13,6 +13,23 @@ namespace OC\Test;
  */
 class OC_TemplateLayout extends \PHPUnit_Framework_TestCase {
 
+	private $oldServerUri;
+	private $oldScriptName;
+
+	public function setUp() {
+		$this->oldServerURI = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
+		$this->oldScriptName = $_SERVER['SCRIPT_NAME'];
+	}
+
+	public function tearDown() {
+		if ($this->oldServerURI === null) {
+			unset($_SERVER['REQUEST_URI']);
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->oldServerURI;
+		}
+		$_SERVER['SCRIPT_NAME'] = $this->oldScriptName;
+	}
+
 	/**
 	 * Contains valid file paths in the scheme array($absolutePath, $expectedPath)
 	 * @return array


### PR DESCRIPTION
There is no need to refer to the absolute path here if we can use the relative one.

@DeepDiver1975 Please take a look. THX!
@karlitschek Backport?
