### PR TITLE
Send the mime icon if we can't generate a preview

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -703,10 +703,7 @@ class Preview {
 
 		// We still don't have a preview, so we send back the mime icon
 		if (is_null($this->preview)) {
-			$this->preview = new \OC_Image();
-			$mimeIconWebPath = \OC_Helper::mimetypeIcon($this->mimeType);
-			$mimeIconServerPath =  str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
-			$this->preview->loadFromFile($mimeIconServerPath);
+			$this->getMimeIcon();
 		}
 
 		return $this->preview;
@@ -1092,6 +1089,30 @@ class Preview {
 		if ($preview) {
 			$this->resizeAndStore($fileId);
 		}
+	}
+
+	/**
+	 * Creates a mime icon preview of the asked dimensions
+	 *
+	 * This will paste the mime icon in the middle of an empty preview of the asked dimension
+	 */
+	private function getMimeIcon() {
+		$image = new \OC_Image();
+		$mimeIconWebPath = \OC_Helper::mimetypeIcon($this->mimeType);
+		if (empty(\OC::$WEBROOT)) {
+			$mimeIconServerPath = \OC::$SERVERROOT . $mimeIconWebPath;
+		} else {
+			$mimeIconServerPath = str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
+		}
+		$image->loadFromFile($mimeIconServerPath);
+
+		$previewWidth = (int)$image->width();
+		$previewHeight = (int)$image->height();
+		$askedWidth = $this->getMaxX();
+		$askedHeight = $this->getMaxY();
+		$this->cropAndFill(
+			$image, $askedWidth, $askedHeight, $previewWidth, $previewHeight
+		);
 	}
 
 	/**

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -812,9 +812,8 @@ class Preview {
 		 */
 		// It turns out the scaled preview is now too big, so we crop the image
 		if ($newPreviewWidth >= $askedWidth && $newPreviewHeight >= $askedHeight) {
-			list($newPreviewWidth, $newPreviewHeight) =
-				$this->crop($image, $askedWidth, $askedHeight, $newPreviewWidth, $newPreviewHeight);
-			$this->storePreview($fileId, $newPreviewWidth, $newPreviewHeight);
+			$this->crop($image, $askedWidth, $askedHeight, $newPreviewWidth, $newPreviewHeight);
+			$this->storePreview($fileId, $askedWidth, $askedHeight);
 
 			return;
 		}
@@ -822,11 +821,10 @@ class Preview {
 		// At least one dimension of the scaled preview is too small,
 		// so we fill the space with a transparent background
 		if (($newPreviewWidth < $askedWidth || $newPreviewHeight < $askedHeight)) {
-			list($newPreviewWidth, $newPreviewHeight) =
-				$this->cropAndFill(
-					$image, $askedWidth, $askedHeight, $newPreviewWidth, $newPreviewHeight
-				);
-			$this->storePreview($fileId, $newPreviewWidth, $newPreviewHeight);
+			$this->cropAndFill(
+				$image, $askedWidth, $askedHeight, $newPreviewWidth, $newPreviewHeight
+			);
+			$this->storePreview($fileId, $askedWidth, $askedHeight);
 
 			return;
 		}
@@ -894,8 +892,6 @@ class Preview {
 	 * @param int $askedHeight
 	 * @param int $previewWidth
 	 * @param null $previewHeight
-	 *
-	 * @return \int[]
 	 */
 	private function crop($image, $askedWidth, $askedHeight, $previewWidth, $previewHeight = null) {
 		$cropX = floor(abs($askedWidth - $previewWidth) * 0.5);
@@ -904,8 +900,6 @@ class Preview {
 		$cropY = 0;
 		$image->crop($cropX, $cropY, $askedWidth, $askedHeight);
 		$this->preview = $image;
-
-		return [$askedWidth, $askedHeight];
 	}
 
 	/**
@@ -917,8 +911,6 @@ class Preview {
 	 * @param int $askedHeight
 	 * @param int $previewWidth
 	 * @param null $previewHeight
-	 *
-	 * @return \int[]
 	 */
 	private function cropAndFill($image, $askedWidth, $askedHeight, $previewWidth, $previewHeight) {
 		if ($previewWidth > $askedWidth) {
@@ -954,8 +946,6 @@ class Preview {
 		$image = new \OC_Image($backgroundLayer);
 
 		$this->preview = $image;
-
-		return [$askedWidth, $askedHeight];
 	}
 
 	/**

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -701,9 +701,12 @@ class Preview {
 			$this->generatePreview($fileId);
 		}
 
-		// We still don't have a preview, so we generate an empty object which can't be displayed
+		// We still don't have a preview, so we send back the mime icon
 		if (is_null($this->preview)) {
 			$this->preview = new \OC_Image();
+			$mimeIconWebPath = \OC_Helper::mimetypeIcon($this->mimeType);
+			$mimeIconServerPath =  str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
+			$this->preview->loadFromFile($mimeIconServerPath);
 		}
 
 		return $this->preview;

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -210,6 +210,27 @@ class Preview extends TestCase {
 	}
 
 	/**
+	 * Tests if the media type icon fits into the asked dimensions
+	 */
+	public function testIsMimePreviewTheRightSize() {
+		$width = 400;
+		$height = 200;
+
+		// Previews for odt files are not enabled
+		$imgData = file_get_contents(\OC::$SERVERROOT . '/tests/data/testimage.odt');
+		$imgPath = '/' . self::TEST_PREVIEW_USER1 . '/files/testimage.odt';
+		$this->rootView->file_put_contents($imgPath, $imgData);
+
+		$preview =
+			new \OC\Preview(self::TEST_PREVIEW_USER1, 'files/', 'testimage.odt', $width, $height);
+		$preview->getPreview();
+		$image = $preview->getPreview();
+
+		$this->assertSame($width, $image->width());
+		$this->assertSame($height, $image->height());
+	}
+
+	/**
 	 * We generate the data to use as it makes it easier to adjust in case we need to test
 	 * something different
 	 *

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -210,9 +210,9 @@ class Preview extends TestCase {
 	}
 
 	/**
-	 * Tests if the media type icon fits into the asked dimensions
+	 * Tests if unsupported previews return an empty object
 	 */
-	public function testIsMimePreviewTheRightSize() {
+	public function testUnsupportedPreviewsReturnEmptyObject() {
 		$width = 400;
 		$height = 200;
 
@@ -226,8 +226,7 @@ class Preview extends TestCase {
 		$preview->getPreview();
 		$image = $preview->getPreview();
 
-		$this->assertSame($width, $image->width());
-		$this->assertSame($height, $image->height());
+		$this->assertSame(false, $image->valid());
 	}
 
 	/**


### PR DESCRIPTION
Sending an invalid OC_Image instance can lead to all sorts of unwanted side effects with 3rd party apps.
The first step to fix this would be to send the mime icon.
Later on we could maybe generate a broken image to send back, to indicate that we were unsuccessful in generating a preview.

It's also possible for individual providers to do a better job by generating their own broken image, but I thought it would be best to have a global solution in place first.

fix #14106
