### PR TITLE
let init() take a ICollection or an INode - fixes PHP message

### DIFF
--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -35,11 +35,11 @@ class ObjectTree extends \Sabre\DAV\ObjectTree {
 	}
 
 	/**
-	 * @param \Sabre\DAV\ICollection $rootNode
+	 * @param \Sabre\DAV\INode $rootNode
 	 * @param \OC\Files\View $view
 	 * @param \OC\Files\Mount\Manager $mountManager
 	 */
-	public function init(\Sabre\DAV\ICollection $rootNode, \OC\Files\View $view, \OC\Files\Mount\Manager $mountManager) {
+	public function init(\Sabre\DAV\INode $rootNode, \OC\Files\View $view, \OC\Files\Mount\Manager $mountManager) {
 		$this->rootNode = $rootNode;
 		$this->fileView = $view;
 		$this->mountManager = $mountManager;


### PR DESCRIPTION
@PVince81 @icewind1991 

I'm getting this exception when testing a single file share:

``` json
{"reqId":"addc222aa7090ae5d973a26542350d57",
"remoteAddr":"::1",
"app":"PHP",
"message":"Argument 1 passed to OC\\Connector\\Sabre\\ObjectTree::init() must be an instance of Sabre\\DAV\\ICollection, instance of OC_Connector_Sabre_File given, called in \/home\/deepdiver\/Development\/ownCloud\/core\/apps\/files_sharing\/publicwebdav.php on line 67 and defined at \/home\/deepdiver\/Development\/ownCloud\/core\/lib\/private\/connector\/sabre\/objecttree.php#42",
"level":3,
"time":"2015-01-26T15:38:09+00:00",
"method":"PROPFIND",
"url":"\/public.php\/webdav\/"
}
```
