### PR TITLE
Cleanup file info formatter

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -524,7 +524,6 @@
 				id: parseInt($el.attr('data-id'), 10),
 				name: $el.attr('data-file'),
 				mimetype: $el.attr('data-mime'),
-				type: $el.attr('data-type'),
 				size: parseInt($el.attr('data-size'), 10),
 				etag: $el.attr('data-etag'),
 				permissions: parseInt($el.attr('data-permissions'), 10)
@@ -636,16 +635,12 @@
 			var td, simpleSize, basename, extension, sizeColor,
 				icon = OC.Util.replaceSVGIcon(fileData.icon),
 				name = fileData.name,
-				type = fileData.type || 'file',
 				mtime = parseInt(fileData.mtime, 10) || new Date().getTime(),
 				mime = fileData.mimetype,
+				type = (mime === 'httpd/unix-directory') ? 'dir' : 'file',
 				path = fileData.path,
 				linkUrl;
 			options = options || {};
-
-			if (type === 'dir') {
-				mime = mime || 'httpd/unix-directory';
-			}
 
 			//containing tr
 			var tr = $('<tr></tr>').attr({
@@ -852,8 +847,7 @@
 		 */
 		_renderRow: function(fileData, options) {
 			options = options || {};
-			var type = fileData.type || 'file',
-				mime = fileData.mimetype,
+			var mime = fileData.mimetype,
 				path = fileData.path || this.getCurrentDirectory(),
 				permissions = parseInt(fileData.permissions, 10) || 0;
 
@@ -861,9 +855,6 @@
 				permissions = permissions | OC.PERMISSION_UPDATE;
 			}
 
-			if (type === 'dir') {
-				mime = mime || 'httpd/unix-directory';
-			}
 			var tr = this._createRow(
 				fileData,
 				options
@@ -876,7 +867,7 @@
 				filenameTd.draggable(this._dragOptions);
 			}
 			// allow dropping on folders
-			if (this._folderDropOptions && fileData.type === 'dir') {
+			if (this._folderDropOptions && mime === 'httpd/unix-directory') {
 				filenameTd.droppable(this._folderDropOptions);
 			}
 
@@ -2035,10 +2026,10 @@
 		 * 0 if they are identify, 1 otherwise.
 		 */
 		name: function(fileInfo1, fileInfo2) {
-			if (fileInfo1.type === 'dir' && fileInfo2.type !== 'dir') {
+			if (fileInfo1.mimetype === 'httpd/unix-directory' && fileInfo2.mimetype !== 'httpd/unix-directory') {
 				return -1;
 			}
-			if (fileInfo1.type !== 'dir' && fileInfo2.type === 'dir') {
+			if (fileInfo1.mimetype !== 'httpd/unix-directory' && fileInfo2.mimetype === 'httpd/unix-directory') {
 				return 1;
 			}
 			return OC.Util.naturalSortCompare(fileInfo1.name, fileInfo2.name);

--- a/apps/files/js/filesummary.js
+++ b/apps/files/js/filesummary.js
@@ -48,7 +48,7 @@
 		 * @param update whether to update the display
 		 */
 		add: function(file, update) {
-			if (file.type === 'dir' || file.mime === 'httpd/unix-directory') {
+			if (file.type === 'dir' || file.mimetype === 'httpd/unix-directory') {
 				this.summary.totalDirs++;
 			}
 			else {
@@ -65,7 +65,7 @@
 		 * @param update whether to update the display
 		 */
 		remove: function(file, update) {
-			if (file.type === 'dir' || file.mime === 'httpd/unix-directory') {
+			if (file.type === 'dir' || file.mimetype === 'httpd/unix-directory') {
 				this.summary.totalDirs--;
 			}
 			else {
@@ -96,7 +96,7 @@
 
 			for (var i = 0; i < files.length; i++) {
 				file = files[i];
-				if (file.type === 'dir' || file.mime === 'httpd/unix-directory') {
+				if (file.type === 'dir' || file.mimetype === 'httpd/unix-directory') {
 					summary.totalDirs++;
 				}
 				else {

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -37,7 +37,7 @@ class Helper
 	 * @return string icon URL
 	 */
 	public static function determineIcon($file) {
-		if($file['type'] === 'dir') {
+		if($file->getType() === 'dir') {
 			$icon = \OC_Helper::mimetypeIcon('dir');
 			// TODO: move this part to the client side, using mountType
 			if ($file->isShared()) {
@@ -107,21 +107,19 @@ class Helper
 	public static function formatFileInfo(FileInfo $i) {
 		$entry = array();
 
-		$entry['id'] = $i['fileid'];
+		$entry['id'] = $i->getId();
 		$entry['parentId'] = $i['parent'];
-		$entry['date'] = \OCP\Util::formatDate($i['mtime']);
-		$entry['mtime'] = $i['mtime'] * 1000;
+		$entry['mtime'] = $i->getMTime() * 1000;
 		// only pick out the needed attributes
 		$entry['icon'] = \OCA\Files\Helper::determineIcon($i);
 		if (\OC::$server->getPreviewManager()->isAvailable($i)) {
 			$entry['isPreviewAvailable'] = true;
 		}
 		$entry['name'] = $i->getName();
-		$entry['permissions'] = $i['permissions'];
-		$entry['mimetype'] = $i['mimetype'];
-		$entry['size'] = $i['size'];
-		$entry['type'] = $i['type'];
-		$entry['etag'] = $i['etag'];
+		$entry['permissions'] = $i->getPermissions();
+		$entry['mimetype'] = $i->getMimeType();
+		$entry['size'] = $i->getSize();
+		$entry['etag'] = $i->getEtag();
 		if (isset($i['displayname_owner'])) {
 			$entry['shareOwner'] = $i['displayname_owner'];
 		}

--- a/apps/files/tests/helper.php
+++ b/apps/files/tests/helper.php
@@ -24,7 +24,7 @@ class Test_Files_Helper extends \Test\TestCase {
 				'mtime' => $mtime,
 				'type' => $isDir ? 'dir' : 'file',
 				'mimetype' => $isDir ? 'httpd/unix-directory' : 'application/octet-stream'
-			)	
+			)
 		);
 	}
 
@@ -93,4 +93,164 @@ class Test_Files_Helper extends \Test\TestCase {
 		);
 	}
 
+	private function getMockStorage($storageId) {
+		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue($storageId));
+
+		return $storage;
+	}
+
+	function fileInfoDataProvider() {
+		return array(
+			array(
+				// regular file
+				new \OC\Files\FileInfo(
+					'/userid/files/storage/subdir/test.txt',
+					$this->getMockStorage('home::user1'),
+					'/subdir/test.txt',
+					array(
+						'fileid' => 123,
+						'parent' => 888,
+						'name' => 'test.txt',
+						'size' => 998,
+						'mtime' => 12345,
+						'type' => 'file',
+						'mimetype' => 'text/plain',
+						'permissions' => 31,
+						'etag' => 'deadbeef',
+						'extraData' => array('custom' => 'data'),
+					)
+				),
+				array(
+					'id' => 123,
+					'parentId' => 888,
+					'mtime' => 12345000,
+					'icon' => '/core/img/filetypes/text.svg',
+					'isPreviewAvailable' => true,
+					'name' => 'test.txt',
+					'path' => '/storage/subdir',
+					'permissions' => 31,
+					'mimetype' => 'text/plain',
+					'size' => 998,
+					'etag' => 'deadbeef',
+					'extraData' => array('custom' => 'data'),
+				),
+			),
+			array(
+				// folder
+				new \OC\Files\FileInfo(
+					'/userid/files/storage/subdir/test',
+					$this->getMockStorage('home::user1'),
+					'/subdir/test',
+					array(
+						'fileid' => 123,
+						'parent' => 888,
+						'name' => 'test',
+						'size' => 998,
+						'mtime' => 12345,
+						'mimetype' => 'httpd/unix-directory',
+						'permissions' => 31,
+						'etag' => 'deadbeef',
+						'extraData' => array('custom' => 'data'),
+					)
+				),
+				array(
+					'id' => 123,
+					'parentId' => 888,
+					'mtime' => 12345000,
+					'icon' => '/core/img/filetypes/folder.svg',
+					'name' => 'test',
+					'path' => '/storage/subdir',
+					'permissions' => 31,
+					'mimetype' => 'httpd/unix-directory',
+					'size' => 998,
+					'etag' => 'deadbeef',
+					'extraData' => array('custom' => 'data'),
+				),
+			),
+			array(
+				// shared folder
+				new \OC\Files\FileInfo(
+					'/userid/files/storage/subdir/test',
+					$this->getMockStorage('shared::user1'),
+					'/subdir/test',
+					array(
+						'fileid' => 123,
+						'parent' => 888,
+						'name' => 'test',
+						'size' => 998,
+						'mtime' => 12345,
+						'mimetype' => 'httpd/unix-directory',
+						'permissions' => 31,
+						'etag' => 'deadbeef',
+						'extraData' => array('custom' => 'data'),
+						'displayname_owner' => 'User One',
+						'is_share_mount_point' => true
+					)
+				),
+				array(
+					'id' => 123,
+					'parentId' => 888,
+					'mtime' => 12345000,
+					'icon' => '/core/img/filetypes/folder-shared.svg',
+					'name' => 'test',
+					'path' => '/storage/subdir',
+					'permissions' => 31,
+					'mimetype' => 'httpd/unix-directory',
+					'size' => 998,
+					'etag' => 'deadbeef',
+					'mountType' => 'shared',
+					'extraData' => array('custom' => 'data'),
+					'shareOwner' => 'User One',
+					'isShareMountPoint' => true
+				),
+			),
+			array(
+				// external folder
+				new \OC\Files\FileInfo(
+					'/userid/files/storage/subdir/test',
+					$this->getMockStorage('smb::'),
+					'/subdir/test',
+					array(
+						'fileid' => 123,
+						'parent' => 888,
+						'name' => 'test',
+						'size' => 998,
+						'mtime' => 12345,
+						'mimetype' => 'httpd/unix-directory',
+						'permissions' => 31,
+						'etag' => 'deadbeef',
+						'extraData' => array('custom' => 'data'),
+						'displayname_owner' => 'User One',
+						'is_share_mount_point' => true
+					)
+				),
+				array(
+					'id' => 123,
+					'parentId' => 888,
+					'mtime' => 12345000,
+					'icon' => '/core/img/filetypes/folder-external.svg',
+					'name' => 'test',
+					'path' => '/storage/subdir',
+					'permissions' => 31,
+					'mimetype' => 'httpd/unix-directory',
+					'size' => 998,
+					'etag' => 'deadbeef',
+					'mountType' => 'external',
+					'extraData' => array('custom' => 'data'),
+					'shareOwner' => 'User One',
+					'isShareMountPoint' => true
+				),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider fileInfoDataProvider
+	 */
+	public function testFormatFileInfo($fileInfo, $formattedData) {
+		$this->assertEquals($formattedData, \OCA\Files\Helper::formatFileInfo($fileInfo));
+	}
 }

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -40,7 +40,6 @@ describe('OCA.Files.FileList tests', function() {
 			name += i + '.txt';
 			files.push({
 				id: i,
-				type: 'file',
 				name: name,
 				mimetype: 'text/plain',
 				size: i * 2,
@@ -93,7 +92,6 @@ describe('OCA.Files.FileList tests', function() {
 
 		testFiles = [{
 			id: 1,
-			type: 'file',
 			name: 'One.txt',
 			mimetype: 'text/plain',
 			size: 12,
@@ -101,7 +99,6 @@ describe('OCA.Files.FileList tests', function() {
 			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 2,
-			type: 'file',
 			name: 'Two.jpg',
 			mimetype: 'image/jpeg',
 			size: 12049,
@@ -109,7 +106,6 @@ describe('OCA.Files.FileList tests', function() {
 			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 3,
-			type: 'file',
 			name: 'Three.pdf',
 			mimetype: 'application/pdf',
 			size: 58009,
@@ -117,7 +113,6 @@ describe('OCA.Files.FileList tests', function() {
 			permissions: OC.PERMISSION_ALL
 		}, {
 			id: 4,
-			type: 'dir',
 			name: 'somedir',
 			mimetype: 'httpd/unix-directory',
 			size: 250,
@@ -159,7 +154,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('generates file element with correct attributes when calling add() with file data', function() {
 			var fileData = {
 				id: 18,
-				type: 'file',
 				name: 'testName.txt',
 				mimetype: 'text/plain',
 				size: '1234',
@@ -188,7 +182,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('generates dir element with correct attributes when calling add() with dir data', function() {
 			var fileData = {
 				id: 19,
-				type: 'dir',
 				name: 'testFolder',
 				mimetype: 'httpd/unix-directory',
 				size: '1234',
@@ -214,7 +207,6 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('generates file element with default attributes when calling add() with minimal data', function() {
 			var fileData = {
-				type: 'file',
 				name: 'testFile.txt'
 			};
 
@@ -236,8 +228,8 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('generates dir element with default attributes when calling add() with minimal data', function() {
 			var fileData = {
-				type: 'dir',
-				name: 'testFolder'
+				name: 'testFolder',
+				mimetype: 'httpd/unix-directory'
 			};
 			clock.tick(123456);
 			var $tr = fileList.add(fileData);
@@ -257,8 +249,8 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('generates file element with zero size when size is explicitly zero', function() {
 			var fileData = {
-				type: 'dir',
 				name: 'testFolder',
+				mimetype: 'httpd/unix-directory',
 				size: '0'
 			};
 			var $tr = fileList.add(fileData);
@@ -267,7 +259,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('adds new file to the end of the list', function() {
 			var $tr;
 			var fileData = {
-				type: 'file',
 				name: 'ZZZ.txt'
 			};
 			fileList.setFiles(testFiles);
@@ -287,7 +278,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('inserts new file at correct position', function() {
 			var $tr;
 			var fileData = {
-				type: 'file',
 				name: 'P comes after O.txt'
 			};
 			for (var i = 0; i < testFiles.length; i++) {
@@ -301,8 +291,8 @@ describe('OCA.Files.FileList tests', function() {
 		it('inserts new folder at correct position in insert mode', function() {
 			var $tr;
 			var fileData = {
-				type: 'dir',
-				name: 'somedir2 comes after somedir'
+				name: 'somedir2 comes after somedir',
+				mimetype: 'httpd/unix-directory'
 			};
 			for (var i = 0; i < testFiles.length; i++) {
 				fileList.add(testFiles[i]);
@@ -314,7 +304,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('inserts new file at the end correctly', function() {
 			var $tr;
 			var fileData = {
-				type: 'file',
 				name: 'zzz.txt'
 			};
 			for (var i = 0; i < testFiles.length; i++) {
@@ -327,7 +316,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('removes empty content message and shows summary when adding first file', function() {
 			var $summary;
 			var fileData = {
-				type: 'file',
 				name: 'first file.txt',
 				size: 12
 			};
@@ -519,7 +507,6 @@ describe('OCA.Files.FileList tests', function() {
 				status: 'success',
 				data: {
 					name: 'Tu_after_three.txt',
-					type: 'file'
 				}
 			}));
 
@@ -665,8 +652,7 @@ describe('OCA.Files.FileList tests', function() {
 			fakeServer.requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
 				status: 'success',
 				data: {
-					name: 'One.txt',
-					type: 'file'
+					name: 'One.txt'
 				}
 			}));
 
@@ -694,8 +680,7 @@ describe('OCA.Files.FileList tests', function() {
 			fakeServer.requests[0].respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
 				status: 'success',
 				data: {
-					name: 'One.txt',
-					type: 'file'
+					name: 'One.txt'
 				}
 			}));
 
@@ -708,8 +693,7 @@ describe('OCA.Files.FileList tests', function() {
 			fakeServer.requests[1].respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
 				status: 'success',
 				data: {
-					name: 'Two.jpg',
-					type: 'file'
+					name: 'Two.jpg'
 				}
 			}));
 
@@ -790,8 +774,8 @@ describe('OCA.Files.FileList tests', function() {
 		it('only add file if in same current directory', function() {
 			$('#dir').val('/current dir');
 			var fileData = {
-				type: 'file',
 				name: 'testFile.txt',
+				mimetype: 'httpd/unix-directory',
 				directory: '/current dir'
 			};
 			var $tr = fileList.add(fileData);
@@ -869,7 +853,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('inserts into the DOM if insertion point is in the visible page ', function() {
 			fileList.add({
 				id: 2000,
-				type: 'file',
 				name: 'File with index 15b.txt'
 			});
 			expect($('#fileList tr').length).toEqual(21);
@@ -878,7 +861,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('does not inserts into the DOM if insertion point is not the visible page ', function() {
 			fileList.add({
 				id: 2000,
-				type: 'file',
 				name: 'File with index 28b.txt'
 			});
 			expect($('#fileList tr').length).toEqual(20);
@@ -890,7 +872,6 @@ describe('OCA.Files.FileList tests', function() {
 		it('appends into the DOM when inserting a file after the last visible element', function() {
 			fileList.add({
 				id: 2000,
-				type: 'file',
 				name: 'File with index 19b.txt'
 			});
 			expect($('#fileList tr').length).toEqual(21);
@@ -907,7 +888,6 @@ describe('OCA.Files.FileList tests', function() {
 			fileList._nextPage(true);
 			fileList.add({
 				id: 2000,
-				type: 'file',
 				name: 'File with index 88.txt'
 			});
 			expect($('#fileList tr').length).toEqual(66);
@@ -951,7 +931,6 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('renders default icon for file when none provided and no preview is available', function() {
 			var fileData = {
-				type: 'file',
 				name: 'testFile.txt'
 			};
 			var $tr = fileList.add(fileData);
@@ -961,8 +940,8 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('renders default icon for dir when none provided and no preview is available', function() {
 			var fileData = {
-				type: 'dir',
-				name: 'test dir'
+				name: 'test dir',
+				mimetype: 'httpd/unix-directory'
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
@@ -971,8 +950,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('renders provided icon for file when provided', function() {
 			var fileData = {
-				type: 'file',
-				name: 'test dir',
+				name: 'test pdf',
 				icon: OC.webroot + '/core/img/filetypes/application-pdf.svg'
 			};
 			var $tr = fileList.add(fileData);
@@ -982,8 +960,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('renders preview when no icon was provided and preview is available', function() {
 			var fileData = {
-				type: 'file',
-				name: 'test dir',
+				name: 'test image',
 				isPreviewAvailable: true
 			};
 			var $tr = fileList.add(fileData);
@@ -996,8 +973,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		it('renders default file type icon when no icon was provided and no preview is available', function() {
 			var fileData = {
-				type: 'file',
-				name: 'test dir',
+				name: 'test image',
 				isPreviewAvailable: false
 			};
 			var $tr = fileList.add(fileData);
@@ -1508,14 +1484,12 @@ describe('OCA.Files.FileList tests', function() {
 					id: 1,
 					name: 'One.txt',
 					mimetype: 'text/plain',
-					type: 'file',
 					size: 12,
 					etag: 'abc',
 					permissions: OC.PERMISSION_ALL
 				});
 				expect(files[1]).toEqual({
 					id: 3,
-					type: 'file',
 					name: 'Three.pdf',
 					mimetype: 'application/pdf',
 					size: 58009,
@@ -1524,7 +1498,6 @@ describe('OCA.Files.FileList tests', function() {
 				});
 				expect(files[2]).toEqual({
 					id: 4,
-					type: 'dir',
 					name: 'somedir',
 					mimetype: 'httpd/unix-directory',
 					size: 250,
@@ -1540,14 +1513,12 @@ describe('OCA.Files.FileList tests', function() {
 					id: 1,
 					name: 'One.txt',
 					mimetype: 'text/plain',
-					type: 'file',
 					size: 12,
 					etag: 'abc',
 					permissions: OC.PERMISSION_ALL
 				});
 				expect(files[1]).toEqual({
 					id: 4,
-					type: 'dir',
 					name: 'somedir',
 					mimetype: 'httpd/unix-directory',
 					size: 250,
@@ -1782,7 +1753,6 @@ describe('OCA.Files.FileList tests', function() {
 			);
 			var newFileData = {
 				id: 999,
-				type: 'file',
 				name: 'new file.txt',
 				mimetype: 'text/plain',
 				size: 40001,
@@ -1828,7 +1798,6 @@ describe('OCA.Files.FileList tests', function() {
 			);
 			var newFileData = {
 				id: 999,
-				type: 'file',
 				name: 'new file.txt',
 				mimetype: 'text/plain',
 				size: 40001,

--- a/apps/files_external/lib/api.php
+++ b/apps/files_external/lib/api.php
@@ -54,7 +54,7 @@ class Api {
 		$entry = array(
 			'name' => basename($mountPoint),
 			'path' => $path,
-			'type' => 'dir',
+			'mimetype' => 'httpd/unix-directory',
 			'backend' => $mountConfig['backend'],
 			'scope' => ( $isSystemMount ? 'system' : 'personal' ),
 			'permissions' => $permissions

--- a/apps/files_external/tests/js/mountsfilelistSpec.js
+++ b/apps/files_external/tests/js/mountsfilelistSpec.js
@@ -83,14 +83,14 @@ describe('OCA.External.FileList tests', function() {
 					data: [{
 						name: 'smb mount',
 						path: '/mount points',
-						type: 'dir',
+						mimetype: 'httpd/unix-directory',
 						backend: 'SMB',
 						scope: 'personal',
 						permissions: OC.PERMISSION_READ | OC.PERMISSION_DELETE
 					}, {
 						name: 'sftp mount',
 						path: '/another mount points',
-						type: 'dir',
+						mimetype: 'httpd/unix-directory',
 						backend: 'SFTP',
 						scope: 'system',
 						permissions: OC.PERMISSION_READ

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -126,8 +126,8 @@ describe('OCA.Sharing.App tests', function() {
 
 			fileListIn.setFiles([{
 				name: 'testdir',
-				type: 'dir',
 				path: '/somewhere/inside/subdir',
+				mimetype: 'httpd/unix-directory',
 				counterParts: ['user2'],
 				shareOwner: 'user2'
 			}]);

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -50,7 +50,6 @@ describe('OCA.Sharing.Util tests', function() {
 
 		testFiles = [{
 			id: 1,
-			type: 'file',
 			name: 'One.txt',
 			path: '/subdir',
 			mimetype: 'text/plain',
@@ -93,10 +92,9 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {};
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
 				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_ALL,
 				etag: 'abc'
@@ -112,10 +110,9 @@ describe('OCA.Sharing.Util tests', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
 				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_ALL,
 				etag: 'abc'
@@ -133,10 +130,9 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {1: {link: true, path: '/subdir'}};
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
 				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_ALL,
 				etag: 'abc'
@@ -153,10 +149,9 @@ describe('OCA.Sharing.Util tests', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
-				name: 'One.txt',
+				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_ALL,
 				shareOwner: 'User One',
@@ -173,10 +168,9 @@ describe('OCA.Sharing.Util tests', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
-				name: 'One.txt',
+				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_ALL,
 				recipientsDisplayName: 'User One, User Two',
@@ -194,10 +188,9 @@ describe('OCA.Sharing.Util tests', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
-				type: 'dir',
 				name: 'One',
 				path: '/subdir',
-				mimetype: 'text/plain',
+				mimetype: 'httpd/unix-directory',
 				size: 12,
 				permissions: OC.PERMISSION_CREATE,
 				etag: 'abc',
@@ -235,7 +228,6 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {};
 			fileList.setFiles([{
 				id: 1,
-				type: 'file',
 				name: 'One.txt',
 				path: '/subdir',
 				mimetype: 'text/plain',
@@ -272,7 +264,6 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
 			fileList.setFiles([{
 				id: 1,
-				type: 'file',
 				name: 'One.txt',
 				path: '/subdir',
 				mimetype: 'text/plain',
@@ -308,7 +299,6 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
 			fileList.setFiles([{
 				id: 1,
-				type: 'file',
 				name: 'One.txt',
 				path: '/subdir',
 				mimetype: 'text/plain',
@@ -340,7 +330,6 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
 			fileList.setFiles([{
 				id: 1,
-				type: 'file',
 				name: 'One.txt',
 				path: '/subdir',
 				mimetype: 'text/plain',
@@ -377,7 +366,6 @@ describe('OCA.Sharing.Util tests', function() {
 			OC.Share.statuses = {1: {link: false, path: '/subdir'}};
 			fileList.setFiles([{
 				id: 1,
-				type: 'file',
 				name: 'One.txt',
 				path: '/subdir',
 				mimetype: 'text/plain',

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -55,12 +55,11 @@ class Helper
 							$originalPath = substr($originalPath, 0, -1);
 						}
 					}
+					$isDir = $view->is_dir($dir . '/' . $entryName);
 					$i = array(
 						'name' => $id,
 						'mtime' => $timestamp,
-						'mimetype' => \OC_Helper::getFileNameMimeType($id),
-						'type' => $view->is_dir($dir . '/' . $entryName) ? 'dir' : 'file',
-						'directory' => ($dir === '/') ? '' : $dir,
+						'mimetype' => $isDir ? 'httpd/unix-directory' : \OC_Helper::getFileNameMimeType($id),
 					);
 					if ($originalPath) {
 						$i['extraData'] = $originalPath.'/'.$id;
@@ -87,6 +86,7 @@ class Helper
 		foreach ($fileInfos as $i) {
 			$entry = \OCA\Files\Helper::formatFileInfo($i);
 			$entry['id'] = $id++;
+			unset($entry['path']); // not needed for trashbin
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
 			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 			if (\OCP\App::isEnabled('files_encryption')) {


### PR DESCRIPTION
- removed "type", can be computed from "mimetype"
- removed unused "date"
- ~~the property "path" is now always returned to the client~~
- added unit test

@icewind1991 FYI
