### PR TITLE
Grammar: Replacing adjective "public" by attribute "publicly"

### DIFF
--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -44,7 +44,7 @@ class Activity implements \OCP\Activity\IExtension {
 		$l = \OC::$server->getL10N('files_sharing', $languageCode);
 		return array(
 			self::TYPE_REMOTE_SHARE => $l->t('A file or folder was shared from <strong>another server</strong>'),
-			self::TYPE_PUBLIC_LINKS => $l->t('A public shared file or folder was <strong>downloaded</strong>'),
+			self::TYPE_PUBLIC_LINKS => $l->t('A publicly shared file or folder was <strong>downloaded</strong>'),
 		);
 	}
 


### PR DESCRIPTION
Small detail, but according to my understanding, we're talking about a file which has been public_ly_ shared rather than about a _public_ file which has been shared.
