### PR TITLE
Fix WebDAV auth for session authentication only

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -101,7 +101,6 @@ class OC_Connector_Sabre_Auth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	public function authenticate(\Sabre\DAV\Server $server, $realm) {
 
 		$result = $this->auth($server, $realm);
-
 		return $result;
     }
 
@@ -111,10 +110,13 @@ class OC_Connector_Sabre_Auth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	 * @return bool
 	 */
 	private function auth(\Sabre\DAV\Server $server, $realm) {
-		if (OC_User::handleApacheAuth()) {
+		if (OC_User::handleApacheAuth() ||
+			(OC_User::isLoggedIn() && is_null(\OC::$server->getSession()->get(self::DAV_AUTHENTICATED)))
+		) {
 			$user = OC_User::getUser();
 			OC_Util::setupFS($user);
 			$this->currentUser = $user;
+			\OC::$server->getSession()->close();
 			return true;
 		}
 

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -320,7 +320,7 @@ class OC_User {
 	 * Tries to login the user with HTTP Basic Authentication
 	 */
 	public static function tryBasicAuthLogin() {
-		if(!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_USER'])) {
+		if(!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
 			\OC_User::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
 		}
 	}


### PR DESCRIPTION
\Sabre\DAV\Auth\Backend\AbstractBasic::authenticate was only calling \OC_Connector_Sabre_Auth::validateUserPass when the response of \Sabre\HTTP\BasicAuth::getUserPass was not null.

However, there is a case where the value can be null and the user could be authenticated anyways: The authentication via ownCloud web-interface and then accessing WebDAV resources. This was not possible anymore with this patch because it never reached the code path in this scenario.

This patchs allows authenticating with a session without isDavAuthenticated value stored (this is for ugly WebDAV clients that send the cookie in any case) and thus the functionality should work again.

To test this go to the admin settings and test if the WebDAV check works fine. Furthermore all the usual stuff (WebDAV / Shibboleth / etc...) needs testing as well.

@DeepDiver1975 As discussed.
