### PR TITLE
enable laxbreak option in jshintrc to comply with our coding guide lines

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,6 +14,7 @@
 	"maxlen": 120,
 	"indent": 4,
 	"browser": true,
+	"laxbreak": true,
 	"globals": {
 		"console": true,
 		"it": true,


### PR DESCRIPTION
Our JS coding guide lines want to have operators in split control structure lines on the left hand sides. Rightfully so for better readability: http://doc.owncloud.org/server/7.0/developer_manual/app/general/codingguidelines.html#id2

However, our JS Hint check results in such errors when applying this rule:

`There seems to be a bad line break before &&.`

See it in thus scrutinizer result:  https://scrutinizer-ci.com/g/owncloud/core/inspections/49a82234-76de-43d5-88fa-ee97b49985aa/issues/files/apps/user_ldap/js/settings.js?status=new&selectedAuthors[0]=blizzz%40owncloud.com&orderField=path&order=asc

The only possibility to make jshint pass is to enable [laxbreak](http://www.jshint.com/docs/options/#laxbreak). 

I have no idea what to do about the prior »You should not use mixed whitespace characters (tabs and spaces).«.

Opinions? @PVince81 @DeepDiver1975 @MorrisJobke others?
