### PR TITLE
if we read a .part file we try to get the file info from the real file

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -345,8 +345,8 @@ class Proxy extends \OC_FileProxy {
 			return $size;
 		}
 
-		// get file info from database/cache if not .part file
-		if (empty($fileInfo) && !Helper::isPartialFilePath($path)) {
+		// get file info from database/cache
+		if (empty($fileInfo)) {
 			$proxyState = \OC_FileProxy::$enabled;
 			\OC_FileProxy::$enabled = false;
 			$fileInfo = $view->getFileInfo($path);

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -637,13 +637,17 @@ class Stream {
 			$path = Helper::stripPartialFileExtension($this->rawPath);
 
 			$fileInfo = array(
+				'mimetype' => $this->rootView->getMimeType($this->rawPath),
 				'encrypted' => true,
-				'size' => $this->size,
 				'unencrypted_size' => $this->unencryptedSize,
 			);
 
-			// set fileinfo
-			$this->rootView->putFileInfo($path, $fileInfo);
+			// if we write a part file we also store the unencrypted size for
+			// the part file so that it can be re-used later
+			$this->rootView->putFileInfo($this->rawPath, $fileInfo);
+			if ($path !== $this->rawPath) {
+				$this->rootView->putFileInfo($path, $fileInfo);
+			}
 
 		}
 

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -71,7 +71,7 @@ class Cache {
 		if (empty(self::$mimetypeIds)) {
 			$this->loadMimetypes();
 		}
-		
+
 		if (!isset(self::$mimetypeIds[$mime])) {
 			try{
 				$result = \OC_DB::executeAudited('INSERT INTO `*PREFIX*mimetypes`(`mimetype`) VALUES(?)', array($mime));
@@ -82,8 +82,8 @@ class Cache {
 				\OC_Log::write('core', 'Exception during mimetype insertion: ' . $e->getmessage(), \OC_Log::DEBUG);
 				return -1;
 			}
-		} 
-				
+		}
+
 		return self::$mimetypeIds[$mime];
 	}
 
@@ -371,7 +371,7 @@ class Cache {
 				$this->remove($child['path']);
 			}
 		}
-		
+
 		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
 		\OC_DB::executeAudited($sql, array($entry['fileid']));
 	}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -902,7 +902,7 @@ class View {
 				$scanner = $storage->getScanner($internalPath);
 				$scanner->scan($internalPath, Cache\Scanner::SCAN_SHALLOW);
 				$data = $cache->get($internalPath);
-			} else if ($watcher->checkUpdate($internalPath, $data)) {
+			} else if (!Cache\Scanner::isPartialFile($internalPath) && $watcher->checkUpdate($internalPath, $data)) {
 				$this->updater->propagate($path);
 				$data = $cache->get($internalPath);
 			}


### PR DESCRIPTION
if we read a .part file we try to get the file info from the real file.

fix issue discussed here https://github.com/owncloud/core/pull/11659#issuecomment-60232838

This makes sure that we don't try to calculate the unencrypted size from part files during upload.

cc @DeepDiver1975 @jknockaert please review, thanks!
