### PR TITLE
migrated OC_Preferences::deleteAppFromAllUsers to deleteApp in \OCP\ICon...

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -567,7 +567,7 @@ class Hooks {
 	public static function preDisable($params) {
 		if ($params['app'] === 'files_encryption') {
 
-			\OC_Preferences::deleteAppFromAllUsers('files_encryption');
+			\OC::$server->getConfig()->deleteAppValues('files_encryption');
 
 			$session = new \OCA\Encryption\Session(new \OC\Files\View('/'));
 			$session->setInitialized(\OCA\Encryption\Session::NOT_INITIALIZED);

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -86,6 +86,15 @@ class AllConfig implements \OCP\IConfig {
 		\OC_Appconfig::deleteKey($appName, $key);
 	}
 
+	/**
+	 * Removes all keys in appconfig belonging to the app
+	 *
+	 * @param string $appName the appName the configs are stored under
+	 */
+	public function deleteAppValues($appName) {
+		\OC_Appconfig::deleteApp($appName);
+	}
+
 
 	/**
 	 * Set a user defined value

--- a/lib/private/legacy/preferences.php
+++ b/lib/private/legacy/preferences.php
@@ -132,16 +132,4 @@ class OC_Preferences{
 		self::$object->deleteUser( $user );
 		return true;
 	}
-
-	/**
-	 * Remove app from all users
-	 * @param string $app app
-	 * @return bool
-	 *
-	 * Removes all keys in preferences belonging to the app.
-	 */
-	public static function deleteAppFromAllUsers( $app ) {
-		self::$object->deleteAppFromAllUsers( $app );
-		return true;
-	}
 }

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -343,23 +343,6 @@ class Preferences {
 
 		unset($this->cache[$user]);
 	}
-
-	/**
-	 * Remove app from all users
-	 * @param string $app app
-	 *
-	 * Removes all keys in preferences belonging to the app.
-	 */
-	public function deleteAppFromAllUsers($app) {
-		$where = array(
-			'appid' => $app,
-		);
-		$this->conn->delete('*PREFIX*preferences', $where);
-
-		foreach ($this->cache as &$userCache) {
-			unset($userCache[$app]);
-		}
-	}
 }
 
 require_once __DIR__ . '/legacy/' . basename(__FILE__);

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -85,6 +85,7 @@ interface IAppConfig {
 	 * Remove app from appconfig
 	 * @param string $app app
 	 * @return bool
+	 * @deprecated use method deleteAppValue of \OCP\IConfig
 	 *
 	 * Removes all keys in appconfig belonging to the app.
 	 */

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -94,6 +94,13 @@ interface IConfig {
 	 */
 	public function deleteAppValue($appName, $key);
 
+	/**
+	 * Removes all keys in appconfig belonging to the app
+	 *
+	 * @param string $appName the appName the configs are stored under
+	 */
+	public function deleteAppValues($appName);
+
 
 	/**
 	 * Set a user defined value

--- a/tests/lib/preferences-singleton.php
+++ b/tests/lib/preferences-singleton.php
@@ -28,7 +28,6 @@ class Test_Preferences extends \Test\TestCase {
 
 		$query->execute(array("Deleteuser", "deleteapp", "deletekey", "somevalue"));
 		$query->execute(array("Deleteuser", "deleteapp", "somekey", "somevalue"));
-		$query->execute(array("Deleteuser", "someapp", "somekey", "somevalue"));
 	}
 
 	public static function tearDownAfterClass() {
@@ -164,13 +163,6 @@ class Test_Preferences extends \Test\TestCase {
 		$this->assertTrue(\OC_Preferences::deleteUser('Deleteuser'));
 		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?');
 		$result = $query->execute(array('Deleteuser'));
-		$this->assertEquals(0, count($result->fetchAll()));
-	}
-
-	public function testDeleteAppFromAllUsers() {
-		$this->assertTrue(\OC_Preferences::deleteAppFromAllUsers('someapp'));
-		$query = \OC_DB::prepare('SELECT `configvalue` FROM `*PREFIX*preferences` WHERE `appid` = ?');
-		$result = $query->execute(array('someapp'));
 		$this->assertEquals(0, count($result->fetchAll()));
 	}
 }

--- a/tests/lib/preferences.php
+++ b/tests/lib/preferences.php
@@ -222,20 +222,4 @@ class Test_Preferences_Object extends \Test\TestCase {
 		$preferences = new OC\Preferences($connectionMock);
 		$preferences->deleteUser('grg');
 	}
-
-	public function testDeleteAppFromAllUsers()
-	{
-		$connectionMock = $this->getMock('\OC\DB\Connection', array(), array(), '', false);
-		$connectionMock->expects($this->once())
-			->method('delete')
-			->with($this->equalTo('*PREFIX*preferences'),
-				$this->equalTo(
-					array(
-						'appid' => 'bar',
-					)
-				));
-
-		$preferences = new OC\Preferences($connectionMock);
-		$preferences->deleteAppFromAllUsers('bar');
-	}
 }


### PR DESCRIPTION
...fig

cc @LukasReschke @DeepDiver1975 @PVince81 @nickvergessen 

Or should we keep the old methods and call the methods from the new config object?
