### PR TITLE
Stable7 Backport Set the debugoutput channel to error_log instead of echoing it

### DIFF
--- a/lib/private/mail.php
+++ b/lib/private/mail.php
@@ -61,6 +61,7 @@ class OC_Mail {
 		$mailo->Port = $SMTPPORT;
 		$mailo->SMTPAuth = $SMTPAUTH;
 		$mailo->SMTPDebug = $SMTPDEBUG;
+		$mailo->Debugoutput = 'error_log';
 		$mailo->SMTPSecure = $SMTPSECURE;
 		$mailo->AuthType = $SMTPAUTHTYPE;
 		$mailo->Username = $SMTPUSERNAME;


### PR DESCRIPTION
Stable 7 version of #13554 

Backport approved:
https://github.com/owncloud/core/pull/13548#issuecomment-70845199

@DeepDiver1975 
