### PR TITLE
Allow dropping files on the table container

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1832,9 +1832,18 @@
 			fileUploadStart.on('fileuploaddrop', function(e, data) {
 				OC.Upload.log('filelist handle fileuploaddrop', e, data);
 
+				if (self.$el.hasClass('hidden')) {
+					// do not upload to invisible lists
+					return false;
+				}
+
 				var dropTarget = $(e.originalEvent.target);
 				// check if dropped inside this container and not another one
-				if (dropTarget.length && !self.$el.is(dropTarget) && !self.$el.has(dropTarget).length) {
+				if (dropTarget.length
+					&& !self.$el.is(dropTarget) // dropped on list directly
+					&& !self.$el.has(dropTarget).length // dropped inside list
+					&& !dropTarget.is(self.$container) // dropped on main container
+					) {
 					return false;
 				}
 


### PR DESCRIPTION
Make it possible to drop files below the table even if the table is
smaller than the window height.

Added a check to make sure upload is not triggered on invisible lists.

Fixes https://github.com/owncloud/core/issues/13199

This should hopefully make dropping independent from CSS.

Please review @LukasReschke @schiesbn @icewind1991 @MorrisJobke @DeepDiver1975 

To test:
#### Regular file list
- [x] drop on file list: uploads
- [x] drop below the summary line: uploads
- [x] drop onto folder inside file list: uploads into targetted folder
- [x] drop onto sidebar: no upload
- [x] drop onto breadcrumb: uploads into targetted folder
- [x] open "All files", switch to "Favorites", drop file onto list: nothing happens (tests the "list is hidden" condition)
#### Public file list (public share)
- [x] drop on file list: uploads
- [x] drop below the summary line: uploads
- [ ] drop onto folder inside file list: uploads into targetted folder. :no_entry_sign: FAIL but unrelated: https://github.com/owncloud/core/issues/13267
- [x] drop onto breadcrumb: uploads into targetted folder
