### PR TITLE
[encryption] don't check if we have a valid user during migration

### DIFF
--- a/apps/files_encryption/lib/migration.php
+++ b/apps/files_encryption/lib/migration.php
@@ -256,11 +256,7 @@ class Migration {
 						if (substr($file, 0, strlen($filename) +1) === $filename . '.') {
 
 							$uid = $this->getUidFromShareKey($file, $filename, $trash);
-							if ($uid === $this->public_share_key_id ||
-									$uid === $this->recovery_key_id ||
-									\OCP\User::userExists($uid)) {
-								$this->view->copy($oldShareKeyPath . '/' . $file, $target . '/' . $uid . '.shareKey');
-							}
+							$this->view->copy($oldShareKeyPath . '/' . $file, $target . '/' . $uid . '.shareKey');
 						}
 					}
 


### PR DESCRIPTION
This problem happens if a system has local users and ldap users.

The first time the user opens ownCloud on the web interface the upgrade will be triggered. In this case we will only find the local users, not the ldap users, so we will migrate the local users only.
But now for any share from a local user to a ldap user the userExists() check will fail (because the ldap backend isn't loaded) and we will skip the share key.

This PR removes the check, in 99% of all use cases we will have a valid user. This is only problematic in the corner case where we have user names and file names where we are no longer able to detect the user name correctly which should happen really seldom. Even in this case nothing will be lost. The key will be only in the wrong folder and the admin will still have the backup we create before the migration. So he will be able to fix it manually. He will have to do this anyway if this corner-case happens, also with the old code where we skipped the key completely.

issue: https://github.com/owncloud/core/issues/13950

cc @PVince81 @DeepDiver1975 
