### PR TITLE
Add check if user is logged-in

### DIFF
--- a/apps/files_versions/ajax/getVersions.php
+++ b/apps/files_versions/ajax/getVersions.php
@@ -1,4 +1,6 @@
 <?php
+OCP\JSON::checkLoggedIn();
+OCP\JSON::callCheck();
 OCP\JSON::checkAppEnabled('files_versions');
 
 $source = $_GET['source'];

--- a/apps/files_versions/ajax/rollbackVersion.php
+++ b/apps/files_versions/ajax/rollbackVersion.php
@@ -1,5 +1,6 @@
 <?php
 
+OCP\JSON::checkLoggedIn();
 OCP\JSON::checkAppEnabled('files_versions');
 OCP\JSON::callCheck();
 


### PR DESCRIPTION
Otherwise a fatal PHP error is thrown since the filesystem is not setup:

```
( ! ) Fatal error: Call to a member function getOwner() on null in /Users/lreschke/Programming/core/lib/private/files/filesystem.php on line 817
Call Stack
1   0.0004  247792  {main}( )   ../index.php:0
2   0.0946  5088776 OC::handleRequest( )    ../index.php:28
3   0.1423  7491280 OC\Route\Router->match( )   ../base.php:748
4   0.1664  8592152 call_user_func:{/Users/lreschke/Programming/core/lib/private/route/router.php:250} ( )  ../router.php:250
5   0.1664  8592216 __lambda_func( )    ../router.php:250
6   0.1665  8599064 require_once( '/Users/lreschke/Programming/core/apps/files_versions/ajax/getVersions.php' ) ../route.php(135) : runtime-created function:1
7   0.1801  9061096 OCA\Files_Versions\Storage::getUidAndFilename( )    ../getVersions.php:7
8   0.1801  9061144 OC\Files\Filesystem::getOwner( )    ../storage.php:45
```

Furthermore this adds the CSRF check as a nice-to-have addition, the requests accessing this are done via the jQuery AJAX methods and thus the header is automatically added to all requests already.
