### PR TITLE
Implement a logger to log to error_log

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -441,8 +441,10 @@ $CONFIG = array(
 
 /**
  * By default the ownCloud logs are sent to the ``owncloud.log`` file in the
- * default ownCloud data directory. If syslogging is desired, set this parameter
- * to ``syslog``.
+ * default ownCloud data directory.
+ * If syslogging is desired, set this parameter to ``syslog``.
+ * Setting this parameter to ``errorlog`` will use the PHP error_log function
+ * for logging.
  */
 'log_type' => 'owncloud',
 

--- a/lib/private/log/errorlog.php
+++ b/lib/private/log/errorlog.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *  The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Christian Kampka <christian@kampka.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+class OC_Log_Errorlog {
+
+
+	/**
+	 * Init class data
+	 */
+	public static function init() {
+	}
+
+	/**
+	 * write a message in the log
+	 * @param string $app
+	 * @param string $message
+	 * @param int $level
+	 */
+	public static function write($app, $message, $level) {
+		$minLevel = min(OC_Config::getValue("loglevel", OC_Log::WARN), OC_Log::ERROR);
+		if ($level >= $minLevel) {
+			error_log('[owncloud]['.$app.'] '.$message);
+		}
+	}
+}
+


### PR DESCRIPTION
This patch creates a logger that uses PHPs error_log to handle logging.
The reason for this is that it is easier for me to handle logs if I can just stream them from php-fpm stdout instead of having to handle a rotating logfile or having a syslogd running in the background.
This way, it offers a simple mechanism to anyone who'd want to handle logs themselves.
