### PR TITLE
Download the current public folder only

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -8,7 +8,7 @@
  *
  */
 
-/* global FileActions, Files */
+/* global FileActions, Files, FileList */
 /* global dragOptions, folderDropOptions */
 if (!OCA.Sharing) {
 	OCA.Sharing = {};
@@ -164,6 +164,11 @@ OCA.Sharing.PublicApp = {
 			// URL history handling
 			this.fileList.$el.on('changeDirectory', _.bind(this._onDirectoryChanged, this));
 			OC.Util.History.addOnPopStateHandler(_.bind(this._onUrlChanged, this));
+
+			$('#download').click(function (e) {
+				e.preventDefault();
+				OC.redirect(FileList.getDownloadUrl());
+			});
 		}
 
 		$(document).on('click', '#directLink', function () {


### PR DESCRIPTION
This is my proposal to fix #11769

From within a shared/public directory, when drilling down folders, some users want to be able to download what they're currently looking at, not the whole shared folder. The whole archive is always a click away anyway since a user can click on the home button.
