### PR TITLE
only create a db entry for the user in case of a name conflict on group share

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1905,7 +1905,11 @@ class Share extends \OC\Share\Constants {
 		$isGroupShare = false;
 		if ($shareType == self::SHARE_TYPE_GROUP) {
 			$isGroupShare = true;
-			$users = \OC_Group::usersInGroup($shareWith['group']);
+			if (isset($shareWith['users'])) {
+				$users = $shareWith['users'];
+			} else {
+				$users = \OC_Group::usersInGroup($shareWith['group']);
+			}
 			// remove current user from list
 			if (in_array(\OCP\User::getUser(), $users)) {
 				unset($users[array_search(\OCP\User::getUser(), $users)]);
@@ -2016,7 +2020,8 @@ class Share extends \OC\Share\Constants {
 					$fileTarget = null;
 				}
 
-				if ($itemTarget === $groupItemTarget && (isset($fileSource) && $fileTarget === $groupItemTarget)) {
+				if (($itemTarget === $groupItemTarget) &&
+					(!isset($fileSource) || $fileTarget === $groupFileTarget)) {
 					continue;
 				}
 			}

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -545,6 +545,13 @@ class Test_Share extends \Test\TestCase {
 		// Valid share
 		$this->shareUserOneTestFileWithGroupOne();
 
+		// check if only the group share was created and not a single db-entry for each user
+		$statement = \OCP\DB::prepare('select `id` from `*PREFIX*share`');
+		$query = $statement->execute();
+		$result = $query->fetchAll();
+		$this->assertSame(1, count($result));
+
+
 		// Attempt to share again
 		OC_User::setUserId($this->user1);
 		$message = 'Sharing test.txt failed, because this item is already shared with '.$this->group1;


### PR DESCRIPTION
A group share should only create one db entry. Only users who get a different target name should get a separate db entry.

See https://github.com/owncloud/core/issues/13725

cc @PVince81 @butonic @icewind1991 
