### PR TITLE
drop OC_Preferences::getUsers and getApps

### DIFF
--- a/lib/private/legacy/preferences.php
+++ b/lib/private/legacy/preferences.php
@@ -28,28 +28,6 @@ OC_Preferences::$object = new \OC\Preferences(OC_DB::getConnection());
  */
 class OC_Preferences{
 	public static $object;
-	/**
-	 * Get all users using the preferences
-	 * @return array an array of user ids
-	 *
-	 * This function returns a list of all users that have at least one entry
-	 * in the preferences table.
-	 */
-	public static function getUsers() {
-		return self::$object->getUsers();
-	}
-
-	/**
-	 * Get all apps of a user
-	 * @param string $user user
-	 * @return integer[] with app ids
-	 *
-	 * This function returns a list of all apps of the user that have at least
-	 * one entry in the preferences table.
-	 */
-	public static function getApps( $user ) {
-		return self::$object->getApps( $user );
-	}
 
 	/**
 	 * Get the available keys for an app

--- a/lib/private/preferences.php
+++ b/lib/private/preferences.php
@@ -68,25 +68,6 @@ class Preferences {
 	}
 
 	/**
-	 * Get all users using the preferences
-	 * @return array an array of user ids
-	 *
-	 * This function returns a list of all users that have at least one entry
-	 * in the preferences table.
-	 */
-	public function getUsers() {
-		$query = 'SELECT DISTINCT `userid` FROM `*PREFIX*preferences`';
-		$result = $this->conn->executeQuery($query);
-
-		$users = array();
-		while ($userid = $result->fetchColumn()) {
-			$users[] = $userid;
-		}
-
-		return $users;
-	}
-
-	/**
 	 * @param string $user
 	 * @return array[]
 	 */
@@ -106,19 +87,6 @@ class Preferences {
 		}
 		$this->cache[$user] = $data;
 		return $data;
-	}
-
-	/**
-	 * Get all apps of an user
-	 * @param string $user user
-	 * @return integer[] with app ids
-	 *
-	 * This function returns a list of all apps of the user that have at least
-	 * one entry in the preferences table.
-	 */
-	public function getApps($user) {
-		$data = $this->getUserValues($user);
-		return array_keys($data);
 	}
 
 	/**

--- a/tests/lib/preferences-singleton.php
+++ b/tests/lib/preferences-singleton.php
@@ -40,34 +40,6 @@ class Test_Preferences extends \Test\TestCase {
 		parent::tearDownAfterClass();
 	}
 
-	public function testGetUsers() {
-		$query = \OC_DB::prepare('SELECT DISTINCT `userid` FROM `*PREFIX*preferences`');
-		$result = $query->execute();
-		$expected = array();
-		while ($row = $result->fetchRow()) {
-			$expected[] = $row['userid'];
-		}
-
-		sort($expected);
-		$users = \OC_Preferences::getUsers();
-		sort($users);
-		$this->assertEquals($expected, $users);
-	}
-
-	public function testGetApps() {
-		$query = \OC_DB::prepare('SELECT DISTINCT `appid` FROM `*PREFIX*preferences` WHERE `userid` = ?');
-		$result = $query->execute(array('Someuser'));
-		$expected = array();
-		while ($row = $result->fetchRow()) {
-			$expected[] = $row['appid'];
-		}
-
-		sort($expected);
-		$apps = \OC_Preferences::getApps('Someuser');
-		sort($apps);
-		$this->assertEquals($expected, $apps);
-	}
-
 	public function testGetKeys() {
 		$query = \OC_DB::prepare('SELECT DISTINCT `configkey` FROM `*PREFIX*preferences` WHERE `userid` = ? AND `appid` = ?');
 		$result = $query->execute(array('Someuser', 'getkeysapp'));


### PR DESCRIPTION
Extracted from #12268 

cc @LukasReschke @DeepDiver1975 @PVince81 @nickvergessen

Or should we keep the old methods and call the methods from the new config object?
