### PR TITLE
Update the cache when renaming even if we dont emit hooks

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -167,6 +167,9 @@ class Trashbin {
 		$trashPath = '/files_trashbin/files/' . $filename . '.d' . $timestamp;
 		try {
 			$sizeOfAddedFiles = $view->filesize('/files/' . $file_path);
+			if ($view->file_exists($trashPath)) {
+				$view->unlink($trashPath);
+			}
 			$view->rename('/files/' . $file_path, $trashPath);
 		} catch (\OCA\Files_Trashbin\Exceptions\CopyRecursiveException $e) {
 			$sizeOfAddedFiles = false;

--- a/lib/private/files/node/root.php
+++ b/lib/private/files/node/root.php
@@ -155,7 +155,7 @@ class Root extends Folder implements IRootFolder {
 	 * @param string $path
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
-	 * @return string
+	 * @return \OCP\Files\Node
 	 */
 	public function get($path) {
 		$path = $this->normalizePath($path);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -537,16 +537,18 @@ class View {
 					if ($this->shouldEmitHooks()) {
 						$this->emit_file_hooks_post($exists, $path2);
 					}
-				} elseif ($this->shouldEmitHooks() && $result !== false) {
+				} elseif ($result !== false) {
 					$this->updater->rename($path1, $path2);
-					\OC_Hook::emit(
-						Filesystem::CLASSNAME,
-						Filesystem::signal_post_rename,
-						array(
-							Filesystem::signal_param_oldpath => $this->getHookPath($path1),
-							Filesystem::signal_param_newpath => $this->getHookPath($path2)
-						)
-					);
+					if ($this->shouldEmitHooks($path1) and $this->shouldEmitHooks($path2)) {
+						\OC_Hook::emit(
+							Filesystem::CLASSNAME,
+							Filesystem::signal_post_rename,
+							array(
+								Filesystem::signal_param_oldpath => $this->getHookPath($path1),
+								Filesystem::signal_param_newpath => $this->getHookPath($path2)
+							)
+						);
+					}
 				}
 				return $result;
 			} else {
@@ -1315,7 +1317,7 @@ class View {
 		$maxLen = min(PHP_MAXPATHLEN, 4000);
 		// Check for the string length - performed using isset() instead of strlen()
 		// because isset() is about 5x-40x faster.
-		if(isset($path[$maxLen])) {
+		if (isset($path[$maxLen])) {
 			$pathLen = strlen($path);
 			throw new \OCP\Files\InvalidPathException("Path length($pathLen) exceeds max path length($maxLen): $path");
 		}
@@ -1351,7 +1353,7 @@ class View {
 	 * @return \OCP\Files\FileInfo
 	 */
 	private function getPartFileInfo($path) {
-		$mount  = $this->getMount($path);
+		$mount = $this->getMount($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($this->getAbsolutePath($path));
 		return new FileInfo(

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -80,7 +80,9 @@ class IntegrationTests extends \Test\TestCase {
 		$this->assertEquals('text/plain', $file->getMimeType());
 		$this->assertEquals('qwerty', $file->getContent());
 		$this->assertFalse($this->root->nodeExists('/bar.txt'));
-		$file->move('/bar.txt');
+		$target = $file->move('/bar.txt');
+		$this->assertEquals($id, $target->getId());
+		$this->assertEquals($id, $file->getId());
 		$this->assertFalse($this->root->nodeExists('/foo.txt'));
 		$this->assertTrue($this->root->nodeExists('/bar.txt'));
 		$this->assertEquals('bar.txt', $file->getName());


### PR DESCRIPTION
Prevent cache issues when using a non-default view (such as when using the node api)

cc @PVince81 @DeepDiver1975 @Raydiation 
