### PR TITLE
Add value if restore of data is possible for a user

### DIFF
--- a/settings/application.php
+++ b/settings/application.php
@@ -90,7 +90,8 @@ class Application extends App {
 				$c->query('Defaults'),
 				$c->query('Mail'),
 				$c->query('DefaultMailAddress'),
-				$c->query('URLGenerator')
+				$c->query('URLGenerator'),
+				$c->query('OCP\\App\\IAppManager')
 			);
 		});
 		$container->registerService('LogSettingsController', function(IContainer $c) {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -132,7 +132,10 @@ input.userFilter {width: 200px;}
 .ie8 table.hascontrols{border-collapse:collapse;width: 100%;}
 .ie8 table.hascontrols tbody tr{border-collapse:collapse;border: 1px solid #ddd !important;}
 
-
+/* used to highlight a user row in red */
+#userlist tr.row-warning {
+	background-color: #FDD;
+}
 
 
 /* APPS */

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -21,9 +21,6 @@ class UsersControllerTest extends \Test\TestCase {
 	/** @var \OCP\AppFramework\IAppContainer */
 	private $container;
 
-	/** @var UsersController */
-	private $usersController;
-
 	protected function setUp() {
 		$app = new Application();
 		$this->container = $app->getContainer();
@@ -54,9 +51,8 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->container['URLGenerator'] = $this->getMockBuilder('\OCP\IURLGenerator')
 			->disableOriginalConstructor()->getMock();
-
-		$this->usersController = $this->container['UsersController'];
-
+		$this->container['OCP\\App\\IAppManager'] = $this->getMockBuilder('OCP\\App\\IAppManager')
+			->disableOriginalConstructor()->getMock();
 	}
 
 	/**
@@ -169,7 +165,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/foo',
 					'lastLogin' => 500,
 					'backend' => 'OC_User_Database',
-					'email' => 'foo@bar.com'
+					'email' => 'foo@bar.com',
+					'isRestoreDisabled' => false,
 				),
 				1 => array(
 					'name' => 'admin',
@@ -180,7 +177,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/admin',
 					'lastLogin' => 12,
 					'backend' => 'OC_User_Dummy',
-					'email' => 'admin@bar.com'
+					'email' => 'admin@bar.com',
+					'isRestoreDisabled' => false,
 				),
 				2 => array(
 					'name' => 'bar',
@@ -191,11 +189,12 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/bar',
 					'lastLogin' => 3999,
 					'backend' => 'OC_User_Dummy',
-					'email' => 'bar@dummy.com'
+					'email' => 'bar@dummy.com',
+					'isRestoreDisabled' => false,
 				),
 			)
 		);
-		$response = $this->usersController->index(0, 10, 'gid', 'pattern');
+		$response = $this->container['UsersController']->index(0, 10, 'gid', 'pattern');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -294,7 +293,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/foo',
 					'lastLogin' => 500,
 					'backend' => 'OC_User_Database',
-					'email' => 'foo@bar.com'
+					'email' => 'foo@bar.com',
+					'isRestoreDisabled' => false,
 				),
 				1 => array(
 					'name' => 'admin',
@@ -305,7 +305,8 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/admin',
 					'lastLogin' => 12,
 					'backend' => 'OC_User_Dummy',
-					'email' => 'admin@bar.com'
+					'email' => 'admin@bar.com',
+					'isRestoreDisabled' => false,
 				),
 				2 => array(
 					'name' => 'bar',
@@ -316,11 +317,12 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/bar',
 					'lastLogin' => 3999,
 					'backend' => 'OC_User_Dummy',
-					'email' => 'bar@dummy.com'
+					'email' => 'bar@dummy.com',
+					'isRestoreDisabled' => false,
 				),
 			)
 		);
-		$response = $this->usersController->index(0, 10, '', 'pattern');
+		$response = $this->container['UsersController']->index(0, 10, '', 'pattern');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -374,11 +376,12 @@ class UsersControllerTest extends \Test\TestCase {
 					'storageLocation' => '/home/foo',
 					'lastLogin' => 500,
 					'backend' => 'OC_User_Database',
-					'email' => null
+					'email' => null,
+					'isRestoreDisabled' => false,
 				)
 			)
 		);
-		$response = $this->usersController->index(0, 10, '','', 'OC_User_Dummy');
+		$response = $this->container['UsersController']->index(0, 10, '','', 'OC_User_Dummy');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -394,7 +397,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue([]));
 
 		$expectedResponse = new DataResponse([]);
-		$response = $this->usersController->index(0, 10, '','', 'OC_User_Dummy');
+		$response = $this->container['UsersController']->index(0, 10, '','', 'OC_User_Dummy');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -432,11 +435,12 @@ class UsersControllerTest extends \Test\TestCase {
 				'displayname' => null,
 				'quota' => null,
 				'subadmin' => array(),
-				'email' => null
+				'email' => null,
+				'isRestoreDisabled' => false,
 			),
 			Http::STATUS_CREATED
 		);
-		$response = $this->usersController->create('foo', 'password', array());
+		$response = $this->container['UsersController']->create('foo', 'password', array());
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -502,11 +506,12 @@ class UsersControllerTest extends \Test\TestCase {
 				'displayname' => null,
 				'quota' => null,
 				'subadmin' => array(),
-				'email' => null
+				'email' => null,
+				'isRestoreDisabled' => false,
 			),
 			Http::STATUS_CREATED
 		);
-		$response = $this->usersController->create('foo', 'password', array('NewGroup', 'ExistingGroup'));
+		$response = $this->container['UsersController']->create('foo', 'password', array('NewGroup', 'ExistingGroup'));
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -525,7 +530,7 @@ class UsersControllerTest extends \Test\TestCase {
 			),
 			Http::STATUS_FORBIDDEN
 		);
-		$response = $this->usersController->create('foo', 'password', array());
+		$response = $this->container['UsersController']->create('foo', 'password', array());
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -553,7 +558,7 @@ class UsersControllerTest extends \Test\TestCase {
 			),
 			Http::STATUS_FORBIDDEN
 		);
-		$response = $this->usersController->destroy('myself');
+		$response = $this->container['UsersController']->destroy('myself');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -591,7 +596,7 @@ class UsersControllerTest extends \Test\TestCase {
 			),
 			Http::STATUS_NO_CONTENT
 		);
-		$response = $this->usersController->destroy('UserToDelete');
+		$response = $this->container['UsersController']->destroy('UserToDelete');
 		$this->assertEquals($expectedResponse, $response);
 	}
 	/**
@@ -628,7 +633,7 @@ class UsersControllerTest extends \Test\TestCase {
 			),
 			Http::STATUS_FORBIDDEN
 		);
-		$response = $this->usersController->destroy('UserToDelete');
+		$response = $this->container['UsersController']->destroy('UserToDelete');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -653,7 +658,7 @@ class UsersControllerTest extends \Test\TestCase {
 			),
 			Http::STATUS_UNPROCESSABLE_ENTITY
 		);
-		$response = $this->usersController->create('foo', 'password', array(), 'invalidMailAdress');
+		$response = $this->container['UsersController']->create('foo', 'password', array(), 'invalidMailAdress');
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -688,8 +693,142 @@ class UsersControllerTest extends \Test\TestCase {
 			->expects($this->never())
 			->method('error');
 
-		$response = $this->usersController->create('foo', 'password', array(), 'validMail@Adre.ss');
+		$response = $this->container['UsersController']->create('foo', 'password', array(), 'validMail@Adre.ss');
 		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+	}
+
+	private function mockUser($userId = 'foo', $displayName = 'M. Foo',
+							  $lastLogin = 500, $home = '/home/foo', $backend = 'OC_User_Database') {
+		$user = $this->getMockBuilder('\OC\User\User')
+			->disableOriginalConstructor()->getMock();
+		$user
+			->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue($userId));
+		$user
+			->expects($this->once())
+			->method('getDisplayName')
+			->will($this->returnValue($displayName));
+		$user
+			->method('getLastLogin')
+			->will($this->returnValue($lastLogin));
+		$user
+			->method('getHome')
+			->will($this->returnValue($home));
+		$user
+			->expects($this->once())
+			->method('getBackendClassName')
+			->will($this->returnValue($backend));
+
+		$result = [
+			'name' => $userId,
+			'displayname' => $displayName,
+			'groups' => null,
+			'subadmin' => array(),
+			'quota' => null,
+			'storageLocation' => $home,
+			'lastLogin' => $lastLogin,
+			'backend' => $backend,
+			'email' => null,
+			'isRestoreDisabled' => false,
+		];
+
+		return [$user, $result];
+	}
+
+	public function testRestorePossibleWithoutEncryption() {
+		list($user, $expectedResult) = $this->mockUser();
+
+		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function testRestorePossibleWithAdminAndUserRestore() {
+		list($user, $expectedResult) = $this->mockUser();
+
+		$this->container['OCP\\App\\IAppManager']
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->with(
+				$this->equalTo('files_encryption')
+			)
+			->will($this->returnValue(true));
+		$this->container['Config']
+			->expects($this->once())
+			->method('getAppValue')
+			->with(
+				$this->equalTo('files_encryption'),
+				$this->equalTo('recoveryAdminEnabled'),
+				$this->anything()
+			)
+			->will($this->returnValue('1'));
+
+		$this->container['Config']
+			->expects($this->at(1))
+			->method('getUserValue')
+			->with(
+				$this->anything(),
+				$this->equalTo('files_encryption'),
+				$this->equalTo('recovery_enabled'),
+				$this->anything()
+			)
+			->will($this->returnValue('1'));
+
+		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function testRestoreNotPossibleWithoutAdminRestore() {
+		list($user, $expectedResult) = $this->mockUser();
+
+		$this->container['OCP\\App\\IAppManager']
+			->method('isEnabledForUser')
+			->with(
+				$this->equalTo('files_encryption')
+			)
+			->will($this->returnValue(true));
+
+		$expectedResult['isRestoreDisabled'] = true;
+
+		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function testRestoreNotPossibleWithoutUserRestore() {
+		list($user, $expectedResult) = $this->mockUser();
+
+		$this->container['OCP\\App\\IAppManager']
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->with(
+				$this->equalTo('files_encryption')
+			)
+			->will($this->returnValue(true));
+		$this->container['Config']
+			->expects($this->once())
+			->method('getAppValue')
+			->with(
+				$this->equalTo('files_encryption'),
+				$this->equalTo('recoveryAdminEnabled'),
+				$this->anything()
+			)
+			->will($this->returnValue('1'));
+
+		$this->container['Config']
+			->expects($this->at(1))
+			->method('getUserValue')
+			->with(
+				$this->anything(),
+				$this->equalTo('files_encryption'),
+				$this->equalTo('recovery_enabled'),
+				$this->anything()
+			)
+			->will($this->returnValue('0'));
+
+		$expectedResult['isRestoreDisabled'] = true;
+
+		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$this->assertEquals($expectedResult, $result);
 	}
 
 }


### PR DESCRIPTION
- reason: nice to know before password change in user management
- restore is possible:
  - encryption is disabled
  - encryption is enabled, admin and user has checked the
    restore option
- if not possible:
  - highlight users row in red once the admin wants to change the password
  - show also a little tipsy

I also don't like to add that much stuff that is encryption specific in core, but we currently we have no way to inject that code from the encryption app nowadays.

fixes #13542

cc @jancborchardt Please have a look at the UI
cc @DeepDiver1975 @LukasReschke Yes I know the container shouldn't contain that much logic, but it isn't possible to mock \OCP\App because it is static

And some fancy images how it looks like:

Usual user, that has recovery enabled or a instance without encryption:
![recovery-enabled](https://cloud.githubusercontent.com/assets/245432/5879075/687a4bd0-a32c-11e4-895c-a95eb77a3721.png)

A user without recovery enabled (or disabled by admin while encryption is active)
![recovery-disabled](https://cloud.githubusercontent.com/assets/245432/5879084/76ec4ede-a32c-11e4-937b-e6051a29f9db.png)
