### PR TITLE
in some case charset can be in lower case.

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1425,10 +1425,12 @@ class OC_Util {
 	}
 
 	/**
+	 * Check if PhpCharset config is UTF-8
+	 *
 	 * @return string
 	 */
 	public static function isPhpCharSetUtf8() {
-		return ini_get('default_charset') === 'UTF-8';
+		return strtoupper(ini_get('default_charset')) === 'UTF-8';
 	}
 
 }


### PR DESCRIPTION
Add strtoupper() in UTF-8 check to avoid error message
