### PR TITLE
Properly catch 503 storage not available in getQuotaInfo

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -205,13 +205,17 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node
 	 * @return array
 	 */
 	public function getQuotaInfo() {
-		$path = \OC\Files\Filesystem::getView()->getRelativePath($this->info->getPath());
-		$storageInfo = OC_Helper::getStorageInfo($path);
-		return array(
-			$storageInfo['used'],
-			$storageInfo['free']
-		);
-
+		try {
+			$path = \OC\Files\Filesystem::getView()->getRelativePath($this->info->getPath());
+			$storageInfo = OC_Helper::getStorageInfo($path);
+			return array(
+				$storageInfo['used'],
+				$storageInfo['free']
+			);
+		}
+		catch (\OCP\Files\StorageNotAvailableException $e) {
+			return array(0, 0);
+		}
 	}
 
 	/**


### PR DESCRIPTION
When doing a PROPFIND on the root and one of the mount points is not
available, the returned quota attributes will now be zero.

This fix prevents the expected exception to make the whole call fail.

Fixes https://github.com/owncloud/core/issues/11759

Please review @icewind1991 @DeepDiver1975 
