### PR TITLE
adapt decrypt all to the new folder structure

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -692,9 +692,9 @@ class OC_Util {
 		$encryptedFiles = false;
 		if (OC_App::isEnabled('files_encryption') === false) {
 			$view = new OC\Files\View('/' . OCP\User::getUser());
-			$keyfilePath = '/files_encryption/keyfiles';
-			if ($view->is_dir($keyfilePath)) {
-				$dircontent = $view->getDirectoryContent($keyfilePath);
+			$keysPath = '/files_encryption/keys';
+			if ($view->is_dir($keysPath)) {
+				$dircontent = $view->getDirectoryContent($keysPath);
 				if (!empty($dircontent)) {
 					$encryptedFiles = true;
 				}
@@ -714,7 +714,7 @@ class OC_Util {
 		$backupExists = false;
 		if (OC_App::isEnabled('files_encryption') === false) {
 			$view = new OC\Files\View('/' . OCP\User::getUser());
-			$backupPath = '/files_encryption/keyfiles.backup';
+			$backupPath = '/files_encryption/backup.decryptAll';
 			if ($view->is_dir($backupPath)) {
 				$dircontent = $view->getDirectoryContent($backupPath);
 				if (!empty($dircontent)) {

--- a/settings/ajax/deletekeys.php
+++ b/settings/ajax/deletekeys.php
@@ -4,13 +4,11 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
 $l = \OC::$server->getL10N('settings');
-$user = \OC_User::getUser();
-$view = new \OC\Files\View('/' . $user . '/files_encryption');
 
-$keyfilesDeleted = $view->deleteAll('keyfiles.backup');
-$sharekeysDeleted = $view->deleteAll('share-keys.backup');
+$util = new \OCA\Files_Encryption\Util(new \OC\Files\View(), \OC_User::getUser());
+$result = $util->deleteBackup('decryptAll');
 
-if ($keyfilesDeleted && $sharekeysDeleted) {
+if ($result) {
 	\OCP\JSON::success(array('data' => array('message' => $l->t('Encryption keys deleted permanently'))));
 } else {
 	\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t permanently delete your encryption keys, please check your owncloud.log or ask your administrator'))));

--- a/settings/ajax/restorekeys.php
+++ b/settings/ajax/restorekeys.php
@@ -4,21 +4,12 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
 $l = \OC::$server->getL10N('settings');
-$user = \OC_User::getUser();
-$view = new \OC\Files\View('/' . $user . '/files_encryption');
 
-$keyfilesRestored = $view->rename('keyfiles.backup', 'keyfiles');
-$sharekeysRestored = $view->rename('share-keys.backup' , 'share-keys');
+$util = new \OCA\Files_Encryption\Util(new \OC\Files\View(), \OC_User::getUser());
+$result = $util->restoreBackup('decryptAll');
 
-if ($keyfilesRestored && $sharekeysRestored) {
+if ($result) {
 	\OCP\JSON::success(array('data' => array('message' => $l->t('Backups restored successfully'))));
 } else {
-	// if one of the move operation was succesful we remove the files back to have a consistent state
-	if($keyfilesRestored) {
-		$view->rename('keyfiles', 'keyfiles.backup');
-	}
-	if($sharekeysRestored) {
-		$view->rename('share-keys' , 'share-keys.backup');
-	}
 	\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t restore your encryption keys, please check your owncloud.log or ask your administrator'))));
 }


### PR DESCRIPTION
adapt decrypt all and restore/delete key backups to the new folder structure for encryption key introduced with OC8. Seems like I missed it during the re-structuring of the encryption key directory...
