### PR TITLE
Improve debugging for ServiceUnavailable exceptions

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -56,12 +56,12 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 				throw new \Sabre\DAV\Exception\Forbidden();
 			}
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("File is not updatable: ".$e->getMessage());
 		}
 
 		// throw an exception if encryption was disabled but the files are still encrypted
 		if (\OC_Util::encryptedFiles()) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("Encryption is disabled");
 		}
 
 		$fileName = basename($this->path);
@@ -107,7 +107,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 		} catch (\OCA\Files_Encryption\Exception\EncryptionException $e) {
 			throw new \Sabre\DAV\Exception\Forbidden($e->getMessage());
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to write file contents: ".$e->getMessage());
 		}
 
 		try {
@@ -147,7 +147,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			}
 			$this->refreshInfo();
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to check file size: ".$e->getMessage());
 		}
 
 		return '"' . $this->info->getEtag() . '"';
@@ -162,14 +162,14 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 
 		//throw exception if encryption is disabled but files are still encrypted
 		if (\OC_Util::encryptedFiles()) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("Encryption is disabled");
 		} else {
 			try {
 				return $this->fileView->fopen(ltrim($this->path, '/'), 'rb');
 			} catch (\OCA\Files_Encryption\Exception\EncryptionException $e) {
 				throw new \Sabre\DAV\Exception\Forbidden($e->getMessage());
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+				throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to open file: ".$e->getMessage());
 			}
 		}
 
@@ -192,7 +192,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 				throw new \Sabre\DAV\Exception\Forbidden();
 			}
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to unlink: ".$e->getMessage());
 		}
 
 		// remove properties
@@ -297,7 +297,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 				$info = $this->fileView->getFileInfo($targetPath);
 				return $info->getEtag();
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+				throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to put file: ".$e->getMessage());
 			}
 		}
 

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -529,7 +529,7 @@ class DAV extends \OC\Files\Storage\Common {
 		} catch (Exception\NotFound $e) {
 			return false;
 		} catch (Exception $e) {
-			throw new StorageNotAvailableException();
+			throw new StorageNotAvailableException(get_class($e).": ".$e->getMessage());
 		}
 	}
 }


### PR DESCRIPTION
I was getting a lot of these in my logs for no apparent reason, and file
uploads were failing:

```
{"app":"webdav","message":"Sabre\\DAV\\Exception\\ServiceUnavailable: ","level":4,"time":"2015-01-06T15:33:39+00:00"}
```

In order to debug it, I had to add unique messages to all the places where
this exception was thrown, to identify which one it was, and that made the
logs much more useful:

```
{"app":"webdav","message":"Sabre\\DAV\\Exception\\ServiceUnavailable: Encryption is disabled","level":4,"time":"2015-01-06T15:36:47+00:00"}
```
