### PR TITLE
URLEncode logout attribute

### DIFF
--- a/lib/private/security/securerandom.php
+++ b/lib/private/security/securerandom.php
@@ -64,8 +64,7 @@ class SecureRandom implements ISecureRandom {
 	 * Generate a random string of specified length.
 	 * @param string $length The length of the generated string
 	 * @param string $characters An optional list of characters to use if no characterlist is
-	 * 							specified 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ./
-	 * 							is used.
+	 * 							specified all valid base64 characters are used.
 	 * @return string
 	 * @throws \Exception If the generator is not initialized.
 	 */

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -366,7 +366,7 @@ class OC_User {
 			return $backend->getLogoutAttribute();
 		}
 
-		return 'href="' . link_to('', 'index.php') . '?logout=true&requesttoken=' . OC_Util::callRegister() . '"';
+		return 'href="' . link_to('', 'index.php') . '?logout=true&requesttoken=' . urlencode(OC_Util::callRegister()) . '"';
 	}
 
 	/**

--- a/lib/public/security/isecurerandom.php
+++ b/lib/public/security/isecurerandom.php
@@ -53,9 +53,10 @@ interface ISecureRandom {
 	/**
 	 * Generate a random string of specified length.
 	 * @param string $length The length of the generated string
-	 * @param string $characters An optional list of characters to use
+	 * @param string $characters An optional list of characters to use if no characterlist is
+	 * 							specified all valid base64 characters are used.
 	 * @return string
-	 * @throws \Exception
+	 * @throws \Exception If the generator is not initialized.
 	 */
 	public function generate($length, $characters = '');
 }


### PR DESCRIPTION
Otherwise logout can fail if the requesttoken contains a `+`

Fixes itself

@karlitschek @DeepDiver1975 I'd like to backport this to stable8
