### PR TITLE
[WIP] read all relevant user attributes on login, in one query. saves us some.

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -537,6 +537,16 @@ class Access extends LDAPUtility implements user\IUserTools {
 	}
 
 	/**
+	 * caches the user display name
+	 * @param string $ocName the internal ownCloud username
+	 * @param string|false $home the home directory path
+	 */
+	public function cacheUserHome($ocName, $home) {
+		$cacheKey = 'getHome'.$ocName;
+		$this->connection->writeToCache($cacheKey, $home);
+	}
+
+	/**
 	 * creates a unique name for internal ownCloud use for users. Don't call it directly.
 	 * @param string $name the display name of the object
 	 * @return string with with the name to use in ownCloud or false if unsuccessful

--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -131,6 +131,31 @@ class Manager {
 	}
 
 	/**
+	 * returns a list of attributes that will be processed further, e.g. quota,
+	 * email, displayname, or others.
+	 * @return string[]
+	 */
+	public function getAttributes() {
+		$attrs = array('dn', 'jpegphoto', 'thumbnailphoto');
+		$possible = array(
+			$this->access->connection->ldapQuotaAttribute,
+			$this->access->connection->ldapEmailAttribute,
+			$this->access->connection->ldapUserDisplayName,
+		);
+		foreach($possible as $attr) {
+			if(!is_null($attr)) {
+				$attrs[] = $attr;
+			}
+		}
+		$homeRule = $this->access->connection->homeFolderNamingRule;
+		if(strpos($homeRule, 'attr:') === 0) {
+			$attrs[] = substr($homeRule, strlen('attr:'));
+		}
+
+		return $attrs;
+	}
+
+	/**
 	 * @brief returns a User object by it's DN or ownCloud username
 	 * @param string the DN or username of the user
 	 * @return \OCA\user_ldap\lib\User | null


### PR DESCRIPTION
What has happened before:
1. upon login, we queried LDAP for the DN corresponding to the username
2. we would do a bind to verify authentication
3. if they need to be updated, single readQueries will be done for quota, email, avatar 
4. home directory attribute would also be read with a single request

What we do now:
1. upon login, we query LDAP for DN, quota, email, avatar, home directory attribute in the same request
2. we do a bing to verfiy authentication
3. we apply (i.e.  store or cache) all the values we fetched before without any single additional request

I.e. in general this brings us performance improvements by less queries to the  LDAP server. LDAP server will be happy, too, about less work. Helped with https://github.com/owncloud/enterprise/issues/442 in a OC 7 version (although it was not the root problem).

Also solves #12823 
## todos left
- [ ] user tests need to be adjusted and extended
