### PR TITLE
[encryption] fix download of public shared files

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -47,31 +47,30 @@ class Proxy extends \OC_FileProxy {
 	 * check if path is excluded from encryption
 	 *
 	 * @param string $path relative to data/
-	 * @param string $uid user
 	 * @return boolean
 	 */
-	protected function isExcludedPath($path, $uid) {
+	protected function isExcludedPath($path) {
 
 		$view = new \OC\Files\View();
 
-		$path = \OC\Files\Filesystem::normalizePath($path);
+		$normalizedPath = \OC\Files\Filesystem::normalizePath($path);
 
-		$parts = explode('/', $path);
+		$parts = explode('/', $normalizedPath);
 
 		// we only encrypt/decrypt files in the files and files_versions folder
 		if(
-			strpos($path, '/' . $uid . '/files/') !== 0 &&
+			!($parts[2] === 'files' && \OCP\User::userExists($parts[1])) &&
 			!($parts[2] === 'files_versions' && \OCP\User::userExists($parts[1]))) {
 
 			return true;
 		}
 
-		if (!$view->file_exists($path)) {
-			$path = dirname($path);
+		if (!$view->file_exists($normalizedPath)) {
+			$normalizedPath = dirname($normalizedPath);
 		}
 
 		// we don't encrypt server-to-server shares
-		list($storage, ) = \OC\Files\Filesystem::resolvePath($path);
+		list($storage, ) = \OC\Files\Filesystem::resolvePath($normalizedPath);
 		/**
 		 * @var \OCP\Files\Storage $storage
 		 */
@@ -93,17 +92,16 @@ class Proxy extends \OC_FileProxy {
 	 */
 	private function shouldEncrypt($path, $mode = 'w') {
 
-		$userId = Helper::getUser($path);
-
 		// don't call the crypt stream wrapper, if...
 		if (
 				Crypt::mode() !== 'server'   // we are not in server-side-encryption mode
-				|| $this->isExcludedPath($path, $userId) // if path is excluded from encryption
+				|| $this->isExcludedPath($path) // if path is excluded from encryption
 				|| substr($path, 0, 8) === 'crypt://' // we are already in crypt mode
 		) {
 			return false;
 		}
 
+		$userId = Helper::getUser($path);
 		$view = new \OC\Files\View('');
 		$util = new Util($view, $userId);
 

--- a/apps/files_encryption/lib/stream.php
+++ b/apps/files_encryption/lib/stream.php
@@ -136,7 +136,8 @@ class Stream {
 		switch ($fileType) {
 			case Util::FILE_TYPE_FILE:
 				$this->relPath = Helper::stripUserFilesPath($this->rawPath);
-				$this->userId = \OC::$server->getUserSession()->getUser()->getUID();
+				$user = \OC::$server->getUserSession()->getUser();
+				$this->userId = $user ? $user->getUID() : Helper::getUserFromPath($this->rawPath);
 				break;
 			case Util::FILE_TYPE_VERSION:
 				$this->relPath = Helper::getPathFromVersion($this->rawPath);
@@ -145,7 +146,8 @@ class Stream {
 			case Util::FILE_TYPE_CACHE:
 				$this->relPath = Helper::getPathFromCachedFile($this->rawPath);
 				Helper::mkdirr($this->rawPath, new \OC\Files\View('/'));
-				$this->userId = \OC::$server->getUserSession()->getUser()->getUID();
+				$user = \OC::$server->getUserSession()->getUser();
+				$this->userId = $user ? $user->getUID() : Helper::getUserFromPath($this->rawPath);
 				break;
 			default:
 				\OCP\Util::writeLog('Encryption library', 'failed to open file "' . $this->rawPath . '" expecting a path to "files", "files_versions" or "cache"', \OCP\Util::ERROR);

--- a/apps/files_encryption/tests/proxy.php
+++ b/apps/files_encryption/tests/proxy.php
@@ -126,9 +126,7 @@ class Proxy extends TestCase {
 		$this->view->mkdir(dirname($path));
 		$this->view->file_put_contents($path, "test");
 
-		$testClass = new DummyProxy();
-
-		$result = $testClass->isExcludedPathTesting($path, $this->userId);
+		$result = \Test_Helper::invokePrivate(new \OCA\Files_Encryption\Proxy(), 'isExcludedPath', array($path));
 		$this->assertSame($expected, $result);
 
 		$this->view->deleteAll(dirname($path));
@@ -149,12 +147,3 @@ class Proxy extends TestCase {
 
 }
 
-
-/**
- * Dummy class to make protected methods available for testing
- */
-class DummyProxy extends \OCA\Files_Encryption\Proxy {
-	public function isExcludedPathTesting($path, $uid) {
-		return $this->isExcludedPath($path, $uid);
-	}
-}


### PR DESCRIPTION
if we download a public shared file we need to retrieve the user from the path

fix #13270

cc @LukasReschke 
