### PR TITLE
Encapsulate require_once to avoid name space bleedind

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -92,7 +92,7 @@ class OC_App {
 			if ($checkUpgrade and self::shouldUpgrade($app)) {
 				throw new \OC\NeedsUpdateException();
 			}
-			require_once $app . '/appinfo/app.php';
+			self::requireAppFile($app);
 			if (self::isType($app, array('authentication'))) {
 				// since authentication apps affect the "is app enabled for group" check,
 				// the enabled apps cache needs to be cleared to make sure that the
@@ -101,6 +101,16 @@ class OC_App {
 				self::$enabledAppsCache = array();
 			}
 		}
+	}
+
+	/**
+	 * Load app.php from the given app
+	 *
+	 * @param string $app app name
+	 */
+	private static function requireAppFile($app) {
+		// encapsulated here to avoid variable scope conflicts
+		require_once $app . '/appinfo/app.php';
 	}
 
 	/**


### PR DESCRIPTION
The script required by require_once might use variable names like $app
which will conflict with the code that follows.

This fix encapsulates require_once into its own function to avoid such
issues.

Fixes https://github.com/owncloud/core/issues/11553

Please review/test @MorrisJobke @DeepDiver1975 @mmattel @kedanli 
