### PR TITLE
Show user backend in user management

### DIFF
--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -185,7 +185,8 @@ class UsersController extends Controller {
 			array(
 				'username' => $username,
 				'groups' => $this->groupManager->getUserGroupIds($user),
-				'storageLocation' => $user->getHome()
+				'storageLocation' => $user->getHome(),
+				'backend' => $user->getBackendClassName()
 			),
 			Http::STATUS_CREATED
 		);

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -94,8 +94,11 @@ td.password>img,td.displayName>img, td.remove>a, td.quota>img { visibility:hidde
 td.password, td.quota, td.displayName { width:12em; cursor:pointer; }
 td.password>span, td.quota>span, rd.displayName>span { margin-right: 1.2em; color: #C7C7C7; }
 span.usersLastLoginTooltip { white-space: nowrap; }
-th#headerLastLogin, td.lastLogin { display : none; }
-th#headerStorageLocation, td.storageLocation { display : none; }
+#userlist .storageLocation,
+#userlist .userBackend,
+#userlist .lastLogin {
+	display : none;
+}
 
 td.remove { width:1em; padding-right:1em; }
 tr:hover>td.password>span, tr:hover>td.displayName>span { margin:0; cursor:pointer; }

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -28,7 +28,7 @@ var UserList = {
 		this.$el.find('.quota-user').singleSelect().on('change', this.onQuotaSelect);
 	},
 
-	add: function (username, displayname, groups, subadmin, quota, storageLocation, lastLogin, sort) {
+	add: function (username, displayname, groups, subadmin, quota, storageLocation, lastLogin, sort, backend) {
 		var $tr = $userListBody.find('tr:first-child').clone();
 		// this removes just the `display:none` of the template row
 		$tr.removeAttr('style');
@@ -115,6 +115,11 @@ var UserList = {
 		 * storage location
 		 */
 		$tr.find('td.storageLocation').text(storageLocation);
+
+		/**
+		 * user backend
+		 */
+		$tr.find('td.userBackend').text(backend);
 
 		/**
 		 * last login
@@ -372,7 +377,7 @@ var UserList = {
 					if(UserList.has(user.name)) {
 						return true;
 					}
-					var $tr = UserList.add(user.name, user.displayname, user.groups, user.subadmin, user.quota, user.storageLocation, user.lastLogin, false);
+					var $tr = UserList.add(user.name, user.displayname, user.groups, user.subadmin, user.quota, user.storageLocation, user.lastLogin, false, user.backend);
 					$tr.addClass('appear transparent');
 					trs.push($tr);
 					loadedUsers++;
@@ -731,7 +736,7 @@ $(document).ready(function () {
 						}, 10000);
 				}
 				if(!UserList.has(username)) {
-					UserList.add(username, username, result.groups, null, 'default', result.storageLocation, 0, true);
+					UserList.add(username, username, result.groups, null, 'default', result.storageLocation, 0, true, result.backend);
 				}
 				$('#newusername').focus();
 				GroupList.incEveryoneCount();
@@ -743,21 +748,25 @@ $(document).ready(function () {
 	// Option to display/hide the "Storage location" column
 	$('#CheckboxStorageLocation').click(function() {
 		if ($('#CheckboxStorageLocation').is(':checked')) {
-			$("#headerStorageLocation").show();
-			$("#userlist td.storageLocation").show();
+			$("#userlist .storageLocation").show();
 		} else {
-			$("#headerStorageLocation").hide();
-			$("#userlist td.storageLocation").hide();
+			$("#userlist .storageLocation").hide();
 		}
 	});
 	// Option to display/hide the "Last Login" column
 	$('#CheckboxLastLogin').click(function() {
 		if ($('#CheckboxLastLogin').is(':checked')) {
-			$("#headerLastLogin").show();
-			$("#userlist td.lastLogin").show();
+			$("#userlist .lastLogin").show();
 		} else {
-			$("#headerLastLogin").hide();
-			$("#userlist td.lastLogin").hide();
+			$("#userlist .lastLogin").hide();
+		}
+	});
+	// Option to display/hide the "Last Login" column
+	$('#CheckboxUserBackend').click(function() {
+		if ($('#CheckboxUserBackend').is(':checked')) {
+			$("#userlist .userBackend").show();
+		} else {
+			$("#userlist .userBackend").hide();
 		}
 	});
 

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -44,14 +44,24 @@ translation('settings');
 			<?php print_unescaped($this->inc('users/part.setquota')); ?>
 
 			<div id="userlistoptions">
-				<p><label>
-						<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation">
+				<p>
+					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation">
+					<label for="CheckboxStorageLocation">
 						<?php p($l->t('Show storage location')) ?>
-				</label></p>
-				<p><label>
+					</label>
+				</p>
+				<p>
 					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin">
-					<?php p($l->t('Show last log in')) ?>
-				</label></p>
+					<label for="CheckboxLastLogin">
+						<?php p($l->t('Show last log in')) ?>
+					</label>
+				</p>
+				<p>
+					<input type="checkbox" name="UserBackend" value="UserBackend" id="CheckboxUserBackend">
+					<label for="CheckboxUserBackend">
+						<?php p($l->t('Show user backend')) ?>
+					</label>
+				</p>
 			</div>
 		</div>
 	</div>

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -12,8 +12,9 @@
 			<th id="headerSubAdmins"><?php p($l->t('Group Admin for')); ?></th>
 			<?php endif;?>
 			<th id="headerQuota"><?php p($l->t('Quota')); ?></th>
-			<th id="headerStorageLocation"><?php p($l->t('Storage Location')); ?></th>
-			<th id="headerLastLogin"><?php p($l->t('Last Login')); ?></th>
+			<th class="storageLocation"><?php p($l->t('Storage Location')); ?></th>
+			<th class="userBackend"><?php p($l->t('User Backend')); ?></th>
+			<th class="lastLogin"><?php p($l->t('Last Login')); ?></th>
 			<th id="headerRemove">&nbsp;</th>
 		</tr>
 	</thead>
@@ -55,6 +56,7 @@
 				</select>
 			</td>
 			<td class="storageLocation"></td>
+			<td class="userBackend"></td>
 			<td class="lastLogin"></td>
 			<td class="remove"></td>
 		</tr>

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -182,6 +182,10 @@ class UsersControllerTest extends \Test\TestCase {
 		$user
 			->method('getHome')
 			->will($this->returnValue('/home/user'));
+		$user
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('bar'));
 
 		$this->container['UserManager']
 			->expects($this->once())
@@ -193,7 +197,8 @@ class UsersControllerTest extends \Test\TestCase {
 			array(
 				'username' => 'foo',
 				'groups' => null,
-				'storageLocation' => '/home/user'
+				'storageLocation' => '/home/user',
+				'backend' => 'bar'
 			),
 			Http::STATUS_CREATED
 		);
@@ -214,6 +219,10 @@ class UsersControllerTest extends \Test\TestCase {
 		$user
 			->method('getHome')
 			->will($this->returnValue('/home/user'));
+		$user
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue('bar'));
 		$existingGroup = $this->getMockBuilder('\OCP\IGroup')
 			->disableOriginalConstructor()->getMock();
 		$existingGroup
@@ -250,7 +259,8 @@ class UsersControllerTest extends \Test\TestCase {
 			array(
 				'username' => 'foo',
 				'groups' => array('NewGroup', 'ExistingGroup'),
-				'storageLocation' => '/home/user'
+				'storageLocation' => '/home/user',
+				'backend' => 'bar'
 			),
 			Http::STATUS_CREATED
 		);


### PR DESCRIPTION
- add switch to settings to show user backend
- user classes for headers and rows to unify the show/hide statement
- add user backend to response of user create request

ref #12604 and #12620
- [x] requires #12790 to be merged first (included in this pr as well)

essential commit:  24895e3

cc @PVince81 @LukasReschke @blizzz 
