### PR TITLE
Call final unlink in trash wrapper's storage

### DIFF
--- a/apps/files_encryption/tests/trashbin.php
+++ b/apps/files_encryption/tests/trashbin.php
@@ -93,6 +93,8 @@ class Trashbin extends TestCase {
 		// cleanup test user
 		\OC_User::deleteUser(self::TEST_ENCRYPTION_TRASHBIN_USER1);
 
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+
 		parent::tearDownAfterClass();
 	}
 

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -46,6 +46,8 @@ class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 		$this->view->unlink($this->folder);
 		$this->view->unlink($this->filename);
 
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+
 		parent::tearDown();
 	}
 

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -111,6 +111,8 @@ class Test_Files_Sharing_Updater extends OCA\Files_sharing\Tests\TestCase {
 		if ($status === false) {
 			\OC_App::disable('files_trashbin');
 		}
+
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 	}
 
 	/**

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -46,6 +46,9 @@ class Storage extends Wrapper {
 			if (count($parts) > 3 && $parts[2] === 'files') {
 				$filesPath = implode('/', array_slice($parts, 3));
 				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
+				// in cross-storage cases the file will be copied
+				// but not deleted, so we delete it here
+				$this->storage->unlink($path);
 			} else {
 				$result = $this->storage->unlink($path);
 			}

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -33,12 +33,43 @@ class Storage extends Wrapper {
 	// move files across storages
 	private $deletedFiles = array();
 
+	/**
+	 * Disable trash logic
+	 *
+	 * @var bool
+	 */
+	private static $disableTrash = false;
+
 	function __construct($parameters) {
 		$this->mountPoint = $parameters['mountPoint'];
 		parent::__construct($parameters);
 	}
 
