### PR TITLE
Async external storage status checking

### DIFF
--- a/apps/files_external/ajax/status.php
+++ b/apps/files_external/ajax/status.php
@@ -1,0 +1,18 @@
+<?php
+
+OCP\JSON::checkAppEnabled('files_external');
+OCP\JSON::callCheck();
+
+if ($_POST['isPersonal'] == 'true') {
+	OCP\JSON::checkLoggedIn();
+	$isPersonal = true;
+} else {
+	OCP\JSON::checkAdminUser();
+	$isPersonal = false;
+}
+
+$class = $_POST['class'];
+$options = $_POST['classOptions'];
+
+$status = OC_Mount_Config::getBackendStatus($class, $options, $isPersonal);
+OCP\JSON::success(array('data' => array('message' => $status)));

--- a/apps/files_external/appinfo/routes.php
+++ b/apps/files_external/appinfo/routes.php
@@ -39,6 +39,8 @@ $this->create('files_external_google', 'ajax/google.php')
 
 $this->create('files_external_list_applicable', '/applicable')
 	->actionInclude('files_external/ajax/applicable.php');
+$this->create('files_external_get_status', '/status')
+	->actionInclude('files_external/ajax/status.php');
 
 OC_API::register('get',
 		'/apps/files_external/api/v1/mounts',

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -354,8 +354,7 @@ class OC_Mount_Config {
 						'backend' => $backends[$mount['class']]['backend'],
 						'priority' => $mount['priority'],
 						'options' => $mount['options'],
-						'applicable' => array('groups' => array($group), 'users' => array()),
-						'status' => self::getBackendStatus($mount['class'], $mount['options'], false)
+						'applicable' => array('groups' => array($group), 'users' => array())
 					);
 					$hash = self::makeConfigHash($config);
 					// If an existing config exists (with same class, mountpoint and options)
@@ -388,8 +387,7 @@ class OC_Mount_Config {
 						'backend' => $backends[$mount['class']]['backend'],
 						'priority' => $mount['priority'],
 						'options' => $mount['options'],
-						'applicable' => array('groups' => array(), 'users' => array($user)),
-						'status' => self::getBackendStatus($mount['class'], $mount['options'], false)
+						'applicable' => array('groups' => array(), 'users' => array($user))
 					);
 					$hash = self::makeConfigHash($config);
 					// If an existing config exists (with same class, mountpoint and options)
@@ -429,8 +427,7 @@ class OC_Mount_Config {
 					// Remove '/uid/files/' from mount point
 					'mountpoint' => substr($mountPoint, strlen($uid) + 8),
 					'backend' => $backEnds[$mount['class']]['backend'],
-					'options' => $mount['options'],
-					'status' => self::getBackendStatus($mount['class'], $mount['options'], true)
+					'options' => $mount['options']
 				);
 			}
 		}
@@ -444,10 +441,19 @@ class OC_Mount_Config {
 	 * @param array $options backend configuration options
 	 * @return bool true if the connection succeeded, false otherwise
 	 */
-	private static function getBackendStatus($class, $options, $isPersonal) {
+	public static function getBackendStatus($class, $options, $isPersonal) {
 		if (self::$skipTest) {
 			return true;
 		}
+		if ($isPersonal) {
+			$allowed_backends = self::getPersonalBackends();
+		} else {
+			$allowed_backends = self::getBackends();
+		}
+		if (!isset($allowed_backends[$class])) {
+			return false;
+		}
+
 		foreach ($options as &$option) {
 			$option = self::setUserVars(OCP\User::getUser(), $option);
 		}

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -17,9 +17,7 @@
 		<?php foreach ($_['mounts'] as $mount): ?>
 			<tr <?php print_unescaped(isset($mount['mountpoint']) ? 'class="'.OC_Util::sanitizeHTML($mount['class']).'"' : 'id="addMountPoint"'); ?>>
 				<td class="status">
-				<?php if (isset($mount['status'])): ?>
-					<span class="<?php p(($mount['status']) ? 'success' : 'error'); ?>"></span>
-				<?php endif; ?>
+					<span></span>
 				</td>
 				<td class="mountPoint"><input type="text" name="mountPoint"
 											  value="<?php p(isset($mount['mountpoint']) ? $mount['mountpoint'] : ''); ?>"


### PR DESCRIPTION
When loading the settings when external storages are configured, the storage status check now happens via AJAX calls rather than synchronous while the page is loading. This makes the settings nice and fast, even if some storages are down and timeout (slowly).

Fixes #11833

cc @LukasReschke @icewind1991 @PVince81 
