### PR TITLE
Remove phpass and migrate to new Hasher interface

### DIFF
--- a/apps/files_sharing/lib/connector/publicauth.php
+++ b/apps/files_sharing/lib/connector/publicauth.php
@@ -48,12 +48,26 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 		if (isset($linkItem['share_with'])) {
 			if ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_LINK) {
 				// Check Password
-				$forcePortable = (CRYPT_BLOWFISH != 1);
-				$hasher = new \PasswordHash(8, $forcePortable);
-				if (!$hasher->CheckPassword($password . $this->config->getSystemValue('passwordsalt', ''), $linkItem['share_with'])) {
-					return false;
-				} else {
+				$newHash = '';
+				if(\OC::$server->getHasher()->verify($password, $linkItem['share_with'], $newHash)) {
+					/**
+					 * FIXME: Migrate old hashes to new hash format
+					 * Due to the fact that there is no reasonable functionality to update the password
+					 * of an existing share no migration is yet performed there.
+					 * The only possibility is to update the existing share which will result in a new
+					 * share ID and is a major hack.
+					 *
+					 * In the future the migration should be performed once there is a proper method
+					 * to update the share's password. (for example `$share->updatePassword($password)`
+					 *
+					 * @link https://github.com/owncloud/core/issues/10671
+					 */
+					if(!empty($newHash)) {
+
+					}
 					return true;
+				} else {
+					return false;
 				}
 			} else {
 				return false;

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -99,6 +99,7 @@ class ShareController extends Controller {
 
 	/**
 	 * @PublicPage
+	 * @UseSession
 	 *
 	 * Authenticates against password-protected shares
 	 * @param $token

--- a/lib/base.php
+++ b/lib/base.php
@@ -464,8 +464,7 @@ class OC {
 		// setup 3rdparty autoloader
 		$vendorAutoLoad = OC::$THIRDPARTYROOT . '/3rdparty/autoload.php';
 		if (file_exists($vendorAutoLoad)) {
-			$loader = require_once $vendorAutoLoad;
-			$loader->add('PasswordHash', OC::$THIRDPARTYROOT . '/3rdparty/phpass');
+			require_once $vendorAutoLoad;
 		} else {
 			OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 			OC_Template::printErrorPage('Composer autoloader not found, unable to continue.');

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -627,9 +627,7 @@ class Share extends \OC\Share\Constants {
 
 				// Generate hash of password - same method as user passwords
 				if (!empty($shareWith)) {
-					$forcePortable = (CRYPT_BLOWFISH != 1);
-					$hasher = new \PasswordHash(8, $forcePortable);
-					$shareWith = $hasher->HashPassword($shareWith.\OC_Config::getValue('passwordsalt', ''));
+					$shareWith = \OC::$server->getHasher()->hash($shareWith);
 				} else {
 					// reuse the already set password, but only if we change permissions
 					// otherwise the user disabled the password protection


### PR DESCRIPTION
This PR removes phpass and migrates to the new Hasher interface.

Please notice that due to https://github.com/owncloud/core/issues/10671 old hashes are not updated but the hashes are backwards compatible so this shouldn't hurt.
Once the sharing classes have a possibility to update the passwords of single shares those methods should be used within the newHash if block.

This required to update all apps that use the old phpass approach to read the password... - I'll prepare PRs for the shipped ones.
