### PR TITLE
Make supported DBs configurable within config.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -801,6 +801,23 @@ $CONFIG = array(
 ),
 
 /**
+ * Database types that are supported for installation
+ * Available:
+ * 	- sqlite (SQLite3)
+ * 	- mysql (MySQL)
+ * 	- pgsql (PostgreSQL)
+ * 	- oci (Oracle)
+ * 	- mssql (Microsoft SQL Server)
+ */
+'supportedDatabases' => array(
+	'sqlite',
+	'mysql',
+	'pgsql',
+	'oci',
+	'mssql'
+),
+
+/**
  * Custom CSP policy, changing this will overwrite the standard policy
  */
 'custom_csp_policy' =>

--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -103,7 +103,7 @@ class Controller {
 		$setup = new \OC_Setup($this->config);
 		$databases = $setup->getSupportedDatabases();
 
-		$datadir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
+		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
 		$vulnerableToNullByte = false;
 		if(@file_exists(__FILE__."\0Nullbyte")) { // Check if the used PHP version is vulnerable to the NULL Byte attack (CVE-2006-7243)
 			$vulnerableToNullByte = true;
@@ -114,25 +114,25 @@ class Controller {
 		// Create data directory to test whether the .htaccess works
 		// Notice that this is not necessarily the same data directory as the one
 		// that will effectively be used.
-		@mkdir($datadir);
-		if (is_dir($datadir) && is_writable($datadir)) {
+		@mkdir($dataDir);
+		$htAccessWorking = true;
+		if (is_dir($dataDir) && is_writable($dataDir)) {
 			// Protect data directory here, so we can test if the protection is working
 			\OC_Setup::protectDataDirectory();
 
 			try {
-				$htaccessWorking = \OC_Util::isHtaccessWorking();
+				$htAccessWorking = \OC_Util::isHtaccessWorking();
 			} catch (\OC\HintException $e) {
 				$errors[] = array(
 					'error' => $e->getMessage(),
 					'hint' => $e->getHint()
 				);
-				$htaccessWorking = false;
+				$htAccessWorking = false;
 			}
 		}
 
 		if (\OC_Util::runningOnMac()) {
 			$l10n = \OC::$server->getL10N('core');
-			$themeName = \OC_Util::getTheme();
 			$theme = new \OC_Defaults();
 			$errors[] = array(
 				'error' => $l10n->t(
@@ -151,8 +151,8 @@ class Controller {
 			'hasOracle' => isset($databases['oci']),
 			'hasMSSQL' => isset($databases['mssql']),
 			'databases' => $databases,
-			'directory' => $datadir,
-			'htaccessWorking' => $htaccessWorking,
+			'directory' => $dataDir,
+			'htaccessWorking' => $htAccessWorking,
 			'vulnerableToNullByte' => $vulnerableToNullByte,
 			'errors' => $errors,
 		);

--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Copyright (c) 2013 Bart Visscher <bartv@thisnet.nl>
+ * Copyright (c) 2014 Lukas Reschke <lukas@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -8,7 +9,19 @@
 
 namespace OC\Core\Setup;
 
+use OCP\IConfig;
+
 class Controller {
+	/** @var \OCP\IConfig */
+	protected $config;
+
+	/**
+	 * @param IConfig $config
+	 */
+	function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
 	public function run($post) {
 		// Check for autosetup:
 		$post = $this->loadAutoConfig($post);
@@ -87,28 +100,10 @@ class Controller {
 	 * in case of errors/warnings
 	 */
 	public function getSystemInfo() {
-		$hasSQLite = class_exists('SQLite3');
-		$hasMySQL = is_callable('mysql_connect');
-		$hasPostgreSQL = is_callable('pg_connect');
-		$hasOracle = is_callable('oci_connect');
-		$hasMSSQL = is_callable('sqlsrv_connect');
-		$databases = array();
-		if ($hasSQLite) {
-			$databases['sqlite'] = 'SQLite';
-		}
-		if ($hasMySQL) {
-			$databases['mysql'] = 'MySQL/MariaDB';
-		}
-		if ($hasPostgreSQL) {
-			$databases['pgsql'] = 'PostgreSQL';
-		}
-		if ($hasOracle) {
-			$databases['oci'] = 'Oracle';
-		}
-		if ($hasMSSQL) {
-			$databases['mssql'] = 'MS SQL';
-		}
-		$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT.'/data');
+		$setup = new \OC_Setup($this->config);
+		$databases = $setup->getSupportedDatabases();
+
+		$datadir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
 		$vulnerableToNullByte = false;
 		if(@file_exists(__FILE__."\0Nullbyte")) { // Check if the used PHP version is vulnerable to the NULL Byte attack (CVE-2006-7243)
 			$vulnerableToNullByte = true;
@@ -150,11 +145,11 @@ class Controller {
 		}
 
 		return array(
-			'hasSQLite' => $hasSQLite,
-			'hasMySQL' => $hasMySQL,
-			'hasPostgreSQL' => $hasPostgreSQL,
-			'hasOracle' => $hasOracle,
-			'hasMSSQL' => $hasMSSQL,
+			'hasSQLite' => isset($databases['sqlite']),
+			'hasMySQL' => isset($databases['mysql']),
+			'hasPostgreSQL' => isset($databases['postgre']),
+			'hasOracle' => isset($databases['oci']),
+			'hasMSSQL' => isset($databases['mssql']),
 			'databases' => $databases,
 			'directory' => $datadir,
 			'htaccessWorking' => $htaccessWorking,

--- a/lib/base.php
+++ b/lib/base.php
@@ -716,7 +716,7 @@ class OC {
 
 		// Check if ownCloud is installed or in maintenance (update) mode
 		if (!OC_Config::getValue('installed', false)) {
-			$controller = new OC\Core\Setup\Controller();
+			$controller = new OC\Core\Setup\Controller(\OC::$server->getConfig());
 			$controller->run($_POST);
 			exit();
 		}

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -90,7 +90,8 @@ class OC_Setup {
 				'name' => 'MS SQL'
 			)
 		);
-		$configuredDatabases = $this->config->getSystemValue('supportedDatabases', array('sqlite', 'mysql', 'pgsql', 'oci', 'mssql'));
+		$configuredDatabases = $this->config->getSystemValue('supportedDatabases',
+			array('sqlite', 'mysql', 'pgsql', 'oci', 'mssql'));
 		if(!is_array($configuredDatabases)) {
 			throw new Exception('Supported databases are not properly configured.');
 		}
@@ -122,7 +123,7 @@ class OC_Setup {
 		$l = self::getTrans();
 
 		$error = array();
-		$dbtype = $options['dbtype'];
+		$dbType = $options['dbtype'];
 
 		if(empty($options['adminlogin'])) {
 			$error[] = $l->t('Set an admin username.');
@@ -134,25 +135,25 @@ class OC_Setup {
 			$options['directory'] = OC::$SERVERROOT."/data";
 		}
 
-		if (!isset(self::$dbSetupClasses[$dbtype])) {
-			$dbtype = 'sqlite';
+		if (!isset(self::$dbSetupClasses[$dbType])) {
+			$dbType = 'sqlite';
 		}
 
 		$username = htmlspecialchars_decode($options['adminlogin']);
 		$password = htmlspecialchars_decode($options['adminpass']);
-		$datadir = htmlspecialchars_decode($options['directory']);
+		$dataDir = htmlspecialchars_decode($options['directory']);
 
-		$class = self::$dbSetupClasses[$dbtype];
+		$class = self::$dbSetupClasses[$dbType];
 		/** @var \OC\Setup\AbstractDatabase $dbSetup */
 		$dbSetup = new $class(self::getTrans(), 'db_structure.xml');
 		$error = array_merge($error, $dbSetup->validate($options));
 
 		// validate the data directory
 		if (
-			(!is_dir($datadir) and !mkdir($datadir)) or
-			!is_writable($datadir)
+			(!is_dir($dataDir) and !mkdir($dataDir)) or
+			!is_writable($dataDir)
 		) {
-			$error[] = $l->t("Can't create or write into the data directory %s", array($datadir));
+			$error[] = $l->t("Can't create or write into the data directory %s", array($dataDir));
 		}
 
 		if(count($error) != 0) {
@@ -168,12 +169,12 @@ class OC_Setup {
 		}
 
 		if (OC_Util::runningOnWindows()) {
-			$datadir = rtrim(realpath($datadir), '\\');
+			$dataDir = rtrim(realpath($dataDir), '\\');
 		}
 
-		//use sqlite3 when available, otherise sqlite2 will be used.
-		if($dbtype=='sqlite' and class_exists('SQLite3')) {
-			$dbtype='sqlite3';
+		//use sqlite3 when available, otherwise sqlite2 will be used.
+		if($dbType=='sqlite' and class_exists('SQLite3')) {
+			$dbType='sqlite3';
 		}
 
 		//generate a random salt that is used to salt the local user passwords
@@ -186,9 +187,9 @@ class OC_Setup {
 
 		//write the config file
 		\OC::$server->getConfig()->setSystemValue('trusted_domains', $trustedDomains);
-		\OC::$server->getConfig()->setSystemValue('datadirectory', $datadir);
+		\OC::$server->getConfig()->setSystemValue('datadirectory', $dataDir);
 		\OC::$server->getConfig()->setSystemValue('overwrite.cli.url', \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . OC::$WEBROOT);
-		\OC::$server->getConfig()->setSystemValue('dbtype', $dbtype);
+		\OC::$server->getConfig()->setSystemValue('dbtype', $dbType);
 		\OC::$server->getConfig()->setSystemValue('version', implode('.', OC_Util::getVersion()));
 
 		try {
@@ -211,8 +212,7 @@ class OC_Setup {
 		//create the user and group
 		try {
 			OC_User::createUser($username, $password);
-		}
-		catch(Exception $exception) {
+		} catch(Exception $exception) {
 			$error[] = $exception->getMessage();
 		}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -436,12 +436,9 @@ class OC_Util {
 		}
 
 		$webServerRestart = false;
-		//check for database drivers
-		if (!(is_callable('sqlite_open') or class_exists('SQLite3'))
-			and !is_callable('mysql_connect')
-			and !is_callable('pg_connect')
-			and !is_callable('oci_connect')
-		) {
+		$setup = new OC_Setup($config);
+		$availableDatabases = $setup->getSupportedDatabases();
+		if (empty($availableDatabases)) {
 			$errors[] = array(
 				'error' => $l->t('No database drivers (sqlite, mysql, or postgresql) installed.'),
 				'hint' => '' //TODO: sane hint

--- a/tests/lib/setup.php
+++ b/tests/lib/setup.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright (c) 2014 Lukas Reschke <lukas@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+use OCP\IConfig;
+
+class Test_OC_Setup extends PHPUnit_Framework_TestCase {
+
+	/** @var IConfig */
+	protected $config;
+	/** @var \OC_Setup */
+	protected $setupClass;
+
+	public function setUp() {
+		$this->config = $this->getMock('\OCP\IConfig');
+		$this->setupClass = $this->getMock('\OC_Setup', array('class_exists', 'is_callable'), array($this->config));
+	}
+
+	public function testGetSupportedDatabasesWithOneWorking() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->will($this->returnValue(
+				array('sqlite', 'mysql', 'oci')
+			));
+		$this->setupClass
+			->expects($this->once())
+			->method('class_exists')
+			->will($this->returnValue(true));
+		$this->setupClass
+			->expects($this->exactly(2))
+			->method('is_callable')
+			->will($this->returnValue(false));
+		$result = $this->setupClass->getSupportedDatabases();
+		$expectedResult = array(
+			'sqlite' => 'SQLite'
+		);
+
+		$this->assertSame($expectedResult, $result);
+	}
+
+	public function testGetSupportedDatabasesWithNoWorking() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->will($this->returnValue(
+				array('sqlite', 'mysql', 'oci', 'pgsql')
+			));
+		$this->setupClass
+			->expects($this->once())
+			->method('class_exists')
+			->will($this->returnValue(false));
+		$this->setupClass
+			->expects($this->exactly(3))
+			->method('is_callable')
+			->will($this->returnValue(false));
+		$result = $this->setupClass->getSupportedDatabases();
+
+		$this->assertSame(array(), $result);
+	}
+
+	public function testGetSupportedDatabasesWitAllWorking() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->will($this->returnValue(
+				array('sqlite', 'mysql', 'pgsql', 'oci', 'mssql')
+			));
+		$this->setupClass
+			->expects($this->once())
+			->method('class_exists')
+			->will($this->returnValue(true));
+		$this->setupClass
+			->expects($this->exactly(4))
+			->method('is_callable')
+			->will($this->returnValue(true));
+		$result = $this->setupClass->getSupportedDatabases();
+		$expectedResult = array(
+			'sqlite' => 'SQLite',
+			'mysql' => 'MySQL/MariaDB',
+			'pgsql' => 'PostgreSQL',
+			'oci' => 'Oracle',
+			'mssql' => 'MS SQL'
+		);
+		$this->assertSame($expectedResult, $result);
+	}
+
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage Supported databases are not properly configured.
+	 */
+	public function testGetSupportedDatabaseException() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->will($this->returnValue('NotAnArray'));
+		$this->setupClass->getSupportedDatabases();
+	}
+}


### PR DESCRIPTION
This commit will make the supported DBs for installation configurable within config.php. By default the following databases are enabled: "sqlite", "mysql", "pgsql". The reason behind this is that there might be instances where we want to prevent SQLite to be used by mistake.

To test this play around with the new configuration parameter "supportedDatabases".

@DeepDiver1975 @PVince81 @karlitschek @MTRichards 
