### PR TITLE
Fix deleting invalid s2s shares

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -167,6 +167,14 @@ class Storage extends DAV implements ISharedStorage {
 		}
 	}
 
+	public function file_exists($path) {
+		if ($path === '') {
+			return true;
+		} else {
+			return parent::file_exists($path);
+		}
+	}
+
 	/**
 	 * check if the configured remote is a valid ownCloud instance
 	 *

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -280,6 +280,11 @@ class View {
 	}
 
 	public function isDeletable($path) {
+		$absolutePath = $this->getAbsolutePath($path);
+		$mount = Filesystem::getMountManager()->find($absolutePath);
+		if ($mount->getInternalPath($absolutePath) === '') {
+			return $mount instanceof MoveableMount;
+		}
 		return $this->basicOperation('isDeletable', $path);
 	}
 


### PR DESCRIPTION
Make sure server-2-server shares can always be deleted, even if the share is no longer valid

fixes #12729

cc @DeepDiver1975 @PVince81 @schiesbn 
