### PR TITLE
Allow read-only configuration

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -434,6 +434,15 @@ $CONFIG = array(
  */
 'check_for_working_htaccess' => true,
 
+/**
+ * In certain environments it is desired to have a read-only config file.
+ * When this switch is set to ``true`` ownCloud will not verify whether the
+ * configuration is writable. However, it will not be possible to configure
+ * all options via the web-interface. Furthermore, when updating ownCloud
+ * it is required to make the config file writable again for the update
+ * process.
+ */
+'config_is_read_only' => false,
 
 /**
  * Logging

--- a/lib/base.php
+++ b/lib/base.php
@@ -194,9 +194,9 @@ class OC {
 
 	public static function checkConfig() {
 		$l = \OC::$server->getL10N('lib');
-		if (file_exists(self::$configDir . "/config.php")
-			and !is_writable(self::$configDir . "/config.php")
-		) {
+		$configFileWritable = file_exists(self::$configDir . "/config.php") && is_writable(self::$configDir . "/config.php");
+		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
+			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
 			if (self::$CLI) {
 				echo $l->t('Cannot write into "config" directory!')."\n";
 				echo $l->t('This can usually be fixed by giving the webserver write access to the config directory')."\n";

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -974,4 +974,12 @@ class OC_Helper {
 		return array('free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative);
 
 	}
+
+	/**
+	 * Returns whether the config file is set manually to read-only
+	 * @return bool
+	 */
+	public static function isReadOnlyConfigEnabled() {
+		return \OC::$server->getConfig()->getSystemValue('config_is_read_only', false);
+	}
 }

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -33,6 +33,7 @@ $template->assign('mail_smtppassword', $config->getSystemValue("mail_smtppasswor
 $template->assign('entries', $entries);
 $template->assign('entriesremain', $entriesRemaining);
 $template->assign('htaccessworking', $htAccessWorking);
+$template->assign('readOnlyConfigEnabled', OC_Helper::isReadOnlyConfigEnabled());
 $template->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
 $template->assign('isPhpCharSetUtf8', OC_Util::isPhpCharSetUtf8());
 $template->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -86,14 +86,28 @@ if (!$_['isConnectedViaHTTPS']) {
 // is htaccess working ?
 if (!$_['htaccessworking']) {
 	?>
-<div class="section">
-	<h2><?php p($l->t('Security Warning'));?></h2>
+	<div class="section">
+		<h2><?php p($l->t('Security Warning')); ?></h2>
 
 	<span class="securitywarning">
 		<?php p($l->t('Your data directory and your files are probably accessible from the internet. The .htaccess file is not working. We strongly suggest that you configure your webserver in a way that the data directory is no longer accessible or you move the data directory outside the webserver document root.')); ?>
 	</span>
 
-</div>
+	</div>
+<?php
+}
+
+// is read only config enabled
+if ($_['readOnlyConfigEnabled']) {
+?>
+<div class="section">
+	<h2><?php p($l->t('Read-Only config enabled'));?></h2>
+
+	<span class="securitywarning">
+		<?php p($l->t('The Read-Only config has been enabled. This prevents setting some configurations via the web-interface. Furthermore, the file needs to be made writable manually for every update.')); ?>
+	</span>
+
+	</div>
 <?php
 }
 // Are doc blocks accessible?


### PR DESCRIPTION
Workaround required for IIS setups running ownCloud to prevent dataloss.

Long-term solution would be to move some configuration settings to the database as described at https://github.com/owncloud/core/issues/11843
