### PR TITLE
Revert "Close cursor early in calculateFolderSize" for now

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -540,7 +540,6 @@ class Cache {
 				'WHERE `parent` = ? AND `storage` = ?';
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
-				$result->closeCursor();
 				list($sum, $min, $unencryptedSum) = array_values($row);
 				$sum = 0 + $sum;
 				$min = 0 + $min;
@@ -563,8 +562,6 @@ class Cache {
 				if ($totalSize !== -1 and $unencryptedSum > 0) {
 					$totalSize = $unencryptedSum;
 				}
-			} else {
-				$result->closeCursor();
 			}
 		}
 		return $totalSize;

--- a/lib/private/files/cache/homecache.php
+++ b/lib/private/files/cache/homecache.php
@@ -35,7 +35,6 @@ class HomeCache extends Cache {
 				'WHERE `parent` = ? AND `storage` = ? AND `size` >= 0';
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
-				$result->closeCursor();
 				list($sum, $unencryptedSum) = array_values($row);
 				$totalSize = 0 + $sum;
 				$unencryptedSize = 0 + $unencryptedSum;


### PR DESCRIPTION
This reverts commit 234f33e01e630f763f34c51114d25986bae02b42.

Fix #13788

@PVince81 @DeepDiver1975 @MorrisJobke 
