### PR TITLE
no fruitless count attempts, and notification should disappear

### DIFF
--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -85,7 +85,7 @@ switch($action) {
 				exit;
 			}
 		} catch (\Exception $e) {
-			\OCP\JSON::error(array('message' => $e->getMessage()));
+			\OCP\JSON::error(array('message' => $e->getMessage(), 'code' => $e->getCode()));
 			exit;
 		}
 		\OCP\JSON::error();

--- a/apps/user_ldap/js/settings.js
+++ b/apps/user_ldap/js/settings.js
@@ -351,7 +351,7 @@ var LdapWizard = {
 				encodeURIComponent($('#ldap_serverconfig_chooser').val());
 
 		LdapWizard.showSpinner(spinnerID);
-		var request = LdapWizard.ajax(param,
+		LdapWizard.ajax(param,
 			function(result) {
 				LdapWizard.applyChanges(result);
 				LdapWizard.hideSpinner(spinnerID);
@@ -360,7 +360,7 @@ var LdapWizard = {
 				}
 			},
 			function (result) {
-				OC.Notification.show('Counting the entries failed with, ' + result.message);
+				OC.Notification.showTemporary('Counting the entries failed with: ' + result.message);
 				LdapWizard.hideSpinner(spinnerID);
 				if(!_.isUndefined(doneCallback)) {
 					doneCallback(method);
@@ -371,11 +371,17 @@ var LdapWizard = {
 	},
 
 	countGroups: function(doneCallback) {
-		LdapWizard._countThings('countGroups', '#ldap_group_count', doneCallback);
+		var groupFilter  = $('#ldap_group_filter').val();
+		if(!_.isEmpty(groupFilter)) {
+			LdapWizard._countThings('countGroups', '#ldap_group_count', doneCallback);
+		}
 	},
 
 	countUsers: function(doneCallback) {
-		LdapWizard._countThings('countUsers', '#ldap_user_count', doneCallback);
+		var userFilter  = $('#ldap_userlist_filter').val();
+		if(!_.isEmpty(userFilter)) {
+			LdapWizard._countThings('countUsers', '#ldap_user_count', doneCallback);
+		}
 	},
 
 	/**


### PR DESCRIPTION
Fixes #13898 

To reproduce:
- have LDAP enabled
- go to Admin → LDAP
- fill out server tab
- switch to Users tab
- before: message as reported in https://github.com/owncloud/core/issues/13898 appears and does not vanish
- now: message does not appear. even the count attempt is not made, because at that point we don't have the user filter compiled yet. And if it would appear,  it will vanish now after 7 seconds (OC default).

Please test/review @jnfrmarks @MorrisJobke 

@DeepDiver1975 original issue is milestoned 8.0 but not showstopper. It's not a big change OTOH. So, 8.0 or 8.0.1?
