### PR TITLE
Work directly on the storage when uploading over webdav

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -71,7 +71,7 @@ class File extends Node implements IFile {
 	 * different object on a subsequent GET you are strongly recommended to not
 	 * return an ETag, and just return null.
 	 *
-	 * @param resource|string $data
+	 * @param resource $data
 	 *
 	 * @throws Forbidden
 	 * @throws UnsupportedMediaType

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -85,6 +85,7 @@ class File extends Node implements IFile {
 		if (is_string($data)) {
 			$stream = fopen('php://temp', 'r+');
 			fwrite($stream, $data);
+			fseek($stream, 0);
 			$data = $stream;
 		};
 		try {
@@ -121,7 +122,7 @@ class File extends Node implements IFile {
 		try {
 			$target = $storage->fopen($internalPartPath, 'wb');
 			if ($target === false) {
-				\OC_Log::write('webdav', '\OC\Files\Filesystem::file_put_contents() failed', \OC_Log::ERROR);
+				\OC_Log::write('webdav', '\OC\Files\Filesystem::fopen() failed', \OC_Log::ERROR);
 				$this->fileView->unlink($partFilePath);
 				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
 				throw new Exception('Could not write file contents');

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -126,7 +126,7 @@ class File extends Node implements IFile {
 				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
 				throw new Exception('Could not write file contents');
 			}
-			$count = stream_copy_to_stream($data, $target);
+			list($count, ) = \OC_Helper::streamCopy($data, $target);
 			fclose($target);
 
 			// if content length is sent by client:

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -82,12 +82,6 @@ class File extends Node implements IFile {
 	 * @return string|null
 	 */
 	public function put($data) {
-		if (is_string($data)) {
-			$stream = fopen('php://temp', 'r+');
-			fwrite($stream, $data);
-			fseek($stream, 0);
-			$data = $stream;
-		};
 		try {
 			$exists = $this->fileView->file_exists($this->path);
 			if ($this->info && $exists && !$this->info->isUpdateable()) {

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -10,6 +10,13 @@ namespace Test\Connector\Sabre;
 
 class File extends \Test\TestCase {
 
+	private function getStream($string) {
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, $string);
+		fseek($stream, 0);
+		return $stream;
+	}
+
 	/**
 	 * @expectedException \Sabre\DAV\Exception
 	 */
@@ -29,7 +36,7 @@ class File extends \Test\TestCase {
 			->will($this->returnValue('/test.txt'));
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions'=>\OCP\Constants::PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		), null);
 
 		$file = new \OC\Connector\Sabre\File($view, $info);
@@ -64,7 +71,7 @@ class File extends \Test\TestCase {
 
 		$file = new \OC\Connector\Sabre\File($view, $info);
 
-		$this->assertNotEmpty($file->put('test data'));
+		$this->assertNotEmpty($file->put($this->getStream('test data')));
 	}
 
 	/**
@@ -99,7 +106,7 @@ class File extends \Test\TestCase {
 		$file = new \OC\Connector\Sabre\File($view, $info);
 
 		// action
-		$file->put('test data');
+		$file->put($this->getStream('test data'));
 	}
 
 	/**
@@ -122,11 +129,12 @@ class File extends \Test\TestCase {
 		$file = new \OC\Connector\Sabre\File($view, $info);
 
 		// action
-		$file->put('test data');
+		$file->put($this->getStream('test data'));
 	}
 
 	/**
 	 * Test setting name with setName() with invalid chars
+	 *
 	 * @expectedException \OC\Connector\Sabre\Exception\InvalidPath
 	 */
 	public function testSetNameInvalidChars() {
@@ -176,7 +184,7 @@ class File extends \Test\TestCase {
 		$file = new \OC\Connector\Sabre\File($view, $info);
 
 		// action
-		$file->put('test data');
+		$file->put($this->getStream('test data'));
 	}
 
 	/**


### PR DESCRIPTION
Not going trough the entire filesystem stack for the part files during uploading saves a good amount of work and database queries.

In my local test instance this saves 24 queries for a regular upload and 89 queries when uploading to a shared folder.

cc @DeepDiver1975 @PVince81 
