### PR TITLE
Do not remove dir entry if it has the same name as the parent

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -267,10 +267,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				$file = basename(
 					isset($object['Key']) ? $object['Key'] : $object['Prefix']
 				);
-
-				if ($file != basename($path)) {
-					$files[] = $file;
-				}
+				$files[] = $file;
 			}
 
 			\OC\Files\Stream\Dir::register('amazons3' . $path, $files);


### PR DESCRIPTION
This fixes an issue when a subdir has the same name as its parent, it
would get exluded from the list.

Not sure why this code was these in the first place, maybe it was necessary for older SDK versions...
I tested this against stable7 and master, both work.

Please review @butonic @craigpg @icewind1991 

Fixes https://github.com/owncloud/core/issues/12152
