### PR TITLE
The bitmap preview class now takes maxX and maxY into consideration

### DIFF
--- a/lib/private/preview/bitmap.php
+++ b/lib/private/preview/bitmap.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Copyright (c) 2013-2014 Georg Ehrke georg@ownCloud.com
+ * Copyright (c) 2014-2015 Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
  * @author Joas Schilling <nickvergessen@owncloud.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Olivier Paroz <github@oparoz.com>
@@ -23,30 +29,91 @@
 
 namespace OC\Preview;
 
+use Imagick;
+
+/**
+ * Creates a PNG preview using ImageMagick via the PECL extension
+ *
+ * @package OC\Preview
+ */
 abstract class Bitmap extends Provider {
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
+
 		$tmpPath = $fileview->toTmpFile($path);
+		if (!$tmpPath) {
+			return false;
+		}
 
-		//create imagick object from bitmap or vector file
+		// Creates \Imagick object from bitmap or vector file
 		try {
-			// Layer 0 contains either the bitmap or
-			// a flat representation of all vector layers
-			$bp = new \Imagick($tmpPath . '[0]');
-
-			$bp->setImageFormat('png');
+			$bp = $this->getResizedPreview($tmpPath, $maxX, $maxY);
 		} catch (\Exception $e) {
-			\OC_Log::write('core', $e->getmessage(), \OC_Log::ERROR);
+			\OC_Log::write('core', 'ImageMagick says: ' . $e->getmessage(), \OC_Log::ERROR);
 			return false;
 		}
 
 		unlink($tmpPath);
 
 		//new bitmap image object
-		$image = new \OC_Image($bp);
+		$image = new \OC_Image();
+		$image->loadFromData($bp);
 		//check if image object is valid
 		return $image->valid() ? $image : false;
 	}
+
+	/**
+	 * Returns a preview of maxX times maxY dimensions in PNG format
+	 *
+	 *    * The default resolution is already 72dpi, no need to change it for a bitmap output
+	 *    * It's possible to have proper colour conversion using profileimage().
+	 *    ICC profiles are here: http://www.color.org/srgbprofiles.xalter
+	 *    * It's possible to Gamma-correct an image via gammaImage()
+	 *
+	 * @param string $tmpPath the location of the file to convert
+	 * @param int $maxX
+	 * @param int $maxY
+	 *
+	 * @return \Imagick
+	 */
+	private function getResizedPreview($tmpPath, $maxX, $maxY) {
+		$bp = new Imagick();
+
+		// Layer 0 contains either the bitmap or a flat representation of all vector layers
+		$bp->readImage($tmpPath . '[0]');
+
+		$bp = $this->resize($bp, $maxX, $maxY);
+
+		$bp->setImageFormat('png');
+
+		return $bp;
+	}
+
+	/**
+	 * Returns a resized \Imagick object
+	 *
+	 * If you want to know more on the various methods available to resize an
+	 * image, check out this link : @link https://stackoverflow.com/questions/8517304/what-the-difference-of-sample-resample-scale-resize-adaptive-resize-thumbnail-im
+	 *
+	 * @param \Imagick $bp
+	 * @param int $maxX
+	 * @param int $maxY
+	 *
+	 * @return \Imagick
+	 */
+	private function resize($bp, $maxX, $maxY) {
+		list($previewWidth, $previewHeight) = array_values($bp->getImageGeometry());
+
+		// We only need to resize a preview which doesn't fit in the maximum dimensions
+		if ($previewWidth > $maxX || $previewHeight > $maxY) {
+			// TODO: LANCZOS is the default filter, CATROM could bring similar results faster
+			$bp->resizeImage($maxX, $maxY, imagick::FILTER_LANCZOS, 1, true);
+		}
+
+		return $bp;
+	}
+
 }


### PR DESCRIPTION
This is a fix for https://github.com/owncloud/core/issues/13607
and is part of the global programme to fix preview caching: https://github.com/owncloud/core/issues/13609
- Original TIFF: 140MB. Waiting an insane amount of time every time you need a preview because a conversion is asked every time
- With https://github.com/owncloud/core/pull/13674: Preview only resizes a 48MB file. Waiting about a minute for each preview
- Combined with this: Preview only resizes a 6.7MB file.  **Waiting about 3 SECONDS.**
