### PR TITLE
Add OCS sharing info to capabilities - take 2

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -56,3 +56,9 @@ $this->create('sharing_external_test_remote', '/testremote')
 		'/apps/files_sharing/api/v1/shares/{id}',
 		array('\OCA\Files_Sharing\API\Local', 'deleteShare'),
 		'files_sharing');
+
+// Register with the capabilities API
+\OC_API::register('get',
+		'/cloud/capabilities',
+		array('OCA\Files_Sharing\Capabilities', 'getCapabilities'),
+		'files_sharing', \OC_API::USER_AUTH);

--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -1,11 +1,23 @@
 <?php
 /**
- * Copyright (c) Roeland Jago Douma <roeland@famdouma.nl>
- * This file is licensed under the Affero General Public License version 3 or
- * later.
- * See the COPYING-README file.
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  */
-
 namespace OCA\Files_Sharing;
 
 use \OCP\IConfig;

--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright (c) Roeland Jago Douma <roeland@famdouma.nl>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+ 
+namespace OCA\Files_Sharing;
+
+use \OCP\IConfig;
+
+/**
+ * Class Capabilities
+ *
+ * @package OCA\Files_Sharing
+ */
+class Capabilities {
+
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public static function getCapabilities() {
+		$config = \OC::$server->getConfig();
+		$cap = new Capabilities($config);
+		return $cap->getCaps();
+	}
+
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public function getCaps() {
+		$res = array();
+
+		$public = false;
+		if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {
+			$public = array();
+			$public['password_enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
+
+			$public['expire_date'] = false;
+			if ($this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes') {
+				$public['expire_date'] = array();
+				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
+				$public['expire_date']['enforce'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'yes') === 'yes';
+			}
+
+			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'yes') === 'yes';
+		}
+		$res["public"] = $public;
+
+		$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'yes') === 'yes';
+
+		$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
+
+
+		return new \OC_OCS_Result(array(
+			'capabilities' => array(
+				'files_sharing' => $res
+				),
+			));
+	}
+	
+}

