### PR TITLE
Cleanup config handling - deprecate old ways to interact with config

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -554,7 +554,7 @@ class Hooks {
 	public static function preDisable($params) {
 		if ($params['app'] === 'files_encryption') {
 
-			\OC_Preferences::deleteAppFromAllUsers('files_encryption');
+			\OC::$server->getConfig()->deleteApp('files_encryption');
 
 			$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
 			$session->setInitialized(\OCA\Encryption\Session::NOT_INITIALIZED);

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -13,6 +13,20 @@ namespace OC;
  * Class to combine all the configuration options ownCloud offers
  */
 class AllConfig implements \OCP\IConfig {
+	/** @var SystemConfig */
+	private $systemConfig;
+	/** @var AppConfig */
+	private $appConfig;
+
+	/**
+	 * @param SystemConfig $systemConfig
+	 * @param AppConfig $appConfig
+	 */
+	function __construct(SystemConfig $systemConfig, AppConfig $appConfig) {
+		$this->systemConfig = $systemConfig;
+		$this->appConfig = $appConfig;
+	}
+
 	/**
 	 * Sets a new system wide value
 	 *
@@ -20,7 +34,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param mixed $value the value that should be stored
 	 */
 	public function setSystemValue($key, $value) {
-		\OCP\Config::setSystemValue($key, $value);
+		$this->systemConfig->setValue($key, $value);
 	}
 
 	/**
@@ -31,7 +45,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return mixed the value or $default
 	 */
 	public function getSystemValue($key, $default = '') {
-		return \OCP\Config::getSystemValue($key, $default);
+		return $this->systemConfig->getValue($key, $default);
 	}
 
 	/**
@@ -40,7 +54,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 */
 	public function deleteSystemValue($key) {
-		\OCP\Config::deleteSystemValue($key);
+		$this->systemConfig->deleteValue($key);
 	}
 
 	/**
@@ -50,7 +64,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string[] the keys stored for the app
 	 */
 	public function getAppKeys($appName) {
-		return \OC::$server->getAppConfig()->getKeys($appName);
+		return $this->appConfig->getKeys($appName);
 	}
 
 	/**
@@ -61,7 +75,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $value the value that should be stored
 	 */
 	public function setAppValue($appName, $key, $value) {
-		\OCP\Config::setAppValue($appName, $key, $value);
+		$this->appConfig->setValue($appName, $key, $value);
 	}
 
 	/**
@@ -73,7 +87,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string the saved value
 	 */
 	public function getAppValue($appName, $key, $default = '') {
-		return \OCP\Config::getAppValue($appName, $key, $default);
+		return $this->appConfig->getValue($appName, $key, $default);
 	}
 
 	/**
@@ -83,7 +97,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 */
 	public function deleteAppValue($appName, $key) {
-		\OC_Appconfig::deleteKey($appName, $key);
+		$this->appConfig->deleteKey($appName, $key);
 	}
 
 
@@ -96,7 +110,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $value the value that you want to store
 	 */
 	public function setUserValue($userId, $appName, $key, $value) {
-		\OCP\Config::setUserValue($userId, $appName, $key, $value);
+		\OC_Preferences::setValue($userId, $appName, $key, $value);
 	}
 
 	/**
@@ -109,7 +123,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '') {
-		return \OCP\Config::getUserValue($userId, $appName, $key, $default);
+		return \OC_Preferences::getValue($userId, $appName, $key, $default);
 	}
 
 	/**

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -100,6 +100,15 @@ class AllConfig implements \OCP\IConfig {
 		$this->appConfig->deleteKey($appName, $key);
 	}
 
+	/**
+	 * Removes all keys in appconfig belonging to the app
+	 *
+	 * @param string $appName the appName the configs are stored under
+	 */
+	public function deleteApp($appName) {
+		$this->appConfig->deleteApp($appName);
+	}
+
 
 	/**
 	 * Set a user defined value

--- a/lib/private/db/connectionfactory.php
+++ b/lib/private/db/connectionfactory.php
@@ -122,23 +122,23 @@ class ConnectionFactory {
 	/**
 	 * Create the connection parameters for the config
 	 *
-	 * @param \OCP\IConfig $config
+	 * @param \OC\SystemConfig $config
 	 * @return array
 	 */
 	public function createConnectionParams($config) {
-		$type = $config->getSystemValue('dbtype', 'sqlite');
+		$type = $config->getValue('dbtype', 'sqlite');
 
 		$connectionParams = array(
-			'user' => $config->getSystemValue('dbuser', ''),
-			'password' => $config->getSystemValue('dbpassword', ''),
+			'user' => $config->getValue('dbuser', ''),
+			'password' => $config->getValue('dbpassword', ''),
 		);
-		$name = $config->getSystemValue('dbname', 'owncloud');
+		$name = $config->getValue('dbname', 'owncloud');
 
 		if ($this->normalizeType($type) === 'sqlite3') {
-			$datadir = $config->getSystemValue("datadirectory", \OC::$SERVERROOT . '/data');
+			$datadir = $config->getValue("datadirectory", \OC::$SERVERROOT . '/data');
 			$connectionParams['path'] = $datadir . '/' . $name . '.db';
 		} else {
-			$host = $config->getSystemValue('dbhost', '');
+			$host = $config->getValue('dbhost', '');
 			if (strpos($host, ':')) {
 				// Host variable may carry a port or socket.
 				list($host, $portOrSocket) = explode(':', $host, 2);
@@ -152,10 +152,10 @@ class ConnectionFactory {
 			$connectionParams['dbname'] = $name;
 		}
 
-		$connectionParams['tablePrefix'] = $config->getSystemValue('dbtableprefix', 'oc_');
+		$connectionParams['tablePrefix'] = $config->getValue('dbtableprefix', 'oc_');
 
 		//additional driver options, eg. for mysql ssl
-		$driverOptions = $config->getSystemValue('dbdriveroptions', null);
+		$driverOptions = $config->getValue('dbdriveroptions', null);
 		if ($driverOptions) {
 			$connectionParams['driverOptions'] = $driverOptions;
 		}

--- a/lib/private/legacy/preferences.php
+++ b/lib/private/legacy/preferences.php
@@ -28,28 +28,6 @@ OC_Preferences::$object = new \OC\Preferences(OC_DB::getConnection());
  */
 class OC_Preferences{
 	public static $object;
-	/**
-	 * Get all users using the preferences
-	 * @return array an array of user ids
-	 *
-	 * This function returns a list of all users that have at least one entry
-	 * in the preferences table.
-	 */
-	public static function getUsers() {
-		return self::$object->getUsers();
-	}
-
-	/**
-	 * Get all apps of a user
-	 * @param string $user user
-	 * @return integer[] with app ids
-	 *
-	 * This function returns a list of all apps of the user that have at least
-	 * one entry in the preferences table.
-	 */
-	public static function getApps( $user ) {
-		return self::$object->getApps( $user );
-	}
 
 	/**
 	 * Get the available keys for an app

--- a/lib/private/legacy/preferences.php
+++ b/lib/private/legacy/preferences.php
@@ -132,16 +132,4 @@ class OC_Preferences{
 		self::$object->deleteUser( $user );
 		return true;
 	}
-
-	/**
-	 * Remove app from all users
-	 * @param string $app app
-	 * @return bool
-	 *
-	 * Removes all keys in preferences belonging to the app.
-	 */
-	public static function deleteAppFromAllUsers( $app ) {
-		self::$object->deleteAppFromAllUsers( $app );
-		return true;
-	}
 }

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -68,25 +68,6 @@ class Preferences {
 	}
 
 	/**
-	 * Get all users using the preferences
-	 * @return array an array of user ids
-	 *
-	 * This function returns a list of all users that have at least one entry
-	 * in the preferences table.
-	 */
-	public function getUsers() {
-		$query = 'SELECT DISTINCT `userid` FROM `*PREFIX*preferences`';
-		$result = $this->conn->executeQuery($query);
-
-		$users = array();
-		while ($userid = $result->fetchColumn()) {
-			$users[] = $userid;
-		}
-
-		return $users;
-	}
-
-	/**
 	 * @param string $user
 	 * @return array[]
 	 */
@@ -106,19 +87,6 @@ class Preferences {
 		}
 		$this->cache[$user] = $data;
 		return $data;
-	}
-
-	/**
-	 * Get all apps of an user
-	 * @param string $user user
-	 * @return integer[] with app ids
-	 *
-	 * This function returns a list of all apps of the user that have at least
-	 * one entry in the preferences table.
-	 */
-	public function getApps($user) {
-		$data = $this->getUserValues($user);
-		return array_keys($data);
 	}
 
 	/**

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -223,36 +223,6 @@ class Preferences {
 	}
 
 	/**
-	 * Gets the users for a preference
-	 * @param string $app
-	 * @param string $key
-	 * @param string $value
-	 * @return array
-	 */
-	public function getUsersForValue($app, $key, $value) {
-		$users = array();
-
-		$query = 'SELECT `userid` '
-			. ' FROM `*PREFIX*preferences` '
-			. ' WHERE `appid` = ? AND `configkey` = ? AND ';
-
-		if (\OC_Config::getValue( 'dbtype', 'sqlite' ) === 'oci') {
-			//FIXME oracle hack: need to explicitly cast CLOB to CHAR for comparison
-			$query .= ' to_char(`configvalue`)= ?';
-		} else {
-			$query .= ' `configvalue` = ?';
-		}
-
-		$result = $this->conn->executeQuery($query, array($app, $key, $value));
-
-		while ($row = $result->fetch()) {
-			$users[] = $row['userid'];
-		}
-
-		return $users;
-	}
-
-	/**
 	 * Deletes a key
 	 * @param string $user user
 	 * @param string $app app

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -223,43 +223,6 @@ class Preferences {
 	}
 
 	/**
-	 * Gets the preference for an array of users
-	 * @param string $app
-	 * @param string $key
-	 * @param array $users
-	 * @return array Mapped values: userid => value
-	 */
-	public function getValueForUsers($app, $key, $users) {
-		if (empty($users) || !is_array($users)) {
-			return array();
-		}
-
-		$chunked_users = array_chunk($users, 50, true);
-		$placeholders_50 = implode(',', array_fill(0, 50, '?'));
-
-		$userValues = array();
-		foreach ($chunked_users as $chunk) {
-			$queryParams = $chunk;
-			array_unshift($queryParams, $key);
-			array_unshift($queryParams, $app);
-
-			$placeholders = (sizeof($chunk) == 50) ? $placeholders_50 : implode(',', array_fill(0, sizeof($chunk), '?'));
-
-			$query = 'SELECT `userid`, `configvalue` '
-				. ' FROM `*PREFIX*preferences` '
-				. ' WHERE `appid` = ? AND `configkey` = ?'
-				. ' AND `userid` IN (' . $placeholders . ')';
-			$result = $this->conn->executeQuery($query, $queryParams);
-
-			while ($row = $result->fetch()) {
-				$userValues[$row['userid']] = $row['configvalue'];
-			}
-		}
-
-		return $userValues;
-	}
-
-	/**
 	 * Gets the users for a preference
 	 * @param string $app
 	 * @param string $key

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -276,23 +276,6 @@ class Preferences {
 
 		unset($this->cache[$user]);
 	}
-
-	/**
-	 * Remove app from all users
-	 * @param string $app app
-	 *
-	 * Removes all keys in preferences belonging to the app.
-	 */
-	public function deleteAppFromAllUsers($app) {
-		$where = array(
-			'appid' => $app,
-		);
-		$this->conn->delete('*PREFIX*preferences', $where);
-
-		foreach ($this->cache as &$userCache) {
-			unset($userCache[$app]);
-		}
-	}
 }
 
 require_once __DIR__ . '/legacy/' . basename(__FILE__);

--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright (c) 2014 Morris Jobke <hey@morrisjobke.de>
+ *               2013 Bart Visscher <bartv@thisnet.nl>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ *
+ */
+
+namespace OC;
+
+/**
+ * Class which provides access to the system config values stored in config.php
+ * Internal class for bootstrap only.
+ * fixes circle DI: AllConfig needs AppConfig needs Database needs SystemConfig
+ */
+class SystemConfig {
+	/**
+	 * Sets a new system wide value
+	 *
+	 * @param string $key the key of the value, under which will be saved
+	 * @param mixed $value the value that should be stored
+	 */
+	public function setValue($key, $value) {
+		\OC_Config::setValue($key, $value);
+	}
+
+	/**
+	 * Looks up a system wide defined value
+	 *
+	 * @param string $key the key of the value, under which it was saved
+	 * @param mixed $default the default value to be returned if the value isn't set
+	 * @return mixed the value or $default
+	 */
+	public function getValue($key, $default = '') {
+		return \OC_Config::getValue($key, $default);
+	}
+
+	/**
+	 * Delete a system wide defined value
+	 *
+	 * @param string $key the key of the value, under which it was saved
+	 */
+	public function deleteValue($key) {
+		\OC_Config::deleteKey($key);
+	}
+}

--- a/lib/public/config.php
+++ b/lib/public/config.php
@@ -37,6 +37,7 @@ namespace OCP;
 /**
  * This class provides functions to read and write configuration data.
  * configuration can be on a system, application or user level
+ * @deprecated use methods of \OCP\IConfig
  */
 class Config {
 	/**
@@ -44,12 +45,13 @@ class Config {
 	 * @param string $key key
 	 * @param mixed $default = null default value
 	 * @return mixed the value or $default
+	 * @deprecated use method getSystemValue of \OCP\IConfig
 	 *
 	 * This function gets the value from config.php. If it does not exist,
 	 * $default will be returned.
 	 */
 	public static function getSystemValue( $key, $default = null ) {
-		return \OC_Config::getValue( $key, $default );
+		return \OC::$server->getConfig()->getSystemValue( $key, $default );
 	}
 
 	/**
@@ -57,13 +59,14 @@ class Config {
 	 * @param string $key key
 	 * @param mixed $value value
 	 * @return bool
+	 * @deprecated use method setSystemValue of \OCP\IConfig
 	 *
 	 * This function sets the value and writes the config.php. If the file can
 	 * not be written, false will be returned.
 	 */
 	public static function setSystemValue( $key, $value ) {
 		try {
-			\OC_Config::setValue( $key, $value );
+			\OC::$server->getConfig()->setSystemValue( $key, $value );
 		} catch (\Exception $e) {
 			return false;
 		}
@@ -73,11 +76,12 @@ class Config {
 	/**
 	 * Deletes a value from config.php
 	 * @param string $key key
+	 * @deprecated use method deleteSystemValue of \OCP\IConfig
 	 *
 	 * This function deletes the value from config.php.
 	 */
 	public static function deleteSystemValue( $key ) {
-		return \OC_Config::deleteKey( $key );
+		\OC::$server->getConfig()->deleteSystemValue( $key );
 	}
 
 	/**
@@ -86,12 +90,13 @@ class Config {
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
 	 * @return string the value or $default
+	 * @deprecated use method getAppValue of \OCP\IConfig
 	 *
 	 * This function gets a value from the appconfig table. If the key does
 	 * not exist the default value will be returned
 	 */
 	public static function getAppValue( $app, $key, $default = null ) {
-		return \OC_Appconfig::getValue( $app, $key, $default );
+		return \OC::$server->getConfig()->getAppValue( $app, $key, $default );
 	}
 
 	/**
@@ -100,12 +105,13 @@ class Config {
 	 * @param string $key key
 	 * @param string $value value
 	 * @return boolean true/false
+	 * @deprecated use method setAppValue of \OCP\IConfig
 	 *
 	 * Sets a value. If the key did not exist before it will be created.
 	 */
 	public static function setAppValue( $app, $key, $value ) {
 		try {
-			\OC_Appconfig::setValue( $app, $key, $value );
+			\OC::$server->getConfig()->setAppValue( $app, $key, $value );
 		} catch (\Exception $e) {
 			return false;
 		}
@@ -119,12 +125,13 @@ class Config {
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
 	 * @return string the value or $default
+	 * @deprecated use method getUserValue of \OCP\IConfig
 	 *
 	 * This function gets a value from the preferences table. If the key does
 	 * not exist the default value will be returned
 	 */
 	public static function getUserValue( $user, $app, $key, $default = null ) {
-		return \OC_Preferences::getValue( $user, $app, $key, $default );
+		return \OC::$server->getConfig()->getUserValue( $user, $app, $key, $default );
 	}
 
 	/**
@@ -134,13 +141,14 @@ class Config {
 	 * @param string $key key
 	 * @param string $value value
 	 * @return bool
+	 * @deprecated use method setUserValue of \OCP\IConfig
 	 *
 	 * Adds a value to the preferences. If the key did not exist before, it
 	 * will be added automagically.
 	 */
 	public static function setUserValue( $user, $app, $key, $value ) {
 		try {
-			\OC_Preferences::setValue( $user, $app, $key, $value );
+			\OC::$server->getConfig()->setUserValue( $user, $app, $key, $value );
 		} catch (\Exception $e) {
 			return false;
 		}

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -26,6 +26,7 @@ interface IAppConfig {
 	 * @param string $key key
 	 * @param string $default = null, default value if the key does not exist
 	 * @return string the value or $default
+	 * @deprecated use method getAppValue of \OCP\IConfig
 	 *
 	 * This function gets a value from the appconfig table. If the key does
 	 * not exist the default value will be returned
@@ -37,8 +38,7 @@ interface IAppConfig {
 	 * @param string $app app
 	 * @param string $key key
 	 * @return bool
-	 *
-	 * Deletes a key.
+	 * @deprecated use method deleteAppValue of \OCP\IConfig
 	 */
 	public function deleteKey($app, $key);
 
@@ -46,6 +46,7 @@ interface IAppConfig {
 	 * Get the available keys for an app
 	 * @param string $app the app we are looking for
 	 * @return array an array of key names
+	 * @deprecated use method getAppKeys of \OCP\IConfig
 	 *
 	 * This function gets all keys of an app. Please note that the values are
 	 * not returned.
@@ -66,6 +67,7 @@ interface IAppConfig {
 	 * @param string $app app
 	 * @param string $key key
 	 * @param string $value value
+	 * @deprecated use method setAppValue of \OCP\IConfig
 	 *
 	 * Sets a value. If the key did not exist before it will be created.
 	 * @return void

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -87,6 +87,7 @@ interface IAppConfig {
 	 * Remove app from appconfig
 	 * @param string $app app
 	 * @return bool
+	 * @deprecated use method deleteApp of \OCP\IConfig
 	 *
 	 * Removes all keys in appconfig belonging to the app.
 	 */

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -94,6 +94,13 @@ interface IConfig {
 	 */
 	public function deleteAppValue($appName, $key);
 
+	/**
+	 * Removes all keys in appconfig belonging to the app
+	 *
+	 * @param string $appName the appName the configs are stored under
+	 */
+	public function deleteApp($appName);
+
 
 	/**
 	 * Set a user defined value

--- a/tests/lib/preferences-singleton.php
+++ b/tests/lib/preferences-singleton.php
@@ -35,34 +35,6 @@ class Test_Preferences extends PHPUnit_Framework_TestCase {
 		$query->execute(array('Anuser'));
 	}
 
-	public function testGetUsers() {
-		$query = \OC_DB::prepare('SELECT DISTINCT `userid` FROM `*PREFIX*preferences`');
-		$result = $query->execute();
-		$expected = array();
-		while ($row = $result->fetchRow()) {
-			$expected[] = $row['userid'];
-		}
-
-		sort($expected);
-		$users = \OC_Preferences::getUsers();
-		sort($users);
-		$this->assertEquals($expected, $users);
-	}
-
-	public function testGetApps() {
-		$query = \OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*preferences` WHERE `userid` = ?');
-		$result = $query->execute(array('Someuser'));
-		$expected = array();
-		while ($row = $result->fetchRow()) {
-			$expected[] = $row['appid'];
-		}
-
-		sort($expected);
-		$apps = \OC_Preferences::getApps('Someuser');
-		sort($apps);
-		$this->assertEquals($expected, $apps);
-	}
-
 	public function testGetKeys() {
 		$query = \OC_DB::prepare('SELECT DISTINCT `configkey` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ?');
 		$result = $query->execute(array('Someuser', 'getkeysapp'));

--- a/tests/lib/preferences-singleton.php
+++ b/tests/lib/preferences-singleton.php
@@ -26,7 +26,6 @@ class Test_Preferences extends PHPUnit_Framework_TestCase {
 
 		$query->execute(array("Deleteuser", "deleteapp", "deletekey", "somevalue"));
 		$query->execute(array("Deleteuser", "deleteapp", "somekey", "somevalue"));
-		$query->execute(array("Deleteuser", "someapp", "somekey", "somevalue"));
 	}
 
 	public static function tearDownAfterClass() {
@@ -160,13 +159,6 @@ class Test_Preferences extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(\OC_Preferences::deleteUser('Deleteuser'));
 		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?');
 		$result = $query->execute(array('Deleteuser'));
-		$this->assertEquals(0, count($result->fetchAll()));
-	}
-
-	public function testDeleteAppFromAllUsers() {
-		$this->assertTrue(\OC_Preferences::deleteAppFromAllUsers('someapp'));
-		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `appid` = ?');
-		$result = $query->execute(array('someapp'));
 		$this->assertEquals(0, count($result->fetchAll()));
 	}
 }

--- a/tests/lib/preferences.php
+++ b/tests/lib/preferences.php
@@ -177,20 +177,4 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 		$preferences = new OC\Preferences($connectionMock);
 		$preferences->deleteUser('grg');
 	}
-
-	public function testDeleteAppFromAllUsers()
-	{
-		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
-		$connectionMock->expects($this->once())
-			->method('delete')
-			->with($this->equalTo('*PREFIX*preferences'),
-				$this->equalTo(
-					array(
-						'appid' => 'bar',
-					)
-				));
-
-		$preferences = new OC\Preferences($connectionMock);
-		$preferences->deleteAppFromAllUsers('bar');
-	}
 }

--- a/tests/lib/preferences.php
+++ b/tests/lib/preferences.php
@@ -117,33 +117,6 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 		$preferences->setValue('grg', 'bar', 'foo', 'v2');
 	}
 
-	public function testGetUserValues()
-	{
-		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*preferences` VALUES(?, ?, ?, ?)');
-		$query->execute(array('SomeUser', 'testGetUserValues', 'somekey', 'somevalue'));
-		$query->execute(array('AnotherUser', 'testGetUserValues', 'somekey', 'someothervalue'));
-		$query->execute(array('AUser', 'testGetUserValues', 'somekey', 'somevalue'));
-
-		$preferences = new OC\Preferences(\OC_DB::getConnection());
-		$users = array('SomeUser', 'AnotherUser', 'NoValueSet');
-
-		$values = $preferences->getValueForUsers('testGetUserValues', 'somekey', $users);
-		$this->assertUserValues($values);
-
-		// Add a lot of users so the array is chunked
-		for ($i = 1; $i <= 75; $i++) {
-			array_unshift($users, 'NoValueBefore#' . $i);
-			array_push($users, 'NoValueAfter#' . $i);
-		}
-
-		$values = $preferences->getValueForUsers('testGetUserValues', 'somekey', $users);
-		$this->assertUserValues($values);
-
-		// Clean DB after the test
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*preferences` WHERE `appid` = ?');
-		$query->execute(array('testGetUserValues'));
-	}
-
 	protected function assertUserValues($values) {
 		$this->assertEquals(2, sizeof($values));
 

--- a/tests/lib/preferences.php
+++ b/tests/lib/preferences.php
@@ -127,24 +127,6 @@ class Test_Preferences_Object extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('someothervalue', $values['AnotherUser']);
 	}
 
-	public function testGetValueUsers()
-	{
-		// Prepare data
-		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*preferences` VALUES(?, ?, ?, ?)');
-		$query->execute(array('SomeUser', 'testGetUsersForValue', 'somekey', 'somevalue'));
-		$query->execute(array('AnotherUser', 'testGetUsersForValue', 'somekey', 'someothervalue'));
-		$query->execute(array('AUser', 'testGetUsersForValue', 'somekey', 'somevalue'));
-
-		$preferences = new OC\Preferences(\OC_DB::getConnection());
-		$result = $preferences->getUsersForValue('testGetUsersForValue', 'somekey', 'somevalue');
-		sort($result);
-		$this->assertEquals(array('AUser', 'SomeUser'), $result);
-
-		// Clean DB after the test
-		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*preferences` WHERE `appid` = ?');
-		$query->execute(array('testGetUsersForValue'));
-	}
-
 	public function testDeleteKey()
 	{
 		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);

--- a/tests/lib/user/user.php
+++ b/tests/lib/user/user.php
@@ -228,7 +228,13 @@ class User extends \PHPUnit_Framework_TestCase {
 			->method('implementsActions')
 			->will($this->returnValue(false));
 
-		$allConfig = new AllConfig();
+		$allConfig = $this->getMock('\OC\AllConfig');
+		$allConfig->expects($this->any())
+			->method('getUserValue')
+			->will($this->returnValue(true));
+		$allConfig->expects($this->any())
+			->method('getSystemValue')
+			->will($this->returnValue(''));
 
 		$user = new \OC\User\User('foo', $backend, null, $allConfig);
 		$this->assertEquals(\OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data") . '/foo', $user->getHome());


### PR DESCRIPTION
- deprecate old and static ways to interact with config
- introduce SystemConfig to avoid DI circle (used by database connection  which is itself needed by AllConfig that itself contains the methods to access the config.php which then would need the database connection - did you get it? ;))
- use DI container and use that method in legacy code paths (for easier refactoring later)

fixes #12260 

@PVince81 @Raydiation @DeepDiver1975 @LukasReschke Opinions?
