### PR TITLE
Deprecate older API wrappers and calls

### DIFF
--- a/lib/private/appframework/core/api.php
+++ b/lib/private/appframework/core/api.php
@@ -49,6 +49,7 @@ class API implements IApi{
 	/**
 	 * Gets the userid of the current user
 	 * @return string the user id of the current user
+	 * @deprecated Use \OC::$server->getUserSession()->getUser()->getUID()
 	 */
 	public function getUserId(){
 		return \OCP\User::getUser();
@@ -112,6 +113,7 @@ class API implements IApi{
 	/**
 	 * used to return and open a new event source
 	 * @return \OCP\IEventSource a new open EventSource class
+	 * @deprecated Use \OC::$server->createEventSource();
 	 */
 	public function openEventSource(){
 		return \OC::$server->createEventSource();
@@ -159,6 +161,7 @@ class API implements IApi{
 	 * @param string $className full namespace and class name of the class
 	 * @param string $methodName the name of the static method that should be
 	 * called
+	 * @deprecated Use \OC::$server->getJobList()->add();
 	 */
 	public function addRegularTask($className, $methodName) {
 		\OCP\Backgroundjob::addRegularTask($className, $methodName);

--- a/lib/public/appframework/iapi.php
+++ b/lib/public/appframework/iapi.php
@@ -37,6 +37,7 @@ interface IApi {
 	/**
 	 * Gets the userid of the current user
 	 * @return string the user id of the current user
+	 * @deprecated Use \OC::$server->getUserSession()->getUser()->getUID()
 	 */
 	function getUserId();
 

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -38,6 +38,7 @@ class User {
 	/**
 	 * Get the user id of the user currently logged in.
 	 * @return string uid or false
+	 * @deprecated Use \OC::$server->getUserSession()->getUser()->getUID()
 	 */
 	public static function getUser() {
 		return \OC_User::getUser();
@@ -94,6 +95,7 @@ class User {
 	/**
 	 * Logs the user out including all the session data
 	 * Logout, destroys session
+	 * @deprecated Use \OC::$server->getUserSession()->logout();
 	 */
 	public static function logout() {
 		\OC_User::logout();
@@ -106,6 +108,7 @@ class User {
 	 * @return string|false username on success, false otherwise
 	 *
 	 * Check if the password is correct without logging in the user
+	 * @deprecated Use \OC::$server->getUserManager()->checkPassword();
 	 */
 	public static function checkPassword( $uid, $password ) {
 		return \OC_User::checkPassword( $uid, $password );


### PR DESCRIPTION
Those old classes have now non-static pendants and can be deprecated IMHO.

@DeepDiver1975 @Raydiation Objections?
