### PR TITLE
Don't encode url unecessary twice

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -818,8 +818,7 @@ class OC_Util {
 			$parameters['user_autofocus'] = true;
 		}
 		if (isset($_REQUEST['redirect_url'])) {
-			$redirectUrl = $_REQUEST['redirect_url'];
-			$parameters['redirect_url'] = urlencode($redirectUrl);
+			$parameters['redirect_url'] = $_REQUEST['redirect_url'];
 		}
 
 		$parameters['alt_login'] = OC_App::getAlternativeLogIns();


### PR DESCRIPTION
The URL was previously encoded twice which leads to getting redirected to a 404 page when the password has been entered incorrect at least once.

Testplan:
- [ ] Opening `http://localhost/core/index.php?redirect_url=%2Fcore%2Findex.php%2Fsettings%2Fadmin` redirects to the admin page when providing the correct credentials
- [ ] Opening `http://localhost/core/index.php?redirect_url=%2Fcore%2Findex.php%2Fsettings%2Fadmin` redirects to the admin page when providing the invalid credentials and then providing valid ones.
- [ ] Logging in as admin then going to the admin page and clearing the cookies and refreshing will show the login and when repeating the above test steps you're redirected correctly.

Fixes https://github.com/owncloud/core/issues/9804
