### PR TITLE
Return UID instead of login name

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -297,7 +297,7 @@ class OC_API {
 				// initialize the user's filesystem
 				\OC_Util::setUpFS(\OC_User::getUser());
 
-				return $authUser;
+				return \OC_User::getUser();
 			}
 		}
 


### PR DESCRIPTION
Without this OCS on LDAP is broken for API requests coming via Basic Authentication...

@DeepDiver1975 @blizzz @karlitschek Or whoever feels responsible for OCS and LDAP. And while you're at it reviewing https://github.com/owncloud/core/pull/12917 would also be cool since OCS is broken otherwise apparently…
