### PR TITLE
Use proper array key

### DIFF
--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -147,7 +147,7 @@ class Controller {
 		return array(
 			'hasSQLite' => isset($databases['sqlite']),
 			'hasMySQL' => isset($databases['mysql']),
-			'hasPostgreSQL' => isset($databases['postgre']),
+			'hasPostgreSQL' => isset($databases['pgsql']),
 			'hasOracle' => isset($databases['oci']),
 			'hasMSSQL' => isset($databases['mssql']),
 			'databases' => $databases,


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/12047

Otherwise the database setup is not shown when only the PGSQL driver is available. It works for PGSQL when also another driver is installed.

@bantu @cippaciong @karlitschek Should get backported.
