### PR TITLE
Properly send expiration date with all share.php calls

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1859,6 +1859,7 @@ class Share extends \OC\Share\Constants {
 
 		$preHookData['itemTarget'] = ($isGroupShare) ? $groupItemTarget : $itemTarget;
 		$preHookData['shareWith'] = ($isGroupShare) ? $shareWith['group'] : $shareWith;
+		$isLinkShare = $shareType === self::SHARE_TYPE_LINK;
 
 		\OC_Hook::emit('OCP\Share', 'pre_shared', $preHookData);
 


### PR DESCRIPTION
There are three share.php calls for link shares:
- when changing password
- when setting expiration date
- when switching "allow public upload"

This fix makes sure that ALL the required info is sent for each of these
calls.

It fixes an issue where the expiration date was not passed when changing
the password.

Fixes https://github.com/owncloud/core/issues/11671

TODO:
- [x] Fix/finish failing JS unit test
