### PR TITLE
Cache responses from the AppStore server

### DIFF
--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -147,7 +147,7 @@ class OC_OCSClient{
 			$app['changed']=strtotime($tmp[$i]->changed);
 			$app['description']=(string)$tmp[$i]->description;
 			$app['score']=(string)$tmp[$i]->score;
-			$app['downloads'] = $tmp[$i]->downloads;
+			$app['downloads'] = (int)$tmp[$i]->downloads;
 
 			$apps[]=$app;
 		}

--- a/settings/ajax/disableapp.php
+++ b/settings/ajax/disableapp.php
@@ -10,5 +10,9 @@ if (!array_key_exists('appid', $_POST)) {
 $appId = $_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
+// FIXME: Clear the cache - move that into some sane helper method
+\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
+\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
+
 OC_App::disable($appId);
 OC_JSON::success();

--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -7,6 +7,9 @@ $groups = isset($_POST['groups']) ? $_POST['groups'] : null;
 
 try {
 	OC_App::enable(OC_App::cleanAppId($_POST['appid']), $groups);
+	// FIXME: Clear the cache - move that into some sane helper method
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
 	OC_JSON::success();
 } catch (Exception $e) {
 	OC_Log::write('core', $e->getMessage(), OC_Log::ERROR);

--- a/settings/ajax/installapp.php
+++ b/settings/ajax/installapp.php
@@ -12,6 +12,9 @@ $appId = OC_App::cleanAppId($appId);
 
 $result = OC_App::installApp($appId);
 if($result !== false) {
+	// FIXME: Clear the cache - move that into some sane helper method
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
 	OC_JSON::success(array('data' => array('appid' => $appId)));
 } else {
 	$l = \OC::$server->getL10N('settings');

--- a/settings/ajax/uninstallapp.php
+++ b/settings/ajax/uninstallapp.php
@@ -12,6 +12,9 @@ $appId = OC_App::cleanAppId($appId);
 
 $result = OC_App::removeApp($appId);
 if($result !== false) {
+	// FIXME: Clear the cache - move that into some sane helper method
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
+	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
 	OC_JSON::success(array('data' => array('appid' => $appId)));
 } else {
 	$l = \OC::$server->getL10N('settings');

--- a/settings/application.php
+++ b/settings/application.php
@@ -55,7 +55,8 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('L10N'),
-				$c->query('Config')
+				$c->query('Config'),
+				$c->query('ICacheFactory')
 			);
 		});
 		$container->registerService('SecuritySettingsController', function(IContainer $c) {
@@ -119,6 +120,9 @@ class Application extends App {
 		 */
 		$container->registerService('Config', function(IContainer $c) {
 			return $c->query('ServerContainer')->getConfig();
+		});
+		$container->registerService('ICacheFactory', function(IContainer $c) {
+			return $c->query('ServerContainer')->getMemCacheFactory();
 		});
 		$container->registerService('L10N', function(IContainer $c) {
 			return $c->query('ServerContainer')->getL10N('settings');


### PR DESCRIPTION
Otherwise every time the AppStore was opened a lot of connections to the AppStore server were made which resulted in a terrible performance.

This changeset will cache the response for a sensible time so that only the first request will be somewhat slow.

Performance changes:
- Loading a category took previously more than 3 seconds on my machine. Now for every follow-up request it takes less than 200ms, resulting in a performance gain of 1950%
- Loading the category list took previously about 750ms - now it takes 154ms, a total performance gain of 395%

Fixes https://github.com/owncloud/core/issues/13209

@DeepDiver1975 @karlitschek FYI - please decide whether 8.0 or 8.1
