### PR TITLE
Read version and product name from update template

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -17,7 +17,7 @@
 		 *
 		 * @param $el progress list element
 		 */
-		start: function($el) {
+		start: function($el, options) {
 			if (this._started) {
 				return;
 			}
@@ -28,8 +28,8 @@
 			this.addMessage(t(
 				'core',
 				'Updating {productName} to version {version}, this may take a while.', {
-					productName: OC.theme.name || 'ownCloud',
-					version: OC.config.versionstring
+					productName: options.productName || 'ownCloud',
+					version: options.version
 				}),
 				'bold'
 			).append('<br />'); // FIXME: these should be ul/li with CSS paddings!
@@ -76,10 +76,14 @@
 
 $(document).ready(function() {
 	$('.updateButton').on('click', function() {
+		var $updateEl = $('.update');
 		var $progressEl = $('.updateProgress');
 		$progressEl.removeClass('hidden');
 		$('.updateOverview').addClass('hidden');
-		OC.Update.start($progressEl);
+		OC.Update.start($progressEl, {
+			productName: $updateEl.attr('data-productname'),
+			version: $updateEl.attr('data-version'),
+		});
 		return false;
 	});
 });

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -1,4 +1,4 @@
-<div class="update">
+<div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
 	<div class="updateOverview">
 		<h2 class="title bold"><?php p($l->t('%s will be updated to version %s.',
 			array($_['productName'], $_['version']))); ?></h2>


### PR DESCRIPTION
During upgrade, the config settings aren't always available due to
base.php changes. This fix makes the update info page read the product
name and version from the update template, which already had them.

This is a better approach as it doesn't involve messing around with base.php.

@LukasReschke @DeepDiver1975 @MorrisJobke 

Fixes https://github.com/owncloud/core/issues/12204
See steps here: https://github.com/owncloud/core/issues/12204#issuecomment-69896053
