### PR TITLE
Intelligent container

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -1,6 +1,28 @@
 <?php
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2014 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace OC\AppFramework\Utility;
+
+use \OCP\AppFramework\QueryException;
 
 /**
  * Class SimpleContainer
@@ -9,12 +31,71 @@ namespace OC\AppFramework\Utility;
  */
 class SimpleContainer extends \Pimple\Container implements \OCP\IContainer {
 
+
+	/**
+	 * @param ReflectionClass $class the class to instantiate
+	 * @return stdClass the created class
+	 */
+	private function buildClass(\ReflectionClass $class) {
+		$constructor = $class->getConstructor();
+		if ($constructor === null) {
+			return $class->newInstance();
+		} else {
+			$parameters = [];
+			foreach ($constructor->getParameters() as $parameter) {
+				$parameterClass = $parameter->getClass();
+
+				// try to find out if it is a class or a simple parameter
+				if ($parameterClass === null) {
+					$resolveName = $parameter->getName();
+				} else {
+					$resolveName = $parameterClass->name;
+				}
+
+				$parameters[] = $this->query($resolveName);
+			}
+			return $class->newInstanceArgs($parameters);
+		}
+	}
+
+
+	/**
+	 * If a parameter is not registered in the container try to instantiate it
+	 * by using reflection to find out how to build the class
+	 * @param string $name the class name to resolve
+	 * @throws QueryException if the class could not be found or instantiated
+	 */
+	private function resolve($name) {
+		$baseMsg = 'Could not resolve ' . $name . '!';
+		try {
+			$class = new \ReflectionClass($name);
+			if ($class->isInstantiable()) {
+				return $this->buildClass($class);
+			} else {
+				throw new QueryException($baseMsg .
+					' Class can not be instantiated');
+			}
+		} catch(\ReflectionException $e) {
+			throw new QueryException($baseMsg . ' ' . $e->getMessage());
+		}
+	}
+
+
 	/**
 	 * @param string $name name of the service to query for
 	 * @return mixed registered service for the given $name
+	 * @throws QueryExcpetion if the query could not be resolved
 	 */
 	public function query($name) {
-		return $this->offsetGet($name);
+		if ($this->offsetExists($name)) {
+			return $this->offsetGet($name);
+		} else {
+			$object = $this->resolve($name);
+			$this->registerService($name, function () use ($object) {
+				return $object;
+			});
+			return $object;
+		}
 	}
 
 	/**
@@ -44,4 +125,6 @@ class SimpleContainer extends \Pimple\Container implements \OCP\IContainer {
 			$this[$name] = parent::factory($closure);
 		}
 	}
+
+
 }

--- a/lib/public/appframework/app.php
+++ b/lib/public/appframework/app.php
@@ -37,6 +37,22 @@ use OC\AppFramework\routing\RouteConfig;
  * to be registered using IContainer::registerService
  */
 class App {
+
+
+	/**
+	 * Turns an app id into a namespace by convetion. The id is split at the
+	 * underscores, all parts are camelcased and reassembled. e.g.:
+	 * some_app_id -> OCA\SomeAppId
+	 * @param string $appId the app id
+	 * @param string $topNamespace the namespace which should be prepended to
+	 * the transformed app id, defaults to OCA\
+	 * @return string the starting namespace for the app
+	 */
+	public static function buildAppNamespace($appId, $topNamespace='OCA\\') {
+		return \OC\AppFramework\App::buildAppNamespace($appId, $topNamespace);
+	}
+
+
 	/**
 	 * @param array $urlParams an array with variables extracted from the routes
 	 */

--- a/lib/public/appframework/queryexception.php
+++ b/lib/public/appframework/queryexception.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2014 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\AppFramework;
+
+use Exception;
+
+
+class QueryException extends Exception {}

--- a/tests/lib/appframework/utility/SimpleContainerTest.php
+++ b/tests/lib/appframework/utility/SimpleContainerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2014 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace Test\AppFramework\Utility;
+
+use OC\AppFramework\Utility\SimpleContainer;
+
+
+interface TestInterface {}
+
+class ClassEmptyConstructor implements IInterfaceConstructor {}
+
+class ClassSimpleConstructor implements IInterfaceConstructor {
+    public $test;
+    public function __construct($test) {
+        $this->test = $test;
+    }
+}
+
+class ClassComplexConstructor {
+    public $class;
+    public $test;
+    public function __construct(ClassSimpleConstructor $class, $test) {
+        $this->class = $class;
+        $this->test = $test;
+    }
+}
+
+interface IInterfaceConstructor {}
+class ClassInterfaceConstructor {
+    public $class;
+    public $test;
+    public function __construct(IInterfaceConstructor $class, $test) {
+        $this->class = $class;
+        $this->test = $test;
+    }
+}
+
+
+class SimpleContainerTest extends \Test\TestCase {
+
+
+    private $container;
+
+    public function setUp() {
+        $this->container = new SimpleContainer();
+    }
+
+
+    public function testRegister() {
+        $this->container->registerParameter('test', 'abc');
+        $this->assertEquals('abc', $this->container->query('test'));
+    }
+
+
+    /**
+     * @expectedException \OCP\AppFramework\QueryException
+     */
+    public function testNothingRegistered() {
+        $this->container->query('something really hard');
+    }
+
+
+    /**
+     * @expectedException \OCP\AppFramework\QueryException
+     */
+    public function testNotAClass() {
+        $this->container->query('Test\AppFramework\Utility\TestInterface');
+    }
+
+
+    public function testNoConstructorClass() {
+        $object = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+        $this->assertTrue($object instanceof ClassEmptyConstructor);
+    }
+
+
+    public function testInstancesOnlyOnce() {
+        $object = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+        $object2 = $this->container->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+        $this->assertSame($object, $object2);
+    }
+
+    public function testConstructorSimple() {
+        $this->container->registerParameter('test', 'abc');
+        $object = $this->container->query(
+            'Test\AppFramework\Utility\ClassSimpleConstructor'
+        );
+        $this->assertTrue($object instanceof ClassSimpleConstructor);
+        $this->assertEquals('abc', $object->test);
+    }
+
+
+    public function testConstructorComplex() {
+        $this->container->registerParameter('test', 'abc');
+        $object = $this->container->query(
+            'Test\AppFramework\Utility\ClassComplexConstructor'
+        );
+        $this->assertTrue($object instanceof ClassComplexConstructor);
+        $this->assertEquals('abc', $object->class->test);
+        $this->assertEquals('abc', $object->test);
+    }
+
+
+    public function testConstructorComplexInterface() {
+        $this->container->registerParameter('test', 'abc');
+        $this->container->registerService(
+        'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
+            return $c->query('Test\AppFramework\Utility\ClassSimpleConstructor');
+        });
+        $object = $this->container->query(
+            'Test\AppFramework\Utility\ClassInterfaceConstructor'
+        );
+        $this->assertTrue($object instanceof ClassInterfaceConstructor);
+        $this->assertEquals('abc', $object->class->test);
+        $this->assertEquals('abc', $object->test);
+    }
+
+
+    public function tesOverrideService() {
+        $this->container->registerParameter('test', 'abc');
+        $this->container->registerService(
+        'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
+            return $c->query('Test\AppFramework\Utility\ClassSimpleConstructor');
+        });
+        $this->container->registerService(
+        'Test\AppFramework\Utility\IInterfaceConstructor', function ($c) {
+            return $c->query('Test\AppFramework\Utility\ClassEmptyConstructor');
+        });
+        $object = $this->container->query(
+            'Test\AppFramework\Utility\ClassInterfaceConstructor'
+        );
+        $this->assertTrue($object instanceof ClassEmptyConstructor);
+        $this->assertEquals('abc', $object->test);
+    }
+
+
+    /**
+     * @expectedException \OCP\AppFramework\QueryException
+     */
+    public function testConstructorComplexNoTestParameterFound() {
+        $object = $this->container->query(
+            'Test\AppFramework\Utility\ClassComplexConstructor'
+        );
+    }
+
+
+}


### PR DESCRIPTION
Implementation for #12829

Generates and injects parameters automatically. You can now build full classes like

```
$c->query('MyClassName')
```

without having to register it as a service. The resolved object's instance will be saved by using registerService. If a constructor parameter is not type hinted, the parameter name will be taken. 

Therefore the following two implementations are identical:

```
class Class1 { function __construct(MyClassName $class)
class Class1 { function __construct($MyClassName)
```

This makes it possible to also inject primitive values such as strings, arrays etc.

In addition if the query could not be resolved, a QueryException is now thrown

Routes can now be returned as an array from routes.php and an appinfo/application.php is optional

@DeepDiver1975 @LukasReschke @MorrisJobke @bantu @PVince81 @nickvergessen @jbtbnl @georgehrke 
