### PR TITLE
Update google-api-php-client to 1.1.2

### DIFF
--- a/apps/files_external/3rdparty/google-api-php-client/autoload.php
+++ b/apps/files_external/3rdparty/google-api-php-client/autoload.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2013 Google Inc.
+ * Copyright 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,19 @@
  * limitations under the License.
  */
 
-require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
-
-class Google_Auth_Exception extends Google_Exception
-{
+function google_api_php_client_autoload($className) {
+  $classPath = explode('_', $className);
+  if ($classPath[0] != 'Google') {
+    return;
+  }
+  if (count($classPath) > 3) {
+    // Maximum class file path depth in this project is 3.
+    $classPath = array_slice($classPath, 0, 3);
+  }
+  $filePath = dirname(__FILE__) . '/src/' . implode('/', $classPath) . '.php';
+  if (file_exists($filePath)) {
+    require_once($filePath);
+  }
 }
+
+spl_autoload_register('google_api_php_client_autoload');

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Abstract.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Abstract.php
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Http/Request.php";
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Abstract class for the Authentication in the API client

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AssertionCredentials.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/AssertionCredentials.php
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/OAuth2.php";
-require_once "Google/Signer/P12.php";
-require_once "Google/Utils.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Credentials object used for OAuth 2.0 Signed JWT assertion grants.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/LoginTicket.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/LoginTicket.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Exception.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Class to hold information about an authenticated login.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/OAuth2.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/OAuth2.php
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Auth/AssertionCredentials.php";
-require_once "Google/Auth/Exception.php";
-require_once "Google/Auth/LoginTicket.php";
-require_once "Google/Client.php";
-require_once "Google/Http/Request.php";
-require_once "Google/Utils.php";
-require_once "Google/Verifier/Pem.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Authentication class that deals with the OAuth 2 web-server authentication flow
@@ -119,15 +112,15 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
     } else {
       $decodedResponse = json_decode($response->getResponseBody(), true);
       if ($decodedResponse != null && $decodedResponse['error']) {
-        $decodedResponse = $decodedResponse['error'];
+        $errorText = $decodedResponse['error'];
         if (isset($decodedResponse['error_description'])) {
-          $decodedResponse .= ": " . $decodedResponse['error_description'];
+          $errorText .= ": " . $decodedResponse['error_description'];
         }
       }
       throw new Google_Auth_Exception(
           sprintf(
               "Error fetching OAuth2 access token, message: '%s'",
-              $decodedResponse
+              $errorText
           ),
           $response->getResponseHttpCode()
       );
@@ -151,11 +144,15 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
         'access_type' => $this->client->getClassConfig($this, 'access_type'),
     );
 
-    $params = $this->maybeAddParam($params, 'approval_prompt');
+    // Prefer prompt to approval prompt.
+    if ($this->client->getClassConfig($this, 'prompt')) {
+      $params = $this->maybeAddParam($params, 'prompt');
+    } else {
+      $params = $this->maybeAddParam($params, 'approval_prompt');
+    }
     $params = $this->maybeAddParam($params, 'login_hint');
     $params = $this->maybeAddParam($params, 'hd');
     $params = $this->maybeAddParam($params, 'openid.realm');
-    $params = $this->maybeAddParam($params, 'prompt');
     $params = $this->maybeAddParam($params, 'include_granted_scopes');
 
     // If the list of scopes contains plus.login, add request_visible_actions
@@ -236,16 +233,20 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       if ($this->assertionCredentials) {
         $this->refreshTokenWithAssertion();
       } else {
+        $this->client->getLogger()->debug('OAuth2 access token expired');
         if (! array_key_exists('refresh_token', $this->token)) {
-            throw new Google_Auth_Exception(
-                "The OAuth 2.0 access token has expired,"
-                ." and a refresh token is not available. Refresh tokens"
-                ." are not returned for responses that were auto-approved."
-            );
+          $error = "The OAuth 2.0 access token has expired,"
+                  ." and a refresh token is not available. Refresh tokens"
+                  ." are not returned for responses that were auto-approved.";
+
+          $this->client->getLogger()->error($error);
+          throw new Google_Auth_Exception($error);
         }
         $this->refreshToken($this->token['refresh_token']);
       }
     }
+
+    $this->client->getLogger()->debug('OAuth2 authentication');
 
     // Add the OAuth2 header to the request
     $request->setRequestHeaders(
@@ -298,6 +299,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       }
     }
 
