### PR TITLE
Set mtime early before rename

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -134,6 +134,13 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 			if ($needsPartFile) {
 				// rename to correct path
 				try {
+					// allow sync clients to send the mtime along in a header
+					$mtime = OC_Request::hasModificationTime();
+					if ($mtime !== false) {
+						if($this->fileView->touch($partFilePath, $mtime)) {
+							header('X-OC-MTime: accepted');
+						}
+					}
 					$renameOkay = $this->fileView->rename($partFilePath, $this->path);
 					$fileExists = $this->fileView->file_exists($this->path);
 					if ($renameOkay === false || $fileExists === false) {
@@ -148,13 +155,6 @@ class OC_Connector_Sabre_File extends OC_Connector_Sabre_Node implements \Sabre\
 				}
 			}
 
-			// allow sync clients to send the mtime along in a header
-			$mtime = OC_Request::hasModificationTime();
-			if ($mtime !== false) {
-				if($this->fileView->touch($this->path, $mtime)) {
-					header('X-OC-MTime: accepted');
-				}
-			}
 			$this->refreshInfo();
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable("Failed to check file size: ".$e->getMessage());


### PR DESCRIPTION
Experimental fix.

Might break external storages... or not. Needs to be tested extensively.

Note: I didn't add mtime in the "else" block because that one is used for OC to OC mounts, where we should rely on https://github.com/owncloud/core/issues/13984 to keep mtime on the remote server.

@icewind1991 @DeepDiver1975 @schiesbn 
