### PR TITLE
Deduplicate findBinaryPath() and do not try "command -v" on windows

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -873,6 +873,23 @@ class OC_Helper {
 	}
 
 	/**
+	 * Try to find a program
+	 * Note: currently windows is not supported
+	 *
+	 * @param string $program
+	 * @return null|string
+	 */
+	public static function findBinaryPath($program) {
+		if (!\OC_Util::runningOnWindows() && self::is_function_enabled('exec')) {
+			exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
+			if ($returnCode === 0 && count($output) > 0) {
+				return escapeshellcmd($output[0]);
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Calculate the disc space for the given path
 	 *
 	 * @param string $path

--- a/lib/private/preview/movies.php
+++ b/lib/private/preview/movies.php
@@ -10,18 +10,10 @@ namespace OC\Preview;
 
 // movie preview is currently not supported on Windows
 if (!\OC_Util::runningOnWindows()) {
-	$isExecEnabled = \OC_Helper::is_function_enabled('exec');
-	$ffmpegBinary = null;
-	$avconvBinary = null;
+	$avconvBinary = \OC_Helper::findBinaryPath('avconv');
+	$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
 
-	if ($isExecEnabled) {
-		$avconvBinary = \OC_Helper::findBinaryPath('avconv');
-		if (!$avconvBinary) {
-			$ffmpegBinary = \OC_Helper::findBinaryPath('ffmpeg');
-		}
-	}
-
-	if($isExecEnabled && ( $avconvBinary || $ffmpegBinary )) {
+	if ($avconvBinary || $ffmpegBinary) {
 
 		class Movie extends Provider {
 			public static $avconvBinary;

--- a/lib/private/preview/movies.php
+++ b/lib/private/preview/movies.php
@@ -8,14 +8,6 @@
  */
 namespace OC\Preview;
 
-function findBinaryPath($program) {
-	exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
-	if ($returnCode === 0 && count($output) > 0) {
-		return escapeshellcmd($output[0]);
-	}
-	return null;
-}
-
 // movie preview is currently not supported on Windows
 if (!\OC_Util::runningOnWindows()) {
 	$isExecEnabled = \OC_Helper::is_function_enabled('exec');
@@ -23,9 +15,9 @@ if (!\OC_Util::runningOnWindows()) {
 	$avconvBinary = null;
 
 	if ($isExecEnabled) {
-		$avconvBinary = findBinaryPath('avconv');
+		$avconvBinary = \OC_Helper::findBinaryPath('avconv');
 		if (!$avconvBinary) {
-			$ffmpegBinary = findBinaryPath('ffmpeg');
+			$ffmpegBinary = \OC_Helper::findBinaryPath('ffmpeg');
 		}
 	}
 

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -17,7 +17,7 @@ $config = \OC::$server->getConfig();
 $appConfig = \OC::$server->getAppConfig();
 
 // Should we display sendmail as an option?
-$template->assign('sendmail_is_available', (bool)findBinaryPath('sendmail'));
+$template->assign('sendmail_is_available', (bool) \OC_Helper::findBinaryPath('sendmail'));
 
 $template->assign('loglevel', $config->getSystemValue("loglevel", 2));
 $template->assign('mail_domain', $config->getSystemValue("mail_domain", ''));
@@ -115,19 +115,3 @@ $formsAndMore[] = array('anchor' => 'log-section', 'section-name' => $l->t('Log'
 $template->assign('forms', $formsAndMore);
 
 $template->printPage();
-
-/**
- * Try to find a program
- *
- * @param string $program
- * @return null|string
- */
-function findBinaryPath($program) {
-	if (!\OC_Util::runningOnWindows() && \OC_Helper::is_function_enabled('exec')) {
-		exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
-		if ($returnCode === 0 && count($output) > 0) {
-			return escapeshellcmd($output[0]);
-		}
-	}
-	return null;
-}

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -123,7 +123,7 @@ $template->printPage();
  * @return null|string
  */
 function findBinaryPath($program) {
-	if (OC_Helper::is_function_enabled('exec')) {
+	if (!\OC_Util::runningOnWindows() && \OC_Helper::is_function_enabled('exec')) {
 		exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
 		if ($returnCode === 0 && count($output) > 0) {
 			return escapeshellcmd($output[0]);


### PR DESCRIPTION
Currently running unit tests prints the following message 3 times:

> The command "command" is misspelt or could not be found.

Instead of trying this, we just skip this now.

@LukasReschke @MorrisJobke 
