### PR TITLE
Do not abort when meeting unfixable legacy storages

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -35,6 +35,12 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updated "%s" to %s', array($app, $version)));
 	});
+	$updater->listen('\OC\Updater', 'repairWarning', function ($description) use ($eventSource, $l) {
+		$eventSource->send('notice', (string)$l->t('Repair warning: ') . $description);
+	});
+	$updater->listen('\OC\Updater', 'repairError', function ($description) use ($eventSource, $l) {
+		$eventSource->send('notice', (string)$l->t('Repair error: ') . $description);
+	});
 	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps) {
 		$incompatibleApps[]= $app;
 	});

--- a/core/command/maintenance/repair.php
+++ b/core/command/maintenance/repair.php
@@ -46,6 +46,9 @@ class Repair extends Command {
 		$this->repair->listen('\OC\Repair', 'info', function ($description) use ($output) {
 			$output->writeln('     - ' . $description);
 		});
+		$this->repair->listen('\OC\Repair', 'warning', function ($description) use ($output) {
+			$output->writeln('     - WARNING: ' . $description);
+		});
 		$this->repair->listen('\OC\Repair', 'error', function ($description) use ($output) {
 			$output->writeln('     - ERROR: ' . $description);
 		});

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -113,6 +113,12 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use($output) {
 				$output->writeln('<info>Disabled 3rd-party app: ' . $app . '</info>');
 			});
+			$updater->listen('\OC\Updater', 'repairWarning', function ($app) use($output) {
+				$output->writeln('<error>Repair warning: ' . $app . '</error>');
+			});
+			$updater->listen('\OC\Updater', 'repairError', function ($app) use($output) {
+				$output->writeln('<error>Repair error: ' . $app . '</error>');
+			});
 			$updater->listen('\OC\Updater', 'appUpgradeCheck', function () use ($output) {
 				$output->writeln('<info>Checked database schema update for apps</info>');
 			});

