### PR TITLE
server to server sharing next generation

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1207,13 +1207,7 @@ class Util {
 
 		// handle public access
 		if ($this->isPublic) {
-			$filename = $path;
-			$fileOwnerUid = $this->userId;
-
-			return array(
-				$fileOwnerUid,
-				$filename
-			);
+			return array($this->userId, $path);
 		} else {
 
 			// Check that UID is valid

--- a/apps/files_encryption/tests/share.php
+++ b/apps/files_encryption/tests/share.php
@@ -115,6 +115,91 @@ class Share extends TestCase {
 		parent::tearDownAfterClass();
 	}
 
+	/**
+	 * @medium
+	 */
+	function testDeclineServer2ServerShare() {
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+				->disableOriginalConstructor()->getMock();
+		$certificateManager = $this->getMock('\OCP\ICertificateManager');
+		$httpHelperMock = $this->getMockBuilder('\OC\HTTPHelper')
+				->setConstructorArgs(array($config, $certificateManager))
+				->getMock();
+		$httpHelperMock->expects($this->once())->method('post')->with($this->anything())->will($this->returnValue(true));
+
+		self::loginHelper(self::TEST_ENCRYPTION_SHARE_USER1);
+
+		// save file with content
+		$cryptedFile = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->filename, $this->dataShort);
+
+		// test that data was successfully written
+		$this->assertTrue(is_int($cryptedFile));
+
+		// get the file info from previous created file
+		$fileInfo = $this->view->getFileInfo(
+			'/' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename);
+
+
+		// share the file
+		$token = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, '', \OCP\Constants::PERMISSION_ALL);
+		$this->assertTrue(is_string($token));
+
+		$publicShareKeyId = \OC::$server->getConfig()->getAppValue('files_encryption', 'publicShareKeyId');
+
+		// check if share key for public exists
+		$this->assertTrue($this->view->file_exists(
+			'/' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files_encryption/keys/'
+			. $this->filename . '/' . $publicShareKeyId . '.shareKey'));
+
+		// manipulate share
+		$query = \OC::$server->getDatabaseConnection()->prepare('UPDATE `*PREFIX*share` SET `share_type` = ?, `share_with` = ? WHERE `token`=?');
+		$this->assertTrue($query->execute(array(\OCP\Share::SHARE_TYPE_REMOTE, 'foo@bar', $token)));
+
+		// check if share key not exists
+		$this->assertTrue($this->view->file_exists(
+			'/' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files_encryption/keys/'
+			. $this->filename . '/' . $publicShareKeyId . '.shareKey'));
+
+
+		$query = \OC::$server->getDatabaseConnection()->prepare('SELECT * FROM `*PREFIX*share` WHERE `token`=?');
+		$query->execute(array($token));
+
+		$share = $query->fetch();
+
+		$this->registerHttpHelper($httpHelperMock);
+		$_POST['token'] = $token;
+		$s2s = new \OCA\Files_Sharing\API\Server2Server();
+		$s2s->declineShare(array('id' => $share['id']));
+		$this->restoreHttpHelper();
+
+		$this->assertFalse($this->view->file_exists(
+			'/' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files_encryption/keys/'
+			. $this->filename . '/' . $publicShareKeyId . '.shareKey'));
+
+	}
+
+
+	/**
+	 * Register an http helper mock for testing purposes.
+	 * @param $httpHelper http helper mock
+	 */
+	private function registerHttpHelper($httpHelper) {
+		$this->oldHttpHelper = \OC::$server->query('HTTPHelper');
+		\OC::$server->registerService('HTTPHelper', function ($c) use ($httpHelper) {
+			return $httpHelper;
+		});
+	}
+
+	/**
+	 * Restore the original http helper
+	 */
+	private function restoreHttpHelper() {
+		$oldHttpHelper = $this->oldHttpHelper;
+		\OC::$server->registerService('HTTPHelper', function ($c) use ($oldHttpHelper) {
+			return $oldHttpHelper;
+		});
+	}
 
 	/**
 	 * @medium
@@ -285,7 +370,7 @@ class Share extends TestCase {
 
 		// save file with content
 		$cryptedFile = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files/'  . $this->folder1 . $this->subfolder . $this->subsubfolder . '/'
-										 . $this->filename, $this->dataShort);
+			. $this->filename, $this->dataShort);
 
 		// test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile));
@@ -677,7 +762,7 @@ class Share extends TestCase {
 		// save file with content
 		$cryptedFile1 = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->filename, $this->dataShort);
 		$cryptedFile2 = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files/' . $this->folder1 . $this->subfolder . $this->subsubfolder . '/'
-										  . $this->filename, $this->dataShort);
+			. $this->filename, $this->dataShort);
 
 		// test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile1));
@@ -784,7 +869,7 @@ class Share extends TestCase {
 		// save file with content
 		$cryptedFile1 = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER2. '/files/' . $this->filename, $this->dataShort);
 		$cryptedFile2 = file_put_contents('crypt:///' . self::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->folder1 . $this->subfolder . $this->subsubfolder . '/'
-										  . $this->filename, $this->dataShort);
+			. $this->filename, $this->dataShort);
 
 		// test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile1));
@@ -925,8 +1010,8 @@ class Share extends TestCase {
 
 		// remove share file
 		$this->view->unlink('/' . self::TEST_ENCRYPTION_SHARE_USER1 . '/files_encryption/keys/'
-							. $this->filename . '/' . self::TEST_ENCRYPTION_SHARE_USER3
-							. '.shareKey');
+			. $this->filename . '/' . self::TEST_ENCRYPTION_SHARE_USER3
+			. '.shareKey');
 
 		// re-enable the file proxy
 		\OC_FileProxy::$enabled = $proxyStatus;
@@ -990,7 +1075,7 @@ class Share extends TestCase {
 
 		// move the file to a subfolder
 		$this->view->rename('/' . self::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->filename,
-				'/' . self::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->folder1 . $this->filename);
+			'/' . self::TEST_ENCRYPTION_SHARE_USER2 . '/files/' . $this->folder1 . $this->filename);
 
 		// check if we can read the moved file
 		$retrievedRenamedFile = $this->view->file_get_contents(

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -31,10 +31,11 @@ if(!\OCP\Util::isValidFileName($name)) {
 }
 
 $externalManager = new \OCA\Files_Sharing\External\Manager(
-	\OC::$server->getDatabaseConnection(),
-	\OC\Files\Filesystem::getMountManager(),
-	\OC\Files\Filesystem::getLoader(),
-	\OC::$server->getUserSession()
+		\OC::$server->getDatabaseConnection(),
+		\OC\Files\Filesystem::getMountManager(),
+		\OC\Files\Filesystem::getLoader(),
+		\OC::$server->getUserSession(),
+		\OC::$server->getHTTPHelper()
 );
 
 $name = OCP\Files::buildNotExistingFileName('/', $name);
@@ -44,7 +45,7 @@ if (substr($remote, 0, 5) === 'https' and !OC_Util::getUrlContent($remote)) {
 	\OCP\JSON::error(array('data' => array('message' => $l->t("Invalid or untrusted SSL certificate"))));
 	exit;
 } else {
-	$mount = $externalManager->addShare($remote, $token, $password, $name, $owner);
+	$mount = $externalManager->addShare($remote, $token, $password, $name, $owner, true);
 	/**
 	 * @var \OCA\Files_Sharing\External\Storage $storage
 	 */

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -1,5 +1,16 @@
 <?php
 
