### PR TITLE
add missing public interface for iOS client app id

### DIFF
--- a/lib/public/defaults.php
+++ b/lib/public/defaults.php
@@ -144,4 +144,12 @@ class Defaults {
 	public function getLongFooter() {
 		return $this->defaults->getLongFooter();
 	}
+
+	/**
+	 * Returns the AppId for the App Store for the iOS Client
+	 * @return string AppId
+	 */
+	public function getiTunesAppId() {
+		return $this->defaults->getiTunesAppId();
+	}
 }


### PR DESCRIPTION
The methods are already in the private code part:

https://github.com/owncloud/core/blob/06267fec8fb57ba6921d4c704cb2c05eb1d4c36e/lib/private/defaults.php#L22
https://github.com/owncloud/core/blob/06267fec8fb57ba6921d4c704cb2c05eb1d4c36e/lib/private/defaults.php#L103

cc @michaelstingl @LukasReschke @jancborchardt 