+    $this->client->getLogger()->debug('OAuth2 access token expired');
     $this->refreshTokenRequest(
         array(
           'grant_type' => 'assertion',
@@ -317,6 +319,14 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
 
   private function refreshTokenRequest($params)
   {
+    if (isset($params['assertion'])) {
+      $this->client->getLogger()->info(
+          'OAuth2 access token refresh with Signed JWT assertion grants.'
+      );
+    } else {
+      $this->client->getLogger()->info('OAuth2 access token refresh');
+    }
+
     $http = new Google_Http_Request(
         self::OAUTH2_TOKEN_URI,
         'POST',
@@ -414,7 +424,9 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
 
   /**
    * Retrieve and cache a certificates file.
-   * @param $url location
+   *
+   * @param $url string location
+   * @throws Google_Auth_Exception
    * @return array certificates
    */
   public function retrieveCertsFromLocation($url)
@@ -477,12 +489,13 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
   /**
    * Verifies the id token, returns the verified token contents.
    *
-   * @param $jwt the token
+   * @param $jwt string the token
    * @param $certs array of certificates
-   * @param $required_audience the expected consumer of the token
+   * @param $required_audience string the expected consumer of the token
    * @param [$issuer] the expected issues, defaults to Google
    * @param [$max_expiry] the max lifetime of a token, defaults to MAX_TOKEN_LIFETIME_SECS
-   * @return token information if valid, false if not
+   * @throws Google_Auth_Exception
+   * @return mixed token information if valid, false if not
    */
   public function verifySignedJwtWithCerts(
       $jwt,

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Simple.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Auth/Simple.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Http/Request.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Simple API access implementation. Can either be used to make requests
@@ -55,6 +54,9 @@ class Google_Auth_Simple extends Google_Auth_Abstract
   {
     $key = $this->client->getClassConfig($this, 'developer_key');
     if ($key) {
+      $this->client->getLogger()->debug(
+          'Simple API Access developer key authentication'
+      );
       $request->setQueryParam('key', $key);
     }
     return $request;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Apc.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Apc.php
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * A persistent storage class based on the APC cache, which is not
@@ -28,11 +27,21 @@ require_once "Google/Cache/Exception.php";
  */
 class Google_Cache_Apc extends Google_Cache_Abstract
 {
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (! function_exists('apc_add') ) {
-      throw new Google_Cache_Exception("Apc functions not available");
+      $error = "Apc functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
   }
 
    /**
@@ -42,12 +51,26 @@ class Google_Cache_Apc extends Google_Cache_Abstract
   {
     $ret = apc_fetch($key);
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'APC cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'APC cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -56,10 +79,21 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function set($key, $value)
   {
-    $rc = apc_store($key, array('time' => time(), 'data' => $value));
+    $var = array('time' => time(), 'data' => $value);
+    $rc = apc_store($key, $var);
+
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'APC cache set failed',
+          array('key' => $key, 'var' => $var)
+      );
       throw new Google_Cache_Exception("Couldn't store data");
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache set',
+        array('key' => $key, 'var' => $var)
+    );
   }
 
   /**
@@ -68,6 +102,10 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function delete($key)
   {
+    $this->client->getLogger()->debug(
+        'APC cache delete',
+        array('key' => $key)
+    );
     apc_delete($key);
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Exception.php
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Exception.php";
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 class Google_Cache_Exception extends Google_Exception
 {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/File.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/File.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /*
  * This class implements a basic on disk storage. While that does
@@ -32,23 +31,37 @@ class Google_Cache_File extends Google_Cache_Abstract
   private $path;
   private $fh;
 
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
-    $this->path = $client->getClassConfig($this, 'directory');
+    $this->client = $client;
+    $this->path = $this->client->getClassConfig($this, 'directory');
   }
-  
+
   public function get($key, $expiration = false)
   {
     $storageFile = $this->getCacheFile($key);
     $data = false;
-    
+
     if (!file_exists($storageFile)) {
+      $this->client->getLogger()->debug(
+          'File cache miss',
+          array('key' => $key, 'file' => $storageFile)
+      );
       return false;
     }
 
     if ($expiration) {
       $mtime = filemtime($storageFile);
       if ((time() - $mtime) >= $expiration) {
+        $this->client->getLogger()->debug(
+            'File cache miss (expired)',
+            array('key' => $key, 'file' => $storageFile)
+        );
         $this->delete($key);
         return false;
       }
@@ -59,6 +72,11 @@ class Google_Cache_File extends Google_Cache_Abstract
       $data =  unserialize($data);
       $this->unlock($storageFile);
     }
+
+    $this->client->getLogger()->debug(
+        'File cache hit',
+        array('key' => $key, 'file' => $storageFile, 'var' => $data)
+    );
 
     return $data;
   }
@@ -72,6 +90,16 @@ class Google_Cache_File extends Google_Cache_Abstract
       $data = serialize($value);
       $result = fwrite($this->fh, $data);
       $this->unlock($storageFile);
+
+      $this->client->getLogger()->debug(
+          'File cache set',
+          array('key' => $key, 'file' => $storageFile, 'var' => $value)
+      );
+    } else {
+      $this->client->getLogger()->notice(
+          'File cache set failed',
+          array('key' => $key, 'file' => $storageFile)
+      );
     }
   }
 
@@ -79,10 +107,19 @@ class Google_Cache_File extends Google_Cache_Abstract
   {
     $file = $this->getCacheFile($key);
     if (file_exists($file) && !unlink($file)) {
+      $this->client->getLogger()->error(
+          'File cache delete failed',
+          array('key' => $key, 'file' => $file)
+      );
       throw new Google_Cache_Exception("Cache file could not be deleted");
     }
+
+    $this->client->getLogger()->debug(
+        'File cache delete',
+        array('key' => $key, 'file' => $file)
+    );
   }
-  
+
   private function getWriteableCacheFile($file)
   {
     return $this->getCacheFile($file, true);
@@ -92,7 +129,7 @@ class Google_Cache_File extends Google_Cache_Abstract
   {
     return $this->getCacheDir($file, $forWrite) . '/' . md5($file);
   }
-  
+
   private function getCacheDir($file, $forWrite)
   {
     // use the first 2 characters of the hash as a directory prefix
@@ -101,26 +138,34 @@ class Google_Cache_File extends Google_Cache_Abstract
     $storageDir = $this->path . '/' . substr(md5($file), 0, 2);
     if ($forWrite && ! is_dir($storageDir)) {
       if (! mkdir($storageDir, 0755, true)) {
+        $this->client->getLogger()->error(
+            'File cache creation failed',
+            array('dir' => $storageDir)
+        );
         throw new Google_Cache_Exception("Could not create storage directory: $storageDir");
       }
     }
     return $storageDir;
   }
-  
+
   private function acquireReadLock($storageFile)
   {
     return $this->acquireLock(LOCK_SH, $storageFile);
   }
-  
+
   private function acquireWriteLock($storageFile)
   {
     $rc = $this->acquireLock(LOCK_EX, $storageFile);
     if (!$rc) {
+      $this->client->getLogger()->notice(
+          'File cache write lock failed',
+          array('file' => $storageFile)
+      );
       $this->delete($storageFile);
     }
     return $rc;
   }
-  
+
   private function acquireLock($type, $storageFile)
   {
     $mode = $type == LOCK_EX ? "w" : "r";
@@ -135,7 +180,7 @@ class Google_Cache_File extends Google_Cache_Abstract
     }
     return true;
   }
-  
+
   public function unlock($storageFile)
   {
     if ($this->fh) {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Memcache.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Cache/Memcache.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * A persistent storage class based on the memcache, which is not
@@ -35,11 +34,22 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
   private $host;
   private $port;
 
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (!function_exists('memcache_connect') && !class_exists("Memcached")) {
-      throw new Google_Cache_Exception("Memcache functions not available");
+      $error = "Memcache functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
+
     if ($client->isAppEngine()) {
       // No credentials needed for GAE.
       $this->mc = new Memcached();
@@ -48,11 +58,14 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $this->host = $client->getClassConfig($this, 'host');
       $this->port = $client->getClassConfig($this, 'port');
       if (empty($this->host) || (empty($this->port) && (string) $this->port != "0")) {
-        throw new Google_Cache_Exception("You need to supply a valid memcache host and port");
+        $error = "You need to supply a valid memcache host and port";
+
+        $client->getLogger()->error($error);
+        throw new Google_Cache_Exception($error);
       }
     }
   }
-  
+
   /**
    * @inheritDoc
    */
@@ -66,12 +79,26 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $ret = memcache_get($this->connection, $key);
     }
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -94,8 +121,18 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $rc = memcache_set($this->connection, $key, $data, false);
     }
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'Memcache cache set failed',
+          array('key' => $key, 'var' => $data)
+      );
+
       throw new Google_Cache_Exception("Couldn't store data in cache");
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache set',
+        array('key' => $key, 'var' => $data)
+    );
   }
 
   /**
@@ -110,11 +147,16 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       memcache_delete($this->connection, $key, 0);
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache delete',
+        array('key' => $key)
+    );
   }
 
   /**
-   * Lazy initialiser for memcache connection. Uses pconnect for to take 
-   * advantage of the persistence pool where possible. 
+   * Lazy initialiser for memcache connection. Uses pconnect for to take
+   * advantage of the persistence pool where possible.
    */
   private function connect()
   {
@@ -129,9 +171,12 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       $this->connection = memcache_pconnect($this->host, $this->port);
     }
-    
+
     if (! $this->connection) {
-      throw new Google_Cache_Exception("Couldn't connect to memcache server");
+      $error = "Couldn't connect to memcache server";
+
+      $this->client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Client.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Client.php
@@ -15,17 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/AssertionCredentials.php';
-require_once 'Google/Cache/File.php';
-require_once 'Google/Cache/Memcache.php';
-require_once 'Google/Config.php';
-require_once 'Google/Collection.php';
-require_once 'Google/Exception.php';
-require_once 'Google/IO/Curl.php';
-require_once 'Google/IO/Stream.php';
-require_once 'Google/Model.php';
-require_once 'Google/Service.php';
-require_once 'Google/Service/Resource.php';
+require_once realpath(dirname(__FILE__) . '/../../autoload.php');
 
 /**
  * The Google API Client
@@ -36,7 +26,7 @@ require_once 'Google/Service/Resource.php';
  */
 class Google_Client
 {
-  const LIBVER = "1.0.6-beta";
+  const LIBVER = "1.1.2";
   const USER_AGENT_SUFFIX = "google-api-php-client/";
   /**
    * @var Google_Auth_Abstract $auth
@@ -57,6 +47,11 @@ class Google_Client
    * @var Google_Config $config
    */
   private $config;
+
+  /**
+   * @var Google_Logger_Abstract $logger
+   */
+  private $logger;
 
   /**
    * @var boolean $deferExecution
@@ -97,7 +92,8 @@ class Google_Client
     }
 
     if ($config->getIoClass() == Google_Config::USE_AUTO_IO_SELECTION) {
-      if (function_exists('curl_version') && function_exists('curl_exec')) {
+      if (function_exists('curl_version') && function_exists('curl_exec')
+          && !$this->isAppEngine()) {
         $config->setIoClass("Google_IO_Curl");
       } else {
         $config->setIoClass("Google_IO_Stream");
@@ -136,6 +132,7 @@ class Google_Client
    * the "Download JSON" button on in the Google Developer
    * Console.
    * @param string $json the configuration json
+   * @throws Google_Exception
    */
   public function setAuthConfig($json)
   {
@@ -164,6 +161,7 @@ class Google_Client
   }
 
   /**
+   * @throws Google_Auth_Exception
    * @return array
    * @visible For Testing
    */
@@ -205,9 +203,9 @@ class Google_Client
 
   /**
    * Set the IO object
-   * @param Google_Io_Abstract $auth
+   * @param Google_IO_Abstract $io
    */
-  public function setIo(Google_Io_Abstract $io)
+  public function setIo(Google_IO_Abstract $io)
   {
     $this->config->setIoClass(get_class($io));
     $this->io = $io;
@@ -215,12 +213,22 @@ class Google_Client
 
   /**
    * Set the Cache object
-   * @param Google_Cache_Abstract $auth
+   * @param Google_Cache_Abstract $cache
    */
   public function setCache(Google_Cache_Abstract $cache)
   {
     $this->config->setCacheClass(get_class($cache));
     $this->cache = $cache;
+  }
+
+  /**
+   * Set the Logger object
+   * @param Google_Logger_Abstract $logger
+   */
+  public function setLogger(Google_Logger_Abstract $logger)
+  {
+    $this->config->setLoggerClass(get_class($logger));
+    $this->logger = $logger;
   }
 
   /**
@@ -414,11 +422,10 @@ class Google_Client
   /**
    * Fetches a fresh OAuth 2.0 access token with the given refresh token.
    * @param string $refreshToken
-   * @return void
    */
   public function refreshToken($refreshToken)
   {
-    return $this->getAuth()->refreshToken($refreshToken);
+    $this->getAuth()->refreshToken($refreshToken);
   }
 
   /**
@@ -449,12 +456,12 @@ class Google_Client
   /**
    * Verify a JWT that was signed with your own certificates.
    *
-   * @param $jwt the token
-   * @param $certs array of certificates
-   * @param $required_audience the expected consumer of the token
-   * @param [$issuer] the expected issues, defaults to Google
+   * @param $id_token string The JWT token
+   * @param $cert_location array of certificates
+   * @param $audience string the expected consumer of the token
+   * @param $issuer string the expected issuer, defaults to Google
    * @param [$max_expiry] the max lifetime of a token, defaults to MAX_TOKEN_LIFETIME_SECS
-   * @return token information if valid, false if not
+   * @return mixed token information if valid, false if not
    */
   public function verifySignedJwt($id_token, $cert_location, $audience, $issuer, $max_expiry = null)
   {
@@ -464,8 +471,7 @@ class Google_Client
   }
 
   /**
-   * @param Google_Auth_AssertionCredentials $creds
-   * @return void
+   * @param $creds Google_Auth_AssertionCredentials
    */
   public function setAssertionCredentials(Google_Auth_AssertionCredentials $creds)
   {
@@ -539,6 +545,8 @@ class Google_Client
   /**
    * Helper method to execute deferred HTTP requests.
    *
+   * @param $request Google_Http_Request|Google_Http_Batch
+   * @throws Google_Exception
    * @return object of the type of the expected class or array.
    */
   public function execute($request)
@@ -607,9 +615,22 @@ class Google_Client
   }
 
   /**
+   * @return Google_Logger_Abstract Logger implementation
+   */
+  public function getLogger()
+  {
+    if (!isset($this->logger)) {
+      $class = $this->config->getLoggerClass();
+      $this->logger = new $class($this);
+    }
+    return $this->logger;
+  }
+
+  /**
    * Retrieve custom configuration for a specific class.
    * @param $class string|object - class or instance of class to retrieve
    * @param $key string optional - key to retrieve
+   * @return array
    */
   public function getClassConfig($class, $key = null)
   {
@@ -623,9 +644,9 @@ class Google_Client
    * Set configuration specific to a given class.
    * $config->setClassConfig('Google_Cache_File',
    *   array('directory' => '/tmp/cache'));
-   * @param $class The class name for the configuration
+   * @param $class string|object - The class name for the configuration
    * @param $config string key or an array of configuration values
-   * @param $value optional - if $config is a key, the value
+   * @param $value string optional - if $config is a key, the value
    *
    */
   public function setClassConfig($class, $config, $value = null)
@@ -633,7 +654,7 @@ class Google_Client
     if (!is_string($class)) {
       $class = get_class($class);
     }
-    return $this->config->setClassConfig($class, $config, $value);
+    $this->config->setClassConfig($class, $config, $value);
 
   }
 

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Collection.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Google/Model.php";
+require_once realpath(dirname(__FILE__) . '/../../autoload.php');
 
 /**
  * Extension to the regular Google_Model that automatically

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Config.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Config.php
@@ -25,6 +25,9 @@ class Google_Config
   const GZIP_UPLOADS_ENABLED = true;
   const GZIP_UPLOADS_DISABLED = false;
   const USE_AUTO_IO_SELECTION = "auto";
+  const TASK_RETRY_NEVER = 0;
+  const TASK_RETRY_ONCE = 1;
+  const TASK_RETRY_ALWAYS = -1;
   protected $configuration;
 
   /**
@@ -44,6 +47,7 @@ class Google_Config
       'auth_class'    => 'Google_Auth_OAuth2',
       'io_class'      => self::USE_AUTO_IO_SELECTION,
       'cache_class'   => 'Google_Cache_File',
+      'logger_class'  => 'Google_Logger_Null',
 
       // Don't change these unless you're working against a special development
       // or testing environment.
@@ -53,6 +57,17 @@ class Google_Config
       'classes' => array(
         'Google_IO_Abstract' => array(
           'request_timeout_seconds' => 100,
+        ),
+        'Google_Logger_Abstract' => array(
+          'level' => 'debug',
+          'log_format' => "[%datetime%] %level%: %message% %context%\n",
+          'date_format' => 'd/M/Y:H:i:s O',
+          'allow_newlines' => true
+        ),
+        'Google_Logger_File' => array(
+          'file' => 'php://stdout',
+          'mode' => 0640,
+          'lock' => false,
         ),
         'Google_Http_Request' => array(
           // Disable the use of gzip on calls if set to true. Defaults to false.
@@ -89,6 +104,36 @@ class Google_Config
           'federated_signon_certs_url' =>
               'https://www.googleapis.com/oauth2/v1/certs',
         ),
+        'Google_Task_Runner' => array(
+          // Delays are specified in seconds
+          'initial_delay' => 1,
+          'max_delay' => 60,
+          // Base number for exponential backoff
+          'factor' => 2,
+          // A random number between -jitter and jitter will be added to the
+          // factor on each iteration to allow for better distribution of
+          // retries.
+          'jitter' => .5,
+          // Maximum number of retries allowed
+          'retries' => 0
+        ),
+        'Google_Service_Exception' => array(
+          'retry_map' => array(
+            '500' => self::TASK_RETRY_ALWAYS,
+            '503' => self::TASK_RETRY_ALWAYS,
+            'rateLimitExceeded' => self::TASK_RETRY_ALWAYS,
+            'userRateLimitExceeded' => self::TASK_RETRY_ALWAYS
+          )
+        ),
+        'Google_IO_Exception' => array(
+          'retry_map' => !extension_loaded('curl') ? array() : array(
+            CURLE_COULDNT_RESOLVE_HOST => self::TASK_RETRY_ALWAYS,
+            CURLE_COULDNT_CONNECT => self::TASK_RETRY_ALWAYS,
+            CURLE_OPERATION_TIMEOUTED => self::TASK_RETRY_ALWAYS,
+            CURLE_SSL_CONNECT_ERROR => self::TASK_RETRY_ALWAYS,
+            CURLE_GOT_NOTHING => self::TASK_RETRY_ALWAYS
+          )
+        ),
         // Set a default directory for the file cache.
         'Google_Cache_File' => array(
           'directory' => sys_get_temp_dir() . '/Google_Client'
@@ -98,7 +143,11 @@ class Google_Config
     if ($ini_file_location) {
       $ini = parse_ini_file($ini_file_location, true);
       if (is_array($ini) && count($ini)) {
-        $this->configuration = array_merge($this->configuration, $ini);
+        $merged_configuration = $ini + $this->configuration;
+        if (isset($ini['classes']) && isset($this->configuration['classes'])) {
+          $merged_configuration['classes'] = $ini['classes'] + $this->configuration['classes'];
+        }
+        $this->configuration = $merged_configuration;
       }
     }
   }
@@ -107,9 +156,9 @@ class Google_Config
    * Set configuration specific to a given class.
    * $config->setClassConfig('Google_Cache_File',
    *   array('directory' => '/tmp/cache'));
-   * @param $class The class name for the configuration
+   * @param $class string The class name for the configuration
    * @param $config string key or an array of configuration values
-   * @param $value optional - if $config is a key, the value
+   * @param $value string optional - if $config is a key, the value
    */
   public function setClassConfig($class, $config, $value = null)
   {
@@ -145,6 +194,15 @@ class Google_Config
   }
 
   /**
+   * Return the configured logger class.
+   * @return string
+   */
+  public function getLoggerClass()
+  {
+    return $this->configuration['logger_class'];
+  }
+
+  /**
    * Return the configured Auth class.
    * @return string
    */
@@ -156,7 +214,7 @@ class Google_Config
   /**
    * Set the auth class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setAuthClass($class)
   {
@@ -172,7 +230,7 @@ class Google_Config
   /**
    * Set the IO class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setIoClass($class)
   {
@@ -188,7 +246,7 @@ class Google_Config
   /**
    * Set the cache class.
    *
-   * @param $class the class name to set
+   * @param $class string the class name to set
    */
   public function setCacheClass($class)
   {
@@ -202,7 +260,24 @@ class Google_Config
   }
 
   /**
+   * Set the logger class.
+   *
+   * @param $class string the class name to set
+   */
+  public function setLoggerClass($class)
+  {
+    $prev = $this->configuration['logger_class'];
+    if (!isset($this->configuration['classes'][$class]) &&
+        isset($this->configuration['classes'][$prev])) {
+      $this->configuration['classes'][$class] =
+          $this->configuration['classes'][$prev];
+    }
+    $this->configuration['logger_class'] = $class;
+  }
+
+  /**
    * Return the configured IO class.
+   *
    * @return string
    */
   public function getIoClass()
@@ -229,7 +304,7 @@ class Google_Config
 
   /**
    * Set the client ID for the auth class.
-   * @param $key string - the API console client ID
+   * @param $clientId string - the API console client ID
    */
   public function setClientId($clientId)
   {
@@ -238,7 +313,7 @@ class Google_Config
 
   /**
    * Set the client secret for the auth class.
-   * @param $key string - the API console client secret
+   * @param $secret string - the API console client secret
    */
   public function setClientSecret($secret)
   {
@@ -248,7 +323,8 @@ class Google_Config
   /**
    * Set the redirect uri for the auth class. Note that if using the
    * Javascript based sign in flow, this should be the string 'postmessage'.
-   * @param $key string - the URI that users should be redirected to
+   *
+   * @param $uri string - the URI that users should be redirected to
    */
   public function setRedirectUri($uri)
   {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Batch.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Batch.php
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/REST.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * @author Chirag Shah <chirags@google.com>
@@ -125,10 +123,10 @@ class Google_Http_Batch
           }
 
           try {
-            $response = Google_Http_REST::decodeHttpResponse($response);
+            $response = Google_Http_REST::decodeHttpResponse($response, $this->client);
             $responses[$key] = $response;
           } catch (Google_Service_Exception $e) {
-            // Store the exception as the response, so succesful responses
+            // Store the exception as the response, so successful responses
             // can be processed.
             $responses[$key] = $e;
           }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/CacheParser.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/CacheParser.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Http/Request.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Implement the caching directives specified in rfc2616. This

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/MediaFileUpload.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/MediaFileUpload.php
@@ -15,11 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Exception.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/REST.php';
-require_once 'Google/Utils.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * @author Chirag Shah <chirags@google.com>
@@ -182,7 +178,7 @@ class Google_Http_MediaFileUpload
       // No problems, but upload not complete.
       return false;
     } else {
-      return Google_Http_REST::decodeHttpResponse($response);
+      return Google_Http_REST::decodeHttpResponse($response, $this->client);
     }
   }
 
@@ -296,6 +292,9 @@ class Google_Http_MediaFileUpload
       }
       $message = rtrim($message, ';');
     }
-    throw new Google_Exception("Failed to start the resumable upload (HTTP {$message})");
+
+    $error = "Failed to start the resumable upload (HTTP {$message})";
+    $this->client->getLogger()->error($error);
+    throw new Google_Exception($error);
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/REST.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/REST.php
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Service/Exception.php';
-require_once 'Google/Utils/URITemplate.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * This class implements the RESTful transport of apiServiceRequest()'s
@@ -29,7 +26,8 @@ require_once 'Google/Utils/URITemplate.php';
 class Google_Http_REST
 {
   /**
-   * Executes a Google_Http_Request
+   * Executes a Google_Http_Request and (if applicable) automatically retries
+   * when errors occur.
    *
    * @param Google_Client $client
    * @param Google_Http_Request $req
@@ -39,9 +37,30 @@ class Google_Http_REST
    */
   public static function execute(Google_Client $client, Google_Http_Request $req)
   {
+    $runner = new Google_Task_Runner(
+        $client,
+        sprintf('%s %s', $req->getRequestMethod(), $req->getUrl()),
+        array(get_class(), 'doExecute'),
+        array($client, $req)
+    );
+
+    return $runner->run();
+  }
+
+  /**
+   * Executes a Google_Http_Request
+   *
+   * @param Google_Client $client
+   * @param Google_Http_Request $req
+   * @return array decoded result
+   * @throws Google_Service_Exception on server side error (ie: not authenticated,
+   *  invalid or malformed post body, invalid url)
+   */
+  public static function doExecute(Google_Client $client, Google_Http_Request $req)
+  {
     $httpRequest = $client->getIo()->makeRequest($req);
     $httpRequest->setExpectedClass($req->getExpectedClass());
-    return self::decodeHttpResponse($httpRequest);
+    return self::decodeHttpResponse($httpRequest, $client);
   }
 
   /**
@@ -49,9 +68,10 @@ class Google_Http_REST
    * @static
    * @throws Google_Service_Exception
    * @param Google_Http_Request $response The http response to be decoded.
+   * @param Google_Client $client
    * @return mixed|null
    */
-  public static function decodeHttpResponse($response)
+  public static function decodeHttpResponse($response, Google_Client $client = null)
   {
     $code = $response->getResponseHttpCode();
     $body = $response->getResponseBody();
@@ -76,14 +96,30 @@ class Google_Http_REST
         $errors = $decoded['error']['errors'];
       }
 
-      throw new Google_Service_Exception($err, $code, null, $errors);
+      $map = null;
+      if ($client) {
+        $client->getLogger()->error(
+            $err,
+            array('code' => $code, 'errors' => $errors)
+        );
+
+        $map = $client->getClassConfig(
+            'Google_Service_Exception',
+            'retry_map'
+        );
+      }
+      throw new Google_Service_Exception($err, $code, null, $errors, $map);
     }
 
     // Only attempt to decode the response, if the response code wasn't (204) 'no content'
     if ($code != '204') {
       $decoded = json_decode($body, true);
       if ($decoded === null || $decoded === "") {
-        throw new Google_Service_Exception("Invalid json in service response: $body");
+        $error = "Invalid json in service response: $body";
+        if ($client) {
+          $client->getLogger()->error($error);
+        }
+        throw new Google_Service_Exception($error);
       }
 
       if ($response->getExpectedClass()) {

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Request.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Http/Request.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Utils.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * HTTP Request to be executed by IO classes. Upon execution, the

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Abstract.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Abstract.php
@@ -19,10 +19,7 @@
  * Abstract IO base class
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/IO/Exception.php';
-require_once 'Google/Http/CacheParser.php';
-require_once 'Google/Http/Request.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 abstract class Google_IO_Abstract
 {
@@ -33,6 +30,17 @@ abstract class Google_IO_Abstract
     "HTTP/1.1 200 Connection established\r\n\r\n",
   );
   private static $ENTITY_HTTP_METHODS = array("POST" => null, "PUT" => null);
+  private static $HOP_BY_HOP = array(
+    'connection' => true,
+    'keep-alive' => true,
+    'proxy-authenticate' => true,
+    'proxy-authorization' => true,
+    'te' => true,
+    'trailers' => true,
+    'transfer-encoding' => true,
+    'upgrade' => true
+  );
+
 
   /** @var Google_Client */
   protected $client;
@@ -58,13 +66,13 @@ abstract class Google_IO_Abstract
    * @param $options
    */
   abstract public function setOptions($options);
-  
+
   /**
    * Set the maximum request time in seconds.
    * @param $timeout in seconds
    */
   abstract public function setTimeout($timeout);
-  
+
   /**
    * Get the maximum request time in seconds.
    * @return timeout in seconds
@@ -99,7 +107,7 @@ abstract class Google_IO_Abstract
 
     return false;
   }
-  
+
   /**
    * Execute an HTTP Request
    *
@@ -131,7 +139,7 @@ abstract class Google_IO_Abstract
     }
 
     if (!isset($responseHeaders['Date']) && !isset($responseHeaders['date'])) {
-      $responseHeaders['Date'] = date("r");
+      $responseHeaders['date'] = date("r");
     }
 
     $request->setResponseHttpCode($respHttpCode);
@@ -224,23 +232,19 @@ abstract class Google_IO_Abstract
    */
   protected function updateCachedRequest($cached, $responseHeaders)
   {
-    if (isset($responseHeaders['connection'])) {
-      $hopByHop = array_merge(
-          self::$HOP_BY_HOP,
-          explode(
-              ',',
-              $responseHeaders['connection']
+    $hopByHop = self::$HOP_BY_HOP;
+    if (!empty($responseHeaders['connection'])) {
+      $connectionHeaders = array_map(
+          'strtolower',
+          array_filter(
+              array_map('trim', explode(',', $responseHeaders['connection']))
           )
       );
-
-      $endToEnd = array();
-      foreach ($hopByHop as $key) {
-        if (isset($responseHeaders[$key])) {
-          $endToEnd[$key] = $responseHeaders[$key];
-        }
-      }
-      $cached->setResponseHeaders($endToEnd);
+      $hopByHop += array_fill_keys($connectionHeaders, true);
     }
+
+    $endToEnd = array_diff_key($responseHeaders, $hopByHop);
+    $cached->setResponseHeaders($endToEnd);
   }
 
   /**
@@ -323,7 +327,7 @@ abstract class Google_IO_Abstract
       // Times will have colons in - so we just want the first match.
       $header_parts = explode(': ', $header, 2);
       if (count($header_parts) == 2) {
-        $headers[$header_parts[0]] = $header_parts[1];
+        $headers[strtolower($header_parts[0])] = $header_parts[1];
       }
     }
 

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Curl.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Curl.php
@@ -21,7 +21,7 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once 'Google/IO/Abstract.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 class Google_IO_Curl extends Google_IO_Abstract
 {
@@ -29,6 +29,18 @@ class Google_IO_Curl extends Google_IO_Abstract
   const NO_QUIRK_VERSION = 0x071E00;
 
   private $options = array();
+
+  public function __construct(Google_Client $client)
+  {
+    if (!extension_loaded('curl')) {
+      $error = 'The cURL IO handler requires the cURL extension to be enabled';
+      $client->getLogger()->critical($error);
+      throw new Google_IO_Exception($error);
+    }
+
+    parent::__construct($client);
+  }
+
   /**
    * Execute an HTTP Request
    *
@@ -53,14 +65,15 @@ class Google_IO_Curl extends Google_IO_Abstract
       }
       curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);
     }
-
     curl_setopt($curl, CURLOPT_URL, $request->getUrl());
-    
+
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getRequestMethod());
     curl_setopt($curl, CURLOPT_USERAGENT, $request->getUserAgent());
 
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+    // 1 is CURL_SSLVERSION_TLSv1, which is not always defined in PHP.
+    curl_setopt($curl, CURLOPT_SSLVERSION, 1);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HEADER, true);
 
@@ -76,15 +89,38 @@ class Google_IO_Curl extends Google_IO_Abstract
       curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/cacerts.pem');
     }
 
+    $this->client->getLogger()->debug(
+        'cURL request',
+        array(
+            'url' => $request->getUrl(),
+            'method' => $request->getRequestMethod(),
+            'headers' => $requestHeaders,
+            'body' => $request->getPostBody()
+        )
+    );
+
     $response = curl_exec($curl);
     if ($response === false) {
-      throw new Google_IO_Exception(curl_error($curl));
+      $error = curl_error($curl);
+      $code = curl_errno($curl);
+      $map = $this->client->getClassConfig('Google_IO_Exception', 'retry_map');
+
+      $this->client->getLogger()->error('cURL ' . $error);
+      throw new Google_IO_Exception($error, $code, null, $map);
     }
     $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
 
     list($responseHeaders, $responseBody) = $this->parseHttpResponse($response, $headerSize);
-
     $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+    $this->client->getLogger()->debug(
+        'cURL response',
+        array(
+            'code' => $responseCode,
+            'headers' => $responseHeaders,
+            'body' => $responseBody,
+        )
+    );
 
     return array($responseBody, $responseHeaders, $responseCode);
   }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/IO/Exception.php
@@ -15,8 +15,53 @@
  * limitations under the License.
  */
 
-require_once 'Google/Exception.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_IO_Exception extends Google_Exception
+class Google_IO_Exception extends Google_Exception implements Google_Task_Retryable
 {
+  /**
+   * @var array $retryMap Map of errors with retry counts.
+   */
+  private $retryMap = array();
+
+  /**
+   * Creates a new IO exception with an optional retry map.
+   *
+   * @param string $message
+   * @param int $code
+   * @param Exception|null $previous
+   * @param array|null $retryMap Map of errors with retry counts.
+   */
+  public function __construct(
+      $message,
+      $code = 0,
+      Exception $previous = null,
+      array $retryMap = null
+  ) {
+    if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+      parent::__construct($message, $code, $previous);
+    } else {
+      parent::__construct($message, $code);
+    }
+
+    if (is_array($retryMap)) {
+      $this->retryMap = $retryMap;
+    }
+  }
+
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries()
+  {
+    if (isset($this->retryMap[$this->code])) {
+      return $this->retryMap[$this->code];
+    }
+
+    return 0;
+  }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Abstract.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Abstract.php
@@ -1,0 +1,406 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Abstract logging class based on the PSR-3 standard.
+ *
+ * NOTE: We don't implement `Psr\Log\LoggerInterface` because we need to
+ * maintain PHP 5.2 support.
+ *
+ * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ */
+abstract class Google_Logger_Abstract
+{
+  /**
+   * Default log format
+   */
+  const DEFAULT_LOG_FORMAT = "[%datetime%] %level%: %message% %context%\n";
+  /**
+   * Default date format
+   *
+   * Example: 16/Nov/2014:03:26:16 -0500
+   */
+  const DEFAULT_DATE_FORMAT = 'd/M/Y:H:i:s O';
+
+  /**
+   * System is unusable
+   */
+  const EMERGENCY = 'emergency';
+  /**
+   * Action must be taken immediately
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   */
+  const ALERT = 'alert';
+  /**
+   * Critical conditions
+   *
+   * Example: Application component unavailable, unexpected exception.
+   */
+  const CRITICAL = 'critical';
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   */
+  const ERROR = 'error';
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   */
+  const WARNING = 'warning';
+  /**
+   * Normal but significant events.
+   */
+  const NOTICE = 'notice';
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   */
+  const INFO = 'info';
+  /**
+   * Detailed debug information.
+   */
+  const DEBUG = 'debug';
+
+  /**
+   * @var array $levels Logging levels
+   */
+  protected static $levels = array(
+      self::EMERGENCY  => 600,
+      self::ALERT => 550,
+      self::CRITICAL => 500,
+      self::ERROR => 400,
+      self::WARNING => 300,
+      self::NOTICE => 250,
+      self::INFO => 200,
+      self::DEBUG => 100,
+  );
+
+  /**
+   * @var integer $level The minimum logging level
+   */
+  protected $level = self::DEBUG;
+
+  /**
+   * @var string $logFormat The current log format
+   */
+  protected $logFormat = self::DEFAULT_LOG_FORMAT;
+  /**
+   * @var string $dateFormat The current date format
+   */
+  protected $dateFormat = self::DEFAULT_DATE_FORMAT;
+
+  /**
+   * @var boolean $allowNewLines If newlines are allowed
+   */
+  protected $allowNewLines = false;
+
+  /**
+   * @param Google_Client $client  The current Google client
+   */
+  public function __construct(Google_Client $client)
+  {
+    $this->setLevel(
+        $client->getClassConfig('Google_Logger_Abstract', 'level')
+    );
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'log_format');
+    $this->logFormat = $format ? $format : self::DEFAULT_LOG_FORMAT;
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'date_format');
+    $this->dateFormat = $format ? $format : self::DEFAULT_DATE_FORMAT;
+
+    $this->allowNewLines = (bool) $client->getClassConfig(
+        'Google_Logger_Abstract',
+        'allow_newlines'
+    );
+  }
+
+  /**
+   * Sets the minimum logging level that this logger handles.
+   *
+   * @param integer $level
+   */
+  public function setLevel($level)
+  {
+    $this->level = $this->normalizeLevel($level);
+  }
+
+  /**
+   * Checks if the logger should handle messages at the provided level.
+   *
+   * @param  integer $level
+   * @return boolean
+   */
+  public function shouldHandle($level)
+  {
+    return $this->normalizeLevel($level) >= $this->level;
+  }
+
+  /**
+   * System is unusable.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function emergency($message, array $context = array())
+  {
+    $this->log(self::EMERGENCY, $message, $context);
+  }
+
+  /**
+   * Action must be taken immediately.
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function alert($message, array $context = array())
+  {
+    $this->log(self::ALERT, $message, $context);
+  }
+
+  /**
+   * Critical conditions.
+   *
+   * Example: Application component unavailable, unexpected exception.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function critical($message, array $context = array())
+  {
+    $this->log(self::CRITICAL, $message, $context);
+  }
+
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function error($message, array $context = array())
+  {
+    $this->log(self::ERROR, $message, $context);
+  }
+
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function warning($message, array $context = array())
+  {
+    $this->log(self::WARNING, $message, $context);
+  }
+
+  /**
+   * Normal but significant events.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function notice($message, array $context = array())
+  {
+    $this->log(self::NOTICE, $message, $context);
+  }
+
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function info($message, array $context = array())
+  {
+    $this->log(self::INFO, $message, $context);
+  }
+
+  /**
+   * Detailed debug information.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function debug($message, array $context = array())
+  {
+    $this->log(self::DEBUG, $message, $context);
+  }
+
+  /**
+   * Logs with an arbitrary level.
+   *
+   * @param mixed $level    The log level
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $message = $this->interpolate(
+        array(
+            'message' => $message,
+            'context' => $context,
+            'level' => strtoupper($levelName),
+            'datetime' => new DateTime(),
+        )
+    );
+
+    $this->write($message);
+  }
+
+  /**
+   * Interpolates log variables into the defined log format.
+   *
+   * @param  array $variables The log variables.
+   * @return string
+   */
+  protected function interpolate(array $variables = array())
+  {
+    $template = $this->logFormat;
+
+    if (!$variables['context']) {
+      $template = str_replace('%context%', '', $template);
+      unset($variables['context']);
+    } else {
+      $this->reverseJsonInContext($variables['context']);
+    }
+
+    foreach ($variables as $key => $value) {
+      if (strpos($template, '%'. $key .'%') !== false) {
+        $template = str_replace(
+            '%' . $key . '%',
+            $this->export($value),
+            $template
+        );
+      }
+    }
+
+    return $template;
+  }
+
+  /**
+   * Reverses JSON encoded PHP arrays and objects so that they log better.
+   *
+   * @param array $context The log context
+   */
+  protected function reverseJsonInContext(array &$context)
+  {
+    if (!$context) {
+      return;
+    }
+
+    foreach ($context as $key => $val) {
+      if (!$val || !is_string($val) || !($val[0] == '{' || $val[0] == '[')) {
+        continue;
+      }
+
+      $json = @json_decode($val);
+      if (is_object($json) || is_array($json)) {
+        $context[$key] = $json;
+      }
+    }
+  }
+
+  /**
+   * Exports a PHP value for logging to a string.
+   *
+   * @param mixed $value The value to
+   */
+  protected function export($value)
+  {
+    if (is_string($value)) {
+      if ($this->allowNewLines) {
+        return $value;
+      }
+
+      return preg_replace('/[\r\n]+/', ' ', $value);
+    }
+
+    if (is_resource($value)) {
+      return sprintf(
+          'resource(%d) of type (%s)',
+          $value,
+          get_resource_type($value)
+      );
+    }
+
+    if ($value instanceof DateTime) {
+      return $value->format($this->dateFormat);
+    }
+
+    if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+      $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+      if ($this->allowNewLines) {
+        $options |= JSON_PRETTY_PRINT;
+      }
+
+      return @json_encode($value, $options);
+    }
+
+    return str_replace('\\/', '/', @json_encode($value));
+  }
+
+  /**
+   * Converts a given log level to the integer form.
+   *
+   * @param  mixed $level   The logging level
+   * @return integer $level The normalized level
+   * @throws Google_Logger_Exception If $level is invalid
+   */
+  protected function normalizeLevel($level)
+  {
+    if (is_int($level) && array_search($level, self::$levels) !== false) {
+      return $level;
+    }
+
+    if (is_string($level) && isset(self::$levels[$level])) {
+      return self::$levels[$level];
+    }
+
+    throw new Google_Logger_Exception(
+        sprintf("Unknown LogLevel: '%s'", $level)
+    );
+  }
+
+  /**
+   * Writes a message to the current log implementation.
+   *
+   * @param string $message The message
+   */
+  abstract protected function write($message);
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Exception.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2013 Google Inc.
+ * Copyright 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 
 require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_Auth_Exception extends Google_Exception
+class Google_Logger_Exception extends Google_Exception
 {
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/File.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/File.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * File logging class based on the PSR-3 standard.
+ *
+ * This logger writes to a PHP stream resource.
+ */
+class Google_Logger_File extends Google_Logger_Abstract
+{
+  /**
+   * @var string|resource $file Where logs are written
+   */
+  private $file;
+  /**
+   * @var integer $mode The mode to use if the log file needs to be created
+   */
+  private $mode = 0640;
+  /**
+   * @var boolean $lock If a lock should be attempted before writing to the log
+   */
+  private $lock = false;
+
+  /**
+   * @var integer $trappedErrorNumber Trapped error number
+   */
+  private $trappedErrorNumber;
+  /**
+   * @var string $trappedErrorString Trapped error string
+   */
+  private $trappedErrorString;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+
+    $file = $client->getClassConfig('Google_Logger_File', 'file');
+    if (!is_string($file) && !is_resource($file)) {
+      throw new Google_Logger_Exception(
+          'File logger requires a filename or a valid file pointer'
+      );
+    }
+
+    $mode = $client->getClassConfig('Google_Logger_File', 'mode');
+    if (!$mode) {
+      $this->mode = $mode;
+    }
+
+    $this->lock = (bool) $client->getClassConfig('Google_Logger_File', 'lock');
+    $this->file = $file;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message)
+  {
+    if (is_string($this->file)) {
+      $this->open();
+    } elseif (!is_resource($this->file)) {
+      throw new Google_Logger_Exception('File pointer is no longer available');
+    }
+
+    if ($this->lock) {
+      flock($this->file, LOCK_EX);
+    }
+
+    fwrite($this->file, (string) $message);
+
+    if ($this->lock) {
+      flock($this->file, LOCK_UN);
+    }
+  }
+
+  /**
+   * Opens the log for writing.
+   *
+   * @return resource
+   */
+  private function open()
+  {
+    // Used for trapping `fopen()` errors.
+    $this->trappedErrorNumber = null;
+    $this->trappedErrorString = null;
+
+    $old = set_error_handler(array($this, 'trapError'));
+
+    $needsChmod = !file_exists($this->file);
+    $fh = fopen($this->file, 'a');
+
+    restore_error_handler();
+
+    // Handles trapped `fopen()` errors.
+    if ($this->trappedErrorNumber) {
+      throw new Google_Logger_Exception(
+          sprintf(
+              "Logger Error: '%s'",
+              $this->trappedErrorString
+          ),
+          $this->trappedErrorNumber
+      );
+    }
+
+    if ($needsChmod) {
+      @chmod($this->file, $this->mode & ~umask());
+    }
+
+    return $this->file = $fh;
+  }
+
+  /**
+   * Closes the log stream resource.
+   */
+  private function close()
+  {
+    if (is_resource($this->file)) {
+      fclose($this->file);
+    }
+  }
+
+  /**
+   * Traps `fopen()` errors.
+   *
+   * @param integer $errno The error number
+   * @param string $errstr The error string
+   */
+  private function trapError($errno, $errstr)
+  {
+    $this->trappedErrorNumber = $errno;
+    $this->trappedErrorString = $errstr;
+  }
+
+  public function __destruct()
+  {
+    $this->close();
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Null.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Null.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2013 Google Inc.
+ * Copyright 2014 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,25 @@
 
 require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_Auth_Exception extends Google_Exception
+/**
+ * Null logger based on the PSR-3 standard.
+ *
+ * This logger simply discards all messages.
+ */
+class Google_Logger_Null extends Google_Logger_Abstract
 {
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return false;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Psr.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Logger/Psr.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Psr logging class based on the PSR-3 standard.
+ *
+ * This logger will delegate all logging to a PSR-3 compatible logger specified
+ * with the `Google_Logger_Psr::setLogger()` method.
+ */
+class Google_Logger_Psr extends Google_Logger_Abstract
+{
+  /**
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  private $logger;
+
+  /**
+   * @param Google_Client $client           The current Google client
+   * @param Psr\Log\LoggerInterface $logger PSR-3 logger where logging will be delegated.
+   */
+  public function __construct(Google_Client $client, /*Psr\Log\LoggerInterface*/ $logger = null)
+  {
+    parent::__construct($client);
+
+    if ($logger) {
+      $this->setLogger($logger);
+    }
+  }
+
+  /**
+   * Sets the PSR-3 logger where logging will be delegated.
+   *
+   * NOTE: The `$logger` should technically implement
+   * `Psr\Log\LoggerInterface`, but we don't explicitly require this so that
+   * we can be compatible with PHP 5.2.
+   *
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  public function setLogger(/*Psr\Log\LoggerInterface*/ $logger)
+  {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return isset($this->logger) && parent::shouldHandle($level);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    if ($context) {
+      $this->reverseJsonInContext($context);
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $this->logger->log($levelName, $message, $context);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
+}

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Model.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Model.php
@@ -33,15 +33,21 @@ class Google_Model implements ArrayAccess
    * Polymorphic - accepts a variable number of arguments dependent
    * on the type of the model subclass.
    */
-  public function __construct()
+  final public function __construct()
   {
     if (func_num_args() == 1 && is_array(func_get_arg(0))) {
       // Initialize the model with the array's contents.
       $array = func_get_arg(0);
       $this->mapTypes($array);
     }
+    $this->gapiInit();
   }
 
+  /**
+   * Getter that handles passthrough access to the data array, and lazy object creation.
+   * @param string $key Property name.
+   * @return mixed The value if any, or null.
+   */
   public function __get($key)
   {
     $keyTypeName = $this->keyType($key);
@@ -100,6 +106,16 @@ class Google_Model implements ArrayAccess
       }
     }
     $this->modelData = $array;
+  }
+
+  /**
+   * Blank initialiser to be used in subclasses to do  post-construction initialisation - this
+   * avoids the need for subclasses to have to implement the variadics handling in their
+   * constructors.
+   */
+  protected function gapiInit()
+  {
+    return;
   }
 
   /**

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Drive.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Drive.php
@@ -19,8 +19,7 @@
  * Service definition for Drive (v2).
  *
  * <p>
- * The API to interact with Drive.
- * </p>
+ * The API to interact with Drive.</p>
  *
  * <p>
  * For more information about this service, see the API
@@ -32,19 +31,26 @@
 class Google_Service_Drive extends Google_Service
 {
   /** View and manage the files and documents in your Google Drive. */
-  const DRIVE = "https://www.googleapis.com/auth/drive";
+  const DRIVE =
+      "https://www.googleapis.com/auth/drive";
   /** View and manage its own configuration data in your Google Drive. */
-  const DRIVE_APPDATA = "https://www.googleapis.com/auth/drive.appdata";
+  const DRIVE_APPDATA =
+      "https://www.googleapis.com/auth/drive.appdata";
   /** View your Google Drive apps. */
-  const DRIVE_APPS_READONLY = "https://www.googleapis.com/auth/drive.apps.readonly";
+  const DRIVE_APPS_READONLY =
+      "https://www.googleapis.com/auth/drive.apps.readonly";
   /** View and manage Google Drive files that you have opened or created with this app. */
-  const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+  const DRIVE_FILE =
+      "https://www.googleapis.com/auth/drive.file";
   /** View metadata for files and documents in your Google Drive. */
-  const DRIVE_METADATA_READONLY = "https://www.googleapis.com/auth/drive.metadata.readonly";
+  const DRIVE_METADATA_READONLY =
+      "https://www.googleapis.com/auth/drive.metadata.readonly";
   /** View the files and documents in your Google Drive. */
-  const DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly";
+  const DRIVE_READONLY =
+      "https://www.googleapis.com/auth/drive.readonly";
   /** Modify your Google Apps Script scripts' behavior. */
-  const DRIVE_SCRIPTS = "https://www.googleapis.com/auth/drive.scripts";
+  const DRIVE_SCRIPTS =
+      "https://www.googleapis.com/auth/drive.scripts";
 
   public $about;
   public $apps;
@@ -470,6 +476,10 @@ class Google_Service_Drive extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
+                'acknowledgeAbuse' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ),
                 'updateViewedDate' => array(
                   'location' => 'query',
                   'type' => 'boolean',
@@ -695,6 +705,10 @@ class Google_Service_Drive extends Google_Service
                   'location' => 'path',
                   'type' => 'string',
                   'required' => true,
+                ),
+                'acknowledgeAbuse' => array(
+                  'location' => 'query',
+                  'type' => 'boolean',
                 ),
                 'updateViewedDate' => array(
                   'location' => 'query',
@@ -1266,14 +1280,15 @@ class Google_Service_Drive_About_Resource extends Google_Service_Resource
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * When calculating the number of remaining change IDs, whether to include public files the user
-    * has opened and shared files. When set to false, this counts only change IDs for owned files and
-    * any shared or public files that the user has explicitly added to a folder they own.
-   * @opt_param string maxChangeIdCount
-   * Maximum number of remaining change IDs to count
-   * @opt_param string startChangeId
-   * Change ID to start counting from when calculating number of remaining change IDs
+   * @opt_param bool includeSubscribed When calculating the number of remaining
+   * change IDs, whether to include public files the user has opened and shared
+   * files. When set to false, this counts only change IDs for owned files and any
+   * shared or public files that the user has explicitly added to a folder they
+   * own.
+   * @opt_param string maxChangeIdCount Maximum number of remaining change IDs to
+   * count
+   * @opt_param string startChangeId Change ID to start counting from when
+   * calculating number of remaining change IDs
    * @return Google_Service_Drive_About
    */
   public function get($optParams = array())
@@ -1298,8 +1313,7 @@ class Google_Service_Drive_Apps_Resource extends Google_Service_Resource
   /**
    * Gets a specific app. (apps.get)
    *
-   * @param string $appId
-   * The ID of the app.
+   * @param string $appId The ID of the app.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_App
    */
@@ -1309,22 +1323,25 @@ class Google_Service_Drive_Apps_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_App");
   }
+
   /**
    * Lists a user's installed apps. (apps.listApps)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string languageCode
-   * A language or locale code, as defined by BCP 47, with some extensions from Unicode's LDML format
-    * (http://www.unicode.org/reports/tr35/).
-   * @opt_param string appFilterExtensions
-   * A comma-separated list of file extensions for open with filtering. All apps within the given app
-    * query scope which can open any of the given file extensions will be included in the response. If
-    * appFilterMimeTypes are provided as well, the result is a union of the two resulting app lists.
-   * @opt_param string appFilterMimeTypes
-   * A comma-separated list of MIME types for open with filtering. All apps within the given app
-    * query scope which can open any of the given MIME types will be included in the response. If
-    * appFilterExtensions are provided as well, the result is a union of the two resulting app lists.
+   * @opt_param string languageCode A language or locale code, as defined by BCP
+   * 47, with some extensions from Unicode's LDML format
+   * (http://www.unicode.org/reports/tr35/).
+   * @opt_param string appFilterExtensions A comma-separated list of file
+   * extensions for open with filtering. All apps within the given app query scope
+   * which can open any of the given file extensions will be included in the
+   * response. If appFilterMimeTypes are provided as well, the result is a union
+   * of the two resulting app lists.
+   * @opt_param string appFilterMimeTypes A comma-separated list of MIME types for
+   * open with filtering. All apps within the given app query scope which can open
+   * any of the given MIME types will be included in the response. If
+   * appFilterExtensions are provided as well, the result is a union of the two
+   * resulting app lists.
    * @return Google_Service_Drive_AppList
    */
   public function listApps($optParams = array())
@@ -1349,8 +1366,7 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
   /**
    * Gets a specific change. (changes.get)
    *
-   * @param string $changeId
-   * The ID of the change.
+   * @param string $changeId The ID of the change.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Change
    */
@@ -1360,23 +1376,20 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Change");
   }
+
   /**
    * Lists the changes for a user. (changes.listChanges)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * Whether to include public files the user has opened and shared files. When set to false, the
-    * list only includes owned files plus any shared or public files the user has explicitly added to
-    * a folder they own.
-   * @opt_param string startChangeId
-   * Change ID to start listing changes from.
-   * @opt_param bool includeDeleted
-   * Whether to include deleted items.
-   * @opt_param int maxResults
-   * Maximum number of changes to return.
-   * @opt_param string pageToken
-   * Page token for changes.
+   * @opt_param bool includeSubscribed Whether to include public files the user
+   * has opened and shared files. When set to false, the list only includes owned
+   * files plus any shared or public files the user has explicitly added to a
+   * folder they own.
+   * @opt_param string startChangeId Change ID to start listing changes from.
+   * @opt_param bool includeDeleted Whether to include deleted items.
+   * @opt_param int maxResults Maximum number of changes to return.
+   * @opt_param string pageToken Page token for changes.
    * @return Google_Service_Drive_ChangeList
    */
   public function listChanges($optParams = array())
@@ -1385,24 +1398,21 @@ class Google_Service_Drive_Changes_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_ChangeList");
   }
+
   /**
    * Subscribe to changes for a user. (changes.watch)
    *
    * @param Google_Channel $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeSubscribed
-   * Whether to include public files the user has opened and shared files. When set to false, the
-    * list only includes owned files plus any shared or public files the user has explicitly added to
-    * a folder they own.
-   * @opt_param string startChangeId
-   * Change ID to start listing changes from.
-   * @opt_param bool includeDeleted
-   * Whether to include deleted items.
-   * @opt_param int maxResults
-   * Maximum number of changes to return.
-   * @opt_param string pageToken
-   * Page token for changes.
+   * @opt_param bool includeSubscribed Whether to include public files the user
+   * has opened and shared files. When set to false, the list only includes owned
+   * files plus any shared or public files the user has explicitly added to a
+   * folder they own.
+   * @opt_param string startChangeId Change ID to start listing changes from.
+   * @opt_param bool includeDeleted Whether to include deleted items.
+   * @opt_param int maxResults Maximum number of changes to return.
+   * @opt_param string pageToken Page token for changes.
    * @return Google_Service_Drive_Channel
    */
   public function watch(Google_Service_Drive_Channel $postBody, $optParams = array())
@@ -1452,10 +1462,8 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
   /**
    * Removes a child from a folder. (children.delete)
    *
-   * @param string $folderId
-   * The ID of the folder.
-   * @param string $childId
-   * The ID of the child.
+   * @param string $folderId The ID of the folder.
+   * @param string $childId The ID of the child.
    * @param array $optParams Optional parameters.
    */
   public function delete($folderId, $childId, $optParams = array())
@@ -1464,13 +1472,12 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific child reference. (children.get)
    *
-   * @param string $folderId
-   * The ID of the folder.
-   * @param string $childId
-   * The ID of the child.
+   * @param string $folderId The ID of the folder.
+   * @param string $childId The ID of the child.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ChildReference
    */
@@ -1480,11 +1487,11 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_ChildReference");
   }
+
   /**
    * Inserts a file into a folder. (children.insert)
    *
-   * @param string $folderId
-   * The ID of the folder.
+   * @param string $folderId The ID of the folder.
    * @param Google_ChildReference $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ChildReference
@@ -1495,19 +1502,16 @@ class Google_Service_Drive_Children_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_ChildReference");
   }
+
   /**
    * Lists a folder's children. (children.listChildren)
    *
-   * @param string $folderId
-   * The ID of the folder.
+   * @param string $folderId The ID of the folder.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string q
-   * Query string for searching children.
-   * @opt_param string pageToken
-   * Page token for children.
-   * @opt_param int maxResults
-   * Maximum number of children to return.
+   * @opt_param string q Query string for searching children.
+   * @opt_param string pageToken Page token for children.
+   * @opt_param int maxResults Maximum number of children to return.
    * @return Google_Service_Drive_ChildList
    */
   public function listChildren($folderId, $optParams = array())
@@ -1532,10 +1536,8 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
   /**
    * Deletes a comment. (comments.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $commentId, $optParams = array())
@@ -1544,18 +1546,16 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a comment by ID. (comments.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeDeleted
-   * If set, this will succeed when retrieving a deleted comment, and will include any deleted
-    * replies.
+   * @opt_param bool includeDeleted If set, this will succeed when retrieving a
+   * deleted comment, and will include any deleted replies.
    * @return Google_Service_Drive_Comment
    */
   public function get($fileId, $commentId, $optParams = array())
@@ -1564,11 +1564,11 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Creates a new comment on the given file. (comments.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1579,24 +1579,22 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Lists a file's comments. (comments.listComments)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string pageToken
-   * The continuation token, used to page through large result sets. To get the next page of results,
-    * set this parameter to the value of "nextPageToken" from the previous response.
-   * @opt_param string updatedMin
-   * Only discussions that were updated after this timestamp will be returned. Formatted as an RFC
-    * 3339 timestamp.
-   * @opt_param bool includeDeleted
-   * If set, all comments and replies, including deleted comments and replies (with content stripped)
-    * will be returned.
-   * @opt_param int maxResults
-   * The maximum number of discussions to include in the response, used for paging.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of "nextPageToken" from the previous response.
+   * @opt_param string updatedMin Only discussions that were updated after this
+   * timestamp will be returned. Formatted as an RFC 3339 timestamp.
+   * @opt_param bool includeDeleted If set, all comments and replies, including
+   * deleted comments and replies (with content stripped) will be returned.
+   * @opt_param int maxResults The maximum number of discussions to include in the
+   * response, used for paging.
    * @return Google_Service_Drive_CommentList
    */
   public function listComments($fileId, $optParams = array())
@@ -1605,14 +1603,13 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_CommentList");
   }
+
   /**
    * Updates an existing comment. This method supports patch semantics.
    * (comments.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1623,13 +1620,12 @@ class Google_Service_Drive_Comments_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Comment");
   }
+
   /**
    * Updates an existing comment. (comments.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_Comment $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Comment
@@ -1656,27 +1652,23 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
   /**
    * Creates a copy of the specified file. (files.copy)
    *
-   * @param string $fileId
-   * The ID of the file to copy.
+   * @param string $fileId The ID of the file to copy.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param string visibility
-   * The visibility of the new file. This parameter is only relevant when the source is not a native
-    * Google Doc and convert=false.
-   * @opt_param bool pinned
-   * Whether to pin the head revision of the new copy. A file can have a maximum of 200 pinned
-    * revisions.
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are ISO 639-1 codes.
+   * @opt_param string visibility The visibility of the new file. This parameter
+   * is only relevant when the source is not a native Google Doc and
+   * convert=false.
+   * @opt_param bool pinned Whether to pin the head revision of the new copy. A
+   * file can have a maximum of 200 pinned revisions.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextTrackName The timed text track name.
+   * @opt_param string timedTextLanguage The language of the timed text.
    * @return Google_Service_Drive_DriveFile
    */
   public function copy($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1685,11 +1677,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('copy', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Permanently deletes a file by ID. Skips the trash. (files.delete)
    *
-   * @param string $fileId
-   * The ID of the file to delete.
+   * @param string $fileId The ID of the file to delete.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $optParams = array())
@@ -1698,6 +1690,7 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Permanently deletes all of the user's trashed files. (files.emptyTrash)
    *
@@ -1709,17 +1702,19 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('emptyTrash', array($params));
   }
+
   /**
    * Gets a file's metadata by ID. (files.get)
    *
-   * @param string $fileId
-   * The ID for the file in question.
+   * @param string $fileId The ID for the file in question.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully retrieving the file.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
+   * @opt_param bool acknowledgeAbuse Whether the user is acknowledging the risk
+   * of downloading known malware or other abusive files.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully retrieving the file.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
    * @return Google_Service_Drive_DriveFile
    */
   public function get($fileId, $optParams = array())
@@ -1728,29 +1723,27 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Insert a new file. (files.insert)
    *
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param string visibility
-   * The visibility of the new file. This parameter is only relevant when convert=false.
-   * @opt_param bool pinned
-   * Whether to pin the head revision of the uploaded file. A file can have a maximum of 200 pinned
-    * revisions.
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are ISO 639-1 codes.
+   * @opt_param string visibility The visibility of the new file. This parameter
+   * is only relevant when convert=false.
+   * @opt_param bool pinned Whether to pin the head revision of the uploaded file.
+   * A file can have a maximum of 200 pinned revisions.
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextTrackName The timed text track name.
+   * @opt_param string timedTextLanguage The language of the timed text.
    * @return Google_Service_Drive_DriveFile
    */
   public function insert(Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1759,21 +1752,19 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Lists the user's files. (files.listFiles)
    *
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string q
-   * Query string for searching files.
-   * @opt_param string pageToken
-   * Page token for files.
-   * @opt_param string corpus
-   * The body of items (files/documents) to which the query applies.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
-   * @opt_param int maxResults
-   * Maximum number of files to return.
+   * @opt_param string q Query string for searching files.
+   * @opt_param string pageToken Page token for files.
+   * @opt_param string corpus The body of items (files/documents) to which the
+   * query applies.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
+   * @opt_param int maxResults Maximum number of files to return.
    * @return Google_Service_Drive_FileList
    */
   public function listFiles($optParams = array())
@@ -1782,41 +1773,38 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_FileList");
   }
+
   /**
    * Updates file metadata and/or content. This method supports patch semantics.
    * (files.patch)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string addParents
-   * Comma-separated list of parent IDs to add.
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully updating the file.
-   * @opt_param string removeParents
-   * Comma-separated list of parent IDs to remove.
-   * @opt_param bool setModifiedDate
-   * Whether to set the modified date with the supplied modified date.
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param bool pinned
-   * Whether to pin the new revision. A file can have a maximum of 200 pinned revisions.
-   * @opt_param bool newRevision
-   * Whether a blob upload should create a new revision. If false, the blob data in the current head
-    * revision is replaced. If true or not set, a new blob is created as head revision, and previous
-    * revisions are preserved (causing increased use of the user's data storage quota).
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
+   * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully updating the file.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
+   * @opt_param bool setModifiedDate Whether to set the modified date with the
+   * supplied modified date.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are ISO 639-1 codes.
+   * @opt_param bool pinned Whether to pin the new revision. A file can have a
+   * maximum of 200 pinned revisions.
+   * @opt_param bool newRevision Whether a blob upload should create a new
+   * revision. If false, the blob data in the current head revision is replaced.
+   * If true or not set, a new blob is created as head revision, and previous
+   * revisions are preserved (causing increased use of the user's data storage
+   * quota).
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextLanguage The language of the timed text.
+   * @opt_param string timedTextTrackName The timed text track name.
    * @return Google_Service_Drive_DriveFile
    */
   public function patch($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1825,11 +1813,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Set the file's updated time to the current server time. (files.touch)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1839,11 +1827,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('touch', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Moves a file to the trash. (files.trash)
    *
-   * @param string $fileId
-   * The ID of the file to trash.
+   * @param string $fileId The ID of the file to trash.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1853,11 +1841,11 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('trash', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Restores a file from the trash. (files.untrash)
    *
-   * @param string $fileId
-   * The ID of the file to untrash.
+   * @param string $fileId The ID of the file to untrash.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_DriveFile
    */
@@ -1867,40 +1855,37 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('untrash', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Updates file metadata and/or content. (files.update)
    *
-   * @param string $fileId
-   * The ID of the file to update.
+   * @param string $fileId The ID of the file to update.
    * @param Google_DriveFile $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string addParents
-   * Comma-separated list of parent IDs to add.
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully updating the file.
-   * @opt_param string removeParents
-   * Comma-separated list of parent IDs to remove.
-   * @opt_param bool setModifiedDate
-   * Whether to set the modified date with the supplied modified date.
-   * @opt_param bool convert
-   * Whether to convert this file to the corresponding Google Docs format.
-   * @opt_param bool useContentAsIndexableText
-   * Whether to use the content as indexable text.
-   * @opt_param string ocrLanguage
-   * If ocr is true, hints at the language to use. Valid values are ISO 639-1 codes.
-   * @opt_param bool pinned
-   * Whether to pin the new revision. A file can have a maximum of 200 pinned revisions.
-   * @opt_param bool newRevision
-   * Whether a blob upload should create a new revision. If false, the blob data in the current head
-    * revision is replaced. If true or not set, a new blob is created as head revision, and previous
-    * revisions are preserved (causing increased use of the user's data storage quota).
-   * @opt_param bool ocr
-   * Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.
-   * @opt_param string timedTextLanguage
-   * The language of the timed text.
-   * @opt_param string timedTextTrackName
-   * The timed text track name.
+   * @opt_param string addParents Comma-separated list of parent IDs to add.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully updating the file.
+   * @opt_param string removeParents Comma-separated list of parent IDs to remove.
+   * @opt_param bool setModifiedDate Whether to set the modified date with the
+   * supplied modified date.
+   * @opt_param bool convert Whether to convert this file to the corresponding
+   * Google Docs format.
+   * @opt_param bool useContentAsIndexableText Whether to use the content as
+   * indexable text.
+   * @opt_param string ocrLanguage If ocr is true, hints at the language to use.
+   * Valid values are ISO 639-1 codes.
+   * @opt_param bool pinned Whether to pin the new revision. A file can have a
+   * maximum of 200 pinned revisions.
+   * @opt_param bool newRevision Whether a blob upload should create a new
+   * revision. If false, the blob data in the current head revision is replaced.
+   * If true or not set, a new blob is created as head revision, and previous
+   * revisions are preserved (causing increased use of the user's data storage
+   * quota).
+   * @opt_param bool ocr Whether to attempt OCR on .jpg, .png, .gif, or .pdf
+   * uploads.
+   * @opt_param string timedTextLanguage The language of the timed text.
+   * @opt_param string timedTextTrackName The timed text track name.
    * @return Google_Service_Drive_DriveFile
    */
   public function update($fileId, Google_Service_Drive_DriveFile $postBody, $optParams = array())
@@ -1909,18 +1894,20 @@ class Google_Service_Drive_Files_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('update', array($params), "Google_Service_Drive_DriveFile");
   }
+
   /**
    * Subscribe to changes on a file (files.watch)
    *
-   * @param string $fileId
-   * The ID for the file in question.
+   * @param string $fileId The ID for the file in question.
    * @param Google_Channel $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool updateViewedDate
-   * Whether to update the view date after successfully retrieving the file.
-   * @opt_param string projection
-   * This parameter is deprecated and has no function.
+   * @opt_param bool acknowledgeAbuse Whether the user is acknowledging the risk
+   * of downloading known malware or other abusive files.
+   * @opt_param bool updateViewedDate Whether to update the view date after
+   * successfully retrieving the file.
+   * @opt_param string projection This parameter is deprecated and has no
+   * function.
    * @return Google_Service_Drive_Channel
    */
   public function watch($fileId, Google_Service_Drive_Channel $postBody, $optParams = array())
@@ -1945,10 +1932,8 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
   /**
    * Removes a parent from a file. (parents.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $parentId
-   * The ID of the parent.
+   * @param string $fileId The ID of the file.
+   * @param string $parentId The ID of the parent.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $parentId, $optParams = array())
@@ -1957,13 +1942,12 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific parent reference. (parents.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $parentId
-   * The ID of the parent.
+   * @param string $fileId The ID of the file.
+   * @param string $parentId The ID of the parent.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentReference
    */
@@ -1973,11 +1957,11 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_ParentReference");
   }
+
   /**
    * Adds a parent folder for a file. (parents.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_ParentReference $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentReference
@@ -1988,11 +1972,11 @@ class Google_Service_Drive_Parents_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_ParentReference");
   }
+
   /**
    * Lists a file's parents. (parents.listParents)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_ParentList
    */
@@ -2018,10 +2002,8 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
   /**
    * Deletes a permission from a file. (permissions.delete)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $permissionId, $optParams = array())
@@ -2030,13 +2012,12 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a permission by ID. (permissions.get)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Permission
    */
@@ -2046,11 +2027,11 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Returns the permission ID for an email address. (permissions.getIdForEmail)
    *
-   * @param string $email
-   * The email address for which to return a permission ID
+   * @param string $email The email address for which to return a permission ID
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PermissionId
    */
@@ -2060,19 +2041,19 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('getIdForEmail', array($params), "Google_Service_Drive_PermissionId");
   }
+
   /**
    * Inserts a permission for a file. (permissions.insert)
    *
-   * @param string $fileId
-   * The ID for the file.
+   * @param string $fileId The ID for the file.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string emailMessage
-   * A custom message to include in notification emails.
-   * @opt_param bool sendNotificationEmails
-   * Whether to send notification emails when sharing to users or groups. This parameter is ignored
-    * and an email is sent if the role is owner.
+   * @opt_param string emailMessage A custom message to include in notification
+   * emails.
+   * @opt_param bool sendNotificationEmails Whether to send notification emails
+   * when sharing to users or groups. This parameter is ignored and an email is
+   * sent if the role is owner.
    * @return Google_Service_Drive_Permission
    */
   public function insert($fileId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2081,11 +2062,11 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Lists a file's permissions. (permissions.listPermissions)
    *
-   * @param string $fileId
-   * The ID for the file.
+   * @param string $fileId The ID for the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PermissionList
    */
@@ -2095,19 +2076,18 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_PermissionList");
   }
+
   /**
    * Updates a permission. This method supports patch semantics.
    * (permissions.patch)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool transferOwnership
-   * Whether changing a role to 'owner' should also downgrade the current owners to writers.
+   * @opt_param bool transferOwnership Whether changing a role to 'owner' should
+   * also downgrade the current owners to writers.
    * @return Google_Service_Drive_Permission
    */
   public function patch($fileId, $permissionId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2116,18 +2096,17 @@ class Google_Service_Drive_Permissions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Permission");
   }
+
   /**
    * Updates a permission. (permissions.update)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $permissionId
-   * The ID for the permission.
+   * @param string $fileId The ID for the file.
+   * @param string $permissionId The ID for the permission.
    * @param Google_Permission $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool transferOwnership
-   * Whether changing a role to 'owner' should also downgrade the current owners to writers.
+   * @opt_param bool transferOwnership Whether changing a role to 'owner' should
+   * also downgrade the current owners to writers.
    * @return Google_Service_Drive_Permission
    */
   public function update($fileId, $permissionId, Google_Service_Drive_Permission $postBody, $optParams = array())
@@ -2152,14 +2131,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
   /**
    * Deletes a property. (properties.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    */
   public function delete($fileId, $propertyKey, $optParams = array())
   {
@@ -2167,17 +2143,15 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a property by its key. (properties.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function get($fileId, $propertyKey, $optParams = array())
@@ -2186,11 +2160,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Adds a property to a file. (properties.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Property
@@ -2201,11 +2175,11 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Lists a file's properties. (properties.listProperties)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_PropertyList
    */
@@ -2215,18 +2189,16 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_PropertyList");
   }
+
   /**
    * Updates a property. This method supports patch semantics. (properties.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function patch($fileId, $propertyKey, Google_Service_Drive_Property $postBody, $optParams = array())
@@ -2235,18 +2207,16 @@ class Google_Service_Drive_Properties_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Property");
   }
+
   /**
    * Updates a property. (properties.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $propertyKey
-   * The key of the property.
+   * @param string $fileId The ID of the file.
+   * @param string $propertyKey The key of the property.
    * @param Google_Property $postBody
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string visibility
-   * The visibility of the property.
+   * @opt_param string visibility The visibility of the property.
    * @return Google_Service_Drive_Property
    */
   public function update($fileId, $propertyKey, Google_Service_Drive_Property $postBody, $optParams = array())
@@ -2272,14 +2242,14 @@ class Google_Service_Drive_Realtime_Resource extends Google_Service_Resource
    * Exports the contents of the Realtime API data model associated with this file
    * as JSON. (realtime.get)
    *
-   * @param string $fileId
-   * The ID of the file that the Realtime API data model is associated with.
+   * @param string $fileId The ID of the file that the Realtime API data model is
+   * associated with.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param int revision
-   * The revision of the Realtime API data model to export. Revisions start at 1 (the initial empty
-    * data model) and are incremented with each change. If this parameter is excluded, the most recent
-    * data model will be returned.
+   * @opt_param int revision The revision of the Realtime API data model to
+   * export. Revisions start at 1 (the initial empty data model) and are
+   * incremented with each change. If this parameter is excluded, the most recent
+   * data model will be returned.
    */
   public function get($fileId, $optParams = array())
   {
@@ -2287,19 +2257,20 @@ class Google_Service_Drive_Realtime_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params));
   }
+
   /**
    * Overwrites the Realtime API data model associated with this file with the
    * provided JSON data model. (realtime.update)
    *
-   * @param string $fileId
-   * The ID of the file that the Realtime API data model is associated with.
+   * @param string $fileId The ID of the file that the Realtime API data model is
+   * associated with.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string baseRevision
-   * The revision of the model to diff the uploaded model against. If set, the uploaded model is
-    * diffed against the provided revision and those differences are merged with any changes made to
-    * the model after the provided revision. If not set, the uploaded model replaces the current model
-    * on the server.
+   * @opt_param string baseRevision The revision of the model to diff the uploaded
+   * model against. If set, the uploaded model is diffed against the provided
+   * revision and those differences are merged with any changes made to the model
+   * after the provided revision. If not set, the uploaded model replaces the
+   * current model on the server.
    */
   public function update($fileId, $optParams = array())
   {
@@ -2323,12 +2294,9 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
   /**
    * Deletes a reply. (replies.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $commentId, $replyId, $optParams = array())
@@ -2337,19 +2305,17 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a reply. (replies.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param bool includeDeleted
-   * If set, this will succeed when retrieving a deleted reply.
+   * @opt_param bool includeDeleted If set, this will succeed when retrieving a
+   * deleted reply.
    * @return Google_Service_Drive_CommentReply
    */
   public function get($fileId, $commentId, $replyId, $optParams = array())
@@ -2358,13 +2324,12 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Creates a new reply to the given comment. (replies.insert)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2375,22 +2340,21 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('insert', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Lists all of the replies to a comment. (replies.listReplies)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
    * @param array $optParams Optional parameters.
    *
-   * @opt_param string pageToken
-   * The continuation token, used to page through large result sets. To get the next page of results,
-    * set this parameter to the value of "nextPageToken" from the previous response.
-   * @opt_param bool includeDeleted
-   * If set, all replies, including deleted replies (with content stripped) will be returned.
-   * @opt_param int maxResults
-   * The maximum number of replies to include in the response, used for paging.
+   * @opt_param string pageToken The continuation token, used to page through
+   * large result sets. To get the next page of results, set this parameter to the
+   * value of "nextPageToken" from the previous response.
+   * @opt_param bool includeDeleted If set, all replies, including deleted replies
+   * (with content stripped) will be returned.
+   * @opt_param int maxResults The maximum number of replies to include in the
+   * response, used for paging.
    * @return Google_Service_Drive_CommentReplyList
    */
   public function listReplies($fileId, $commentId, $optParams = array())
@@ -2399,16 +2363,14 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_CommentReplyList");
   }
+
   /**
    * Updates an existing reply. This method supports patch semantics.
    * (replies.patch)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2419,15 +2381,13 @@ class Google_Service_Drive_Replies_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_CommentReply");
   }
+
   /**
    * Updates an existing reply. (replies.update)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $commentId
-   * The ID of the comment.
-   * @param string $replyId
-   * The ID of the reply.
+   * @param string $fileId The ID of the file.
+   * @param string $commentId The ID of the comment.
+   * @param string $replyId The ID of the reply.
    * @param Google_CommentReply $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_CommentReply
@@ -2454,10 +2414,8 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
   /**
    * Removes a revision. (revisions.delete)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $revisionId
-   * The ID of the revision.
+   * @param string $fileId The ID of the file.
+   * @param string $revisionId The ID of the revision.
    * @param array $optParams Optional parameters.
    */
   public function delete($fileId, $revisionId, $optParams = array())
@@ -2466,13 +2424,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('delete', array($params));
   }
+
   /**
    * Gets a specific revision. (revisions.get)
    *
-   * @param string $fileId
-   * The ID of the file.
-   * @param string $revisionId
-   * The ID of the revision.
+   * @param string $fileId The ID of the file.
+   * @param string $revisionId The ID of the revision.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
    */
@@ -2482,11 +2439,11 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('get', array($params), "Google_Service_Drive_Revision");
   }
+
   /**
    * Lists a file's revisions. (revisions.listRevisions)
    *
-   * @param string $fileId
-   * The ID of the file.
+   * @param string $fileId The ID of the file.
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_RevisionList
    */
@@ -2496,13 +2453,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('list', array($params), "Google_Service_Drive_RevisionList");
   }
+
   /**
    * Updates a revision. This method supports patch semantics. (revisions.patch)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $revisionId
-   * The ID for the revision.
+   * @param string $fileId The ID for the file.
+   * @param string $revisionId The ID for the revision.
    * @param Google_Revision $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
@@ -2513,13 +2469,12 @@ class Google_Service_Drive_Revisions_Resource extends Google_Service_Resource
     $params = array_merge($params, $optParams);
     return $this->call('patch', array($params), "Google_Service_Drive_Revision");
   }
+
   /**
    * Updates a revision. (revisions.update)
    *
-   * @param string $fileId
-   * The ID for the file.
-   * @param string $revisionId
-   * The ID for the revision.
+   * @param string $fileId The ID for the file.
+   * @param string $revisionId The ID for the revision.
    * @param Google_Revision $postBody
    * @param array $optParams Optional parameters.
    * @return Google_Service_Drive_Revision
@@ -2571,231 +2526,187 @@ class Google_Service_Drive_About extends Google_Collection
   protected $userType = 'Google_Service_Drive_User';
   protected $userDataType = '';
 
+
   public function setAdditionalRoleInfo($additionalRoleInfo)
   {
     $this->additionalRoleInfo = $additionalRoleInfo;
   }
-
   public function getAdditionalRoleInfo()
   {
     return $this->additionalRoleInfo;
   }
-
   public function setDomainSharingPolicy($domainSharingPolicy)
   {
     $this->domainSharingPolicy = $domainSharingPolicy;
   }
-
   public function getDomainSharingPolicy()
   {
     return $this->domainSharingPolicy;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExportFormats($exportFormats)
   {
     $this->exportFormats = $exportFormats;
   }
-
   public function getExportFormats()
   {
     return $this->exportFormats;
   }
-
   public function setFeatures($features)
   {
     $this->features = $features;
   }
-
   public function getFeatures()
   {
     return $this->features;
   }
-
   public function setImportFormats($importFormats)
   {
     $this->importFormats = $importFormats;
   }
-
   public function getImportFormats()
   {
     return $this->importFormats;
   }
-
   public function setIsCurrentAppInstalled($isCurrentAppInstalled)
   {
     $this->isCurrentAppInstalled = $isCurrentAppInstalled;
   }
-
   public function getIsCurrentAppInstalled()
   {
     return $this->isCurrentAppInstalled;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLanguageCode($languageCode)
   {
     $this->languageCode = $languageCode;
   }
-
   public function getLanguageCode()
   {
     return $this->languageCode;
   }
-
   public function setLargestChangeId($largestChangeId)
   {
     $this->largestChangeId = $largestChangeId;
   }
-
   public function getLargestChangeId()
   {
     return $this->largestChangeId;
   }
-
   public function setMaxUploadSizes($maxUploadSizes)
   {
     $this->maxUploadSizes = $maxUploadSizes;
   }
-
   public function getMaxUploadSizes()
   {
     return $this->maxUploadSizes;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setPermissionId($permissionId)
   {
     $this->permissionId = $permissionId;
   }
-
   public function getPermissionId()
   {
     return $this->permissionId;
   }
-
   public function setQuotaBytesByService($quotaBytesByService)
   {
     $this->quotaBytesByService = $quotaBytesByService;
   }
-
   public function getQuotaBytesByService()
   {
     return $this->quotaBytesByService;
   }
-
   public function setQuotaBytesTotal($quotaBytesTotal)
   {
     $this->quotaBytesTotal = $quotaBytesTotal;
   }
-
   public function getQuotaBytesTotal()
   {
     return $this->quotaBytesTotal;
   }
-
   public function setQuotaBytesUsed($quotaBytesUsed)
   {
     $this->quotaBytesUsed = $quotaBytesUsed;
   }
-
   public function getQuotaBytesUsed()
   {
     return $this->quotaBytesUsed;
   }
-
   public function setQuotaBytesUsedAggregate($quotaBytesUsedAggregate)
   {
     $this->quotaBytesUsedAggregate = $quotaBytesUsedAggregate;
   }
-
   public function getQuotaBytesUsedAggregate()
   {
     return $this->quotaBytesUsedAggregate;
   }
-
   public function setQuotaBytesUsedInTrash($quotaBytesUsedInTrash)
   {
     $this->quotaBytesUsedInTrash = $quotaBytesUsedInTrash;
   }
-
   public function getQuotaBytesUsedInTrash()
   {
     return $this->quotaBytesUsedInTrash;
   }
-
   public function setQuotaType($quotaType)
   {
     $this->quotaType = $quotaType;
   }
-
   public function getQuotaType()
   {
     return $this->quotaType;
   }
-
   public function setRemainingChangeIds($remainingChangeIds)
   {
     $this->remainingChangeIds = $remainingChangeIds;
   }
-
   public function getRemainingChangeIds()
   {
     return $this->remainingChangeIds;
   }
-
   public function setRootFolderId($rootFolderId)
   {
     $this->rootFolderId = $rootFolderId;
   }
-
   public function getRootFolderId()
   {
     return $this->rootFolderId;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setUser(Google_Service_Drive_User $user)
   {
     $this->user = $user;
   }
-
   public function getUser()
   {
     return $this->user;
@@ -2811,21 +2722,19 @@ class Google_Service_Drive_AboutAdditionalRoleInfo extends Google_Collection
   protected $roleSetsDataType = 'array';
   public $type;
 
+
   public function setRoleSets($roleSets)
   {
     $this->roleSets = $roleSets;
   }
-
   public function getRoleSets()
   {
     return $this->roleSets;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -2840,21 +2749,19 @@ class Google_Service_Drive_AboutAdditionalRoleInfoRoleSets extends Google_Collec
   public $additionalRoles;
   public $primaryRole;
 
+
   public function setAdditionalRoles($additionalRoles)
   {
     $this->additionalRoles = $additionalRoles;
   }
-
   public function getAdditionalRoles()
   {
     return $this->additionalRoles;
   }
-
   public function setPrimaryRole($primaryRole)
   {
     $this->primaryRole = $primaryRole;
   }
-
   public function getPrimaryRole()
   {
     return $this->primaryRole;
@@ -2869,21 +2776,19 @@ class Google_Service_Drive_AboutExportFormats extends Google_Collection
   public $source;
   public $targets;
 
+
   public function setSource($source)
   {
     $this->source = $source;
   }
-
   public function getSource()
   {
     return $this->source;
   }
-
   public function setTargets($targets)
   {
     $this->targets = $targets;
   }
-
   public function getTargets()
   {
     return $this->targets;
@@ -2897,21 +2802,19 @@ class Google_Service_Drive_AboutFeatures extends Google_Model
   public $featureName;
   public $featureRate;
 
+
   public function setFeatureName($featureName)
   {
     $this->featureName = $featureName;
   }
-
   public function getFeatureName()
   {
     return $this->featureName;
   }
-
   public function setFeatureRate($featureRate)
   {
     $this->featureRate = $featureRate;
   }
-
   public function getFeatureRate()
   {
     return $this->featureRate;
@@ -2926,21 +2829,19 @@ class Google_Service_Drive_AboutImportFormats extends Google_Collection
   public $source;
   public $targets;
 
+
   public function setSource($source)
   {
     $this->source = $source;
   }
-
   public function getSource()
   {
     return $this->source;
   }
-
   public function setTargets($targets)
   {
     $this->targets = $targets;
   }
-
   public function getTargets()
   {
     return $this->targets;
@@ -2954,21 +2855,19 @@ class Google_Service_Drive_AboutMaxUploadSizes extends Google_Model
   public $size;
   public $type;
 
+
   public function setSize($size)
   {
     $this->size = $size;
   }
-
   public function getSize()
   {
     return $this->size;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -2982,21 +2881,19 @@ class Google_Service_Drive_AboutQuotaBytesByService extends Google_Model
   public $bytesUsed;
   public $serviceName;
 
+
   public function setBytesUsed($bytesUsed)
   {
     $this->bytesUsed = $bytesUsed;
   }
-
   public function getBytesUsed()
   {
     return $this->bytesUsed;
   }
-
   public function setServiceName($serviceName)
   {
     $this->serviceName = $serviceName;
   }
-
   public function getServiceName()
   {
     return $this->serviceName;
@@ -3034,241 +2931,195 @@ class Google_Service_Drive_App extends Google_Collection
   public $supportsOfflineCreate;
   public $useByDefault;
 
+
   public function setAuthorized($authorized)
   {
     $this->authorized = $authorized;
   }
-
   public function getAuthorized()
   {
     return $this->authorized;
   }
-
   public function setCreateInFolderTemplate($createInFolderTemplate)
   {
     $this->createInFolderTemplate = $createInFolderTemplate;
   }
-
   public function getCreateInFolderTemplate()
   {
     return $this->createInFolderTemplate;
   }
-
   public function setCreateUrl($createUrl)
   {
     $this->createUrl = $createUrl;
   }
-
   public function getCreateUrl()
   {
     return $this->createUrl;
   }
-
   public function setHasDriveWideScope($hasDriveWideScope)
   {
     $this->hasDriveWideScope = $hasDriveWideScope;
   }
-
   public function getHasDriveWideScope()
   {
     return $this->hasDriveWideScope;
   }
-
   public function setIcons($icons)
   {
     $this->icons = $icons;
   }
-
   public function getIcons()
   {
     return $this->icons;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setInstalled($installed)
   {
     $this->installed = $installed;
   }
-
   public function getInstalled()
   {
     return $this->installed;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLongDescription($longDescription)
   {
     $this->longDescription = $longDescription;
   }
-
   public function getLongDescription()
   {
     return $this->longDescription;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setObjectType($objectType)
   {
     $this->objectType = $objectType;
   }
-
   public function getObjectType()
   {
     return $this->objectType;
   }
-
   public function setOpenUrlTemplate($openUrlTemplate)
   {
     $this->openUrlTemplate = $openUrlTemplate;
   }
-
   public function getOpenUrlTemplate()
   {
     return $this->openUrlTemplate;
   }
-
   public function setPrimaryFileExtensions($primaryFileExtensions)
   {
     $this->primaryFileExtensions = $primaryFileExtensions;
   }
-
   public function getPrimaryFileExtensions()
   {
     return $this->primaryFileExtensions;
   }
-
   public function setPrimaryMimeTypes($primaryMimeTypes)
   {
     $this->primaryMimeTypes = $primaryMimeTypes;
   }
-
   public function getPrimaryMimeTypes()
   {
     return $this->primaryMimeTypes;
   }
-
   public function setProductId($productId)
   {
     $this->productId = $productId;
   }
-
   public function getProductId()
   {
     return $this->productId;
   }
-
   public function setProductUrl($productUrl)
   {
     $this->productUrl = $productUrl;
   }
-
   public function getProductUrl()
   {
     return $this->productUrl;
   }
-
   public function setSecondaryFileExtensions($secondaryFileExtensions)
   {
     $this->secondaryFileExtensions = $secondaryFileExtensions;
   }
-
   public function getSecondaryFileExtensions()
   {
     return $this->secondaryFileExtensions;
   }
-
   public function setSecondaryMimeTypes($secondaryMimeTypes)
   {
     $this->secondaryMimeTypes = $secondaryMimeTypes;
   }
-
   public function getSecondaryMimeTypes()
   {
     return $this->secondaryMimeTypes;
   }
-
   public function setShortDescription($shortDescription)
   {
     $this->shortDescription = $shortDescription;
   }
-
   public function getShortDescription()
   {
     return $this->shortDescription;
   }
-
   public function setSupportsCreate($supportsCreate)
   {
     $this->supportsCreate = $supportsCreate;
   }
-
   public function getSupportsCreate()
   {
     return $this->supportsCreate;
   }
-
   public function setSupportsImport($supportsImport)
   {
     $this->supportsImport = $supportsImport;
   }
-
   public function getSupportsImport()
   {
     return $this->supportsImport;
   }
-
   public function setSupportsMultiOpen($supportsMultiOpen)
   {
     $this->supportsMultiOpen = $supportsMultiOpen;
   }
-
   public function getSupportsMultiOpen()
   {
     return $this->supportsMultiOpen;
   }
-
   public function setSupportsOfflineCreate($supportsOfflineCreate)
   {
     $this->supportsOfflineCreate = $supportsOfflineCreate;
   }
-
   public function getSupportsOfflineCreate()
   {
     return $this->supportsOfflineCreate;
   }
-
   public function setUseByDefault($useByDefault)
   {
     $this->useByDefault = $useByDefault;
   }
-
   public function getUseByDefault()
   {
     return $this->useByDefault;
@@ -3283,31 +3134,27 @@ class Google_Service_Drive_AppIcons extends Google_Model
   public $iconUrl;
   public $size;
 
+
   public function setCategory($category)
   {
     $this->category = $category;
   }
-
   public function getCategory()
   {
     return $this->category;
   }
-
   public function setIconUrl($iconUrl)
   {
     $this->iconUrl = $iconUrl;
   }
-
   public function getIconUrl()
   {
     return $this->iconUrl;
   }
-
   public function setSize($size)
   {
     $this->size = $size;
   }
-
   public function getSize()
   {
     return $this->size;
@@ -3326,51 +3173,43 @@ class Google_Service_Drive_AppList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setDefaultAppIds($defaultAppIds)
   {
     $this->defaultAppIds = $defaultAppIds;
   }
-
   public function getDefaultAppIds()
   {
     return $this->defaultAppIds;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3390,71 +3229,59 @@ class Google_Service_Drive_Change extends Google_Model
   public $modificationDate;
   public $selfLink;
 
+
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setFile(Google_Service_Drive_DriveFile $file)
   {
     $this->file = $file;
   }
-
   public function getFile()
   {
     return $this->file;
   }
-
   public function setFileId($fileId)
   {
     $this->fileId = $fileId;
   }
-
   public function getFileId()
   {
     return $this->fileId;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModificationDate($modificationDate)
   {
     $this->modificationDate = $modificationDate;
   }
-
   public function getModificationDate()
   {
     return $this->modificationDate;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3475,71 +3302,59 @@ class Google_Service_Drive_ChangeList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLargestChangeId($largestChangeId)
   {
     $this->largestChangeId = $largestChangeId;
   }
-
   public function getLargestChangeId()
   {
     return $this->largestChangeId;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3561,101 +3376,83 @@ class Google_Service_Drive_Channel extends Google_Model
   public $token;
   public $type;
 
+
   public function setAddress($address)
   {
     $this->address = $address;
   }
-
   public function getAddress()
   {
     return $this->address;
   }
-
   public function setExpiration($expiration)
   {
     $this->expiration = $expiration;
   }
-
   public function getExpiration()
   {
     return $this->expiration;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setParams($params)
   {
     $this->params = $params;
   }
-
   public function getParams()
   {
     return $this->params;
   }
-
   public function setPayload($payload)
   {
     $this->payload = $payload;
   }
-
   public function getPayload()
   {
     return $this->payload;
   }
-
   public function setResourceId($resourceId)
   {
     $this->resourceId = $resourceId;
   }
-
   public function getResourceId()
   {
     return $this->resourceId;
   }
-
   public function setResourceUri($resourceUri)
   {
     $this->resourceUri = $resourceUri;
   }
-
   public function getResourceUri()
   {
     return $this->resourceUri;
   }
-
   public function setToken($token)
   {
     $this->token = $token;
   }
-
   public function getToken()
   {
     return $this->token;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
@@ -3664,8 +3461,6 @@ class Google_Service_Drive_Channel extends Google_Model
 
 class Google_Service_Drive_ChannelParams extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_ChildList extends Google_Collection
@@ -3681,61 +3476,51 @@ class Google_Service_Drive_ChildList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3751,41 +3536,35 @@ class Google_Service_Drive_ChildReference extends Google_Model
   public $kind;
   public $selfLink;
 
+
   public function setChildLink($childLink)
   {
     $this->childLink = $childLink;
   }
-
   public function getChildLink()
   {
     return $this->childLink;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -3816,151 +3595,123 @@ class Google_Service_Drive_Comment extends Google_Collection
   public $selfLink;
   public $status;
 
+
   public function setAnchor($anchor)
   {
     $this->anchor = $anchor;
   }
-
   public function getAnchor()
   {
     return $this->anchor;
   }
-
   public function setAuthor(Google_Service_Drive_User $author)
   {
     $this->author = $author;
   }
-
   public function getAuthor()
   {
     return $this->author;
   }
-
   public function setCommentId($commentId)
   {
     $this->commentId = $commentId;
   }
-
   public function getCommentId()
   {
     return $this->commentId;
   }
-
   public function setContent($content)
   {
     $this->content = $content;
   }
-
   public function getContent()
   {
     return $this->content;
   }
-
   public function setContext(Google_Service_Drive_CommentContext $context)
   {
     $this->context = $context;
   }
-
   public function getContext()
   {
     return $this->context;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setFileId($fileId)
   {
     $this->fileId = $fileId;
   }
-
   public function getFileId()
   {
     return $this->fileId;
   }
-
   public function setFileTitle($fileTitle)
   {
     $this->fileTitle = $fileTitle;
   }
-
   public function getFileTitle()
   {
     return $this->fileTitle;
   }
-
   public function setHtmlContent($htmlContent)
   {
     $this->htmlContent = $htmlContent;
   }
-
   public function getHtmlContent()
   {
     return $this->htmlContent;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setReplies($replies)
   {
     $this->replies = $replies;
   }
-
   public function getReplies()
   {
     return $this->replies;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setStatus($status)
   {
     $this->status = $status;
   }
-
   public function getStatus()
   {
     return $this->status;
@@ -3974,21 +3725,19 @@ class Google_Service_Drive_CommentContext extends Google_Model
   public $type;
   public $value;
 
+
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
@@ -4007,51 +3756,43 @@ class Google_Service_Drive_CommentList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -4073,91 +3814,75 @@ class Google_Service_Drive_CommentReply extends Google_Model
   public $replyId;
   public $verb;
 
+
   public function setAuthor(Google_Service_Drive_User $author)
   {
     $this->author = $author;
   }
-
   public function getAuthor()
   {
     return $this->author;
   }
-
   public function setContent($content)
   {
     $this->content = $content;
   }
-
   public function getContent()
   {
     return $this->content;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDeleted($deleted)
   {
     $this->deleted = $deleted;
   }
-
   public function getDeleted()
   {
     return $this->deleted;
   }
-
   public function setHtmlContent($htmlContent)
   {
     $this->htmlContent = $htmlContent;
   }
-
   public function getHtmlContent()
   {
     return $this->htmlContent;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setReplyId($replyId)
   {
     $this->replyId = $replyId;
   }
-
   public function getReplyId()
   {
     return $this->replyId;
   }
-
   public function setVerb($verb)
   {
     $this->verb = $verb;
   }
-
   public function getVerb()
   {
     return $this->verb;
@@ -4176,51 +3901,43 @@ class Google_Service_Drive_CommentReplyList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -4295,501 +4012,403 @@ class Google_Service_Drive_DriveFile extends Google_Collection
   public $webViewLink;
   public $writersCanShare;
 
+
   public function setAlternateLink($alternateLink)
   {
     $this->alternateLink = $alternateLink;
   }
-
   public function getAlternateLink()
   {
     return $this->alternateLink;
   }
-
   public function setAppDataContents($appDataContents)
   {
     $this->appDataContents = $appDataContents;
   }
-
   public function getAppDataContents()
   {
     return $this->appDataContents;
   }
-
   public function setCopyable($copyable)
   {
     $this->copyable = $copyable;
   }
-
   public function getCopyable()
   {
     return $this->copyable;
   }
-
   public function setCreatedDate($createdDate)
   {
     $this->createdDate = $createdDate;
   }
-
   public function getCreatedDate()
   {
     return $this->createdDate;
   }
-
   public function setDefaultOpenWithLink($defaultOpenWithLink)
   {
     $this->defaultOpenWithLink = $defaultOpenWithLink;
   }
-
   public function getDefaultOpenWithLink()
   {
     return $this->defaultOpenWithLink;
   }
-
   public function setDescription($description)
   {
     $this->description = $description;
   }
-
   public function getDescription()
   {
     return $this->description;
   }
-
   public function setDownloadUrl($downloadUrl)
   {
     $this->downloadUrl = $downloadUrl;
   }
-
   public function getDownloadUrl()
   {
     return $this->downloadUrl;
   }
-
   public function setEditable($editable)
   {
     $this->editable = $editable;
   }
-
   public function getEditable()
   {
     return $this->editable;
   }
-
   public function setEmbedLink($embedLink)
   {
     $this->embedLink = $embedLink;
   }
-
   public function getEmbedLink()
   {
     return $this->embedLink;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExplicitlyTrashed($explicitlyTrashed)
   {
     $this->explicitlyTrashed = $explicitlyTrashed;
   }
-
   public function getExplicitlyTrashed()
   {
     return $this->explicitlyTrashed;
   }
-
   public function setExportLinks($exportLinks)
   {
     $this->exportLinks = $exportLinks;
   }
-
   public function getExportLinks()
   {
     return $this->exportLinks;
   }
-
   public function setFileExtension($fileExtension)
   {
     $this->fileExtension = $fileExtension;
   }
-
   public function getFileExtension()
   {
     return $this->fileExtension;
   }
-
   public function setFileSize($fileSize)
   {
     $this->fileSize = $fileSize;
   }
-
   public function getFileSize()
   {
     return $this->fileSize;
   }
-
   public function setHeadRevisionId($headRevisionId)
   {
     $this->headRevisionId = $headRevisionId;
   }
-
   public function getHeadRevisionId()
   {
     return $this->headRevisionId;
   }
-
   public function setIconLink($iconLink)
   {
     $this->iconLink = $iconLink;
   }
-
   public function getIconLink()
   {
     return $this->iconLink;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setImageMediaMetadata(Google_Service_Drive_DriveFileImageMediaMetadata $imageMediaMetadata)
   {
     $this->imageMediaMetadata = $imageMediaMetadata;
   }
-
   public function getImageMediaMetadata()
   {
     return $this->imageMediaMetadata;
   }
-
   public function setIndexableText(Google_Service_Drive_DriveFileIndexableText $indexableText)
   {
     $this->indexableText = $indexableText;
   }
-
   public function getIndexableText()
   {
     return $this->indexableText;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLabels(Google_Service_Drive_DriveFileLabels $labels)
   {
     $this->labels = $labels;
   }
-
   public function getLabels()
   {
     return $this->labels;
   }
-
   public function setLastModifyingUser(Google_Service_Drive_User $lastModifyingUser)
   {
     $this->lastModifyingUser = $lastModifyingUser;
   }
-
   public function getLastModifyingUser()
   {
     return $this->lastModifyingUser;
   }
-
   public function setLastModifyingUserName($lastModifyingUserName)
   {
     $this->lastModifyingUserName = $lastModifyingUserName;
   }
-
   public function getLastModifyingUserName()
   {
     return $this->lastModifyingUserName;
   }
-
   public function setLastViewedByMeDate($lastViewedByMeDate)
   {
     $this->lastViewedByMeDate = $lastViewedByMeDate;
   }
-
   public function getLastViewedByMeDate()
   {
     return $this->lastViewedByMeDate;
   }
-
   public function setMarkedViewedByMeDate($markedViewedByMeDate)
   {
     $this->markedViewedByMeDate = $markedViewedByMeDate;
   }
-
   public function getMarkedViewedByMeDate()
   {
     return $this->markedViewedByMeDate;
   }
-
   public function setMd5Checksum($md5Checksum)
   {
     $this->md5Checksum = $md5Checksum;
   }
-
   public function getMd5Checksum()
   {
     return $this->md5Checksum;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
   }
-
   public function setModifiedByMeDate($modifiedByMeDate)
   {
     $this->modifiedByMeDate = $modifiedByMeDate;
   }
-
   public function getModifiedByMeDate()
   {
     return $this->modifiedByMeDate;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setOpenWithLinks($openWithLinks)
   {
     $this->openWithLinks = $openWithLinks;
   }
-
   public function getOpenWithLinks()
   {
     return $this->openWithLinks;
   }
-
   public function setOriginalFilename($originalFilename)
   {
     $this->originalFilename = $originalFilename;
   }
-
   public function getOriginalFilename()
   {
     return $this->originalFilename;
   }
-
   public function setOwnerNames($ownerNames)
   {
     $this->ownerNames = $ownerNames;
   }
-
   public function getOwnerNames()
   {
     return $this->ownerNames;
   }
-
   public function setOwners($owners)
   {
     $this->owners = $owners;
   }
-
   public function getOwners()
   {
     return $this->owners;
   }
-
   public function setParents($parents)
   {
     $this->parents = $parents;
   }
-
   public function getParents()
   {
     return $this->parents;
   }
-
   public function setPermissions($permissions)
   {
     $this->permissions = $permissions;
   }
-
   public function getPermissions()
   {
     return $this->permissions;
   }
-
   public function setProperties($properties)
   {
     $this->properties = $properties;
   }
-
   public function getProperties()
   {
     return $this->properties;
   }
-
   public function setQuotaBytesUsed($quotaBytesUsed)
   {
     $this->quotaBytesUsed = $quotaBytesUsed;
   }
-
   public function getQuotaBytesUsed()
   {
     return $this->quotaBytesUsed;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setShared($shared)
   {
     $this->shared = $shared;
   }
-
   public function getShared()
   {
     return $this->shared;
   }
-
   public function setSharedWithMeDate($sharedWithMeDate)
   {
     $this->sharedWithMeDate = $sharedWithMeDate;
   }
-
   public function getSharedWithMeDate()
   {
     return $this->sharedWithMeDate;
   }
-
   public function setSharingUser(Google_Service_Drive_User $sharingUser)
   {
     $this->sharingUser = $sharingUser;
   }
-
   public function getSharingUser()
   {
     return $this->sharingUser;
   }
-
   public function setThumbnail(Google_Service_Drive_DriveFileThumbnail $thumbnail)
   {
     $this->thumbnail = $thumbnail;
   }
-
   public function getThumbnail()
   {
     return $this->thumbnail;
   }
-
   public function setThumbnailLink($thumbnailLink)
   {
     $this->thumbnailLink = $thumbnailLink;
   }
-
   public function getThumbnailLink()
   {
     return $this->thumbnailLink;
   }
-
   public function setTitle($title)
   {
     $this->title = $title;
   }
-
   public function getTitle()
   {
     return $this->title;
   }
-
   public function setUserPermission(Google_Service_Drive_Permission $userPermission)
   {
     $this->userPermission = $userPermission;
   }
-
   public function getUserPermission()
   {
     return $this->userPermission;
   }
-
   public function setVersion($version)
   {
     $this->version = $version;
   }
-
   public function getVersion()
   {
     return $this->version;
   }
-
   public function setVideoMediaMetadata(Google_Service_Drive_DriveFileVideoMediaMetadata $videoMediaMetadata)
   {
     $this->videoMediaMetadata = $videoMediaMetadata;
   }
-
   public function getVideoMediaMetadata()
   {
     return $this->videoMediaMetadata;
   }
-
   public function setWebContentLink($webContentLink)
   {
     $this->webContentLink = $webContentLink;
   }
-
   public function getWebContentLink()
   {
     return $this->webContentLink;
   }
-
   public function setWebViewLink($webViewLink)
   {
     $this->webViewLink = $webViewLink;
   }
-
   public function getWebViewLink()
   {
     return $this->webViewLink;
   }
-
   public function setWritersCanShare($writersCanShare)
   {
     $this->writersCanShare = $writersCanShare;
   }
-
   public function getWritersCanShare()
   {
     return $this->writersCanShare;
@@ -4798,8 +4417,6 @@ class Google_Service_Drive_DriveFile extends Google_Collection
 
 class Google_Service_Drive_DriveFileExportLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_DriveFileImageMediaMetadata extends Google_Model
@@ -4829,211 +4446,171 @@ class Google_Service_Drive_DriveFileImageMediaMetadata extends Google_Model
   public $whiteBalance;
   public $width;
 
+
   public function setAperture($aperture)
   {
     $this->aperture = $aperture;
   }
-
   public function getAperture()
   {
     return $this->aperture;
   }
-
   public function setCameraMake($cameraMake)
   {
     $this->cameraMake = $cameraMake;
   }
-
   public function getCameraMake()
   {
     return $this->cameraMake;
   }
-
   public function setCameraModel($cameraModel)
   {
     $this->cameraModel = $cameraModel;
   }
-
   public function getCameraModel()
   {
     return $this->cameraModel;
   }
-
   public function setColorSpace($colorSpace)
   {
     $this->colorSpace = $colorSpace;
   }
-
   public function getColorSpace()
   {
     return $this->colorSpace;
   }
-
   public function setDate($date)
   {
     $this->date = $date;
   }
-
   public function getDate()
   {
     return $this->date;
   }
-
   public function setExposureBias($exposureBias)
   {
     $this->exposureBias = $exposureBias;
   }
-
   public function getExposureBias()
   {
     return $this->exposureBias;
   }
-
   public function setExposureMode($exposureMode)
   {
     $this->exposureMode = $exposureMode;
   }
-
   public function getExposureMode()
   {
     return $this->exposureMode;
   }
-
   public function setExposureTime($exposureTime)
   {
     $this->exposureTime = $exposureTime;
   }
-
   public function getExposureTime()
   {
     return $this->exposureTime;
   }
-
   public function setFlashUsed($flashUsed)
   {
     $this->flashUsed = $flashUsed;
   }
-
   public function getFlashUsed()
   {
     return $this->flashUsed;
   }
-
   public function setFocalLength($focalLength)
   {
     $this->focalLength = $focalLength;
   }
-
   public function getFocalLength()
   {
     return $this->focalLength;
   }
-
   public function setHeight($height)
   {
     $this->height = $height;
   }
-
   public function getHeight()
   {
     return $this->height;
   }
-
   public function setIsoSpeed($isoSpeed)
   {
     $this->isoSpeed = $isoSpeed;
   }
-
   public function getIsoSpeed()
   {
     return $this->isoSpeed;
   }
-
   public function setLens($lens)
   {
     $this->lens = $lens;
   }
-
   public function getLens()
   {
     return $this->lens;
   }
-
   public function setLocation(Google_Service_Drive_DriveFileImageMediaMetadataLocation $location)
   {
     $this->location = $location;
   }
-
   public function getLocation()
   {
     return $this->location;
   }
-
   public function setMaxApertureValue($maxApertureValue)
   {
     $this->maxApertureValue = $maxApertureValue;
   }
-
   public function getMaxApertureValue()
   {
     return $this->maxApertureValue;
   }
-
   public function setMeteringMode($meteringMode)
   {
     $this->meteringMode = $meteringMode;
   }
-
   public function getMeteringMode()
   {
     return $this->meteringMode;
   }
-
   public function setRotation($rotation)
   {
     $this->rotation = $rotation;
   }
-
   public function getRotation()
   {
     return $this->rotation;
   }
-
   public function setSensor($sensor)
   {
     $this->sensor = $sensor;
   }
-
   public function getSensor()
   {
     return $this->sensor;
   }
-
   public function setSubjectDistance($subjectDistance)
   {
     $this->subjectDistance = $subjectDistance;
   }
-
   public function getSubjectDistance()
   {
     return $this->subjectDistance;
   }
-
   public function setWhiteBalance($whiteBalance)
   {
     $this->whiteBalance = $whiteBalance;
   }
-
   public function getWhiteBalance()
   {
     return $this->whiteBalance;
   }
-
   public function setWidth($width)
   {
     $this->width = $width;
   }
-
   public function getWidth()
   {
     return $this->width;
@@ -5048,31 +4625,27 @@ class Google_Service_Drive_DriveFileImageMediaMetadataLocation extends Google_Mo
   public $latitude;
   public $longitude;
 
+
   public function setAltitude($altitude)
   {
     $this->altitude = $altitude;
   }
-
   public function getAltitude()
   {
     return $this->altitude;
   }
-
   public function setLatitude($latitude)
   {
     $this->latitude = $latitude;
   }
-
   public function getLatitude()
   {
     return $this->latitude;
   }
-
   public function setLongitude($longitude)
   {
     $this->longitude = $longitude;
   }
-
   public function getLongitude()
   {
     return $this->longitude;
@@ -5085,11 +4658,11 @@ class Google_Service_Drive_DriveFileIndexableText extends Google_Model
   );
   public $text;
 
+
   public function setText($text)
   {
     $this->text = $text;
   }
-
   public function getText()
   {
     return $this->text;
@@ -5106,51 +4679,43 @@ class Google_Service_Drive_DriveFileLabels extends Google_Model
   public $trashed;
   public $viewed;
 
+
   public function setHidden($hidden)
   {
     $this->hidden = $hidden;
   }
-
   public function getHidden()
   {
     return $this->hidden;
   }
-
   public function setRestricted($restricted)
   {
     $this->restricted = $restricted;
   }
-
   public function getRestricted()
   {
     return $this->restricted;
   }
-
   public function setStarred($starred)
   {
     $this->starred = $starred;
   }
-
   public function getStarred()
   {
     return $this->starred;
   }
-
   public function setTrashed($trashed)
   {
     $this->trashed = $trashed;
   }
-
   public function getTrashed()
   {
     return $this->trashed;
   }
-
   public function setViewed($viewed)
   {
     $this->viewed = $viewed;
   }
-
   public function getViewed()
   {
     return $this->viewed;
@@ -5159,8 +4724,6 @@ class Google_Service_Drive_DriveFileLabels extends Google_Model
 
 class Google_Service_Drive_DriveFileOpenWithLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_DriveFileThumbnail extends Google_Model
@@ -5170,21 +4733,19 @@ class Google_Service_Drive_DriveFileThumbnail extends Google_Model
   public $image;
   public $mimeType;
 
+
   public function setImage($image)
   {
     $this->image = $image;
   }
-
   public function getImage()
   {
     return $this->image;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
@@ -5199,31 +4760,27 @@ class Google_Service_Drive_DriveFileVideoMediaMetadata extends Google_Model
   public $height;
   public $width;
 
+
   public function setDurationMillis($durationMillis)
   {
     $this->durationMillis = $durationMillis;
   }
-
   public function getDurationMillis()
   {
     return $this->durationMillis;
   }
-
   public function setHeight($height)
   {
     $this->height = $height;
   }
-
   public function getHeight()
   {
     return $this->height;
   }
-
   public function setWidth($width)
   {
     $this->width = $width;
   }
-
   public function getWidth()
   {
     return $this->width;
@@ -5243,61 +4800,51 @@ class Google_Service_Drive_FileList extends Google_Collection
   public $nextPageToken;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setNextLink($nextLink)
   {
     $this->nextLink = $nextLink;
   }
-
   public function getNextLink()
   {
     return $this->nextLink;
   }
-
   public function setNextPageToken($nextPageToken)
   {
     $this->nextPageToken = $nextPageToken;
   }
-
   public function getNextPageToken()
   {
     return $this->nextPageToken;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5315,41 +4862,35 @@ class Google_Service_Drive_ParentList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5366,51 +4907,43 @@ class Google_Service_Drive_ParentReference extends Google_Model
   public $parentLink;
   public $selfLink;
 
+
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setIsRoot($isRoot)
   {
     $this->isRoot = $isRoot;
   }
-
   public function getIsRoot()
   {
     return $this->isRoot;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setParentLink($parentLink)
   {
     $this->parentLink = $parentLink;
   }
-
   public function getParentLink()
   {
     return $this->parentLink;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5437,141 +4970,115 @@ class Google_Service_Drive_Permission extends Google_Collection
   public $value;
   public $withLink;
 
+
   public function setAdditionalRoles($additionalRoles)
   {
     $this->additionalRoles = $additionalRoles;
   }
-
   public function getAdditionalRoles()
   {
     return $this->additionalRoles;
   }
-
   public function setAuthKey($authKey)
   {
     $this->authKey = $authKey;
   }
-
   public function getAuthKey()
   {
     return $this->authKey;
   }
-
   public function setDomain($domain)
   {
     $this->domain = $domain;
   }
-
   public function getDomain()
   {
     return $this->domain;
   }
-
   public function setEmailAddress($emailAddress)
   {
     $this->emailAddress = $emailAddress;
   }
-
   public function getEmailAddress()
   {
     return $this->emailAddress;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setName($name)
   {
     $this->name = $name;
   }
-
   public function getName()
   {
     return $this->name;
   }
-
   public function setPhotoLink($photoLink)
   {
     $this->photoLink = $photoLink;
   }
-
   public function getPhotoLink()
   {
     return $this->photoLink;
   }
-
   public function setRole($role)
   {
     $this->role = $role;
   }
-
   public function getRole()
   {
     return $this->role;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setType($type)
   {
     $this->type = $type;
   }
-
   public function getType()
   {
     return $this->type;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
   }
-
   public function setWithLink($withLink)
   {
     $this->withLink = $withLink;
   }
-
   public function getWithLink()
   {
     return $this->withLink;
@@ -5585,21 +5092,19 @@ class Google_Service_Drive_PermissionId extends Google_Model
   public $id;
   public $kind;
 
+
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
@@ -5617,41 +5122,35 @@ class Google_Service_Drive_PermissionList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5669,61 +5168,51 @@ class Google_Service_Drive_Property extends Google_Model
   public $value;
   public $visibility;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setKey($key)
   {
     $this->key = $key;
   }
-
   public function getKey()
   {
     return $this->key;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
   }
-
   public function setValue($value)
   {
     $this->value = $value;
   }
-
   public function getValue()
   {
     return $this->value;
   }
-
   public function setVisibility($visibility)
   {
     $this->visibility = $visibility;
   }
-
   public function getVisibility()
   {
     return $this->visibility;
@@ -5741,41 +5230,35 @@ class Google_Service_Drive_PropertyList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5806,181 +5289,147 @@ class Google_Service_Drive_Revision extends Google_Model
   public $publishedOutsideDomain;
   public $selfLink;
 
+
   public function setDownloadUrl($downloadUrl)
   {
     $this->downloadUrl = $downloadUrl;
   }
-
   public function getDownloadUrl()
   {
     return $this->downloadUrl;
   }
-
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setExportLinks($exportLinks)
   {
     $this->exportLinks = $exportLinks;
   }
-
   public function getExportLinks()
   {
     return $this->exportLinks;
   }
-
   public function setFileSize($fileSize)
   {
     $this->fileSize = $fileSize;
   }
-
   public function getFileSize()
   {
     return $this->fileSize;
   }
-
   public function setId($id)
   {
     $this->id = $id;
   }
-
   public function getId()
   {
     return $this->id;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setLastModifyingUser(Google_Service_Drive_User $lastModifyingUser)
   {
     $this->lastModifyingUser = $lastModifyingUser;
   }
-
   public function getLastModifyingUser()
   {
     return $this->lastModifyingUser;
   }
-
   public function setLastModifyingUserName($lastModifyingUserName)
   {
     $this->lastModifyingUserName = $lastModifyingUserName;
   }
-
   public function getLastModifyingUserName()
   {
     return $this->lastModifyingUserName;
   }
-
   public function setMd5Checksum($md5Checksum)
   {
     $this->md5Checksum = $md5Checksum;
   }
-
   public function getMd5Checksum()
   {
     return $this->md5Checksum;
   }
-
   public function setMimeType($mimeType)
   {
     $this->mimeType = $mimeType;
   }
-
   public function getMimeType()
   {
     return $this->mimeType;
   }
-
   public function setModifiedDate($modifiedDate)
   {
     $this->modifiedDate = $modifiedDate;
   }
-
   public function getModifiedDate()
   {
     return $this->modifiedDate;
   }
-
   public function setOriginalFilename($originalFilename)
   {
     $this->originalFilename = $originalFilename;
   }
-
   public function getOriginalFilename()
   {
     return $this->originalFilename;
   }
-
   public function setPinned($pinned)
   {
     $this->pinned = $pinned;
   }
-
   public function getPinned()
   {
     return $this->pinned;
   }
-
   public function setPublishAuto($publishAuto)
   {
     $this->publishAuto = $publishAuto;
   }
-
   public function getPublishAuto()
   {
     return $this->publishAuto;
   }
-
   public function setPublished($published)
   {
     $this->published = $published;
   }
-
   public function getPublished()
   {
     return $this->published;
   }
-
   public function setPublishedLink($publishedLink)
   {
     $this->publishedLink = $publishedLink;
   }
-
   public function getPublishedLink()
   {
     return $this->publishedLink;
   }
-
   public function setPublishedOutsideDomain($publishedOutsideDomain)
   {
     $this->publishedOutsideDomain = $publishedOutsideDomain;
   }
-
   public function getPublishedOutsideDomain()
   {
     return $this->publishedOutsideDomain;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -5989,8 +5438,6 @@ class Google_Service_Drive_Revision extends Google_Model
 
 class Google_Service_Drive_RevisionExportLinks extends Google_Model
 {
-  protected $internal_gapi_mappings = array(
-  );
 }
 
 class Google_Service_Drive_RevisionList extends Google_Collection
@@ -6004,41 +5451,35 @@ class Google_Service_Drive_RevisionList extends Google_Collection
   public $kind;
   public $selfLink;
 
+
   public function setEtag($etag)
   {
     $this->etag = $etag;
   }
-
   public function getEtag()
   {
     return $this->etag;
   }
-
   public function setItems($items)
   {
     $this->items = $items;
   }
-
   public function getItems()
   {
     return $this->items;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setSelfLink($selfLink)
   {
     $this->selfLink = $selfLink;
   }
-
   public function getSelfLink()
   {
     return $this->selfLink;
@@ -6057,61 +5498,51 @@ class Google_Service_Drive_User extends Google_Model
   protected $pictureType = 'Google_Service_Drive_UserPicture';
   protected $pictureDataType = '';
 
+
   public function setDisplayName($displayName)
   {
     $this->displayName = $displayName;
   }
-
   public function getDisplayName()
   {
     return $this->displayName;
   }
-
   public function setEmailAddress($emailAddress)
   {
     $this->emailAddress = $emailAddress;
   }
-
   public function getEmailAddress()
   {
     return $this->emailAddress;
   }
-
   public function setIsAuthenticatedUser($isAuthenticatedUser)
   {
     $this->isAuthenticatedUser = $isAuthenticatedUser;
   }
-
   public function getIsAuthenticatedUser()
   {
     return $this->isAuthenticatedUser;
   }
-
   public function setKind($kind)
   {
     $this->kind = $kind;
   }
-
   public function getKind()
   {
     return $this->kind;
   }
-
   public function setPermissionId($permissionId)
   {
     $this->permissionId = $permissionId;
   }
-
   public function getPermissionId()
   {
     return $this->permissionId;
   }
-
   public function setPicture(Google_Service_Drive_UserPicture $picture)
   {
     $this->picture = $picture;
   }
-
   public function getPicture()
   {
     return $this->picture;
@@ -6124,11 +5555,11 @@ class Google_Service_Drive_UserPicture extends Google_Model
   );
   public $url;
 
+
   public function setUrl($url)
   {
     $this->url = $url;
   }
-
   public function getUrl()
   {
     return $this->url;

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Exception.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Exception.php
@@ -1,8 +1,23 @@
 <?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-require_once 'Google/Exception.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_Service_Exception extends Google_Exception
+class Google_Service_Exception extends Google_Exception implements Google_Task_Retryable
 {
   /**
    * Optional list of errors returned in a JSON body of an HTTP error response.
@@ -10,19 +25,27 @@ class Google_Service_Exception extends Google_Exception
   protected $errors = array();
 
   /**
-   * Override default constructor to add ability to set $errors.
+   * @var array $retryMap Map of errors with retry counts.
+   */
+  private $retryMap = array();
+
+  /**
+   * Override default constructor to add the ability to set $errors and a retry
+   * map.
    *
    * @param string $message
    * @param int $code
    * @param Exception|null $previous
    * @param [{string, string}] errors List of errors returned in an HTTP
    * response.  Defaults to [].
+   * @param array|null $retryMap Map of errors with retry counts.
    */
   public function __construct(
       $message,
       $code = 0,
       Exception $previous = null,
-      $errors = array()
+      $errors = array(),
+      array $retryMap = null
   ) {
     if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
       parent::__construct($message, $code, $previous);
@@ -31,6 +54,10 @@ class Google_Service_Exception extends Google_Exception
     }
 
     $this->errors = $errors;
+
+    if (is_array($retryMap)) {
+      $this->retryMap = $retryMap;
+    }
   }
 
   /**
@@ -49,5 +76,28 @@ class Google_Service_Exception extends Google_Exception
   public function getErrors()
   {
     return $this->errors;
+  }
+
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries()
+  {
+    if (isset($this->retryMap[$this->code])) {
+      return $this->retryMap[$this->code];
+    }
+
+    $errors = $this->getErrors();
+
+    if (!empty($errors) && isset($errors[0]['reason']) &&
+        isset($this->retryMap[$errors[0]['reason']])) {
+      return $this->retryMap[$errors[0]['reason']];
+    }
+
+    return 0;
   }
 }

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resource.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Service/Resource.php
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Exception.php';
-require_once 'Google/Utils.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/MediaFileUpload.php';
-require_once 'Google/Http/REST.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Implements the actual methods/resources of the discovered Google API using magic function
@@ -84,6 +79,15 @@ class Google_Service_Resource
   public function call($name, $arguments, $expected_class = null)
   {
     if (! isset($this->methods[$name])) {
+      $this->client->getLogger()->error(
+          'Service method unknown',
+          array(
+              'service' => $this->serviceName,
+              'resource' => $this->resourceName,
+              'method' => $name
+          )
+      );
+
       throw new Google_Exception(
           "Unknown function: " .
           "{$this->serviceName}->{$this->resourceName}->{$name}()"
@@ -129,6 +133,15 @@ class Google_Service_Resource
     );
     foreach ($parameters as $key => $val) {
       if ($key != 'postBody' && ! isset($method['parameters'][$key])) {
+        $this->client->getLogger()->error(
+            'Service parameter unknown',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $key
+            )
+        );
         throw new Google_Exception("($name) unknown parameter: '$key'");
       }
     }
@@ -138,6 +151,15 @@ class Google_Service_Resource
           $paramSpec['required'] &&
           ! isset($parameters[$paramName])
       ) {
+        $this->client->getLogger()->error(
+            'Service parameter missing',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $paramName
+            )
+        );
         throw new Google_Exception("($name) missing required param: '$paramName'");
       }
       if (isset($parameters[$paramName])) {
@@ -152,6 +174,16 @@ class Google_Service_Resource
     }
 
     $servicePath = $this->service->servicePath;
+
+    $this->client->getLogger()->info(
+        'Service Call',
+        array(
+            'service' => $this->serviceName,
+            'resource' => $this->resourceName,
+            'method' => $name,
+            'arguments' => $parameters,
+        )
+    );
 
     $url = Google_Http_REST::createRequestUri(
         $servicePath,

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Signer/P12.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Signer/P12.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Signer/Abstract.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Signs data.

--- a/apps/files_external/3rdparty/google-api-php-client/src/Google/Verifier/Pem.php
+++ b/apps/files_external/3rdparty/google-api-php-client/src/Google/Verifier/Pem.php
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
  
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Verifier/Abstract.php';
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
  * Verifies signatures using PEM encoded certificates.


### PR DESCRIPTION
Just keeping up to date with upstream. Adds an autoloader. Also adds a logging mechanism with a couple of implementations, we could perhaps see if we can take advantage of that to stream the library's logs into the OC logs, but I didn't look into that yet.

I'm getting an error from doctrine-dbal trying to run the tests ATM, but I at least did a manual test of 1.1.2 on my server and it seems to work fine. If anyone else can run the test suite on this it'd be a help, thanks.
