### PR TITLE
filter tables by table prefix

### DIFF
--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -228,10 +228,8 @@ class ConvertType extends Command {
 	}
 
 	protected function getTables(Connection $db) {
-		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
-			if($r->hasMethod('setPrefixFilterString'))
-				$db->getSchemaManager()->setPrefixFilterString(
-					\OCP\Config::getSystemValue('dbtableprefix'));
+		$db->getConfiguration()->
+			setFilterSchemaAssetsExpression('^'.$this->config->getSystemValue('dbtableprefix'));
 		return $db->getSchemaManager()->listTableNames();
 	}
 

--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -229,7 +229,7 @@ class ConvertType extends Command {
 
 	protected function getTables(Connection $db) {
 		$db->getConfiguration()->
-			setFilterSchemaAssetsExpression('^'.$this->config->getSystemValue('dbtableprefix'));
+			setFilterSchemaAssetsExpression('/^'.$this->config->getSystemValue('dbtableprefix').'/');
 		return $db->getSchemaManager()->listTableNames();
 	}
 

--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -228,6 +228,10 @@ class ConvertType extends Command {
 	}
 
 	protected function getTables(Connection $db) {
+		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
+			if($r->hasMethod('setPrefixFilterString'))
+				$db->getSchemaManager()->setPrefixFilterString(
+					\OCP\Config::getSystemValue('dbtableprefix'));
 		return $db->getSchemaManager()->listTableNames();
 	}
 

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -36,9 +36,7 @@ class MDB2SchemaManager {
 	 * TODO: write more documentation
 	 */
 	public function getDbStructure($file, $mode = MDB2_SCHEMA_DUMP_STRUCTURE) {
-		$sm = $this->conn->getSchemaManager();
-
-		return \OC_DB_MDB2SchemaWriter::saveSchemaToFile($file, $sm);
+		return \OC_DB_MDB2SchemaWriter::saveSchemaToFile($file, $this->conn);
 	}
 
 	/**

--- a/lib/private/db/mdb2schemawriter.php
+++ b/lib/private/db/mdb2schemawriter.php
@@ -19,6 +19,11 @@ class OC_DB_MDB2SchemaWriter {
 		$xml->addChild('create', 'true');
 		$xml->addChild('overwrite', 'false');
 		$xml->addChild('charset', 'utf8');
+		
+		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
+		if($r->hasMethod('setPrefixFilterString'))
+			$sm->setPrefixFilterString(\OCP\Config::getSystemValue('dbtableprefix'));
+		
 		foreach ($sm->listTables() as $table) {
 			self::saveTable($table, $xml->addChild('table'));
 		}

--- a/lib/private/db/mdb2schemawriter.php
+++ b/lib/private/db/mdb2schemawriter.php
@@ -13,18 +13,17 @@ class OC_DB_MDB2SchemaWriter {
 	 * @param \Doctrine\DBAL\Schema\AbstractSchemaManager $sm
 	 * @return bool
 	 */
-	static public function saveSchemaToFile($file, $sm) {
+	static public function saveSchemaToFile($file, $conn) {
 		$xml = new SimpleXMLElement('<database/>');
 		$xml->addChild('name', OC_Config::getValue( "dbname", "owncloud" ));
 		$xml->addChild('create', 'true');
 		$xml->addChild('overwrite', 'false');
 		$xml->addChild('charset', 'utf8');
 		
-		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
-		if($r->hasMethod('setPrefixFilterString'))
-			$sm->setPrefixFilterString(\OCP\Config::getSystemValue('dbtableprefix'));
+		$conn->getConfiguration()->
+			setFilterSchemaAssetsExpression('/^'.\OCP\Config::getSystemValue('dbtableprefix'.'/'));
 		
-		foreach ($sm->listTables() as $table) {
+		foreach ($conn->getSchemaManager()->listTables() as $table) {
 			self::saveTable($table, $xml->addChild('table'));
 		}
 		file_put_contents($file, $xml->asXML());

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -70,11 +70,8 @@ class Migrator {
 		 */
 		$tables = $targetSchema->getTables();
 		
-		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
-		if($r->hasMethod('setPrefixFilterString'))
-			$this->connection->getSchemaManager()->setPrefixFilterString(
-				\OCP\Config::getSystemValue('dbtableprefix'));
-
+		$this->connection->getConfiguration()->
+			setFilterSchemaAssetsExpression('/^'.\OCP\Config::getSystemValue('dbtableprefix').'/');
 		$existingTables = $this->connection->getSchemaManager()->listTableNames();
 
 		foreach ($tables as $table) {
@@ -158,6 +155,8 @@ class Migrator {
 	}
 
 	protected function getDiff(Schema $targetSchema, \Doctrine\DBAL\Connection $connection) {
+		$connection->getConfiguration()->
+			setFilterSchemaAssetsExpression('/^'.\OCP\Config::getSystemValue('dbtableprefix').'/');
 		$sourceSchema = $connection->getSchemaManager()->createSchema();
 
 		// remove tables we don't know about

--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -69,6 +69,11 @@ class Migrator {
 		 * @var \Doctrine\DBAL\Schema\Table[] $tables
 		 */
 		$tables = $targetSchema->getTables();
+		
+		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
+		if($r->hasMethod('setPrefixFilterString'))
+			$this->connection->getSchemaManager()->setPrefixFilterString(
+				\OCP\Config::getSystemValue('dbtableprefix'));
 
 		$existingTables = $this->connection->getSchemaManager()->listTableNames();
 

--- a/lib/private/db/pgsqltools.php
+++ b/lib/private/db/pgsqltools.php
@@ -21,11 +21,8 @@ class PgSqlTools {
 	*/
 	public function resynchronizeDatabaseSequences(Connection $conn) {
 		$databaseName = $conn->getDatabase();
-		
-		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
-			if($r->hasMethod('setPrefixFilterString'))
-				$conn->getSchemaManager()->setPrefixFilterString(
-					\OCP\Config::getSystemValue('dbtableprefix'));
+		$conn->getConfiguration()->
+			setFilterSchemaAssetsExpression('/^'.\OCP\Config::getSystemValue('dbtableprefix').'/');
 
 		foreach ($conn->getSchemaManager()->listSequences() as $sequence) {
 			$sequenceName = $sequence->getName();

--- a/lib/private/db/pgsqltools.php
+++ b/lib/private/db/pgsqltools.php
@@ -21,6 +21,12 @@ class PgSqlTools {
 	*/
 	public function resynchronizeDatabaseSequences(Connection $conn) {
 		$databaseName = $conn->getDatabase();
+		
+		$r=new ReflectionClass('\Doctrine\DBAL\Schema\AbstractSchemaManager')
+			if($r->hasMethod('setPrefixFilterString'))
+				$conn->getSchemaManager()->setPrefixFilterString(
+					\OCP\Config::getSystemValue('dbtableprefix'));
+
 		foreach ($conn->getSchemaManager()->listSequences() as $sequence) {
 			$sequenceName = $sequence->getName();
 			$sqlInfo = 'SELECT table_schema, table_name, column_name


### PR DESCRIPTION
One has a problem when other tables are in the database/schema then owncloud's. Therefore I requestet a change in Doctrine's AbstractSchemaManager. When the distributed Doctrine version contains this change owncloud will use filtering out its own tables by tableprefix.
