### PR TITLE
introduce alt text for rename icon - fixes #12067

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -264,6 +264,7 @@
 		_renderRenameAction: function(actionSpec, isDefault, context) {
 			var $actionEl = this._makeActionLink(actionSpec, context);
 			var $container = context.$file.find('a.name span.nametext');
+			$actionEl.find('img').attr('alt', t('files', 'Rename'));
 			$container.find('.action-rename').remove();
 			$container.append($actionEl);
 			return $actionEl;


### PR DESCRIPTION
But there is no little tooltip that indicates that this means "rename" (even not a tooltip from browser - tested with FF and Chrome)

fixes #12067 

cc @owncloud/designers 
