### PR TITLE
Properly update internal file info with updated tags

### DIFF
--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -110,10 +110,17 @@
 						dir + '/' + fileName,
 						tags
 					).then(function(result) {
+						// response from server should contain updated tags
+						var newTags = result.tags;
+						if (_.isUndefined(newTags)) {
+							newTags = tags;
+						}
+						var fileInfo = context.fileList.files[$file.index()];
 						// read latest state from result
-						toggleStar($actionEl, (result.tags.indexOf(OC.TAG_FAVORITE) >= 0));
-						$file.attr('data-tags', tags.join('|'));
+						toggleStar($actionEl, (newTags.indexOf(OC.TAG_FAVORITE) >= 0));
+						$file.attr('data-tags', newTags.join('|'));
 						$file.attr('data-favorite', !isFavorite);
+						fileInfo.tags = newTags;
 					});
 				}
 			});

--- a/apps/files/tests/js/tagspluginspec.js
+++ b/apps/files/tests/js/tagspluginspec.js
@@ -77,11 +77,39 @@ describe('OCA.Files.TagsPlugin tests', function() {
 	});
 	describe('Applying tags', function() {
 		it('sends request to server and updates icon', function() {
-			// TODO
+			var request;
 			fileList.setFiles(testFiles);
-		});
-		it('sends all tags to server when applyFileTags() is called ', function() {
-			// TODO
+			$tr = fileList.$el.find('tbody tr:first');
+			$action = $tr.find('.action-favorite');
+			$action.click();
+
+			expect(fakeServer.requests.length).toEqual(1);
+			var request = fakeServer.requests[0];
+			expect(JSON.parse(request.requestBody)).toEqual({
+				tags: ['tag1', 'tag2', OC.TAG_FAVORITE]
+			});
+			request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
+				tags: ['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]
+			}));
+
+			expect($tr.attr('data-favorite')).toEqual('true');
+			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
+			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3', OC.TAG_FAVORITE]);
+			expect($action.find('img').attr('src')).toEqual(OC.imagePath('core', 'actions/starred'));
+
+			$action.click();
+			request = fakeServer.requests[1];
+			expect(JSON.parse(request.requestBody)).toEqual({
+				tags: ['tag1', 'tag2', 'tag3']
+			});
+			request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({
+				tags: ['tag1', 'tag2', 'tag3']
+			}));
+
+			expect($tr.attr('data-favorite')).toEqual('false');
+			expect($tr.attr('data-tags').split('|')).toEqual(['tag1', 'tag2', 'tag3']);
+			expect(fileList.files[0].tags).toEqual(['tag1', 'tag2', 'tag3']);
+			expect($action.find('img').attr('src')).toEqual(OC.imagePath('core', 'actions/star'));
 		});
 	});
 });


### PR DESCRIPTION
Whenever tags are updated, they need to be updated in the file list's
file info array as well.

This commit also adds unit tests and makes sure that whichever tags are
sent back by the server after update are used when updating
attributes/fileinfo.

Fixes https://github.com/owncloud/core/issues/13283

Please review @MorrisJobke @icewind1991 @schiesbn @nickvergessen 
