### PR TITLE
drop unneeded var_dump - fixes #9997

### DIFF
--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -243,7 +243,6 @@ class Router implements IRouter {
 		if (isset($parameters['action'])) {
 			$action = $parameters['action'];
 			if (!is_callable($action)) {
-				var_dump($action);
 				throw new \Exception('not a callable action');
 			}
 			unset($parameters['action']);


### PR DESCRIPTION
cc @DeepDiver1975 @LukasReschke 

There is not a single bug report with this exception in it. Also this is just shown to the user and not logged. Therefore it's often useless and maybe leak info.
