### PR TITLE
Generate stable etags for local files

### DIFF
--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -90,6 +90,7 @@ if (\OC_Util::runningOnWindows()) {
 		}
 
 		public function stat($path) {
+			clearstatcache();
 			$fullPath = $this->datadir . $path;
 			$statResult = stat($fullPath);
 			if (PHP_INT_SIZE === 4 && !$this->is_dir($path)) {
@@ -275,6 +276,26 @@ if (\OC_Util::runningOnWindows()) {
 		 */
 		public function isLocal() {
 			return true;
+		}
+
+		/**
+		 * get the ETag for a file or folder
+		 *
+		 * @param string $path
+		 * @return string
+		 */
+		public function getETag($path) {
+			if ($this->is_file($path)) {
+				$stat = $this->stat($path);
+				return md5(
+					$stat['mtime'] .
+					$stat['ino'] .
+					$stat['dev'] .
+					$stat['size']
+				);
+			} else {
+				return parent::getETag($path);
+			}
 		}
 	}
 }

--- a/tests/lib/files/storage/local.php
+++ b/tests/lib/files/storage/local.php
@@ -1,24 +1,24 @@
 <?php
 /**
-* ownCloud
-*
-* @author Robin Appelman
-* @copyright 2012 Robin Appelman icewind@owncloud.com
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * ownCloud
+ *
+ * @author Robin Appelman
+ * @copyright 2012 Robin Appelman icewind@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace Test\Files\Storage;
 
@@ -27,13 +27,30 @@ class Local extends Storage {
 	 * @var string tmpDir
 	 */
 	private $tmpDir;
+
 	public function setUp() {
-		$this->tmpDir=\OC_Helper::tmpFolder();
-		$this->instance=new \OC\Files\Storage\Local(array('datadir'=>$this->tmpDir));
+		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->instance = new \OC\Files\Storage\Local(array('datadir' => $this->tmpDir));
 	}
 
 	public function tearDown() {
 		\OC_Helper::rmdirr($this->tmpDir);
+	}
+
+	public function testStableEtag() {
+		$this->instance->file_put_contents('test.txt', 'foobar');
+		$etag1 = $this->instance->getETag('test.txt');
+		$etag2 = $this->instance->getETag('test.txt');
+		$this->assertEquals($etag1, $etag2);
+	}
+
+	public function testEtagChange() {
+		$this->instance->file_put_contents('test.txt', 'foo');
+		$this->instance->touch('test.txt', time() - 2);
+		$etag1 = $this->instance->getETag('test.txt');
+		$this->instance->file_put_contents('test.txt', 'bar');
+		$etag2 = $this->instance->getETag('test.txt');
+		$this->assertNotEquals($etag1, $etag2);
 	}
 }
 


### PR DESCRIPTION
Generate etag for local files based on mtime, inode, device number and other information returned by `stat`

prevents the sync client from having to re-download files in case of cache inconsitencies.

cc @DeepDiver1975 @PVince81
