### PR TITLE
make regex in controllermethodreflector.php compatible with PCRE 6.x

### DIFF
--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -54,7 +54,7 @@ class ControllerMethodReflector {
 		$this->annotations = $matches[1];
 
 		// extract type parameter information
-		preg_match_all('/@param (?<type>\w+) \$(?<var>\w+)/', $docs, $matches);
+		preg_match_all('/@param (?P<type>\w+) \$(?P<var>\w+)/', $docs, $matches);
 		// this is just a fix for PHP 5.3 (array_combine raises warning if called with
 		// two empty arrays
 		if($matches['var'] === array() && $matches['type'] === array()) {


### PR DESCRIPTION
The syntax ?<...> seems to be only supported from PCRE 7.0 on. For
backwards-compability ?P<...> is used.

The patch should probably also be merged with master.
