### PR TITLE
Only accept EventSource events from where we sent the request to

### DIFF
--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -140,6 +140,11 @@ OC.EventSource.prototype={
 					this.listeners[type].push(callback);
 				}else{
 					this.source.addEventListener(type,function(e){
+						var parser = document.createElement('a');
+						parser.href = this.url;
+						if (e.origin !== parser.protocol + '//' + parser.hostname) {
+							return;
+						}
 						if (typeof e.data !== 'undefined') {
 							callback(JSON.parse(e.data));
 						} else {


### PR DESCRIPTION
It's important to make sure the EventSource events the browser gets actually come from where it has sent them to and I don't think OC does any sort of checks.
https://html.spec.whatwg.org/multipage/comms.html#authors

This is one way of doing it, maybe there are better ways.
