### PR TITLE
Fix for sticky grey highlight / selection in file list

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -258,6 +258,8 @@ table td.filename .thumbnail {
 	margin-top: 9px;
 	cursor: pointer;
 	float: left;
+	position: absolute;
+	z-index: 4;
 }
 table td.filename input.filename {
 	width: 70%;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -369,6 +369,8 @@
 							dir: $tr.attr('data-path') || this.getCurrentDirectory()
 						});
 					}
+					// deselect row
+					$(event.target).closest('a').blur();
 				}
 			}
 		},

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -323,7 +323,7 @@
 		 */
 		_onClickFile: function(event) {
 			var $tr = $(event.target).closest('tr');
-			if (event.ctrlKey || event.shiftKey) {
+			if (this._allowSelection && (event.ctrlKey || event.shiftKey)) {
 				event.preventDefault();
 				if (event.shiftKey) {
 					var $lastTr = $(this._lastChecked);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1790,6 +1790,36 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileList.$el.find('.select-all').prop('checked')).toEqual(false);
 			expect(fileList.getSelectedFiles()).toEqual([]);
 		});
+		describe('Disabled selection', function() {
+			beforeEach(function() {
+				fileList._allowSelection = false;
+				fileList.setFiles(testFiles);
+			});
+			it('Does not render checkboxes', function() {
+				expect(fileList.$fileList.find('.selectCheckBox').length).toEqual(0);
+			});
+			it('Does not select a file with Ctrl or Shift if selection is not allowed', function() {
+				var $tr = fileList.findFileEl('One.txt');
+				var $tr2 = fileList.findFileEl('Three.pdf');
+				var e;
+				e = new $.Event('click');
+				e.ctrlKey = true;
+				$tr.find('td.filename .name').trigger(e);
+
+				// click on second entry, does not clear the selection
+				e = new $.Event('click');
+				e.ctrlKey = true;
+				$tr2.find('td.filename .name').trigger(e);
+
+				expect(fileList.getSelectedFiles().length).toEqual(0);
+
+				// deselect now
+				e = new $.Event('click');
+				e.shiftKey = true;
+				$tr2.find('td.filename .name').trigger(e);
+				expect(fileList.getSelectedFiles().length).toEqual(0);
+			});
+		})
 	});
 	describe('File actions', function() {
 		it('Clicking on a file name will trigger default action', function() {


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/13290:
1) Thumbnail is now shown properly over the highlight in "All files" and other views
2) Clicking on a file name in "All files" and other views will auto-deselect it (no more sticky highlight)
3) Bonus fix: in "Favorites" and other lists, cannot select with ctrl+click or shift+click any more

Please review @MorrisJobke @jancborchardt @Xenopathic 
