### PR TITLE
Revert "Fix: X-Accel-Redirect did not support custom data dir and local ...

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -161,11 +161,12 @@ class OC_Files {
 	 * @param false|string $filename
 	 */
 	private static function addSendfileHeader($filename) {
-		$filename = \OC\Files\Filesystem::getLocalFile($filename);
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			if (isset($_SERVER['HTTP_RANGE']) &&
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
@@ -181,6 +182,7 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
+			$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}


### PR DESCRIPTION
Reverts owncloud/core#13060
This merge causes regressions that I previously fixed for NGINX with X-Accel-Redirect.
https://github.com/owncloud/core/pull/8045 https://github.com/owncloud/core/issues/7754
#### 

owncloud/core#13060 should not have been merged, it "fixed" things according to the OC6 docs which did not operate properly in regards with X-Accel-Redirect. NGINX should be passed a URI not a full path. Sending NGINX a full path can cause location collisions and has possible security implications if you used an NGINX config with root = /
http://wiki.nginx.org/XSendfile

If you have any questions how NGINX configs/processing feel free to ask me. It seemed this merge was approved without anyone 100% understanding how NGINX processes locations.
