### PR TITLE
[stable7] Convert StorageNotAvailableException to SabreDAV exception

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -50,9 +50,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 	 * @return string|null
 	 */
 	public function put($data) {
-		if ($this->info && $this->fileView->file_exists($this->path) &&
-			!$this->info->isUpdateable()) {
-			throw new \Sabre\DAV\Exception\Forbidden();
+		try {
+			if ($this->info && $this->fileView->file_exists($this->path) &&
+				!$this->info->isUpdateable()) {
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
+		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		}
 
 		// throw an exception if encryption was disabled but the files are still encrypted
@@ -100,42 +104,48 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		} catch (\OCP\Files\LockNotAcquiredException $e) {
 			// the file is currently being written to by another process
 			throw new OC_Connector_Sabre_Exception_FileLocked($e->getMessage(), $e->getCode(), $e);
+		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		}
 
-		// double check if the file was fully received
-		// compare expected and actual size
-		if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] !== 'LOCK') {
-			$expected = $_SERVER['CONTENT_LENGTH'];
-			$actual = $this->fileView->filesize($partFilePath);
-			if ($actual != $expected) {
-				$this->fileView->unlink($partFilePath);
-				throw new \Sabre\DAV\Exception\BadRequest('expected filesize ' . $expected . ' got ' . $actual);
-			}
-		}
-
-		// rename to correct path
 		try {
-			$renameOkay = $this->fileView->rename($partFilePath, $this->path);
-			$fileExists = $this->fileView->file_exists($this->path);
-			if ($renameOkay === false || $fileExists === false) {
-				\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
-				$this->fileView->unlink($partFilePath);
-				throw new \Sabre\DAV\Exception('Could not rename part file to final file');
+			// double check if the file was fully received
+			// compare expected and actual size
+			if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] !== 'LOCK') {
+				$expected = $_SERVER['CONTENT_LENGTH'];
+				$actual = $this->fileView->filesize($partFilePath);
+				if ($actual != $expected) {
+					$this->fileView->unlink($partFilePath);
+					throw new \Sabre\DAV\Exception\BadRequest('expected filesize ' . $expected . ' got ' . $actual);
+				}
 			}
-		}
-		catch (\OCP\Files\LockNotAcquiredException $e) {
-			// the file is currently being written to by another process
-			throw new OC_Connector_Sabre_Exception_FileLocked($e->getMessage(), $e->getCode(), $e);
-		}
 
-		// allow sync clients to send the mtime along in a header
-		$mtime = OC_Request::hasModificationTime();
-		if ($mtime !== false) {
-			if($this->fileView->touch($this->path, $mtime)) {
-				header('X-OC-MTime: accepted');
+			// rename to correct path
+			try {
+				$renameOkay = $this->fileView->rename($partFilePath, $this->path);
+				$fileExists = $this->fileView->file_exists($this->path);
+				if ($renameOkay === false || $fileExists === false) {
+					\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
+					$this->fileView->unlink($partFilePath);
+					throw new \Sabre\DAV\Exception('Could not rename part file to final file');
+				}
 			}
+			catch (\OCP\Files\LockNotAcquiredException $e) {
+				// the file is currently being written to by another process
+				throw new OC_Connector_Sabre_Exception_FileLocked($e->getMessage(), $e->getCode(), $e);
+			}
+
+			// allow sync clients to send the mtime along in a header
+			$mtime = OC_Request::hasModificationTime();
+			if ($mtime !== false) {
+				if($this->fileView->touch($this->path, $mtime)) {
+					header('X-OC-MTime: accepted');
+				}
+			}
+			$this->refreshInfo();
+		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		}
-		$this->refreshInfo();
 
 		return '"' . $this->info->getEtag() . '"';
 	}
@@ -151,7 +161,11 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		if (\OC_Util::encryptedFiles()) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable();
 		} else {
-			return $this->fileView->fopen(ltrim($this->path, '/'), 'rb');
+			try {
+				return $this->fileView->fopen(ltrim($this->path, '/'), 'rb');
+			} catch (\OCP\Files\StorageNotAvailableException $e) {
+				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			}
 		}
 
 	}
