### PR TITLE
[encryption] remove check for PHP version

### DIFF
--- a/apps/files_encryption/hooks/hooks.php
+++ b/apps/files_encryption/hooks/hooks.php
@@ -66,7 +66,7 @@ class Hooks {
 			//check if all requirements are met
 			if (!Helper::checkRequirements() || !Helper::checkConfiguration()) {
 				$error_msg = $l->t("Missing requirements.");
-				$hint = $l->t('Please make sure that PHP 5.3.3 or newer is installed and that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
+				$hint = $l->t('Please make sure that OpenSSL together with the PHP extension is enabled and configured properly. For now, the encryption app has been disabled.');
 				\OC_App::disable('files_encryption');
 				\OCP\Util::writeLog('Encryption library', $error_msg . ' ' . $hint, \OCP\Util::ERROR);
 				\OCP\Template::printErrorPage($error_msg, $hint);

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -392,14 +392,10 @@ class Helper {
 	 * @return bool true if requirements are met
 	 */
 	public static function checkRequirements() {
-		$result = true;
 
 		//openssl extension needs to be loaded
-		$result &= extension_loaded("openssl");
-		// we need php >= 5.3.3
-		$result &= version_compare(phpversion(), '5.3.3', '>=');
+		return extension_loaded("openssl");
 
-		return (bool) $result;
 	}
 
 	/**


### PR DESCRIPTION
OC8 and later requires PHP >= 5.4, so we can remove the check from the encryption app
