### PR TITLE
Add thumbnails to capabilities

### DIFF
--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Copyright (c) 2013 Tom Needham <tom@owncloud.com>
+ * Copyright (c) 2015 Roeland Jago Douma <roeland@famdouma.nl>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -9,14 +10,31 @@
 namespace OCA\Files; 
 
 class Capabilities {
-	
+
+	private $config;
+
+	public function __construct($config) {
+		$this->config = $config;
+	}
+
 	public static function getCapabilities() {
+        $config = \OC::$server->getConfig();
+	    $cap = new Capabilities($config);
+	    return $cap->getCaps();
+	}
+
+	public function getCaps() {
+		$res = array(
+			'bigfilechunking' => true,
+		);
+
+		if ($this->config->getSystemValue('enable_previews', true) == true) {
+			$res["thumbnails"] = true;
+		}
+
 		return new \OC_OCS_Result(array(
 			'capabilities' => array(
-				'files' => array(
-					'bigfilechunking' => true,
-					'thumbnails' => true,
-					),
+				'files' => $res,
 				),
 			));
 	}

--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -15,6 +15,7 @@ class Capabilities {
 			'capabilities' => array(
 				'files' => array(
 					'bigfilechunking' => true,
+					'thumbnails' => true,
 					),
 				),
 			));

--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -11,18 +11,28 @@ namespace OCA\Files;
 
 class Capabilities {
 
+	/** @var \OCP\IConfig */
 	private $config;
 
-	public function __construct($config) {
+	/**
+	 * @param \OCP\IConfig $config
+	 */
+	public function __construct(\OCP\IConfig $config) {
 		$this->config = $config;
 	}
 
+	/**
+	 * @return \OC_OCS_Result
+	 */
 	public static function getCapabilities() {
 		$config = \OC::$server->getConfig();
 		$cap = new Capabilities($config);
 		return $cap->getCaps();
 	}
 
+	/**
+	 * @return \OC-OCS_Result
+	 */
 	public function getCaps() {
 		$res = array(
 			'bigfilechunking' => true,

--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -28,7 +28,7 @@ class Capabilities {
 			'bigfilechunking' => true,
 		);
 
-		if ($this->config->getSystemValue('enable_previews', true) == true) {
+		if ($this->config->getSystemValue('enable_previews', true) === true) {
 			$res["thumbnails"] = true;
 		}
 

--- a/apps/files/lib/capabilities.php
+++ b/apps/files/lib/capabilities.php
@@ -18,9 +18,9 @@ class Capabilities {
 	}
 
 	public static function getCapabilities() {
-        $config = \OC::$server->getConfig();
-	    $cap = new Capabilities($config);
-	    return $cap->getCaps();
+		$config = \OC::$server->getConfig();
+		$cap = new Capabilities($config);
+		return $cap->getCaps();
 	}
 
 	public function getCaps() {

--- a/apps/files/tests/capabilities.php
+++ b/apps/files/tests/capabilities.php
@@ -6,12 +6,12 @@
   * See the COPYING-README file.
   */
 
-use OCA\Files;
+use OCA\Files\Tests;
 
 /**
  * Class Test_Files_Capabilties
  */
-class Test_Files_Capabilities extends \PHPUnit_Framework_TestCase {
+class Test_Files_Capabilities extends \Test\TestCase {
 
 	/**
 	 * Test for the general part in each return statement and assert
@@ -38,19 +38,18 @@ class Test_Files_Capabilities extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @covers OCA\Files\Capabilities::getCaps
 	 */
-	public function testCapabilities() {
-		/*
-		 * Test for thumbnails
-		 */
+	public function test_thumbnails() {
 		$map = array(
 			array('enable_previews', true, true)
 		);
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('thumbnails', $result);
+	}
 
-		/*
-		 * Test for no thumbnails
-		 */
+	/**
+	 * @covers OCA\Files\Capabilities::getCaps
+	 */
+	public function test_no_thumbnails() {
 		$map = array(
 			array('enable_previews', true, false)
 		);

--- a/apps/files/tests/capabilities.php
+++ b/apps/files/tests/capabilities.php
@@ -1,0 +1,60 @@
+<?php
+/**
+  * Copyright (c) 2015 Roeland Jago Douma <roeland@famdouma.nl>
+  * This file is licensed under the Affero General Public License version 3 or
+  * later.
+  * See the COPYING-README file.
+  */
+
+use OCA\Files;
+
+/**
+ * Class Test_Files_Capabilties
+ */
+class Test_Files_Capabilities extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * Test for the general part in each return statement and assert
+	 */
+	function getFilesPart($data) {
+		$this->assertArrayHasKey('capabilities', $data);
+		$this->assertArrayHasKey('files', $data['capabilities']);
+		return $data['capabilities']['files'];
+	}
+
+	/**
+	 * Create a mock config object and insert the values in $map tot the getSystemValue
+	 * function. Then obtain the capabilities and extract the first few
+	 * levels in the array
+	 */
+	function getResults($map) {
+		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
+		$stub->method('getSystemValue')->will($this->returnValueMap($map));
+		$cap = new \OCA\Files\Capabilities($stub);
+		$result = $this->getFilesPart($cap->getCaps()->getData());
+		return $result;
+	}
+
+	/**
+	 * @covers OCA\Files\Capabilities::getCaps
+	 */
+	public function testCapabilities() {
+		/*
+		 * Test for thumbnails
+		 */
+		$map = array(
+			array('enable_previews', true, true)
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('thumbnails', $result);
+
+		/*
+		 * Test for no thumbnails
+		 */
+		$map = array(
+			array('enable_previews', true, false)
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayNotHasKey('thumbnails', $result);
+	}
+}


### PR DESCRIPTION
In order to know when the client can request thumbnails this should be set in the capabilities. Trivial patch.