--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -58,13 +58,14 @@ class Capabilities {
 		$public = [];
 		$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 		if ($public['enabled']) {
-			$public['password_enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
+			$public['password'] = [];
+			$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
 
 			$public['expire_date'] = [];
 			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes';
 			if ($public['expire_date']['enabled']) {
 				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
-				$public['expire_date']['enforce'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'yes') === 'yes';
+				$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'yes') === 'yes';
 			}
 
 			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'yes') === 'yes';

--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -5,7 +5,7 @@
  * later.
  * See the COPYING-README file.
  */
- 
+
 namespace OCA\Files_Sharing;
 
 use \OCP\IConfig;
@@ -43,14 +43,14 @@ class Capabilities {
 	public function getCaps() {
 		$res = array();
 
-		$public = false;
-		if ($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {
-			$public = array();
+		$public = array();
+		$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
+		if ($public['enabled']) {
 			$public['password_enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
 
-			$public['expire_date'] = false;
-			if ($this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes') {
-				$public['expire_date'] = array();
+			$public['expire_date'] = array();
+			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes';
+			if ($public['expire_date']['enabled']) {
 				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
 				$public['expire_date']['enforce'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'yes') === 'yes';
 			}

--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -53,14 +53,14 @@ class Capabilities {
 	 * @return \OC_OCS_Result
 	 */
 	public function getCaps() {
-		$res = array();
+		$res = [];
 
-		$public = array();
+		$public = [];
 		$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 		if ($public['enabled']) {
 			$public['password_enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
 
-			$public['expire_date'] = array();
+			$public['expire_date'] = [];
 			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes';
 			if ($public['expire_date']['enabled']) {
 				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
@@ -76,11 +76,11 @@ class Capabilities {
 		$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 
 
-		return new \OC_OCS_Result(array(
-			'capabilities' => array(
+		return new \OC_OCS_Result([
+			'capabilities' => [
 				'files_sharing' => $res
-				),
-			));
+				],
+			]);
 	}
 	
 }

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -61,9 +61,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testNoLinkSharing() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertInternalType('array', $result['public']);
 		$this->assertFalse($result['public']['enabled']);
@@ -73,9 +73,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testOnlyLinkSharing() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertInternalType('array', $result['public']);
 		$this->assertTrue($result['public']['enabled']);
@@ -85,10 +85,10 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkPassword() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_enforce_links_password', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_enforce_links_password', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password_enforced', $result['public']);
 		$this->assertTrue($result['public']['password_enforced']);
@@ -98,10 +98,10 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkNoPassword() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_enforce_links_password', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_enforce_links_password', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password_enforced', $result['public']);
 		$this->assertFalse($result['public']['password_enforced']);
@@ -111,10 +111,10 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkNoExpireDate() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_default_expire_date', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
 		$this->assertInternalType('array', $result['public']['expire_date']);
@@ -125,12 +125,12 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkExpireDate() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_default_expire_date', 'yes', 'yes'),
-			array('core', 'shareapi_expire_after_n_days', '7', '7'),
-			array('core', 'shareapi_enforce_expire_date', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date', 'yes', 'yes'],
+			['core', 'shareapi_expire_after_n_days', '7', '7'],
+			['core', 'shareapi_enforce_expire_date', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
 		$this->assertInternalType('array', $result['public']['expire_date']);
@@ -143,11 +143,11 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkExpireDateEnforced() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_default_expire_date', 'yes', 'yes'),
-			array('core', 'shareapi_enforce_expire_date', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date', 'yes', 'yes'],
+			['core', 'shareapi_enforce_expire_date', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
 		$this->assertInternalType('array', $result['public']['expire_date']);
@@ -158,10 +158,10 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkSendMail() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_allow_public_notification', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_public_notification', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['public']['send_mail']);
 	}
@@ -170,10 +170,10 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testLinkNoSendMail() {
-		$map = array(
-			array('core', 'shareapi_allow_links', 'yes', 'yes'),
-			array('core', 'shareapi_allow_public_notification', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_public_notification', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['public']['send_mail']);
 	}
@@ -182,9 +182,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testUserSendMail() {
-		$map = array(
-			array('core', 'shareapi_allow_mail_notification', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_mail_notification', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['user']['send_mail']);
 	}
@@ -193,9 +193,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testUserNoSendMail() {
-		$map = array(
-			array('core', 'shareapi_allow_mail_notification', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_mail_notification', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['user']['send_mail']);
 	}
@@ -204,9 +204,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testResharing() {
-		$map = array(
-			array('core', 'shareapi_allow_resharing', 'yes', 'yes'),
-		);
+		$map = [
+			['core', 'shareapi_allow_resharing', 'yes', 'yes'],
+		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['resharing']);
 	}
@@ -215,9 +215,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @covers OCA\Files_Sharing\Capabilities::getCaps
 	 */
 	public function testNoResharing() {
-		$map = array(
-			array('core', 'shareapi_allow_resharing', 'yes', 'no'),
-		);
+		$map = [
+			['core', 'shareapi_allow_resharing', 'yes', 'no'],
+		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['resharing']);
 	}

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -1,11 +1,23 @@
 <?php
 /**
-  * Copyright (c) 2015 Roeland Jago Douma <roeland@famdouma.nl>
-  * This file is licensed under the Affero General Public License version 3 or
-  * later.
-  * See the COPYING-README file.
-  */
-
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\Capabilities;

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -1,0 +1,208 @@
+<?php
+/**
+  * Copyright (c) 2015 Roeland Jago Douma <roeland@famdouma.nl>
+  * This file is licensed under the Affero General Public License version 3 or
+  * later.
+  * See the COPYING-README file.
+  */
+
+namespace OCA\Files_Sharing\Tests;
+
+use OCA\Files_Sharing\Capabilities;
+use OCA\Files_Sharing\Tests\TestCase;
+
+/**
+ * Class FilesSharingCapabilitiesTest
+ */
+class FilesSharingCapabilitiesTest extends \Test\TestCase {
+
+	/**
+	 * Test for the general part in each return statement and assert.
+	 * Strip of the general part on the way.
+	 *
+	 * @param string[] $data Capabilities
+	 * @return string[]
+	 */
+	function getFilesSharingPart(array $data) {
+		$this->assertArrayHasKey('capabilities', $data);
+		$this->assertArrayHasKey('files_sharing', $data['capabilities']);
+		return $data['capabilities']['files_sharing'];
+	}
+
+	/**
+	 * Create a mock config object and insert the values in $map tot the getAppValue
+	 * function. Then obtain the capabilities and extract the first few
+	 * levels in the array
+	 *
+	 * @param (string[])[] $map Map of arguments to return types for the getAppValue function in the mock
+	 * @return string[]
+	 */
+	function getResults(array $map) {
+		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
+		$stub->method('getAppValue')->will($this->returnValueMap($map));
+		$cap = new Capabilities($stub);
+		$result = $this->getFilesSharingPart($cap->getCaps()->getData());
+		return $result;
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testNoLinkSharing() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertFalse($result['public']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testOnlyLinkSharing() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertInternalType('array', $result['public']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkPassword() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_enforce_links_password', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('password_enforced', $result['public']);
+		$this->assertTrue($result['public']['password_enforced']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkNoPassword() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_enforce_links_password', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('password_enforced', $result['public']);
+		$this->assertFalse($result['public']['password_enforced']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkNoExpireDate() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_default_expire_date', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('expire_date', $result['public']);
+		$this->assertFalse($result['public']['expire_date']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkExpireDate() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_default_expire_date', 'yes', 'yes'),
+			array('core', 'shareapi_expire_after_n_days', '7', '7'),
+			array('core', 'shareapi_enforce_expire_date', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('expire_date', $result['public']);
+		$this->assertInternalType('array', $result['public']['expire_date']);
+		$this->assertArrayHasKey('days', $result['public']['expire_date']);
+		$this->assertFalse($result['public']['expire_date']['enforce']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkExpireDateEnforced() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_default_expire_date', 'yes', 'yes'),
+			array('core', 'shareapi_enforce_expire_date', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('expire_date', $result['public']);
+		$this->assertInternalType('array', $result['public']['expire_date']);
+		$this->assertTrue($result['public']['expire_date']['enforce']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkSendMail() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_allow_public_notification', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertTrue($result['public']['send_mail']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testLinkNoSendMail() {
+		$map = array(
+			array('core', 'shareapi_allow_links', 'yes', 'yes'),
+			array('core', 'shareapi_allow_public_notification', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertFalse($result['public']['send_mail']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testUserSendMail() {
+		$map = array(
+			array('core', 'shareapi_allow_mail_notification', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertTrue($result['user']['send_mail']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testUserNoSendMail() {
+		$map = array(
+			array('core', 'shareapi_allow_mail_notification', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertFalse($result['user']['send_mail']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testResharing() {
+		$map = array(
+			array('core', 'shareapi_allow_resharing', 'yes', 'yes'),
+		);
+		$result = $this->getResults($map);
+		$this->assertTrue($result['resharing']);
+	}
+
+	/**
+	 * @covers OCA\Files_Sharing\Capabilities::getCaps
+	 */
+	public function testNoResharing() {
+		$map = array(
+			array('core', 'shareapi_allow_resharing', 'yes', 'no'),
+		);
+		$result = $this->getResults($map);
+		$this->assertFalse($result['resharing']);
+	}
+}

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -53,7 +53,8 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 			array('core', 'shareapi_allow_links', 'yes', 'no'),
 		);
 		$result = $this->getResults($map);
-		$this->assertFalse($result['public']);
+		$this->assertInternalType('array', $result['public']);
+		$this->assertFalse($result['public']['enabled']);
 	}
 
 	/**
@@ -65,6 +66,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		);
 		$result = $this->getResults($map);
 		$this->assertInternalType('array', $result['public']);
+		$this->assertTrue($result['public']['enabled']);
 	}
 
 	/**
@@ -103,7 +105,8 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		);
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
-		$this->assertFalse($result['public']['expire_date']);
+		$this->assertInternalType('array', $result['public']['expire_date']);
+		$this->assertFalse($result['public']['expire_date']['enabled']);
 	}
 
 	/**
@@ -119,6 +122,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
 		$this->assertInternalType('array', $result['public']['expire_date']);
+		$this->assertTrue($result['public']['expire_date']['enabled']);
 		$this->assertArrayHasKey('days', $result['public']['expire_date']);
 		$this->assertFalse($result['public']['expire_date']['enforce']);
 	}

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -57,9 +57,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		return $result;
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testNoLinkSharing() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'no'],
@@ -69,9 +66,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['enabled']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testOnlyLinkSharing() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -81,35 +75,28 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['public']['enabled']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkPassword() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password', 'yes', 'yes'],
 		];
 		$result = $this->getResults($map);
-		$this->assertArrayHasKey('password_enforced', $result['public']);
-		$this->assertTrue($result['public']['password_enforced']);
+		$this->assertArrayHasKey('password', $result['public']);
+		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertTrue($result['public']['password']['enforced']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkNoPassword() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password', 'yes', 'no'],
 		];
 		$result = $this->getResults($map);
-		$this->assertArrayHasKey('password_enforced', $result['public']);
-		$this->assertFalse($result['public']['password_enforced']);
+		$this->assertArrayHasKey('password', $result['public']);
+		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertFalse($result['public']['password']['enforced']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkNoExpireDate() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -121,9 +108,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['expire_date']['enabled']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkExpireDate() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -136,12 +120,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertInternalType('array', $result['public']['expire_date']);
 		$this->assertTrue($result['public']['expire_date']['enabled']);
 		$this->assertArrayHasKey('days', $result['public']['expire_date']);
-		$this->assertFalse($result['public']['expire_date']['enforce']);
+		$this->assertFalse($result['public']['expire_date']['enforced']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkExpireDateEnforced() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -151,12 +132,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
 		$this->assertInternalType('array', $result['public']['expire_date']);
-		$this->assertTrue($result['public']['expire_date']['enforce']);
+		$this->assertTrue($result['public']['expire_date']['enforced']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkSendMail() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -166,9 +144,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['public']['send_mail']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testLinkNoSendMail() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
@@ -178,9 +153,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['send_mail']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testUserSendMail() {
 		$map = [
 			['core', 'shareapi_allow_mail_notification', 'yes', 'yes'],
@@ -189,9 +161,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['user']['send_mail']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testUserNoSendMail() {
 		$map = [
 			['core', 'shareapi_allow_mail_notification', 'yes', 'no'],
@@ -200,9 +169,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['user']['send_mail']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testResharing() {
 		$map = [
 			['core', 'shareapi_allow_resharing', 'yes', 'yes'],
@@ -211,9 +177,6 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['resharing']);
 	}
 
-	/**
-	 * @covers OCA\Files_Sharing\Capabilities::getCaps
-	 */
 	public function testNoResharing() {
 		$map = [
 			['core', 'shareapi_allow_resharing', 'yes', 'no'],

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -35,7 +35,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @param string[] $data Capabilities
 	 * @return string[]
 	 */
-	function getFilesSharingPart(array $data) {
+	private function getFilesSharingPart(array $data) {
 		$this->assertArrayHasKey('capabilities', $data);
 		$this->assertArrayHasKey('files_sharing', $data['capabilities']);
 		return $data['capabilities']['files_sharing'];
@@ -49,7 +49,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	 * @param (string[])[] $map Map of arguments to return types for the getAppValue function in the mock
 	 * @return string[]
 	 */
-	function getResults(array $map) {
+	private function getResults(array $map) {
 		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
 		$stub->method('getAppValue')->will($this->returnValueMap($map));
 		$cap = new Capabilities($stub);


### PR DESCRIPTION
Since the previous request was already merged (which was a bit to soon). Here is another take. It is still a patch for #13673.
