### PR TITLE
Limit blacklist to php files

### DIFF
--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -568,7 +568,7 @@ class OC_Installer{
 
 			// iterate the bad patterns
 			foreach($blacklist as $bl) {
-				$cmd = 'grep -ri '.escapeshellarg($bl).' '.$folder.'';
+				$cmd = 'grep --include \\*.php -ri '.escapeshellarg($bl).' '.$folder.'';
 				$result = exec($cmd);
 				// bad pattern found
 				if($result<>'') {


### PR DESCRIPTION
During performance optimization I have discovered that the installer scans all files for the blacklisted words. This greatly impacts speed on lower end devices such as the raspberry pie. This commit limits it to PHP files which seems to achieve the desired effect. 

I have used the --include option to achieve this, see http://stackoverflow.com/questions/1987926/how-do-i-grep-recursively

This contribution is MIT licensed
