### PR TITLE
Fix deleting non deletable files by selecting them

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -27,7 +27,9 @@ $success = true;
 //Now delete
 foreach ($files as $file) {
 	if (\OC\Files\Filesystem::file_exists($dir . '/' . $file) &&
-			!\OC\Files\Filesystem::unlink($dir . '/' . $file)) {
+		!(\OC\Files\Filesystem::isDeletable($dir . '/' . $file) &&
+			\OC\Files\Filesystem::unlink($dir . '/' . $file))
+	) {
 		$filesWithError .= $file . "\n";
 		$success = false;
 	}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -526,7 +526,8 @@
 				mimetype: $el.attr('data-mime'),
 				type: $el.attr('data-type'),
 				size: parseInt($el.attr('data-size'), 10),
-				etag: $el.attr('data-etag')
+				etag: $el.attr('data-etag'),
+				permissions: parseInt($el.attr('data-permissions'), 10)
 			};
 		},
 
@@ -1636,7 +1637,7 @@
 				this.$el.find('.selectedActions').addClass('hidden');
 			}
 			else {
-				canDelete = (this.getDirectoryPermissions() & OC.PERMISSION_DELETE);
+				canDelete = (this.getDirectoryPermissions() & OC.PERMISSION_DELETE) && this.isSelectedDeletable();
 				this.$el.find('.selectedActions').removeClass('hidden');
 				this.$el.find('#headerSize a>span:first').text(OC.Util.humanFileSize(summary.totalSize));
 				var selection = '';
@@ -1654,6 +1655,15 @@
 				this.$el.find('table').addClass('multiselect');
 				this.$el.find('.delete-selected').toggleClass('hidden', !canDelete);
 			}
+		},
+
+		/**
+		 * Check whether all selected files are deletable
+		 */
+		isSelectedDeletable: function() {
+			return _.reduce(this.getSelectedFiles(), function(deletable, file) {
+				return deletable && (file.permissions & OC.PERMISSION_DELETE);
+			}, true);
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -97,7 +97,8 @@ describe('OCA.Files.FileList tests', function() {
 			name: 'One.txt',
 			mimetype: 'text/plain',
 			size: 12,
-			etag: 'abc'
+			etag: 'abc',
+			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 2,
 			type: 'file',
@@ -105,6 +106,7 @@ describe('OCA.Files.FileList tests', function() {
 			mimetype: 'image/jpeg',
 			size: 12049,
 			etag: 'def',
+			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 3,
 			type: 'file',
@@ -112,13 +114,15 @@ describe('OCA.Files.FileList tests', function() {
 			mimetype: 'application/pdf',
 			size: 58009,
 			etag: '123',
+			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 4,
 			type: 'dir',
 			name: 'somedir',
 			mimetype: 'httpd/unix-directory',
 			size: 250,
-			etag: '456'
+			etag: '456',
+			permissions: OC.PERMISSION_ALL
 		}];
 		pageSizeStub = sinon.stub(OCA.Files.FileList.prototype, 'pageSize').returns(20);
 		fileList = new OCA.Files.FileList($('#app-content-files'));
@@ -1479,6 +1483,17 @@ describe('OCA.Files.FileList tests', function() {
 				$('.select-all').click();
 				expect(fileList.$el.find('.delete-selected').hasClass('hidden')).toEqual(true);
 			});
+			it('show doesnt show the delete action if one or more files are not deletable', function () {
+				fileList.setFiles(testFiles);
+				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_DELETE);
+				$('.select-all').click();
+				expect(fileList.$el.find('.delete-selected').hasClass('hidden')).toEqual(false);
+				testFiles[0].permissions = OC.PERMISSION_READ;
+				$('.select-all').click();
+				fileList.setFiles(testFiles);
+				$('.select-all').click();
+				expect(fileList.$el.find('.delete-selected').hasClass('hidden')).toEqual(true);
+			});
 		});
 		describe('Actions', function() {
 			beforeEach(function() {
@@ -1495,7 +1510,8 @@ describe('OCA.Files.FileList tests', function() {
 					mimetype: 'text/plain',
 					type: 'file',
 					size: 12,
-					etag: 'abc'
+					etag: 'abc',
+					permissions: OC.PERMISSION_ALL
 				});
 				expect(files[1]).toEqual({
 					id: 3,
@@ -1503,7 +1519,8 @@ describe('OCA.Files.FileList tests', function() {
 					name: 'Three.pdf',
 					mimetype: 'application/pdf',
 					size: 58009,
-					etag: '123'
+					etag: '123',
+					permissions: OC.PERMISSION_ALL
 				});
 				expect(files[2]).toEqual({
 					id: 4,
@@ -1511,7 +1528,8 @@ describe('OCA.Files.FileList tests', function() {
 					name: 'somedir',
 					mimetype: 'httpd/unix-directory',
 					size: 250,
-					etag: '456'
+					etag: '456',
+					permissions: OC.PERMISSION_ALL
 				});
 			});
 			it('Removing a file removes it from the selection', function() {
@@ -1524,7 +1542,8 @@ describe('OCA.Files.FileList tests', function() {
 					mimetype: 'text/plain',
 					type: 'file',
 					size: 12,
-					etag: 'abc'
+					etag: 'abc',
+					permissions: OC.PERMISSION_ALL
 				});
 				expect(files[1]).toEqual({
 					id: 4,
@@ -1532,7 +1551,8 @@ describe('OCA.Files.FileList tests', function() {
 					name: 'somedir',
 					mimetype: 'httpd/unix-directory',
 					size: 250,
-					etag: '456'
+					etag: '456',
+					permissions: OC.PERMISSION_ALL
 				});
 			});
 			describe('Download', function() {


### PR DESCRIPTION
- Check permissions before trying to delete a file, prevents hooks being triggered/cache being updated for failed deletes
- Check if all selected files are deletable before showing the delete button for selected files

Fixes #12161

cc @PVince81 @DeepDiver1975 
