### PR TITLE
Disable MSSQL and OCI for new CE installations

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -831,7 +831,7 @@ $CONFIG = array(
 
 /**
  * Database types that are supported for installation. (SQLite is available only in 
- * ownCloud Community Edition)
+ * ownCloud Community Edition, oci and mssql only for the Enterprise Edition)
  *
  * Available:
  * 	- sqlite (SQLite3)

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -88,7 +88,7 @@ class OC_Setup {
 			)
 		);
 		$configuredDatabases = $this->config->getSystemValue('supportedDatabases',
-			array('sqlite', 'mysql', 'pgsql', 'oci'));
+			array('sqlite', 'mysql', 'pgsql'));
 		if(!is_array($configuredDatabases)) {
 			throw new Exception('Supported databases are not properly configured.');
 		}

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -88,7 +88,7 @@ class OC_Setup {
 			)
 		);
 		$configuredDatabases = $this->config->getSystemValue('supportedDatabases',
-			array('sqlite', 'mysql', 'pgsql', 'oci', 'mssql'));
+			array('sqlite', 'mysql', 'pgsql', 'oci'));
 		if(!is_array($configuredDatabases)) {
 			throw new Exception('Supported databases are not properly configured.');
 		}


### PR DESCRIPTION
Since automatic schema migrations are not yet possible let's disable this for now.

@karlitschek @DeepDiver1975 
