### PR TITLE
Use mixed as type

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -11,14 +11,17 @@ class SimpleContainer extends \Pimple implements \OCP\IContainer {
 
 	/**
 	 * @param string $name name of the service to query for
-	 * @return object registered service for the given $name
+	 * @return mixed registered service for the given $name
 	 */
 	public function query($name) {
 		return $this->offsetGet($name);
 	}
 
-	function registerParameter($name, $value)
-	{
+	/**
+	 * @param string $name
+	 * @param mixed $value
+	 */
+	function registerParameter($name, $value) {
 		$this[$name] = $value;
 	}
 
@@ -29,9 +32,9 @@ class SimpleContainer extends \Pimple implements \OCP\IContainer {
 	 *
 	 * @param string $name name of the service to register another backend for
 	 * @param \Closure $closure the closure to be called on service creation
+	 * @param bool $shared
 	 */
-	function registerService($name, \Closure $closure, $shared = true)
-	{
+	function registerService($name, \Closure $closure, $shared = true) {
 		if ($shared) {
 			$this[$name] = \Pimple::share($closure);
 		} else {


### PR DESCRIPTION
Actually query() returns a value of the type "mixed" (as is also stated in the interface) - this is purely there to make our IDEs and Scrutinizer happier.

@Raydiation 
