### PR TITLE
[trashbin] replace hook with storage wrapper

### DIFF
--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -50,6 +50,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 	}
 
 	protected function tearDown() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		$this->view->unlink($this->filename);
 		$this->view->deleteAll($this->folder);
 

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -186,6 +186,7 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertFalse(\OC\Files\Filesystem::file_exists("newFileName"));
 
 		//cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, 'testGroup');
 		\OC_Group::removeFromGroup(self::TEST_FILES_SHARING_API_USER1, 'testGroup');
 		\OC_Group::removeFromGroup(self::TEST_FILES_SHARING_API_USER2, 'testGroup');

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -29,7 +29,7 @@ class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-
+		\OCA\Files_Trashbin\Trashbin::registerHooks();
 		$this->folder = '/folder_share_storage_test';
 
 		$this->filename = '/share-api-storage.txt';

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -98,12 +98,12 @@ class Test_Files_Sharing_Updater extends OCA\Files_sharing\Tests\TestCase {
 
 		// trashbin should contain the local file but not the mount point
 		$rootView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
-		$dirContent = $rootView->getDirectoryContent('files_trashbin/files');
-		$this->assertSame(1, count($dirContent));
-		$firstElement = reset($dirContent);
-		$ext = pathinfo($firstElement['path'], PATHINFO_EXTENSION);
-		$this->assertTrue($rootView->file_exists('files_trashbin/files/localFolder.' . $ext . '/localFile.txt'));
-		$this->assertFalse($rootView->file_exists('files_trashbin/files/localFolder.' . $ext . '/' . $this->folder));
+		$trashContent = \OCA\Files_Trashbin\Helper::getTrashFiles('/', self::TEST_FILES_SHARING_API_USER2);
+		$this->assertSame(1, count($trashContent));
+		$firstElement = reset($trashContent);
+		$timestamp = $firstElement['mtime'];
+		$this->assertTrue($rootView->file_exists('files_trashbin/files/localFolder.d' . $timestamp . '/localFile.txt'));
+		$this->assertFalse($rootView->file_exists('files_trashbin/files/localFolder.d' . $timestamp . '/' . $this->folder));
 
 		//cleanup
 		$rootView->deleteAll('files_trashin');

--- a/apps/files_trashbin/lib/hooks.php
+++ b/apps/files_trashbin/lib/hooks.php
@@ -29,21 +29,6 @@ namespace OCA\Files_Trashbin;
 class Hooks {
 
 	/**
-	 * Copy files to trash bin
-	 * @param array $params
-	 *
-	 * This function is connected to the delete signal of OC_Filesystem
-	 * to copy the file to the trash bin
-	 */
-	public static function remove_hook($params) {
-
-		if ( \OCP\App::isEnabled('files_trashbin') ) {
-			$path = $params['path'];
-			Trashbin::move2trash($path);
-		}
-	}
-
-	/**
 	 * clean up user specific settings if user gets deleted
 	 * @param array $params array with uid
 	 *

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @copyright (C) 2015 ownCloud, Inc.
+ *
+ * @author Bjoern Schiessle <schiessle@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Files_Trashbin;
+
+use OC\Files\Storage\Wrapper\Wrapper;
+
+class Storage extends Wrapper {
+
+	private $mountPoint;
+	// remember already deleted files to avoid infinite loops if the trash bin
+	// move files across storages
+	private $deletedFiles = array();
+
+	function __construct($parameters) {
+		$this->mountPoint = $parameters['mountPoint'];
+		parent::__construct($parameters);
+	}
+
+	public function unlink($path) {
+		$normalized = \OC\Files\Filesystem::normalizePath($this->mountPoint . '/' . $path);
+		$result = true;
+		if (!isset($this->deletedFiles[$normalized])) {
+			$this->deletedFiles[$normalized] = $normalized;
+			$parts = explode('/', $normalized);
+			if (count($parts) > 3 && $parts[2] === 'files') {
+				$filesPath = implode('/', array_slice($parts, 3));
+				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
+			} else {
+				$result = $this->storage->unlink($path);
+			}
+			unset($this->deletedFiles[$normalized]);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Setup the storate wrapper callback
+	 */
+	public static function setupStorage() {
+		\OC\Files\Filesystem::addStorageWrapper('oc_trashbin', function ($mountPoint, $storage) {
+			return new \OCA\Files_Trashbin\Storage(array('storage' => $storage, 'mountPoint' => $mountPoint));
+		});
+	}
+
+}

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -327,7 +327,7 @@ class Storage {
 						} else {
 							$versions[$key]['preview'] = \OCP\Util::linkToRoute('core_ajax_versions_preview', array('file' => $userFullPath, 'version' => $timestamp));
 						}
-						$versions[$key]['path'] = $pathinfo['dirname'] . '/' . $filename;
+						$versions[$key]['path'] = \OC\Files\Filesystem::normalizePath($pathinfo['dirname'] . '/' . $filename);
 						$versions[$key]['name'] = $versionedFile;
 						$versions[$key]['size'] = $view->filesize($dir . '/' . $entryName);
 					}


### PR DESCRIPTION
This is a minimal approach to replace the delete hook with a storage wrapper. This allows us to perform a move instead of a copy while moving files to the trash bin which will give us a huge performance improvement.

cc @DeepDiver1975 @icewind1991 
