### PR TITLE
Issue/10991 Make unit tests pass on windows

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -34,7 +34,14 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 	 */
 	private $files;
 
-	function setUp() {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+
 		// mock OC_L10n
 		if (!self::$user) {
 			self::$user = uniqid();
@@ -59,10 +66,13 @@ class Test_OC_Files_App_Rename extends \PHPUnit_Framework_TestCase {
 		$this->files = new \OCA\Files\App($viewMock, $l10nMock);
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		$result = \OC_User::deleteUser(self::$user);
 		$this->assertTrue($result);
 		\OC\Files\Filesystem::tearDown();
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	/**

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -573,6 +573,7 @@ class Stream {
 				\OC_FileProxy::$enabled = false;
 
 				if ($this->rootView->file_exists($this->rawPath) && $this->size === 0) {
+					fclose($this->handle);
 					$this->rootView->unlink($this->rawPath);
 				}
 

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -12,7 +12,7 @@ use OCA\Encryption;
 /**
  * Class Test_Encryption_Crypt
  */
-class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Crypt extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_CRYPT_USER1 = "test-crypt-user1";
 
@@ -31,6 +31,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	public $genPublicKey;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -46,12 +48,14 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1, true);
+		self::loginHelper(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// set user id
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1);
+		self::loginHelper(\Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1);
 		$this->userId = \Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1;
 		$this->pass = \Test_Encryption_Crypt::TEST_ENCRYPTION_CRYPT_USER1;
 
@@ -77,7 +81,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		\OC_App::disable('files_trashbin');
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
@@ -87,6 +91,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(\OC_FileProxy::$enabled);
 		\OCP\Config::deleteSystemValue('cipher');
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
@@ -100,12 +106,14 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**
 	 * @medium
 	 */
-	function testGenerateKey() {
+	public function testGenerateKey() {
 
 		# TODO: use more accurate (larger) string length for test confirmation
 
@@ -115,7 +123,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 	}
 
-	function testDecryptPrivateKey() {
+	public function testDecryptPrivateKey() {
 
 		// test successful decrypt
 		$crypted = Encryption\Crypt::symmetricEncryptFileContent($this->genPrivateKey, 'hat');
@@ -137,7 +145,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricEncryptFileContent() {
+	public function testSymmetricEncryptFileContent() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
 
@@ -155,7 +163,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricEncryptFileContentAes128() {
+	public function testSymmetricEncryptFileContentAes128() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
 
@@ -173,9 +181,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricStreamEncryptShortFileContent() {
+	public function testSymmetricStreamEncryptShortFileContent() {
 
-		$filename = 'tmp-' . uniqid() . '.test';
+		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/'. $filename, $this->dataShort);
 
@@ -210,9 +218,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testSymmetricStreamEncryptShortFileContentAes128() {
+	public function testSymmetricStreamEncryptShortFileContentAes128() {
 
-		$filename = 'tmp-' . uniqid() . '.test';
+		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
 		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
 
@@ -255,10 +263,10 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
 	 * reassembly of its data
 	 */
-	function testSymmetricStreamEncryptLongFileContent() {
+	public function testSymmetricStreamEncryptLongFileContent() {
 
 		// Generate a a random filename
-		$filename = 'tmp-' . uniqid() . '.test';
+		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong . $this->dataLong);
@@ -299,10 +307,10 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
 	 * reassembly of its data
 	 */
-	function testSymmetricStreamEncryptLongFileContentAes128() {
+	public function testSymmetricStreamEncryptLongFileContentAes128() {
 
 		// Generate a a random filename
-		$filename = 'tmp-' . uniqid() . '.test';
+		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
 		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
 
@@ -347,10 +355,10 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	 * @note If this test fails with truncate content, check that enough array slices are being rejoined to form $e, as the crypt.php file may have gotten longer and broken the manual
 	 * reassembly of its data
 	 */
-	function testStreamDecryptLongFileContentWithoutHeader() {
+	public function testStreamDecryptLongFileContentWithoutHeader() {
 
 		// Generate a a random filename
-		$filename = 'tmp-' . uniqid() . '.test';
+		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
 		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
 
@@ -395,7 +403,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testIsEncryptedContent() {
+	public function testIsEncryptedContent() {
 
 		$this->assertFalse(Encryption\Crypt::isCatfileContent($this->dataUrl));
 
@@ -410,7 +418,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @large
 	 */
-	function testMultiKeyEncrypt() {
+	public function testMultiKeyEncrypt() {
 
 		# TODO: search in keyfile for actual content as IV will ensure this test always passes
 
@@ -437,9 +445,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testRenameFile() {
+	public function testRenameFile() {
 
-		$filename = 'tmp-' . uniqid();
+		$filename = 'tmp-' . $this->getUniqueID();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -452,7 +460,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFilename = 'tmp-new-' . uniqid();
+		$newFilename = 'tmp-new-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 		$view->rename($filename, $newFilename);
 
@@ -468,9 +476,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testMoveFileIntoFolder() {
+	public function testMoveFileIntoFolder() {
 
-		$filename = 'tmp-' . uniqid();
+		$filename = 'tmp-' . $this->getUniqueID();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -483,8 +491,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFolder = '/newfolder' . uniqid();
-		$newFilename = 'tmp-new-' . uniqid();
+		$newFolder = '/newfolder' . $this->getUniqueID();
+		$newFilename = 'tmp-new-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 		$view->mkdir($newFolder);
 		$view->rename($filename, $newFolder . '/' . $newFilename);
@@ -501,12 +509,12 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testMoveFolder() {
+	public function testMoveFolder() {
 
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
-		$filename = '/tmp-' . uniqid();
-		$folder = '/folder' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
+		$folder = '/folder' . $this->getUniqueID();
 
 		$view->mkdir($folder);
 
@@ -521,7 +529,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataLong, $decrypt);
 
-		$newFolder = '/newfolder/subfolder' . uniqid();
+		$newFolder = '/newfolder/subfolder' . $this->getUniqueID();
 		$view->mkdir('/newfolder');
 
 		$view->rename($folder, $newFolder);
@@ -539,8 +547,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testChangePassphrase() {
-		$filename = 'tmp-' . uniqid();
+	public function testChangePassphrase() {
+		$filename = 'tmp-' . $this->getUniqueID();
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong);
@@ -576,9 +584,9 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testViewFilePutAndGetContents() {
+	public function testViewFilePutAndGetContents() {
 
-		$filename = '/tmp-' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -610,8 +618,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @large
 	 */
-	function testTouchExistingFile() {
-		$filename = '/tmp-' . uniqid();
+	public function testTouchExistingFile() {
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -634,8 +642,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testTouchFile() {
-		$filename = '/tmp-' . uniqid();
+	public function testTouchFile() {
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		$view->touch($filename);
@@ -658,8 +666,8 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @medium
 	 */
-	function testFopenFile() {
-		$filename = '/tmp-' . uniqid();
+	public function testFopenFile() {
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -676,6 +684,7 @@ class Test_Encryption_Crypt extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->dataShort, $decrypt);
 
 		// tear down
+		fclose($handle);
 		$view->unlink($filename);
 	}
 

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -6,32 +6,38 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Helper
  */
-class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Helper extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_HELPER_USER1 = "test-helper-user1";
 	const TEST_ENCRYPTION_HELPER_USER2 = "test-helper-user2";
 
-	public function setUp() {
+	protected function setUpUsers() {
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER2, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1, true);
+		self::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER2, true);
+		self::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1, true);
 	}
 
-	public function tearDown() {
+	protected  function cleanUpUsers() {
 		// cleanup test user
 		\OC_User::deleteUser(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1);
 		\OC_User::deleteUser(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER2);
 	}
 
-	public static function tearDownAfterClass() {
+	public static function setupHooks() {
+		// Filesystem related hooks
+		\OCA\Encryption\Helper::registerFilesystemHooks();
 
+		// clear and register hooks
+		\OC_FileProxy::clearProxies();
+		\OC_FileProxy::register(new OCA\Encryption\Proxy());
+	}
+
+	public static function tearDownAfterClass() {
 		\OC_Hook::clear();
 		\OC_FileProxy::clearProxies();
 
@@ -39,6 +45,8 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**
@@ -90,19 +98,20 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testGetUser() {
+		self::setUpUsers();
 
 		$path1 = "/" . self::TEST_ENCRYPTION_HELPER_USER1 . "/files/foo/bar.txt";
 		$path2 = "/" . self::TEST_ENCRYPTION_HELPER_USER1 . "/cache/foo/bar.txt";
 		$path3 = "/" . self::TEST_ENCRYPTION_HELPER_USER2 . "/thumbnails/foo";
 		$path4 ="/" . "/" . self::TEST_ENCRYPTION_HELPER_USER1;
 
-		\Test_Encryption_Util::loginHelper(self::TEST_ENCRYPTION_HELPER_USER1);
+		self::loginHelper(self::TEST_ENCRYPTION_HELPER_USER1);
 
 		// if we are logged-in every path should return the currently logged-in user
 		$this->assertEquals(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path3));
 
 		// now log out
-		\Test_Encryption_Util::logoutHelper();
+		self::logoutHelper();
 
 		// now we should only get the user from /user/files and user/cache paths
 		$this->assertEquals(self::TEST_ENCRYPTION_HELPER_USER1, Encryption\Helper::getUser($path1));
@@ -112,12 +121,13 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse(Encryption\Helper::getUser($path4));
 
 		// Log-in again
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1);
+		self::loginHelper(\Test_Encryption_Helper::TEST_ENCRYPTION_HELPER_USER1);
+		self::cleanUpUsers();
 	}
 
 	function userNamesProvider() {
 		return array(
-			array('testuser' . uniqid()),
+			array('testuser' . $this->getUniqueID()),
 			array('user.name.with.dots'),
 		);
 	}
@@ -128,12 +138,13 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider userNamesProvider
 	 */
 	function testFindShareKeys($userName) {
+		self::setUpUsers();
 		// note: not using dataProvider as we want to make
 		// sure that the correct keys are match and not any
 		// other ones that might happen to have similar names
-		\Test_Encryption_Util::setupHooks();
-		\Test_Encryption_Util::loginHelper($userName, true);
-		$testDir = 'testFindShareKeys' . uniqid() . '/';
+		self::setupHooks();
+		self::loginHelper($userName, true);
+		$testDir = 'testFindShareKeys' . $this->getUniqueID() . '/';
 		$baseDir = $userName . '/files/' . $testDir;
 		$fileList = array(
 			't est.txt',
@@ -164,6 +175,6 @@ class Test_Encryption_Helper extends \PHPUnit_Framework_TestCase {
 				$result
 			);
 		}
+		self::cleanUpUsers();
 	}
-
 }

--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -20,24 +20,22 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Hooks
  * this class provide basic hook app tests
  */
-class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Hooks extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_HOOKS_USER1 = "test-encryption-hooks-user1.dot";
 	const TEST_ENCRYPTION_HOOKS_USER2 = "test-encryption-hooks-user2.dot";
 
-	/**
-	 * @var \OC\Files\View
-	 */
+	/** @var \OC\Files\View */
 	public $user1View;     // view on /data/user1/files
+	/** @var \OC\Files\View */
 	public $user2View;     // view on /data/user2/files
+	/** @var \OC\Files\View */
 	public $rootView; // view on /data/user
 	public $data;
 	public $filename;
@@ -46,6 +44,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 	private static $testFiles;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// note: not using a data provider because these
 		// files all need to coexist to make sure the
 		// share keys are found properly (pattern matching)
@@ -86,13 +86,15 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2, true);
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1, true);
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// set user id
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 		\OC_User::setUserId(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 
 		// init filesystem view
@@ -102,8 +104,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
 		// init short data
 		$this->data = 'hats';
-		$this->filename = 'enc_hooks_tests-' . uniqid() . '.txt';
-		$this->folder = 'enc_hooks_tests_folder-' . uniqid();
+		$this->filename = 'enc_hooks_tests-' . $this->getUniqueID() . '.txt';
+		$this->folder = 'enc_hooks_tests_folder-' . $this->getUniqueID();
 
 	}
 
@@ -119,6 +121,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	function testDisableHook() {
@@ -140,7 +144,7 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
 		// relogin user to initialize the encryption again
 		$user =  \OCP\User::getUser();
-		\Test_Encryption_Util::loginHelper($user);
+		self::loginHelper($user);
 
 	}
 
@@ -165,8 +169,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 			self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/keyfiles/' . $this->filename . '.key'));
 
 
-		\Test_Encryption_Util::logoutHelper();
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
+		self::logoutHelper();
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
 		\OC_User::setUserId(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
 
 
@@ -223,8 +227,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
 	function testDeleteHooksForSharedFiles() {
 
-		\Test_Encryption_Util::logoutHelper();
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
+		self::logoutHelper();
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 		\OC_User::setUserId(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 
 		// remember files_trashbin state
@@ -259,8 +263,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 			self::TEST_ENCRYPTION_HOOKS_USER1 . '/files_encryption/share-keys/'
 			. $this->filename . '.' . \Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2 . '.shareKey'));
 
-		\Test_Encryption_Util::logoutHelper();
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
+		self::logoutHelper();
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
 		\OC_User::setUserId(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER2);
 
 		// user2 update the shared file
@@ -290,8 +294,8 @@ class Test_Encryption_Hooks extends \PHPUnit_Framework_TestCase {
 
 		// cleanup
 
-		\Test_Encryption_Util::logoutHelper();
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
+		self::logoutHelper();
+		self::loginHelper(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 		\OC_User::setUserId(\Test_Encryption_Hooks::TEST_ENCRYPTION_HOOKS_USER1);
 
 		if ($stateFilesTrashbin) {

--- a/apps/files_encryption/tests/keymanager.php
+++ b/apps/files_encryption/tests/keymanager.php
@@ -6,14 +6,12 @@
  * See the COPYING-README file.
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Keymanager
  */
-class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Keymanager extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_USER = "test-keymanager-user.dot";
 
@@ -28,6 +26,8 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	public $dataShort;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -50,10 +50,11 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		// create test user
 		\OC_User::deleteUser(\Test_Encryption_Keymanager::TEST_USER);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Keymanager::TEST_USER, true);
+		parent::loginHelper(\Test_Encryption_Keymanager::TEST_USER, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
 		// set content for encrypting / decrypting in tests
 		$this->dataLong = file_get_contents(__DIR__ . '/../lib/crypt.php');
 		$this->dataShort = 'hats';
@@ -68,7 +69,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		$this->view = new \OC\Files\View('/');
 
-		\Test_Encryption_Util::loginHelper(Test_Encryption_Keymanager::TEST_USER);
+		self::loginHelper(Test_Encryption_Keymanager::TEST_USER);
 		$this->userId = \Test_Encryption_Keymanager::TEST_USER;
 		$this->pass = \Test_Encryption_Keymanager::TEST_USER;
 
@@ -79,6 +80,8 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 	function tearDown() {
 		$this->view->deleteAll('/'.Test_Encryption_Keymanager::TEST_USER.'/files_encryption/share-keys');
 		$this->view->deleteAll('/'.Test_Encryption_Keymanager::TEST_USER.'/files_encryption/keyfiles');
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
@@ -98,6 +101,8 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**
@@ -163,7 +168,7 @@ class Test_Encryption_Keymanager extends \PHPUnit_Framework_TestCase {
 
 		$key = $this->randomKey;
 
-		$file = 'unittest-' . uniqid() . '.txt';
+		$file = 'unittest-' . $this->getUniqueID() . '.txt';
 
 		$util = new Encryption\Util($this->view, $this->userId);
 

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -20,15 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Proxy
  * this class provide basic proxy app tests
  */
-class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Proxy extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_PROXY_USER1 = "test-proxy-user1";
 
@@ -44,6 +42,8 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 	public $filename;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -59,10 +59,12 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1, true);
+		self::loginHelper(\Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// set user id
 		\OC_User::setUserId(\Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1);
 		$this->userId = \Test_Encryption_Proxy::TEST_ENCRYPTION_PROXY_USER1;
@@ -75,7 +77,7 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 		// init short data
 		$this->data = 'hats';
 		$this->dataLong = file_get_contents(__DIR__ . '/../lib/crypt.php');
-		$this->filename = 'enc_proxy_tests-' . uniqid() . '.txt';
+		$this->filename = 'enc_proxy_tests-' . $this->getUniqueID() . '.txt';
 
 	}
 
@@ -90,6 +92,8 @@ class Test_Encryption_Proxy extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -20,14 +20,12 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Share
  */
-class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_SHARE_USER1 = "test-share-user1";
 	const TEST_ENCRYPTION_SHARE_USER2 = "test-share-user2";
@@ -47,6 +45,8 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	public $subsubfolder;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -73,10 +73,10 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create users
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, true);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1, true);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, true);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, true);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, true);
 
 		// create group and assign users
 		\OC_Group::createGroup(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1);
@@ -84,7 +84,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_Group::addToGroup(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		$this->dataShort = 'hats';
 		$this->view = new \OC\Files\View('/');
 
@@ -101,16 +103,18 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OC_App::disable('files_trashbin');
 
 		// login as first user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
 		} else {
 			OC_App::disable('files_trashbin');
 		}
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
@@ -130,6 +134,8 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 
@@ -139,7 +145,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	 */
 	function testShareFile($withTeardown = true) {
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename, $this->dataShort);
@@ -168,7 +174,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user1 exists
 		$this->assertTrue($this->view->file_exists(
@@ -176,7 +182,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '.shareKey'));
 
 		// login as user1
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -189,7 +195,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		if ($withTeardown) {
 
 			// login as admin
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 			// unshare the file
 			\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
@@ -219,7 +225,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->testShareFile(false);
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		// get the file info
 		$fileInfo = $this->view->getFileInfo(
@@ -229,7 +235,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user2 exists
 		$this->assertTrue($this->view->file_exists(
@@ -237,7 +243,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '.shareKey'));
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -250,13 +256,13 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		if ($withTeardown) {
 
 			// login as user1
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 			// unshare the file with user2
 			\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 			// login as admin
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 			// check if share key not exists
 			$this->assertFalse($this->view->file_exists(
@@ -290,7 +296,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	 */
 	function testShareFolder($withTeardown = true) {
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// create folder structure
 		$this->view->mkdir('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files' . $this->folder1);
@@ -325,7 +331,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user1 exists
 		$this->assertTrue($this->view->file_exists(
@@ -334,7 +340,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '.shareKey'));
 
 		// login as user1
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -348,7 +354,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		if ($withTeardown) {
 
 			// login as admin
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 			// unshare the folder with user1
 			\OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
@@ -382,7 +388,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$fileInfoFolder1 = $this->testShareFolder(false);
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		// disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -403,7 +409,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('folder', $fileInfoSubFolder['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user3 exists
 		$this->assertTrue($this->view->file_exists(
@@ -412,7 +418,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '.shareKey'));
 
 		// login as user3
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -434,7 +440,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user3 exists
 		$this->assertTrue($this->view->file_exists(
@@ -443,7 +449,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4 . '.shareKey'));
 
 		// login as user3
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -456,7 +462,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		if ($withTeardown) {
 
 			// login as user2
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 			// unshare the file with user3
 			\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4);
@@ -468,7 +474,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 				. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4 . '.shareKey'));
 
 			// login as user1
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 			// unshare the folder with user2
 			\OCP\Share::unshare('folder', $fileInfoSubFolder['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
@@ -480,7 +486,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 				. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3 . '.shareKey'));
 
 			// login as admin
-			\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+			self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 			// unshare the folder1 with user1
 			\OCP\Share::unshare('folder', $fileInfoFolder1['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
@@ -507,7 +513,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 	function testPublicShareFile() {
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->filename, $this->dataShort);
@@ -536,7 +542,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, false, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		$publicShareKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'publicShareKeyId');
 
@@ -548,7 +554,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		// some hacking to simulate public link
 		//$GLOBALS['app'] = 'files_sharing';
 		//$GLOBALS['fileOwner'] = \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1;
-		\Test_Encryption_Util::logoutHelper();
+		self::logoutHelper();
 
 		// get file contents
 		$retrievedCryptedFile = file_get_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->filename);
@@ -559,7 +565,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		// tear down
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// unshare the file
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
@@ -585,7 +591,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	 */
 	function testShareFileWithGroup() {
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename, $this->dataShort);
@@ -614,7 +620,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user2 and user3 exists
 		$this->assertTrue($this->view->file_exists(
@@ -625,7 +631,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4 . '.shareKey'));
 
 		// login as user1
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3);
 
 		// get file contents
 		$retrievedCryptedFile = $this->view->file_get_contents(
@@ -635,7 +641,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->dataShort, $retrievedCryptedFile);
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// unshare the file
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1);
@@ -666,13 +672,13 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	function testRecoveryFile() {
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		\OCA\Encryption\Helper::adminEnableRecovery(null, 'test123');
 		$recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryKeyId');
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		$util = new \OCA\Encryption\Util(new \OC\Files\View('/'), \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
@@ -772,7 +778,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	function testRecoveryForUser() {
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		$result = \OCA\Encryption\Helper::adminEnableRecovery(null, 'test123');
 		$this->assertTrue($result);
@@ -780,7 +786,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'recoveryKeyId');
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		$util = new \OCA\Encryption\Util(new \OC\Files\View('/'), \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
@@ -824,7 +830,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 			. $this->filename . '.' . $recoveryKeyId . '.shareKey'));
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// change password
 		\OC_User::setPassword(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, 'test', 'test123');
@@ -834,7 +840,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		\OCA\Encryption\Hooks::setPassphrase($params);
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, false, 'test');
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, false, 'test');
 
 		// get file contents
 		$retrievedCryptedFile1 = file_get_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->filename);
@@ -886,7 +892,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	 */
 	function testFailShareFile() {
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename, $this->dataShort);
@@ -924,7 +930,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// check if share key for user1 not exists
 		$this->assertFalse($this->view->file_exists(
@@ -969,7 +975,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	function testRename() {
 
 		// login as admin
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename, $this->dataShort);
@@ -994,7 +1000,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 
 		// login as user2
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2);
 
 		$this->assertTrue($this->view->file_exists('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->filename));
 
@@ -1017,7 +1023,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($this->dataShort, $retrievedRenamedFile);
 
 		// cleanup
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 		$this->view->unlink('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename);
 	}
 
@@ -1029,8 +1035,8 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 		$view = new \OC\Files\View('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
-		$filename = '/tmp-' . uniqid();
-		$folder = '/folder' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
+		$folder = '/folder' . $this->getUniqueID();
 
 		\OC\Files\Filesystem::mkdir($folder);
 
@@ -1045,7 +1051,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataShort, $decrypt);
 
-		$newFolder = '/newfolder/subfolder' . uniqid();
+		$newFolder = '/newfolder/subfolder' . $this->getUniqueID();
 		\OC\Files\Filesystem::mkdir('/newfolder');
 
 		// get the file info from previous created file
@@ -1087,8 +1093,8 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 	function testMoveFileToFolder($userId) {
 		$view = new \OC\Files\View('/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
-		$filename = '/tmp-' . uniqid();
-		$folder = '/folder' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
+		$folder = '/folder' . $this->getUniqueID();
 
 		\OC\Files\Filesystem::mkdir($folder);
 
@@ -1103,7 +1109,7 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($this->dataShort, $decrypt);
 
-		$subFolder = $folder . '/subfolder' . uniqid();
+		$subFolder = $folder . '/subfolder' . $this->getUniqueID();
 		\OC\Files\Filesystem::mkdir($subFolder);
 
 		// get the file info from previous created file
@@ -1118,9 +1124,9 @@ class Test_Encryption_Share extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($view->file_exists('files_encryption/share-keys' . $folder . '/' . $filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '.shareKey'));
 
 		// move the file into the subfolder as the test user
-		\Test_Encryption_Util::loginHelper($userId);
+		self::loginHelper($userId);
 		\OC\Files\Filesystem::rename($folder . $filename, $subFolder . $filename);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
+		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
 
 		// Get file decrypted contents
 		$newDecrypt = \OC\Files\Filesystem::file_get_contents($subFolder . $filename);

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -134,6 +134,13 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 
 		$handle = $view->fopen($filename, 'r');
 
+
+		if (\OC_Util::runningOnWindows()) {
+			fclose($handle);
+			$view->unlink($filename);
+			$this->markTestSkipped('[Windows] stream_set_blocking() does not work as expected on Windows.');
+		}
+
 		// set stream options
 		$this->assertTrue(stream_set_blocking($handle, 1));
 

--- a/apps/files_encryption/tests/stream.php
+++ b/apps/files_encryption/tests/stream.php
@@ -20,15 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Stream
  * this class provide basic stream tests
  */
-class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Stream extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_STREAM_USER1 = "test-stream-user1";
 
@@ -42,6 +40,8 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	public $stateFilesTrashbin;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -54,10 +54,12 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Stream::TEST_ENCRYPTION_STREAM_USER1, true);
+		self::loginHelper(\Test_Encryption_Stream::TEST_ENCRYPTION_STREAM_USER1, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// set user id
 		\OC_User::setUserId(\Test_Encryption_Stream::TEST_ENCRYPTION_STREAM_USER1);
 		$this->userId = \Test_Encryption_Stream::TEST_ENCRYPTION_STREAM_USER1;
@@ -76,7 +78,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		\OC_App::disable('files_trashbin');
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
@@ -84,6 +86,8 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		else {
 			OC_App::disable('files_trashbin');
 		}
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
@@ -97,10 +101,12 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	function testStreamOptions() {
-		$filename = '/tmp-' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -118,12 +124,14 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue(flock($handle, LOCK_SH));
 		$this->assertTrue(flock($handle, LOCK_UN));
 
+		fclose($handle);
+
 		// tear down
 		$view->unlink($filename);
 	}
 
 	function testStreamSetBlocking() {
-		$filename = '/tmp-' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -154,7 +162,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	 * @medium
 	 */
 	function testStreamSetTimeout() {
-		$filename = '/tmp-' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -175,7 +183,7 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	}
 
 	function testStreamSetWriteBuffer() {
-		$filename = '/tmp-' . uniqid();
+		$filename = '/tmp-' . $this->getUniqueID();
 		$view = new \OC\Files\View('/' . $this->userId . '/files');
 
 		// Save short data as encrypted file using stream wrapper
@@ -201,9 +209,9 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 	 */
 	function testStreamFromLocalFile() {
 
-		$filename = '/' . $this->userId . '/files/' . 'tmp-' . uniqid().'.txt';
+		$filename = '/' . $this->userId . '/files/' . 'tmp-' . $this->getUniqueID().'.txt';
 
-		$tmpFilename = "/tmp/" . uniqid() . ".txt";
+		$tmpFilename = "/tmp/" . $this->getUniqueID() . ".txt";
 
 		// write an encrypted file
 		$cryptedFile = $this->view->file_put_contents($filename, $this->dataShort);
@@ -227,6 +235,8 @@ class Test_Encryption_Stream extends \PHPUnit_Framework_TestCase {
 
 		// check if it was successful
 		$this->assertEquals($this->dataShort, $contentFromTmpFile);
+
+		fclose($handle);
 
 		// clean up
 		unlink($tmpFilename);

--- a/apps/files_encryption/tests/testcase.php
+++ b/apps/files_encryption/tests/testcase.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright (c) 2012 Sam Tuke <samtuke@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_Encryption\Tests;
+
+use OCA\Encryption;
+
+/**
+ * Class Test_Encryption_TestCase
+ */
+abstract class TestCase extends \Test\TestCase {
+	/**
+	 * @param string $user
+	 * @param bool $create
+	 * @param bool $password
+	 */
+	public static function loginHelper($user, $create = false, $password = false, $loadEncryption = true) {
+		if ($create) {
+			try {
+				\OC_User::createUser($user, $user);
+			} catch (\Exception $e) {
+				// catch username is already being used from previous aborted runs
+			}
+		}
+
+		if ($password === false) {
+			$password = $user;
+		}
+
+		\OC_Util::tearDownFS();
+		\OC_User::setUserId('');
+		\OC\Files\Filesystem::tearDown();
+		\OC_User::setUserId($user);
+		\OC_Util::setupFS($user);
+
+		if ($loadEncryption) {
+			$params['uid'] = $user;
+			$params['password'] = $password;
+			\OCA\Encryption\Hooks::login($params);
+		}
+	}
+
+	public static function logoutHelper() {
+		\OC_Util::tearDownFS();
+		\OC_User::setUserId(false);
+		\OC\Files\Filesystem::tearDown();
+	}
+}

--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -20,15 +20,13 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
  * Class Test_Encryption_Trashbin
  * this class provide basic trashbin app tests
  */
-class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Trashbin extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_TRASHBIN_USER1 = "test-trashbin-user1";
 
@@ -45,6 +43,8 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	public $subsubfolder;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -63,14 +63,16 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1, true);
+		self::loginHelper(self::TEST_ENCRYPTION_TRASHBIN_USER1, true);
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// set user id
-		\OC_User::setUserId(\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1);
-		$this->userId = \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1;
-		$this->pass = \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1;
+		\OC_User::setUserId(self::TEST_ENCRYPTION_TRASHBIN_USER1);
+		$this->userId = self::TEST_ENCRYPTION_TRASHBIN_USER1;
+		$this->pass = self::TEST_ENCRYPTION_TRASHBIN_USER1;
 
 		// init filesystem view
 		$this->view = new \OC\Files\View('/');
@@ -89,7 +91,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 		\OC_App::enable('files_trashbin');
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
@@ -97,11 +99,13 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 		else {
 			OC_App::disable('files_trashbin');
 		}
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
 		// cleanup test user
-		\OC_User::deleteUser(\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1);
+		\OC_User::deleteUser(self::TEST_ENCRYPTION_TRASHBIN_USER1);
 
 		\OC_Hook::clear();
 		\OC_FileProxy::clearProxies();
@@ -110,6 +114,8 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**
@@ -119,12 +125,12 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	function testDeleteFile() {
 
 		// generate filename
-		$filename = 'tmp-' . uniqid() . '.txt';
+		$filename = 'tmp-' . $this->getUniqueID() . '.txt';
 		$filename2 = $filename . '.backup'; // a second file with similar name
 
 		// save file with content
-		$cryptedFile = file_put_contents('crypt:///' .\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename, $this->dataShort);
-		$cryptedFile2 = file_put_contents('crypt:///' .\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename2, $this->dataShort);
+		$cryptedFile = file_put_contents('crypt:///' .self::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename, $this->dataShort);
+		$cryptedFile2 = file_put_contents('crypt:///' .self::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename2, $this->dataShort);
 
 		// test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile));
@@ -132,59 +138,59 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
 			. '.key'));
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename2
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename2
 			. '.key'));
 
 		// check if share key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename2 . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename2 . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// delete first file
 		\OC\FIles\Filesystem::unlink($filename);
 
 		// check if file not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
 
 		// check if key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
 			. '.key'));
 
 		// check if share key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// check that second file still exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename2));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename2));
 
 		// check that key for second file still exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename2
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename2
 			. '.key'));
 
 		// check that share key for second file still exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename2 . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename2 . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// get files
 		$trashFiles = $this->view->getDirectoryContent(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/');
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/');
 
 		$trashFileSuffix = null;
 		// find created file with timestamp
 		foreach ($trashFiles as $file) {
-			if (strncmp($file['path'], $filename, strlen($filename))) {
+			if (strpos($file['path'], $filename . '.d') !== false) {
 				$path_parts = pathinfo($file['name']);
 				$trashFileSuffix = $path_parts['extension'];
 			}
@@ -195,13 +201,13 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if key for admin not exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
 			. '.key.' . $trashFileSuffix));
 
 		// check if share key for admin not exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
-			. '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
+			. '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
 	}
 
 	/**
@@ -210,31 +216,26 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	 */
 	function testRestoreFile() {
 		// generate filename
-		$filename = 'tmp-' . uniqid() . '.txt';
+		$filename = 'tmp-' . $this->getUniqueID() . '.txt';
 		$filename2 = $filename . '.backup'; // a second file with similar name
 
 		// save file with content
-		$cryptedFile = file_put_contents('crypt:///' .\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename, $this->dataShort);
-		$cryptedFile2 = file_put_contents('crypt:///' .\Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename2, $this->dataShort);
+		$cryptedFile = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename, $this->dataShort);
+		$cryptedFile2 = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_TRASHBIN_USER1. '/files/'. $filename2, $this->dataShort);
 
 		// delete both files
 		\OC\Files\Filesystem::unlink($filename);
 		\OC\Files\Filesystem::unlink($filename2);
 
-		$trashFiles = $this->view->getDirectoryContent(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/');
+		$trashFiles = $this->view->getDirectoryContent('/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/');
 
 		$trashFileSuffix = null;
 		$trashFileSuffix2 = null;
 		// find created file with timestamp
 		foreach ($trashFiles as $file) {
-			if (strncmp($file['path'], $filename, strlen($filename))) {
+			if (strpos($file['path'], $filename . '.d') !== false) {
 				$path_parts = pathinfo($file['name']);
 				$trashFileSuffix = $path_parts['extension'];
-			}
-			if (strncmp($file['path'], $filename2, strlen($filename2))) {
-				$path_parts = pathinfo($file['name']);
-				$trashFileSuffix2 = $path_parts['extension'];
 			}
 		}
 
@@ -246,31 +247,31 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if file exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
 
 		// check if key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/'
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/'
 			. $filename . '.key'));
 
 		// check if share key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// check that second file was NOT restored
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename2));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename2));
 
 		// check if key for admin exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/'
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/'
 			. $filename2 . '.key'));
 
 		// check if share key for admin exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename2 . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename2 . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 	}
 
 	/**
@@ -280,7 +281,7 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 	function testPermanentDeleteFile() {
 
 		// generate filename
-		$filename = 'tmp-' . uniqid() . '.txt';
+		$filename = 'tmp-' . $this->getUniqueID() . '.txt';
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' .$this->userId. '/files/' . $filename, $this->dataShort);
@@ -290,30 +291,30 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
 			. '.key'));
 
 		// check if share key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// delete file
 		\OC\Files\Filesystem::unlink($filename);
 
 		// check if file not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files/' . $filename));
 
 		// check if key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/keyfiles/' . $filename
 			. '.key'));
 
 		// check if share key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
-			. $filename . '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_encryption/share-keys/'
+			. $filename . '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey'));
 
 		// find created file with timestamp
 		$query = \OC_DB::prepare('SELECT `timestamp`,`type` FROM `*PREFIX*files_trash`'
@@ -327,13 +328,13 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
 			. '.key.' . $trashFileSuffix));
 
 		// check if share key for admin exists
 		$this->assertTrue($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
-			. '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
+			. '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
 
 		// get timestamp from file
 		$timestamp = str_replace('d', '', $trashFileSuffix);
@@ -343,18 +344,18 @@ class Test_Encryption_Trashbin extends \PHPUnit_Framework_TestCase {
 
 		// check if key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/' . $filename . '.'
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/files/' . $filename . '.'
 			. $trashFileSuffix));
 
 		// check if key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/keyfiles/' . $filename
 			. '.key.' . $trashFileSuffix));
 
 		// check if share key for admin not exists
 		$this->assertFalse($this->view->file_exists(
-			'/' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
-			. '.' . \Test_Encryption_Trashbin::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
+			'/' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '/files_trashbin/share-keys/' . $filename
+			. '.' . self::TEST_ENCRYPTION_TRASHBIN_USER1 . '.shareKey.' . $trashFileSuffix));
 	}
 
 }

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -11,7 +11,7 @@ use OCA\Encryption;
 /**
  * Class Test_Encryption_Util
  */
-class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Util extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_UTIL_USER1 = "test-util-user1";
 	const TEST_ENCRYPTION_UTIL_USER2 = "test-util-user2";
@@ -41,6 +41,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	public $stateFilesTrashbin;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -48,9 +50,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		self::setupHooks();
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER2, true);
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER, true);
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER1, true);
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER2, true);
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_LEGACY_USER, true);
 
 		// create groups
 		\OC_Group::createGroup(self::TEST_ENCRYPTION_UTIL_GROUP1);
@@ -60,13 +62,14 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		\OC_Group::addToGroup(self::TEST_ENCRYPTION_UTIL_USER1, self::TEST_ENCRYPTION_UTIL_GROUP1);
 	}
 
+	protected function setUp() {
+		parent::setUp();
 
-	function setUp() {
 		// login user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
-		\OC_User::setUserId(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
-		$this->userId = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1;
-		$this->pass = \Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1;
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER1);
+		\OC_User::setUserId(self::TEST_ENCRYPTION_UTIL_USER1);
+		$this->userId = self::TEST_ENCRYPTION_UTIL_USER1;
+		$this->pass = self::TEST_ENCRYPTION_UTIL_USER1;
 
 		// set content for encrypting / decrypting in tests
 		$this->dataUrl = __DIR__ . '/../lib/crypt.php';
@@ -101,7 +104,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		\OC_App::disable('files_trashbin');
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
@@ -109,13 +112,15 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		else {
 			OC_App::disable('files_trashbin');
 		}
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
 		// cleanup test user
-		\OC_User::deleteUser(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
-		\OC_User::deleteUser(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER2);
-		\OC_User::deleteUser(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_LEGACY_USER);
+		\OC_User::deleteUser(self::TEST_ENCRYPTION_UTIL_USER1);
+		\OC_User::deleteUser(self::TEST_ENCRYPTION_UTIL_USER2);
+		\OC_User::deleteUser(self::TEST_ENCRYPTION_UTIL_LEGACY_USER);
 
 		//cleanup groups
 		\OC_Group::deleteGroup(self::TEST_ENCRYPTION_UTIL_GROUP1);
@@ -128,6 +133,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	public static function setupHooks() {
@@ -164,8 +171,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		self::loginHelper($this->userId);
 
-		$unencryptedFile = '/tmpUnencrypted-' . uniqid() . '.txt';
-		$encryptedFile =  '/tmpEncrypted-' . uniqid() . '.txt';
+		$unencryptedFile = '/tmpUnencrypted-' . $this->getUniqueID() . '.txt';
+		$encryptedFile =  '/tmpEncrypted-' . $this->getUniqueID() . '.txt';
 
 		// Disable encryption proxy to write a unencrypted file
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -244,9 +251,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	 */
 	function testGetUidAndFilename() {
 
-		\OC_User::setUserId(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
+		\OC_User::setUserId(self::TEST_ENCRYPTION_UTIL_USER1);
 
-		$filename = '/tmp-' . uniqid() . '.test';
+		$filename = '/tmp-' . $this->getUniqueID() . '.test';
 
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -261,7 +268,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 		list($fileOwnerUid, $file) = $util->getUidAndFilename($filename);
 
-		$this->assertEquals(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1, $fileOwnerUid);
+		$this->assertEquals(self::TEST_ENCRYPTION_UTIL_USER1, $fileOwnerUid);
 
 		$this->assertEquals($file, $filename);
 
@@ -272,9 +279,9 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 	 * Test that data that is read by the crypto stream wrapper
 	 */
 	function testGetFileSize() {
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Util::TEST_ENCRYPTION_UTIL_USER1);
+		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER1);
 
-		$filename = 'tmp-' . uniqid();
+		$filename = 'tmp-' . $this->getUniqueID();
 		$externalFilename = '/' . $this->userId . '/files/' . $filename;
 
 		// Test for 0 byte files
@@ -298,7 +305,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	function testEncryptAll() {
 
-		$filename = "/encryptAll" . uniqid() . ".txt";
+		$filename = "/encryptAll" . $this->getUniqueID() . ".txt";
 		$util = new Encryption\Util($this->view, $this->userId);
 
 		// disable encryption to upload a unencrypted file
@@ -329,7 +336,7 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	function testDecryptAll() {
 
-		$filename = "/decryptAll" . uniqid() . ".txt";
+		$filename = "/decryptAll" . $this->getUniqueID() . ".txt";
 		$datadir = \OC_Config::getValue('datadirectory', \OC::$SERVERROOT . '/data/');
 		$userdir = $datadir . '/' . $this->userId . '/files/';
 
@@ -448,8 +455,8 @@ class Test_Encryption_Util extends \PHPUnit_Framework_TestCase {
 
 	function testDescryptAllWithBrokenFiles() {
 
-		$file1 = "/decryptAll1" . uniqid() . ".txt";
-		$file2 = "/decryptAll2" . uniqid() . ".txt";
+		$file1 = "/decryptAll1" . $this->getUniqueID() . ".txt";
+		$file2 = "/decryptAll2" . $this->getUniqueID() . ".txt";
 
 		$util = new Encryption\Util($this->view, $this->userId);
 

--- a/apps/files_encryption/tests/webdav.php
+++ b/apps/files_encryption/tests/webdav.php
@@ -20,8 +20,6 @@
  *
  */
 
-require_once __DIR__ . '/util.php';
-
 use OCA\Encryption;
 
 /**
@@ -29,7 +27,7 @@ use OCA\Encryption;
  *
  * this class provide basic webdav tests for PUT,GET and DELETE
  */
-class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
+class Test_Encryption_Webdav extends \OCA\Files_Encryption\Tests\TestCase {
 
 	const TEST_ENCRYPTION_WEBDAV_USER1 = "test-webdav-user1";
 
@@ -45,6 +43,8 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	private $storage;
 
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
@@ -60,11 +60,13 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 		\OC_FileProxy::register(new OCA\Encryption\Proxy());
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Webdav::TEST_ENCRYPTION_WEBDAV_USER1, true);
+		self::loginHelper(\Test_Encryption_Webdav::TEST_ENCRYPTION_WEBDAV_USER1, true);
 
 	}
 
-	function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
 		// reset backend
 		\OC_User::useBackend('database');
 
@@ -86,16 +88,18 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 		\OC_App::disable('files_trashbin');
 
 		// create test user
-		\Test_Encryption_Util::loginHelper(\Test_Encryption_Webdav::TEST_ENCRYPTION_WEBDAV_USER1);
+		self::loginHelper(\Test_Encryption_Webdav::TEST_ENCRYPTION_WEBDAV_USER1);
 	}
 
-	function tearDown() {
+	protected function tearDown() {
 		// reset app files_trashbin
 		if ($this->stateFilesTrashbin) {
 			OC_App::enable('files_trashbin');
 		} else {
 			OC_App::disable('files_trashbin');
 		}
+
+		parent::tearDown();
 	}
 
 	public static function tearDownAfterClass() {
@@ -109,6 +113,8 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 		$view = new \OC\Files\View('/');
 		$view->rmdir('public-keys');
 		$view->rmdir('owncloud_private_key');
+
+		parent::tearDownAfterClass();
 	}
 
 	/**
@@ -117,7 +123,7 @@ class Test_Encryption_Webdav extends \PHPUnit_Framework_TestCase {
 	function testWebdavPUT() {
 
 		// generate filename
-		$filename = '/tmp-' . uniqid() . '.txt';
+		$filename = '/tmp-' . $this->getUniqueID() . '.txt';
 
 		// set server vars
 		$_SERVER['REQUEST_METHOD'] = 'OPTIONS';

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -30,6 +30,18 @@ class Test_Files_Sharing_Cache extends TestCase {
 	 */
 	public $user2View;
 
+	/** @var \OC\Files\Cache\Cache */
+	protected $ownerCache;
+
+	/** @var \OC\Files\Cache\Cache */
+	protected $sharedCache;
+
+	/** @var \OC\Files\Storage\Storage */
+	protected $ownerStorage;
+
+	/** @var \OC\Files\Storage\Storage */
+	protected $sharedStorage;
+
 	function setUp() {
 		parent::setUp();
 
@@ -54,7 +66,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 		$this->view->file_put_contents('container/shareddir/subdir/another too.txt', $textData);
 		$this->view->file_put_contents('container/shareddir/subdir/not a text file.xml', '<xml></xml>');
 
-		list($this->ownerStorage, $internalPath) = $this->view->resolvePath('');
+		list($this->ownerStorage,) = $this->view->resolvePath('');
 		$this->ownerCache = $this->ownerStorage->getCache();
 		$this->ownerStorage->getScanner()->scan('');
 
@@ -72,7 +84,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 
 		// retrieve the shared storage
 		$secondView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
-		list($this->sharedStorage, $internalPath) = $secondView->resolvePath('files/shareddir');
+		list($this->sharedStorage,) = $secondView->resolvePath('files/shareddir');
 		$this->sharedCache = $this->sharedStorage->getCache();
 	}
 
@@ -354,7 +366,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Files\Filesystem::mkdir('foo');
 		\OC\Files\Filesystem::mkdir('foo/bar');
-		\OC\Files\Filesystem::touch('foo/bar/test.txt', 'bar');
+		\OC\Files\Filesystem::touch('foo/bar/test.txt');
 		$folderInfo = \OC\Files\Filesystem::getFileInfo('foo');
 		$fileInfo = \OC\Files\Filesystem::getFileInfo('foo/bar/test.txt');
 		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -698,12 +698,21 @@ class Filesystem {
 	 * @param bool $stripTrailingSlash
 	 * @return string
 	 */
-	public static function normalizePath($path, $stripTrailingSlash = true) {
+	public static function normalizePath($path, $stripTrailingSlash = true, $isAbsolutePath = false) {
 		if ($path == '') {
 			return '/';
 		}
+
 		//no windows style slashes
 		$path = str_replace('\\', '/', $path);
+
+		// When normalizing an absolute path, we need to ensure that the drive-letter
+		// is still at the beginning on windows
+		$windows_drive_letter = '';
+		if ($isAbsolutePath && \OC_Util::runningOnWindows() && preg_match('#^([a-zA-Z])$#', $path[0]) && $path[1] == ':' && $path[2] == '/') {
+			$windows_drive_letter = substr($path, 0, 2);
+			$path = substr($path, 2);
+		}
 
 		//add leading slash
 		if ($path[0] !== '/') {
@@ -733,7 +742,7 @@ class Filesystem {
 		//normalize unicode if possible
 		$path = \OC_Util::normalizeUnicode($path);
 
-		return $path;
+		return $windows_drive_letter . $path;
 	}
 
 	/**

--- a/lib/private/security/certificatemanager.php
+++ b/lib/private/security/certificatemanager.php
@@ -49,6 +49,7 @@ class CertificateManager implements ICertificateManager {
 				} catch(\Exception $e) {}
 			}
 		}
+		closedir($handle);
 		return $result;
 	}
 

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -460,6 +460,9 @@ class Test_App extends PHPUnit_Framework_TestCase {
 		\OC::$server->registerService('AppConfig', function ($c) use ($oldService){
 			return $oldService;
 		});
+
+		// Remove the cache of the mocked apps list with a forceRefresh
+		\OC_App::getEnabledApps(true);
 	}
 }
 

--- a/tests/lib/archive/tar.php
+++ b/tests/lib/archive/tar.php
@@ -9,7 +9,7 @@
 class Test_Archive_TAR extends Test_Archive {
 	public function setUp() {
 		if (OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('tar archives are not supported on windows');
+			$this->markTestSkipped('[Windows] tar archives are not supported on Windows');
 		}
 		parent::setUp();
 	}

--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -23,8 +23,12 @@
 namespace Test\Cache;
 
 class FileCache extends \Test_Cache {
+	/** @var string */
 	private $user;
+	/** @var string */
 	private $datadir;
+	/** @var \OC\Files\Storage\Storage */
+	private $storage;
 
 	function skip() {
 		//$this->skipUnless(OC_User::isLoggedIn());
@@ -42,6 +46,7 @@ class FileCache extends \Test_Cache {
 		//}
 
 		//set up temporary storage
+		$this->storage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
 		$storage = new \OC\Files\Storage\Temporary(array());
 		\OC\Files\Filesystem::mount($storage,array(),'/');
@@ -68,5 +73,11 @@ class FileCache extends \Test_Cache {
 	public function tearDown() {
 		\OC_User::setUserId($this->user);
 		\OC_Config::setValue('cachedirectory', $this->datadir);
+
+		// Restore the original mount point
+		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($this->storage, array(), '/');
+
+		parent::tearDown();
 	}
 }

--- a/tests/lib/cache/usercache.php
+++ b/tests/lib/cache/usercache.php
@@ -23,8 +23,12 @@
 namespace Test\Cache;
 
 class UserCache extends \Test_Cache {
+	/** @var string */
 	private $user;
+	/** @var string */
 	private $datadir;
+	/** @var \OC\Files\Storage\Storage */
+	private $storage;
 
 	public function setUp() {
 		//clear all proxies and hooks so we can do clean testing
@@ -38,6 +42,7 @@ class UserCache extends \Test_Cache {
 		//}
 
 		//set up temporary storage
+		$this->storage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
 		$storage = new \OC\Files\Storage\Temporary(array());
 		\OC\Files\Filesystem::mount($storage,array(),'/');
@@ -63,5 +68,12 @@ class UserCache extends \Test_Cache {
 
 	public function tearDown() {
 		\OC_User::setUserId($this->user);
+		\OC_Config::setValue('cachedirectory', $this->datadir);
+
+		// Restore the original mount point
+		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($this->storage, array(), '/');
+
+		parent::tearDown();
 	}
 }

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -33,13 +33,26 @@ class Updater extends \PHPUnit_Framework_TestCase {
 	 */
 	protected $updater;
 
-	public function setUp() {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = Filesystem::getStorage('/');
 		$this->storage = new Temporary(array());
 		Filesystem::clearMounts();
 		Filesystem::mount($this->storage, array(), '/');
 		$this->view = new View('');
 		$this->updater = new \OC\Files\Cache\Updater($this->view);
 		$this->cache = $this->storage->getCache();
+	}
+
+	protected function tearDown() {
+		Filesystem::clearMounts();
+		Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	public function testNewFile() {

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -29,6 +29,9 @@ class UpdaterLegacy extends \PHPUnit_Framework_TestCase {
 	 */
 	private $cache;
 
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
 	private static $user;
 
 	public function setUp() {
@@ -51,7 +54,8 @@ class UpdaterLegacy extends \PHPUnit_Framework_TestCase {
 		$this->scanner->scan('');
 		$this->cache = $this->storage->getCache();
 
-		\OC\Files\Filesystem::tearDown();
+		$this->originalStorage = Filesystem::getStorage('/');
+		Filesystem::tearDown();
 		if (!self::$user) {
 			self::$user = uniqid();
 		}
@@ -59,7 +63,7 @@ class UpdaterLegacy extends \PHPUnit_Framework_TestCase {
 		\OC_User::createUser(self::$user, 'password');
 		\OC_User::setUserId(self::$user);
 
-		\OC\Files\Filesystem::init(self::$user, '/' . self::$user . '/files');
+		Filesystem::init(self::$user, '/' . self::$user . '/files');
 
 		Filesystem::clearMounts();
 		Filesystem::mount($this->storage, array(), '/' . self::$user . '/files');
@@ -74,6 +78,7 @@ class UpdaterLegacy extends \PHPUnit_Framework_TestCase {
 		$result = \OC_User::deleteUser(self::$user);
 		$this->assertTrue($result);
 		Filesystem::tearDown();
+		Filesystem::mount($this->originalStorage, array(), '/');
 		// reset app files_encryption
 		if ($this->stateFilesEncryption) {
 			\OC_App::enable('files_encryption');

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -15,16 +15,27 @@ class Watcher extends \PHPUnit_Framework_TestCase {
 	 */
 	private $storages = array();
 
-	public function setUp() {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		foreach ($this->storages as $storage) {
 			$cache = $storage->getCache();
 			$ids = $cache->getAll();
 			$cache->clear();
 		}
+
+		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -11,7 +11,7 @@ namespace Test\Files;
 use OC\Files\Filesystem;
 use OCP\Share;
 
-class EtagTest extends \PHPUnit_Framework_TestCase {
+class EtagTest extends \Test\TestCase {
 	private $datadir;
 
 	private $tmpDir;
@@ -23,7 +23,12 @@ class EtagTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private $userBackend;
 
-	public function setUp() {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
 		\OC_Hook::clear('OC_Filesystem', 'setup');
 		\OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 		\OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
@@ -37,13 +42,17 @@ class EtagTest extends \PHPUnit_Framework_TestCase {
 
 		$this->userBackend = new \OC_User_Dummy();
 		\OC_User::useBackend($this->userBackend);
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC_Util::tearDownFS();
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		\OC_Config::setValue('datadirectory', $this->datadir);
 		\OC_User::setUserId($this->uid);
 		\OC_Util::setupFS($this->uid);
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	public function testNewUser() {

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -22,11 +22,14 @@
 
 namespace Test\Files;
 
-class Filesystem extends \PHPUnit_Framework_TestCase {
+class Filesystem extends \Test\TestCase {
 	/**
 	 * @var array tmpDirs
 	 */
 	private $tmpDirs = array();
+
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
 
 	/**
 	 * @return array
@@ -37,17 +40,21 @@ class Filesystem extends \PHPUnit_Framework_TestCase {
 		return array('datadir' => $dir);
 	}
 
-	public function tearDown() {
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+		\OC_User::setUserId('');
+		\OC\Files\Filesystem::clearMounts();
+	}
+
+	protected function tearDown() {
 		foreach ($this->tmpDirs as $dir) {
 			\OC_Helper::rmdirr($dir);
 		}
 		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 		\OC_User::setUserId('');
-	}
-
-	public function setUp() {
-		\OC_User::setUserId('');
-		\OC\Files\Filesystem::clearMounts();
 	}
 
 	public function testMount() {

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -20,6 +20,9 @@ class IntegrationTests extends \PHPUnit_Framework_TestCase {
 	 */
 	private $root;
 
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
 	/**
 	 * @var \OC\Files\Storage\Storage[]
 	 */
@@ -30,7 +33,10 @@ class IntegrationTests extends \PHPUnit_Framework_TestCase {
 	 */
 	private $view;
 
-	public function setUp() {
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::init('', '');
 		\OC\Files\Filesystem::clearMounts();
 		$manager = \OC\Files\Filesystem::getMountManager();
@@ -54,11 +60,15 @@ class IntegrationTests extends \PHPUnit_Framework_TestCase {
 		$this->root->mount($subStorage, '/substorage/');
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		foreach ($this->storages as $storage) {
 			$storage->getCache()->clear();
 		}
 		\OC\Files\Filesystem::clearMounts();
+
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	public function testBasicFile() {

--- a/tests/lib/files/storage/home.php
+++ b/tests/lib/files/storage/home.php
@@ -75,7 +75,12 @@ class Home extends Storage {
 	 * Tests that the root path matches the data dir
 	 */
 	public function testRoot() {
-		$this->assertEquals($this->tmpDir, $this->instance->getLocalFolder(''));
+		if (\OC_Util::runningOnWindows()) {
+			// Windows removes trailing slashes when returning paths
+			$this->assertEquals(rtrim($this->tmpDir, '/'), $this->instance->getLocalFolder(''));
+		} else {
+			$this->assertEquals($this->tmpDir, $this->instance->getLocalFolder(''));
+		}
 	}
 
 	/**

--- a/tests/lib/files/storage/local.php
+++ b/tests/lib/files/storage/local.php
@@ -39,7 +39,7 @@ class Local extends Storage {
 
 	public function testStableEtag() {
 		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('On Windows platform we have no stable etag generation - yet');
+			$this->markTestSkipped('[Windows] On Windows platform we have no stable etag generation - yet');
 		}
 
 		$this->instance->file_put_contents('test.txt', 'foobar');
@@ -50,7 +50,7 @@ class Local extends Storage {
 
 	public function testEtagChange() {
 		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('On Windows platform we have no stable etag generation - yet');
+			$this->markTestSkipped('[Windows] On Windows platform we have no stable etag generation - yet');
 		}
 
 		$this->instance->file_put_contents('test.txt', 'foo');

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -38,7 +38,23 @@ class TestScanner extends \OC\Files\Utils\Scanner {
 	}
 }
 
-class Scanner extends \PHPUnit_Framework_TestCase {
+
+class Scanner extends \Test\TestCase {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+	}
+
+	protected function tearDown() {
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
+	}
+
 	public function testReuseExistingRoot() {
 		$storage = new Temporary(array());
 		$mount = new Mount($storage, '');

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -22,9 +22,15 @@ class View extends \PHPUnit_Framework_TestCase {
 	private $storages = array();
 	private $user;
 
+	/** @var \OC\Files\Storage\Storage */
 	private $tempStorage;
 
-	public function setUp() {
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
 		\OC_User::clearBackends();
 		\OC_User::useBackend(new \OC_User_Dummy());
 
@@ -33,12 +39,13 @@ class View extends \PHPUnit_Framework_TestCase {
 		$this->user = \OC_User::getUser();
 		\OC_User::setUserId('test');
 
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
 
 		$this->tempStorage = null;
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		\OC_User::setUserId($this->user);
 		foreach ($this->storages as $storage) {
 			$cache = $storage->getCache();
@@ -49,6 +56,11 @@ class View extends \PHPUnit_Framework_TestCase {
 		if ($this->tempStorage && !\OC_Util::runningOnWindows()) {
 			system('rm -rf ' . escapeshellarg($this->tempStorage->getDataDir()));
 		}
+
+		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -598,7 +598,7 @@ class View extends \PHPUnit_Framework_TestCase {
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
 		$tmpdirLength = strlen(\OC_Helper::tmpFolder());
 		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped();
+			$this->markTestSkipped('[Windows] ');
 			$depth = ((260 - $tmpdirLength) / 57);
 		}elseif(\OC_Util::runningOnMac()){
 			$depth = ((1024 - $tmpdirLength) / 57);

--- a/tests/lib/group.php
+++ b/tests/lib/group.php
@@ -22,38 +22,39 @@
  *
  */
 
-class Test_Group extends PHPUnit_Framework_TestCase {
-	function setUp() {
+class Test_Group extends \Test\TestCase {
+	protected function setUp() {
+		parent::setUp();
 		OC_Group::clearBackends();
 		OC_User::clearBackends();
 	}
 
-	function testSingleBackend() {
+	public function testSingleBackend() {
 		$userBackend = new \OC_User_Dummy();
 		\OC_User::getManager()->registerBackend($userBackend);
 		OC_Group::useBackend(new OC_Group_Dummy());
 
-		$group1 = uniqid();
-		$group2 = uniqid();
+		$group1 = $this->getUniqueID();
+		$group2 = $this->getUniqueID();
 		OC_Group::createGroup($group1);
 		OC_Group::createGroup($group2);
 
-		$user1 = uniqid();
-		$user2 = uniqid();
+		$user1 = $this->getUniqueID();
+		$user2 = $this->getUniqueID();
 		$userBackend->createUser($user1, '');
 		$userBackend->createUser($user2, '');
 
-		$this->assertFalse(OC_Group::inGroup($user1, $group1));
-		$this->assertFalse(OC_Group::inGroup($user2, $group1));
-		$this->assertFalse(OC_Group::inGroup($user1, $group2));
-		$this->assertFalse(OC_Group::inGroup($user2, $group2));
+		$this->assertFalse(OC_Group::inGroup($user1, $group1), 'Asserting that user1 is not in group1');
+		$this->assertFalse(OC_Group::inGroup($user2, $group1), 'Asserting that user2 is not in group1');
+		$this->assertFalse(OC_Group::inGroup($user1, $group2), 'Asserting that user1 is not in group2');
+		$this->assertFalse(OC_Group::inGroup($user2, $group2), 'Asserting that user2 is not in group2');
 
 		$this->assertTrue(OC_Group::addToGroup($user1, $group1));
 
-		$this->assertTrue(OC_Group::inGroup($user1, $group1));
-		$this->assertFalse(OC_Group::inGroup($user2, $group1));
-		$this->assertFalse(OC_Group::inGroup($user1, $group2));
-		$this->assertFalse(OC_Group::inGroup($user2, $group2));
+		$this->assertTrue(OC_Group::inGroup($user1, $group1), 'Asserting that user1 is in group1');
+		$this->assertFalse(OC_Group::inGroup($user2, $group1), 'Asserting that user2 is not in group1');
+		$this->assertFalse(OC_Group::inGroup($user1, $group2), 'Asserting that user1 is not in group2');
+		$this->assertFalse(OC_Group::inGroup($user2, $group2), 'Asserting that user2 is not in group2');
 
 		$this->assertTrue(OC_Group::addToGroup($user1, $group1));
 
@@ -80,7 +81,7 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 
 	public function testNoGroupsTwice() {
 		OC_Group::useBackend(new OC_Group_Dummy());
-		$group = uniqid();
+		$group = $this->getUniqueID();
 		OC_Group::createGroup($group);
 
 		$groupCopy = $group;
@@ -103,7 +104,7 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 	public function testDontAddUserToNonexistentGroup() {
 		OC_Group::useBackend(new OC_Group_Dummy());
 		$groupNonExistent = 'notExistent';
-		$user = uniqid();
+		$user = $this->getUniqueID();
 
 		$this->assertEquals(false, OC_Group::addToGroup($user, $groupNonExistent));
 		$this->assertEquals(array(), OC_Group::getGroups());
@@ -114,12 +115,12 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 		$userBackend = new \OC_User_Dummy();
 		\OC_User::getManager()->registerBackend($userBackend);
 
-		$group1 = uniqid();
-		$group2 = uniqid();
-		$group3 = uniqid();
-		$user1 = uniqid();
-		$user2 = uniqid();
-		$user3 = uniqid();
+		$group1 = $this->getUniqueID();
+		$group2 = $this->getUniqueID();
+		$group3 = $this->getUniqueID();
+		$user1 = $this->getUniqueID();
+		$user2 = $this->getUniqueID();
+		$user3 = $this->getUniqueID();
 		OC_Group::createGroup($group1);
 		OC_Group::createGroup($group2);
 		OC_Group::createGroup($group3);
@@ -139,8 +140,7 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 		// FIXME: needs more parameter variation
 	}
 
-
-	function testMultiBackend() {
+	public function testMultiBackend() {
 		$userBackend = new \OC_User_Dummy();
 		\OC_User::getManager()->registerBackend($userBackend);
 		$backend1 = new OC_Group_Dummy();
@@ -148,8 +148,8 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 		OC_Group::useBackend($backend1);
 		OC_Group::useBackend($backend2);
 
-		$group1 = uniqid();
-		$group2 = uniqid();
+		$group1 = $this->getUniqueID();
+		$group2 = $this->getUniqueID();
 		OC_Group::createGroup($group1);
 
 		//groups should be added to the first registered backend
@@ -166,8 +166,8 @@ class Test_Group extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(OC_Group::groupExists($group1));
 		$this->assertTrue(OC_Group::groupExists($group2));
 
-		$user1 = uniqid();
-		$user2 = uniqid();
+		$user1 = $this->getUniqueID();
+		$user2 = $this->getUniqueID();
 
 		$userBackend->createUser($user1, '');
 		$userBackend->createUser($user2, '');

--- a/tests/lib/group/backend.php
+++ b/tests/lib/group/backend.php
@@ -20,7 +20,7 @@
 *
 */
 
-abstract class Test_Group_Backend extends PHPUnit_Framework_TestCase {
+abstract class Test_Group_Backend extends \Test\TestCase {
 	/**
 	 * @var OC_Group_Backend $backend
 	 */
@@ -33,7 +33,7 @@ abstract class Test_Group_Backend extends PHPUnit_Framework_TestCase {
 	 */
 	public function getGroupName($name = null) {
 		if(is_null($name)) {
-			return uniqid('test_');
+			return $this->getUniqueID('test_');
 		} else {
 			return $name;
 		}
@@ -45,7 +45,7 @@ abstract class Test_Group_Backend extends PHPUnit_Framework_TestCase {
 	 * @return string
 	 */
 	public function getUserName() {
-		return uniqid('test_');
+		return $this->getUniqueID('test_');
 	}
 
 	public function testAddRemove() {
@@ -138,6 +138,4 @@ abstract class Test_Group_Backend extends PHPUnit_Framework_TestCase {
 		$result = $this->backend->countUsersInGroup($group, 'bar');
 		$this->assertSame(2, $result);
 	}
-
-
 }

--- a/tests/lib/group/database.php
+++ b/tests/lib/group/database.php
@@ -22,36 +22,27 @@
 
 class Test_Group_Database extends Test_Group_Backend {
 	private $groups=array();
-	
+
 	/**
 	 * get a new unique group name
 	 * test cases can override this in order to clean up created groups
 	 * @return string
 	 */
 	public function getGroupName($name = null) {
-		if(is_null($name)) {
-			$name=uniqid('test_');
-		}
-		$this->groups[]=$name;
+		$name = parent::getGroupName($name);
+		$this->groups[] = $name;
 		return $name;
 	}
 
-	/**
-	 * get a new unique user name
-	 * test cases can override this in order to clean up created user
-	 * @return string
-	 */
-	public function getUserName() {
-		return uniqid('test_');
-	}
-	
-	public function setUp() {
+	protected function setUp() {
+		parent::setUp();
 		$this->backend=new OC_Group_Database();
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		foreach($this->groups as $group) {
 			$this->backend->deleteGroup($group);
 		}
+		parent::tearDown();
 	}
 }

--- a/tests/lib/group/dummy.php
+++ b/tests/lib/group/dummy.php
@@ -21,7 +21,8 @@
 */
 
 class Test_Group_Dummy extends Test_Group_Backend {
-	public function setUp() {
+	protected function setUp() {
+		parent::setUp();
 		$this->backend=new OC_Group_Dummy();
 	}
 }

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -115,6 +115,10 @@ class Test_Helper extends PHPUnit_Framework_TestCase {
 	}
 
 	function testGetStringMimeType() {
+		if (\OC_Util::runningOnWindows()) {
+			$this->markTestSkipped('[Windows] Strings have mimetype application/octet-stream on Windows');
+		}
+
 		$result = OC_Helper::getStringMimeType("/data/data.tar.gz");
 		$expected = 'text/plain; charset=us-ascii';
 		$this->assertEquals($result, $expected);

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -9,14 +9,22 @@
 /**
  * Test the storage functions of OC_Helper
  */
-class Test_Helper_Storage extends PHPUnit_Framework_TestCase {
-	private $user;
-	private $storageMock;
 
-	public function setUp() {
-		$this->user = 'user_' . uniqid();
+class Test_Helper_Storage extends \Test\TestCase {
+	/** @var string */
+	private $user;
+	/** @var \OC\Files\Storage\Storage */
+	private $storageMock;
+	/** @var \OC\Files\Storage\Storage */
+	private $storage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->user = $this->getUniqueID('user_');
 		\OC_User::createUser($this->user, $this->user);
 
+		$this->storage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($this->user);
 		\OC\Files\Filesystem::init($this->user, '/' . $this->user . '/files');
@@ -25,7 +33,7 @@ class Test_Helper_Storage extends PHPUnit_Framework_TestCase {
 		$this->storageMock = null;
 	}
 
-	public function tearDown() {
+	protected function tearDown() {
 		$this->user = null;
 
 		if ($this->storageMock) {
@@ -33,10 +41,13 @@ class Test_Helper_Storage extends PHPUnit_Framework_TestCase {
 			$this->storageMock = null;
 		}
 		\OC\Files\Filesystem::tearDown();
+		\OC\Files\Filesystem::mount($this->storage, array(), '/');
 
 		\OC_User::setUserId('');
 		\OC_User::deleteUser($this->user);
 		\OC_Preferences::deleteUser($this->user);
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/lib/image.php
+++ b/tests/lib/image.php
@@ -62,14 +62,18 @@ class Test_Image extends PHPUnit_Framework_TestCase {
 		$img = new \OC_Image(OC::$SERVERROOT.'/tests/data/testimage.png');
 		$this->assertEquals('image/png', $img->mimeType());
 
+		$img = new \OC_Image(null);
+		$this->assertEquals('', $img->mimeType());
+
+		if (\OC_Util::runningOnWindows()) {
+			$this->markTestSkipped('[Windows] Images created with imagecreate() are pngs on windows');
+		}
+
 		$img = new \OC_Image(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.jpg'));
 		$this->assertEquals('image/jpeg', $img->mimeType());
 
 		$img = new \OC_Image(base64_encode(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.gif')));
 		$this->assertEquals('image/gif', $img->mimeType());
-
-		$img = new \OC_Image(null);
-		$this->assertEquals('', $img->mimeType());
 	}
 
 	public function testWidth() {

--- a/tests/lib/largefilehelpergetfilesize.php
+++ b/tests/lib/largefilehelpergetfilesize.php
@@ -13,58 +13,77 @@ namespace Test;
 * Large files are not considered yet.
 */
 class LargeFileHelperGetFileSize extends \PHPUnit_Framework_TestCase {
-	protected $filename;
-	protected $fileSize;
+	/** @var \OC\LargeFileHelper */
 	protected $helper;
 
 	public function setUp() {
 		parent::setUp();
-		$ds = DIRECTORY_SEPARATOR;
-		$this->filename = dirname(__DIR__) . "{$ds}data{$ds}strängé filename (duplicate #2).txt";
-		$this->fileSize = 446;
-		$this->helper = new \OC\LargeFileHelper;
+		$this->helper = new \OC\LargeFileHelper();
 	}
 
-	public function testGetFileSizeViaCurl() {
+	public function dataFileNameProvider() {
+		$path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR;
+
+		$filePaths = array(array($path . 'lorem.txt', 446));
+		if (!\OC_Util::runningOnWindows()) {
+			$filePaths[] = array($path . 'strängé filename (duplicate #2).txt', 446);
+		}
+
+		return $filePaths;
+	}
+
+	/**
+	 * @dataProvider dataFileNameProvider
+	 */
+	public function testGetFileSizeViaCurl($filename, $fileSize) {
 		if (!extension_loaded('curl')) {
 			$this->markTestSkipped(
 				'The PHP curl extension is required for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->fileSize,
-			$this->helper->getFileSizeViaCurl($this->filename)
+			$fileSize,
+			$this->helper->getFileSizeViaCurl($filename)
 		);
 	}
 
-	public function testGetFileSizeViaCOM() {
+	/**
+	 * @dataProvider dataFileNameProvider
+	 */
+	public function testGetFileSizeViaCOM($filename, $fileSize) {
 		if (!extension_loaded('COM')) {
 			$this->markTestSkipped(
 				'The PHP Windows COM extension is required for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->fileSize,
-			$this->helper->getFileSizeViaCOM($this->filename)
+			$fileSize,
+			$this->helper->getFileSizeViaCOM($filename)
 		);
 	}
 
-	public function testGetFileSizeViaExec() {
+	/**
+	 * @dataProvider dataFileNameProvider
+	 */
+	public function testGetFileSizeViaExec($filename, $fileSize) {
 		if (!\OC_Helper::is_function_enabled('exec')) {
 			$this->markTestSkipped(
 				'The exec() function needs to be enabled for this test.'
 			);
 		}
 		$this->assertSame(
-			$this->fileSize,
-			$this->helper->getFileSizeViaExec($this->filename)
+			$fileSize,
+			$this->helper->getFileSizeViaExec($filename)
 		);
 	}
 
-	public function testGetFileSizeNative() {
+	/**
+	 * @dataProvider dataFileNameProvider
+	 */
+	public function testGetFileSizeNative($filename, $fileSize) {
 		$this->assertSame(
-			$this->fileSize,
-			$this->helper->getFileSizeNative($this->filename)
+			$fileSize,
+			$this->helper->getFileSizeNative($filename)
 		);
 	}
 }

--- a/tests/lib/migrate.php
+++ b/tests/lib/migrate.php
@@ -11,6 +11,28 @@ class Test_Migrate extends PHPUnit_Framework_TestCase {
 	public $users;
 	public $tmpfiles = array();
 
+	/** @var \OC\Files\Storage\Storage */
+	private $originalStorage;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+	}
+
+	protected function tearDown() {
+		$u = new OC_User();
+		foreach($this->users as $user) {
+			$u->deleteUser($user);
+		}
+		foreach($this->tmpfiles as $file) {
+			\OC_Helper::rmdirr($file);
+		}
+
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+		parent::tearDown();
+	}
+
 	/**
 	 * Generates a test user and sets up their file system
 	 * @return string the test users id
@@ -73,18 +95,4 @@ class Test_Migrate extends PHPUnit_Framework_TestCase {
 		// Validate the export
 		$this->validateUserExport($user2, $user, json_decode($export)->data);
 	}
-
-	public function tearDown() {
-		$u = new OC_User();
-		foreach($this->users as $user) {
-			$u->deleteUser($user);
-		}
-		foreach($this->tmpfiles as $file) {
-			\OC_Helper::rmdirr($file);
-		}
-	}
-
-
-
-
 }

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -8,7 +8,7 @@
 
 use \OC\Security\CertificateManager;
 
-class CertificateManagerTest extends \PHPUnit_Framework_TestCase {
+class CertificateManagerTest extends \Test\TestCase {
 
 	/** @var CertificateManager */
 	private $certificateManager;
@@ -18,8 +18,8 @@ class CertificateManagerTest extends \PHPUnit_Framework_TestCase {
 	private $user;
 
 	function setUp() {
-		$this->username = OC_Util::generateRandomBytes(20);
-		OC_User::createUser($this->username, OC_Util::generateRandomBytes(20));
+		$this->username = $this->getUniqueID('', 20);
+		OC_User::createUser($this->username, $this->getUniqueID('', 20));
 
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');

--- a/tests/lib/streamwrappers.php
+++ b/tests/lib/streamwrappers.php
@@ -65,7 +65,9 @@ class Test_StreamWrappers extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testOC() {
+		$originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
+
 		$storage = new \OC\Files\Storage\Temporary(array());
 		$storage->file_put_contents('foo.txt', 'asd');
 		\OC\Files\Filesystem::mount($storage, array(), '/');
@@ -91,5 +93,8 @@ class Test_StreamWrappers extends PHPUnit_Framework_TestCase {
 
 		unlink('oc:///foo.txt');
 		$this->assertEquals(array('.', '..', 'bar.txt'), scandir('oc:///'));
+
+		\OC\Files\Filesystem::clearMounts();
+		\OC\Files\Filesystem::mount($originalStorage, array(), '/');
 	}
 }

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -122,6 +122,10 @@ class TempManager extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testLogCantCreateFile() {
+		if (\OC_Util::runningOnWindows()) {
+			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
+		}
+
 		$logger = $this->getMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
@@ -132,6 +136,10 @@ class TempManager extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testLogCantCreateFolder() {
+		if (\OC_Util::runningOnWindows()) {
+			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
+		}
+
 		$logger = $this->getMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling
+ * @copyright 2014 Joas Schilling nickvergessen@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test;
+
+abstract class TestCase extends \PHPUnit_Framework_TestCase {
+	protected function getUniqueID($prefix = '', $length = 13) {
+		// Do not use dots and slashes as we use the value for file names
+		return $prefix . \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(
+			$length,
+			'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+		);
+	}
+}

--- a/tests/lib/user/backend.php
+++ b/tests/lib/user/backend.php
@@ -30,7 +30,7 @@
  * For an example see /tests/lib/user/dummy.php
  */
 
-abstract class Test_User_Backend extends PHPUnit_Framework_TestCase {
+abstract class Test_User_Backend extends \Test\TestCase {
 	/**
 	 * @var OC_User_Backend $backend
 	 */
@@ -42,7 +42,7 @@ abstract class Test_User_Backend extends PHPUnit_Framework_TestCase {
 	 * @return string
 	 */
 	public function getUser() {
-		return uniqid('test_');
+		return $this->getUniqueID('test_');
 	}
 
 	public function testAddRemove() {
@@ -68,29 +68,29 @@ abstract class Test_User_Backend extends PHPUnit_Framework_TestCase {
 		$this->assertTrue((array_search($name1, $this->backend->getUsers())!==false));
 		$this->assertFalse((array_search($name2, $this->backend->getUsers())!==false));
 	}
-	
+
 	public function testLogin() {
 		$name1=$this->getUser();
 		$name2=$this->getUser();
-		
+
 		$this->assertFalse($this->backend->userExists($name1));
 		$this->assertFalse($this->backend->userExists($name2));
-		
+
 		$this->backend->createUser($name1, 'pass1');
 		$this->backend->createUser($name2, 'pass2');
-		
+
 		$this->assertTrue($this->backend->userExists($name1));
 		$this->assertTrue($this->backend->userExists($name2));
-		
+
 		$this->assertSame($name1, $this->backend->checkPassword($name1, 'pass1'));
 		$this->assertSame($name2, $this->backend->checkPassword($name2, 'pass2'));
-		
+
 		$this->assertFalse($this->backend->checkPassword($name1, 'pass2'));
 		$this->assertFalse($this->backend->checkPassword($name2, 'pass1'));
-		
+
 		$this->assertFalse($this->backend->checkPassword($name1, 'dummy'));
 		$this->assertFalse($this->backend->checkPassword($name2, 'foobar'));
-		
+
 		$this->backend->setPassword($name1, 'newpass1');
 		$this->assertFalse($this->backend->checkPassword($name1, 'pass1'));
 		$this->assertSame($name1, $this->backend->checkPassword($name1, 'newpass1'));
@@ -112,5 +112,4 @@ abstract class Test_User_Backend extends PHPUnit_Framework_TestCase {
 		$result = $this->backend->getDisplayNames('bar');
 		$this->assertSame(2, count($result));
 	}
-
 }

--- a/tests/lib/user/database.php
+++ b/tests/lib/user/database.php
@@ -21,22 +21,27 @@
 */
 
 class Test_User_Database extends Test_User_Backend {
+	/** @var array */
+	private $users;
+
 	public function getUser() {
 		$user = parent::getUser();
 		$this->users[]=$user;
 		return $user;
 	}
-	
-	public function setUp() {
+
+	protected function setUp() {
+		parent::setUp();
 		$this->backend=new OC_User_Database();
 	}
-	
-	public function tearDown() {
+
+	protected function tearDown() {
 		if(!isset($this->users)) {
 			return;
 		}
 		foreach($this->users as $user) {
 			$this->backend->deleteUser($user);
 		}
+		parent::tearDown();
 	}
 }

--- a/tests/lib/user/dummy.php
+++ b/tests/lib/user/dummy.php
@@ -21,7 +21,8 @@
 */
 
 class Test_User_Dummy extends Test_User_Backend {
-	public function setUp() {
+	protected function setUp() {
+		parent::setUp();
 		$this->backend=new OC_User_Dummy();
 	}
 }

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -138,6 +138,10 @@ class Test_Util_CheckServer extends PHPUnit_Framework_TestCase {
 	 * Tests an error is given when the datadir is not writable
 	 */
 	public function testDataDirNotWritable() {
+		if (\OC_Util::runningOnWindows()) {
+			$this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
+		}
+
 		chmod($this->datadir, 0300);
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => true,


### PR DESCRIPTION
Further fixing to get #10991 done
## Common Problems
#### `uniqid()` is not unique on Windows:

If you need a random string in your test please extend the `\Test\TestCase` class instead of `\PHPUnit_Framework_TestCase` (Once this PR is merged) and use `$this->getUniqueID()` instead.
#### Unclosed handles cause unlink() to fail:

On Windows php can not delete files which still have an open handle. Be sure to `fclose()` any handles you open, especially before deleting the file or directory.
#### `chmod()` does not work on Windows:

Windows does not have read/write permissions like UNIX. If you set chmod to 000 you can still write to the file/directory on Windows. In case you need to test something like that, Please mark the test as skipped for Windows, by adding the following code, right before the first assertion relying on the chmod change. We can still make all other assertions that happen till the change, so add it as late as possible:

``` php
    if (\OC_Util::runningOnWindows()) {
        $this->markTestSkipped('[Windows] chmod() does not work as intended on Windows.');
    }
```
