### PR TITLE
[stable7] fixes undefined appitem - fixes #12396

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -235,7 +235,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 				element.val(t('settings','Uninstall'));
 			} else {
 				OC.Settings.Apps.removeNavigation(appid);
-				appitem.removeClass('active');
+				$('#app-navigation ul li').filterAttr('data-id', appid).remove();
 			}
 		},'json');
 	},


### PR DESCRIPTION
cc @ppaysant @DeepDiver1975 @jancborchardt 

This simply removes the entry in the navigation menu. Nothing big and persistent just UX (better than an error). Another solution would be to simply drop that line. Opinions?

@karlitschek @craigpg Please approve this fix in stable7

No need to forward port this to master as this is a stable7 only problem.
