### PR TITLE
Merge headers

### DIFF
--- a/lib/public/appframework/controller.php
+++ b/lib/public/appframework/controller.php
@@ -70,7 +70,7 @@ abstract class Controller {
 						$data->getData(),
 						$data->getStatus()
 					);
-					$response->setHeaders($data->getHeaders());
+					$response->setHeaders(array_merge($data->getHeaders(), $response->getHeaders()));
 					return $response;
 				} else {
 					return new JSONResponse($data);

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -173,7 +173,8 @@ class ControllerTest extends \Test\TestCase {
 	public function testFormatDataResponseJSON() {
 		$expectedHeaders = array(
 			'test' => 'something',
-			'Cache-Control' => 'no-cache, must-revalidate'
+			'Cache-Control' => 'no-cache, must-revalidate',
+			'Content-Type' => 'application/json; charset=utf-8'
 		);
 
 		$response = $this->controller->customDataResponse(array('hi'));


### PR DESCRIPTION
Otherwise the headers from `JSONResponse` are gone and the Content-Type of the response would be `text/html` instead of `application/json; charset=utf-8`. This leads to broken scripts since we set the `nosniff` header, furthermore this is very bad from a security PoV.

Fixes itself.

@Raydiation @MorrisJobke 
