### PR TITLE
fix broken link on app management page for apps without ocsid 

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -104,7 +104,12 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		if (app.internal === false) {
 			page.find('span.score').show();
 			page.find('p.appstore').show();
-			page.find('a#appstorelink').attr('href', 'http://apps.owncloud.com/content/show.php?content=' + app.id);
+			var link = page.find('a#appstorelink');
+			if(app.ocsid) {
+				link.attr('href', 'https://apps.owncloud.com/content/show.php?content=' + app.ocsid);
+			} else {
+				link.hide();
+			}
 			page.find('small.externalapp').hide();
 		} else {
 			page.find('p.appslink').hide();


### PR DESCRIPTION
fix #9574 fix #10461 

cc @PVince81 @georgehrke @karlitschek @nazar-pc @donniezazen @cosenal @LukasReschke 

@karlitschek This is against stable7 and is only valid for OC7. I would like to merge this not before 7.0.4 is out. 

~~:warning: Keep the stable7 freeze in mind~~ ;)
