### PR TITLE
Drop the hide and show of new users in user list

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -404,7 +404,6 @@ var UserList = {
 						return true;
 					}
 					var $tr = UserList.add(user, user.lastLogin, false, user.backend);
-					$tr.addClass('appear transparent');
 					trs.push($tr);
 					loadedUsers++;
 				});
@@ -419,12 +418,6 @@ var UserList = {
 					$userList.siblings('.loading').remove();
 				}
 				UserList.offset += loadedUsers;
-				// animate
-				setTimeout(function() {
-					for (var i = 0; i < trs.length; i++) {
-						trs[i].removeClass('transparent');
-					}
-				}, 0);
 			}).always(function() {
 				UserList.updating = false;
 			});


### PR DESCRIPTION
- causes the first load after the initial load to hide some users in the viewport
  and showing them again, but with a scrolled up viewport
- causes higher load for nearly never visible effects
- fixes #12962

@jancborchardt I removed the animation, but the animation is mostly not in the viewport, because the loading of users is triggered before reaching the end of the list and causes high load

cc @PVince81 
