### PR TITLE
Avatars in share dialog

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -68,6 +68,12 @@
 	overflow: hidden;
 	vertical-align: middle;
 }
+#shareWithList .avatar {
+	margin-right: 2px;
+	display: inline-block;
+	overflow: hidden;
+	vertical-align: middle;
+}
 #shareWithList li label{
 	margin-right: 8px;
 }

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -74,6 +74,7 @@ $array = array(
 			'session_keepalive'	=> \OCP\Config::getSystemValue('session_keepalive', true),
 			'version'			=> implode('.', OC_Util::getVersion()),
 			'versionstring'		=> OC_Util::getVersionString(),
+			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true),
 		)
 	),
 	"oc_appconfig" => json_encode(

--- a/core/js/core.json
+++ b/core/js/core.json
@@ -9,7 +9,8 @@
 	],
 	"libraries": [
 		"jquery-showpassword.js",
-		"jquery-tipsy.js"
+		"jquery-tipsy.js",
+		"jquery.avatar.js"
 	],
 	"modules": [
 		"compatibility.js",

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -656,7 +656,7 @@ OC.Share={
 			var html = '<li style="clear: both;" data-share-type="'+escapeHTML(shareType)+'" data-share-with="'+escapeHTML(shareWith)+'" title="' + escapeHTML(shareWith) + '">';
 			var showCrudsButton;
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
-			if (shareType == OC.Share.SHARE_TYPE_USER) {
+			if (shareType === OC.Share.SHARE_TYPE_USER) {
 				html += '<div id="avatar-' + escapeHTML(shareWith) + '" class="avatar"></div>';
 			} else {
 				html += '<div class="avatar" style="padding-right: 32px"></div>';
@@ -692,7 +692,7 @@ OC.Share={
 			html += '</div>';
 			html += '</li>';
 			html = $(html).appendTo('#shareWithList');
-			if (shareType == OC.Share.SHARE_TYPE_USER) {
+			if (shareType === OC.Share.SHARE_TYPE_USER) {
 				$('#avatar-' + escapeHTML(shareWith)).avatar(escapeHTML(shareWith), 32);
 			}
 			// insert cruds button into last label element

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -358,9 +358,9 @@ OC.Share={
 		var html = '<div id="dropdown" class="drop shareDropDown" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
 		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
 			if (data.reshare.share_type == OC.Share.SHARE_TYPE_GROUP) {
-				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.displayname_owner})+'</span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.displayname_owner})+' <div id="avatar-share-owner" style="display: inline-block"></div></span>';
 			} else {
-				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner})+'</span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner})+' <div id="avatar-share-owner" style="display: inline-block"></div></span>';
 			}
 			html += '<br />';
 			// reduce possible permissions to what the original share allowed
@@ -437,6 +437,12 @@ OC.Share={
 			html += '</div>';
 			dropDownEl = $(html);
 			dropDownEl = dropDownEl.appendTo(appendTo);
+
+			//Get owner avatars
+			if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
+				$('#avatar-share-owner').avatar(data.reshare.uid_owner, 32);
+			}
+
 			// Reset item shares
 			OC.Share.itemShares = [];
 			OC.Share.currentShares = {};
@@ -650,6 +656,11 @@ OC.Share={
 			var html = '<li style="clear: both;" data-share-type="'+escapeHTML(shareType)+'" data-share-with="'+escapeHTML(shareWith)+'" title="' + escapeHTML(shareWith) + '">';
 			var showCrudsButton;
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
+			if (shareType == OC.Share.SHARE_TYPE_USER) {
+				html += '<div id="avatar-' + escapeHTML(shareWith) + '" class="avatar"></div>';
+			} else {
+				html += '<div class="avatar" style="padding-right: 32px"></div>';
+			}
 			html += '<span class="username">' + escapeHTML(shareWithDisplayName) + '</span>';
 			var mailNotificationEnabled = $('input:hidden[name=mailNotificationEnabled]').val();
 			if (mailNotificationEnabled === 'yes' && shareType !== OC.Share.SHARE_TYPE_REMOTE) {
@@ -681,6 +692,9 @@ OC.Share={
 			html += '</div>';
 			html += '</li>';
 			html = $(html).appendTo('#shareWithList');
+			if (shareType == OC.Share.SHARE_TYPE_USER) {
+				$('#avatar-' + escapeHTML(shareWith)).avatar(escapeHTML(shareWith), 32);
+			}
 			// insert cruds button into last label element
 			var lastLabel = html.find('>label:last');
 			if (lastLabel.exists()){

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -358,9 +358,17 @@ OC.Share={
 		var html = '<div id="dropdown" class="drop shareDropDown" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
 		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
 			if (data.reshare.share_type == OC.Share.SHARE_TYPE_GROUP) {
-				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.displayname_owner})+' <div id="avatar-share-owner" style="display: inline-block"></div></span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you and the group {group} by {owner}', {group: data.reshare.share_with, owner: data.reshare.displayname_owner});
+				if (oc_config.enable_avatars === true) {
+					html += ' <div id="avatar-share-owner" style="display: inline-block"></div>';
+				}
+				html += '</span>';
 			} else {
-				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner})+' <div id="avatar-share-owner" style="display: inline-block"></div></span>';
+				html += '<span class="reshare">'+t('core', 'Shared with you by {owner}', {owner: data.reshare.displayname_owner});
+				if (oc_config.enable_avatars === true) {
+					html += ' <div id="avatar-share-owner" style="display: inline-block"></div>';
+				}
+				html += '</span>';
 			}
 			html += '<br />';
 			// reduce possible permissions to what the original share allowed
@@ -439,7 +447,7 @@ OC.Share={
 			dropDownEl = dropDownEl.appendTo(appendTo);
 
 			//Get owner avatars
-			if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
+			if (oc_config.enable_avatars === true && data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
 				$('#avatar-share-owner').avatar(data.reshare.uid_owner, 32);
 			}
 
@@ -656,10 +664,12 @@ OC.Share={
 			var html = '<li style="clear: both;" data-share-type="'+escapeHTML(shareType)+'" data-share-with="'+escapeHTML(shareWith)+'" title="' + escapeHTML(shareWith) + '">';
 			var showCrudsButton;
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
-			if (shareType === OC.Share.SHARE_TYPE_USER) {
-				html += '<div id="avatar-' + escapeHTML(shareWith) + '" class="avatar"></div>';
-			} else {
-				html += '<div class="avatar" style="padding-right: 32px"></div>';
+			if (oc_config.enable_avatars === true) {
+				if (shareType === OC.Share.SHARE_TYPE_USER) {
+					html += '<div id="avatar-' + escapeHTML(shareWith) + '" class="avatar"></div>';
+				} else {
+					html += '<div class="avatar" style="padding-right: 32px"></div>';
+				}
 			}
 			html += '<span class="username">' + escapeHTML(shareWithDisplayName) + '</span>';
 			var mailNotificationEnabled = $('input:hidden[name=mailNotificationEnabled]').val();
@@ -692,7 +702,7 @@ OC.Share={
 			html += '</div>';
 			html += '</li>';
 			html = $(html).appendTo('#shareWithList');
-			if (shareType === OC.Share.SHARE_TYPE_USER) {
+			if (oc_config.enable_avatars === true && shareType === OC.Share.SHARE_TYPE_USER) {
 				$('#avatar-' + escapeHTML(shareWith)).avatar(escapeHTML(shareWith), 32);
 			}
 			// insert cruds button into last label element

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -26,6 +26,7 @@ describe('OC.Share tests', function() {
 		var oldAppConfig;
 		var loadItemStub;
 		var autocompleteStub;
+		var avatarStub;
 
 		beforeEach(function() {
 			$('#testArea').append($('<div id="shareContainer"></div>'));
@@ -54,6 +55,8 @@ describe('OC.Share tests', function() {
 				var $el = $('<div></div>').data('ui-autocomplete', {});
 				return $el;
 			});
+
+			avatarStub = sinon.stub($.fn, 'avatar');
 		});
 		afterEach(function() {
 			/* jshint camelcase:false */
@@ -61,6 +64,7 @@ describe('OC.Share tests', function() {
 			loadItemStub.restore();
 
 			autocompleteStub.restore();
+			avatarStub.restore();
 			$('#dropdown').remove();
 		});
 		it('calls loadItem with the correct arguments', function() {
@@ -403,6 +407,37 @@ describe('OC.Share tests', function() {
 					expect($.datepicker._defaults.minDate).toEqual(expectedMinDate);
 					expect($.datepicker._defaults.maxDate).toEqual(new Date(2014, 0, 27, 0, 0, 0, 0));
 				});
+			});
+		});
+		describe('check for avatar', function() {
+			beforeEach(function() {
+				loadItemStub.returns({
+					reshare: [],
+					shares: [{
+						id: 100,
+						item_source: 123,
+						permissions: 31,
+						share_type: OC.Share.SHARE_TYPE_USER,
+						share_with: 'user1',
+						share_with_displayname: 'User One'
+					}]
+				});
+				OC.Share.showDropDown(
+					'file',
+					123,
+					$container,
+					true,
+					31,
+					'shared_file_name.txt'
+				);
+			});
+			it('test correct function call', function() {
+				expect(avatarStub.calledOnce).toEqual(true);
+				var args = avatarStub.getCall(0).args;
+
+				expect($('#avatar-user1')[0]).toEqual(jasmine.anything());
+				expect(args.length).toEqual(2);
+				expect(args[0]).toEqual('user1');
 			});
 		});
 		describe('"sharesChanged" event', function() {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -26,6 +26,7 @@ describe('OC.Share tests', function() {
 		var oldAppConfig;
 		var loadItemStub;
 		var autocompleteStub;
+		var oldEnableAvatars;
 		var avatarStub;
 
 		beforeEach(function() {
@@ -56,6 +57,8 @@ describe('OC.Share tests', function() {
 				return $el;
 			});
 
+			oldEnableAvatars = oc_config.enable_avatars;
+			oc_config.enable_avatars = false;
 			avatarStub = sinon.stub($.fn, 'avatar');
 		});
 		afterEach(function() {
@@ -65,6 +68,7 @@ describe('OC.Share tests', function() {
 
 			autocompleteStub.restore();
 			avatarStub.restore();
+			oc_config.enable_avatars = oldEnableAvatars;
 			$('#dropdown').remove();
 		});
 		it('calls loadItem with the correct arguments', function() {
@@ -420,24 +424,67 @@ describe('OC.Share tests', function() {
 						share_type: OC.Share.SHARE_TYPE_USER,
 						share_with: 'user1',
 						share_with_displayname: 'User One'
+					},{
+						id: 101,
+						item_source: 123,
+						permissions: 31,
+						share_type: OC.Share.SHARE_TYPE_GROUP,
+						share_with: 'group',
+						share_with_displayname: 'group'
 					}]
 				});
-				OC.Share.showDropDown(
-					'file',
-					123,
-					$container,
-					true,
-					31,
-					'shared_file_name.txt'
-				);
 			});
-			it('test correct function call', function() {
-				expect(avatarStub.calledOnce).toEqual(true);
-				var args = avatarStub.getCall(0).args;
 
-				expect($('#avatar-user1').length).toEqual(1);
-				expect(args.length).toEqual(2);
-				expect(args[0]).toEqual('user1');
+			describe('avatars enabled', function() {
+				beforeEach(function() {
+					oc_config.enable_avatars = true;
+					OC.Share.showDropDown(
+						'file',
+						123,
+						$container,
+						true,
+						31,
+						'shared_file_name.txt'
+					);
+				});
+
+				afterEach(function() {
+					oc_config.enable_avatars = false;
+				});
+
+				it('test correct function call', function() {
+					expect(avatarStub.calledOnce).toEqual(true);
+					var args = avatarStub.getCall(0).args;
+
+
+					expect($('#shareWithList').children().length).toEqual(2);
+
+					expect($('#avatar-user1').length).toEqual(1);
+					expect(args.length).toEqual(2);
+					expect(args[0]).toEqual('user1');
+				});
+
+				it('test no avatar for groups', function() {
+					expect($('#shareWithList').children().length).toEqual(2);
+					expect($('#shareWithList li:nth-child(2) .avatar').attr('id')).not.toBeDefined();
+				});
+			});
+
+			describe('avatars disabled', function() {
+				beforeEach(function() {
+					OC.Share.showDropDown(
+						'file',
+						123,
+						$container,
+						true,
+						31,
+						'shared_file_name.txt'
+					);
+				});
+
+				it('no avatar classes', function() {
+					expect($('.avatar').length).toEqual(0);
+				});
 			});
 		});
 		describe('"sharesChanged" event', function() {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -435,7 +435,7 @@ describe('OC.Share tests', function() {
 				expect(avatarStub.calledOnce).toEqual(true);
 				var args = avatarStub.getCall(0).args;
 
-				expect($('#avatar-user1')[0]).toEqual(jasmine.anything());
+				expect($('#avatar-user1').length).toEqual(1);
 				expect(args.length).toEqual(2);
 				expect(args[0]).toEqual('user1');
 			});


### PR DESCRIPTION
As mentioned in #5506 and better illustrated in #3224 this PR add user avatars to the share dialog. Not int the auto complete list but of the users we have shared with. To add it to the autocompletelist probably requires some rework.

If a user does not have an avatar the placeholder image is shown so that formatting stays consistent.
