### PR TITLE
Do not allow invalid default expire days

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -85,6 +85,13 @@ $(document).ready(function(){
 		});
 	});
 
+	$('#shareapiExpireAfterNDays').change(function() {
+		var value = $(this).val();
+		if (value <= 0) {
+			$(this).val("1");
+		}
+	});
+
 	$('#shareAPI input:not(#excludedGroups)').change(function() {
 		var value = $(this).val();
 		if ($(this).attr('type') === 'checkbox') {


### PR DESCRIPTION
Currently it is possible to set a negative number of days in which a
public share expires. This results in public sharing not working and it
is undesired.

Weird thing is that the API still lets you create shares and gives back
an URL. However the id is "unkown" and the URL invalid.
