### PR TITLE
Respect `mod_unique_id` and refactor `OC_Request::getRequestId`

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -68,7 +68,7 @@ class OC_Log_Owncloud {
 				$timezone = new DateTimeZone('UTC');
 			}
 			$time = new DateTime(null, $timezone);
-			$reqId = \OC_Request::getRequestID();
+			$reqId = \OC::$server->getRequest()->getId();
 			$remoteAddr = \OC_Request::getRemoteAddress();
 			// remove username/passwords from URLs before writing the to the log file
 			$time = $time->format($format);

--- a/lib/private/request.php
+++ b/lib/private/request.php
@@ -13,7 +13,6 @@ class OC_Request {
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
 	const USER_AGENT_FREEBOX = '#^Mozilla/5\.0$#';
 	const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost)$/';
-	static protected $reqId;
 
 	/**
 	 * Returns the remote address, if the connection came from a trusted proxy and `forwarded_for_headers` has been configured
@@ -41,17 +40,6 @@ class OC_Request {
 		}
 
 		return $remoteAddress;
-	}
-
-	/**
-	 * Returns an ID for the request, value is not guaranteed to be unique and is mostly meant for logging
-	 * @return string
-	 */
-	public static function getRequestID() {
-		if(self::$reqId === null) {
-			self::$reqId = hash('md5', microtime().\OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(20));
-		}
-		return self::$reqId;
 	}
 
 	/**

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -10,7 +10,6 @@ use OC\Cache\UserCache;
 use OC\Diagnostics\NullQueryLogger;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
-use OC\Files\Config\StorageManager;
 use OC\Security\CertificateManager;
 use OC\Files\Node\Root;
 use OC\Files\View;
@@ -64,7 +63,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 
 			return new Request(
-				array(
+				[
 					'get' => $_GET,
 					'post' => $_POST,
 					'files' => $_FILES,
@@ -76,7 +75,9 @@ class Server extends SimpleContainer implements IServerContainer {
 						: null,
 					'urlParams' => $urlParams,
 					'requesttoken' => $requestToken,
-				), $stream
+				],
+				$this->getSecureRandom(),
+				$stream
 			);
 		});
 		$this->registerService('PreviewManager', function ($c) {

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -223,7 +223,7 @@ class OC_Template extends \OC\Template\Base {
 		$content->assign('trace', $exception->getTraceAsString());
 		$content->assign('debugMode', defined('DEBUG') && DEBUG === true);
 		$content->assign('remoteAddr', OC_Request::getRemoteAddress());
-		$content->assign('requestID', OC_Request::getRequestID());
+		$content->assign('requestID', \OC::$server->getRequest()->getId());
 		$content->printPage();
 		die();
 	}

--- a/lib/public/irequest.php
+++ b/lib/public/irequest.php
@@ -127,4 +127,11 @@ interface IRequest {
 	 * @return bool true if CSRF check passed
 	 */
 	public function passesCSRFCheck();
+
+	/**
+	 * Returns an ID for the request, value is not guaranteed to be unique and is mostly meant for logging
+	 * If `mod_unique_id` is installed this value will be taken.
+	 * @return string
+	 */
+	public function getId();
 }

--- a/tests/lib/appframework/controller/ApiControllerTest.php
+++ b/tests/lib/appframework/controller/ApiControllerTest.php
@@ -25,18 +25,19 @@
 namespace OCP\AppFramework;
 
 use OC\AppFramework\Http\Request;
