### PR TITLE
Add timeout for notifications

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -669,6 +669,7 @@ OC.msg={
 OC.Notification={
 	queuedNotifications: [],
 	getDefaultNotificationFunction: null,
+	notificationTimer: 0,
 
 	/**
 	 * @param callback
@@ -728,6 +729,42 @@ OC.Notification={
 			notification.fadeIn().css('display','inline-block');
 		}else{
 			OC.Notification.queuedNotifications.push($('<div/>').text(text).html());
+		}
+	},
+
+
+	/**
+	 * Shows a notification that disappears after x seconds, default is
+	 * 7 seconds
+	 * @param {string} text Message to show
+	 * @param {array} [options] options array
+	 * @param {int} [options.timeout=7] timeout in seconds, if this is 0 it will show the message permanently
+	 * @param {boolean} [options.isHTML=false] an indicator for HTML notifications (true) or text (false)
+	 */
+	showTemporary: function(text, options) {
+		var defaults = {
+				isHTML: false,
+				timeout: 7
+			},
+			options = options || {};
+		// merge defaults with passed in options
+		_.defaults(options, defaults);
+
+		// clear previous notifications
+		OC.Notification.hide();
+		if(OC.Notification.notificationTimer) {
+			clearTimeout(OC.Notification.notificationTimer);
+		}
+
+		if(options.isHTML) {
+			OC.Notification.showHtml(text);
+		} else {
+			OC.Notification.show(text);
+		}
+
+		if(options.timeout > 0) {
+			// register timeout to vanish notification
+			OC.Notification.notificationTimer = setTimeout(OC.Notification.hide, (options.timeout * 1000));
 		}
 	},
 

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -686,5 +686,102 @@ describe('Core base tests', function() {
 			expect(obj.attached).not.toBeDefined();
 		});
 	});
+	describe('Notifications', function() {
+		beforeEach(function(){
+			notificationMock = sinon.mock(OC.Notification);
+		});
+		afterEach(function(){
+			// verify that all expectations are met
+			notificationMock.verify();
+			// restore mocked methods
+			notificationMock.restore();
+			// clean up the global variable
+			delete notificationMock;
+		});
+		it('Should show a plain text notification' , function() {
+			// one is shown ...
+			notificationMock.expects('show').once().withExactArgs('My notification test');
+			// ... but not the HTML one
+			notificationMock.expects('showHtml').never();
+
+			OC.Notification.showTemporary('My notification test');
+
+			// verification is done in afterEach
+		});
+		it('Should show a HTML notification' , function() {
+			// no plain is shown ...
+			notificationMock.expects('show').never();
+			// ... but one HTML notification
+			notificationMock.expects('showHtml').once().withExactArgs('<a>My notification test</a>');
+
+			OC.Notification.showTemporary('<a>My notification test</a>', { isHTML: true });
+
+			// verification is done in afterEach
+		});
+		it('Should hide previous notification and hide itself after 7 seconds' , function() {
+			var clock = sinon.useFakeTimers();
+
+			// previous notifications get hidden
+			notificationMock.expects('hide').once();
+
+			OC.Notification.showTemporary('');
+
+			// verify the first call
+			notificationMock.verify();
+
+			// expect it a second time
+			notificationMock.expects('hide').once();
+
+			// travel in time +7000 milliseconds
+			clock.tick(7000);
+
+			// verification is done in afterEach
+		});
+		it('Should hide itself after a given time' , function() {
+			var clock = sinon.useFakeTimers();
+
+			// previous notifications get hidden
+			notificationMock.expects('hide').once();
+
+			OC.Notification.showTemporary('', { timeout: 10 });
+
+			// verify the first call
+			notificationMock.verify();
+
+			// expect to not be called after 9 seconds
+			notificationMock.expects('hide').never();
+
+			// travel in time +9 seconds
+			clock.tick(9000);
+			// verify this
+			notificationMock.verify();
+
+			// expect the second call one second later
+			notificationMock.expects('hide').once();
+			// travel in time +1 seconds
+			clock.tick(1000);
+
+			// verification is done in afterEach
+		});
+		it('Should not hide itself after a given time if a timeout of 0 is defined' , function() {
+			var clock = sinon.useFakeTimers();
+
+			// previous notifications get hidden
+			notificationMock.expects('hide').once();
+
+			OC.Notification.showTemporary('', { timeout: 0 });
+
+			// verify the first call
+			notificationMock.verify();
+
+			// expect to not be called after 1000 seconds
+			notificationMock.expects('hide').never();
+
+			// travel in time +1000 seconds
+			clock.tick(1000000);
+
+			// verification is done in afterEach
+		});
+	});
 });
 


### PR DESCRIPTION
- options for timeout in seconds and if it contains HTML
- removes the notification after a given (default: 5 seconds) timeframe
- based on work by @brantje - replaces #9787

tested in IE8, Firefox and Chrome

I would like to migrate every notification to this later, because this method also removes previous notifications and handles the cleanup that needs to be done for app developers otherwise. cc @jancborchardt 

cc @brantje @PVince81 @DeepDiver1975 
