### PR TITLE
Only populate tags in main file list

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -26,6 +26,7 @@ try {
 	// make filelist
 
 	$files = \OCA\Files\Helper::getFiles($dir, $sortAttribute, $sortDirection);
+	$files = \OCA\Files\Helper::populateTags($files);
 	$data['directory'] = $dir;
 	$data['files'] = \OCA\Files\Helper::formatFileInfos($files);
 	$data['permissions'] = $permissions;

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -174,7 +174,6 @@ class Helper
 	 */
 	public static function getFiles($dir, $sortAttribute = 'name', $sortDescending = false) {
 		$content = \OC\Files\Filesystem::getDirectoryContent($dir);
-		$content = self::populateTags($content);
 
 		return self::sortFiles($content, $sortAttribute, $sortDescending);
 	}


### PR DESCRIPTION
Moved populateTags to be done on the main file list.
This prevents the public file list to go through the same code and cause
an error when there is no user.

Fixes https://github.com/owncloud/core/issues/12934

@LukasReschke @icewind1991 @MorrisJobke please review
