### PR TITLE
Configurabe owncloud temporary directory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -86,6 +86,16 @@ $CONFIG = array(
 'datadirectory' => '/var/www/owncloud/data',
 
 /**
+ * Where ownCloud stores temporary files. Only needed in conjunction with 
+ * external storage types who do not support piping and high temporary data volume 
+ * is expected. May occur with many concurrent data uploads with big sizes.  
+ * Grant write permissions of the webserver user to the path given.
+ * If not used, ownCloud takes the system default.
+ * The path used can be seen in the ownCloud log if loglevel is set to debug.
+ */
+'tempdirectory' => '/mnt/owncloudtemp',
+
+/**
  * The current version number of your ownCloud installation. This is set up
  * during installation and update, so you shouldn't need to change it.
  */

--- a/lib/base.php
+++ b/lib/base.php
@@ -974,60 +974,15 @@ class OC {
 		}
 		return true;
 	}
-}
-
-if (!function_exists('get_temp_dir')) {
 	/**
-	 * Get the temporary directory to store transfer data
-	 * @return null|string Path to the temporary directory or null
-	 */
+	* Get the temporary dir to store uploaded data
+	* @return null|string Path to the temporary directory or null
+	*/
 	function get_temp_dir() {
-		// Get the temporary directory and log the path if loglevel is set to debug
-		// Info: based on the temp dir, further directories may be created unique to the instance
-		$temp = gather_temp_dir();
-		\OCP\Util::writeLog('Core', 'Temporary directory set to: ' . ($temp ? $temp : 'NULL'), \OCP\Util::DEBUG);
-		return $temp;
+		return \OC::$server->getTempManager()->t_get_temp_dir();
 	}
 
-	/**
-	 * Get a temporary directory from possible sources
-	 * If a temporary directory is set in config.php, use this one
-	 * @return null|string Path to the temporary directory or null
-	 */
-	function gather_temp_dir() {
-		if ($temp = get_config_temp_dir()) return $temp;
-		if ($temp = ini_get('upload_tmp_dir')) return $temp;
-		if ($temp = getenv('TMP')) return $temp;
-		if ($temp = getenv('TEMP')) return $temp;
-		if ($temp = getenv('TMPDIR')) return $temp;
-		$temp = tempnam(__FILE__, '');
-		if (file_exists($temp)) {
-			unlink($temp);
-			return dirname($temp);
-		}
-		if ($temp = sys_get_temp_dir()) return $temp;
-		return null;
-	}
-
-	/**
-	 * Check if the temporary directory is defined in config.php and is present and writable
-	 * @return bool|string Path to the temporary directory or false
-	 */
-	function get_config_temp_dir() {
-		$temp = \OC::$server->getConfig()->getSystemValue('tempdirectory', false);
-		// supress any possible errors caused by is_writable
-		// checks missing or invalid path or characters, wrong permissions ect
-		try {
-			if (is_writeable($temp)) {
-				return $temp;
-			} else {
-				\OCP\Util::writeLog('Core', 'Manually set temporary directory in config.php is not present or writable: ' . $temp, \OCP\Util::WARN);
-				return false;
-			}
-		} catch (Exception $e) {
-			return false;
-		}
-	}
 }
