### PR TITLE
LDAP Wizared: update user or group count only, when the multiselect is closed

### DIFF
--- a/apps/user_ldap/js/experiencedAdmin.js
+++ b/apps/user_ldap/js/experiencedAdmin.js
@@ -25,12 +25,11 @@ function ExperiencedAdmin(wizard, initialState) {
 /**
  * toggles whether the admin is an experienced one or not
  *
- * @param {boolean} whether the admin is experienced or not
+ * @param {boolean} isExperienced whether the admin is experienced or not
  */
 ExperiencedAdmin.prototype.setExperienced = function(isExperienced) {
 	this._isExperienced = isExperienced;
-	if(this._isExperienced) {
-		this.enableRawMode();
+	if(this._isExperienced) {		this.enableRawMode();
 		this.hideEntryCounters();
 	} else {
 		this.showEntryCounters();

--- a/apps/user_ldap/js/experiencedAdmin.js
+++ b/apps/user_ldap/js/experiencedAdmin.js
@@ -29,7 +29,8 @@ function ExperiencedAdmin(wizard, initialState) {
  */
 ExperiencedAdmin.prototype.setExperienced = function(isExperienced) {
 	this._isExperienced = isExperienced;
-	if(this._isExperienced) {		this.enableRawMode();
+	if(this._isExperienced) {
+		this.enableRawMode();
 		this.hideEntryCounters();
 	} else {
 		this.showEntryCounters();

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -19,6 +19,8 @@ function LdapFilter(target, determineModeCallback) {
 
 LdapFilter.prototype.activate = function() {
 	if(this.activated) {
+		// might be necessary, if configuration changes happened.
+		this.findFeatures();
 		return;
 	}
 	this.activated = true;
@@ -136,8 +138,15 @@ LdapFilter.prototype.unlock = function() {
 	}
 };
 
+/**
+ * resets this.foundFeatures so that LDAP queries can be fired again to retrieve
+ * objectClasses, groups, etc.
+ */
+LdapFilter.prototype.reAllowFeatureLookup = function () {
+	this.foundFeatures = false;
+};
+
 LdapFilter.prototype.findFeatures = function() {
-	//TODO: reset this.foundFeatures when any base DN changes
 	if(!this.foundFeatures && !this.locked && this.mode === LdapWizard.filterModeAssisted) {
 		this.foundFeatures = true;
 		var objcEl, avgrEl;

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -70,14 +70,6 @@ LdapFilter.prototype.compose = function(updateCount) {
 };
 
 /**
- * this function is triggered after attribute detectors have completed in
- * LdapWizard
- */
-LdapFilter.prototype.afterDetectorsRan = function() {
-	this.updateCount();
-};
-
-/**
  * this function is triggered after LDAP filters have been composed successfully
  * @param {object} result returned by the ajax call
  */
@@ -99,11 +91,13 @@ LdapFilter.prototype.determineMode = function() {
 		function(result) {
 			var property = 'ldap' + filter.target + 'FilterMode';
 			filter.mode = parseInt(result.changes[property], 10);
-			if(filter.mode === LdapWizard.filterModeRaw &&
-				$('#raw'+filter.target+'FilterContainer').hasClass('invisible')) {
+			var rawContainerIsInvisible =
+				$('#raw'+filter.target+'FilterContainer').hasClass('invisible');
+			if(filter.mode === LdapWizard.filterModeRaw
+				&& rawContainerIsInvisible) {
 				LdapWizard['toggleRaw'+filter.target+'Filter']();
-			} else if(filter.mode === LdapWizard.filterModeAssisted &&
-				!$('#raw'+filter.target+'FilterContainer').hasClass('invisible')) {
+			} else if(filter.mode === LdapWizard.filterModeAssisted
+				      && !rawContainerIsInvisible) {
 				LdapWizard['toggleRaw'+filter.target+'Filter']();
 			} else {
 				console.log('LDAP Wizard determineMode: returned mode was »' +
@@ -167,7 +161,6 @@ LdapFilter.prototype.findFeatures = function() {
 /**
  * this function is triggered before user and group counts are executed
  * resolving the passed status variable will fire up counting
- * @param {object} status an instance of $.Deferred
  */
 LdapFilter.prototype.beforeUpdateCount = function() {
 	var status = $.Deferred();

--- a/apps/user_ldap/js/ldapFilter.js
+++ b/apps/user_ldap/js/ldapFilter.js
@@ -95,11 +95,13 @@ LdapFilter.prototype.determineMode = function() {
 			filter.mode = parseInt(result.changes[property], 10);
 			var rawContainerIsInvisible =
 				$('#raw'+filter.target+'FilterContainer').hasClass('invisible');
-			if(filter.mode === LdapWizard.filterModeRaw
-				&& rawContainerIsInvisible) {
+			if (   filter.mode === LdapWizard.filterModeRaw
+				&& rawContainerIsInvisible
+			) {
 				LdapWizard['toggleRaw'+filter.target+'Filter']();
-			} else if(filter.mode === LdapWizard.filterModeAssisted
-				      && !rawContainerIsInvisible) {
+			} else if (    filter.mode === LdapWizard.filterModeAssisted
+						&& !rawContainerIsInvisible
+			) {
 				LdapWizard['toggleRaw'+filter.target+'Filter']();
 			} else {
 				console.log('LDAP Wizard determineMode: returned mode was »' +

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -207,7 +207,7 @@ var LdapWizard = {
 	},
 
 	basicStatusCheck: function() {
-		//criterias to continue from the first tab
+		//criteria to continue from the first tab
 		// - host, port, user filter, agent dn, password, base dn
 		var host  = $('#ldap_host').val();
 		var port  = $('#ldap_port').val();
@@ -224,7 +224,7 @@ var LdapWizard = {
 
 
 	blacklistAdd: function(id) {
-		obj = $('#'+id);
+		var obj = $('#' + id);
 		if(!(obj[0].hasOwnProperty('multiple') && obj[0]['multiple'] === true)) {
 			//no need to blacklist multiselect
 			LdapWizard.saveBlacklist[id] = true;
@@ -242,14 +242,14 @@ var LdapWizard = {
 	},
 
 	checkBaseDN: function() {
-		host = $('#ldap_host').val();
-		port = $('#ldap_port').val();
-		user = $('#ldap_dn').val();
-		pass = $('#ldap_agent_password').val();
+		var host = $('#ldap_host').val();
+		var port = $('#ldap_port').val();
+		var user = $('#ldap_dn').val();
+		var pass = $('#ldap_agent_password').val();
 
 		//FIXME: determine base dn with anonymous access
 		if(host && port && user && pass) {
-			param = 'action=guessBaseDN'+
+			var param = 'action=guessBaseDN'+
 					'&ldap_serverconfig_chooser='+
 					encodeURIComponent($('#ldap_serverconfig_chooser').val());
 
@@ -276,11 +276,11 @@ var LdapWizard = {
 	},
 
 	checkPort: function() {
-		host = $('#ldap_host').val();
-		port = $('#ldap_port').val();
+		var host = $('#ldap_host').val();
+		var port = $('#ldap_port').val();
 
 		if(host && !port) {
-			param = 'action=guessPortAndTLS'+
+			var param = 'action=guessPortAndTLS'+
 					'&ldap_serverconfig_chooser='+
 					encodeURIComponent($('#ldap_serverconfig_chooser').val());
 
@@ -307,7 +307,7 @@ var LdapWizard = {
 	},
 
 	controlBack: function() {
-		curTabIndex = $('#ldapSettings').tabs('option', 'active');
+		var curTabIndex = $('#ldapSettings').tabs('option', 'active');
 		if(curTabIndex == 0) {
 			return;
 		}
@@ -316,7 +316,7 @@ var LdapWizard = {
 	},
 
 	controlContinue: function() {
-		curTabIndex = $('#ldapSettings').tabs('option', 'active');
+		var curTabIndex = $('#ldapSettings').tabs('option', 'active');
 		if(curTabIndex == 3) {
 			return;
 		}
@@ -529,7 +529,7 @@ var LdapWizard = {
 		if(type !== 'User' && type !== 'Group') {
 			return false;
 		}
-		param = 'action=determine'+encodeURIComponent(type)+'ObjectClasses'+
+		var param = 'action=determine'+encodeURIComponent(type)+'ObjectClasses'+
 				'&ldap_serverconfig_chooser='+
 				encodeURIComponent($('#ldap_serverconfig_chooser').val());
 
@@ -571,11 +571,11 @@ var LdapWizard = {
 	functionalityCheck: function() {
 		//criteria to enable the connection:
 		// - host, port, basedn, user filter, login filter
-		host        = $('#ldap_host').val();
-		port        = $('#ldap_port').val();
-		base        = $('#ldap_base').val();
-		userfilter  = $('#ldap_userlist_filter').val();
-		loginfilter = $('#ldap_login_filter').val();
+		var host        = $('#ldap_host').val();
+		var port        = $('#ldap_port').val();
+		var base        = $('#ldap_base').val();
+		var userfilter  = $('#ldap_userlist_filter').val();
+		var loginfilter = $('#ldap_login_filter').val();
 
 		//FIXME: activates a manually deactivated configuration.
 		if(host && port && base && userfilter && loginfilter) {

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -149,6 +149,7 @@ var LdapWizard = {
 	loginFilter: false,
 	groupFilter: false,
 	ajaxRequests: {},
+	lastTestSuccessful: true,
 
 	ajax: function(param, fnOnSuccess, fnOnError, reqID) {
 		if(!_.isUndefined(reqID)) {
@@ -619,6 +620,7 @@ var LdapWizard = {
 		LdapWizard.detectorsRunInXPMode = 0;
 		LdapWizard.instantiateFilters();
 		LdapWizard.admin.setExperienced($('#ldap_experienced_admin').is(':checked'));
+		LdapWizard.lastTestSuccessful = true;
 		LdapWizard.basicStatusCheck();
 		LdapWizard.functionalityCheck();
 		LdapWizard.isConfigurationActiveControlLocked = false;
@@ -760,7 +762,19 @@ var LdapWizard = {
 		}
 	},
 
-	processChanges: function(triggerObj) {
+	/**
+	 * allows UserFilter, LoginFilter and GroupFilter to lookup objectClasses
+	 * and similar again. This should be called after essential changes, e.g.
+	 * Host or BaseDN changes, or positive functionality check
+	 *
+	 */
+	allowFilterFeatureSearch: function () {
+		LdapWizard.userFilter.reAllowFeatureLookup();
+		LdapWizard.loginFilter.reAllowFeatureLookup();
+		LdapWizard.groupFilter.reAllowFeatureLookup();
+	},
+
+	processChanges: function (triggerObj) {
 		LdapWizard.hideInfoBox();
 
 		if(triggerObj.id === 'ldap_host'
@@ -771,6 +785,7 @@ var LdapWizard = {
 			if($('#ldap_port').val()) {
 				//if Port is already set, check BaseDN
 				LdapWizard.checkBaseDN();
+				LdapWizard.allowFilterFeatureSearch();
 			}
 		}
 
@@ -1002,6 +1017,10 @@ var LdapWizard = {
 					$('.ldap_config_state_indicator').addClass('ldap_grey');
 					$('.ldap_config_state_indicator_sign').removeClass('error');
 					$('.ldap_config_state_indicator_sign').addClass('success');
+					if(!LdapWizard.lastTestSuccessful) {
+						LdapWizard.lastTestSuccessful = true;
+						LdapWizard.allowFilterFeatureSearch();
+					}
 				},
 				//onError
 				function(result) {
@@ -1011,6 +1030,7 @@ var LdapWizard = {
 					$('.ldap_config_state_indicator').removeClass('ldap_grey');
 					$('.ldap_config_state_indicator_sign').addClass('error');
 					$('.ldap_config_state_indicator_sign').removeClass('success');
+					LdapWizard.lastTestSuccessful = false;
 				}
 			);
 		} else {


### PR DESCRIPTION
fixes #11442

Reproduction steps:
1. have  an LDAP with maaany users (e.g. ~ 1 million) and some groups
2. configure the first tab and go to the seconds (user filter)
3. open any of the multiselects (objectclasses or groups) and click around. Every change will be saved and triggers an update of the user count. If the settings return a lot of users, counting will take long. subsequent actions will therefore be delayed leading to a not so good UX as described in #11442
NOW:
userCounting only happens after the multiselect has been closed. I.e. every change will be saved immediately, but this is pretty fast. The number of users will be updated after the multiselect is closed. 
Alas, if this takes long and the user opens a multiselect again and does changes there, actions are delayed after counting anyway. However, the user is not disturbed while he is finishing one task. So this should be a good improvement.

It also fixes that objectClasses and groups are not refreshed (read again) when
- successful connection test after it was a failing one before
- basic server configuration (host, port,  bases, user agent) changes

Comments, reviews? @craigpg @jnfrmarks @Xenopathic 
