### PR TITLE
fix the RST syntax of config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -551,9 +551,11 @@ $CONFIG = array(
 
 /**
  * By default, ownCloud can generate previews for the following filetypes:
- * Images files
- * Covers of MP3 files
- * Text documents
+ *
+ * - Images files
+ * - Covers of MP3 files
+ * - Text documents
+ *
  * Valid values are ``true``, to enable previews, or
  * ``false``, to disable previews
  */


### PR DESCRIPTION
With this the latest fixes for the config.sample.php -> doc generation are fixed.

cc @LukasReschke @wakeup @carlaschroder 

The result is already in documentation repo and provide a working syntax of the RST file: owncloud/documentation@12f2b5cb249a48003b7af788bcdcc7de4535dfbe

@karlitschek This also needs a backport to stable7
