### PR TITLE
add config-option for an image's maximum filesize when generating previews

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -621,6 +621,18 @@ $CONFIG = array(
  * original size. A value of ``1`` or ``null`` disables scaling.
  */
 'preview_max_scale_factor' => 10,
+
+/**
+ * max file size for generating image previews with imagegd (default behaviour)
+ * If the image is bigger, it'll try other preview generators,
+ * but will most likely show the default mimetype icon
+ *
+ * Value represents the maximum filesize in megabytes
+ * Default is 50
+ * Set to -1 for no limit
+ */
+'preview_max_filesize_image' => 50,
+
 /**
  * custom path for LibreOffice/OpenOffice binary
  */

--- a/lib/private/preview/image.php
+++ b/lib/private/preview/image.php
@@ -26,6 +26,13 @@ class Image extends Provider {
 			return false;
 		}
 
+		$maxSizeForImages = \OC::$server->getConfig()->getSystemValue('preview_max_filesize_image', 50);
+		$size = $fileInfo->getSize();
+
+		if ($maxSizeForImages !== -1 && $size > ($maxSizeForImages * 1024 * 1024)) {
+			return false;
+		}
+
 		$image = new \OC_Image();
 
 		if($fileInfo['encrypted'] === true) {


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/13218
