### PR TITLE
Properly call parent::tearDown() in MDB2SchemaManager::tearDown().

### DIFF
--- a/tests/lib/db/mdb2schemamanager.php
+++ b/tests/lib/db/mdb2schemamanager.php
@@ -17,10 +17,9 @@ class MDB2SchemaManager extends \Test\TestCase {
 	protected function tearDown() {
 		// do not drop the table for Oracle as it will create a bogus transaction
 		// that will break the following test suites requiring transactions
-		if (\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'oci') {
-			return;
+		if (\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') !== 'oci') {
+			\OC_DB::dropTable('table');
 		}
-		\OC_DB::dropTable('table');
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
The early return introduced by 04c982a96e19f2254739c24ee8c6b568edcb4190 prevents parent::tearDown() being called on Oracle.

This patch is ultra low priority as it is merely a precaution in case tearDown() is used later on.

@PVince81 @LukasReschke @nickvergessen 
