### PR TITLE
Use memcache for findBinaryPath

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -882,13 +882,19 @@ class OC_Helper {
 	 * @return null|string
 	 */
 	public static function findBinaryPath($program) {
+		$memcache = \OC::$server->getMemCacheFactory()->create('findBinaryPath');
+		if ($memcache->hasKey($program)) {
+			return $memcache->get($program);
+		}
+		$result = null;
 		if (!\OC_Util::runningOnWindows() && self::is_function_enabled('exec')) {
 			exec('command -v ' . escapeshellarg($program) . ' 2> /dev/null', $output, $returnCode);
 			if ($returnCode === 0 && count($output) > 0) {
-				return escapeshellcmd($output[0]);
+				$result = escapeshellcmd($output[0]);
 			}
 		}
-		return null;
+		$memcache->set($program, $result, 3600);
+		return $result;
 	}
 
 	/**

--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -24,7 +24,7 @@ class Factory implements ICacheFactory {
 	}
 
 	/**
-	 * get a cache instance, will return null if no backend is available
+	 * get a cache instance, or Null backend if no backend available
 	 *
 	 * @param string $prefix
 	 * @return \OC\Memcache\Cache
@@ -42,7 +42,7 @@ class Factory implements ICacheFactory {
 		} elseif (Memcached::isAvailable()) {
 			return new Memcached($prefix);
 		} else {
-			return null;
+			return new Null($prefix);
 		}
 	}
 

--- a/lib/private/memcache/null.php
+++ b/lib/private/memcache/null.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Memcache;
+
+class Null extends Cache {
+	public function get($key) {
+		return null;
+	}
+
+	public function set($key, $value, $ttl = 0) {
+		return true;
+	}
+
+	public function hasKey($key) {
+		return false;
+	}
+
+	public function remove($key) {
+		return true;
+	}
+
+	public function clear($prefix = '') {
+		return true;
+	}
+
+	static public function isAvailable() {
+		return true;
+	}
+}


### PR DESCRIPTION
Finding executables is slow, so I memcache'd it. (not expecting this for oC 8, just putting it here while I'm doing performance stuff)

Also introduces a Null memcache backend, that is returned from the factory instead of `null`, which pretends to do caching but really does nothing. It means we no longer need to explicitly check if a memcache is available every time we use it. It's like `/dev/null`!

cc @PVince81 @nickvergessen @icewind1991 
