### PR TITLE
Move basic auth login out of `isLoggedIn`

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -760,6 +760,7 @@ class OC {
 		// Load minimum set of apps
 		if (!self::checkUpgrade(false)) {
 			// For logged-in users: Load everything
+			\OC_User::tryBasicAuthLogin();
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();
 			} else {

--- a/lib/base.php
+++ b/lib/base.php
@@ -760,13 +760,13 @@ class OC {
 		// Load minimum set of apps
 		if (!self::checkUpgrade(false)) {
 			// For logged-in users: Load everything
-			\OC_User::tryBasicAuthLogin();
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();
 			} else {
 				// For guests: Load only authentication, filesystem and logging
 				OC_App::loadApps(array('authentication'));
 				OC_App::loadApps(array('filesystem', 'logging'));
+				\OC_User::tryBasicAuthLogin();
 			}
 		}
 

--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -47,6 +47,7 @@ class OC_API {
 	 */
 	protected static $actions = array();
 	private static $logoutRequired = false;
+	private static $isLoggedIn = false;
 
 	/**
 	 * registers an api call
@@ -269,7 +270,10 @@ class OC_API {
 	 * http basic auth
 	 * @return string|false (username, or false on failure)
 	 */
-	private static function loginUser(){
+	private static function loginUser() {
+		if(self::$isLoggedIn === true) {
+			return \OC_User::getUser();
+		}
 
 		// reuse existing login
 		$loggedIn = OC_User::isLoggedIn();
@@ -279,6 +283,7 @@ class OC_API {
 
 				// initialize the user's filesystem
 				\OC_Util::setUpFS(\OC_User::getUser());
+				self::$isLoggedIn = true;
 
 				return OC_User::getUser();
 			}
@@ -296,6 +301,7 @@ class OC_API {
 
 				// initialize the user's filesystem
 				\OC_Util::setUpFS(\OC_User::getUser());
+				self::$isLoggedIn = true;
 
 				return $authUser;
 			}

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -320,17 +320,21 @@ class OC_User {
 	}
 
 	/**
+	 * Tries to login the user with HTTP Basic Authentication
+	 */
+	public static function tryBasicAuthLogin() {
+		if(!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_USER'])) {
+			\OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+		}
+	}
+
+	/**
 	 * Check if the user is logged in, considers also the HTTP basic credentials
 	 * @return bool
 	 */
 	public static function isLoggedIn() {
 		if (\OC::$server->getSession()->get('user_id') !== null && self::$incognitoMode === false) {
 			return self::userExists(\OC::$server->getSession()->get('user_id'));
-		}
-
-		// Check whether the user has authenticated using Basic Authentication
-		if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
-			return \OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
 		}
 
 		return false;


### PR DESCRIPTION
Potentially fixes https://github.com/owncloud/core/issues/12915 and https://github.com/owncloud/core/issues/12339 and opens the door for potential other bugs...

Please test very carefully, this includes:
- Testing from OCS via cURL (as in #12915)
- Testing from OCS via browser (Open the "Von Dir geteilt" shares overview)
- WebDAV
- CalDAV
- CardDAV

@PVince81 Please test with your awesome Python library. - I think this might potentially also fixes some other problems that we found…
@DeepDiver1975 As discussed.
