### PR TITLE
Register the call in the appframework before the session is closed

### DIFF
--- a/lib/private/appframework/middleware/security/corsmiddleware.php
+++ b/lib/private/appframework/middleware/security/corsmiddleware.php
@@ -37,6 +37,15 @@ class CORSMiddleware extends Middleware {
 		$this->reflector = $reflector;
 	}
 
+	/**
+	 * Register the call before the session middleware closes the session
+	 *
+	 * @param \OCP\AppFramework\Controller $controller
+	 * @param string $methodName
+	 */
+	public function beforeController($controller, $methodName) {
+		\OCP\Util::callRegister();
+	}
 
 	/**
 	 * This is being run after a successful controllermethod call and allows


### PR DESCRIPTION
Since the appframework automatically closes the session it's not possible to register the call after the controller has finished.

To test: try to open a password protected public share in a private browsing session (to ensure we have a clean session)

cc @DeepDiver1975 @LukasReschke @Raydiation 
