### PR TITLE
make sure that we get the correct user from the path

### DIFF
--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -293,8 +293,8 @@ class Helper {
 	public static function getUserFromPath($path) {
 		$split = self::splitPath($path);
 
-		if (count($split) > 3 && (
-			$split[2] === 'files' || $split[2] === 'files_versions' || $split[2] === 'cache')) {
+		if (count($split) > 2 && (
+			$split[2] === 'files' || $split[2] === 'files_versions' || $split[2] === 'cache' || $split[2] === 'files_trashbin')) {
 
 			$user = $split[1];
 

--- a/apps/files_encryption/tests/helper.php
+++ b/apps/files_encryption/tests/helper.php
@@ -219,6 +219,7 @@ class TestHelper extends TestCase {
 		return array(
 			array('/' . self::TEST_ENCRYPTION_HELPER_USER1 . '/files/foo.txt', self::TEST_ENCRYPTION_HELPER_USER1),
 			array('//' . self::TEST_ENCRYPTION_HELPER_USER2 . '/files_versions/foo.txt', self::TEST_ENCRYPTION_HELPER_USER2),
+			array('/' . self::TEST_ENCRYPTION_HELPER_USER1 . '/files_trashbin/', self::TEST_ENCRYPTION_HELPER_USER1),
 			array(self::TEST_ENCRYPTION_HELPER_USER1 . '//cache/foo/bar.txt', self::TEST_ENCRYPTION_HELPER_USER1),
 		);
 	}

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -152,7 +152,6 @@ class Trashbin {
 
 		self::setUpTrash($user);
 
-		$view = new \OC\Files\View('/' . $user);
 		$path_parts = pathinfo($file_path);
 
 		$filename = $path_parts['basename'];


### PR DESCRIPTION
In case of a remote share no user will be logged in if a file gets deleted/moved. To be able to get the correct size we need to get the user from the path. Otherwise deleting and moving files in remote shared folders will not work.

fix #13758
