### PR TITLE
adjust autocomplete behavior for sharing menu

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -444,7 +444,7 @@ OC.Share={
 					}
 				});
 			}
-			$('#shareWith').autocomplete({minLength: 1, source: function(search, response) {
+			$('#shareWith').autocomplete({minLength: 2, delay: 750, source: function(search, response) {
 				var $loading = $('#dropdown .shareWithLoading');
 				$loading.removeClass('hidden');
 				$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term, itemShares: OC.Share.itemShares }, function(result) {


### PR DESCRIPTION
To improve user experience and eliminate unnecessary server requests, we should adjust the settings of the autocomplete field.
