### PR TITLE
adopt text "no external storage configured"

### DIFF
--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -6,7 +6,7 @@
 
 <div id="emptycontent" class="hidden">
 	<div class="icon-external"></div>
-	<h2><?php p($l->t('No external storages')); ?></h2>
+	<h2><?php p($l->t('No external storages configured')); ?></h2>
 	<p><?php p($l->t('You can configure external storages in the personal settings')); ?></p>
 </div>
 


### PR DESCRIPTION
This commit is about to fix a text shown when no external storage is configured.
1. No external storages --> No external storage configured.
2. Use singular form of storage.

According to Wikipedia, the plural form (storages) is more commonly used in Australian English but not in the rest of the world. Therefore I vote to use the singular form (storage).

Please let me know if these changes also need to be set in a ln10 file or if this is sufficient.

If this PR gets agreed/merged, I will take care on the English->German translation on Transifex.
