### PR TITLE
google: delete original after successful rename

### DIFF
--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -370,10 +370,22 @@ class Google extends \OC\Files\Storage\Common {
 					return false;
 				}
 			}
+			// We need to get the object for the existing file with the same
+			// name (if there is one) before we do the patch. If oldfile
+			// exists and is a directory we have to delete it before we
+			// do the rename too.
+			$oldfile = $this->getDriveFile($path2);
+			if ($oldfile && $this->is_dir($path2)) {
+				$this->rmdir($path2);
+				$oldfile = false;
+			}
 			$result = $this->service->files->patch($file->getId(), $file);
 			if ($result) {
 				$this->setDriveFile($path1, false);
 				$this->setDriveFile($path2, $result);
+				if ($oldfile) {
+					$this->service->files->delete($oldfile->getId());
+				}
 			}
 			return (bool)$result;
 		} else {


### PR DESCRIPTION
In GDrive, filenames aren't unique, and directories are just special files - so you can have multiple files with the same name, multiple directories with the same name, and even files with the same names as directories.

OC doesn't handle this at all, though, and just wants to act as if file and directory names _are_ unique. So when renaming, we must check if there's an existing object with the same file or directory name before we commit the rename, and explicitly delete it if the rename is successful. (Other providers like dropbox do the same for files, but intentionally don't do it for directories; we really need to do it for directories too.)

A good way to observe this is to run the storage unit tests and look at the state of the Drive afterwards. Without this commit, there will be several copies of all the test files and directories. After this commit, there's just one of each.

We can't just say "hey, Drive lets us do this, what's the problem?" because we don't handle multiple-objects, same-name cases - getDriveFile() just bails and prints an error if it searches for the file or directory with a given name and gets multiple results.

This is another issue @PVince81 and I spotted while testing my 1.x update - PR #6989 - but again it's not specific to the 1.x update, the same issue existed before, so I'm separating the fix from the 1.x update PR.
