### PR TITLE
Fix searchCommon to properly match path name

### DIFF
--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -259,6 +259,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		 * @var \OC\Files\Storage\Storage $storage
 		 */
 		list($storage, $internalPath) = $this->view->resolvePath($this->path);
+		$internalPath = rtrim($internalPath, '/') . '/';
 		$internalRootLength = strlen($internalPath);
 
 		$cache = $storage->getCache('');

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -405,6 +405,45 @@ class Folder extends \Test\TestCase {
 		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
 	}
 
+	public function testSearchInRoot() {
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		/**
+		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 */
+		$view = $this->getMock('\OC\Files\View');
+		$root = $this->getMock('\OC\Files\Node\Root', array('getUser', 'getMountsIn'), array($manager, $view, $this->user));
+		$root->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($this->user));
+		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+
+		$storage->expects($this->once())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$cache->expects($this->once())
+			->method('search')
+			->with('%qw%')
+			->will($this->returnValue(array(
+				array('fileid' => 3, 'path' => 'files/foo', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'),
+				array('fileid' => 3, 'path' => 'files_trashbin/foo2.d12345', 'name' => 'foo2.d12345', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'),
+			)));
+
+		$root->expects($this->once())
+			->method('getMountsIn')
+			->with('')
+			->will($this->returnValue(array()));
+
+		$view->expects($this->once())
+			->method('resolvePath')
+			->will($this->returnValue(array($storage, 'files')));
+
+		$result = $root->search('qw');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals('/foo', $result[0]->getPath());
+	}
+
 	public function testSearchByTag() {
 		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**


### PR DESCRIPTION
The internal path was matched without the last "/" which caused
"files_trashbin" to also match when the internal path was "files".

This adds the missing slash for the comparison.

Partial fix for: https://github.com/owncloud/core/issues/13287

To reproduce:
1. Create three files "test1", "test2", "test3".
2. Delete "test1" to make it go to trashbin
3. Favorite "test2" and "test3"
4. Change the database entry in `oc_vcategory_to_object` for "test3", set its objid to the objid of "test1" from the trashbin
5. Go to "Favorites" page

Before the fix: the exception from https://github.com/owncloud/core/issues/13287 appears in the log, no results
After the fix: the result list contains only "test2".

Even though the original issue cannot be reproduced yet, this fix is necessary to avoid potential other errors.

Please review @icewind1991 @MorrisJobke @LukasReschke @DeepDiver1975 
