### PR TITLE
Add special parameterlist to manager

### DIFF
--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -94,13 +94,44 @@ class Activity implements \OCP\Activity\IExtension {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
 					return $l->t('You received a new remote share from %s', $params)->__toString();
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
-					return $l->t('%1$s accepted remote share <strong>%2$s</strong>', $params)->__toString();
+					return $l->t('%1$s accepted remote share %2$s', $params)->__toString();
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
-					return $l->t('%1$s declined remote share <strong>%2$s</strong>', $params)->__toString();
+					return $l->t('%1$s declined remote share %2$s', $params)->__toString();
 					case self::SUBJECT_REMOTE_SHARE_UNSHARED:
-					return $l->t('%1$s unshared <strong>%2$s</strong>', $params)->__toString();
+					return $l->t('%1$s unshared %2$s', $params)->__toString();
 			}
 		}
+	}
+
+	/**
+	 * The extension can define the type of parameters for translation
+	 *
+	 * Currently known types are:
+	 * * file		=> will strip away the path of the file and add a tooltip with it
+	 * * username	=> will add the avatar of the user
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 */
+	public function getSpecialParameterList($app, $text) {
+		if ($app === 'files_sharing') {
+			switch ($text) {
+				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
+					return array(
+						0 => '',// We can not use 'username' since the user is in a different ownCloud
+					);
+				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
+				case self::SUBJECT_REMOTE_SHARE_DECLINED:
+				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
+					return array(
+						0 => '',// We can not use 'username' since the user is in a different ownCloud
+						1 => 'file',
+					);
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -168,6 +168,25 @@ class ActivityManager implements IManager {
 	}
 
 	/**
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 */
+	function getSpecialParameterList($app, $text) {
+		foreach($this->extensions as $extension) {
+			$c = $extension();
+			if ($c instanceof IExtension) {
+				$specialParameter = $c->getSpecialParameterList($app, $text);
+				if (is_array($specialParameter)) {
+					return $specialParameter;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @param string $type
 	 * @return string
 	 */

--- a/lib/public/activity/iextension.php
+++ b/lib/public/activity/iextension.php
@@ -80,6 +80,19 @@ interface IExtension {
 	public function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode);
 
 	/**
+	 * The extension can define the type of parameters for translation
+	 *
+	 * Currently known types are:
+	 * * file		=> will strip away the path of the file and add a tooltip with it
+	 * * username	=> will add the avatar of the user
+	 *
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 */
+	function getSpecialParameterList($app, $text);
+
+	/**
 	 * A string naming the css class for the icon to be used can be returned.
 	 * If no icon is known for the given type false is to be returned.
 	 *

--- a/lib/public/activity/imanager.php
+++ b/lib/public/activity/imanager.php
@@ -100,6 +100,13 @@ interface IManager {
 	function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode);
 
 	/**
+	 * @param string $app
+	 * @param string $text
+	 * @return array|false
+	 */
+	function getSpecialParameterList($app, $text);
+
+	/**
 	 * @param string $type
 	 * @return string
 	 */

--- a/tests/lib/activitymanager.php
+++ b/tests/lib/activitymanager.php
@@ -59,6 +59,14 @@ class Test_ActivityManager extends \Test\TestCase {
 		$this->assertFalse($result);
 	}
 
+	public function testGetSpecialParameterList() {
+		$result = $this->activityManager->getSpecialParameterList('APP0', '');
+		$this->assertEquals(array(0 => 'file', 1 => 'username'), $result);
+
+		$result = $this->activityManager->getSpecialParameterList('APP1', '');
+		$this->assertFalse($result);
+	}
+
 	public function testTypeIcon() {
 		$result = $this->activityManager->getTypeIcon('NT1');
 		$this->assertEquals('icon-nt-one', $result);
@@ -132,6 +140,14 @@ class SimpleExtension implements \OCP\Activity\IExtension {
 		return false;
 	}
 
+	public function getSpecialParameterList($app, $text) {
+		if ($app === 'APP0') {
+			return array(0 => 'file', 1 => 'username');
+		}
+
+		return false;
+	}
+
 	public function getTypeIcon($type) {
 		if ($type === 'NT1') {
 			return 'icon-nt-one';
@@ -182,6 +198,10 @@ class NoOpExtension implements \OCP\Activity\IExtension {
 	}
 
 	public function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode) {
+		return false;
+	}
+
+	public function getSpecialParameterList($app, $text) {
 		return false;
 	}
 


### PR DESCRIPTION
Allows extensions to specify special parameters, eg username (adds avatar) file (moves path to tooltip)

Fixes https://github.com/owncloud/core/pull/12749/files#r21623294 as soon as https://github.com/owncloud/activity/pull/192 has been merged afterwards

@LukasReschke @schiesbn @MorrisJobke 

Previous PR #12788 
