### PR TITLE
Remove delete button in shared with others list

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -103,7 +103,11 @@
 		},
 
 		getDirectoryPermissions: function() {
-			return OC.PERMISSION_READ | OC.PERMISSION_DELETE;
+			var perms = OC.PERMISSION_READ;
+			if (this._sharedWithUser) {
+				perms |= OC.PERMISSION_DELETE;
+			}
+			return perms;
 		},
 
 		updateStorageStatistics: function() {
@@ -203,7 +207,11 @@
 						}
 						file.name = OC.basename(share.path);
 						file.path = OC.dirname(share.path);
-						file.permissions = OC.PERMISSION_ALL;
+						if (this._sharedWithUser) {
+							file.permissions = OC.PERMISSION_ALL;
+						} else {
+							file.permissions = OC.PERMISSION_ALL - OC.PERMISSION_DELETE;
+						}
 						if (file.path) {
 							file.extraData = share.path;
 						}

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -436,6 +436,7 @@ describe('OCA.Sharing.FileList tests', function() {
 
 			fileList.reload();
 
+			/* jshint camelcase: false */
 			ocsResponse = {
 				ocs: {
 					meta: {
@@ -641,7 +642,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			}]);
 			$tr = fileList.$el.find('tr:first');
 
-			expect(parseInt($tr.attr('data-share-permissions'), 10)).toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE);
+			expect(parseInt($tr.attr('data-share-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE);
 		});
 	});
 });

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -91,7 +91,7 @@ describe('OCA.Sharing.FileList tests', function() {
 						file_source: 49,
 						file_target: '/local path/local name.txt',
 						path: 'files/something shared.txt',
-						permissions: 31,
+						permissions: OC.PERMISSION_ALL,
 						stime: 11111,
 						share_type: OC.Share.SHARE_TYPE_USER,
 						share_with: 'user1',
@@ -127,7 +127,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL); // read and delete
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).toEqual('User Two');
@@ -169,7 +170,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL); // read and delete
 			expect($tr.attr('data-mime')).toEqual('httpd/unix-directory');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).toEqual('User Two');
@@ -244,7 +246,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
@@ -285,7 +288,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('httpd/unix-directory');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
@@ -336,7 +340,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-owner')).not.toBeDefined();
@@ -404,7 +409,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			// always use the most recent stime
 			expect($tr.attr('data-mtime')).toEqual('22222000');
@@ -496,7 +502,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();
@@ -537,7 +544,8 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect($tr.attr('data-file')).toEqual('local name.txt');
 			expect($tr.attr('data-path')).toEqual('/local path');
 			expect($tr.attr('data-size')).not.toBeDefined();
-			expect($tr.attr('data-permissions')).toEqual('31'); // read and delete
+			expect(parseInt($tr.attr('data-permissions'), 10))
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_DELETE); // read
 			expect($tr.attr('data-mime')).toEqual('text/plain');
 			expect($tr.attr('data-mtime')).toEqual('11111000');
 			expect($tr.attr('data-share-recipients')).not.toBeDefined();


### PR DESCRIPTION
Whenever a file is shared with others or with link, a delete button used to be visible that triggered a direct deletion.

This button has been removed to avoid accidental deletion from people who might believe it was an unshare button. Unsharing is still possible inside the share dropdown.

Fixes https://github.com/owncloud/core/issues/11599

Please review @jancborchardt @MorrisJobke @icewind1991 @schiesbn 
