### PR TITLE
remove unnecessary require calls - the ownCloud class loader is supposed...

### DIFF
--- a/apps/files/tests/helper.php
+++ b/apps/files/tests/helper.php
@@ -6,8 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/../lib/helper.php';
-
 use OCA\Files;
 
 /**

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -7,16 +7,6 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../lib/helper.php';
-require_once __DIR__ . '/../appinfo/app.php';
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -6,8 +6,6 @@
  * See the COPYING-README file.
  */
 
-
-require_once __DIR__ . '/../lib/helper.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -20,12 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -6,14 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../lib/helper.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -20,13 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -20,14 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../lib/helper.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -20,13 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -20,14 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
-require_once __DIR__ . '/../../files_trashbin/appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -6,14 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
-
 use OCA\Encryption;
 
 /**

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -20,13 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-require_once __DIR__ . '/../lib/crypt.php';
-require_once __DIR__ . '/../lib/keymanager.php';
-require_once __DIR__ . '/../lib/proxy.php';
-require_once __DIR__ . '/../lib/stream.php';
-require_once __DIR__ . '/../lib/util.php';
-require_once __DIR__ . '/../appinfo/app.php';
 require_once __DIR__ . '/util.php';
 
 use OCA\Encryption;

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -20,14 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 use OCA\Files\Share;
+use OCA\Files_sharing\Tests\TestCase;
 
 /**
  * Class Test_Files_Sharing_Api
  */
-class Test_Files_Sharing_Api extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Api extends TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/backend.php
+++ b/apps/files_sharing/tests/backend.php
@@ -20,14 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 use OCA\Files\Share;
+use OCA\Files_sharing\Tests\TestCase;
 
 /**
  * Class Test_Files_Sharing
  */
-class Test_Files_Sharing_Backend extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Backend extends TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -1,4 +1,6 @@
 <?php
+use OCA\Files_sharing\Tests\TestCase;
+
 /**
  * ownCloud
  *
@@ -20,9 +22,8 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-require_once __DIR__ . '/base.php';
 
-class Test_Files_Sharing_Cache extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Cache extends TestCase {
 
 	/**
 	 * @var OC\Files\View

--- a/apps/files_sharing/tests/externalstorage.php
+++ b/apps/files_sharing/tests/externalstorage.php
@@ -20,8 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 /**
  * Tests for the external Storage class for remote shares.
  */

--- a/apps/files_sharing/tests/helper.php
+++ b/apps/files_sharing/tests/helper.php
@@ -1,4 +1,6 @@
 <?php
+use OCA\Files_sharing\Tests\TestCase;
+
 /**
  * ownCloud
  *
@@ -19,9 +21,8 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-require_once __DIR__ . '/base.php';
 
-class Test_Files_Sharing_Helper extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Helper extends TestCase {
 
 	/**
 	 * test set and get share folder

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -23,9 +23,8 @@ use OC\Files\Cache\Cache;
 use OC\Files\Storage\Storage;
 use OC\Files\View;
 
-require_once __DIR__ . '/base.php';
 
-class Test_Files_Sharing_Permissions extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Permissions extends OCA\Files_sharing\Tests\TestCase {
 
 	/**
 	 * @var Storage

--- a/apps/files_sharing/tests/proxy.php
+++ b/apps/files_sharing/tests/proxy.php
@@ -20,14 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
 
 use OCA\Files\Share;
 
 /**
  * Class Test_Files_Sharing_Proxy
  */
-class Test_Files_Sharing_Proxy extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Proxy extends OCA\Files_sharing\Tests\TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -20,14 +20,12 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 use OCA\Files\Share;
 
 /**
  * Class Test_Files_Sharing
  */
