### PR TITLE
this allows a non-existant config/config.php for starting the autotest.s...

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -40,7 +40,7 @@ if ! [ $PHPUNIT_MAJOR_VERSION -gt 3 -o \( $PHPUNIT_MAJOR_VERSION -eq 3 -a $PHPUN
 	exit 4
 fi
 
-if ! [ -w config -a -w config/config.php ]; then
+if ! [ \( -w config -a ! -f config/config.php \) -o \( -f config/config.php -a -w config/config.php \) ]; then
 	echo "Please enable write permissions on config and config/config.php" >&2
 	exit 1
 fi


### PR DESCRIPTION
...h

To test:
remove config/config.php and run autotest.sh (on master it fails with config not readable)

cc @PVince81 @DeepDiver1975 
