### PR TITLE
detect root of mountpoint also if the trailing slash is missed

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -87,6 +87,11 @@ class View {
 		if ($this->fakeRoot == '') {
 			return $path;
 		}
+
+		if (rtrim($path,'/') === rtrim($this->fakeRoot, '/')) {
+			return '/';
+		}
+
 		if (strpos($path, $this->fakeRoot) !== 0) {
 			return null;
 		} else {

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -729,6 +729,28 @@ class View extends \Test\TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider relativePathProvider
+	 */
+	function testGetRelativePath($absolutePath, $expectedPath) {
+		$view = new \OC\Files\View('/files');
+		// simulate a external storage mount point which has a trailing slash
+		$view->chroot('/files/');
+		$this->assertEquals($expectedPath, $view->getRelativePath($absolutePath));
+	}
+
+	function relativePathProvider() {
+		return array(
+			array('/files/', '/'),
+			array('/files', '/'),
+			array('/files/0', '0'),
+			array('/files/false', 'false'),
+			array('/files/true', 'true'),
+			array('/files/test', 'test'),
+			array('/files/test/foo', 'test/foo'),
+		);
+	}
+
 	public function testFileView() {
 		$storage = new Temporary(array());
 		$scanner = $storage->getScanner();


### PR DESCRIPTION
fix #13878

We share a folder from server1 to server2 to server3. Now server3 wants to write a file to the folder. Since the folder is the root of the mount point on server2 the isCreatable()-check will lead us to this place https://github.com/owncloud/core/blob/master/lib/private/files/view.php#L90
At this point 'path' will be something like "/user/files/mountpoint" and "fakeRoot" will be "/user/files/mountpoint/" so strpos() will be false and we will return null which again will return false for the isCreatable()-check.

This PR makes sure that we detect the mount point correctly even if the path doesn't have a trailing slash.

cc @icewind1991 please review, thanks!
cc @DeepDiver1975 @nickvergessen @PVince81 
