### PR TITLE
adding dependencies for command line tools and php libraries

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1112,8 +1112,8 @@ class OC_App {
 			}
 
 			// check for required dependencies
-			$dependencyAnalyzer = new DependencyAnalyzer($app, new Platform($config), $l);
-			$missing = $dependencyAnalyzer->analyze();
+			$dependencyAnalyzer = new DependencyAnalyzer(new Platform($config), $l);
+			$missing = $dependencyAnalyzer->analyze($app);
 			if(!empty($missing)) {
 				$missingMsg = join(PHP_EOL, $missing);
 				throw new \Exception(

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -25,6 +25,8 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+use OC\App\DependencyAnalyzer;
+use OC\App\Platform;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
@@ -1082,6 +1084,7 @@ class OC_App {
 	 */
 	public static function installApp($app) {
 		$l = \OC::$server->getL10N('core');
+		$config = \OC::$server->getConfig();
 		$appData=OC_OCSClient::getApplication($app);
 
 		// check if app is a shipped app or not. OCS apps have an integer as id, shipped apps use a string
@@ -1106,13 +1109,25 @@ class OC_App {
 						array($info['name'])
 					)
 				);
-			}else{
-				OC_Appconfig::setValue( $app, 'enabled', 'yes' );
-				if(isset($appData['id'])) {
-					OC_Appconfig::setValue( $app, 'ocsid', $appData['id'] );
-				}
-				\OC_Hook::emit('OC_App', 'post_enable', array('app' => $app));
 			}
+
+			// check for required dependencies
+			$dependencyAnalyzer = new DependencyAnalyzer($app, new Platform($config), $l);
+			$missing = $dependencyAnalyzer->analyze();
+			if(!empty($missing)) {
+				$missingMsg = join(PHP_EOL, $missing);
+				throw new \Exception(
+					$l->t('App \"%s\" cannot be installed because the following dependencies are not fulfilled: %s',
+						array($info['name'], $missingMsg)
+					)
+				);
+			}
+
+			$config->setAppValue($app, 'enabled', 'yes');
+			if(isset($appData['id'])) {
+				$config->setAppValue($app, 'ocsid', $appData['id'] );
+			}
+			\OC_Hook::emit('OC_App', 'post_enable', array('app' => $app));
 		}else{
 			throw new \Exception($l->t("No app name specified"));
 		}

--- a/lib/private/app/dependencyanalyzer.php
+++ b/lib/private/app/dependencyanalyzer.php
@@ -48,6 +48,7 @@ class DependencyAnalyzer {
 		$this->analyzeDatabases();
 		$this->analyzeCommands();
 		$this->analyzeLibraries();
+		$this->analyzeOS();
 		return $this->missing;
 	}
 
@@ -134,6 +135,26 @@ class DependencyAnalyzer {
 			}
 		}
 	}
