### PR TITLE
Use source storage permissions when scanning shared storage

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -4,6 +4,7 @@ $l = \OC::$server->getL10N('files_sharing');
 OC::$CLASSPATH['OC_Share_Backend_File'] = 'files_sharing/lib/share/file.php';
 OC::$CLASSPATH['OC_Share_Backend_Folder'] = 'files_sharing/lib/share/folder.php';
 OC::$CLASSPATH['OC\Files\Storage\Shared'] = 'files_sharing/lib/sharedstorage.php';
+OC::$CLASSPATH['OC\Files\Cache\SharedScanner'] = 'files_sharing/lib/scanner.php';
 OC::$CLASSPATH['OC\Files\Cache\Shared_Cache'] = 'files_sharing/lib/cache.php';
 OC::$CLASSPATH['OC\Files\Cache\Shared_Permissions'] = 'files_sharing/lib/permissions.php';
 OC::$CLASSPATH['OC\Files\Cache\Shared_Updater'] = 'files_sharing/lib/updater.php';

--- a/apps/files_sharing/lib/scanner.php
+++ b/apps/files_sharing/lib/scanner.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Vincent Petry
+ * @copyright 2015 Vincent Petry <pvince81@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OC\Files\Cache;
+
+/**
+ * Scanner for SharedStorage
+ */
+class SharedScanner extends Scanner {
+
+	/**
+	 * Returns metadata from the shared storage, but
+	 * with permissions from the source storage.
+	 *
+	 * @param string $path path of the file for which to retrieve metadata
+	 *
+	 * @return array an array of metadata of the file
+	 */
+	public function getData($path){
+		$data = parent::getData($path);
+		$sourcePath = $this->storage->getSourcePath($path);
+		list($sourceStorage, $internalPath) = \OC\Files\Filesystem::resolvePath($sourcePath);
+		$data['permissions'] = $sourceStorage->getPermissions($internalPath);
+		return $data;
+	}
+}
+

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -501,7 +501,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OC\Files\Cache\Scanner($storage);
+		return new \OC\Files\Cache\SharedScanner($storage);
 	}
 
 	public function getWatcher($path = '', $storage = null) {


### PR DESCRIPTION
Tentative hack/quickfix for https://github.com/owncloud/core/issues/10299

@icewind1991 keeping in mind that we might want this in stable7 as the regression is there.
Should we add a `SharedScanner` that overrides `scanFile()` to enclose this logic ?

I suppose that on master we'd want to use the `Jail` logic, but it currently doesn't work because the scanner is operating on the lowest level / unwrapped storage.

Let's discuss here.
