### PR TITLE
Remove duplicated slashes from the requested url

### DIFF
--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -278,6 +278,8 @@ class OC_Request {
 			$requestUri = '/' . ltrim($requestUri, '/');
 		}
 
+		$requestUri = preg_replace('%/{2,}%', '/', $requestUri);
+
 		// Remove the query string from REQUEST_URI
 		if ($pos = strpos($requestUri, '?')) {
 			$requestUri = substr($requestUri, 0, $pos);

--- a/tests/lib/request.php
+++ b/tests/lib/request.php
@@ -84,6 +84,7 @@ class Test_Request extends \Test\TestCase {
 			array('/core/ajax/translations.php', '/core/ajax/translations.php', 'index.php'),
 			array('/core/ajax/translations.php', '//core/ajax/translations.php', '/index.php'),
 			array('/core/ajax/translations.php', '/oc/core/ajax/translations.php', '/oc/index.php'),
+			array('/core/ajax/translations.php', '/oc//index.php/core/ajax/translations.php', '/oc/index.php'),
 			array('/1', '/oc/core/1', '/oc/core/index.php'),
 		);
 	}


### PR DESCRIPTION
Duplicate slashes mess with the path info detection and can cause a request to not be routed correctly.

This broke s2s sharing for me in certain cases.

To test:
- Visit a non-files app with a duplicate slash in the url (i.e. `http://localhost/owncloud//index.php/apps/gallery/`)
- Check if the route is matched correctly and the app is loaded

cc @PVince81 @DeepDiver1975 
