### PR TITLE
google: fix touch() when $mtime is set (Google wants RFC3339) #11267

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -496,7 +496,10 @@ class Google extends \OC\Files\Storage\Common {
 		$result = false;
 		if ($file) {
 			if (isset($mtime)) {
-				$file->setModifiedDate($mtime);
+				// This is just RFC3339, but frustratingly, GDrive's API *requires*
+				// the fractions portion be present, while no handy PHP constant
+				// for RFC3339 or ISO8601 includes it. So we do it ourselves.
+				$file->setModifiedDate(date('Y-m-d\TH:i:s.uP', $mtime));
 				$result = $this->service->files->patch($file->getId(), $file, array(
 					'setModifiedDate' => true,
 				));


### PR DESCRIPTION
ownCloud passes us a Unix time integer, but the GDrive API wants an RFC3339-formatted date. Actually it wants a single particular RFC3339 format, not just anything that complies will do - it requires the fractions to be specified, though RFC3339 doesn't.

This resolves issue #11267 (and was also noted by PVince81 in reviewing PR #6989).
