### PR TITLE
Add a transaction for the config write actions

### DIFF
--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -289,10 +289,12 @@ class ConvertType extends Command {
 			$dbhost .= ':'.$input->getOption('port');
 		}
 
+		$this->config->systemConfigTransactionBegin();
 		$this->config->setSystemValue('dbtype', $type);
 		$this->config->setSystemValue('dbname', $dbname);
 		$this->config->setSystemValue('dbhost', $dbhost);
 		$this->config->setSystemValue('dbuser', $username);
 		$this->config->setSystemValue('dbpassword', $password);
+		$this->config->systemConfigTransactionCommit();
 	}
 }

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -402,4 +402,33 @@ class AllConfig implements \OCP\IConfig {
 
 		return $userIDs;
 	}
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * systemConfigTransactionCommit() is being called. The changes can be
+	 * reverted by systemConfigTransactionRollback()
+	 */
+	public function systemConfigTransactionBegin() {
+		$this->systemConfig->transactionBegin();
+	}
+
+	/**
+	 * Commits a transaction
+	 *
+	 * The config.php file is only written if a value changed
+	 */
+	public function systemConfigTransactionCommit() {
+		$this->systemConfig->transactionCommit();
+	}
+
+	/**
+	 * Rolls back a transaction
+	 *
+	 * It re-reads the configs from the config.php and throws away any changes
+	 */
+	public function systemConfigTransactionRollback() {
+		$this->systemConfig->transactionRollback();
+	}
 }

