### PR TITLE
Additional controllermethodreflector inheritance tests

### DIFF
--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -37,6 +37,11 @@ class BaseController {
 	 */
 	public function test2(){}
 
+	/**
+	 * @Annotation
+	 */
+	public function test3(){}
+
 }
 
 class MiddleController extends BaseController {
@@ -45,6 +50,8 @@ class MiddleController extends BaseController {
 	 * @NoAnnotation
 	 */
 	public function test2() {}
+
+	public function test3() {}
 
 }
 
@@ -153,5 +160,12 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$this->assertFalse($reader->hasAnnotation('Annotation'));
 	}
 
+
+	public function testInheritanceOverrideNoDocblock() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect('OC\AppFramework\Utility\EndController', 'test3');
+
+		$this->assertFalse($reader->hasAnnotation('Annotation'));
+	}
 
 }

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -25,6 +25,31 @@
 namespace OC\AppFramework\Utility;
 
 
+class BaseController {
+
+	/**
+	 * @Annotation
+	 */
+	public function test(){}
+
+	/**
+	 * @Annotation
+	 */
+	public function test2(){}
+
+}
+
+class MiddleController extends BaseController {
+
+	/**
+	 * @NoAnnotation
+	 */
+	public function test2() {}
+
+}
+
+class EndController extends MiddleController {}
+
 class ControllerMethodReflectorTest extends \Test\TestCase {
 
 
@@ -96,7 +121,7 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 			'arguments'
 		);
 
-		$this->assertEquals(array('arg' => null, 'arg2' => 'hi'), $reader->getParameters());	
+		$this->assertEquals(array('arg' => null, 'arg2' => 'hi'), $reader->getParameters());
 	}
 
 
@@ -108,7 +133,24 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 			'arguments2'
 		);
 
-		$this->assertEquals(array('arg' => null), $reader->getParameters());	
+		$this->assertEquals(array('arg' => null), $reader->getParameters());
+	}
+
+
+	public function testInheritance() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect('OC\AppFramework\Utility\EndController', 'test');
+
+		$this->assertTrue($reader->hasAnnotation('Annotation'));
+	}
+
+
+	public function testInheritanceOverride() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect('OC\AppFramework\Utility\EndController', 'test2');
+
+		$this->assertTrue($reader->hasAnnotation('NoAnnotation'));
+		$this->assertFalse($reader->hasAnnotation('Annotation'));
 	}
 
 


### PR DESCRIPTION
Adds additional tests that show that annotations for controller methods are inherited correctly. Initially I wanted to add the feature only to find out that it already works xD

This makes it possible for instance to directly inherit from an internal controller when creating an API controller and only override the methods where the results differ. Basically inheritance. With working annotations support :)