+
+	private function analyzeOS() {
+		if (!isset($this->dependencies['os'])) {
+			return;
+		}
+
+		$oss = $this->dependencies['os'];
+		if (empty($oss)) {
+			return;
+		}
+		$oss = array_map(function($os) {
+			return $this->getValue($os);
+		}, $oss);
+		$currentOS = $this->platform->getOS();
+		if (!in_array($currentOS, $oss)) {
+			$this->addMissing((string)$this->l->t('Following platforms are supported: %s', join(', ', $oss)));
+		}
+	}
+
+
 
 	/**
 	 * @param $element

--- a/lib/private/app/dependencyanalyzer.php
+++ b/lib/private/app/dependencyanalyzer.php
@@ -79,6 +79,9 @@ class DependencyAnalyzer {
 		if (empty($supportedDatabases)) {
 			return;
 		}
+		if (!is_array($supportedDatabases)) {
+			$supportedDatabases = array($supportedDatabases);
+		}
 		$supportedDatabases = array_map(function($db) {
 			return $this->getValue($db);
 		}, $supportedDatabases);
@@ -94,6 +97,9 @@ class DependencyAnalyzer {
 		}
 
 		$commands = $this->dependencies['command'];
+		if (!is_array($commands)) {
+			$commands = array($commands);
+		}
 		$os = $this->platform->getOS();
 		foreach($commands as $command) {
 			if (isset($command['@attributes']['os']) && $command['@attributes']['os'] !== $os) {
@@ -112,6 +118,9 @@ class DependencyAnalyzer {
 		}
 
 		$libs = $this->dependencies['lib'];
+		if (!is_array($libs)) {
+			$libs = array($libs);
+		}
 		foreach($libs as $lib) {
 			$libName = $this->getValue($lib);
 			$libVersion = $this->platform->getLibraryVersion($libName);
@@ -148,9 +157,13 @@ class DependencyAnalyzer {
 		if (empty($oss)) {
 			return;
 		}
-		$oss = array_map(function($os) {
-			return $this->getValue($os);
-		}, $oss);
+		if (is_array($oss)) {
+			$oss = array_map(function ($os) {
+				return $this->getValue($os);
+			}, $oss);
+		} else {
+			$oss = array($oss);
+		}
 		$currentOS = $this->platform->getOS();
 		if (!in_array($currentOS, $oss)) {
 			$this->addMissing((string)$this->l->t('Following platforms are supported: %s', join(', ', $oss)));
@@ -165,8 +178,8 @@ class DependencyAnalyzer {
 			$minVersion = $this->appInfo['requiremin'];
 		}
 		$maxVersion = null;
-		if (isset($this->dependencies['oc']['@attributes']['max-version'])) {
-			$maxVersion = $this->dependencies['oc']['@attributes']['max-version'];
+		if (isset($this->dependencies['owncloud']['@attributes']['max-version'])) {
+			$maxVersion = $this->dependencies['owncloud']['@attributes']['max-version'];
 		} elseif (isset($this->appInfo['requiremax'])) {
 			$maxVersion = $this->appInfo['requiremax'];
 		}
@@ -190,7 +203,7 @@ class DependencyAnalyzer {
 	private function getValue($element) {
 		if (isset($element['@value']))
 			return $element['@value'];
-		return strval($element);
+		return (string)$element;
 	}
 
 	/**

--- a/lib/private/app/dependencyanalyzer.php
+++ b/lib/private/app/dependencyanalyzer.php
@@ -26,6 +26,8 @@ class DependencyAnalyzer {
 	/** @var array  */
 	private $dependencies = array();
 
