### PR TITLE
Trim port from domain

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -86,17 +86,22 @@ class OC_Request {
 	 * of trusted domains. If no trusted domains have been configured, returns
 	 * true.
 	 * This is used to prevent Host Header Poisoning.
-	 * @param string $domain
+	 * @param string $domainWithPort
 	 * @return bool true if the given domain is trusted or if no trusted domains
 	 * have been configured
 	 */
-	public static function isTrustedDomain($domain) {
+	public static function isTrustedDomain($domainWithPort) {
 		// Extract port from domain if needed
-		$domain = self::getDomainWithoutPort($domain);
+		$domain = self::getDomainWithoutPort($domainWithPort);
 
 		// FIXME: Empty config array defaults to true for now. - Deprecate this behaviour with ownCloud 8.
 		$trustedList = \OC::$server->getConfig()->getSystemValue('trusted_domains', array());
 		if (empty($trustedList)) {
+			return true;
+		}
+
+		// FIXME: Workaround for older instances still with port applied. Remove for ownCloud 9.
+		if(in_array($domainWithPort, $trustedList)) {
 			return true;
 		}
 

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -66,6 +66,22 @@ class OC_Request {
 	}
 
 	/**
+	 * Strips a potential port from a domain (in format domain:port)
+	 * @param $host
+	 * @return string $host without appended port
+	 */
+	public static function getDomainWithoutPort($host) {
+		$pos = strrpos($host, ':');
+		if ($pos !== false) {
+			$port = substr($host, $pos + 1);
+			if (is_numeric($port)) {
+				$host = substr($host, 0, $pos);
+			}
+		}
+		return $host;
+	}
+
+	/**
 	 * Checks whether a domain is considered as trusted from the list
 	 * of trusted domains. If no trusted domains have been configured, returns
 	 * true.
@@ -76,13 +92,7 @@ class OC_Request {
 	 */
 	public static function isTrustedDomain($domain) {
 		// Extract port from domain if needed
-		$pos = strrpos($domain, ':');
-		if ($pos !== false) {
-			$port = substr($domain, $pos + 1);
-			if (is_numeric($port)) {
-				$domain = substr($domain, 0, $pos);
-			}
-		}
+		$domain = self::getDomainWithoutPort($domain);
 
 		// FIXME: Empty config array defaults to true for now. - Deprecate this behaviour with ownCloud 8.
 		$trustedList = \OC::$server->getConfig()->getSystemValue('trusted_domains', array());

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -162,7 +162,7 @@ class OC_Setup {
 		    && is_array($options['trusted_domains'])) {
 			$trustedDomains = $options['trusted_domains'];
 		} else {
-			$trustedDomains = array(OC_Request::serverHost());
+			$trustedDomains = array(\OC_Request::getDomainWithoutPort(\OC_Request::serverHost()));
 		}
 
 		if (OC_Util::runningOnWindows()) {

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -232,7 +232,8 @@ class Test_Request extends \Test\TestCase {
 		return array(
 			array('localhost:500', 'localhost'),
 			array('foo.com', 'foo.com'),
-			array('[1fff:0:a88:85a3::ac1f]:801', '[1fff:0:a88:85a3::ac1f]')
+			array('[1fff:0:a88:85a3::ac1f]:801', '[1fff:0:a88:85a3::ac1f]'),
+			array('[1fff:0:a88:85a3::ac1f]', '[1fff:0:a88:85a3::ac1f]')
 		);
 	}
 

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -228,6 +228,22 @@ class Test_Request extends \Test\TestCase {
 		OC_Config::deleteKey('overwritehost');
 	}
 
+	public function hostWithPortProvider() {
+		return array(
+			array('localhost:500', 'localhost'),
+			array('foo.com', 'foo.com'),
+			array('[1fff:0:a88:85a3::ac1f]:801', '[1fff:0:a88:85a3::ac1f]')
+		);
+	}
+
+	/**
+	 * @dataProvider hostWithPortProvider
+	 */
+	public function testGetDomainWithoutPort($hostWithPort, $host) {
+		$this->assertEquals($host, OC_Request::getDomainWithoutPort($hostWithPort));
+
+	}
+
 	/**
 	 * @dataProvider trustedDomainDataProvider
 	 */


### PR DESCRIPTION
Depending on the used environment the port might be appended to the host header resulting in an inaccessible instance when initially setting up on a system with a different HTTP or HTTPS port. (for example test:500)

To test this setup ownCloud under a different port with and without this patch. (heads-up: localhost is always white-listed, so use a different domain)

@jnfrmarks Please test carefully and also decide (together with @karlitschek) whether this warrants a backport. I'd vote for yes.
