### PR TITLE
Encryption fix key lost if group share gets renamed

### DIFF
--- a/apps/files_encryption/lib/hooks.php
+++ b/apps/files_encryption/lib/hooks.php
@@ -428,8 +428,10 @@ class Hooks {
 
 		// we only need to rename the keys if the rename happens on the same mountpoint
 		// otherwise we perform a stream copy, so we get a new set of keys
-		$mp1 = $view->getMountPoint('/' . $user . '/files/' . $params['oldpath']);
-		$mp2 = $view->getMountPoint('/' . $user . '/files/' . $params['newpath']);
+		$oldPath = \OC\Files\Filesystem::normalizePath('/' . $user . '/files/' . $params['oldpath']);
+		$newPath = \OC\Files\Filesystem::normalizePath('/' . $user . '/files/' . $params['newpath']);
+		$mp1 = $view->getMountPoint($oldPath);
+		$mp2 = $view->getMountPoint($newPath);
 
 		$oldKeysPath = Keymanager::getKeyPath($view, $util, $params['oldpath']);
 
@@ -438,7 +440,7 @@ class Hooks {
 				'operation' => $operation,
 				'oldKeysPath' => $oldKeysPath,
 				);
-		} else {
+		} elseif ($mp1 !== $oldPath . '/') {
 			self::$renamedFiles[$params['oldpath']] = array(
 				'operation' => 'cleanup',
 				'oldKeysPath' => $oldKeysPath,


### PR DESCRIPTION
In master we lose all encryption keys if a file gets shared with a group and one of the group members renamed/moved the share.

This was not detected because the unit tests only tried to read the file again after rename. A few weeks ago we introduced caching for the encryption keys therefore we never detected during the second read operation that the keys no longer exists. This PR adapt the unit tests to check if the keys still exists and fixes the bug. 

It seems like the hooks.php was converted to the dos file format while it was moved to a different location a few weeks ago. I reformatted it back to the unix file format, sorry. The crucial change is at this line: 

old: https://github.com/owncloud/core/compare/enc_fix_key_lost?expand=1#diff-fa12f63daf51643b442e9f6efc7ed784L441 
new: https://github.com/owncloud/core/compare/enc_fix_key_lost?expand=1#diff-fa12f63daf51643b442e9f6efc7ed784R443
