### PR TITLE
Prevent wrapping null storage

### DIFF
--- a/tests/lib/files/mount/mountpoint.php
+++ b/tests/lib/files/mount/mountpoint.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright (c) 2015 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Files\Mount;
+
+class MountPoint extends \Test\TestCase {
+
+	public function testGetStorage() {
+		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage->expects($this->once())
+			->method('getId')
+			->will($this->returnValue(123));
+
+		$loader = $this->getMock('\OCP\Files\Storage\IStorageFactory');
+		$loader->expects($this->once())
+			->method('getInstance')
+			->will($this->returnValue($storage));
+
+		$mountPoint = new \OC\Files\Mount\MountPoint(
+			// just use this because a real class is needed
+			'\Test\Files\Mount\MountPoint',
+			'/mountpoint',
+			null,
+			$loader
+		);
+
+		$this->assertEquals($storage, $mountPoint->getStorage());
+		$this->assertEquals(123, $mountPoint->getStorageId());
+	}
+
+	public function testInvalidStorage() {
+		$loader = $this->getMock('\OCP\Files\Storage\IStorageFactory');
+		$loader->expects($this->once())
+			->method('getInstance')
+			->will($this->throwException(new \Exception('Test storage init exception')));
+
+		$called = false;
+		$wrapper = function($mountPoint, $storage) use ($called) {
+			$called = true;
+		};
+
+		$mountPoint = new \OC\Files\Mount\MountPoint(
+			// just use this because a real class is needed
+			'\Test\Files\Mount\MountPoint',
+			'/mountpoint',
+			null,
+			$loader
+		);
+
+		$this->assertNull($mountPoint->getStorage());
+		// call it again to make sure the init code only ran once
+		$this->assertNull($mountPoint->getStorage());
+
+		$this->assertNull($mountPoint->getStorageId());
+
+		// wrapping doesn't fail
+		$mountPoint->wrapStorage($wrapper);
+
+		$this->assertNull($mountPoint->getStorage());
+
+		// storage wrapper never called
+		$this->assertFalse($called);
+	}
+}


### PR DESCRIPTION
Can happen when trying to instantiate external storages that have
incomplete config, where the constructor throws an exception (the
exception is caught in createStorage())

Please review @icewind1991 @Xenopathic 

If this approach is fine I'll add a unit test.

I suspect this could happen on stable7 if a third party app uses storage wrappers.
