### PR TITLE
Streamline auth and CSRF check in scan.php

### DIFF
--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -1,11 +1,15 @@
 <?php
 set_time_limit(0); //scanning can take ages
+
+\OCP\JSON::checkLoggedIn();
+\OCP\JSON::callCheck();
+
 \OC::$server->getSession()->close();
 
 $force = (isset($_GET['force']) and ($_GET['force'] === 'true'));
 $dir = isset($_GET['dir']) ? $_GET['dir'] : '';
 if (isset($_GET['users'])) {
-	OC_JSON::checkAdminUser();
+	\OCP\JSON::checkAdminUser();
 	if ($_GET['users'] === 'all') {
 		$users = OC_User::getUsers();
 	} else {


### PR DESCRIPTION
Furthermore a not logged-in user was able to access this page before which resulted in a Fatal PHP error since the filesystem could not get setup properly.
