### PR TITLE
Force browser to redraw favorite icon on src change 

### DIFF
--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -53,6 +53,7 @@
 	 */
 	function toggleStar($actionEl, state) {
 		$actionEl.find('img').attr('src', getStarImage(state));
+		$actionEl.hide().show(0); //force Safari to redraw element on src change
 		$actionEl.toggleClass('permanent', state);
 	}
 


### PR DESCRIPTION
Fix #13322 Safari doesn't honor css size for image on src change.

In issue i mentioned that redraw takes 1 second, it was a local bug. 
Now invisibility time for icon is unnoticeable:
![favoritefix](https://cloud.githubusercontent.com/assets/10269200/5746144/c35e1670-9c3e-11e4-8903-9fb66b7abcd1.gif)
