### PR TITLE
Don't double encode string

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1692,7 +1692,7 @@
 				this.$el.find('#emptycontent').addClass('hidden');
 				if ( $('#searchresults').length === 0 || $('#searchresults').hasClass('hidden')) {
 					this.$el.find('.nofilterresults').removeClass('hidden').
-						find('p').text(t('files', "No entries in this folder match '{filter}'", {filter:this._filter}));
+						find('p').text(t('files', "No entries in this folder match '{filter}'", {filter:this._filter},  null, {'escape': false}));
 				}
 			} else {
 				this.$el.find('#filestable thead th').toggleClass('hidden', this.isEmpty);


### PR DESCRIPTION
We already use `.text()` here which automatically properly encodes the string. Thus the string will be double-encoded and look ugly. (i.e. when you search for `>` you will see `No results found for &gt;`)

Fixes itself.

@MorrisJobke Please review.
