### PR TITLE
Show warning for PHP versions older than 5.4.0

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,6 +21,14 @@
 *
 */
 
+// Show warning if a PHP version below 5.4.0 is used, this has to happen here
+// because base.php will already use 5.4 syntax.
+if (version_compare(PHP_VERSION, '5.4.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 5.4.0<br/>';
+	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
+	return;
+}
+
 try {
 	
 	require_once 'lib/base.php';


### PR DESCRIPTION
We can't check the PHP version in the installer since base.php already uses 5.4 syntax. Thus for a better UX we show a simple warning instead of a fatal PHP error.
