### PR TITLE
Write the parameter 'logtimezone' into config.php during setup

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -236,6 +236,11 @@ class OC_Setup {
 				self::protectDataDirectory();
 			}
 
+			//try to write logtimezone
+			if (date_default_timezone_get()) {
+				OC_Config::setValue('logtimezone', date_default_timezone_get());
+			}
+
 			//and we are done
 			OC_Config::setValue('installed', true);
 		}


### PR DESCRIPTION
This small PR tries to writes the timezone queried via `date_default_timezone_get()` to parameter `logtimezone` in `config.php` during the setup as pre last step before `installed = true`

Benefits:
- The timezone is properly set and any logs created have the right timestamp
- It is easier after setup to correct to the suitable timezone if necessary
- Or to identify that the php timezone queried is not properly set up in the corresponding php configuration
