### PR TITLE
[encryption] check if the provided password is really the current log-in password

### DIFF
--- a/apps/files_encryption/ajax/updatePrivateKeyPassword.php
+++ b/apps/files_encryption/ajax/updatePrivateKeyPassword.php
@@ -18,6 +18,7 @@ use OCA\Encryption;
 $l = \OC::$server->getL10N('core');
 
 $return = false;
+$errorMessage = $l->t('Could not update the private key password.');
 
 $oldPassword = $_POST['oldPassword'];
 $newPassword = $_POST['newPassword'];
@@ -25,6 +26,11 @@ $newPassword = $_POST['newPassword'];
 $view = new \OC\Files\View('/');
 $session = new \OCA\Encryption\Session($view);
 $user = \OCP\User::getUser();
+
+// check new password
+$passwordCorrect = \OCP\User::checkPassword($user, $newPassword);
+
+if ($passwordCorrect !== false) {
 
 $proxyStatus = \OC_FileProxy::$enabled;
 \OC_FileProxy::$enabled = false;
@@ -42,14 +48,22 @@ if ($decryptedKey) {
 		$session->setPrivateKey($decryptedKey);
 		$return = true;
 	}
+} else {
+	$result = false;
+	$errorMessage = $l->t('The old password was not correct, please try again.');
 }
 
 \OC_FileProxy::$enabled = $proxyStatus;
+
+} else {
+	$result = false;
+	$errorMessage = $l->t('The current log-in password was not correct, please try again.');
+}
 
 // success or failure
 if ($return) {
 	$session->setInitialized(\OCA\Encryption\Session::INIT_SUCCESSFUL);
 	\OCP\JSON::success(array('data' => array('message' => $l->t('Private key password successfully updated.'))));
 } else {
-	\OCP\JSON::error(array('data' => array('message' => $l->t('Could not update the private key password. Maybe the old password was not correct.'))));
+	\OCP\JSON::error(array('data' => array('message' => $errorMessage)));
 }


### PR DESCRIPTION
Verify that the new password is really the current login password from the user before updating the private key password.

fix #11667
