### PR TITLE
[WIP] Resolve mount conflicts in mount manager

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -204,6 +204,7 @@ class Helper {
 	 * @return string $path
 	 */
 	public static function generateUniqueTarget($path, $excludeList, $view) {
+		// TODO: move this function to \OC_Filesystem or \OC_View
 		$pathinfo = pathinfo($path);
 		$ext = (isset($pathinfo['extension'])) ? '.'.$pathinfo['extension'] : '';
 		$name = $pathinfo['filename'];

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -31,7 +31,7 @@ class SharedMount extends Mount implements MoveableMount {
 	 * check if the parent folder exists otherwise move the mount point up
 	 */
 	private static function verifyMountPoint(&$share) {
-
+		// TODO: refactor and rely on the mount manager's conflict detection instead
 		$mountPoint = basename($share['file_target']);
 		$parent = dirname($share['file_target']);
 


### PR DESCRIPTION
:warning: EXPERIMENTAL :warning: 

Experimental fix to resolve mount point conflicts in the mount manager.
@icewind1991 @schiesbn can you give me some feedback about this ?
Do you see any case where this could go wrong, apart from race conditions ?

Commit comment:

Whenever a mount point is added, call file_exists() to check for an
existing file/folder/mount point.

In case of conflict, try and rename to newly added mount point. Else
rename the target.

TODO:
- [ ] add unit tests (once the case is accepted)
- [ ] extensive regression testing of all combinations of mount type conflicts
- [ ] extensive regression testing of mount types conflict with folder/filer
