### PR TITLE
add 'namespace' for automatically created navigation divs, fixes #12080

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -92,7 +92,7 @@ $formsMap = array_map(function ($form) {
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(
-			'anchor' => $anchor,
+			'anchor' => 'goto-' . $anchor,
 			'section-name' => $sectionName,
 			'form' => $form
 		);

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -114,7 +114,7 @@ $formsMap = array_map(function($form){
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(
-			'anchor' => $anchor,
+			'anchor' => 'goto-' . $anchor,
 			'section-name' => $sectionName,
 			'form' => $form
 		);


### PR DESCRIPTION
Currently the sidebar creates div with IDs which are already in use, breaking things as in #12080. Therefore, they should get a prefix. I think "goto_" is a good one? :)

@DeepDiver1975 @jancborchardt @MorrisJobke 
