### PR TITLE
Expose backend type via REST API

### DIFF
--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -218,6 +218,15 @@ class User implements IUser {
 	}
 
 	/**
+	 * Get the name of the backend class the user is connected with
+	 *
+	 * @return string
+	 */
+	public function getBackendClassName() {
+		return get_class($this->backend);
+	}
+
+	/**
 	 * check if the backend allows the user to change his avatar on Personal page
 	 *
 	 * @return bool

--- a/lib/public/iuser.php
+++ b/lib/public/iuser.php
@@ -69,6 +69,13 @@ interface IUser {
 	public function getHome();
 
 	/**
+	 * Get the name of the backend class the user is connected with
+	 *
+	 * @return string
+	 */
+	public function getBackendClassName();
+
+	/**
 	 * check if the backend allows the user to change his avatar on Personal page
 	 *
 	 * @return bool

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -331,35 +331,34 @@ var UserList = {
 			function (result) {
 				var loadedUsers = 0;
 				var trs = [];
-				if (result.status === 'success') {
-					//The offset does not mirror the amount of users available,
-					//because it is backend-dependent. For correct retrieval,
-					//always the limit(requested amount of users) needs to be added.
-					$.each(result.data, function (index, user) {
-						if(UserList.has(user.name)) {
-							return true;
-						}
-						var $tr = UserList.add(user.name, user.displayname, user.groups, user.subadmin, user.quota, user.storageLocation, user.lastLogin, false);
-						$tr.addClass('appear transparent');
-						trs.push($tr);
-						loadedUsers++;
-					});
-					if (result.data.length > 0) {
-						UserList.doSort();
-						$userList.siblings('.loading').css('visibility', 'hidden');
+				//The offset does not mirror the amount of users available,
+				//because it is backend-dependent. For correct retrieval,
+				//always the limit(requested amount of users) needs to be added.
+				$.each(result, function (index, user) {
+					if(UserList.has(user.name)) {
+						return true;
 					}
-					else {
-						UserList.noMoreEntries = true;
-						$userList.siblings('.loading').remove();
-					}
-					UserList.offset += loadedUsers;
-					// animate
-					setTimeout(function() {
-						for (var i = 0; i < trs.length; i++) {
-							trs[i].removeClass('transparent');
-						}
-					}, 0);
+					var $tr = UserList.add(user.name, user.displayname, user.groups, user.subadmin, user.quota, user.storageLocation, user.lastLogin, false);
+					$tr.addClass('appear transparent');
+					trs.push($tr);
+					loadedUsers++;
+				});
+				if (result.length > 0) {
+					UserList.doSort();
+					$userList.siblings('.loading').css('visibility', 'hidden');
 				}
+				else {
+					UserList.noMoreEntries = true;
+					$userList.siblings('.loading').remove();
+				}
+				UserList.offset += loadedUsers;
+				// animate
+				setTimeout(function() {
+					for (var i = 0; i < trs.length; i++) {
+						trs[i].removeClass('transparent');
+					}
+				}, 0);
+			}).always(function() {
 				UserList.updating = false;
 			});
 	},

--- a/tests/lib/contacts/localadressbook.php
+++ b/tests/lib/contacts/localadressbook.php
@@ -78,6 +78,9 @@ class SimpleUserForTesting implements \OCP\IUser {
 	public function getHome() {
 	}
 
+	public function getBackendClassName() {
+	}
+
 	public function canChangeAvatar() {
 	}
 

--- a/tests/lib/user/user.php
+++ b/tests/lib/user/user.php
@@ -216,6 +216,13 @@ class User extends \Test\TestCase {
 		$this->assertEquals('/home/foo', $user->getHome());
 	}
 
+	public function testGetBackendClassName() {
+		$user = new \OC\User\User('foo', new \OC_User_Dummy());
+		$this->assertEquals('OC_User_Dummy', $user->getBackendClassName());
+		$user = new \OC\User\User('foo', new \OC_User_Database());
+		$this->assertEquals('OC_User_Database', $user->getBackendClassName());
+	}
+
 	public function testGetHomeNotSupported() {
 		/**
 		 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -54,30 +54,68 @@ class UsersControllerTest extends \Test\TestCase {
 	 * to test for subadmins. Thus the test always assumes you have admin permissions...
 	 */
 	public function testIndex() {
-		$admin = $this->getMockBuilder('\OC\User\User')
-			->disableOriginalConstructor()->getMock();
-		$admin
-			->method('getLastLogin')
-			->will($this->returnValue(12));
-		$admin
-			->method('getHome')
-			->will($this->returnValue('/home/admin'));
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
+		$foo
+			->expects($this->exactly(3))
+			->method('getUID')
+			->will($this->returnValue('foo'));
+		$foo
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue('M. Foo'));
 		$foo
 			->method('getLastLogin')
 			->will($this->returnValue(500));
 		$foo
 			->method('getHome')
 			->will($this->returnValue('/home/foo'));
