### PR TITLE
Fix formatting of bad dates from external storages

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -637,11 +637,15 @@
 				icon = OC.Util.replaceSVGIcon(fileData.icon),
 				name = fileData.name,
 				type = fileData.type || 'file',
-				mtime = parseInt(fileData.mtime, 10) || new Date().getTime(),
+				mtime = parseInt(fileData.mtime, 10),
 				mime = fileData.mimetype,
 				path = fileData.path,
 				linkUrl;
 			options = options || {};
+
+			if (isNaN(mtime)) {
+				mtime = new Date().getTime()
+			}
 
 			if (type === 'dir') {
 				mime = mime || 'httpd/unix-directory';
@@ -753,12 +757,21 @@
 			if (modifiedColor >= '160') {
 				modifiedColor = 160;
 			}
+			var formatted;
+			var text;
+			if (mtime > 0) {
+				formatted = formatDate(mtime);
+				text = OC.Util.relativeModifiedDate(mtime);
+			} else {
+				formatted = t('files', 'Unable to determine date');
+				text = '?';
+			}
 			td = $('<td></td>').attr({ "class": "date" });
 			td.append($('<span></span>').attr({
 				"class": "modified",
-				"title": formatDate(mtime),
+				"title": formatted,
 				"style": 'color:rgb('+modifiedColor+','+modifiedColor+','+modifiedColor+')'
-			}).text(OC.Util.relativeModifiedDate(mtime)));
+			}).text(text));
 			tr.find('.filesize').text(simpleSize);
 			tr.append(td);
 			return tr;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -183,6 +183,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.find('.nametext').text().trim()).toEqual('testName.txt');
 
 			expect($tr.find('.filesize').text()).toEqual('1 kB');
+			expect($tr.find('.date').text()).not.toEqual('?');
 			expect(fileList.findFileEl('testName.txt')[0]).toEqual($tr[0]);
 		});
 		it('generates dir element with correct attributes when calling add() with dir data', function() {
@@ -209,6 +210,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('123456');
 
 			expect($tr.find('.filesize').text()).toEqual('1 kB');
+			expect($tr.find('.date').text()).not.toEqual('?');
 
 			expect(fileList.findFileEl('testFolder')[0]).toEqual($tr[0]);
 		});
@@ -233,6 +235,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('123456');
 
 			expect($tr.find('.filesize').text()).toEqual('Pending');
+			expect($tr.find('.date').text()).not.toEqual('?');
 		});
 		it('generates dir element with default attributes when calling add() with minimal data', function() {
 			var fileData = {
@@ -254,6 +257,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mtime')).toEqual('123456');
 
 			expect($tr.find('.filesize').text()).toEqual('Pending');
+			expect($tr.find('.date').text()).not.toEqual('?');
 		});
 		it('generates file element with zero size when size is explicitly zero', function() {
 			var fileData = {
@@ -263,6 +267,15 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			expect($tr.find('.filesize').text()).toEqual('0 kB');
+		});
+		it('generates file element with unknown date when mtime invalid', function() {
+			var fileData = {
+				type: 'dir',
+				name: 'testFolder',
+				mtime: -1
+			};
+			var $tr = fileList.add(fileData);
+			expect($tr.find('.date').text()).toEqual('?');
 		});
 		it('adds new file to the end of the list', function() {
 			var $tr;

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -132,7 +132,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 
 	public function filemtime($path) {
 		$stat = $this->stat($path);
-		if (isset($stat['mtime'])) {
+		if (isset($stat['mtime']) && $stat['mtime'] > 0) {
 			return $stat['mtime'];
 		} else {
 			return 0;


### PR DESCRIPTION
When getting a bad mtime for a file (such as for FTP directories), the Modified time will be replaced with `?` and the tooltip will contain 'Unable to determine date'. Fixes #6395
