### PR TITLE
[stable7] Close cursor early in calculateFolderSize

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -540,6 +540,7 @@ class Cache {
 				'WHERE `parent` = ? AND `storage` = ?';
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
+				$result->closeCursor();
 				list($sum, $min, $unencryptedSum) = array_values($row);
 				$sum = 0 + $sum;
 				$min = 0 + $min;
@@ -562,6 +563,8 @@ class Cache {
 				if ($totalSize !== -1 and $unencryptedSum > 0) {
 					$totalSize = $unencryptedSum;
 				}
+			} else {
+				$result->closeCursor();
 			}
 		}
 		return $totalSize;

--- a/lib/private/files/cache/homecache.php
+++ b/lib/private/files/cache/homecache.php
@@ -35,6 +35,7 @@ class HomeCache extends Cache {
 				'WHERE `parent` = ? AND `storage` = ? AND `size` >= 0';
 			$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
 			if ($row = $result->fetchRow()) {
+				$result->closeCursor();
 				list($sum, $unencryptedSum) = array_values($row);
 				$totalSize = 0 + $sum;
 				$unencryptedSize = 0 + $unencryptedSum;


### PR DESCRIPTION
This method triggers additional queries in $this->update() so to avoid
potential database locks or delays, we close the cursor as soon as it is not needed any more

This is the backport that will fail with Oracle (which we reverted here #13803)
- [ ] fix Oracle unit test issues
