### PR TITLE
Check if the size field is available

### DIFF
--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -122,7 +122,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return int
 	 */
 	public function getSize() {
-		return $this->data['size'];
+		return isset($this->data['size']) ? $this->data['size'] : 0;
 	}
 
 	/**


### PR DESCRIPTION
In some cases the 'size' field is not available resulting in some PHP errors such as:

``` json
{"reqId":"03548fd9e3d3aca15a5796b3b35d7b9d","remoteAddr":"::1","app":"PHP","message":"Undefined index: size at \/Users\/lreschke\/Programming\/core\/lib\/private\/files\/fileinfo.php#125","level":3,"time":"2014-11-17T21:38:57+00:00"}
```

This can be experienced when creating a new empty file and deleting it right away, then when going to the trash bin this error is thrown.

@icewind1991 What do you think?
