### PR TITLE
Use isset() instead of strlen()

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1278,8 +1278,10 @@ class View {
 
 	private function assertPathLength($path) {
 		$maxLen = min(PHP_MAXPATHLEN, 4000);
-		$pathLen = strlen($path);
-		if ($pathLen > $maxLen) {
+		// Check for the string length - performed using isset() instead of strlen()
+		// because isset() is about 5x-40x faster.
+		if(isset($path[$maxLen])) {
+			$pathLen = strlen($path);
 			throw new \OCP\Files\InvalidPathException("Path length($pathLen) exceeds max path length($maxLen): $path");
 		}
 	}


### PR DESCRIPTION
Isset is a native language construct and thus A LOT faster than using strlen() (5x - 40x depending on input)

On my local machine this leads to a per average 20% performance gain, for about 1 million processed paths on my local machine this means a 1s faster processing time. Considering that this function will be called a lot for every file operation this makes a noticeable difference.

@DeepDiver1975 @karlitschek @MorrisJobke 
