### PR TITLE
Add filter for backend to rest index

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -546,6 +546,7 @@ class OC_User {
 	 * @return array associative array with all display names (value) and corresponding uids (key)
 	 *
 	 * Get a list of all display names and user ids.
+	 * @deprecated Use \OC::$server->getUserManager->searchDisplayName($search, $limit, $offset) instead.
 	 */
 	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = array();

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -63,6 +63,14 @@ class Manager extends PublicEmitter implements IUserManager {
 	}
 
 	/**
+	 * Get the active backends
+	 * @return \OC_User_Interface[]
+	 */
+	public function getBackends() {
+		return $this->backends;
+	}
+
+	/**
 	 * register a user backend
 	 *
 	 * @param \OC_User_Interface $backend

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -28,7 +28,7 @@ use OCP\IConfig;
  */
 class Manager extends PublicEmitter implements IUserManager {
 	/**
-	 * @var \OC_User_Interface[] $backends
+	 * @var \OCP\UserInterface [] $backends
 	 */
 	private $backends = array();
 
@@ -64,7 +64,7 @@ class Manager extends PublicEmitter implements IUserManager {
 
 	/**
 	 * Get the active backends
-	 * @return \OC_User_Interface[]
+	 * @return \OCP\UserInterface[]
 	 */
 	public function getBackends() {
 		return $this->backends;
@@ -73,7 +73,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * register a user backend
 	 *
-	 * @param \OC_User_Interface $backend
+	 * @param \OCP\UserInterface $backend
 	 */
 	public function registerBackend($backend) {
 		$this->backends[] = $backend;
@@ -82,7 +82,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * remove a user backend
 	 *
-	 * @param \OC_User_Interface $backend
+	 * @param \OCP\UserInterface $backend
 	 */
 	public function removeBackend($backend) {
 		$this->cachedUsers = array();
@@ -121,7 +121,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * get or construct the user object
 	 *
 	 * @param string $uid
-	 * @param \OC_User_Interface $backend
+	 * @param \OCP\UserInterface $backend
 	 * @return \OC\User\User
 	 */
 	protected function getUserObject($uid, $backend) {

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -32,6 +32,12 @@ interface IUserManager {
 	public function registerBackend($backend);
 
 	/**
+	 * Get the active backends
+	 * @return \OC_User_Interface[]
+	 */
+	public function getBackends();
+
+	/**
 	 * remove a user backend
 	 *
 	 * @param \OCP\UserInterface $backend

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -33,7 +33,7 @@ interface IUserManager {
 
 	/**
 	 * Get the active backends
-	 * @return \OC_User_Interface[]
+	 * @return \OCP\UserInterface[]
 	 */
 	public function getBackends();
 

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -91,7 +91,7 @@ class UsersController extends Controller {
 	 */
 	private function getUsersForUID(array $userIDs) {
 		$users = [];
-		foreach ($userIDs as $uid) {
+		foreach ($userIDs as $uid => $displayName) {
 			$users[] = $this->userManager->get($uid);
 		}
 		return $users;

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -86,7 +86,7 @@ class UsersController extends Controller {
 	}
 
 	/**
-	 * @param array $userIDs
+	 * @param array $userIDs Array with schema [$uid => $displayName]
 	 * @return IUser[]
 	 */
 	private function getUsersForUID(array $userIDs) {

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -11,6 +11,7 @@
 namespace OC\Settings\Controller;
 
 use OC\AppFramework\Http;
+use OC\User\Manager;
 use OC\User\User;
 use \OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
@@ -85,45 +86,66 @@ class UsersController extends Controller {
 	}
 
 	/**
+	 * @param array $userIDs
+	 * @return IUser[]
+	 */
+	private function getUsersForUID(array $userIDs) {
+		$users = [];
+		foreach ($userIDs as $uid) {
+			$users[] = $this->userManager->get($uid);
+		}
+		return $users;
+	}
+
+	/**
 	 * @NoAdminRequired
 	 *
 	 * @param int $offset
 	 * @param int $limit
-	 * @param string $gid
-	 * @param string $pattern
+	 * @param string $gid GID to filter for
+	 * @param string $pattern Pattern to search for in the username
+	 * @param string $backend Backend to filter for (class-name)
 	 * @return DataResponse
 	 *
 	 * TODO: Tidy up and write unit tests - code is mainly static method calls
 	 */
-	public function index($offset = 0, $limit = 10, $gid = '', $pattern = '') {
+	public function index($offset = 0, $limit = 10, $gid = '', $pattern = '', $backend = '') {
 		// FIXME: The JS sends the group '_everyone' instead of no GID for the "all users" group.
 		if($gid === '_everyone') {
 			$gid = '';
 		}
+
+		// Remove backends
+		if(!empty($backend)) {
+			$activeBackends = $this->userManager->getBackends();
+			$this->userManager->clearBackends();
+			foreach($activeBackends as $singleActiveBackend) {
+				if($backend === get_class($singleActiveBackend)) {
+					$this->userManager->registerBackend($singleActiveBackend);
+				}
+			}
+		}
+
 		$users = array();
 		if ($this->isAdmin) {
+
 			if($gid !== '') {
-				$batch = $this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset);
+				$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
 			} else {
-				// FIXME: Remove static method call
-				$batch = \OC_User::getDisplayNames($pattern, $limit, $offset);
+				$batch = $this->userManager->search('');
 			}
 
-			foreach ($batch as $uid => $displayname) {
-				$users[] = $this->formatUserForIndex($this->userManager->get($uid));
+			foreach ($batch as $user) {
+				$users[] = $this->formatUserForIndex($user);
 			}
+
 		} else {
-			$groups = \OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID());
-			if($gid !== '' && in_array($gid, $groups)) {
-				$groups = array($gid);
-			} elseif($gid !== '') {
-				//don't you try to investigate loops you must not know about
-				$groups = array();
+			if($gid !== '' && !in_array($gid, \OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID()))) {
+				$gid = '';
 			}
-			$batch = \OC_Group::usersInGroups($groups, $pattern, $limit, $offset);
-			foreach ($batch as $uid) {
-				$user = $this->userManager->get($uid);
 
+			$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
+			foreach ($batch as $user) {
 				// Only add the groups, this user is a subadmin of
 				$userGroups = array_intersect($this->groupManager->getUserGroupIds($user),
 					\OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID()));

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -141,6 +141,7 @@ class UsersController extends Controller {
 			}
 
 		} else {
+			// Set the $gid parameter to an empty value if the subadmin has no rights to access a specific group
 			if($gid !== '' && !in_array($gid, \OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID()))) {
 				$gid = '';
 			}

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -133,7 +133,7 @@ class UsersController extends Controller {
 			if($gid !== '') {
 				$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
 			} else {
-				$batch = $this->userManager->search('');
+				$batch = $this->userManager->search('', $limit, $offset);
 			}
 
 			foreach ($batch as $user) {

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -122,6 +122,7 @@ class UsersController extends Controller {
 			foreach($activeBackends as $singleActiveBackend) {
 				if($backend === get_class($singleActiveBackend)) {
 					$this->userManager->registerBackend($singleActiveBackend);
+					break;
 				}
 			}
 		}

--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -10,6 +10,17 @@
 namespace Test\User;
 
 class Manager extends \Test\TestCase {
+	public function testGetBackends() {
+		$userDummyBackend = $this->getMock('\OC_User_Dummy');
+		$manager = new \OC\User\Manager();
+		$manager->registerBackend($userDummyBackend);
+		$this->assertEquals([$userDummyBackend], $manager->getBackends());
+		$dummyDatabaseBackend = $this->getMock('\OC_User_Database');
+		$manager->registerBackend($dummyDatabaseBackend);
+		$this->assertEquals([$userDummyBackend, $dummyDatabaseBackend], $manager->getBackends());
+	}
+
+
 	public function testUserExistsSingleBackendExists() {
 		/**
 		 * @var \OC_User_Dummy | \PHPUnit_Framework_MockObject_MockObject $backend

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -126,9 +126,20 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('getUserGroupIds')
 			->will($this->onConsecutiveCalls(array('Users', 'Support'), array('admins', 'Support'), array('External Users')));
 		$this->container['UserManager']
-			->expects($this->exactly(3))
+			->expects($this->at(0))
 			->method('get')
-			->will($this->onConsecutiveCalls($foo, $admin, $bar));
+			->with('foo')
+			->will($this->returnValue($foo));
+		$this->container['UserManager']
+			->expects($this->at(1))
+			->method('get')
+			->with('admin')
+			->will($this->returnValue($admin));
+		$this->container['UserManager']
+			->expects($this->at(2))
+			->method('get')
+			->with('bar')
+			->will($this->returnValue($bar));
 		$this->container['Config']
 			->expects($this->exactly(3))
 			->method('getUserValue')
@@ -168,7 +179,7 @@ class UsersControllerTest extends \Test\TestCase {
 				),
 			)
 		);
-		$response = $this->usersController->index(0, 10, 'pattern');
+		$response = $this->usersController->index(0, 10, 'gid', 'pattern');
 		$this->assertEquals($expectedResponse, $response);
 	}
 

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -172,6 +172,62 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertEquals($expectedResponse, $response);
 	}
 
+	public function testIndexWithBackend() {
+		$user = $this->getMockBuilder('\OC\User\User')
+			->disableOriginalConstructor()->getMock();
+		$user
+			->expects($this->exactly(3))
+			->method('getUID')
+			->will($this->returnValue('foo'));
+		$user
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue('M. Foo'));
+		$user
+			->method('getLastLogin')
+			->will($this->returnValue(500));
+		$user
+			->method('getHome')
+			->will($this->returnValue('/home/foo'));
+		$user
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('OC_User_Database'));
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('getBackends')
+			->will($this->returnValue([new \OC_User_Dummy(), new \OC_User_Database()]));
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('clearBackends');
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('registerBackend')
+			->with(new \OC_User_Dummy());
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('search')
+			->with('')
+			->will($this->returnValue([$user]));
+
+		$expectedResponse = new DataResponse(
+			array(
+				0 => array(
+					'name' => 'foo',
+					'displayname' => 'M. Foo',
+					'groups' => null,
+					'subadmin' => array(),
+					'quota' => null,
+					'storageLocation' => '/home/foo',
+					'lastLogin' => 500,
+					'backend' => 'OC_User_Database'
+				)
+			)
+		);
+		$response = $this->usersController->index(0, 10, '','', 'OC_User_Dummy');
+		$this->assertEquals($expectedResponse, $response);
+	}
+
 	/**
 	 * TODO: Since the function uses the static OC_Subadmin class it can't be mocked
 	 * to test for subadmins. Thus the test always assumes you have admin permissions...

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -228,6 +228,22 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertEquals($expectedResponse, $response);
 	}
 
+	public function testIndexWithBackendNoUser() {
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('getBackends')
+			->will($this->returnValue([new \OC_User_Dummy(), new \OC_User_Database()]));
+		$this->container['UserManager']
+			->expects($this->once())
+			->method('search')
+			->with('')
+			->will($this->returnValue([]));
+
+		$expectedResponse = new DataResponse([]);
+		$response = $this->usersController->index(0, 10, '','', 'OC_User_Dummy');
+		$this->assertEquals($expectedResponse, $response);
+	}
+
 	/**
 	 * TODO: Since the function uses the static OC_Subadmin class it can't be mocked
 	 * to test for subadmins. Thus the test always assumes you have admin permissions...


### PR DESCRIPTION
This adds a "backend" type filter to the index REST route which is a pre-requisite for #12620

For example when calling `index.php/settings/users/users?offset=0&limit=10&gid=&pattern=&backend=OC_User_Database` only users within the backend `OC_User_Database` would be shown. (requires sending a CSRF token as well)
