### PR TITLE
ignore trailing slash for remote URL

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -706,6 +706,7 @@ class Share extends \OC\Share\Constants {
 			$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(self::TOKEN_LENGTH, \OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
 				\OCP\Security\ISecureRandom::CHAR_DIGITS);
 
+			$shareWith = rtrim($shareWith, '/');
 			$shareId = self::put($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, null, $token, $itemSourceName);
 
 			$send = false;


### PR DESCRIPTION
ignore trailing slashes if the user enters a remote URL to the share drop-down

Problem mentioned here: https://github.com/owncloud/core/issues/13678#issuecomment-71640906

cc @LukasReschke 
