### PR TITLE
fix retrieval of user groups

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -149,7 +149,11 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$this->abandonPagedSearch();
 		// openLDAP requires that we init a new Paged Search. Not needed by AD,
 		// but does not hurt either.
-		$this->initPagedSearch($filter, array($dn), array($attr), 1, 0);
+		$pagingSize = intval($this->connection->ldapPagingSize);
+		// 0 won't result in replies, small numbers may leave out groups
+		// (cf. #12306), 500 is default for paging and should work everywhere.
+		$maxResults = $pagingSize < 20 ? $pagingSize : 500;
+		$this->initPagedSearch($filter, array($dn), array($attr), $maxResults, 0);
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));
 		if(!$this->ldap->isResource($rr)) {

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -26,11 +26,13 @@ namespace OCA\user_ldap\lib;
 //magic properties (incomplete)
 /**
  * responsible for LDAP connections in context with the provided configuration
+ *
  * @property string ldapUserFilter
  * @property string ldapUserDisplayName
  * @property boolean hasPagedResultSupport
  * @property string[] ldapBaseUsers
-*/
+ * @property int|string ldapPagingSize holds an integer
+ */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;
 	private $configPrefix;


### PR DESCRIPTION
This fixes #12306.

We need to reset the paged search to work properly with a certain LDAP server when reading an attribute. However, the number of entries to be returned should not be one, as it bring problems here or there. We now use the Chunk Size therefore (defaults to 500) or 500 is the specified one is too small.

How to test? 
1. Have an LDAP user who is member of more than 2 groups. 
2. Run https://gist.github.com/blizzz/736339dc4938a920e087 and pass the users ownCloud username as first parameter and nonsense as second (not needed here). You will see that only one (LDAP!)  group is returned.
3. Apply this patch and do 2) again. Now all groups are listed.

Please test/review @MorrisJobke @tkaufm @oxivanisher @d-tamm @jnfrmarks 
