### PR TITLE
Check for XMLWriter class

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -562,6 +562,7 @@ class OC_Util {
 			'classes' => array(
 				'ZipArchive' => 'zip',
 				'DOMDocument' => 'dom',
+				'XMLWriter' => 'XMLWriter'
 			),
 			'functions' => array(
 				'xml_parser_create' => 'libxml',


### PR DESCRIPTION
This is not installed by default in all cases and will break the OCS features of ownCloud. Lot's of reports such as https://github.com/owncloud/ios-issues/issues/167#issuecomment-63798507

@rperezb FYI
