### PR TITLE
fixes #12434

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -90,7 +90,6 @@
 	left: 0 !important;
 	background-color: #fff;
 	overflow-x: hidden !important;
-	z-index: 1000;
 }
 
 /* allow horizontal scrollbar in settings


### PR DESCRIPTION
Z-index on mobile is too high and covers settings drop-down and I think it is not actually needed so I removed it.
Tested the fix on my 7.0.3 and it fixes the problem and does not introduce any one as far as I can tell after switching to different apps and settings itself.
