### PR TITLE
HHVM: Call libxml_use_internal_errors() instead of surpressing errors.

### DIFF
--- a/lib/private/app/infoparser.php
+++ b/lib/private/app/infoparser.php
@@ -41,8 +41,9 @@ class InfoParser {
 			return null;
 		}
 
+		libxml_use_internal_errors(true);
 		$loadEntities = libxml_disable_entity_loader(false);
-		$xml = @simplexml_load_file($file);
+		$xml = simplexml_load_file($file);
 		libxml_disable_entity_loader($loadEntities);
 		if ($xml == false) {
 			return null;


### PR DESCRIPTION
In contrast to the previous solution, this also works on HHVM.

@DeepDiver1975 @nickvergessen @LukasReschke 
