### PR TITLE
why does it fail - it shouldn't affect anything

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -487,7 +487,7 @@ class Storage {
 			$softQuota = true;
 			$quota = \OC_Preferences::getValue($uid, 'files', 'quota');
 			if ( $quota === null || $quota === 'default') {
-				$quota = \OC::$server->getAppConfig()->getValue('files', 'default_quota');
+				$quota = \OC::$server->getConfig()->getAppValue('files', 'default_quota');
 			}
 			if ( $quota === null || $quota === 'none' ) {
 				$quota = \OC\Files\Filesystem::free_space('/');


### PR DESCRIPTION
cc @Raydiation @LukasReschke 

It calls after some wrappers the same methods. But with this applied a unit test fails

```
Test_Files_Versioning::testCopy
Failed asserting that false is true.

/home/mjob/Projekte/owncloud/master/apps/files_versions/tests/versions.php:366
```
