### PR TITLE
remove skip to content for now, see #12999

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -7,6 +7,7 @@
 	-ms-user-select: none;
 }
 
+/* removed until content-focusing issue is fixed */
 #skip-to-content a {
 	position: absolute;
 	left: -10000px;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -62,10 +62,6 @@
 				<div class="icon-caret svg"></div>
 			</a>
 
-			<div id="skip-to-content">
-				<a href="#app-content" tabindex="1"><?php p($l->t('Skip to content')); ?></a>
-			</div>
-
 			<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 			<div id="settings" class="svg">
 				<div id="expand" tabindex="4" role="link">


### PR DESCRIPTION
Since the »skip to content« link does not work yet, we shouldn’t display it. We should reintroduce it alongside a content-focusing fix for #12999 

Please review @owncloud/designers @DeepDiver1975 
