### PR TITLE
Accessibility: Keyboard navigation feedback

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -105,6 +105,7 @@
 #filestable tbody tr { background-color:#fff; height:40px; }
 #filestable tbody tr:hover,
 #filestable tbody tr:focus,
+#filestable tbody .name:focus,
 #filestable tbody tr:active {
 	background-color: rgb(240,240,240);
 }
@@ -503,7 +504,7 @@ a.action>img {
 
 #fileList a.action {
 	display: inline;
-	padding: 18px 8px;
+	padding: 17px 8px;
 	line-height: 50px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
 	filter: alpha(opacity=0);
@@ -516,15 +517,19 @@ a.action>img {
 	position: relative;
 	top: -21px;
 }
-#fileList tr:hover a.action, #fileList a.action.permanent
-#fileList tr:focus a.action, #fileList a.action.permanent {
+#fileList tr:hover a.action,
+#fileList a.action.permanent,
+#fileList tr:focus a.action,
+#fileList a.action.permanent
+/*#fileList .name:focus .action*/ {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;
 	display:inline;
 }
 #fileList tr:hover a.action:hover,
-#fileList tr:focus a.action:focus {
+#fileList tr:focus a.action:focus,
+#fileList .name:focus a.action:focus {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity=100);
 	opacity: 1;

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -56,6 +56,7 @@
 
 #app-navigation li:hover > a,
 #app-navigation li:focus > a,
+#app-navigation a:focus,
 #app-navigation .selected,
 #app-navigation .selected a {
 	background-color: #ddd;

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -7,6 +7,22 @@
 	-ms-user-select: none;
 }
 
+#skip-to-content a {
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+#skip-to-content a:focus {
+	left: 76px;
+	top: -9px;
+	color: #fff;
+	width: auto;
+	height: auto;
+}
+
 
 
 /* HEADERS ------------------------------------------------------------------ */

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -83,9 +83,9 @@
 }
 .menutoggle:hover .header-appname,
 .menutoggle:hover .icon-caret,
-.menutoggle:focus .header-appname
-.menutoggle:focus .icon-caret
-.menutoggle.active .header-appname
+.menutoggle:focus .header-appname,
+.menutoggle:focus .icon-caret,
+.menutoggle.active .header-appname,
 .menutoggle.active .icon-caret {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity=100);

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -192,6 +192,7 @@ input[type="submit"]:hover, input[type="submit"]:focus,
 input[type="button"]:hover, input[type="button"]:focus,
 button:hover, button:focus,
 .button:hover, .button:focus,
+.button a:focus,
 select:hover, select:focus, select:active {
 	background-color: rgba(255, 255, 255, .95);
 	color: #111;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -975,6 +975,7 @@ div.crumb a.ellipsislink {
 /* some feedback for hover/tap on breadcrumbs */
 div.crumb:hover,
 div.crumb:focus,
+div.crumb a:focus,
 div.crumb:active {
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)";
 	filter:alpha(opacity=70);

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -40,14 +40,16 @@
 		<?php endif; ?>
 	</div>
 	<header><div id="header">
-			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud">
+			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
+				title="" id="owncloud" tabindex="-1">
 				<div class="logo-icon svg">
 					<h1 class="hidden-visually">
 						<?php p($theme->getName()); ?>
 					</h1>
 				</div>
 			</a>
-			<a href="#" class="menutoggle" tabindex="1">
+
+			<a href="#" class="menutoggle" tabindex="2">
 				<h1 class="header-appname">
 					<?php
 						if(OC_Util::getEditionString() === '') {
@@ -59,9 +61,14 @@
 				</h1>
 				<div class="icon-caret svg"></div>
 			</a>
+
+			<div id="skip-to-content">
+				<a href="#app-content" tabindex="1"><?php p($l->t('Skip to content')); ?></a>
+			</div>
+
 			<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 			<div id="settings" class="svg">
-				<div id="expand" tabindex="3" role="link">
+				<div id="expand" tabindex="4" role="link">
 					<?php if ($_['enableAvatars']): ?>
 					<div class="avatardiv<?php if ($_['userAvatarSet']) { print_unescaped(' avatardiv-shown"'); } else { print_unescaped('" style="display: none"'); } ?>>
 						<?php if ($_['userAvatarSet']): ?>
@@ -100,7 +107,7 @@
 				</label>
 				<input id="searchbox" class="svg" type="search" name="query"
 					value="<?php if(isset($_POST['query'])) {p($_POST['query']);};?>"
-					autocomplete="off" tabindex="2" />
+					autocomplete="off" tabindex="3" />
 			</form>
 		</div></header>
 


### PR DESCRIPTION
It’s now way more apparent where you are when using the keyboard. For example in the app navigation, on the apps menu, in the file list, in the breadcrumbs and on certain buttons.

Two problems remain, and I need help here from @PVince81 @MorrisJobke or some @owncloud/designers:
1. When using the newly introduced »Skip to content« link (tab once to make it visible, then Enter to use), the content refreshes. That resets the tabindex and defeats the purpose of the link since you start from the beginning again.
2. When tabbing through the file list, the file actions should be displayed as well. That’s what line 524 was for – but when that is enabled, the tabindex resets after reaching the first file.

It seems that both issues have to do with lazy loading. Any ideas?
