### PR TITLE
Add a try catch block

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1101,13 +1101,17 @@ class OC_App {
 			return $versions; // when function is used besides in checkUpgrade
 		}
 		$versions = array();
-		$query = OC_DB::prepare('SELECT `appid`, `configvalue` FROM `*PREFIX*appconfig`'
-			. ' WHERE `configkey` = \'installed_version\'');
-		$result = $query->execute();
-		while ($row = $result->fetchRow()) {
-			$versions[$row['appid']] = $row['configvalue'];
+		try {
+			$query = OC_DB::prepare('SELECT `appid`, `configvalue` FROM `*PREFIX*appconfig`'
+				. ' WHERE `configkey` = \'installed_version\'');
+			$result = $query->execute();
+			while ($row = $result->fetchRow()) {
+				$versions[$row['appid']] = $row['configvalue'];
+			}
+			return $versions;
+		} catch (\Exception $e) {
+			return array();
 		}
-		return $versions;
 	}
 
 


### PR DESCRIPTION
This function might also be called before ownCloud is setup which results in a PHP fatal error. We therefore should gracefully catch errors in there.

@butonic @PVince81 As discussed.

@karlitschek Regression due to a race condition - I'll backport this to stable7 because the concerning commit is in there since today and breaks the setup.