-class Test_Files_Sharing extends Test_Files_Sharing_Base {
+class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -20,12 +20,10 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 /**
  * Class Test_Files_Sharing_Api
  */
-class Test_Files_Sharing_Mount extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -20,14 +20,12 @@
  *
  */
 
-require_once __DIR__ . '/base.php';
-
 use OCA\Files\Share;
 
 /**
  * Class Test_Files_Sharing_Api
  */
-class Test_Files_Sharing_Storage extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 
 	function setUp() {
 		parent::setUp();

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -20,7 +20,7 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
+namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files\Share;
 
@@ -29,7 +29,7 @@ use OCA\Files\Share;
  *
  * Base class for sharing tests.
  */
-abstract class Test_Files_Sharing_Base extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	const TEST_FILES_SHARING_API_USER1 = "test-share-user1";
 	const TEST_FILES_SHARING_API_USER2 = "test-share-user2";
@@ -41,7 +41,7 @@ abstract class Test_Files_Sharing_Base extends \PHPUnit_Framework_TestCase {
 	public $filename;
 	public $data;
 	/**
-	 * @var OC\Files\View
+	 * @var \OC\Files\View
 	 */
 	public $view;
 	public $folder;

--- a/apps/files_sharing/tests/update.php
+++ b/apps/files_sharing/tests/update.php
@@ -22,12 +22,11 @@
  */
 
 require_once __DIR__ . '/../appinfo/update.php';
-require_once __DIR__ . '/base.php';
 
 /**
  * Class Test_Files_Sharing_Update
  */
-class Test_Files_Sharing_Update_Routine extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Update_Routine extends OCA\Files_Sharing\Tests\TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_api_test';
 

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -21,12 +21,11 @@
  */
 
 require_once __DIR__ . '/../appinfo/update.php';
-require_once __DIR__ . '/base.php';
 
 /**
  * Class Test_Files_Sharing_Updater
  */
-class Test_Files_Sharing_Updater extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Updater extends OCA\Files_sharing\Tests\TestCase {
 
 	const TEST_FOLDER_NAME = '/folder_share_updater_test';
 

--- a/apps/files_sharing/tests/watcher.php
+++ b/apps/files_sharing/tests/watcher.php
@@ -19,9 +19,28 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-require_once __DIR__ . '/base.php';
 
-class Test_Files_Sharing_Watcher extends Test_Files_Sharing_Base {
+class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
+
+	/**
+	 * @var \OC\Files\Storage\Storage
+	 */
+	private $ownerStorage;
+
+	/**
+	 * @var \OC\Files\Cache\Cache
+	 */
+	private $ownerCache;
+
+	/**
+	 * @var \OC\Files\Storage\Storage
+	 */
+	private $sharedStorage;
+
+	/**
+	 * @var \OC\Files\Cache\Cache
+	 */
+	private $sharedCache;
 
 	function setUp() {
 		parent::setUp();

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -20,8 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/../../../lib/base.php';
-
 use OCA\Files_Trashbin;
 
 /**

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -32,6 +32,9 @@ class Test_Files_Versioning extends \PHPUnit_Framework_TestCase {
 	const TEST_VERSIONS_USER = 'test-versions-user';
 	const USERS_VERSIONS_ROOT = '/test-versions-user/files_versions';
 
+	/**
+	 * @var \OC\Files\View
+	 */
 	private $rootView;
 
 	public static function setUpBeforeClass() {
@@ -63,7 +66,7 @@ class Test_Files_Versioning extends \PHPUnit_Framework_TestCase {
 	 */
 	function testGetExpireList($versions, $sizeOfAllDeletedFiles) {
 
-		// last interval enda at 2592000
+		// last interval end at 2592000
 		$startTime = 5000000;
 
 		$testClass = new VersionStorageToTest();

--- a/tests/lib/appframework/http/DownloadResponseTest.php
+++ b/tests/lib/appframework/http/DownloadResponseTest.php
@@ -25,14 +25,16 @@
 namespace OCP\AppFramework\Http;
 
 
-//require_once(__DIR__ . "/../classloader.php");
+class ChildDownloadResponse extends DownloadResponse {
 
-
-class ChildDownloadResponse extends DownloadResponse {};
+};
 
 
 class DownloadResponseTest extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * @var ChildDownloadResponse
+	 */
 	protected $response;
 
 	protected function setUp(){

--- a/tests/lib/appframework/http/HttpTest.php
+++ b/tests/lib/appframework/http/HttpTest.php
@@ -26,13 +26,14 @@ namespace OC\AppFramework\Http;
 
 use OC\AppFramework\Http;
 
-//require_once(__DIR__ . "/../classloader.php");
-
-
 
 class HttpTest extends \PHPUnit_Framework_TestCase {
 
 	private $server;
+
+	/**
+	 * @var Http
+	 */
 	private $http;
 
 	protected function setUp(){

--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -30,10 +30,6 @@ namespace OC\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http;
 
-//require_once(__DIR__ . "/../classloader.php");
-
-
-
 class JSONResponseTest extends \PHPUnit_Framework_TestCase {
 
 	/**

--- a/tests/lib/appframework/http/RedirectResponseTest.php
+++ b/tests/lib/appframework/http/RedirectResponseTest.php
@@ -26,13 +26,12 @@ namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
 
-//require_once(__DIR__ . "/../classloader.php");
-
-
 
 class RedirectResponseTest extends \PHPUnit_Framework_TestCase {
 
-
+	/**
+	 * @var RedirectResponse
+	 */
 	protected $response;
 
 	protected function setUp(){

--- a/tests/lib/archive/tar.php
+++ b/tests/lib/archive/tar.php
@@ -6,8 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once 'archive.php';
-
 class Test_Archive_TAR extends Test_Archive {
 	public function setUp() {
 		if (OC_Util::runningOnWindows()) {

--- a/tests/lib/archive/zip.php
+++ b/tests/lib/archive/zip.php
@@ -6,8 +6,6 @@
  * See the COPYING-README file.
  */
 
-require_once 'archive.php';
-
 if (!OC_Util::runningOnWindows()) {
 class Test_Archive_ZIP extends Test_Archive {
 	protected function getExisting() {


### PR DESCRIPTION
... to take care of this

@schiesbn this mainly touches your code base - please have a look

What's the reason for these changes?
Within our phpunit configuration we already require lib/base.php which fires up the whole ownCloud instance including the class loader. There is no need to require all these files explicitly.

Further reviewers please @PVince81 @icewind1991 @bantu THX