+namespace OCA\Files_Sharing\AppInfo;
+
+use OCA\Files_Sharing\Application;
+
+$application = new Application();
+$application->registerRoutes($this, [
+	'resources' => [
+		'ExternalShares' => ['url' => '/api/externalShares'],
+	]
+]);
+
 /** @var $this \OCP\Route\IRouter */
 $this->create('core_ajax_public_preview', '/publicpreview')->action(
 	function() {
@@ -16,31 +27,32 @@ $this->create('sharing_external_add', '/external')
 	->actionInclude('files_sharing/ajax/external.php');
 $this->create('sharing_external_test_remote', '/testremote')
 	->actionInclude('files_sharing/ajax/testremote.php');
+
 // OCS API
 
 //TODO: SET: mail notification, waiting for PR #4689 to be accepted
 
-OC_API::register('get',
+\OC_API::register('get',
 		'/apps/files_sharing/api/v1/shares',
 		array('\OCA\Files_Sharing\API\Local', 'getAllShares'),
 		'files_sharing');
 
-OC_API::register('post',
+\OC_API::register('post',
 		'/apps/files_sharing/api/v1/shares',
 		array('\OCA\Files_Sharing\API\Local', 'createShare'),
 		'files_sharing');
 
-OC_API::register('get',
+\OC_API::register('get',
 		'/apps/files_sharing/api/v1/shares/{id}',
 		array('\OCA\Files_Sharing\API\Local', 'getShare'),
 		'files_sharing');
 
-OC_API::register('put',
+\OC_API::register('put',
 		'/apps/files_sharing/api/v1/shares/{id}',
 		array('\OCA\Files_Sharing\API\Local', 'updateShare'),
 		'files_sharing');
 
-OC_API::register('delete',
+\OC_API::register('delete',
 		'/apps/files_sharing/api/v1/shares/{id}',
 		array('\OCA\Files_Sharing\API\Local', 'deleteShare'),
 		'files_sharing');

--- a/apps/files_sharing/application.php
+++ b/apps/files_sharing/application.php
@@ -11,6 +11,7 @@
 namespace OCA\Files_Sharing;
 
 use OC\AppFramework\Utility\SimpleContainer;
+use OCA\Files_Sharing\Controllers\ExternalSharesController;
 use OCA\Files_Sharing\Controllers\ShareController;
 use OCA\Files_Sharing\Middleware\SharingCheckMiddleware;
 use \OCP\AppFramework\App;
@@ -44,6 +45,14 @@ class Application extends App {
 				$c->query('ServerContainer')->getLogger()
 			);
 		});
+		$container->registerService('ExternalSharesController', function(SimpleContainer $c) {
+			return new ExternalSharesController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('IsIncomingShareEnabled'),
+				$c->query('ExternalManager')
+			);
+		});
 
 		/**
 		 * Core class wrappers
@@ -53,6 +62,18 @@ class Application extends App {
 		});
 		$container->registerService('URLGenerator', function(SimpleContainer $c) {
 			return $c->query('ServerContainer')->getUrlGenerator();
+		});
+		$container->registerService('IsIncomingShareEnabled', function(SimpleContainer $c) {
+			return Helper::isIncomingServer2serverShareEnabled();
+		});
+		$container->registerService('ExternalManager', function(SimpleContainer $c) {
+			return new \OCA\Files_Sharing\External\Manager(
+					\OC::$server->getDatabaseConnection(),
+					\OC\Files\Filesystem::getMountManager(),
+					\OC\Files\Filesystem::getLoader(),
+					\OC::$server->getUserSession(),
+					\OC::$server->getHTTPHelper()
+			);
 		});
 
 		/**

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -98,7 +98,7 @@ class Activity implements \OCP\Activity\IExtension {
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
 					return $l->t('%1$s declined remote share %2$s', $params)->__toString();
 					case self::SUBJECT_REMOTE_SHARE_UNSHARED:
-					return $l->t('%1$s unshared %2$s', $params)->__toString();
+					return $l->t('%1$s unshared %2$s from you', $params)->__toString();
 			}
 		}
 	}

--- a/apps/files_sharing/lib/connector/publicauth.php
+++ b/apps/files_sharing/lib/connector/publicauth.php
@@ -69,6 +69,8 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 				} else {
 					return false;
 				}
+			} elseif ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_REMOTE) {
+				return true;
 			} else {
 				return false;
 			}

--- a/apps/files_sharing/lib/controllers/externalsharescontroller.php
+++ b/apps/files_sharing/lib/controllers/externalsharescontroller.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ * @copyright 2014 Lukas Reschke
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_Sharing\Controllers;
+
+use OC;
+use OCP;
+use OCP\AppFramework\Controller;
+use OCP\IRequest;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * Class ExternalSharesController
+ *
+ * @package OCA\Files_Sharing\Controllers
+ */
+class ExternalSharesController extends Controller {
+
+	/** @var bool */
+	private $incomingShareEnabled;
+	/** @var \OCA\Files_Sharing\External\Manager */
+	private $externalManager;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param \OCA\Files_Sharing\External\Manager $externalManager
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								$incomingShareEnabled,
+								\OCA\Files_Sharing\External\Manager $externalManager) {
+		parent::__construct($appName, $request);
+		$this->incomingShareEnabled = $incomingShareEnabled;
+		$this->externalManager = $externalManager;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @return JSONResponse
+	 */
+	public function index() {
+		$shares = [];
+		if ($this->incomingShareEnabled) {
+			$shares = $this->externalManager->getOpenShares();
+		}
+		return new JSONResponse($shares);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $id
+	 * @return JSONResponse
+	 */
+	public function create($id) {
+		if ($this->incomingShareEnabled) {
+			$this->externalManager->acceptShare($id);
+		}
+
+		return new JSONResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param $id
+	 * @return JSONResponse
+	 */
+	public function destroy($id) {
+		if ($this->incomingShareEnabled) {
+			$this->externalManager->declineShare($id);
+		}
+
+		return new JSONResponse();
+	}
+
+}

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -2,8 +2,6 @@
 
 namespace OCA\Files_Sharing;
 
-use OC_Config;
-
 class Helper {
 
 	public static function registerHooks() {
@@ -18,30 +16,6 @@ class Helper {
 		\OCP\Util::connectHook('OCP\Share', 'post_shared', '\OC\Files\Cache\Shared_Updater', 'postShareHook');
 		\OCP\Util::connectHook('OCP\Share', 'post_unshare', '\OC\Files\Cache\Shared_Updater', 'postUnshareHook');
 		\OCP\Util::connectHook('OCP\Share', 'post_unshareFromSelf', '\OC\Files\Cache\Shared_Updater', 'postUnshareFromSelfHook');
-	}
-
-	/**
-	 * add server-to-server share to database
-	 *
-	 * @param string $remote
-	 * @param string $token
-	 * @param string $name
-	 * @param string $mountPoint
-	 * @param string $owner
-	 * @param string $user
-	 * @param string $password
-	 * @param int $remoteId
-	 * @param bool $accepted
-	 */
-	public static function addServer2ServerShare($remote, $token, $name, $mountPoint, $owner, $user, $password='', $remoteId=-1, $accepted = false) {
-		$accepted = $accepted ? 1 : 0;
-		$query = \OCP\DB::prepare('
-				INSERT INTO `*PREFIX*share_external`
-					(`remote`, `share_token`, `password`, `name`, `owner`, `user`, `mountpoint`, `mountpoint_hash`, `accepted`, `remote_id`)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			');
-			$hash = md5($mountPoint);
-			$query->execute(array($remote, $token, $password, $name, $owner, $user, $mountPoint, $hash, $accepted, $remoteId));
 	}
 
 	/**
@@ -89,7 +63,7 @@ class Helper {
 			exit();
 		}
 
-		if (isset($linkItem['share_with'])) {
+		if (isset($linkItem['share_with']) && (int)$linkItem['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
 			if (!self::authenticate($linkItem, $password)) {
 				\OC_Response::setStatus(403);
 				\OCP\JSON::error(array('success' => false));

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -160,6 +160,20 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	}
 
 	/**
+	 * check if server2server share is enabled
+	 *
+	 * @param int $shareType
+	 * @return boolean
+	 */
+	public function isShareTypeAllowed($shareType) {
+		if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+			return \OCA\Files_Sharing\Helper::isOutgoingServer2serverShareEnabled();
+		}
+
+		return true;
+	}
+
+	/**
 	 * resolve reshares to return the correct source item
 	 * @param array $source
 	 * @return array source item

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -161,7 +161,10 @@ class Shared_Updater {
 	 */
 	static public function postUnshareHook($params) {
 
-		if ($params['itemType'] === 'file' || $params['itemType'] === 'folder') {
+		// only update etags for file/folders shared to local users/groups
+		if (($params['itemType'] === 'file' || $params['itemType'] === 'folder') &&
+				$params['shareType'] !== \OCP\Share::SHARE_TYPE_LINK &&
+				$params['shareType'] !== \OCP\Share::SHARE_TYPE_REMOTE) {
 
 			$deletedShares = isset($params['deletedShares']) ? $params['deletedShares'] : array();
 
@@ -212,7 +215,7 @@ class Shared_Updater {
 
 	/**
 	 * rename mount point from the children if the parent was renamed
-	 * 
+	 *
 	 * @param string $oldPath old path relative to data/user/files
 	 * @param string $newPath new path relative to data/user/files
 	 */

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -36,7 +36,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$shareWith = null;
 					}
  					$itemSourceName=(isset($_POST['itemSourceName'])) ? $_POST['itemSourceName']:'';
-					
+
 					$token = OCP\Share::shareItem(
 						$_POST['itemType'],
 						$_POST['itemSource'],
@@ -309,6 +309,21 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						break;
 					}
 				}
+
+				// allow user to add unknown remote addresses for server-to-server share
+				$backend = \OCP\Share::getBackend($_GET['itemType']);
+				if ($backend->isShareTypeAllowed(\OCP\Share::SHARE_TYPE_REMOTE)) {
+					if (substr_count($_GET['search'], '@') === 1) {
+						$shareWith[] = array(
+							'label' => $_GET['search'],
+							'value' => array(
+								'shareType' => \OCP\Share::SHARE_TYPE_REMOTE,
+								'shareWith' => $_GET['search']
+							)
+						);
+					}
+				}
+
 				$sorter = new \OC\Share\SearchResultSorter($_GET['search'],
 														   'label',
 														   new \OC\Log());

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -8,6 +8,7 @@ OC.Share={
 	SHARE_TYPE_GROUP:1,
 	SHARE_TYPE_LINK:3,
 	SHARE_TYPE_EMAIL:4,
+	SHARE_TYPE_REMOTE:6,
 
 	/**
 	 * Regular expression for splitting parts of remote share owners:
@@ -444,7 +445,11 @@ OC.Share={
 						if (share.collection) {
 							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, share.collection);
 						} else {
-							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, false);
+							if (share.share_type === OC.Share.SHARE_TYPE_REMOTE) {
+								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE, share.mail_send, false);
+							} else {
+								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, false);
+							}
 						}
 					}
 					if (share.expiration != null) {
@@ -455,7 +460,7 @@ OC.Share={
 			$('#shareWith').autocomplete({minLength: 2, delay: 750, source: function(search, response) {
 				var $loading = $('#dropdown .shareWithLoading');
 				$loading.removeClass('hidden');
-				$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term.trim(), itemShares: OC.Share.itemShares }, function(result) {
+				$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term.trim(), itemShares: OC.Share.itemShares, itemType: itemType }, function(result) {
 					$loading.addClass('hidden');
 					if (result.status == 'success' && result.data.length > 0) {
 						$( "#shareWith" ).autocomplete( "option", "autoFocus", true );
@@ -484,19 +489,22 @@ OC.Share={
 				// Default permissions are Edit (CRUD) and Share
 				// Check if these permissions are possible
 				var permissions = OC.PERMISSION_READ;
-				if (possiblePermissions & OC.PERMISSION_UPDATE) {
-					permissions = permissions | OC.PERMISSION_UPDATE;
+				if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
+					permissions = OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_READ;
+				} else {
+					if (possiblePermissions & OC.PERMISSION_UPDATE) {
+						permissions = permissions | OC.PERMISSION_UPDATE;
+					}
+					if (possiblePermissions & OC.PERMISSION_CREATE) {
+						permissions = permissions | OC.PERMISSION_CREATE;
+					}
+					if (possiblePermissions & OC.PERMISSION_DELETE) {
+						permissions = permissions | OC.PERMISSION_DELETE;
+					}
+					if (oc_appconfig.core.resharingAllowed && (possiblePermissions & OC.PERMISSION_SHARE)) {
+						permissions = permissions | OC.PERMISSION_SHARE;
+					}
 				}
-				if (possiblePermissions & OC.PERMISSION_CREATE) {
-					permissions = permissions | OC.PERMISSION_CREATE;
-				}
-				if (possiblePermissions & OC.PERMISSION_DELETE) {
-					permissions = permissions | OC.PERMISSION_DELETE;
-				}
-				if (oc_appconfig.core.resharingAllowed && (possiblePermissions & OC.PERMISSION_SHARE)) {
-					permissions = permissions | OC.PERMISSION_SHARE;
-				}
-
 
 				var $input = $(this);
 				var $loading = $dropDown.find('.shareWithLoading');
@@ -507,7 +515,11 @@ OC.Share={
 				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, itemSourceName, expirationDate, function() {
 					$input.prop('disabled', false);
 					$loading.addClass('hidden');
-					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, possiblePermissions);
+					var posPermissions = possiblePermissions;
+					if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
+						posPermissions = permissions;
+					}
+					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, posPermissions);
 					$('#shareWith').val('');
 					$('#dropdown').trigger(new $.Event('sharesChanged', {shares: OC.Share.currentShares}));
 					OC.Share.updateIcon(itemType, itemSource);
@@ -518,13 +530,18 @@ OC.Share={
 			// customize internal _renderItem function to display groups and users differently
 			.data("ui-autocomplete")._renderItem = function( ul, item ) {
 				var insert = $( "<a>" );
-				var text = (item.value.shareType == 1)? item.label + ' ('+t('core', 'group')+')' : item.label;
+				var text = item.label;
+				if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
+					text = text +  ' ('+t('core', 'group')+')';
+				} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
+					text = text +  ' ('+t('core', 'remote')+')';
+				}
 				insert.text( text );
-				if(item.value.shareType == 1) {
+				if(item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 					insert = insert.wrapInner('<strong></strong>');
 				}
 				return $( "<li>" )
-					.addClass((item.value.shareType == 1)?'group':'user')
+					.addClass((item.value.shareType === OC.Share.SHARE_TYPE_GROUP)?'group':'user')
 					.append( insert )
 					.appendTo( ul );
 			};
@@ -585,8 +602,11 @@ OC.Share={
 			share_with_displayname: shareWithDisplayName,
 			permissions: permissions
 		};
-		if (shareType === 1) {
+		if (shareType === OC.Share.SHARE_TYPE_GROUP) {
 			shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'group') + ')';
+		}
+		if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
+			shareWithDisplayName = shareWithDisplayName + " (" + t('core', 'remote') + ')';
 		}
 		if (!OC.Share.itemShares[shareType]) {
 			OC.Share.itemShares[shareType] = [];
@@ -627,7 +647,7 @@ OC.Share={
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
 			html += '<span class="username">' + escapeHTML(shareWithDisplayName) + '</span>';
 			var mailNotificationEnabled = $('input:hidden[name=mailNotificationEnabled]').val();
-			if (mailNotificationEnabled === 'yes') {
+			if (mailNotificationEnabled === 'yes' && shareType !== OC.Share.SHARE_TYPE_REMOTE) {
 				var checked = '';
 				if (mailSend === '1') {
 					checked = 'checked';
@@ -640,17 +660,19 @@ OC.Share={
 			if (possiblePermissions & OC.PERMISSION_CREATE || possiblePermissions & OC.PERMISSION_UPDATE || possiblePermissions & OC.PERMISSION_DELETE) {
 				html += '<input id="canEdit-'+escapeHTML(shareWith)+'" type="checkbox" name="edit" class="permissions" '+editChecked+' /><label for="canEdit-'+escapeHTML(shareWith)+'">'+t('core', 'can edit')+'</label>';
 			}
-			showCrudsButton = '<a href="#" class="showCruds"><img class="svg" alt="'+t('core', 'access control')+'" src="'+OC.imagePath('core', 'actions/triangle-s')+'"/></a>';
+			if (shareType !== OC.Share.SHARE_TYPE_REMOTE) {
+				showCrudsButton = '<a href="#" class="showCruds"><img class="svg" alt="'+t('core', 'access control')+'" src="'+OC.imagePath('core', 'actions/triangle-s')+'"/></a>';
+			}
 			html += '<div class="cruds" style="display:none;">';
-				if (possiblePermissions & OC.PERMISSION_CREATE) {
-					html += '<input id="canCreate-'+escapeHTML(shareWith)+'" type="checkbox" name="create" class="permissions" '+createChecked+' data-permissions="'+OC.PERMISSION_CREATE+'"/><label for="canCreate-'+escapeHTML(shareWith)+'">'+t('core', 'create')+'</label>';
-				}
-				if (possiblePermissions & OC.PERMISSION_UPDATE) {
-					html += '<input id="canUpdate-'+escapeHTML(shareWith)+'" type="checkbox" name="update" class="permissions" '+updateChecked+' data-permissions="'+OC.PERMISSION_UPDATE+'"/><label for="canUpdate-'+escapeHTML(shareWith)+'">'+t('core', 'change')+'</label>';
-				}
-				if (possiblePermissions & OC.PERMISSION_DELETE) {
-					html += '<input id="canDelete-'+escapeHTML(shareWith)+'" type="checkbox" name="delete" class="permissions" '+deleteChecked+' data-permissions="'+OC.PERMISSION_DELETE+'"/><label for="canDelete-'+escapeHTML(shareWith)+'">'+t('core', 'delete')+'</label>';
-				}
+			if (possiblePermissions & OC.PERMISSION_CREATE) {
+				html += '<input id="canCreate-' + escapeHTML(shareWith) + '" type="checkbox" name="create" class="permissions" ' + createChecked + ' data-permissions="' + OC.PERMISSION_CREATE + '"/><label for="canCreate-' + escapeHTML(shareWith) + '">' + t('core', 'create') + '</label>';
+			}
+			if (possiblePermissions & OC.PERMISSION_UPDATE) {
+				html += '<input id="canUpdate-' + escapeHTML(shareWith) + '" type="checkbox" name="update" class="permissions" ' + updateChecked + ' data-permissions="' + OC.PERMISSION_UPDATE + '"/><label for="canUpdate-' + escapeHTML(shareWith) + '">' + t('core', 'change') + '</label>';
+			}
+			if (possiblePermissions & OC.PERMISSION_DELETE) {
+				html += '<input id="canDelete-' + escapeHTML(shareWith) + '" type="checkbox" name="delete" class="permissions" ' + deleteChecked + ' data-permissions="' + OC.PERMISSION_DELETE + '"/><label for="canDelete-' + escapeHTML(shareWith) + '">' + t('core', 'delete') + '</label>';
+			}
 			html += '</div>';
 			html += '</li>';
 			html = $(html).appendTo('#shareWithList');

--- a/lib/private/security/certificatemanager.php
+++ b/lib/private/security/certificatemanager.php
@@ -33,7 +33,7 @@ class CertificateManager implements ICertificateManager {
 	 * @return \OCP\ICertificate[]
 	 */
 	public function listCertificates() {
-		$path = $this->user->getHome() . '/files_external/uploads/';
+		$path = $this->getPathToCertificates() . 'uploads/';
 		if (!is_dir($path)) {
 			return array();
 		}
@@ -57,7 +57,7 @@ class CertificateManager implements ICertificateManager {
 	 * create the certificate bundle of all trusted certificated
 	 */
 	protected function createCertificateBundle() {
-		$path = $this->user->getHome() . '/files_external/';
+		$path = $this->getPathToCertificates();
 		$certs = $this->listCertificates();
 
 		$fh_certs = fopen($path . '/rootcerts.crt', 'w');
@@ -86,7 +86,7 @@ class CertificateManager implements ICertificateManager {
 			return false;
 		}
 
-		$dir = $this->user->getHome() . '/files_external/uploads/';
+		$dir = $this->getPathToCertificates() . 'uploads/';
 		if (!file_exists($dir)) {
 			//path might not exist (e.g. non-standard OC_User::getHome() value)
 			//in this case create full path using 3rd (recursive=true) parameter.
@@ -116,7 +116,7 @@ class CertificateManager implements ICertificateManager {
 		if (!Filesystem::isValidPath($name)) {
 			return false;
 		}
-		$path = $this->user->getHome() . '/files_external/uploads/';
+		$path = $this->getPathToCertificates() . 'uploads/';
 		if (file_exists($path . $name)) {
 			unlink($path . $name);
 			$this->createCertificateBundle();
@@ -130,6 +130,12 @@ class CertificateManager implements ICertificateManager {
 	 * @return string
 	 */
 	public function getCertificateBundle() {
-		return $this->user->getHome() . '/files_external/rootcerts.crt';
+		return $this->getPathToCertificates() . 'rootcerts.crt';
+	}
+
+	private function getPathToCertificates() {
+		$path = $this->user ? $this->user->getHome() . '/files_external/' : '/files_external/';
+
+		return $path;
 	}
 }

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -249,7 +249,7 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('HTTPHelper', function (Server $c) {
 			$config = $c->getConfig();
-			return new HTTPHelper($config);
+			return new HTTPHelper($config, new \OC\Security\CertificateManager($c->getUserSession()->getUser()));
 		});
 		$this->registerService('EventLogger', function (Server $c) {
 			if (defined('DEBUG') and DEBUG) {

--- a/lib/private/share/constants.php
+++ b/lib/private/share/constants.php
@@ -34,7 +34,11 @@ class Constants {
 	const FORMAT_STATUSES = -2;
 	const FORMAT_SOURCES = -3;  // ToDo Check if it is still in use otherwise remove it
 
+	const RESPONSE_FORMAT = 'json'; // default resonse format for ocs calls
+
 	const TOKEN_LENGTH = 15; // old (oc7) length is 32, keep token length in db at least that for compatibility
+
+	const BASE_PATH_TO_SHARE_API = '/ocs/v1.php/cloud/shares';
 
 	protected static $shareTypeUserAndGroups = -1;
 	protected static $shareTypeGroupUserUnique = 2;

--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -38,7 +38,7 @@ class Helper extends \OC\Share\Constants {
 	public static function generateTarget($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $suggestedTarget = null, $groupParent = null) {
 		// FIXME: $uidOwner and $groupParent seems to be unused
 		$backend = \OC\Share\Share::getBackend($itemType);
-		if ($shareType == self::SHARE_TYPE_LINK) {
+		if ($shareType === self::SHARE_TYPE_LINK || $shareType === self::SHARE_TYPE_REMOTE) {
 			if (isset($suggestedTarget)) {
 				return $suggestedTarget;
 			}

--- a/lib/public/share_backend.php
+++ b/lib/public/share_backend.php
@@ -65,4 +65,16 @@ interface Share_Backend {
 	 */
 	public function formatItems($items, $format, $parameters = null);
 
+	/**
+	 * Check if a given share type is allowd by the back-end
+	 *
+	 * @param int $shareType share type
+	 * @return boolean
+	 *
+	 * The back-end can enable/disable specific share types. Just return true if
+	 * the back-end doesn't provide any specific settings for it and want to allow
+	 * all share types defined by the share API
+	 */
+	public function isShareTypeAllowed($shareType);
+
 }

--- a/tests/lib/app/infoparser.php
+++ b/tests/lib/app/infoparser.php
@@ -21,8 +21,9 @@ class InfoParser extends \PHPUnit_Framework_TestCase {
 	public function setUp() {
 		$config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
+		$certificateManager = $this->getMock('\OCP\ICertificateManager');
 		$httpHelper = $this->getMockBuilder('\OC\HTTPHelper')
-			->setConstructorArgs(array($config))
+			->setConstructorArgs(array($config, $certificateManager))
 			->setMethods(array('getHeaders'))
 			->getMock();
 		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')

--- a/tests/lib/httphelper.php
+++ b/tests/lib/httphelper.php
@@ -12,14 +12,17 @@ class TestHTTPHelper extends \Test\TestCase {
 	private $config;
 	/** @var \OC\HTTPHelper */
 	private $httpHelperMock;
+	/** @var \OC\Security\CertificateManager */
+	private $certificateManager;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
+		$this->certificateManager = $this->getMock('\OCP\ICertificateManager');
 		$this->httpHelperMock = $this->getMockBuilder('\OC\HTTPHelper')
-			->setConstructorArgs(array($this->config))
+			->setConstructorArgs(array($this->config, $this->certificateManager))
 			->setMethods(array('getHeaders'))
 			->getMock();
 	}
@@ -86,5 +89,24 @@ class TestHTTPHelper extends \Test\TestCase {
 	public function testIsHTTP($url, $expected) {
 			$this->assertSame($expected, $this->httpHelperMock->isHTTPURL($url));
 	}
+
+
+	/**
+	 * @dataProvider postParameters
+	 */
+	public function testassemblePostParameters($parameterList, $expectedResult) {
+		$helper = \OC::$server->getHTTPHelper();
+		$result = \Test_Helper::invokePrivate($helper, 'assemblePostParameters', array($parameterList));
+		$this->assertSame($expectedResult, $result);
+	}
+
+	public function postParameters() {
+		return array(
+			array(array('k1' => 'v1'), 'k1=v1'),
+			array(array('k1' => 'v1', 'k2' => 'v2'), 'k1=v1&k2=v2'),
+			array(array(), ''),
+		);
+	}
+
 
 }

--- a/tests/lib/share/backend.php
+++ b/tests/lib/share/backend.php
@@ -84,4 +84,8 @@ class Test_Share_Backend implements OCP\Share_Backend {
 		return $testItems;
 	}
 
+	public function isShareTypeAllowed($shareType) {
+		return true;
+	}
+
 }

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -849,6 +849,23 @@ class Test_Share extends \Test\TestCase {
 	}
 
 	/**
+	 * @dataProvider urls
+	 */
+	function testRemoveProtocolFromUrl($url, $expectedResult) {
+		$share = new \OC\Share\Share();
+		$result = \Test_Helper::invokePrivate($share, 'removeProtocolFromUrl', array($url));
+		$this->assertSame($expectedResult, $result);
+	}
+
+	function urls() {
+		return array(
+			array('http://owncloud.org', 'owncloud.org'),
+			array('https://owncloud.org', 'owncloud.org'),
+			array('owncloud.org', 'owncloud.org'),
+		);
+	}
+
+	/**
 	 * @dataProvider dataProviderTestGroupItems
 	 * @param type $ungrouped
 	 * @param type $grouped


### PR DESCRIPTION
Next step in server-to-server sharing next generation, see https://github.com/owncloud/core/issues/12285

Beside some small improvements and bug fixes this will probably the final state for OC8.

To test this you need to set up two ownCloud instances. Let's say:
- URL: myPC/firstOwnCloud user: user1
- URL: myPC/secondOwnCloud user: user2

Now user1 can share a file with user2 by entering the username and the URL to the second ownCloud to the share-drop-down, in this case "user2@myPC/secondOwnCloud".

The next time user2 login he will get a notification that he received a server-to-server share with the option to accept/decline it. If he accept it the share will be mounted. In both cases a event will be send back to user1 and add a notification to the activity stream that the share was accepted/declined.

If user1 decides to unshare the file again from user2 the share will automatically be removed from the second ownCloud server and user2 will see a notification in his activity stream that user1@myPC/firstOwnCloud has unshared the file/folder from him.

ToDo (I will provide PRs for it):
- [x] add implementation  isShareTypeAllowed() in share_backend for calendar (https://github.com/owncloud/calendar/pull/643)
- [x] add implementation  isShareTypeAllowed() in share_backend for contacts (https://github.com/owncloud/contacts/pull/738)

This is ready for testing and reviewing cc @LukasReschke @icewind1991 @MorrisJobke @PVince81 
