### PR TITLE
Try to read the file only instead of trying to touch

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -138,12 +138,12 @@ class Config {
 
 		// Include file and merge config
 		foreach ($configFiles as $file) {
-			if($file === $this->configFilePath && !@touch($file)) {
-				// Writing to the main config might not be possible, e.g. if the wrong
+			$filePointer = @fopen($file, 'r');
+			if($file === $this->configFilePath && $filePointer === false) {
+				// Opening the main config might not be possible, e.g. if the wrong
 				// permissions are set (likely on a new installation)
 				continue;
 			}
-			$filePointer = fopen($file, 'r');
 
 			// Try to acquire a file lock
 			if(!flock($filePointer, LOCK_SH)) {


### PR DESCRIPTION
The permissions are already catched properly on the installation so we just have to check whether the file is readable to prevent fatal errors from happening.

Fixes https://github.com/owncloud/core/issues/12135
