### PR TITLE
Don't disclose relative directory path for single shared files of user

### DIFF
--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -23,7 +23,6 @@ use OCP\AppFramework\Controller;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\RedirectResponse;
-use OCP\AppFramework\IApi;
 use OC\URLGenerator;
 use OC\AppConfig;
 use OCP\ILogger;
@@ -160,7 +159,6 @@ class ShareController extends Controller {
 			$originalSharePath .= $path;
 		}
 
-		$dir = dirname($originalSharePath);
 		$file = basename($originalSharePath);
 
 		$shareTmpl = array();

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -172,7 +172,7 @@ class ShareController extends Controller {
 		$shareTmpl['sharingToken'] = $token;
 		$shareTmpl['server2serversharing'] = Helper::isOutgoingServer2serverShareEnabled();
 		$shareTmpl['protected'] = isset($linkItem['share_with']) ? 'true' : 'false';
-		$shareTmpl['dir'] = $dir;
+		$shareTmpl['dir'] = '';
 		$shareTmpl['fileSize'] = \OCP\Util::humanFileSize(\OC\Files\Filesystem::filesize($originalSharePath));
 
 		// Show file list

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -12,6 +12,6 @@
 
 $urlGenerator = new \OC\URLGenerator(\OC::$server->getConfig());
 $token = isset($_GET['t']) ? $_GET['t'] : '';
-$route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadshare' : 'files_sharing.sharecontroller.showshare';
+$route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadShare' : 'files_sharing.sharecontroller.showShare';
 
 OC_Response::redirect($urlGenerator->linkToRoute($route, array('token' => $token)));

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -153,7 +153,7 @@ class ShareControllerTest extends \PHPUnit_Framework_TestCase {
 			'sharingToken' => $this->token,
 			'server2serversharing' => true,
 			'protected' => 'true',
-			'dir' => '/',
+			'dir' => '',
 			'downloadURL' => null,
 			'fileSize' => '33 B'
 		);


### PR DESCRIPTION
The "dir" key is used within the public sharing template to indicate in which directory the user currently is when sharing a directory with subdirectories. This is needed by the JS scripts.

However, when not accessing a directory then "dir" was set to the relative path of the file (from the user's home directory), meaning that for every public shared file the sharee can see the path.
(For example if you share the file "foo.txt" from "finances/topsecret/" the sharee would still see the path "finances/topsecret/" from the shared HTML template)

This is not the excpected behaviour and can be considered a privacy problem, this patch addresses this by setting "dir" to an empty key.

@PVince81 @icewind1991 Oh dear co-developers can I beg you to test and review this PR?
@karlitschek I think https://github.com/owncloud/core/commit/bedda4448c783b9fd3057f34e5e41d2c68a1860d warrants a backport to stable7.
