### PR TITLE
Add console command for encryption

### DIFF
--- a/apps/files_encryption/appinfo/register_command.php
+++ b/apps/files_encryption/appinfo/register_command.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @var $application Symfony\Component\Console\Application */
+$application->add(new OCA\Files_Encryption\Command\Decrypt);
+$application->add(new OCA\Files_Encryption\Command\Encrypt);
+$application->add(new OCA\Files_Encryption\Command\EnableRecovery);
+$application->add(new OCA\Files_Encryption\Command\DisableRecovery);

--- a/apps/files_encryption/command/abstractencryptioncommand.php
+++ b/apps/files_encryption/command/abstractencryptioncommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Encryption\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractEncryptionCommand extends Command {
+
+	protected function configure() {
+		$this	->addArgument(
+				'uid',
+				InputArgument::REQUIRED,
+				'specified user id'
+			)
+			->addArgument(
+				'password',
+				InputArgument::REQUIRED,
+				'specified password'
+			)
+		;
+	}
+	
+	private function rutime($begin, $end) {
+	    return $end - $begin;
+	}
+
+	final protected function execute(InputInterface $input, OutputInterface $output) {
+		// Script start
+		$begin = time();
+
+		$uid = $input->getArgument('uid');
+		$password = $input->getArgument('password');
+		
+		// load apps
+		\OC_App::loadApps();
+
+		// Filesystem related hooks
+		\OCA\Files_Encryption\Helper::registerFilesystemHooks();
+		
+		// User related hooks
+		\OCA\Files_Encryption\Helper::registerUserHooks();
+
+		// clear and register hooks
+		\OC_FileProxy::clearProxies();
+		\OC_FileProxy::register(new \OCA\Files_Encryption\Proxy());
+
+		// login user
+		\OC_Util::tearDownFS();
+                \OC_User::setUserId('');
+                \OC\Files\Filesystem::tearDown();
+                \OC_User::setUserId($uid);
+                \OC_Util::setupFS($uid);
+
+                $params['uid'] = $uid;
+                $params['password'] = $password;
+                $logged = \OCA\Files_Encryption\Hooks::login($params);
+
+		if($logged) {
+			$view = new \OC\Files\View('/');
+			$session = new \OCA\Files_Encryption\Session($view);
+			$encryptionInitStatus = $session->getInitialized();
+
+			if($encryptionInitStatus === \OCA\Files_Encryption\Session::INIT_SUCCESSFUL) {
+				$this->executeEncryptionCommand($input, $output, $view, $uid);
+				$end = time();
+				$output->writeln("This process used " . $this->rutime($begin, $end) . " s for its computation");
+				return;
+			}
+		}
+
+		$output->writeln("The user $uid is not properly initialized, please check the password or its encryption status.");
+	}
+
+	abstract protected function executeEncryptionCommand(InputInterface $input, OutputInterface $output, \OC\Files\View $view, $uid);
+}

--- a/apps/files_encryption/command/decrypt.php
+++ b/apps/files_encryption/command/decrypt.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Encryption\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Decrypt extends AbstractEncryptionCommand {
+
+	protected function configure() {
+		parent::configure();
+		$this	->setName('encryption:decrypt')
+			->setDescription('decrypt command for encryption');
+	}
+
+	protected function executeEncryptionCommand(InputInterface $input, OutputInterface $output, \OC\Files\View $view, $uid) {
+		$util = new \OCA\Files_Encryption\Util($view, $uid);
+                $result = $util->decryptAll('/' . $uid . '/' . 'files');
+		if($result) {
+			$output->writeln("The user $uid has all files decrypted.");
+		} else {
+			$output->writeln("The user $uid had some problems in the decryption phase.");
+		}
+	}
+}

--- a/apps/files_encryption/command/disablerecovery.php
+++ b/apps/files_encryption/command/disablerecovery.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Encryption\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DisableRecovery extends AbstractEncryptionCommand {
+
+	protected function configure() {
+		parent::configure();
+		$this	->setName('encryption:disable-recovery')
+			->setDescription('disable recovery command for encryption');
+	}
+
+	protected function executeEncryptionCommand(InputInterface $input, OutputInterface $output, \OC\Files\View $view, $uid) {
+		$util = new \OCA\Files_Encryption\Util($view, $uid);
+		$util->setRecoveryForUser('0');
+		$util->removeRecoveryKeys();
+		$output->writeln("The user $uid has recovery disabled.");
+	}
+}

--- a/apps/files_encryption/command/enablerecovery.php
+++ b/apps/files_encryption/command/enablerecovery.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Encryption\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnableRecovery extends AbstractEncryptionCommand {
+
+	protected function configure() {
+		parent::configure();
+		$this	->setName('encryption:enable-recovery')
+			->setDescription('enable recovery command for encryption');
+	}
+
+	protected function executeEncryptionCommand(InputInterface $input, OutputInterface $output, \OC\Files\View $view, $uid) {
+		$util = new \OCA\Files_Encryption\Util($view, $uid);
+		$util->setRecoveryForUser('1');
+		$util->addRecoveryKeys();
+		$output->writeln("The user $uid has recovery enabled.");
+	}
+}

--- a/apps/files_encryption/command/encrypt.php
+++ b/apps/files_encryption/command/encrypt.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2014 Simon Vocella <voxsim@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Encryption\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Encrypt extends AbstractEncryptionCommand {
+
+	protected function configure() {
+		parent::configure();
+		$this	->setName('encryption:encrypt')
+			->setDescription('encrypt command for encryption');
+	}
+
+	protected function executeEncryptionCommand(InputInterface $input, OutputInterface $output, \OC\Files\View $view, $uid) {
+		$util = new \OCA\Files_Encryption\Util($view, $uid);
+                $result = $util->encryptAll('/' . $uid . '/files');
+		if($result) {
+			$output->writeln("The user $uid has all files encrypted.");
+		} else {
+			$output->writeln("The user $uid had some problems in the encryption phase.");
+		}
+	}
+}


### PR DESCRIPTION
I created four console commands for encryption:
- Encrypt
- Decrypt
- Enable Recovery
- Disable Recovery

I don't know the policy for testing the console commands, because right now it's not testable without an owncloud fully installed.

The reason why I created these commands it's because when there are _many_ keys I had some timeout issue because every encryption operation is online.

Suppose to have a clean installation with only one user admin with password admin, I will describe each command:

`php occ encryption:encrypt admin admin`

This command will initialize encryption and encrypt the directory of user admin

`php occ encryption:decrypt admin admin`

This command will decrypt the directory of user admin if it's encrypted, otherwise it will do nothing

`php occ encryption:enable-recovery admin admin`

This command will enable the recovery keys for the user admin if only if the recovery password was created before, otherwise it will do nothing.
In practice it will add a new share key for each file related to the recovery.

`php occ encryption:disable-recovery admin admin`

This command will disable the recovery keys for the user admin if only if the recovery password was created before, otherwise it will do nothing.
In practice it will delete a share key for each file related to the recovery.

Let me know if you don't like something,
cheers,
Simon
