### PR TITLE
be more explicit in JS unit tests - caused by accessibility issues

### DIFF
--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -275,7 +275,7 @@ describe('OCA.Files.FileList tests', function() {
 				mtime: -1
 			};
 			var $tr = fileList.add(fileData);
-			expect($tr.find('.date').text()).toEqual('?');
+			expect($tr.find('.date .modified').text()).toEqual('?');
 		});
 		it('adds new file to the end of the list', function() {
 			var $tr;

--- a/apps/files_external/tests/js/mountsfilelistSpec.js
+++ b/apps/files_external/tests/js/mountsfilelistSpec.js
@@ -144,7 +144,7 @@ describe('OCA.External.FileList tests', function() {
 				'?dir=/mount%20points/smb%20mount'
 			);
 			expect($tr.find('.nametext').text().trim()).toEqual('smb mount');
-			expect($tr.find('.column-scope').text().trim()).toEqual('Personal');
+			expect($tr.find('.column-scope > span').text().trim()).toEqual('Personal');
 			expect($tr.find('.column-backend').text().trim()).toEqual('SMB');
 
 		});


### PR DESCRIPTION
cc @jancborchardt @DeepDiver1975 
