### PR TITLE
Deprecated \OCP\IAppConfig - add missing methods to IConfig

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -1283,9 +1283,19 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	public function testDefaultExpireDate() {
 		\Test_Files_Sharing_Api::loginHelper(\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER1);
-		\OC::$server->getAppConfig()->setValue('core', 'shareapi_default_expire_date', 'yes');
-		\OC::$server->getAppConfig()->setValue('core', 'shareapi_enforce_expire_date', 'yes');
-		\OC::$server->getAppConfig()->setValue('core', 'shareapi_expire_after_n_days', '2');
+
+		// TODO drop this once all code paths use the DI version - otherwise
+		// the cache inside this config object is out of date because
+		// OC_Appconfig is used and bypasses this cache which lead to integrity
+		// constraint violations
+		$config = \OC::$server->getConfig();
+		$config->deleteAppValue('core', 'shareapi_default_expire_date');
+		$config->deleteAppValue('core', 'shareapi_enforce_expire_date');
+		$config->deleteAppValue('core', 'shareapi_expire_after_n_days');
+
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_expire_after_n_days', '2');
 
 		// default expire date is set to 2 days
 		// the time when the share was created is set to 3 days in the past
@@ -1329,8 +1339,8 @@ class Test_Files_Sharing_Api extends TestCase {
 		//cleanup
 		$result = \OCP\Share::unshare('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue($result);
-		\OC::$server->getAppConfig()->setValue('core', 'shareapi_default_expire_date', 'no');
-		\OC::$server->getAppConfig()->setValue('core', 'shareapi_enforce_expire_date', 'no');
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'no');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'no');
 
 	}
 }

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -8,6 +8,8 @@
  */
 
 namespace OC;
