### PR TITLE
fix user loading

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -422,7 +422,7 @@ var UserList = {
 					UserList.noMoreEntries = true;
 					$userList.siblings('.loading').remove();
 				}
-				UserList.offset += loadedUsers;
+				UserList.offset += limit;
 			}).always(function() {
 				UserList.updating = false;
 			});
@@ -866,6 +866,11 @@ $(document).ready(function () {
 		containerHeight = $('#app-content').height();
 	if(containerHeight > 40) {
 		initialUserCountLimit = Math.floor(containerHeight/40);
+		while((initialUserCountLimit % UserList.usersToLoad) !== 0) {
+			// must be a multiple of this, otherwise LDAP freaks out.
+			// FIXME: solve this in LDAP backend in  8.1
+			initialUserCountLimit = initialUserCountLimit + 1;
+		}
 	}
 
 	// trigger loading of users on startup


### PR DESCRIPTION
Fixes #13644 

How to tests:
- have enough ldap users that would usually be good enough to reload 3 times or more
- go to users page and scroll down, wait for user load, and do it again
- before: users where loaded only once
- now: should work as expected

It is an easy fix in JS, in future we want/should treat odd limit and offset combinations this in the LDAP backend. I started with that version, but it is too complex and big, now (in LDAP you cannot simply request a random subset).

@MorrisJobke @jnfrmarks @DeepDiver1975 @PVince81 
