### PR TITLE
Add support for font previews

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -679,6 +679,7 @@ $CONFIG = array(
  *  - OC\Preview\StarOffice
  *  - OC\Preview\SVG
  *  - OC\Preview\TIFF
+ *  - OC\Preview\Font
  *
  * .. note:: Troubleshooting steps for the MS Word previews are available
  *    at the :doc:`collaborative_documents_configuration` section

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -731,6 +731,7 @@ class Preview {
 		 *  - OC\Preview\Illustrator
 		 *  - OC\Preview\Postscript
 		 *  - OC\Preview\Photoshop
+		 *  - OC\Preview\Font
 		 */
 		if(empty(self::$enabledProviders)) {
 			self::$enabledProviders = \OC::$server->getConfig()->getSystemValue('enabledPreviewProviders', array(
@@ -790,8 +791,8 @@ class Preview {
 				'PDF'	=> 'OC\Preview\PDF',
 				'AI'	=> 'OC\Preview\Illustrator',
 				'PSD'	=> 'OC\Preview\Photoshop',
-				// Requires adding 'eps' => array('application/postscript', null), to lib/private/mimetypes.list.php
 				'EPS'	=> 'OC\Preview\Postscript',
+				'TTF'	=> 'OC\Preview\Font',
 			);
 
 			foreach ($imagickProviders as $queryFormat => $provider) {

--- a/lib/private/preview/font.php
+++ b/lib/private/preview/font.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @copyright Olivier Paroz 2015 <owncloud@interfasys.ch>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Preview;
+
+// .otf, .ttf and .pfb
+class Font extends Bitmap {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType() {
+		return '/application\/(?:font-sfnt|x-font$)/';
+	}
+}


### PR DESCRIPTION
This will allow the preview system to generate both thumbnails and large previews of a type face
- **Full screen previews requires a Gallery app which supports all media types supported by ownCloud**
