### PR TITLE
Only update favorite icon if the operation was successful

### DIFF
--- a/apps/files/controller/apicontroller.php
+++ b/apps/files/controller/apicontroller.php
@@ -76,11 +76,11 @@ class ApiController extends Controller {
 			try {
 				$this->tagService->updateFileTags($path, $tags);
 			} catch (\OCP\Files\NotFoundException $e) {
-				return new DataResponse($e->getMessage(), Http::STATUS_NOT_FOUND);
+				return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
-				return new DataResponse($e->getMessage(), Http::STATUS_SERVICE_UNAVAILABLE);
+				return new DataResponse(['message' => $e->getMessage()], Http::STATUS_SERVICE_UNAVAILABLE);
 			} catch (\Exception $e) {
-				return new DataResponse($e->getMessage(), Http::STATUS_NOT_FOUND);
+				return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 			}
 			$result['tags'] = $tags;
 		}

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -105,12 +105,12 @@
 					} else {
 						tags.push(OC.TAG_FAVORITE);
 					}
+					toggleStar($actionEl, !isFavorite);
 
 					self.applyFileTags(
 						dir + '/' + fileName,
 						tags
 					).then(function(result) {
-						toggleStar($actionEl, !isFavorite);
 						// response from server should contain updated tags
 						var newTags = result.tags;
 						if (_.isUndefined(newTags)) {
@@ -171,8 +171,13 @@
 				}),
 				dataType: 'json',
 				type: 'POST'
-			}).fail(function() {
-				OC.Notification.showTemporary(t('files', 'An error occurred while trying to update the tags'));
+			}).fail(function(response) {
+				var message = '';
+				// show message if it is available
+				if(response.responseJSON && response.responseJSON.message) {
+					message = ': ' + response.responseJSON.message;
+				}
+				OC.Notification.showTemporary(t('files', 'An error occurred while trying to update the tags') + message);
 			});
 		}
 	};

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -105,12 +105,12 @@
 					} else {
 						tags.push(OC.TAG_FAVORITE);
 					}
-					toggleStar($actionEl, !isFavorite);
 
 					self.applyFileTags(
 						dir + '/' + fileName,
 						tags
 					).then(function(result) {
+						toggleStar($actionEl, !isFavorite);
 						// response from server should contain updated tags
 						var newTags = result.tags;
 						if (_.isUndefined(newTags)) {
@@ -171,6 +171,8 @@
 				}),
 				dataType: 'json',
 				type: 'POST'
+			}).fail(function() {
+				OC.Notification.showTemporary(t('files', 'An error occurred while trying to update the tags'));
 			});
 		}
 	};

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -109,7 +109,9 @@
 
 					self.applyFileTags(
 						dir + '/' + fileName,
-						tags
+						tags,
+						$actionEl,
+						isFavorite
 					).then(function(result) {
 						// response from server should contain updated tags
 						var newTags = result.tags;
@@ -157,8 +159,10 @@
 		 *
 		 * @param {String} fileName path to the file or folder to tag
 		 * @param {Array.<String>} tagNames array of tag names
+		 * @param {Object} $actionEl element
+		 * @param {boolean} isFavorite Was the item favorited before
 		 */
-		applyFileTags: function(fileName, tagNames) {
+		applyFileTags: function(fileName, tagNames, $actionEl, isFavorite) {
 			var encodedPath = OC.encodePath(fileName);
 			while (encodedPath[0] === '/') {
 				encodedPath = encodedPath.substr(1);
@@ -178,6 +182,7 @@
 					message = ': ' + response.responseJSON.message;
 				}
 				OC.Notification.showTemporary(t('files', 'An error occurred while trying to update the tags') + message);
+				toggleStar($actionEl, isFavorite);
 			});
 		}
 	};


### PR DESCRIPTION
Also shows a notification in case an error occured on updating the tags

Related to #13624 (but not fixing fully, since the ticket is also for another case)
The problems can be easily reproduced, by mounting an external storage and then split the connection to it (e.g. remove password from the mount config, change url, etc).

@PVince81 @MorrisJobke 
