### PR TITLE
Adding repair step to fix missing etags - fixes #12172

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -12,6 +12,7 @@ use OC\Hooks\BasicEmitter;
 use OC\Hooks\Emitter;
 use OC\Repair\AssetCache;
 use OC\Repair\Collation;
+use OC\Repair\FillETags;
 use OC\Repair\InnoDB;
 use OC\Repair\RepairConfig;
 use OC\Repair\RepairLegacyStorages;
@@ -79,7 +80,8 @@ class Repair extends BasicEmitter {
 			new RepairMimeTypes(),
 			new RepairLegacyStorages(\OC::$server->getConfig(), \OC_DB::getConnection()),
 			new RepairConfig(),
-			new AssetCache()
+			new AssetCache(),
+			new FillETags(\OC_DB::getConnection())
 		);
 	}
 

--- a/lib/repair/filletags.php
+++ b/lib/repair/filletags.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2015 Thomas Müller <deepdiver@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Repair;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use OC\Hooks\BasicEmitter;
+
+class FillETags extends BasicEmitter implements \OC\RepairStep {
+
+	/** @var \OC\DB\Connection */
+	protected $connection;
+
+	/**
+	 * @param \OC\DB\Connection $connection
+	 */
+	public function __construct($connection) {
+		$this->connection = $connection;
+	}
+
+	public function getName() {
+		return 'Generate ETags for file where no ETag is present.';
+	}
+
+	public function run() {
+		$qb = $this->connection->createQueryBuilder();
+		$qb->update('`*PREFIX*filecache`')
+			->set('`etag`', $qb->expr()->literal('xxx'))
+			->where($qb->expr()->eq('`etag`', $qb->expr()->literal('')))
+			->orWhere($qb->expr()->isNull('`etag`'));
+
+		$result = $qb->execute();
+		$this->emit('\OC\Repair', 'info', array("ETags have been fixed for $result files/folders."));
+	}
+}
+


### PR DESCRIPTION
fixes #12172

@dragotin @PVince81 @icewind1991 

From the pure sync algorithm pov it is sufficient to fill the etag with any random string which is not empty.
