### PR TITLE
Autoload app's js translations

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -29,7 +29,6 @@ OCP\User::checkLoggedIn();
 OCP\Util::addStyle('files', 'files');
 OCP\Util::addStyle('files', 'upload');
 OCP\Util::addStyle('files', 'mobile');
-OCP\Util::addTranslations('files');
 OCP\Util::addscript('files', 'app');
 OCP\Util::addscript('files', 'file-upload');
 OCP\Util::addscript('files', 'jquery.iframe-transport');

--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -1,6 +1,5 @@
 <?php
 
-\OCP\Util::addTranslations('files_encryption');
 \OCP\Util::addscript('files_encryption', 'encryption');
 \OCP\Util::addscript('files_encryption', 'detect-migration');
 

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -21,8 +21,6 @@ OC::$CLASSPATH['OC\Files\Storage\SFTP'] = 'files_external/lib/sftp.php';
 OC::$CLASSPATH['OC_Mount_Config'] = 'files_external/lib/config.php';
 OC::$CLASSPATH['OCA\Files\External\Api'] = 'files_external/lib/api.php';
 
-OCP\Util::addTranslations('files_external');
-
 OCP\App::registerAdmin('files_external', 'settings');
 if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == 'yes') {
 	OCP\App::registerPersonal('files_external', 'personal');

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -21,7 +21,6 @@ OC::$CLASSPATH['OCA\Files_Sharing\Exceptions\BrokenPath'] = 'files_sharing/lib/e
 OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
 
-OCP\Util::addTranslations('files_sharing');
 OCP\Util::addScript('files_sharing', 'share');
 OCP\Util::addScript('files_sharing', 'external');
 

--- a/apps/files_trashbin/appinfo/app.php
+++ b/apps/files_trashbin/appinfo/app.php
@@ -1,8 +1,6 @@
 <?php
 $l = \OC::$server->getL10N('files_trashbin');
 
-OCP\Util::addTranslations('files_trashbin');
-
 // register hooks
 \OCA\Files_Trashbin\Trashbin::registerHooks();
 

--- a/apps/files_versions/appinfo/app.php
+++ b/apps/files_versions/appinfo/app.php
@@ -1,6 +1,5 @@
 <?php
 
-OCP\Util::addTranslations('files_versions');
 OCP\Util::addscript('files_versions', 'versions');
 OCP\Util::addStyle('files_versions', 'versions');
 

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -57,7 +57,6 @@ if(count($configPrefixes) > 0) {
 	OC_Group::useBackend($groupBackend);
 }
 
-OCP\Util::addTranslations('user_ldap');
 OCP\Backgroundjob::registerJob('OCA\user_ldap\lib\Jobs');
 OCP\Backgroundjob::registerJob('\OCA\User_LDAP\Jobs\CleanUp');
 

--- a/apps/user_webdavauth/appinfo/app.php
+++ b/apps/user_webdavauth/appinfo/app.php
@@ -28,8 +28,6 @@ OC_APP::registerAdmin('user_webdavauth', 'settings');
 OC_User::registerBackend("WEBDAVAUTH");
 OC_User::useBackend( "WEBDAVAUTH" );
 
-OCP\Util::addTranslations('user_webdavauth');
-
 // add settings page to navigation
 $entry = array(
 	'id' => "user_webdavauth_settings",

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -365,9 +365,9 @@ class OC_Util {
 		if (!in_array($path, self::$scripts)) {
 			// load javascript translations if it is the first time an app's
 			// script is loaded.
-			if (!in_array($application, self::$loadedScriptTranslations)) {
+			if (!isset(self::$loadedScriptTranslations[$application])) {
 				self::addTranslations($application);
-				self::$loadedScriptTranslations[] = $application;
+				self::$loadedScriptTranslations[$application] = true;
 			}
 			self::$scripts[] = $path;
 		}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -362,7 +362,10 @@ class OC_Util {
 	public static function addScript($application, $file = null) {
 		$path = OC_Util::generatePath($application, 'js', $file);
 		if (!in_array($path, self::$scripts)) {
-			self::addTranslations($application);
+			// core js files need separate handling
+			if ($application !== 'core' && $file !== null) {
+				self::addTranslations($application);
+			}
 			self::$scripts[] = $path;
 		}
 	}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -10,7 +10,6 @@ class OC_Util {
 	public static $headers = array();
 	private static $rootMounted = false;
 	private static $fsSetup = false;
-	private static $loadedScriptTranslations = array();
 
 	private static function initLocalStorageRootFS() {
 		// mount local file backend as root
@@ -363,14 +362,7 @@ class OC_Util {
 	public static function addScript($application, $file = null) {
 		$path = OC_Util::generatePath($application, 'js', $file);
 		if (!in_array($path, self::$scripts)) {
-			// load javascript translations if it is the first time an app's
-			// script is loaded.
-			if (!isset(self::$loadedScriptTranslations[$application]) && $file && $application !== 'core') {
-				error_log("adding " . $application . " "  . $file);
-
-				self::addTranslations($application);
-				self::$loadedScriptTranslations[$application] = true;
-			}
+			self::addTranslations($application);
 			self::$scripts[] = $path;
 		}
 	}
@@ -406,9 +398,7 @@ class OC_Util {
 			$path = "l10n/$languageCode";
 		}
 		if (!in_array($path, self::$scripts)) {
-		error_log("translation " . $path);
 			self::$scripts[] = $path;
-			error_log(print_r(self::$scripts, true));
 		}
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -365,7 +365,9 @@ class OC_Util {
 		if (!in_array($path, self::$scripts)) {
 			// load javascript translations if it is the first time an app's
 			// script is loaded.
-			if (!isset(self::$loadedScriptTranslations[$application])) {
+			if (!isset(self::$loadedScriptTranslations[$application]) && $file) {
+				error_log("adding " . $application . " "  . $file);
+
 				self::addTranslations($application);
 				self::$loadedScriptTranslations[$application] = true;
 			}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -365,7 +365,7 @@ class OC_Util {
 		if (!in_array($path, self::$scripts)) {
 			// load javascript translations if it is the first time an app's
 			// script is loaded.
-			if (!isset(self::$loadedScriptTranslations[$application]) && $file) {
+			if (!isset(self::$loadedScriptTranslations[$application]) && $file && $application !== 'core') {
 				error_log("adding " . $application . " "  . $file);
 
 				self::addTranslations($application);
@@ -406,7 +406,9 @@ class OC_Util {
 			$path = "l10n/$languageCode";
 		}
 		if (!in_array($path, self::$scripts)) {
+		error_log("translation " . $path);
 			self::$scripts[] = $path;
+			error_log(print_r(self::$scripts, true));
 		}
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -10,6 +10,7 @@ class OC_Util {
 	public static $headers = array();
 	private static $rootMounted = false;
 	private static $fsSetup = false;
+	private static $loadedScriptTranslations = array();
 
 	private static function initLocalStorageRootFS() {
 		// mount local file backend as root
@@ -362,6 +363,12 @@ class OC_Util {
 	public static function addScript($application, $file = null) {
 		$path = OC_Util::generatePath($application, 'js', $file);
 		if (!in_array($path, self::$scripts)) {
+			// load javascript translations if it is the first time an app's
+			// script is loaded.
+			if (!in_array($application, self::$loadedScriptTranslations)) {
+				self::addTranslations($application);
+				self::$loadedScriptTranslations[] = $application;
+			}
 			self::$scripts[] = $path;
 		}
 	}


### PR DESCRIPTION
As discussed on IRC this tries to automatically load js translations for all apps (that is if your app calls OC_Util::addScript('appName', 'file') and not OC_Util::addScript('madnessmagic'). 

This currently breaks calendar because they exploit a bug in the method to do weird shit like 

```
OC_Util::addScript('calendar/3rdparty/js', 'file') 
```

instead of  

```
OC_Util::addScript('calendar', '../3rdparty/js/file') 
```

We can patch this easily though

PS: this also loads translations for apps that register their scripts in app.php which is an antipattern.

@PVince81 your addTranslations method seems broken. It does not seem to add any translations at all unless i add translation('news') to my index.php. Then all translations are added properly. We also should handle non existent translations so that the page does not break if the translation is not present. You need to add a check for this in your addTranslations method and fall back to english if no file is found

@georgehrke @raghunayyar  @MorrisJobke @DeepDiver1975 

Fixes #12490
