### PR TITLE
Show warning when invalid user was passed

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -121,6 +121,14 @@ class OC_Mount_Config {
 
 		if ($data['user']) {
 			$user = \OC::$server->getUserManager()->get($data['user']);
+			if (!$user) {
+				\OC_Log::write(
+					'files_external',
+					'Cannot init external mount points for non-existant user "' . $data['user'] . '".',
+					\OC_Log::WARN
+				);
+				return;
+			}
 			$userView = new \OC\Files\View('/' . $user->getUID() . '/files');
 			$changePropagator = new \OC\Files\Cache\ChangePropagator($userView);
 			$etagPropagator = new \OCA\Files_External\EtagPropagator($user, $changePropagator, \OC::$server->getConfig());


### PR DESCRIPTION
Sometimes there are bugs that cause setupFS() to be called for
non-existing users. Instead of failing hard and breaking the instance,
this fix simply logs a warning.

Supersedes #12175 due to Jenkins' inability to properly check out code from branches where code was force pushed
