### PR TITLE
sharing: make sure that we only find the shares from a given owner 

### DIFF
--- a/apps/files_sharing/lib/share/folder.php
+++ b/apps/files_sharing/lib/share/folder.php
@@ -26,13 +26,14 @@ class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share
 	 *
 	 * @param int $itemSource item source ID
 	 * @param string $shareWith with whom should the item be shared
+	 * @param string $owner owner of the item
 	 * @return array with shares
 	 */
-	public function getParents($itemSource, $shareWith = null) {
+	public function getParents($itemSource, $shareWith = null, $owner = null) {
 		$result = array();
 		$parent = $this->getParentId($itemSource);
 		while ($parent) {
-			$shares = \OCP\Share::getItemSharedWithUser('folder', $parent, $shareWith);
+			$shares = \OCP\Share::getItemSharedWithUser('folder', $parent, $shareWith, $owner);
 			if ($shares) {
 				foreach ($shares as $share) {
 					$name = substr($share['path'], strrpos($share['path'], '/') + 1);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -287,12 +287,12 @@ class Share extends \OC\Share\Constants {
 	 * Get the item of item type shared with a given user by source
 	 * @param string $itemType
 	 * @param string $itemSource
-	 * @param string $user User user to whom the item was shared
+	 * @param string $user User to whom the item was shared
+	 * @param string $owner Owner of the share
 	 * @param int $shareType only look for a specific share type
 	 * @return array Return list of items with file_target, permissions and expiration
 	 */
-	public static function getItemSharedWithUser($itemType, $itemSource, $user, $shareType = null) {
-
+	public static function getItemSharedWithUser($itemType, $itemSource, $user, $owner = null, $shareType = null) {
 		$shares = array();
 		$fileDependend = false;
 
@@ -318,6 +318,11 @@ class Share extends \OC\Share\Constants {
 		if ($shareType !== null) {
 			$where .= ' AND `share_type` = ? ';
 			$arguments[] = $shareType;
+		}
+
+		if ($owner !== null) {
+			$where .= ' AND `uid_owner` = ? ';
+			$arguments[] = $owner;
 		}
 
 		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` '. $where);
@@ -701,7 +706,7 @@ class Share extends \OC\Share\Constants {
 		// check if it is a valid itemType
 		self::getBackend($itemType);
 
-		$items = self::getItemSharedWithUser($itemType, $itemSource, $shareWith, $shareType);
+		$items = self::getItemSharedWithUser($itemType, $itemSource, $shareWith, null, $shareType);
 
 		$toDelete = array();
 		$newParent = null;
@@ -1629,7 +1634,7 @@ class Share extends \OC\Share\Constants {
 			// Need to find a solution which works for all back-ends
 			$collectionItems = array();
 			$collectionBackend = self::getBackend('folder');
-			$sharedParents = $collectionBackend->getParents($item, $shareWith);
+			$sharedParents = $collectionBackend->getParents($item, $shareWith, $uidOwner);
 			foreach ($sharedParents as $parent) {
 				$collectionItems[] = $parent;
 			}

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -125,11 +125,12 @@ class Share extends \OC\Share\Constants {
 	 * Get the item of item type shared with a given user by source
 	 * @param string $itemType
 	 * @param string $itemSource
-	 * @param string $user User user to whom the item was shared
+	 * @param string $user User to whom the item was shared
+	 * @param string $owner Owner of the share
 	 * @return array Return list of items with file_target, permissions and expiration
 	 */
-	public static function getItemSharedWithUser($itemType, $itemSource, $user) {
-		return \OC\Share\Share::getItemSharedWithUser($itemType, $itemSource, $user);
+	public static function getItemSharedWithUser($itemType, $itemSource, $user, $owner = null) {
+		return \OC\Share\Share::getItemSharedWithUser($itemType, $itemSource, $user, $owner);
 	}
 
 	/**


### PR DESCRIPTION
Make sure that we only find the shares from a given owner and don't expose shares from other users.

How to test:
- create three user: user1, user2, user3, user4
- user1 creates following folder structure: /folder/subfolder/subsubfolder
- user1 shares folder to user2 and to user3
- login as user2
- user2 shares folder/subfolder to user4
- user2 open share drop down for folder/subfolder/subsubfolder

Expected Result:
The drop down shows 

```
Shared in subfolder with user4
```

Result before this patch:
The drop down shows

```
Shared in folder with user2, user3
Shared in subfolder with user4
```
