### PR TITLE
Clean-up of messages (orthography, format)

### DIFF
--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -78,7 +78,7 @@ class Controller {
 					$l = new \OC_L10n('settings');
 					\OC_JSON::error(array(
 						"data" => array(
-							"message" => $l->t("Back-end doesn't support password change, but the users encryption key was successfully updated.")
+							"message" => $l->t("Backend doesn't support password change, but the user's encryption key was successfully updated.")
 						)
 					));
 				} elseif (!$result && !$recoveryEnabledForUser) {

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -516,7 +516,7 @@ if ($_['suggestedOverwriteCliUrl']) {
 	<?php if ($_['logFileSize'] > (100 * 1024 * 1024)): ?>
 	<br>
 	<em>
-		<?php p($l->t('The logfile is bigger than 100MB. Downloading it may take some time!')); ?>
+		<?php p($l->t('The logfile is bigger than 100 MB. Downloading it may take some time!')); ?>
 	</em>
 	<?php endif; ?>
 	<?php endif; ?>


### PR DESCRIPTION
**Changes:**
- "the users encryption key" in line 81 of controller.php is corrected to "the user's encryption key" (correct genitive).
- "Back-end" in line 81 of controller.php is changed to "Backend" without a hyphen. It's written like that in all other instances across ownCloud (e.g. [here](https://github.com/owncloud/contacts/blob/master/lib/contact.php#L282), [here](https://github.com/owncloud/contacts/blob/master/lib/addressbook.php#L426), [here](https://github.com/owncloud/core/blob/master/core/templates/installation.php#L160) …).
- A missing space between value and unit is added to line 519 of admin.php ("100 MB" instead of "100MB").
