### PR TITLE
remove border from user menu, adjust to apps menu

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -273,8 +273,8 @@
 	z-index: 2000;
 	display: none;
 	background-color: #383c43;
-	border-bottom-left-radius:7px; border-bottom:1px #333 solid; border-left:1px #333 solid;
-	box-shadow:0 0 7px rgb(29,45,68);
+	border-bottom-left-radius: 7px;
+	box-shadow: 0 0 7px rgb(29,45,68);
 	-moz-box-sizing: border-box; box-sizing: border-box;
 }
 	#expanddiv a {


### PR DESCRIPTION
Small detail: Remove the border on the user menu dropdown to make it the same as the apps menu.

Please review @owncloud/designers 
