### PR TITLE
Simple Plugin system for Javascript

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -166,6 +166,9 @@
 			}
 
 			this.$el = $el;
+			if (options.id) {
+				this.id = options.id;
+			}
 			this.$container = options.scrollContainer || $(window);
 			this.$table = $el.find('table:first');
 			this.$fileList = $el.find('#fileList');
@@ -215,6 +218,8 @@
 					self.scrollTo(options.scrollTo);
 				});
 			}
+
+			OC.Plugins.attach('OCA.Files.FileList', this);
 		},
 
 		/**
@@ -224,6 +229,7 @@
 			// TODO: also unregister other event handlers
 			this.fileActions.off('registerAction', this._onFileActionsUpdated);
 			this.fileActions.off('setDefault', this._onFileActionsUpdated);
+			OC.Plugins.detach('OCA.Files.FileList', this);
 		},
 
 		/**

--- a/apps/files_external/tests/js/mountsfilelistSpec.js
+++ b/apps/files_external/tests/js/mountsfilelistSpec.js
@@ -9,8 +9,7 @@
  */
 
 describe('OCA.External.FileList tests', function() {
-	var testFiles, alertStub, notificationStub, fileList, fileActions;
-	var oldFileListPrototype;
+	var testFiles, alertStub, notificationStub, fileList;
 
 	beforeEach(function() {
 		alertStub = sinon.stub(OC.dialogs, 'alert');
@@ -49,14 +48,11 @@ describe('OCA.External.FileList tests', function() {
 			'<div id="emptycontent">Empty content message</div>' +
 			'</div>'
 		);
-		fileActions = new OCA.Files.FileActions();
 	});
 	afterEach(function() {
-		OCA.Files.FileList.prototype = oldFileListPrototype;
 		testFiles = undefined;
 		fileList.destroy();
 		fileList = undefined;
-		fileActions = undefined;
 
 		notificationStub.restore();
 		alertStub.restore();

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -30,6 +30,7 @@ OCA.Sharing.App = {
 		this._inFileList = new OCA.Sharing.FileList(
 			$el,
 			{
+				id: 'shares.self',
 				scrollContainer: $('#app-content'),
 				sharedWithUser: true,
 				fileActions: this._createFileActions()
@@ -49,6 +50,7 @@ OCA.Sharing.App = {
 		this._outFileList = new OCA.Sharing.FileList(
 			$el,
 			{
+				id: 'shares.others',
 				scrollContainer: $('#app-content'),
 				sharedWithUser: false,
 				fileActions: this._createFileActions()
@@ -68,6 +70,7 @@ OCA.Sharing.App = {
 		this._linkFileList = new OCA.Sharing.FileList(
 			$el,
 			{
+				id: 'shares.link',
 				scrollContainer: $('#app-content'),
 				linksOnly: true,
 				fileActions: this._createFileActions()

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -53,6 +53,7 @@ OCA.Sharing.PublicApp = {
 			this.fileList = new OCA.Files.FileList(
 				$el,
 				{
+					id: 'files.public',
 					scrollContainer: $(window),
 					dragOptions: dragOptions,
 					folderDropOptions: folderDropOptions,
@@ -61,6 +62,9 @@ OCA.Sharing.PublicApp = {
 			);
 			this.files = OCA.Files.Files;
 			this.files.initialize();
+			// TODO: move to PublicFileList.initialize() once
+			// the code was split into a separate class
+			OC.Plugins.attach('OCA.Sharing.PublicFileList', this.fileList);
 		}
 
 		var mimetype = $('#mimetype').val();

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -55,6 +55,7 @@
 			if (options && options.linksOnly) {
 				this._linksOnly = true;
 			}
+			OC.Plugins.attach('OCA.Sharing.FileList', this);
 		},
 
 		_renderRow: function() {

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -41,12 +41,12 @@ describe('OCA.Sharing.Util tests', function() {
 		$('#content').append($div);
 
 		var fileActions = new OCA.Files.FileActions();
-		OCA.Sharing.Util.initialize(fileActions);
 		fileList = new OCA.Files.FileList(
 			$div, {
 				fileActions : fileActions
 			}
 		);
+		OCA.Sharing.Util.attach(fileList);
 
 		testFiles = [{
 			id: 1,

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -9,7 +9,6 @@
  */
 
 describe('OCA.Sharing.Util tests', function() {
-	var oldFileListPrototype;
 	var fileList;
 	var testFiles;
 
@@ -24,10 +23,6 @@ describe('OCA.Sharing.Util tests', function() {
 	}
 
 	beforeEach(function() {
-		// back up prototype, as it will be extended by
-		// the sharing code
-		oldFileListPrototype = _.extend({}, OCA.Files.FileList.prototype);
-
 		var $content = $('<div id="content"></div>');
 		$('#testArea').append($content);
 		// dummy file list
@@ -67,7 +62,6 @@ describe('OCA.Sharing.Util tests', function() {
 		};
 	});
 	afterEach(function() {
-		OCA.Files.FileList.prototype = oldFileListPrototype;
 		delete OCA.Sharing.sharesLoaded;
 		delete OC.Share.droppedDown;
 		fileList.destroy();

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -50,7 +50,6 @@ describe('OCA.Sharing.FileList tests', function() {
 		// the sharing code
 		oldFileListPrototype = _.extend({}, OCA.Files.FileList.prototype);
 		fileActions = new OCA.Files.FileActions();
-		OCA.Sharing.Util.initialize(fileActions);
 	});
 	afterEach(function() {
 		OCA.Files.FileList.prototype = oldFileListPrototype;
@@ -72,6 +71,7 @@ describe('OCA.Sharing.FileList tests', function() {
 					sharedWithUser: true
 				}
 			);
+			OCA.Sharing.Util.attach(fileList);
 
 			fileList.reload();
 
@@ -193,6 +193,7 @@ describe('OCA.Sharing.FileList tests', function() {
 					sharedWithUser: false
 				}
 			);
+			OCA.Sharing.Util.attach(fileList);
 
 			fileList.reload();
 
@@ -433,6 +434,7 @@ describe('OCA.Sharing.FileList tests', function() {
 					linksOnly: true
 				}
 			);
+			OCA.Sharing.Util.attach(fileList);
 
 			fileList.reload();
 
@@ -580,6 +582,7 @@ describe('OCA.Sharing.FileList tests', function() {
 					fileActions: fileActions
 				}
 			);
+			OCA.Sharing.Util.attach(fileList);
 		});
 
 		it('external storage root folder', function () {

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -9,8 +9,7 @@
  */
 
 describe('OCA.Sharing.FileList tests', function() {
-	var testFiles, alertStub, notificationStub, fileList, fileActions;
-	var oldFileListPrototype;
+	var testFiles, alertStub, notificationStub, fileList;
 
 	beforeEach(function() {
 		alertStub = sinon.stub(OC.dialogs, 'alert');
@@ -46,17 +45,11 @@ describe('OCA.Sharing.FileList tests', function() {
 			'<div id="emptycontent">Empty content message</div>' +
 			'</div>'
 		);
-		// back up prototype, as it will be extended by
-		// the sharing code
-		oldFileListPrototype = _.extend({}, OCA.Files.FileList.prototype);
-		fileActions = new OCA.Files.FileActions();
 	});
 	afterEach(function() {
-		OCA.Files.FileList.prototype = oldFileListPrototype;
 		testFiles = undefined;
 		fileList.destroy();
 		fileList = undefined;
-		fileActions = undefined;
 
 		notificationStub.restore();
 		alertStub.restore();
@@ -577,11 +570,7 @@ describe('OCA.Sharing.FileList tests', function() {
 				'</div>');
 			$('#content').append($div);
 
-			fileList = new OCA.Files.FileList(
-				$div, {
-					fileActions: fileActions
-				}
-			);
+			fileList = new OCA.Files.FileList($div);
 			OCA.Sharing.Util.attach(fileList);
 		});
 

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -64,6 +64,7 @@
 				return parts;
 			};
 
+			OC.Plugins.attach('OCA.Trashbin.FileList', this);
 			return result;
 		},
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -499,6 +499,87 @@ var OC={
 };
 
 /**
+ * @namespace OC.Plugins
+ */
+OC.Plugins = {
+	/**
+	 * @type Array.<OC.Plugin>
+	 */
+	_plugins: {},
+
+	/**
+	 * Register plugin
+	 *
+	 * @param {String} targetName app name / class name to hook into
+	 * @param {OC.Plugin} plugin
+	 */
+	register: function(targetName, plugin) {
+		var plugins = this._plugins[targetName];
+		if (!plugins) {
+			plugins = this._plugins[targetName] = [];
+		}
+		plugins.push(plugin);
+	},
+
+	/**
+	 * Returns all plugin registered to the given target
+	 * name / app name / class name.
+	 *
+	 * @param {String} targetName app name / class name to hook into
+	 * @return {Array.<OC.Plugin>} array of plugins
+	 */
+	getPlugins: function(targetName) {
+		return this._plugins[targetName] || [];
+	},
+
+	/**
+	 * Call attach() on all plugins registered to the given target name.
+	 *
+	 * @param {String} targetName app name / class name
+	 * @param {Object} object to be extended
+	 * @param {Object} [options] options
+	 */
+	attach: function(targetName, targetObject, options) {
+		var plugins = this.getPlugins(targetName);
+		for (var i = 0; i < plugins.length; i++) {
+			if (plugins[i].attach) {
+				plugins[i].attach(targetObject, options);
+			}
+		}
+	},
+
+	/**
+	 * Call detach() on all plugins registered to the given target name.
+	 *
+	 * @param {String} targetName app name / class name
+	 * @param {Object} object to be extended
+	 * @param {Object} [options] options
+	 */
+	detach: function(targetName, targetObject, options) {
+		var plugins = this.getPlugins(targetName);
+		for (var i = 0; i < plugins.length; i++) {
+			if (plugins[i].detach) {
+				plugins[i].detach(targetObject, options);
+			}
+		}
+	},
+
+	/**
+	 * Plugin
+	 *
+	 * @todo make this a real class in the future
+	 * @typedef {Object} OC.Plugin
+	 *
+	 * @property {String} name plugin name
+	 * @property {Function} attach function that will be called when the
+	 * plugin is attached
+	 * @property {Function} [detach] function that will be called when the
+	 * plugin is detached
+	 */
+
+};
+
+/**
  * @namespace OC.search
  */
 OC.search.customResults={};

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -120,6 +120,9 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		if (!OC.TestUtil) {
 			OC.TestUtil = TestUtil;
 		}
+
+		// reset plugins
+		OC.Plugins._plugins = [];
 	});
 
 	afterEach(function() {

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -655,5 +655,36 @@ describe('Core base tests', function() {
 			]);
 		});
 	});
+	describe('Plugins', function() {
+		var plugin;
+
+		beforeEach(function() {
+			plugin = {
+				name: 'Some name',
+				attach: function(obj) {
+					obj.attached = true;
+				},
+
+				detach: function(obj) {
+					obj.attached = false;
+				}
+			};
+			OC.Plugins.register('OC.Test.SomeName', plugin);
+		});
+		it('attach plugin to object', function() {
+			var obj = {something: true};
+			OC.Plugins.attach('OC.Test.SomeName', obj);
+			expect(obj.attached).toEqual(true);
+			OC.Plugins.detach('OC.Test.SomeName', obj);
+			expect(obj.attached).toEqual(false);
+		});
+		it('only call handler for target name', function() {
+			var obj = {something: true};
+			OC.Plugins.attach('OC.Test.SomeOtherName', obj);
+			expect(obj.attached).not.toBeDefined();
+			OC.Plugins.detach('OC.Test.SomeOtherName', obj);
+			expect(obj.attached).not.toBeDefined();
+		});
+	});
 });
 


### PR DESCRIPTION
Goal is to make it possible for apps to inject code into classes.
Real use case is the FileList instances.

Registering a plugin with `OC.Plugins.register("OCA.Files.FileList", plugin)` makes it possible for the plugin to be called for **every** instance of `OCA.Files.FileList` and gives them a chance to modify its state (for example add columns, register actions, etc).

This is required for the favorites app, used to add a "star" column here: https://github.com/owncloud/metadata/pull/2/files#diff-f322429cb3a473127be65bbb8859131bR142

@icewind1991 @MorrisJobke @schiesbn what do you think ?
