### PR TITLE
use uid provided by setupfs hook to mount server2server shares

### DIFF
--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -34,8 +34,8 @@ $externalManager = new \OCA\Files_Sharing\External\Manager(
 		\OC::$server->getDatabaseConnection(),
 		\OC\Files\Filesystem::getMountManager(),
 		\OC\Files\Filesystem::getLoader(),
-		\OC::$server->getUserSession(),
-		\OC::$server->getHTTPHelper()
+		\OC::$server->getHTTPHelper(),
+		\OC::$server->getUserSession()->getUser()->getUID()
 );
 
 $name = OCP\Files::buildNotExistingFileName('/', $name);

--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -60,8 +60,9 @@ class Server2Server {
 					\OC::$server->getDatabaseConnection(),
 					\OC\Files\Filesystem::getMountManager(),
 					\OC\Files\Filesystem::getLoader(),
-					\OC::$server->getUserSession(),
-					\OC::$server->getHTTPHelper());
+					\OC::$server->getHTTPHelper(),
+					$shareWith
+				);
 
 			$name = \OCP\Files::buildNotExistingFileName('/', $name);
 

--- a/apps/files_sharing/application.php
+++ b/apps/files_sharing/application.php
@@ -69,12 +69,14 @@ class Application extends App {
 			return Helper::isIncomingServer2serverShareEnabled();
 		});
 		$container->registerService('ExternalManager', function(SimpleContainer $c) use ($server){
+			$user = $server->getUserSession()->getUser();
+			$uid = $user ? $user->getUID() : null;
 			return new \OCA\Files_Sharing\External\Manager(
 					$server->getDatabaseConnection(),
 					\OC\Files\Filesystem::getMountManager(),
 					\OC\Files\Filesystem::getLoader(),
-					$server->getUserSession(),
-					$server->getHTTPHelper()
+					$server->getHTTPHelper(),
+					$uid
 			);
 		});
 

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -142,7 +142,6 @@ class ShareController extends Controller {
 			return new TemplateResponse('core', '404', array(), 'guest');
 		}
 
