### PR TITLE
add timeout to curl request

### DIFF
--- a/lib/private/httphelper.php
+++ b/lib/private/httphelper.php
@@ -214,7 +214,8 @@ class HTTPHelper {
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_POST, count($fields));
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $fieldsString);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, (string)$fieldsString);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		if (is_readable($certBundle)) {
 			curl_setopt($ch, CURLOPT_CAINFO, $certBundle);
 		}


### PR DESCRIPTION
If we don't set a timeout requests can take for ever. I discovered this while testing server-to-server shares where we first try https and fall-back to http if https is not supported. In this case the request takes for ever because we don't return from the first try with https in some situations.

I think having a timeout is a good thing, I'm not completely sure about the right value. Right now I set it to 10 seconds but I'm open for other reasonable suggestions.

cc @DeepDiver1975 @LukasReschke 
