### PR TITLE
Expose syslog tag in the configuration

### DIFF
--- a/lib/private/log/syslog.php
+++ b/lib/private/log/syslog.php
@@ -19,7 +19,7 @@ class OC_Log_Syslog {
 	 * Init class data
 	 */
 	public static function init() {
-		openlog('ownCloud', LOG_PID | LOG_CONS, LOG_USER);
+		openlog(OC_Config::getValue("syslog_tag", "ownCloud"), LOG_PID | LOG_CONS, LOG_USER);
 		// Close at shutdown
 		register_shutdown_function('closelog');
 	}


### PR DESCRIPTION
Currently the syslog tag is hard-coded to "ownCloud" in lib/private/log/syslog.php. If you are running different instances, you may want to distinguish between them.

This POC patch adds the configuration keyword "syslog_tag". It falls back to "ownCloud", if not specified. Its value probably requires some kind of validation!
