### PR TITLE
Verify whether type is correct

### DIFF
--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -29,21 +29,17 @@ if ($maxX === 0 || $maxY === 0) {
 	exit;
 }
 
-try {
-	$preview = new \OC\Preview(\OC_User::getUser(), 'files');
-	$info = \OC\Files\Filesystem::getFileInfo($file);
-	if (!$always and !$preview->isAvailable($info)) {
-		\OC_Response::setStatus(404);
-	} else {
-		$preview->setFile($file);
-		$preview->setMaxX($maxX);
-		$preview->setMaxY($maxY);
-		$preview->setScalingUp($scalingUp);
-		$preview->setKeepAspect($keepAspect);
-		$preview->showPreview();
-	}
+$preview = new \OC\Preview(\OC_User::getUser(), 'files');
 
-} catch (\Exception $e) {
-	\OC_Response::setStatus(500);
-	\OC_Log::write('core', $e->getmessage(), \OC_Log::DEBUG);
+$info = \OC\Files\Filesystem::getFileInfo($file);
+
+if (!$info instanceof OCP\Files\FileInfo || !$always && !$preview->isAvailable($info)) {
+	\OC_Response::setStatus(404);
+} else {
+	$preview->setFile($file);
+	$preview->setMaxX($maxX);
+	$preview->setMaxY($maxY);
+	$preview->setScalingUp($scalingUp);
+	$preview->setKeepAspect($keepAspect);
+	$preview->showPreview();
 }

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -200,14 +200,15 @@ class Preview {
 	/**
 	 * set the path of the file you want a thumbnail from
 	 * @param string $file
-	 * @return \OC\Preview $this
+	 * @return $this
 	 */
 	public function setFile($file) {
 		$this->file = $file;
 		$this->info = null;
+
 		if ($file !== '') {
 			$this->getFileInfo();
-			if($this->info !== null && $this->info !== false) {
+			if($this->info instanceof \OCP\Files\FileInfo) {
 				$this->mimeType = $this->info->getMimetype();
 			}
 		}


### PR DESCRIPTION
`$this->info` can very well contain an empty array or possibly other values. This means that when this code path is called a PHP Fatal error might get thrown which is not what we want. This is for example the case when you requested a thumbnail for a not existing file. (for example `/index.php/core/preview.png?file=IDontExist.txt&c=c1b631cf86c72ce0ad7a130efbe32809&x=45&y=45&forceIcon=0`)

Furthermore, the `try` and `catch` block is here not required since this will already get properly handled by ownCloud itself.

Fixes itself.

@georgehrke FYI - please review.
@karlitschek @DeepDiver1975 Please decide whether 8.0 or 8.1
