### PR TITLE
Catch exception properly

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -36,7 +36,12 @@ foreach ($files as $file) {
 }
 
 // get array with updated storage stats (e.g. max file size) after upload
-$storageStats = \OCA\Files\Helper::buildFileStorageStatistics($dir);
+try {
+	$storageStats = \OCA\Files\Helper::buildFileStorageStatistics($dir);
+} catch(\OCP\Files\NotFoundException $e) {
+	OCP\JSON::error(['data' => ['message' => 'File not found']]);
+	return;
+}
 
 if ($success) {
 	OCP\JSON::success(array("data" => array_merge(array("dir" => $dir, "files" => $files), $storageStats)));

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -13,21 +13,26 @@ use OCP\Files\FileInfo;
 /**
  * Helper class for manipulating file information
  */
-class Helper
-{
+class Helper {
+	/**
+	 * @param string $dir
+	 * @return array
+	 * @throws \OCP\Files\NotFoundException
+	 */
 	public static function buildFileStorageStatistics($dir) {
 		// information about storage capacities
 		$storageInfo = \OC_Helper::getStorageInfo($dir);
-
 		$l = new \OC_L10N('files');
 		$maxUploadFileSize = \OCP\Util::maxUploadFilesize($dir, $storageInfo['free']);
 		$maxHumanFileSize = \OCP\Util::humanFileSize($maxUploadFileSize);
 		$maxHumanFileSize = $l->t('Upload (max. %s)', array($maxHumanFileSize));
 
-		return array('uploadMaxFilesize' => $maxUploadFileSize,
-					 'maxHumanFilesize'  => $maxHumanFileSize,
-					 'freeSpace' => $storageInfo['free'],
-					 'usedSpacePercent'  => (int)$storageInfo['relative']);
+		return [
+			'uploadMaxFilesize' => $maxUploadFileSize,
+			'maxHumanFilesize'  => $maxHumanFileSize,
+			'freeSpace' => $storageInfo['free'],
+			'usedSpacePercent'  => (int)$storageInfo['relative']
+		];
 	}
 
 	/**


### PR DESCRIPTION
`\OCA\Files\Helper::buildFileStorageStatistics` might throw an exception from `OC_Helper::getStorageInfo`, previously this lead to a uncatched exception being thrown when invoking this methods.

This was user triggable by for example calling `/index.php/apps/files/ajax/delete.php` with a not existing dir (for example `dir=asdf/../&allfiles=true`)
