### PR TITLE
Parse backslash as directory separator in breadcrumb

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -67,6 +67,7 @@
 		 * @param dir path to be displayed as breadcrumb
 		 */
 		setDirectory: function(dir) {
+			dir = dir.replace(/\\/g, '/');
 			dir = dir || '/';
 			if (dir !== this.dir) {
 				this.dir = dir;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1009,6 +1009,7 @@
 		 * @param changeUrl true to also update the URL, false otherwise (default)
 		 */
 		_setCurrentDir: function(targetDir, changeUrl) {
+			targetDir = targetDir.replace(/\\/g, '/');
 			var previousDir = this.getCurrentDirectory(),
 				baseDir = OC.basename(targetDir);
 

--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -93,6 +93,31 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			expect($crumbs.eq(3).find('img').length).toEqual(0);
 			expect($crumbs.eq(3).attr('data-dir')).toEqual('/somedir/with space/abc');
 		});
+		it('Renders backslashes as regular directory separator', function() {
+			var $crumbs;
+			bc.setDirectory('/somedir\\with/mixed\\separators');
+			$crumbs = bc.$el.find('.crumb');
+			expect($crumbs.length).toEqual(5);
+			expect($crumbs.eq(0).find('a').attr('href')).toEqual('/#0');
+			expect($crumbs.eq(0).find('img').length).toEqual(1);
+			expect($crumbs.eq(0).attr('data-dir')).toEqual('/');
+
+			expect($crumbs.eq(1).find('a').attr('href')).toEqual('/somedir#1');
+			expect($crumbs.eq(1).find('img').length).toEqual(0);
+			expect($crumbs.eq(1).attr('data-dir')).toEqual('/somedir');
+
+			expect($crumbs.eq(2).find('a').attr('href')).toEqual('/somedir/with#2');
+			expect($crumbs.eq(2).find('img').length).toEqual(0);
+			expect($crumbs.eq(2).attr('data-dir')).toEqual('/somedir/with');
+
+			expect($crumbs.eq(3).find('a').attr('href')).toEqual('/somedir/with/mixed#3');
+			expect($crumbs.eq(3).find('img').length).toEqual(0);
+			expect($crumbs.eq(3).attr('data-dir')).toEqual('/somedir/with/mixed');
+
+			expect($crumbs.eq(4).find('a').attr('href')).toEqual('/somedir/with/mixed/separators#4');
+			expect($crumbs.eq(4).find('img').length).toEqual(0);
+			expect($crumbs.eq(4).attr('data-dir')).toEqual('/somedir/with/mixed/separators');
+		});
 	});
 	describe('Events', function() {
 		it('Calls onClick handler when clicking on a crumb', function() {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1221,7 +1221,7 @@ describe('OCA.Files.FileList tests', function() {
 						"Content-Type": "application/json"
 					},
 					JSON.stringify(data)
-			]);
+				]);
 		});
 		it('fetches file list from server and renders it when reload() is called', function() {
 			fileList.reload();
@@ -1241,6 +1241,10 @@ describe('OCA.Files.FileList tests', function() {
 			var query = url.substr(url.indexOf('?') + 1);
 			expect(OC.parseQueryString(query)).toEqual({'dir': '/anothersubdir', sort: 'name', sortdirection: 'asc'});
 			fakeServer.respond();
+		});
+		it('converts backslashes to slashes when calling changeDirectory()', function() {
+			fileList.changeDirectory('/another\\subdir');
+			expect(fileList.getCurrentDirectory()).toEqual('/another/subdir');
 		});
 		it('switches to root dir when current directory does not exist', function() {
 			fakeServer.respondWith(/\/index\.php\/apps\/files\/ajax\/list.php\?dir=%2funexist/, [


### PR DESCRIPTION
This will parse backslashes as directory separators in breadcrumbs. Thus when accessing something like `/index.php/apps/files?dir=foo\foo` the breadcrumb will properly resolve this instead of showing `foo\foo`

Fixes https://github.com/owncloud/core/issues/13643

@MorrisJobke @PVince81 
