### PR TITLE
Add route for download of versions

### DIFF
--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -11,6 +11,8 @@ function() {
 	require_once __DIR__ . '/../ajax/preview.php';
 });
 
+$this->create('files_versions_download', 'download.php')
+	->actionInclude('files_versions/download.php');
 $this->create('files_versions_ajax_getVersions', 'ajax/getVersions.php')
 	->actionInclude('files_versions/ajax/getVersions.php');
 $this->create('files_versions_ajax_rollbackVersion', 'ajax/rollbackVersion.php')

--- a/apps/files_versions/download.php
+++ b/apps/files_versions/download.php
@@ -22,7 +22,7 @@
 */
 
 OCP\JSON::checkAppEnabled('files_versions');
-//OCP\JSON::callCheck();
+OCP\JSON::checkLoggedIn();
 
 $file = $_GET['file'];
 $revision=(int)$_GET['revision'];


### PR DESCRIPTION
Otherwise on master it was not possible anymore to download older versions.

Fixes itself.

@nickvergessen As discussed.
