### PR TITLE
Add a controller and reponse for ocs

### DIFF
--- a/lib/private/ocs.php
+++ b/lib/private/ocs.php
@@ -121,7 +121,7 @@ class OC_OCS {
 	 * @param int|string $itemsperpage
 	 * @return string xml/json
 	 */
-	private static function generateXml($format, $status, $statuscode,
+	public static function generateXml($format, $status, $statuscode,
 		$message, $data=array(), $tag='', $tagattribute='', $dimension=-1, $itemscount='', $itemsperpage='') {
 		if($format=='json') {
 			$json=array();

--- a/lib/public/appframework/apicontroller.php
+++ b/lib/public/appframework/apicontroller.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -44,17 +44,17 @@ abstract class ApiController extends Controller {
      * constructor of the controller
      * @param string $appName the name of the app
      * @param IRequest $request an instance of the request
-     * @param string $corsMethods: comma seperated string of HTTP verbs which 
+     * @param string $corsMethods: comma seperated string of HTTP verbs which
      * should be allowed for websites or webapps when calling your API, defaults to
      * 'PUT, POST, GET, DELETE, PATCH'
      * @param string $corsAllowedHeaders: comma seperated string of HTTP headers
-     * which should be allowed for websites or webapps when calling your API, 
+     * which should be allowed for websites or webapps when calling your API,
      * defaults to 'Authorization, Content-Type, Accept'
      * @param int $corsMaxAge number in seconds how long a preflighted OPTIONS
      * request should be cached, defaults to 1728000 seconds
      */
-    public function __construct($appName, 
-                                IRequest $request, 
+    public function __construct($appName,
+                                IRequest $request,
                                 $corsMethods='PUT, POST, GET, DELETE, PATCH',
                                 $corsAllowedHeaders='Authorization, Content-Type, Accept',
                                 $corsMaxAge=1728000){

--- a/lib/public/appframework/http/ocsresponse.php
+++ b/lib/public/appframework/http/ocsresponse.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * AppFramework\HTTP\JSONResponse class
+ */
+
+namespace OCP\AppFramework\Http;
+
+use OCP\AppFramework\Http;
+
+use OC_OCS;
+
+/**
+ * A renderer for OCS responses
+ */
+class OCSResponse extends Response {
+
+	private $data;
+	private $format;
+	private $statuscode;
+	private $message;
+	private $tag;
+	private $tagattribute;
+	private $dimension;
+	private $itemscount;
+	private $itemsperpage;
+
+	/**
+	 * generates the xml or json response for the API call from an multidimenional data array.
+	 * @param string $format
+	 * @param string $status
+	 * @param string $statuscode
+	 * @param string $message
+	 * @param array $data
+	 * @param string $tag
+	 * @param string $tagattribute
+	 * @param int $dimension
+	 * @param int|string $itemscount
+	 * @param int|string $itemsperpage
+	 */
+	public function __construct($format, $status, $statuscode, $message,
+								$data=[], $tag='', $tagattribute='',
+								$dimension=-1, $itemscount='',
+								$itemsperpage='') {
+		$this->format = $format;
+		$this->status = $status;
+		$this->statuscode = $statuscode;
+		$this->message = $message;
+		$this->data = $data;
+		$this->tag = $tag;
+		$this->tagattribute = $tagattribute;
+		$this->dimension = $dimension;
+		$this->itemscount = $itemscount;
+		$this->itemsperpage = $itemsperpage;
+
+		// set the correct header based on the format parameter
+		if ($format === 'json') {
+			$this->addHeader(
+				'Content-Type', 'application/json; charset=utf-8'
+			);
+		} else {
+			$this->addHeader(
+				'Content-Type', 'application/xml; charset=utf-8'
+			);
+		}
+	}
+
+
+	public function render() {
+		return OC_OCS::generateXml(
+			$this->format, $this->status, $this->statuscode, $this->message,
+			$this->data, $this->tag, $this->tagattribute, $this->dimension,
+			$this->itemscount, $this->itemsperpage
+		);
+	}
+
+
+}

--- a/lib/public/appframework/ocscontroller.php
+++ b/lib/public/appframework/ocscontroller.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt nukeawhale@gmail.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * AppFramework\Controller class
+ */
+
+namespace OCP\AppFramework;
+
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\OCSResponse;
+use OCP\IRequest;
+
+
+/**
+ * Base class to inherit your controllers from that are used for RESTful APIs
+ */
+abstract class OCSController extends ApiController {
+
+	/**
+	 * constructor of the controller
+	 * @param string $appName the name of the app
+	 * @param IRequest $request an instance of the request
+	 * @param string $corsMethods: comma seperated string of HTTP verbs which
+	 * should be allowed for websites or webapps when calling your API, defaults to
+	 * 'PUT, POST, GET, DELETE, PATCH'
+	 * @param string $corsAllowedHeaders: comma seperated string of HTTP headers
+	 * which should be allowed for websites or webapps when calling your API,
+	 * defaults to 'Authorization, Content-Type, Accept'
+	 * @param int $corsMaxAge number in seconds how long a preflighted OPTIONS
+	 * request should be cached, defaults to 1728000 seconds
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								$corsMethods='PUT, POST, GET, DELETE, PATCH',
+								$corsAllowedHeaders='Authorization, Content-Type, Accept',
+								$corsMaxAge=1728000){
+		parent::__construct($appName, $request, $corsMethods,
+							$corsAllowedHeaders, $corsMaxAge);
+		$this->registerResponder('json', function ($data) {
+			return $this->buildOCSResponse('json', $data);
+		});
+		$this->registerResponder('xml', function ($data) {
+			return $this->buildOCSResponse('xml', $data);
+		});
+	}
+
+
+	/**
+	 * Unwrap data and build ocs response
+	 * @param string $format json or xml
+	 * @param array|DataResponse $data the data which should be transformed
+	 */
+	private function buildOCSResponse($format, $data) {
+		if ($data instanceof DataResponse) {
+			$data = $data->getData();
+		}
+
+		$params = [
+			'status' => 'OK',
+			'statuscode' => 100,
+			'message' => 'OK',
+			'data' => [],
+			'tag' => '',
+			'tagattribute' => '',
+			'dimension' => 'dynamic',
+			'itemscount' => '',
+			'itemsperpage' => ''
+		];
+
+		foreach ($data as $key => $value) {
+			$params[$key] = $value;
+		}
+
+		return new OCSResponse(
+			$format, $params['status'], $params['statuscode'],
+			$params['message'], $params['data'], $params['tag'],
+			$params['tagattribute'], $params['dimension'],
+			$params['itemscount'], $params['itemsperpage']
+		);
+	}
+
+}

--- a/lib/public/appframework/ocscontroller.php
+++ b/lib/public/appframework/ocscontroller.php
@@ -3,7 +3,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2015 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/ApiControllerTest.php
+++ b/tests/lib/appframework/controller/ApiControllerTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2012 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/OCSControllerTest.php
+++ b/tests/lib/appframework/controller/OCSControllerTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2015 Bernhard Posselt nukeawhale@gmail.com
+ * @copyright 2015 Bernhard Posselt dev@bernhard-posselt.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/OCSControllerTest.php
+++ b/tests/lib/appframework/controller/OCSControllerTest.php
@@ -4,7 +4,7 @@
  * ownCloud - App Framework
  *
  * @author Bernhard Posselt
- * @copyright 2015 Bernhard Posselt dev@bernhard-posselt.com
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/lib/appframework/controller/OCSControllerTest.php
+++ b/tests/lib/appframework/controller/OCSControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt nukeawhale@gmail.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCP\AppFramework;
+
+use OC\AppFramework\Http\Request;
+use OCP\AppFramework\Http\DataResponse;
+
+
+class ChildOCSController extends OCSController {}
+
+
+class OCSControllerTest extends \Test\TestCase {
+
+
+	public function testCors() {
+		$request = new Request(
+			array('server' => array('HTTP_ORIGIN' => 'test'))
+		);
+		$this->controller = new ChildOCSController('app', $request, 'verbs',
+			'headers', 100);
+
+		$response = $this->controller->preflightedCors();
+
+		$headers = $response->getHeaders();
+
+		$this->assertEquals('test', $headers['Access-Control-Allow-Origin']);
+		$this->assertEquals('verbs', $headers['Access-Control-Allow-Methods']);
+		$this->assertEquals('headers', $headers['Access-Control-Allow-Headers']);
+		$this->assertEquals('false', $headers['Access-Control-Allow-Credentials']);
+		$this->assertEquals(100, $headers['Access-Control-Max-Age']);
+	}
+
+
+	public function testXML() {
+		$controller = new ChildOCSController('app', new Request);
+		$expected = "<?xml version=\"1.0\"?>\n" .
+		"<ocs>\n" .
+		" <meta>\n" .
+		"  <status>OK</status>\n" .
+		"  <statuscode>400</statuscode>\n" .
+		"  <message>OK</message>\n" .
+		" </meta>\n" .
+		" <data>\n" .
+		"  <test>hi</test>\n" .
+		" </data>\n" .
+		"</ocs>\n";
+
+		$params = [
+			'data' => [
+				'test' => 'hi'
+			],
+			'statuscode' => 400
+		];
+
+		$out = $controller->buildResponse($params, 'xml')->render();
+		$this->assertEquals($expected, $out);
+	}
+
+
+	public function testXMLDataResponse() {
+		$controller = new ChildOCSController('app', new Request);
+		$expected = "<?xml version=\"1.0\"?>\n" .
+		"<ocs>\n" .
+		" <meta>\n" .
+		"  <status>OK</status>\n" .
+		"  <statuscode>400</statuscode>\n" .
+		"  <message>OK</message>\n" .
+		" </meta>\n" .
+		" <data>\n" .
+		"  <test>hi</test>\n" .
+		" </data>\n" .
+		"</ocs>\n";
+
+		$params = new DataResponse([
+			'data' => [
+				'test' => 'hi'
+			],
+			'statuscode' => 400
+		]);
+
+		$out = $controller->buildResponse($params, 'xml')->render();
+		$this->assertEquals($expected, $out);
+	}
+
+
+	public function testJSON() {
+		$controller = new ChildOCSController('app', new Request);
+		$expected = '{"status":"OK","statuscode":400,"message":"OK",' .
+		            '"totalitems":"","itemsperpage":"","data":{"test":"hi"}}';
+		$params = [
+			'data' => [
+				'test' => 'hi'
+			],
+			'statuscode' => 400
+		];
+
+		$out = $controller->buildResponse($params, 'json')->render();
+		$this->assertEquals($expected, $out);
+	}
+
+
+}

--- a/tests/lib/appframework/http/OCSResponseTest.php
+++ b/tests/lib/appframework/http/OCSResponseTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright 2015 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OC\AppFramework\Http;
+
+
+use OCP\AppFramework\Http\OCSResponse;
+
+
+class OCSResponseTest extends \Test\TestCase {
+
+
+    public function testHeadersJSON() {
+        $response = new OCSResponse('json', 1, 2, 3);
+        $type = $response->getHeaders()['Content-Type'];
+        $this->assertEquals('application/json; charset=utf-8', $type);
+    }
+
+
+    public function testHeadersXML() {
+        $response = new OCSResponse('xml', 1, 2, 3);
+        $type = $response->getHeaders()['Content-Type'];
+        $this->assertEquals('application/xml; charset=utf-8', $type);
+    }
+
+
+    public function testRender() {
+        $response = new OCSResponse(
+            'xml', 'status', 2, 'message', ['test' => 'hi'], 'tag', 'abc',
+            'dynamic', 3, 4
+        );
+        $out = $response->render();
+        $expected = "<?xml version=\"1.0\"?>\n" .
+        "<ocs>\n" .
+        " <meta>\n" .
+        "  <status>status</status>\n" .
+        "  <statuscode>2</statuscode>\n" .
+        "  <message>message</message>\n" .
+        "  <totalitems>3</totalitems>\n" .
+        "  <itemsperpage>4</itemsperpage>\n" .
+        " </meta>\n" .
+        " <data>\n" .
+        "  <test>hi</test>\n" .
+        " </data>\n" .
+        "</ocs>\n";
+
+        $this->assertEquals($expected, $out);
+
+    }
+
+
+}


### PR DESCRIPTION
Regarding App Framework integration in #12454

usage: Inherit from **OCP\AppFramework\OCSController** and return either an array or DataResponse encapsulating the array:

``` php
return [
    'data' => [
        'test' => 'hi'
    ],
    'statuscode' => 400
];
```

where the array keys are first level information for OCS. They keys are exactly the same as the parameters for OC_OCS::generateXML and will default to reasonable values if not provided, meaning you can also return an empty array for a 100 OK response or simply an array with the data key to return data.

@LukasReschke @PVince81 @butonic @karlitschek @schiesbn @DeepDiver1975 
