### PR TITLE
Issue/6101 remove namespace permission constants

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -7,7 +7,7 @@ OCP\JSON::setContentTypeHeader('text/plain');
 // If not, check the login.
 // If no token is sent along, rely on login only
 
-$allowedPermissions = OCP\PERMISSION_ALL;
+$allowedPermissions = \OCP\Constants::PERMISSION_ALL;
 $errorCode = null;
 
 $l = \OC::$server->getL10N('files');
@@ -27,7 +27,7 @@ if (empty($_POST['dirToken'])) {
 	\OC_User::setIncognitoMode(true);
 
 	// return only read permissions for public upload
-	$allowedPermissions = OCP\PERMISSION_READ;
+	$allowedPermissions = \OCP\Constants::PERMISSION_READ;
 	$publicDirectory = !empty($_POST['subdir']) ? $_POST['subdir'] : '/';
 
 	$linkItem = OCP\Share::getShareByToken($_POST['dirToken']);
@@ -36,7 +36,7 @@ if (empty($_POST['dirToken'])) {
 		die();
 	}
 
-	if (!($linkItem['permissions'] & OCP\PERMISSION_CREATE)) {
+	if (!($linkItem['permissions'] & \OCP\Constants::PERMISSION_CREATE)) {
 		OCP\JSON::checkLoggedIn();
 	} else {
 		// resolve reshares

--- a/apps/files_encryption/tests/hooks.php
+++ b/apps/files_encryption/tests/hooks.php
@@ -256,7 +256,7 @@ class Test_Encryption_Hooks extends \OCA\Files_Encryption\Tests\TestCase {
 		$this->assertTrue($fileInfo instanceof \OC\Files\FileInfo);
 
 		// share the file with user2
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_ENCRYPTION_HOOKS_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_ENCRYPTION_HOOKS_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// check if new share key exists
 		$this->assertTrue($this->rootView->file_exists(

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -171,7 +171,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the file
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -232,7 +232,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 			'/' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->filename);
 
 		// share the file with user3
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -328,7 +328,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the folder with user1
-		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -406,7 +406,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the file with user3
-		\OCP\Share::shareItem('folder', $fileInfoSubFolder['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $fileInfoSubFolder['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER3, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -437,7 +437,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		$this->assertTrue($fileInfo instanceof \OC\Files\FileInfo);
 
 		// share the file with user3
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER4, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -539,7 +539,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the file
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, false, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, false, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -617,7 +617,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		\OC_FileProxy::$enabled = $proxyStatus;
 
 		// share the file
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, \OCP\Constants::PERMISSION_ALL);
 
 		// login as admin
 		self::loginHelper(\Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1);
@@ -923,7 +923,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 
 		// share the file
 		try {
-			\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, OCP\PERMISSION_ALL);
+			\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_GROUP1, \OCP\Constants::PERMISSION_ALL);
 		} catch (Exception $e) {
 			$this->assertEquals(0, strpos($e->getMessage(), "Following users are not set up for encryption"));
 		}
@@ -991,7 +991,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		$this->assertTrue($fileInfo instanceof \OC\Files\FileInfo);
 
 		// share the file
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// check if share key for user2 exists
 		$this->assertTrue($this->view->file_exists(
@@ -1059,7 +1059,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		$this->assertTrue($fileInfo instanceof \OC\Files\FileInfo);
 
 		// share the folder
-		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		\OC\Files\Filesystem::rename($folder, $newFolder);
 
@@ -1117,7 +1117,7 @@ class Test_Encryption_Share extends \OCA\Files_Encryption\Tests\TestCase {
 		$this->assertTrue($fileInfo instanceof \OC\Files\FileInfo);
 
 		// share the folder
-		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// check that the share keys exist
 		$this->assertTrue($view->file_exists('files_encryption/share-keys' . $folder . '/' . $filename . '.' . \Test_Encryption_Share::TEST_ENCRYPTION_SHARE_USER1 . '.shareKey'));

--- a/apps/files_external/lib/api.php
+++ b/apps/files_external/lib/api.php
@@ -45,10 +45,10 @@ class Api {
 
 		$isSystemMount = !$mountConfig['personal'];
 
-		$permissions = \OCP\PERMISSION_READ;
+		$permissions = \OCP\Constants::PERMISSION_READ;
 		// personal mounts can be deleted
 		if (!$isSystemMount) {
-			$permissions |= \OCP\PERMISSION_DELETE;
+			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
 		$entry = array(

--- a/apps/files_sharing/ajax/list.php
+++ b/apps/files_sharing/ajax/list.php
@@ -65,7 +65,7 @@ $formattedFiles = array();
 foreach ($files as $file) {
 	$entry = \OCA\Files\Helper::formatFileInfo($file);
 	unset($entry['directory']); // for now
-	$entry['permissions'] = \OCP\PERMISSION_READ;
+	$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 	$formattedFiles[] = $entry;
 }
 
@@ -78,7 +78,7 @@ $permissions = $linkItem['permissions'];
 // if globally disabled
 if (\OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes') === 'no') {
 	// only allow reading
-	$permissions = \OCP\PERMISSION_READ;
+	$permissions = \OCP\Constants::PERMISSION_READ;
 }
 
 $data['permissions'] = $permissions;

--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -31,7 +31,7 @@ $linkItem = $data['linkItem'];
 // Load the files
 $path = $data['realPath'];
 
-$isWritable = $linkItem['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
+$isWritable = $linkItem['permissions'] & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
 if (!$isWritable) {
 	\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {
 		return new \OCA\Files_Sharing\ReadOnlyWrapper(array('storage' => $storage));

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -182,7 +182,7 @@ class ShareController extends Controller {
 			$folder = new Template('files', 'list', '');
 			$folder->assign('dir', $getPath);
 			$folder->assign('dirToken', $linkItem['token']);
-			$folder->assign('permissions', OCP\PERMISSION_READ);
+			$folder->assign('permissions', \OCP\Constants::PERMISSION_READ);
 			$folder->assign('isPublic', true);
 			$folder->assign('publicUploadEnabled', 'no');
 			$folder->assign('files', $files);

--- a/apps/files_sharing/lib/readonlycache.php
+++ b/apps/files_sharing/lib/readonlycache.php
@@ -13,14 +13,14 @@ use OC\Files\Cache\Cache;
 class ReadOnlyCache extends Cache {
 	public function get($path) {
 		$data = parent::get($path);
-		$data['permissions'] &= (\OCP\PERMISSION_READ | \OCP\PERMISSION_SHARE);
+		$data['permissions'] &= (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
 		return $data;
 	}
 
 	public function getFolderContents($path) {
 		$content = parent::getFolderContents($path);
 		foreach ($content as &$data) {
-			$data['permissions'] &= (\OCP\PERMISSION_READ | \OCP\PERMISSION_SHARE);
+			$data['permissions'] &= (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
 		}
 		return $content;
 	}

--- a/apps/files_sharing/lib/readonlywrapper.php
+++ b/apps/files_sharing/lib/readonlywrapper.php
@@ -24,7 +24,7 @@ class ReadOnlyWrapper extends Wrapper {
 	}
 
 	public function getPermissions($path) {
-		return $this->storage->getPermissions($path) & (\OCP\PERMISSION_READ | \OCP\PERMISSION_SHARE);
+		return $this->storage->getPermissions($path) & (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
 	}
 
 	public function rename($path1, $path2) {

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -67,7 +67,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 				if ($source) {
 					$source['path'] .= '.part';
 					// All partial files have delete permission
-					$source['permissions'] |= \OCP\PERMISSION_DELETE;
+					$source['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
 				}
 			} else {
 				$source = \OC_Share_Backend_File::getSource($target, $this->getMountPoint(), $this->getItemType());
@@ -109,11 +109,11 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$permissions = $this->share['permissions'];
 		// part files and the mount point always have delete permissions
 		if ($target === '' || pathinfo($target, PATHINFO_EXTENSION) === 'part') {
-			$permissions |= \OCP\PERMISSION_DELETE;
+			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
 		if (\OC_Util::isSharingDisabledForUser()) {
-			$permissions &= ~\OCP\PERMISSION_SHARE;
+			$permissions &= ~\OCP\Constants::PERMISSION_SHARE;
 		}
 
 		return $permissions;
@@ -197,7 +197,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	}
 
 	public function isCreatable($path) {
-		return ($this->getPermissions($path) & \OCP\PERMISSION_CREATE);
+		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_CREATE);
 	}
 
 	public function isReadable($path) {
@@ -205,18 +205,18 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	}
 
 	public function isUpdatable($path) {
-		return ($this->getPermissions($path) & \OCP\PERMISSION_UPDATE);
+		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_UPDATE);
 	}
 
 	public function isDeletable($path) {
-		return ($this->getPermissions($path) & \OCP\PERMISSION_DELETE);
+		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_DELETE);
 	}
 
 	public function isSharable($path) {
 		if (\OCP\Util::isSharingDisabledForUser()) {
 			return false;
 		}
-		return ($this->getPermissions($path) & \OCP\PERMISSION_SHARE);
+		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
 	}
 
 	public function file_exists($path) {

--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -41,7 +41,7 @@ $server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('webdav'));
 $server->subscribeEvent('beforeMethod', function () use ($server, $objectTree, $authBackend) {
 	$share = $authBackend->getShare();
 	$owner = $share['uid_owner'];
-	$isWritable = $share['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
+	$isWritable = $share['permissions'] & (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE);
 	$fileId = $share['file_source'];
 
 	if (!$isWritable) {

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -788,7 +788,7 @@ class Test_Files_Sharing_Api extends TestCase {
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
 		$result = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// share was successful?
 		$this->assertTrue($result);
@@ -822,7 +822,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 		// check if share have expected permissions, single shared files never have
 		// delete permissions
-		$this->assertEquals(\OCP\PERMISSION_ALL & ~\OCP\PERMISSION_DELETE, $userShare['permissions']);
+		$this->assertEquals(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_DELETE, $userShare['permissions']);
 
 		// update permissions
 
@@ -1228,7 +1228,7 @@ class Test_Files_Sharing_Api extends TestCase {
 		$info = OC\Files\Filesystem::getFileInfo($this->filename);
 		$this->assertTrue($info instanceof \OC\Files\FileInfo);
 
-		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\PERMISSION_READ);
+		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertTrue(is_string($result));
 
 		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2, 31);

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -348,7 +348,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Files\Filesystem::file_put_contents('test.txt', 'foo');
 		$info = \OC\Files\Filesystem::getFileInfo('test.txt');
-		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
 		\OC_Util::tearDownFS();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -369,7 +369,7 @@ class Test_Files_Sharing_Cache extends TestCase {
 		\OC\Files\Filesystem::touch('foo/bar/test.txt');
 		$folderInfo = \OC\Files\Filesystem::getFileInfo('foo');
 		$fileInfo = \OC\Files\Filesystem::getFileInfo('foo/bar/test.txt');
-		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
 		\OC_Util::tearDownFS();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);

--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -105,12 +105,12 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
 		$result = \OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP,
-				\Test_Files_Sharing::TEST_FILES_SHARING_API_GROUP1, \OCP\PERMISSION_READ);
+				\Test_Files_Sharing::TEST_FILES_SHARING_API_GROUP1, \OCP\Constants::PERMISSION_READ);
 
 		$this->assertTrue($result);
 
 		$result = \OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-				\Test_Files_Sharing::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_UPDATE);
+				\Test_Files_Sharing::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_UPDATE);
 
 		$this->assertTrue($result);
 
@@ -124,7 +124,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertSame(1, count($result));
 
 		$share = reset($result);
-		$this->assertSame(\OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE, $share['permissions']);
+		$this->assertSame(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE, $share['permissions']);
 
 		\OC\Files\Filesystem::rename($this->filename, $this->filename . '-renamed');
 
@@ -136,7 +136,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertSame(1, count($result));
 
 		$share = reset($result);
-		$this->assertSame(\OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE, $share['permissions']);
+		$this->assertSame(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE, $share['permissions']);
 		$this->assertSame($this->filename . '-renamed', $share['file_target']);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -157,7 +157,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 
 		$share = reset($result);
 		// only the group share permissions should be available now
-		$this->assertSame(\OCP\PERMISSION_READ, $share['permissions']);
+		$this->assertSame(\OCP\Constants::PERMISSION_READ, $share['permissions']);
 		$this->assertSame($this->filename . '-renamed', $share['file_target']);
 
 	}
@@ -172,8 +172,8 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
 		// share the file to group1 (user2 is a member of this group) and explicitely to user2
-		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1, \OCP\PERMISSION_ALL);
-		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1, \OCP\Constants::PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// user1 should have to shared files
 		$shares = \OCP\Share::getItemsShared('file');
@@ -203,7 +203,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertSame(1, count($shares));
 
 		// user1 shares a gain the file directly to user2
-		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		// user2 should see again welcome.txt and the shared file
 		\Test_Files_Sharing::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -271,14 +271,14 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 	}
 
 	function DataProviderTestFileSharePermissions() {
-		$permission1 = \OCP\PERMISSION_ALL;
-		$permission3 = \OCP\PERMISSION_READ;
-		$permission4 = \OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE;
-		$permission5 = \OCP\PERMISSION_READ | \OCP\PERMISSION_DELETE;
-		$permission6 = \OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE | \OCP\PERMISSION_DELETE;
+		$permission1 = \OCP\Constants::PERMISSION_ALL;
+		$permission3 = \OCP\Constants::PERMISSION_READ;
+		$permission4 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE;
+		$permission5 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE;
+		$permission6 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 
 		return array(
-			array($permission1, \OCP\PERMISSION_ALL & ~\OCP\PERMISSION_DELETE),
+			array($permission1, \OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_DELETE),
 			array($permission3, $permission3),
 			array($permission4, $permission4),
 			array($permission5, $permission3),

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -88,7 +88,7 @@ class Helper
 			$entry = \OCA\Files\Helper::formatFileInfo($i);
 			$entry['id'] = $id++;
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
-			$entry['permissions'] = \OCP\PERMISSION_READ;
+			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 			if (\OCP\App::isEnabled('files_encryption')) {
 				$entry['isPreviewAvailable'] = false;
 			}

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -277,7 +277,7 @@ class Test_Files_Versioning extends \Test\TestCase {
 		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
 
-		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 
@@ -320,7 +320,7 @@ class Test_Files_Versioning extends \Test\TestCase {
 		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
 
-		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, OCP\PERMISSION_ALL);
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_VERSIONS_USER2, \OCP\Constants::PERMISSION_ALL);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 

--- a/lib/private/contacts/localaddressbook.php
+++ b/lib/private/contacts/localaddressbook.php
@@ -91,7 +91,7 @@ class LocalAddressBook implements \OCP\IAddressBook {
 	 * @return int
 	 */
 	public function getPermissions() {
-		return \OCP\PERMISSION_READ;
+		return \OCP\Constants::PERMISSION_READ;
 	}
 
 	/**

--- a/lib/private/contactsmanager.php
+++ b/lib/private/contactsmanager.php
@@ -62,7 +62,7 @@ namespace OC {
 				return null;
 			}
 
-			if ($addressBook->getPermissions() & \OCP\PERMISSION_DELETE) {
+			if ($addressBook->getPermissions() & \OCP\Constants::PERMISSION_DELETE) {
 				return null;
 			}
 
@@ -83,7 +83,7 @@ namespace OC {
 				return null;
 			}
 
-			if ($addressBook->getPermissions() & \OCP\PERMISSION_CREATE) {
+			if ($addressBook->getPermissions() & \OCP\Constants::PERMISSION_CREATE) {
 				return null;
 			}
 

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -173,14 +173,14 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return bool
 	 */
 	public function isReadable() {
-		return $this->checkPermissions(\OCP\PERMISSION_READ);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_READ);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isUpdateable() {
-		return $this->checkPermissions(\OCP\PERMISSION_UPDATE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE);
 	}
 
 	/**
@@ -189,21 +189,21 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return bool
 	 */
 	public function isCreatable() {
-		return $this->checkPermissions(\OCP\PERMISSION_CREATE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_CREATE);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isDeletable() {
-		return $this->checkPermissions(\OCP\PERMISSION_DELETE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_DELETE);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isShareable() {
-		return $this->checkPermissions(\OCP\PERMISSION_SHARE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_SHARE);
 	}
 
 	/**

--- a/lib/private/files/node/file.php
+++ b/lib/private/files/node/file.php
@@ -16,7 +16,7 @@ class File extends Node implements \OCP\Files\File {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function getContent() {
-		if ($this->checkPermissions(\OCP\PERMISSION_READ)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_READ)) {
 			/**
 			 * @var \OC\Files\Storage\Storage $storage;
 			 */
@@ -31,7 +31,7 @@ class File extends Node implements \OCP\Files\File {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function putContent($data) {
-		if ($this->checkPermissions(\OCP\PERMISSION_UPDATE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE)) {
 			$this->sendHooks(array('preWrite'));
 			$this->view->file_put_contents($this->path, $data);
 			$this->sendHooks(array('postWrite'));
@@ -55,7 +55,7 @@ class File extends Node implements \OCP\Files\File {
 	public function fopen($mode) {
 		$preHooks = array();
 		$postHooks = array();
-		$requiredPermissions = \OCP\PERMISSION_READ;
+		$requiredPermissions = \OCP\Constants::PERMISSION_READ;
 		switch ($mode) {
 			case 'r+':
 			case 'rb+':
@@ -73,7 +73,7 @@ class File extends Node implements \OCP\Files\File {
 			case 'ab':
 				$preHooks[] = 'preWrite';
 				$postHooks[] = 'postWrite';
-				$requiredPermissions |= \OCP\PERMISSION_UPDATE;
+				$requiredPermissions |= \OCP\Constants::PERMISSION_UPDATE;
 				break;
 		}
 
@@ -88,7 +88,7 @@ class File extends Node implements \OCP\Files\File {
 	}
 
 	public function delete() {
-		if ($this->checkPermissions(\OCP\PERMISSION_DELETE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
 			$this->sendHooks(array('preDelete'));
 			$this->view->unlink($this->path);
 			$nonExisting = new NonExistingFile($this->root, $this->view, $this->path);

--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -180,7 +180,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function newFolder($path) {
-		if ($this->checkPermissions(\OCP\PERMISSION_CREATE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'preWrite', array($nonExisting));
@@ -201,7 +201,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function newFile($path) {
-		if ($this->checkPermissions(\OCP\PERMISSION_CREATE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFile($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'preWrite', array($nonExisting));
@@ -325,11 +325,11 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return bool
 	 */
 	public function isCreatable() {
-		return $this->checkPermissions(\OCP\PERMISSION_CREATE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_CREATE);
 	}
 
 	public function delete() {
-		if ($this->checkPermissions(\OCP\PERMISSION_DELETE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
 			$this->sendHooks(array('preDelete'));
 			$this->view->rmdir($this->path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $this->path);

--- a/lib/private/files/node/node.php
+++ b/lib/private/files/node/node.php
@@ -81,7 +81,7 @@ class Node implements \OCP\Files\Node {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function touch($mtime = null) {
-		if ($this->checkPermissions(\OCP\PERMISSION_UPDATE)) {
+		if ($this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE)) {
 			$this->sendHooks(array('preTouch'));
 			$this->view->touch($this->path, $mtime);
 			$this->sendHooks(array('postTouch'));
@@ -163,28 +163,28 @@ class Node implements \OCP\Files\Node {
 	 * @return bool
 	 */
 	public function isReadable() {
-		return $this->checkPermissions(\OCP\PERMISSION_READ);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_READ);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isUpdateable() {
-		return $this->checkPermissions(\OCP\PERMISSION_UPDATE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_UPDATE);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isDeletable() {
-		return $this->checkPermissions(\OCP\PERMISSION_DELETE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_DELETE);
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isShareable() {
-		return $this->checkPermissions(\OCP\PERMISSION_SHARE);
+		return $this->checkPermissions(\OCP\Constants::PERMISSION_SHARE);
 	}
 
 	/**

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -262,7 +262,7 @@ class Root extends Folder implements Emitter {
 	 * @return int
 	 */
 	public function getPermissions() {
-		return \OCP\PERMISSION_CREATE;
+		return \OCP\Constants::PERMISSION_CREATE;
 	}
 
 	/**

--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -72,7 +72,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			'size' => 0,
 			'mtime' => $mTime,
 			'storage_mtime' => $mTime,
-			'permissions' => \OCP\PERMISSION_ALL,
+			'permissions' => \OCP\Constants::PERMISSION_ALL,
 		);
 
 		if ($dirName === '' && !$parentExists) {
@@ -332,7 +332,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				'size' => 0,
 				'mtime' => $mtime,
 				'storage_mtime' => $mtime,
-				'permissions' => \OCP\PERMISSION_ALL,
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
 			);
 			$fileId = $this->getCache()->put($path, $stat);
 			try {
@@ -357,7 +357,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if (empty($stat)) {
 			// create new file
 			$stat = array(
-				'permissions' => \OCP\PERMISSION_ALL,
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
 			);
 		}
 		// update stat with new data

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -113,19 +113,19 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	public function getPermissions($path) {
 		$permissions = 0;
 		if ($this->isCreatable($path)) {
-			$permissions |= \OCP\PERMISSION_CREATE;
+			$permissions |= \OCP\Constants::PERMISSION_CREATE;
 		}
 		if ($this->isReadable($path)) {
-			$permissions |= \OCP\PERMISSION_READ;
+			$permissions |= \OCP\Constants::PERMISSION_READ;
 		}
 		if ($this->isUpdatable($path)) {
-			$permissions |= \OCP\PERMISSION_UPDATE;
+			$permissions |= \OCP\Constants::PERMISSION_UPDATE;
 		}
 		if ($this->isDeletable($path)) {
-			$permissions |= \OCP\PERMISSION_DELETE;
+			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 		if ($this->isSharable($path)) {
-			$permissions |= \OCP\PERMISSION_SHARE;
+			$permissions |= \OCP\Constants::PERMISSION_SHARE;
 		}
 		return $permissions;
 	}

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -416,19 +416,19 @@ class DAV extends \OC\Files\Storage\Common {
 	}
 
 	public function isUpdatable($path) {
-		return (bool)($this->getPermissions($path) & \OCP\PERMISSION_UPDATE);
+		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_UPDATE);
 	}
 
 	public function isCreatable($path) {
-		return (bool)($this->getPermissions($path) & \OCP\PERMISSION_CREATE);
+		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_CREATE);
 	}
 
 	public function isSharable($path) {
-		return (bool)($this->getPermissions($path) & \OCP\PERMISSION_SHARE);
+		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
 	}
 
 	public function isDeletable($path) {
-		return (bool)($this->getPermissions($path) & \OCP\PERMISSION_DELETE);
+		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_DELETE);
 	}
 
 	public function getPermissions($path) {
@@ -438,9 +438,9 @@ class DAV extends \OC\Files\Storage\Common {
 		if (isset($response['{http://owncloud.org/ns}permissions'])) {
 			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
 		} else if ($this->is_dir($path)) {
-			return \OCP\PERMISSION_ALL;
+			return \OCP\Constants::PERMISSION_ALL;
 		} else if ($this->file_exists($path)) {
-			return \OCP\PERMISSION_ALL - \OCP\PERMISSION_CREATE;
+			return \OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE;
 		} else {
 			return 0;
 		}
@@ -451,19 +451,19 @@ class DAV extends \OC\Files\Storage\Common {
 	 * @return int
 	 */
 	protected function parsePermissions($permissionsString) {
-		$permissions = \OCP\PERMISSION_READ;
+		$permissions = \OCP\Constants::PERMISSION_READ;
 		if (strpos($permissionsString, 'R') !== false) {
-			$permissions |= \OCP\PERMISSION_SHARE;
+			$permissions |= \OCP\Constants::PERMISSION_SHARE;
 		}
 		if (strpos($permissionsString, 'D') !== false) {
-			$permissions |= \OCP\PERMISSION_DELETE;
+			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 		if (strpos($permissionsString, 'W') !== false) {
-			$permissions |= \OCP\PERMISSION_UPDATE;
+			$permissions |= \OCP\Constants::PERMISSION_UPDATE;
 		}
 		if (strpos($permissionsString, 'CK') !== false) {
-			$permissions |= \OCP\PERMISSION_CREATE;
-			$permissions |= \OCP\PERMISSION_UPDATE;
+			$permissions |= \OCP\Constants::PERMISSION_CREATE;
+			$permissions |= \OCP\Constants::PERMISSION_UPDATE;
 		}
 		return $permissions;
 	}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -933,7 +933,7 @@ class View {
 		}
 
 		if ($mount instanceof MoveableMount && $internalPath === '') {
-			$data['permissions'] |= \OCP\PERMISSION_DELETE | \OCP\PERMISSION_UPDATE;
+			$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
 		}
 
 		$data = \OC_FileProxy::runPostProxies('getFileInfo', $path, $data);
@@ -988,7 +988,7 @@ class View {
 				}
 				// if sharing was disabled for the user we remove the share permissions
 				if (\OCP\Util::isSharingDisabledForUser()) {
-					$content['permissions'] = $content['permissions'] & ~\OCP\PERMISSION_SHARE;
+					$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 				}
 				$files[] = new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content);
 			}
@@ -1025,9 +1025,9 @@ class View {
 							// do not allow renaming/deleting the mount point if they are not shared files/folders
 							// for shared files/folders we use the permissions given by the owner
 							if ($mount instanceof MoveableMount) {
-								$rootEntry['permissions'] = $permissions | \OCP\PERMISSION_UPDATE | \OCP\PERMISSION_DELETE;
+								$rootEntry['permissions'] = $permissions | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 							} else {
-								$rootEntry['permissions'] = $permissions & (\OCP\PERMISSION_ALL - (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_DELETE));
+								$rootEntry['permissions'] = $permissions & (\OCP\Constants::PERMISSION_ALL - (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE));
 							}
 
 							//remove any existing entry with the same name
@@ -1041,7 +1041,7 @@ class View {
 
 							// if sharing was disabled for the user we remove the share permissions
 							if (\OCP\Util::isSharingDisabledForUser()) {
-								$content['permissions'] = $content['permissions'] & ~\OCP\PERMISSION_SHARE;
+								$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 							}
 
 							$files[] = new FileInfo($path . '/' . $rootEntry['name'], $subStorage, '', $rootEntry);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -547,7 +547,7 @@ class Share extends \OC\Share\Constants {
 
 		// single file shares should never have delete permissions
 		if ($itemType === 'file') {
-			$permissions = (int)$permissions & ~\OCP\PERMISSION_DELETE;
+			$permissions = (int)$permissions & ~\OCP\Constants::PERMISSION_DELETE;
 		}
 
 		// Verify share type and sharing conditions are met
@@ -929,7 +929,7 @@ class Share extends \OC\Share\Constants {
 			// Check if permissions were removed
 			if ($item['permissions'] & ~$permissions) {
 				// If share permission is removed all reshares must be deleted
-				if (($item['permissions'] & \OCP\PERMISSION_SHARE) && (~$permissions & \OCP\PERMISSION_SHARE)) {
+				if (($item['permissions'] & \OCP\Constants::PERMISSION_SHARE) && (~$permissions & \OCP\Constants::PERMISSION_SHARE)) {
 					Helper::delete($item['id'], true);
 				} else {
 					$ids = array();
@@ -1458,8 +1458,8 @@ class Share extends \OC\Share\Constants {
 						}
 						// Switch ids if sharing permission is granted on only
 						// one share to ensure correct parent is used if resharing
-						if (~(int)$items[$id]['permissions'] & \OCP\PERMISSION_SHARE
-							&& (int)$row['permissions'] & \OCP\PERMISSION_SHARE) {
+						if (~(int)$items[$id]['permissions'] & \OCP\Constants::PERMISSION_SHARE
+							&& (int)$row['permissions'] & \OCP\Constants::PERMISSION_SHARE) {
 							$items[$row['id']] = $items[$id];
 							$switchedItems[$id] = $row['id'];
 							unset($items[$id]);
@@ -1516,7 +1516,7 @@ class Share extends \OC\Share\Constants {
 			}
 			// Check if resharing is allowed, if not remove share permission
 			if (isset($row['permissions']) && (!self::isResharingAllowed() | \OC_Util::isSharingDisabledForUser())) {
-				$row['permissions'] &= ~\OCP\PERMISSION_SHARE;
+				$row['permissions'] &= ~\OCP\Constants::PERMISSION_SHARE;
 			}
 			// Add display names to result
 			if ( isset($row['share_with']) && $row['share_with'] != '' &&
@@ -1911,7 +1911,7 @@ class Share extends \OC\Share\Constants {
 			}
 
 			// Check if share permissions is granted
-			if (self::isResharingAllowed() && (int)$checkReshare['permissions'] & \OCP\PERMISSION_SHARE) {
+			if (self::isResharingAllowed() && (int)$checkReshare['permissions'] & \OCP\Constants::PERMISSION_SHARE) {
 				if (~(int)$checkReshare['permissions'] & $permissions) {
 					$message = 'Sharing %s failed, because the permissions exceed permissions granted to %s';
 					$message_t = $l->t('Sharing %s failed, because the permissions exceed permissions granted to %s', array($itemSourceName, $uidOwner));

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1336,7 +1336,7 @@ class OC_Util {
 			return false;
 		}
 		foreach (str_split($trimmed) as $char) {
-			if (strpos(\OCP\FILENAME_INVALID_CHARS, $char) !== false) {
+			if (strpos(\OCP\Constants::FILENAME_INVALID_CHARS, $char) !== false) {
 				return false;
 			}
 		}

--- a/lib/public/constants.php
+++ b/lib/public/constants.php
@@ -26,15 +26,37 @@
 
 namespace OCP;
 
-/**
- * CRUDS permissions.
- */
+/** @deprecated Use \OCP\Constants::PERMISSION_CREATE instead */
 const PERMISSION_CREATE = 4;
+
+/** @deprecated Use \OCP\Constants::PERMISSION_READ instead */
 const PERMISSION_READ = 1;
+
+/** @deprecated Use \OCP\Constants::PERMISSION_UPDATE instead */
 const PERMISSION_UPDATE = 2;
+
+/** @deprecated Use \OCP\Constants::PERMISSION_DELETE instead */
 const PERMISSION_DELETE = 8;
+
+/** @deprecated Use \OCP\Constants::PERMISSION_SHARE instead */
 const PERMISSION_SHARE = 16;
+
+/** @deprecated Use \OCP\Constants::PERMISSION_ALL instead */
 const PERMISSION_ALL = 31;
 
+/** @deprecated Use \OCP\Constants::FILENAME_INVALID_CHARS instead */
 const FILENAME_INVALID_CHARS = "\\/<>:\"|?*\n";
 
+class Constants {
+	/**
+	 * CRUDS permissions.
+	 */
+	const PERMISSION_CREATE = 4;
+	const PERMISSION_READ = 1;
+	const PERMISSION_UPDATE = 2;
+	const PERMISSION_DELETE = 8;
+	const PERMISSION_SHARE = 16;
+	const PERMISSION_ALL = 31;
+
+	const FILENAME_INVALID_CHARS = "\\/<>:\"|?*\n";
+}

--- a/lib/public/files/fileinfo.php
+++ b/lib/public/files/fileinfo.php
@@ -103,12 +103,12 @@ interface FileInfo {
 
 	/**
 	 * Get the permissions of the file or folder as bitmasked combination of the following constants
-	 * \OCP\PERMISSION_CREATE
-	 * \OCP\PERMISSION_READ
-	 * \OCP\PERMISSION_UPDATE
-	 * \OCP\PERMISSION_DELETE
-	 * \OCP\PERMISSION_SHARE
-	 * \OCP\PERMISSION_ALL
+	 * \OCP\Constants::PERMISSION_CREATE
+	 * \OCP\Constants::PERMISSION_READ
+	 * \OCP\Constants::PERMISSION_UPDATE
+	 * \OCP\Constants::PERMISSION_DELETE
+	 * \OCP\Constants::PERMISSION_SHARE
+	 * \OCP\Constants::PERMISSION_ALL
 	 *
 	 * @return int
 	 */

--- a/lib/public/files/node.php
+++ b/lib/public/files/node.php
@@ -128,11 +128,11 @@ interface Node {
 
 	/**
 	 * Get the permissions of the file or folder as a combination of one or more of the following constants:
-	 *  - \OCP\PERMISSION_READ
-	 *  - \OCP\PERMISSION_UPDATE
-	 *  - \OCP\PERMISSION_CREATE
-	 *  - \OCP\PERMISSION_DELETE
-	 *  - \OCP\PERMISSION_SHARE
+	 *  - \OCP\Constants::PERMISSION_READ
+	 *  - \OCP\Constants::PERMISSION_UPDATE
+	 *  - \OCP\Constants::PERMISSION_CREATE
+	 *  - \OCP\Constants::PERMISSION_DELETE
+	 *  - \OCP\Constants::PERMISSION_SHARE
 	 *
 	 * @return int
 	 */

--- a/lib/public/iavatar.php
+++ b/lib/public/iavatar.php
@@ -23,9 +23,9 @@ interface IAvatar {
 	/**
 	 * sets the users avatar
 	 * @param Image $data mixed imagedata or path to set a new avatar
-	 * @throws Exception if the provided file is not a jpg or png image
-	 * @throws Exception if the provided image is not valid
-	 * @throws \OCP\NotSquareException if the image is not square
+	 * @throws \Exception if the provided file is not a jpg or png image
+	 * @throws \Exception if the provided image is not valid
+	 * @throws \OC\NotSquareException if the image is not square
 	 * @return void
 	 */
 	function set($data);

--- a/lib/public/template.php
+++ b/lib/public/template.php
@@ -88,7 +88,7 @@ function human_file_size( $bytes ) {
  * Return the relative date in relation to today. Returns something like "last hour" or "two month ago"
  * @param int $timestamp unix timestamp
  * @param boolean $dateOnly
- * @return OC_L10N_String human readable interpretation of the timestamp
+ * @return \OC_L10N_String human readable interpretation of the timestamp
  */
 function relative_modified_date( $timestamp, $dateOnly = false ) {
 	return(\relative_modified_date($timestamp, null, $dateOnly));

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -508,8 +508,8 @@ class Util {
 
 	/**
 	 * Compare two strings to provide a natural sort
-	 * @param $a first string to compare
-	 * @param $b second string to compare
+	 * @param string $a first string to compare
+	 * @param string $b second string to compare
 	 * @return -1 if $b comes before $a, 1 if $a comes before $b
 	 * or 0 if the strings are identical
 	 */

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -23,7 +23,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 			->will($this->returnValue('/test.txt'));
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions'=>\OCP\PERMISSION_ALL
+			'permissions'=>\OCP\Constants::PERMISSION_ALL
 		));
 
 		$file = new OC_Connector_Sabre_File($view, $info);
@@ -58,7 +58,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 
 		$file = new OC_Connector_Sabre_File($view, $info);
@@ -82,7 +82,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 			->will($this->returnValue('/super*star.txt'));
 
 		$info = new \OC\Files\FileInfo('/super*star.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -103,7 +103,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 			->will($this->returnValue('/super*star.txt'));
 
 		$info = new \OC\Files\FileInfo('/super*star.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 		$file = new OC_Connector_Sabre_File($view, $info);
 		$file->setName('/super*star.txt');
@@ -135,7 +135,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 
 		$file = new OC_Connector_Sabre_File($view, $info);
@@ -157,7 +157,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 
 		$file = new OC_Connector_Sabre_File($view, $info);
@@ -198,7 +198,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
-			'permissions' => \OCP\PERMISSION_ALL
+			'permissions' => \OCP\Constants::PERMISSION_ALL
 		));
 
 		$file = new OC_Connector_Sabre_File($view, $info);

--- a/tests/lib/connector/sabre/node.php
+++ b/tests/lib/connector/sabre/node.php
@@ -15,15 +15,15 @@ use OC\Files\View;
 class Node extends \Test\TestCase {
 	public function davPermissionsProvider() {
 		return array(
-			array(\OCP\PERMISSION_ALL, 'file', false, false, 'RDNVW'),
-			array(\OCP\PERMISSION_ALL, 'dir', false, false, 'RDNVCK'),
-			array(\OCP\PERMISSION_ALL, 'file', true, false, 'SRDNVW'),
-			array(\OCP\PERMISSION_ALL, 'file', true, true, 'SRMDNVW'),
-			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_SHARE, 'file', true, false, 'SDNVW'),
-			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_UPDATE, 'file', false, false, 'RDNV'),
-			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_DELETE, 'file', false, false, 'RW'),
-			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_CREATE, 'file', false, false, 'RDNVW'),
-			array(\OCP\PERMISSION_ALL - \OCP\PERMISSION_CREATE, 'dir', false, false, 'RDNV'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', false, false, 'RDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL, 'dir', false, false, 'RDNVCK'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', true, false, 'SRDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL, 'file', true, true, 'SRMDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_SHARE, 'file', true, false, 'SDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_UPDATE, 'file', false, false, 'RDNV'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE, 'file', false, false, 'RW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'file', false, false, 'RDNVW'),
+			array(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE, 'dir', false, false, 'RDNV'),
 		);
 	}
 

--- a/tests/lib/files/node/file.php
+++ b/tests/lib/files/node/file.php
@@ -39,7 +39,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$view->expects($this->once())
 			->method('unlink')
@@ -89,7 +89,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL, 'fileid' => 1)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1)));
 
 		$view->expects($this->once())
 			->method('unlink')
@@ -124,7 +124,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->delete();
@@ -156,7 +156,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$this->assertEquals('bar', $node->getContent());
@@ -201,7 +201,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$view->expects($this->once())
 			->method('file_put_contents')
@@ -226,7 +226,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->putContent('bar');
@@ -279,7 +279,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$fh = $node->fopen('r');
@@ -316,7 +316,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$fh = $node->fopen('w');
@@ -375,7 +375,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_UPDATE)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_UPDATE)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->fopen('w');
@@ -402,7 +402,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->fopen('w');
@@ -425,7 +425,7 @@ class File extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL, 'fileid' => 3)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 3)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -469,7 +469,7 @@ class File extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ, 'fileid' => 3)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ, 'fileid' => 3)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -556,7 +556,7 @@ class File extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL, 'fileid' => 1)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1)));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -587,7 +587,7 @@ class File extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$view->expects($this->never())
 			->method('rename');

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -39,7 +39,7 @@ class Folder extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$view->expects($this->once())
 			->method('rmdir')
@@ -87,7 +87,7 @@ class Folder extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL, 'fileid' => 1)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1)));
 
 		$view->expects($this->once())
 			->method('rmdir')
@@ -121,7 +121,7 @@ class Folder extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->delete();
@@ -255,7 +255,7 @@ class Folder extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$view->expects($this->once())
 			->method('mkdir')
@@ -285,7 +285,7 @@ class Folder extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->newFolder('asd');
@@ -305,7 +305,7 @@ class Folder extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$view->expects($this->once())
 			->method('touch')
@@ -335,7 +335,7 @@ class Folder extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->newFile('asd');

--- a/tests/lib/files/node/node.php
+++ b/tests/lib/files/node/node.php
@@ -246,7 +246,7 @@ class Node extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);
@@ -299,7 +299,7 @@ class Node extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_ALL)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_ALL)));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);
@@ -323,7 +323,7 @@ class Node extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue(array('permissions' => \OCP\PERMISSION_READ)));
+			->will($this->returnValue(array('permissions' => \OCP\Constants::PERMISSION_READ)));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -89,7 +89,7 @@ class Test_Share extends \Test\TestCase {
 	public function testShareInvalidShareType() {
 		$message = 'Share type foobar is not valid for test.txt';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', 'foobar', $this->user2, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', 'foobar', $this->user2, \OCP\Constants::PERMISSION_READ);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
@@ -98,7 +98,7 @@ class Test_Share extends \Test\TestCase {
 	public function testInvalidItemType() {
 		$message = 'Sharing backend for foobar not found';
 		try {
-			OCP\Share::shareItem('foobar', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('foobar', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -134,7 +134,7 @@ class Test_Share extends \Test\TestCase {
 			$this->assertEquals($message, $exception->getMessage());
 		}
 		try {
-			OCP\Share::setPermissions('foobar', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_UPDATE);
+			OCP\Share::setPermissions('foobar', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_UPDATE);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -144,7 +144,7 @@ class Test_Share extends \Test\TestCase {
 	protected function shareUserOneTestFileWithUserTwo() {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ),
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared text.txt with user 2.'
 		);
 		$this->assertContains(
@@ -163,7 +163,7 @@ class Test_Share extends \Test\TestCase {
 
 	protected function shareUserTestFileAsLink() {
 		OC_User::setUserId($this->user1);
-		$result = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, OCP\PERMISSION_READ);
+		$result = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertTrue(is_string($result));
 	}
 
@@ -174,7 +174,7 @@ class Test_Share extends \Test\TestCase {
 	protected function shareUserTestFileWithUser($sharer, $receiver) {
 		OC_User::setUserId($sharer);
 		$this->assertTrue(
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $receiver, OCP\PERMISSION_READ | OCP\PERMISSION_SHARE),
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $receiver, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE),
 			'Failed asserting that ' . $sharer . ' successfully shared text.txt with ' . $receiver . '.'
 		);
 		$this->assertContains(
@@ -195,21 +195,21 @@ class Test_Share extends \Test\TestCase {
 		// Invalid shares
 		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the item owner';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
 		$message = 'Sharing test.txt failed, because the user foobar does not exist';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, 'foobar', OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, 'foobar', \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
 		$message = 'Sharing foobar failed, because the sharing backend for test could not find its source';
 		try {
-			OCP\Share::shareItem('test', 'foobar', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'foobar', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -222,7 +222,7 @@ class Test_Share extends \Test\TestCase {
 		OC_User::setUserId($this->user1);
 		$message = 'Sharing test.txt failed, because this item is already shared with '.$this->user2;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -232,7 +232,7 @@ class Test_Share extends \Test\TestCase {
 		OC_User::setUserId($this->user2);
 		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the original sharer';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -243,11 +243,11 @@ class Test_Share extends \Test\TestCase {
 		$this->assertTrue(OCP\Share::unshare('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2));
 
 		// Attempt reshare without share permission
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user2);
 		$message = 'Sharing test.txt failed, because resharing is not allowed';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -255,30 +255,30 @@ class Test_Share extends \Test\TestCase {
 
 		// Owner grants share and update permission
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE | OCP\PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE));
 
 		// Attempt reshare with escalated permissions
 		OC_User::setUserId($this->user2);
 		$message = 'Sharing test.txt failed, because the permissions exceed permissions granted to '.$this->user2;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ | OCP\PERMISSION_DELETE);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
 		}
 
 		// Valid reshare
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE));
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemShared('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE));
 		OC_User::setUserId($this->user3);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_SOURCE));
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 
 		// Attempt to escalate permissions
 		OC_User::setUserId($this->user2);
 		$message = 'Setting permissions for test.txt failed, because the permissions exceed permissions granted to '.$this->user2;
 		try {
-			OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ | OCP\PERMISSION_DELETE);
+			OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -286,25 +286,25 @@ class Test_Share extends \Test\TestCase {
 
 		// Remove update permission
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ | OCP\PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE));
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_SHARE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 		OC_User::setUserId($this->user3);
-		$this->assertEquals(array(OCP\PERMISSION_READ), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 
 		// Remove share permission
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(array(OCP\PERMISSION_READ), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 		OC_User::setUserId($this->user3);
 		$this->assertSame(array(), OCP\Share::getItemSharedWith('test', 'test.txt'));
 
 		// Reshare again, and then have owner unshare
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ | OCP\PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::setPermissions('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE));
 		OC_User::setUserId($this->user2);
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(OCP\Share::unshare('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2));
 		OC_User::setUserId($this->user2);
@@ -314,9 +314,9 @@ class Test_Share extends \Test\TestCase {
 
 		// Attempt target conflict
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user3);
-		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 
 		OC_User::setUserId($this->user2);
 		$to_test = OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET);
@@ -333,9 +333,9 @@ class Test_Share extends \Test\TestCase {
 		$this->assertEquals(array(), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user3);
-		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ));
 
 		OC_User::setUserId($this->user2);
 		$to_test = OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET);
@@ -412,7 +412,7 @@ class Test_Share extends \Test\TestCase {
 
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, OCP\PERMISSION_ALL),
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, \OCP\Constants::PERMISSION_ALL),
 			'Failed asserting that user 1 successfully shared text.txt with user 4.'
 		);
 		$this->assertContains(
@@ -429,7 +429,7 @@ class Test_Share extends \Test\TestCase {
 
 		$share = OCP\Share::getItemSharedWith('test', 'test.txt');
 
-		$this->assertSame(\OCP\PERMISSION_ALL & ~OCP\PERMISSION_SHARE, $share['permissions'],
+		$this->assertSame(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_SHARE, $share['permissions'],
 				'Failed asserting that user 4 is excluded from re-sharing');
 
 		\OC_Appconfig::deleteKey('core', 'shareapi_exclude_groups_list');
@@ -440,7 +440,7 @@ class Test_Share extends \Test\TestCase {
 	protected function shareUserOneTestFileWithGroupOne() {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ),
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ),
 			'Failed asserting that user 1 successfully shared text.txt with group 1.'
 		);
 		$this->assertContains(
@@ -468,7 +468,7 @@ class Test_Share extends \Test\TestCase {
 		// Invalid shares
 		$message = 'Sharing test.txt failed, because the group foobar does not exist';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, 'foobar', OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, 'foobar', \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -477,7 +477,7 @@ class Test_Share extends \Test\TestCase {
 		OC_Appconfig::setValue('core', 'shareapi_only_share_with_group_members', 'yes');
 		$message = 'Sharing test.txt failed, because '.$this->user1.' is not a member of the group '.$this->group2;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group2, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group2, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -491,7 +491,7 @@ class Test_Share extends \Test\TestCase {
 		OC_User::setUserId($this->user1);
 		$message = 'Sharing test.txt failed, because this item is already shared with '.$this->group1;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -501,7 +501,7 @@ class Test_Share extends \Test\TestCase {
 		OC_User::setUserId($this->user2);
 		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the original sharer';
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -510,7 +510,7 @@ class Test_Share extends \Test\TestCase {
 		// Attempt to share back to group
 		$message = 'Sharing test.txt failed, because this item is already shared with '.$this->group1;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -519,7 +519,7 @@ class Test_Share extends \Test\TestCase {
 		// Attempt to share back to member of group
 		$message ='Sharing test.txt failed, because this item is already shared with '.$this->user3;
 		try {
-			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, OCP\PERMISSION_READ);
+			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user3, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
 		} catch (Exception $exception) {
 			$this->assertEquals($message, $exception->getMessage());
@@ -530,18 +530,18 @@ class Test_Share extends \Test\TestCase {
 		$this->assertTrue(OCP\Share::unshare('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1));
 
 		// Valid share with same person - user then group
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ | OCP\PERMISSION_DELETE | OCP\PERMISSION_SHARE));
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE));
 		OC_User::setUserId($this->user2);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE | OCP\PERMISSION_DELETE | OCP\PERMISSION_SHARE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_SHARE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 		OC_User::setUserId($this->user3);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 
 		// Valid reshare
 		OC_User::setUserId($this->user2);
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, OCP\PERMISSION_READ));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, \OCP\Constants::PERMISSION_READ));
 		OC_User::setUserId($this->user4);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 
@@ -549,26 +549,26 @@ class Test_Share extends \Test\TestCase {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(OCP\Share::unshare('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2));
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 		OC_User::setUserId($this->user4);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 
 		// Valid share with same person - group then user
 		OC_User::setUserId($this->user1);
-		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, OCP\PERMISSION_READ | OCP\PERMISSION_DELETE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE));
 		OC_User::setUserId($this->user2);
 		$this->assertEquals(array('test.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE | OCP\PERMISSION_DELETE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 
 		// Unshare from group only
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(OCP\Share::unshare('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1));
 		OC_User::setUserId($this->user2);
-		$this->assertEquals(array(OCP\PERMISSION_READ | OCP\PERMISSION_DELETE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
+		$this->assertEquals(array(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE), OCP\Share::getItemSharedWith('test', 'test.txt', Test_Share_Backend::FORMAT_PERMISSIONS));
 
 		// Attempt user specific target conflict
 		OC_User::setUserId($this->user3);
-		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, OCP\PERMISSION_READ | OCP\PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE));
 		OC_User::setUserId($this->user2);
 		$to_test = OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET);
 		$this->assertEquals(2, count($to_test));
@@ -576,7 +576,7 @@ class Test_Share extends \Test\TestCase {
 		$this->assertTrue(in_array('test1.txt', $to_test));
 
 		// Valid reshare
-		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, OCP\PERMISSION_READ | OCP\PERMISSION_SHARE));
+		$this->assertTrue(OCP\Share::shareItem('test', 'share.txt', OCP\Share::SHARE_TYPE_USER, $this->user4, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE));
 		OC_User::setUserId($this->user4);
 		$this->assertEquals(array('test1.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 
@@ -628,7 +628,7 @@ class Test_Share extends \Test\TestCase {
 		$this->assertTrue(OCP\Share::unshareAll('test', 'test.txt'));
 
 		$this->assertTrue(
-				OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->groupAndUser, OCP\PERMISSION_READ),
+				OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_GROUP, $this->groupAndUser, \OCP\Constants::PERMISSION_READ),
 				'Failed asserting that user 1 successfully shared text.txt with group 1.'
 		);
 
@@ -704,7 +704,7 @@ class Test_Share extends \Test\TestCase {
 
 	public function testShareItemWithLink() {
 		OC_User::setUserId($this->user1);
-		$token = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, OCP\PERMISSION_READ);
+		$token = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertInternalType(
 			'string',
 			$token,
@@ -750,7 +750,7 @@ class Test_Share extends \Test\TestCase {
 		\OC_Appconfig::setValue('core', 'shareapi_default_expire_date', 'yes');
 		\OC_Appconfig::setValue('core', 'shareapi_expire_after_n_days', '2');
 
-		$token = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, OCP\PERMISSION_READ);
+		$token = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertInternalType(
 			'string',
 			$token,
@@ -876,20 +876,20 @@ class Test_Share extends \Test\TestCase {
 			// one array with one share
 			array(
 				array( // input
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_ALL, 'item_target' => 't1')),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_ALL, 'item_target' => 't1')),
 				array( // expected result
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_ALL, 'item_target' => 't1'))),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_ALL, 'item_target' => 't1'))),
 			// two shares both point to the same source
 			array(
 				array( // input
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't1'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1'),
 					),
 				array( // expected result
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE, 'item_target' => 't1',
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1',
 						'grouped' => array(
-							array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-							array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't1'),
+							array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+							array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1'),
 							)
 						),
 					)
@@ -897,29 +897,29 @@ class Test_Share extends \Test\TestCase {
 			// two shares both point to the same source but with different targets
 			array(
 				array( // input
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't2'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't2'),
 					),
 				array( // expected result
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't2'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't2'),
 					)
 				),
 			// three shares two point to the same source
 			array(
 				array( // input
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-					array('item_source' => 2, 'permissions' => \OCP\PERMISSION_CREATE, 'item_target' => 't2'),
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't1'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+					array('item_source' => 2, 'permissions' => \OCP\Constants::PERMISSION_CREATE, 'item_target' => 't2'),
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1'),
 					),
 				array( // expected result
-					array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ | \OCP\PERMISSION_UPDATE, 'item_target' => 't1',
+					array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1',
 						'grouped' => array(
-							array('item_source' => 1, 'permissions' => \OCP\PERMISSION_READ, 'item_target' => 't1'),
-							array('item_source' => 1, 'permissions' => \OCP\PERMISSION_UPDATE, 'item_target' => 't1'),
+							array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_READ, 'item_target' => 't1'),
+							array('item_source' => 1, 'permissions' => \OCP\Constants::PERMISSION_UPDATE, 'item_target' => 't1'),
 							)
 						),
-					array('item_source' => 2, 'permissions' => \OCP\PERMISSION_CREATE, 'item_target' => 't2'),
+					array('item_source' => 2, 'permissions' => \OCP\Constants::PERMISSION_CREATE, 'item_target' => 't2'),
 					)
 				),
 		);

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -214,7 +214,7 @@ class Test_Tags extends \Test\TestCase {
 		$this->assertFalse($other_tagger->hasTag($test_tag));
 
 		OC_User::setUserId($this->user);
-		OCP\Share::shareItem('test', 1, OCP\Share::SHARE_TYPE_USER, $other_user, OCP\PERMISSION_READ);
+		OCP\Share::shareItem('test', 1, OCP\Share::SHARE_TYPE_USER, $other_user, \OCP\Constants::PERMISSION_READ);
 
 		OC_User::setUserId($other_user);
 		$other_tagger = $other_tagMgr->load('test', array(), true); // Update tags, load shared ones.


### PR DESCRIPTION
@bantu @DeepDiver1975 

If we do not want to replace the usages, we can remove the second commit.
But I think we can do it
#6101 for reference
