### PR TITLE
Fix js error in personal settings if there is no password field

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -168,7 +168,9 @@ function avatarResponseHandler (data) {
 }
 
 $(document).ready(function () {
-	$('#pass2').showPassword().keyup();
+	if($('#pass2').length) {
+		$('#pass2').showPassword().keyup();
+	}
 	$("#passwordbutton").click(function () {
 		if ($('#pass1').val() !== '' && $('#pass2').val() !== '') {
 			// Serialize the data


### PR DESCRIPTION
For backends that dont support the user changing it's password
