### PR TITLE
[LDAP] Login: dont fail with 500 if configured display name attribute is not set

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -64,8 +64,14 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 			return false;
 		}
 		$dn = $ldap_users[0];
-
 		$user = $this->access->userManager->get($dn);
+		if(is_null($user)) {
+			\OCP\Util::writeLog('user_ldap',
+				'LDAP Login: Could not get user object for DN ' . $dn .
+				'. Maybe the LDAP entry has no set display name attribute?',
+				\OCP\Util::WARN);
+			return false;
+		}
 		if($user->getUsername() !== false) {
 			//are the credentials OK?
 			if(!$this->access->areCredentialsValid($dn, $password)) {


### PR DESCRIPTION
If a user has no display name, login will end up with a server error. Instead now, login is still not possible, but ownCloud does not result in a blank page and a corresponding log messages is written. Unit test included. Fixes #11762 

How to test?
- configure LDAP
- set display name attribute to something not existing
- attempt to log in with an LDAP user
- before the fix: blank page
- now: login mask again, log message: 'LDAP Login: Could not get user object for DN  $dn  Maybe the LDAP entry has no set display name attribute?'

Please test and review @theonlydoo @Xenopathic @PVince81 @craigpg 
