### PR TITLE
Add callCheck to testremote.php

### DIFF
--- a/apps/files_sharing/ajax/testremote.php
+++ b/apps/files_sharing/ajax/testremote.php
@@ -6,6 +6,7 @@
  * See the COPYING-README file.
  */
 
+OCP\JSON::callCheck();
 OCP\JSON::checkAppEnabled('files_sharing');
 
 $remote = $_GET['remote'];


### PR DESCRIPTION
Without CSRF check this file might be tricked into requesting itself which would result in an endless loop and thus potentially ending in a Denial of Service.

IMHO not that severe to warrant a backport to 7.

@nickvergessen As discussed.
