### PR TITLE
[stable6] Fix source path when share is a mount point

### DIFF
--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -157,7 +157,9 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 			$folder = substr($target, 0, $pos);
 			$source = \OCP\Share::getItemSharedWith('folder', $folder, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
 			if ($source) {
-				$source['path'] = $source['path'].substr($target, strlen($folder));
+				// note: in case of ext storage mount points the path might be empty
+				// which would cause a leading slash to appear
+				$source['path'] = ltrim($source['path'] . substr($target, strlen($folder)), '/');
 			}
 		} else {
 			$source = \OCP\Share::getItemSharedWith('file', $target, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);


### PR DESCRIPTION
Whenever an external storage mount point is shared directly, its path is
empty which causes a leading slash to appear in the source path.

This fix removes the bogus leading slash in such situation.

Backport of https://github.com/owncloud/core/pull/13170 to stable6

Please review/test @icewind1991 @Xenopathic @MorrisJobke @schiesbn 
I have tested this myself and it worked for me.
