### PR TITLE
Fix WebDAV put for single file shares

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -64,7 +64,7 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			throw new \Sabre\DAV\Exception\ServiceUnavailable("Encryption is disabled");
 		}
 
-		$fileName = basename($this->path);
+		$fileName = basename($this->info->getPath());
 		if (!\OCP\Util::isValidFileName($fileName)) {
 			throw new \Sabre\DAV\Exception\BadRequest();
 		}
@@ -74,8 +74,8 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			return $this->createFileChunked($data);
 		}
 
-		list($storage, ) = $this->fileView->resolvePath($this->path);
-		$needsPartFile = $this->needsPartFile($storage);
+		list($storage,) = $this->fileView->resolvePath($this->path);
+		$needsPartFile = $this->needsPartFile($storage) && (strlen($this->path) > 1);
 
 		if ($needsPartFile) {
 			// mark file as partial while uploading (ignored by the scanner)

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -293,7 +293,7 @@ class Filesystem {
 		}
 		$mount = self::$mounts->find($path);
 		if ($mount) {
-			return array($mount->getStorage(), $mount->getInternalPath($path));
+			return array($mount->getStorage(), rtrim($mount->getInternalPath($path), '/'));
 		} else {
 			return array(null, null);
 		}

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -32,6 +32,31 @@ class Test_OC_Connector_Sabre_File extends \Test\TestCase {
 		$file->put('test data');
 	}
 
+	public function testPutSingleFileShare() {
+		// setup
+		$storage = $this->getMock('\OCP\Files\Storage');
+		$view = $this->getMock('\OC\Files\View', array('file_put_contents', 'getRelativePath'), array());
+		$view->expects($this->any())
+			->method('resolvePath')
+			->with('')
+			->will($this->returnValue(array($storage, '')));
+		$view->expects($this->any())
+			->method('getRelativePath')
+			->will($this->returnValue(''));
+		$view->expects($this->any())
+			->method('file_put_contents')
+			->with('')
+			->will($this->returnValue(true));
+
+		$info = new \OC\Files\FileInfo('/foo.txt', null, null, array(
+			'permissions' => \OCP\Constants::PERMISSION_ALL
+		), null);
+
+		$file = new OC_Connector_Sabre_File($view, $info);
+
+		$this->assertNotEmpty($file->put('test data'));
+	}
+
 	/**
 	 * @expectedException \Sabre\DAV\Exception
 	 */

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -729,6 +729,22 @@ class View extends \Test\TestCase {
 		);
 	}
 
+	public function testFileView() {
+		$storage = new Temporary(array());
+		$scanner = $storage->getScanner();
+		$storage->file_put_contents('foo.txt', 'bar');
+		\OC\Files\Filesystem::mount($storage, array(), '/test/');
+		$scanner->scan('');
+		$view = new \OC\Files\View('/test/foo.txt');
+
+		$this->assertEquals('bar', $view->file_get_contents(''));
+		$fh = tmpfile();
+		fwrite($fh, 'foo');
+		rewind($fh);
+		$view->file_put_contents('', $fh);
+		$this->assertEquals('foo', $view->file_get_contents(''));
+	}
+
 	/**
 	 * @dataProvider tooLongPathDataProvider
 	 * @expectedException \OCP\Files\InvalidPathException


### PR DESCRIPTION
Fixes writing to single file public link s2s shares.
Note that atm it's not possible in the gui to create a single file public share with write permissions

To test:
- Share a single text file by link
- manually set the share permissions to `31` for the share in the database
- mount the public link as s2s share
- try to write to the file as share recipient

cc @PVince81 @DeepDiver1975 
