### PR TITLE
Drop form_factor that is appended to JS, CSS and template filenames

### DIFF
--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -50,16 +50,13 @@ class OC_Template extends \OC\Template\Base {
 		// Read the selected theme from the config file
 		$theme = OC_Util::getTheme();
 
-		// Read the detected formfactor and use the right file name.
-		$fext = self::getFormFactorExtension();
-
 		$requesttoken = (OC::$server->getSession() and $registerCall) ? OC_Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = \OC::$server->getL10N($parts[0]);
 		$themeDefaults = new OC_Defaults();
 
-		list($path, $template) = $this->findTemplate($theme, $app, $name, $fext);
+		list($path, $template) = $this->findTemplate($theme, $app, $name);
 
 		// Set the private data
 		$this->renderas = $renderas;
@@ -70,85 +67,23 @@ class OC_Template extends \OC\Template\Base {
 	}
 
 	/**
-	 * autodetect the formfactor of the used device
-	 * default -> the normal desktop browser interface
-	 * mobile -> interface for smartphones
-	 * tablet -> interface for tablets
-	 * standalone -> the default interface but without header, footer and
-	 *	sidebar, just the application. Useful to use just a specific
-	 *	app on the desktop in a standalone window.
-	 */
-	public static function detectFormfactor() {
-		// please add more useragent strings for other devices
-		if(isset($_SERVER['HTTP_USER_AGENT'])) {
-			if(stripos($_SERVER['HTTP_USER_AGENT'], 'ipad')>0) {
-				$mode='tablet';
-			}elseif(stripos($_SERVER['HTTP_USER_AGENT'], 'iphone')>0) {
-				$mode='mobile';
-			}elseif((stripos($_SERVER['HTTP_USER_AGENT'], 'N9')>0)
-				and (stripos($_SERVER['HTTP_USER_AGENT'], 'nokia')>0)) {
-				$mode='mobile';
-			}else{
-				$mode='default';
-			}
-		}else{
-			$mode='default';
-		}
-		return($mode);
-	}
-
-	/**
-	 * Returns the formfactor extension for current formfactor
-	 */
-	static public function getFormFactorExtension()
-	{
-		if (!\OC::$server->getSession()) {
-			return '';
-		}
-		// if the formfactor is not yet autodetected do the
-		// autodetection now. For possible formfactors check the
-		// detectFormfactor documentation
-		if (!\OC::$server->getSession()->exists('formfactor')) {
-			\OC::$server->getSession()->set('formfactor', self::detectFormfactor());
-		}
-		// allow manual override via GET parameter
-		if(isset($_GET['formfactor'])) {
-			\OC::$server->getSession()->set('formfactor', $_GET['formfactor']);
-		}
-		$formfactor = \OC::$server->getSession()->get('formfactor');
-		if($formfactor==='default') {
-			$fext='';
-		}elseif($formfactor==='mobile') {
-			$fext='.mobile';
-		}elseif($formfactor==='tablet') {
-			$fext='.tablet';
-		}elseif($formfactor==='standalone') {
-			$fext='.standalone';
-		}else{
-			$fext='';
-		}
-		return $fext;
-	}
-
-	/**
 	 * find the template with the given name
 	 * @param string $name of the template file (without suffix)
 	 *
-	 * Will select the template file for the selected theme and formfactor.
+	 * Will select the template file for the selected theme.
 	 * Checking all the possible locations.
 	 * @param string $theme
 	 * @param string $app
-	 * @param string $fext
 	 * @return array
 	 */
-	protected function findTemplate($theme, $app, $name, $fext) {
+	protected function findTemplate($theme, $app, $name) {
 		// Check if it is a app template or not.
 		if( $app !== '' ) {
 			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
 		} else {
 			$dirs = $this->getCoreTemplateDirs($theme, OC::$SERVERROOT);
 		}
-		$locator = new \OC\Template\TemplateFileLocator( $fext, $dirs );
+		$locator = new \OC\Template\TemplateFileLocator( $dirs );
 		$template = $locator->find($name);
 		$path = $locator->getPath();
 		return array($path, $template);

--- a/lib/private/template/cssresourcelocator.php
+++ b/lib/private/template/cssresourcelocator.php
@@ -12,9 +12,7 @@ class CSSResourceLocator extends ResourceLocator {
 	public function doFind( $style ) {
 		if (strpos($style, '3rdparty') === 0
 			&& $this->appendIfExist($this->thirdpartyroot, $style.'.css')
-			|| $this->appendIfExist($this->serverroot, $style.$this->form_factor.'.css')
 			|| $this->appendIfExist($this->serverroot, $style.'.css')
-			|| $this->appendIfExist($this->serverroot, 'core/'.$style.$this->form_factor.'.css')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$style.'.css')
 		) {
 			return;
@@ -23,8 +21,7 @@ class CSSResourceLocator extends ResourceLocator {
 		$style = substr($style, strpos($style, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		$app_url = \OC_App::getAppWebPath($app);
-		if ($this->appendIfExist($app_path, $style.$this->form_factor.'.css', $app_url)
-			|| $this->appendIfExist($app_path, $style.'.css', $app_url)
+		if ($this->appendIfExist($app_path, $style.'.css', $app_url)
 		) {
 			return;
 		}
@@ -33,11 +30,8 @@ class CSSResourceLocator extends ResourceLocator {
 
 	public function doFindTheme( $style ) {
 		$theme_dir = 'themes/'.$this->theme.'/';
-		$this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$style.$this->form_factor.'.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$style.'.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.$style.$this->form_factor.'.css')
+		$this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$style.'.css')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.$style.'.css')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$style.$this->form_factor.'.css')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$style.'.css');
 	}
 }

--- a/lib/private/template/jsresourcelocator.php
+++ b/lib/private/template/jsresourcelocator.php
@@ -13,15 +13,10 @@ class JSResourceLocator extends ResourceLocator {
 		$theme_dir = 'themes/'.$this->theme.'/';
 		if (strpos($script, '3rdparty') === 0
 			&& $this->appendIfExist($this->thirdpartyroot, $script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.$this->form_factor.'.js')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.'apps/'.$script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.$script.$this->form_factor.'.js')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.$script.'.js')
-			|| $this->appendIfExist($this->serverroot, $script.$this->form_factor.'.js')
 			|| $this->appendIfExist($this->serverroot, $script.'.js')
-			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.$this->form_factor.'.js')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js')
-			|| $this->appendIfExist($this->serverroot, 'core/'.$script.$this->form_factor.'.js')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$script.'.js')
 		) {
 			return;
@@ -30,9 +25,7 @@ class JSResourceLocator extends ResourceLocator {
 		$script = substr($script, strpos($script, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		$app_url = \OC_App::getAppWebPath($app);
-		if ($this->appendIfExist($app_path, $script.$this->form_factor.'.js', $app_url)
-			|| $this->appendIfExist($app_path, $script.'.js', $app_url)
-		) {
+		if ($this->appendIfExist($app_path, $script.'.js', $app_url)) {
 			return;
 		}
 		// missing translations files fill be ignored

--- a/lib/private/template/resourcelocator.php
+++ b/lib/private/template/resourcelocator.php
@@ -10,7 +10,6 @@ namespace OC\Template;
 
 abstract class ResourceLocator {
 	protected $theme;
-	protected $form_factor;
 
 	protected $mapping;
 	protected $serverroot;
@@ -21,11 +20,9 @@ abstract class ResourceLocator {
 
 	/**
 	 * @param string $theme
-	 * @param string $form_factor
 	 */
-	public function __construct( $theme, $form_factor, $core_map, $party_map ) {
+	public function __construct( $theme, $core_map, $party_map ) {
 		$this->theme = $theme;
-		$this->form_factor = $form_factor;
 		$this->mapping = $core_map + $party_map;
 		$this->serverroot = key($core_map);
 		$this->thirdpartyroot = key($party_map);
@@ -46,8 +43,7 @@ abstract class ResourceLocator {
 				}
 			}
 		} catch (\Exception $e) {
-			throw new \Exception($e->getMessage().' formfactor:'.$this->form_factor
-						.' serverroot:'.$this->serverroot);
+			throw new \Exception($e->getMessage().' serverroot:'.$this->serverroot);
 		}
 	}
 

--- a/lib/private/template/templatefilelocator.php
+++ b/lib/private/template/templatefilelocator.php
@@ -9,16 +9,13 @@
 namespace OC\Template;
 
 class TemplateFileLocator {
-	protected $form_factor;
 	protected $dirs;
 	private $path;
 
 	/**
 	 * @param string[] $dirs
-	 * @param string $form_factor
 	 */
-	public function __construct( $form_factor, $dirs ) {
-		$this->form_factor = $form_factor;
+	public function __construct( $dirs ) {
 		$this->dirs = $dirs;
 	}
 
@@ -33,18 +30,13 @@ class TemplateFileLocator {
 		}
 
 		foreach($this->dirs as $dir) {
-			$file = $dir.$template.$this->form_factor.'.php';
-			if (is_file($file)) {
-				$this->path = $dir;
-				return $file;
-			}
 			$file = $dir.$template.'.php';
 			if (is_file($file)) {
 				$this->path = $dir;
 				return $file;
 			}
 		}
-		throw new \Exception('template file not found: template:'.$template.' formfactor:'.$this->form_factor);
+		throw new \Exception('template file not found: template:'.$template);
 	}
 
 	public function getPath() {

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -131,10 +131,7 @@ class OC_TemplateLayout extends OC_Template {
 		// Read the selected theme from the config file
 		$theme = OC_Util::getTheme();
 
-		// Read the detected form factor and use the right file name.
-		$formFactorExt = self::getFormFactorExtension();
-
-		$locator = new \OC\Template\CSSResourceLocator( $theme, $formFactorExt,
+		$locator = new \OC\Template\CSSResourceLocator( $theme,
 			array( OC::$SERVERROOT => OC::$WEBROOT ),
 			array( OC::$THIRDPARTYROOT => OC::$THIRDPARTYWEBROOT ));
 		$locator->find($styles);
@@ -149,10 +146,7 @@ class OC_TemplateLayout extends OC_Template {
 		// Read the selected theme from the config file
 		$theme = OC_Util::getTheme();
 
-		// Read the detected form factor and use the right file name.
-		$formFactorExt = self::getFormFactorExtension();
-
-		$locator = new \OC\Template\JSResourceLocator( $theme, $formFactorExt,
+		$locator = new \OC\Template\JSResourceLocator( $theme,
 			array( OC::$SERVERROOT => OC::$WEBROOT ),
 			array( OC::$THIRDPARTYROOT => OC::$THIRDPARTYWEBROOT ));
 		$locator->find($scripts);

--- a/tests/lib/template/resourcelocator.php
+++ b/tests/lib/template/resourcelocator.php
@@ -10,19 +10,17 @@ class Test_ResourceLocator extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @param string $theme
-	 * @param string $form_factor
 	 */
-	public function getResourceLocator( $theme, $form_factor, $core_map, $party_map, $appsroots ) {
+	public function getResourceLocator( $theme, $core_map, $party_map, $appsroots ) {
 		return $this->getMockForAbstractClass('OC\Template\ResourceLocator',
-			array( $theme, $form_factor, $core_map, $party_map, $appsroots ),
+			array( $theme, $core_map, $party_map, $appsroots ),
 			'', true, true, true, array());
 	}
 
 	public function testConstructor() {
-		$locator = $this->getResourceLocator('theme', 'form_factor',
+		$locator = $this->getResourceLocator('theme',
 			array('core'=>'map'), array('3rd'=>'party'), array('foo'=>'bar'));
 		$this->assertAttributeEquals('theme', 'theme', $locator);
-		$this->assertAttributeEquals('form_factor', 'form_factor', $locator);
 		$this->assertAttributeEquals('core', 'serverroot', $locator);
 		$this->assertAttributeEquals(array('core'=>'map','3rd'=>'party'), 'mapping', $locator);
 		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);
@@ -31,7 +29,7 @@ class Test_ResourceLocator extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFind() {
-		$locator = $this->getResourceLocator('theme', 'form_factor',
+		$locator = $this->getResourceLocator('theme',
 			array('core'=>'map'), array('3rd'=>'party'), array('foo'=>'bar'));
 		$locator->expects($this->once())
 			->method('doFind')
@@ -41,7 +39,7 @@ class Test_ResourceLocator extends PHPUnit_Framework_TestCase {
 			->with('foo');
 		$locator->find(array('foo'));
 
-		$locator = $this->getResourceLocator('theme', 'form_factor',
+		$locator = $this->getResourceLocator('theme',
 			array('core'=>'map'), array('3rd'=>'party'), array('foo'=>'bar'));
 		$locator->expects($this->once())
 			->method('doFind')
@@ -50,12 +48,12 @@ class Test_ResourceLocator extends PHPUnit_Framework_TestCase {
 		try {
 			$locator->find(array('foo'));
 		} catch (\Exception $e) {
-			$this->assertEquals('test formfactor:form_factor serverroot:core', $e->getMessage());
+			$this->assertEquals('test serverroot:core', $e->getMessage());
 		}
 	}
 
 	public function testAppendIfExist() {
-		$locator = $this->getResourceLocator('theme', 'form_factor',
+		$locator = $this->getResourceLocator('theme',
 			array(__DIR__=>'map'), array('3rd'=>'party'), array('foo'=>'bar'));
 		$method = new ReflectionMethod($locator, 'appendIfExist');
 		$method->setAccessible(true);


### PR DESCRIPTION
fixes #12127

For CSS there is a better approach of detecting the correct form factor. In the current implementation we check for `iphone`, `ipad`, `nokia` and `N9`... it's already a huge amount of devices ... but really?

I checked all core apps. Unit tests run fine locally. Also I found no file (template, CSS or JS) which actually use this functionality.

cc @jancborchardt @DeepDiver1975 @LukasReschke 
