### PR TITLE
Indicate that the share owner is remote in the filelist

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -203,6 +203,9 @@ OC.Share={
 			tooltip += '@' + userDomain;
 		}
 		if (server) {
+			if (!userDomain) {
+				userDomain = '…';
+			}
 			tooltip += '@' + server;
 		}
 

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -702,17 +702,17 @@ describe('OC.Share tests', function() {
 			it('displays the user name part of a remote share owner', function() {
 				checkOwner(
 					'User One@someserver.com',
-					'User One',
+					'User One@…',
 					'User One@someserver.com'
 				);
 				checkOwner(
 					'User One@someserver.com/',
-					'User One',
+					'User One@…',
 					'User One@someserver.com'
 				);
 				checkOwner(
 					'User One@someserver.com/root/of/owncloud',
-					'User One',
+					'User One@…',
 					'User One@someserver.com'
 				);
 			});


### PR DESCRIPTION
Simple enough and improving UX quite a lot.
the remote domain is displayed on hover with tipsy

Fix #13571 

@jnfrmarks you reported this
@LukasReschke for the "social engineering attempt"
@jancborchardt for design approval
