### PR TITLE
Use `/` as redirect location if webroot is set to an empty value

### DIFF
--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -112,7 +112,11 @@ OC.Lostpassword = {
 	},
 
 	redirect : function(msg){
-		window.location = OC.webroot;
+		if(OC.webroot !== '') {
+			window.location = OC.webroot;
+		} else {
+			window.location = '/';
+		}
 	},
 
 	resetError : function(msg){


### PR DESCRIPTION
If the webroot has been set to an empty value or ownCloud has been installed at the root location (`/``) there is a fair chance that the redirect for password resets does not work at all.

This means that while the password is getting resetted the user is not redirected to the login/index page.

I'm aware that it might be better to just set the webroot to `/` in those cases but this patch is better in the regard that it cannot break stuff.

Thanks to @PVince81 for helping me debugging this. (I'm a moron and assumed it couldn't be THAT easy)

Reported by @cdamken

@karlitschek No-brainer in my opinion that we should backport. Blue one.
