### PR TITLE
Remove checks for safe mode and magic quotes

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -481,10 +481,6 @@ class OC {
 		date_default_timezone_set('UTC');
 		ini_set('arg_separator.output', '&amp;');
 
-		// try to switch magic quotes off.
-		if (get_magic_quotes_gpc() == 1) {
-			ini_set('magic_quotes_runtime', 0);
-		}
 		//try to configure php to enable big file uploads.
 		//this doesn´t work always depending on the webserver and php configuration.
 		//Let´s try to overwrite some defaults anyways

--- a/lib/private/httphelper.php
+++ b/lib/private/httphelper.php
@@ -72,7 +72,7 @@ class HTTPHelper {
 				curl_setopt($curl, CURLOPT_PROXYUSERPWD, $proxyUserPwd);
 			}
 
-			if (ini_get('open_basedir') === '' && (ini_get('safe_mode') === false) || strtolower(ini_get('safe_mode')) === 'off') {
+			if (ini_get('open_basedir') === '') {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 				curl_setopt($curl, CURLOPT_MAXREDIRS, $max_redirects);
 				$data = curl_exec($curl);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -613,26 +613,6 @@ class OC_Util {
 			);
 			$webServerRestart = true;
 		}
-		if (((strtolower(@ini_get('safe_mode')) == 'on')
-			|| (strtolower(@ini_get('safe_mode')) == 'yes')
-			|| (strtolower(@ini_get('safe_mode')) == 'true')
-			|| (ini_get("safe_mode") == 1))
-		) {
-			$errors[] = array(
-				'error' => $l->t('PHP Safe Mode is enabled. ownCloud requires that it is disabled to work properly.'),
-				'hint' => $l->t('PHP Safe Mode is a deprecated and mostly useless setting that should be disabled. '
-					. 'Please ask your server administrator to disable it in php.ini or in your webserver config.')
-			);
-			$webServerRestart = true;
-		}
-		if (get_magic_quotes_gpc() == 1) {
-			$errors[] = array(
-				'error' => $l->t('Magic Quotes is enabled. ownCloud requires that it is disabled to work properly.'),
-				'hint' => $l->t('Magic Quotes is a deprecated and mostly useless setting that should be disabled. '
-					. 'Please ask your server administrator to disable it in php.ini or in your webserver config.')
-			);
-			$webServerRestart = true;
-		}
 		if (!self::isAnnotationsWorking()) {
 			$errors[] = array(
 				'error' => 'PHP is apparently setup to strip inline doc blocks. This will make several core apps inaccessible.',


### PR DESCRIPTION
Both are removed from 5.4.0

Safe Mode: http://php.net/manual/en/features.safe-mode.php

> This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.

Magic Quotes: http://php.net/manual/en/security.magicquotes.php

> This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
