### PR TITLE
Make getURLParameter available as a universal parser

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1187,7 +1187,7 @@ function formatDate(timestamp){
  * @link http://stackoverflow.com/questions/1403888/get-url-parameter-with-jquery
  * @param {string} name URL parameter
  * @param {string} url URL
- * @return {string}
+ * @return {string|null}
  */
 function getURLParameter (name, url) {
 	if ('undefined' === typeof url) {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1186,12 +1186,16 @@ function formatDate(timestamp){
  * Get the value of a URL parameter
  * @link http://stackoverflow.com/questions/1403888/get-url-parameter-with-jquery
  * @param {string} name URL parameter
+ * @param {string} url URL
  * @return {string}
  */
-function getURLParameter(name) {
-	return decodeURI(
-			(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search) || [, null])[1]
-			);
+function getURLParameter (name, url) {
+	if ('undefined' === typeof url) {
+		url = location.search;
+	}
+	return decodeURIComponent(
+		(new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(url) || [, ""])[1].replace(/\+/g, '%20')
+	) || null;
 }
 
 /**

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -322,6 +322,20 @@ describe('Core base tests', function() {
 			setIntervalStub.restore();
 		});
 	});
+	describe('Get URL parameter', function() {
+		it('Extract parameter value from passed URL', function() {
+			var parameter = getURLParameter ('file', 'http://localhost/index.php?service=files&file=%C3%A9l%C3%A9phant.jpg');
+			expect(parameter).toEqual('éléphant.jpg');
+		});
+		it('Return null if parameter from passed URL is empty', function() {
+			var parameter = getURLParameter ('file', 'http://localhost/index.php?service=files&file=');
+			expect(parameter).toEqual(null);
+		});
+		it('Return null if parameter is not in the passed URL', function() {
+			var parameter = getURLParameter ('files', 'http://localhost/index.php?service=files&file=%C3%A9l%C3%A9phant.jpg');
+			expect(parameter).toEqual(null);
+		});
+	});
 	describe('Parse query string', function() {
 		it('Parses query string from full URL', function() {
 			var query = OC.parseQueryString('http://localhost/stuff.php?q=a&b=x');


### PR DESCRIPTION
It seems to me like it could be useful to have one JS URL parser to
extract the value of a parameter in both the address in the browser and
a URL passed as a parameter
