### PR TITLE
fix initial loading limit of user management on large screens

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -353,9 +353,12 @@ var UserList = {
 			UserDeleteHandler.deleteEntry();
 		});
 	},
-	update: function (gid) {
+	update: function (gid, limit) {
 		if (UserList.updating) {
 			return;
+		}
+		if(!limit) {
+			limit = UserList.usersToLoad;
 		}
 		$userList.siblings('.loading').css('visibility', 'visible');
 		UserList.updating = true;
@@ -366,7 +369,7 @@ var UserList = {
 		var pattern = filter.getPattern();
 		$.get(
 			OC.generateUrl('/settings/users/users'),
-			{ offset: UserList.offset, limit: UserList.usersToLoad, gid: gid, pattern: pattern },
+			{ offset: UserList.offset, limit: limit, gid: gid, pattern: pattern },
 			function (result) {
 				var loadedUsers = 0;
 				var trs = [];
@@ -385,6 +388,8 @@ var UserList = {
 				if (result.length > 0) {
 					UserList.doSort();
 					$userList.siblings('.loading').css('visibility', 'hidden');
+					// reset state on load
+					UserList.noMoreEntries = false;
 				}
 				else {
 					UserList.noMoreEntries = true;
@@ -537,7 +542,7 @@ var UserList = {
 			return;
 		}
 		if (UserList.scrollArea.scrollTop() + UserList.scrollArea.height() > UserList.scrollArea.get(0).scrollHeight - 500) {
-			UserList.update(UserList.currentGid, true);
+			UserList.update(UserList.currentGid);
 		}
 	},
 
@@ -770,7 +775,14 @@ $(document).ready(function () {
 		}
 	});
 
+	// calculate initial limit of users to load
+	var initialUserCountLimit = 20,
+		containerHeight = $('#app-content').height();
+	if(containerHeight > 40) {
+		initialUserCountLimit = Math.floor(containerHeight/40);
+	}
+
 	// trigger loading of users on startup
-	UserList.update(UserList.currentGid);
+	UserList.update(UserList.currentGid, initialUserCountLimit);
 
 });


### PR DESCRIPTION
ref #12620 

Steps to reproduce: 
- have a large screen (vertical height) where more than 10 user rows fits in
- open user management
- before this fix: just 10 users are loaded - no lazy loading because there is no scrolling -> no invocation of lazy loading
- after this fix: the whole screen list users and there are even more - on scrolling the lazy load of additional users hits in
- requirement: many users (if you just have 10 users it won't show more ;))

cc @PVince81 @LukasReschke @blizzz 
