### PR TITLE
Simplify isValidPath and add unit tests

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -502,7 +502,7 @@ class Filesystem {
 		if (!$path || $path[0] !== '/') {
 			$path = '/' . $path;
 		}
-		if (strstr($path, '/../') || strrchr($path, '/') === '/..') {
+		if (strpos($path, '/../') !== FALSE || strrchr($path, '/') === '/..') {
 			return false;
 		}
 		return true;

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -154,6 +154,39 @@ class Filesystem extends \Test\TestCase {
 		$this->assertEquals($expected, \OC\Files\Filesystem::normalizePath($path, $stripTrailingSlash));
 	}
 
+	public function isValidPathData() {
+		return array(
+			array('/', true),
+			array('/path', true),
+			array('/foo/bar', true),
+			array('/foo//bar/', true),
+			array('/foo////bar', true),
+			array('/foo//\///bar', true),
+			array('/foo/bar/.', true),
+			array('/foo/bar/./', true),
+			array('/foo/bar/./.', true),
+			array('/foo/bar/././', true),
+			array('/foo/bar/././..bar', true),
+			array('/foo/bar/././..bar/a', true),
+			array('/foo/bar/././..', false),
+			array('/foo/bar/././../', false),
+			array('/foo/bar/.././', false),
+			array('/foo/bar/../../', false),
+			array('/foo/bar/../..\\', false),
+			array('..', false),
+			array('../', false),
+			array('../foo/bar', false),
+			array('..\foo/bar', false),
+		);
+	}
+
+	/**
+	 * @dataProvider isValidPathData
+	 */
+	public function testIsValidPath($path, $expected) {
+		$this->assertSame($expected, \OC\Files\Filesystem::isValidPath($path));
+	}
+
 	public function normalizePathWindowsAbsolutePathData() {
 		return array(
 			array('C:/', 'C:\\'),


### PR DESCRIPTION
The check for invalid paths is actually over-complicated and performed with the not really performant  `strstr` resulting in a performance penalty. Additionally, I decided to add unit-tests to that function.

Part of https://github.com/owncloud/core/issues/13221

@icewind1991 Your review would be appreciated.
