### PR TITLE
delete old previews

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -101,7 +101,7 @@ class Repair extends BasicEmitter {
 		//only 7.0.0 through 7.0.2 generated broken previews
 		$currentVersion = \OC::$server->getConfig()->getSystemValue('version');
 		if (version_compare($currentVersion, '7.0.0.0', '>=') &&
-			version_compare($currentVersion, '7.0.2.2', '<=')) {
+			version_compare($currentVersion, '7.0.3.4', '<=')) {
 			$steps[] = new \OC\Repair\Preview();
 		}
 


### PR DESCRIPTION
ownCloud 7.0.3 still generated some cached previews with a rather bad naming schema. https://github.com/owncloud/core/pull/10639 was not backported, but it's now. (see https://github.com/owncloud/core/pull/12373).

needs backport

please review @karlitschek @MorrisJobke 
