### PR TITLE
Issue/12227 formatDate() improvements

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -432,12 +432,25 @@ class OC_Util {
 	 * formats a timestamp in the "right" way
 	 *
 	 * @param int $timestamp
-	 * @param bool $dateOnly option to omit time from the result
+	 * @param array|boolean $options The following options are available:
+	 *			format		=> Can be date, datetime or time
+	 *			language	=> \OC_L10N object which should be used
+	 *			width		=> It can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short'
+	 *							You can also append an asterisk ('^') to the date part.
+	 *							If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
+	 *				If $options is false, the current language and width full are used with format datetime
+	 *				If $options is true, the current language and width full are used with format date
 	 * @param DateTimeZone|string $timeZone where the given timestamp shall be converted to
 	 * @return string timestamp
 	 * @description adjust to clients timezone if we know it
 	 */
-	public static function formatDate($timestamp, $dateOnly = false, $timeZone = null) {
+	public static function formatDate($timestamp, $options = false, $timeZone = null) {
+		if (!$options) {
+			$options = array('format' => 'datetime');
+		} else if ($options === true) {
+			$options = array('format' => 'date');
+		}
+
 		if (is_null($timeZone)) {
 			if (\OC::$server->getSession()->exists('timezone')) {
 				$systemTimeZone = intval(date('O'));
@@ -454,8 +467,14 @@ class OC_Util {
 			$offset = $timeZone->getOffset($dt);
 			$timestamp += $offset;
 		}
-		$l = \OC::$server->getL10N('lib');
-		return $l->l($dateOnly ? 'date' : 'datetime', $timestamp);
+
+		if (isset($options['language']) && $options['language'] instanceof \OC_L10N) {
+			$l = $options['language'];
+		} else {
+			$l = \OC::$server->getL10N('lib');
+		}
+
+		return $l->l($options['format'], $timestamp, $options);
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -160,12 +160,19 @@ class Util {
 	/**
 	 * formats a timestamp in the "right" way
 	 * @param int $timestamp $timestamp
-	 * @param bool $dateOnly option to omit time from the result
+	 * @param array|boolean $options The following options are available:
+	 *			format		=> Can be date, datetime or time
+	 *			language	=> \OC_L10N object which should be used
+	 *			width		=> It can be 'full', 'long', 'medium', 'short' or a combination for date+time like 'full|short'
+	 *							You can also append an asterisk ('^') to the date part.
+	 *							If so, special day names may be used (like 'Today', 'Yesterday', 'Tomorrow') instead of the date part.
+	 *				If $options is false, the current language and width full are used with format datetime
+	 *				If $options is true, the current language and width full are used with format date
 	 * @param DateTimeZone|string $timeZone where the given timestamp shall be converted to
 	 * @return string timestamp
 	 */
-	public static function formatDate($timestamp, $dateOnly=false, $timeZone = null) {
-		return(\OC_Util::formatDate($timestamp, $dateOnly, $timeZone));
+	public static function formatDate($timestamp, $options = false, $timeZone = null) {
+		return(\OC_Util::formatDate($timestamp, $options, $timeZone));
 	}
 
 	/**

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -27,9 +27,27 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 
 	public function formatDateData() {
 		return array(
+			// Basic tests
 			array(1350129205, false, null, 'October 13, 2012 at 11:53:25 AM GMT+0'),
 			array(1102831200, true, null, 'December 12, 2004'),
+
+			// Test different timezone
 			array(1350129205, false, 'Europe/Berlin', 'October 13, 2012 at 1:53:25 PM GMT+0'),
+
+			// Test format and width options
+			array(1350129205, array('format' => 'date', 'width' => 'long'), null, 'October 13, 2012'),
+			array(1350129205, array('format' => 'date', 'width' => 'short'), null, '10/13/12'),
+			array(1350129205, array('format' => 'time', 'width' => 'long'), null, '11:53:25 AM GMT+0'),
+			array(1350129205, array('format' => 'time', 'width' => 'short'), null, '11:53 AM'),
+			array(1350129205, array('format' => 'datetime', 'width' => 'long'), null, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+			array(1350129205, array('format' => 'datetime', 'width' => 'long|short'), null, 'October 13, 2012 at 11:53 AM'),
+			array(1350129205, array('format' => 'datetime', 'width' => 'short|long'), null, '10/13/12 at 11:53:25 AM GMT+0'),
+			array(1350129205, array('format' => 'datetime', 'width' => 'short'), null, '10/13/12, 11:53 AM'),
+
+			// Test relative days
+			array(time(), array('format' => 'date', 'width' => 'long^'), null, 'Today'),
+			array(time() - 86400, array('format' => 'date', 'width' => 'long^'), null, 'Yesterday'),
+			array(time() + 86400, array('format' => 'date', 'width' => 'long^'), null, 'Tomorrow'),
 		);
 	}
 
@@ -41,6 +59,27 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 
 		$result = OC_Util::formatDate($timestamp, $options, $timezone);
 		$this->assertEquals($expected, $result);
+	}
+
+	public function formatDateStartsWithData() {
+		return array(
+			array(time(), array('format' => 'date', 'width' => 'long^'), 'Today'),
+			array(time() - 86400, array('format' => 'date', 'width' => 'long^'), 'Yesterday'),
+			array(time() + 86400, array('format' => 'date', 'width' => 'long^'), 'Tomorrow'),
+			array(time(), array('format' => 'datetime', 'width' => 'long^'), 'Today'),
+			array(time() - 86400, array('format' => 'datetime', 'width' => 'long^'), 'Yesterday'),
+			array(time() + 86400, array('format' => 'datetime', 'width' => 'long^'), 'Tomorrow'),
+		);
+	}
+
+	/**
+	 * @dataProvider formatDateStartsWithData
+	 */
+	function testFormatDateStartsWith($timestamp, $options, $expected) {
+		date_default_timezone_set("UTC");
+
+		$result = OC_Util::formatDate($timestamp, $options);
+		$this->assertStringStartsWith($expected, $result);
 	}
 
 	/**

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -25,23 +25,21 @@ class Test_Util extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(is_string($edition));
 	}
 
-	function testFormatDate() {
-		date_default_timezone_set("UTC");
-
-		$result = OC_Util::formatDate(1350129205);
-		$expected = 'October 13, 2012 at 11:53:25 AM GMT+0';
-		$this->assertEquals($expected, $result);
-
-		$result = OC_Util::formatDate(1102831200, true);
-		$expected = 'December 12, 2004';
-		$this->assertEquals($expected, $result);
+	public function formatDateData() {
+		return array(
+			array(1350129205, false, null, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+			array(1102831200, true, null, 'December 12, 2004'),
+			array(1350129205, false, 'Europe/Berlin', 'October 13, 2012 at 1:53:25 PM GMT+0'),
+		);
 	}
 
-	function testFormatDateWithTZ() {
+	/**
+	 * @dataProvider formatDateData
+	 */
+	function testFormatDate($timestamp, $options, $timezone, $expected) {
 		date_default_timezone_set("UTC");
 
-		$result = OC_Util::formatDate(1350129205, false, 'Europe/Berlin');
-		$expected = 'October 13, 2012 at 1:53:25 PM GMT+0';
+		$result = OC_Util::formatDate($timestamp, $options, $timezone);
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
- Add support for giving L10N
- Add support for $options from `$l->l()` to `formatDate()`
- Add support for relative dates (can be done with above step, as Punic\Calendar just requires adding a ^ to the format string)

Fixes #12227 

@DeepDiver1975 @PVince81 @MorrisJobke 
