### PR TITLE
Don't show favicon to prevent iteration through subfolders

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -38,7 +38,7 @@ $server->setBaseUri($baseuri);
 $defaults = new OC_Defaults();
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
 $server->addPlugin(new \Sabre\DAV\Locks\Plugin($lockBackend));
-$server->addPlugin(new \Sabre\DAV\Browser\Plugin(false)); // Show something in the Browser, but no upload
+$server->addPlugin(new \Sabre\DAV\Browser\Plugin(false, false)); // Show something in the Browser, but no upload
 $server->addPlugin(new OC_Connector_Sabre_FilesPlugin());
 $server->addPlugin(new OC_Connector_Sabre_MaintenancePlugin());
 $server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('webdav'));


### PR DESCRIPTION
The codepath for generating the favicons iterates through subnodes and if one of those nodes is unavailable is throwing a 503 exception. Since these favicons don't have any use except of "making a tool for developers looking nicer" I consider it feasible to remove them.

@DeepDiver1975 @PVince81 