+
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 
@@ -20,6 +22,9 @@ class AllConfig implements \OCP\IConfig {
 
 	/** @var IDBConnection */
 	private $connection;
+
+	/** @var IAppConfig */
+	private $appConfig;
 
 	/**
 	 * 3 dimensional array with the following structure:
@@ -62,10 +67,16 @@ class AllConfig implements \OCP\IConfig {
 	 *
 	 * otherwise a SQLite database is created in the wrong directory
 	 * because the database connection was created with an uninitialized config
+	 *
+	 * The same applies for the app config, because it uses the database
+	 * connection itself
 	 */
 	private function fixDIInit() {
 		if($this->connection === null) {
 			$this->connection = \OC::$server->getDatabaseConnection();
+		}
+		if ($this->appConfig === null) {
+			$this->appConfig = \OC::$server->getAppConfig();
 		}
 	}
 
@@ -116,7 +127,10 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string[] the keys stored for the app
 	 */
 	public function getAppKeys($appName) {
-		return \OC::$server->getAppConfig()->getKeys($appName);
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		return $this->appConfig->getKeys($appName);
 	}
 
 	/**
@@ -127,7 +141,24 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $value the value that should be stored
 	 */
 	public function setAppValue($appName, $key, $value) {
-		\OC::$server->getAppConfig()->setValue($appName, $key, $value);
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$this->appConfig->setValue($appName, $key, $value);
+	}
+
+	/**
+	 * Checks if a key is set in the apps config
+	 *
+	 * @param string $appName the appName tto look a key up
+	 * @param string $key the key to look up
+	 * @return bool
+	 */
+	public function hasAppKey($appName, $key) {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$this->appConfig->hasKey($appName, $key);
 	}
 
 	/**
@@ -139,7 +170,49 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string the saved value
 	 */
 	public function getAppValue($appName, $key, $default = '') {
-		return \OC::$server->getAppConfig()->getValue($appName, $key, $default);
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		return $this->appConfig->getValue($appName, $key, $default);
+	}
+
+	/**
+	 * Get all app values that are stored
+	 *
+	 * @param string $appName the appName
+	 * @return array with key - value pair as they are saved previously
+	 */
+	public function getAppValuesByApp($appName) {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		return $this->appConfig->getValues($appName, false);
+	}
+
+	/**
+	 * Get all app values that use the same key
+	 *
+	 * @param string $key the appName
+	 * @return array with key - value pair as they are saved previously with the
+	 *                 app name as key
+	 */
+	public function getAppValuesByKey($key) {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		return $this->appConfig->getValues(false, $key);
+	}
+
+	/**
+	 * Get all apps that have at least one value saved
+	 *
+	 * @return array containing app names
+	 */
+	public function getApps() {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		return $this->appConfig->getApps();
 	}
 
 	/**
@@ -149,7 +222,10 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 */
 	public function deleteAppValue($appName, $key) {
-		\OC::$server->getAppConfig()->deleteKey($appName, $key);
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$this->appConfig->deleteKey($appName, $key);
 	}
 
 	/**
@@ -158,7 +234,10 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $appName the appName the configs are stored under
 	 */
 	public function deleteAppValues($appName) {
-		\OC::$server->getAppConfig()->deleteApp($appName);
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$this->appConfig->deleteApp($appName);
 	}
 
 

--- a/lib/private/legacy/appconfig.php
+++ b/lib/private/legacy/appconfig.php
@@ -25,7 +25,7 @@
  * This class provides an easy way for apps to store config values in the
  * database.
  *
- * @deprecated use \OC::$server->getAppConfig() to get an \OCP\IAppConfig instance
+ * @deprecated use \OC::$server->getConfig() to get an \OCP\IConfig instance
  */
 class OC_Appconfig {
 	/**

--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -164,14 +164,16 @@ class Helper extends \OC\Share\Constants {
 	 */
 	public static function getDefaultExpireSetting() {
 
+		$config = \OC::$server->getConfig();
+
 		$defaultExpireSettings = array('defaultExpireDateSet' => false);
 
 		// get default expire settings
-		$defaultExpireDate = \OC_Appconfig::getValue('core', 'shareapi_default_expire_date', 'no');
+		$defaultExpireDate = $config->getAppValue('core', 'shareapi_default_expire_date', 'no');
 		if ($defaultExpireDate === 'yes') {
-			$enforceExpireDate = \OC_Appconfig::getValue('core', 'shareapi_enforce_expire_date', 'no');
+			$enforceExpireDate = $config->getAppValue('core', 'shareapi_enforce_expire_date', 'no');
 			$defaultExpireSettings['defaultExpireDateSet'] = true;
-			$defaultExpireSettings['expireAfterDays'] = (int)\OC_Appconfig::getValue('core', 'shareapi_expire_after_n_days', '7');
+			$defaultExpireSettings['expireAfterDays'] = (int)($config->getAppValue('core', 'shareapi_expire_after_n_days', '7'));
 			$defaultExpireSettings['enforceExpireDate'] = $enforceExpireDate === 'yes' ? true : false;
 		}
 

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -10,6 +10,10 @@ namespace OCP;
 /**
  * This class provides an easy way for apps to store config values in the
  * database.
+ *
+ * @deprecated This interface will be dropped with ownCloud 10.1 which will be
+ *             released in the first quarter of 2017. Use the methods of
+ *             \OCP\IConfig instead
  */
 interface IAppConfig {
 	/**
@@ -17,6 +21,7 @@ interface IAppConfig {
 	 * @param string $app
 	 * @param string $key
 	 * @return bool
+	 * @deprecated use method hasAppKey of \OCP\IConfig
 	 */
 	public function hasKey($app, $key);
 
@@ -59,6 +64,7 @@ interface IAppConfig {
 	 * @param string|false $key
 	 * @param string|false $app
 	 * @return array|false
+	 * @deprecated use method getAppValuesByApp or getAppValuesByKey of \OCP\IConfig
 	 */
 	public function getValues($app, $key);
 
@@ -77,6 +83,7 @@ interface IAppConfig {
 	/**
 	 * Get all apps using the config
 	 * @return array an array of app ids
+	 * @deprecated use method getApps of \OCP\IConfig
 	 *
 	 * This function returns a list of all apps that have at least one
 	 * entry in the appconfig table.

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -85,6 +85,16 @@ interface IConfig {
 	public function setAppValue($appName, $key, $value);
 
 	/**
+	 * Checks if a key is set in the apps config
+	 *
+	 * @param string $appName the appName tto look a key up
+	 * @param string $key the key to look up
+	 * @return bool
+	 * @since 8.1.0
+	 */
+	public function hasAppKey($appName, $key);
+
+	/**
 	 * Looks up an app wide defined value
 	 *
 	 * @param string $appName the appName that we stored the value under
@@ -93,6 +103,33 @@ interface IConfig {
 	 * @return string the saved value
 	 */
 	public function getAppValue($appName, $key, $default = '');
+
+	/**
+	 * Get all app values that are stored
+	 *
+	 * @param string $appName the appName
+	 * @return array with key - value pair as they are saved previously
+	 * @since 8.1.0
+	 */
+	public function getAppValuesByApp($appName);
+
+	/**
+	 * Get all app values that use the same key
+	 *
+	 * @param string $key the appName
+	 * @return array with key - value pair as they are saved previously with the
+	 * 	             app name as key
+	 * @since 8.1.0
+	 */
+	public function getAppValuesByKey($key);
+
+	/**
+	 * Get all apps that have at least one value saved
+	 *
+	 * @return array containing app names
+	 * @since 8.1.0
+	 */
+	public function getApps();
 
 	/**
 	 * Delete an app wide defined value

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -857,8 +857,10 @@ class Test_Share extends \Test\TestCase {
 	public function testShareItemWithLinkAndDefaultExpireDate() {
 		OC_User::setUserId($this->user1);
 
-		\OC_Appconfig::setValue('core', 'shareapi_default_expire_date', 'yes');
-		\OC_Appconfig::setValue('core', 'shareapi_expire_after_n_days', '2');
+		$config = \OC::$server->getConfig();
+
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_expire_after_n_days', '2');
 
 		$token = OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
 		$this->assertInternalType(
@@ -875,8 +877,8 @@ class Test_Share extends \Test\TestCase {
 			'Failed asserting that the returned row has an default expiration date.'
 		);
 
-		\OC_Appconfig::deleteKey('core', 'shareapi_default_expire_date');
-		\OC_Appconfig::deleteKey('core', 'shareapi_expire_after_n_days');
+		$config->deleteAppValue('core', 'shareapi_default_expire_date');
+		$config->deleteAppValue('core', 'shareapi_expire_after_n_days');
 
 	}
 


### PR DESCRIPTION
ref #12260 

@karlitschek @DeepDiver1975  I added a deprecation note into the header. In here I added a 2 year time frame, because it involves a interface of the public namespace \OCP. This is meant to be discussed.

I added all the missing methods to our central config interface and added a deprecation note to each method.

Is this the way we want to deal with deprecations?

Opinions @PVince81 @icewind1991 @nickvergessen @LukasReschke ?
