### PR TITLE
[WIP] Added upload size unit selection

### DIFF
--- a/apps/files/admin.php
+++ b/apps/files/admin.php
@@ -28,10 +28,15 @@ $htaccessWorking=(getenv('htaccessWorking')=='true');
 $upload_max_filesize = OCP\Util::computerFileSize(ini_get('upload_max_filesize'));
 $post_max_size = OCP\Util::computerFileSize(ini_get('post_max_size'));
 $maxUploadFilesize = OCP\Util::humanFileSize(min($upload_max_filesize, $post_max_size));
+$maxUploadFilesizeValue = explode(" ", $maxUploadFilesize)[0];
+$maxUploadFilesizeUnit = explode(" ", $maxUploadFilesize)[1];
 if($_POST && OC_Util::isCallRegistered()) {
-	if(isset($_POST['maxUploadSize'])) {
-		if(($setMaxSize = OC_Files::setUploadLimit(OCP\Util::computerFileSize($_POST['maxUploadSize']))) !== false) {
+	if(isset($_POST['maxUploadSizeValue']) && isset($_POST['maxUploadSizeUnit'])) {
+		$maxUploadFilesize = $_POST['maxUploadSizeValue']." ".$_POST['maxUploadSizeUnit'];
+		if(($setMaxSize = OC_Files::setUploadLimit(OCP\Util::computerFileSize($maxUploadFilesize))) !== false) {
 			$maxUploadFilesize = OCP\Util::humanFileSize($setMaxSize);
+			$maxUploadFilesizeValue = explode(" ", $maxUploadFilesize)[0];
+			$maxUploadFilesizeUnit = explode(" ", $maxUploadFilesize)[1];
 		}
 	}
 }
@@ -42,7 +47,8 @@ $htaccessWritable=is_writable(OC::$SERVERROOT.'/.htaccess');
 
 $tmpl = new OCP\Template( 'files', 'admin' );
 $tmpl->assign( 'uploadChangable', $htaccessWorking and $htaccessWritable );
-$tmpl->assign( 'uploadMaxFilesize', $maxUploadFilesize);
+$tmpl->assign( 'uploadMaxFilesizeValue', $maxUploadFilesizeValue);
+$tmpl->assign( 'uploadMaxFilesizeUnit', $maxUploadFilesizeUnit);
 // max possible makes only sense on a 32 bit system
 $tmpl->assign( 'displayMaxPossibleUploadSize', PHP_INT_SIZE===4);
 $tmpl->assign( 'maxPossibleUploadSize', OCP\Util::humanFileSize(PHP_INT_MAX));

--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -2,10 +2,29 @@
 
 	<?php OCP\Util::addscript('files', 'admin'); ?>
 
+	<?php
+		$maxuploadsizeunits = array(
+		'B',
+		'kB',
+		'MB',
+		'GB',
+		'TB',
+		);
+	?>
+
 	<form name="filesForm" class="section" action="#" method="post">
 		<h2><?php p($l->t('File handling')); ?></h2>
 		<label for="maxUploadSize"><?php p($l->t( 'Maximum upload size' )); ?> </label>
-		<input type="text" name='maxUploadSize' id="maxUploadSize" value='<?php p($_['uploadMaxFilesize']) ?>'/>
+		<input type="text" name='maxUploadSizeValue' id="maxUploadSizeValue" value='<?php p($_['uploadMaxFilesizeValue']) ?>'/>
+		<select name="maxUploadSizeUnit" id="maxUploadSizeUnit">
+			<?php foreach ($maxuploadsizeunits as $unit):
+				$selected = '';
+				if ($unit == $_['uploadMaxFilesizeUnit']):
+					$selected = 'selected="selected"';
+				endif; ?>
+				<option value='<?php p($unit)?>' <?php p($selected) ?>><?php p($unit) ?></option>
+			<?php endforeach;?>
+		</select>
 		<?php if($_['displayMaxPossibleUploadSize']):?>
 			(<?php p($l->t('max. possible: ')); p($_['maxPossibleUploadSize']) ?>)
 		<?php endif;?>

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -239,6 +239,11 @@ span.securitywarning, span.connectionwarning, .setupwarning {
 	color:#C33;
 	font-weight:bold;
 }
+
+#maxUploadSizeUnit {
+	vertical-align: top;
+}
+
 #shareAPI p { padding-bottom: 0.8em; }
 #shareAPI input#shareapiExpireAfterNDays {width: 25px;}
 #shareAPI .indent {


### PR DESCRIPTION
This is in response to [Pull Request 13026](https://github.com/owncloud/core/pull/13026).

The selection list is added and works.

It uses the existing functionality to determine which units to use when displaying the page. If the user submits 1024 MB then it will display 1 GB when loading the resulting page.

The selection list isn't perfectly aligned (it's about 1-2 px lower than the text box to the left of it). I think this is a separate issue, since it also occurs on the "settings/user" page where you choose the groups.
