### PR TITLE
allow css/js asset directory to be relocated ('assetdirectory')

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -811,6 +811,16 @@ $CONFIG = array(
 'asset-pipeline.enabled' => false,
 
 /**
+ * The parent of the directory where css and js assets will be stored if
+ * piplelining is enabled; this defaults to the ownCloud directory. The assets
+ * will be stored in a subdirectory of this directory named 'assets'. The
+ * server *must* be configured to serve that directory as $WEBROOT/assets.
+ * You will only likely need to change this if the main ownCloud directory
+ * is not writeable by the web server in your configuration.
+ */
+'assetdirectory' => '/var/www/owncloud',
+
+/**
  * Where ``mount.json`` file should be stored, defaults to ``data/mount.json``
  */
 'mount_file' => 'data/mount.json',

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -233,13 +233,14 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	public static function isAssetPipelineEnabled() {
 		// asset management enabled?
-		$useAssetPipeline = \OC::$server->getConfig()->getSystemValue('asset-pipeline.enabled', false);
+		$config = \OC::$server->getConfig();
+		$useAssetPipeline = $config->getSystemValue('asset-pipeline.enabled', false);
 		if (!$useAssetPipeline) {
 			return false;
 		}
 
 		// assets folder exists?
-		$assetDir = \OC::$SERVERROOT . '/assets';
+		$assetDir = $config->getSystemValue('assetdirectory', \OC::$SERVERROOT) . '/assets';
 		if (!is_dir($assetDir)) {
 			if (!mkdir($assetDir)) {
 				\OCP\Util::writeLog('assets',

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -154,10 +154,11 @@ class OC_TemplateLayout extends OC_Template {
 	}
 
 	public function generateAssets() {
+		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT);
 		$jsFiles = self::findJavascriptFiles(OC_Util::$scripts);
 		$jsHash = self::hashFileNames($jsFiles);
 
-		if (!file_exists("assets/$jsHash.js")) {
+		if (!file_exists("$assetDir/assets/$jsHash.js")) {
 			$jsFiles = array_map(function ($item) {
 				$root = $item[0];
 				$file = $item[2];
@@ -172,14 +173,14 @@ class OC_TemplateLayout extends OC_Template {
 			$jsCollection = new AssetCollection($jsFiles);
 			$jsCollection->setTargetPath("assets/$jsHash.js");
 
-			$writer = new AssetWriter(\OC::$SERVERROOT);
+			$writer = new AssetWriter($assetDir);
 			$writer->writeAsset($jsCollection);
 		}
 
 		$cssFiles = self::findStylesheetFiles(OC_Util::$styles);
 		$cssHash = self::hashFileNames($cssFiles);
 
-		if (!file_exists("assets/$cssHash.css")) {
+		if (!file_exists("$assetDir/assets/$cssHash.css")) {
 			$cssFiles = array_map(function ($item) {
 				$root = $item[0];
 				$file = $item[2];
@@ -200,7 +201,7 @@ class OC_TemplateLayout extends OC_Template {
 			$cssCollection = new AssetCollection($cssFiles);
 			$cssCollection->setTargetPath("assets/$cssHash.css");
 
-			$writer = new AssetWriter(\OC::$SERVERROOT);
+			$writer = new AssetWriter($assetDir);
 			$writer->writeAsset($cssCollection);
 		}
 

--- a/lib/repair/assetcache.php
+++ b/lib/repair/assetcache.php
@@ -22,7 +22,7 @@ class AssetCache extends BasicEmitter implements \OC\RepairStep {
 			$this->emit('\OC\Repair', 'info', array('Asset pipeline disabled -> nothing to do'));
 			return;
 		}
-		$assetDir = \OC::$SERVERROOT . '/assets';
+		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT) . '/assets';
 		\OC_Helper::rmdirr($assetDir, false);
 		$this->emit('\OC\Repair', 'info', array('Asset cache cleared.'));
 	}


### PR DESCRIPTION
This allows the directory where CSS/JS asset collections are written to be changed, in case SERVERROOT is not writeable. Note it does _not_ allow the expected URL to be changed: whatever directory is used, the server must be configured to serve it at WEBROOT/assets. It would be possible to add another config parameter to allow the admin to specify a custom asset URL, but I thought I'd keep the first implementation simple.
