### PR TITLE
Only check credentials when credentials are supplied

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -285,7 +285,10 @@ class OC_API {
 		// basic auth
 		$authUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : '';
 		$authPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : '';
-		$return = OC_User::login($authUser, $authPw);
+		$return = false;
+		if($authUser !== '' && $authPw !== '') {
+			$return = OC_User::login($authUser, $authPw);
+		}
 		if ($return === true) {
 			self::$logoutRequired = true;
 


### PR DESCRIPTION
Every request to the OCS API has previously triggered an authentication try. In case no credentials have been supplied (as some clients do) this lead to an authentication error in the logfile such as:

``` json
{"app":"core","message":"Login failed: '' (Remote IP: '::1', X-Forwarded-For: '')","level":2,"time":"2014-11-18T21:46:39+00:00"}
```

To test this open a private browser window and access `ocs/v1.php/cloud/users/admin` with and without the patch and compare the log entries.

Potentially fixes https://github.com/owncloud/core/issues/12269 though this might also have another reason.

@karlitschek This is against stable7. Please confirm. The current implementation can lead to problems when used in combination with fail2ban etc...
@MorrisJobke Care to review this? :)