-use OCP\AppFramework\Http\TemplateResponse;
 
 
 class ChildApiController extends ApiController {};
 
 
 class ApiControllerTest extends \Test\TestCase {
-
+    /** @var ChildApiController */
+    protected $controller;
 
     public function testCors() {
         $request = new Request(
-            array('server' => array('HTTP_ORIGIN' => 'test'))
+            ['server' => ['HTTP_ORIGIN' => 'test']],
+            $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
         );
         $this->controller = new ChildApiController('app', $request, 'verbs',
             'headers', 100);

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -66,15 +66,16 @@ class ControllerTest extends \Test\TestCase {
 		parent::setUp();
 
 		$request = new Request(
-			array(
-				'get' => array('name' => 'John Q. Public', 'nickname' => 'Joey'),
-				'post' => array('name' => 'Jane Doe', 'nickname' => 'Janey'),
-				'urlParams' => array('name' => 'Johnny Weissmüller'),
-				'files' => array('file' => 'filevalue'),
-				'env' => array('PATH' => 'daheim'),
-				'session' => array('sezession' => 'kein'),
+			[
+				'get' => ['name' => 'John Q. Public', 'nickname' => 'Joey'],
+				'post' => ['name' => 'Jane Doe', 'nickname' => 'Janey'],
+				'urlParams' => ['name' => 'Johnny Weissmüller'],
+				'files' => ['file' => 'filevalue'],
+				'env' => ['PATH' => 'daheim'],
+				'session' => ['sezession' => 'kein'],
 				'method' => 'hi',
-			)
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
 		);
 
 		$this->app = $this->getMock('OC\AppFramework\DependencyInjection\DIContainer',

--- a/tests/lib/appframework/dependencyinjection/DIContainerTest.php
+++ b/tests/lib/appframework/dependencyinjection/DIContainerTest.php
@@ -71,7 +71,10 @@ class DIContainerTest extends \Test\TestCase {
 
 
 	public function testMiddlewareDispatcherIncludesSecurityMiddleware(){
-		$this->container['Request'] = new Request(array('method' => 'GET'));
+		$this->container['Request'] = new Request(
+			['method' => 'GET'],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$security = $this->container['SecurityMiddleware'];
 		$dispatcher = $this->container['MiddlewareDispatcher'];
 

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -276,13 +276,16 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testControllerParametersInjected() {
-		$this->request = new Request(array(
-			'post' => array(
+		$this->request = new Request(
+			[
+				'post' => [
 				'int' => '3',
 				'bool' => 'false'
-			),
-			'method' => 'POST'
-		));
+				],
+				'method' => 'POST'
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request
@@ -298,14 +301,17 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testControllerParametersInjectedDefaultOverwritten() {
-		$this->request = new Request(array(
-			'post' => array(
-				'int' => '3',
-				'bool' => 'false',
-				'test2' => 7
-			),
-			'method' => 'POST'
-		));
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false',
+					'test2' => 7
+				],
+				'method' => 'POST',
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request
@@ -322,16 +328,19 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testResponseTransformedByUrlFormat() {
-		$this->request = new Request(array(
-			'post' => array(
-				'int' => '3',
-				'bool' => 'false'
-			),
-			'urlParams' => array(
-				'format' => 'text'
-			),
-			'method' => 'GET'
-		));
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false'
+				],
+				'urlParams' => [
+					'format' => 'text'
+				],
+				'method' => 'GET'
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request
@@ -347,16 +356,19 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testResponseTransformsDataResponse() {
-		$this->request = new Request(array(
-			'post' => array(
-				'int' => '3',
-				'bool' => 'false'
-			),
-			'urlParams' => array(
-				'format' => 'json'
-			),
-			'method' => 'GET'
-		));
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false'
+				],
+				'urlParams' => [
+					'format' => 'json'
+				],
+				'method' => 'GET'
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request
@@ -372,17 +384,20 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testResponseTransformedByAcceptHeader() {
-		$this->request = new Request(array(
-			'post' => array(
-				'int' => '3',
-				'bool' => 'false'
-			),
-			'server' => array(
-				'HTTP_ACCEPT' => 'application/text, test',
-				'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded'
-			),
-			'method' => 'PUT'
-		));
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false'
+				],
+				'server' => [
+					'HTTP_ACCEPT' => 'application/text, test',
+					'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+				],
+				'method' => 'PUT'
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request
@@ -398,19 +413,22 @@ class DispatcherTest extends \Test\TestCase {
 
 
 	public function testResponsePrimarilyTransformedByParameterFormat() {
-		$this->request = new Request(array(
-			'post' => array(
-				'int' => '3',
-				'bool' => 'false'
-			),
-			'get' => array(
-				'format' => 'text'
-			),
-			'server' => array(
-				'HTTP_ACCEPT' => 'application/json, test'
-			),
-			'method' => 'POST'
-		));
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false'
+				],
+				'get' => [
+					'format' => 'text'
+				],
+				'server' => [
+					'HTTP_ACCEPT' => 'application/json, test'
+				],
+				'method' => 'POST'
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->dispatcher = new Dispatcher(
 			$this->http, $this->middlewareDispatcher, $this->reflector,
 			$this->request

--- a/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
@@ -126,8 +126,16 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 
 
 	private function getControllerMock(){
-		return $this->getMock('OCP\AppFramework\Controller', array('method'),
-			array('app', new Request(array('method' => 'GET'))));
+		return $this->getMock(
+			'OCP\AppFramework\Controller',
+			['method'],
+			['app',
+				new Request(
+					['method' => 'GET'],
+					$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+				)
+			]
+		);
 	}
 
 

--- a/tests/lib/appframework/middleware/MiddlewareTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareTest.php
@@ -51,8 +51,14 @@ class MiddlewareTest extends \Test\TestCase {
 				->disableOriginalConstructor()
 				->getMock();
 
-		$this->controller = $this->getMock('OCP\AppFramework\Controller',
-				array(), array($this->api, new Request()));
+		$this->controller = $this->getMock(
+			'OCP\AppFramework\Controller',
+			[],
+			[
+				$this->api,
+				new Request([], $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock())
+			]
+		);
 		$this->exception = new \Exception();
 		$this->response = $this->getMock('OCP\AppFramework\Http\Response');
 	}

--- a/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
@@ -32,7 +32,12 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	 */
 	public function testSetCORSAPIHeader() {
 		$request = new Request(
-			array('server' => array('HTTP_ORIGIN' => 'test'))
+			[
+				'server' => [
+					'HTTP_ORIGIN' => 'test'
+				]
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware($request, $this->reflector);
@@ -45,7 +50,12 @@ class CORSMiddlewareTest extends \Test\TestCase {
 
 	public function testNoAnnotationNoCORSHEADER() {
 		$request = new Request(
-			array('server' => array('HTTP_ORIGIN' => 'test'))
+			[
+				'server' => [
+					'HTTP_ORIGIN' => 'test'
+				]
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
 		);
 		$middleware = new CORSMiddleware($request, $this->reflector);
 
@@ -59,7 +69,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	 * @CORS
 	 */
 	public function testNoOriginHeaderNoCORSHEADER() {
-		$request = new Request();
+		$request = new Request([], $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock());
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware($request, $this->reflector);
 
@@ -75,7 +85,12 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	 */
 	public function testCorsIgnoredIfWithCredentialsHeaderPresent() {
 		$request = new Request(
-			array('server' => array('HTTP_ORIGIN' => 'test'))
+			[
+				'server' => [
+					'HTTP_ORIGIN' => 'test'
+				]
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware($request, $this->reflector);

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -314,10 +314,14 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 
 	public function testAfterExceptionReturnsRedirect(){
 		$this->request = new Request(
-			array('server' =>
-				array('HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-					'REQUEST_URI' => 'owncloud/index.php/apps/specialapp')
-			)
+			[
+				'server' =>
+				[
+					'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+					'REQUEST_URI' => 'owncloud/index.php/apps/specialapp'
+				]
+			],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
 		);
 		$this->middleware = $this->getMiddleware(true, true);
 		$response = $this->middleware->afterException($this->controller, 'test',

--- a/tests/lib/appframework/middleware/sessionmiddlewaretest.php
+++ b/tests/lib/appframework/middleware/sessionmiddlewaretest.php
@@ -33,7 +33,10 @@ class SessionMiddlewareTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->request = new Request();
+		$this->request = new Request(
+			[],
+			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock()
+		);
 		$this->reflector = new ControllerMethodReflector();
 	}
 


### PR DESCRIPTION
When `mod_unique_id` is enabled the ID generated by it will be used for logging. This allows for correlation of the Apache logs and the ownCloud logs.

Testplan:
- [ ] When `mod_unique_id` is enabled the request ID equals the one generated by `mod_unique_id`.
- [ ] When `mod_unique_id` is not available the request ID is a 20 character long random string
- [ ] The generated Id is stable over the lifespan of one request

Changeset looks a little bit larger since I had to adjust every unit test using the HTTP\Request class for proper DI.

Fixes https://github.com/owncloud/core/issues/13366

@MorrisJobke @PVince81 Please review.
