### PR TITLE
Only rescan trash folder when checking deleted versions

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -933,7 +933,7 @@ class Trashbin {
 		//force rescan of versions, local storage may not have updated the cache
 		/** @var \OC\Files\Storage\Storage $storage */
 		list($storage, ) = $view->resolvePath('/');
-		$storage->getScanner()->scan('');
+		$storage->getScanner()->scan('files_trashbin');
 
 		if ($timestamp) {
 			// fetch for old versions


### PR DESCRIPTION
This fix prevents the file scanner to rescan the WHOLE storage and reset
the etags by mistake.

Fixes https://github.com/owncloud/core/issues/11932

Please review @butonic @schiesbn @icewind1991 
