### PR TITLE
Issue/6553 Fix recursive removePath() in Files\Mapper

### DIFF
--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -63,6 +63,13 @@ class Mapper
 		}
 
 		\OC_DB::executeAudited('DELETE FROM `*PREFIX*file_map` WHERE `' . $fieldName . '` = ?', array($path));
+
+		$cleanRelativePath = $this->resolveRelativePath($path);
+		if ($path !== $cleanRelativePath) {
+			// In case we somehow ended up deleting a path `foo/../bar`
+			// we also need to make sure to delete the path `bar`
+			$this->removePath($cleanRelativePath, $isLogicPath, $recursive);
+		}
 	}
 
 	/**

--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -10,17 +10,17 @@ class Mapper {
 	private $unchangedPhysicalRoot;
 
 	/** @var bool */
-	private $isMySQL;
+	private $requireDoubleBackslashes;
 
 	/**
 	 * Constructor
 	 *
 	 * @param string $rootDir
-	 * @param bool $isMySQL
+	 * @param bool $requireDoubleBackslashes
 	 */
-	public function __construct($rootDir, $isMySQL) {
+	public function __construct($rootDir, $requireDoubleBackslashes) {
 		$this->unchangedPhysicalRoot = $rootDir;
-		$this->isMySQL = $isMySQL;
+		$this->requireDoubleBackslashes = $requireDoubleBackslashes;
 	}
 
 	/**
@@ -51,8 +51,12 @@ class Mapper {
 		return $physicalPath;
 	}
 
+	/**
+	 * @param string $path
+	 * @return string
+	 */
 	protected function preparePathForLikeQuery($path) {
-		return ($this->isMySQL) ? str_replace('\\', '\\\\', $path) : $path;
+		return ($this->requireDoubleBackslashes) ? str_replace('\\', '\\\\', $path) : $path;
 	}
 
 	/**

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -20,7 +20,7 @@ class MappedLocal extends \OC\Files\Storage\Common {
 			$this->datadir .= '/';
 		}
 
-		$this->mapper = new \OC\Files\Mapper($this->datadir);
+		$this->mapper = new \OC\Files\Mapper($this->datadir, \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
 	}
 
 	public function __destruct() {

--- a/lib/private/files/storage/mappedlocal.php
+++ b/lib/private/files/storage/mappedlocal.php
@@ -20,7 +20,8 @@ class MappedLocal extends \OC\Files\Storage\Common {
 			$this->datadir .= '/';
 		}
 
-		$this->mapper = new \OC\Files\Mapper($this->datadir, \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
+		$dbType = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite');
+		$this->mapper = new \OC\Files\Mapper($this->datadir, in_array($dbType, array('mysql', 'pgsql')));
 	}
 
 	public function __destruct() {

--- a/tests/lib/files/mapper.php
+++ b/tests/lib/files/mapper.php
@@ -31,7 +31,7 @@ class Mapper extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->mapper = new \OC\Files\Mapper('D:/');
+		$this->mapper = new \OC\Files\Mapper('D:/', \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
 	}
 
 	public function removePathData() {
@@ -63,7 +63,7 @@ class Mapper extends \Test\TestCase {
 	 */
 	public function testRemovePath($removePath, $recursive, $isLogical = true) {
 		$dataDir = 'D:\\testing/';
-		$mapper = new \OC\Files\Mapper($dataDir);
+		$mapper = new \OC\Files\Mapper($dataDir, \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
 		$removePathSlash = (substr($removePath, -1) == '/') ? $removePath : $removePath . '/';
 
 		$physicalEuro	= $mapper->logicToPhysical($dataDir . 'h€llo-h€llo.txt', true);

--- a/tests/lib/files/mapper.php
+++ b/tests/lib/files/mapper.php
@@ -31,7 +31,9 @@ class Mapper extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->mapper = new \OC\Files\Mapper('D:/', \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
+
+		$dbType = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite');
+		$this->mapper = new \OC\Files\Mapper('D:/', in_array($dbType, array('mysql', 'pgsql')));
 	}
 
 	public function removePathData() {
@@ -63,7 +65,8 @@ class Mapper extends \Test\TestCase {
 	 */
 	public function testRemovePath($removePath, $recursive, $isLogical = true) {
 		$dataDir = 'D:\\testing/';
-		$mapper = new \OC\Files\Mapper($dataDir, \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql');
+		$dbType = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite');
+		$mapper = new \OC\Files\Mapper($dataDir, in_array($dbType, array('mysql', 'pgsql')));
 		$removePathSlash = (substr($removePath, -1) == '/') ? $removePath : $removePath . '/';
 
 		$physicalEuro	= $mapper->logicToPhysical($dataDir . 'h€llo-h€llo.txt', true);

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -42,9 +42,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	public static function tearDownAfterClass() {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
-		$isMySQL = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql';
+		$dbType = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite');
+		$requireDoubleBackslashes = in_array($dbType, array('mysql', 'pgsql'));
 
-		self::tearDownAfterClassCleanFileMapper($dataDir, $isMySQL);
+		self::tearDownAfterClassCleanFileMapper($dataDir, $requireDoubleBackslashes);
 		self::tearDownAfterClassCleanStorages();
 		self::tearDownAfterClassCleanFileCache();
 		self::tearDownAfterClassCleanStrayDataFiles($dataDir);
@@ -57,11 +58,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	/**
 	 * Remove all entries from the files map table
 	 * @param string $dataDir
-	 * @param bool $isMySQL
+	 * @param bool $requireDoubleBackslashes
 	 */
-	static protected function tearDownAfterClassCleanFileMapper($dataDir, $isMySQL) {
+	static protected function tearDownAfterClassCleanFileMapper($dataDir, $requireDoubleBackslashes) {
 		if (\OC_Util::runningOnWindows()) {
-			$mapper = new \OC\Files\Mapper($dataDir, $isMySQL);
+			$mapper = new \OC\Files\Mapper($dataDir, $requireDoubleBackslashes);
 			$mapper->removePath($dataDir, true, true);
 		}
 	}

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -42,8 +42,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	public static function tearDownAfterClass() {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
+		$isMySQL = \OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'mysql';
 
-		self::tearDownAfterClassCleanFileMapper($dataDir);
+		self::tearDownAfterClassCleanFileMapper($dataDir, $isMySQL);
 		self::tearDownAfterClassCleanStorages();
 		self::tearDownAfterClassCleanFileCache();
 		self::tearDownAfterClassCleanStrayDataFiles($dataDir);
@@ -56,10 +57,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	/**
 	 * Remove all entries from the files map table
 	 * @param string $dataDir
+	 * @param bool $isMySQL
 	 */
-	static protected function tearDownAfterClassCleanFileMapper($dataDir) {
+	static protected function tearDownAfterClassCleanFileMapper($dataDir, $isMySQL) {
 		if (\OC_Util::runningOnWindows()) {
-			$mapper = new \OC\Files\Mapper($dataDir);
+			$mapper = new \OC\Files\Mapper($dataDir, $isMySQL);
 			$mapper->removePath($dataDir, true, true);
 		}
 	}


### PR DESCRIPTION
Previous PR by @windaishi #11583
- [x] Correctly delete only entries that are in the directory, if `$recursive` is set
- [x] Correctly also delete the `$this->resolveRelativePath($path)` if necessary
- [x] Add unit tests for removePath, which fail on master without this patch

Fix #6553 

@DeepDiver1975 @MorrisJobke @windaishi 

PS: Similar patch is incoming for copy() which also solves the recursion from #12594 
