### PR TITLE
HHVM: Do not use key() on array as the result depends on the internal array pointer.

### DIFF
--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -96,12 +96,13 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	public function formatItems($items, $format, $parameters = null) {
 		if ($format == self::FORMAT_SHARED_STORAGE) {
 			// Only 1 item should come through for this format call
+			$item = array_shift($items);
 			return array(
-				'parent' => $items[key($items)]['parent'],
-				'path' => $items[key($items)]['path'],
-				'storage' => $items[key($items)]['storage'],
-				'permissions' => $items[key($items)]['permissions'],
-				'uid_owner' => $items[key($items)]['uid_owner'],
+				'parent' => $item['parent'],
+				'path' => $item['path'],
+				'storage' => $item['storage'],
+				'permissions' => $item['permissions'],
+				'uid_owner' => $item['uid_owner'],
 			);
 		} else if ($format == self::FORMAT_GET_FOLDER_CONTENTS) {
 			$files = array();


### PR DESCRIPTION
HHVM behaves differently in this rather complex scenario involving references to arrays being created using `foreach ($items as &$row)` and being passed around. Specifically `key($items)` returns `NULL` because the internal array pointer points outside of the array. My interpretation of the code is that `$items` here always contains a single element, which should be used. `array_values($items)[0]` (which requires PHP 5.4, btw.) correctly returns the first element of the `$items` array. The root cause was not further investigated.

@DeepDiver1975 
