### PR TITLE
Activity manager performance improvements

### DIFF
--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -25,6 +25,15 @@ class ActivityManager implements IManager {
 	 */
 	private $extensions = array();
 
+	/** @var array list of filters "name" => "is valid" */
+	protected $validFilters = array();
+
+	/** @var array list of type icons "type" => "css class" */
+	protected $typeIcons = array();
+
+	/** @var array list of special parameters "app" => ["text" => ["parameter" => "type"]] */
+	protected $specialParameters = array();
+
 	/**
 	 * @param $app
 	 * @param $subject
@@ -173,16 +182,26 @@ class ActivityManager implements IManager {
 	 * @return array|false
 	 */
 	function getSpecialParameterList($app, $text) {
+		if (isset($this->specialParameters[$app][$text])) {
+			return $this->specialParameters[$app][$text];
+		}
+
+		if (!isset($this->specialParameters[$app])) {
+			$this->specialParameters[$app] = array();
+		}
+
 		foreach($this->extensions as $extension) {
 			$c = $extension();
 			if ($c instanceof IExtension) {
 				$specialParameter = $c->getSpecialParameterList($app, $text);
 				if (is_array($specialParameter)) {
+					$this->specialParameters[$app][$text] = $specialParameter;
 					return $specialParameter;
 				}
 			}
 		}
 
+		$this->specialParameters[$app][$text] = false;
 		return false;
 	}
 
@@ -191,16 +210,22 @@ class ActivityManager implements IManager {
 	 * @return string
 	 */
 	function getTypeIcon($type) {
+		if (isset($this->typeIcons[$type])) {
+			return $this->typeIcons[$type];
+		}
+
 		foreach($this->extensions as $extension) {
 			$c = $extension();
 			if ($c instanceof IExtension) {
 				$icon = $c->getTypeIcon($type);
 				if (is_string($icon)) {
+					$this->typeIcons[$type] = $icon;
 					return $icon;
 				}
 			}
 		}
 
+		$this->typeIcons[$type] = '';
 		return '';
 	}
 
@@ -249,15 +274,21 @@ class ActivityManager implements IManager {
 	 * @return boolean
 	 */
 	function isFilterValid($filterValue) {
+		if (isset($this->validFilters[$filterValue])) {
+			return $this->validFilters[$filterValue];
+		}
+
 		foreach($this->extensions as $extension) {
 			$c = $extension();
 			if ($c instanceof IExtension) {
 				if ($c->isFilterValid($filterValue) === true) {
+					$this->validFilters[$filterValue] = true;
 					return true;
 				}
 			}
 		}
 
+		$this->validFilters[$filterValue] = false;
 		return false;
 	}
 

--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -26,7 +26,11 @@ class ActivityManager implements IManager {
 	private $extensions = array();
 
 	/** @var array list of filters "name" => "is valid" */
-	protected $validFilters = array();
+	protected $validFilters = array(
+		'all'	=> true,
+		'by'	=> true,
+		'self'	=> true,
+	);
 
 	/** @var array list of type icons "type" => "css class" */
 	protected $typeIcons = array();
@@ -123,6 +127,10 @@ class ActivityManager implements IManager {
 	 * @return array
 	 */
 	function filterNotificationTypes($types, $filter) {
+		if (!$this->isFilterValid($filter)) {
+			return $types;
+		}
+
 		foreach($this->extensions as $extension) {
 			$c = $extension();
 			if ($c instanceof IExtension) {
@@ -297,6 +305,9 @@ class ActivityManager implements IManager {
 	 * @return array
 	 */
 	function getQueryForFilter($filter) {
+		if (!$this->isFilterValid($filter)) {
+			return [null, null];
+		}
 
 		$conditions = array();
 		$parameters = array();

--- a/lib/private/activitymanager.php
+++ b/lib/private/activitymanager.php
@@ -122,28 +122,6 @@ class ActivityManager implements IManager {
 	}
 
 	/**
-	 * @param array $types
-	 * @param string $filter
-	 * @return array
-	 */
-	function filterNotificationTypes($types, $filter) {
-		if (!$this->isFilterValid($filter)) {
-			return $types;
-		}
-
-		foreach($this->extensions as $extension) {
-			$c = $extension();
-			if ($c instanceof IExtension) {
-				$result = $c->filterNotificationTypes($types, $filter);
-				if (is_array($result)) {
-					$types = $result;
-				}
-			}
-		}
-		return $types;
-	}
-
-	/**
 	 * @param string $method
 	 * @return array
 	 */
@@ -159,6 +137,30 @@ class ActivityManager implements IManager {
 			}
 		}
 		return $defaultTypes;
+	}
+
+	/**
+	 * @param string $type
+	 * @return string
+	 */
+	function getTypeIcon($type) {
+		if (isset($this->typeIcons[$type])) {
+			return $this->typeIcons[$type];
+		}
+
+		foreach($this->extensions as $extension) {
+			$c = $extension();
+			if ($c instanceof IExtension) {
+				$icon = $c->getTypeIcon($type);
+				if (is_string($icon)) {
+					$this->typeIcons[$type] = $icon;
+					return $icon;
+				}
+			}
+		}
+
+		$this->typeIcons[$type] = '';
+		return '';
 	}
 
 	/**
@@ -211,30 +213,6 @@ class ActivityManager implements IManager {
 
 		$this->specialParameters[$app][$text] = false;
 		return false;
-	}
-
-	/**
-	 * @param string $type
-	 * @return string
-	 */
-	function getTypeIcon($type) {
-		if (isset($this->typeIcons[$type])) {
-			return $this->typeIcons[$type];
-		}
-
-		foreach($this->extensions as $extension) {
-			$c = $extension();
-			if ($c instanceof IExtension) {
-				$icon = $c->getTypeIcon($type);
-				if (is_string($icon)) {
-					$this->typeIcons[$type] = $icon;
-					return $icon;
-				}
-			}
-		}
-
-		$this->typeIcons[$type] = '';
-		return '';
 	}
 
 	/**
@@ -298,6 +276,28 @@ class ActivityManager implements IManager {
 
 		$this->validFilters[$filterValue] = false;
 		return false;
+	}
+
+	/**
+	 * @param array $types
+	 * @param string $filter
+	 * @return array
+	 */
+	function filterNotificationTypes($types, $filter) {
+		if (!$this->isFilterValid($filter)) {
+			return $types;
+		}
+
+		foreach($this->extensions as $extension) {
+			$c = $extension();
+			if ($c instanceof IExtension) {
+				$result = $c->filterNotificationTypes($types, $filter);
+				if (is_array($result)) {
+					$types = $result;
+				}
+			}
+		}
+		return $types;
 	}
 
 	/**

--- a/lib/public/activity/iextension.php
+++ b/lib/public/activity/iextension.php
@@ -47,16 +47,6 @@ interface IExtension {
 	public function getNotificationTypes($languageCode);
 
 	/**
-	 * The extension can filter the types based on the filter if required.
-	 * In case no filter is to be applied false is to be returned unchanged.
-	 *
-	 * @param array $types
-	 * @param string $filter
-	 * @return array|false
-	 */
-	public function filterNotificationTypes($types, $filter);
-
-	/**
 	 * For a given method additional types to be displayed in the settings can be returned.
 	 * In case no additional types are to be added false is to be returned.
 	 *
@@ -64,6 +54,15 @@ interface IExtension {
 	 * @return array|false
 	 */
 	public function getDefaultTypes($method);
+
+	/**
+	 * A string naming the css class for the icon to be used can be returned.
+	 * If no icon is known for the given type false is to be returned.
+	 *
+	 * @param string $type
+	 * @return string|false
+	 */
+	public function getTypeIcon($type);
 
 	/**
 	 * The extension can translate a given message to the requested languages.
@@ -93,15 +92,6 @@ interface IExtension {
 	function getSpecialParameterList($app, $text);
 
 	/**
-	 * A string naming the css class for the icon to be used can be returned.
-	 * If no icon is known for the given type false is to be returned.
-	 *
-	 * @param string $type
-	 * @return string|false
-	 */
-	public function getTypeIcon($type);
-
-	/**
 	 * The extension can define the parameter grouping by returning the index as integer.
 	 * In case no grouping is required false is to be returned.
 	 *
@@ -126,6 +116,16 @@ interface IExtension {
 	 * @return boolean
 	 */
 	public function isFilterValid($filterValue);
+
+	/**
+	 * The extension can filter the types based on the filter if required.
+	 * In case no filter is to be applied false is to be returned unchanged.
+	 *
+	 * @param array $types
+	 * @param string $filter
+	 * @return array|false
+	 */
+	public function filterNotificationTypes($types, $filter);
 
 	/**
 	 * For a given filter the extension can specify the sql query conditions including parameters for that query.

--- a/lib/public/activity/imanager.php
+++ b/lib/public/activity/imanager.php
@@ -76,17 +76,16 @@ interface IManager {
 	function getNotificationTypes($languageCode);
 
 	/**
-	 * @param array $types
-	 * @param string $filter
-	 * @return array
-	 */
-	function filterNotificationTypes($types, $filter);
-
-	/**
 	 * @param string $method
 	 * @return array
 	 */
 	function getDefaultTypes($method);
+
+	/**
+	 * @param string $type
+	 * @return string
+	 */
+	function getTypeIcon($type);
 
 	/**
 	 * @param string $app
@@ -107,12 +106,6 @@ interface IManager {
 	function getSpecialParameterList($app, $text);
 
 	/**
-	 * @param string $type
-	 * @return string
-	 */
-	function getTypeIcon($type);
-
-	/**
 	 * @param array $activity
 	 * @return integer|false
 	 */
@@ -128,6 +121,13 @@ interface IManager {
 	 * @return boolean
 	 */
 	function isFilterValid($filterValue);
+
+	/**
+	 * @param array $types
+	 * @param string $filter
+	 * @return array
+	 */
+	function filterNotificationTypes($types, $filter);
 
 	/**
 	 * @param string $filter


### PR DESCRIPTION
- [x] Some methods are called quite often with the same values and the results can not change, so we can "cache" the result for the page call, e.g. `getSpecialParameterList()` is now only called once instead of 120-times in case the 30 activities of the same type are displayed :-X
- [x] Check whether filters are valid, before querying extensions about them.
- [x] Ordered the methods of the extension to be more logically related.

PS: Look at the individual commits, to easily see that the methods have not changed their signature, but have only been moved.

/cc @LukasReschke @DeepDiver1975 
