### PR TITLE
fix LDAP update routine to OC 7

### DIFF
--- a/apps/user_ldap/appinfo/update.php
+++ b/apps/user_ldap/appinfo/update.php
@@ -20,7 +20,7 @@ foreach($configPrefixes as $config) {
 		'user_ldap', $config.'ldap_uuid_user_attribute', 'not existing');
 	if($state === 'non existing') {
 		$value = \OCP\Config::getAppValue(
-			'user_ldap', $config.'ldap_uuid_attribute', '');
+			'user_ldap', $config.'ldap_uuid_attribute', 'auto');
 		\OCP\Config::setAppValue(
 			'user_ldap', $config.'ldap_uuid_user_attribute', $value);
 		\OCP\Config::setAppValue(


### PR DESCRIPTION
Supposed to fix https://github.com/owncloud/core/issues/12035 and #12801 

Please review and test @butonic @MorrisJobke @PVince81 @jcfischer @fleish

(sidenote: for OC 8 the whole update.php can be dropped imho, as there where no relevant changed. will test and do a PR later).
