### PR TITLE
Add mount specific options

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -107,7 +107,7 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 				'etag' => 'abcdef',
 				'directory' => '/',
 				'name' => 'new_name',
-			))));
+			), null)));
 
 		$result = $this->files->rename($dir, $oldname, $newname);
 

--- a/apps/files/tests/helper.php
+++ b/apps/files/tests/helper.php
@@ -24,7 +24,8 @@ class Test_Files_Helper extends \Test\TestCase {
 				'mtime' => $mtime,
 				'type' => $isDir ? 'dir' : 'file',
 				'mimetype' => $isDir ? 'httpd/unix-directory' : 'application/octet-stream'
-			)	
+			),
+			null
 		);
 	}
 

--- a/apps/files_external/lib/config/configadapter.php
+++ b/apps/files_external/lib/config/configadapter.php
@@ -33,10 +33,11 @@ class ConfigAdapter implements IMountProvider {
 				$objectClass = $options['options']['objectstore']['class'];
 				$options['options']['objectstore'] = new $objectClass($options['options']['objectstore']);
 			}
+			$mountOptions = isset($options['mountOptions']) ? $options['mountOptions'] : [];
 			if (isset($options['personal']) && $options['personal']) {
-				$mounts[] = new PersonalMount($options['class'], $mountPoint, $options['options'], $loader);
+				$mounts[] = new PersonalMount($options['class'], $mountPoint, $options['options'], $loader, $mountOptions);
 			} else {
-				$mounts[] = new MountPoint($options['class'], $mountPoint, $options['options'], $loader);
+				$mounts[] = new MountPoint($options['class'], $mountPoint, $options['options'], $loader, $mountOptions);
 			}
 		}
 		return $mounts;

--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -31,8 +31,10 @@ class Helper
 			return $result;
 		}
 
-		list($storage, $internalPath) = $view->resolvePath($dir);
+		$mount = $view->getMount($dir);
+		$storage = $mount->getStorage();
 		$absoluteDir = $view->getAbsolutePath($dir);
+		$internalPath = $mount->getInternalPath($absoluteDir);
 
 		if (is_resource($dirContent)) {
 			$originalLocations = \OCA\Files_Trashbin\Trashbin::getLocations($user);
@@ -65,7 +67,7 @@ class Helper
 					if ($originalPath) {
 						$i['extraData'] = $originalPath.'/'.$id;
 					}
-					$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i);
+					$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 				}
 			}
 			closedir($dirContent);

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -72,7 +72,7 @@ class OC_Connector_Sabre_Directory extends OC_Connector_Sabre_Node
 
 			$path = $this->fileView->getAbsolutePath($this->path) . '/' . $name;
 			// using a dummy FileInfo is acceptable here since it will be refreshed after the put is complete
