### PR TITLE
Fix filtering for users when $gid is empty

### DIFF
--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -161,7 +161,7 @@ class UsersController extends Controller {
 			if($gid !== '') {
 				$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
 			} else {
-				$batch = $this->userManager->search('', $limit, $offset);
+				$batch = $this->userManager->search($pattern, $limit, $offset);
 			}
 
 			foreach ($batch as $user) {


### PR DESCRIPTION
Previously when $gid was empty the users were not filtered at all. Rendering the search function in the user management pretty useless.

Fixes itself

@MorrisJobke Please review.
