### PR TITLE
Enc stop uploading if private key is missing

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -13,6 +13,7 @@ OC::$CLASSPATH['OCA\Encryption\Helper'] = 'files_encryption/lib/helper.php';
 // Exceptions
 OC::$CLASSPATH['OCA\Encryption\Exceptions\MultiKeyEncryptException'] = 'files_encryption/lib/exceptions.php';
 OC::$CLASSPATH['OCA\Encryption\Exceptions\MultiKeyDecryptException'] = 'files_encryption/lib/exceptions.php';
+OC::$CLASSPATH['OCA\Encryption\Exceptions\EncryptionException'] = 'files_encryption/lib/exceptions.php';
 
 \OCP\Util::addTranslations('files_encryption');
 \OCP\Util::addscript('files_encryption', 'encryption');

--- a/apps/files_encryption/lib/exceptions.php
+++ b/apps/files_encryption/lib/exceptions.php
@@ -30,8 +30,16 @@ namespace OCA\Encryption\Exceptions;
  * 30 - encryption header to large
  * 40 - unknown cipher
  * 50 - encryption failed
+ * 60 - no private key available
  */
 class EncryptionException extends \Exception {
+	const UNEXPECTED_END_OF_ENCRTYPTION_HEADER = 10;
+	const UNEXPECTED_BLOG_SIZE = 20;
+	const ENCRYPTION_HEADER_TO_LARGE = 30;
+	const UNKNOWN_CIPHER = 40;
+	const ENCRYPTION_FAILED = 50;
+	const NO_PRIVATE_KEY_AVAILABLE = 60;
+
 }
 
 /**

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -95,8 +95,7 @@ class Proxy extends \OC_FileProxy {
 
 		// don't call the crypt stream wrapper, if...
 		if (
-				$session->getInitialized() !== Session::INIT_SUCCESSFUL // encryption successful initialized
-				|| Crypt::mode() !== 'server'   // we are not in server-side-encryption mode
+				Crypt::mode() !== 'server'   // we are not in server-side-encryption mode
 				|| $this->isExcludedPath($path, $userId) // if path is excluded from encryption
 				|| substr($path, 0, 8) === 'crypt://' // we are already in crypt mode
 		) {

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -30,6 +30,7 @@
  */
 
 namespace OCA\Encryption;
+use OCA\Encryption\Exceptions\EncryptionException;
 
 /**
  * Provides 'crypt://' stream wrapper protocol.
@@ -106,6 +107,10 @@ class Stream {
 		$this->session = new \OCA\Encryption\Session($this->rootView);
 
 		$this->privateKey = $this->session->getPrivateKey();
+		if ($this->privateKey === false) {
+			throw new EncryptionException('Session does not contain a private key, maybe your login password changed?',
+					EncryptionException::NO_PRIVATE_KEY_AVAILABLE);
+		}
 
 		$normalizedPath = \OC\Files\Filesystem::normalizePath(str_replace('crypt://', '', $path));
 		if ($originalFile = Helper::getPathFromTmpFile($normalizedPath)) {

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -100,6 +100,8 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		} catch (\OCP\Files\LockNotAcquiredException $e) {
 			// the file is currently being written to by another process
 			throw new OC_Connector_Sabre_Exception_FileLocked($e->getMessage(), $e->getCode(), $e);
+		} catch (\OCA\Encryption\Exceptions\EncryptionException $e) {
+			throw new \Sabre\DAV\Exception\Forbidden($e->getMessage());
 		}
 
 		// if content length is sent by client:
@@ -152,7 +154,11 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		if (\OC_Util::encryptedFiles()) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable();
 		} else {
-			return $this->fileView->fopen(ltrim($this->path, '/'), 'rb');
+			try {
+				return $this->fileView->fopen(ltrim($this->path, '/'), 'rb');
+			} catch (\OCA\Encryption\Exceptions\EncryptionException $e) {
+				throw new \Sabre\DAV\Exception\Forbidden($e->getMessage());
+			}
 		}
 
 	}


### PR DESCRIPTION
If no unencrypted private key exists we throw a exception instead of continue silently. This can for example happen if the user reset his login password and didn't adjusted his private key password

fix #11926
