### PR TITLE
Use json_encode on string

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -715,7 +715,7 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function normalizePath($path, $stripTrailingSlash = true, $isAbsolutePath = false) {
-		$cacheKey = $path.'-'.-$stripTrailingSlash.'-'.$isAbsolutePath;
+		$cacheKey = json_encode([$path, $stripTrailingSlash, $isAbsolutePath]);
 
 		if(isset(self::$normalizedPathCache[$cacheKey])) {
 			return self::$normalizedPathCache[$cacheKey];


### PR DESCRIPTION
It's better to encode the string to prevent possible (yet unknown) bugs in combination with PHP's type juggling.

Previously the boolean statements evaluated to either an empty string (false) or a not empty one (true, then it was 1). Now it always evaluates to false or true.

This also removes a stray `-` that was not intended there but shouldn't have produced any bugs. Just to increase readability.

Thanks @nickvergessen for spotting.

Addresses https://github.com/owncloud/core/pull/13235/files#r22852319
