### PR TITLE
Refactor \OC\Memcache\Factory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -783,9 +783,32 @@ $CONFIG = array(
 
 
 /**
+ * Memory caching backend configuration
+ *
+ * Available cache backends:
+ * - \OC\Memcache\APC        Alternative PHP Cache backend
+ * - \OC\Memcache\APCu       APC user backend
+ * - \OC\Memcache\ArrayCache In-memory array-based backend (not recommended)
+ * - \OC\Memcache\Memcached  Memcached backend
+ * - \OC\Memcache\Redis      Redis backend
+ * - \OC\Memcache\XCache     XCache backend
+ */
+
+/**
+ * Memory caching backend for locally stored data
+ * Used for host-specific data, e.g. file paths
+ */
+'memcache.local' => '\OC\Memcache\APCu',
+
+/**
+ * Memory caching backend for distributed data
+ * Used for installation-specific data, e.g. database caching
+ * If unset, defaults to the value of memcache.local
+ */
+'memcache.distributed' => '\OC\Memcache\Memcached',
+
+/**
  * Connection details for redis to use for memory caching.
- * Redis is only used if other memory cache options (xcache, apc, apcu) are
- * not available.
  */
 'redis' => array(
 	'host' => 'localhost', // can also be a unix domain socket: '/tmp/redis.sock'
@@ -795,8 +818,6 @@ $CONFIG = array(
 
 /**
  * Server details for one or more memcached servers to use for memory caching.
- * Memcache is only used if other memory cache options (xcache, apc, apcu,
- * redis) are not available.
  */
 'memcached_servers' => array(
 	// hostname, port and optional weight. Also see:
@@ -805,6 +826,7 @@ $CONFIG = array(
 	array('localhost', 11211),
 	//array('other.host.local', 11211),
 ),
+
 
 /**
  * Location of the cache folder, defaults to ``data/$user/cache`` where

--- a/lib/base.php
+++ b/lib/base.php
@@ -726,8 +726,8 @@ class OC {
 		$instanceId = \OC::$server->getSystemConfig()->getValue('instanceid', null);
 		if ($instanceId) {
 			try {
-				$memcacheFactory = new \OC\Memcache\Factory($instanceId);
-				self::$loader->setMemoryCache($memcacheFactory->createLowLatency('Autoloader'));
+				$memcacheFactory = \OC::$server->getMemCacheFactory();
+				self::$loader->setMemoryCache($memcacheFactory->createLocal('Autoloader'));
 			} catch (\Exception $ex) {
 			}
 		}

--- a/lib/private/memcache/cache.php
+++ b/lib/private/memcache/cache.php
@@ -8,7 +8,7 @@
 
 namespace OC\Memcache;
 
-abstract class Cache implements \ArrayAccess {
+abstract class Cache implements \ArrayAccess, \OCP\ICache {
 	/**
 	 * @var string $prefix
 	 */

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -155,8 +155,12 @@ class Server extends SimpleContainer implements IServerContainer {
 			return new UserCache();
 		});
 		$this->registerService('MemCacheFactory', function ($c) {
+			$config = $c->getConfig();
 			$instanceId = \OC_Util::getInstanceId();
-			return new \OC\Memcache\Factory($instanceId);
+			return new \OC\Memcache\Factory($instanceId,
+				$config->getSystemValue('memcache.local', null),
+				$config->getSystemValue('memcache.distributed', null)
+			);
 		});
 		$this->registerService('ActivityManager', function ($c) {
 			return new ActivityManager();

--- a/tests/lib/memcache/factory.php
+++ b/tests/lib/memcache/factory.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Memcache;
+
+class Test_Factory_Available_Cache1 {
+	public function __construct($prefix = '') {
+	}
+
+	public static function isAvailable() {
+		return true;
+	}
+}
+
+class Test_Factory_Available_Cache2 {
+	public function __construct($prefix = '') {
+	}
+
+	public static function isAvailable() {
+		return true;
+	}
+}
+
+class Test_Factory_Unavailable_Cache1 {
+	public function __construct($prefix = '') {
+	}
+
+	public static function isAvailable() {
+		return false;
+	}
+}
+
+class Test_Factory_Unavailable_Cache2 {
+	public function __construct($prefix = '') {
+	}
+
+	public static function isAvailable() {
+		return false;
+	}
+}
+
+class Test_Factory extends \Test\TestCase {
+	const AVAILABLE1 = '\\Test\\Memcache\\Test_Factory_Available_Cache1';
+	const AVAILABLE2 = '\\Test\\Memcache\\Test_Factory_Available_Cache2';
+	const UNAVAILABLE1 = '\\Test\\Memcache\\Test_Factory_Unavailable_Cache1';
+	const UNAVAILABLE2 = '\\Test\\Memcache\\Test_Factory_Unavailable_Cache2';
+
+	public function cacheAvailabilityProvider() {
+		return [
+			[
+				// local and distributed available
+				self::AVAILABLE1, self::AVAILABLE2,
+				self::AVAILABLE1, self::AVAILABLE2
+			],
+			[
+				// local available, distributed unavailable
+				self::AVAILABLE1, self::UNAVAILABLE1,
+				self::AVAILABLE1, self::AVAILABLE1
+			],
+			[
+				// local unavailable, distributed available
+				self::UNAVAILABLE1, self::AVAILABLE1,
+				\OC\Memcache\Factory::NULL_CACHE, self::AVAILABLE1
+			],
+			[
+				// local and distributed unavailable
+				self::UNAVAILABLE1, self::UNAVAILABLE2,
+				\OC\Memcache\Factory::NULL_CACHE, \OC\Memcache\Factory::NULL_CACHE
+			],
+			[
+				// local and distributed null
+				null, null,
+				\OC\Memcache\Factory::NULL_CACHE, \OC\Memcache\Factory::NULL_CACHE
+			],
+			[
+				// local available, distributed null (most common scenario)
+				self::AVAILABLE1, null,
+				self::AVAILABLE1, self::AVAILABLE1
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider cacheAvailabilityProvider
+	 */
+	public function testCacheAvailability($localCache, $distributedCache,
+		$expectedLocalCache, $expectedDistributedCache)
+	{
+		$factory = new \OC\Memcache\Factory('abc', $localCache, $distributedCache);
+		$this->assertTrue(is_a($factory->createLocal(), $expectedLocalCache));
+		$this->assertTrue(is_a($factory->createDistributed(), $expectedDistributedCache));
+	}
+}


### PR DESCRIPTION
Caches divided up into two groups: distributed and local. 'Low latency' is an alias for local caches, while the standard `create()` call tries to get distributed caches first, then local caches.

New functions:
- `createLocal()/createDistributed()` - creates local/distributed memcache
- `getAvailableLocal()/getAvailableDistributed()` - gets an available backend class, or `null`

Fixes #13227 

cc @LukasReschke @DeepDiver1975 @MorrisJobke 
