### PR TITLE
HHVM: Add workaround for missing Memcached::deleteMulti()

### DIFF
--- a/lib/private/memcache/memcached.php
+++ b/lib/private/memcache/memcached.php
@@ -74,7 +74,13 @@ class Memcached extends Cache {
 				$keys[] = $key;
 			}
 		}
-		self::$cache->deleteMulti($keys);
+		if (method_exists(self::$cache, 'deleteMulti')) {
+			self::$cache->deleteMulti($keys);
+		} else {
+			foreach ($keys as $key) {
+				self::$cache->delete($key);
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
@bartv2 @LukasReschke @DeepDiver1975 @icewind1991 @PVince81 
