### PR TITLE
add activity priorities to core so that other apps can reuse it

### DIFF
--- a/lib/public/activity/iextension.php
+++ b/lib/public/activity/iextension.php
@@ -30,6 +30,13 @@
 namespace OCP\Activity;
 
 interface IExtension {
+
+	const PRIORITY_VERYLOW 	= 10;
+	const PRIORITY_LOW	= 20;
+	const PRIORITY_MEDIUM	= 30;
+	const PRIORITY_HIGH	= 40;
+	const PRIORITY_VERYHIGH	= 50;
+
 	/**
 	 * The extension can return an array of additional notification types.
 	 * If no additional types are to be added false is to be returned


### PR DESCRIPTION
add activity priorities to core so that other apps can reuse it, as discussed with @nickvergessen 

cc @DeepDiver1975 
