### PR TITLE
Add check for `HTTP_RAW_POST_DATA` setting for >= 5.6

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,6 +12,7 @@ php_value upload_max_filesize 513M
 php_value post_max_size 513M
 php_value memory_limit 512M
 php_value mbstring.func_overload 0
+php_value always_populate_raw_post_data -1
 <IfModule env_module>
   SetEnv htaccessWorking true
 </IfModule>

--- a/.user.ini
+++ b/.user.ini
@@ -2,3 +2,4 @@ upload_max_filesize=513M
 post_max_size=513M
 memory_limit=512M
 mbstring.func_overload=0
+always_populate_raw_post_data=-1

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -638,15 +638,15 @@ class OC_Util {
 		if(version_compare(phpversion(), '5.6.0', '>=') &&
 			\OC::$server->getIniWrapper()->getNumeric('always_populate_raw_post_data') !== -1) {
 			$errors[] = array(
-				'error' => 'PHP is configured to populate raw post data. Since PHP 5.6 this will lead to PHP throwing notices for perfectly valid code.',
-				'hint' => 'To fix this issue set <code>always_populate_raw_post_data</code> to <code>-1</code> in your php.ini'
+				'error' => $l->t('PHP is configured to populate raw post data. Since PHP 5.6 this will lead to PHP throwing notices for perfectly valid code.'),
+				'hint' => $l->t('To fix this issue set <code>always_populate_raw_post_data</code> to <code>-1</code> in your php.ini')
 			);
 		}
 
 		if (!self::isAnnotationsWorking()) {
 			$errors[] = array(
-				'error' => 'PHP is apparently setup to strip inline doc blocks. This will make several core apps inaccessible.',
-				'hint' => 'This is probably caused by a cache/accelerator such as Zend OPcache or eAccelerator.'
+				'error' => $l->t('PHP is apparently setup to strip inline doc blocks. This will make several core apps inaccessible.'),
+				'hint' => $l->t('This is probably caused by a cache/accelerator such as Zend OPcache or eAccelerator.')
 			);
 		}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -628,6 +628,21 @@ class OC_Util {
 			);
 			$webServerRestart = true;
 		}
+
+		/**
+		 * PHP 5.6 ships with a PHP setting which throws notices by default for a
+		 * lot of endpoints. Thus we need to ensure that the value is set to -1
+		 *
+		 * @link https://github.com/owncloud/core/issues/13592
+		 */
+		if(version_compare(phpversion(), '5.6.0', '>=') &&
+			\OC::$server->getIniWrapper()->getNumeric('always_populate_raw_post_data') !== -1) {
+			$errors[] = array(
+				'error' => 'PHP is configured to populate raw post data. Since PHP 5.6 this will lead to PHP throwing notices for perfectly valid code.',
+				'hint' => 'To fix this issue set <code>always_populate_raw_post_data</code> to <code>-1</code> in your php.ini'
+			);
+		}
+
 		if (!self::isAnnotationsWorking()) {
 			$errors[] = array(
 				'error' => 'PHP is apparently setup to strip inline doc blocks. This will make several core apps inaccessible.',


### PR DESCRIPTION
PHP 5.6 otherwise throws notices for perfectly valid code which results in broken endpoints.

Fixes https://github.com/owncloud/core/issues/13592, https://github.com/owncloud/updater/issues/56 and https://github.com/owncloud/documents/issues/431

@MorrisJobke Please test.

@carlaschroder Requires documentation update. When running PHP >= 5.6 the setting needs to set to `-1` in the php.ini (or the shipped .htaccess file has to be able to modify php.ini settings)
