### PR TITLE
Cache results of `normalizePath`

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -47,6 +47,8 @@ class Filesystem {
 
 	static private $usersSetup = array();
 
+	static private $normalizedPathCache = array();
+
 	/**
 	 * classname which used for hooks handling
 	 * used as signalclass in OC_Hooks::emit()
@@ -713,6 +715,12 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function normalizePath($path, $stripTrailingSlash = true, $isAbsolutePath = false) {
+		$cacheKey = $path.'-'.-$stripTrailingSlash.'-'.$isAbsolutePath;
+
+		if(isset(self::$normalizedPathCache[$cacheKey])) {
+			return self::$normalizedPathCache[$cacheKey];
+		}
+
 		if ($path == '') {
 			return '/';
 		}
@@ -756,7 +764,10 @@ class Filesystem {
 		//normalize unicode if possible
 		$path = \OC_Util::normalizeUnicode($path);
 
-		return $windows_drive_letter . $path;
+		$normalizedPath = $windows_drive_letter . $path;
+		self::$normalizedPathCache[$cacheKey] = $normalizedPath;
+
+		return $normalizedPath;
 	}
 
 	/**


### PR DESCRIPTION
`normalizePath` is a rather expensive operation and called multiple times for a single path for every file related operation.

In my development installation with about 9GB of data and 60k files this leads to a performance boost of 24% - in seconds that are _1.61s_ (!) - for simple searches. With more files the impact will be even more noticeable. Obviously this affects every operation that has in any regard something to do with using OC\Files\Filesystem.

The following trace is from a request to `/index.php/search/ajax/search.php?query=test&inApps%5B%5D=files&page=1&size=30`:

![screen shot 2015-01-10 at 11 14 17](https://cloud.githubusercontent.com/assets/878997/5691171/d7be7390-98b9-11e4-8e0c-06cb7d8acfbf.png)
![performance-win](https://cloud.githubusercontent.com/assets/878997/5691182/4a9f5028-98ba-11e4-9648-49fa40eff856.png)

Part of https://github.com/owncloud/core/issues/13221

@karlitschek @DeepDiver1975 @MorrisJobke FYI
