### PR TITLE
Return real mime type on PROPFIND

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -219,6 +219,10 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 	public function getContentType() {
 		$mimeType = $this->info->getMimetype();
 
+		// PROPFIND needs to return the correct mime type, for consistency with the web UI
+		if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'PROPFIND' ) {
+			return $mimeType;
+		}
 		return \OC_Helper::getSecureMimeType($mimeType);
 	}
 


### PR DESCRIPTION
Return the real (insecure) mime type on PROPFIND

This can be tested by propfinding a SVG file with curl and checking that the mime type is the one from SVG.

Before this fix: the returned mime type for SVG was "text/plain".

Please review @icewind1991 @LukasReschke @MorrisJobke 
