### PR TITLE
Fix reshare permission issue

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -360,6 +360,8 @@ OC.Share={
 				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner})+'</span>';
 			}
 			html += '<br />';
+			// reduce possible permissions to what the original share allowed
+			possiblePermissions = possiblePermissions & data.reshare.permissions;
 		}
 
 		if (possiblePermissions & OC.PERMISSION_SHARE) {


### PR DESCRIPTION
The actual share permissions sent to the server on reshare are now based
on possiblePermissions + permissions inherited from parent share

Fixes https://github.com/owncloud/core/issues/12976

Please review @icewind1991 @schiesbn @MorrisJobke 

Note: permissions masking is a mess, need to clean this up at some point. There are so many different cases...
