### PR TITLE
Dont update the cache when working with part files

### DIFF
--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -31,6 +31,9 @@ class Updater {
 	}
 
 	public function propagate($path, $time = null) {
+		if (Scanner::isPartialFile($path)) {
+			return;
+		}
 		$this->propagator->addChange($path);
 		$this->propagator->propagateChanges($time);
 	}
@@ -42,6 +45,9 @@ class Updater {
 	 * @param int $time
 	 */
 	public function update($path, $time = null) {
+		if(Scanner::isPartialFile($path)) {
+			return;
+		}
 		/**
 		 * @var \OC\Files\Storage\Storage $storage
 		 * @var string $internalPath
@@ -64,6 +70,9 @@ class Updater {
 	 * @param string $path
 	 */
 	public function remove($path) {
+		if (Scanner::isPartialFile($path)) {
+			return;
+		}
 		/**
 		 * @var \OC\Files\Storage\Storage $storage
 		 * @var string $internalPath
@@ -88,6 +97,9 @@ class Updater {
 	 * @param string $target
 	 */
 	public function rename($source, $target) {
+		if (Scanner::isPartialFile($source) or Scanner::isPartialFile($target)) {
+			return;
+		}
 		/**
 		 * @var \OC\Files\Storage\Storage $sourceStorage
 		 * @var \OC\Files\Storage\Storage $targetStorage

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -811,7 +811,7 @@ class View {
 				if (in_array('delete', $hooks) and $result) {
 					$this->updater->remove($path);
 				}
-				if (in_array('write', $hooks)) {
+				if (in_array('write', $hooks) and $operation !== 'fopen') {
 					$this->updater->update($path);
 				}
 				if (in_array('touch', $hooks)) {


### PR DESCRIPTION
The actually write to the cache is already not done for the part files but atm it still trigers things like the change propagator.

Also includes a fix to not update the cache after an fopen (since the file isn't changed until the handle is actually used)

Combined it saves 14 queries when doing a WebDAV PUT in my instance ([comparison](https://blackfire.io/profiles/compare/d13115f3-1e4f-4359-8f6e-bbbab1502cdd/graph))

cc @DeepDiver1975 @PVince81 
