### PR TITLE
Move the Null-Byte LDAP check to the user manager

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -212,9 +212,6 @@ class OC_User {
 	 * Log in a user and regenerate a new session - if the password is ok
 	 */
 	public static function login($loginname, $password) {
-		$loginname = str_replace("\0", '', $loginname);
-		$password = str_replace("\0", '', $password);
-
 		session_regenerate_id(true);
 		$result = self::getUserSession()->login($loginname, $password);
 		if ($result) {

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -151,6 +151,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return mixed the User object on success, false otherwise
 	 */
 	public function checkPassword($loginname, $password) {
+		$loginname = str_replace("\0", '', $loginname);
+		$password = str_replace("\0", '', $password);
+		
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC_User_Backend::CHECK_PASSWORD)) {
 				$uid = $backend->checkPassword($loginname, $password);


### PR DESCRIPTION
The existing method is deprecated and just a wrapper around the manager method. Since in the future other code paths might call this function instead we need to perform that check here. (aka "only relevant for master")

Related to http://owncloud.org/security/advisory/?id=oc-sa-2014-020

@blizzz @icewind1991 Please review. 
