### PR TITLE
Dont create exclude list for generating the share target

### DIFF
--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -44,24 +44,9 @@ class Helper extends \OC\Share\Constants {
 			}
 			return $backend->generateTarget($itemSource, false);
 		} else {
-			if ($itemType == 'file' || $itemType == 'folder') {
-				$column = 'file_target';
-				$columnSource = 'file_source';
-			} else {
-				$column = 'item_target';
-				$columnSource = 'item_source';
-			}
 			if ($shareType == self::SHARE_TYPE_USER) {
 				// Share with is a user, so set share type to user and groups
 				$shareType = self::$shareTypeUserAndGroups;
-			}
-			$exclude = array();
-
-			$result = \OCP\Share::getItemsSharedWithUser($itemType, $shareWith);
-			foreach ($result as $row) {
-				if ($row['permissions'] > 0) {
-					$exclude[] = $row[$column];
-				}
 			}
 
 			// Check if suggested target exists first
@@ -69,9 +54,9 @@ class Helper extends \OC\Share\Constants {
 				$suggestedTarget = $itemSource;
 			}
 			if ($shareType == self::SHARE_TYPE_GROUP) {
-				$target = $backend->generateTarget($suggestedTarget, false, $exclude);
+				$target = $backend->generateTarget($suggestedTarget, false);
 			} else {
-				$target = $backend->generateTarget($suggestedTarget, $shareWith, $exclude);
+				$target = $backend->generateTarget($suggestedTarget, $shareWith);
 			}
 
 			return $target;


### PR DESCRIPTION
The exclude list is deprecated since the removal of the Shared folder in 7.

Part of #13725

cc @schiesbn @PVince81 @DeepDiver1975 
