### PR TITLE
Increase initial user count to 50

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -12,7 +12,7 @@ var filter;
 
 var UserList = {
 	availableGroups: [],
-	offset: 30, //The first 30 users are there. No prob, if less in total.
+	offset: 50, //The first 30 users are there. No prob, if less in total.
 				//hardcoded in settings/users.php
 
 	usersToLoad: 10, //So many users will be loaded when user scrolls down
@@ -215,11 +215,11 @@ var UserList = {
 		}
 	},
 	checkUsersToLoad: function() {
-		//30 shall be loaded initially, from then on always 10 upon scrolling
+		//50 shall be loaded initially, from then on always 10 upon scrolling
 		if(UserList.isEmpty === false) {
 			UserList.usersToLoad = 10;
 		} else {
-			UserList.usersToLoad = 30;
+			UserList.usersToLoad = 50;
 		}
 	},
 	empty: function() {

--- a/settings/users.php
+++ b/settings/users.php
@@ -32,7 +32,7 @@ $recoveryAdminEnabled = OC_App::isEnabled('files_encryption') &&
 					    OC_Appconfig::getValue( 'files_encryption', 'recoveryAdminEnabled' );
 
 if($isAdmin) {
-	$accessibleUsers = OC_User::getDisplayNames('', 30);
+	$accessibleUsers = OC_User::getDisplayNames('', 50);
 	$subadmins = OC_SubAdmin::getAllSubAdmins();
 }else{
 	/* Retrieve group IDs from $groups array, so we can pass that information into OC_Group::displayNamesInGroups() */
@@ -42,7 +42,7 @@ if($isAdmin) {
 			$gids[] = $group['id'];
 		}
 	}
-	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 30);
+	$accessibleUsers = OC_Group::displayNamesInGroups($gids, '', 50);
 	$subadmins = false;
 }
 


### PR DESCRIPTION
- fix initial user count if you have a big screen (or a portrait mode screen)

@crylium This should fix your problem of the initial listed users. Workaround for the meantime: descrease the window size  on loading. Then scroll and after some users are loaded you can increase the size again. ;)

Fixes the problem described in https://github.com/owncloud/core/issues/12962#issuecomment-70273074

Fixed already in master with #12790 and #12820

@karlitschek Backport request as it breaks listing and loading of users on high DPI and portrait mode screens ;) 
