### PR TITLE
don't delete share table entries for the unique name if re-share permission was removed

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -73,9 +73,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$return = OCP\Share::setPermissions(
 					$_POST['itemType'],
 					$_POST['itemSource'],
-					$_POST['shareType'],
+					(int)$_POST['shareType'],
 					$_POST['shareWith'],
-					$_POST['permissions']
+					(int)$_POST['permissions']
 				);
 				($return) ? OC_JSON::success() : OC_JSON::error();
 			}

--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -96,12 +96,12 @@ class Helper extends \OC\Share\Constants {
 			// finding and deleting the reshares by a single user of a group share
 			if (count($ids) == 1 && isset($uidOwner)) {
 				$query = \OC_DB::prepare('SELECT `id`, `share_with`, `item_type`, `share_type`, `item_target`, `file_target`, `parent`'
-					.' FROM `*PREFIX*share` WHERE `parent` IN ('.$parents.') AND `uid_owner` = ?');
-				$result = $query->execute(array($uidOwner));
+					.' FROM `*PREFIX*share` WHERE `parent` IN ('.$parents.') AND `uid_owner` = ? AND `share_type` != ?');
+				$result = $query->execute(array($uidOwner, self::$shareTypeGroupUserUnique));
 			} else {
 				$query = \OC_DB::prepare('SELECT `id`, `share_with`, `item_type`, `share_type`, `item_target`, `file_target`, `parent`, `uid_owner`'
-					.' FROM `*PREFIX*share` WHERE `parent` IN ('.$parents.')');
-				$result = $query->execute();
+					.' FROM `*PREFIX*share` WHERE `parent` IN ('.$parents.') AND `share_type` != ?');
+				$result = $query->execute(array(self::$shareTypeGroupUserUnique));
 			}
 			// Reset parents array, only go through loop again if items are found
 			$parents = array();


### PR DESCRIPTION
If reshare permission was removed from a share we remove all reshares from the table. But we should keep the table entries for the unique name.
