### PR TITLE
Properly show the warning about the missing composer autoloader

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -478,7 +478,10 @@ class OC {
 			require_once $vendorAutoLoad;
 		} else {
 			OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
-			OC_Template::printErrorPage('Composer autoloader not found, unable to continue.');
+			// we can't use the template error page here, because this needs the
+			// DI container which isn't available yet
+			print('Composer autoloader not found, unable to continue. Check the folder "3rdparty".');
+			exit();
 		}
 
 		// setup the basic server


### PR DESCRIPTION
fixes #13808 

cc @DeepDiver1975 @LukasReschke 

Steps to reproduce:
- `rm 3rdparty/autoload.php`
