### PR TITLE
fix safari rename button positioning #11348

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -305,7 +305,6 @@ table td.filename .nametext .innernametext {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	position: relative;
-	display: inline-block;
 }
 
 @media only screen and (min-width: 1366px) {
@@ -518,9 +517,9 @@ a.action>img {
 
 #fileList a.action[data-action="Rename"] {
 	padding: 16px 14px 17px !important;
-	position: relative;
-	top: -21px;
 }
+
+.ie8 #fileList a.action img,
 #fileList tr:hover a.action,
 #fileList a.action.permanent,
 #fileList tr:focus a.action,
@@ -531,6 +530,7 @@ a.action>img {
 	opacity: .5;
 	display:inline;
 }
+.ie8 #fileList a.action:hover img,
 #fileList tr:hover a.action:hover,
 #fileList tr:focus a.action:focus,
 #fileList .name:focus a.action:focus {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -305,6 +305,8 @@ table td.filename .nametext .innernametext {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	position: relative;
+	display: inline-block;
+	vertical-align: top;
 }
 
 @media only screen and (min-width: 1366px) {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -296,6 +296,10 @@ table td.filename .nametext {
 	max-width: 800px;
 	height: 100%;
 }
+/* IE8 text-overflow: ellipsis support */
+.ie8 table td.filename .nametext {
+	min-width: 50%;
+}
 .has-favorites #fileList td.filename a.name {
 	left: 50px;
 	margin-right: 50px;
@@ -307,6 +311,13 @@ table td.filename .nametext .innernametext {
 	position: relative;
 	display: inline-block;
 	vertical-align: top;
+}
+/* IE8 text-overflow: ellipsis support */
+.ie8 table td.filename .nametext .innernametext {
+	white-space: nowrap;
+	word-wrap: normal;
+	-ms-text-overflow: ellipsis;
+	max-width: 47%;
 }
 
 @media only screen and (min-width: 1366px) {

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -247,8 +247,9 @@
 				html += '<img class="svg" alt="" src="' + img + '" />';
 			}
 			if (actionSpec.displayName) {
-				html += '<span> ' + actionSpec.displayName + '</span></a>';
+				html += '<span> ' + actionSpec.displayName + '</span>';
 			}
+			html += '</a>';
 
 			return $(html);
 		},


### PR DESCRIPTION
This fixes #11348 
Compared on safari 8, IE11, Chrome 39 - positioning looks the same
