### PR TITLE
Only make sure the cache directory exists when we use it

### DIFF
--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -9,22 +9,31 @@
 
 namespace OC\Cache;
 
+use OC\Files\Filesystem;
+use OC\Files\View;
+
 class File {
 	protected $storage;
 
 	/**
 	 * Returns the cache storage for the logged in user
+	 *
 	 * @return \OC\Files\View cache storage
 	 */
 	protected function getStorage() {
 		if (isset($this->storage)) {
 			return $this->storage;
 		}
-		if(\OC_User::isLoggedIn()) {
-			\OC\Files\Filesystem::initMountPoints(\OC_User::getUser());
-			$this->storage = new \OC\Files\View('/' . \OC_User::getUser() . '/cache');
+		if (\OC_User::isLoggedIn()) {
+			$rootView = new View();
+			$user = \OC::$server->getUserSession()->getUser();
+			Filesystem::initMountPoints($user->getUID());
+			if (!$rootView->file_exists('/' . $user->getUID() . '/cache')) {
+				$rootView->mkdir('/' . $user->getUID() . '/cache');
+			}
+			$this->storage = new View('/' . $user->getUID() . '/cache');
 			return $this->storage;
-		}else{
+		} else {
 			\OC_Log::write('core', 'Can\'t get cache storage, user not logged in', \OC_Log::ERROR);
 			throw new \OC\ForbiddenException('Can\t get cache storage, user not logged in');
 		}
@@ -66,7 +75,7 @@ class File {
 	/**
 	 * @param string $key
 	 */
-	public function set($key, $value, $ttl=0) {
+	public function set($key, $value, $ttl = 0) {
 		$storage = $this->getStorage();
 		$result = false;
 		$proxyStatus = \OC_FileProxy::$enabled;
@@ -94,20 +103,20 @@ class File {
 	 */
 	public function remove($key) {
 		$storage = $this->getStorage();
-		if(!$storage) {
+		if (!$storage) {
 			return false;
 		}
 		return $storage->unlink($key);
 	}
 
-	public function clear($prefix='') {
+	public function clear($prefix = '') {
 		$storage = $this->getStorage();
-		if($storage and $storage->is_dir('/')) {
-			$dh=$storage->opendir('/');
-			if(is_resource($dh)) {
+		if ($storage and $storage->is_dir('/')) {
+			$dh = $storage->opendir('/');
+			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if($file!='.' and $file!='..' and ($prefix==='' || strpos($file, $prefix) === 0)) {
-						$storage->unlink('/'.$file);
+					if ($file != '.' and $file != '..' and ($prefix === '' || strpos($file, $prefix) === 0)) {
+						$storage->unlink('/' . $file);
 					}
 				}
 			}
@@ -117,17 +126,17 @@ class File {
 
 	public function gc() {
 		$storage = $this->getStorage();
-		if($storage and $storage->is_dir('/')) {
+		if ($storage and $storage->is_dir('/')) {
 			$now = time();
-			$dh=$storage->opendir('/');
-			if(!is_resource($dh)) {
+			$dh = $storage->opendir('/');
+			if (!is_resource($dh)) {
 				return null;
 			}
 			while (($file = readdir($dh)) !== false) {
-				if($file!='.' and $file!='..') {
-					$mtime = $storage->filemtime('/'.$file);
+				if ($file != '.' and $file != '..') {
+					$mtime = $storage->filemtime('/' . $file);
 					if ($mtime < $now) {
-						$storage->unlink('/'.$file);
+						$storage->unlink('/' . $file);
 					}
 				}
 			}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -395,14 +395,7 @@ class Filesystem {
 	 */
 	private static function mountCacheDir($user) {
 		$cacheBaseDir = \OC_Config::getValue('cache_path', '');
-		if ($cacheBaseDir === '') {
-			// use local cache dir relative to the user's home
-			$subdir = 'cache';
-			$view = new \OC\Files\View('/' . $user);
-			if(!$view->file_exists($subdir)) {
-				$view->mkdir($subdir);
-			}
-		} else {
+		if ($cacheBaseDir !== '') {
 			$cacheDir = rtrim($cacheBaseDir, '/') . '/' . $user;
 			if (!file_exists($cacheDir)) {
 				mkdir($cacheDir, 0770, true);


### PR DESCRIPTION
When setting up the filesystem for a lot of users (such as creating a share with a large group) checking the existence of the cache dir can become time consuming.
This switches it to only check for the cache dir when the cache is being used.

Part of #13725

cc @DeepDiver1975 @PVince81 
