### PR TITLE
Use transactions when renaming directory contents

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -408,12 +408,14 @@ class Cache {
 			$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $source . '/%'));
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($source);
+			\OC_DB::beginTransaction();
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ? WHERE `fileid` = ?');
 
 			foreach ($childEntries as $child) {
 				$targetPath = $target . substr($child['path'], $sourceLength);
 				\OC_DB::executeAudited($query, array($targetPath, md5($targetPath), $child['fileid']));
 			}
+			\OC_DB::commit();
 		}
 
 		$sql = 'UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?';


### PR DESCRIPTION
Or "how to save 99% execution time with 2 simple lines" :smile: 

From 33s to ~600ms when moving ~5000 files ([comparison](https://blackfire.io/profiles/compare/42db61f0-4a91-4288-a634-9d57c2975510/graph))

For #13391

cc @PVince81 @DeepDiver1975 
