### PR TITLE
Use new hashing API for OC_User_Database

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -457,7 +457,8 @@ class OC {
 		// setup 3rdparty autoloader
 		$vendorAutoLoad = OC::$THIRDPARTYROOT . '/3rdparty/autoload.php';
 		if (file_exists($vendorAutoLoad)) {
-			require_once $vendorAutoLoad;
+			$loader = require_once $vendorAutoLoad;
+			$loader->add('PasswordHash', OC::$THIRDPARTYROOT . '/3rdparty/phpass');
 		} else {
 			OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 			OC_Template::printErrorPage('Composer autoloader not found, unable to continue.');


### PR DESCRIPTION
This will use the new Hashing API for OC_User_Database and migrate old passwords upon initial login of the user.

I'll migrate other occurences such as Sharing later. Changing this now makes no sense until the new Sharing PR has been merged.

To test this ensure that:
- [ ] Old logins still work
- [ ] Old login hashes gets converted
- [ ] New users can be created and can login

@DeepDiver1975 @bantu @PVince81 
