### PR TITLE
Include primary groups in user and login filter when restricting group access and also fix user counting in primary groups

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -251,7 +251,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * returns a filter for a "users in primary group" search or count operation
 	 *
-	 * @param $groupDN
+	 * @param string $groupDN
 	 * @param string $search
 	 * @return string
 	 * @throws \Exception
@@ -281,7 +281,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return \string[]
+	 * @return string[]
 	 */
 	public function getUsersInPrimaryGroup($groupDN, $search = '', $limit = -1, $offset = 0) {
 		try {
@@ -300,7 +300,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * returns the number of users that have the given group as primary group
 	 *
-	 * @param $groupDN
+	 * @param string $groupDN
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -310,7 +310,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		try {
 			$filter = $this->prepareFilterForUsersInPrimaryGroup($groupDN, $search);
 			$users = $this->access->countUsers($filter, array('dn'), $limit, $offset);
-			return (is_int($users)) ? $users : 0;
+			return (int)$users;
 		} catch (\Exception $e) {
 			return 0;
 		}

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -444,6 +444,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!$this->groupExists($gid)) {
 			return array();
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$cacheKey = 'usersInGroup-'.$gid.'-'.$search.'-'.$limit.'-'.$offset;
 		// check for cache of the exact query
 		$groupUsers = $this->access->connection->getFromCache($cacheKey);
@@ -557,6 +558,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$this->access->connection->writeToCache($cacheKey, $groupUsers);
 			return $groupUsers;
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$isMemberUid =
 			(strtolower($this->access->connection->ldapGroupMemberAssocAttr)
 			=== 'memberuid');
@@ -663,6 +665,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!$this->enabled) {
 			return array();
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$pagingSize = $this->access->connection->ldapPagingSize;
 		if ((! $this->access->connection->hasPagedResultSupport)
 		   	|| empty($pagingSize)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -958,7 +958,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	/**
 	* escapes (user provided) parts for LDAP filter
 	* @param string $input, the provided value
-	* @param bool $allowAsterisk wether in * at the beginning should be preserved
+	* @param bool $allowAsterisk whether in * at the beginning should be preserved
 	* @return string the escaped string
 	*/
 	public function escapeFilterPart($input, $allowAsterisk = false) {

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -32,6 +32,7 @@ namespace OCA\user_ldap\lib;
  * @property boolean hasPagedResultSupport
  * @property string[] ldapBaseUsers
  * @property int|string ldapPagingSize holds an integer
+ * @property bool|mixed|void ldapGroupMemberAssocAttr
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -850,13 +850,23 @@ class Wizard extends LDAPUtility {
 						}
 						$base = $this->configuration->ldapBase[0];
 						foreach($cns as $cn) {
-							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn'));
+							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn', 'primaryGroupToken'));
 							if(!$this->ldap->isResource($rr)) {
 								continue;
 							}
 							$er = $this->ldap->firstEntry($cr, $rr);
+							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
-							$filter .= '(memberof=' . $dn . ')';
+							if(empty($dn)) {
+								continue;
+							}
+							$filterPart = '(memberof=' . $dn . ')';
+							if(isset($attrs['primaryGroupToken'])) {
+								$pgt = $attrs['primaryGroupToken'][0];
+								$primaryFilterPart = '(primaryGroupID=' . $pgt .')';
+								$filterPart = '(|' . $filterPart . $primaryFilterPart . ')';
+							}
+							$filter .= $filterPart;
 						}
 						$filter .= ')';
 					}

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -76,10 +76,15 @@ class Test_Group_Ldap extends \Test\TestCase {
 			->method('readAttribute')
 			->will($this->returnValue(array('u11', 'u22', 'u33', 'u34')));
 
+		// for primary groups
+		$access->expects($this->once())
+			->method('countUsers')
+			->will($this->returnValue(2));
+
 		$groupBackend = new GroupLDAP($access);
 		$users = $groupBackend->countUsersInGroup('group');
 
-		$this->assertSame(4, $users);
+		$this->assertSame(6, $users);
 	}
 
 	public function testCountWithSearchString() {


### PR DESCRIPTION
This is the continuation of https://github.com/owncloud/core/pull/12233 plus user counting fix.

How to test the fixed filter creation? See in the original PR https://github.com/owncloud/core/pull/12233

How to test the user counting? Now, that's a bit more tricky. Partly, I used this script for this: https://gist.github.com/blizzz/5747a97f9332c392a81c
1. have an LDAP configuration towards and AD
2. run this script like `sudo -u www-data ./primGrGetUsers.php "cn=domain users,cn=users,dc=owncloud1,dc=com" s08`  (replace group DN and config prefix accordingly)
3. check whether the output makes sense. My successful looks like this:

user list:
  Alicia(cn=alicia…
  and…
  many…
  more…
  users…
Number of users: 27 took: 1.307079076767
Number of users (counted): 27 took: 0.51463603973389

user list 's…':
  Sergey…
  and…
  3other…
  users…
Number of users with 's…': 4 took: 0.50409507751465
Number of users with 's…' (counted): 4 took: 0.50409507751465
4. Because this is not enough, go to the user management. The number next to the group you are checking should equal the number of users who have this group as primay plus number of users who are members of this as ordinary group
5. You should check the filter now, too. Unfortunately it looks like the filter result numbers for the groups are not updated (in master). However, they are retrieved correctly, you can check with the developer console, network tab and response bodies being logged.

This fixes #12190 and #13533 

request for testing and reviews :) @craigpg @sbelov1 @bboule @MorrisJobke
