### PR TITLE
Use UID instead of login name

### DIFF
--- a/settings/ajax/geteveryonecount.php
+++ b/settings/ajax/geteveryonecount.php
@@ -25,7 +25,7 @@ OC_JSON::checkSubAdminUser();
 
 $userCount = 0;
 
-$currentUser = \OC::$server->getUserSession()->getLoginName();
+$currentUser = \OC::$server->getUserSession()->getUser()->getUID();
 
 if (!OC_User::isAdminUser($currentUser)) {
 	$groups = OC_SubAdmin::getSubAdminsGroups($currentUser);


### PR DESCRIPTION
Login name can be something different and thus I'm pretty sure this will break in combination with external auth providers such as LDAP.

Fixes itself.

@blizzz Do you agree?
