### PR TITLE
Handle readonly shared files

### DIFF
--- a/apps/files/css/upload.css
+++ b/apps/files/css/upload.css
@@ -64,6 +64,28 @@
 	font-size: 13px;
 }
 
+.oc-dialog .fileexists {
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.oc-dialog .fileexists .conflict .filename,
+.oc-dialog .fileexists .conflict .mtime,
+.oc-dialog .fileexists .conflict .size {
+	-webkit-touch-callout: initial;
+	-webkit-user-select: initial;
+	-khtml-user-select: initial;
+	-moz-user-select: initial;
+	-ms-user-select: initial;
+	user-select: initial;
+}
+.oc-dialog .fileexists .conflict .message {
+	color: #e9322d;
+}
 .oc-dialog .fileexists table {
 	width: 100%;
 }

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -175,7 +175,14 @@ OC.Upload = {
 	 * @param {function} callbacks.onCancel
 	 */
 	checkExistingFiles: function (selection, callbacks) {
-		// TODO check filelist before uploading and show dialog on conflicts, use callbacks
+		/*
+		$.each(selection.uploads, function(i, upload) {
+			var $row = OCA.Files.App.fileList.findFileEl(upload.files[0].name);
+			if ($row) {
+				// TODO check filelist before uploading and show dialog on conflicts, use callbacks
+			}
+		});
+		*/
 		callbacks.onNoConflicts(selection);
 	},
 
@@ -417,11 +424,15 @@ OC.Upload = {
 						data.textStatus = 'servererror';
 						data.errorThrown = t('files', 'Could not get result from server.');
 						fu._trigger('fail', e, data);
+					} else if (result[0].status === 'readonly') {
+						var original = result[0];
+						var replacement = data.files[0];
+						OC.dialogs.fileexists(data, original, replacement, OC.Upload);
 					} else if (result[0].status === 'existserror') {
 						//show "file already exists" dialog
 						var original = result[0];
 						var replacement = data.files[0];
-						OC.dialogs.fileexists(data, original, replacement, OC.Upload, fu);
+						OC.dialogs.fileexists(data, original, replacement, OC.Upload);
 					} else if (result[0].status !== 'success') {
 						//delete data.jqXHR;
 						data.textStatus = 'servererror';

--- a/apps/files/templates/fileexists.html
+++ b/apps/files/templates/fileexists.html
@@ -20,6 +20,7 @@
 				<span class="svg icon"></span>
 				<div class="mtime"></div>
 				<div class="size"></div>
+				<div class="message"></div>
 			</div>
 		</div>
 	</div>

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -363,56 +363,69 @@ var OCdialogs = {
 			return canvas.toDataURL("image/png", 0.7);
 		};
 
-		var addConflict = function(conflicts, original, replacement) {
+		var addConflict = function($conflicts, original, replacement) {
 
-			var conflict = conflicts.find('.template').clone().removeClass('template').addClass('conflict');
+			var $conflict = $conflicts.find('.template').clone().removeClass('template').addClass('conflict');
+			var $originalDiv = $conflict.find('.original');
+			var $replacementDiv = $conflict.find('.replacement');
 
-			conflict.data('data',data);
+			$conflict.data('data',data);
 
-			conflict.find('.filename').text(original.name);
-			conflict.find('.original .size').text(humanFileSize(original.size));
-			conflict.find('.original .mtime').text(formatDate(original.mtime));
+			$conflict.find('.filename').text(original.name);
+			$originalDiv.find('.size').text(humanFileSize(original.size));
+			$originalDiv.find('.mtime').text(formatDate(original.mtime));
 			// ie sucks
 			if (replacement.size && replacement.lastModifiedDate) {
-				conflict.find('.replacement .size').text(humanFileSize(replacement.size));
-				conflict.find('.replacement .mtime').text(formatDate(replacement.lastModifiedDate));
+				$replacementDiv.find('.size').text(humanFileSize(replacement.size));
+				$replacementDiv.find('.mtime').text(formatDate(replacement.lastModifiedDate));
 			}
 			var path = original.directory + '/' +original.name;
 			Files.lazyLoadPreview(path, original.mimetype, function(previewpath){
-				conflict.find('.original .icon').css('background-image','url('+previewpath+')');
+				$originalDiv.find('.icon').css('background-image','url('+previewpath+')');
 			}, 96, 96, original.etag);
 			getCroppedPreview(replacement).then(
 				function(path){
-					conflict.find('.replacement .icon').css('background-image','url(' + path + ')');
+					$replacementDiv.find('.icon').css('background-image','url(' + path + ')');
 				}, function(){
 					Files.getMimeIcon(replacement.type,function(path){
-						conflict.find('.replacement .icon').css('background-image','url(' + path + ')');
+						$replacementDiv.find('.icon').css('background-image','url(' + path + ')');
 					});
 				}
 			);
-			conflicts.append(conflict);
+			$conflicts.append($conflict);
 
 			//set more recent mtime bold
 			// ie sucks
 			if (replacement.lastModifiedDate && replacement.lastModifiedDate.getTime() > original.mtime) {
-				conflict.find('.replacement .mtime').css('font-weight', 'bold');
+				$replacementDiv.find('.mtime').css('font-weight', 'bold');
 			} else if (replacement.lastModifiedDate && replacement.lastModifiedDate.getTime() < original.mtime) {
-				conflict.find('.original .mtime').css('font-weight', 'bold');
+				$originalDiv.find('.mtime').css('font-weight', 'bold');
 			} else {
 				//TODO add to same mtime collection?
 			}
 
 			// set bigger size bold
 			if (replacement.size && replacement.size > original.size) {
-				conflict.find('.replacement .size').css('font-weight', 'bold');
+				$replacementDiv.find('.size').css('font-weight', 'bold');
 			} else if (replacement.size && replacement.size < original.size) {
-				conflict.find('.original .size').css('font-weight', 'bold');
+				$originalDiv.find('.size').css('font-weight', 'bold');
 			} else {
 				//TODO add to same size collection?
 			}
 
 			//TODO show skip action for files with same size and mtime in bottom row
 
+			// always keep readonly files
+
+			if (original.status === 'readonly') {
+				$originalDiv
+					.addClass('readonly')
+					.find('input[type="checkbox"]')
+						.prop('checked', true)
+						.prop('disabled', true);
+				$originalDiv.find('.message')
+					.text(t('core','read-only'))
+			}
 		};
 		//var selection = controller.getSelection(data.originalFiles);
 		//if (selection.defaultAction) {
@@ -423,8 +436,8 @@ var OCdialogs = {
 		if (this._fileexistsshown) {
 			// add conflict
 
-			var conflicts = $(dialogId+ ' .conflicts');
-			addConflict(conflicts, original, replacement);
+			var $conflicts = $(dialogId+ ' .conflicts');
+			addConflict($conflicts, original, replacement);
 
 			var count = $(dialogId+ ' .conflict').length;
 			var title = n('core',
@@ -456,8 +469,8 @@ var OCdialogs = {
 				});
 				$('body').append($dlg);
 
-				var conflicts = $($dlg).find('.conflicts');
-				addConflict(conflicts, original, replacement);
+				var $conflicts = $dlg.find('.conflicts');
+				addConflict($conflicts, original, replacement);
 
 				var buttonlist = [{
 						text: t('core', 'Cancel'),
@@ -496,20 +509,20 @@ var OCdialogs = {
 
 				//add checkbox toggling actions
 				$(dialogId).find('.allnewfiles').on('click', function() {
-					var checkboxes = $(dialogId).find('.conflict .replacement input[type="checkbox"]');
-					checkboxes.prop('checked', $(this).prop('checked'));
+					var $checkboxes = $(dialogId).find('.conflict .replacement input[type="checkbox"]');
+					$checkboxes.prop('checked', $(this).prop('checked'));
 				});
 				$(dialogId).find('.allexistingfiles').on('click', function() {
-					var checkboxes = $(dialogId).find('.conflict .original input[type="checkbox"]');
-					checkboxes.prop('checked', $(this).prop('checked'));
+					var $checkboxes = $(dialogId).find('.conflict .original:not(.readonly) input[type="checkbox"]');
+					$checkboxes.prop('checked', $(this).prop('checked'));
 				});
-				$(dialogId).find('.conflicts').on('click', '.replacement,.original', function() {
-					var checkbox = $(this).find('input[type="checkbox"]');
-					checkbox.prop('checked', !checkbox.prop('checked'));
+				$(dialogId).find('.conflicts').on('click', '.replacement,.original:not(.readonly)', function() {
+					var $checkbox = $(this).find('input[type="checkbox"]');
+					$checkbox.prop('checked', !$checkbox.prop('checked'));
 				});
-				$(dialogId).find('.conflicts').on('click', 'input[type="checkbox"]', function() {
-					var checkbox = $(this);
-					checkbox.prop('checked', !checkbox.prop('checked'));
+				$(dialogId).find('.conflicts').on('click', '.replacement input[type="checkbox"],.original:not(.readonly) input[type="checkbox"]', function() {
+					var $checkbox = $(this);
+					$checkbox.prop('checked', !checkbox.prop('checked'));
 				});
 
 				//update counters

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -678,7 +678,7 @@ class View {
 
 			$source = fopen($tmpFile, 'r');
 			if ($source) {
-				$this->file_put_contents($path, $source);
+				$result = $this->file_put_contents($path, $source);
 				// $this->file_put_contents() might have already closed
 				// the resource, so we check it, before trying to close it
 				// to avoid messages in the error log.
@@ -686,7 +686,7 @@ class View {
 					fclose($source);
 				}
 				unlink($tmpFile);
-				return true;
+				return $result;
 			} else {
 				return false;
 			}


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/10306 by showing a "Readonly" message and disabling the checkbox. As a result the user has the option between autorename (selecting both) or keeping the original.

![bildschirmfoto von 2014-12-08 15 30 05](https://cloud.githubusercontent.com/assets/956847/5340624/2c8d01c8-7eef-11e4-9b08-7413d8a2f440.png)

cc @PVince81 @philxtian 
