### PR TITLE
setup filesystem by username, not login name, fixes #11637

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -234,7 +234,7 @@ class OC_User {
 		session_regenerate_id(true);
 		$result = self::getUserSession()->login($uid, $password);
 		if ($result) {
-			OC_Util::setupFS($uid);
+			OC_Util::setupFS(self::getUserSession()->getUser()->getUID());
 		}
 		return $result;
 	}

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -224,16 +224,17 @@ class OC_User {
 
 	/**
 	 * Try to login a user
-	 * @param string $uid The username of the user to log in
+	 * @param string $loginname The login name of the user to log in
 	 * @param string $password The password of the user
 	 * @return boolean|null
 	 *
 	 * Log in a user and regenerate a new session - if the password is ok
 	 */
-	public static function login($uid, $password) {
+	public static function login($loginname, $password) {
 		session_regenerate_id(true);
-		$result = self::getUserSession()->login($uid, $password);
+		$result = self::getUserSession()->login($loginname, $password);
 		if ($result) {
+			//we need to pass the user name, which may differ from login name
 			OC_Util::setupFS(self::getUserSession()->getUser()->getUID());
 		}
 		return $result;


### PR DESCRIPTION
User names and login names may differ with other user backends. If they differ, login via webdav was broken, because the login name was passed which caused the user not to be found and setup fail.

This can be tested properly using integration tests, only.

This must get into 7.0.3!

Please review @PVince81 @icewind1991 @DeepDiver1975 @davivel

cc @craigpg @karlitschek 