+		$foo
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('OC_User_Database'));
+		$admin = $this->getMockBuilder('\OC\User\User')
+			->disableOriginalConstructor()->getMock();
+		$admin
+			->expects($this->exactly(3))
+			->method('getUID')
+			->will($this->returnValue('admin'));
+		$admin
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue('S. Admin'));
+		$admin
+			->expects($this->once())
+			->method('getLastLogin')
+			->will($this->returnValue(12));
+		$admin
+			->expects($this->once())
+			->method('getHome')
+			->will($this->returnValue('/home/admin'));
+		$admin
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('OC_User_Dummy'));
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
+		$bar
+			->expects($this->exactly(3))
+			->method('getUID')
+			->will($this->returnValue('bar'));
+		$bar
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue('B. Ar'));
 		$bar
 			->method('getLastLogin')
 			->will($this->returnValue(3999));
 		$bar
 			->method('getHome')
 			->will($this->returnValue('/home/bar'));
+		$bar
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('OC_User_Dummy'));
 
 		$this->container['GroupManager']
 			->expects($this->once())
@@ -98,36 +136,36 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$expectedResponse = new DataResponse(
 			array(
-				'status' => 'success',
-				'data' => array(
-					0 => array(
-						'name' => 'foo',
-						'displayname' => 'M. Foo',
-						'groups' => array('Users', 'Support'),
-						'subadmin' => array(),
-						'quota' => 1024,
-						'storageLocation' => '/home/foo',
-						'lastLogin' => 500
-					),
-					1 => array(
-						'name' => 'admin',
-						'displayname' => 'S. Admin',
-						'groups' => array('admins', 'Support'),
-						'subadmin' => array(),
-						'quota' => 404,
-						'storageLocation' => '/home/admin',
-						'lastLogin' => 12
-					),
-					2 => array(
-						'name' => 'bar',
-						'displayname' => 'B. Ar',
-						'groups' => array('External Users'),
-						'subadmin' => array(),
-						'quota' => 2323,
-						'storageLocation' => '/home/bar',
-						'lastLogin' => 3999
-					),
-				)
+				0 => array(
+					'name' => 'foo',
+					'displayname' => 'M. Foo',
+					'groups' => array('Users', 'Support'),
+					'subadmin' => array(),
+					'quota' => 1024,
+					'storageLocation' => '/home/foo',
+					'lastLogin' => 500,
+					'backend' => 'OC_User_Database'
+				),
+				1 => array(
+					'name' => 'admin',
+					'displayname' => 'S. Admin',
+					'groups' => array('admins', 'Support'),
+					'subadmin' => array(),
+					'quota' => 404,
+					'storageLocation' => '/home/admin',
+					'lastLogin' => 12,
+					'backend' => 'OC_User_Dummy'
+				),
+				2 => array(
+					'name' => 'bar',
+					'displayname' => 'B. Ar',
+					'groups' => array('External Users'),
+					'subadmin' => array(),
+					'quota' => 2323,
+					'storageLocation' => '/home/bar',
+					'lastLogin' => 3999,
+					'backend' => 'OC_User_Dummy'
+				),
 			)
 		);
 		$response = $this->usersController->index(0, 10, 'pattern');
@@ -341,4 +379,5 @@ class UsersControllerTest extends \Test\TestCase {
 		$response = $this->usersController->destroy('UserToDelete');
 		$this->assertEquals($expectedResponse, $response);
 	}
+
 }


### PR DESCRIPTION
This change will expose the user backend via the REST API which is a pre-requisite for https://github.com/owncloud/core/issues/12620.

For example:

``` json
[{
    "name": "9707A09E-CA9A-4ABE-A66A-3F632F16C409",
    "displayname": "Document Conversion User Account",
    "groups": [],
    "subadmin": [],
    "quota": "default",
    "storageLocation": "\/Users\/lreschke\/Programming\/core\/data\/9707A09E-CA9A-4ABE-A66A-3F632F16C409",
    "lastLogin": 0,
    "backend": "OCA\\user_ldap\\USER_LDAP"
}, {
    "name": "ED86733E-745C-4E4D-90CB-278A9737DB3C",
    "displayname": "Hacker",
    "groups": [],
    "subadmin": [],
    "quota": "default",
    "storageLocation": "\/Users\/lreschke\/Programming\/core\/data\/ED86733E-745C-4E4D-90CB-278A9737DB3C",
    "lastLogin": 0,
    "backend": "OCA\\user_ldap\\USER_LDAP"
}, {
    "name": "71CDF45B-E125-450D-983C-D9192F36EC88",
    "displayname": "admin",
    "groups": [],
    "subadmin": [],
    "quota": "default",
    "storageLocation": "\/Users\/lreschke\/Programming\/core\/data\/71CDF45B-E125-450D-983C-D9192F36EC88",
    "lastLogin": 0,
    "backend": "OCA\\user_ldap\\USER_LDAP"
}, {
    "name": "admin",
    "displayname": "admin",
    "groups": ["admin"],
    "subadmin": [],
    "quota": "default",
    "storageLocation": "\/Users\/lreschke\/Programming\/core\/data\/admin",
    "lastLogin": "1418057287",
    "backend": "OC_User_Database"
}, {
    "name": "test",
    "displayname": "test",
    "groups": [],
    "subadmin": [],
    "quota": "default",
    "storageLocation": "\/Users\/lreschke\/Programming\/core\/data\/test",
    "lastLogin": 0,
    "backend": "OC_User_Database"
}]
```

@MorrisJobke Please review.
