### PR TITLE
use Composer autoloader not OC for non-Composer 3rdparty (#9643)

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -22,26 +22,6 @@ class Autoloader {
 	protected $memoryCache;
 
 	/**
-	 * Add a custom prefix to the autoloader
-	 *
-	 * @param string $prefix
-	 * @param string $path
-	 */
-	public function registerPrefix($prefix, $path) {
-		$this->prefixPaths[$prefix] = $path;
-	}
-
-	/**
-	 * Add a custom classpath to the autoloader
-	 *
-	 * @param string $class
-	 * @param string $path
-	 */
-	public function registerClass($class, $path) {
-		$this->classPaths[$class] = $path;
-	}
-
-	/**
 	 * disable the usage of the global classpath \OC::$CLASSPATH
 	 */
 	public function disableGlobalClassPath() {
@@ -99,14 +79,6 @@ class Autoloader {
 			$paths[] = 'tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
 		} elseif (strpos($class, 'Test\\') === 0) {
 			$paths[] = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
-		} else {
-			foreach ($this->prefixPaths as $prefix => $dir) {
-				if (0 === strpos($class, $prefix)) {
-					$path = str_replace('\\', '/', $class) . '.php';
-					$path = str_replace('_', '/', $path);
-					$paths[] = $dir . '/' . $path;
-				}
-			}
 		}
 		return $paths;
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -447,17 +447,27 @@ class OC {
 		$loaderStart = microtime(true);
 		require_once __DIR__ . '/autoloader.php';
 		self::$loader = new \OC\Autoloader();
-		self::$loader->registerPrefix('Doctrine\\Common', 'doctrine/common/lib');
-		self::$loader->registerPrefix('Doctrine\\DBAL', 'doctrine/dbal/lib');
-		self::$loader->registerPrefix('Symfony\\Component\\Routing', 'symfony/routing');
-		self::$loader->registerPrefix('Symfony\\Component\\Console', 'symfony/console');
-		self::$loader->registerPrefix('Patchwork', '3rdparty');
-		self::$loader->registerPrefix('Pimple', '3rdparty/Pimple');
 		spl_autoload_register(array(self::$loader, 'load'));
 		$loaderEnd = microtime(true);
 
-		// setup the basic server
 		self::initPaths();
+
+		// setup 3rdparty autoloader
+		$vendorAutoLoad = OC::$THIRDPARTYROOT . '/3rdparty/autoload.php';
+		if (file_exists($vendorAutoLoad)) {
+			$loader = require_once $vendorAutoLoad;
+			$loader->add('Pimple',OC::$THIRDPARTYROOT . '/3rdparty/Pimple');
+			$loader->add('Doctrine\\Common',OC::$THIRDPARTYROOT . '/3rdparty/doctrine/common/lib');
+			$loader->add('Doctrine\\DBAL',OC::$THIRDPARTYROOT . '/3rdparty/doctrine/dbal/lib');
+			$loader->add('Symfony\\Component\\Routing',OC::$THIRDPARTYROOT . '/3rdparty/symfony/routing');
+			$loader->add('Symfony\\Component\\Console',OC::$THIRDPARTYROOT . '/3rdparty/symfony/console');
+			$loader->add('Patchwork',OC::$THIRDPARTYROOT . '/3rdparty');
+		} else {
+			OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
+			OC_Template::printErrorPage('Composer autoloader not found, unable to continue.');
+		}
+
+		// setup the basic server
 		self::$server = new \OC\Server();
 		\OC::$server->getEventLogger()->log('autoloader', 'Autoloader', $loaderStart, $loaderEnd);
 		\OC::$server->getEventLogger()->start('boot', 'Initialize');
@@ -494,17 +504,9 @@ class OC {
 		self::handleAuthHeaders();
 		self::registerAutoloaderCache();
 
-
-		OC_Util::isSetLocaleWorking();
-
-		// setup 3rdparty autoloader
-		$vendorAutoLoad = OC::$THIRDPARTYROOT . '/3rdparty/autoload.php';
-		if (file_exists($vendorAutoLoad)) {
-			require_once $vendorAutoLoad;
-		}
-
 		// initialize intl fallback is necessary
 		\Patchwork\Utf8\Bootup::initIntl();
+		OC_Util::isSetLocaleWorking();
 
 		if (!defined('PHPUNIT_RUN')) {
 			OC\Log\ErrorHandler::setLogger(OC_Log::$object);

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -30,21 +30,6 @@ class AutoLoader extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('private/legacy/files.php', 'private/files.php'), $this->loader->findClass('OC_Files'));
 	}
 
-	public function testClassPath() {
-		$this->loader->registerClass('Foo\Bar', 'foobar.php');
-		$this->assertEquals(array('foobar.php'), $this->loader->findClass('Foo\Bar'));
-	}
-
-	public function testPrefixNamespace() {
-		$this->loader->registerPrefix('Foo', 'foo');
-		$this->assertEquals(array('foo/Foo/Bar.php'), $this->loader->findClass('Foo\Bar'));
-	}
-
-	public function testPrefix() {
-		$this->loader->registerPrefix('Foo_', 'foo');
-		$this->assertEquals(array('foo/Foo/Bar.php'), $this->loader->findClass('Foo_Bar'));
-	}
-
 	public function testLoadTestNamespace() {
 		$this->assertEquals(array('tests/lib/foo/bar.php'), $this->loader->findClass('Test\Foo\Bar'));
 	}


### PR DESCRIPTION
Composer's autoloader is rather better than the OwnCloud autoloader's
handling of non-OC classes. Plus we can rely on upstream Composer to
maintain it and not worry about it ourselves.

With this change, we drop the bits of OwnCloud's autoloader that
handled non-OC classes, and register the classes that were being
handled by that code with Composer's autoloader instead. As these
dependencies are converted to actually being managed by Composer,
the explicit registrations can be dropped as they won't be needed
any more.

Since OwnCloud's autoloader isn't going to handle non-OC classes any
more, we no longer need to test to make sure it does it right.

drop unneeded registerPrefix() and registerClass() from autoloader

Now we're not handling anything but OC's own classes, these are
unnecessary.

error out if composer autoloader is not found (thanks bantu)

We're never going to be able to work without the autoloader, if it's not
there we should just throw our hands up and surrender.
