### PR TITLE
Verify existence of $_GET key

### DIFF
--- a/apps/files/ajax/mimeicon.php
+++ b/apps/files/ajax/mimeicon.php
@@ -1,4 +1,6 @@
 <?php
 \OC::$server->getSession()->close();
 
-print OC_Helper::mimetypeIcon($_GET['mime']);
+$mime = isset($_GET['mime']) ? $_GET['mime'] : '';
+
+print OC_Helper::mimetypeIcon($mime);


### PR DESCRIPTION
Otherwise when the file without any specified mimetype was accessed the error log was flooded with entries such as "Undefined index: mime", there can be multiple issues found about this in the forum and our [bugtracker](https://github.com/owncloud/core/issues?q=is%3Aissue+%22Undefined+index%3A+mime%22+).

To test this access `/index.php/apps/files/ajax/mimeicon.php` with and without `$_GET['mime']`.

Fixes itself.

@karlitschek Easy patch - 8.0?
