### PR TITLE
drop files_external tests from autotest - they will be executed with aut...

### DIFF
--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -19,7 +19,6 @@ function enableApp($app) {
 enableApp('files_sharing');
 enableApp('files_trashbin');
 enableApp('files_encryption');
-enableApp('files_external');
 enableApp('user_ldap');
 enableApp('files_versions');
 

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -20,8 +20,7 @@
 			<exclude>
 				<directory suffix=".php">../3rdparty</directory>
 				<directory suffix=".php">../apps/files/l10n</directory>
-				<directory suffix=".php">../apps/files_external/l10n</directory>
-				<directory suffix=".php">../apps/files_external/3rdparty</directory>
+				<directory suffix=".php">../apps/files_external</directory>
 				<directory suffix=".php">../apps/files_versions/l10n</directory>
 				<directory suffix=".php">../apps/files_encryption/l10n</directory>
 				<directory suffix=".php">../apps/files_encryption/3rdparty</directory>


### PR DESCRIPTION
...otest-external.sh which is coming

see #12168 for the autotest-external.sh

This just drops all those skipped tests.

Without this (sqlite only):

```
Time: 3.06 minutes, Memory: 129.75Mb
624 skipped tests
```

With this (sqlite only):

```
Time: 2.38 minutes, Memory: 98.25Mb 
107 skipped tests 
```

cc @LukasReschke @DeepDiver1975 
