### PR TITLE
Allow read-only configuration

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -429,6 +429,15 @@ $CONFIG = array(
  */
 'check_for_working_htaccess' => true,
 
+/**
+ * In certain environments it is desired to have a read-only config file.
+ * When this switch is set to ``true`` ownCloud will not verify whether the
+ * configuration is writable. However, it will not be possible to configure
+ * all options via the web-interface. Furthermore, when updating ownCloud
+ * it is required to make the config file writable again for the update
+ * process.
+ */
+'config_is_read_only' => false,
 
 /**
  * Logging

--- a/lib/base.php
+++ b/lib/base.php
@@ -188,9 +188,9 @@ class OC {
 
 	public static function checkConfig() {
 		$l = OC_L10N::get('lib');
-		if (file_exists(self::$configDir . "/config.php")
-			and !is_writable(self::$configDir . "/config.php")
-		) {
+		$configFileWritable = file_exists(self::$configDir . "/config.php") && is_writable(self::$configDir . "/config.php");
+		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
+			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
 			if (self::$CLI) {
 				echo $l->t('Cannot write into "config" directory!')."\n";
 				echo $l->t('This can usually be fixed by giving the webserver write access to the config directory')."\n";

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -1049,4 +1049,12 @@ class OC_Helper {
 		return array('free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative);
 
 	}
+
+	/**
+	 * Returns whether the config file is set manually to read-only
+	 * @return bool
+	 */
+	public static function isReadOnlyConfigEnabled() {
+		return \OC::$server->getConfig()->getSystemValue('config_is_read_only', false);
+	}
 }

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -42,6 +42,7 @@ $tmpl->assign('mail_smtppassword', OC_Config::getValue( "mail_smtppassword", '' 
 $tmpl->assign('entries', $entries);
 $tmpl->assign('entriesremain', $entriesremain);
 $tmpl->assign('htaccessworking', $htaccessworking);
+$tmpl->assign('readOnlyConfigEnabled', OC_Helper::isReadOnlyConfigEnabled());
 $tmpl->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
 $tmpl->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());
 $tmpl->assign('has_fileinfo', OC_Util::fileInfoLoaded());
@@ -56,6 +57,7 @@ $tmpl->assign('shareEnforceExpireDate', OC_Appconfig::getValue('core', 'shareapi
 $excludeGroups = OC_Appconfig::getValue('core', 'shareapi_exclude_groups', 'no') === 'yes' ? true : false;
 $tmpl->assign('shareExcludeGroups', $excludeGroups);
 $excludedGroupsList = OC_Appconfig::getValue('core', 'shareapi_exclude_groups_list', '');
+
 $excludedGroupsList = explode(',', $excludedGroupsList); // FIXME: this should be JSON!
 $tmpl->assign('shareExcludedGroupsList', implode('|', $excludedGroupsList));
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -62,14 +62,28 @@ if (!$_['isConnectedViaHTTPS']) {
 // is htaccess working ?
 if (!$_['htaccessworking']) {
 	?>
-<div class="section">
-	<h2><?php p($l->t('Security Warning'));?></h2>
+	<div class="section">
+		<h2><?php p($l->t('Security Warning')); ?></h2>
 
 	<span class="securitywarning">
 		<?php p($l->t('Your data directory and your files are probably accessible from the internet. The .htaccess file is not working. We strongly suggest that you configure your webserver in a way that the data directory is no longer accessible or you move the data directory outside the webserver document root.')); ?>
 	</span>
 
-</div>
+	</div>
+<?php
+}
+
+// is read only config enabled
+if ($_['readOnlyConfigEnabled']) {
+?>
+<div class="section">
+	<h2><?php p($l->t('Read-Only config enabled'));?></h2>
+
+	<span class="securitywarning">
+		<?php p($l->t('The Read-Only config has been enabled. This prevents setting some configurations via the web-interface. Furthermore, the file needs to be made writable manually for every update.')); ?>
+	</span>
+
+	</div>
 <?php
 }
 


### PR DESCRIPTION
Workaround required for IIS setups running ownCloud to prevent dataloss.

Long-term solution would be to move some configuration settings to the database

Conflicts:
    lib/base.php
    settings/admin.php

Backport of #12419
