### PR TITLE
HHVM: Do not call filesize(null), this function expects a string.

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -37,7 +37,7 @@ class OC_Image {
 	 */
 	static public function getMimeTypeForFile($filePath) {
 		// exif_imagetype throws "read error!" if file is less than 12 byte
-		if (filesize($filePath) > 11) {
+		if ($filePath !== null && filesize($filePath) > 11) {
 			$imageType = exif_imagetype($filePath);
 		} else {
 			$imageType = false;


### PR DESCRIPTION
This fixes

```
1) Test_Image::testGetMimeTypeForFile
Filename cannot be empty
```

test failure on HHVM.

This is a call mistake regardless of HHVM, as the function only accepts strings.

@LukasReschke @DeepDiver1975 @nickvergessen 
