### PR TITLE
Fix root path handling for WebDAV ext storage

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -433,6 +433,7 @@ class DAV extends \OC\Files\Storage\Common {
 
 	public function getPermissions($path) {
 		$this->init();
+		$path = $this->cleanPath($path);
 		$response = $this->client->propfind($this->encodePath($path), array('{http://owncloud.org/ns}permissions'));
 		if (isset($response['{http://owncloud.org/ns}permissions'])) {
 			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
@@ -477,6 +478,7 @@ class DAV extends \OC\Files\Storage\Common {
 	 */
 	public function hasUpdated($path, $time) {
 		$this->init();
+		$path = $this->cleanPath($path);
 		try {
 			$response = $this->client->propfind($this->encodePath($path), array(
 				'{DAV:}getlastmodified',


### PR DESCRIPTION
Added missing cleanPath() call that converts "/" to "" when calling
SabreDAV. This is needed because SabreDAV will discard its base URL when
passing "/".

Please review @DeepDiver1975 @icewind1991 @MorrisJobke 

Note: if you run the unit tests locally there's only one unrelated failing test related to mimetypes.
But this PR fixes all the other failing ones.

To test:
1) Setup another OC instance
2) Edit "apps/files_external/tests/config.php" and put the config in webdav and owncloud
3) Run unit test for "apps/files_external/tests/webdav.php" and "apps/files_external/tests/owncloud.php"