--- a/lib/private/repair/repairlegacystorages.php
+++ b/lib/private/repair/repairlegacystorages.php
@@ -146,75 +146,88 @@ class RepairLegacyStorages extends BasicEmitter {
 
 		$this->connection->beginTransaction();
 
-		try {
-			// note: not doing a direct UPDATE with the REPLACE function
-			// because regexp search/extract is needed and it is not guaranteed
-			// to work on all database types
-			$sql = 'SELECT `id`, `numeric_id` FROM `*PREFIX*storages`'
-				. ' WHERE `id` LIKE ?'
-				. ' ORDER BY `id`';
-			$result = $this->connection->executeQuery($sql, array($dataDirId . '%'));
-			while ($row = $result->fetch()) {
-				$currentId = $row['id'];
-				// one entry is the datadir itself
-				if ($currentId === $dataDirId) {
-					continue;
-				}
+		// note: not doing a direct UPDATE with the REPLACE function
+		// because regexp search/extract is needed and it is not guaranteed
+		// to work on all database types
+		$sql = 'SELECT `id`, `numeric_id` FROM `*PREFIX*storages`'
+			. ' WHERE `id` LIKE ?'
+			. ' ORDER BY `id`';
+		$result = $this->connection->executeQuery($sql, array($dataDirId . '%'));
 
+		while ($row = $result->fetch()) {
+			$currentId = $row['id'];
+			// one entry is the datadir itself
+			if ($currentId === $dataDirId) {
+				continue;
+			}
+
+			try {
 				if ($this->fixLegacyStorage($currentId, (int)$row['numeric_id'])) {
 					$count++;
 				}
 			}
+			catch (\OC\RepairException $e) {
+				$this->emit(
+					'\OC\Repair',
+					'warning',
+					array('Could not repair legacy storage ' . $currentId . ' automatically.')
+				);
+			}
+		}
 
-			// check for md5 ids, not in the format "prefix::"
-			$sql = 'SELECT COUNT(*) AS "c" FROM `*PREFIX*storages`'
-				. ' WHERE `id` NOT LIKE \'%::%\'';
-			$result = $this->connection->executeQuery($sql);
-			$row = $result->fetch();
-			// find at least one to make sure it's worth
-			// querying the user list
-			if ((int)$row['c'] > 0) {
-				$userManager = \OC_User::getManager();
+		// check for md5 ids, not in the format "prefix::"
+		$sql = 'SELECT COUNT(*) AS "c" FROM `*PREFIX*storages`'
+			. ' WHERE `id` NOT LIKE \'%::%\'';
+		$result = $this->connection->executeQuery($sql);
+		$row = $result->fetch();
+		// find at least one to make sure it's worth
+		// querying the user list
+		if ((int)$row['c'] > 0) {
+			$userManager = \OC_User::getManager();
 
-				// use chunks to avoid caching too many users in memory
-				$limit = 30;
-				$offset = 0;
+			// use chunks to avoid caching too many users in memory
+			$limit = 30;
+			$offset = 0;
 
-				do {
-					// query the next page of users
-					$results = $userManager->search('', $limit, $offset);
-					$storageIds = array();
-					$userIds = array();
-					foreach ($results as $uid => $userObject) {
-						$storageId = $dataDirId . $uid . '/';
-						if (strlen($storageId) <= 64) {
-							// skip short storage ids as they were handled in the previous section
-							continue;
-						}
-						$storageIds[$uid] = $storageId;
+			do {
+				// query the next page of users
+				$results = $userManager->search('', $limit, $offset);
+				$storageIds = array();
+				$userIds = array();
+				foreach ($results as $uid => $userObject) {
+					$storageId = $dataDirId . $uid . '/';
+					if (strlen($storageId) <= 64) {
+						// skip short storage ids as they were handled in the previous section
+						continue;
 					}
+					$storageIds[$uid] = $storageId;
+				}
 
-					if (count($storageIds) > 0) {
-						// update the storages of these users
-						foreach ($storageIds as $uid => $storageId) {
-							$numericId = \OC\Files\Cache\Storage::getNumericStorageId($storageId);
+				if (count($storageIds) > 0) {
+					// update the storages of these users
+					foreach ($storageIds as $uid => $storageId) {
+						$numericId = \OC\Files\Cache\Storage::getNumericStorageId($storageId);
+						try {
 							if (!is_null($numericId) && $this->fixLegacyStorage($storageId, (int)$numericId)) {
 								$count++;
 							}
 						}
+						catch (\OC\RepairException $e) {
+							$this->emit(
+								'\OC\Repair',
+								'warning',
+								array('Could not repair legacy storage ' . $storageId . ' automatically.')
+							);
+						}
 					}
-					$offset += $limit;
-				} while (count($results) >= $limit);
-			}
-
-			$this->emit('\OC\Repair', 'info', array('Updated ' . $count . ' legacy home storage ids'));
-
-			$this->connection->commit();
+				}
+				$offset += $limit;
+			} while (count($results) >= $limit);
 		}
-		catch (\OC\RepairException $e) {
-			$this->connection->rollback();
-			throw $e;
-		}
+
+		$this->emit('\OC\Repair', 'info', array('Updated ' . $count . ' legacy home storage ids'));
+
+		$this->connection->commit();
 
 		$this->config->setAppValue('core', 'repairlegacystoragesdone', 'yes');
 	}

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -173,6 +173,20 @@ class Updater extends BasicEmitter {
 	}
 
 	/**
+	 * Forward messages emitted by the repair routine
+	 *
+	 * @param Repair $repair repair routine
+	 */
+	private function emitRepairMessages(Repair $repair) {
+		$repair->listen('\OC\Repair', 'warning', function ($description) {
+			$this->emit('\OC\Updater', 'repairWarning', array($description));
+		});
+		$repair->listen('\OC\Repair', 'error', function ($description) {
+			$this->emit('\OC\Updater', 'repairError', array($description));
+		});
+	}
+
+	/**
 	 * runs the update actions in maintenance mode, does not upgrade the source files
 	 * except the main .htaccess file
 	 *
@@ -204,6 +218,7 @@ class Updater extends BasicEmitter {
 
 		// pre-upgrade repairs
 		$repair = new Repair(Repair::getBeforeUpgradeRepairSteps());
+		$this->emitRepairMessages($repair);
 		$repair->run();
 
 		// simulate DB upgrade
@@ -223,6 +238,7 @@ class Updater extends BasicEmitter {
 
 			// post-upgrade repairs
 			$repair = new Repair(Repair::getRepairSteps());
+			$this->emitRepairMessages($repair);
 			$repair->run();
 
 			//Invalidate update feed

--- a/tests/lib/repair/repairlegacystorage.php
+++ b/tests/lib/repair/repairlegacystorage.php
@@ -24,6 +24,8 @@ class TestRepairLegacyStorages extends \Test\TestCase {
 	private $legacyStorageId;
 	private $newStorageId;
 
+	private $warnings;
+
 	protected function setUp() {
 		parent::setUp();
 
@@ -32,6 +34,12 @@ class TestRepairLegacyStorages extends \Test\TestCase {
 		$this->oldDataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data/');
 
 		$this->repair = new \OC\Repair\RepairLegacyStorages($this->config, $this->connection);
+
+		$this->warnings = [];
+
+		$this->repair->listen('\OC\Repair', 'warning', function ($description){
+			$this->warnings[] = $description;
+		});
 	}
 
 	protected function tearDown() {
@@ -181,22 +189,17 @@ class TestRepairLegacyStorages extends \Test\TestCase {
 		$this->createData($this->legacyStorageId);
 		$this->createData($this->newStorageId);
 
-		try {
-			$thrown = false;
-			$this->repair->run();
-		}
-		catch (\OC\RepairException $e) {
-			$thrown = true;
-		}
+		$this->repair->run();
 
-		$this->assertTrue($thrown);
+		$this->assertEquals(1, count($this->warnings));
+		$this->assertEquals('Could not repair legacy storage ', substr(current($this->warnings), 0, 32));
 
 		// storages left alone
 		$this->assertEquals($legacyStorageNumId, $this->getStorageId($this->legacyStorageId));
 		$this->assertEquals($newStorageNumId, $this->getStorageId($this->newStorageId));
 
-		// did not set the done flag
-		$this->assertNotEquals('yes', $this->config->getAppValue('core', 'repairlegacystoragesdone'));
+		// set the done flag
+		$this->assertEquals('yes', $this->config->getAppValue('core', 'repairlegacystoragesdone'));
 	}
 
 	/**

--- a/tests/lib/repair/repairlegacystorage.php
+++ b/tests/lib/repair/repairlegacystorage.php
@@ -191,7 +191,7 @@ class TestRepairLegacyStorages extends \Test\TestCase {
 
 		$this->repair->run();
 
-		$this->assertEquals(1, count($this->warnings));
+		$this->assertEquals(2, count($this->warnings));
 		$this->assertEquals('Could not repair legacy storage ', substr(current($this->warnings), 0, 32));
 
 		// storages left alone

--- a/tests/lib/repair/repairlegacystorage.php
+++ b/tests/lib/repair/repairlegacystorage.php
@@ -198,8 +198,8 @@ class TestRepairLegacyStorages extends \Test\TestCase {
 		$this->assertEquals($legacyStorageNumId, $this->getStorageId($this->legacyStorageId));
 		$this->assertEquals($newStorageNumId, $this->getStorageId($this->newStorageId));
 
-		// set the done flag
-		$this->assertEquals('yes', $this->config->getAppValue('core', 'repairlegacystoragesdone'));
+		// do not set the done flag
+		$this->assertNotEquals('yes', $this->config->getAppValue('core', 'repairlegacystoragesdone'));
 	}
 
 	/**


### PR DESCRIPTION
I had a long thought about the repair step that tries and automatically fix legacy storages.
There are cases where automatic repair isn't possible.
So far, the code would bail out and refuse the upgrade.

I think it is not a good idea to prevent upgrading in such cases. It is best to show error messages and let the admin decide what to do. Some setups might run fine, especially if the broken users are old/unused ones.

This PR will change the behavior to only show an error for every storage that could not be fixed automatically.
We can then provide a documentation about the possibilities there are for manual fixing, because this heavily depends on the usage scenario and the time where the data folder was renamed.

@DeepDiver1975 @karlitschek 
- [x] manual test
- [x] adjust unit tests + assert on error message
