### PR TITLE
Fix undefined offset 1 for wrong user mail address

### DIFF
--- a/lib/private/mail.php
+++ b/lib/private/mail.php
@@ -126,6 +126,9 @@ class OC_Mail {
 	 * @return bool
 	 */
 	public static function validateAddress($emailAddress) {
+		if (strpos($emailAddress, '@') === false) {
+			return false;
+		}
 		$emailAddress = self::buildAsciiEmail($emailAddress);
 		return PHPMailer::ValidateAddress($emailAddress);
 	}

--- a/tests/lib/mail.php
+++ b/tests/lib/mail.php
@@ -8,34 +8,46 @@
 
 class Test_Mail extends \Test\TestCase {
 
-	protected function setUp()
-	{
-		parent::setUp();
-
-		if (!function_exists('idn_to_ascii')) {
-			$this->markTestSkipped(
-				'The intl extension is not available.'
-			);
-		}
-	}
-
 	/**
 	 * @dataProvider buildAsciiEmailProvider
 	 * @param $expected
 	 * @param $address
 	 */
 	public function testBuildAsciiEmail($expected, $address) {
+		if (!function_exists('idn_to_ascii')) {
+			$this->markTestSkipped(
+				'The intl extension is not available.'
+			);
+		}
+
 		$actual = \OC_Mail::buildAsciiEmail($address);
 		$this->assertEquals($expected, $actual);
 	}
 
-	function buildAsciiEmailProvider() {
+	public function buildAsciiEmailProvider() {
 		return array(
 			array('info@example.com', 'info@example.com'),
 			array('info@xn--cjr6vy5ejyai80u.com', 'info@國際化域名.com'),
 			array('info@xn--mller-kva.de', 'info@müller.de'),
 			array('info@xn--mller-kva.xn--mller-kva.de', 'info@müller.müller.de'),
 		);
+	}
+
+	public function validateMailProvider() {
+		return array(
+			array('infoatexample.com', false),
+			array('info', false),
+		);
+	}
+
+	/**
+	 * @dataProvider validateMailProvider
+	 * @param $address
+	 * @param $expected
+	 */
+	public function testValidateEmail($address, $expected) {
+		$actual = \OC_Mail::validateAddress($address);
+		$this->assertEquals($expected, $actual);
 	}
 
 }


### PR DESCRIPTION
- fixes Undefined offset: 1 at lib/private/mail.php#143

Steps to reproduce:
- go to personal settings
- type in a string without an @ as email address
  *Following log appeared: 
  
  ```
  {"reqId":"82168f27be8ddec69c7069f6adacfba2","remoteAddr":"127.0.0.1","app":"PHP","message":"Undefined offset: 1 at lib/private/mail.php#143","level":0,"time":"2015-01-22T14:16:42+00:00","method":"PUT","url":"/master/index.php/settings/users/mjob/mailAddress"}
  ```

cc @LukasReschke @nickvergessen
