### PR TITLE
prevent creation of ghost directories

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1166,13 +1166,20 @@ class Share extends \OC\Share\Constants {
 	 * @return null
 	 */
 	protected static function unshareItem(array $item, $newParent = null) {
+
+		$shareType = (int)$item['share_type'];
+		$shareWith = null;
+		if ($shareType !== \OCP\Share::SHARE_TYPE_LINK) {
+			$shareWith = $item['share_with'];
+		}
+
 		// Pass all the vars we have for now, they may be useful
 		$hookParams = array(
 			'id'            => $item['id'],
 			'itemType'      => $item['item_type'],
 			'itemSource'    => $item['item_source'],
-			'shareType'     => (int)$item['share_type'],
-			'shareWith'     => $item['share_with'],
+			'shareType'     => $shareType,
+			'shareWith'     => $shareWith,
 			'itemParent'    => $item['parent'],
 			'uidOwner'      => $item['uid_owner'],
 		);


### PR DESCRIPTION
for password protected link shares the password is stored in shareWith, so we need to set this manually to null for the hooks.

forward port of https://github.com/owncloud/core/pull/13927. I can't reproduce the creation of the ghost files on master but still it is good to not have a wrong value in shareWith of the hook parameters. You never know what a app will do with it.
