### PR TITLE
Backport #12262

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -174,7 +174,7 @@ if (isset($path)) {
 			$tmpl->assign('downloadURL',
 				OCP\Util::linkToPublic('files') . $urlLinkIdentifiers . '&download&path=' . urlencode($getPath));
 		} else {
-			$tmpl->assign('dir', $dir);
+			$tmpl->assign('dir', '');
 
 			// Show file preview if viewer is available
 			if ($type == 'file') {


### PR DESCRIPTION
The "dir" key is used within the public sharing template to indicate in which directory the user currently is when sharing a directory with subdirectories. This is needed by the JS scripts.

However, when not accessing a directory then "dir" was set to the relative path of the file (from the user's home directory), meaning that for every public shared file the sharee can see the path.
(For example if you share the file "foo.txt" from "finances/topsecret/" the sharee would still see the path "finances/topsecret/" from the shared HTML template)

This is not the excpected behaviour and can be considered a privacy problem, this patch addresses this by setting "dir" to an empty key.

Port of https://github.com/owncloud/core/pull/12262, approved with https://github.com/owncloud/core/pull/12262#issuecomment-64394040

@MorrisJobke @PVince81 Up for a review?
