### PR TITLE
[WIP] Use exceptions in SFTP backend

### DIFF
--- a/apps/files_external/lib/authenticationfailureexception.php
+++ b/apps/files_external/lib/authenticationfailureexception.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Robin McCorkell
+ * @copyright 2015 Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_External;
+
+/**
+ * Exception for authentication failures
+ */
+class AuthenticationFailureException extends \Exception {}

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -497,6 +497,8 @@ class OC_Mount_Config {
 				if ($storage->test($isPersonal)) {
 					return self::STATUS_SUCCESS;
 				}
+			} catch (\OCP\Files\StorageNotAvailableException $e) {
+				// this is normal
 			} catch (Exception $exception) {
 				\OCP\Util::logException('files_external', $exception);
 			}


### PR DESCRIPTION
Exceptions are reported for errors instead of returning false. If an exception occurs during connection, a StorageNotAvailableException is thrown. One difference is that files that cannot be accessed will give an 'Unknown error' in the web UI, instead of allowing access to the folder but silently failing on anything inside it. It's not ideal, but better than before IMHO.

This commit also makes the file cache scanner more robust when it comes to exceptions - there are a few more `try {} catch {}` blocks in strategic locations.

Fixes #13238 (needs tested though!)

cc @icewind1991 @PVince81 @LukasReschke @DeepDiver1975 @MorrisJobke 
