### PR TITLE
Cleanup of PHPDoc return types

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -45,7 +45,7 @@ class Shared_Cache extends Cache {
 	 * Get the source cache of a shared file or folder
 	 *
 	 * @param string $target Shared target file path
-	 * @return \OC\Files\Cache\Cache
+	 * @return \OC\Files\Cache\Cache|false
 	 */
 	private function getSourceCache($target) {
 		if ($target === false || $target === $this->storage->getMountPoint()) {
@@ -82,7 +82,7 @@ class Shared_Cache extends Cache {
 	 * get the stored metadata of a file or folder
 	 *
 	 * @param string|int $file
-	 * @return array
+	 * @return array|false
 	 */
 	public function get($file) {
 		if (is_string($file)) {
@@ -148,7 +148,7 @@ class Shared_Cache extends Cache {
 	 * get the metadata of all files stored in $folder
 	 *
 	 * @param string $folderId
-	 * @return array
+	 * @return array|false
 	 */
 	public function getFolderContentsById($folderId) {
 		$cache = $this->getSourceCache('');
@@ -178,7 +178,7 @@ class Shared_Cache extends Cache {
 	 * @param string $file
 	 * @param array $data
 	 *
-	 * @return int file id
+	 * @return int|false file id
 	 */
 	public function put($file, array $data) {
 		$file = ($file === false) ? '' : $file;

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -131,7 +131,7 @@ class ShareController extends Controller {
 	 *
 	 * @param string $token
 	 * @param string $path
-	 * @return TemplateResponse
+	 * @return TemplateResponse|RedirectResponse
 	 */
 	public function showShare($token, $path = '') {
 		\OC_User::setIncognitoMode(true);

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -80,7 +80,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	/**
 	 * Get the source file path for a shared file
 	 * @param string $target Shared target file path
-	 * @return string source file path or false if not found
+	 * @return string|false source file path or false if not found
 	 */
 	public function getSourcePath($target) {
 		$source = $this->getFile($target);

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -303,7 +303,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	/**
 	 * returns the LDAP DN for the given internal ownCloud name of the user
 	 * @param string $name the ownCloud name in question
-	 * @return string with the LDAP DN on success, otherwise false
+	 * @return string|false with the LDAP DN on success, otherwise false
 	 */
 	public function username2dn($name) {
 		$fdn = $this->userMapper->getDNbyName($name);
@@ -322,7 +322,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * returns the internal ownCloud name for the given LDAP DN of the group, false on DN outside of search DN or failure
 	 * @param string $fdn the dn of the group object
 	 * @param string $ldapName optional, the display name of the object
-	 * @return string with the name to use in ownCloud, false on DN outside of search DN
+	 * @return string|false with the name to use in ownCloud, false on DN outside of search DN
 	 */
 	public function dn2groupname($fdn, $ldapName = null) {
 		//To avoid bypassing the base DN settings under certain circumstances
@@ -339,7 +339,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * returns the internal ownCloud name for the given LDAP DN of the user, false on DN outside of search DN or failure
 	 * @param string $dn the dn of the user object
 	 * @param string $ldapName optional, the display name of the object
-	 * @return string with with the name to use in ownCloud
+	 * @return string|false with with the name to use in ownCloud
 	 */
 	public function dn2username($fdn, $ldapName = null) {
 		//To avoid bypassing the base DN settings under certain circumstances
@@ -357,7 +357,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * @param string $dn the dn of the user object
 	 * @param string $ldapName optional, the display name of the object
 	 * @param bool $isUser optional, whether it is a user object (otherwise group assumed)
-	 * @return string with with the name to use in ownCloud
+	 * @return string|false with with the name to use in ownCloud
 	 */
 	public function dn2ocname($fdn, $ldapName = null, $isUser = true) {
 		if($isUser) {
@@ -508,7 +508,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	/**
 	 * creates a unique name for internal ownCloud use for users. Don't call it directly.
 	 * @param string $name the display name of the object
-	 * @return string with with the name to use in ownCloud or false if unsuccessful
+	 * @return string|false with with the name to use in ownCloud or false if unsuccessful
 	 *
 	 * Instead of using this method directly, call
 	 * createAltInternalOwnCloudName($name, true)
@@ -530,7 +530,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	/**
 	 * creates a unique name for internal ownCloud use for groups. Don't call it directly.
 	 * @param string $name the display name of the object
-	 * @return string with with the name to use in ownCloud or false if unsuccessful.
+	 * @return string|false with with the name to use in ownCloud or false if unsuccessful.
 	 *
 	 * Instead of using this method directly, call
 	 * createAltInternalOwnCloudName($name, false)
@@ -569,7 +569,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * creates a unique name for internal ownCloud use.
 	 * @param string $name the display name of the object
 	 * @param boolean $isUser whether name should be created for a user (true) or a group (false)
-	 * @return string with with the name to use in ownCloud or false if unsuccessful
+	 * @return string|false with with the name to use in ownCloud or false if unsuccessful
 	 */
 	private function createAltInternalOwnCloudName($name, $isUser) {
 		$originalTTL = $this->connection->ldapCacheTTL;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -110,7 +110,7 @@ class Wizard extends LDAPUtility {
 			return false;
 		}
 		$groupsTotal = ($groupsTotal !== false) ? $groupsTotal : 0;
-		$output = self::$l->n('%s group found', '%s groups found', $groupsTotal, $groupsTotal);
+		$output = self::$l->n('%s group found', '%s groups found', $groupsTotal, array($groupsTotal));
 		$this->result->addChange('ldap_group_count', $output);
 		return $this->result;
 	}
@@ -124,7 +124,7 @@ class Wizard extends LDAPUtility {
 
 		$usersTotal = $this->countEntries($filter, 'users');
 		$usersTotal = ($usersTotal !== false) ? $usersTotal : 0;
-		$output = self::$l->n('%s user found', '%s users found', $usersTotal, $usersTotal);
+		$output = self::$l->n('%s user found', '%s users found', $usersTotal, array($usersTotal));
 		$this->result->addChange('ldap_user_count', $output);
 		return $this->result;
 	}
@@ -314,7 +314,7 @@ class Wizard extends LDAPUtility {
 
 	/**
 	 * detects the available LDAP attributes
-	 * @return array The instance's WizardResult instance
+	 * @return array|false The instance's WizardResult instance
 	 * @throws \Exception
 	 */
 	private function getUserAttributes() {
@@ -348,7 +348,7 @@ class Wizard extends LDAPUtility {
 
 	/**
 	 * detects the available LDAP groups
-	 * @return WizardResult the instance's WizardResult instance
+	 * @return WizardResult|false the instance's WizardResult instance
 	 */
 	public function determineGroupsForGroups() {
 		return $this->determineGroups('ldap_groupfilter_groups',
@@ -358,7 +358,7 @@ class Wizard extends LDAPUtility {
 
 	/**
 	 * detects the available LDAP groups
-	 * @return WizardResult the instance's WizardResult instance
+	 * @return WizardResult|false the instance's WizardResult instance
 	 */
 	public function determineGroupsForUsers() {
 		return $this->determineGroups('ldap_userfilter_groups',
@@ -370,7 +370,7 @@ class Wizard extends LDAPUtility {
 	 * @param string $dbKey
 	 * @param string $confKey
 	 * @param bool $testMemberOf
-	 * @return WizardResult the instance's WizardResult instance
+	 * @return WizardResult|false the instance's WizardResult instance
 	 * @throws \Exception
 	 */
 	private function determineGroups($dbKey, $confKey, $testMemberOf = true) {
@@ -467,7 +467,7 @@ class Wizard extends LDAPUtility {
 
 	/**
 	 * Detects the available object classes
-	 * @return WizardResult the instance's WizardResult instance
+	 * @return WizardResult|false the instance's WizardResult instance
 	 * @throws \Exception
 	 */
 	public function determineGroupObjectClasses() {
@@ -524,7 +524,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @return WizardResult
+	 * @return WizardResult|false
 	 * @throws \Exception
 	 */
 	public function getGroupFilter() {
@@ -548,7 +548,7 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @return WizardResult
+	 * @return WizardResult|false
 	 * @throws \Exception
 	 */
 	public function getUserListFilter() {
@@ -1146,7 +1146,7 @@ class Wizard extends LDAPUtility {
 	 * Configuration class
 	 * @param bool $po whether the objectClass with most result entries
 	 * shall be pre-selected via the result
-	 * @return array, list of found items.
+	 * @return array|false list of found items.
 	 * @throws \Exception
 	 */
 	private function determineFeature($objectclasses, $attr, $dbkey, $confkey, $po = false) {

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -303,7 +303,7 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
-	 * @return string display name
+	 * @return string|false display name
 	 */
 	public function getDisplayName($uid) {
 		if(!$this->userExists($uid)) {

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -489,7 +489,7 @@ class OC_App {
 	/**
 	 * Get the path where to install apps
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	public static function getInstallPath() {
 		if (OC_Config::getValue('appstoreenabled', true) == false) {
@@ -891,7 +891,7 @@ class OC_App {
 
 	/**
 	 * get a list of all apps on apps.owncloud.com
-	 * @return array, multi-dimensional array of apps.
+	 * @return array|false multi-dimensional array of apps.
 	 *     Keys: id, name, type, typename, personid, license, detailpage, preview, changed, description
 	 */
 	public static function getAppstoreApps($filter = 'approved', $category = null) {
@@ -1180,7 +1180,7 @@ class OC_App {
 
 	/**
 	 * @param string $appId
-	 * @return \OC\Files\View
+	 * @return \OC\Files\View|false
 	 */
 	public static function getStorage($appId) {
 		if (OC_App::isEnabled($appId)) { //sanity check

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -245,7 +245,7 @@ class AppConfig implements \OCP\IAppConfig {
 	 *
 	 * @param string|false $app
 	 * @param string|false $key
-	 * @return array
+	 * @return array|false
 	 */
 	public function getValues($app, $key) {
 		if (($app !== false) == ($key !== false)) {

--- a/lib/private/appframework/core/api.php
+++ b/lib/private/appframework/core/api.php
@@ -136,7 +136,7 @@ class API implements IApi{
 	 * @param string $slotName name of slot, in another word, this is the
 	 *               name of the method that will be called when registered
 	 *               signal is emitted.
-	 * @return bool, always true
+	 * @return bool always true
 	 */
 	public function connectHook($signalClass, $signalName, $slotClass, $slotName) {
 		return \OCP\Util::connectHook($signalClass, $signalName, $slotClass, $slotName);
@@ -148,7 +148,7 @@ class API implements IApi{
 	 * @param string $signalClass class name of emitter
 	 * @param string $signalName name of signal
 	 * @param array $params default: array() array with additional data
-	 * @return bool, true if slots exists or false if not
+	 * @return bool true if slots exists or false if not
 	 */
 	public function emitHook($signalClass, $signalName, $params = array()) {
 		return  \OCP\Util::emitHook($signalClass, $signalName, $params);

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -434,7 +434,7 @@ class Cache {
 	/**
 	 * @param string $file
 	 *
-	 * @return int, Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
+	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
 	public function getStatus($file) {
 		// normalize file
@@ -684,7 +684,7 @@ class Cache {
 	 * instead does a global search in the cache table
 	 *
 	 * @param int $id
-	 * @return array, first element holding the storage id, second the path
+	 * @return array first element holding the storage id, second the path
 	 */
 	static public function getById($id) {
 		$sql = 'SELECT `storage`, `path` FROM `*PREFIX*filecache` WHERE `fileid` = ?';

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -163,7 +163,7 @@ class CacheJail extends CacheWrapper {
 	/**
 	 * @param string $file
 	 *
-	 * @return int, Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
+	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
 	public function getStatus($file) {
 		return $this->cache->getStatus($this->getSourcePath($file));

--- a/lib/private/files/cache/wrapper/cachewrapper.php
+++ b/lib/private/files/cache/wrapper/cachewrapper.php
@@ -152,7 +152,7 @@ class CacheWrapper extends Cache {
 	/**
 	 * @param string $file
 	 *
-	 * @return int, Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
+	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
 	public function getStatus($file) {
 		return $this->cache->getStatus($file);
@@ -260,7 +260,7 @@ class CacheWrapper extends Cache {
 	 * instead does a global search in the cache table
 	 *
 	 * @param int $id
-	 * @return array, first element holding the storage id, second the path
+	 * @return array first element holding the storage id, second the path
 	 */
 	static public function getById($id) {
 		return parent::getById($id);

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -343,7 +343,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 * get the owner of a path
 	 *
 	 * @param string $path The path to get the owner
-	 * @return string uid or false
+	 * @return string|false uid or false
 	 */
 	public function getOwner($path) {
 		return \OC_User::getUser();
@@ -353,7 +353,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 * get the ETag for a file or folder
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getETag($path) {
 		$ETagFunction = \OC_Connector_Sabre_Node::$ETagFunction;
@@ -400,7 +400,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 * get the free space in the storage
 	 *
 	 * @param string $path
-	 * @return int
+	 * @return int|false
 	 */
 	public function free_space($path) {
 		return \OCP\Files\FileInfo::SPACE_UNKNOWN;
@@ -445,7 +445,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 	 * For now the returned array can hold the parameter url - in future more attributes might follow.
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|false
 	 */
 	public function getDirectDownload($path) {
 		return [];

--- a/lib/private/hook.php
+++ b/lib/private/hook.php
@@ -52,7 +52,7 @@ class OC_Hook{
 	 * @param string $signalclass class name of emitter
 	 * @param string $signalname name of signal
 	 * @param mixed $params default: array() array with additional data
-	 * @return bool, true if slots exists or false if not
+	 * @return bool true if slots exists or false if not
 	 *
 	 * Emits a signal. To get data from the slot use references!
 	 *

--- a/lib/private/tags.php
+++ b/lib/private/tags.php
@@ -247,7 +247,7 @@ class Tags implements \OCP\ITags {
 	* Throws an exception if the tag could not be found.
 	*
 	* @param string $tag Tag id or name.
-	* @return array An array of object ids or false on error.
+	* @return array|false An array of object ids or false on error.
 	*/
 	public function getIdsForTag($tag) {
 		$result = null;
@@ -337,7 +337,7 @@ class Tags implements \OCP\ITags {
 	* Add a new tag.
 	*
 	* @param string $name A string with a name of the tag
-	* @return false|string the id of the added tag or false on error.
+	* @return false|int the id of the added tag or false on error.
 	*/
 	public function add($name) {
 		$name = trim($name);
@@ -575,7 +575,7 @@ class Tags implements \OCP\ITags {
 	/**
 	* Get favorites for an object type
 	*
-	* @return array An array of object ids.
+	* @return array|false An array of object ids.
 	*/
 	public function getFavorites() {
 		try {

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -72,7 +72,7 @@ interface Storage {
 	 * see http://php.net/manual/en/function.opendir.php
 	 *
 	 * @param string $path
-	 * @return resource
+	 * @return resource|false
 	 */
 	public function opendir($path);
 
@@ -97,7 +97,7 @@ interface Storage {
 	 * only the following keys are required in the result: size and mtime
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|false
 	 */
 	public function stat($path);
 
@@ -105,7 +105,7 @@ interface Storage {
 	 * see http://php.net/manual/en/function.filetype.php
 	 *
 	 * @param string $path
-	 * @return bool
+	 * @return string|false
 	 */
 	public function filetype($path);
 
@@ -114,7 +114,7 @@ interface Storage {
 	 * The result for filesize when called on a folder is required to be 0
 	 *
 	 * @param string $path
-	 * @return int
+	 * @return int|false
 	 */
 	public function filesize($path);
 
@@ -179,7 +179,7 @@ interface Storage {
 	 * see http://php.net/manual/en/function.filemtime.php
 	 *
 	 * @param string $path
-	 * @return int
+	 * @return int|false
 	 */
 	public function filemtime($path);
 
@@ -187,7 +187,7 @@ interface Storage {
 	 * see http://php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function file_get_contents($path);
 
@@ -231,7 +231,7 @@ interface Storage {
 	 *
 	 * @param string $path
 	 * @param string $mode
-	 * @return resource
+	 * @return resource|false
 	 */
 	public function fopen($path, $mode);
 
@@ -240,7 +240,7 @@ interface Storage {
 	 * The mimetype for a folder is required to be "httpd/unix-directory"
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getMimeType($path);
 
@@ -250,7 +250,7 @@ interface Storage {
 	 * @param string $type
 	 * @param string $path
 	 * @param bool $raw
-	 * @return string
+	 * @return string|false
 	 */
 	public function hash($type, $path, $raw = false);
 
@@ -258,7 +258,7 @@ interface Storage {
 	 * see http://php.net/manual/en/function.free_space.php
 	 *
 	 * @param string $path
-	 * @return int
+	 * @return int|false
 	 */
 	public function free_space($path);
 
@@ -266,7 +266,7 @@ interface Storage {
 	 * search for occurrences of $query in file names
 	 *
 	 * @param string $query
-	 * @return array
+	 * @return array|false
 	 */
 	public function search($query);
 
@@ -285,7 +285,7 @@ interface Storage {
 	 * The local version of the file can be temporary and doesn't have to be persistent across requests
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getLocalFile($path);
 
@@ -294,7 +294,7 @@ interface Storage {
 	 * The local version of the folder can be temporary and doesn't have to be persistent across requests
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getLocalFolder($path);
 	/**
@@ -313,7 +313,7 @@ interface Storage {
 	 * get the ETag for a file or folder
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getETag($path);
 
@@ -342,7 +342,7 @@ interface Storage {
 	 * For now the returned array can hold the parameter url - in future more attributes might follow.
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|false
 	 */
 	public function getDirectDownload($path);
 }

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -58,7 +58,7 @@ interface IAppConfig {
 	 *
 	 * @param string|false $key
 	 * @param string|false $app
-	 * @return array
+	 * @return array|false
 	 */
 	public function getValues($app, $key);
 

--- a/lib/public/itags.php
+++ b/lib/public/itags.php
@@ -97,7 +97,7 @@ interface ITags {
 	* Throws an exception if the tag could not be found.
 	*
 	* @param string|integer $tag Tag id or name.
-	* @return array An array of object ids or false on error.
+	* @return array|false An array of object ids or false on error.
 	*/
 	public function getIdsForTag($tag);
 
@@ -123,7 +123,7 @@ interface ITags {
 	* Add a new tag.
 	*
 	* @param string $name A string with a name of the tag
-	* @return int the id of the added tag or false if it already exists.
+	* @return int|false the id of the added tag or false if it already exists.
 	*/
 	public function add($name);
 
@@ -158,7 +158,7 @@ interface ITags {
 	/**
 	* Get favorites for an object type
 	*
-	* @return array An array of object ids.
+	* @return array|false An array of object ids.
 	*/
 	public function getFavorites();
 

--- a/lib/public/share_backend.php
+++ b/lib/public/share_backend.php
@@ -46,7 +46,7 @@ interface Share_Backend {
 	 * Converts the shared item sources back into the item in the specified format
 	 * @param array $items Shared items
 	 * @param int $format
-	 * @return TODO
+	 * @return array
 	 *
 	 * The items array is a 3-dimensional array with the item_source as the
 	 * first key and the share id as the second key to an array with the share


### PR DESCRIPTION
Pretty much exclusively needing to specify `false` as a valid return type.
