### PR TITLE
Use proper namespace

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -65,7 +65,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getAppConfig();
 		});
 
-		$this->registerService('OCP\\IAppManager', function($c) {
+		$this->registerService('OCP\\App\\IAppManager', function($c) {
 			return $this->getServer()->getAppManager();
 		});
 


### PR DESCRIPTION
IAppManager lives in OCP\App and not in OCP.

Fixes https://github.com/owncloud/core/issues/13710

@Raydiation @MorrisJobke Please review. Couldn't find this used anywhere so we don't need to adjust it somewhere else.
