### PR TITLE
Fix remaining unit tests for provisioning_api

### DIFF
--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -31,6 +31,11 @@ use \OC_SubAdmin;
 
 class Groups{
 
+	public function setUp() {
+		// These seems to be deleted by another test.
+		OC_Group::createGroup('admin');
+	}
+
 	/**
 	 * returns a list of groups
 	 */

--- a/apps/provisioning_api/lib/users.php
+++ b/apps/provisioning_api/lib/users.php
@@ -70,7 +70,7 @@ class Users {
 		// Admin? Or SubAdmin?
 		if(OC_User::isAdminUser(OC_User::getUser()) || OC_SubAdmin::isUserAccessible(OC_User::getUser(), $userId)) {
 			// Check they exist
-			if(!OC_user::userExists($userId)) {
+			if(!OC_User::userExists($userId)) {
 				return new OC_OCS_Result(null, \OC_API::RESPOND_NOT_FOUND, 'The requested user could not be found');
 			}
 			// Show all

--- a/apps/provisioning_api/tests/AppsTest.php
+++ b/apps/provisioning_api/tests/AppsTest.php
@@ -27,6 +27,9 @@ class Test_Provisioning_Api_Apps extends PHPUnit_Framework_TestCase {
 
 	private $users = array();
 
+	function setUp() {
+		OC_Group::createGroup('admin');
+	}
 	/**
 	 * Generates a temp user
 	 * @param $num int number of users to generate
@@ -96,6 +99,10 @@ class Test_Provisioning_Api_Apps extends PHPUnit_Framework_TestCase {
 		$disabled = array_diff($list, \OC_App::getEnabledApps());
 		$this->assertEquals(count($disabled), count($data['apps']));
 
+	}
+
+	function tearDown() {
+		OC_Group::deleteGroup('admin');
 	}
 
 }

--- a/apps/provisioning_api/tests/groupsTest.php
+++ b/apps/provisioning_api/tests/groupsTest.php
@@ -27,6 +27,11 @@ class Test_Provisioning_Api_Groups extends PHPUnit_Framework_TestCase {
 
 	private $users = array();
 
+	public function setUp() {
+		// These seems to be deleted by another test.
+		OC_Group::createGroup('admin');
+	}
+
 	/**
 	 * Generates a temp user
 	 * @param $num int number of users to generate

--- a/apps/provisioning_api/tests/groupsTest.php
+++ b/apps/provisioning_api/tests/groupsTest.php
@@ -145,10 +145,8 @@ class Test_Provisioning_Api_Groups extends PHPUnit_Framework_TestCase {
 		OC_Group::deleteGroup($group1);
 
 		$user1 = $this->generateUsers();
-		$user2 = $this->generateUsers();
 		OC_User::setUserId($user1);
 		OC_Group::addToGroup($user1, 'admin');
-		$group1 = uniqid();
 		$result = \OCA\provisioning_api\Groups::getSubAdminsOfGroup(array(
 			'groupid' => uniqid(),
 		));

--- a/apps/provisioning_api/tests/groupsTest.php
+++ b/apps/provisioning_api/tests/groupsTest.php
@@ -167,6 +167,7 @@ class Test_Provisioning_Api_Groups extends PHPUnit_Framework_TestCase {
 		foreach($this->users as $user) {
 			\OC_User::deleteUser($user);
 		}
+		OC_Group::deleteGroup('admin');
 	}
 
 

--- a/apps/provisioning_api/tests/usersTest.php
+++ b/apps/provisioning_api/tests/usersTest.php
@@ -26,6 +26,10 @@ class Test_Provisioning_Api_Users extends PHPUnit_Framework_TestCase {
 
 	private $users = array();
 
+	public function setUp() {
+		OC_Group::createGroup('admin');
+	}
+
 	/**
 	 * Generates a temp user
 	 * @param $num int number of users to generate
@@ -436,7 +440,6 @@ class Test_Provisioning_Api_Users extends PHPUnit_Framework_TestCase {
 			));
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertFalse($result->succeeded());
-		$data = $result->getData();
 		OC_Group::deleteGroup($group);
 	}
 

--- a/apps/provisioning_api/tests/usersTest.php
+++ b/apps/provisioning_api/tests/usersTest.php
@@ -793,6 +793,7 @@ class Test_Provisioning_Api_Users extends PHPUnit_Framework_TestCase {
 		foreach($this->users as $user) {
 			\OC_User::deleteUser($user);
 		}
+		OC_Group::deleteGroup('admin');
 	}
 
 }


### PR DESCRIPTION
Fixes self

Since these aren't real unit tests they need a better setup and tear down methods.

~~Still [WIP] as one test is still failing.~~
- [x] Fix `Test_Provisioning_Api_Groups::testGetGroupAsAdmin` with error: 

```
1) Test_Provisioning_Api_Groups::testGetGroupAsAdmin
Failed asserting that false is true.

/var/www/owncloud.dev/cloud/apps/provisioning_api/tests/groupsTest.php:125
```
