### PR TITLE
AppFramework StreamResponse

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -28,6 +28,7 @@ use OC;
 use OC\AppFramework\Http;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Http\Dispatcher;
+use OC\AppFramework\Http\Output;
 use OC\AppFramework\Core\API;
 use OC\AppFramework\Middleware\MiddlewareDispatcher;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
@@ -67,6 +68,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\\App\\IAppManager', function($c) {
 			return $this->getServer()->getAppManager();
+		});
+
+		$this->registerService('OCP\\AppFramework\\Http\\IOutput', function($c){
+			return new Output();
 		});
 
 		$this->registerService('OCP\\IAvatarManager', function($c) {

--- a/lib/private/appframework/http/dispatcher.php
+++ b/lib/private/appframework/http/dispatcher.php
@@ -100,17 +100,15 @@ class Dispatcher {
 		$response = $this->middlewareDispatcher->afterController(
 			$controller, $methodName, $response);
 
-		// get the output which should be printed and run the after output
-		// middleware to modify the response
-		$output = $response->render();
-		$out[3] = $this->middlewareDispatcher->beforeOutput(
-			$controller, $methodName, $output);
-
 		// depending on the cache object the headers need to be changed
 		$out[0] = $this->protocol->getStatusHeader($response->getStatus(),
 			$response->getLastModified(), $response->getETag());
 		$out[1] = array_merge($response->getHeaders());
 		$out[2] = $response->getCookies();
+		$out[3] = $this->middlewareDispatcher->beforeOutput(
+			$controller, $methodName, $response->render()
+		);
+		$out[4] = $response;
 
 		return $out;
 	}

--- a/lib/private/appframework/http/output.php
+++ b/lib/private/appframework/http/output.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\AppFramework\Http;
+
+use OCP\AppFramework\Http\IOutput;
+
+/**
+ * Very thin wrapper class to make output testable
+ */
+class Output implements IOutput {
+
+	/**
+	 * @param string $out
+	 */
+	public function setOutput($out) {
+		print($out);
+	}
+
+	/**
+	 * @param string $path
+	 *
+	 * @return bool false if an error occured
+	 */
+	public function setReadfile($path) {
+		return @readfile($path);
+	}
+
+	/**
+	 * @param string $header
+	 */
+	public function setHeader($header) {
+		header($header);
+	}
+
+	/**
+	 * @param int $code sets the http status code
+	 */
+	public function setHttpResponseCode($code) {
+		http_response_code($code);
+	}
+
+	/**
+	 * @return int returns the current http response code
+	 */
+	public function getHttpResponseCode() {
+		return http_response_code();
+	}
+
+	/**
+	 * @param string $name
+	 * @param string $value
+	 * @param int $expire
+	 * @param string $path
+	 * @param string $domain
+	 * @param bool $secure
+	 * @param bool $httponly
+	 */
+	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httponly) {
+		setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+	}
+
+}

--- a/lib/public/appframework/http/icallbackresponse.php
+++ b/lib/public/appframework/http/icallbackresponse.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\AppFramework\Http;
+
+
+/**
+ * Interface ICallbackResponse
+ *
+ * @package OCP\AppFramework\Http
+ */
+interface ICallbackResponse {
+
+	/**
+	 * Outputs the content that should be printed
+	 *
+	 * @param IOutput a small wrapper that handles output
+	 */
+	function callback(IOutput $output);
+
+}

--- a/lib/public/appframework/http/ioutput.php
+++ b/lib/public/appframework/http/ioutput.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\AppFramework\Http;
+
+
+/**
+ * Very thin wrapper class to make output testable
+ */
+interface IOutput {
+
+	/**
+	 * @param string $out
+	 */
+	public function setOutput($out);
+
+	/**
+	 * @param string $path
+	 *
+	 * @return bool false if an error occured
+	 */
+	public function setReadfile($path);
+
+	/**
+	 * @param string $header
+	 */
+	public function setHeader($header);
+
+	/**
+	 * @return int returns the current http response code
+	 */
+	public function getHttpResponseCode();
+
+	/**
+	 * @param int $code sets the http status code
+	 */
+	public function setHttpResponseCode($code);
+
+	/**
+	 * @param string $name
+	 * @param string $value
+	 * @param int $expire
+	 * @param string $path
+	 * @param string $domain
+	 * @param bool $secure
+	 * @param bool $httponly
+	 */
+	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+
+}

--- a/lib/public/appframework/http/streamresponse.php
+++ b/lib/public/appframework/http/streamresponse.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\AppFramework\Http;
+
+use OCP\AppFramework\Http;
+
+/**
+ * Class StreamResponse
+ *
+ * @package OCP\AppFramework\Http
+ */
+class StreamResponse extends Response implements ICallbackResponse {
+	/** @var string */
+	private $filePath;
+
+	/**
+	 * @param string $filePath the path to the file which should be streamed
+	 */
+	public function __construct ($filePath) {
+		$this->filePath = $filePath;
+	}
+
+
+	/**
+	 * Streams the file using readfile
+	 *
+	 * @param IOutput a small wrapper that handles output
+	 */
+	public function callback (IOutput $output) {
+		// handle caching
+		if ($output->getHttpResponseCode() !== Http::STATUS_NOT_MODIFIED) {
+			if (!file_exists($this->filePath)) {
+				$output->setHttpResponseCode(Http::STATUS_NOT_FOUND);
+			} elseif ($output->setReadfile($this->filePath) === false) {
+				$output->setHttpResponseCode(Http::STATUS_BAD_REQUEST);
+			}
+		}
+	}
+
+}

--- a/tests/lib/appframework/http/StreamResponseTest.php
+++ b/tests/lib/appframework/http/StreamResponseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\AppFramework\Http;
+
+
+use OCP\AppFramework\Http\StreamResponse;
+use OCP\AppFramework\Http;
+
+
+class StreamResponseTest extends \Test\TestCase {
+
+	/** @var IOutput */
+	private $output;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->output = $this->getMock('OCP\\AppFramework\\Http\\IOutput');
+	}
+
+	public function testOutputNotModified(){
+		$path = __FILE__;
+		$this->output->expects($this->once())
+			->method('getHttpResponseCode')
+			->will($this->returnValue(Http::STATUS_NOT_MODIFIED));
+		$this->output->expects($this->never())
+			->method('setReadfile');
+		$response = new StreamResponse($path);
+
+		$response->callback($this->output);
+	}
+
+	public function testOutputOk(){
+		$path = __FILE__;
+		$this->output->expects($this->once())
+			->method('getHttpResponseCode')
+			->will($this->returnValue(Http::STATUS_OK));
+		$this->output->expects($this->once())
+			->method('setReadfile')
+			->with($this->equalTo($path))
+			->will($this->returnValue(true));
+		$response = new StreamResponse($path);
+
+		$response->callback($this->output);
+	}
+
+	public function testOutputNotFound(){
+		$path = __FILE__ . 'test';
+		$this->output->expects($this->once())
+			->method('getHttpResponseCode')
+			->will($this->returnValue(Http::STATUS_OK));
+		$this->output->expects($this->never())
+			->method('setReadfile');
+		$this->output->expects($this->once())
+			->method('setHttpResponseCode')
+			->with($this->equalTo(Http::STATUS_NOT_FOUND));
+		$response = new StreamResponse($path);
+
+		$response->callback($this->output);
+	}
+
+	public function testOutputReadFileError(){
+		$path = __FILE__;
+		$this->output->expects($this->once())
+			->method('getHttpResponseCode')
+			->will($this->returnValue(Http::STATUS_OK));
+		$this->output->expects($this->once())
+			->method('setReadfile')
+			->will($this->returnValue(false));
+		$this->output->expects($this->once())
+			->method('setHttpResponseCode')
+			->with($this->equalTo(Http::STATUS_BAD_REQUEST));
+		$response = new StreamResponse($path);
+
+		$response->callback($this->output);
+	}
+
+}


### PR DESCRIPTION
First stab at the StreamResponse, see #12988

The idea is to use an interface ICallbackResponse (I'm not 100% happy with the name yet, suggestions?) that allow the response to output things in its own way, for instance stream the file using readfile

Unittests are atm lacking, plan is to 
- [x] check if a mock of ICallbackResponse will be used by calling its callback (also unhappy with this name) method

Usage is:

``` php
$response = new StreamResponse('path/to/file');
```

@DeepDiver1975 @MorrisJobke @LukasReschke @PVince81 @oparoz 
