### PR TITLE
Use `file_exists` to verify that config file exists

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -166,7 +166,9 @@ class Config {
 		// Include file and merge config
 		foreach ($configFiles as $file) {
 			$filePointer = @fopen($file, 'r');
-			if($file === $this->configFilePath && $filePointer === false) {
+			if($file === $this->configFilePath &&
+				$filePointer === false &&
+				@!file_exists($this->configFilePath)) {
 				// Opening the main config might not be possible, e.g. if the wrong
 				// permissions are set (likely on a new installation)
 				continue;


### PR DESCRIPTION
There might be the case that `fopen($file, 'r')` returns false and thus ownCloud might believe that the config file is empty and thus potentially leading to an overwrite of the config file.

This changeset introduces `file_exists` again which was used in ownCloud 5-7 where no such problems where reported and should not be affected by such problems. This specific problem seem to have appeared when we switched the approach to this code path in stable7. (at some point of time)

Ref https://github.com/owncloud/core/issues/12785#issuecomment-71548720
