### PR TITLE
drop dependency of some commands on old config object

### DIFF
--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -10,7 +10,7 @@
 
 namespace OC\Core\Command\Db;
 
-use OC\Config;
+use \OCP\IConfig;
 use OC\DB\Connection;
 use OC\DB\ConnectionFactory;
 
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConvertType extends Command {
 	/**
-	 * @var \OC\Config
+	 * @var \OCP\IConfig
 	 */
 	protected $config;
 
@@ -32,10 +32,10 @@ class ConvertType extends Command {
 	protected $connectionFactory;
 
 	/**
-	 * @param \OC\Config $config
+	 * @param \OCP\IConfig $config
 	 * @param \OC\DB\ConnectionFactory $connectionFactory
 	 */
-	public function __construct(Config $config, ConnectionFactory $connectionFactory) {
+	public function __construct(IConfig $config, ConnectionFactory $connectionFactory) {
 		$this->config = $config;
 		$this->connectionFactory = $connectionFactory;
 		parent::__construct();
@@ -104,7 +104,7 @@ class ConvertType extends Command {
 				'Converting to Microsoft SQL Server (mssql) is currently not supported.'
 			);
 		}
-		if ($type === $this->config->getValue('dbtype', '')) {
+		if ($type === $this->config->getSystemValue('dbtype', '')) {
 			throw new \InvalidArgumentException(sprintf(
 				'Can not convert from %1$s to %1$s.',
 				$type
@@ -209,7 +209,7 @@ class ConvertType extends Command {
 			'user' => $input->getArgument('username'),
 			'password' => $input->getOption('password'),
 			'dbname' => $input->getArgument('database'),
-			'tablePrefix' => $this->config->getValue('dbtableprefix', 'oc_'),
+			'tablePrefix' => $this->config->getSystemValue('dbtableprefix', 'oc_'),
 		);
 		if ($input->getOption('port')) {
 			$connectionParams['port'] = $input->getOption('port');
@@ -256,7 +256,7 @@ class ConvertType extends Command {
 	}
 
 	protected function convertDB(Connection $fromDB, Connection $toDB, array $tables, InputInterface $input, OutputInterface $output) {
-		$this->config->setValue('maintenance', true);
+		$this->config->setSystemValue('maintenance', true);
 		try {
 			// copy table rows
 			foreach($tables as $table) {
@@ -270,10 +270,10 @@ class ConvertType extends Command {
 			// save new database config
 			$this->saveDBInfo($input);
 		} catch(\Exception $e) {
-			$this->config->setValue('maintenance', false);
+			$this->config->setSystemValue('maintenance', false);
 			throw $e;
 		}
-		$this->config->setValue('maintenance', false);
+		$this->config->setSystemValue('maintenance', false);
 	}
 
 	protected function saveDBInfo(InputInterface $input) {
@@ -286,10 +286,10 @@ class ConvertType extends Command {
 			$dbhost .= ':'.$input->getOption('port');
 		}
 
-		$this->config->setValue('dbtype', $type);
-		$this->config->setValue('dbname', $dbname);
-		$this->config->setValue('dbhost', $dbhost);
-		$this->config->setValue('dbuser', $username);
-		$this->config->setValue('dbpassword', $password);
+		$this->config->setSystemValue('dbtype', $type);
+		$this->config->setSystemValue('dbname', $dbname);
+		$this->config->setSystemValue('dbhost', $dbhost);
+		$this->config->setSystemValue('dbuser', $username);
+		$this->config->setSystemValue('dbpassword', $password);
 	}
 }

--- a/core/command/maintenance/mode.php
+++ b/core/command/maintenance/mode.php
@@ -9,7 +9,7 @@
 
 namespace OC\Core\Command\Maintenance;
 
-use OC\Config;
+use \OCP\IConfig;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,9 +18,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Mode extends Command {
 
+	/** @var IConfig */
 	protected $config;
 
-	public function __construct(Config $config) {
+	public function __construct(IConfig $config) {
 		$this->config = $config;
 		parent::__construct();
 	}
@@ -45,13 +46,13 @@ class Mode extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if ($input->getOption('on')) {
-			$this->config->setValue('maintenance', true);
+			$this->config->setSystemValue('maintenance', true);
 			$output->writeln('Maintenance mode enabled');
 		} elseif ($input->getOption('off')) {
-			$this->config->setValue('maintenance', false);
+			$this->config->setSystemValue('maintenance', false);
 			$output->writeln('Maintenance mode disabled');
 		} else {
-			if ($this->config->getValue('maintenance', false)) {
+			if ($this->config->getSystemValue('maintenance', false)) {
 				$output->writeln('Maintenance mode is currently enabled');
 			} else {
 				$output->writeln('Maintenance mode is currently disabled');

--- a/core/command/maintenance/repair.php
+++ b/core/command/maintenance/repair.php
@@ -17,12 +17,14 @@ class Repair extends Command {
 	 * @var \OC\Repair $repair
 	 */
 	protected $repair;
+	/** @var \OCP\IConfig */
+	protected $config;
 
 	/**
 	 * @param \OC\Repair $repair
-	 * @param \OC\Config $config
+	 * @param \OCP\IConfig $config
 	 */
-	public function __construct(\OC\Repair $repair, \OC\Config $config) {
+	public function __construct(\OC\Repair $repair, \OCP\IConfig $config) {
 		$this->repair = $repair;
 		$this->config = $config;
 		parent::__construct();
@@ -35,8 +37,8 @@ class Repair extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$maintenanceMode = $this->config->getValue('maintenance', false);
-		$this->config->setValue('maintenance', true);
+		$maintenanceMode = $this->config->getSystemValue('maintenance', false);
+		$this->config->setSystemValue('maintenance', true);
 
 		$this->repair->listen('\OC\Repair', 'step', function ($description) use ($output) {
 			$output->writeln(' - ' . $description);
@@ -50,6 +52,6 @@ class Repair extends Command {
 
 		$this->repair->run();
 
-		$this->config->setValue('maintenance', $maintenanceMode);
+		$this->config->setSystemValue('maintenance', $maintenanceMode);
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -11,14 +11,14 @@ $repair = new \OC\Repair(\OC\Repair::getRepairSteps());
 /** @var $application Symfony\Component\Console\Application */
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Db\GenerateChangeScript());
-$application->add(new OC\Core\Command\Db\ConvertType(OC_Config::getObject(), new \OC\DB\ConnectionFactory()));
+$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory()));
 $application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig()));
 $application->add(new OC\Core\Command\Maintenance\SingleUser());
-$application->add(new OC\Core\Command\Maintenance\Mode(OC_Config::getObject()));
+$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 $application->add(new OC\Core\Command\App\Disable());
 $application->add(new OC\Core\Command\App\Enable());
 $application->add(new OC\Core\Command\App\ListApps());
-$application->add(new OC\Core\Command\Maintenance\Repair($repair, OC_Config::getObject()));
+$application->add(new OC\Core\Command\Maintenance\Repair($repair, \OC::$server->getConfig()));
 $application->add(new OC\Core\Command\User\Report());
 $application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
 $application->add(new OC\Core\Command\User\LastSeen());

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -49,7 +49,7 @@ class MDB2SchemaManager {
 	 * TODO: write more documentation
 	 */
 	public function createDbFromStructure($file) {
-		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $this->conn->getDatabasePlatform());
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
 		$toSchema = $schemaReader->loadSchemaFromFile($file);
 		return $this->executeSchemaChange($toSchema);
 	}
@@ -83,7 +83,7 @@ class MDB2SchemaManager {
 	 */
 	private function readSchemaFromFile($file) {
 		$platform = $this->conn->getDatabasePlatform();
-		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $platform);
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $platform);
 		return $schemaReader->loadSchemaFromFile($file);
 	}
 
@@ -131,7 +131,7 @@ class MDB2SchemaManager {
 	 * @param string $file the xml file describing the tables
 	 */
 	public function removeDBStructure($file) {
-		$schemaReader = new MDB2SchemaReader(\OC_Config::getObject(), $this->conn->getDatabasePlatform());
+		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
 		$fromSchema = $schemaReader->loadSchemaFromFile($file);
 		$toSchema = clone $fromSchema;
 		/** @var $table \Doctrine\DBAL\Schema\Table */

--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -8,6 +8,9 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use OCP\IConfig;
+
 class MDB2SchemaReader {
 	/**
 	 * @var string $DBNAME
@@ -25,13 +28,13 @@ class MDB2SchemaReader {
 	protected $platform;
 
 	/**
-	 * @param \OC\Config $config
+	 * @param \OCP\IConfig $config
 	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
 	 */
-	public function __construct($config, $platform) {
+	public function __construct(IConfig $config, AbstractPlatform $platform) {
 		$this->platform = $platform;
-		$this->DBNAME = $config->getValue('dbname', 'owncloud');
-		$this->DBTABLEPREFIX = $config->getValue('dbtableprefix', 'oc_');
+		$this->DBNAME = $config->getSystemValue('dbname', 'owncloud');
+		$this->DBTABLEPREFIX = $config->getSystemValue('dbtableprefix', 'oc_');
 	}
 
 	/**

--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -23,14 +23,6 @@ class OC_Config {
 	public static $object;
 
 	/**
-	 * Returns the config instance
-	 * @return \OC\Config
-	 */
-	public static function getObject() {
-		return self::$object;
-	}
-
-	/**
 	 * Lists all available config keys
 	 * @return array an array of key names
 	 *


### PR DESCRIPTION
Now the commands use the better public interface of our config.

@DeepDiver1975 I will now proceed in small steps, to get rid of the early init of the config object (that prevents the usage in the DI container)

cc @Raydiation @LukasReschke @PVince81 
