### PR TITLE
Fix exif orientation for flipped images

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -358,34 +358,41 @@ class OC_Image {
 		$o = $this->getOrientation();
 		$this->logger->debug('OC_Image->fixOrientation() Orientation: ' . $o, array('app' => 'core'));
 		$rotate = 0;
+		$flip = false;
 		switch ($o) {
 			case -1:
 				return false; //Nothing to fix
 			case 1:
 				$rotate = 0;
 				break;
-			case 2: // Not tested
+			case 2:
 				$rotate = 0;
+				$flip = true;
 				break;
 			case 3:
 				$rotate = 180;
 				break;
-			case 4: // Not tested
+			case 4:
 				$rotate = 180;
+				$flip = true;
 				break;
-			case 5: // Not tested
+			case 5:
 				$rotate = 90;
+				$flip = true;
 				break;
 			case 6:
-				//$rotate = 90;
 				$rotate = 270;
 				break;
-			case 7: // Not tested
+			case 7:
 				$rotate = 270;
+				$flip = true;
 				break;
 			case 8:
 				$rotate = 90;
 				break;
+		}
+		if($flip) {
+			imageflip($this->resource, IMG_FLIP_HORIZONTAL);
 		}
 		if ($rotate) {
 			$res = imagerotate($this->resource, $rotate, 0);


### PR DESCRIPTION
fixes #13363

Links:
- http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
- Example data: https://github.com/recurser/exif-orientation-examples

cc @georgehrke @tobiasKaminsky @oparoz 

Before:

![exif-orientation-before](https://cloud.githubusercontent.com/assets/245432/5794308/57a2e190-9f68-11e4-84af-474e8b13acb8.png)

After:

![exif-orientation-after](https://cloud.githubusercontent.com/assets/245432/5794311/614081bc-9f68-11e4-80ee-eb8c8bec9968.png)
