### PR TITLE
Use full path instead of only the filename

### DIFF
--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -173,7 +173,7 @@ class ShareController extends Controller {
 		$shareTmpl['server2serversharing'] = Helper::isOutgoingServer2serverShareEnabled();
 		$shareTmpl['protected'] = isset($linkItem['share_with']) ? 'true' : 'false';
 		$shareTmpl['dir'] = $dir;
-		$shareTmpl['fileSize'] = \OCP\Util::humanFileSize(\OC\Files\Filesystem::filesize($file));
+		$shareTmpl['fileSize'] = \OCP\Util::humanFileSize(\OC\Files\Filesystem::filesize($originalSharePath));
 
 		// Show file list
 		if (Filesystem::is_dir($originalSharePath)) {


### PR DESCRIPTION
$file only contains the filename and not the absolute path, that means that files in a subdirectory will not get properly resolved and an empty filesize is returned.

This feature only exists on master. - I'll investigate if I can write an unit test for that. 

@PVince81 As discussed
