### PR TITLE
[files_external] add SMB autotest

### DIFF
--- a/apps/files_external/tests/backends/smb.php
+++ b/apps/files_external/tests/backends/smb.php
@@ -16,12 +16,12 @@ class SMB extends Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.php');
-		if (!is_array($this->config) or !isset($this->config['smb']) or !$this->config['smb']['run']) {
+		$config = include('files_external/tests/config.smb.php');
+		if (!is_array($config) or !$config['run']) {
 			$this->markTestSkipped('Samba backend not configured');
 		}
-		$this->config['smb']['root'] .= $id; //make sure we have an new empty folder to work in
-		$this->instance = new \OC\Files\Storage\SMB($this->config['smb']);
+		$config['root'] .= $id; //make sure we have an new empty folder to work in
+		$this->instance = new \OC\Files\Storage\SMB($config);
 		$this->instance->mkdir('/');
 	}
 

--- a/apps/files_external/tests/env/start-smb-silvershell.sh
+++ b/apps/files_external/tests/env/start-smb-silvershell.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# This script start a docker container to test the files_external tests
+# against. It will also change the files_external config to use the docker
+# container as testing environment. This is reverted in the stop step.W
+#
+# Set environment variable DEBUG to print config file
+#
+# @author Morris Jobke
+# @copyright 2015 Morris Jobke <hey@morrisjobke.de>
+#
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "No docker executable found - skipped docker setup"
+    exit 0;
+fi
+
+echo "Docker executable found - setup docker"
+
+echo "Fetch recent silvershell/samba docker image"
+docker pull silvershell/samba
+
+# retrieve current folder to place the config in the parent folder
+thisFolder=`echo $0 | replace "env/start-smb-silvershell.sh" ""`
+
+if [ -z "$thisFolder" ]; then
+    thisFolder="."
+fi;
+
+container=`docker run -d -e SMB_USER=test -e SMB_PWD=test silvershell/samba`
+
+host=`docker inspect $container | grep IPAddress | cut -d '"' -f 4`
+
+cat > $thisFolder/config.smb.php <<DELIM
+<?php
+
+return array(
+    'run'=>true,
+    'host'=>'$host',
+    'user'=>'test',
+    'password'=>'test',
+    'root'=>'',
+    'share'=>'public',
+);
+
+DELIM
+
+echo "samba container: $container"
+
+# put container IDs into a file to drop them after the test run (keep in mind that multiple tests run in parallel on the same host)
+echo $container >> $thisFolder/dockerContainerSilvershell.$EXECUTOR_NUMBER.smb
+
+if [ -n "$DEBUG" ]; then
+    cat $thisFolder/config.smb.php
+    cat $thisFolder/dockerContainerSilvershell.$EXECUTOR_NUMBER.smb
+fi
+
+# TODO find a way to determine the successful initialization inside the docker container
+echo "Waiting 5 seconds for smbd initialization ... "
+sleep 5
+

--- a/apps/files_external/tests/env/start-webdav-ownCloud.sh
+++ b/apps/files_external/tests/env/start-webdav-ownCloud.sh
@@ -28,6 +28,10 @@ docker pull morrisjobke/owncloud
 # retrieve current folder to place the config in the parent folder
 thisFolder=`echo $0 | replace "env/start-webdav-ownCloud.sh" ""`
 
+if [ -z "$thisFolder" ]; then
+    thisFolder="."
+fi;
+
 if [ -n "$RUN_DOCKER_MYSQL" ]; then
     echo "Fetch recent mysql docker image"
     docker pull mysql
@@ -78,5 +82,6 @@ if [ -n "$databaseContainer" ]; then
 fi
 
 if [ -n "$DEBUG" ]; then
-    echo $thisFolder/config.webdav.php
+    cat $thisFolder/config.webdav.php
+    cat $thisFolder/dockerContainerOwnCloud.$EXECUTOR_NUMBER.webdav
 fi

--- a/apps/files_external/tests/env/stop-smb-silvershell.sh
+++ b/apps/files_external/tests/env/stop-smb-silvershell.sh
@@ -6,7 +6,7 @@
 # against. It will also revert the config changes done in start step.
 #
 # @author Morris Jobke
-# @copyright 2014 Morris Jobke <hey@morrisjobke.de>
+# @copyright 2015 Morris Jobke <hey@morrisjobke.de>
 #
 
 if ! command -v docker >/dev/null 2>&1; then
@@ -17,20 +17,20 @@ fi
 echo "Docker executable found - stop and remove docker containers"
 
 # retrieve current folder to remove the config from the parent folder
-thisFolder=`echo $0 | replace "env/stop-webdav-ownCloud.sh" ""`
+thisFolder=`echo $0 | replace "env/stop-smb-silvershell.sh" ""`
 
 if [ -z "$thisFolder" ]; then
     thisFolder="."
 fi;
 
 # stopping and removing docker containers
-for container in `cat $thisFolder/dockerContainerOwnCloud.$EXECUTOR_NUMBER.webdav`; do
+for container in `cat $thisFolder/dockerContainerSilvershell.$EXECUTOR_NUMBER.smb`; do
     echo "Stopping and removing docker container $container"
     # kills running container and removes it
     docker rm -f $container
 done;
 
 # cleanup
-rm $thisFolder/config.webdav.php
-rm $thisFolder/dockerContainerOwnCloud.$EXECUTOR_NUMBER.webdav
+rm $thisFolder/config.smb.php
+rm $thisFolder/dockerContainerSilvershell.$EXECUTOR_NUMBER.smb
 


### PR DESCRIPTION
I used this docker container some days ago to test some SMB external backend stuff. With this PR I build this container into our autotest-external script.

I doesn't go very well, but 5 out of the 55 are passing. It even creates some files in the backend.

To run these unit tests simply do:

```
DEBUG=true ./autotest.sh smb-silvershell
```

Or go to the folder `apps/files_external/tests`:

```
env/start-smb-silvershell.sh    # this will fire up the docker container and will write the config files
phpunit --configuration ../../../tests/phpunit-autotest-external.xml  backends/smb.php
# debug here - maybe connect to the samba server - for port see config.smb.php
env/stop-smb-silvershell.sh # stop the docker container
```

A first look at the samba share reveals this:
![smb-external-tests](https://cloud.githubusercontent.com/assets/245432/6062042/df456d2e-ad4c-11e4-9065-24f93ab53e2e.png)

So it looks like something was executed correct.

cc @icewind1991 @PVince81 @DeepDiver1975 
- [ ] depends on #10673  
