### PR TITLE
Fix subadmin listing of group

### DIFF
--- a/settings/application.php
+++ b/settings/application.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author Lukas Reschke
- * @copyright 2014 Lukas Reschke lukas@owncloud.com
+ * @copyright 2014-2015 Lukas Reschke lukas@owncloud.com
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later.
@@ -91,7 +91,8 @@ class Application extends App {
 				$c->query('Mail'),
 				$c->query('DefaultMailAddress'),
 				$c->query('URLGenerator'),
-				$c->query('OCP\\App\\IAppManager')
+				$c->query('OCP\\App\\IAppManager'),
+				$c->query('SubAdminOfGroups')
 			);
 		});
 		$container->registerService('LogSettingsController', function(IContainer $c) {
@@ -144,6 +145,10 @@ class Application extends App {
 		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
 		$container->registerService('IsSubAdmin', function(IContainer $c) {
 			return \OC_Subadmin::isSubAdmin(\OC_User::getUser());
+		});
+		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
+		$container->registerService('SubAdminOfGroups', function(IContainer $c) {
+			return \OC_SubAdmin::getSubAdminsGroups(\OC_User::getUser());
 		});
 		$container->registerService('Mail', function(IContainer $c) {
 			return new \OC_Mail;

--- a/settings/application.php
+++ b/settings/application.php
@@ -16,6 +16,7 @@ use OC\Settings\Controller\LogSettingsController;
 use OC\Settings\Controller\MailSettingsController;
 use OC\Settings\Controller\SecuritySettingsController;
 use OC\Settings\Controller\UsersController;
+use OC\Settings\Factory\SubAdminFactory;
 use OC\Settings\Middleware\SubadminMiddleware;
 use \OCP\AppFramework\App;
 use OCP\IContainer;
@@ -92,7 +93,7 @@ class Application extends App {
 				$c->query('DefaultMailAddress'),
 				$c->query('URLGenerator'),
 				$c->query('OCP\\App\\IAppManager'),
-				$c->query('SubAdminOfGroups')
+				$c->query('SubAdminFactory')
 			);
 		});
 		$container->registerService('LogSettingsController', function(IContainer $c) {
@@ -147,8 +148,8 @@ class Application extends App {
 			return \OC_Subadmin::isSubAdmin(\OC_User::getUser());
 		});
 		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
-		$container->registerService('SubAdminOfGroups', function(IContainer $c) {
-			return \OC_SubAdmin::getSubAdminsGroups(\OC_User::getUser());
+		$container->registerService('SubAdminFactory', function(IContainer $c) {
+			return new SubAdminFactory();
 		});
 		$container->registerService('Mail', function(IContainer $c) {
 			return new \OC_Mail;

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -273,16 +273,16 @@ class UsersController extends Controller {
 		}
 
 		if (!$this->isAdmin) {
-			$uid = $this->userSession->getUser()->getUID();
+			$userId = $this->userSession->getUser()->getUID();
 			if (!empty($groups)) {
 				foreach ($groups as $key => $group) {
-					if (!$this->subAdminFactory->isGroupAccessible($uid, $group)) {
+					if (!$this->subAdminFactory->isGroupAccessible($userId, $group)) {
 						unset($groups[$key]);
 					}
 				}
 			}
 			if (empty($groups)) {
-				$groups = $this->subAdminFactory->getSubAdminsOfGroups($uid);
+				$groups = $this->subAdminFactory->getSubAdminsOfGroups($userId);
 			}
 		}
 
@@ -367,8 +367,8 @@ class UsersController extends Controller {
 	 * @return DataResponse
 	 */
 	public function destroy($id) {
-		$UserId = $this->userSession->getUser()->getUID();
-		if($UserId === $id) {
+		$userId = $this->userSession->getUser()->getUID();
+		if($userId === $id) {
 			return new DataResponse(
 				array(
 					'status' => 'error',
@@ -380,7 +380,7 @@ class UsersController extends Controller {
 			);
 		}
 
-		if(!$this->isAdmin && !$this->subAdminFactory->isUserAccessible($UserId, $id)) {
+		if(!$this->isAdmin && !$this->subAdminFactory->isUserAccessible($userId, $id)) {
 			return new DataResponse(
 				array(
 					'status' => 'error',
@@ -429,11 +429,10 @@ class UsersController extends Controller {
 	 * @return DataResponse
 	 */
 	public function setMailAddress($id, $mailAddress) {
-		$UserId = $this->userSession->getUser()->getUID();
-		// FIXME: Remove this static function call at some point…
-		if($this->userSession->getUser()->getUID() !== $id
+		$userId = $this->userSession->getUser()->getUID();
+		if($userId !== $id
 			&& !$this->isAdmin
-			&& !$this->subAdminFactory->isUserAccessible($UserId, $id)) {
+			&& !$this->subAdminFactory->isUserAccessible($userId, $id)) {
 			return new DataResponse(
 				array(
 					'status' => 'error',

--- a/settings/factory/subadminfactory.php
+++ b/settings/factory/subadminfactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Lukas Reschke
+ * @copyright 2015 Lukas Reschke lukas@owncloud.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Settings\Factory;
+
+/**
+ * @package OC\Settings\Factory
+ */
+class SubAdminFactory {
+	/**
+	 * Get the groups $uid is SubAdmin of
+	 * @param string $uid
+	 * @return array Array of groups that $uid is subadmin of
+	 */
+	function getSubAdminsOfGroups($uid) {
+		return \OC_SubAdmin::getSubAdminsGroups($uid);
+	}
+
+	/**
+	 * Whether the $group is accessible to $uid as subadmin
+	 * @param string $uid
+	 * @param string $group
+	 * @return bool
+	 */
+	function isGroupAccessible($uid, $group) {
+		return \OC_SubAdmin::isGroupAccessible($uid, $group);
+	}
+
+	/**
+	 * Whether $uid is accessible to $subAdmin
+	 * @param string $subAdmin
+	 * @param string $uid
+	 * @return bool
+	 */
+	function isUserAccessible($subAdmin, $uid) {
+		return \OC_SubAdmin::isUserAccessible($subAdmin, $uid);
+	}
+}

--- a/tests/settings/controller/logsettingscontrollertest.php
+++ b/tests/settings/controller/logsettingscontrollertest.php
@@ -10,6 +10,7 @@
 namespace Test\Settings\Controller;
 
 use \OC\Settings\Application;
+use OC\Settings\Controller\LogSettingsController;
 
 /**
  * @package OC\Settings\Controller


### PR DESCRIPTION
Without this patch filtering for the "_everyone" (empty) group did not work for subadmins.

Fixes itself. – ~~Not really testable due to static OC_Subadmin stuff :see_no_evil:~~

@MorrisJobke As discussed.
