### PR TITLE
Add a better way to check if an avatar exists for the user

### DIFF
--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -43,6 +43,15 @@ class OC_Avatar implements \OCP\IAvatar {
 	}
 
 	/**
+	 * Check if an avatar exists for the user
+	 *
+	 * @return bool
+	 */
+	public function exists() {
+		return $this->view->file_exists('avatar.jpg') || $this->view->file_exists('avatar.png');
+	}
+
+	/**
 	 * sets the users avatar
 	 * @param \OC_Image|resource|string $data OC_Image, imagedata or path to set a new avatar
 	 * @throws Exception if the provided file is not a jpg or png image

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -288,12 +288,7 @@ class OC_Helper {
 	**/
 	public static function userAvatarSet($user) {
 		$avatar = new \OC_Avatar($user);
-		$image = $avatar->get(1);
-		if ($image instanceof \OC_Image) {
-			return true;
-		} else {
-			return false;
-		}
+		return $avatar->exists();
 	}
 
 	/**

--- a/lib/public/iavatar.php
+++ b/lib/public/iavatar.php
@@ -21,6 +21,13 @@ interface IAvatar {
 	function get($size = 64);
 
 	/**
+	 * Check if an avatar exists for the user
+	 *
+	 * @return bool
+	 */
+	public function exists();
+
+	/**
 	 * sets the users avatar
 	 * @param Image $data mixed imagedata or path to set a new avatar
 	 * @throws \Exception if the provided file is not a jpg or png image


### PR DESCRIPTION
The old approach required loading the avatar.

Saves having to decode and resize the image only to throw the result away.

[comparison](https://blackfire.io/profiles/compare/4ac57077-4ebf-4d55-a5bb-5c1f586cc468/graph)

cc @DeepDiver1975 @PVince81 @Kondou-ger 
