### PR TITLE
[WIP] Auto-delete tag mappings when files deleted or unshare from self

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -151,6 +151,13 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @return bool
 	 */
 	public function removeMount() {
+		\OC_Hook::emit(
+			\OC\Files\Filesystem::CLASSNAME,
+			\OC\Files\Filesystem::signal_delete_mount,
+			array(
+				\OC\Files\Filesystem::signal_param_path => $this->mountPoint
+			)
+		);
 		$mountManager = \OC\Files\Filesystem::getMountManager();
 		/** @var \OC\Files\Storage\Shared */
 		$storage = $this->getStorage();

--- a/lib/base.php
+++ b/lib/base.php
@@ -583,6 +583,7 @@ class OC {
 		self::registerCacheHooks();
 		self::registerFilesystemHooks();
 		self::registerPreviewHooks();
+		self::registerTagHooks();
 		self::registerShareHooks();
 		self::registerLogRotate();
 		self::registerLocalAddressBook();
@@ -681,6 +682,16 @@ class OC {
 		OC_Hook::connect('OC_Filesystem', 'post_delete', 'OC\Preview', 'post_delete_files');
 		OC_Hook::connect('\OCP\Versions', 'delete', 'OC\Preview', 'post_delete');
 		OC_Hook::connect('\OCP\Trashbin', 'delete', 'OC\Preview', 'post_delete');
+	}
+
+	/**
+	 * register hooks for tags
+	 */
+	public static function registerTagHooks() {
+		if (\OC::$server->getUserSession() !== null) {
+			OC_Hook::connect('OC_Filesystem', 'delete', 'OC\TagHooks', 'fileDeletedHook');
+			OC_Hook::connect('OC_Filesystem', 'delete_mount', 'OC\TagHooks', 'unmountHook');
+		}
 	}
 
 	/**

--- a/lib/private/taghooks.php
+++ b/lib/private/taghooks.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* ownCloud
+*
+* @author Vincent Petry
+* @copyright 2015 Vincent Petry <pvince81@owncloud.com>
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+namespace OC;
+
+/**
+ * Receiver for tag related hooks, rewires them
+ * to the TagManager.
+ */
+class TagHooks {
+
+	/**
+	 * Hook for whenever a file or folder was deleted.
+	 *
+	 * Delete the tag mapping for every file in the folder.
+	 */
+	static function fileDeletedHook($args) {
+		self::deleteFileTagMappings($path);
+	}
+
+	static function unmountHook($args) {
+		$path = trim($args['path'], '/');
+		// strip prefix "$user/files"
+		$path = explode('/', 2);
+		self::deleteFileTagMappings($path[1]);
+	}
+
+	/**
+	 * Delete all tag mappings for all files inside the
+	 * given path
+	 *
+	 * @param $path path for which to delete tag mappings
+	 */
+	static function deleteFileTagMappings($path) {
+		$root = \OC::$server->getUserFolder();
+		try {
+			$node = $root->get($path);
+		} catch (\OCP\Files\NotFoundException $e) {
+			return;
+		}
+
+		$tagManager = \OC::$server->getTagManager();
+		$tagger = $tagManager->load('files');
+
+		// TODO: if no tags exist for that user, skip ?
+
+		$fileIds = array($node->getId());
+
+		// traverse subdirectories
+		$exploreDirs = array();
+		if ($node instanceof \OCP\Files\Folder) {
+			$exploreDirs[] = $node;
+		}
+
+		while (count($exploreDirs) > 0) {
+			$node = array_pop($exploreDirs);
+
+			$children = $node->getDirectoryListing();
+			foreach ($children as $child) {
+				if ($child instanceof \OCP\Files\Folder) {
+					$exploreDirs[] = $child;
+				}
+				$fileIds[] = $child->getId();
+			}
+		}
+
+		$tagger->purgeObjects($fileIds);
+	}
+}


### PR DESCRIPTION
Automatically delete the tag mappings of files that are about to be
deleted either by a delete operation or "unshare from self".

Partial fix for: https://github.com/owncloud/core/issues/12858

Note: this doesn't fix the case when shared files are deleted by another user.

I don't like this fix because:
1) it introduces more static code
2) need to iterate over all subfolders to delete tag to file mappings by file id. This means that file deletion will be even slower than before. (the preview code already iterates in a similar manner)

For 1) I thought maybe about moving "TagService" from the files app to core.
Or core should have a "FileTagManager" that provides such utilities.

What do you think ?

@Raydiation @DeepDiver1975 @icewind1991 @LukasReschke @schiesbn 
- [ ] add unit tests
