### PR TITLE
Skip headers that can not be split

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -120,6 +120,9 @@ if($source) {
 			$freeSpace = $storageStats['freeSpace'];
 
 			foreach($meta['wrapper_data'] as $header) {
+				if (strpos($header, ':') === false){
+					continue;
+				}
 				list($name, $value) = explode(':', $header);
 				if ('content-length' === strtolower(trim($name))) {
 					$length = (int) trim($value);


### PR DESCRIPTION
Fixes #11955 

How to test:
Click New -> from Link
Add a link. e.g.: http://www.stadtwolke.de/m/f9104abd.png
Check owncloud.log:
`Debug PHP Undefined offset: 1 at /apps/files/ajax/newfile.php#xyz`
will appear. Exact line number depends on OC version
