### PR TITLE
password column needs to allow null (oc7 backport)

### DIFF
--- a/apps/files_sharing/appinfo/database.xml
+++ b/apps/files_sharing/appinfo/database.xml
@@ -32,7 +32,7 @@
 			<field>
 				<name>password</name>
 				<type>text</type>
-				<notnull>true</notnull>
+				<notnull>false</notnull>
 				<length>64</length>
 				<comments>Optional password for the public share</comments>
 			</field>


### PR DESCRIPTION
password column needs to allow null otherwise Oracle will break for empty passwords

This problem was discovered here: https://github.com/owncloud/core/pull/12567#issuecomment-65516071

Oracle treats empty strings as null so we need to allow null for the password field otherwise non-password protected server-to-server shares will fail on Oracle.

cc @icewind1991 

@karlitschek do you agree on the backport?
