### PR TITLE
Reuse the array key of mimetypes

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -28,6 +28,75 @@ class OC_Helper {
 	private static $mimetypeIcons = array();
 	private static $mimetypeDetector;
 	private static $templateManager;
+	/** @var string[] */
+	private static $mimeTypeAlias = array(
+		'application/octet-stream' => 'file', // use file icon as fallback
+
+		'application/illustrator' => 'image/vector',
+		'application/postscript' => 'image/vector',
+		'image/svg+xml' => 'image/vector',
+
+		'application/coreldraw' => 'image',
+		'application/x-gimp' => 'image',
+		'application/x-photoshop' => 'image',
+
+		'application/x-font-ttf' => 'font',
+		'application/font-woff' => 'font',
+		'application/vnd.ms-fontobject' => 'font',
+
+		'application/json' => 'text/code',
+		'application/x-perl' => 'text/code',
+		'application/x-php' => 'text/code',
+		'text/x-shellscript' => 'text/code',
+		'application/xml' => 'text/html',
+		'text/css' => 'text/code',
+		'application/x-tex' => 'text',
+
+		'application/x-compressed' => 'package/x-generic',
+		'application/x-7z-compressed' => 'package/x-generic',
+		'application/x-deb' => 'package/x-generic',
+		'application/x-gzip' => 'package/x-generic',
+		'application/x-rar-compressed' => 'package/x-generic',
+		'application/x-tar' => 'package/x-generic',
+		'application/vnd.android.package-archive' => 'package/x-generic',
+		'application/zip' => 'package/x-generic',
+
+		'application/msword' => 'x-office/document',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'x-office/document',
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.template' => 'x-office/document',
+		'application/vnd.ms-word.document.macroEnabled.12' => 'x-office/document',
+		'application/vnd.ms-word.template.macroEnabled.12' => 'x-office/document',
+		'application/vnd.oasis.opendocument.text' => 'x-office/document',
+		'application/vnd.oasis.opendocument.text-template' => 'x-office/document',
+		'application/vnd.oasis.opendocument.text-web' => 'x-office/document',
+		'application/vnd.oasis.opendocument.text-master' => 'x-office/document',
+
+		'application/mspowerpoint' => 'x-office/presentation',
+		'application/vnd.ms-powerpoint' => 'x-office/presentation',
+		'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'x-office/presentation',
+		'application/vnd.openxmlformats-officedocument.presentationml.template' => 'x-office/presentation',
+		'application/vnd.openxmlformats-officedocument.presentationml.slideshow' => 'x-office/presentation',
+		'application/vnd.ms-powerpoint.addin.macroEnabled.12' => 'x-office/presentation',
+		'application/vnd.ms-powerpoint.presentation.macroEnabled.12' => 'x-office/presentation',
+		'application/vnd.ms-powerpoint.template.macroEnabled.12' => 'x-office/presentation',
+		'application/vnd.ms-powerpoint.slideshow.macroEnabled.12' => 'x-office/presentation',
+		'application/vnd.oasis.opendocument.presentation' => 'x-office/presentation',
+		'application/vnd.oasis.opendocument.presentation-template' => 'x-office/presentation',
+
+		'application/msexcel' => 'x-office/spreadsheet',
+		'application/vnd.ms-excel' => 'x-office/spreadsheet',
+		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'x-office/spreadsheet',
+		'application/vnd.openxmlformats-officedocument.spreadsheetml.template' => 'x-office/spreadsheet',
+		'application/vnd.ms-excel.sheet.macroEnabled.12' => 'x-office/spreadsheet',
+		'application/vnd.ms-excel.template.macroEnabled.12' => 'x-office/spreadsheet',
+		'application/vnd.ms-excel.addin.macroEnabled.12' => 'x-office/spreadsheet',
+		'application/vnd.ms-excel.sheet.binary.macroEnabled.12' => 'x-office/spreadsheet',
+		'application/vnd.oasis.opendocument.spreadsheet' => 'x-office/spreadsheet',
+		'application/vnd.oasis.opendocument.spreadsheet-template' => 'x-office/spreadsheet',
+		'text/csv' => 'x-office/spreadsheet',
+
+		'application/msaccess' => 'database',
+	);
 
 	/**
 	 * Creates an url using a defined route
@@ -155,77 +224,9 @@ class OC_Helper {
 	 * Returns the path to the image of this file type.
 	 */
 	public static function mimetypeIcon($mimetype) {
-		$alias = array(
-			'application/octet-stream' => 'file', // use file icon as fallback
 
-			'application/illustrator' => 'image/vector',
-			'application/postscript' => 'image/vector',
-			'image/svg+xml' => 'image/vector',
-			
-			'application/coreldraw' => 'image',
-			'application/x-gimp' => 'image',
-			'application/x-photoshop' => 'image',
-
-			'application/x-font-ttf' => 'font',
-			'application/font-woff' => 'font',
-			'application/vnd.ms-fontobject' => 'font',
-
-			'application/json' => 'text/code',
-			'application/x-perl' => 'text/code',
-			'application/x-php' => 'text/code',
-			'text/x-shellscript' => 'text/code',
-			'application/xml' => 'text/html',
-			'text/css' => 'text/code',
-			'application/x-tex' => 'text',
-
-			'application/x-compressed' => 'package/x-generic',
-			'application/x-7z-compressed' => 'package/x-generic',
-			'application/x-deb' => 'package/x-generic',
-			'application/x-gzip' => 'package/x-generic',
-			'application/x-rar-compressed' => 'package/x-generic',
-			'application/x-tar' => 'package/x-generic',
-			'application/vnd.android.package-archive' => 'package/x-generic',
-			'application/zip' => 'package/x-generic',
-
-			'application/msword' => 'x-office/document',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'x-office/document',
-			'application/vnd.openxmlformats-officedocument.wordprocessingml.template' => 'x-office/document',
-			'application/vnd.ms-word.document.macroEnabled.12' => 'x-office/document',
-			'application/vnd.ms-word.template.macroEnabled.12' => 'x-office/document',
-			'application/vnd.oasis.opendocument.text' => 'x-office/document',
-			'application/vnd.oasis.opendocument.text-template' => 'x-office/document',
-			'application/vnd.oasis.opendocument.text-web' => 'x-office/document',
-			'application/vnd.oasis.opendocument.text-master' => 'x-office/document',
-
-			'application/mspowerpoint' => 'x-office/presentation',
-			'application/vnd.ms-powerpoint' => 'x-office/presentation',
-			'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'x-office/presentation',
-			'application/vnd.openxmlformats-officedocument.presentationml.template' => 'x-office/presentation',
-			'application/vnd.openxmlformats-officedocument.presentationml.slideshow' => 'x-office/presentation',
-			'application/vnd.ms-powerpoint.addin.macroEnabled.12' => 'x-office/presentation',
-			'application/vnd.ms-powerpoint.presentation.macroEnabled.12' => 'x-office/presentation',
-			'application/vnd.ms-powerpoint.template.macroEnabled.12' => 'x-office/presentation',
-			'application/vnd.ms-powerpoint.slideshow.macroEnabled.12' => 'x-office/presentation',
-			'application/vnd.oasis.opendocument.presentation' => 'x-office/presentation',
-			'application/vnd.oasis.opendocument.presentation-template' => 'x-office/presentation',
-
-			'application/msexcel' => 'x-office/spreadsheet',
-			'application/vnd.ms-excel' => 'x-office/spreadsheet',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'x-office/spreadsheet',
-			'application/vnd.openxmlformats-officedocument.spreadsheetml.template' => 'x-office/spreadsheet',
-			'application/vnd.ms-excel.sheet.macroEnabled.12' => 'x-office/spreadsheet',
-			'application/vnd.ms-excel.template.macroEnabled.12' => 'x-office/spreadsheet',
-			'application/vnd.ms-excel.addin.macroEnabled.12' => 'x-office/spreadsheet',
-			'application/vnd.ms-excel.sheet.binary.macroEnabled.12' => 'x-office/spreadsheet',
-			'application/vnd.oasis.opendocument.spreadsheet' => 'x-office/spreadsheet',
-			'application/vnd.oasis.opendocument.spreadsheet-template' => 'x-office/spreadsheet',
-			'text/csv' => 'x-office/spreadsheet',
-
-			'application/msaccess' => 'database',
-		);
-
-		if (isset($alias[$mimetype])) {
-			$mimetype = $alias[$mimetype];
+		if (isset(self::$mimeTypeAlias[$mimetype])) {
+			$mimetype = self::$mimeTypeAlias[$mimetype];
 		}
 		if (isset(self::$mimetypeIcons[$mimetype])) {
 			return self::$mimetypeIcons[$mimetype];


### PR DESCRIPTION
This function is called a lot of times and was really slow before due to not reusing the same array.

Previously when it was called 500'000 times it took about 2seconds, now we're down to 0.2 seconds on my local machine.

Ref https://github.com/owncloud/core/issues/13434
