### PR TITLE
Add getTagsForObjects in ITags

### DIFF
--- a/lib/public/itags.php
+++ b/lib/public/itags.php
@@ -76,7 +76,23 @@ interface ITags {
 	public function getTags();
 
 	/**
-	* Get the a list if items tagged with $tag.
+	 * Get a list of tags for the given item ids.
+	 *
+	 * This returns an array with object id / tag names:
+	 * [
+	 *   1 => array('First tag', 'Second tag'),
+	 *   2 => array('Second tag'),
+	 *   3 => array('Second tag', 'Third tag'),
+	 * ]
+	 *
+	 * @param array $objIds item ids
+	 * @return array|boolean with object id as key and an array
+	 * of tag names as value or false if an error occurred
+	 */
+	public function getTagsForObjects(array $objIds);
+
+	/**
+	* Get a list of items tagged with $tag.
 	*
 	* Throws an exception if the tag could not be found.
 	*

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -132,6 +132,36 @@ class Test_Tags extends \Test\TestCase {
 		$this->assertFalse($tagger->isEmpty());
 	}
 
+	public function testGetTagsForObjects() {
+		$defaultTags = array('Friends', 'Family', 'Work', 'Other');
+		$tagger = $this->tagMgr->load($this->objectType, $defaultTags);
+
+		$tagger->tagAs(1, 'Friends');
+		$tagger->tagAs(1, 'Other');
+		$tagger->tagAs(2, 'Family');
+
+		$tags = $tagger->getTagsForObjects(array(1));
+		$this->assertEquals(1, count($tags));
+		$tags = current($tags);
+		sort($tags);
+		$this->assertSame(array('Friends', 'Other'), $tags);
+
+		$tags = $tagger->getTagsForObjects(array(1, 2));
+		$this->assertEquals(2, count($tags));
+		$tags1 = $tags[1];
+		sort($tags1);
+		$this->assertSame(array('Friends', 'Other'), $tags1);
+		$this->assertSame(array('Family'), $tags[2]);
+		$this->assertEquals(
+			array(),
+			$tagger->getTagsForObjects(array(4))
+		);
+		$this->assertEquals(
+			array(),
+			$tagger->getTagsForObjects(array(4, 5))
+		);
+	}
+
 	public function testdeleteTags() {
 		$defaultTags = array('Friends', 'Family', 'Work', 'Other');
 		$tagger = $this->tagMgr->load($this->objectType, $defaultTags);


### PR DESCRIPTION
Returns the list of tags that are set on the given object ids.

Required for the "favorites/tags" task (#2368)  but also a nice addition to the API.
See https://github.com/owncloud/core/pull/12360/files#diff-471be045dd1eb605d9a1197b9ba90560R52

Please review @ockham @LukasReschke @icewind1991 @DeepDiver1975 
