### PR TITLE
Only show undelete capability if files_trashbin is enabled

### DIFF
--- a/apps/files_trashbin/appinfo/routes.php
+++ b/apps/files_trashbin/appinfo/routes.php
@@ -13,3 +13,7 @@ $this->create('files_trashbin_ajax_list', 'ajax/list.php')
 	->actionInclude('files_trashbin/ajax/list.php');
 $this->create('files_trashbin_ajax_undelete', 'ajax/undelete.php')
 	->actionInclude('files_trashbin/ajax/undelete.php');
+
+
+// Register with the capabilities API
+\OC_API::register('get', '/cloud/capabilities', array('OCA\Files_Trashbin\Capabilities', 'getCapabilities'), 'files_trashbin', \OC_API::USER_AUTH);

--- a/apps/files_trashbin/lib/capabilities.php
+++ b/apps/files_trashbin/lib/capabilities.php
@@ -1,20 +1,29 @@
 <?php
 /**
- * Copyright (c) 2013 Tom Needham <tom@owncloud.com>
+ * Copyright (c) Lukas Reschke <lukas@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
  */
  
-namespace OCA\Files; 
+namespace OCA\Files_Trashbin;
 
+
+/**
+ * Class Capabilities
+ *
+ * @package OCA\Files_Trashbin
+ */
 class Capabilities {
-	
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
 	public static function getCapabilities() {
 		return new \OC_OCS_Result(array(
 			'capabilities' => array(
 				'files' => array(
-					'bigfilechunking' => true,
+					'undelete' => true,
 					),
 				),
 			));


### PR DESCRIPTION
Fixes the OCS capability API at /ocs/v1.php/cloud/capabilities

@MorrisJobke @tomneedham As discussed.
