### PR TITLE
Initialize SSL enforcement before starting session

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -538,13 +538,13 @@ class OC {
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
 		OC_App::loadApps(array('session'));
 		if (!self::$CLI) {
+			self::checkSSL();
 			self::initSession();
 		}
 		\OC::$server->getEventLogger()->end('init_session');
 		self::initTemplateEngine();
 		self::checkConfig();
 		self::checkInstalled();
-		self::checkSSL();
 		OC_Response::addSecurityHeaders();
 
 		$errors = OC_Util::checkServer(\OC::$server->getConfig());


### PR DESCRIPTION
Otherwise not logged-in users will receive a cookie that is not set to secure. However, this is not really relevant since the cookie does not contain any sensitive information at this time.

However, it's nice to have since some automated security scanners will report this as security bug _sigh_

Fixes https://github.com/owncloud/core/issues/13821
