### PR TITLE
rework getFileSize

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -385,7 +385,7 @@ class Util {
 			&& $this->isEncryptedPath($path)
 		) {
 
-			$cipher = Helper::getCipher();
+			$cipher = 'AES-128-CFB';
 			$realSize = 0;
 
 			// get the size from filesystem

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -439,6 +439,7 @@ class Util {
 				$relPath = \OCA\Encryption\Helper::stripUserFilesPath($path);
 				$shareKey = Keymanager::getShareKey($this->view, $this->keyId, $this, $relPath);
 				if($shareKey===false) {
+					\OC_FileProxy::$enabled = $proxyStatus;
 					return $result;
 				}
 				$session = new \OCA\Encryption\Session($this->view);

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -435,15 +435,16 @@ class Util {
 						$lastChunkContentEncrypted=substr($lastChunkContentEncrypted,Crypt::BLOCKSIZE);
 					}
 				}
-
+				fclose($stream);
 				$relPath = \OCA\Encryption\Helper::stripUserFilesPath($path);
-				$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
+				$shareKey = Keymanager::getShareKey($this->view, $this->keyId, $this, $relPath);
+				if($shareKey===false) {
+					return $result;
+				}
+				$session = new \OCA\Encryption\Session($this->view);
 				$privateKey = $session->getPrivateKey();
 				$plainKeyfile = $this->decryptKeyfile($relPath, $privateKey);
-				$shareKey = Keymanager::getShareKey($this->view, $this->keyId, $this, $relPath);
-
 				$plainKey = Crypt::multiKeyDecrypt($plainKeyfile, $shareKey, $privateKey);
-				
 				$lastChunkContent=Crypt::symmetricDecryptFileContent($lastChunkContentEncrypted, $plainKey, $cipher);
 
 				// calc the real file size with the size of the last chunk

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -398,7 +398,8 @@ class Util {
 			// we set the cipher
 			// and we update the size
 			if ($this->containHeader($path)) {
-				$header = fread($stream,Crypt::BLOCKSIZE);
+				$data = fread($stream,Crypt::BLOCKSIZE);
+				$header = Crypt::parseHeader($data);
 				$cipher = Crypt::getCipher($header);
 				$size -= Crypt::BLOCKSIZE;
 			}


### PR DESCRIPTION
I have been rewriting getFileSize with the purpose of avoiding opening the encrypted file as an encrypted stream. I will need this to avoid recursion when I rework #8390 (to make the encrypted stream seekable the unencrypted filesize is required upon opening the stream).
I used the opportunity to make the procedure more robust for a number of exotic situation, such as local streams that are non-seekable or streams that return less than 8192 bytes upon fread. That should all be covered now.
I didn't do much testing yet. It seems to work on my installation. Any feedback appreciated.
