### PR TITLE
always set url parameters when they are available in the app dispatch

### DIFF
--- a/lib/private/appframework/app.php
+++ b/lib/private/appframework/app.php
@@ -75,7 +75,9 @@ class App {
 	 */
 	public static function main($controllerName, $methodName, DIContainer $container, array $urlParams = null) {
 		if (!is_null($urlParams)) {
-			$container['urlParams'] = $urlParams;
+			$container['OCP\\IRequest']->setUrlParameters($urlParams);
+		} else if (isset($container['urlParams']) && !is_null($container['urlParams'])) {
+			$container['OCP\\IRequest']->setUrlParameters($container['urlParams']);
 		}
 		$appName = $container['AppName'];
 

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -233,7 +233,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			/** @var $c SimpleContainer */
 			/** @var $server SimpleContainer */
 			$server = $c->query('ServerContainer');
-			$server->registerParameter('urlParams', $c['urlParams']);
 			/** @var $server IServerContainer */
 			return $server->getRequest();
 		});

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -68,12 +68,12 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$this->items['params'] = array();
 
 		if(!array_key_exists('method', $vars)) {
-			$vars['method'] = 'GET';			
+			$vars['method'] = 'GET';
 		}
 
 		foreach($this->allowedKeys as $name) {
 			$this->items[$name] = isset($vars[$name])
-				? $vars[$name] 
+				? $vars[$name]
 				: array();
 		}
 
@@ -83,7 +83,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			if(count($params) > 0) {
 				$this->items['params'] = $params;
 				if($vars['method'] === 'POST') {
-					$this->items['post'] = $params;					
+					$this->items['post'] = $params;
 				}
 			}
 		// Handle application/x-www-form-urlencoded for methods other than GET
@@ -91,12 +91,12 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		} elseif($vars['method'] !== 'GET'
 				&& $vars['method'] !== 'POST'
 				&& strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') !== false) {
-			
+
 			parse_str(file_get_contents($this->inputStream), $params);
 			if(is_array($params)) {
 				$this->items['params'] = $params;
 			}
-		} 
+		}
 
 		$this->items['parameters'] = array_merge(
 			$this->items['get'],
@@ -105,6 +105,14 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			$this->items['params']
 		);
 
+	}
+
+	public function setUrlParameters($parameters) {
+		$this->items['urlParams'] = $parameters;
+		$this->items['parameters'] = array_merge(
+			$this->items['parameters'],
+			$this->items['urlParams']
+		);
 	}
 
 	// Countable method.
@@ -207,8 +215,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				return $this->items['method'];
 				break;
 			default;
-				return isset($this[$name]) 
-					? $this[$name] 
+				return isset($this[$name])
+					? $this[$name]
 					: null;
 				break;
 		}

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -214,4 +214,21 @@ class RequestTest extends \Test\TestCase {
 		$this->fail('Expected LogicException.');
 
 	}
+
+
+	public function testSetUrlParameters() {
+		$vars = array(
+			'post' => array(),
+			'method' => 'POST',
+			'urlParams' => array('id' => '2'),
+		);
+
+		$request = new Request($vars, $this->stream);
+
+		$newParams = array('id' => '3', 'test' => 'test2');
+		$request->setUrlParameters($newParams);
+		$this->assertEquals('test2', $request->getParam('test'));
+		$this->assertEquals('3', $request->getParam('id'));
+		$this->assertEquals('3', $request->getParams()['id']);
+	}
 }


### PR DESCRIPTION
If the request is accessed from any app outside of a middleware controller dispatch, the urlparameters wont be set. This PR always sets the url parameters when an app dispatch happens. Fixes the tutorial app DELETE and PUT requests for me

@LukasReschke @MorrisJobke @DeepDiver1975 @PVince81 @georgehrke 

might fix  #13382
