### PR TITLE
Fixes issues when renaming favorite file

### DIFF
--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -104,9 +104,10 @@ class App {
 		) {
 			// successful rename
 			$meta = $this->view->getFileInfo($normalizedNewPath);
-			$fileinfo = \OCA\Files\Helper::formatFileInfo($meta);
+			$meta = \OCA\Files\Helper::populateTags(array($meta));
+			$fileInfo = \OCA\Files\Helper::formatFileInfo(current($meta));
 			$result['success'] = true;
-			$result['data'] = $fileinfo;
+			$result['data'] = $fileInfo;
 		} else {
 			// rename failed
 			$result['data'] = array(

--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -106,6 +106,7 @@ class App {
 			$meta = $this->view->getFileInfo($normalizedNewPath);
 			$meta = \OCA\Files\Helper::populateTags(array($meta));
 			$fileInfo = \OCA\Files\Helper::formatFileInfo(current($meta));
+			$fileInfo['path'] = dirname($normalizedNewPath);
 			$result['success'] = true;
 			$result['data'] = $fileInfo;
 		} else {

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -118,6 +118,7 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals('httpd/unix-directory', $result['data']['mimetype']);
 		$this->assertEquals('abcdef', $result['data']['etag']);
 		$this->assertFalse(isset($result['data']['tags']));
+		$this->assertEquals('/', $result['data']['path']);
 		$icon = \OC_Helper::mimetypeIcon('dir');
 		$icon = substr($icon, 0, -3) . 'svg';
 		$this->assertEquals($icon, $result['data']['icon']);
@@ -182,6 +183,7 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals('text/plain', $result['data']['mimetype']);
 		$this->assertEquals('abcdef', $result['data']['etag']);
 		$this->assertEquals(array('tag1', 'tag2'), $result['data']['tags']);
+		$this->assertEquals('/', $result['data']['path']);
 		$icon = \OC_Helper::mimetypeIcon('text');
 		$icon = substr($icon, 0, -3) . 'svg';
 		$this->assertEquals($icon, $result['data']['icon']);

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -117,9 +117,78 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals(18, $result['data']['size']);
 		$this->assertEquals('httpd/unix-directory', $result['data']['mimetype']);
 		$this->assertEquals('abcdef', $result['data']['etag']);
+		$this->assertFalse(isset($result['data']['tags']));
 		$icon = \OC_Helper::mimetypeIcon('dir');
 		$icon = substr($icon, 0, -3) . 'svg';
 		$this->assertEquals($icon, $result['data']['icon']);
+	}
+
+	/**
+	 * test rename of file with tag
+	 */
+	function testRenameFileWithTag() {
+		$taggerMock = $this->getMock('\OCP\ITags');
+		$taggerMock->expects($this->any())
+			->method('getTagsForObjects')
+			->with(array(123))
+			->will($this->returnValue(array(123 => array('tag1', 'tag2'))));
+		$tagManagerMock = $this->getMock('\OCP\ITagManager');
+		$tagManagerMock->expects($this->any())
+			->method('load')
+			->with('files')
+			->will($this->returnValue($taggerMock));
+		$oldTagManager = \OC::$server->query('TagManager');
+		\OC::$server->registerService('TagManager', function ($c) use ($tagManagerMock) {
+			return $tagManagerMock;
+		});
+
+		$dir = '/';
+		$oldname = 'oldname.txt';
+		$newname = 'newname.txt';
+
+		$this->viewMock->expects($this->any())
+			->method('file_exists')
+			->with($this->anything())
+			->will($this->returnValueMap(array(
+				array('/', true),
+				array('/oldname.txt', true)
+				)));
+
+
+		$this->viewMock->expects($this->any())
+			->method('getFileInfo')
+			->will($this->returnValue(new \OC\Files\FileInfo(
+				'/new_name.txt',
+				new \OC\Files\Storage\Local(array('datadir' => '/')),
+				'/',
+				array(
+				'fileid' => 123,
+				'type' => 'file',
+				'mimetype' => 'text/plain',
+				'mtime' => 0,
+				'permissions' => 31,
+				'size' => 18,
+				'etag' => 'abcdef',
+				'directory' => '/',
+				'name' => 'new_name.txt',
+			), null)));
+
+		$result = $this->files->rename($dir, $oldname, $newname);
+
+		$this->assertTrue($result['success']);
+		$this->assertEquals(123, $result['data']['id']);
+		$this->assertEquals('new_name.txt', $result['data']['name']);
+		$this->assertEquals(18, $result['data']['size']);
+		$this->assertEquals('text/plain', $result['data']['mimetype']);
+		$this->assertEquals('abcdef', $result['data']['etag']);
+		$this->assertEquals(array('tag1', 'tag2'), $result['data']['tags']);
+		$icon = \OC_Helper::mimetypeIcon('text');
+		$icon = substr($icon, 0, -3) . 'svg';
+		$this->assertEquals($icon, $result['data']['icon']);
+
+		\OC::$server->registerService('TagManager', function ($c) use ($oldTagManager) {
+			return $oldTagManager;
+		});
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/13215 (star disappears after rename)
Fixes https://github.com/owncloud/core/issues/12944 (cannot rename file twice in favorite view)

Please review @icewind1991 @MorrisJobke @LukasReschke @nickvergessen 
