### PR TITLE
Trim leading or trailing slashes in file cache paths

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -699,6 +699,6 @@ class Cache {
 	 */
 	public function normalize($path) {
 
-		return \OC_Util::normalizeUnicode($path);
+		return trim(\OC_Util::normalizeUnicode($path), '/');
 	}
 }

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -30,7 +30,7 @@ class CacheJail extends CacheWrapper {
 		if ($path === '') {
 			return $this->root;
 		} else {
-			return $this->root . '/' . $path;
+			return $this->root . '/' . ltrim($path, '/');
 		}
 	}
 


### PR DESCRIPTION
This is just an additional safety in case bugs similar to https://github.com/owncloud/core/pull/13170 pop up.

Passing a file name with a leading slash to the file cache would store it as is and in some cases have -1 as parent id instead of the root's parent.

This fix trims leading and trailing slashes.

But also I'm not sure whether it makes sense API-wise.
Should every filesystem-based function auto-trim slashes everywhere ?

@icewind1991 @MorrisJobke
