### PR TITLE
smb: rename textfield from root to subfolder

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -132,7 +132,7 @@ if (!OC_Util::runningOnWindows()) {
 			'user' => (string)$l->t('Username'),
 			'password' => '*'.$l->t('Password'),
 			'share' => (string)$l->t('Share'),
-			'root' => '&'.$l->t('Root')),
+			'root' => '&'.$l->t('Subfolder')),
 		'has_dependencies' => true));
 
 	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB_OC', array(
@@ -142,7 +142,7 @@ if (!OC_Util::runningOnWindows()) {
 				'host' => (string)$l->t('Host'),
 				'username_as_share' => '!'.$l->t('Username as share'),
 				'share' => '&'.$l->t('Share'),
-				'root' => '&'.$l->t('Root')),
+				'root' => '&'.$l->t('Subfolder')),
 		'has_dependencies' => true));
 }
 

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -90,7 +90,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\FTP', array(
 		'host' => (string)$l->t('Host'),
 		'user' => (string)$l->t('Username'),
 		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Root'),
+		'root' => '&'.$l->t('Remote subfolder'),
 		'secure' => '!'.$l->t('Secure ftps://')),
 	'has_dependencies' => true));
 
@@ -132,7 +132,7 @@ if (!OC_Util::runningOnWindows()) {
 			'user' => (string)$l->t('Username'),
 			'password' => '*'.$l->t('Password'),
 			'share' => (string)$l->t('Share'),
-			'root' => '&'.$l->t('Subfolder')),
+			'root' => '&'.$l->t('Remote subfolder')),
 		'has_dependencies' => true));
 
 	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB_OC', array(
@@ -142,7 +142,7 @@ if (!OC_Util::runningOnWindows()) {
 				'host' => (string)$l->t('Host'),
 				'username_as_share' => '!'.$l->t('Username as share'),
 				'share' => '&'.$l->t('Share'),
-				'root' => '&'.$l->t('Subfolder')),
+				'root' => '&'.$l->t('Remote subfolder')),
 		'has_dependencies' => true));
 }
 
@@ -153,7 +153,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\DAV', array(
 		'host' => (string)$l->t('URL'),
 		'user' => (string)$l->t('Username'),
 		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Root'),
+		'root' => '&'.$l->t('Remote subfolder'),
 		'secure' => '!'.$l->t('Secure https://')),
 	'has_dependencies' => true));
 
@@ -175,7 +175,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP', array(
 		'host' => (string)$l->t('Host'),
 		'user' => (string)$l->t('Username'),
 		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Root'))));
+		'root' => '&'.$l->t('Remote subfolder'))));
 
 $mountProvider = new \OCA\Files_External\Config\ConfigAdapter();
 \OC::$server->getMountProviderCollection()->registerProvider($mountProvider);


### PR DESCRIPTION
This PR is based on: https://github.com/owncloud/core/issues/12826 (Suggestion: renaming some box texts when you do a SMB mount)
@karlitschek this is the corresponding PR for.

It is about that some translations in SMB are too aggressive and should stay with the original wording as they are proper names commonly used.

Right now there are two terms which should be changed:

Already done on Transifex
English: Share
German: Teilen --> Share 

This PR
English: Root --> Subfolder
German:  Root --> Subfolder

(example, see also: https://answers.uchicago.edu/22499)

Is there another place where I should/must add the term "Subfolder" or is this done automatically?

The term "Root" can stay because this PR only affects SMB and other extenal storages use the term root too.

If this PR gets agreed and merged, I will also do a PR at documentation/configuration/files_external to finalize this adoption.
