### PR TITLE
Clarify return values

### DIFF
--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -121,7 +121,7 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * get the current active user
 	 *
-	 * @return \OC\User\User
+	 * @return \OCP\IUser|null Current user, otherwise null
 	 */
 	public function getUser() {
 		if ($this->activeUser) {

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -138,7 +138,7 @@ class Session implements IUserSession, Emitter {
 	}
 
 	/**
-	 * Checks wether the user is logged in
+	 * Checks whether the user is logged in
 	 *
 	 * @return bool if logged in
 	 */

--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -66,7 +66,7 @@ interface IUserSession {
 	public function getUser();
 
 	/**
-	 * Checks wether the user is logged in
+	 * Checks whether the user is logged in
 	 *
 	 * @return bool if logged in
 	 */

--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -61,7 +61,7 @@ interface IUserSession {
 	/**
 	 * get the current active user
 	 *
-	 * @return \OCP\IUser
+	 * @return \OCP\IUser|null Current user, otherwise null
 	 */
 	public function getUser();
 


### PR DESCRIPTION
This function returns `null` when no user is logged-in.
