### PR TITLE
Fix check if a duplicate share entry is needed in a group share

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1900,7 +1900,7 @@ class Share extends \OC\Share\Constants {
 					$fileTarget = null;
 				}
 
-				if ($itemTarget === $groupItemTarget && (isset($fileSource) && $fileTarget === $groupItemTarget)) {
+				if ($itemTarget === $groupItemTarget && (isset($fileSource) && $fileTarget === $groupFileTarget)) {
 					continue;
 				}
 			}


### PR DESCRIPTION
Fixes the creation of N share entries when sharing with a group of N users

For #13725

[comparison](bhttps://blackfire.io/profiles/compare/ba1b4448-b745-4200-b601-a40b7ab3766f/graph)

cc @DeepDiver1975 @PVince81 @schiesbn 
