### PR TITLE
Remove hard coded limit of 15 from getShareWith

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -281,8 +281,10 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$users = array();
 				$limit = 0;
 				$offset = 0;
-				while ($count < 15 && count($users) == $limit) {
-					$limit = 15 - $count;
+				// limit defaults to 15 if not specified via request parameter and can be no larger than 500
+				$request_limit = min((int)$_GET['limit'] ?: 15, 500);
+				while ($count < $request_limit && count($users) == $limit) {
+					$limit = $request_limit - $count;
 					if ($shareWithinGroupOnly) {
 						$users = OC_Group::displayNamesInGroups($usergroups, (string)$_GET['search'], $limit, $offset);
 					} else {
@@ -319,7 +321,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						continue;
 					}
 
-					if ($count < 15) {
+					if ($count < $request_limit) {
 						if (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
 							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -491,7 +491,7 @@ OC.Share={
 			$('#shareWith').autocomplete({minLength: 2, delay: 750, source: function(search, response) {
 				var $loading = $('#dropdown .shareWithLoading');
 				$loading.removeClass('hidden');
-				$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term.trim(), itemShares: OC.Share.itemShares, itemType: itemType }, function(result) {
+				$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term.trim(), limit: 200, itemShares: OC.Share.itemShares, itemType: itemType }, function(result) {
 					$loading.addClass('hidden');
 					if (result.status == 'success' && result.data.length > 0) {
 						$( "#shareWith" ).autocomplete( "option", "autoFocus", true );


### PR DESCRIPTION
With a large directory we're seeing a case where the sharing menu is missing a user we expect to be there.  Moreover, this behavior is inconsistent where some users are reliably found while others simply cannot be found it all.

It's our suspicion that the search filter is working just fine and that the real problem is that we're to aggressively truncating the max # of users returned by getShareWith to 15 (hardcoded) and this is simply too small when dealing with a large directory.

Instead of changing the hardcoded value on the server, this PR adds support for a `limit` request parameter and sets the "default" limit in javascript to 200.  This default should ideally be pulled from a setting, but let's not consider that until we prove that increasing the limit addresses the problem at hand.

If the `limit` request parameter is not specified, the server reverts to using 15 as the limit.
