### PR TITLE
Fix source path when share is a mount point

### DIFF
--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -213,7 +213,9 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 		if ($itemType === 'folder') {
 			$source = \OCP\Share::getItemSharedWith('folder', $mountPoint, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
 			if ($source && $target !== '') {
-				$source['path'] = $source['path'].'/'.$target;
+				// note: in case of ext storage mount points the path might be empty
+				// which would cause a leading slash to appear
+				$source['path'] = ltrim($source['path'] . '/' . $target, '/');
 			}
 		} else {
 			$source = \OCP\Share::getItemSharedWith('file', $mountPoint, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);


### PR DESCRIPTION
Whenever an external storage mount point is shared directly, its path is
empty which causes a leading slash to appear in the source path.

This fix removes the bogus leading slash in such situation.
### Steps to reproduce:
1. Create two users "user1" and "user2"
2. Mount SFTP storage as "user1" (personal mount) under "/sftp"
3. Share "/sftp" with "user2"
4. Login as "user2"
5. Upload files as "user2"
6. `select * from oc_filecache`
### Before fix

oc_filecache entries have a "path" field with a bogus leading slash.
For example "/test.jpg" instead of "test.jpg".
For additional fun try uploading a file "test.jpg" again as "user1" into "/sftp".
It will have two entries: one "/test.jpg" and "test.jpg", so the UI will show the file twice...
### After fix

All database entries have no leading slash in their path.

Please review @icewind1991 @schiesbn @MorrisJobke 