+	/**
+	 * @internal
+	 */
+	public static function preRenameHook($params) {
+		// in cross-storage cases, a rename is a copy + unlink,
+		// that last unlink must not go to trash
+		self::$disableTrash = true;
+	}
+
+	/**
+	 * @internal
+	 */
+	public static function postRenameHook($params) {
+		self::$disableTrash = false;
+	}
+
+	/**
+	 * Deletes the given file by moving it into the trashbin.
+	 *
+	 * @param string $path
+	 */
 	public function unlink($path) {
+		if (self::$disableTrash) {
+			return $this->storage->unlink($path);
+		}
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$result = true;
 		if (!isset($this->deletedFiles[$normalized])) {

--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Files_Trashbin;
 
+use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Wrapper;
 
 class Storage extends Wrapper {
@@ -38,13 +39,13 @@ class Storage extends Wrapper {
 	}
 
 	public function unlink($path) {
-		$normalized = \OC\Files\Filesystem::normalizePath($this->mountPoint . '/' . $path);
+		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$result = true;
 		if (!isset($this->deletedFiles[$normalized])) {
+			$view = Filesystem::getView();
 			$this->deletedFiles[$normalized] = $normalized;
-			$parts = explode('/', $normalized);
-			if (count($parts) > 3 && $parts[2] === 'files') {
-				$filesPath = implode('/', array_slice($parts, 3));
+			if ($filesPath = $view->getRelativePath($normalized)) {
+				$filesPath = trim($filesPath, '/');
 				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
 				// in cross-storage cases the file will be copied
 				// but not deleted, so we delete it here

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -166,7 +166,8 @@ class Trashbin {
 		\OC_FileProxy::$enabled = false;
 		$trashPath = '/files_trashbin/files/' . $filename . '.d' . $timestamp;
 		try {
-			$sizeOfAddedFiles = self::renameRecursive('/files/'.$file_path, $trashPath, $view);
+			$sizeOfAddedFiles = $view->filesize('/files/' . $file_path);
+			$view->rename('/files/' . $file_path, $trashPath);
 		} catch (\OCA\Files_Trashbin\Exceptions\CopyRecursiveException $e) {
 			$sizeOfAddedFiles = false;
 			if ($view->file_exists($trashPath)) {
@@ -801,46 +802,6 @@ class Trashbin {
 				throw new \OCA\Files_Trashbin\Exceptions\CopyRecursiveException();
 			}
 			$view->touch($destination, $view->filemtime($source));
-		}
-		return $size;
-	}
-
-	/**
-	 * recursive rename a whole directory and preserve timestamps
-	 *
-	 * @param string $source source path, relative to the users files directory
-	 * @param string $destination destination path relative to the users root directoy
-	 * @param \OC\Files\View $view file view for the users root directory
-	 * @return int
-	 * @throws Exceptions\CopyRecursiveException
-	 */
-	private static function renameRecursive($source, $destination, \OC\Files\View $view) {
-		$size = 0;
-		if ($view->is_dir($source)) {
-			$view->mkdir($destination);
-			$view->touch($destination, $view->filemtime($source));
-			foreach ($view->getDirectoryContent($source) as $i) {
-				$pathDir = $source . '/' . $i['name'];
-				if ($view->is_dir($pathDir)) {
-					$size += self::renameRecursive($pathDir, $destination . '/' . $i['name'], $view);
-				} else {
-					$size += $view->filesize($pathDir);
-					$mtime = $view->filemtime($pathDir);
-					$result = $view->rename($pathDir, $destination . '/' . $i['name']);
-					if (!$result) {
-						throw new \OCA\Files_Trashbin\Exceptions\CopyRecursiveException();
-					}
-					$view->touch($destination . '/' . $i['name'], $mtime);
-				}
-			}
-		} else {
-			$size += $view->filesize($source);
-			$mtime = $view->filemtime($source);
-			$result = $view->rename($source, $destination);
-			if (!$result) {
-				throw new \OCA\Files_Trashbin\Exceptions\CopyRecursiveException();
-			}
-			$view->touch($destination, $mtime);
 		}
 		return $size;
 	}

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -928,6 +928,9 @@ class Trashbin {
 		\OCP\Util::connectHook('OC_User', 'pre_deleteUser', 'OCA\Files_Trashbin\Hooks', 'deleteUser_hook');
 		//Listen to post write hook
 		\OCP\Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Files_Trashbin\Hooks', 'post_write_hook');
+		// pre and post-rename, disable trash logic for the copy+unlink case
+		\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
 	}
 
 	/**

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright (c) 2015 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_trashbin\Tests\Storage;
+
+use OC\Files\Storage\Home;
+use OC\Files\Storage\Temporary;
+use OC\Files\Mount\MountPoint;
+use OC\Files\Filesystem;
+
+class Storage extends \Test\TestCase {
+	/**
+	 * @var \OCA\Files_trashbin\Storage
+	 */
+	private $wrapper;
+
+	/**
+	 * @var \OCP\Files\Storage
+	 */
+	private $storage;
+
+	/**
+	 * @var string
+	 */
+	private $user;
+
+	/**
+	 * @var \OC\Files\Storage\Storage
+	 **/
+	private $originalStorage;
+
+	/**
+	 * @var \OC\Files\View
+	 */
+	private $userView;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->user = $this->getUniqueId('user');
+		\OC_User::createUser($this->user, $this->user);
+
+		// this will setup the FS
+		$this->loginAsUser($this->user);
+
+		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+
+		$mockUser = $this->getMock('\OCP\IUser');
+		$mockUser->expects($this->any())
+			->method('getHome')
+			->will($this->returnValue($this->originalStorage->getLocalFolder($this->user)));
+		$mockUser->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue($this->user));
+
+		// use temp as root storage so we can wrap it for testing
+		$this->storage = new Home(
+			array('user' => $mockUser)
+		);
+		$this->wrapper = new \OCA\Files_Trashbin\Storage(
+			array(
+				'storage' => $this->storage,
+				'mountPoint' => $this->user,
+			)
+		);
+
+		// make room for a new root
+		Filesystem::clearMounts();
+		$rootMount = new MountPoint($this->originalStorage, '');
+		Filesystem::getMountManager()->addMount($rootMount);
+		$homeMount = new MountPoint($this->wrapper, $this->user);
+		Filesystem::getMountManager()->addMount($homeMount);
+
+		$this->userView = new \OC\Files\View('/' . $this->user . '/files/');
+		$this->userView->file_put_contents('test.txt', 'foo');
+	}
+
+	protected function tearDown() {
+		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
+		$this->logout();
+		parent::tearDown();
+	}
+
+	public function testSingleStorageDelete() {
+		$this->assertTrue($this->storage->file_exists('files/test.txt'));
+		$this->userView->unlink('test.txt');
+		$this->storage->getScanner()->scan('');
+		$this->assertFalse($this->userView->getFileInfo('test.txt'));
+		$this->assertFalse($this->storage->file_exists('files/test.txt'));
+
+		// check if file is in trashbin
+		$rootView = new \OC\Files\View('/');
+		$results = $rootView->getDirectoryContent($this->user . '/files_trashbin/files/');
+		$this->assertEquals(1, count($results));
+		$name = $results[0]->getName();
+		$this->assertEquals('test.txt', substr($name, 0, strrpos($name, '.')));
+	}
+
+	public function testCrossStorageDelete() {
+		$storage2 = new Temporary(array());
+		$wrapper2 = new \OCA\Files_Trashbin\Storage(
+			array(
+				'storage' => $storage2,
+				'mountPoint' => $this->user . '/files/substorage',
+			)
+		);
+
+		$mount = new MountPoint($wrapper2, $this->user . '/files/substorage');
+		Filesystem::getMountManager()->addMount($mount);
+
+		$this->userView->file_put_contents('substorage/subfile.txt', 'foo');
+		$storage2->getScanner()->scan('');
+		$this->assertTrue($storage2->file_exists('subfile.txt'));
+		$this->userView->unlink('substorage/subfile.txt');
+
+		$storage2->getScanner()->scan('');
+		$this->assertFalse($this->userView->getFileInfo('substorage/subfile.txt'));
+		$this->assertFalse($storage2->file_exists('subfile.txt'));
+
+		// check if file is in trashbin
+		$rootView = new \OC\Files\View('/');
+		$results = $rootView->getDirectoryContent($this->user . '/files_trashbin/files');
+		$this->assertEquals(1, count($results));
+		$name = $results[0]->getName();
+		$this->assertEquals('subfile.txt', substr($name, 0, strrpos($name, '.')));
+	}
+}

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -37,6 +37,9 @@ class Storage extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		\OC_Hook::clear();
+		\OCA\Files_Trashbin\Trashbin::registerHooks();
+
 		$this->user = $this->getUniqueId('user');
 		\OC::$server->getUserManager()->createUser($this->user, $this->user);
 
@@ -58,6 +61,7 @@ class Storage extends \Test\TestCase {
 		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 		$this->logout();
 		\OC_User::deleteUser($this->user);
+		\OC_Hook::clear();
 		parent::tearDown();
 	}
 

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -88,6 +88,8 @@ class Test_Trashbin extends \Test\TestCase {
 
 		\OC_Hook::clear();
 
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+
 		parent::tearDownAfterClass();
 	}
 

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -175,7 +175,10 @@ class Filesystem {
 	 * @param callable $wrapper
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper) {
-		self::getLoader()->addStorageWrapper($wrapperName, $wrapper);
+		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper)) {
+			// do not re-wrap if storage with this name already existed
+			return;
+		}
 
 		$mounts = self::getMountManager()->getAll();
 		foreach ($mounts as $mount) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -175,14 +175,10 @@ class Filesystem {
 	 * @param callable $wrapper
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper) {
-		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper)) {
+		$mounts = self::getMountManager()->getAll();
+		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper, $mounts)) {
 			// do not re-wrap if storage with this name already existed
 			return;
-		}
-
-		$mounts = self::getMountManager()->getAll();
-		foreach ($mounts as $mount) {
-			$mount->wrapStorage($wrapper);
 		}
 	}
 
@@ -201,7 +197,7 @@ class Filesystem {
 	/**
 	 * Returns the mount manager
 	 *
-	 * @return \OC\Files\Filesystem\Mount\Manager
+	 * @return \OC\Files\Mount\Manager
 	 */
 	public static function getMountManager() {
 		if (!self::$mounts) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -186,6 +186,11 @@ class Filesystem {
 		}
 	}
 
+	/**
+	 * Returns the storage factory
+	 *
+	 * @return \OCP\Files\Storage\IStorageFactory
+	 */
 	public static function getLoader() {
 		if (!self::$loader) {
 			self::$loader = new StorageFactory();
@@ -193,6 +198,11 @@ class Filesystem {
 		return self::$loader;
 	}
 
+	/**
+	 * Returns the mount manager
+	 *
+	 * @return \OC\Files\Filesystem\Mount\Manager
+	 */
 	public static function getMountManager() {
 		if (!self::$mounts) {
 			\OC_Util::setupFS();

--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -23,13 +23,20 @@ class StorageFactory implements IStorageFactory {
 	 *
 	 * @param string $wrapperName name of the wrapper
 	 * @param callable $callback callback
+	 * @param \OCP\Files\Mount\IMountPoint[] $existingMounts existing mount points to apply the wrapper to
 	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
 	 * name registered
 	 */
-	public function addStorageWrapper($wrapperName, $callback) {
+	public function addStorageWrapper($wrapperName, $callback, $existingMounts = []) {
 		if (isset($this->storageWrappers[$wrapperName])) {
 			return false;
 		}
+
+		// apply to existing mounts before registering it to prevent applying it double in MountPoint::createStorage
+		foreach ($existingMounts as $mount) {
+			$mount->wrapStorage($callback);
+		}
+
 		$this->storageWrappers[$wrapperName] = $callback;
 		return true;
 	}

--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -23,9 +23,15 @@ class StorageFactory implements IStorageFactory {
 	 *
 	 * @param string $wrapperName
 	 * @param callable $callback
+	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback) {
+		if (isset($this->storageWrappers[$wrapperName])) {
+			return false;
+		}
 		$this->storageWrappers[$wrapperName] = $callback;
+		return true;
 	}
 
 	/**

--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -21,9 +21,9 @@ class StorageFactory implements IStorageFactory {
 	 *
 	 * $callback should be a function of type (string $mountPoint, Storage $storage) => Storage
 	 *
-	 * @param string $wrapperName
-	 * @param callable $callback
-	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * @param string $wrapperName name of the wrapper
+	 * @param callable $callback callback
+	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
 	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback) {
@@ -32,6 +32,17 @@ class StorageFactory implements IStorageFactory {
 		}
 		$this->storageWrappers[$wrapperName] = $callback;
 		return true;
+	}
+
+	/**
+	 * Remove a storage wrapper by name.
+	 * Note: internal method only to be used for cleanup
+	 *
+	 * @param string $wrapperName name of the wrapper
+	 * @internal
+	 */
+	public function removeStorageWrapper($wrapperName) {
+		unset($this->storageWrappers[$wrapperName]);
 	}
 
 	/**

--- a/lib/public/files/storage/istoragefactory.php
+++ b/lib/public/files/storage/istoragefactory.php
@@ -19,6 +19,8 @@ interface IStorageFactory {
 	 *
 	 * @param string $wrapperName
 	 * @param callable $callback
+	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback);
 

--- a/lib/public/files/storage/istoragefactory.php
+++ b/lib/public/files/storage/istoragefactory.php
@@ -19,7 +19,7 @@ interface IStorageFactory {
 	 *
 	 * @param string $wrapperName
 	 * @param callable $callback
-	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
 	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback);

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -613,7 +613,7 @@ class View extends \Test\TestCase {
 		if (\OC_Util::runningOnWindows()) {
 			$this->markTestSkipped('[Windows] ');
 			$depth = ((260 - $tmpdirLength) / 57);
-		}elseif(\OC_Util::runningOnMac()){
+		} elseif (\OC_Util::runningOnMac()) {
 			$depth = ((1024 - $tmpdirLength) / 57);
 		} else {
 			$depth = ((4000 - $tmpdirLength) / 57);
@@ -805,5 +805,32 @@ class View extends \Test\TestCase {
 			array('hasUpdated', 0),
 			array('putFileInfo', array()),
 		);
+	}
+
+	public function testRenameCrossStoragePreserveMtime() {
+		$storage1 = new Temporary(array());
+		$storage2 = new Temporary(array());
+		$scanner1 = $storage1->getScanner();
+		$scanner2 = $storage2->getScanner();
+		$storage1->mkdir('sub');
+		$storage1->mkdir('foo');
+		$storage1->file_put_contents('foo.txt', 'asd');
+		$storage1->file_put_contents('foo/bar.txt', 'asd');
+		\OC\Files\Filesystem::mount($storage1, array(), '/test/');
+		\OC\Files\Filesystem::mount($storage2, array(), '/test/sub/storage');
+
+		$view = new \OC\Files\View('');
+		$time = time() - 200;
+		$view->touch('/test/foo.txt', $time);
+		$view->touch('/test/foo', $time);
+		$view->touch('/test/foo/bar.txt', $time);
+
+		$view->rename('/test/foo.txt', '/test/sub/storage/foo.txt');
+
+		$this->assertEquals($time, $view->filemtime('/test/sub/storage/foo.txt'));
+
+		$view->rename('/test/foo', '/test/sub/storage/foo');
+
+		$this->assertEquals($time, $view->filemtime('/test/sub/storage/foo/bar.txt'));
 	}
 }


### PR DESCRIPTION
In the case of cross-storage delete, the files are copied to the trash,
then deleted. The final delete on the source storage would still reach
the trash wrapper.

This fix makes forwards that second call to the wrapped storage to make
the final delete work.

It fixes the issue with remote shares, local shares and external
storage.

Fixes https://github.com/owncloud/core/issues/13557
