### PR TITLE
Check for return value null before accessing object

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -66,7 +66,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 		$dn = $ldap_users[0];
 
 		$user = $this->access->userManager->get($dn);
-		if($user->getUsername() !== false) {
+		if($user !== null && $user->getUsername() !== false) {
 			//are the credentials OK?
 			if(!$this->access->areCredentialsValid($dn, $password)) {
 				return false;


### PR DESCRIPTION
- fixes a blank page on login if something with LDAP is broken and null instead of the user is returned

possible return values: https://github.com/owncloud/core/blob/master/apps/user_ldap/lib/user/manager.php#L136

I experienced this while trying to set up LDAP locally.
