### PR TITLE
Fix Pimple unset

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -35,7 +35,7 @@ class SimpleContainer extends \Pimple\Container implements \OCP\IContainer {
 	 * @param bool $shared
 	 */
 	function registerService($name, \Closure $closure, $shared = true) {
-		if (!empty($this[$name]))  {
+		if (isset($this[$name]))  {
 			unset($this[$name]);
 		}
 		if ($shared) {


### PR DESCRIPTION
Very annoying bug :D 

To explain the problem

```
if (!empty($this[$name]))
```

$this[$name] accesses the container. The container implements ArrayAccess so the offsetGet method is called https://github.com/silexphp/Pimple/blob/master/src/Pimple/Container.php#L92 

Because Pimple saves an instance the first time it is accessed, the callback that you're trying to overwrite is **actually executed by the empty($this[$name]) call** which leads to failing unit tests on my behalf and may lead to all sorts of probably funky and hard to detect bugs (aka Heisenbugs). 

The solution is to use isset which seems to call the offsetExists method on ArrayAccess https://github.com/silexphp/Pimple/blob/master/src/Pimple/Container.php#L127. 

I know, this is higher PHP magic and empty and isset are "special functions". I suppose empty works only when calling it on the object that implements ArrayAccess directly and not on its keys, e.g.: empty($container) would work, but not empty($container['index']) 

@LukasReschke @DeepDiver1975 @PVince81 @MorrisJobke 
