### PR TITLE
[WIP] Keep file ids when moving between storages

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -281,7 +281,7 @@ class Cache {
 	function buildParts(array $data) {
 		$fields = array(
 			'path', 'parent', 'name', 'mimetype', 'size', 'mtime', 'storage_mtime', 'encrypted', 'unencrypted_size',
-			'etag', 'permissions');
+			'etag', 'permissions', 'fileid');
 		$params = array();
 		$queryParts = array();
 		foreach ($data as $name => $value) {

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -104,9 +104,10 @@ class Scanner extends BasicEmitter {
 	 *
 	 * @param string $file
 	 * @param int $reuseExisting
+	 * @param int $reuseFileId file id to reuse
 	 * @return array an array of metadata of the scanned file
 	 */
-	public function scanFile($file, $reuseExisting = 0) {
+	public function scanFile($file, $reuseExisting = 0, $reuseFileId = null) {
 		if (!self::isPartialFile($file)
 			and !Filesystem::isFileBlacklisted($file)
 		) {
@@ -114,6 +115,9 @@ class Scanner extends BasicEmitter {
 			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
 			$data = $this->getData($file);
 			if ($data) {
+				if ($reuseFileId) {
+					$data['fileid'] = $reuseFileId;
+				}
 				$parent = dirname($file);
 				if ($parent === '.' or $parent === '/') {
 					$parent = '';

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -302,6 +302,7 @@ class View extends \Test\TestCase {
 
 		$rootView = new \OC\Files\View('');
 		$rootView->mkdir('substorage/emptyfolder');
+		$fileInfo = $rootView->getFileInfo('substorage');
 		$rootView->copy('substorage', 'anotherfolder');
 		$this->assertTrue($rootView->is_dir('/anotherfolder'));
 		$this->assertTrue($rootView->is_dir('/substorage'));
@@ -313,6 +314,12 @@ class View extends \Test\TestCase {
 		$this->assertTrue($rootView->file_exists('/substorage/foo.txt'));
 		$this->assertTrue($rootView->file_exists('/substorage/foo.png'));
 		$this->assertTrue($rootView->file_exists('/substorage/folder/bar.txt'));
+		$fileInfo2 = $rootView->getFileInfo('substorage');
+		$fileInfo3 = $rootView->getFileInfo('anotherfolder');
+		// file id of original stays
+		$this->assertEquals($fileInfo->getId(), $fileInfo2->getId());
+		// file id of copy is different
+		$this->assertNotEquals($fileInfo->getId(), $fileInfo3->getId());
 	}
 
 	/**
@@ -325,13 +332,29 @@ class View extends \Test\TestCase {
 		\OC\Files\Filesystem::mount($storage2, array(), '/substorage');
 
 		$rootView = new \OC\Files\View('');
+		$fileInfo = $rootView->getFileInfo('foo.txt');
 		$rootView->rename('foo.txt', 'substorage/folder/foo.txt');
+
 		$this->assertFalse($rootView->file_exists('foo.txt'));
 		$this->assertTrue($rootView->file_exists('substorage/folder/foo.txt'));
+		$fileInfo2 = $rootView->getFileInfo('substorage/folder/foo.txt');
+		// file id stays the same after move
+		$this->assertEquals($fileInfo->getId(), $fileInfo2->getId());
+
+		$fileInfoFolder = $rootView->getFileInfo('substorage/folder');
 		$rootView->rename('substorage/folder', 'anotherfolder');
 		$this->assertFalse($rootView->is_dir('substorage/folder'));
 		$this->assertTrue($rootView->file_exists('anotherfolder/foo.txt'));
 		$this->assertTrue($rootView->file_exists('anotherfolder/bar.txt'));
+
+		// file id of folder stays the same after move
+		$fileInfoFolder2 = $rootView->getFileInfo('anotherfolder');
+		$this->assertEquals($fileInfoFolder->getId(), $fileInfoFolder2->getId());
+
+		// file id of folder contentts stays the same as well
+		$fileInfo2 = $rootView->getFileInfo('anotherfolder/foo.txt');
+		$this->assertEquals($fileInfo->getId(), $fileInfo2->getId());
+
 	}
 
 	/**
@@ -693,6 +716,7 @@ class View extends \Test\TestCase {
 		$newFolderInfo = $view->getFileInfo('/test');
 
 		$this->assertNotEquals($newFolderInfo->getEtag(), $oldFolderInfo->getEtag());
+		$this->assertEquals($newFolderInfo->getId(), $oldFolderInfo->getId());
 	}
 
 	/**
@@ -759,6 +783,26 @@ class View extends \Test\TestCase {
 		}
 
 		call_user_func(array($rootView, $operation), $longPath, $param0);
+	}
+
+	public function testOverwriteFileKeepsId() {
+		$storage1 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, array(), '/');
+
+		$rootView = new \OC\Files\View('');
+		$fileInfo = $rootView->getFileInfo('foo.txt');
+
+		$rootView->file_put_contents('foo.txt', 'changed');
+
+		$fileInfo2 = $rootView->getFileInfo('foo.txt');
+		$this->assertEquals($fileInfo->getId(), $fileInfo2->getId());
+
+		$fh = $rootView->fopen('foo.txt');
+		fwrite($fh, 'bla');
+		fclose($fh);
+
+		$fileInfo3 = $rootView->getFileInfo('foo.txt');
+		$this->assertEquals($fileInfo->getId(), $fileInfo3->getId());
 	}
 
 	public function tooLongPathDataProvider() {


### PR DESCRIPTION
- [x] keep file id when moving file between storages
- [ ] keep file id when moving folders between storages
- [ ] test for possible side effects
- [ ] unit tests

@icewind1991 note, this is hacky and I'm afraid the change to the DB "Cache" class could cause some other side effects

Tentative fix for #13310 
