### PR TITLE
Replace all hard-coded occurences of user_id

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -570,8 +570,8 @@ class OC {
 		$systemConfig = \OC::$server->getSystemConfig();
 
 		// User and Groups
-		if (!$systemConfig->getValue("installed", false)) {
-			self::$server->getSession()->set('user_id', '');
+		if (!$systemConfig->getValue('installed', false)) {
+			self::$server->getUserSession()->logout();
 		}
 
 		OC_User::useBackend(new OC_User_Database());

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -204,8 +204,14 @@ class DIContainer extends SimpleContainer implements IAppContainer{
 		return \OC_User::isAdminUser($uid);
 	}
 
+	/**
+	 * @return string|null UID of currently logged-in user or null
+	 */
 	private function getUserId() {
-		return \OC::$server->getSession()->get('user_id');
+		if(!is_null(\OC::$server->getUserSession()->getUser())) {
+			return \OC::$server->getUserSession()->getUser()->getUID();
+		}
+		return null;
 	}
 
 	/**

--- a/lib/private/datetimezone.php
+++ b/lib/private/datetimezone.php
@@ -16,6 +16,7 @@ namespace OC;
 use OCP\IConfig;
 use OCP\IDateTimeZone;
 use OCP\ISession;
+use OCP\IUserSession;
 
 class DateTimeZone implements IDateTimeZone {
 	/** @var IConfig */
@@ -24,14 +25,19 @@ class DateTimeZone implements IDateTimeZone {
 	/** @var ISession */
 	protected $session;
 
+	/** @var IUserSession */
+	protected $userSession;
+
 	/**
-	 * Constructor
-	 *
 	 * @param IConfig $config
+	 * @param IUserSession $userSession
 	 * @param ISession $session
 	 */
-	public function __construct(IConfig $config, ISession $session) {
+	public function __construct(IConfig $config,
+								IUserSession $userSession,
+								ISession $session) {
 		$this->config = $config;
+		$this->userSession = $userSession;
 		$this->session = $session;
 	}
 
@@ -41,7 +47,7 @@ class DateTimeZone implements IDateTimeZone {
 	 * @return \DateTimeZone
 	 */
 	public function getTimeZone() {
-		$timeZone = $this->config->getUserValue($this->session->get('user_id'), 'core', 'timezone', null);
+		$timeZone = $this->config->getUserValue($this->userSession->getUser()->getUID(), 'core', 'timezone', null);
 		if ($timeZone === null) {
 			if ($this->session->exists('timezone')) {
 				$offsetHours = $this->session->get('timezone');

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -277,11 +277,12 @@ class Server extends SimpleContainer implements IServerContainer {
 		$this->registerService('DateTimeZone', function(Server $c) {
 			return new DateTimeZone(
 				$c->getConfig(),
+				$c->getUserSession(),
 				$c->getSession()
 			);
 		});
 		$this->registerService('DateTimeFormatter', function(Server $c) {
-			$language = $c->getConfig()->getUserValue($c->getSession()->get('user_id'), 'core', 'lang', null);
+			$language = $c->getConfig()->getUserValue($c->getUserSession()->getUser()->getUID(), 'core', 'lang', null);
 
 			return new DateTimeFormatter(
 				$c->getDateTimeZone()->getTimeZone(),

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -289,7 +289,8 @@ class OC_User {
 	 * Sets user id for session and triggers emit
 	 */
 	public static function setUserId($uid) {
-		\OC::$server->getSession()->set('user_id', $uid);
+		$user = \OC::$server->getUserManager()->get($uid);
+		\OC::$server->getUserSession()->setUser($user);
 	}
 
 	/**
@@ -324,8 +325,8 @@ class OC_User {
 	 * @return bool
 	 */
 	public static function isLoggedIn() {
-		if (\OC::$server->getSession()->get('user_id') !== null && self::$incognitoMode === false) {
-			return self::userExists(\OC::$server->getSession()->get('user_id'));
+		if (\OC::$server->getUserSession()->getUser() !== null && self::$incognitoMode === false) {
+			return self::userExists(\OC::$server->getUserSession()->getUser()->getUID());
 		}
 
 		// Check whether the user has authenticated using Basic Authentication
@@ -379,9 +380,8 @@ class OC_User {
 	 * @return string uid or false
 	 */
 	public static function getUser() {
-		$uid = \OC::$server->getSession() ? \OC::$server->getSession()->get('user_id') : null;
-		if (!is_null($uid) && self::$incognitoMode === false) {
-			return $uid;
+		if (!is_null(\OC::$server->getUserSession()->getUser()) && self::$incognitoMode === false) {
+			return \OC::$server->getUserSession()->getUser()->getUID();
 		} else {
 			return false;
 		}

--- a/tests/lib/ocs/privatedata.php
+++ b/tests/lib/ocs/privatedata.php
@@ -25,7 +25,6 @@ class Test_OC_OCS_Privatedata extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		\OC::$server->getSession()->set('user_id', 'user1');
 		$this->appKey = $this->getUniqueID('app');
 	}
 


### PR DESCRIPTION
It's better to use the explicit methods to get and set the user instead of fiddling with the session manually.

Related to https://github.com/owncloud/core/issues/12891 - first step to migrating the incognito mode. - More coming…

\cc @schiesbn @PVince81 
