### PR TITLE
this must be larger then (>), since buggy behaviour occurs when the para...

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -152,7 +152,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$pagingSize = intval($this->connection->ldapPagingSize);
 		// 0 won't result in replies, small numbers may leave out groups
 		// (cf. #12306), 500 is default for paging and should work everywhere.
-		$maxResults = $pagingSize < 20 ? $pagingSize : 500;
+		$maxResults = $pagingSize > 20 ? $pagingSize : 500;
 		$this->initPagedSearch($filter, array($dn), array($attr), $maxResults, 0);
 		$dn = $this->DNasBaseParameter($dn);
 		$rr = @$this->ldap->read($cr, $dn, $filter, array($attr));


### PR DESCRIPTION
...meter is a small number

Thanks to @Flugtiger https://github.com/owncloud/core/commit/f28235a7ef6664978a8b4f6d16a47df508244294#commitcomment-9354126

review pls @MorrisJobke @d-tamm @tkaufm 
