### PR TITLE
Memcache route collections

### DIFF
--- a/lib/private/route/cachingrouter.php
+++ b/lib/private/route/cachingrouter.php
@@ -22,6 +22,21 @@ class CachingRouter extends Router {
 		parent::__construct();
 	}
 
+	protected function loadCollection($collection, $files) {
+		$key = 'collection:' . $collection;
+		if ($this->cache->hasKey($key)) {
+			return unserialize($this->cache->get($key));
+		}
+		$object = parent::loadCollection($collection, $files);
+		try {
+			$serialized = serialize($object);
+			$this->cache->set($key, $serialized, 3600);
+		} catch (\Exception $e) {
+			// unable to serialize routes
+		}
+		return $object;
+	}
+
 	/**
 	 * Generate url based on $name and $parameters
 	 *


### PR DESCRIPTION
Only works for serializable objects, which do not contain closures (anonymous functions). Kill `actionInclude()` and anonymous functions in route files!

Confirmed working for:
- ocs
- files_external
- user_ldap

Doesn't work for:
- root (core)
- files
- files_sharing
- files_versions

cc @DeepDiver1975 @Raydiation @MorrisJobke
