### PR TITLE
fix creation of ghost directories

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1102,13 +1102,20 @@ class Share extends \OC\Share\Constants {
 	 * @return null
 	 */
 	protected static function unshareItem(array $item, $newParent = null) {
+
+		$shareType = (int)$item['share_type'];
+		$shareWith = null;
+		if ($shareType !== \OCP\Share::SHARE_TYPE_LINK) {
+			$shareWith = $item['share_with'];
+		}
+
 		// Pass all the vars we have for now, they may be useful
 		$hookParams = array(
 			'id'            => $item['id'],
 			'itemType'      => $item['item_type'],
 			'itemSource'    => $item['item_source'],
-			'shareType'     => (int)$item['share_type'],
-			'shareWith'     => $item['share_with'],
+			'shareType'     => $shareType,
+			'shareWith'     => $shareWith,
 			'itemParent'    => $item['parent'],
 			'uidOwner'      => $item['uid_owner'],
 		);


### PR DESCRIPTION
for password protected link shares the password is stored in shareWith, so we need to set this manually to null for the hooks.

Steps to reproduce:
- Share a file as link
- set a password for the link share
- close share drop down
- reopen share drop down
- unshare the link

Without the patch some apps will create a directory `data/<link_password>` because the password is used as "shareWith" parameter at the hook. With this patch no password should be created.

cc @butonic @blizzz @MorrisJobke 
