### PR TITLE
Chain Composer autoloader through \OC\Autoloader to allow for memcaching

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -475,7 +475,10 @@ class OC {
 		// setup 3rdparty autoloader
 		$vendorAutoLoad = OC::$THIRDPARTYROOT . '/3rdparty/autoload.php';
 		if (file_exists($vendorAutoLoad)) {
-			require_once $vendorAutoLoad;
+			$vendorAutoloader = require_once $vendorAutoLoad;
+			// chain with \OC\Autoloader for memcaching
+			$vendorAutoloader->unregister();
+			self::$loader->addFinder(array($vendorAutoloader, 'findFile'), true);
 		} else {
 			OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 			OC_Template::printErrorPage('Composer autoloader not found, unable to continue.');


### PR DESCRIPTION
Instead of registering the Composer autoloader through `spl_autoload_register()`, this PR only registers the `findClass` functionality of it, but does the actual execution from \OC\Autoloader. This allows the memcaching of the autoloader to work for non-oC files.

It seems to result in about an 8% performance increase on my system (profiling the main page through Blackfire.io), but it was highly unscientific. It's going to be a pain to get some proper metrics though, given that you can't autoload a class twice!
