### PR TITLE
Check for existence of $_GET keys

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -25,8 +25,8 @@
 OCP\User::checkLoggedIn();
 \OC::$server->getSession()->close();
 
-$files = $_GET["files"];
-$dir = $_GET["dir"];
+$files = isset($_GET['files']) ? $_GET['files'] : '';
+$dir = isset($_GET['dir']) ? $_GET['dir'] : '';
 
 $files_list = json_decode($files);
 // in case we get only a single file


### PR DESCRIPTION
`$dir` may for example very well not get passed at well.

Easy one @icewind1991 @MorrisJobke 
