### PR TITLE
require OC 7.8 not 8, or we don't work with current master

### DIFF
--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -13,7 +13,7 @@
 	</description>
 	<licence>AGPL</licence>
 	<author>Tom Needham</author>
-	<requiremin>8</requiremin>
+	<requiremin>7.8</requiremin>
 	<shipped>true</shipped>
 	<default_enable/>
 	<documentation>


### PR DESCRIPTION
core has its version set to x.8.y before pre-releases start shipping, then x.9.y when pre-releases are shipping; requiring 8 means the app is disabled until much later.

of course, don't apply if the app isn't actually meant to be enabled yet :)