--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -27,6 +27,11 @@ class Config {
 	/** @var bool */
 	protected $debugMode;
 
+	/** @var bool */
+	protected $transaction = false;
+	/** @var bool */
+	protected $transactionDirty = false;
+
 	/**
 	 * @param string $configDir Path to the config dir, needs to end with '/'
 	 * @param string $fileName (Optional) Name of the config file. Defaults to config.php
@@ -37,6 +42,41 @@ class Config {
 		$this->configFileName = $fileName;
 		$this->readData();
 		$this->debugMode = (defined('DEBUG') && DEBUG);
+	}
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * transactionCommit() is being called. The changes can be reverted by
+	 * transactionRollback()
+	 */
+	public function transactionBegin() {
+		$this->transaction = true;
+	}
+
+	/**
+	 * Commits a transaction
+	 *
+	 * The config.php file is only written if a value changed
+	 */
+	public function transactionCommit() {
+		$this->transaction = false;
+		if ($this->transactionDirty) {
+			$this->writeData();
+		}
+		$this->transactionDirty = false;
+	}
+
+	/**
+	 * Rolls back a transaction
+	 *
+	 * It re-reads the configs from the config.php and throws away the changes
+	 */
+	public function transactionRollback() {
+		$this->transaction = false;
+		$this->transactionDirty = false;
+		$this->readData();
 	}
 
 	/**
@@ -76,11 +116,13 @@ class Config {
 	 *
 	 */
 	public function setValue($key, $value) {
-		// Add change
-		$this->cache[$key] = $value;
+		if (!isset($this->cache[$key]) || $this->cache[$key] !== $value) {
+			// Add change
+			$this->cache[$key] = $value;
 
-		// Write changes
-		$this->writeData();
+			// Write changes
+			$this->writeData();
+		}
 	}
 
 	/**
@@ -153,6 +195,12 @@ class Config {
 	 * @throws \Exception If no file lock can be acquired
 	 */
 	private function writeData() {
+		if ($this->transaction) {
+			// We should write the config on commit
+			$this->transactionDirty = true;
+			return;
+		}
+
 		// Create a php file ...
 		$content = "<?php\n";
 		if ($this->debugMode) {

--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -67,4 +67,33 @@ class OC_Config {
 	public static function deleteKey($key) {
 		self::$object->deleteKey($key);
 	}
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * transactionCommit() is being called. The changes can be reverted by
+	 * transactionRollback()
+	 */
+	public static function transactionBegin() {
+		self::$object->transactionBegin();
+	}
+
+	/**
+	 * Commits a transaction
+	 *
+	 * The config.php file is only written if a value changed
+	 */
+	public static function transactionCommit() {
+		self::$object->transactionCommit();
+	}
+
+	/**
+	 * Rolls back a transaction
+	 *
+	 * It re-reads the configs from the config.php and throws away any changes
+	 */
+	public static function transactionRollback() {
+		self::$object->transactionRollback();
+	}
 }

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -174,6 +174,8 @@ class OC_Setup {
 			$dbType='sqlite3';
 		}
 
+		\OC::$server->getConfig()->systemConfigTransactionBegin();
+
 		//generate a random salt that is used to salt the local user passwords
 		$salt = \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(30);
 		\OC::$server->getConfig()->setSystemValue('passwordsalt', $salt);
@@ -188,6 +190,8 @@ class OC_Setup {
 		\OC::$server->getConfig()->setSystemValue('overwrite.cli.url', \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . OC::$WEBROOT);
 		\OC::$server->getConfig()->setSystemValue('dbtype', $dbType);
 		\OC::$server->getConfig()->setSystemValue('version', implode('.', OC_Util::getVersion()));
+
+		\OC::$server->getConfig()->systemConfigTransactionCommit();
 
 		try {
 			$dbSetup->initialize($options);

--- a/lib/private/setup/abstractdatabase.php
+++ b/lib/private/setup/abstractdatabase.php
@@ -41,9 +41,11 @@ abstract class AbstractDatabase {
 		$dbhost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbtableprefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
+		\OC_Config::transactionBegin();
 		\OC_Config::setValue('dbname', $dbname);
 		\OC_Config::setValue('dbhost', $dbhost);
 		\OC_Config::setValue('dbtableprefix', $dbtableprefix);
+		\OC_Config::transactionCommit();
 
 		$this->dbuser = $dbuser;
 		$this->dbpassword = $dbpass;

--- a/lib/private/setup/mssql.php
+++ b/lib/private/setup/mssql.php
@@ -21,8 +21,10 @@ class MSSQL extends AbstractDatabase {
 					$this->trans->t('You need to enter either an existing account or the administrator.'));
 		}
 
+		\OC_Config::transactionBegin();
 		\OC_Config::setValue('dbuser', $this->dbuser);
 		\OC_Config::setValue('dbpassword', $this->dbpassword);
+		\OC_Config::transactionCommit();
 
 		$this->createDBLogin($masterConnection);
 

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -51,8 +51,10 @@ class MySQL extends AbstractDatabase {
 				}
 			};
 
+			\OC_Config::transactionBegin();
 			\OC_Config::setValue('dbuser', $this->dbuser);
 			\OC_Config::setValue('dbpassword', $this->dbpassword);
+			\OC_Config::transactionCommit();
 		}
 
 		//create the database

--- a/lib/private/setup/oci.php
+++ b/lib/private/setup/oci.php
@@ -16,8 +16,10 @@ class OCI extends AbstractDatabase {
 		}
 		// allow empty hostname for oracle
 		$this->dbhost = $config['dbhost'];
+		\OC_Config::transactionBegin();
 		\OC_Config::setValue('dbhost', $this->dbhost);
 		\OC_Config::setValue('dbtablespace', $this->dbtablespace);
+		\OC_Config::transactionCommit();
 	}
 
 	public function validate($config) {
@@ -87,22 +89,16 @@ class OCI extends AbstractDatabase {
 			$this->dbpassword=substr($this->dbpassword, 0, 30);
 
 			$this->createDBUser($connection);
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbname', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database not necessary, oracle implies user = schema
-			//$this->createDatabase($this->dbname, $this->dbuser, $connection);
-		} else {
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbname', $this->dbname);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database not necessary, oracle implies user = schema
-			//$this->createDatabase($this->dbname, $this->dbuser, $connection);
 		}
+
+		\OC_Config::transactionBegin();
+		\OC_Config::setValue('dbuser', $this->dbuser);
+		\OC_Config::setValue('dbname', $this->dbname);
+		\OC_Config::setValue('dbpassword', $this->dbpassword);
+		\OC_Config::transactionCommit();
+
+		//create the database not necessary, oracle implies user = schema
+		//$this->createDatabase($this->dbname, $this->dbuser, $connection);
 
 		//FIXME check tablespace exists: select * from user_tablespaces
 

--- a/lib/private/setup/postgresql.php
+++ b/lib/private/setup/postgresql.php
@@ -43,20 +43,15 @@ class PostgreSQL extends AbstractDatabase {
 			$this->dbpassword=\OC_Util::generateRandomBytes(30);
 
 			$this->createDBUser($connection);
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database
-			$this->createDatabase($connection);
 		}
-		else {
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
 
-			//create the database
-			$this->createDatabase($connection);
-		}
+		\OC_Config::transactionBegin();
+		\OC_Config::setValue('dbuser', $this->dbuser);
+		\OC_Config::setValue('dbpassword', $this->dbpassword);
+		\OC_Config::transactionCommit();
+
+		//create the database
+		$this->createDatabase($connection);
 
 		// the connection to dbname=postgres is not needed anymore
 		pg_close($connection);

--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -46,4 +46,44 @@ class SystemConfig {
 	public function deleteValue($key) {
 		\OC_Config::deleteKey($key);
 	}
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * transactionCommit() is being called. The changes can be reverted by
+	 * transactionRollback()
+	 */
+	public function transaction() {
+		\OC_Config::transactionBegin();
+	}
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * transactionCommit() is being called. The changes can be reverted by
+	 * transactionRollback()
+	 */
+	public function transactionBegin() {
+		\OC_Config::transactionBegin();
+	}
+
+	/**
+	 * Commits a transaction
+	 *
+	 * The config.php file is only written if a value changed
+	 */
+	public function transactionCommit() {
+		\OC_Config::transactionCommit();
+	}
+
+	/**
+	 * Rolls back a transaction
+	 *
+	 * It re-reads the configs from the config.php and throws away any changes
+	 */
+	public function transactionRollback() {
+		\OC_Config::transactionRollback();
+	}
 }

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -176,4 +176,27 @@ interface IConfig {
 	 * @return array of user IDs
 	 */
 	public function getUsersForUserValue($appName, $key, $value);
+
+	/**
+	 * Begins a transaction
+	 *
+	 * Config changes are no longer written to the config.php file, until
+	 * systemConfigTransactionCommit() is being called. The changes can be
+	 * reverted by systemConfigTransactionRollback()
+	 */
+	public function systemConfigTransactionBegin();
+
+	/**
+	 * Commits a transaction
+	 *
+	 * The config.php file is only written if a value changed
+	 */
+	public function systemConfigTransactionCommit();
+
+	/**
+	 * Rolls back a transaction
+	 *
+	 * It re-reads the configs from the config.php and throws away any changes
+	 */
+	public function systemConfigTransactionRollback();
 }

--- a/settings/controller/mailsettingscontroller.php
+++ b/settings/controller/mailsettingscontroller.php
@@ -84,6 +84,7 @@ class MailSettingsController extends Controller {
 									$mail_smtpport) {
 
 		$params = get_defined_vars();
+		$this->config->systemConfigTransactionBegin();
 		foreach($params as $key => $value) {
 			if(empty($value)) {
 				$this->config->deleteSystemValue($key);
@@ -97,6 +98,7 @@ class MailSettingsController extends Controller {
 			$this->config->deleteSystemValue('mail_smtpname');
 			$this->config->deleteSystemValue('mail_smtppassword');
 		}
+		$this->config->systemConfigTransactionCommit();
 
 		return array('data' =>
 			array('message' =>
@@ -113,8 +115,10 @@ class MailSettingsController extends Controller {
 	 * @return array
 	 */
 	public function storeCredentials($mail_smtpname, $mail_smtppassword) {
+		$this->config->systemConfigTransactionBegin();
 		$this->config->setSystemValue('mail_smtpname', $mail_smtpname);
 		$this->config->setSystemValue('mail_smtppassword', $mail_smtppassword);
+		$this->config->systemConfigTransactionCommit();
 
 		return array('data' =>
 			array('message' =>


### PR DESCRIPTION
Related #12785 

Currently when we set "n" configs in one go, we write the file "n"-times.
Instead we should reduce it almost "1".

This patch adds a transaction method, which stops writing the file, until an explicit `transactionCommit()` is called.
When changing the SMTP settings now only 1 write action is performed instead of 8-10.

With less write actions, we might break the config.php less often. Worth a try.

@LukasReschke @DeepDiver1975 
