### PR TITLE
Create config if it does not exists

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -188,7 +188,15 @@ class OC {
 
 	public static function checkConfig() {
 		$l = \OC::$server->getL10N('lib');
-		$configFileWritable = file_exists(self::$configDir . "/config.php") && is_writable(self::$configDir . "/config.php");
+
+		// Create config in case it does not already exists
+		$configFilePath = self::$configDir .'/config.php';
+		if(!file_exists($configFilePath)) {
+			@touch($configFilePath);
+		}
+
+		// Check if config is writable
+		$configFileWritable = is_writable($configFilePath);
 		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
 			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
 			if (self::$CLI) {


### PR DESCRIPTION
The codepath that is executed when executing ownCloud via CLI is different than via browser. Specifically, the config is created by the user session already in `OC_Util::getInstanceId()` by a call to `setValue`. That said, this seems to be quite a bad side-effect, but for the sake of "not breaking whatever might break if we touch this" let's keep it that way for now.

When executing the autoconfig via `php -f index.php` the said session was not setup and thus no `config/config.php` file was created resulting in an installation error.

To reproduce this try to setup ownCloud via `php -f index.php` with and without that patch. (ensure to delete all existing configs before and don't access ownCloud with a browser in the meantime)

Fixes itself.

@jnfrmarks As discussed.