+
 
 OC::init();

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -266,7 +266,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 		});
 		$this->registerService('TempManager', function (Server $c) {
-			return new TempManager(get_temp_dir(), $c->getLogger());
+			return new TempManager($c->getLogger());
 		});
 		$this->registerService('AppManager', function(Server $c) {
 			$userSession = $c->getUserSession();

--- a/lib/private/tempmanager.php
+++ b/lib/private/tempmanager.php
@@ -33,11 +33,10 @@ class TempManager implements ITempManager {
 	protected $log;
 
 	/**
-	 * @param string $baseDir
 	 * @param \OCP\ILogger $logger
 	 */
-	public function __construct($baseDir, ILogger $logger) {
-		$this->tmpBaseDir = $baseDir;
+	public function __construct(ILogger $logger) {
+		$this->tmpBaseDir = $this->t_get_temp_dir();
 		$this->log = $logger;
 	}
 
@@ -143,4 +142,59 @@ class TempManager implements ITempManager {
 		}
 		return $files;
 	}
+
+	/**
+	 * Get the temporary directory to store transfer data
+	 * @return null|string Path to the temporary directory or null
+	 */
+	public function t_get_temp_dir() {
+		// Get the temporary directory and log the path if loglevel is set to debug
+		// Info: based on the temp dir, further directories may be created unique to the instance
+		$temp = self::gather_temp_dir();
+		\OCP\Util::writeLog('Core', 'Temporary directory set to: ' . ($temp ? $temp : 'NULL'), \OCP\Util::DEBUG);
+		return $temp;
+	}
+
+	/**
+	 * Get a temporary directory from possible sources
+	 * If a temporary directory is set in config.php, use this one
+	 * @return null|string Path to the temporary directory or null
+	 */
+	private function gather_temp_dir() {
+		if ($temp = self::get_config_temp_dir()) return $temp;
+		if ($temp = ini_get('upload_tmp_dir')) return $temp;
+		if ($temp = getenv('TMP')) return $temp;
+		if ($temp = getenv('TEMP')) return $temp;
+		if ($temp = getenv('TMPDIR')) return $temp;
+		$temp = tempnam(__FILE__, '');
+		if (file_exists($temp)) {
+			unlink($temp);
+			return dirname($temp);
+		}
+		if ($temp = sys_get_temp_dir()) return $temp;
+		return null;
+	}
+
+	/**
+	 * Check if the temporary directory is defined in config.php and is present and writable
+	 * @return bool|string Path to the temporary directory or false
+	 */
+	private function get_config_temp_dir() {
+		$temp = \OC::$server->getConfig()->getSystemValue('tempdirectory', false);
+		// surpress any possible errors caused by is_writable
+		// checks missing or invalid path or characters, wrong permissions ect
+		if ($temp) {
+			try {
+				if (is_writeable($temp)) {
+					return $temp;
+				} else {
+					\OCP\Util::writeLog('Core', 'Manually set temporary directory in config.php is not present or writable: ' . $temp, \OCP\Util::WARN);
+					return false;
+				}
+			} catch (Exception $e) {
+				return false;
+			}
+		}
+	}
+
 }

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -22,12 +22,11 @@ class NullLogger extends Log {
 }
 
 class TempManager extends \Test\TestCase {
-	protected $baseDir;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->baseDir = get_temp_dir() . $this->getUniqueID('/oc_tmp_test');
+		$this->baseDir = $this->getManager()->t_get_temp_dir() . $this->getUniqueID('/oc_tmp_test');
 		if (!is_dir($this->baseDir)) {
 			mkdir($this->baseDir);
 		}
@@ -46,7 +45,7 @@ class TempManager extends \Test\TestCase {
 		if (!$logger) {
 			$logger = new NullLogger();
 		}
-		return new \OC\TempManager($this->baseDir, $logger);
+		return new \OC\TempManager($logger);
 	}
 
 	public function testGetFile() {


### PR DESCRIPTION
This is a PR for #12910

It is now possible to make the temporary directory used by owncloud configurable via config.php

The tag used is: 'tempdirectory' 

If this parameter does not exist, all stays the same as before.
If the parameter exists, the given path is used if the path is physically present and writable by owncloud.

I have tried all possibilities:
- having no tag present
- tag present but path contains special/invalid characters
- tag and path present but path is physically not present
- tag and path present, path exists physically but is not writable (wrong permissions)

I also added two debug log entries:
- log which temporary path is used by owncloud (in any case)
- log if the config.php path given is not present / not writable

If this PR gets approved and merged, I would also do a PR for the documentation.

Marry Christmas to you all
