### PR TITLE
Coherent use of "SQLite" in lines 119 and 124

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -121,7 +121,7 @@ if ($_['databaseOverload']) {
 	</p>
 	<p>
 		<strong>
-			<?php p($l->t('Especially when using desktop client for file syncing the use of sqlite is discouraged.')); ?>
+			<?php p($l->t('Especially when using the desktop client for file syncing the use of SQLite is discouraged.')); ?>
 		</strong>
 	</p>
 	<p>


### PR DESCRIPTION
In line 124, "SQLite" has now the same capitalisation as in line 119. Just a cosmetic detail, but very obvious when working on localisations.
