### PR TITLE
Avoid dropdown to float under sidebar for mid narrow screens

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -16,6 +16,13 @@
 	padding:16px;
 }
 
+@media only screen and (min-width: 768px) and (max-width: 990px) {
+	#dropdown {
+		/* this limits the dropdown to float below the sidebar for mid narrow screens */
+		left: 20px;
+	}
+}
+
 #dropdown.shareDropDown .unshare.icon-loading-small {
 	margin-top: 1px;
 }


### PR DESCRIPTION
cc @jancborchardt @owncloud/designers 

Before:
![bildschirmfoto von 2015-02-06 22 45 09](https://cloud.githubusercontent.com/assets/245432/6087959/d84341d0-ae51-11e4-8596-0210e361218c.png)

After:
![bildschirmfoto von 2015-02-06 22 44 56](https://cloud.githubusercontent.com/assets/245432/6087961/db238eaa-ae51-11e4-9204-fd9333962db2.png)

Tested with Firefox, Chromium, IE9+
