### PR TITLE
Use md5() instead of hash() for md5sum

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -879,7 +879,7 @@ class OC_Mount_Config {
 				'o' => $config['options']
 			)
 		);
-		return hash('md5', $data);
+		return md5($data);
 	}
 
 	private static function addStorageIdToConfig($user) {


### PR DESCRIPTION
Although the PHP docs say otherwise, hash() isn't available everywhere, whereas md5() is.

I'm running ownCloud on an ARM-based router running TomatoWRT with PHP5.5, and it doesn't have any extensions installed.  It complains that hash() is not a known function, but is quite happy with md5() as a replacement
