### PR TITLE
Tell Sabre Client to actually send an AuthHeader with each request.

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -72,6 +72,7 @@ class DAV extends \OC\Files\Storage\Common {
 			'baseUri' => $this->createBaseUri(),
 			'userName' => $this->user,
 			'password' => $this->password,
+			'authType' => \Sabre\DAV\Client::AUTH_BASIC,
 		);
 
 		$this->client = new \Sabre\DAV\Client($settings);


### PR DESCRIPTION
That saves half of the requests to the other dav backend because no
unauthorized reply is coming back, but the request is authenticated in
the first place.