-			$info = new \OC\Files\FileInfo($path, null, null, array());
+			$info = new \OC\Files\FileInfo($path, null, null, array(), null);
 			$node = new OC_Connector_Sabre_File($this->fileView, $info);
 			return $node->put($data);
 		} catch (\OCP\Files\StorageNotAvailableException $e) {

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -71,7 +71,9 @@ class ObjectTree extends \Sabre\DAV\ObjectTree {
 		if (pathinfo($path, PATHINFO_EXTENSION) === 'part') {
 			// read from storage
 			$absPath = $this->fileView->getAbsolutePath($path);
-			list($storage, $internalPath) = Filesystem::resolvePath('/' . $absPath);
+			$mount = $this->fileView->getMount($path);
+			$storage = $mount->getStorage();
+			$internalPath = $mount->getInternalPath($absPath);
 			if ($storage) {
 				/**
 				 * @var \OC\Files\Storage\Storage $storage
@@ -79,7 +81,7 @@ class ObjectTree extends \Sabre\DAV\ObjectTree {
 				$scanner = $storage->getScanner($internalPath);
 				// get data directly
 				$data = $scanner->getData($internalPath);
-				$info = new FileInfo($absPath, $storage, $internalPath, $data);
+				$info = new FileInfo($absPath, $storage, $internalPath, $data, $mount);
 			} else {
 				$info = null;
 			}

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -30,14 +30,23 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	private $internalPath;
 
 	/**
+	 * @var \OCP\Files\Mount\IMountPoint
+	 */
+	private $mount;
+
+	/**
 	 * @param string|boolean $path
 	 * @param Storage\Storage $storage
+	 * @param string $internalPath
+	 * @param array $data
+	 * @param \OCP\Files\Mount\IMountPoint $mount
 	 */
-	public function __construct($path, $storage, $internalPath, $data) {
+	public function __construct($path, $storage, $internalPath, $data, $mount) {
 		$this->path = $path;
 		$this->storage = $storage;
 		$this->internalPath = $internalPath;
 		$this->data = $data;
+		$this->mount = $mount;
 	}
 
 	public function offsetSet($offset, $value) {
@@ -208,6 +217,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 
 	/**
 	 * Check if a file or folder is shared
+	 *
 	 * @return bool
 	 */
 	public function isShared() {
@@ -228,5 +238,14 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get the mountpoint the file belongs to
+	 *
+	 * @return \OCP\Files\Mount\IMountPoint
+	 */
+	public function getMountPoint() {
+		return $this->mount;
 	}
 }

--- a/lib/private/files/mount/mountpoint.php
+++ b/lib/private/files/mount/mountpoint.php
@@ -20,8 +20,21 @@ class MountPoint implements IMountPoint {
 	protected $storage = null;
 	protected $class;
 	protected $storageId;
+
+	/**
+	 * Configuration options for the storage backend
+	 *
+	 * @var array
+	 */
 	protected $arguments = array();
 	protected $mountPoint;
+
+	/**
+	 * Mount specific options
+	 *
+	 * @var array
+	 */
+	protected $mountOptions = array();
 
 	/**
 	 * @var \OC\Files\Storage\StorageFactory $loader
@@ -31,10 +44,11 @@ class MountPoint implements IMountPoint {
 	/**
 	 * @param string|\OC\Files\Storage\Storage $storage
 	 * @param string $mountpoint
-	 * @param array $arguments (optional)\
+	 * @param array $arguments (optional) configuration for the storage backend
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
+	 * @param array $mountOptions mount specific options
 	 */
-	public function __construct($storage, $mountpoint, $arguments = null, $loader = null) {
+	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null) {
 		if (is_null($arguments)) {
 			$arguments = array();
 		}
@@ -42,6 +56,10 @@ class MountPoint implements IMountPoint {
 			$this->loader = new StorageFactory();
 		} else {
 			$this->loader = $loader;
+		}
+
+		if (!is_null($mountOptions)) {
+			$this->mountOptions = $mountOptions;
 		}
 
 		$mountpoint = $this->formatPath($mountpoint);
@@ -160,5 +178,16 @@ class MountPoint implements IMountPoint {
 	 */
 	public function wrapStorage($wrapper) {
 		$this->storage = $wrapper($this->mountPoint, $this->getStorage());
+	}
+
+	/**
+	 * Get a mount option
+	 *
+	 * @param string $name Name of the mount option to get
+	 * @param mixed $default Default value for the mount option
+	 * @return mixed
+	 */
+	public function getOption($name, $default) {
+		return isset($this->mountOptions[$name]) ? $this->mountOptions[$name] : $default;
 	}
 }

--- a/lib/private/files/node/node.php
+++ b/lib/private/files/node/node.php
@@ -288,4 +288,8 @@ class Node implements \OCP\Files\Node, FileInfo {
 	public function isEncrypted() {
 		return $this->getFileInfo()->isEncrypted();
 	}
+
+	public function getMountPoint() {
+		return $this->getFileInfo()->getMountPoint();
+	}
 }

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -922,6 +922,11 @@ class Preview {
 			return false;
 		}
 
+		$mount = $file->getMountPoint();
+		if ($mount and !$mount->getOption('previews', true)){
+			return false;
+		}
+
 		//check if there are preview backends
 		if (empty(self::$providers)) {
 			self::initProviders();

--- a/lib/public/files/fileinfo.php
+++ b/lib/public/files/fileinfo.php
@@ -169,4 +169,11 @@ interface FileInfo {
 	 * @return bool
 	 */
 	public function isMounted();
+
+	/**
+	 * Get the mountpoint the file belongs to
+	 *
+	 * @return \OCP\Files\Mount\IMountPoint
+	 */
+	public function getMountPoint();
 }

--- a/lib/public/files/mount/imountpoint.php
+++ b/lib/public/files/mount/imountpoint.php
@@ -55,4 +55,13 @@ interface IMountPoint {
 	 * @param callable $wrapper
 	 */
 	public function wrapStorage($wrapper);
+
+	/**
+	 * Get a mount option
+	 *
+	 * @param string $name Name of the mount option to get
+	 * @param mixed $default Default value for the mount option
+	 * @return mixed
+	 */
+	public function getOption($name, $default);
 }

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -24,7 +24,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions'=>\OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -59,7 +59,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -83,7 +83,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/super*star.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 		$file = new OC_Connector_Sabre_File($view, $info);
 
 		// action
@@ -104,7 +104,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/super*star.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 		$file = new OC_Connector_Sabre_File($view, $info);
 		$file->setName('/super*star.txt');
 	}
@@ -136,7 +136,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -158,7 +158,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -176,7 +176,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => 0
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 
@@ -199,7 +199,7 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', null, null, array(
 			'permissions' => \OCP\Constants::PERMISSION_ALL
-		));
+		), null);
 
 		$file = new OC_Connector_Sabre_File($view, $info);
 

--- a/tests/lib/connector/sabre/objecttree.php
+++ b/tests/lib/connector/sabre/objecttree.php
@@ -101,7 +101,7 @@ class ObjectTree extends \Test\TestCase {
 	private function moveTest($source, $dest, $updatables, $deletables) {
 		$view = new TestDoubleFileView($updatables, $deletables);
 
-		$info = new FileInfo('', null, null, array());
+		$info = new FileInfo('', null, null, array(), null);
 
 		$rootDir = new OC_Connector_Sabre_Directory($view, $info);
 		$objectTree = $this->getMock('\OC\Connector\Sabre\ObjectTree',

--- a/tests/lib/files/node/file.php
+++ b/tests/lib/files/node/file.php
@@ -22,7 +22,7 @@ class File extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', null, '', $data);
+		return new FileInfo('', null, '', $data, null);
 	}
 
 	public function testDelete() {

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -25,7 +25,7 @@ class Folder extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', null, '', $data);
+		return new FileInfo('', null, '', $data, null);
 	}
 
 	public function testDelete() {

--- a/tests/lib/files/node/node.php
+++ b/tests/lib/files/node/node.php
@@ -19,7 +19,7 @@ class Node extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', null, '', $data);
+		return new FileInfo('', null, '', $data, null);
 	}
 
 	public function testStat() {

--- a/tests/lib/files/node/root.php
+++ b/tests/lib/files/node/root.php
@@ -21,7 +21,7 @@ class Root extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', null, '', $data);
+		return new FileInfo('', null, '', $data, null);
 	}
 
 	public function testGet() {


### PR DESCRIPTION
Adds mount options and allow disabling previews for a mount point
- Extend `FileInfo` with `getMountPoint()`
- Add `getOption($name, $default)` to `MountPoint` for getting mount specific options from the mountpoint
- Read mount options from mount.json

Does not yet add an interface to configure storage options, currently you're required to manually change the mount.json

Note that there are both mount and storage options, storage options are passed to the storage object and define how the storage should connect to it's backend (hostname, username, password, etc).
Mount options on the other hand are not passed to the storage object (since the behavior of a storage backend is not affected by whether previews are enabled or not) and control how _other_ systems (like previews) behave for files on the mount point.

To test: 
- mount an external storage and storage some pictures on it.
- Check in the web ui that previews are shown for the pictures
- Add `"mountOptions": {"previews": false}` to the mount config for the storage (resulting mount.json should look something like [this](https://gist.github.com/icewind1991/ab2aa907c6ae81488dd1))
- Check in the web ui that previews are no longer shown for pictures in the storage

Part of #12216

cc @DeepDiver1975 @PVince81 
