### PR TITLE
Add provisioning_api app.php so app is detected

### DIFF
--- a/apps/provisioning_api/appinfo/app.php
+++ b/apps/provisioning_api/appinfo/app.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @copyright (C) 2014 ownCloud, Inc.
+ *
+ * @author Tom <tom@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/apps/provisioning_api/tests/groupsTest.php
+++ b/apps/provisioning_api/tests/groupsTest.php
@@ -67,8 +67,8 @@ class Test_Provisioning_Api_Groups extends PHPUnit_Framework_TestCase {
 
 		$group = uniqid();
 		\OC_Group::createGroup($group);
-		\OC_Group::addToGroup($users[1], $group);
 		\OC_Group::addToGroup($users[0], $group);
+		\OC_Group::addToGroup($users[1], $group);
 
 		\OC_SubAdmin::createSubAdmin($users[0], $group);
 


### PR DESCRIPTION
Fixes self

And swap array element order to fix failing test: https://ci.owncloud.org/job/server-master-linux/database=sqlite,label=SLAVE/lastBuild/testReport/(root)/Test_Provisioning_Api_Groups/testGetGroupAsSubadmin/

Are these tests failing for anyone else? Locally they run ok. Wondering if it is related to the missing app.php.
