### PR TITLE
[nginx] Extending X-Accel-Redirect support

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -183,12 +183,7 @@ class OC_Files {
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'])) {
-				$prefix = $_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'];
-				// nginx is picky about double slashes when matching locations
-				if($prefix[strlen($prefix) - 1] === '/'){
-					$prefix = substr($prefix, 0, -1);
-				}
-				$filename = $prefix . \OC\Files\Filesystem::getLocalFile($filename);
+				$filename = $_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'] . \OC\Files\Filesystem::getLocalFile($filename);
 			} else {
 				$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
 			}

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -184,8 +184,8 @@ class OC_Files {
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'])) {
 				$prefix = $_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'];
-				// nginx is picky about double slashes
-				while($prefix[strlen($prefix) - 1] === '/'){
+				// nginx is picky about double slashes when matching locations
+				if($prefix[strlen($prefix) - 1] === '/'){
 					$prefix = substr($prefix, 0, -1);
 				}
 				$filename = $prefix . \OC\Files\Filesystem::getLocalFile($filename);

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -182,7 +182,16 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
-			$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
+			if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'])) {
+				$prefix = $_SERVER['MOD_X_ACCEL_REDIRECT_PREFIX'];
+				// nginx is picky about double slashes
+				while($prefix[strlen($prefix) - 1] === '/'){
+					$prefix = substr($prefix, 0, -1);
+				}
+				$filename = $prefix . \OC\Files\Filesystem::getLocalFile($filename);
+			} else {
+				$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
+			}
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -161,11 +161,12 @@ class OC_Files {
 	 * @param false|string $filename
 	 */
 	private static function addSendfileHeader($filename) {
-		$filename = \OC\Files\Filesystem::getLocalFile($filename);
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Sendfile: " . $filename);
  		}
  		if (isset($_SERVER['MOD_X_SENDFILE2_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			if (isset($_SERVER['HTTP_RANGE']) &&
 				preg_match("/^bytes=([0-9]+)-([0-9]*)$/", $_SERVER['HTTP_RANGE'], $range)) {
 				$filelength = filesize($filename);
@@ -181,6 +182,7 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
+			$filename = \OC\Files\Filesystem::getLocalFile($filename);
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -182,7 +182,7 @@ class OC_Files {
 		}
 
 		if (isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
-			$filename = \OC\Files\Filesystem::getLocalFile($filename);
+			$filename = \OC::$WEBROOT . '/data' . \OC\Files\Filesystem::getRoot() . $filename;
 			header("X-Accel-Redirect: " . $filename);
 		}
 	}


### PR DESCRIPTION
@josh4trunks @bantu 
In the last few days, I had a considerable debate (see #14090) with @josh4trunks about my earlier pull request reverting the X-Accel-Redirect support to the old, OC6 behavior (#13060). While what I did was a rushed, probably bad decision. However, I still did feel that the OC7 behavior, which, according to josh4trunks, was coined by @bantu, is inadequate, as it requires explicitly stating every user of every local mount which is not available to all users in the nginx configuration file. Therefore, I recommend to use another behavior, which works by prefixing the actual filesystem path with a configurable prefix, to avoid any collisions. I have implemented it in a way that it will not break OC7-based configs. This compromise hinges around a new environmental variable, `MOD_X_ACCEL_REDIRECT_PREFIX`, which, if set, activates the new behavior.

I am not sure if I am suited for writing a proper documentation for this (I'm not a native speaker, and I seem to be terrible at explaining things), but I have gist-ed my configuration file annotated: https://gist.github.com/dratini0/4e4a5282f25eb2d6ea9c

Regarding security, I think if we use the settings that are in the gist, it is the exact same thing as the Apache version. I have been thinking about recommending to configure it with a single alias /, for simplicity's sake, saying that whatever attack can force OwnCloud to emit an X-Accel-Redirect header (only happens in addSendfileRedirect) would force it to readfile the same file on an install configured without header support, but I am not sure if this is enough.

P. s.: @josh4trunks: I found out that shares are considered to be remote. I don't think that is good, but there is probably a reason for that, which I still have to figure out.
