### PR TITLE
Run preupdate before an update

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1186,10 +1186,6 @@ class OC_App {
 	 * @return bool
 	 */
 	public static function updateApp($appId) {
-		if (file_exists(self::getAppPath($appId) . '/appinfo/preupdate.php')) {
-			self::loadApp($appId, false);
-			include self::getAppPath($appId) . '/appinfo/preupdate.php';
-		}
 		if (file_exists(self::getAppPath($appId) . '/appinfo/database.xml')) {
 			OC_DB::updateDbFromStructure(self::getAppPath($appId) . '/appinfo/database.xml');
 		}

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -262,7 +262,6 @@ class Updater extends BasicEmitter {
 	protected function checkAppUpgrade($version) {
 		$apps = \OC_App::getEnabledApps();
 
-
 		foreach ($apps as $appId) {
 			if ($version) {
 				$info = \OC_App::getAppInfo($appId);
@@ -272,6 +271,15 @@ class Updater extends BasicEmitter {
 			}
 
 			if ($compatible && \OC_App::shouldUpgrade($appId)) {
+				/**
+				 * FIXME: The preupdate check is performed before the database migration, otherwise database changes
+				 * are not possible anymore within it. - Consider this when touching the code.
+				 * @link https://github.com/owncloud/core/issues/10980
+				 * @see \OC_App::updateApp
+				 */
+				if (file_exists(\OC_App::getAppPath($appId) . '/appinfo/preupdate.php')) {
+					$this->includePreUpdate($appId);
+				}
 				if (file_exists(\OC_App::getAppPath($appId) . '/appinfo/database.xml')) {
 					\OC_DB::simulateUpdateDbFromStructure(\OC_App::getAppPath($appId) . '/appinfo/database.xml');
 				}
@@ -279,6 +287,14 @@ class Updater extends BasicEmitter {
 		}
 
 		$this->emit('\OC\Updater', 'appUpgradeCheck');
+	}
+
+	/**
+	 * Includes the pre-update file. Done here to prevent namespace mixups.
+	 * @param string $appId
+	 */
+	private function includePreUpdate($appId) {
+		include \OC_App::getAppPath($appId) . '/appinfo/preupdate.php';
 	}
 
 	protected function doAppUpgrade() {


### PR DESCRIPTION
The update routine tries to test the database migration before actually performing the update.

However, this will fail hard if the schema has changed (for example an unique key has been added). App developers can convert the DB in preupdate.php, however it is not called before and therefore the update fails.

This actually breaks ownCloud updates from ownCloud 6 to ownCloud 7 when the files_antivirus app is enabled. This change is related to https://github.com/owncloud/apps/pull/1970

@karlitschek This is kinda important.... :-/
