### PR TITLE
Do not call wrapStorage if storate with same name added twice

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -175,7 +175,10 @@ class Filesystem {
 	 * @param callable $wrapper
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper) {
-		self::getLoader()->addStorageWrapper($wrapperName, $wrapper);
+		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper)) {
+			// do not re-wrap if storage with this name already existed
+			return;
+		}
 
 		$mounts = self::getMountManager()->getAll();
 		foreach ($mounts as $mount) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -186,6 +186,11 @@ class Filesystem {
 		}
 	}
 
+	/**
+	 * Returns the storage factory
+	 *
+	 * @return \OCP\Files\Storage\IStorageFactory
+	 */
 	public static function getLoader() {
 		if (!self::$loader) {
 			self::$loader = new StorageFactory();
@@ -193,6 +198,11 @@ class Filesystem {
 		return self::$loader;
 	}
 
+	/**
+	 * Returns the mount manager
+	 *
+	 * @return \OC\Files\Filesystem\Mount\Manager
+	 */
 	public static function getMountManager() {
 		if (!self::$mounts) {
 			\OC_Util::setupFS();

--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -23,9 +23,15 @@ class StorageFactory implements IStorageFactory {
 	 *
 	 * @param string $wrapperName
 	 * @param callable $callback
+	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback) {
+		if (isset($this->storageWrappers[$wrapperName])) {
+			return false;
+		}
 		$this->storageWrappers[$wrapperName] = $callback;
+		return true;
 	}
 
 	/**

--- a/lib/private/files/storage/storagefactory.php
+++ b/lib/private/files/storage/storagefactory.php
@@ -35,6 +35,16 @@ class StorageFactory implements IStorageFactory {
 	}
 
 	/**
+	 * Remove a storage wrapper by name.
+	 * Note: internal method only to be used for cleanup
+	 *
+	 * @param string $wrapperName
+	 */
+	public function removeStorageWrapper($wrapperName) {
+		unset($this->storageWrappers[$wrapperName]);
+	}
+
+	/**
 	 * Create an instance of a storage and apply the registered storage wrappers
 	 *
 	 * @param string|boolean $mountPoint

--- a/lib/public/files/storage/istoragefactory.php
+++ b/lib/public/files/storage/istoragefactory.php
@@ -19,6 +19,8 @@ interface IStorageFactory {
 	 *
 	 * @param string $wrapperName
 	 * @param callable $callback
+	 * @return true if the wrapper was added, false if there was already a wrapper with this
+	 * name registered
 	 */
 	public function addStorageWrapper($wrapperName, $callback);
 


### PR DESCRIPTION
Prevent storage wrappers to be wrap a storage multiple times, can happen because we always use the "setup" hook which can be called multiple times, especially during unit test runs. This might explain some bugs we saw with the LockingWrapper being added twice.

Here is the case where it happened with the trashbin unit tests: https://github.com/owncloud/core/pull/13561#issuecomment-70923447

This also means it's not possible to overwrite an existing wrapper with a new one.
I also added an internal method `removeStorageWrapper()` in case we do want to remove an existing wrapper (mostly in unit tests)

@icewind1991 @schiesbn please have a look
