### PR TITLE
Add $uid and $password templates to 'files_external' configuration

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -182,11 +182,11 @@ class OC_Mount_Config {
 			$mounts = $mountConfig[self::MOUNT_TYPE_USER]['all'];
 			foreach ($mounts as $mountPoint => $options) {
 				$mountPoint = self::setUserVars($user, $mountPoint);
+				$options['personal'] = false;
+				$options['options'] = self::decryptPasswords($options['options']);
 				foreach ($options as &$option) {
 					$option = self::setUserVars($user, $option);
 				}
-				$options['personal'] = false;
-				$options['options'] = self::decryptPasswords($options['options']);
 				if (!isset($options['priority'])) {
 					$options['priority'] = $backends[$options['class']]['priority'];
 				}
@@ -206,11 +206,11 @@ class OC_Mount_Config {
 				if (\OC_Group::inGroup($user, $group)) {
 					foreach ($mounts as $mountPoint => $options) {
 						$mountPoint = self::setUserVars($user, $mountPoint);
+						$options['personal'] = false;
+						$options['options'] = self::decryptPasswords($options['options']);
 						foreach ($options as &$option) {
 							$option = self::setUserVars($user, $option);
 						}
-						$options['personal'] = false;
-						$options['options'] = self::decryptPasswords($options['options']);
 						if (!isset($options['priority'])) {
 							$options['priority'] = $backends[$options['class']]['priority'];
 						}
@@ -233,11 +233,11 @@ class OC_Mount_Config {
 				if (strtolower($mountUser) === strtolower($user)) {
 					foreach ($mounts as $mountPoint => $options) {
 						$mountPoint = self::setUserVars($user, $mountPoint);
+						$options['personal'] = false;
+						$options['options'] = self::decryptPasswords($options['options']);
 						foreach ($options as &$option) {
 							$option = self::setUserVars($user, $option);
 						}
-						$options['personal'] = false;
-						$options['options'] = self::decryptPasswords($options['options']);
 						if (!isset($options['priority'])) {
 							$options['priority'] = $backends[$options['class']]['priority'];
 						}
@@ -284,7 +284,13 @@ class OC_Mount_Config {
 	 * @return string
 	 */
 	private static function setUserVars($user, $input) {
-		return str_replace('$user', $user, $input);
+		$output = str_replace('$user', $user, $input);
+		if( \OC::$server->getSession()->exists('smb-credentials') ) {
+			$params_auth = \OC::$server->getSession()->get('smb-credentials');
+			$output = str_replace('$uid', $params_auth['uid'], $output);
+			$output = str_replace('$password', $params_auth['password'], $output);
+		}
+		return $output;
 	}
 
 


### PR DESCRIPTION
Pull 'uid' and 'password' variables from PHP session 'smb-credentials'
array - if existing - and allow them to be used as $uid and $password
templates when configuring system mounts (in data/mount.json).

This allows to dynamically mount users' home directories using their
login credentials and comes handy when using the 'user_ldap' authentication
App/backend.

It has been verified to work successfully using OC 7.0.2 and SFTP.

I Hope it can help!

Best,

Cédric
