### PR TITLE
drop unused library chosen

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -15,8 +15,6 @@ OC_Util::addScript( 'settings', 'personal' );
 OC_Util::addStyle( 'settings', 'settings' );
 OC_Util::addScript( '3rdparty', 'strengthify/jquery.strengthify' );
 OC_Util::addStyle( '3rdparty', 'strengthify/strengthify' );
-OC_Util::addScript( '3rdparty', 'chosen/chosen.jquery.min' );
-OC_Util::addStyle( '3rdparty', 'chosen/chosen' );
 \OC_Util::addScript('files', 'jquery.fileupload');
 if (\OC_Config::getValue('enable_avatars', true) === true) {
 	\OC_Util::addScript('3rdparty/Jcrop', 'jquery.Jcrop.min');


### PR DESCRIPTION
commit that introduced this: daee88fd26b69d997b5a203c42d6a3cb1dbe46dc

I ack-greped but couldn't find any trace. Therefore I vote for the drop.

cc @Deepdiver1975 @lukasreschke @pvince81 @blizzz 
