### PR TITLE
Coherent use of "SQLite" in lines 159 and 161

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -158,7 +158,7 @@ script('core', [
 			<legend><?php p($l->t('Performance Warning'));?></legend>
 			<p><?php p($l->t('SQLite will be used as database.'));?></p>
 			<p><?php p($l->t('For larger installations we recommend to choose a different database backend.'));?></p>
-			<p><?php p($l->t('Especially when using desktop client for file syncing the use of sqlite is discouraged.')); ?></p>
+			<p><?php p($l->t('Especially when using the desktop client for file syncing the use of SQLite is discouraged.')); ?></p>
 		</fieldset>
 	<?php endif ?>
 


### PR DESCRIPTION
In line 161, "SQLite" has now the same capitalisation as in line 159.
