### PR TITLE
Revert "adding OC-ETag header"

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -220,6 +220,21 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 	}
 
 	/**
+	 * Returns the ETag for a file
+	 *
+	 * An ETag is a unique identifier representing the current version of the
+	 * file. If the file changes, the ETag MUST change.  The ETag is an
+	 * arbitrary string, but MUST be surrounded by double-quotes.
+	 *
+	 * Return null if the ETag can not effectively be determined
+	 *
+	 * @return mixed
+	 */
+	public function getETag() {
+		return '"' . $this->info->getEtag() . '"';
+	}
+
+	/**
 	 * Returns the mime-type for a file
 	 *
 	 * If null is returned, we'll assume application/octet-stream

--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -123,10 +123,6 @@ class OC_Connector_Sabre_FilesPlugin extends \Sabre\DAV\ServerPlugin
 			if (!is_null($fileId)) {
 				$this->server->httpResponse->setHeader('OC-FileId', $fileId);
 			}
-			$eTag = $node->getETag();
-			if (!is_null($eTag)) {
-				$this->server->httpResponse->setHeader('OC-ETag', $eTag);
-			}
 		}
 	}
 

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -281,20 +281,4 @@ abstract class OC_Connector_Sabre_Node implements \Sabre\DAV\INode, \Sabre\DAV\I
 		}
 		return $p;
 	}
-
-	/**
-	 * Returns the ETag for a file
-	 *
-	 * An ETag is a unique identifier representing the current version of the
-	 * file. If the file changes, the ETag MUST change.  The ETag is an
-	 * arbitrary string, but MUST be surrounded by double-quotes.
-	 *
-	 * Return null if the ETag can not effectively be determined
-	 *
-	 * @return mixed
-	 */
-	public function getETag() {
-		return '"' . $this->info->getEtag() . '"';
-	}
-
 }


### PR DESCRIPTION
This reverts commit 96a931929ea837a40a7e9b836252587c949a8127.

Reverts https://github.com/owncloud/core/pull/10725 which introduces this regression in OC 8: https://github.com/owncloud/core/issues/13931

At this point it's already too late to come up with a proper fix so I suggest to revert it and take the time to find a proper fix for 8.0.1

@karlitschek @icewind1991 @DeepDiver1975 @guruz @dragotin @danimo @realrancor
