### PR TITLE
Generate etag when missing

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -926,6 +926,15 @@ class View {
 						}
 					}
 				}
+				if (empty($data['etag'])) {
+					\OC_Log::write(
+						'core',
+						'Existing file "' . $path . '" has no etag, generating a new one',
+						\OC_Log::DEBUG
+					);
+					$data['etag'] = $storage->getETag($data['path']);
+					$cache->update($data['fileid'], array('etag' => $data['etag']));
+				}
 			}
 		}
 		if (!$data) {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -208,6 +208,23 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($textSize, $folderData[0]['size']);
 	}
 
+	public function testRepairEmptyEtag() {
+		$storage1 = $this->getTestStorage(true);
+		\OC\Files\Filesystem::mount($storage1, array(), '/');
+
+		$cache = $storage1->getCache();
+		// clear etag
+		$cache->put('foo.txt', array('etag' => ''));
+		$check = $cache->get('foo.txt');
+		// just to make sure the etag clearing worked
+		$this->assertEmpty($check['etag']);
+
+		$rootView = new \OC\Files\View('');
+
+		$cachedData = $rootView->getFileInfo('/foo.txt');
+		$this->assertNotEmpty($cachedData['etag']);
+	}
+
 	/**
 	 * @medium
 	 */


### PR DESCRIPTION
Tentative fix for https://github.com/owncloud/core/issues/12172

Note: this doesn't cover all code paths, only the ones that explicitly request the file's metadata (PROPFIND)

Please carefully review @icewind1991 @DeepDiver1975 
