### PR TITLE
Create HTTP_Authorization header when none exists

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -828,6 +828,11 @@ class OC {
 			$_SERVER['HTTP_AUTHORIZATION'] = $_SERVER['HTTP_XAUTHORIZATION'];
 		}
 
+		// Workaround for PHP-FPM without mod_rewrite see https://github.com/owncloud/core/issues/13398#issuecomment-70138390
+		if (!isset($_SERVER['HTTP_AUTHORIZATION']) && isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+			$_SERVER['HTTP_AUTHORIZATION'] = 'Basic '. base64_encode($_SERVER['PHP_AUTH_USER'].':'.$_SERVER['PHP_AUTH_PW']);
+		}
+
 		// Extract PHP_AUTH_USER/PHP_AUTH_PW from other headers if necessary.
 		$vars = array(
 			'HTTP_AUTHORIZATION', // apache+php-cgi work around


### PR DESCRIPTION
This is an unbelievable hacky workaround for https://github.com/owncloud/core/issues/13398, the issue there was that when using PHP-FPM and having either our .htaccess not enabled or mod_rewrite is not enabled no basic auth headers were passed.

This failed when a login was tried without a password since SabreDAV only uses credentials in PHP_AUTH_USER and PHP_AUTH_PW when both are not null. In all other cases the Authorization header is decoded. However, PHP-FPM strips it and thus the login failed and S2S was horribly broken.
