### PR TITLE
Setup shared mounts for the correct user when setting up the filesystem

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -22,15 +22,15 @@ class SharedMount extends Mount implements MoveableMount {
 
 	public function __construct($storage, $mountpoint, $arguments = null, $loader = null) {
 		// first update the mount point before creating the parent
-		$newMountPoint = self::verifyMountPoint($arguments['share']);
-		$absMountPoint = '/' . \OCP\User::getUser() . '/files' . $newMountPoint;
+		$newMountPoint = $this->verifyMountPoint($arguments['share'], $arguments['user']);
+		$absMountPoint = '/' . $arguments['user'] . '/files' . $newMountPoint;
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
 
 	/**
 	 * check if the parent folder exists otherwise move the mount point up
 	 */
-	private static function verifyMountPoint(&$share) {
+	private function verifyMountPoint(&$share, $user) {
 
 		$mountPoint = basename($share['file_target']);
 		$parent = dirname($share['file_target']);
@@ -42,7 +42,7 @@ class SharedMount extends Mount implements MoveableMount {
 		$newMountPoint = \OCA\Files_Sharing\Helper::generateUniqueTarget(
 				\OC\Files\Filesystem::normalizePath($parent . '/' . $mountPoint),
 				array(),
-				new \OC\Files\View('/' . \OCP\User::getUser() . '/files')
+				new \OC\Files\View('/' . $user . '/files')
 				);
 
 		if($newMountPoint !== $share['file_target']) {

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -397,7 +397,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	}
 
 	public static function setup($options) {
-		$shares = \OCP\Share::getItemsSharedWith('file');
+		$shares = \OCP\Share::getItemsSharedWithUser('file', $options['user']);
 		$manager = Filesystem::getMountManager();
 		$loader = Filesystem::getLoader();
 		if (!\OCP\User::isLoggedIn() || \OCP\User::getUser() != $options['user']
@@ -411,7 +411,8 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 							$options['user_dir'] . '/' . $share['file_target'],
 							array(
 								'share' => $share,
-								),
+								'user' => $options['user']
+							),
 							$loader
 							);
 					$manager->addMount($mount);

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -35,6 +35,9 @@ class Test_Files_Sharing_Api extends TestCase {
 	function setUp() {
 		parent::setUp();
 
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_expire_after_n_days', '7');
+
 		$this->folder = self::TEST_FOLDER_NAME;
 		$this->subfolder  = '/subfolder_share_api_test';
 		$this->subsubfolder = '/subsubfolder_share_api_test';

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -226,6 +226,10 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 }
 
 class DummyTestClassSharedMount extends \OCA\Files_Sharing\SharedMount {
+	public function __construct($storage, $mountpoint, $arguments = null, $loader = null){
+		// noop
+	}
+
 	public function stripUserFilesPathDummy($path) {
 		return $this->stripUserFilesPath($path);
 	}

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -65,9 +65,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		\OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 
 		// create users
-		self::loginHelper(self::TEST_FILES_SHARING_API_USER1, true);
-		self::loginHelper(self::TEST_FILES_SHARING_API_USER2, true);
-		self::loginHelper(self::TEST_FILES_SHARING_API_USER3, true);
+		$backend = new \OC_User_Dummy();
+		\OC_User::useBackend($backend);
+		$backend->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
+		$backend->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
+		$backend->createUser(self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER3);
 
 		// create group
 		\OC_Group::createGroup(self::TEST_FILES_SHARING_API_GROUP1);

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -72,8 +72,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER3);
 
 		// create group
-		\OC_Group::createGroup(self::TEST_FILES_SHARING_API_GROUP1);
-		\OC_Group::addToGroup(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_GROUP1);
+		$groupBackend = new \OC_Group_Dummy();
+		$groupBackend->createGroup(self::TEST_FILES_SHARING_API_GROUP1);
+		$groupBackend->createGroup('group');
+		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER1, 'group');
+		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, 'group');
+		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER3, 'group');
+		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_GROUP1);
+		\OC_Group::useBackend($groupBackend);
 
 	}
 

--- a/lib/private/user/dummy.php
+++ b/lib/private/user/dummy.php
@@ -26,9 +26,11 @@
  */
 class OC_User_Dummy extends OC_User_Backend {
 	private $users = array();
+	private $displayNames = array();
 
 	/**
 	 * Create a new user
+	 *
 	 * @param string $uid The username of the user to create
 	 * @param string $password The password of the new user
 	 * @return bool
@@ -47,6 +49,7 @@ class OC_User_Dummy extends OC_User_Backend {
 
 	/**
 	 * delete a user
+	 *
 	 * @param string $uid The username of the user to delete
 	 * @return bool
 	 *
@@ -63,6 +66,7 @@ class OC_User_Dummy extends OC_User_Backend {
 
 	/**
 	 * Set password
+	 *
 	 * @param string $uid The username
 	 * @param string $password The new password
 	 * @return bool
@@ -80,6 +84,7 @@ class OC_User_Dummy extends OC_User_Backend {
 
 	/**
 	 * Check if the password is correct
+	 *
 	 * @param string $uid The username
 	 * @param string $password The password
 	 * @return string
@@ -97,6 +102,7 @@ class OC_User_Dummy extends OC_User_Backend {
 
 	/**
 	 * Get a list of all users
+	 *
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -105,12 +111,12 @@ class OC_User_Dummy extends OC_User_Backend {
 	 * Get a list of all users.
 	 */
 	public function getUsers($search = '', $limit = null, $offset = null) {
-		if(empty($search)) {
+		if (empty($search)) {
 			return array_keys($this->users);
 		}
 		$result = array();
-		foreach(array_keys($this->users) as $user) {
-			if(stripos($user, $search) !== false) {
+		foreach (array_keys($this->users) as $user) {
+			if (stripos($user, $search) !== false) {
 				$result[] = $user;
 			}
 		}
@@ -119,6 +125,7 @@ class OC_User_Dummy extends OC_User_Backend {
 
 	/**
 	 * check if a user exists
+	 *
 	 * @param string $uid the username
 	 * @return boolean
 	 */
@@ -140,5 +147,13 @@ class OC_User_Dummy extends OC_User_Backend {
 	 */
 	public function countUsers() {
 		return 0;
+	}
+
+	public function setDisplayName($uid, $displayName) {
+		$this->displayNames[$uid] = $displayName;
+	}
+
+	public function getDisplayName($uid) {
+		return isset($this->displayNames[$uid])? $this->displayNames[$uid]: $uid;
 	}
 }


### PR DESCRIPTION
Currently the mountpoint setup logic for files_shared will always setup the shared mountpoints for the logged in user, no matter what user the filesystem is being setup for.

Besides resulting in the filesystem not being in the state we expect it to this causes the shared mounts for the logged in user to be setup multiple times leading to the `(2) (2) (2)` explosion.

cc @DeepDiver1975 @PVince81 @schiesbn 
