### PR TITLE
Close cursor for appframework and manipulation queries if applicable

### DIFF
--- a/lib/private/db/statementwrapper.php
+++ b/lib/private/db/statementwrapper.php
@@ -69,6 +69,7 @@ class OC_DB_StatementWrapper {
 			return false;
 		}
 		if ($this->isManipulation) {
+			$this->statement->closeCursor();
 			return $this->statement->rowCount();
 		} else {
 			return $this;

--- a/tests/lib/appframework/db/mappertest.php
+++ b/tests/lib/appframework/db/mappertest.php
@@ -74,7 +74,7 @@ class MapperTest extends MapperTestUtility {
 		$rows = array(
 			array('hi')
 		);
-		$this->setMapperResult($sql, $params, $rows);		
+		$this->setMapperResult($sql, $params, $rows);
 		$this->mapper->find($sql, $params);
 	}
 
@@ -84,7 +84,7 @@ class MapperTest extends MapperTestUtility {
 		$rows = array(
 			array('pre_name' => 'hi')
 		);
-		$this->setMapperResult($sql, $params, $rows);
+		$this->setMapperResult($sql, $params, $rows, null, null, true);
 		$this->mapper->findOneEntity($sql, $params);
 	}
 
@@ -92,7 +92,7 @@ class MapperTest extends MapperTestUtility {
 		$sql = 'hi';
 		$params = array('jo');
 		$rows = array();
-		$this->setMapperResult($sql, $params, $rows);		
+		$this->setMapperResult($sql, $params, $rows);
 		$this->setExpectedException(
 			'\OCP\AppFramework\Db\DoesNotExistException');
 		$this->mapper->find($sql, $params);
@@ -102,7 +102,7 @@ class MapperTest extends MapperTestUtility {
 		$sql = 'hi';
 		$params = array('jo');
 		$rows = array();
-		$this->setMapperResult($sql, $params, $rows);
+		$this->setMapperResult($sql, $params, $rows, null, null, true);
 		$this->setExpectedException(
 			'\OCP\AppFramework\Db\DoesNotExistException');
 		$this->mapper->findOneEntity($sql, $params);
@@ -114,7 +114,7 @@ class MapperTest extends MapperTestUtility {
 		$rows = array(
 			array('jo'), array('ho')
 		);
-		$this->setMapperResult($sql, $params, $rows);
+		$this->setMapperResult($sql, $params, $rows, null, null, true);
 		$this->setExpectedException(
 			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
 		$this->mapper->find($sql, $params);
@@ -126,7 +126,7 @@ class MapperTest extends MapperTestUtility {
 		$rows = array(
 			array('jo'), array('ho')
 		);
-		$this->setMapperResult($sql, $params, $rows);
+		$this->setMapperResult($sql, $params, $rows, null, null, true);
 		$this->setExpectedException(
 			'\OCP\AppFramework\Db\MultipleObjectsReturnedException');
 		$this->mapper->findOneEntity($sql, $params);
@@ -249,7 +249,7 @@ class MapperTest extends MapperTestUtility {
 		$entity = new Example();
 		$entity->setPreName('hi');
 		$entity->resetUpdatedFields();
-		$this->setMapperResult($sql, array(), $rows);
+		$this->setMapperResult($sql, array(), $rows, null, null, true);
 		$result = $this->mapper->findAllEntities($sql);
 		$this->assertEquals(array($entity), $result);
 	}

--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -36,7 +36,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 	private $prepareAt;
 	private $fetchAt;
 	private $iterators;
-	
+
 
 	/**
 	 * Run this function before the actual test to either set or initialize the
@@ -51,7 +51,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 			->getMock();
 
 		$this->query = $this->getMock('Query', array('execute', 'bindValue'));
-		$this->pdoResult = $this->getMock('Result', array('fetch'));
+		$this->pdoResult = $this->getMock('Result', array('fetch', 'closeCursor'));
 		$this->queryAt = 0;
 		$this->prepareAt = 0;
 		$this->iterators = array();
@@ -90,7 +90,8 @@ abstract class MapperTestUtility extends \Test\TestCase {
 					return $result;
 			  	}
 			));
-
+		$this->pdoResult->expects($this->any())
+			->method('closeCursor');
 		$index = 1;
 		foreach($arguments as $argument) {
 			switch (gettype($argument)) {
@@ -105,7 +106,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 				case 'boolean':
 					$pdoConstant = \PDO::PARAM_BOOL;
 					break;
-				
+
 				default:
 					$pdoConstant = \PDO::PARAM_STR;
 					break;
@@ -138,14 +139,14 @@ abstract class MapperTestUtility extends \Test\TestCase {
 		} elseif($limit === null && $offset !== null) {
 			$this->db->expects($this->at($this->prepareAt))
 				->method('prepareQuery')
-				->with($this->equalTo($sql), 
+				->with($this->equalTo($sql),
 					$this->equalTo(null),
 					$this->equalTo($offset))
 				->will(($this->returnValue($this->query)));
 		} else  {
 			$this->db->expects($this->at($this->prepareAt))
 				->method('prepareQuery')
-				->with($this->equalTo($sql), 
+				->with($this->equalTo($sql),
 					$this->equalTo($limit),
 					$this->equalTo($offset))
 				->will(($this->returnValue($this->query)));
@@ -162,11 +163,11 @@ abstract class MapperTestUtility extends \Test\TestCase {
 class ArgumentIterator {
 
 	private $arguments;
-	
+
 	public function __construct($arguments){
 		$this->arguments = $arguments;
 	}
-	
+
 	public function next(){
 		$result = array_shift($this->arguments);
 		if($result === null){

--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -69,7 +69,7 @@ abstract class MapperTestUtility extends \Test\TestCase {
 	 * will be called on the result
 	 */
 	protected function setMapperResult($sql, $arguments=array(), $returnRows=array(),
-		$limit=null, $offset=null){
+		$limit=null, $offset=null, $expectClose=false){
 
 		$this->iterators[] = new ArgumentIterator($returnRows);
 
@@ -90,8 +90,14 @@ abstract class MapperTestUtility extends \Test\TestCase {
 					return $result;
 			  	}
 			));
-		$this->pdoResult->expects($this->any())
-			->method('closeCursor');
+		if ($expectClose) {
+            $closing = $this->once();
+        } else {
+            $closing = $this->any();
+        }
+        $this->pdoResult->expects($closing)
+            ->method('closeCursor');
+
 		$index = 1;
 		foreach($arguments as $argument) {
 			switch (gettype($argument)) {

--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -88,15 +88,14 @@ abstract class MapperTestUtility extends \Test\TestCase {
 					}
 
 					return $result;
-			  	}
+				}
 			));
 		if ($expectClose) {
-            $closing = $this->once();
-        } else {
-            $closing = $this->any();
-        }
-        $this->pdoResult->expects($closing)
-            ->method('closeCursor');
+			$closing = $this->once();
+		} else {
+			$closing = $this->any();
+		}
+		$this->pdoResult->expects($closing)->method('closeCursor');
 
 		$index = 1;
 		foreach($arguments as $argument) {


### PR DESCRIPTION
See #10566

Automatically close the cursor for findEntity, findEntities, update, insert and delete queries

The only thing where this has to be done manually is when you run an execute and fetch manually which is almost never the use case

@PVince81 @oparoz @MorrisJobke @DeepDiver1975 @butonic 
