### PR TITLE
Disable JS plugin for sharing in public mode

### DIFF
--- a/apps/files_sharing/ajax/list.php
+++ b/apps/files_sharing/ajax/list.php
@@ -64,7 +64,10 @@ $files = \OCA\Files\Helper::getFiles($dir, $sortAttribute, $sortDirection);
 $formattedFiles = array();
 foreach ($files as $file) {
 	$entry = \OCA\Files\Helper::formatFileInfo($file);
-	unset($entry['directory']); // for now
+	// for now
+	unset($entry['directory']);
+	// do not disclose share owner
+	unset($entry['shareOwner']);
 	$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 	$formattedFiles[] = $entry;
 }

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -25,7 +25,7 @@
 		 * @param {OCA.Files.FileList} fileList file list to be extended
 		 */
 		attach: function(fileList) {
-			if (fileList.id === 'trashbin') {
+			if (fileList.id === 'trashbin' || fileList.id === 'files.public') {
 				return;
 			}
 			var fileActions = fileList.fileActions;

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -27,7 +27,7 @@ describe('OCA.Sharing.Util tests', function() {
 		$('#testArea').append($content);
 		// dummy file list
 		var $div = $(
-			'<div>' +
+			'<div id="listContainer">' +
 			'<table id="filestable">' +
 			'<thead></thead>' +
 			'<tbody id="fileList"></tbody>' +
@@ -448,6 +448,30 @@ describe('OCA.Sharing.Util tests', function() {
 			];
 			expect(OCA.Sharing.Util.formatRecipients(recipients, 10))
 				.toEqual('User four, User one, User three, User two, +6');
+		});
+	});
+	describe('Excluded lists', function() {
+		function createListThenAttach(listId) {
+			var fileActions = new OCA.Files.FileActions();
+			fileList.destroy();
+			fileList = new OCA.Files.FileList(
+				$('#listContainer'), {
+					id: listId,
+					fileActions: fileActions
+				}
+			);
+			OCA.Sharing.Util.attach(fileList);
+			fileList.setFiles(testFiles);
+			return fileList;
+		}
+
+		it('does not attach to trashbin or public file lists', function() {
+			createListThenAttach('trashbin');
+			expect($('.action-share').length).toEqual(0);
+			expect($('[data-share-recipient]').length).toEqual(0);
+			createListThenAttach('files.public');
+			expect($('.action-share').length).toEqual(0);
+			expect($('[data-share-recipient]').length).toEqual(0);
 		});
 	});
 	


### PR DESCRIPTION
This removes the logic that registers the share action and modifies the
rows. Share actions aren't needed in the public file list.

Fixes https://github.com/owncloud/core/issues/13492 (requires https://github.com/owncloud/core/pull/13490 to be able to test the s2s case)
- [x] wait for https://github.com/owncloud/core/pull/13490 to be merged then rebase

@schiesbn
