### PR TITLE
[stable7] Use certificate bundle from files_external for external shares

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -190,6 +190,11 @@ class Storage extends DAV implements ISharedStorage {
 			http_build_query(array('password' => $password)));
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+		$path = \OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
+		curl_setopt($ch, CURLOPT_CAINFO, $path);
+
 		$result = curl_exec($ch);
 
 		$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Fixes #11413 for stable7 (master has a way better fix already)

Requires the certificate the be added trough the files_external app

cc @PVince81 @DeepDiver1975 @LukasReschke 
