### PR TITLE
remove PHP generated user list and move all to the existing JS part

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -52,6 +52,9 @@ var UserList = {
 		$tr.find('td.name').text(username);
 		$tr.find('td.displayName > span').text(displayname);
 
+		/**
+		 * groups and subadmins
+		 */
 		// make them look like the multiselect buttons
 		// until they get time to really get initialized
 		groupsSelect = $('<select multiple="multiple" class="groupsselect multiselect button" data-placehoder="Groups" title="' + t('settings', 'no group') + '"></select>')
@@ -75,6 +78,10 @@ var UserList = {
 		if (subAdminsEl.length > 0) {
 			subAdminsEl.append(subAdminSelect);
 		}
+
+		/**
+		 * remove action
+		 */
 		if ($tr.find('td.remove img').length === 0 && OC.currentUser !== username) {
 			var deleteImage = $('<img class="svg action">').attr({
 				src: OC.imagePath('core', 'actions/delete')
@@ -86,6 +93,10 @@ var UserList = {
 		} else if (OC.currentUser === username) {
 			$tr.find('td.remove a').remove();
 		}
+
+		/**
+		 * quota
+		 */
 		var $quotaSelect = $tr.find('.quota-user');
 		if (quota === 'default') {
 			$quotaSelect
@@ -99,8 +110,15 @@ var UserList = {
 				$quotaSelect.append('<option value="' + escapeHTML(quota) + '" selected="selected">' + escapeHTML(quota) + '</option>');
 			}
 		}
+
+		/**
+		 * storage location
+		 */
 		$tr.find('td.storageLocation').text(storageLocation);
 
+		/**
+		 * last login
+		 */
 		var lastLoginRel = t('settings', 'never');
 		var lastLoginAbs = lastLoginRel;
 		if(lastLogin !== 0) {
@@ -115,6 +133,10 @@ var UserList = {
 		var tooltip = $('<div>').html($($tdLastLogin.attr('original-title')).text(lastLoginAbs)).html();
 		$tdLastLogin.tipsy({gravity:'s', fade:true, html:true});
 		$tdLastLogin.attr('title', tooltip);
+
+		/**
+		 * append generated row to user list
+		 */
 		$tr.appendTo($userList);
 		if(UserList.isEmpty === true) {
 			//when the list was emptied, one row was left, necessary to keep
@@ -124,6 +146,10 @@ var UserList = {
 			UserList.isEmpty = false;
 			UserList.checkUsersToLoad();
 		}
+
+		/**
+		 * sort list
+		 */
 		if (sort) {
 			UserList.doSort();
 		}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -12,9 +12,7 @@ var filter;
 
 var UserList = {
 	availableGroups: [],
-	offset: 30, //The first 30 users are there. No prob, if less in total.
-				//hardcoded in settings/users.php
-
+	offset: 0,
 	usersToLoad: 10, //So many users will be loaded when user scrolls down
 	currentGid: '',
 
@@ -32,13 +30,23 @@ var UserList = {
 
 	add: function (username, displayname, groups, subadmin, quota, storageLocation, lastLogin, sort) {
 		var $tr = $userListBody.find('tr:first-child').clone();
+		// this removes just the `display:none` of the template row
+		$tr.removeAttr('style');
 		var subAdminsEl;
 		var subAdminSelect;
 		var groupsSelect;
+
+		/**
+		 * Avatar or placeholder
+		 */
 		if ($tr.find('div.avatardiv').length){
 			$tr.find('.avatardiv').imageplaceholder(username, displayname);
 			$('div.avatardiv', $tr).avatar(username, 32);
 		}
+
+		/**
+		 * add username and displayname to row (in data and visible markup
+		 */
 		$tr.data('uid', username);
 		$tr.data('displayname', displayname);
 		$tr.find('td.name').text(username);
@@ -727,6 +735,7 @@ $(document).ready(function () {
 		}
 	});
 
-
+	// trigger loading of users on startup
+	UserList.update(UserList.currentGid);
 
 });

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -4,6 +4,19 @@
  * This file is licensed under the Affero General Public License version 3 or later.
  * See the COPYING-README file.
  */
+
+script('settings', [
+	'users/deleteHandler',
+	'users/filter',
+	'users/users',
+	'users/groups'
+]);
+script('core', [
+	'multiselect',
+	'singleselect'
+]);
+style('settings', 'settings');
+
 $userlistParams = array();
 $allGroups=array();
 foreach($_["groups"] as $group) {

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -18,14 +18,13 @@
 		</tr>
 	</thead>
 	<tbody>
-		<?php foreach($_["users"] as $user): ?>
-		<tr data-uid="<?php p($user["name"]) ?>"
-			data-displayname="<?php p($user["displayName"]) ?>">
+		<!-- the following <tr> is used as a template for the JS part -->
+		<tr style="display:none">
 			<?php if ($_['enableAvatars']): ?>
-			<td class="avatar"><div class="avatardiv"></div></td>
+				<td class="avatar"><div class="avatardiv"></div></td>
 			<?php endif; ?>
-			<td class="name"><?php p($user["name"]); ?></td>
-			<td class="displayName"><span><?php p($user["displayName"]); ?></span> <img class="svg action"
+			<td class="name"></td>
+			<td class="displayName"><span></span> <img class="svg action"
 				src="<?php p(image_path('core', 'actions/rename.svg'))?>"
 				alt="<?php p($l->t("change full name"))?>" title="<?php p($l->t("change full name"))?>"/>
 			</td>
@@ -33,84 +32,31 @@
 				src="<?php print_unescaped(image_path('core', 'actions/rename.svg'))?>"
 				alt="<?php p($l->t("set new password"))?>" title="<?php p($l->t("set new password"))?>"/>
 			</td>
-			<td class="groups">
-				<select
-					class="groupsselect"
-					data-username="<?php p($user['name']) ;?>"
-					data-user-groups="<?php p(json_encode($user['groups'])) ;?>"
-					data-placeholder="groups" title="<?php p($l->t('no group'))?>"
-					multiple="multiple">
-						<?php foreach($_["adminGroup"] as $adminGroup): ?>
-						<option value="<?php p($adminGroup['name']);?>"><?php p($adminGroup['name']); ?></option>
-						<?php endforeach; ?>
-						<?php foreach($_["groups"] as $group): ?>
-						<option value="<?php p($group['name']);?>"><?php p($group['name']);?></option>
-						<?php endforeach;?>
-				</select>
-			</td>
+			<td class="groups"></td>
 			<?php if(is_array($_['subadmins']) || $_['subadmins']): ?>
-				<td class="subadmins">
-					<select
-						class="subadminsselect"
-						data-username="<?php p($user['name']) ;?>"
-						data-subadmin="<?php p(json_encode($user['subadmin']));?>"
-						data-placeholder="subadmins" title="<?php p($l->t('no group'))?>"
-						multiple="multiple">
-						<?php foreach($_["subadmingroups"] as $group): ?>
-							<option value="<?php p($group);?>"><?php p($group);?></option>
-						<?php endforeach;?>
-					</select>
-				</td>
+				<td class="subadmins"></td>
 			<?php endif;?>
 			<td class="quota">
 				<select class='quota-user' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>">
-					<option
-						<?php if($user['quota'] === 'default') print_unescaped('selected="selected"');?>
-							value='default'>
+					<option	value='default'>
 						<?php p($l->t('Default'));?>
 					</option>
-					<option
-					<?php if($user['quota'] === 'none') print_unescaped('selected="selected"');?>
-							value='none'>
+					<option value='none'>
 						<?php p($l->t('Unlimited'));?>
 					</option>
 					<?php foreach($_['quota_preset'] as $preset):?>
-					<option
-					<?php if($user['quota']==$preset) print_unescaped('selected="selected"');?>
-						value='<?php p($preset);?>'>
-						<?php p($preset);?>
-					</option>
+						<option value='<?php p($preset);?>'>
+							<?php p($preset);?>
+						</option>
 					<?php endforeach;?>
-					<?php if($user['isQuotaUserDefined']):?>
-					<option selected="selected" value='<?php p($user['quota']);?>'>
-						<?php p($user['quota']);?>
-					</option>
-					<?php endif;?>
 					<option value='other' data-new>
-						<?php p($l->t('Other'));?>
-						...
+						<?php p($l->t('Other'));?> ...
 					</option>
 				</select>
 			</td>
-			<td class="storageLocation"><?php p($user["storageLocation"]); ?></td>
-			<?php
-			if($user["lastLogin"] === 0) {
-				$lastLogin = $l->t('never');
-				$lastLoginDate = $lastLogin;
-			} else {
-				$lastLogin = relative_modified_date($user["lastLogin"]);
-				$lastLoginDate = \OC_Util::formatDate($user["lastLogin"]);
-			}
-			?>
-			<td class="lastLogin" title="<?php p('<span class="usersLastLoginTooltip">'.$lastLoginDate.'</span>'); ?>"><?php p($lastLogin); ?></td>
-			<td class="remove">
-				<?php if($user['name']!=OC_User::getUser()):?>
-					<a href="#" class="action delete" original-title="<?php p($l->t('Delete'))?>">
-						<img src="<?php print_unescaped(image_path('core', 'actions/delete.svg')) ?>" class="svg" />
-					</a>
-				<?php endif;?>
-			</td>
+			<td class="storageLocation"></td>
+			<td class="lastLogin"></td>
+			<td class="remove"></td>
 		</tr>
-		<?php endforeach; ?>
 	</tbody>
 </table>

--- a/settings/users.php
+++ b/settings/users.php
@@ -17,7 +17,6 @@ OC_Util::addScript( 'core', 'singleselect' );
 OC_Util::addStyle( 'settings', 'settings' );
 OC_App::setActiveNavigationEntry( 'core_users' );
 
-$users = array();
 $userManager = \OC_User::getManager();
 $groupManager = \OC_Group::getManager();
 
@@ -33,7 +32,6 @@ $recoveryAdminEnabled = OC_App::isEnabled('files_encryption') &&
 					    $config->getAppValue( 'files_encryption', 'recoveryAdminEnabled', null );
 
 if($isAdmin) {
-	$accessibleUsers = OC_User::getDisplayNames('', 30);
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
 	/* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
@@ -43,48 +41,22 @@ if($isAdmin) {
 			$gids[] = $group['id'];
 		}
 	}
-	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 30);
 	$subadmins = false;
 }
 
 // load preset quotas
-$quotaPreset=OC_Appconfig::getValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
+$quotaPreset=$config->getAppValue('files', 'quota_preset', '1 GB, 5 GB, 10 GB');
 $quotaPreset=explode(',', $quotaPreset);
 foreach($quotaPreset as &$preset) {
 	$preset=trim($preset);
 }
 $quotaPreset=array_diff($quotaPreset, array('default', 'none'));
 
-$defaultQuota=OC_Appconfig::getValue('files', 'default_quota', 'none');
+$defaultQuota=$config->getAppValue('files', 'default_quota', 'none');
 $defaultQuotaIsUserDefined=array_search($defaultQuota, $quotaPreset)===false
 	&& array_search($defaultQuota, array('none', 'default'))===false;
 
-// load users and quota
-foreach($accessibleUsers as $uid => $displayName) {
-	$quota = $config->getUserValue($uid, 'files', 'quota', 'default');
-	$isQuotaUserDefined = array_search($quota, $quotaPreset) === false
-		&& array_search($quota, array('none', 'default')) === false;
-
-	$name = $displayName;
-	if ($displayName !== $uid) {
-		$name = $name . ' (' . $uid . ')';
-	}
-
-	$user = $userManager->get($uid);
-	$users[] = array(
-		"name" => $uid,
-		"displayName" => $displayName,
-		"groups" => OC_Group::getUserGroups($uid),
-		'quota' => $quota,
-		'isQuotaUserDefined' => $isQuotaUserDefined,
-		'subadmin' => OC_SubAdmin::getSubAdminsGroups($uid),
-		'storageLocation' => $user->getHome(),
-		'lastLogin' => $user->getLastLogin(),
-	);
-}
-
 $tmpl = new OC_Template("settings", "users/main", "user");
-$tmpl->assign('users', $users);
 $tmpl->assign('groups', $groups);
 $tmpl->assign('adminGroup', $adminGroup);
 $tmpl->assign('isAdmin', (int)$isAdmin);

--- a/settings/users.php
+++ b/settings/users.php
@@ -7,14 +7,6 @@
 
 OC_Util::checkSubAdminUser();
 
-// We have some javascript foo!
-OC_Util::addScript('settings', 'users/deleteHandler');
-OC_Util::addScript('settings', 'users/filter');
-OC_Util::addScript( 'settings', 'users/users' );
-OC_Util::addScript( 'settings', 'users/groups' );
-OC_Util::addScript( 'core', 'multiselect' );
-OC_Util::addScript( 'core', 'singleselect' );
-OC_Util::addStyle( 'settings', 'settings' );
 OC_App::setActiveNavigationEntry( 'core_users' );
 
 $userManager = \OC_User::getManager();


### PR DESCRIPTION
I cleaned up the PHP part of the user management. The whole user list is now generated via the existing JS code.
- moved loading of JS and CSS to template

ref #12620

@blizzz @LukasReschke @PVince81 Give this a try and report back problems.

TODO:
- [x] changing groups cause problems with the group drop down
