### PR TITLE
Deprecate old and replaced appframework apis

### DIFF
--- a/lib/private/appframework/core/api.php
+++ b/lib/private/appframework/core/api.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\IApi;
  *
  * Should you find yourself in need for more methods, simply inherit from this
  * class and add your methods
+ * @deprecated
  */
 class API implements IApi{
 
@@ -58,6 +59,7 @@ class API implements IApi{
 
 	/**
 	 * Adds a new javascript file
+	 * @deprecated include javascript and css in template files
 	 * @param string $scriptName the name of the javascript in js/ without the suffix
 	 * @param string $appName the name of the app, defaults to the current one
 	 */
@@ -71,6 +73,7 @@ class API implements IApi{
 
 	/**
 	 * Adds a new css file
+	 * @deprecated include javascript and css in template files
 	 * @param string $styleName the name of the css file in css/without the suffix
 	 * @param string $appName the name of the app, defaults to the current one
 	 */
@@ -83,6 +86,7 @@ class API implements IApi{
 
 
 	/**
+	 * @deprecated include javascript and css in template files
 	 * shorthand for addScript for files in the 3rdparty directory
 	 * @param string $name the name of the file without the suffix
 	 */
@@ -92,6 +96,7 @@ class API implements IApi{
 
 
 	/**
+	 * @deprecated include javascript and css in template files
 	 * shorthand for addStyle for files in the 3rdparty directory
 	 * @param string $name the name of the file without the suffix
 	 */
@@ -101,7 +106,10 @@ class API implements IApi{
 
 
 	/**
+	 * @deprecated communication between apps should happen over built in
+	 * callbacks or interfaces (check the contacts and calendar managers)
 	 * Checks if an app is enabled
+	 * also use \OC::$server->getAppManager()->isEnabledForUser($appName)
 	 * @param string $appName the name of an app
 	 * @return bool true if app is enabled
 	 */
@@ -120,6 +128,7 @@ class API implements IApi{
 	}
 
 	/**
+	 * @deprecated register hooks directly for class that build in hook interfaces
 	 * connects a function to a hook
 	 * @param string $signalClass class name of emitter
 	 * @param string $signalName name of signal
@@ -134,6 +143,7 @@ class API implements IApi{
 	}
 
 	/**
+	 * @deprecated implement the emitter interface instead
 	 * Emits a signal. To get data from the slot use references!
 	 * @param string $signalClass class name of emitter
 	 * @param string $signalName name of signal
@@ -146,6 +156,7 @@ class API implements IApi{
 
 	/**
 	 * clear hooks
+	 * @deprecated clear hooks directly for class that build in hook interfaces
 	 * @param string $signalClass
 	 * @param string $signalName
 	 */

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -155,6 +155,7 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 
 
 	/**
+	 * @deprecated implements only deprecated methods
 	 * @return IApi
 	 */
 	function getCoreApi()
@@ -194,6 +195,8 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 	}
 
 	/**
+	 * @deprecated use the groupmanager instead to find out if the user is in
+	 * the admin group
 	 * @return boolean
 	 */
 	function isAdminUser() {
@@ -206,6 +209,7 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 	}
 
 	/**
+	 * @deprecated use the ILogger instead
 	 * @param string $message
 	 * @param string $level
 	 * @return mixed

--- a/lib/public/appframework/iapi.php
+++ b/lib/public/appframework/iapi.php
@@ -30,6 +30,7 @@ namespace OCP\AppFramework;
 
 /**
  * A few very basic and frequently used API functions are combined in here
+ * @deprecated
  */
 interface IApi {
 
@@ -44,6 +45,7 @@ interface IApi {
 
 	/**
 	 * Adds a new javascript file
+	 * @deprecated include javascript and css in template files
 	 * @param string $scriptName the name of the javascript in js/ without the suffix
 	 * @param string $appName the name of the app, defaults to the current one
 	 * @return void
@@ -53,6 +55,7 @@ interface IApi {
 
 	/**
 	 * Adds a new css file
+	 * @deprecated include javascript and css in template files
 	 * @param string $styleName the name of the css file in css/without the suffix
 	 * @param string $appName the name of the app, defaults to the current one
 	 * @return void
@@ -61,6 +64,7 @@ interface IApi {
 
 
 	/**
+	 * @deprecated include javascript and css in template files
 	 * shorthand for addScript for files in the 3rdparty directory
 	 * @param string $name the name of the file without the suffix
 	 * @return void
@@ -69,6 +73,7 @@ interface IApi {
 
 
 	/**
+	 * @deprecated include javascript and css in template files
 	 * shorthand for addStyle for files in the 3rdparty directory
 	 * @param string $name the name of the file without the suffix
 	 * @return void
@@ -78,6 +83,10 @@ interface IApi {
 
 	/**
 	 * Checks if an app is enabled
+	 * @deprecated communication between apps should happen over built in
+	 * callbacks or interfaces (check the contacts and calendar managers)
+	 * Checks if an app is enabled
+	 * also use \OC::$server->getAppManager()->isEnabledForUser($appName)
 	 * @param string $appName the name of an app
 	 * @return bool true if app is enabled
 	 */

--- a/lib/public/appframework/iappcontainer.php
+++ b/lib/public/appframework/iappcontainer.php
@@ -40,6 +40,7 @@ interface IAppContainer extends IContainer{
 	function getAppName();
 
 	/**
+	 * @deprecated implements only deprecated methods
 	 * @return IApi
 	 */
 	function getCoreApi();
@@ -62,10 +63,13 @@ interface IAppContainer extends IContainer{
 
 	/**
 	 * @return boolean
+	 * @deprecated use the groupmanager instead to find out if the user is in
+	 * the admin group
 	 */
 	function isAdminUser();
 
 	/**
+	 * @deprecated use the ILogger instead
 	 * @param string $message
 	 * @param string $level
 	 * @return mixed


### PR DESCRIPTION
This PR adds a deprecation label to api methods which are already migrated to their own classes and should not be used anymore.

@MorrisJobke @DeepDiver1975 @LukasReschke @nickvergessen 
