### PR TITLE
Use a more universal shebang

### DIFF
--- a/occ
+++ b/occ
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
  * Copyright (c) 2013 Thomas Müller <thomas.mueller@tmit.eu>


### PR DESCRIPTION
On FreeBSD, php is usually in /usr/local and I'm sure there are many more exceptions.
