### PR TITLE
[WIP] Throw an exception when a user was not found in FS setup

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -341,6 +341,10 @@ class Filesystem {
 		$root = \OC_User::getHome($user);
 
 		$userObject = \OC_User::getManager()->get($user);
+		if (empty($userObject) && !empty($user)) {
+			// no user object found for user
+			throw new \Exception('Cannot setup FS for user "' . $user . '" who was not found by the user manager');
+		}
 
 		if (!is_null($userObject)) {
 			$homeStorage = \OC_Config::getValue( 'objectstore' );


### PR DESCRIPTION
To avoid unwanted side effects with a wrongly setup FS, if the user was
not found by the user manager, an exception will be thrown.

Should increase robustness a bit and avoid fatal side effects like https://github.com/owncloud/core/issues/12801#issuecomment-72687186

@icewind1991 @Xenopathic @blizzz @schiesbn @DeepDiver1975 
