### PR TITLE
Added function to load translations from JS

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -253,6 +253,17 @@ var OC={
 	},
 
 	/**
+	 * Loads translations for the given app asynchronously.
+	 *
+	 * @param {String} app app name
+	 * @param {Function} callback callback to call after loading
+	 * @return {Promise}
+	 */
+	addTranslations: function(app, callback) {
+		return OC.L10N.load(app, callback);
+	},
+
+	/**
 	 * Returns the base name of the given path.
 	 * For example for "/abc/somefile.txt" it will return "somefile.txt"
 	 *
@@ -475,6 +486,15 @@ var OC={
 			return window.matchMedia(media);
 		}
 		return false;
+	},
+
+	/**
+	 * Returns the user's locale
+	 *
+	 * @return {String} locale string
+	 */
+	getLocale: function() {
+		return $('html').prop('lang');
 	}
 };
 
@@ -869,9 +889,9 @@ function object(o) {
 function initCore() {
 
 	/**
-	 * Set users local to moment.js as soon as possible
+	 * Set users locale to moment.js as soon as possible
 	 */
-	moment.locale($('html').prop('lang'));
+	moment.locale(OC.getLocale());
 
 
 	/**

--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -45,11 +45,6 @@ OC.L10N = {
 
 		var self = this;
 		var deferred = $.Deferred();
-		var url = OC.generateUrl(
-			'apps/{app}/l10n/{locale}.json',
-			{app: appName, locale: OC.getLocale()}
-		);
-
 		var url = OC.filePath(appName, 'l10n', OC.getLocale() + '.json');
 
 		// load JSON translation bundle per AJAX

--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -27,6 +27,47 @@ OC.L10N = {
 	_pluralFunctions: {},
 
 	/**
+	 * Load an app's translation bundle if not loaded already.
+	 *
+	 * @param {String} appName name of the app
+	 * @param {Function} callback callback to be called when
+	 * the translations are loaded
+	 * @return {Promise} promise
+	 */
+	load: function(appName, callback) {
+		// already available ?
+		if (this._bundles[appName] || OC.getLocale() === 'en') {
+			if (callback) {
+				callback();
+			}
+			return;
+		}
+
+		var self = this;
+		var deferred = $.Deferred();
+		var url = OC.generateUrl(
+			'apps/{app}/l10n/{locale}.json',
+			{app: appName, locale: OC.getLocale()}
+		);
+
+		var url = OC.filePath(appName, 'l10n', OC.getLocale() + '.json');
+
+		// load JSON translation bundle per AJAX
+		$.get(url,
+			function(result) {
+				if (result.translations) {
+					self.register(appName, result.translations, result.pluralForm);
+				}
+				if (callback) {
+					callback();
+					deferred.resolve();
+				}
+			}
+		);
+		return deferred.promise();
+	},
+
+	/**
 	 * Register an app's translation bundle.
 	 *
 	 * @param {String} appName name of the app

--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -44,22 +44,17 @@ OC.L10N = {
 		}
 
 		var self = this;
-		var deferred = $.Deferred();
 		var url = OC.filePath(appName, 'l10n', OC.getLocale() + '.json');
 
 		// load JSON translation bundle per AJAX
-		$.get(url,
-			function(result) {
-				if (result.translations) {
-					self.register(appName, result.translations, result.pluralForm);
-				}
-				if (callback) {
-					callback();
-					deferred.resolve();
-				}
-			}
-		);
-		return deferred.promise();
+		return $.get(url)
+			.then(
+				function(result) {
+					if (result.translations) {
+						self.register(appName, result.translations, result.pluralForm);
+					}
+				})
+			.then(callback);
 	},
 
 	/**

--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -37,10 +37,11 @@ OC.L10N = {
 	load: function(appName, callback) {
 		// already available ?
 		if (this._bundles[appName] || OC.getLocale() === 'en') {
-			if (callback) {
-				callback();
-			}
-			return;
+			var deferred = $.Deferred();
+			var promise = deferred.promise();
+			promise.then(callback);
+			deferred.resolve();
+			return promise;
 		}
 
 		var self = this;

--- a/core/js/tests/specs/l10nSpec.js
+++ b/core/js/tests/specs/l10nSpec.js
@@ -130,19 +130,23 @@ describe('OC.L10N tests', function() {
 			localeStub.restore();
 		});
 		it('calls callback if translation already available', function() {
+			var promiseStub = sinon.stub();
 			var callbackStub = sinon.stub();
 			OC.L10N.register(TEST_APP, {
 				'Hello world!': 'Hallo Welt!'
 			});
-			OC.L10N.load(TEST_APP, callbackStub);
+			OC.L10N.load(TEST_APP, callbackStub).then(promiseStub);
 			expect(callbackStub.calledOnce).toEqual(true);
+			expect(promiseStub.calledOnce).toEqual(true);
 			expect(fakeServer.requests.length).toEqual(0);
 		});
 		it('calls callback if locale is en', function() {
 			var localeStub = sinon.stub(OC, 'getLocale').returns('en');
+			var promiseStub = sinon.stub();
 			var callbackStub = sinon.stub();
-			OC.L10N.load(TEST_APP, callbackStub);
+			OC.L10N.load(TEST_APP, callbackStub).then(promiseStub);
 			expect(callbackStub.calledOnce).toEqual(true);
+			expect(promiseStub.calledOnce).toEqual(true);
 			expect(fakeServer.requests.length).toEqual(0);
 		});
 	});


### PR DESCRIPTION
For apps that support async translation loading, a new function
OC.L10N.load() can be used to asynchronously load the translations
for a given app.

Some app devs prefer to load their asserts dynamically from the JS side, for example using "OC.addScript()", "OC.addStyle()". This PR adds a method "OC.addTranslations()" to load them asynchronously.

Note: we cannot use that method in core yet because most of the code has no clear entry point where the translations could be loaded.

Please review @DeepDiver1975 @icewind1991 @th3fallen @LukasReschke 
