### PR TITLE
[WIP] cron: use exclusive create for lock file

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -44,6 +44,21 @@ function handleUnexpectedShutdown() {
 	}
 }
 
+/**
+ * Exclusively create a lock file.
+ *
+ * @param string $lockf lock file name.
+ * @return bool TRUE if lock file was created and FALSE other wise.
+ */
+function createLockFile($lockf) {
+	$f = fopen($lockf, 'x');
+	if ($f === FALSE) {
+		return FALSE;
+	}
+	fclose($f);
+	return TRUE;
+}
+
 try {
 
 	require_once 'lib/base.php';
@@ -96,15 +111,13 @@ try {
 		}
 
 		// check if backgroundjobs is still running
-		if (file_exists(TemporaryCronClass::$lockfile)) {
+		if (!createLockFile(TemporaryCronClass::$lockfile)) {
 			TemporaryCronClass::$keeplock = true;
 			TemporaryCronClass::$sent = true;
 			echo "Another instance of cron.php is still running!" . PHP_EOL;
 			exit(1);
 		}
 
-		// Create a lock file
-		touch(TemporaryCronClass::$lockfile);
 
 		// Work
 		$jobList = \OC::$server->getJobList();


### PR DESCRIPTION
Currently cron uses two step flock file creation: check for existence an touch.
This approach is broken, as two two servers can perform those operations
at very same time and both will succeed.

With this change file_exists + touch combination replaced with exclusive
create.

MIT licensed.
