### PR TITLE
Move CSRF check

### DIFF
--- a/lib/private/appframework/middleware/security/securitymiddleware.php
+++ b/lib/private/appframework/middleware/security/securitymiddleware.php
@@ -35,6 +35,7 @@ use OCP\IURLGenerator;
 use OCP\IRequest;
 use OCP\ILogger;
 use OCP\AppFramework\Controller;
+use OCP\Util;
 
 
 /**
@@ -111,6 +112,8 @@ class SecurityMiddleware extends Middleware {
 			}
 		}
 
+		// CSRF check - also registers the CSRF token since the session may be closed later
+		Util::callRegister();
 		if(!$this->reflector->hasAnnotation('NoCSRFRequired')) {
 			if(!$this->request->passesCSRFCheck()) {
 				throw new SecurityException('CSRF check failed', Http::STATUS_PRECONDITION_FAILED);


### PR DESCRIPTION
Because we're closing the session now before controllers are executed there are cases where we cannot write the session.

Fixes a regression in master. 
