### PR TITLE
Remove unnecessary setUp method from provisioning_api

### DIFF
--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -31,11 +31,6 @@ use \OC_SubAdmin;
 
 class Groups{
 
-	public function setUp() {
-		// These seems to be deleted by another test.
-		OC_Group::createGroup('admin');
-	}
-
 	/**
 	 * returns a list of groups
 	 */


### PR DESCRIPTION
Fixes self.

Remove setUp method that was meant to end up in a test case.

@MorrisJobke Made it in before the day end ;)