@@ -167,9 +181,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
-		if (!$this->fileView->unlink($this->path)) {
-			// assume it wasn't possible to delete due to permissions
-			throw new \Sabre\DAV\Exception\Forbidden();
+		try {
+			if (!$this->fileView->unlink($this->path)) {
+				// assume it wasn't possible to delete due to permissions
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
+		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		}
 
 		// remove properties
@@ -243,33 +261,37 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 
 		if ($chunk_handler->isComplete()) {
 
-			// we first assembly the target file as a part file
-			$partFile = $path . '/' . $info['name'] . '.ocTransferId' . $info['transferid'] . '.part';
-			$chunk_handler->file_assemble($partFile);
+			try {
+				// we first assembly the target file as a part file
+				$partFile = $path . '/' . $info['name'] . '.ocTransferId' . $info['transferid'] . '.part';
+				$chunk_handler->file_assemble($partFile);
 
-			// here is the final atomic rename
-			$targetPath = $path . '/' . $info['name'];
-			$renameOkay = $this->fileView->rename($partFile, $targetPath);
-			$fileExists = $this->fileView->file_exists($targetPath);
-			if ($renameOkay === false || $fileExists === false) {
-				\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
-				// only delete if an error occurred and the target file was already created
-				if ($fileExists) {
-					$this->fileView->unlink($targetPath);
+				// here is the final atomic rename
+				$targetPath = $path . '/' . $info['name'];
+				$renameOkay = $this->fileView->rename($partFile, $targetPath);
+				$fileExists = $this->fileView->file_exists($targetPath);
+				if ($renameOkay === false || $fileExists === false) {
+					\OC_Log::write('webdav', '\OC\Files\Filesystem::rename() failed', \OC_Log::ERROR);
+					// only delete if an error occurred and the target file was already created
+					if ($fileExists) {
+						$this->fileView->unlink($targetPath);
+					}
+					throw new \Sabre\DAV\Exception('Could not rename part file assembled from chunks');
 				}
-				throw new \Sabre\DAV\Exception('Could not rename part file assembled from chunks');
-			}
 
-			// allow sync clients to send the mtime along in a header
-			$mtime = OC_Request::hasModificationTime();
-			if ($mtime !== false) {
-				if($this->fileView->touch($targetPath, $mtime)) {
-					header('X-OC-MTime: accepted');
+				// allow sync clients to send the mtime along in a header
+				$mtime = OC_Request::hasModificationTime();
+				if ($mtime !== false) {
+					if($this->fileView->touch($targetPath, $mtime)) {
+						header('X-OC-MTime: accepted');
+					}
 				}
-			}
 
-			$info = $this->fileView->getFileInfo($targetPath);
-			return $info->getEtag();
+				$info = $this->fileView->getFileInfo($targetPath);
+				return $info->getEtag();
+			} catch (\OCP\Files\StorageNotAvailableException $e) {
+				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			}
 		}
 
 		return null;

--- a/lib/private/connector/sabre/quotaplugin.php
+++ b/lib/private/connector/sabre/quotaplugin.php
@@ -102,7 +102,11 @@ class OC_Connector_Sabre_QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return mixed
 	 */
 	public function getFreeSpace($parentUri) {
-		$freeSpace = $this->view->free_space($parentUri);
-		return $freeSpace;
+		try {
+			$freeSpace = $this->view->free_space($parentUri);
+			return $freeSpace;
+		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+		}
 	}
 }


### PR DESCRIPTION
Convert \OCP\Files\StorageNotAvailableException to
\Sabre\DAV\Exception\ServiceUnavailable for every file/directory
operation happening inside of SabreDAV.

This is necessary to avoid having the exception bubble up to remote.php
which would return an exception page instead of an appropriate response.

Backport of https://github.com/owncloud/core/pull/11992 to stable7

@DeepDiver1975 @craigpg @icewind1991 

Before we accept this backport we need to test whether that really fixes https://github.com/owncloud/core/issues/11869 (CC @karlitschek)
