### PR TITLE
remove duplicate loaded personal.js - fixes #12674

### DIFF
--- a/apps/files_encryption/settings-personal.php
+++ b/apps/files_encryption/settings-personal.php
@@ -28,7 +28,6 @@ $result = false;
 if ($recoveryAdminEnabled || !$privateKeySet) {
 
 	\OCP\Util::addscript('files_encryption', 'settings-personal');
-	\OCP\Util::addScript('settings', 'personal');
 
 	$tmpl->assign('recoveryEnabled', $recoveryAdminEnabled);
 	$tmpl->assign('recoveryEnabledForUser', $recoveryEnabledForUser);


### PR DESCRIPTION
fixes #12674

steps to reproduce:
- enable `files_encryption`
- go to personal settings
- verify that `settings/js/personal.js` is loaded twice
- patch it with this changes
- go to personal settings
- verify that `settings/js/personal.js` is loaded once

@DeepDiver1975 Shouldn't that be prevent by the addScript handler that a file is only added once?

cc @PVince81 @LukasReschke @schiesbn @wakeup @chrsch 

This was introduced with https://github.com/owncloud/core/commit/64d94c540aeaba67e2f779b2551c72a80334aa3e#diff-5419adee45fc55a23d91d2dc9ede0fbaR35
