### PR TITLE
extended blacklisting and whitelisting with wildcard and group rules support

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -880,6 +880,11 @@ $CONFIG = array(
     ),
 ),
 
+/* these blacklisted groups won't be proposed for sharing */
+'share_blacklisted_groups' => array(
+    'dontsharewithme'
+),
+
 
 );
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -856,3 +856,30 @@ $CONFIG = array(
 'secret' => 'ICertainlyShouldHaveChangedTheDefaultSecret',
 
 );
+
+/**
+ * Blacklist a specific file or files and disallow the upload of files
+ * with this name. ``.htaccess`` is blocked by default.
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ * Wildcards (*) are supported for file names.
+ */
+'blacklisted_files' => array(
+	'.htaccess', // default entry
+),
+
+'whitelisted_files' => array(
+),
+
+'groups_blacklisted_files' => array(
+	'admin' => array(
+	),
+),
+
+'groups_whitelisted_files' => array(
+    'admin' => array(
+    ),
+),
+
+
+);
+

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -257,6 +257,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					$usergroups = OC_Group::getUserGroups(OC_User::getUser());
 					$groups = array_intersect($groups, $usergroups);
 				}
+				// don't propose some blacklisted groups for sharing, e.g. if they are only used for rights management
+				$blacklist_groups = \OC_Config::getValue('share_blacklisted_groups', array());
+				$groups = array_diff($groups, $blacklist_groups);
 				$count = 0;
 				$users = array();
 				$limit = 0;


### PR DESCRIPTION
This extends configurable settings for blacklisting and whitelisting of allowed files.
- extended blacklisting (e.g. "*.exe")
- whitelisting (e.g. "owncloud_client.exe")
- group-based black-and whitelisting rules
