### PR TITLE
Ensure that passed argument is always a string

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -5,7 +5,7 @@ OCP\JSON::checkLoggedIn();
 $l = \OC::$server->getL10N('files');
 
 // Load the files
-$dir = isset($_GET['dir']) ? $_GET['dir'] : '';
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
 $dir = \OC\Files\Filesystem::normalizePath($dir);
 
 try {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -723,9 +723,18 @@ class Filesystem {
 	 * Fix common problems with a file path
 	 * @param string $path
 	 * @param bool $stripTrailingSlash
+	 * @param bool $isAbsolutePath
 	 * @return string
 	 */
 	public static function normalizePath($path, $stripTrailingSlash = true, $isAbsolutePath = false) {
+		/**
+		 * FIXME: This is a workaround for existing classes and files which call
+		 *        this function with another type than a valid string. This
+		 *        conversion should get removed as soon as all existing
+		 *        function calls have been fixed.
+		 */
+		$path = (string)$path;
+
 		$cacheKey = json_encode([$path, $stripTrailingSlash, $isAbsolutePath]);
 
 		if(isset(self::$normalizedPathCache[$cacheKey])) {


### PR DESCRIPTION
Some code paths called the `normalizePath` functionality with types other than a string which resulted in unexpected behaviour.

Thus the function is now manually casting the type to a string and I corrected the usage in list.php as well.

I'll go through all other AJAX files and ensure that they use proper types, this is tracked at https://github.com/owncloud/core/issues/14196

@PVince81 @nickvergessen Please review and test.
