### PR TITLE
Use proper hooks

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -679,7 +679,7 @@ class OC {
 			OC_Hook::connect('OC_User', 'post_deleteUser', 'OC\Share\Hooks', 'post_deleteUser');
 			OC_Hook::connect('OC_User', 'post_addToGroup', 'OC\Share\Hooks', 'post_addToGroup');
 			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OC\Share\Hooks', 'post_removeFromGroup');
-			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC\Share\Hooks', 'post_deleteGroup');
+			OC_Hook::connect('OC_Group', 'post_deleteGroup', 'OC\Share\Hooks', 'post_deleteGroup');
 		}
 	}
 

--- a/lib/private/group.php
+++ b/lib/private/group.php
@@ -103,7 +103,7 @@ class OC_Group {
 		$group = self::getManager()->get($gid);
 		if ($group) {
 			if ($group->delete()) {
-				OC_Hook::emit("OC_User", "post_deleteGroup", array("gid" => $gid));
+				OC_Hook::emit("OC_Group", "post_deleteGroup", array("gid" => $gid));
 				return true;
 			}
 		}

--- a/lib/private/subadmin.php
+++ b/lib/private/subadmin.php
@@ -20,7 +20,7 @@
  *
  */
 OC_Hook::connect('OC_User', 'post_deleteUser', 'OC_SubAdmin', 'post_deleteUser');
-OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC_SubAdmin', 'post_deleteGroup');
+OC_Hook::connect('OC_Group', 'post_deleteGroup', 'OC_SubAdmin', 'post_deleteGroup');
 /**
  * This class provides all methods needed for managing groups.
  *


### PR DESCRIPTION
As documented in `private/group.php`, this is a `OC_Group` hook and not `OC_User`…

``` php
/**
 * This class provides all methods needed for managing groups.
 *
 * Hooks provided:
 *   pre_createGroup(&run, gid)
 *   post_createGroup(gid)
 *   pre_deleteGroup(&run, gid)
 *   post_deleteGroup(gid)
 *   pre_addToGroup(&run, uid, gid)
 *   post_addToGroup(uid, gid)
 *   pre_removeFromGroup(&run, uid, gid)
 *   post_removeFromGroup(uid, gid)
 */
```

Fixes itself.
