### PR TITLE
Fix SVG icons

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -85,7 +85,7 @@ OCA.Sharing.PublicApp = {
 		};
 
 		var img = $('<img class="publicpreview">');
-		if (previewSupported === 'true' || mimetype.substr(0, mimetype.indexOf('/')) === 'image') {
+		if (previewSupported === 'true' || mimetype.substr(0, mimetype.indexOf('/')) === 'image' && mimetype !== 'image/svg+xml') {
 			img.attr('src', OC.filePath('files_sharing', 'ajax', 'publicpreview.php') + '?' + OC.buildQueryString(params));
 			img.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) !== 'video') {

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -786,7 +786,6 @@ class Preview {
 			return false;
 		}
 
-		//remove last element because it has the mimetype *
 		foreach(self::$providers as $supportedMimetype => $provider) {
 			if(preg_match($supportedMimetype, $mimeType)) {
 				return true;

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -776,8 +776,19 @@ class Preview {
 			self::initProviders();
 		}
 
-		foreach (self::$providers as $supportedMimeType => $provider) {
-			if (preg_match($supportedMimeType, $mimeType)) {
+		// FIXME: Ugly hack to prevent SVG of being returned if the SVG
+		// provider is not enabled.
+		// This is required because the preview system is designed in a
+		// bad way and relies on opt-in with asterisks (i.e. image/*)
+		// which will lead to the fact that a SVG will also match the image
+		// provider.
+		if($mimeType === 'image/svg+xml' && !array_key_exists('/image\/svg\+xml/', self::$providers)) {
+			return false;
+		}
+
+		//remove last element because it has the mimetype *
+		foreach(self::$providers as $supportedMimetype => $provider) {
+			if(preg_match($supportedMimetype, $mimeType)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Without this the `image/*` provider also matches `image/svg+xml` which results in a broken public sharing preview icon.

@PVince81 as discussed
