### PR TITLE
Add a DateTimeFormatter class which allows overwriting the language and ...

### DIFF
--- a/lib/private/datetimeformatter.php
+++ b/lib/private/datetimeformatter.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling
+ * @copyright 2014 Joas Schilling nickvergessen@owncloud.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC;
+
+class DateTimeFormatter implements \OCP\iDateTimeFormatter {
+	/** @var \DateTimeZone */
+	protected $defaultTimeZone;
+
+	/** @var \OC_L10N */
+	protected $defaultL10N;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \DateTimeZone $defaultTimeZone Set the timezone for the format
+	 * @param \OC_L10N $defaultL10N Set the language for the format
+	 */
+	public function __construct(\DateTimeZone $defaultTimeZone, \OC_L10N $defaultL10N) {
+		$this->defaultTimeZone = $defaultTimeZone;
+		$this->defaultL10N = $defaultL10N;
+	}
+
+	/**
+	 * Get TimeZone to use
+	 *
+	 * @param \DateTimeZone $timeZone	The timezone to use
+	 * @return \DateTimeZone		The timezone to use, falling back to the current user's timezone
+	 */
+	protected function getTimeZone($timeZone = null) {
+		if ($timeZone === null) {
+			$timeZone = $this->defaultTimeZone;
+		}
+
+		return $timeZone;
+	}
+
+	/**
+	 * Get OC_L10N to use
+	 *
+	 * @param \OC_L10N $l	The locale to use
+	 * @return \OC_L10N		The locale to use, falling back to the current user's locale
+	 */
+	protected function getLocale($l = null) {
+		if ($l === null) {
+			$l = $this->defaultL10N;
+		}
+
+		return $l;
+	}
+
+	/**
+	 * Generates a DateTime object with the given timestamp and TimeZone
+	 *
+	 * @param mixed $timestamp
+	 * @param \DateTimeZone $timeZone	The timezone to use
+	 * @return \DateTime
+	 */
+	protected function getDateTime($timestamp, \DateTimeZone $timeZone = null) {
+		if ($timestamp === null) {
+			return new \DateTime('now', $timeZone);
+		} else if (!$timestamp instanceof \DateTime) {
+			$dateTime = new \DateTime('now', $timeZone);
+			$dateTime->setTimestamp($timestamp);
+			return $dateTime;
+		}
+		if ($timeZone) {
+			$timestamp->setTimezone($timeZone);
+		}
+		return $timestamp;
+	}
+
+	/**
+	 * Formats the date of the given timestamp
+	 *
+	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
+	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
+	 * 				medium:	e.g. 'MMM d, y'			=> 'Aug 20, 2014'
+	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
+	 * 				The exact format is dependent on the language
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted date string
+	 */
+	public function formatDate($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		return $this->format($timestamp, 'date', $format, $timeZone, $l);
+	}
+
+	/**
+	 * Formats the date of the given timestamp
+	 *
+	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
+	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
+	 * 				medium:	e.g. 'MMM d, y'			=> 'Aug 20, 2014'
+	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
+	 * 				The exact format is dependent on the language
+	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted relative date string
+	 */
+	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		if (substr($format, -1) !== '*' && substr($format, -1) !== '*') {
+			$format .= '^';
+		}
+
+		return $this->format($timestamp, 'date', $format, $timeZone, $l);
+	}
+
+	/**
+	 * Gives the relative date of the timestamp
+	 * Only works for past dates
+	 *
+	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @return string	Dates returned are:
+	 * 				<  1 month	=> Today, Yesterday, n days ago
+	 * 				< 13 month	=> last month, n months ago
+	 * 				>= 13 month	=> last year, n years ago
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return \OC_L10N_String Formatted date span
+	 */
+	public function formatDateSpan($timestamp, $baseTimestamp = null, \OC_L10N $l = null) {
+		$l = $this->getLocale($l);
+		$timestamp = $this->getDateTime($timestamp);
+		$timestamp->setTime(0, 0, 0);
+		if ($baseTimestamp === null) {
+			$baseTimestamp = time();
+		}
+		$baseTimestamp = $this->getDateTime($baseTimestamp);
+		$baseTimestamp->setTime(0, 0, 0);
+		$dateInterval = $timestamp->diff($baseTimestamp);
+
+		if ($dateInterval->y == 0 && $dateInterval->m == 0 && $dateInterval->d == 0) {
+			return $l->t('today');
+		} else if ($dateInterval->y == 0 && $dateInterval->m == 0 && $dateInterval->d == 1) {
+			return $l->t('yesterday');
+		} else if ($dateInterval->y == 0 && $dateInterval->m == 0) {
+			return $l->n('%n day ago', '%n days ago', $dateInterval->d);
+		} else if ($dateInterval->y == 0 && $dateInterval->m == 1) {
+			return $l->t('last month');
+		} else if ($dateInterval->y == 0) {
+			return $l->n('%n month ago', '%n months ago', $dateInterval->m);
+		} else if ($dateInterval->y == 1) {
+			return $l->t('last year');
+		}
+		return $l->n('%n year go', '%n years ago', $dateInterval->y);
+	}
+
+	/**
+	 * Formats the time of the given timestamp
+	 *
+	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'h:mm:ss a zzzz'	=> '11:42:13 AM GMT+0:00'
+	 * 				long:	e.g. 'h:mm:ss a z'		=> '11:42:13 AM GMT'
+	 * 				medium:	e.g. 'h:mm:ss a'		=> '11:42:13 AM'
+	 * 				short:	e.g. 'h:mm a'			=> '11:42 AM'
+	 * 				The exact format is dependent on the language
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted time string
+	 */
+	public function formatTime($timestamp, $format = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		return $this->format($timestamp, 'time', $format, $timeZone, $l);
+	}
+
+	/**
+	 * Gives the relative past time of the timestamp
+	 *
+	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @return string	Dates returned are:
+	 * 				< 60 sec	=> seconds ago
+	 * 				<  1 hour	=> n minutes ago
+	 * 				<  1 day	=> n hours ago
+	 * 				<  1 month	=> Yesterday, n days ago
+	 * 				< 13 month	=> last month, n months ago
+	 * 				>= 13 month	=> last year, n years ago
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return \OC_L10N_String Formatted time span
+	 */
+	public function formatTimeSpan($timestamp, $baseTimestamp = null, \OC_L10N $l = null) {
+		$l = $this->getLocale($l);
+		$timestamp = $this->getDateTime($timestamp);
+		if ($baseTimestamp === null) {
+			$baseTimestamp = time();
+		}
+		$baseTimestamp = $this->getDateTime($baseTimestamp);
+
+		$diff = $timestamp->diff($baseTimestamp);
+		if ($diff->y > 0 || $diff->m > 0 || $diff->d > 0) {
+			return $this->formatDateSpan($timestamp, $baseTimestamp);
+		}
+
+		if ($diff->h > 0) {
+			return $l->n('%n hour ago', '%n hours ago', $diff->h);
+		} else if ($diff->i > 0) {
+			return $l->n('%n minute ago', '%n minutes ago', $diff->i);
+		}
+		return $l->t('seconds ago');
+	}
+
+	/**
+	 * Formats the date and time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp	Either a Unix timestamp or DateTime object
+	 * @param string	$formatDate		See formatDate() for description
+	 * @param string	$formatTime		See formatTime() for description
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted date and time string
+	 */
+	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		return $this->format($timestamp, 'datetime', $formatDate . '|' . $formatTime, $timeZone, $l);
+	}
+
+	/**
+	 * Formats the date and time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp	Either a Unix timestamp or DateTime object
+	 * @param string	$formatDate		See formatDate() for description
+	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
+	 * @param string	$formatTime		See formatTime() for description
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted relative date and time string
+	 */
+	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		if (substr($formatDate, -1) !== '^' && substr($formatDate, -1) !== '*') {
+			$formatDate .= '^';
+		}
+
+		return $this->format($timestamp, 'datetime', $formatDate . '|' . $formatTime, $timeZone, $l);
+	}
+
+	/**
+	 * Formats the date and time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp	Either a Unix timestamp or DateTime object
+	 * @param string		$type		One of 'date', 'datetime' or 'time'
+	 * @param string		$format		Format string
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted date and time string
+	 */
+	protected function format($timestamp, $type, $format, \DateTimeZone $timeZone = null, \OC_L10N $l = null) {
+		$l = $this->getLocale($l);
+		$timeZone = $this->getTimeZone($timeZone);
+		$timestamp = $this->getDateTime($timestamp, $timeZone);
+
+		return $l->l($type, $timestamp, array(
+			'width' => $format,
+		));
+	}
+}

