### PR TITLE
Remove confusingly names \OC\User\Manager::delete and fix the automatic ...

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -211,9 +211,6 @@ class OC_User {
 
 				// Delete the users entry in the storage table
 				\OC\Files\Cache\Storage::remove('home::' . $uid);
-
-				// Remove it from the Cache
-				self::getManager()->delete($uid);
 			}
 
 			return true;

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -46,17 +46,17 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function __construct($config = null) {
 		$this->config = $config;
-		$cachedUsers = $this->cachedUsers;
+		$cachedUsers = &$this->cachedUsers;
 		$this->listen('\OC\User', 'postDelete', function ($user) use (&$cachedUsers) {
-			$i = array_search($user, $cachedUsers);
-			if ($i !== false) {
-				unset($cachedUsers[$i]);
-			}
+			/** @var \OC\User\User $user */
+			unset($cachedUsers[$user->getUID()]);
 		});
 		$this->listen('\OC\User', 'postLogin', function ($user) {
+			/** @var \OC\User\User $user */
 			$user->updateLastLoginTimestamp();
 		});
 		$this->listen('\OC\User', 'postRememberedLogin', function ($user) {
+			/** @var \OC\User\User $user */
 			$user->updateLastLoginTimestamp();
 		});
 	}
@@ -132,20 +132,6 @@ class Manager extends PublicEmitter implements IUserManager {
 	public function userExists($uid) {
 		$user = $this->get($uid);
 		return ($user !== null);
-	}
-
-	/**
-	 * remove deleted user from cache
-	 *
-	 * @param string $uid
-	 * @return bool
-	 */
-	public function delete($uid) {
-		if (isset($this->cachedUsers[$uid])) {
-			unset($this->cachedUsers[$uid]);
-			return true;
-		}
-		return false;
 	}
 
 	/**

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -360,10 +360,7 @@ class Test_App extends PHPUnit_Framework_TestCase {
 		$user1->delete();
 		$user2->delete();
 		$user3->delete();
-		// clear user cache...
-		$userManager->delete(self::TEST_USER1);
-		$userManager->delete(self::TEST_USER2);
-		$userManager->delete(self::TEST_USER3);
+
 		$group1->delete();
 		$group2->delete();
 	}
@@ -399,8 +396,6 @@ class Test_App extends PHPUnit_Framework_TestCase {
 		\OC_User::setUserId(null);
 
 		$user1->delete();
-		// clear user cache...
-		$userManager->delete(self::TEST_USER1);
 	}
 
 	/**

--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -416,6 +416,17 @@ class Manager extends \PHPUnit_Framework_TestCase {
 
 		$users = array_shift($result);
 		//users from backends shall be summed up
-		$this->assertEquals(7+16, $users);
+		$this->assertEquals(7 + 16, $users);
+	}
+
+	public function testDeleteUser() {
+		$manager = new \OC\User\Manager();
+		$backend = new \OC_User_Dummy();
+
+		$backend->createUser('foo', 'bar');
+		$manager->registerBackend($backend);
+		$this->assertTrue($manager->userExists('foo'));
+		$manager->get('foo')->delete();
+		$this->assertFalse($manager->userExists('foo'));
 	}
 }


### PR DESCRIPTION
...cache cleanup instead

Dont confuse @Raydiation with poorly names methods :smile: 

cc @DeepDiver1975 @PVince81 
