### PR TITLE
Catch storage exception in scanner for remote shares

### DIFF
--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -77,7 +77,7 @@ if (substr($remote, 0, 5) === 'https' and !OC_Util::getUrlContent($remote)) {
 		);
 		$externalManager->removeShare($mount->getMountPoint());
 		\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
-		throw new \OCP\Files\StorageNotAvailableException(get_class($e).': '.$e->getMessage());
+		exit();
 	}
 	$result = $storage->file_exists('');
 	if ($result) {

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -42,20 +42,70 @@ $name = OCP\Files::buildNotExistingFileName('/', $name);
 
 // check for ssl cert
 if (substr($remote, 0, 5) === 'https' and !OC_Util::getUrlContent($remote)) {
-	\OCP\JSON::error(array('data' => array('message' => $l->t("Invalid or untrusted SSL certificate"))));
+	\OCP\JSON::error(array('data' => array('message' => $l->t('Invalid or untrusted SSL certificate'))));
 	exit;
 } else {
 	$mount = $externalManager->addShare($remote, $token, $password, $name, $owner, true);
+
 	/**
 	 * @var \OCA\Files_Sharing\External\Storage $storage
 	 */
 	$storage = $mount->getStorage();
+	try {
+		// check if storage exists
+		$storage->checkStorageAvailability();
+	} catch (\OCP\Files\StorageInvalidException $e) {
+		// note: checkStorageAvailability will already remove the invalid share
+		\OCP\Util::writeLog(
+			'files_sharing',
+			'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+			\OCP\Util::DEBUG
+		);
+		\OCP\JSON::error(
+			array(
+				'data' => array(
+					'message' => $l->t('Could not authenticate to remote share, password might be wrong')
+				)
+			)
+		);
+		exit();
+	} catch (\Exception $e) {
+		\OCP\Util::writeLog(
+			'files_sharing',
+			'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+			\OCP\Util::DEBUG
+		);
+		$externalManager->removeShare($mount->getMountPoint());
+		\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
+		throw new \OCP\Files\StorageNotAvailableException(get_class($e).': '.$e->getMessage());
+	}
 	$result = $storage->file_exists('');
 	if ($result) {
-		$storage->getScanner()->scanAll();
-		\OCP\JSON::success();
+		try {
+			$storage->getScanner()->scanAll();
+			\OCP\JSON::success();
+		} catch (\OCP\Files\StorageInvalidException $e) {
+			\OCP\Util::writeLog(
+				'files_sharing',
+				'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+				\OCP\Util::DEBUG
+			);
+			\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
+		} catch (\Exception $e) {
+			\OCP\Util::writeLog(
+				'files_sharing',
+				'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+				\OCP\Util::DEBUG
+			);
+			\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t add remote share'))));
+		}
 	} else {
 		$externalManager->removeShare($mount->getMountPoint());
-		\OCP\JSON::error(array('data' => array('message' => $l->t("Couldn't add remote share"))));
+		\OCP\Util::writeLog(
+			'files_sharing',
+			'Couldn\'t add remote share',
+			\OCP\Util::DEBUG
+		);
+		\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t add remote share'))));
 	}
 }

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -95,7 +95,7 @@
 							name: share.name,
 							password: password}, function(result) {
 							if (result.status === 'error') {
-								OC.Notification.show(result.data.message);
+								OC.Notification.showTemporary(result.data.message);
 							} else {
 								fileList.reload();
 							}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1037,7 +1037,22 @@ class View {
 
 					if ($subCache->getStatus('') === Cache\Cache::NOT_FOUND) {
 						$subScanner = $subStorage->getScanner('');
-						$subScanner->scanFile('');
+						try {
+							$subScanner->scanFile('');
+						} catch (\OCP\Files\StorageNotAvailableException $e) {
+							continue;
+						} catch (\OCP\Files\StorageInvalidException $e) {
+							continue;
+						} catch (\Exception $e) {
+							// sometimes when the storage is not available it can be any exception
+							\OCP\Util::writeLog(
+								'core',
+								'Exception while scanning storage "' . $subStorage->getId() . '": ' .
+								get_class($e) . ': ' . $e->getMessage(),
+								\OC_Log::ERROR
+							);
+							continue;
+						}
 					}
 
 					$rootEntry = $subCache->get('');

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1049,7 +1049,7 @@ class View {
 								'core',
 								'Exception while scanning storage "' . $subStorage->getId() . '": ' .
 								get_class($e) . ': ' . $e->getMessage(),
-								\OC_Log::ERROR
+								\OCP\Util::ERROR
 							);
 							continue;
 						}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/13089
- [x] Requires https://github.com/owncloud/core/pull/13506 to be merged first

Please review @icewind1991 @DeepDiver1975 @MorrisJobke @nickvergessen @schiesbn 

Needs extensive testing, especially with sync client:
#### Test with:
- [x] remote share without password
- [x] remote share with password (this is broken for some other reason to be looked into, but should fail gracefully)
- [x] sync with remote share without password
- [x] sync with remote share with password
- [x] test expiring a remote share, folder will disappear
