### PR TITLE
make versions of shared files downloadable

### DIFF
--- a/apps/files_encryption/lib/crypt.php
+++ b/apps/files_encryption/lib/crypt.php
@@ -148,9 +148,6 @@ class Crypt {
 		// Fetch encryption metadata from end of file
 		$meta = substr($noPadding, -22);
 
-		// Fetch IV from end of file
-		$iv = substr($meta, -16);
-
 		// Fetch identifier from start of metadata
 		$identifier = substr($meta, 0, 6);
 

--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -56,10 +56,12 @@ class Proxy extends \OC_FileProxy {
 
 		$path = \OC\Files\Filesystem::normalizePath($path);
 
+		$parts = explode('/', $path);
+
 		// we only encrypt/decrypt files in the files and files_versions folder
 		if(
 			strpos($path, '/' . $uid . '/files/') !== 0 &&
-			strpos($path, '/' . $uid . '/files_versions/') !== 0) {
+			!($parts[2] === 'files_versions' && \OCP\User::userExists($parts[1]))) {
 
 			return true;
 		}

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -39,6 +39,10 @@ class Util {
 	const MIGRATION_IN_PROGRESS = -1; // migration is running
 	const MIGRATION_OPEN = 0;         // user still needs to be migrated
 
+	const FILE_TYPE_FILE = 0;
+	const FILE_TYPE_VERSION = 1;
+	const FILE_TYPE_CACHE = 2;
+
 	private $view; // OC\Files\View object for filesystem operations
 	private $userId; // ID of the user we use to encrypt/decrypt files
 	private $keyId; // ID of the key we want to manipulate

--- a/apps/files_encryption/tests/testcase.php
+++ b/apps/files_encryption/tests/testcase.php
@@ -34,7 +34,7 @@ abstract class TestCase extends \Test\TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		\OC\Files\Filesystem::tearDown();
-		\OC_User::setUserId($user);
+		\OC::$server->getUserSession()->setUser(new \OC\User\User($user, new \OC_User_Database()));
 		\OC_Util::setupFS($user);
 
 		if ($loadEncryption) {

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -575,43 +575,6 @@ class Util extends TestCase {
 	}
 
 	/**
-	 * @param string $user
-	 * @param bool $create
-	 * @param bool $password
-	 */
-	public static function loginHelper($user, $create = false, $password = false, $loadEncryption = true) {
-		if ($create) {
-			try {
-				\OC_User::createUser($user, $user);
-			} catch(\Exception $e) { // catch username is already being used from previous aborted runs
-
-			}
-		}
-
-		if ($password === false) {
-			$password = $user;
-		}
-
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
-		\OC\Files\Filesystem::tearDown();
-		\OC_User::setUserId($user);
-		\OC_Util::setupFS($user);
-
-		if ($loadEncryption) {
-			$params['uid'] = $user;
-			$params['password'] = $password;
-			\OCA\Files_Encryption\Hooks::login($params);
-		}
-	}
-
-	public static function logoutHelper() {
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId(false);
-		\OC\Files\Filesystem::tearDown();
-	}
-
-	/**
 	 * helper function to set migration status to the right value
 	 * to be able to test the migration path
 	 *

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -139,10 +139,10 @@ class Storage {
 			\OC_FileProxy::$enabled = false;
 
 			// store a new version of a file
-			$mtime = $users_view->filemtime('files'.$filename);
-			$users_view->copy('files'.$filename, 'files_versions'.$filename.'.v'. $mtime);
+			$mtime = $users_view->filemtime('files/' . $filename);
+			$users_view->copy('files/' . $filename, 'files_versions/' . $filename . '.v' . $mtime);
 			// call getFileInfo to enforce a file cache entry for the new version
-			$users_view->getFileInfo('files_versions'.$filename.'.v'.$mtime);
+			$users_view->getFileInfo('files_versions/' . $filename . '.v' . $mtime);
 
 			// reset proxy state
 			\OC_FileProxy::$enabled = $proxyStatus;


### PR DESCRIPTION
fix download of versions from shared files.

Step to test:
- enable encryption
- user1 creates a file "test.txt"
- user1 edits the file so that we have at least one version
- user1 shares the file with user2
- login as user2
- try to download a version from the shared file

fix #12221
