### PR TITLE
Fix getItemSharedWithUser for groups

### DIFF
--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -692,6 +692,41 @@ class Test_Share extends \Test\TestCase {
 		$this->verifyResult($result4, array('target1', 'target2', 'target3', 'target4'));
 	}
 
+	public function testGetItemSharedWithUserFromGroupShare() {
+		OC_User::setUserId($this->user1);
+
+		//add dummy values to the share table
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` ('
+			.' `item_type`, `item_source`, `item_target`, `share_type`,'
+			.' `share_with`, `uid_owner`) VALUES (?,?,?,?,?,?)');
+		$args = array('test', 99, 'target1', OCP\Share::SHARE_TYPE_GROUP, $this->group1, $this->user1);
+		$query->execute($args);
+		$args = array('test', 99, 'target2', OCP\Share::SHARE_TYPE_GROUP, $this->group2, $this->user1);
+		$query->execute($args);
+		$args = array('test', 99, 'target3', OCP\Share::SHARE_TYPE_GROUP, $this->group1, $this->user2);
+		$query->execute($args);
+		$args = array('test', 99, 'target4', OCP\Share::SHARE_TYPE_GROUP, $this->group1, $this->user4);
+		$query->execute($args);
+
+		// user2 is in group1 and group2
+		$result1 = \OCP\Share::getItemSharedWithUser('test', 99, $this->user2, $this->user1);
+		$this->assertSame(2, count($result1));
+		$this->verifyResult($result1, array('target1', 'target2'));
+
+		$result2 = \OCP\Share::getItemSharedWithUser('test', 99, null, $this->user1);
+		$this->assertSame(2, count($result2));
+		$this->verifyResult($result2, array('target1', 'target2'));
+
+		// user3 is in group1 and group2
+		$result3 = \OCP\Share::getItemSharedWithUser('test', 99, $this->user3);
+		$this->assertSame(3, count($result3));
+		$this->verifyResult($result3, array('target1', 'target3', 'target4'));
+
+		$result4 = \OCP\Share::getItemSharedWithUser('test', 99, null, null);
+		$this->assertSame(4, count($result4));
+		$this->verifyResult($result4, array('target1', 'target2', 'target3', 'target4'));
+	}
+
 	public function verifyResult($result, $expected) {
 		foreach ($result as $r) {
 			if (in_array($r['item_target'], $expected)) {


### PR DESCRIPTION
Fixed SQL query for whenever a user has more than one group.
Added missing $owner where clause for group lookup.
Added unit tests for the group cases.

Fixes https://github.com/owncloud/core/issues/12475

Please review @icewind1991 @schiesbn @LukasReschke @MorrisJobke @DeepDiver1975 