--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -311,7 +311,13 @@ class OC_L10N implements \OCP\IL10N {
 		} else {
 			$value->setTimestamp($data);
 		}
-		$locale = self::findLanguage();
+
+		// Use the language of the instance, before falling back to the current user's language
+		$locale = $this->lang;
+		if ($locale === null) {
+			$locale = self::findLanguage();
+		}
+
 		$options = array_merge(array('width' => 'long'), $options);
 		$width = $options['width'];
 		switch($type) {

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -206,35 +206,17 @@ function strip_time($timestamp){
  * @param int $fromTime timestamp to compare from, defaults to current time
  * @param bool $dateOnly whether to strip time information
  * @return OC_L10N_String timestamp
+ *
+ * @deprecated Use \OC::$server->query('DateTimeFormatter') instead
  */
 function relative_modified_date($timestamp, $fromTime = null, $dateOnly = false) {
-	$l = \OC::$server->getL10N('lib');
-	if (!isset($fromTime) || $fromTime === null){
-		$fromTime = time();
-	}
-	if ($dateOnly){
-		$fromTime = strip_time($fromTime);
-		$timestamp = strip_time($timestamp);
-	}
-	$timediff = $fromTime - $timestamp;
-	$diffminutes = round($timediff/60);
-	$diffhours = round($diffminutes/60);
-	$diffdays = round($diffhours/24);
-	$diffmonths = round($diffdays/31);
+	/** @var \OC\DateTimeFormatter $formatter */
+	$formatter = \OC::$server->query('DateTimeFormatter');
 
-	if(!$dateOnly && $timediff < 60) { return $l->t('seconds ago'); }
-	else if(!$dateOnly && $timediff < 3600) { return $l->n('%n minute ago', '%n minutes ago', $diffminutes); }
-	else if(!$dateOnly && $timediff < 86400) { return $l->n('%n hour ago', '%n hours ago', $diffhours); }
-	else if((date('G', $fromTime)-$diffhours) >= 0) { return $l->t('today'); }
-	else if((date('G', $fromTime)-$diffhours) >= -24) { return $l->t('yesterday'); }
-	// 86400 * 31 days = 2678400
-	else if($timediff < 2678400) { return $l->n('%n day go', '%n days ago', $diffdays); }
-	// 86400 * 60 days = 518400
-	else if($timediff < 5184000) { return $l->t('last month'); }
-	else if((date('n', $fromTime)-$diffmonths) > 0) { return $l->n('%n month ago', '%n months ago', $diffmonths); }
-	// 86400 * 365.25 days * 2 = 63113852
-	else if($timediff < 63113852) { return $l->t('last year'); }
-	else { return $l->t('years ago'); }
+	if ($dateOnly){
+		return $formatter->formatDateSpan($timestamp, $fromTime);
+	}
+	return $formatter->formatTimeSpan($timestamp, $fromTime);
 }
 
 function html_select_options($options, $selected, $params=array()) {

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -435,27 +435,20 @@ class OC_Util {
 	 * @param bool $dateOnly option to omit time from the result
 	 * @param DateTimeZone|string $timeZone where the given timestamp shall be converted to
 	 * @return string timestamp
-	 * @description adjust to clients timezone if we know it
+	 *
+	 * @deprecated Use \OC::$server->query('DateTimeFormatter') instead
 	 */
 	public static function formatDate($timestamp, $dateOnly = false, $timeZone = null) {
-		if (is_null($timeZone)) {
-			if (\OC::$server->getSession()->exists('timezone')) {
-				$systemTimeZone = intval(date('O'));
-				$systemTimeZone = (round($systemTimeZone / 100, 0) * 60) + ($systemTimeZone % 100);
-				$clientTimeZone = \OC::$server->getSession()->get('timezone') * 60;
-				$offset = $clientTimeZone - $systemTimeZone;
-				$timestamp = $timestamp + $offset * 60;
-			}
-		} else {
-			if (!$timeZone instanceof DateTimeZone) {
-				$timeZone = new DateTimeZone($timeZone);
-			}
-			$dt = new DateTime("@$timestamp");
-			$offset = $timeZone->getOffset($dt);
-			$timestamp += $offset;
+		if ($timeZone !== null && !$timeZone instanceof \DateTimeZone) {
+			$timeZone = new \DateTimeZone($timeZone);
 		}
-		$l = \OC::$server->getL10N('lib');
-		return $l->l($dateOnly ? 'date' : 'datetime', $timestamp);
+
+		/** @var \OC\DateTimeFormatter $formatter */
+		$formatter = \OC::$server->query('DateTimeFormatter');
+		if ($dateOnly) {
+			return $formatter->formatDate($timestamp, 'long', $timeZone);
+		}
+		return $formatter->formatDateTime($timestamp, 'long', 'long', $timeZone);
 	}
 
 	/**

--- a/lib/public/idatetimeformatter.php
+++ b/lib/public/idatetimeformatter.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling
+ * @copyright 2014 Joas Schilling nickvergessen@owncloud.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP;
+
+interface iDateTimeFormatter {
+	/**
+	 * Formats the date of the given timestamp
+	 *
+	 * @param int|\DateTime		$timestamp
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
+	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
+	 * 				medium:	e.g. 'MMM d, y'			=> 'Aug 20, 2014'
+	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
+	 * 				The exact format is dependent on the language
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted date string
+	 */
+	public function formatDate($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OC_L10N $l = null);
+
+	/**
+	 * Formats the date of the given timestamp
+	 *
+	 * @param int|\DateTime		$timestamp
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'EEEE, MMMM d, y'	=> 'Wednesday, August 20, 2014'
+	 * 				long:	e.g. 'MMMM d, y'		=> 'August 20, 2014'
+	 * 				medium:	e.g. 'MMM d, y'			=> 'Aug 20, 2014'
+	 * 				short:	e.g. 'M/d/yy'			=> '8/20/14'
+	 * 				The exact format is dependent on the language
+	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted relative date string
+	 */
+	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OC_L10N $l = null);
+
+	/**
+	 * Gives the relative date of the timestamp
+	 * Only works for past dates
+	 *
+	 * @param int|\DateTime	$timestamp
+	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @return string	Dates returned are:
+	 * 				<  1 month	=> Today, Yesterday, n days ago
+	 * 				< 13 month	=> last month, n months ago
+	 * 				>= 13 month	=> last year, n years ago
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return \OC_L10N_String Formatted date span
+	 */
+	public function formatDateSpan($timestamp, $baseTimestamp = null, \OC_L10N $l = null);
+
+	/**
+	 * Formats the time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp
+	 * @param string	$format			Either 'full', 'long', 'medium' or 'short'
+	 * 				full:	e.g. 'h:mm:ss a zzzz'	=> '11:42:13 AM GMT+0:00'
+	 * 				long:	e.g. 'h:mm:ss a z'		=> '11:42:13 AM GMT'
+	 * 				medium:	e.g. 'h:mm:ss a'		=> '11:42:13 AM'
+	 * 				short:	e.g. 'h:mm a'			=> '11:42 AM'
+	 * 				The exact format is dependent on the language
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted time string
+	 */
+	public function formatTime($timestamp, $format = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null);
+
+	/**
+	 * Gives the relative past time of the timestamp
+	 *
+	 * @param int|\DateTime	$timestamp
+	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
+	 * @return string	Dates returned are:
+	 * 				< 60 sec	=> seconds ago
+	 * 				<  1 hour	=> n minutes ago
+	 * 				<  1 day	=> n hours ago
+	 * 				<  1 month	=> Yesterday, n days ago
+	 * 				< 13 month	=> last month, n months ago
+	 * 				>= 13 month	=> last year, n years ago
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return \OC_L10N_String Formatted time span
+	 */
+	public function formatTimeSpan($timestamp, $baseTimestamp = null, \OC_L10N $l = null);
+
+	/**
+	 * Formats the date and time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp
+	 * @param string	$formatDate		See formatDate() for description
+	 * @param string	$formatTime		See formatTime() for description
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted date and time string
+	 */
+	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null);
+
+	/**
+	 * Formats the date and time of the given timestamp
+	 *
+	 * @param int|\DateTime $timestamp
+	 * @param string	$formatDate		See formatDate() for description
+	 * 					Uses 'Today', 'Yesterday' and 'Tomorrow' when applicable
+	 * @param string	$formatTime		See formatTime() for description
+	 * @param \DateTimeZone	$timeZone	The timezone to use
+	 * @param \OC_L10N		$l			The locale to use
+	 * @return string Formatted relative date and time string
+	 */
+	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OC_L10N $l = null);
+}

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -89,6 +89,8 @@ function human_file_size( $bytes ) {
  * @param int $timestamp unix timestamp
  * @param boolean $dateOnly
  * @return \OC_L10N_String human readable interpretation of the timestamp
+ *
+ * @deprecated Use \OC::$server->query('DateTimeFormatter') instead
  */
 function relative_modified_date( $timestamp, $dateOnly = false ) {
 	return(\relative_modified_date($timestamp, null, $dateOnly));

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -163,6 +163,8 @@ class Util {
 	 * @param bool $dateOnly option to omit time from the result
 	 * @param DateTimeZone|string $timeZone where the given timestamp shall be converted to
 	 * @return string timestamp
+	 *
+	 * @deprecated Use \OC::$server->query('DateTimeFormatter') instead
 	 */
 	public static function formatDate($timestamp, $dateOnly=false, $timeZone = null) {
 		return(\OC_Util::formatDate($timestamp, $dateOnly, $timeZone));

--- a/tests/lib/datetimeformatter.php
+++ b/tests/lib/datetimeformatter.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright (c) 2014 Joas Schilling nickvergessen@owncloud.com
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test;
+
+class DateTimeFormatter extends TestCase {
+	/** @var \OC\DateTimeFormatter */
+	protected $formatter;
+	static protected $oneMinute = 60;
+	static protected $oneHour = 3600;
+	static protected $oneDay;
+	static protected $oneYear;
+
+	static protected $defaultTimeZone;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$defaultTimeZone = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		self::$oneDay = self::$oneHour * 24;
+		self::$oneYear = self::$oneDay * 365;
+	}
+
+	public static function tearDownAfterClass() {
+		date_default_timezone_set(self::$defaultTimeZone);
+		parent::tearDownAfterClass();
+	}
+
+	protected function setUp() {
+		parent::setUp();
+		$this->formatter = new \OC\DateTimeFormatter(new \DateTimeZone('UTC'), new \OC_L10N('lib', 'en'));
+	}
+
+	protected function getTimestampAgo($seconds = 0, $minutes = 0, $hours = 0, $days = 0, $years = 0) {
+		return time() - $seconds - $minutes * 60 - $hours * 3600 - $days * 24*3600 - $years * 365*24*3600;
+	}
+
+	public function formatTimeSpanData() {
+		$deL10N = new \OC_L10N('lib', 'de');
+		return array(
+			array('seconds ago',	$this->getTimestampAgo()),
+			array('1 minute ago',	$this->getTimestampAgo(30, 1)),
+			array('15 minutes ago',	$this->getTimestampAgo(30, 15)),
+			array('1 hour ago',		$this->getTimestampAgo(30, 15, 1)),
+			array('3 hours ago',	$this->getTimestampAgo(30, 15, 3)),
+			array('4 days ago',		$this->getTimestampAgo(30, 15, 3, 4)),
+
+			array($deL10N->t('seconds ago'),		$this->getTimestampAgo(), null, $deL10N),
+			array($deL10N->n('%n minute ago', '%n minutes ago', 1),	$this->getTimestampAgo(30, 1), null, $deL10N),
+			array($deL10N->n('%n minute ago', '%n minutes ago', 15),	$this->getTimestampAgo(30, 15), null, $deL10N),
+			array($deL10N->n('%n hour ago', '%n hours ago', 1),	$this->getTimestampAgo(30, 15, 1), null, $deL10N),
+			array($deL10N->n('%n hour ago', '%n hours ago', 3),	$this->getTimestampAgo(30, 15, 3), null, $deL10N),
+			array($deL10N->n('%n day ago', '%n days ago', 4),	$this->getTimestampAgo(30, 15, 3, 4), null, $deL10N),
+
+			array('seconds ago', new \DateTime('Wed, 02 Oct 2013 23:59:58 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('seconds ago', new \DateTime('Wed, 02 Oct 2013 23:59:00 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('1 minute ago', new \DateTime('Wed, 02 Oct 2013 23:58:30 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('3 minutes ago', new \DateTime('Wed, 02 Oct 2013 23:56:30 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('59 minutes ago', new \DateTime('Wed, 02 Oct 2013 23:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('1 hour ago', new \DateTime('Wed, 02 Oct 2013 22:59:59 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('3 hours ago', new \DateTime('Wed, 02 Oct 2013 20:39:59 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('yesterday', new \DateTime('Tue, 01 Oct 2013 20:39:59 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('2 days ago', new \DateTime('Mon, 30 Sep 2013 20:39:59 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+		);
+	}
+
+	/**
+	 * @dataProvider formatTimeSpanData
+	 */
+	public function testFormatTimeSpan($expected, $timestamp, $compare = null, $locale = null) {
+		$this->assertEquals($expected, (string) $this->formatter->formatTimeSpan($timestamp, $compare, $locale));
+	}
+
+	public function formatDateSpanData() {
+		$deL10N = new \OC_L10N('lib', 'de');
+		return array(
+			// Normal testing
+			array('today',			$this->getTimestampAgo(30, 15)),
+			array('yesterday',		$this->getTimestampAgo(0, 0, 0, 1)),
+			array('4 days ago',		$this->getTimestampAgo(0, 0, 0, 4)),
+			array('5 months ago',	$this->getTimestampAgo(0, 0, 0, 155)),
+			array('2 years ago',	$this->getTimestampAgo(0, 0, 0, 0, 2)),
+
+			// Test with compare timestamp
+			array('today',			$this->getTimestampAgo( 0,  0, 0, 0, 1), $this->getTimestampAgo(0, 0, 0, 0, 1)),
+			array('yesterday',		$this->getTimestampAgo(30, 15, 3, 1, 1), $this->getTimestampAgo(0, 0, 0, 0, 1)),
+			array('4 days ago',		$this->getTimestampAgo(30, 15, 3, 4, 1), $this->getTimestampAgo(0, 0, 0, 0, 1)),
+			array('5 months ago',	$this->getTimestampAgo(30, 15, 3, 155, 1), $this->getTimestampAgo(0, 0, 0, 0, 1)),
+			array('2 years ago',	$this->getTimestampAgo(30, 15, 3, 35, 3), $this->getTimestampAgo(0, 0, 0, 0, 1)),
+
+			// Test translations
+			array($deL10N->t('today'),			$this->getTimestampAgo(30, 15, 3, 0, 1), $this->getTimestampAgo(0, 0, 0, 0, 1), $deL10N),
+			array($deL10N->t('yesterday'),		$this->getTimestampAgo(30, 15, 3, 1, 1), $this->getTimestampAgo(0, 0, 0, 0, 1), $deL10N),
+			array($deL10N->n('%n day ago', '%n days ago', 4),	$this->getTimestampAgo(30, 15, 3, 4, 1), $this->getTimestampAgo(0, 0, 0, 0, 1), $deL10N),
+			array($deL10N->n('%n month ago', '%n months ago', 5),$this->getTimestampAgo(30, 15, 3, 155, 1), $this->getTimestampAgo(0, 0, 0, 0, 1), $deL10N),
+			array($deL10N->n('%n year ago', '%n years ago', 2),	$this->getTimestampAgo(30, 15, 3, 35, 3), $this->getTimestampAgo(0, 0, 0, 0, 1), $deL10N),
+
+			// Test time
+			array('today', new \DateTime('Wed, 02 Oct 2013 00:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('today', new \DateTime('Wed, 02 Oct 2013 12:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('today', new \DateTime('Wed, 02 Oct 2013 23:59:58 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+
+			// Test some special yesterdays
+			array('yesterday', new \DateTime('Tue, 01 Oct 2013 00:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 00:00:00 +0000')),
+			array('yesterday', new \DateTime('Tue, 01 Oct 2013 00:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('yesterday', new \DateTime('Tue, 01 Oct 2013 23:59:58 +0000'), new \DateTime('Wed, 02 Oct 2013 00:00:00 +0000')),
+			array('yesterday', new \DateTime('Tue, 01 Oct 2013 23:59:58 +0000'), new \DateTime('Wed, 02 Oct 2013 23:59:59 +0000')),
+			array('yesterday', new \DateTime('Mon, 30 Sep 2013 00:00:00 +0000'), new \DateTime('Tue, 01 Oct 2013 00:00:00 +0000')),
+			array('yesterday', new \DateTime('Mon, 31 Dec 2012 00:00:00 +0000'), new \DateTime('Tue, 01 Jan 2013 00:00:00 +0000')),
+
+			// Test last month
+			array('2 days ago', new \DateTime('Mon, 30 Sep 2013 00:00:00 +0000'), new \DateTime('Wed, 02 Oct 2013 00:00:00 +0000')),
+			array('last month', new \DateTime('Mon, 30 Sep 2013 00:00:00 +0000'), new \DateTime('Tue, 31 Oct 2013 00:00:00 +0000')),
+			array('last month', new \DateTime('Sun, 01 Sep 2013 00:00:00 +0000'), new \DateTime('Tue, 01 Oct 2013 00:00:00 +0000')),
+			array('last month', new \DateTime('Sun, 01 Sep 2013 00:00:00 +0000'), new \DateTime('Thu, 31 Oct 2013 00:00:00 +0000')),
+
+			// Test last year
+			array('9 months ago', new \DateTime('Tue, 31 Dec 2013 00:00:00 +0000'), new \DateTime('Thu, 02 Oct 2014 00:00:00 +0000')),
+			array('11 months ago', new \DateTime('Thu, 03 Oct 2013 00:00:00 +0000'), new \DateTime('Thu, 02 Oct 2014 00:00:00 +0000')),
+			array('last year', new \DateTime('Wed, 02 Oct 2013 00:00:00 +0000'), new \DateTime('Thu, 02 Oct 2014 00:00:00 +0000')),
+			array('last year', new \DateTime('Tue, 01 Jan 2013 00:00:00 +0000'), new \DateTime('Thu, 02 Oct 2014 00:00:00 +0000')),
+			array('2 years ago', new \DateTime('Sun, 01 Jan 2012 00:00:00 +0000'), new \DateTime('Thu, 02 Oct 2014 00:00:00 +0000')),
+		);
+	}
+
+	/**
+	 * @dataProvider formatDateSpanData
+	 */
+	public function testFormatDateSpan($expected, $timestamp, $compare = null, $locale = null) {
+		$this->assertEquals((string) $expected, (string) $this->formatter->formatDateSpan($timestamp, $compare, $locale));
+	}
+
+	public function formatDateData() {
+		return array(
+			array(1102831200, 'December 12, 2004'),
+		);
+	}
+
+	/**
+	 * @dataProvider formatDateData
+	 */
+	public function testFormatDate($timestamp, $expected) {
+		$this->assertEquals($expected, (string) $this->formatter->formatDate($timestamp));
+	}
+
+	public function formatDateTimeData() {
+		return array(
+			array(1350129205, null, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+			array(1350129205, new \DateTimeZone('Europe/Berlin'), 'October 13, 2012 at 1:53:25 PM GMT+2'),
+		);
+	}
+
+	/**
+	 * @dataProvider formatDateTimeData
+	 */
+	public function testFormatDateTime($timestamp, $timeZone, $expected) {
+		$this->assertEquals($expected, (string) $this->formatter->formatDateTime($timestamp, 'long', 'long', $timeZone));
+	}
+
+	/**
+	 * @expectedException \Exception
+	 */
+	function testFormatDateWithInvalidTZ() {
+		$this->formatter->formatDate(1350129205, 'long', new \DateTimeZone('Mordor/Barad-dûr'));
+	}
+}

--- a/tests/lib/template.php
+++ b/tests/lib/template.php
@@ -117,15 +117,15 @@ class Test_TemplateFunctions extends \Test\TestCase {
 
 	public function testRelativeDateMonthsAgo(){
 		$currentTime = 1380703592;
-		$elementTime = $currentTime - 86400 * 60;
-		$result = (string)relative_modified_date($elementTime, $currentTime, true);
-
-		$this->assertEquals('2 months ago', $result);
-
 		$elementTime = $currentTime - 86400 * 65;
 		$result = (string)relative_modified_date($elementTime, $currentTime, true);
 
 		$this->assertEquals('2 months ago', $result);
+
+		$elementTime = $currentTime - 86400 * 130;
+		$result = (string)relative_modified_date($elementTime, $currentTime, true);
+
+		$this->assertEquals('4 months ago', $result);
 	}
 
 	public function testRelativeDateLastYear(){
@@ -146,12 +146,12 @@ class Test_TemplateFunctions extends \Test\TestCase {
 		$elementTime = $currentTime - 86400 * 365.25 * 2;
 		$result = (string)relative_modified_date($elementTime, $currentTime, true);
 
-		$this->assertEquals('years ago', $result);
+		$this->assertEquals('2 years ago', $result);
 
 		$elementTime = $currentTime - 86400 * 365.25 * 3;
 		$result = (string)relative_modified_date($elementTime, $currentTime, true);
 
-		$this->assertEquals('years ago', $result);
+		$this->assertEquals('3 years ago', $result);
 	}
 
 	// ---------------------------------------------------------------------------
@@ -211,15 +211,15 @@ class Test_TemplateFunctions extends \Test\TestCase {
 
 	public function testRelativeTimeMonthsAgo(){
 		$currentTime = 1380703592;
-		$elementTime = $currentTime - 86400 * 60;
-		$result = (string)relative_modified_date($elementTime, $currentTime, false);
-
-		$this->assertEquals('2 months ago', $result);
-
 		$elementTime = $currentTime - 86400 * 65;
 		$result = (string)relative_modified_date($elementTime, $currentTime, false);
 
 		$this->assertEquals('2 months ago', $result);
+
+		$elementTime = $currentTime - 86400 * 130;
+		$result = (string)relative_modified_date($elementTime, $currentTime, false);
+
+		$this->assertEquals('4 months ago', $result);
 	}
 
 	public function testRelativeTimeLastYear(){
@@ -240,11 +240,11 @@ class Test_TemplateFunctions extends \Test\TestCase {
 		$elementTime = $currentTime - 86400 * 365.25 * 2;
 		$result = (string)relative_modified_date($elementTime, $currentTime, false);
 
-		$this->assertEquals('years ago', $result);
+		$this->assertEquals('2 years ago', $result);
 
 		$elementTime = $currentTime - 86400 * 365.25 * 3;
 		$result = (string)relative_modified_date($elementTime, $currentTime, false);
 
-		$this->assertEquals('years ago', $result);
+		$this->assertEquals('3 years ago', $result);
 	}
 }

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -41,7 +41,7 @@ class Test_Util extends \Test\TestCase {
 		date_default_timezone_set("UTC");
 
 		$result = OC_Util::formatDate(1350129205, false, 'Europe/Berlin');
-		$expected = 'October 13, 2012 at 1:53:25 PM GMT+0';
+		$expected = 'October 13, 2012 at 1:53:25 PM GMT+2';
 		$this->assertEquals($expected, $result);
 	}
 
@@ -55,10 +55,22 @@ class Test_Util extends \Test\TestCase {
 	function testFormatDateWithTZFromSession() {
 		date_default_timezone_set("UTC");
 
+		$oldDateTimeFormatter = \OC::$server->query('DateTimeFormatter');
 		\OC::$server->getSession()->set('timezone', 3);
+		$newDateTimeFormatter = new \OC\DateTimeFormatter(\OC::$server->getTimeZone(), new \OC_L10N('lib', 'en'));
+		$this->setDateFormatter($newDateTimeFormatter);
+
 		$result = OC_Util::formatDate(1350129205, false);
-		$expected = 'October 13, 2012 at 2:53:25 PM GMT+0';
+		$expected = 'October 13, 2012 at 2:53:25 PM GMT+3';
 		$this->assertEquals($expected, $result);
+
+		$this->setDateFormatter($oldDateTimeFormatter);
+	}
+
+	protected function setDateFormatter($formatter) {
+		\OC::$server->registerService('DateTimeFormatter', function ($c) use ($formatter) {
+			return $formatter;
+		});
 	}
 
 	function testCallRegister() {


### PR DESCRIPTION
Fix #12227

ToDo:
- [x] Write tests
- [x] Bring back "Last year/month"
- [x] OCP
- [x] Add to service container with current user's locale and timezone as default
- [x] Deprecate `Util::formatDate()` and `relative_modified_date()`

@DeepDiver1975 if you have a moment to look at the first implementation scratch
