### PR TITLE
"Group admin" default label (issue #7706)

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -50,7 +50,7 @@ var UserList = {
 			.data('username', username)
 			.data('user-groups', groups);
 		if ($tr.find('td.subadmins').length > 0) {
-			subAdminSelect = $('<select multiple="multiple" class="subadminsselect multiselect button" data-placehoder="subadmins" title="' + t('settings', 'Group Admin') + '">')
+			subAdminSelect = $('<select multiple="multiple" class="subadminsselect multiselect button" data-placehoder="subadmins" title="' + t('settings', 'no group') + '">')
 				.data('username', username)
 				.data('user-groups', groups)
 				.data('subadmin', subadmin);

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -9,7 +9,7 @@
 			<th id="headerPassword"><?php p($l->t( 'Password' )); ?></th>
 			<th id="headerGroups"><?php p($l->t( 'Groups' )); ?></th>
 			<?php if(is_array($_['subadmins']) || $_['subadmins']): ?>
-			<th id="headerSubAdmins"><?php p($l->t('Group Admin')); ?></th>
+			<th id="headerSubAdmins"><?php p($l->t('Group Admin for')); ?></th>
 			<?php endif;?>
 			<th id="headerQuota"><?php p($l->t('Quota')); ?></th>
 			<th id="headerStorageLocation"><?php p($l->t('Storage Location')); ?></th>
@@ -38,7 +38,7 @@
 					class="groupsselect"
 					data-username="<?php p($user['name']) ;?>"
 					data-user-groups="<?php p(json_encode($user['groups'])) ;?>"
-					data-placeholder="groups" title="<?php p($l->t('Groups'))?>"
+					data-placeholder="groups" title="<?php p($l->t('no group'))?>"
 					multiple="multiple">
 						<?php foreach($_["adminGroup"] as $adminGroup): ?>
 						<option value="<?php p($adminGroup['name']);?>"><?php p($adminGroup['name']); ?></option>
@@ -54,7 +54,7 @@
 						class="subadminsselect"
 						data-username="<?php p($user['name']) ;?>"
 						data-subadmin="<?php p(json_encode($user['subadmin']));?>"
-						data-placeholder="subadmins" title="<?php p($l->t('Group Admin'))?>"
+						data-placeholder="subadmins" title="<?php p($l->t('no group'))?>"
 						multiple="multiple">
 						<?php foreach($_["subadmingroups"] as $group): ?>
 							<option value="<?php p($group);?>"><?php p($group);?></option>


### PR DESCRIPTION
Changed the column header to "Group Admin for" and the default value of
the multiselect box to "no group" if user is not a groupadmin for any
group.
