### PR TITLE
Fix: X-Accel-Redirect did not support custom data dir and local mounts

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -161,12 +161,11 @@ class OC_Files {
 	 * @param false|string $filename
 	 */
 	private static function addSendfileHeader($filename) {
+		$filename = \OC\Files\Filesystem::getLocalFile($filename);
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
-			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
-			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			if (isset($_SERVER['HTTP_RANGE']) &&
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
@@ -182,7 +181,6 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
-			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -182,7 +182,7 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
-			$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}


### PR DESCRIPTION
I was moving my install with a custom data directory and a local mount to ngnix, and I ran into this problem. (Cloud not download anything with MOD_X_ACCEL_REDIRECT_ENABLED on). It was a nightmare to debug, but here it is.

This contribution is MIT licensed.
