### PR TITLE
Always display max upload size in admin panel

### DIFF
--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -1,18 +1,18 @@
-<?php if($_['uploadChangable']):?>
-
 	<?php OCP\Util::addscript('files', 'admin'); ?>
 
 	<form name="filesForm" class="section" action="#" method="post">
 		<h2><?php p($l->t('File handling')); ?></h2>
 		<label for="maxUploadSize"><?php p($l->t( 'Maximum upload size' )); ?> </label>
-		<input type="text" name='maxUploadSize' id="maxUploadSize" value='<?php p($_['uploadMaxFilesize']) ?>'/>
+		<input type="text" name='maxUploadSize' id="maxUploadSize" value='<?php p($_['uploadMaxFilesize']) ?>' <?php if(!$_['uploadChangable']) { p('disabled'); } ?> />
 		<?php if($_['displayMaxPossibleUploadSize']):?>
 			(<?php p($l->t('max. possible: ')); p($_['maxPossibleUploadSize']) ?>)
 		<?php endif;?>
 		<br/>
 		<input type="hidden" value="<?php p($_['requesttoken']); ?>" name="requesttoken" />
-		<input type="submit" name="submitFilesAdminSettings" id="submitFilesAdminSettings"
-			   value="<?php p($l->t( 'Save' )); ?>"/>
+		<?php if($_['uploadChangable']): ?>
+			<input type="submit" name="submitFilesAdminSettings" id="submitFilesAdminSettings"
+				   value="<?php p($l->t( 'Save' )); ?>"/>
+		<?php else: ?>
+			<?php p($l->t('Can not be edited from here due to insufficient permissions.')); ?>
+		<?php endif; ?>
 	</form>
-
-<?php endif;?>


### PR DESCRIPTION
Patch for #10600 (and by extend #523).

Always show the max upload size. But just disable it if we cannot change it. As stated in #10600 we probably should add some extra text to explain why it is greyed out... Any designers with ideas?
