### PR TITLE
Fix node interface

### DIFF
--- a/lib/private/files/node/node.php
+++ b/lib/private/files/node/node.php
@@ -8,10 +8,9 @@
 
 namespace OC\Files\Node;
 
-use OCP\Files\FileInfo;
 use OCP\Files\NotPermittedException;
 
-class Node implements \OCP\Files\Node, FileInfo {
+class Node implements \OCP\Files\Node {
 	/**
 	 * @var \OC\Files\View $view
 	 */

--- a/lib/public/files/node.php
+++ b/lib/public/files/node.php
@@ -29,7 +29,7 @@
 // This means that they should be used by apps instead of the internal ownCloud classes
 namespace OCP\Files;
 
-interface Node {
+interface Node extends FileInfo {
 	/**
 	 * Move the file or folder to a new location
 	 *


### PR DESCRIPTION
Creating an interface for a node that does not implement all the methods makes it hard to impossible to create proper mocks for unit tests, also there will never be a node instance without the FileInfo interface.

Would be awesome if we could get this in for 8, otherwise unittests for the notes app wont work.

@icewind1991 @DeepDiver1975 @PVince81 @MorrisJobke 
