### PR TITLE
Lazy initialize external storages

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -44,6 +44,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 			$this->id = 'dropbox::'.$params['app_key'] . $params['token']. '/' . $this->root;
 			$oauth = new \Dropbox_OAuth_Curl($params['app_key'], $params['app_secret']);
 			$oauth->setToken($params['token'], $params['token_secret']);
+			// note: Dropbox_API connection is lazy
 			$this->dropbox = new \Dropbox_API($oauth, 'auto');
 		} else {
 			throw new \Exception('Creating \OC\Files\Storage\Dropbox storage failed');

--- a/apps/files_external/lib/ftp.php
+++ b/apps/files_external/lib/ftp.php
@@ -39,7 +39,7 @@ class FTP extends \OC\Files\Storage\StreamWrapper{
 				$this->root .= '/';
 			}
 		} else {
-			throw new \Exception();
+			throw new \Exception('Creating \OC\Files\Storage\FTP storage failed');
 		}
 		
 	}

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -52,6 +52,7 @@ class Google extends \OC\Files\Storage\Common {
 			$client->setScopes(array('https://www.googleapis.com/auth/drive'));
 			$client->setUseObjects(true);
 			$client->setAccessToken($params['token']);
+			// note: API connection is lazy
 			$this->service = new \Google_DriveService($client);
 			$token = json_decode($params['token'], true);
 			$this->id = 'google::'.substr($params['client_id'], 0, 30).$token['created'];


### PR DESCRIPTION
Fixed the following external storages to not connect in the constructor,
but do it on-demand when getConnection() is called.
- S3
- SWIFT
- SFTP

Prerequisite for the fix of https://github.com/owncloud/core/issues/10820

Please review/test @butonic @bantu @icewind1991 

I tested SFTP (manual+unit tests) and SWIFT (manual+unit tests against devstack) and this change did not break them.