-		$linkItem = OCP\Share::getShareByToken($token, false);
 		$shareOwner = $linkItem['uid_owner'];
 		$originalSharePath = null;
 		$rootLinkItem = OCP\Share::resolveReShare($linkItem);

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -199,7 +199,7 @@ class Manager {
 		$data['manager'] = $this;
 		$mountPoint = '/' . $this->uid . '/files' . $data['mountpoint'];
 		$data['mountpoint'] = $mountPoint;
-		$data['certificateManager'] = \OC::$server->getCertificateManager(\OC::$server->getUserSession()->getUser());
+		$data['certificateManager'] = \OC::$server->getCertificateManager($this->uid);
 		$mount = new Mount(self::STORAGE, $mountPoint, $data, $this, $this->storageLoader);
 		$this->mountManager->addMount($mount);
 		return $mount;

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -42,6 +42,7 @@ class Manager {
 	 * @param \OCP\IDBConnection $connection
 	 * @param \OC\Files\Mount\Manager $mountManager
 	 * @param \OC\Files\Storage\StorageFactory $storageLoader
+	 * @param \OC\HTTPHelper $httpHelper
 	 * @param string $uid
 	 */
 	public function __construct(\OCP\IDBConnection $connection, \OC\Files\Mount\Manager $mountManager,
@@ -53,6 +54,19 @@ class Manager {
 		$this->uid = $uid;
 	}
 
+	/**
+	 * add new server-to-server share
+	 *
+	 * @param string $remote
+	 * @param string $token
+	 * @param string $password
+	 * @param string $name
+	 * @param string $owner
+	 * @param boolean $accepted
+	 * @param string $user
+	 * @param int $remoteId
+	 * @return mixed
+	 */
 	public function addShare($remote, $token, $password, $name, $owner, $accepted=false, $user = null, $remoteId = -1) {
 
 		$user = $user ? $user : $this->uid;
@@ -174,7 +188,12 @@ class Manager {
 		return ($result['success'] && $status['ocs']['meta']['statuscode'] === 100);
 	}
 
-	public static function setup($params) {
+	/**
+	 * setup the server-to-server mounts
+	 *
+	 * @param array $params
+	 */
+	public static function setup(array $params) {
 		$externalManager = new \OCA\Files_Sharing\External\Manager(
 				\OC::$server->getDatabaseConnection(),
 				\OC\Files\Filesystem::getMountManager(),
@@ -186,6 +205,12 @@ class Manager {
 		$externalManager->setupMounts();
 	}
 
+	/**
+	 * remove '/user/files' from the path and trailing slashes
+	 *
+	 * @param string $path
+	 * @return string
+	 */
 	protected function stripPath($path) {
 		$prefix = '/' . $this->uid . '/files';
 		return rtrim(substr($path, strlen($prefix)), '/');

--- a/apps/files_sharing/lib/hooks.php
+++ b/apps/files_sharing/lib/hooks.php
@@ -30,8 +30,8 @@ class Hooks {
 			\OC::$server->getDatabaseConnection(),
 			\OC\Files\Filesystem::getMountManager(),
 			\OC\Files\Filesystem::getLoader(),
-			\OC::$server->getUserSession(),
-			\OC::$server->getHTTPHelper());
+			\OC::$server->getHTTPHelper(),
+			$params['uid']);
 
 		$manager->removeUserShares($params['uid']);
 	}

--- a/apps/files_sharing/tests/server2server.php
+++ b/apps/files_sharing/tests/server2server.php
@@ -153,8 +153,9 @@ class Test_Files_Sharing_S2S_OCS_API extends TestCase {
 			\OC::$server->getDatabaseConnection(),
 			\OC\Files\Filesystem::getMountManager(),
 			\OC\Files\Filesystem::getLoader(),
-			\OC::$server->getUserSession(),
-			\OC::$server->getHTTPHelper());
+			\OC::$server->getHTTPHelper(),
+			$toDelete
+			);
 
 		$manager->removeUserShares($toDelete);
 

--- a/lib/private/security/certificatemanager.php
+++ b/lib/private/security/certificatemanager.php
@@ -16,15 +16,15 @@ use OCP\ICertificateManager;
  */
 class CertificateManager implements ICertificateManager {
 	/**
-	 * @var \OCP\IUser
+	 * @var string
 	 */
-	protected $user;
+	protected $uid;
 
 	/**
-	 * @param \OCP\IUser $user
+	 * @param string $uid
 	 */
-	public function __construct($user) {
-		$this->user = $user;
+	public function __construct($uid) {
+		$this->uid = $uid;
 	}
 
 	/**
@@ -134,7 +134,7 @@ class CertificateManager implements ICertificateManager {
 	}
 
 	private function getPathToCertificates() {
-		$path = $this->user ? $this->user->getHome() . '/files_external/' : '/files_external/';
+		$path = is_null($this->uid) ? '/files_external/' : '/' . $this->uid . '/files_external/';
 
 		return $path;
 	}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -249,7 +249,9 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('HTTPHelper', function (Server $c) {
 			$config = $c->getConfig();
-			return new HTTPHelper($config, new \OC\Security\CertificateManager($c->getUserSession()->getUser()));
+			$user = $c->getUserSession()->getUser();
+			$uid = $user ? $user->getUID() : null;
+			return new HTTPHelper($config, new \OC\Security\CertificateManager($uid));
 		});
 		$this->registerService('EventLogger', function (Server $c) {
 			if (defined('DEBUG') and DEBUG) {
@@ -631,18 +633,19 @@ class Server extends SimpleContainer implements IServerContainer {
 	/**
 	 * Get the certificate manager for the user
 	 *
-	 * @param \OCP\IUser $user (optional) if not specified the current loggedin user is used
+	 * @param string $uid (optional) if not specified the current loggedin user is used
 	 * @return \OCP\ICertificateManager
 	 */
-	function getCertificateManager($user = null) {
-		if (is_null($user)) {
+	function getCertificateManager($uid = null) {
+		if (is_null($uid)) {
 			$userSession = $this->getUserSession();
 			$user = $userSession->getUser();
 			if (is_null($user)) {
 				return null;
 			}
+			$uid = $user->getUID();
 		}
-		return new CertificateManager($user);
+		return new CertificateManager($uid);
 	}
 
 	/**

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -251,7 +251,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			$config = $c->getConfig();
 			$user = $c->getUserSession()->getUser();
 			$uid = $user ? $user->getUID() : null;
-			return new HTTPHelper($config, new \OC\Security\CertificateManager($uid));
+			return new HTTPHelper($config, new \OC\Security\CertificateManager($uid, new \OC\Files\View()));
 		});
 		$this->registerService('EventLogger', function (Server $c) {
 			if (defined('DEBUG') and DEBUG) {
@@ -645,7 +645,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 			$uid = $user->getUID();
 		}
-		return new CertificateManager($uid);
+		return new CertificateManager($uid, new \OC\Files\View());
 	}
 
 	/**

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -28,7 +28,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_Util::setupFS($this->username);
 
-		$this->certificateManager = new CertificateManager($this->username);
+		$this->certificateManager = new CertificateManager($this->username, new \OC\Files\View());
 	}
 
 	protected function tearDown() {

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -28,9 +28,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_Util::setupFS($this->username);
 
-		$this->user = \OC::$server->getUserManager()->get($this->username);
-
-		$this->certificateManager = new CertificateManager($this->user);
+		$this->certificateManager = new CertificateManager($this->username);
 	}
 
 	protected function tearDown() {
@@ -84,7 +82,7 @@ class CertificateManagerTest extends \Test\TestCase {
 	}
 
 	function testGetCertificateBundle() {
-		$this->assertSame($this->user->getHome().'/files_external/rootcerts.crt', $this->certificateManager->getCertificateBundle());
+		$this->assertSame('/' . $this->username . '/files_external/rootcerts.crt', $this->certificateManager->getCertificateBundle());
 	}
 
 }


### PR DESCRIPTION
use uid provided by setupfs hook to mount server2server shares, otherwise mount will fail for public link shares.

Steps to reproduce:
1. share folder from server1 to server2
2. recipient at server2 shares folder as public link
3. try to open public link -> will fail without this patch and should work with patch

Note: on master you need to disable trashbin because of https://github.com/owncloud/core/issues/13491
