### PR TITLE
Close session for files_trashbin

### DIFF
--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -2,6 +2,8 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
+\OC::$server->getSession()->close();
+
 $folder = isset($_POST['dir']) ? $_POST['dir'] : '/';
 
 // "empty trash" command

--- a/apps/files_trashbin/ajax/isEmpty.php
+++ b/apps/files_trashbin/ajax/isEmpty.php
@@ -6,6 +6,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
+\OC::$server->getSession()->close();
 
 $trashStatus = OCA\Files_Trashbin\Trashbin::isEmpty(OCP\User::getUser());
 

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -1,6 +1,7 @@
 <?php
 
 OCP\JSON::checkLoggedIn();
+\OC::$server->getSession()->close();
 
 // Load the files
 $dir = isset( $_GET['dir'] ) ? $_GET['dir'] : '';

--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -6,6 +6,7 @@
  * See the COPYING-README file.
  */
 \OC_Util::checkLoggedIn();
+\OC::$server->getSession()->close();
 
 if(!\OC_App::isEnabled('files_trashbin')){
 	exit;

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -2,6 +2,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
+\OC::$server->getSession()->close();
 
 $files = $_POST['files'];
 $dir = '/';


### PR DESCRIPTION
When restoring huge folders the interface will be unresponsive otherwise.

Something I realized why accidentially deleting and restoring a huge folder on S3...