+	private $appInfo = array();
+
 	/**
 	 * @param array $app
 	 * @param Platform $platform
@@ -49,6 +51,7 @@ class DependencyAnalyzer {
 		$this->analyzeCommands();
 		$this->analyzeLibraries();
 		$this->analyzeOS();
+		$this->analyzeOC();
 		return $this->missing;
 	}
 
@@ -154,7 +157,31 @@ class DependencyAnalyzer {
 		}
 	}
 
+	private function analyzeOC() {
+		$minVersion = null;
+		if (isset($this->dependencies['owncloud']['@attributes']['min-version'])) {
+			$minVersion = $this->dependencies['owncloud']['@attributes']['min-version'];
+		} elseif (isset($this->appInfo['requiremin'])) {
+			$minVersion = $this->appInfo['requiremin'];
+		}
+		$maxVersion = null;
+		if (isset($this->dependencies['oc']['@attributes']['max-version'])) {
+			$maxVersion = $this->dependencies['oc']['@attributes']['max-version'];
+		} elseif (isset($this->appInfo['requiremax'])) {
+			$maxVersion = $this->appInfo['requiremax'];
+		}
 
+		if (!is_null($minVersion)) {
+			if (version_compare($this->platform->getOcVersion(), $minVersion, '<')) {
+				$this->addMissing((string)$this->l->t('ownCloud %s or higher is required.', $minVersion));
+			}
+		}
+		if (!is_null($maxVersion)) {
+			if (version_compare($this->platform->getOcVersion(), $maxVersion, '>')) {
+				$this->addMissing((string)$this->l->t('ownCloud with a version lower than %s is required.', $maxVersion));
+			}
+		}
+	}
 
 	/**
 	 * @param $element

--- a/lib/private/app/platform.php
+++ b/lib/private/app/platform.php
@@ -10,6 +10,7 @@
 
 namespace OC\App;
 
+use OC_Util;
 use OCP\IConfig;
 
 /**
@@ -33,6 +34,13 @@ class Platform {
 	 */
 	public function getPhpVersion() {
 		return phpversion();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getOcVersion() {
+		return OC_Util::getVersion();
 	}
 
 	/**

--- a/lib/private/app/platform.php
+++ b/lib/private/app/platform.php
@@ -12,16 +12,32 @@ namespace OC\App;
 
 use OCP\IConfig;
 
+/**
+ * Class Platform
+ *
+ * This class basically abstracts any kind of information which can be retrieved from the underlying system.
+ *
+ * @package OC\App
+ */
 class Platform {
 
+	/**
+	 * @param IConfig $config
+	 */
 	function __construct(IConfig $config) {
 		$this->config = $config;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function getPhpVersion() {
 		return phpversion();
 	}
 
+	/**
+	 * @return string
+	 */
 	public function getDatabase() {
 		$dbType = $this->config->getSystemValue('dbtype', 'sqlite');
 		if ($dbType === 'sqlite3') {
@@ -29,5 +45,21 @@ class Platform {
 		}
 
 		return $dbType;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getOS() {
+		return php_uname('s');
+	}
+
+	/**
+	 * @param $command
+	 * @return bool
+	 */
+	public function isCommandKnown($command) {
+		$path = \OC_Helper::findBinaryPath($command);
+		return ($path !== null);
 	}
 }

--- a/lib/private/app/platform.php
+++ b/lib/private/app/platform.php
@@ -62,4 +62,10 @@ class Platform {
 		$path = \OC_Helper::findBinaryPath($command);
 		return ($path !== null);
 	}
+
+	public function getLibraryVersion($name) {
+		$repo = new PlatformRepository();
+		$lib = $repo->findLibrary($name);
+		return $lib;
+	}
 }

--- a/lib/private/app/platform.php
+++ b/lib/private/app/platform.php
@@ -40,7 +40,8 @@ class Platform {
 	 * @return string
 	 */
 	public function getOcVersion() {
-		return OC_Util::getVersion();
+		$v = OC_Util::getVersion();
+		return join('.', $v);
 	}
 
 	/**

--- a/lib/private/app/platformrepository.php
+++ b/lib/private/app/platformrepository.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace OC\App;
+
+/**
+ * Class PlatformRepository
+ *
+ * Inspired by the composer project - licensed under MIT
+ * https://github.com/composer/composer/blob/master/src/Composer/Repository/PlatformRepository.php#L82
+ *
+ * @package OC\App
+ */
+class PlatformRepository {
+	public function __construct() {
+		$this->packages = $this->initialize();
+	}
+
+	protected function initialize() {
+		$loadedExtensions = get_loaded_extensions();
+		$packages = array();
+
+		// Extensions scanning
+		foreach ($loadedExtensions as $name) {
+			if (in_array($name, array('standard', 'Core'))) {
+				continue;
+			}
+
+			$ext = new \ReflectionExtension($name);
+			try {
+				$prettyVersion = $ext->getVersion();
+			} catch (\UnexpectedValueException $e) {
+				$prettyVersion = '0';
+			}
+			try {
+				$prettyVersion = $this->normalizeVersion($prettyVersion);
+			} catch (\UnexpectedValueException $e) {
+				continue;
+			}
+
+			$packages[$this->buildPackageName($name)] = $prettyVersion;
+		}
+
+		foreach ($loadedExtensions as $name) {
+			$prettyVersion = null;
+			switch ($name) {
+				case 'curl':
+					$curlVersion = curl_version();
+					$prettyVersion = $curlVersion['version'];
+					break;
+
+				case 'iconv':
+					$prettyVersion = ICONV_VERSION;
+					break;
+
+				case 'intl':
+					$name = 'ICU';
+					if (defined('INTL_ICU_VERSION')) {
+						$prettyVersion = INTL_ICU_VERSION;
+					} else {
+						$reflector = new \ReflectionExtension('intl');
+
+						ob_start();
+						$reflector->info();
+						$output = ob_get_clean();
+
+						preg_match('/^ICU version => (.*)$/m', $output, $matches);
+						$prettyVersion = $matches[1];
+					}
+
+					break;
+
+				case 'libxml':
+					$prettyVersion = LIBXML_DOTTED_VERSION;
+					break;
+
+				case 'openssl':
+					$prettyVersion = preg_replace_callback('{^(?:OpenSSL\s*)?([0-9.]+)([a-z]?).*}', function ($match) {
+						return $match[1] . (empty($match[2]) ? '' : '.' . (ord($match[2]) - 96));
+					}, OPENSSL_VERSION_TEXT);
+					break;
+
+				case 'pcre':
+					$prettyVersion = preg_replace('{^(\S+).*}', '$1', PCRE_VERSION);
+					break;
+
+				case 'uuid':
+					$prettyVersion = phpversion('uuid');
+					break;
+
+				case 'xsl':
+					$prettyVersion = LIBXSLT_DOTTED_VERSION;
+					break;
+
+				default:
+					// None handled extensions have no special cases, skip
+					continue 2;
+			}
+
+			try {
+				$prettyVersion = $this->normalizeVersion($prettyVersion);
+			} catch (\UnexpectedValueException $e) {
+				continue;
+			}
+
+			$packages[$this->buildPackageName($name)] = $prettyVersion;
+		}
+
+		return $packages;
+	}
+
+	private function buildPackageName($name) {
+		return str_replace(' ', '-', $name);
+	}
+
+	/**
+	 * @param $name
+	 * @return string
+	 */
+	public function findLibrary($name) {
+		$extName = $this->buildPackageName($name);
+		if (isset($this->packages[$extName])) {
+			return $this->packages[$extName];
+		}
+		return null;
+	}
+
+	private static $modifierRegex = '[._-]?(?:(stable|beta|b|RC|alpha|a|patch|pl|p)(?:[.-]?(\d+))?)?([.-]?dev)?';
+
+	/**
+	 * Normalizes a version string to be able to perform comparisons on it
+	 *
+	 * https://github.com/composer/composer/blob/master/src/Composer/Package/Version/VersionParser.php#L94
+	 *
+	 * @param string $version
+	 * @param string $fullVersion optional complete version string to give more context
+	 * @throws \UnexpectedValueException
+	 * @return string
+	 */
+	public function normalizeVersion($version, $fullVersion = null) {
+		$version = trim($version);
+		if (null === $fullVersion) {
+			$fullVersion = $version;
+		}
+		// ignore aliases and just assume the alias is required instead of the source
+		if (preg_match('{^([^,\s]+) +as +([^,\s]+)$}', $version, $match)) {
+			$version = $match[1];
+		}
+		// match master-like branches
+		if (preg_match('{^(?:dev-)?(?:master|trunk|default)$}i', $version)) {
+			return '9999999-dev';
+		}
+		if ('dev-' === strtolower(substr($version, 0, 4))) {
+			return 'dev-' . substr($version, 4);
+		}
+		// match classical versioning
+		if (preg_match('{^v?(\d{1,3})(\.\d+)?(\.\d+)?(\.\d+)?' . self::$modifierRegex . '$}i', $version, $matches)) {
+			$version = $matches[1]
+				. (!empty($matches[2]) ? $matches[2] : '.0')
+				. (!empty($matches[3]) ? $matches[3] : '.0')
+				. (!empty($matches[4]) ? $matches[4] : '.0');
+			$index = 5;
+		} elseif (preg_match('{^v?(\d{4}(?:[.:-]?\d{2}){1,6}(?:[.:-]?\d{1,3})?)' . self::$modifierRegex . '$}i', $version, $matches)) { // match date-based versioning
+			$version = preg_replace('{\D}', '-', $matches[1]);
+			$index = 2;
+		} elseif (preg_match('{^v?(\d{4,})(\.\d+)?(\.\d+)?(\.\d+)?' . self::$modifierRegex . '$}i', $version, $matches)) {
+			$version = $matches[1]
+				. (!empty($matches[2]) ? $matches[2] : '.0')
+				. (!empty($matches[3]) ? $matches[3] : '.0')
+				. (!empty($matches[4]) ? $matches[4] : '.0');
+			$index = 5;
+		}
+		// add version modifiers if a version was matched
+		if (isset($index)) {
+			if (!empty($matches[$index])) {
+				if ('stable' === $matches[$index]) {
+					return $version;
+				}
+				$version .= '-' . $this->expandStability($matches[$index]) . (!empty($matches[$index + 1]) ? $matches[$index + 1] : '');
+			}
+			if (!empty($matches[$index + 2])) {
+				$version .= '-dev';
+			}
+			return $version;
+		}
+		$extraMessage = '';
+		if (preg_match('{ +as +' . preg_quote($version) . '$}', $fullVersion)) {
+			$extraMessage = ' in "' . $fullVersion . '", the alias must be an exact version';
+		} elseif (preg_match('{^' . preg_quote($version) . ' +as +}', $fullVersion)) {
+			$extraMessage = ' in "' . $fullVersion . '", the alias source must be an exact version, if it is a branch name you should prefix it with dev-';
+		}
+		throw new \UnexpectedValueException('Invalid version string "' . $version . '"' . $extraMessage);
+	}
+
+	private function expandStability($stability) {
+		$stability = strtolower($stability);
+		switch ($stability) {
+			case 'a':
+				return 'alpha';
+			case 'b':
+				return 'beta';
+			case 'p':
+			case 'pl':
+				return 'patch';
+			case 'rc':
+				return 'RC';
+			default:
+				return $stability;
+		}
+	}
+}

--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -118,7 +118,8 @@ class AppSettingsController extends Controller {
 		}
 
 		// fix groups to be an array
-		$apps = array_map(function($app){
+		$dependencyAnalyzer = new DependencyAnalyzer(new Platform($this->config), $this->l10n);
+		$apps = array_map(function($app) use ($dependencyAnalyzer) {
 			$groups = array();
 			if (is_string($app['groups'])) {
 				$groups = json_decode($app['groups']);
@@ -127,8 +128,7 @@ class AppSettingsController extends Controller {
 			$app['canUnInstall'] = !$app['active'] && $app['removable'];
 
 			// analyse dependencies
-			$dependencyAnalyzer = new DependencyAnalyzer($app, new Platform($this->config), $this->l10n);
-			$missing = $dependencyAnalyzer->analyze();
+			$missing = $dependencyAnalyzer->analyze($app);
 
 			$app['canInstall'] = empty($missing);
 			$app['missingDependencies'] = $missing;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -200,6 +200,11 @@ span.version { margin-left:1em; margin-right:1em; color:#555; }
 	border-bottom: 1px solid #e8e8e8;
 }
 
+.app-dependencies {
+	margin-top: 10px;
+	color: #c33;
+}
+
 .missing-dependencies {
 	list-style: initial;
 	list-style-type: initial;

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -52,12 +52,14 @@
 	</p>
 	{{/if}}
 	{{#unless canInstall}}
-	<div><?php p($l->t('This app cannot be installed because the following dependencies are not fulfilled:')); ?></div>
+	<div class="app-dependencies">
+	<p><?php p($l->t('This app cannot be installed because the following dependencies are not fulfilled:')); ?></p>
 	<ul class="missing-dependencies">
 	{{#each missingDependencies}}
 	<li>{{this}}</li>
 	{{/each}}
 	</ul>
+	</div>
 	{{/unless}}
 
 	{{#if update}}
@@ -70,9 +72,7 @@
 	<br />
 	<input type="hidden" id="group_select" title="<?php p($l->t('All')); ?>" style="width: 200px">
 	{{else}}
-	{{#if canInstall}}
-	<input class="enable" type="submit" data-appid="{{id}}" data-active="false" value="<?php p($l->t("Enable"));?>"/>
-	{{/if}}
+	<input class="enable" type="submit" data-appid="{{id}}" data-active="false" {{#unless canInstall}}disabled="disabled"{{/unless}} value="<?php p($l->t("Enable"));?>"/>
 	{{/if}}
 	{{#if canUnInstall}}
 	<input class="uninstall" type="submit" value="<?php p($l->t('Uninstall App')); ?>" data-appid="{{id}}" />

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -44,6 +44,21 @@
 				},
 				"@value": "notepad.exe"
 			}
+		],
+		"lib": [
+			{
+				"@attributes" : {
+					"min-version": "1.2"
+				},
+				"@value": "xml"
+			},
+			{
+				"@attributes" : {
+					"max-version": "2.0"
+				},
+				"@value": "intl"
+			},
+			"curl"
 		]
 	}
 }

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -59,6 +59,7 @@
 				"@value": "intl"
 			},
 			"curl"
-		]
+		],
+		"os": "Linux"
 	}
 }

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -60,6 +60,12 @@
 			},
 			"curl"
 		],
-		"os": "Linux"
+		"os": "Linux",
+		"owncloud": {
+			"@attributes" : {
+				"min-version": "7.01",
+				"max-version": "8"
+			}
+		}
 	}
 }

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -63,7 +63,7 @@
 		"os": "Linux",
 		"owncloud": {
 			"@attributes" : {
-				"min-version": "7.01",
+				"min-version": "7.0.1",
 				"max-version": "8"
 			}
 		}

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -28,5 +28,6 @@
 		<lib min-version="1.2">xml</lib>
 		<lib max-version="2.0">intl</lib>
 		<lib>curl</lib>
+		<os>Linux</os>
 	</dependencies>
 </info>

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -25,5 +25,8 @@
 		<database>mysql</database>
 		<command os="linux">grep</command>
 		<command os="windows">notepad.exe</command>
+		<lib min-version="1.2">xml</lib>
+		<lib max-version="2.0">intl</lib>
+		<lib>curl</lib>
 	</dependencies>
 </info>

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -29,5 +29,6 @@
 		<lib max-version="2.0">intl</lib>
 		<lib>curl</lib>
 		<os>Linux</os>
+		<owncloud min-version="7.0.1" max-version="8" />
 	</dependencies>
 </info>

--- a/tests/lib/app/dependencyanalyzer.php
+++ b/tests/lib/app/dependencyanalyzer.php
@@ -141,6 +141,34 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($expectedMissing, $missing);
 	}
 
+	/**
+	 * @dataProvider providesOS
+	 * @param $expectedMissing
+	 * @param $oss
+	 */
+	function testOS($expectedMissing, $oss) {
+		$app = array(
+			'dependencies' => array()
+		);
+		if (!is_null($oss)) {
+			$app['dependencies']['os'] = $oss;
+		}
+
+		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
+		$missing = $analyser->analyze();
+
+		$this->assertTrue(is_array($missing));
+		$this->assertEquals($expectedMissing, $missing);
+	}
+
+	function providesOS() {
+		return array(
+			array(array(), null),
+			array(array(), array()),
+			array(array('Following platforms are supported: WINNT'), array('WINNT'))
+		);
+	}
+
 	function providesLibs() {
 		return array(
 			// we expect curl to exist

--- a/tests/lib/app/dependencyanalyzer.php
+++ b/tests/lib/app/dependencyanalyzer.php
@@ -51,6 +51,9 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 				}
 				return null;
 			}));
+		$this->platformMock->expects($this->any())
+			->method('getOcVersion')
+			->will( $this->returnValue('8.0.1'));
 
 		$this->l10nMock = $this->getMockBuilder('\OCP\IL10N')
 			->disableOriginalConstructor()
@@ -159,6 +162,35 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
+	}
+
+	/**
+	 * @dataProvider providesOC
+	 * @param $expectedMissing
+	 * @param $oc
+	 */
+	function testOC($expectedMissing, $oc) {
+		$app = array(
+			'dependencies' => array()
+		);
+		if (!is_null($oc)) {
+			$app['dependencies']['oc'] = $oc;
+		}
+
+		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
+		$missing = $analyser->analyze();
+
+		$this->assertTrue(is_array($missing));
+		$this->assertEquals($expectedMissing, $missing);
+	}
+
+	function providesOC() {
+		return array(
+			// no version -> no missing dependency
+			array(array(), null),
+			array(array('ownCloud 9 or higher is required.'), array('@attributes' => array('min-version' => '9'))),
+			array(array('ownCloud with a version lower than 5.1.2 is required.'), array('@attributes' => array('max-version' => '5.1.2'))),
+		);
 	}
 
 	function providesOS() {

--- a/tests/lib/app/dependencyanalyzer.php
+++ b/tests/lib/app/dependencyanalyzer.php
@@ -15,15 +15,14 @@ use OCP\IL10N;
 
 class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 * @var Platform
-	 */
+	/** @var Platform */
 	private $platformMock;
 
-	/**
-	 * @var IL10N
-	 */
+	/** @var IL10N */
 	private $l10nMock;
+
+	/** @var \OC\App\DependencyAnalyzer */
+	private $analyser;
 
 	public function setUp() {
 		$this->platformMock = $this->getMockBuilder('\OC\App\Platform')
@@ -63,6 +62,8 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			->will($this->returnCallback(function($text, $parameters = array()) {
 				return vsprintf($text, $parameters);
 			}));
+
+		$this->analyser = new \OC\App\DependencyAnalyzer($this->platformMock, $this->l10nMock);
 	}
 
 	/**
@@ -80,8 +81,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		if (!is_null($maxVersion)) {
 			$app['dependencies']['php']['@attributes']['max-version'] = $maxVersion;
 		}
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
@@ -98,8 +98,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		if (!is_null($databases)) {
 			$app['dependencies']['database'] = $databases;
 		}
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
@@ -116,8 +115,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		if (!is_null($commands)) {
 			$app['dependencies']['command'] = $commands;
 		}
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
@@ -137,8 +135,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			$app['dependencies']['lib'] = $libs;
 		}
 
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
@@ -157,8 +154,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			$app['dependencies']['os'] = $oss;
 		}
 
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);
@@ -177,8 +173,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			$app['dependencies']['owncloud'] = $oc;
 		}
 
-		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
-		$missing = $analyser->analyze();
+		$missing = $this->analyser->analyze($app);
 
 		$this->assertTrue(is_array($missing));
 		$this->assertEquals($expectedMissing, $missing);

--- a/tests/lib/app/dependencyanalyzer.php
+++ b/tests/lib/app/dependencyanalyzer.php
@@ -174,7 +174,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			'dependencies' => array()
 		);
 		if (!is_null($oc)) {
-			$app['dependencies']['oc'] = $oc;
+			$app['dependencies']['owncloud'] = $oc;
 		}
 
 		$analyser = new \OC\App\DependencyAnalyzer($app, $this->platformMock, $this->l10nMock);
@@ -197,6 +197,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		return array(
 			array(array(), null),
 			array(array(), array()),
+			array(array('Following platforms are supported: ANDROID'), 'ANDROID'),
 			array(array('Following platforms are supported: WINNT'), array('WINNT'))
 		);
 	}
@@ -204,7 +205,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 	function providesLibs() {
 		return array(
 			// we expect curl to exist
-			array(array(), array('curl')),
+			array(array(), 'curl'),
 			// we expect abcde to exist
 			array(array('The library abcde is not available.'), array('abcde')),
 			// curl in version 100.0 does not exist
@@ -226,7 +227,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			// we don't care about tools on Windows - we are on Linux
 			array(array(), array(array('@attributes' => array('os' => 'Windows'), '@value' => 'grepp'))),
 			// grep is known on all systems
-			array(array(), array('grep')),
+			array(array(), 'grep'),
 		);
 	}
 
@@ -235,6 +236,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			// non BC - in case on databases are defined -> all are supported
 			array(array(), null),
 			array(array(), array()),
+			array(array('Following databases are supported: mongodb'), 'mongodb'),
 			array(array('Following databases are supported: sqlite, postgres'), array('sqlite', array('@value' => 'postgres'))),
 		);
 	}

--- a/tests/lib/app/platformrepository.php
+++ b/tests/lib/app/platformrepository.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @author Thomas Müller
+ * @copyright 2014 Thomas Müller deepdiver@owncloud.com
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\App;
+
+use OC;
+
+class PlatformRepository extends \Test\TestCase {
+
+	/**
+	 * @dataProvider providesVersions
+	 * @param $expected
+	 * @param $input
+	 */
+	public function testVersion($input, $expected) {
+		$pr = new OC\App\PlatformRepository();
+		$normalizedVersion = $pr->normalizeVersion($input);
+		$this->assertEquals($expected, $normalizedVersion);
+	}
+
+	public function providesVersions() {
+		return array(
+			'none' => array('1.0.0', '1.0.0.0'),
+			'none/2' => array('1.2.3.4', '1.2.3.4'),
+			'parses state' => array('1.0.0RC1dev', '1.0.0.0-RC1-dev'),
+			'CI parsing' => array('1.0.0-rC15-dev', '1.0.0.0-RC15-dev'),
+			'delimiters' => array('1.0.0.RC.15-dev', '1.0.0.0-RC15-dev'),
+			'RC uppercase' => array('1.0.0-rc1', '1.0.0.0-RC1'),
+			'patch replace' => array('1.0.0.pl3-dev', '1.0.0.0-patch3-dev'),
+			'forces w.x.y.z' => array('1.0-dev', '1.0.0.0-dev'),
+			'forces w.x.y.z/2' => array('0', '0.0.0.0'),
+			'parses long' => array('10.4.13-beta', '10.4.13.0-beta'),
+			'parses long/2' => array('10.4.13beta2', '10.4.13.0-beta2'),
+			'parses long/semver' => array('10.4.13beta.2', '10.4.13.0-beta2'),
+			'expand shorthand' => array('10.4.13-b', '10.4.13.0-beta'),
+			'expand shorthand2' => array('10.4.13-b5', '10.4.13.0-beta5'),
+			'strips leading v' => array('v1.0.0', '1.0.0.0'),
+			'strips v/datetime' => array('v20100102', '20100102'),
+			'parses dates y-m' => array('2010.01', '2010-01'),
+			'parses dates w/ .' => array('2010.01.02', '2010-01-02'),
+			'parses dates w/ -' => array('2010-01-02', '2010-01-02'),
+			'parses numbers' => array('2010-01-02.5', '2010-01-02-5'),
+			'parses dates y.m.Y' => array('2010.1.555', '2010.1.555.0'),
+			'parses datetime' => array('20100102-203040', '20100102-203040'),
+			'parses dt+number' => array('20100102203040-10', '20100102203040-10'),
+			'parses dt+patch' => array('20100102-203040-p1', '20100102-203040-patch1'),
+			'parses master' => array('dev-master', '9999999-dev'),
+			'parses trunk' => array('dev-trunk', '9999999-dev'),
+//			'parses branches' => array('1.x-dev', '1.9999999.9999999.9999999-dev'),
+			'parses arbitrary' => array('dev-feature-foo', 'dev-feature-foo'),
+			'parses arbitrary2' => array('DEV-FOOBAR', 'dev-FOOBAR'),
+			'parses arbitrary3' => array('dev-feature/foo', 'dev-feature/foo'),
+			'ignores aliases' => array('dev-master as 1.0.0', '9999999-dev'),
+//			'semver metadata' => array('dev-master+foo.bar', '9999999-dev'),
+//			'semver metadata/2' => array('1.0.0-beta.5+foo', '1.0.0.0-beta5'),
+//			'semver metadata/3' => array('1.0.0+foo', '1.0.0.0'),
+//			'metadata w/ alias' => array('1.0.0+foo as 2.0', '1.0.0.0'),
+		);
+	}}


### PR DESCRIPTION
This PR adds dependency management for php extensions, command line tools, operating systems and owncloud version

``` xml
    <dependencies>
        <php min-version="5.4" max-version="5.5"/>
        <database min-version="3.0">sqlite</database>
        <database>mysql</database>
        <command os="linux">grep</command>
        <command os="windows">notepad.exe</command>
        <lib min-version="1.2">libxml</lib>
        <lib max-version="2.0">intl</lib>
        <lib>curl</lib>
        <os>Linux</os>
        <owncloud min-version="6.0.4" max-version="8"/>
    </dependencies>
```
