### PR TITLE
strip whitespace from the beginning and end of the display name

### DIFF
--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -89,8 +89,17 @@ class User implements IUser {
 	 */
 	public function getDisplayName() {
 		if (!isset($this->displayName)) {
+			$displayName = '';
 			if ($this->backend and $this->backend->implementsActions(OC_USER_BACKEND_GET_DISPLAYNAME)) {
-				$this->displayName = $this->backend->getDisplayName($this->uid);
+				// get display name and strip whitespace from the beginning and end of it
+				$backendDisplayName = $this->backend->getDisplayName($this->uid);
+				if (is_string($backendDisplayName)) {
+					$displayName = trim($backendDisplayName);
+				}
+			}
+
+			if (!empty($displayName)) {
+				$this->displayName = $displayName;
 			} else {
 				$this->displayName = $this->uid;
 			}
@@ -105,7 +114,8 @@ class User implements IUser {
 	 * @return bool
 	 */
 	public function setDisplayName($displayName) {
-		if ($this->canChangeDisplayName()) {
+		$displayName = trim($displayName);
+		if ($this->canChangeDisplayName() && !empty($displayName)) {
 			$this->displayName = $displayName;
 			$result = $this->backend->setDisplayName($this->uid, $displayName);
 			return $result !== false;

--- a/tests/lib/user/user.php
+++ b/tests/lib/user/user.php
@@ -32,6 +32,28 @@ class User extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
 
+	/**
+	 * if the display name contain whitespaces only, we expect the uid as result
+	 */
+	public function testDisplayNameEmpty() {
+		/**
+		 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->getMock('\OC_User_Backend');
+		$backend->expects($this->once())
+			->method('getDisplayName')
+			->with($this->equalTo('foo'))
+			->will($this->returnValue('  '));
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->with($this->equalTo(\OC_USER_BACKEND_GET_DISPLAYNAME))
+			->will($this->returnValue(true));
+
+		$user = new \OC\User\User('foo', $backend);
+		$this->assertEquals('foo', $user->getDisplayName());
+	}
+
 	public function testDisplayNameNotSupported() {
 		/**
 		 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend
@@ -303,6 +325,30 @@ class User extends \PHPUnit_Framework_TestCase {
 		$user = new \OC\User\User('foo', $backend);
 		$this->assertTrue($user->setDisplayName('Foo'));
 		$this->assertEquals('Foo',$user->getDisplayName());
+	}
+
+	/**
+	 * don't allow display names containing whitespaces only
+	 */
+	public function testSetDisplayNameEmpty() {
+		/**
+		 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend
+		 */
+		$backend = $this->getMock('\OC_User_Database');
+
+		$backend->expects($this->any())
+			->method('implementsActions')
+			->will($this->returnCallback(function ($actions) {
+				if ($actions === \OC_USER_BACKEND_SET_DISPLAYNAME) {
+					return true;
+				} else {
+					return false;
+				}
+			}));
+
+		$user = new \OC\User\User('foo', $backend);
+		$this->assertFalse($user->setDisplayName(' '));
+		$this->assertEquals('foo',$user->getDisplayName());
 	}
 
 	public function testSetDisplayNameNotSupported() {


### PR DESCRIPTION
 strip whitespace from the beginning and end of the display name to avoid empty display names

If a display name stored in the database contains whitespaces only we return the uid. Before we set a new display name we check if it contains real characters, not only whitespaces.

cc @blizzz @PVince81 

fix #10817 
