### PR TITLE
Add a method to set/unset multiple config values with one write

### DIFF
--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -282,17 +282,17 @@ class ConvertType extends Command {
 	protected function saveDBInfo(InputInterface $input) {
 		$type = $input->getArgument('type');
 		$username = $input->getArgument('username');
-		$dbhost = $input->getArgument('hostname');
-		$dbname = $input->getArgument('database');
+		$dbHost = $input->getArgument('hostname');
+		$dbName = $input->getArgument('database');
 		$password = $input->getOption('password');
 		if ($input->getOption('port')) {
-			$dbhost .= ':'.$input->getOption('port');
+			$dbHost .= ':'.$input->getOption('port');
 		}
 
 		$this->config->setSystemValues([
 			'dbtype'		=> $type,
-			'dbname'		=> $dbname,
-			'dbhost'		=> $dbhost,
+			'dbname'		=> $dbName,
+			'dbhost'		=> $dbHost,
 			'dbuser'		=> $username,
 			'dbpassword'	=> $password,
 		]);

--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -289,10 +289,12 @@ class ConvertType extends Command {
 			$dbhost .= ':'.$input->getOption('port');
 		}
 
-		$this->config->setSystemValue('dbtype', $type);
-		$this->config->setSystemValue('dbname', $dbname);
-		$this->config->setSystemValue('dbhost', $dbhost);
-		$this->config->setSystemValue('dbuser', $username);
-		$this->config->setSystemValue('dbpassword', $password);
+		$this->config->setSystemValues([
+			'dbtype'		=> $type,
+			'dbname'		=> $dbname,
+			'dbhost'		=> $dbhost,
+			'dbuser'		=> $username,
+			'dbpassword'	=> $password,
+		]);
 	}
 }

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -70,6 +70,16 @@ class AllConfig implements \OCP\IConfig {
 	}
 
 	/**
+	 * Sets and deletes system wide values
+	 *
+	 * @param array $configs Associative array with `key => value` pairs
+	 *                       If value is null, the config key will be deleted
+	 */
+	public function setSystemValues(array $configs) {
+		$this->systemConfig->setValues($configs);
+	}
+
+	/**
 	 * Sets a new system wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved

--- a/lib/private/legacy/config.php
+++ b/lib/private/legacy/config.php
@@ -59,6 +59,16 @@ class OC_Config {
 	}
 
 	/**
+	 * Sets and deletes values and writes the config.php
+	 *
+	 * @param array $configs Associative array with `key => value` pairs
+	 *                       If value is null, the config key will be deleted
+	 */
+	public static function setValues(array $configs) {
+		self::$object->setValues($configs);
+	}
+
+	/**
 	 * Removes a key from the config
 	 * @param string $key key
 	 *

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -176,18 +176,19 @@ class OC_Setup {
 
 		//generate a random salt that is used to salt the local user passwords
 		$salt = \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(30);
-		\OC::$server->getConfig()->setSystemValue('passwordsalt', $salt);
-
 		// generate a secret
 		$secret = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(48);
-		\OC::$server->getConfig()->setSystemValue('secret', $secret);
 
 		//write the config file
-		\OC::$server->getConfig()->setSystemValue('trusted_domains', $trustedDomains);
-		\OC::$server->getConfig()->setSystemValue('datadirectory', $dataDir);
-		\OC::$server->getConfig()->setSystemValue('overwrite.cli.url', \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . OC::$WEBROOT);
-		\OC::$server->getConfig()->setSystemValue('dbtype', $dbType);
-		\OC::$server->getConfig()->setSystemValue('version', implode('.', OC_Util::getVersion()));
+		\OC::$server->getConfig()->setSystemValues([
+			'passwordsalt'		=> $salt,
+			'secret'			=> $secret,
+			'trusted_domains'	=> $trustedDomains,
+			'datadirectory'		=> $dataDir,
+			'overwrite.cli.url'	=> \OC_Request::serverProtocol() . '://' . \OC_Request::serverHost() . OC::$WEBROOT,
+			'dbtype'			=> $dbType,
+			'version'			=> implode('.', OC_Util::getVersion()),
+		]);
 
 		try {
 			$dbSetup->initialize($options);

--- a/lib/private/setup/abstractdatabase.php
+++ b/lib/private/setup/abstractdatabase.php
@@ -41,9 +41,11 @@ abstract class AbstractDatabase {
 		$dbhost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbtableprefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
-		\OC_Config::setValue('dbname', $dbname);
-		\OC_Config::setValue('dbhost', $dbhost);
-		\OC_Config::setValue('dbtableprefix', $dbtableprefix);
+		\OC_Config::setValues([
+			'dbname'		=> $dbname,
+			'dbhost'		=> $dbhost,
+			'dbtableprefix'	=> $dbtableprefix,
+		]);
 
 		$this->dbuser = $dbuser;
 		$this->dbpassword = $dbpass;

--- a/lib/private/setup/abstractdatabase.php
+++ b/lib/private/setup/abstractdatabase.php
@@ -35,22 +35,24 @@ abstract class AbstractDatabase {
 	}
 
 	public function initialize($config) {
-		$dbuser = $config['dbuser'];
-		$dbpass = $config['dbpass'];
-		$dbname = $config['dbname'];
-		$dbhost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
-		$dbtableprefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
+		$dbUser = $config['dbuser'];
+		$dbPass = $config['dbpass'];
+		$dbName = $config['dbname'];
+		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
+		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
 		\OC_Config::setValues([
-			'dbname'		=> $dbname,
-			'dbhost'		=> $dbhost,
-			'dbtableprefix'	=> $dbtableprefix,
+			'dbname'		=> $dbName,
+			'dbhost'		=> $dbHost,
+			'dbtableprefix'	=> $dbTablePrefix,
 		]);
 
-		$this->dbuser = $dbuser;
-		$this->dbpassword = $dbpass;
-		$this->dbname = $dbname;
-		$this->dbhost = $dbhost;
-		$this->tableprefix = $dbtableprefix;
+		$this->dbuser = $dbUser;
+		$this->dbpassword = $dbPass;
+		$this->dbname = $dbName;
+		$this->dbhost = $dbHost;
+		$this->tableprefix = $dbTablePrefix;
 	}
+
+	abstract public function setupDatabase($userName);
 }

--- a/lib/private/setup/mssql.php
+++ b/lib/private/setup/mssql.php
@@ -5,7 +5,7 @@ namespace OC\Setup;
 class MSSQL extends AbstractDatabase {
 	public $dbprettyname = 'MS SQL Server';
 
-	public function setupDatabase() {
+	public function setupDatabase($username) {
 		//check if the database user has admin right
 		$masterConnectionInfo = array( "Database" => "master", "UID" => $this->dbuser, "PWD" => $this->dbpassword);
 

--- a/lib/private/setup/mssql.php
+++ b/lib/private/setup/mssql.php
@@ -21,8 +21,10 @@ class MSSQL extends AbstractDatabase {
 					$this->trans->t('You need to enter either an existing account or the administrator.'));
 		}
 
-		\OC_Config::setValue('dbuser', $this->dbuser);
-		\OC_Config::setValue('dbpassword', $this->dbpassword);
+		\OC_Config::setValues([
+			'dbuser'		=> $this->dbuser,
+			'dbpassword'	=> $this->dbpassword,
+		]);
 
 		$this->createDBLogin($masterConnection);
 

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -51,8 +51,10 @@ class MySQL extends AbstractDatabase {
 				}
 			};
 
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
+			\OC_Config::setValues([
+				'dbuser'		=> $this->dbuser,
+				'dbpassword'	=> $this->dbpassword,
+			]);
 		}
 
 		//create the database

--- a/lib/private/setup/oci.php
+++ b/lib/private/setup/oci.php
@@ -16,8 +16,11 @@ class OCI extends AbstractDatabase {
 		}
 		// allow empty hostname for oracle
 		$this->dbhost = $config['dbhost'];
-		\OC_Config::setValue('dbhost', $this->dbhost);
-		\OC_Config::setValue('dbtablespace', $this->dbtablespace);
+
+		\OC_Config::setValues([
+			'dbhost'		=> $this->dbhost,
+			'dbtablespace'	=> $this->dbtablespace,
+		]);
 	}
 
 	public function validate($config) {
@@ -72,37 +75,32 @@ class OCI extends AbstractDatabase {
 		$result = oci_execute($stmt);
 		if($result) {
 			$row = oci_fetch_row($stmt);
+
+			if ($row[0] > 0) {
+				//use the admin login data for the new database user
+
+				//add prefix to the oracle user name to prevent collisions
+				$this->dbuser='oc_'.$username;
+				//create a new password so we don't need to store the admin config in the config file
+				$this->dbpassword=\OC_Util::generateRandomBytes(30);
+
+				//oracle passwords are treated as identifiers:
+				//  must start with alphanumeric char
+				//  needs to be shortened to 30 bytes, as the two " needed to escape the identifier count towards the identifier length.
+				$this->dbpassword=substr($this->dbpassword, 0, 30);
+
+				$this->createDBUser($connection);
+			}
 		}
-		if($result and $row[0] > 0) {
-			//use the admin login data for the new database user
 
-			//add prefix to the oracle user name to prevent collisions
-			$this->dbuser='oc_'.$username;
-			//create a new password so we don't need to store the admin config in the config file
-			$this->dbpassword=\OC_Util::generateRandomBytes(30);
+		\OC_Config::setValues([
+			'dbuser'		=> $this->dbuser,
+			'dbname'		=> $this->dbname,
+			'dbpassword'	=> $this->dbpassword,
+		]);
 
-			//oracle passwords are treated as identifiers:
-			//  must start with alphanumeric char
-			//  needs to be shortened to 30 bytes, as the two " needed to escape the identifier count towards the identifier length.
-			$this->dbpassword=substr($this->dbpassword, 0, 30);
-
-			$this->createDBUser($connection);
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbname', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database not necessary, oracle implies user = schema
-			//$this->createDatabase($this->dbname, $this->dbuser, $connection);
-		} else {
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbname', $this->dbname);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database not necessary, oracle implies user = schema
-			//$this->createDatabase($this->dbname, $this->dbuser, $connection);
-		}
+		//create the database not necessary, oracle implies user = schema
+		//$this->createDatabase($this->dbname, $this->dbuser, $connection);
 
 		//FIXME check tablespace exists: select * from user_tablespaces
 

--- a/lib/private/setup/postgresql.php
+++ b/lib/private/setup/postgresql.php
@@ -43,20 +43,15 @@ class PostgreSQL extends AbstractDatabase {
 			$this->dbpassword=\OC_Util::generateRandomBytes(30);
 
 			$this->createDBUser($connection);
-
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
-
-			//create the database
-			$this->createDatabase($connection);
 		}
-		else {
-			\OC_Config::setValue('dbuser', $this->dbuser);
-			\OC_Config::setValue('dbpassword', $this->dbpassword);
 
-			//create the database
-			$this->createDatabase($connection);
-		}
+		\OC_Config::setValues([
+			'dbuser'		=> $this->dbuser,
+			'dbpassword'	=> $this->dbpassword,
+		]);
+
+		//create the database
+		$this->createDatabase($connection);
 
 		// the connection to dbname=postgres is not needed anymore
 		pg_close($connection);

--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -28,6 +28,16 @@ class SystemConfig {
 	}
 
 	/**
+	 * Sets and deletes values and writes the config.php
+	 *
+	 * @param array $configs Associative array with `key => value` pairs
+	 *                       If value is null, the config key will be deleted
+	 */
+	public function setValues(array $configs) {
+		\OC_Config::setValues($configs);
+	}
+
+	/**
 	 * Looks up a system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -35,6 +35,14 @@ namespace OCP;
  */
 interface IConfig {
 	/**
+	 * Sets and deletes system wide values
+	 *
+	 * @param array $configs Associative array with `key => value` pairs
+	 *                       If value is null, the config key will be deleted
+	 */
+	public function setSystemValues(array $configs);
+
+	/**
 	 * Sets a new system wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved

--- a/settings/controller/mailsettingscontroller.php
+++ b/settings/controller/mailsettingscontroller.php
@@ -84,19 +84,18 @@ class MailSettingsController extends Controller {
 									$mail_smtpport) {
 
 		$params = get_defined_vars();
+		$configs = [];
 		foreach($params as $key => $value) {
-			if(empty($value)) {
-				$this->config->deleteSystemValue($key);
-			} else {
-				$this->config->setSystemValue($key, $value);
-			}
+			$configs[$key] = (empty($value)) ? null : $value;
 		}
 
 		// Delete passwords from config in case no auth is specified
-		if($params['mail_smtpauth'] !== 1) {
-			$this->config->deleteSystemValue('mail_smtpname');
-			$this->config->deleteSystemValue('mail_smtppassword');
+		if ($params['mail_smtpauth'] !== 1) {
+			$configs['mail_smtpname'] = null;
+			$configs['mail_smtppassword'] = null;
 		}
+
+		$this->config->setSystemValues($configs);
 
 		return array('data' =>
 			array('message' =>
@@ -113,8 +112,10 @@ class MailSettingsController extends Controller {
 	 * @return array
 	 */
 	public function storeCredentials($mail_smtpname, $mail_smtppassword) {
-		$this->config->setSystemValue('mail_smtpname', $mail_smtpname);
-		$this->config->setSystemValue('mail_smtppassword', $mail_smtppassword);
+		$this->config->setSystemValues([
+			'mail_smtpname'		=> $mail_smtpname,
+			'mail_smtppassword'	=> $mail_smtppassword,
+		]);
 
 		return array('data' =>
 			array('message' =>

--- a/tests/lib/config.php
+++ b/tests/lib/config.php
@@ -71,6 +71,36 @@ class Test_Config extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
+	public function testSetValues() {
+		$content = file_get_contents($this->configFile);
+		$this->assertEquals(self::TESTCONTENT, $content);
+
+		// Changing configs to existing values and deleting non-existing once
+		// should not rewrite the config.php
+		$this->config->setValues([
+			'foo'			=> 'bar',
+			'not_exists'	=> null,
+		]);
+
+		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
+		$content = file_get_contents($this->configFile);
+		$this->assertEquals(self::TESTCONTENT, $content);
+
+		$this->config->setValues([
+			'foo'			=> 'moo',
+			'alcohol_free'	=> null,
+		]);
+		$expectedConfig = $this->initialConfig;
+		$expectedConfig['foo'] = 'moo';
+		unset($expectedConfig['alcohol_free']);
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+
+		$content = file_get_contents($this->configFile);
+		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n);\n";
+		$this->assertEquals($expected, $content);
+	}
+
 	public function testDeleteKey() {
 		$this->config->deleteKey('foo');
 		$expectedConfig = $this->initialConfig;

--- a/tests/settings/controller/mailsettingscontrollertest.php
+++ b/tests/settings/controller/mailsettingscontrollertest.php
@@ -69,26 +69,37 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			);
 		 */
 
-		$this->container['Config']
-			->expects($this->exactly(15))
-			->method('setSystemValue');
-
+		/** @var \PHPUnit_Framework_MockObject_MockObject $config */
+		$config = $this->container['Config'];
+		$config->expects($this->exactly(2))
+			->method('setSystemValues');
 		/**
 		 * FIXME: Use the following block once Jenkins uses PHPUnit >= 4.1
-		 */
-		/*
-		$this->container['Config']
-			->expects($this->exactly(3))
-			->method('deleteSystemValue')
 			->withConsecutive(
-				array($this->equalTo('mail_smtpauth')),
-				array($this->equalTo('mail_smtpname')),
-				array($this->equalTo('mail_smtppassword'))
+				[[
+					'mail_domain' => 'owncloud.com',
+					'mail_from_address' => 'demo@owncloud.com',
+					'mail_smtpmode' => 'smtp',
+					'mail_smtpsecure' => 'ssl',
+					'mail_smtphost' => 'mx.owncloud.org',
+					'mail_smtpauthtype' => 'NTLM',
+					'mail_smtpauth' => 1,
+					'mail_smtpport' => '25',
+				]],
+				[[
+					'mail_domain' => 'owncloud.com',
+					'mail_from_address' => 'demo@owncloud.com',
+					'mail_smtpmode' => 'smtp',
+					'mail_smtpsecure' => 'ssl',
+					'mail_smtphost' => 'mx.owncloud.org',
+					'mail_smtpauthtype' => 'NTLM',
+					'mail_smtpauth' => null,
+					'mail_smtpport' => '25',
+					'mail_smtpname' => null,
+					'mail_smtppassword' => null,
+				]]
 			);
-		*/
-		$this->container['Config']
-			->expects($this->exactly(3))
-			->method('deleteSystemValue');
+		 */
 
 		// With authentication
 		$response = $this->container['MailSettingsController']->setMailSettings(
@@ -126,21 +137,13 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			->method('t')
 			->will($this->returnValue('Saved'));
 
-		/**
-		 * FIXME: Use this block once Jenkins uses PHPUnit >= 4.1
-		 */
-		/*
 		$this->container['Config']
-			->expects($this->exactly(2))
-			->method('setSystemValue')
-			->withConsecutive(
-				array($this->equalTo('mail_smtpname'), $this->equalTo('UsernameToStore')),
-				array($this->equalTo('mail_smtppassword'), $this->equalTo('PasswordToStore'))
-			);
-		*/
-		$this->container['Config']
-			->expects($this->exactly(2))
-			->method('setSystemValue');
+			->expects($this->once())
+			->method('setSystemValues')
+			->with([
+				'mail_smtpname' => 'UsernameToStore',
+				'mail_smtppassword' => 'PasswordToStore',
+			]);
 
 		$response = $this->container['MailSettingsController']->storeCredentials('UsernameToStore', 'PasswordToStore');
 		$expectedResponse = array('data' => array('message' =>'Saved'), 'status' => 'success');


### PR DESCRIPTION
Related #12785

Based on the idea from https://github.com/owncloud/core/pull/13556#issuecomment-71110473

Currently when we set "n" configs in one go, we write the file "n"-times.
Instead we should reduce it almost "1". E.g.: when changing the SMTP settings now only 1 write action is performed instead of 8-10.

With less write actions, we might break the config.php less often. Worth a try.

@LukasReschke @MorrisJobke @DeepDiver1975 requested second version
