### PR TITLE
Fix for core/js/share.js Line 432

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2092,6 +2092,9 @@ class Share extends \OC\Share\Constants {
 		if (isset($row['file_source'])) {
 			$row['file_source'] = (int) $row['file_source'];
 		}
+		if (isset($row['item_source'])) {
+			$row['item_source'] = (int) $row['item_source'];
+		}
 		if (isset($row['permissions'])) {
 			$row['permissions'] = (int) $row['permissions'];
 		}


### PR DESCRIPTION
Without this fix the link checkbox will not shown cause the compare:

```
if (itemSource === share.file_source || itemSource === share.item_source) {
```

itemSource is type of number and share.item_source is type of string

https://github.com/owncloud/core/blob/master/core/js/share.js#L432
