### PR TITLE
unify count filters and introduce display name attribute detection

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -62,6 +62,7 @@ switch($action) {
 	case 'guessPortAndTLS':
 	case 'guessBaseDN':
 	case 'detectEmailAttribute':
+	case 'detectUserDisplayNameAttribute':
 	case 'determineGroupMemberAssoc':
 	case 'determineUserObjectClasses':
 	case 'determineGroupObjectClasses':
@@ -115,4 +116,3 @@ switch($action) {
 		//TODO: return 4xx error
 		break;
 }
-

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -159,17 +159,17 @@ LdapFilter.prototype.findFeatures = function() {
  * resolving the passed status variable will fire up counting
  * @param {object} status an instance of $.Deferred
  */
-LdapFilter.prototype.beforeUpdateCount = function(status) {
-	return LdapWizard.runDetectors(this.target, function() {
+LdapFilter.prototype.beforeUpdateCount = function() {
+	var status = $.Deferred();
+	LdapWizard.runDetectors(this.target, function() {
 		status.resolve();
 	});
+	return status;
 };
 
 LdapFilter.prototype.updateCount = function(doneCallback) {
-	var beforeUpdateCountDone = $.Deferred();
-	this.beforeUpdateCount(beforeUpdateCountDone);
 	var filter = this;
-	$.when(beforeUpdateCountDone).done(function() {
+	$.when(this.beforeUpdateCount()).done(function() {
 		if(filter.target === 'User') {
 			LdapWizard.countUsers(doneCallback);
 		} else if (filter.target === 'Group') {

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -63,12 +63,21 @@ LdapFilter.prototype.compose = function() {
 	);
 };
 
+/**
+ * this function is triggered after attribute detectors have completed in
+ * LdapWizard
+ */
 LdapFilter.prototype.afterDetectorsRan = function() {
 	this.updateCount();
 };
 
+/**
+ * this function is triggered after LDAP filters have been composed successfully
+ * @param {object} result returned by the ajax call
+ */
 LdapFilter.prototype.afterComposeSuccess = function(result) {
 	LdapWizard.applyChanges(result);
+	//best time to run attribute detectors
 	LdapWizard.runDetectors(this.target, this.afterDetectorsRan);
 };
 
@@ -147,6 +156,11 @@ LdapFilter.prototype.findFeatures = function() {
 	}
 };
 
+/**
+ * this function is triggered before user and group counts are executed
+ * resolving the passed status variable will fire up counting
+ * @param {object} status an instance of $.Deferred
+ */
 LdapFilter.prototype.beforeUpdateCount = function(status) {
 	return LdapWizard.runDetectors(this.target, function() {
 		status.resolve();

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -77,8 +77,6 @@ LdapFilter.prototype.afterDetectorsRan = function() {
  */
 LdapFilter.prototype.afterComposeSuccess = function(result) {
 	LdapWizard.applyChanges(result);
-	//best time to run attribute detectors
-	LdapWizard.runDetectors(this.target, this.afterDetectorsRan);
 };
 
 LdapFilter.prototype.determineMode = function() {

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -8,6 +8,7 @@ function LdapFilter(target, determineModeCallback) {
 	this.determineModeCallback = determineModeCallback;
 	this.foundFeatures = false;
 	this.activated = false;
+	this.countPending = false;
 
 	if( target === 'User' ||
 		target === 'Login' ||
@@ -25,8 +26,12 @@ LdapFilter.prototype.activate = function() {
 	this.determineMode();
 };
 
-LdapFilter.prototype.compose = function() {
+LdapFilter.prototype.compose = function(updateCount = false) {
 	var action;
+
+	if(updateCount) {
+		this.countPending = updateCount;
+	}
 
 	if(this.locked) {
 		this.lazyRunCompose = true;
@@ -57,6 +62,7 @@ LdapFilter.prototype.compose = function() {
 			filter.afterComposeSuccess(result);
 		},
 		function () {
+			filter.countPending = false;
 			console.log('LDAP Wizard: could not compose filter. '+
 				'Please check owncloud.log');
 		}
@@ -77,6 +83,10 @@ LdapFilter.prototype.afterDetectorsRan = function() {
  */
 LdapFilter.prototype.afterComposeSuccess = function(result) {
 	LdapWizard.applyChanges(result);
+	if(this.countPending) {
+		this.countPending = false;
+		this.updateCount();
+	}
 };
 
 LdapFilter.prototype.determineMode = function() {

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -26,10 +26,10 @@ LdapFilter.prototype.activate = function() {
 	this.determineMode();
 };
 
-LdapFilter.prototype.compose = function(updateCount = false) {
+LdapFilter.prototype.compose = function(updateCount) {
 	var action;
 
-	if(updateCount) {
+	if(updateCount === true) {
 		this.countPending = updateCount;
 	}
 

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -151,8 +151,10 @@ var LdapWizard = {
 	ajaxRequests: {},
 
 	ajax: function(param, fnOnSuccess, fnOnError, reqID) {
-		if(reqID !== undefined) {
+		if(typeof reqID !== 'undefined') {
 			if(LdapWizard.ajaxRequests.hasOwnProperty(reqID)) {
+				console.log('aborting ' + reqID);
+				console.log(param);
 				LdapWizard.ajaxRequests[reqID].abort();
 			}
 		}
@@ -167,7 +169,7 @@ var LdapWizard = {
 				}
 			}
 		);
-		if(reqID !== undefined) {
+		if(typeof reqID !== 'undefined') {
 			LdapWizard.ajaxRequests[reqID] = request;
 		}
 	},
@@ -342,7 +344,7 @@ var LdapWizard = {
 	},
 
 	_countThings: function(method, spinnerID, doneCallback) {
-		param = 'action='+method+
+		var param = 'action='+method+
 				'&ldap_serverconfig_chooser='+
 				encodeURIComponent($('#ldap_serverconfig_chooser').val());
 
@@ -371,7 +373,12 @@ var LdapWizard = {
 	},
 
 	countUsers: function(doneCallback) {
-		LdapWizard._countThings('countUsers', '#ldap_user_count', doneCallback);
+		//we make user counting depending on having a display name attribute
+		var param = 'action=detectUserDisplayNameAttribute' +
+			'&ldap_serverconfig_chooser='+
+			encodeURIComponent($('#ldap_serverconfig_chooser').val());
+
+			LdapWizard._countThings('countUsers', '#ldap_user_count', doneCallback);
 	},
 
 	detectEmailAttribute: function() {

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -377,6 +377,16 @@ var LdapWizard = {
 		LdapWizard._countThings('countUsers', '#ldap_user_count', doneCallback);
 	},
 
+	/**
+	 * called after detectors have run
+	 * @callback runDetectorsCallback
+	 */
+
+	/**
+	 * runs detectors to determine appropriate attributes, e.g. displayName
+	 * @param {string} type either "User" or "Group"
+	 * @param {runDetectorsCallback} triggered after all detectors have completed
+	 */
 	runDetectors: function(type, callback) {
 		if(type === 'Group') {
 			$.when(LdapWizard.detectGroupMemberAssoc())
@@ -397,6 +407,9 @@ var LdapWizard = {
 		}
 	},
 
+	/**
+	 * runs detector to find out a fitting user display name attribute
+	 */
 	detectUserDisplayNameAttribute: function() {
 		var param = 'action=detectUserDisplayNameAttribute' +
 			'&ldap_serverconfig_chooser='+

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -151,7 +151,7 @@ var LdapWizard = {
 	ajaxRequests: {},
 
 	ajax: function(param, fnOnSuccess, fnOnError, reqID) {
-		if(typeof reqID !== 'undefined') {
+		if(!_.isUndefined(reqID)) {
 			if(LdapWizard.ajaxRequests.hasOwnProperty(reqID)) {
 				console.log('aborting ' + reqID);
 				console.log(param);
@@ -169,7 +169,7 @@ var LdapWizard = {
 				}
 			}
 		);
-		if(typeof reqID !== 'undefined') {
+		if(!_.isUndefined(reqID)) {
 			LdapWizard.ajaxRequests[reqID] = request;
 		}
 		return request;
@@ -354,14 +354,14 @@ var LdapWizard = {
 			function(result) {
 				LdapWizard.applyChanges(result);
 				LdapWizard.hideSpinner(spinnerID);
-				if(doneCallback !== undefined) {
+				if(!_.isUndefined(doneCallback)) {
 					doneCallback(method);
 				}
 			},
 			function (result) {
 				OC.Notification.show('Counting the entries failed with, ' + result.message);
 				LdapWizard.hideSpinner(spinnerID);
-				if(doneCallback !== undefined) {
+				if(!_.isUndefined(doneCallback)) {
 					doneCallback(method);
 				}
 			},

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -670,7 +670,7 @@ var LdapWizard = {
 		delete LdapWizard.userFilter;
 		LdapWizard.userFilter = new LdapFilter('User', function(mode) {
 			if(mode === LdapWizard.filterModeAssisted) {
-				LdapWizard.groupFilter.updateCount();
+				LdapWizard.userFilter.updateCount();
 			}
 			LdapWizard.userFilter.findFeatures();
 		});

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -669,7 +669,8 @@ var LdapWizard = {
 	instantiateFilters: function() {
 		delete LdapWizard.userFilter;
 		LdapWizard.userFilter = new LdapFilter('User', function(mode) {
-			if(mode === LdapWizard.filterModeAssisted) {
+			if( !LdapWizard.admin.isExperienced()
+			   || mode === LdapWizard.filterModeAssisted) {
 				LdapWizard.userFilter.updateCount();
 			}
 			LdapWizard.userFilter.findFeatures();
@@ -689,7 +690,8 @@ var LdapWizard = {
 
 		delete LdapWizard.groupFilter;
 		LdapWizard.groupFilter = new LdapFilter('Group', function(mode) {
-			if(mode === LdapWizard.filterModeAssisted) {
+			if( !LdapWizard.admin.isExperienced()
+			   || mode === LdapWizard.filterModeAssisted) {
 				LdapWizard.groupFilter.updateCount();
 			}
 			LdapWizard.groupFilter.findFeatures();
@@ -775,6 +777,12 @@ var LdapWizard = {
 		if(triggerObj.id === 'ldap_loginfilter_username'
 		   || triggerObj.id === 'ldap_loginfilter_email') {
 			LdapWizard.loginFilter.compose();
+		} else if (!LdapWizard.admin.isExperienced()) {
+			if(triggerObj.id === 'ldap_userlist_filter') {
+				LdapWizard.userFilter.updateCount();
+			} else if (triggerObj.id === 'ldap_group_filter') {
+				LdapWizard.groupFilter.updateCount();
+			}
 		}
 
 		if($('#ldapSettings').tabs('option', 'active') == 0) {
@@ -804,7 +812,7 @@ var LdapWizard = {
 		LdapWizard._save($('#'+originalObj)[0], $.trim(values));
 		if(originalObj === 'ldap_userfilter_objectclass'
 		   || originalObj === 'ldap_userfilter_groups') {
-			LdapWizard.userFilter.compose();
+			LdapWizard.userFilter.compose(!LdapWizard.admin.isExperienced());
 			//when user filter is changed afterwards, login filter needs to
 			//be adjusted, too
 			if(!LdapWizard.loginFilter) {
@@ -815,7 +823,7 @@ var LdapWizard = {
 			LdapWizard.loginFilter.compose();
 		} else if(originalObj === 'ldap_groupfilter_objectclass'
 		   || originalObj === 'ldap_groupfilter_groups') {
-			LdapWizard.groupFilter.compose();
+			LdapWizard.groupFilter.compose(!LdapWizard.admin.isExperienced());
 		}
 	},
 
@@ -885,10 +893,10 @@ var LdapWizard = {
 			LdapWizard._save({ id: modeKey }, LdapWizard.filterModeAssisted);
 			if(isUser) {
 				LdapWizard.blacklistRemove('ldap_userlist_filter');
-				LdapWizard.userFilter.compose();
+				LdapWizard.userFilter.compose(!LdapWizard.admin.isExperienced());
 			} else {
 				LdapWizard.blacklistRemove('ldap_group_filter');
-				LdapWizard.groupFilter.compose();
+				LdapWizard.groupFilter.compose(!LdapWizard.admin.isExperienced());
 			}
 		}
 	},

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -812,7 +812,7 @@ var LdapWizard = {
 		LdapWizard._save($('#'+originalObj)[0], $.trim(values));
 		if(originalObj === 'ldap_userfilter_objectclass'
 		   || originalObj === 'ldap_userfilter_groups') {
-			LdapWizard.userFilter.compose(!LdapWizard.admin.isExperienced());
+			LdapWizard.userFilter.compose(true);
 			//when user filter is changed afterwards, login filter needs to
 			//be adjusted, too
 			if(!LdapWizard.loginFilter) {
@@ -823,7 +823,7 @@ var LdapWizard = {
 			LdapWizard.loginFilter.compose();
 		} else if(originalObj === 'ldap_groupfilter_objectclass'
 		   || originalObj === 'ldap_groupfilter_groups') {
-			LdapWizard.groupFilter.compose(!LdapWizard.admin.isExperienced());
+			LdapWizard.groupFilter.compose(true);
 		}
 	},
 
@@ -893,10 +893,10 @@ var LdapWizard = {
 			LdapWizard._save({ id: modeKey }, LdapWizard.filterModeAssisted);
 			if(isUser) {
 				LdapWizard.blacklistRemove('ldap_userlist_filter');
-				LdapWizard.userFilter.compose(!LdapWizard.admin.isExperienced());
+				LdapWizard.userFilter.compose(true);
 			} else {
 				LdapWizard.blacklistRemove('ldap_group_filter');
-				LdapWizard.groupFilter.compose(!LdapWizard.admin.isExperienced());
+				LdapWizard.groupFilter.compose(true);
 			}
 		}
 	},

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1168,6 +1168,18 @@ class Access extends LDAPUtility implements user\IUserTools {
 	}
 
 	/**
+	 * returns the filter used for counting users
+	 */
+	public function getFilterForUserCount() {
+		$filter = $this->combineFilterWithAnd(array(
+			$this->connection->ldapUserFilter,
+			$this->connection->ldapUserDisplayName . '=*'
+		));
+
+		return $filter;
+	}
+
+	/**
 	 * @param string $name
 	 * @param string $password
 	 * @return bool

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -813,7 +813,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		}
 
 		//check whether paged search should be attempted
-		$pagedSearchOK = $this->initPagedSearch($filter, $base, $attr, $limit, $offset);
+		$pagedSearchOK = $this->initPagedSearch($filter, $base, $attr, intval($limit), $offset);
 
 		$linkResources = array_pad(array(), count($base), $cr);
 		$sr = $this->ldap->search($linkResources, $base, $filter, $attr);
@@ -887,10 +887,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 	private function count($filter, $base, $attr = null, $limit = null, $offset = null, $skipHandling = false) {
 		\OCP\Util::writeLog('user_ldap', 'Count filter:  '.print_r($filter, true), \OCP\Util::DEBUG);
 
-		$limitPerPage = (intval($limit) < intval($this->connection->ldapPagingSize)) ?
-			intval($limit) : intval($this->connection->ldapPagingSize);
-		if(is_null($limit) || $limit <= 0) {
-			$limitPerPage = intval($this->connection->ldapPagingSize);
+		$limitPerPage = intval($this->connection->ldapPagingSize);
+		if(!is_null($limit) && $limit < $limitPerPage && $limit > 0) {
+			$limitPerPage = $limit;
 		}
 
 		$counter = 0;
@@ -1472,7 +1471,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 */
 	private function initPagedSearch($filter, $bases, $attr, $limit, $offset) {
 		$pagedSearchOK = false;
-		if($this->connection->hasPagedResultSupport && !is_null($limit)) {
+		if($this->connection->hasPagedResultSupport && ($limit !== 0)) {
 			$offset = intval($offset); //can be null
 			\OCP\Util::writeLog('user_ldap',
 				'initializing paged search for  Filter '.$filter.' base '.print_r($bases, true)

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1171,6 +1171,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 
 	/**
 	 * returns the filter used for counting users
+	 * @return string
 	 */
 	public function getFilterForUserCount() {
 		$filter = $this->combineFilterWithAnd(array(

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -121,10 +121,7 @@ class Wizard extends LDAPUtility {
 	 */
 	public function countUsers() {
 		$this->detectUserDisplayNameAttribute();
-		$filter = $this->access->combineFilterWithAnd(array(
-			$this->configuration->ldapUserFilter,
-			$this->configuration->ldapUserDisplayName . '=*'
-		));
+		$filter = $this->access->getFilterForUserCount();
 
 		$usersTotal = $this->countEntries($filter, 'users');
 		$usersTotal = ($usersTotal !== false) ? $usersTotal : 0;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -120,7 +120,6 @@ class Wizard extends LDAPUtility {
 	 * @throws \Exception
 	 */
 	public function countUsers() {
-		$this->detectUserDisplayNameAttribute();
 		$filter = $this->access->getFilterForUserCount();
 
 		$usersTotal = $this->countEntries($filter, 'users');

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -233,7 +233,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		if($winner !== '') {
-			$this->result->addChange('ldap_email_attr', $winner);
+			$this->applyFind('ldap_email_attr', $winner);
 			if($writeLog) {
 				\OCP\Util::writeLog('user_ldap', 'The mail attribute has ' .
 					'automatically been reset, because the original value ' .

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -132,9 +132,10 @@ class Wizard extends LDAPUtility {
 	/**
 	 * counts users with a specified attribute
 	 * @param string $attr
+	 * @param bool $existsCheck
 	 * @return int|bool
 	 */
-	public function countUsersWithAttribute($attr) {
+	public function countUsersWithAttribute($attr, $existsCheck = false) {
 		if(!$this->checkRequirements(array('ldapHost',
 										   'ldapPort',
 										   'ldapBase',
@@ -148,7 +149,9 @@ class Wizard extends LDAPUtility {
 			$attr . '=*'
 		));
 
-		return $this->access->countUsers($filter);
+		$limit = ($existsCheck === false) ? null : 1;
+
+		return $this->access->countUsers($filter, array('dn'), $limit);
 	}
 
 	/**
@@ -169,7 +172,7 @@ class Wizard extends LDAPUtility {
 		if($attr !== 'displayName' && !empty($attr)) {
 			// most likely not the default value with upper case N,
 			// verify it still produces a result
-			$count = intval($this->countUsersWithAttribute($attr));
+			$count = intval($this->countUsersWithAttribute($attr, true));
 			if($count > 0) {
 				//no change, but we sent it back to make sure the user interface
 				//is still correct, even if the ajax call was cancelled inbetween
@@ -181,7 +184,7 @@ class Wizard extends LDAPUtility {
 		// first attribute that has at least one result wins
 		$displayNameAttrs = array('displayname', 'cn');
 		foreach ($displayNameAttrs as $attr) {
-			$count = intval($this->countUsersWithAttribute($attr));
+			$count = intval($this->countUsersWithAttribute($attr, true));
 
 			if($count > 0) {
 				$this->applyFind('ldap_display_name', $attr);
@@ -209,7 +212,7 @@ class Wizard extends LDAPUtility {
 
 		$attr = $this->configuration->ldapEmailAttribute;
 		if(!empty($attr)) {
-			$count = intval($this->countUsersWithAttribute($attr));
+			$count = intval($this->countUsersWithAttribute($attr, true));
 			if($count > 0) {
 				return false;
 			}

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -158,6 +158,7 @@ class Wizard extends LDAPUtility {
 	 * detects the display name attribute. If a setting is already present that
 	 * returns at least one hit, the detection will be canceled.
 	 * @return WizardResult|bool
+	 * @throws \Exception
 	 */
 	public function detectUserDisplayNameAttribute() {
 		if(!$this->checkRequirements(array('ldapHost',
@@ -192,7 +193,7 @@ class Wizard extends LDAPUtility {
 			}
 		};
 
-		throw new \Exception(self::$t->l('Could not detect user display name attribute. Please specify it yourself in advanced ldap settings.'));
+		throw new \Exception(self::$l->t('Could not detect user display name attribute. Please specify it yourself in advanced ldap settings.'));
 	}
 
 	/**

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -550,23 +550,9 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 	public function testCountUsers() {
 		$access = $this->getAccessMock();
 
-		$access->connection->expects($this->once())
-			   ->method('__get')
-			   ->will($this->returnCallback(function($name) {
-					if($name === 'ldapLoginFilter') {
-						return 'uid=%uid';
-					}
-					return null;
-			   }));
-
 		$access->expects($this->once())
 			   ->method('countUsers')
-			   ->will($this->returnCallback(function($filter, $a, $b, $c) {
-				   if($filter !== 'uid=*') {
-					   return false;
-				   }
-				   return 5;
-			   }));
+			   ->will($this->returnValue(5));
 
 		$backend = new UserLDAP($access);
 
@@ -577,23 +563,9 @@ class Test_User_Ldap_Direct extends \PHPUnit_Framework_TestCase {
 	public function testCountUsersFailing() {
 		$access = $this->getAccessMock();
 
-		$access->connection->expects($this->once())
-			   ->method('__get')
-			   ->will($this->returnCallback(function($name) {
-					if($name === 'ldapLoginFilter') {
-						return 'invalidFilter';
-					}
-					return null;
-			   }));
-
 		$access->expects($this->once())
 			   ->method('countUsers')
-			   ->will($this->returnCallback(function($filter, $a, $b, $c) {
-				   if($filter !== 'uid=*') {
-					   return false;
-				   }
-				   return 5;
-			   }));
+			   ->will($this->returnValue(false));
 
 		$backend = new UserLDAP($access);
 

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -290,8 +290,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	 * @return int|bool
 	 */
 	public function countUsers() {
-		$filter = \OCP\Util::mb_str_replace(
-			'%uid', '*', $this->access->connection->ldapLoginFilter, 'UTF-8');
+		$filter = $this->access->getFilterForUserCount();
 		$entries = $this->access->countUsers($filter);
 		return $entries;
 	}


### PR DESCRIPTION
This fixes https://github.com/owncloud/core/issues/11328 and introduces some bigger changes.
1. we introduce the detection of the display name attribute, because on not so few LDAP setups "displayname" is not present. The detectors first checks whether there are entries having "displayname" according to the current user filter. If not it checks "cn". "cn", short for "common name" should be available everywhere. If necessary we can extend it with "uid" and "samaccountname" although those are not meant to be displayed to users. This also ensures that users will be able to log in since a present display name is a condition.
2. The wizard and the user backend created different filters for counting users by there own. They have been consolidated in Access and are used by both. The created filter also takes display name into account, and the number of LDAP users in user managament and wizard is now the same.
3. We now have three detectors, one for the email attribute and one for the group member association was already there. They were called in several places, now I cleaned it up so that they are always one run just before a count action. For setups using the totally assisted mode it means that the detectors will run anyway. They will also run in experienced mode, when "test filter" is clicked. To make sure they run even if the button is not clicked, we watch the state and run them ONCE when the user respectively group tab is left. All in all that saves some initiated and cancelled calls.
4. The wizard backend was improved in a way that for certain count operations a flag can be set limits the query to just 1. We need this to verifiy whether an attribute does still work with the current filter (email, displayname) where it is not necessary to count every single object, one presence is enough. This is done to avoid another full detection run. Also, when determining the display name this limit is used. I.e. those actions are faster now. It incorporates a fix where the limit was not respected properly in the count method (no side effects as it was not used anywhere else).
5. it incorporates a fix where the email attribute was detected and presented in the user interface, but not saved.

While testing i have seen some disbehaviour in the wizard which however is also present in master. Those I will investigated independtly from this PR.

Call for comments, tests and reviews @craigpg @jnfrmarks @PVince81 @Xenopathic @butonic 
