### PR TITLE
LDAP: cache total  user count

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -292,7 +292,12 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	public function countUsers() {
 		$filter = \OCP\Util::mb_str_replace(
 			'%uid', '*', $this->access->connection->ldapLoginFilter, 'UTF-8');
+		$cacheKey = 'countUsers-'.$filter;
+		if(!is_null($entries = $this->access->connection->getFromCache($cacheKey))) {
+			return $entries;
+		}
 		$entries = $this->access->countUsers($filter);
+		$this->access->connection->writeToCache($cacheKey, $entries);
 		return $entries;
 	}
 }


### PR DESCRIPTION
to avoid calculating it again and again if Users page is opened more often (in as long as LDAP cache TTL goes).

@craigpg @bboule @MorrisJobke 
