### PR TITLE
Fix Basic Auth in master for applications

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -737,7 +737,9 @@ class OC {
 		}
 
 		// Load minimum set of apps
-		if (!self::checkUpgrade(false)) {
+		if (!self::checkUpgrade(false)
+			&& !$systemConfig->getValue('maintenance', false)
+			&& !\OCP\Util::needUpgrade()) {
 			// For logged-in users: Load everything
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();

--- a/lib/base.php
+++ b/lib/base.php
@@ -736,6 +736,19 @@ class OC {
 			self::checkUpgrade();
 		}
 
+		// Load minimum set of apps
+		if (!self::checkUpgrade(false)) {
+			// For logged-in users: Load everything
+			if(OC_User::isLoggedIn()) {
+				OC_App::loadApps();
+			} else {
+				// For guests: Load only authentication, filesystem and logging
+				OC_App::loadApps(array('authentication'));
+				OC_App::loadApps(array('filesystem', 'logging'));
+				\OC_User::tryBasicAuthLogin();
+			}
+		}
+
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
 				if (!$systemConfig->getValue('maintenance', false) && !\OCP\Util::needUpgrade()) {
@@ -752,19 +765,6 @@ class OC {
 			} catch (Symfony\Component\Routing\Exception\MethodNotAllowedException $e) {
 				OC_Response::setStatus(405);
 				return;
-			}
-		}
-
-		// Load minimum set of apps
-		if (!self::checkUpgrade(false)) {
-			// For logged-in users: Load everything
-			if(OC_User::isLoggedIn()) {
-				OC_App::loadApps();
-			} else {
-				// For guests: Load only authentication, filesystem and logging
-				OC_App::loadApps(array('authentication'));
-				OC_App::loadApps(array('filesystem', 'logging'));
-				\OC_User::tryBasicAuthLogin();
 			}
 		}
 


### PR DESCRIPTION
The current behaviour of the authenticion logic in base.php prevents REST APIs in ownCloud applications to work.

Because `!self::$CLI` is usually always a true statement the previously above block was entered which returned, thus the authentication logic for this part does not trigger in.

This can be reproduced by installing apps such as the News app and issuing the following command:

`curl -u admin:admin http://localhost/index.php/apps/news/api/v1-2/feeds`

The following parts needs to get throughly tested:
- [ ] OCS
- [x] remote.php's DAV features
- [x] Regular login features

This bug affects master ~~and stable7~~. I'd propose that we merge this for 8.0 since this has the potential to break every component that relies on Basic Auth features. ~~A backport would also be very nice. Probably caused by https://github.com/owncloud/core/pull/12917~~

Remark to myself: We really need to move out the authentication code for 8.1 out of base.php - I already have a local branch that does that somewhere which I will get in shape for 8.1... - This untested code is a night-mare.

Fixes itself.

@Raydiation Please test with your news app and so on.
@PVince81 Can you run the OCS test suite against this?
@jnfrmarks For QA.
@karlitschek @DeepDiver1975 FYI
