### PR TITLE
dropbox: use Composer autoloader

### DIFF
--- a/apps/files_external/ajax/dropbox.php
+++ b/apps/files_external/ajax/dropbox.php
@@ -23,8 +23,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-require_once __DIR__ . '/../3rdparty/Dropbox/autoload.php';
-
 OCP\JSON::checkAppEnabled('files_external');
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -46,7 +46,9 @@ OC::$CLASSPATH['OC\Files\Storage\SFTP_Key'] = 'files_external/lib/sftp_key.php';
 OC::$CLASSPATH['OC_Mount_Config'] = 'files_external/lib/config.php';
 OC::$CLASSPATH['OCA\Files\External\Api'] = 'files_external/lib/api.php';
 
-require_once __DIR__ . '/../3rdparty/autoload.php';
+// Activate the Composer autoloader and register the Dropbox lib with it
+$loader = require __DIR__ . '/../3rdparty/autoload.php';
+$loader->set('Dropbox', __DIR__ . '/../3rdparty');
 
 OCP\App::registerAdmin('files_external', 'settings');
 if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == 'yes') {

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -29,8 +29,6 @@
  */
 namespace OC\Files\Storage;
 
-require_once __DIR__ . '/../3rdparty/Dropbox/autoload.php';
-
 class Dropbox extends \OC\Files\Storage\Common {
 
 	private $dropbox;


### PR DESCRIPTION
This reduces the number of crappy autoloaders we're registering by one, consolidates on the Composer autoloading code, and helps downstreams unbundle deps.

Requiring 3rdparty/autoload.php in this way returns the already-registered Composer autoloader instance, it doesn't create a new one or anything. So we're just adding another path to its prefix list.
