### PR TITLE
Improved bulk sharing

### DIFF
--- a/apps/files_sharing/tests/watcher.php
+++ b/apps/files_sharing/tests/watcher.php
@@ -52,7 +52,6 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		// prepare user1's dir structure
-		$textData = "dummy file data\n";
 		$this->view->mkdir('container');
 		$this->view->mkdir('container/shareddir');
 		$this->view->mkdir('container/shareddir/subdir');
@@ -62,8 +61,8 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 		$this->ownerStorage->getScanner()->scan('');
 
 		// share "shareddir" with user2
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::shareItem('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+		$fileInfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
 			self::TEST_FILES_SHARING_API_USER2, 31);
 
 		// login as user2
@@ -76,12 +75,14 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 	}
 
 	protected function tearDown() {
-		$this->sharedCache->clear();
+		if (!is_null($this->sharedCache)) {
+			$this->sharedCache->clear();
+		}
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		$fileinfo = $this->view->getFileInfo('container/shareddir');
-		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+		$fileInfo = $this->view->getFileInfo('container/shareddir');
+		\OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
 			self::TEST_FILES_SHARING_API_USER2);
 
 		$this->view->deleteAll('container');
@@ -157,7 +158,9 @@ class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 	/**
 	 * Returns the sizes of the path and its parent dirs in a hash
 	 * where the key is the path and the value is the size.
+	 *
 	 * @param string $path
+	 * @return array
 	 */
 	function getOwnerDirSizes($path) {
 		$result = array();

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2217,28 +2217,28 @@ class Share extends \OC\Share\Constants {
 
 		$result = false;
 		foreach ($shareData as $data) {
-			$result = $query->execute([
-				$data['itemType'],
-				$data['itemSource'],
-				$data['itemTarget'],
-				$data['shareType'],
-				$data['shareWith'],
-				$data['uidOwner'],
-				$data['permissions'],
-				$data['shareTime'],
-				$data['fileSource'],
-				$data['fileTarget'],
-				$data['token'],
-				$parent,
-				$data['expiration']
-			]);
+			$query->bindValue(1, $data['itemType']);
+			$query->bindValue(2, $data['itemSource']);
+			$query->bindValue(3, $data['itemTarget']);
+			$query->bindValue(4, $data['shareType']);
+			$query->bindValue(5, $data['shareWith']);
+			$query->bindValue(6, $data['uidOwner']);
+			$query->bindValue(7, $data['permissions']);
+			$query->bindValue(8, $data['shareTime']);
+			$query->bindValue(9, $data['fileSource']);
+			$query->bindValue(10, $data['fileTarget']);
+			$query->bindValue(11, $data['token']);
+			$query->bindValue(12, $data['parent']);
+			$query->bindValue(13, $data['expiration'], 'datetime');
+
+			$result = $query->execute();
 		}
 		$query->closeCursor();
 		$connection->commit();
 
 		$id = false;
 		if ($result) {
-			$id = $connection->lastInsertId('share');
+			$id = $connection->lastInsertId('*PREFIX*share');
 		}
 
 		return $id;
@@ -2272,7 +2272,7 @@ class Share extends \OC\Share\Constants {
 
 		$id = false;
 		if ($result) {
-			$id = \OC::$server->getDatabaseConnection()->lastInsertId();
+			$id = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*share');
 			// Fallback, if lastInterId() doesn't work we need to perform a select
 			// to get the ID (seems to happen sometimes on Oracle)
 			if (!$id) {

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -62,11 +62,13 @@ class Share extends \OC\Share\Constants {
 	 *
 	 * Apps are required to handle permissions on their own, this class only
 	 * stores and manages the permissions of shares
+	 *
 	 * @see lib/public/constants.php
 	 */
 
 	/**
 	 * Register a sharing backend class that implements OCP\Share_Backend for an item type
+	 *
 	 * @param string $itemType Item type
 	 * @param string $class Backend class
 	 * @param string $collectionOf (optional) Depends on item type
@@ -81,15 +83,15 @@ class Share extends \OC\Share\Constants {
 					'collectionOf' => $collectionOf,
 					'supportedFileExtensions' => $supportedFileExtensions
 				);
-				if(count(self::$backendTypes) === 1) {
+				if (count(self::$backendTypes) === 1) {
 					\OC_Util::addScript('core', 'share');
 					\OC_Util::addStyle('core', 'share');
 				}
 				return true;
 			}
 			\OC_Log::write('OCP\Share',
-				'Sharing backend '.$class.' not registered, '.self::$backendTypes[$itemType]['class']
-				.' is already registered for '.$itemType,
+				'Sharing backend ' . $class . ' not registered, ' . self::$backendTypes[$itemType]['class']
+				. ' is already registered for ' . $itemType,
 				\OC_Log::WARN);
 		}
 		return false;
@@ -97,6 +99,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Check if the Share API is enabled
+	 *
 	 * @return boolean true if enabled or false
 	 *
 	 * The Share API is enabled by default if not configured
@@ -110,6 +113,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Find which users can access a shared item
+	 *
 	 * @param string $path to the file
 	 * @param string $ownerUser owner of the file
 	 * @param boolean $includeOwner include owner to the list of users with access to the file
@@ -135,7 +139,7 @@ class Share extends \OC\Share\Constants {
 			$meta = $view->getFileInfo(dirname($path));
 		}
 
-		if($meta !== false) {
+		if ($meta !== false) {
 			$source = $meta['fileid'];
 			$cache = new \OC\Files\Cache\Cache($meta['storage']);
 		}
@@ -158,7 +162,7 @@ class Share extends \OC\Share\Constants {
 				while ($row = $result->fetchRow()) {
 					$shares[] = $row['share_with'];
 					if ($returnUserPaths) {
-						$fileTargets[(int) $row['file_source']][$row['share_with']] = $row;
+						$fileTargets[(int)$row['file_source']][$row['share_with']] = $row;
 					}
 				}
 			}
@@ -182,7 +186,7 @@ class Share extends \OC\Share\Constants {
 					$shares = array_merge($shares, $usersInGroup);
 					if ($returnUserPaths) {
 						foreach ($usersInGroup as $user) {
-							$fileTargets[(int) $row['file_source']][$user] = $row;
+							$fileTargets[(int)$row['file_source']][$user] = $row;
 						}
 					}
 				}
@@ -228,7 +232,7 @@ class Share extends \OC\Share\Constants {
 
 			// let's get the parent for the next round
 			$meta = $cache->get((int)$source);
-			if($meta !== false) {
+			if ($meta !== false) {
 				$source = (int)$meta['parent'];
 			} else {
 				$source = -1;
@@ -261,7 +265,7 @@ class Share extends \OC\Share\Constants {
 					while ($row = $result->fetchRow()) {
 						foreach ($fileTargets[$row['fileid']] as $uid => $shareData) {
 							$sharedPath = $shareData['file_target'];
-							$sharedPath .= substr($path, strlen($row['path']) -5);
+							$sharedPath .= substr($path, strlen($row['path']) - 5);
 							$sharePaths[$uid] = $sharedPath;
 						}
 					}
@@ -276,6 +280,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the items of item type shared with the current user
+	 *
 	 * @param string $itemType
 	 * @param int $format (optional) Format type must be defined by the backend
 	 * @param mixed $parameters (optional)
@@ -291,6 +296,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the items of item type shared with a user
+	 *
 	 * @param string $itemType
 	 * @param string $user id for which user we want the shares
 	 * @param int $format (optional) Format type must be defined by the backend
@@ -307,6 +313,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the item of item type shared with the current user
+	 *
 	 * @param string $itemType
 	 * @param string $itemTarget
 	 * @param int $format (optional) Format type must be defined by the backend
@@ -322,6 +329,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the item of item type shared with a given user by source
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $user User to whom the item was shared
@@ -364,7 +372,7 @@ class Share extends \OC\Share\Constants {
 			$arguments[] = $owner;
 		}
 
-		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` '. $where);
+		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` ' . $where);
 
 		$result = \OC_DB::executeAudited($query, $arguments);
 
@@ -376,7 +384,7 @@ class Share extends \OC\Share\Constants {
 		}
 
 		//if didn't found a result than let's look for a group share.
-		if(empty($shares) && $user !== null) {
+		if (empty($shares) && $user !== null) {
 			$groups = \OC_Group::getUserGroups($user);
 
 			if (!empty($groups)) {
@@ -411,6 +419,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the item of item type shared with the current user by source
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $format (optional) Format type must be defined by the backend
@@ -428,6 +437,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the item of item type shared by a link
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $uidOwner Owner of link
@@ -440,6 +450,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Based on the given token the share information will be returned - password protected shares will be verified
+	 *
 	 * @param string $token
 	 * @return array|boolean false will be returned in case the token is unknown or unauthorized
 	 */
@@ -467,11 +478,11 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * resolves reshares down to the last real share
+	 *
 	 * @param array $linkItem
 	 * @return array file owner
 	 */
-	public static function resolveReShare($linkItem)
-	{
+	public static function resolveReShare($linkItem) {
 		if (isset($linkItem['parent'])) {
 			$parent = $linkItem['parent'];
 			while (isset($parent)) {
@@ -490,6 +501,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the shared items of item type owned by the current user
+	 *
 	 * @param string $itemType
 	 * @param int $format (optional) Format type must be defined by the backend
 	 * @param mixed $parameters
@@ -505,6 +517,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the shared item of item type owned by the current user
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $format (optional) Format type must be defined by the backend
@@ -520,6 +533,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get all users an item is shared with
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $uidOwner
@@ -545,6 +559,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Share an item with a user, group, or via private link
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
@@ -631,7 +646,7 @@ class Share extends \OC\Share\Constants {
 				$inGroup = array_intersect(\OC_Group::getUserGroups($uidOwner), \OC_Group::getUserGroups($shareWith));
 				if (empty($inGroup)) {
 					$message = 'Sharing %s failed, because the user '
-						.'%s is not a member of any groups that %s is a member of';
+						. '%s is not a member of any groups that %s is a member of';
 					$message_t = $l->t('Sharing %s failed, because the user %s is not a member of any groups that %s is a member of', array($itemSourceName, $shareWith, $uidOwner));
 					\OC_Log::write('OCP\Share', sprintf($message, $itemSourceName, $shareWith, $uidOwner), \OC_Log::ERROR);
 					throw new \Exception($message_t);
@@ -639,7 +654,8 @@ class Share extends \OC\Share\Constants {
 			}
 			// Check if the item source is already shared with the user, either from the same owner or a different user
 			if ($checkExists = self::getItems($itemType, $itemSource, self::$shareTypeUserAndGroups,
-				$shareWith, null, self::FORMAT_NONE, null, 1, true, true)) {
+				$shareWith, null, self::FORMAT_NONE, null, 1, true, true)
+			) {
 				// Only allow the same share to occur again if it is the same
 				// owner and is not a user share, this use case is for increasing
 				// permissions for a specific user
@@ -659,7 +675,7 @@ class Share extends \OC\Share\Constants {
 			}
 			if ($shareWithinGroupOnly && !\OC_Group::inGroup($uidOwner, $shareWith)) {
 				$message = 'Sharing %s failed, because '
-					.'%s is not a member of the group %s';
+					. '%s is not a member of the group %s';
 				$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', array($itemSourceName, $uidOwner, $shareWith));
 				\OC_Log::write('OCP\Share', sprintf($message, $itemSourceName, $uidOwner, $shareWith), \OC_Log::ERROR);
 				throw new \Exception($message_t);
@@ -667,7 +683,8 @@ class Share extends \OC\Share\Constants {
 			// Check if the item source is already shared with the group, either from the same owner or a different user
 			// The check for each user in the group is done inside the put() function
 			if ($checkExists = self::getItems($itemType, $itemSource, self::SHARE_TYPE_GROUP, $shareWith,
-				null, self::FORMAT_NONE, null, 1, true, true)) {
+				null, self::FORMAT_NONE, null, 1, true, true)
+			) {
 				// Only allow the same share to occur again if it is the same
 				// owner and is not a group share, this use case is for increasing
 				// permissions for a specific user
@@ -690,7 +707,8 @@ class Share extends \OC\Share\Constants {
 				// when updating a link share
 				// FIXME Don't delete link if we update it
 				if ($checkExists = self::getItems($itemType, $itemSource, self::SHARE_TYPE_LINK, null,
-					$uidOwner, self::FORMAT_NONE, null, 1)) {
+					$uidOwner, self::FORMAT_NONE, null, 1)
+				) {
 					// remember old token
 					$oldToken = $checkExists['token'];
 					$oldPermissions = $checkExists['permissions'];
@@ -719,7 +737,8 @@ class Share extends \OC\Share\Constants {
 
 				if ($updateExistingShare === false &&
 					self::isDefaultExpireDateEnabled() &&
-					empty($expirationDate)) {
+					empty($expirationDate)
+				) {
 					$expirationDate = Helper::calcExpireDate();
 				}
 
@@ -728,7 +747,7 @@ class Share extends \OC\Share\Constants {
 					$token = $oldToken;
 				} else {
 					$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(self::TOKEN_LENGTH,
-						\OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_UPPER.
+						\OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
 						\OCP\Security\ISecureRandom::CHAR_DIGITS
 					);
 				}
@@ -780,6 +799,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Unshare an item from a user, group, or delete a private link
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
@@ -820,13 +840,14 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Unshare an item from all users, groups, and remove all links
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @return boolean true on success or false on failure
 	 */
 	public static function unshareAll($itemType, $itemSource) {
 		// Get all of the owners of shares of this item.
-		$query = \OC_DB::prepare( 'SELECT `uid_owner` from `*PREFIX*share` WHERE `item_type`=? AND `item_source`=?' );
+		$query = \OC_DB::prepare('SELECT `uid_owner` FROM `*PREFIX*share` WHERE `item_type`=? AND `item_source`=?');
 		$result = $query->execute(array($itemType, $itemSource));
 		$shares = array();
 		// Add each owner's shares to the array of all shares for this item.
@@ -852,6 +873,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Unshare an item shared with the current user
+	 *
 	 * @param string $itemType
 	 * @param string $itemOrigin Item target or source
 	 * @param boolean $originIsSource true if $itemOrigin is the source, false if $itemOrigin is the target (optional)
@@ -864,9 +886,9 @@ class Share extends \OC\Share\Constants {
 		$uid = \OCP\User::getUser();
 
 		if ($itemType === 'file' || $itemType === 'folder') {
-			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `file_' . $originType . '` = ?';
+			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? AND `file_' . $originType . '` = ?';
 		} else {
-			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `item_' . $originType . '` = ?';
+			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? AND `item_' . $originType . '` = ?';
 		}
 
 		$query = \OCP\DB::prepare($statement);
@@ -879,7 +901,8 @@ class Share extends \OC\Share\Constants {
 		$itemUnshared = false;
 		foreach ($shares as $share) {
 			if ((int)$share['share_type'] === \OCP\Share::SHARE_TYPE_USER &&
-				$share['share_with'] === $uid) {
+				$share['share_with'] === $uid
+			) {
 				$deletedShares = Helper::delete($share['id']);
 				$shareTmp = array(
 					'id' => $share['id'],
@@ -899,16 +922,17 @@ class Share extends \OC\Share\Constants {
 					$groupShare = $share;
 				}
 			} elseif ((int)$share['share_type'] === self::$shareTypeGroupUserUnique &&
-				$share['share_with'] === $uid) {
+				$share['share_with'] === $uid
+			) {
 				$uniqueGroupShare = $share;
 			}
 		}
 
 		if (!$itemUnshared && isset($groupShare) && !isset($uniqueGroupShare)) {
 			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share`'
-				.' (`item_type`, `item_source`, `item_target`, `parent`, `share_type`,'
-				.' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`, `file_target`)'
-				.' VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+				. ' (`item_type`, `item_source`, `item_target`, `parent`, `share_type`,'
+				. ' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`, `file_target`)'
+				. ' VALUES (?,?,?,?,?,?,?,?,?,?,?)');
 			$query->execute(array($groupShare['item_type'], $groupShare['item_source'], $groupShare['item_target'],
 				$groupShare['id'], self::$shareTypeGroupUserUnique,
 				\OC_User::getUser(), $groupShare['uid_owner'], 0, $groupShare['stime'], $groupShare['file_source'],
@@ -952,6 +976,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * sent status if users got informed by mail about share
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
@@ -968,13 +993,14 @@ class Share extends \OC\Share\Constants {
 
 		$result = $query->execute(array($status, $itemType, $itemSource, $shareType, $recipient));
 
-		if($result === false) {
+		if ($result === false) {
 			\OC_Log::write('OCP\Share', 'Couldn\'t set send mail status', \OC_Log::ERROR);
 		}
 	}
 
 	/**
 	 * Set the permissions of an item for a specific user or group
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
@@ -985,7 +1011,8 @@ class Share extends \OC\Share\Constants {
 	public static function setPermissions($itemType, $itemSource, $shareType, $shareWith, $permissions) {
 		$l = \OC::$server->getL10N('lib');
 		if ($item = self::getItems($itemType, $itemSource, $shareType, $shareWith,
-			\OC_User::getUser(), self::FORMAT_NONE, null, 1, false)) {
+			\OC_User::getUser(), self::FORMAT_NONE, null, 1, false)
+		) {
 			// Check if this item is a reshare and verify that the permissions
 			// granted don't exceed the parent shared item
 			if (isset($item['parent'])) {
@@ -993,7 +1020,7 @@ class Share extends \OC\Share\Constants {
 				$result = $query->execute(array($item['parent']))->fetchRow();
 				if (~(int)$result['permissions'] & $permissions) {
 					$message = 'Setting permissions for %s failed,'
-						.' because the permissions exceed permissions granted to %s';
+						. ' because the permissions exceed permissions granted to %s';
 					$message_t = $l->t('Setting permissions for %s failed, because the permissions exceed permissions granted to %s', array($itemSource, \OC_User::getUser()));
 					\OC_Log::write('OCP\Share', sprintf($message, $itemSource, \OC_User::getUser()), \OC_Log::ERROR);
 					throw new \Exception($message_t);
@@ -1022,9 +1049,9 @@ class Share extends \OC\Share\Constants {
 					$ids = array();
 					$parents = array($item['id']);
 					while (!empty($parents)) {
-						$parents = "'".implode("','", $parents)."'";
+						$parents = "'" . implode("','", $parents) . "'";
 						$query = \OC_DB::prepare('SELECT `id`, `permissions` FROM `*PREFIX*share`'
-							.' WHERE `parent` IN ('.$parents.')');
+							. ' WHERE `parent` IN (' . $parents . ')');
 						$result = $query->execute();
 						// Reset parents array, only go through loop again if
 						// items are found that need permissions removed
@@ -1040,15 +1067,15 @@ class Share extends \OC\Share\Constants {
 					}
 					// Remove the permissions for all reshares of this item
 					if (!empty($ids)) {
-						$ids = "'".implode("','", $ids)."'";
+						$ids = "'" . implode("','", $ids) . "'";
 						// TODO this should be done with Doctrine platform objects
-						if (\OC_Config::getValue( "dbtype") === 'oci') {
+						if (\OC_Config::getValue("dbtype") === 'oci') {
 							$andOp = 'BITAND(`permissions`, ?)';
 						} else {
 							$andOp = '`permissions` & ?';
 						}
-						$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `permissions` = '.$andOp
-							.' WHERE `id` IN ('.$ids.')');
+						$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `permissions` = ' . $andOp
+							. ' WHERE `id` IN (' . $ids . ')');
 						$query->execute(array($permissions));
 					}
 				}
@@ -1112,6 +1139,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Set expiration date for a share
+	 *
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $date expiration date
@@ -1228,6 +1256,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Checks whether a share has expired, calls unshareItem() if yes.
+	 *
 	 * @param array $item Share data (usually database row)
 	 * @return boolean True if item was expired, false otherwise.
 	 */
@@ -1236,7 +1265,7 @@ class Share extends \OC\Share\Constants {
 		$result = false;
 
 		// only use default expiration date for link shares
-		if ((int) $item['share_type'] === self::SHARE_TYPE_LINK) {
+		if ((int)$item['share_type'] === self::SHARE_TYPE_LINK) {
 
 			// calculate expiration date
 			if (!empty($item['expiration'])) {
@@ -1265,6 +1294,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Unshares a share given a share data array
+	 *
 	 * @param array $item Share data (usually database row)
 	 * @param int new parent ID
 	 * @return null
@@ -1287,7 +1317,7 @@ class Share extends \OC\Share\Constants {
 			'itemParent'    => $item['parent'],
 			'uidOwner'      => $item['uid_owner'],
 		);
-		if($item['item_type'] === 'file' || $item['item_type'] === 'folder') {
+		if ($item['item_type'] === 'file' || $item['item_type'] === 'folder') {
 			$hookParams['fileSource'] = $item['file_source'];
 			$hookParams['fileTarget'] = $item['file_target'];
 		}
@@ -1305,6 +1335,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get the backend class for the specified item type
+	 *
 	 * @param string $itemType
 	 * @throws \Exception
 	 * @return \OCP\Share_Backend
@@ -1339,6 +1370,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Check if resharing is allowed
+	 *
 	 * @return boolean true if allowed or false
 	 *
 	 * Resharing is allowed by default if not configured
@@ -1356,6 +1388,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get a list of collection item types for the specified item type
+	 *
 	 * @param string $itemType
 	 * @return array
 	 */
@@ -1431,6 +1464,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Get shared items from the database
+	 *
 	 * @param string $itemType
 	 * @param string $item Item source or target (optional)
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, SHARE_TYPE_LINK, $shareTypeUserAndGroups, or $shareTypeGroupUserUnique
@@ -1449,7 +1483,7 @@ class Share extends \OC\Share\Constants {
 	 */
 	public static function getItems($itemType, $item = null, $shareType = null, $shareWith = null,
 									$uidOwner = null, $format = self::FORMAT_NONE, $parameters = null, $limit = -1,
-									$includeCollections = false, $itemShareWithBySource = false, $checkExpireDate  = true) {
+									$includeCollections = false, $itemShareWithBySource = false, $checkExpireDate = true) {
 		if (!self::isEnabled()) {
 			return array();
 		}
@@ -1458,7 +1492,7 @@ class Share extends \OC\Share\Constants {
 		// Get filesystem root to add it to the file target and remove from the
 		// file source, match file_source with the file cache
 		if ($itemType == 'file' || $itemType == 'folder') {
-			if(!is_null($uidOwner)) {
+			if (!is_null($uidOwner)) {
 				$root = \OC\Files\Filesystem::getRoot();
 			} else {
 				$root = '';
@@ -1482,7 +1516,7 @@ class Share extends \OC\Share\Constants {
 					$itemTypes = $collectionTypes;
 				}
 				$placeholders = join(',', array_fill(0, count($itemTypes), '?'));
-				$where = ' WHERE `item_type` IN ('.$placeholders.'))';
+				$where = ' WHERE `item_type` IN (' . $placeholders . '))';
 				$queryArgs = $itemTypes;
 			} else {
 				$where = ' WHERE `item_type` = ?';
@@ -1503,7 +1537,7 @@ class Share extends \OC\Share\Constants {
 				$groups = \OC_Group::getUserGroups($shareWith);
 				if (!empty($groups)) {
 					$placeholders = join(',', array_fill(0, count($groups), '?'));
-					$where .= ' OR (`share_type` = ? AND `share_with` IN ('.$placeholders.')) ';
+					$where .= ' OR (`share_type` = ? AND `share_with` IN (' . $placeholders . ')) ';
 					$queryArgs[] = self::SHARE_TYPE_GROUP;
 					$queryArgs = array_merge($queryArgs, $groups);
 				}
@@ -1568,7 +1602,7 @@ class Share extends \OC\Share\Constants {
 			$queryArgs[] = $item;
 			if ($includeCollections && $collectionTypes && !in_array('folder', $collectionTypes)) {
 				$placeholders = join(',', array_fill(0, count($collectionTypes), '?'));
-				$where .= ' OR `item_type` IN ('.$placeholders.'))';
+				$where .= ' OR `item_type` IN (' . $placeholders . '))';
 				$queryArgs = array_merge($queryArgs, $collectionTypes);
 			}
 		}
@@ -1594,7 +1628,7 @@ class Share extends \OC\Share\Constants {
 		}
 		$select = self::createSelectStatement($format, $fileDependent, $uidOwner);
 		$root = strlen($root);
-		$query = \OC_DB::prepare('SELECT '.$select.' FROM `*PREFIX*share` '.$where, $queryLimit);
+		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` ' . $where, $queryLimit);
 		$result = $query->execute($queryArgs);
 		if (\OC_DB::isError($result)) {
 			\OC_Log::write('OCP\Share',
@@ -1641,7 +1675,8 @@ class Share extends \OC\Share\Constants {
 						// Switch ids if sharing permission is granted on only
 						// one share to ensure correct parent is used if resharing
 						if (~(int)$items[$id]['permissions'] & \OCP\Constants::PERMISSION_SHARE
-							&& (int)$row['permissions'] & \OCP\Constants::PERMISSION_SHARE) {
+							&& (int)$row['permissions'] & \OCP\Constants::PERMISSION_SHARE
+						) {
 							$items[$row['id']] = $items[$id];
 							$switchedItems[$id] = $row['id'];
 							unset($items[$id]);
@@ -1684,14 +1719,14 @@ class Share extends \OC\Share\Constants {
 						}
 					}
 					if (!empty($mounts[$row['storage']])) {
-						$path = $mounts[$row['storage']]->getMountPoint().$row['path'];
+						$path = $mounts[$row['storage']]->getMountPoint() . $row['path'];
 						$relPath = substr($path, $root); // path relative to data/user
 						$row['path'] = rtrim($relPath, '/');
 					}
 				}
 			}
 
-			if($checkExpireDate) {
+			if ($checkExpireDate) {
 				if (self::expireItem($row)) {
 					continue;
 				}
@@ -1701,13 +1736,14 @@ class Share extends \OC\Share\Constants {
 				$row['permissions'] &= ~\OCP\Constants::PERMISSION_SHARE;
 			}
 			// Add display names to result
-			if ( isset($row['share_with']) && $row['share_with'] != '' &&
-				isset($row['share_with']) && $row['share_type'] === self::SHARE_TYPE_USER) {
+			if (isset($row['share_with']) && $row['share_with'] != '' &&
+				isset($row['share_with']) && $row['share_type'] === self::SHARE_TYPE_USER
+			) {
 				$row['share_with_displayname'] = \OCP\User::getDisplayName($row['share_with']);
 			} else {
 				$row['share_with_displayname'] = $row['share_with'];
 			}
-			if ( isset($row['uid_owner']) && $row['uid_owner'] != '') {
+			if (isset($row['uid_owner']) && $row['uid_owner'] != '') {
 				$row['displayname_owner'] = \OCP\User::getDisplayName($row['uid_owner']);
 			}
 
@@ -1736,7 +1772,8 @@ class Share extends \OC\Share\Constants {
 				// Check if this is a collection of the requested item type
 				if ($includeCollections && $collectionTypes && $row['item_type'] !== 'folder' && in_array($row['item_type'], $collectionTypes)) {
 					if (($collectionBackend = self::getBackend($row['item_type']))
-						&& $collectionBackend instanceof \OCP\Share_Backend_Collection) {
+						&& $collectionBackend instanceof \OCP\Share_Backend_Collection
+					) {
 						// Collections can be inside collections, check if the item is a collection
 						if (isset($item) && $row['item_type'] == $itemType && $row[$column] == $item) {
 							$collectionItems[] = $row;
@@ -1848,13 +1885,14 @@ class Share extends \OC\Share\Constants {
 				// for file/folder shares we need to compare file_source, otherwise we compare item_source
 				// only group shares if they already point to the same target, otherwise the file where shared
 				// before grouping of shares was added. In this case we don't group them toi avoid confusions
-				if (( $fileSharing && $item['file_source'] === $r['file_source'] && $item['file_target'] === $r['file_target']) ||
-					(!$fileSharing && $item['item_source'] === $r['item_source'] && $item['item_target'] === $r['item_target'])) {
+				if (($fileSharing && $item['file_source'] === $r['file_source'] && $item['file_target'] === $r['file_target']) ||
+					(!$fileSharing && $item['item_source'] === $r['item_source'] && $item['item_target'] === $r['item_target'])
+				) {
 					// add the first item to the list of grouped shares
 					if (!isset($result[$key]['grouped'])) {
 						$result[$key]['grouped'][] = $result[$key];
 					}
-					$result[$key]['permissions'] = (int) $item['permissions'] | (int) $r['permissions'];
+					$result[$key]['permissions'] = (int)$item['permissions'] | (int)$r['permissions'];
 					$result[$key]['grouped'][] = $item;
 					$grouped = true;
 					break;
@@ -1872,6 +1910,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * Put shared item into the database
+	 *
 	 * @param string $itemType Item type
 	 * @param string $itemSource Item source
 	 * @param int $shareType SHARE_TYPE_USER, SHARE_TYPE_GROUP, or SHARE_TYPE_LINK
@@ -1892,7 +1931,7 @@ class Share extends \OC\Share\Constants {
 		$suggestedItemTarget = null;
 
 		$result = self::checkReshare($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, $itemSourceName, $expirationDate);
-		if(!empty($result)) {
+		if (!empty($result)) {
 			$parent = $result['parent'];
 			$itemSource = $result['itemSource'];
 			$fileSource = $result['fileSource'];
@@ -1917,19 +1956,19 @@ class Share extends \OC\Share\Constants {
 
 			// add group share to table and remember the id as parent
 			$queriesToExecute['groupShare'] = array(
-				'itemType'			=> $itemType,
-				'itemSource'		=> $itemSource,
-				'itemTarget'		=> $groupItemTarget,
-				'shareType'			=> $shareType,
-				'shareWith'			=> $shareWith['group'],
-				'uidOwner'			=> $uidOwner,
-				'permissions'		=> $permissions,
-				'shareTime'			=> time(),
-				'fileSource'		=> $fileSource,
-				'fileTarget'		=> $groupFileTarget,
-				'token'				=> $token,
-				'parent'			=> $parent,
-				'expiration'		=> $expirationDate,
+				'itemType' => $itemType,
+				'itemSource' => $itemSource,
+				'itemTarget' => $groupItemTarget,
+				'shareType' => $shareType,
+				'shareWith' => $shareWith['group'],
+				'uidOwner' => $uidOwner,
+				'permissions' => $permissions,
+				'shareTime' => time(),
+				'fileSource' => $fileSource,
+				'fileTarget' => $groupFileTarget,
+				'token' => $token,
+				'parent' => $parent,
+				'expiration' => $expirationDate,
 			);
 
 		} else {
@@ -1973,11 +2012,11 @@ class Share extends \OC\Share\Constants {
 				$itemTarget = $sourceExists['item_target'];
 
 				// for group shares we don't need a additional entry if the target is the same
-				if($isGroupShare && $groupItemTarget === $itemTarget) {
+				if ($isGroupShare && $groupItemTarget === $itemTarget) {
 					continue;
 				}
 
-			} elseif(!$sourceExists && !$isGroupShare)  {
+			} elseif (!$sourceExists && !$isGroupShare) {
 
 				$itemTarget = Helper::generateTarget($itemType, $itemSource, $userShareType, $user,
 					$uidOwner, $suggestedItemTarget, $parent);
@@ -1990,7 +2029,7 @@ class Share extends \OC\Share\Constants {
 								$parentFolders[$user]['folder'] = $fileTarget;
 							}
 						} else if (isset($parentFolder[$user])) {
-							$fileTarget = $parentFolder[$user]['folder'].$itemSource;
+							$fileTarget = $parentFolder[$user]['folder'] . $itemSource;
 							$parent = $parentFolder[$user]['id'];
 						}
 					} else {
@@ -2039,18 +2078,14 @@ class Share extends \OC\Share\Constants {
 
 		}
 
-		$id = false;
 		if ($isGroupShare) {
-			$id = self::insertShare($queriesToExecute['groupShare']);
+			self::insertShare($queriesToExecute['groupShare']);
 			// Save this id, any extra rows for this group share will need to reference it
 			$parent = \OC_DB::insertid('*PREFIX*share');
 			unset($queriesToExecute['groupShare']);
 		}
 
-		foreach ($queriesToExecute as $shareQuery) {
-			$shareQuery['parent'] = $parent;
-			$id = self::insertShare($shareQuery);
-		}
+		$id = self::insertBulkShare($queriesToExecute, $parent);
 
 		$postHookData = array(
 			'itemType' => $itemType,
@@ -2137,7 +2172,7 @@ class Share extends \OC\Share\Constants {
 			$result['expirationDate'] = $expirationDate;
 			if (!$backend->isValidSource($itemSource, $uidOwner)) {
 				$message = 'Sharing %s failed, because the sharing backend for '
-					.'%s could not find its source';
+					. '%s could not find its source';
 				$message_t = $l->t('Sharing %s failed, because the sharing backend for %s could not find its source', array($itemSource, $itemType));
 				\OC_Log::write('OCP\Share', sprintf($message, $itemSource, $itemType), \OC_Log::ERROR);
 				throw new \Exception($message_t);
@@ -2169,14 +2204,56 @@ class Share extends \OC\Share\Constants {
 	/**
 	 *
 	 * @param array $shareData
+	 * @param int $parent
 	 * @return mixed false in case of a failure or the id of the new share
 	 */
-	private static function insertShare(array $shareData)
-	{
+	private static function insertBulkShare(array $shareData, $parent) {
+		$connection = \OC::$server->getDatabaseConnection();
+		$connection->beginTransaction();
+		$query = $connection->prepare('INSERT INTO `*PREFIX*share` ('
+			. ' `item_type`, `item_source`, `item_target`, `share_type`,'
+			. ' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
+			. ' `file_target`, `token`, `parent`, `expiration`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)');
+
+		$result = false;
+		foreach ($shareData as $data) {
+			$result = $query->execute([
+				$data['itemType'],
+				$data['itemSource'],
+				$data['itemTarget'],
+				$data['shareType'],
+				$data['shareWith'],
+				$data['uidOwner'],
+				$data['permissions'],
+				$data['shareTime'],
+				$data['fileSource'],
+				$data['fileTarget'],
+				$data['token'],
+				$parent,
+				$data['expiration']
+			]);
+		}
+		$connection->commit();
+
+		$id = false;
+		if ($result) {
+			$id = $connection->lastInsertId('share');
+		}
+
+		return $id;
+
+	}
+
+	/**
+	 *
+	 * @param array $shareData
+	 * @return mixed false in case of a failure or the id of the new share
+	 */
+	private static function insertShare(array $shareData) {
 		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` ('
-			.' `item_type`, `item_source`, `item_target`, `share_type`,'
-			.' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
-			.' `file_target`, `token`, `parent`, `expiration`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)');
+			. ' `item_type`, `item_source`, `item_target`, `share_type`,'
+			. ' `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
+			. ' `file_target`, `token`, `parent`, `expiration`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)');
 		$query->bindValue(1, $shareData['itemType']);
 		$query->bindValue(2, $shareData['itemSource']);
 		$query->bindValue(3, $shareData['itemTarget']);
@@ -2194,7 +2271,7 @@ class Share extends \OC\Share\Constants {
 
 		$id = false;
 		if ($result) {
-			$id =  \OC::$server->getDatabaseConnection()->lastInsertId();
+			$id = \OC::$server->getDatabaseConnection()->lastInsertId();
 			// Fallback, if lastInterId() doesn't work we need to perform a select
 			// to get the ID (seems to happen sometimes on Oracle)
 			if (!$id) {
@@ -2215,6 +2292,7 @@ class Share extends \OC\Share\Constants {
 		return $id;
 
 	}
+
 	/**
 	 * Delete all shares with type SHARE_TYPE_LINK
 	 */
@@ -2248,8 +2326,9 @@ class Share extends \OC\Share\Constants {
 			return true;
 		}
 
-		if ( \OC::$server->getSession()->exists('public_link_authenticated')
-			&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id'] ) {
+		if (\OC::$server->getSession()->exists('public_link_authenticated')
+			&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id']
+		) {
 			return true;
 		}
 
@@ -2258,6 +2337,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * construct select statement
+	 *
 	 * @param int $format
 	 * @param boolean $fileDependent ist it a file/folder share or a generla share
 	 * @param string $uidOwner
@@ -2307,37 +2387,39 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * transform db results
+	 *
 	 * @param array $row result
 	 */
 	private static function transformDBResults(&$row) {
 		if (isset($row['id'])) {
-			$row['id'] = (int) $row['id'];
+			$row['id'] = (int)$row['id'];
 		}
 		if (isset($row['share_type'])) {
-			$row['share_type'] = (int) $row['share_type'];
+			$row['share_type'] = (int)$row['share_type'];
 		}
 		if (isset($row['parent'])) {
-			$row['parent'] = (int) $row['parent'];
+			$row['parent'] = (int)$row['parent'];
 		}
 		if (isset($row['file_parent'])) {
-			$row['file_parent'] = (int) $row['file_parent'];
+			$row['file_parent'] = (int)$row['file_parent'];
 		}
 		if (isset($row['file_source'])) {
-			$row['file_source'] = (int) $row['file_source'];
+			$row['file_source'] = (int)$row['file_source'];
 		}
 		if (isset($row['permissions'])) {
-			$row['permissions'] = (int) $row['permissions'];
+			$row['permissions'] = (int)$row['permissions'];
 		}
 		if (isset($row['storage'])) {
-			$row['storage'] = (int) $row['storage'];
+			$row['storage'] = (int)$row['storage'];
 		}
 		if (isset($row['stime'])) {
-			$row['stime'] = (int) $row['stime'];
+			$row['stime'] = (int)$row['stime'];
 		}
 	}
 
 	/**
 	 * format result
+	 *
 	 * @param array $items result
 	 * @param string $column is it a file share or a general share ('file_target' or 'item_target')
 	 * @param \OCP\Share_Backend $backend sharing backend
@@ -2345,7 +2427,7 @@ class Share extends \OC\Share\Constants {
 	 * @param array $parameters additional format parameters
 	 * @return array format result
 	 */
-	private static function formatResult($items, $column, $backend, $format = self::FORMAT_NONE , $parameters = null) {
+	private static function formatResult($items, $column, $backend, $format = self::FORMAT_NONE, $parameters = null) {
 		if ($format === self::FORMAT_NONE) {
 			return $items;
 		} else if ($format === self::FORMAT_STATUSES) {
@@ -2445,7 +2527,7 @@ class Share extends \OC\Share\Constants {
 	/**
 	 * send server-to-server unshare to remote server
 	 *
-	 * @param string remote url
+	 * @param string $remote url
 	 * @param int $id share id
 	 * @param string $token
 	 * @return bool
@@ -2461,6 +2543,7 @@ class Share extends \OC\Share\Constants {
 
 	/**
 	 * check if user can only share with group members
+	 *
 	 * @return bool
 	 */
 	public static function shareWithGroupMembersOnly() {

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2085,6 +2085,7 @@ class Share extends \OC\Share\Constants {
 			unset($queriesToExecute['groupShare']);
 		}
 
+
 		$id = self::insertBulkShare($queriesToExecute, $parent);
 
 		$postHookData = array(
@@ -2208,6 +2209,9 @@ class Share extends \OC\Share\Constants {
 	 * @return mixed false in case of a failure or the id of the new share
 	 */
 	private static function insertBulkShare(array $shareData, $parent) {
+		if (empty($shareData)) {
+			return $parent;
+		}
 		$connection = \OC::$server->getDatabaseConnection();
 		$connection->beginTransaction();
 		$query = $connection->prepare('INSERT INTO `*PREFIX*share` ('
@@ -2228,7 +2232,7 @@ class Share extends \OC\Share\Constants {
 			$query->bindValue(9, $data['fileSource']);
 			$query->bindValue(10, $data['fileTarget']);
 			$query->bindValue(11, $data['token']);
-			$query->bindValue(12, $data['parent']);
+			$query->bindValue(12, $parent);
 			$query->bindValue(13, $data['expiration'], 'datetime');
 
 			$result = $query->execute();

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2233,6 +2233,7 @@ class Share extends \OC\Share\Constants {
 				$data['expiration']
 			]);
 		}
+		$query->closeCursor();
 		$connection->commit();
 
 		$id = false;


### PR DESCRIPTION
Dong only a single prepare and having the loop of executes in transaction makes inserting a lot of share a lot faster (~80% less time spent with the db when inserting a thousand shares on my local instance)

Part of #13725

cc @schiesbn @DeepDiver1975 @PVince81 
