### PR TITLE
Add version to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,4 @@
+# Version: 8.0.0
 <IfModule mod_fcgid.c>
 <IfModule mod_setenvif.c>
 <IfModule mod_headers.c>

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -189,7 +189,11 @@ class Updater extends BasicEmitter {
 
 		// Update htaccess files for apache hosts
 		if (isset($_SERVER['SERVER_SOFTWARE']) && strstr($_SERVER['SERVER_SOFTWARE'], 'Apache')) {
-			\OC_Setup::updateHtaccess();
+			try {
+				\OC_Setup::updateHtaccess();
+			} catch (\Exception $e) {
+				throw new \Exception($e->getMessage());
+			}
 		}
 
 		// create empty file in data dir, so we can later find

--- a/tests/lib/setup.php
+++ b/tests/lib/setup.php
@@ -19,7 +19,7 @@ class Test_OC_Setup extends \Test\TestCase {
 		parent::setUp();
 
 		$this->config = $this->getMock('\OCP\IConfig');
-		$this->setupClass = $this->getMock('\OC_Setup', array('class_exists', 'is_callable'), array($this->config));
+		$this->setupClass = $this->getMock('\OC_Setup', ['class_exists', 'is_callable'], [$this->config]);
 	}
 
 	public function testGetSupportedDatabasesWithOneWorking() {
@@ -101,5 +101,18 @@ class Test_OC_Setup extends \Test\TestCase {
 			->method('getSystemValue')
 			->will($this->returnValue('NotAnArray'));
 		$this->setupClass->getSupportedDatabases();
+	}
+
+	/**
+	 * This is actual more an integration test whether the version parameter in the .htaccess
+	 * was updated as well when the version has been incremented.
+	 * If it hasn't this test will fail.
+	 */
+	public function testHtaccessIsCurrent() {
+		$result = Test_Helper::invokePrivate(
+			$this->setupClass,
+			'isCurrentHtaccess'
+		);
+		$this->assertTrue($result);
 	}
 }


### PR DESCRIPTION
Currently if a user does not replace the .htaccess file with the new update this can lead to serious problems in case Apache is used as webserver.

This commit adds the version to the .htaccess file and the update routine fails in case not the newest version is specified in there. This obviously means that every release has to update the version specified in .htaccess as well. But I see no better solution for it.

Replacement for https://github.com/owncloud/core/pull/11114

fixes #9937
