### PR TITLE
first step to drop \OCP\Config:: in favour of IConfig

### DIFF
--- a/apps/files/appinfo/update.php
+++ b/apps/files/appinfo/update.php
@@ -1,8 +1,0 @@
-<?php
-
-// this drops the keys below, because they aren't needed anymore
-// core related
-if (version_compare(\OCP\Config::getSystemValue('version', '0.0.0'), '7.0.0', '<')) {
-	\OCP\Config::deleteSystemValue('allowZipDownload');
-	\OCP\Config::deleteSystemValue('maxZipInputSize');
-}

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -427,7 +427,7 @@ class Helper {
 	 */
 	public static function getOpenSSLConfig() {
 		$config = array('private_key_bits' => 4096);
-		$config = array_merge(\OCP\Config::getSystemValue('openssl', array()), $config);
+		$config = array_merge(\OC::$server->getConfig()->getSystemValue('openssl', array()), $config);
 		return $config;
 	}
 
@@ -460,7 +460,7 @@ class Helper {
 	 */
 	public static function getCipher() {
 
-		$cipher = \OCP\Config::getSystemValue('cipher', Crypt::DEFAULT_CIPHER);
+		$cipher = \OC::$server->getConfig()->getSystemValue('cipher', Crypt::DEFAULT_CIPHER);
 
 		if ($cipher !== 'AES-256-CFB' && $cipher !== 'AES-128-CFB') {
 			\OCP\Util::writeLog('files_encryption',

--- a/apps/files_encryption/tests/crypt.php
+++ b/apps/files_encryption/tests/crypt.php
@@ -30,6 +30,9 @@ class Crypt extends TestCase {
 	public $genPrivateKey;
 	public $genPublicKey;
 
+	/** @var  \OCP\IConfig */
+	private $config;
+
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
@@ -65,6 +68,8 @@ class Crypt extends TestCase {
 
 		// we don't want to tests with app files_trashbin enabled
 		\OC_App::disable('files_trashbin');
+
+		$this->config = \OC::$server->getConfig();
 	}
 
 	protected function tearDown() {
@@ -76,7 +81,7 @@ class Crypt extends TestCase {
 		}
 
 		$this->assertTrue(\OC_FileProxy::$enabled);
-		\OCP\Config::deleteSystemValue('cipher');
+		$this->config->deleteSystemValue('cipher');
 
 		parent::tearDown();
 	}
@@ -198,14 +203,14 @@ class Crypt extends TestCase {
 
 		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
-		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+		$this->config->setSystemValue('cipher', 'AES-128-CFB');
 
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/'. $filename, $this->dataShort);
 
 		// Test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile));
 
-		\OCP\Config::deleteSystemValue('cipher');
+		$this->config->deleteSystemValue('cipher');
 
 		// Disable encryption proxy to prevent recursive calls
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -282,7 +287,7 @@ class Crypt extends TestCase {
 		// Generate a a random filename
 		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
-		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+		$this->config->setSystemValue('cipher', 'AES-128-CFB');
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong . $this->dataLong);
@@ -294,7 +299,7 @@ class Crypt extends TestCase {
 		$proxyStatus = \OC_FileProxy::$enabled;
 		\OC_FileProxy::$enabled = false;
 
-		\OCP\Config::deleteSystemValue('cipher');
+		$this->config->deleteSystemValue('cipher');
 
 		// Get file contents without using any wrapper to get it's actual contents on disk
 		$retreivedCryptedFile = $this->view->file_get_contents($this->userId . '/files/' . $filename);
@@ -326,12 +331,12 @@ class Crypt extends TestCase {
 		// Generate a a random filename
 		$filename = 'tmp-' . $this->getUniqueID() . '.test';
 
-		\OCP\Config::setSystemValue('cipher', 'AES-128-CFB');
+		$this->config->setSystemValue('cipher', 'AES-128-CFB');
 
 		// Save long data as encrypted file using stream wrapper
 		$cryptedFile = file_put_contents('crypt:///' . $this->userId . '/files/' . $filename, $this->dataLong . $this->dataLong);
 
-		\OCP\Config::deleteSystemValue('cipher');
+		$this->config->deleteSystemValue('cipher');
 
 		// Test that data was successfully written
 		$this->assertTrue(is_int($cryptedFile));

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -831,7 +831,7 @@ class OC_Mount_Config {
 			include('Crypt/AES.php');
 		}
 		$cipher = new Crypt_AES(CRYPT_AES_MODE_CBC);
-		$cipher->setKey(\OCP\Config::getSystemValue('passwordsalt'));
+		$cipher->setKey(\OC::$server->getConfig()->getSystemValue('passwordsalt', null));
 		return $cipher;
 	}
 

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -112,7 +112,7 @@ class SFTP extends \OC\Files\Storage\Common {
 		try {
 			$storage_view = \OCP\Files::getStorage('files_external');
 			if ($storage_view) {
-				return \OCP\Config::getSystemValue('datadirectory') .
+				return \OC::$server->getConfig()->getSystemValue('datadirectory') .
 					$storage_view->getAbsolutePath('') .
 					'ssh_hostKeys';
 			}

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -280,7 +280,7 @@ class Helper {
 	 * @return string
 	 */
 	public static function getShareFolder() {
-		$shareFolder = \OCP\Config::getSystemValue('share_folder', '/');
+		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
 
 		return \OC\Files\Filesystem::normalizePath($shareFolder);
 	}
@@ -291,7 +291,7 @@ class Helper {
 	 * @param string $shareFolder
 	 */
 	public static function setShareFolder($shareFolder) {
-		\OCP\Config::setSystemValue('share_folder', $shareFolder);
+		\OC::$server->getConfig()->setSystemValue('share_folder', $shareFolder);
 	}
 
 }

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -948,10 +948,11 @@ class Test_Files_Sharing_Api extends TestCase {
 	function testUpdateShareExpireDate() {
 
 		$fileInfo = $this->view->getFileInfo($this->folder);
+		$config = \OC::$server->getConfig();
 
 		// enforce expire date, by default 7 days after the file was shared
-		\OCP\Config::setAppValue('core', 'shareapi_default_expire_date', 'yes');
-		\OCP\Config::setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
 
 		$dateWithinRange = new \DateTime();
 		$dateWithinRange->add(new \DateInterval('P5D'));
@@ -1008,8 +1009,8 @@ class Test_Files_Sharing_Api extends TestCase {
 		$this->assertEquals($dateWithinRange->format('Y-m-d') . ' 00:00:00', $updatedLinkShare['expiration']);
 
 		// cleanup
-		\OCP\Config::setAppValue('core', 'shareapi_default_expire_date', 'no');
-		\OCP\Config::setAppValue('core', 'shareapi_enforce_expire_date', 'no');
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'no');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'no');
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
 
 	}

--- a/apps/files_sharing/tests/helper.php
+++ b/apps/files_sharing/tests/helper.php
@@ -35,7 +35,7 @@ class Test_Files_Sharing_Helper extends TestCase {
 		$this->assertSame('/Shared', \OCA\Files_Sharing\Helper::getShareFolder());
 
 		// cleanup
-		\OCP\Config::deleteSystemValue('share_folder');
+		\OC::$server->getConfig()->deleteSystemValue('share_folder');
 
 	}
 

--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -243,7 +243,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('/Shared/subfolder/' . $this->folder));
 
 		//cleanup
-		\OCP\Config::deleteSystemValue('share_folder');
+		\OC::$server->getConfig()->deleteSystemValue('share_folder');
 	}
 
 	/**

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -874,7 +874,7 @@ class Trashbin {
 	 * @return integer size of the folder
 	 */
 	private static function calculateSize($view) {
-		$root = \OCP\Config::getSystemValue('datadirectory') . $view->getAbsolutePath('');
+		$root = \OC::$server->getConfig()->getSystemValue('datadirectory') . $view->getAbsolutePath('');
 		if (!file_exists($root)) {
 			return 0;
 		}

--- a/apps/user_ldap/appinfo/update.php
+++ b/apps/user_ldap/appinfo/update.php
@@ -1,13 +1,15 @@
 <?php
 
+$configInstance = \OC::$server->getConfig();
+
 //detect if we can switch on naming guidelines. We won't do it on conflicts.
 //it's a bit spaghetti, but hey.
-$state = OCP\Config::getSystemValue('ldapIgnoreNamingRules', 'unset');
+$state = $configInstance->getSystemValue('ldapIgnoreNamingRules', 'unset');
 if($state === 'unset') {
-	OCP\Config::setSystemValue('ldapIgnoreNamingRules', false);
+	$configInstance->setSystemValue('ldapIgnoreNamingRules', false);
 }
 
-$installedVersion = OCP\Config::getAppValue('user_ldap', 'installed_version');
+$installedVersion = $configInstance->getAppValue('user_ldap', 'installed_version');
 $enableRawMode = version_compare($installedVersion, '0.4.1', '<');
 
 $configPrefixes = OCA\user_ldap\lib\Helper::getServerConfigurationPrefixes(true);
@@ -15,31 +17,31 @@ $ldap = new OCA\user_ldap\lib\LDAP();
 foreach($configPrefixes as $config) {
 	$connection = new OCA\user_ldap\lib\Connection($ldap, $config);
 
-	$state = \OCP\Config::getAppValue(
+	$state = $configInstance->getAppValue(
 		'user_ldap', $config.'ldap_uuid_user_attribute', 'not existing');
 	if($state === 'non existing') {
-		$value = \OCP\Config::getAppValue(
+		$value = $configInstance->getAppValue(
 			'user_ldap', $config.'ldap_uuid_attribute', '');
-		\OCP\Config::setAppValue(
+		$configInstance->setAppValue(
 			'user_ldap', $config.'ldap_uuid_user_attribute', $value);
-		\OCP\Config::setAppValue(
+		$configInstance->setAppValue(
 			'user_ldap', $config.'ldap_uuid_group_attribute', $value);
 	}
 
-	$state = \OCP\Config::getAppValue(
+	$state = $configInstance->getAppValue(
 		'user_ldap', $config.'ldap_expert_uuid_user_attr', 'not existing');
 	if($state === 'non existing') {
-		$value = \OCP\Config::getAppValue(
+		$value = $configInstance->getAppValue(
 			'user_ldap', $config.'ldap_expert_uuid_attr', '');
-		\OCP\Config::setAppValue(
+		$configInstance->setAppValue(
 			'user_ldap', $config.'ldap_expert_uuid_user_attr', $value);
-		\OCP\Config::setAppValue(
+		$configInstance->setAppValue(
 			'user_ldap', $config.'ldap_expert_uuid_group_attr', $value);
 	}
 
 	if($enableRawMode) {
-		\OCP\Config::setAppValue('user_ldap', $config.'ldap_user_filter_mode', 1);
-		\OCP\Config::setAppValue('user_ldap', $config.'ldap_login_filter_mode', 1);
-		\OCP\Config::setAppValue('user_ldap', $config.'ldap_group_filter_mode', 1);
+		$configInstance->setAppValue('user_ldap', $config.'ldap_user_filter_mode', 1);
+		$configInstance->setAppValue('user_ldap', $config.'ldap_login_filter_mode', 1);
+		$configInstance->setAppValue('user_ldap', $config.'ldap_group_filter_mode', 1);
 	}
 }

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -673,7 +673,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$table = $this->getMapTable($isUser);
 
 		$sqlAdjustment = '';
-		$dbType = \OCP\Config::getSystemValue('dbtype');
+		$dbType = \OC::$server->getConfig()->getSystemValue('dbtype', null);
 		if($dbType === 'mysql' || $dbType == 'oci') {
 			$sqlAdjustment = 'FROM DUAL';
 		}

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -199,7 +199,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 				) {
 					$homedir = $path;
 				} else {
-					$homedir = \OCP\Config::getSystemValue('datadirectory',
+					$homedir = \OC::$server->getConfig()->getSystemValue('datadirectory',
 						\OC::$SERVERROOT.'/data' ) . '/' . $homedir[0];
 				}
 				$this->access->connection->writeToCache($cacheKey, $homedir);


### PR DESCRIPTION
files update is unneeded as it just is the update of pre-7.0 to 7.0 and we don't support updates from pre-7.0 to 8.0 
