### PR TITLE
Cache results of available languages

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -20,6 +20,7 @@ class OC_L10N implements \OCP\IL10N {
 	 * cache
 	 */
 	protected static $cache = array();
+	protected static $availableLanguages = array();
 
 	/**
 	 * The best language
@@ -468,6 +469,9 @@ class OC_L10N implements \OCP\IL10N {
 	 * @return array an array of available languages
 	 */
 	public static function findAvailableLanguages($app=null) {
+		if(!empty(self::$availableLanguages)) {
+			return self::$availableLanguages;
+		}
 		$available=array('en');//english is always available
 		$dir = self::findI18nDir($app);
 		if(is_dir($dir)) {
@@ -479,6 +483,8 @@ class OC_L10N implements \OCP\IL10N {
 				}
 			}
 		}
+
+		self::$availableLanguages = $available;
 		return $available;
 	}
 


### PR DESCRIPTION
This function is about 8 times calles for every single page call, when caching this variable I was able to gain a small performance improvement from 20,512 µs to 708 µs. (profiled with xhprof)

Surely, this is no gigantic gain but if we would do that for every function out there...

Before:
![screen shot 2014-11-27 at 00 07 35](https://cloud.githubusercontent.com/assets/878997/5210254/7e443d8a-75c9-11e4-9087-7d071a082666.png)

After:
![screen shot 2014-11-27 at 00 09 21](https://cloud.githubusercontent.com/assets/878997/5210265/acb0c3b4-75c9-11e4-827a-7054eb75147e.png)
