### PR TITLE
When sharing a link via e-mail set users e-mail as sender

### DIFF
--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -61,6 +61,7 @@ class MailNotifications {
 			$this->from = \OCP\Config::getUserValue($this->senderId, 'settings', 'email', $this->from);
 			$this->senderDisplayName = \OCP\User::getDisplayName($this->senderId);
 		} else {
+			$this->from = \OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', $this->from);
 			$this->senderDisplayName = \OCP\User::getDisplayName();
 		}
 	}


### PR DESCRIPTION
When sharing a link via e-mail from the webinterface use the users e-mail adress (if it is set). This fixes #10545
