### PR TITLE
Verify whether value is already normalized

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1274,14 +1274,17 @@ class OC_Util {
 	 * @return bool|string
 	 */
 	public static function normalizeUnicode($value) {
-		$normalizedValue = normalizer_normalize($value);
-		if ($normalizedValue === null || $normalizedValue === false) {
-			\OC_Log::write('core', 'normalizing failed for "' . $value . '"', \OC_Log::WARN);
-		} else {
-			$value = $normalizedValue;
+		if(Normalizer::isNormalized($value)) {
+			return $value;
 		}
 
-		return $value;
+		$normalizedValue = Normalizer::normalize($value);
+		if ($normalizedValue === null || $normalizedValue === false) {
+			\OC::$server->getLogger()->warning('normalizing failed for "' . $value . '"', ['app' => 'core']);
+			return $value;
+		}
+
+		return $normalizedValue;
 	}
 
 	/**


### PR DESCRIPTION
Apparently `normalizer_normalize` is not verifying itself whether the string needs to be converted or not. Or does it at least not very performantly.

This simple change leads to a 4% performance gain on the processing of normalizeUnicode. Since this method is called quite often (i.e. for every file path) this has actually a measurable impact. For examples searches are now 200ms faster on my machine. Still not perfect but way to go.

Part of https://github.com/owncloud/core/issues/13221
