### PR TITLE
storage test: use new file for testTouchCreateFile()

### DIFF
--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -340,10 +340,10 @@ abstract class Storage extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testTouchCreateFile() {
-		$this->assertFalse($this->instance->file_exists('foo'));
+		$this->assertFalse($this->instance->file_exists('touch'));
 		// returns true on success
-		$this->assertTrue($this->instance->touch('foo'));
-		$this->assertTrue($this->instance->file_exists('foo'));
+		$this->assertTrue($this->instance->touch('touch'));
+		$this->assertTrue($this->instance->file_exists('touch'));
 	}
 
 	public function testRecursiveRmdir() {


### PR DESCRIPTION
this test would never succeed, because the previous test - testFOpen() - creates the file 'foo', but testTouchCreateFile() starts out by asserting it doesn't exist. Change the test to use a file called 'touch' instead (which does not previously exist).
