### PR TITLE
Fix JS asset generation

### DIFF
--- a/lib/private/assetic/separatorfilter.php
+++ b/lib/private/assetic/separatorfilter.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * Copyright (C) 2014 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Assetic;
+
+use Assetic\Filter\FilterInterface;
+use Assetic\Asset\AssetInterface;
+
+/**
+ * Inserts a separator between assets to prevent merge failures
+ * e.g. missing semicolon at the end of a JS file
+ */
+class SeparatorFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    private $separator;
+
+    /**
+     * Constructor.
+     *
+     * @param string $separator Separator to use between assets
+     */
+    public function __construct($separator = ';')
+    {
+        $this->separator = $separator;
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+    }
+
+    public function filterDump(AssetInterface $asset)
+    {
+        $asset->setContent($asset->getContent() . $this->separator);
+    }
+}

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -6,6 +6,7 @@ use Assetic\Filter\CssImportFilter;
 use Assetic\Filter\CssMinFilter;
 use Assetic\Filter\CssRewriteFilter;
 use Assetic\Filter\JSMinFilter;
+use OC\Assetic\SeparatorFilter; // waiting on upstream
 
 /**
  * Copyright (c) 2012 Bart Visscher <bartv@thisnet.nl>
@@ -163,10 +164,13 @@ class OC_TemplateLayout extends OC_Template {
 				$file = $item[2];
 				// no need to minifiy minified files
 				if (substr($file, -strlen('.min.js')) === '.min.js') {
-					return new FileAsset($root . '/' . $file, array(), $root, $file);
+					return new FileAsset($root . '/' . $file, array(
+						new SeparatorFilter(';')
+					), $root, $file);
 				}
 				return new FileAsset($root . '/' . $file, array(
-					new JSMinFilter()
+					new JSMinFilter(),
+					new SeparatorFilter(';')
 				), $root, $file);
 			}, $jsFiles);
 			$jsCollection = new AssetCollection($jsFiles);


### PR DESCRIPTION
At some point SeparatorFilter should be included upstream (kriswallsmith/assetic), then lib/private/assetic/separatorfilter.php can be removed and the `use` in lib/private/templatelayout.php rewritten.

SeparatorFilter inserts a separator between assets, preventing issues when files are incorrectly terminated. For JS this is a semicolon.

Fixes #10327

cc @MorrisJobke @PVince81 @ldidry @DeepDiver1975 

To test:
1. Enable `files_external`
2. Enable asset pipeline (`asset-pipeline.enabled => true` in config.php)
3. Go to Personal Settings
4. Attempt to create a new mount (select a mount type in the drop down)
5. Without patch, nothing happens (notice JS errors in log)
6. With patch, correctly works

Remember to clear browser caches if testing with/without! (caught me out)
