### PR TITLE
Dont remove a file from cache if the delete operation failed

### DIFF
--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -80,7 +80,9 @@ class Storage extends Wrapper {
 				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
 				// in cross-storage cases the file will be copied
 				// but not deleted, so we delete it here
-				$this->storage->unlink($path);
+				if ($result) {
+					$this->storage->unlink($path);
+				}
 			} else {
 				$result = $this->storage->unlink($path);
 			}

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -85,6 +85,8 @@ class Storage extends Wrapper {
 				$result = $this->storage->unlink($path);
 			}
 			unset($this->deletedFiles[$normalized]);
+		} else if ($this->storage->file_exists($path)) {
+			$result = $this->storage->unlink($path);
 		}
 
 		return $result;

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -180,6 +180,11 @@ class Trashbin {
 		}
 		\OC_FileProxy::$enabled = $proxyStatus;
 
+		if ($view->file_exists('/files/' . $file_path)) { // failed to delete the original file, abort
+			$view->unlink($trashPath);
+			return false;
+		}
+
 		if ($sizeOfAddedFiles !== false) {
 			$size = $sizeOfAddedFiles;
 			$query = \OC_DB::prepare("INSERT INTO `*PREFIX*files_trash` (`id`,`timestamp`,`location`,`user`) VALUES (?,?,?,?)");

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -803,7 +803,7 @@ class View {
 
 				$result = \OC_FileProxy::runPostProxies($operation, $this->getAbsolutePath($path), $result);
 
-				if (in_array('delete', $hooks)) {
+				if (in_array('delete', $hooks) and $result) {
 					$this->updater->remove($path);
 				}
 				if (in_array('write', $hooks)) {

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -527,7 +527,7 @@ class View {
 						fclose($target);
 
 						if ($result !== false) {
-							$storage1->unlink($internalPath1);
+							$result &= $storage1->unlink($internalPath1);
 						}
 					}
 				}
@@ -537,7 +537,7 @@ class View {
 					if ($this->shouldEmitHooks()) {
 						$this->emit_file_hooks_post($exists, $path2);
 					}
-				} elseif ($result !== false) {
+				} elseif ($result) {
 					$this->updater->rename($path1, $path2);
 					if ($this->shouldEmitHooks($path1) and $this->shouldEmitHooks($path2)) {
 						\OC_Hook::emit(

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -849,4 +849,27 @@ class View extends \Test\TestCase {
 
 		$this->assertEquals($time, $view->filemtime('/test/sub/storage/foo/bar.txt'));
 	}
+
+	public function testDeleteFailKeepCache() {
+		/**
+		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Files\Storage\Temporary $storage
+		 */
+		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+			->setConstructorArgs(array(array()))
+			->setMethods(array('unlink'))
+			->getMock();
+		$storage->expects($this->once())
+			->method('unlink')
+			->will($this->returnValue(false));
+		$scanner = $storage->getScanner();
+		$cache = $storage->getCache();
+		$storage->file_put_contents('foo.txt', 'asd');
+		$scanner->scan('');
+		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+
+		$view = new \OC\Files\View('/test');
+
+		$this->assertFalse($view->unlink('foo.txt'));
+		$this->assertTrue($cache->inCache('foo.txt'));
+	}
 }


### PR DESCRIPTION
Steps to reproduce:
- Create a folder and upload some files
- Remove write permissions from the folder (`chmod 0555 ....`)
- In the WebUI check that oC still thinks the folder is writable
- Try to delete a file in the folder over WebDAV
- Refresh the folder to check if the file is still in the cache after the failed delete

It's important here that oC thinks the folder is writable otherwise the delete operation fails at an earlier step

Fixes #13488

cc @DeepDiver1975 @PVince81 @MorrisJobke 
