### PR TITLE
Get rid of `stripslashes()`

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -6,7 +6,7 @@ OCP\JSON::callCheck();
 
 
 // Get data
-$dir = stripslashes($_POST["dir"]);
+$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
 $allFiles = isset($_POST["allfiles"]) ? $_POST["allfiles"] : false;
 
 // delete all files in dir ?

--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -5,9 +5,9 @@ OCP\JSON::callCheck();
 \OC::$server->getSession()->close();
 
 // Get data
-$dir = stripslashes($_POST["dir"]);
-$file = stripslashes($_POST["file"]);
-$target = stripslashes(rawurldecode($_POST["target"]));
+$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
+$file = isset($_POST['file']) ? $_POST['file'] : '';
+$target = isset($_POST['target']) ? rawurldecode($_POST['target']) : '';
 
 $l = \OC::$server->getL10N('files');
 

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -81,7 +81,6 @@ if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
 	exit();
 }
 
-//TODO why is stripslashes used on foldername in newfolder.php but not here?
 $target = $dir.'/'.$filename;
 
 if (\OC\Files\Filesystem::file_exists($target)) {

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -8,8 +8,8 @@ OCP\JSON::callCheck();
 \OC::$server->getSession()->close();
 
 // Get the params
-$dir = isset( $_POST['dir'] ) ? stripslashes($_POST['dir']) : '';
-$foldername = isset( $_POST['foldername'] ) ? stripslashes($_POST['foldername']) : '';
+$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
+$foldername = isset($_POST['foldername']) ? $_POST['foldername'] : '';
 
 $l10n = \OC::$server->getL10N('files');
 

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -132,9 +132,9 @@ if (strpos($dir, '..') === false) {
 		// $path needs to be normalized - this failed within drag'n'drop upload to a sub-folder
 		if ($resolution === 'autorename') {
 			// append a number in brackets like 'filename (2).ext'
-			$target = OCP\Files::buildNotExistingFileName(stripslashes($dir . $relativePath), $files['name'][$i]);
+			$target = OCP\Files::buildNotExistingFileName($dir . $relativePath, $files['name'][$i]);
 		} else {
-			$target = \OC\Files\Filesystem::normalizePath(stripslashes($dir . $relativePath).'/'.$files['name'][$i]);
+			$target = \OC\Files\Filesystem::normalizePath($dir . $relativePath.'/'.$files['name'][$i]);
 		}
 
 		// relative dir to return to the client


### PR DESCRIPTION
This conversions are actually totally unneeded and probably left-overs from ages where the safe_mode and magic quotes was still a valid thing.
