### PR TITLE
Prevent double slash in shareinfo request URL

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -194,7 +194,7 @@ class Storage extends DAV implements ISharedStorage {
 		$remote = $this->getRemote();
 		$token = $this->getToken();
 		$password = $this->getPassword();
-		$url = $remote . '/index.php/apps/files_sharing/shareinfo?t=' . $token;
+		$url = rtrim($remote, '/') . '/index.php/apps/files_sharing/shareinfo?t=' . $token;
 
 		$ch = curl_init();
 


### PR DESCRIPTION
Steps to reproduce:
1. Share a folder and type "user1@host/owncloud/" (with a trailing slash)
2. Accept the folder as user1
3. Navigate into it

Before this fix: "unexpected error", the resulting URL is: 'http://localhost/owncloud//index.php/apps/files_sharing/shareinfo?t=0MpaFg7snUrettb' (notice the double slash) and causes a 500 internal server error

After this fix: works

@schiesbn @icewind1991 @MorrisJobke @nickvergessen 
