### PR TITLE
google: drop duplicate path trim from opendir()

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -228,8 +228,6 @@ class Google extends \OC\Files\Storage\Common {
 	}
 
 	public function opendir($path) {
-		// Remove leading and trailing slashes
-		$path = trim($path, '/');
 		$folder = $this->getDriveFile($path);
 		if ($folder) {
 			$files = array();


### PR DESCRIPTION
opendir() trims the path passed then calls getDriveFile() - which immediately does the same trim operation. This breaks opendir() on the root directory, which causes the failure of the testStat() test when it checks the ctime of the root dir. We spotted this while testing my PR #6989 , but in fact the failure is not related to the library update (it failed before and it fails after), so submitting the fix separately.
