### PR TITLE
Show mail address & display name if it is read only

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -102,6 +102,13 @@ if($_['displayNameChangeSupported']) {
 	<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
 </form>
 <?php
+} else {
+?>
+<div class="section">
+	<h2><?php echo $l->t('Full Name');?></h2>
+	<span><?php p($_['displayName'])?></span>
+</div>
+<?php
 }
 ?>
 
@@ -118,6 +125,13 @@ if($_['passwordChangeSupported']) {
 	<span class="msg"></span><br />
 	<em><?php p($l->t('Fill in an email address to enable password recovery and receive notifications'));?></em>
 </form>
+<?php
+} else {
+?>
+<div class="section">
+	<h2><?php echo $l->t('Email'); ?></h2>
+	<span><?php if($_['email']) { p($_['email']); } else { p($l->t('No email address set')); }?></span>
+</div>
 <?php
 }
 ?>


### PR DESCRIPTION
- gives the user the chance to verify it's mail address
  and display name
- ref #12823
- fixes #13393 

![readonly-mail-address](https://cloud.githubusercontent.com/assets/245432/5762068/c741081e-9cdf-11e4-995d-08b66d2ccffe.png)

If no mail is set it looks like:

![readonly-mail-address-not-set](https://cloud.githubusercontent.com/assets/245432/5762066/c462a2c4-9cdf-11e4-9bf7-b74e38079695.png)

cc @nickvergessen @blizzz @LukasReschke @jancborchardt 

@DeepDiver1975 8.0 ?
