### PR TITLE
HHVM: In APC cache clear, only request the cache key in APCIterator.

### DIFF
--- a/lib/private/memcache/apc.php
+++ b/lib/private/memcache/apc.php
@@ -32,7 +32,7 @@ class APC extends Cache {
 	public function clear($prefix = '') {
 		$ns = $this->getPrefix() . $prefix;
 		$ns = preg_quote($ns, '/');
-		$iter = new \APCIterator('user', '/^' . $ns . '/');
+		$iter = new \APCIterator('user', '/^' . $ns . '/', APC_ITER_KEY);
 		return apc_delete($iter);
 	}
 


### PR DESCRIPTION
The default value of the $format parameter of the APCIterator constructur is
APC_ITER_ALL which instructs the iterator to provide all available information
on cache values being iterated over. Only the key value is necessary for
matching and deletion via apc_delete(), though.

This prevents a "Format values FILENAME, DEVICE, INODE, MD5, NUM_HITS, MTIME,
CTIME, DTIME, ATIME, REFCOUNT not supported yet." notice on HHVM.

@icewind1991 @DeepDiver1975 @LukasReschke 

Tested apc.php against HHVM and apcu.php against PHP.

Also see https://github.com/facebook/hhvm/blob/master/hphp/system/php/apc/APCIterator.php
