### PR TITLE
Add error handling to getstoragestats.php

### DIFF
--- a/apps/files/ajax/getstoragestats.php
+++ b/apps/files/ajax/getstoragestats.php
@@ -10,4 +10,8 @@ OCP\JSON::checkLoggedIn();
 \OC::$server->getSession()->close();
 
 // send back json
-OCP\JSON::success(array('data' => \OCA\Files\Helper::buildFileStorageStatistics($dir)));
+try {
+	OCP\JSON::success(array('data' => \OCA\Files\Helper::buildFileStorageStatistics($dir)));
+} catch (\OCP\Files\NotFoundException $e) {
+	OCP\JSON::error(['data' => ['message' => 'Folder not found']]);
+}

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -905,6 +905,9 @@ class OC_Helper {
 		if (!$rootInfo) {
 			$rootInfo = \OC\Files\Filesystem::getFileInfo($path, false);
 		}
+		if (!$rootInfo instanceof \OCP\Files\FileInfo) {
+			throw new \OCP\Files\NotFoundException();
+		}
 		$used = $rootInfo->getSize();
 		if ($used < 0) {
 			$used = 0;


### PR DESCRIPTION
Fixes #13127

Throw an exception when trying to get storage info for a non existing file and catch the exception in `getstoragestats.php`

cc @MorrisJobke @LukasReschke 
