### PR TITLE
Do not retrieve shares through group if user has no group

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -337,27 +337,29 @@ class Share extends \OC\Share\Constants {
 		if(empty($shares) && $user !== null) {
 			$groups = \OC_Group::getUserGroups($user);
 
-			$where = 'WHERE `' . $column . '` = ? AND `item_type` = ? AND `share_with` in (?)';
-			$arguments = array($itemSource, $itemType, $groups);
-			$types = array(null, null, \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
+			if (!empty($groups)) {
+				$where = 'WHERE `' . $column . '` = ? AND `item_type` = ? AND `share_with` in (?)';
+				$arguments = array($itemSource, $itemType, $groups);
+				$types = array(null, null, \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
 
-			if ($owner !== null) {
-				$where .= ' AND `uid_owner` = ?';
-				$arguments[] = $owner;
-				$types[] = null;
-			}
+				if ($owner !== null) {
+					$where .= ' AND `uid_owner` = ?';
+					$arguments[] = $owner;
+					$types[] = null;
+				}
 
-			// TODO: inject connection, hopefully one day in the future when this
-			// class isn't static anymore...
-			$conn = \OC_DB::getConnection();
-			$result = $conn->executeQuery(
-				'SELECT * FROM `*PREFIX*share` ' . $where,
-				$arguments,
-				$types
-			);
+				// TODO: inject connection, hopefully one day in the future when this
+				// class isn't static anymore...
+				$conn = \OC_DB::getConnection();
+				$result = $conn->executeQuery(
+					'SELECT * FROM `*PREFIX*share` ' . $where,
+					$arguments,
+					$types
+				);
 
-			while ($row = $result->fetch()) {
-				$shares[] = $row;
+				while ($row = $result->fetch()) {
+					$shares[] = $row;
+				}
 			}
 		}
 


### PR DESCRIPTION
Follow up for https://github.com/owncloud/core/pull/13423

On master, this saves on query.
It seems that the query just becomes `shared_with in (NULL)` when the user has no groups assigned.

On stable7 however it fails with an exception and breaks.
So this fix here will be required for the backport of https://github.com/owncloud/core/pull/13423 (discovered during backport)

Please review @schiesbn @MorrisJobke @LukasReschke @DeepDiver1975 
