### PR TITLE
inlcude AD primary group in user filter, if a group is selected. 

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -804,13 +804,23 @@ class Wizard extends LDAPUtility {
 						}
 						$base = $this->configuration->ldapBase[0];
 						foreach($cns as $cn) {
-							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn'));
+							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn', 'primaryGroupToken'));
 							if(!$this->ldap->isResource($rr)) {
 								continue;
 							}
 							$er = $this->ldap->firstEntry($cr, $rr);
+							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
-							$filter .= '(memberof=' . $dn . ')';
+							if(empty($dn)) {
+								continue;
+							}
+							$filterPart = '(memberof=' . $dn . ')';
+							if(isset($attrs['primaryGroupToken'])) {
+								$pgt = $attrs['primaryGroupToken'][0];
+								$primaryFilterPart = '(primaryGroupID=' . $pgt .')';
+								$filterPart = '(|' . $filterPart . $primaryFilterPart . ')';
+							}
+							$filter .= $filterPart;
 						}
 						$filter .= ')';
 					}


### PR DESCRIPTION
fixes #12190

How to test?
- configure User Filter in the LDAP Wizard and select a group
- on AD, the resulting filter should look like `(&(|(objectclass=person))(|(|((memberof=CN=Domain Users,CN=Users,DC=madder,DC=owncloud,DC=bzoc)(primaryGroupID=513)))(|((memberof=CN=Wolfpack 8,OU=packs,DC=madder,DC=owncloud,DC=bzoc)(primaryGroupID=968988)`(2 selected groups)
- on OpenLDAP the `(primaryGroupID=XXX)` part should not show up!
- in the User list users should appear, that have the selected group  as primary, but are not regular member of any of those selected
