### PR TITLE
use JShrink instead of JSMin (#13052)

### DIFF
--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -5,7 +5,7 @@ use Assetic\AssetWriter;
 use Assetic\Filter\CssImportFilter;
 use Assetic\Filter\CssMinFilter;
 use Assetic\Filter\CssRewriteFilter;
-use Assetic\Filter\JSMinFilter;
+use Assetic\Filter\JShrinkFilter;
 use OC\Assetic\SeparatorFilter; // waiting on upstream
 
 /**
@@ -170,7 +170,7 @@ class OC_TemplateLayout extends OC_Template {
 					), $root, $file);
 				}
 				return new FileAsset($root . '/' . $file, array(
-					new JSMinFilter(),
+					new JShrinkFilter(),
 					new SeparatorFilter(';')
 				), $root, $file);
 			}, $jsFiles);


### PR DESCRIPTION
The JSMin minifier is non-free. JShrink is free, it's also a currently-maintained project following good development practices (though we may wish to switch to JSqueeze soon for performance reasons; waiting on
https://github.com/kriswallsmith/assetic/pull/698 reaching upstream Assetic 1.2 for that). This goes along with https://github.com/owncloud/3rdparty/pull/149 , a 3rdparty PR that drops mrclay/minify and adds JShrink.

**NOTE**: this will fail without the matching 3rdparty commit, as JShrink will not be available.
