### PR TITLE
Manually type-cast all AJAX files

### DIFF
--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -7,10 +7,10 @@ OCP\JSON::callCheck();
 
 // Get data
 $dir = isset($_POST['dir']) ? (string)$_POST['dir'] : '';
-$allFiles = isset($_POST["allfiles"]) ? (bool)$_POST["allfiles"] : false;
+$allFiles = isset($_POST["allfiles"]) ? (string)$_POST["allfiles"] : false;
 
 // delete all files in dir ?
-if ($allFiles === true) {
+if ($allFiles === 'true') {
 	$files = array();
 	$fileList = \OC\Files\Filesystem::getDirectoryContent($dir);
 	foreach ($fileList as $fileInfo) {

--- a/apps/files/ajax/delete.php
+++ b/apps/files/ajax/delete.php
@@ -6,18 +6,18 @@ OCP\JSON::callCheck();
 
 
 // Get data
-$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
-$allFiles = isset($_POST["allfiles"]) ? $_POST["allfiles"] : false;
+$dir = isset($_POST['dir']) ? (string)$_POST['dir'] : '';
+$allFiles = isset($_POST["allfiles"]) ? (bool)$_POST["allfiles"] : false;
 
 // delete all files in dir ?
-if ($allFiles === 'true') {
+if ($allFiles === true) {
 	$files = array();
 	$fileList = \OC\Files\Filesystem::getDirectoryContent($dir);
 	foreach ($fileList as $fileInfo) {
 		$files[] = $fileInfo['name'];
 	}
 } else {
-	$files = isset($_POST["file"]) ? $_POST["file"] : $_POST["files"];
+	$files = isset($_POST["file"]) ? (string)$_POST["file"] : (string)$_POST["files"];
 	$files = json_decode($files);
 }
 $filesWithError = '';

--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -25,8 +25,8 @@
 OCP\User::checkLoggedIn();
 \OC::$server->getSession()->close();
 
-$files = isset($_GET['files']) ? $_GET['files'] : '';
-$dir = isset($_GET['dir']) ? $_GET['dir'] : '';
+$files = isset($_GET['files']) ? (string)$_GET['files'] : '';
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
 
 $files_list = json_decode($files);
 // in case we get only a single file

--- a/apps/files/ajax/getstoragestats.php
+++ b/apps/files/ajax/getstoragestats.php
@@ -3,7 +3,7 @@
 $dir = '/';
 
 if (isset($_GET['dir'])) {
-	$dir = $_GET['dir'];
+	$dir = (string)$_GET['dir'];
 }
 
 OCP\JSON::checkLoggedIn();

--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -5,7 +5,7 @@ OCP\JSON::checkLoggedIn();
 $l = \OC::$server->getL10N('files');
 
 // Load the files
-$dir = isset($_GET['dir']) ? $_GET['dir'] : '';
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
 $dir = \OC\Files\Filesystem::normalizePath($dir);
 
 try {
@@ -20,7 +20,7 @@ try {
 
 	$permissions = $dirInfo->getPermissions();
 
-	$sortAttribute = isset($_GET['sort']) ? $_GET['sort'] : 'name';
+	$sortAttribute = isset($_GET['sort']) ? (string)$_GET['sort'] : 'name';
 	$sortDirection = isset($_GET['sortdirection']) ? ($_GET['sortdirection'] === 'desc') : false;
 
 	// make filelist

--- a/apps/files/ajax/mimeicon.php
+++ b/apps/files/ajax/mimeicon.php
@@ -1,6 +1,6 @@
 <?php
 \OC::$server->getSession()->close();
 
-$mime = isset($_GET['mime']) ? $_GET['mime'] : '';
+$mime = isset($_GET['mime']) ? (string)$_GET['mime'] : '';
 
 print OC_Helper::mimetypeIcon($mime);

--- a/apps/files/ajax/move.php
+++ b/apps/files/ajax/move.php
@@ -5,9 +5,9 @@ OCP\JSON::callCheck();
 \OC::$server->getSession()->close();
 
 // Get data
-$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
-$file = isset($_POST['file']) ? $_POST['file'] : '';
-$target = isset($_POST['target']) ? rawurldecode($_POST['target']) : '';
+$dir = isset($_POST['dir']) ? (string)$_POST['dir'] : '';
+$file = isset($_POST['file']) ? (string)$_POST['file'] : '';
+$target = isset($_POST['target']) ? rawurldecode((string)$_POST['target']) : '';
 
 $l = \OC::$server->getL10N('files');
 

--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -9,10 +9,10 @@ global $eventSource;
 \OC::$server->getSession()->close();
 
 // Get the params
-$dir = isset( $_REQUEST['dir'] ) ? '/'.trim($_REQUEST['dir'], '/\\') : '';
-$filename = isset( $_REQUEST['filename'] ) ? trim($_REQUEST['filename'], '/\\') : '';
-$content = isset( $_REQUEST['content'] ) ? $_REQUEST['content'] : '';
-$source = isset( $_REQUEST['source'] ) ? trim($_REQUEST['source'], '/\\') : '';
+$dir = isset( $_REQUEST['dir'] ) ? '/'.trim((string)$_REQUEST['dir'], '/\\') : '';
+$filename = isset( $_REQUEST['filename'] ) ? trim((string)$_REQUEST['filename'], '/\\') : '';
+$content = isset( $_REQUEST['content'] ) ? (string)$_REQUEST['content'] : '';
+$source = isset( $_REQUEST['source'] ) ? trim((string)$_REQUEST['source'], '/\\') : '';
 
 if($source) {
 	$eventSource = \OC::$server->createEventSource();

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -8,8 +8,8 @@ OCP\JSON::callCheck();
 \OC::$server->getSession()->close();
 
 // Get the params
-$dir = isset($_POST['dir']) ? $_POST['dir'] : '';
-$foldername = isset($_POST['foldername']) ? $_POST['foldername'] : '';
+$dir = isset($_POST['dir']) ? (string)$_POST['dir'] : '';
+$foldername = isset($_POST['foldername']) ?(string) $_POST['foldername'] : '';
 
 $l10n = \OC::$server->getL10N('files');
 

--- a/apps/files/ajax/rename.php
+++ b/apps/files/ajax/rename.php
@@ -30,9 +30,9 @@ $files = new \OCA\Files\App(
 	\OC::$server->getL10N('files')
 );
 $result = $files->rename(
-	isset($_GET['dir']) ? $_GET['dir'] : '',
-	isset($_GET['file']) ? $_GET['file'] : '',
-	isset($_GET['newname']) ? $_GET['newname'] : ''
+	isset($_GET['dir']) ? (string)$_GET['dir'] : '',
+	isset($_GET['file']) ? (string)$_GET['file'] : '',
+	isset($_GET['newname']) ? (string)$_GET['newname'] : ''
 );
 
 if($result['success'] === true){

--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -3,7 +3,7 @@ set_time_limit(0); //scanning can take ages
 \OC::$server->getSession()->close();
 
 $force = (isset($_GET['force']) and ($_GET['force'] === 'true'));
-$dir = isset($_GET['dir']) ? $_GET['dir'] : '';
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
 if (isset($_GET['users'])) {
 	OC_JSON::checkAdminUser();
 	if ($_GET['users'] === 'all') {

--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -16,7 +16,7 @@ $l = \OC::$server->getL10N('files');
 if (empty($_POST['dirToken'])) {
 	// The standard case, files are uploaded through logged in users :)
 	OCP\JSON::checkLoggedIn();
-	$dir = isset($_POST['dir']) ? $_POST['dir'] : "";
+	$dir = isset($_POST['dir']) ? (string)$_POST['dir'] : '';
 	if (!$dir || empty($dir) || $dir === false) {
 		OCP\JSON::error(array('data' => array_merge(array('message' => $l->t('Unable to set upload directory.')))));
 		die();
@@ -30,9 +30,9 @@ if (empty($_POST['dirToken'])) {
 
 	// return only read permissions for public upload
 	$allowedPermissions = \OCP\Constants::PERMISSION_READ;
-	$publicDirectory = !empty($_POST['subdir']) ? $_POST['subdir'] : '/';
+	$publicDirectory = !empty($_POST['subdir']) ? (string)$_POST['subdir'] : '/';
 
-	$linkItem = OCP\Share::getShareByToken($_POST['dirToken']);
+	$linkItem = OCP\Share::getShareByToken((string)$_POST['dirToken']);
 	if ($linkItem === false) {
 		OCP\JSON::error(array('data' => array_merge(array('message' => $l->t('Invalid Token')))));
 		die();

--- a/apps/files_encryption/ajax/adminrecovery.php
+++ b/apps/files_encryption/ajax/adminrecovery.php
@@ -43,7 +43,7 @@ $recoveryKeyId = \OC::$server->getAppConfig()->getValue('files_encryption', 'rec
 
 if (isset($_POST['adminEnableRecovery']) && $_POST['adminEnableRecovery'] === '1') {
 
-	$return = Helper::adminEnableRecovery($recoveryKeyId, $_POST['recoveryPassword']);
+	$return = Helper::adminEnableRecovery($recoveryKeyId, (string)$_POST['recoveryPassword']);
 
 	// Return success or failure
 	if ($return) {
@@ -57,7 +57,7 @@ if (isset($_POST['adminEnableRecovery']) && $_POST['adminEnableRecovery'] === '1
 	isset($_POST['adminEnableRecovery'])
 	&& '0' === $_POST['adminEnableRecovery']
 ) {
-	$return = Helper::adminDisableRecovery($_POST['recoveryPassword']);
+	$return = Helper::adminDisableRecovery((string)$_POST['recoveryPassword']);
 
 	if ($return) {
 		$successMessage = $l->t('Recovery key successfully disabled');

--- a/apps/files_encryption/ajax/changeRecoveryPassword.php
+++ b/apps/files_encryption/ajax/changeRecoveryPassword.php
@@ -17,9 +17,9 @@ $l = \OC::$server->getL10N('core');
 
 $return = false;
 
-$oldPassword = $_POST['oldPassword'];
-$newPassword = $_POST['newPassword'];
-$confirmPassword = $_POST['confirmPassword'];
+$oldPassword = (string)$_POST['oldPassword'];
+$newPassword = (string)$_POST['newPassword'];
+$confirmPassword = (string)$_POST['confirmPassword'];
 
 //check if both passwords are the same
 if (empty($_POST['oldPassword'])) {

--- a/apps/files_encryption/ajax/getMigrationStatus.php
+++ b/apps/files_encryption/ajax/getMigrationStatus.php
@@ -11,8 +11,8 @@ use OCA\Files_Encryption\Util;
 
 \OCP\JSON::checkAppEnabled('files_encryption');
 
-$loginname = isset($_POST['user']) ? $_POST['user'] : '';
-$password = isset($_POST['password']) ? $_POST['password'] : '';
+$loginname = isset($_POST['user']) ? (string)$_POST['user'] : '';
+$password = isset($_POST['password']) ? (string)$_POST['password'] : '';
 
 $migrationStatus = Util::MIGRATION_COMPLETED;
 

--- a/apps/files_encryption/ajax/updatePrivateKeyPassword.php
+++ b/apps/files_encryption/ajax/updatePrivateKeyPassword.php
@@ -18,8 +18,8 @@ $l = \OC::$server->getL10N('core');
 $return = false;
 $errorMessage = $l->t('Could not update the private key password.');
 
-$oldPassword = $_POST['oldPassword'];
-$newPassword = $_POST['newPassword'];
+$oldPassword = (string)$_POST['oldPassword'];
+$newPassword = (string)$_POST['newPassword'];
 
 $view = new \OC\Files\View('/');
 $session = new \OCA\Files_Encryption\Session($view);

--- a/apps/files_encryption/ajax/userrecovery.php
+++ b/apps/files_encryption/ajax/userrecovery.php
@@ -23,7 +23,7 @@ if (
 	$util = new \OCA\Files_Encryption\Util($view, $userId);
 
 	// Save recovery preference to DB
-	$return = $util->setRecoveryForUser($_POST['userEnableRecovery']);
+	$return = $util->setRecoveryForUser((string)$_POST['userEnableRecovery']);
 
 	if ($_POST['userEnableRecovery'] === '1') {
 		$util->addRecoveryKeys();

--- a/apps/files_external/ajax/addMountPoint.php
+++ b/apps/files_external/ajax/addMountPoint.php
@@ -11,12 +11,12 @@ if ($_POST['isPersonal'] == 'true') {
 	$isPersonal = false;
 }
 
-$mountPoint = $_POST['mountPoint'];
-$oldMountPoint = $_POST['oldMountPoint'];
-$class = $_POST['class'];
-$options = $_POST['classOptions'];
-$type = $_POST['mountType'];
-$applicable = $_POST['applicable'];
+$mountPoint = (string)$_POST['mountPoint'];
+$oldMountPoint = (string)$_POST['oldMountPoint'];
+$class = (string)$_POST['class'];
+$options = (string)$_POST['classOptions'];
+$type = (string)$_POST['mountType'];
+$applicable = (string)$_POST['applicable'];
 
 if ($oldMountPoint and $oldMountPoint !== $mountPoint) {
 	OC_Mount_Config::removeMountPoint($oldMountPoint, $type, $applicable, $isPersonal);

--- a/apps/files_external/ajax/applicable.php
+++ b/apps/files_external/ajax/applicable.php
@@ -9,13 +9,13 @@ $pattern = '';
 $limit = null;
 $offset = null;
 if (isset($_GET['pattern'])) {
-	$pattern = $_GET['pattern'];
+	$pattern = (string)$_GET['pattern'];
 }
 if (isset($_GET['limit'])) {
-	$limit = $_GET['limit'];
+	$limit = (int)$_GET['limit'];
 }
 if (isset($_GET['offset'])) {
-	$offset = $_GET['offset'];
+	$offset = (int)$_GET['offset'];
 }
 
 $groups = \OC_Group::getGroups($pattern, $limit, $offset);

--- a/apps/files_external/ajax/dropbox.php
+++ b/apps/files_external/ajax/dropbox.php
@@ -8,13 +8,13 @@ OCP\JSON::callCheck();
 $l = \OC::$server->getL10N('files_external');
 
 if (isset($_POST['app_key']) && isset($_POST['app_secret'])) {
-	$oauth = new Dropbox_OAuth_Curl($_POST['app_key'], $_POST['app_secret']);
+	$oauth = new Dropbox_OAuth_Curl((string)$_POST['app_key'], (string)$_POST['app_secret']);
 	if (isset($_POST['step'])) {
 		switch ($_POST['step']) {
 			case 1:
 				try {
 					if (isset($_POST['callback'])) {
-						$callback = $_POST['callback'];
+						$callback = (string)$_POST['callback'];
 					} else {
 						$callback = null;
 					}
@@ -31,7 +31,7 @@ if (isset($_POST['app_key']) && isset($_POST['app_secret'])) {
 			case 2:
 				if (isset($_POST['request_token']) && isset($_POST['request_token_secret'])) {
 					try {
-						$oauth->setToken($_POST['request_token'], $_POST['request_token_secret']);
+						$oauth->setToken((string)$_POST['request_token'], (string)$_POST['request_token_secret']);
 						$token = $oauth->getAccessToken();
 						OCP\JSON::success(array('access_token' => $token['token'],
 												'access_token_secret' => $token['token_secret']));

--- a/apps/files_external/ajax/google.php
+++ b/apps/files_external/ajax/google.php
@@ -10,9 +10,9 @@ $l = \OC::$server->getL10N('files_external');
 
 if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST['redirect'])) {
 	$client = new Google_Client();
-	$client->setClientId($_POST['client_id']);
-	$client->setClientSecret($_POST['client_secret']);
-	$client->setRedirectUri($_POST['redirect']);
+	$client->setClientId((string)$_POST['client_id']);
+	$client->setClientSecret((string)$_POST['client_secret']);
+	$client->setRedirectUri((string)$_POST['redirect']);
 	$client->setScopes(array('https://www.googleapis.com/auth/drive'));
 	$client->setAccessType('offline');
 	if (isset($_POST['step'])) {
@@ -30,7 +30,7 @@ if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST
 			}
 		} else if ($step == 2 && isset($_POST['code'])) {
 			try {
-				$token = $client->authenticate($_POST['code']);
+				$token = $client->authenticate((string)$_POST['code']);
 				OCP\JSON::success(array('data' => array(
 					'token' => $token
 				)));

--- a/apps/files_external/ajax/removeMountPoint.php
+++ b/apps/files_external/ajax/removeMountPoint.php
@@ -20,4 +20,4 @@ if ($_POST['isPersonal'] == 'true') {
 	$isPersonal = false;
 }
 
-OC_Mount_Config::removeMountPoint($_POST['mountPoint'], $_POST['mountType'], $_POST['applicable'], $isPersonal);
+OC_Mount_Config::removeMountPoint((string)$_POST['mountPoint'], (string)$_POST['mountType'], (string)$_POST['applicable'], $isPersonal);

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -7,7 +7,7 @@ OCP\JSON::callCheck();
 $folder = isset($_POST['dir']) ? $_POST['dir'] : '/';
 
 // "empty trash" command
-if (isset($_POST['allfiles']) and $_POST['allfiles'] === 'true'){
+if (isset($_POST['allfiles']) && (string)$_POST['allfiles'] === 'true'){
 	$deleteAll = true;
 	if ($folder === '/' || $folder === '') {
 		OCA\Files_Trashbin\Trashbin::deleteAll();
@@ -19,7 +19,7 @@ if (isset($_POST['allfiles']) and $_POST['allfiles'] === 'true'){
 }
 else {
 	$deleteAll = false;
-	$files = $_POST['files'];
+	$files = (string)$_POST['files'];
 	$list = json_decode($files);
 }
 

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -4,9 +4,9 @@ OCP\JSON::checkLoggedIn();
 \OC::$server->getSession()->close();
 
 // Load the files
-$dir = isset( $_GET['dir'] ) ? $_GET['dir'] : '';
-$sortAttribute = isset( $_GET['sort'] ) ? $_GET['sort'] : 'name';
-$sortDirection = isset( $_GET['sortdirection'] ) ? ($_GET['sortdirection'] === 'desc') : false;
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
+$sortAttribute = isset($_GET['sort']) ? (string)$_GET['sort'] : 'name';
+$sortDirection = isset($_GET['sortdirection']) ? ($_GET['sortdirection'] === 'desc') : false;
 $data = array();
 
 // make filelist

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -7,10 +7,10 @@ OCP\JSON::callCheck();
 $files = $_POST['files'];
 $dir = '/';
 if (isset($_POST['dir'])) {
-	$dir = rtrim($_POST['dir'], '/'). '/';
+	$dir = rtrim((string)$_POST['dir'], '/'). '/';
 }
 $allFiles = false;
-if (isset($_POST['allfiles']) and $_POST['allfiles'] === 'true') {
+if (isset($_POST['allfiles']) && (string)$_POST['allfiles'] === 'true') {
 	$allFiles = true;
 	$list = array();
 	$dirListing = true;

--- a/apps/files_versions/ajax/getVersions.php
+++ b/apps/files_versions/ajax/getVersions.php
@@ -4,7 +4,7 @@ OCP\JSON::callCheck();
 OCP\JSON::checkAppEnabled('files_versions');
 
 $source = (string)$_GET['source'];
-$start = (string)$_GET['start'];
+$start = (int)$_GET['start'];
 list ($uid, $filename) = OCA\Files_Versions\Storage::getUidAndFilename($source);
 $count = 5; //show the newest revisions
 $versions = OCA\Files_Versions\Storage::getVersions($uid, $filename, $source);

--- a/apps/files_versions/ajax/getVersions.php
+++ b/apps/files_versions/ajax/getVersions.php
@@ -3,8 +3,8 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 OCP\JSON::checkAppEnabled('files_versions');
 
-$source = $_GET['source'];
-$start = $_GET['start'];
+$source = (string)$_GET['source'];
+$start = (string)$_GET['start'];
 list ($uid, $filename) = OCA\Files_Versions\Storage::getUidAndFilename($source);
 $count = 5; //show the newest revisions
 $versions = OCA\Files_Versions\Storage::getVersions($uid, $filename, $source);

--- a/apps/files_versions/ajax/rollbackVersion.php
+++ b/apps/files_versions/ajax/rollbackVersion.php
@@ -4,7 +4,7 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::checkAppEnabled('files_versions');
 OCP\JSON::callCheck();
 
-$file = $_GET['file'];
+$file = (string)$_GET['file'];
 $revision=(int)$_GET['revision'];
 
 if(OCA\Files_Versions\Storage::rollback( $file, $revision )) {

--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -29,7 +29,7 @@ OCP\JSON::checkAdminUser();
 OCP\JSON::checkAppEnabled('user_ldap');
 OCP\JSON::callCheck();
 
-$subject = $_POST['ldap_clear_mapping'];
+$subject = (string)$_POST['ldap_clear_mapping'];
 $mapping = null;
 if($subject === 'user') {
 	$mapping = new UserMapping(\OC::$server->getDatabaseConnection());

--- a/apps/user_ldap/ajax/deleteConfiguration.php
+++ b/apps/user_ldap/ajax/deleteConfiguration.php
@@ -26,7 +26,7 @@ OCP\JSON::checkAdminUser();
 OCP\JSON::checkAppEnabled('user_ldap');
 OCP\JSON::callCheck();
 
-$prefix = $_POST['ldap_serverconfig_chooser'];
+$prefix = (string)$_POST['ldap_serverconfig_chooser'];
 $helper = new \OCA\user_ldap\lib\Helper();
 if($helper->deleteServerConfiguration($prefix)) {
 	OCP\JSON::success();

--- a/apps/user_ldap/ajax/getConfiguration.php
+++ b/apps/user_ldap/ajax/getConfiguration.php
@@ -26,7 +26,7 @@ OCP\JSON::checkAdminUser();
 OCP\JSON::checkAppEnabled('user_ldap');
 OCP\JSON::callCheck();
 
-$prefix = $_POST['ldap_serverconfig_chooser'];
+$prefix = (string)$_POST['ldap_serverconfig_chooser'];
 $ldapWrapper = new OCA\user_ldap\lib\LDAP();
 $connection = new \OCA\user_ldap\lib\Connection($ldapWrapper, $prefix);
 OCP\JSON::success(array('configuration' => $connection->getConfiguration()));

--- a/apps/user_ldap/ajax/setConfiguration.php
+++ b/apps/user_ldap/ajax/setConfiguration.php
@@ -26,7 +26,7 @@ OCP\JSON::checkAdminUser();
 OCP\JSON::checkAppEnabled('user_ldap');
 OCP\JSON::callCheck();
 
-$prefix = $_POST['ldap_serverconfig_chooser'];
+$prefix = (string)$_POST['ldap_serverconfig_chooser'];
 
 // Checkboxes are not submitted, when they are unchecked. Set them manually.
 // only legacy checkboxes (Advanced and Expert tab) need to be handled here,

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -31,13 +31,13 @@ $l = \OC::$server->getL10N('user_ldap');
 if(!isset($_POST['action'])) {
 	\OCP\JSON::error(array('message' => $l->t('No action specified')));
 }
-$action = $_POST['action'];
+$action = (string)$_POST['action'];
 
 
 if(!isset($_POST['ldap_serverconfig_chooser'])) {
 	\OCP\JSON::error(array('message' => $l->t('No configuration specified')));
 }
-$prefix = $_POST['ldap_serverconfig_chooser'];
+$prefix = (string)$_POST['ldap_serverconfig_chooser'];
 
 $ldapWrapper = new \OCA\user_ldap\lib\LDAP();
 $configuration = new \OCA\user_ldap\lib\Configuration($prefix);

--- a/core/ajax/appconfig.php
+++ b/core/ajax/appconfig.php
@@ -11,14 +11,14 @@ OCP\JSON::callCheck();
 $action=isset($_POST['action'])?$_POST['action']:$_GET['action'];
 
 if(isset($_POST['app']) || isset($_GET['app'])) {
-	$app=OC_App::cleanAppId(isset($_POST['app'])?$_POST['app']:$_GET['app']);
+	$app=OC_App::cleanAppId(isset($_POST['app'])? (string)$_POST['app']: (string)$_GET['app']);
 }
 
 // An admin should not be able to add remote and public services
 // on its own. This should only be possible programmatically.
 // This change is due the fact that an admin may not be expected 
 // to execute arbitrary code in every environment.
-if($app === 'core' && isset($_POST['key']) &&(substr($_POST['key'],0,7) === 'remote_' || substr($_POST['key'],0,7) === 'public_')) {
+if($app === 'core' && isset($_POST['key']) &&(substr((string)$_POST['key'],0,7) === 'remote_' || substr((string)$_POST['key'],0,7) === 'public_')) {
 	OC_JSON::error(array('data' => array('message' => 'Unexpected error!')));
 	return;
 }
@@ -27,10 +27,10 @@ $result=false;
 $appConfig = \OC::$server->getAppConfig();
 switch($action) {
 	case 'getValue':
-		$result=$appConfig->getValue($app, $_GET['key'], $_GET['defaultValue']);
+		$result=$appConfig->getValue($app, (string)$_GET['key'], (string)$_GET['defaultValue']);
 		break;
 	case 'setValue':
-		$result=$appConfig->setValue($app, $_POST['key'], $_POST['value']);
+		$result=$appConfig->setValue($app, (string)$_POST['key'], (string)$_POST['value']);
 		break;
 	case 'getApps':
 		$result=$appConfig->getApps();
@@ -39,10 +39,10 @@ switch($action) {
 		$result=$appConfig->getKeys($app);
 		break;
 	case 'hasKey':
-		$result=$appConfig->hasKey($app, $_GET['key']);
+		$result=$appConfig->hasKey($app, (string)$_GET['key']);
 		break;
 	case 'deleteKey':
-		$result=$appConfig->deleteKey($app, $_POST['key']);
+		$result=$appConfig->deleteKey($app, (string)$_POST['key']);
 		break;
 	case 'deleteApp':
 		$result=$appConfig->deleteApp($app);

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -31,11 +31,11 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				try {
 					$shareType = (int)$_POST['shareType'];
 					$shareWith = $_POST['shareWith'];
-					$itemSourceName = isset($_POST['itemSourceName']) ? $_POST['itemSourceName'] : null;
+					$itemSourceName = isset($_POST['itemSourceName']) ? (string)$_POST['itemSourceName'] : null;
 					if ($shareType === OCP\Share::SHARE_TYPE_LINK && $shareWith == '') {
 						$shareWith = null;
 					}
- 					$itemSourceName=(isset($_POST['itemSourceName'])) ? $_POST['itemSourceName']:'';
+ 					$itemSourceName=(isset($_POST['itemSourceName'])) ? (string)$_POST['itemSourceName']:'';
 
 					$token = OCP\Share::shareItem(
 						$_POST['itemType'],
@@ -44,7 +44,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						$shareWith,
 						$_POST['permissions'],
 						$itemSourceName,
-						(!empty($_POST['expirationDate']) ? new \DateTime($_POST['expirationDate']) : null)
+						(!empty($_POST['expirationDate']) ? new \DateTime((string)$_POST['expirationDate']) : null)
 					);
 
 					if (is_string($token)) {
@@ -62,19 +62,19 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				if ((int)$_POST['shareType'] === OCP\Share::SHARE_TYPE_LINK && $_POST['shareWith'] == '') {
 					$shareWith = null;
 				} else {
-					$shareWith = $_POST['shareWith'];
+					$shareWith = (string)$_POST['shareWith'];
 				}
-				$return = OCP\Share::unshare($_POST['itemType'], $_POST['itemSource'], $_POST['shareType'], $shareWith);
+				$return = OCP\Share::unshare((string)$_POST['itemType'],(string) $_POST['itemSource'], (int)$_POST['shareType'], $shareWith);
 				($return) ? OC_JSON::success() : OC_JSON::error();
 			}
 			break;
 		case 'setPermissions':
 			if (isset($_POST['shareType']) && isset($_POST['shareWith']) && isset($_POST['permissions'])) {
 				$return = OCP\Share::setPermissions(
-					$_POST['itemType'],
-					$_POST['itemSource'],
+					(string)$_POST['itemType'],
+					(string)$_POST['itemSource'],
 					(int)$_POST['shareType'],
-					$_POST['shareWith'],
+					(string)$_POST['shareWith'],
 					(int)$_POST['permissions']
 				);
 				($return) ? OC_JSON::success() : OC_JSON::error();
@@ -83,7 +83,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 		case 'setExpirationDate':
 			if (isset($_POST['date'])) {
 				try {
-					$return = OCP\Share::setExpirationDate($_POST['itemType'], $_POST['itemSource'], $_POST['date']);
+					$return = OCP\Share::setExpirationDate((string)$_POST['itemType'], (string)$_POST['itemSource'], (string)$_POST['date']);
 					($return) ? OC_JSON::success() : OC_JSON::error();
 				} catch (\Exception $e) {
 					OC_JSON::error(array('data' => array('message' => $e->getMessage())));
@@ -93,9 +93,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 		case 'informRecipients':
 			$l = \OC::$server->getL10N('core');
 			$shareType = (int) $_POST['shareType'];
-			$itemType = $_POST['itemType'];
-			$itemSource = $_POST['itemSource'];
-			$recipient = $_POST['recipient'];
+			$itemType = (string)$_POST['itemType'];
+			$itemSource = (string)$_POST['itemSource'];
+			$recipient = (string)$_POST['recipient'];
 
 			if($shareType === \OCP\Share::SHARE_TYPE_USER) {
 				$recipientList[] = $recipient;
@@ -123,26 +123,26 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			}
 			break;
 		case 'informRecipientsDisabled':
-			$itemSource = $_POST['itemSource'];
-			$shareType = $_POST['shareType'];
-			$itemType = $_POST['itemType'];
-			$recipient = $_POST['recipient'];
+			$itemSource = (string)$_POST['itemSource'];
+			$shareType = (int)$_POST['shareType'];
+			$itemType = (string)$_POST['itemType'];
+			$recipient = (string)$_POST['recipient'];
 			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, false);
 			OCP\JSON::success();
 			break;
 
 		case 'email':
 			// read post variables
-			$link = $_POST['link'];
-			$file = $_POST['file'];
-			$to_address = $_POST['toaddress'];
+			$link = (string)$_POST['link'];
+			$file = (string)$_POST['file'];
+			$to_address = (string)$_POST['toaddress'];
 
 			$mailNotification = new \OC\Share\MailNotifications();
 
 			$expiration = null;
 			if (isset($_POST['expiration']) && $_POST['expiration'] !== '') {
 				try {
-					$date = new DateTime($_POST['expiration']);
+					$date = new DateTime((string)$_POST['expiration']);
 					$expiration = $date->getTimestamp();
 				} catch (Exception $e) {
 					\OCP\Util::writeLog('sharing', "Couldn't read date: " . $e->getMessage(), \OCP\Util::ERROR);
@@ -170,7 +170,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 	switch ($_GET['fetch']) {
 		case 'getItemsSharedStatuses':
 			if (isset($_GET['itemType'])) {
-				$return = OCP\Share::getItemsShared($_GET['itemType'], OCP\Share::FORMAT_STATUSES);
+				$return = OCP\Share::getItemsShared((string)$_GET['itemType'], OCP\Share::FORMAT_STATUSES);
 				is_array($return) ? OC_JSON::success(array('data' => $return)) : OC_JSON::error();
 			}
 			break;
@@ -181,8 +181,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				&& isset($_GET['checkShares'])) {
 				if ($_GET['checkReshare'] == 'true') {
 					$reshare = OCP\Share::getItemSharedWithBySource(
-						$_GET['itemType'],
-						$_GET['itemSource'],
+						(string)$_GET['itemType'],
+						(string)$_GET['itemSource'],
 						OCP\Share::FORMAT_NONE,
 						null,
 						true
@@ -192,8 +192,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				}
 				if ($_GET['checkShares'] == 'true') {
 					$shares = OCP\Share::getItemShared(
-						$_GET['itemType'],
-						$_GET['itemSource'],
+						(string)$_GET['itemType'],
+						(string)$_GET['itemSource'],
 						OCP\Share::FORMAT_NONE,
 						null,
 						true
@@ -209,7 +209,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			if (isset($_GET['search'])) {
 				$cm = OC::$server->getContactsManager();
 				if (!is_null($cm) && $cm->isEnabled()) {
-					$contacts = $cm->search($_GET['search'], array('FN', 'EMAIL'));
+					$contacts = $cm->search((string)$_GET['search'], array('FN', 'EMAIL'));
 					foreach ($contacts as $contact) {
 						if (!isset($contact['EMAIL'])) {
 							continue;
@@ -236,7 +236,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			if (isset($_GET['search'])) {
 				$shareWithinGroupOnly = OC\Share\Share::shareWithGroupMembersOnly();
 				$shareWith = array();
-				$groups = OC_Group::getGroups($_GET['search']);
+				$groups = OC_Group::getGroups((string)$_GET['search']);
 				if ($shareWithinGroupOnly) {
 					$usergroups = OC_Group::getUserGroups(OC_User::getUser());
 					$groups = array_intersect($groups, $usergroups);
@@ -248,15 +248,15 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				while ($count < 15 && count($users) == $limit) {
 					$limit = 15 - $count;
 					if ($shareWithinGroupOnly) {
-						$users = OC_Group::DisplayNamesInGroups($usergroups, $_GET['search'], $limit, $offset);
+						$users = OC_Group::DisplayNamesInGroups($usergroups, (string)$_GET['search'], $limit, $offset);
 					} else {
-						$users = OC_User::getDisplayNames($_GET['search'], $limit, $offset);
+						$users = OC_User::getDisplayNames((string)$_GET['search'], $limit, $offset);
 					}
 					$offset += $limit;
 					foreach ($users as $uid => $displayName) {
 						if ((!isset($_GET['itemShares'])
-							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])
-							|| !in_array($uid, $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]))
+							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])
+							|| !in_array($uid, (string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]))
 							&& $uid != OC_User::getUser()) {
 							$shareWith[] = array(
 								'label' => $displayName,
@@ -277,8 +277,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					if ($count < 15) {
 						if (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
-							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
-							|| !in_array($group, $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
+							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
+							|| !in_array($group, (string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
 							$shareWith[] = array(
 								'label' => $group,
 								'value' => array(
@@ -294,20 +294,20 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				}
 
 				// allow user to add unknown remote addresses for server-to-server share
-				$backend = \OCP\Share::getBackend($_GET['itemType']);
+				$backend = \OCP\Share::getBackend((string)$_GET['itemType']);
 				if ($backend->isShareTypeAllowed(\OCP\Share::SHARE_TYPE_REMOTE)) {
-					if (substr_count($_GET['search'], '@') === 1) {
+					if (substr_count((string)$_GET['search'], '@') === 1) {
 						$shareWith[] = array(
-							'label' => $_GET['search'],
+							'label' => (string)$_GET['search'],
 							'value' => array(
 								'shareType' => \OCP\Share::SHARE_TYPE_REMOTE,
-								'shareWith' => $_GET['search']
+								'shareWith' => (string)$_GET['search']
 							)
 						);
 					}
 				}
 
-				$sorter = new \OC\Share\SearchResultSorter($_GET['search'],
+				$sorter = new \OC\Share\SearchResultSorter((string)$_GET['search'],
 														   'label',
 														   new \OC\Log());
 				usort($shareWith, array($sorter, 'sort'));

--- a/lib/base.php
+++ b/lib/base.php
@@ -956,13 +956,13 @@ class OC {
 		//setup extra user backends
 		OC_User::setupBackends();
 
-		if (OC_User::login($_POST["user"], $_POST["password"])) {
+		if (OC_User::login((string)$_POST["user"], (string)$_POST["password"])) {
 			$userId = OC_User::getUser();
 
 			// setting up the time zone
 			if (isset($_POST['timezone-offset'])) {
-				self::$server->getSession()->set('timezone', $_POST['timezone-offset']);
-				self::$server->getConfig()->setUserValue($userId, 'core', 'timezone', $_POST['timezone']);
+				self::$server->getSession()->set('timezone', (string)$_POST['timezone-offset']);
+				self::$server->getConfig()->setUserValue($userId, 'core', 'timezone', (string)$_POST['timezone']);
 			}
 
 			self::cleanupLoginTokens($userId);

--- a/settings/ajax/changedisplayname.php
+++ b/settings/ajax/changedisplayname.php
@@ -7,7 +7,7 @@ OC_JSON::checkLoggedIn();
 $l = \OC::$server->getL10N('settings');
 
 $username = isset($_POST["username"]) ? $_POST["username"] : OC_User::getUser();
-$displayName = $_POST["displayName"];
+$displayName = (string)$_POST["displayName"];
 
 $userstatus = null;
 if(OC_User::isAdminUser(OC_User::getUser())) {

--- a/settings/ajax/decryptall.php
+++ b/settings/ajax/decryptall.php
@@ -8,7 +8,7 @@ OC_App::loadApp('files_encryption');
 
 // init encryption app
 $params = array('uid' => \OCP\User::getUser(),
-				'password' => $_POST['password']);
+				'password' => (string)$_POST['password']);
 
 $view = new OC\Files\View('/');
 $util = new \OCA\Files_Encryption\Util($view, \OCP\User::getUser());

--- a/settings/ajax/disableapp.php
+++ b/settings/ajax/disableapp.php
@@ -7,7 +7,7 @@ if (!array_key_exists('appid', $_POST)) {
 	exit;
 }
 
-$appId = $_POST['appid'];
+$appId = (string)$_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
 // FIXME: Clear the cache - move that into some sane helper method

--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -3,7 +3,7 @@
 OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
 
-$groups = isset($_POST['groups']) ? (string)$_POST['groups'] : null;
+$groups = isset($_POST['groups']) ? (array)$_POST['groups'] : null;
 
 try {
 	OC_App::enable(OC_App::cleanAppId((string)$_POST['appid']), $groups);

--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -3,10 +3,10 @@
 OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
 
-$groups = isset($_POST['groups']) ? $_POST['groups'] : null;
+$groups = isset($_POST['groups']) ? (string)$_POST['groups'] : null;
 
 try {
-	OC_App::enable(OC_App::cleanAppId($_POST['appid']), $groups);
+	OC_App::enable(OC_App::cleanAppId((string)$_POST['appid']), $groups);
 	// FIXME: Clear the cache - move that into some sane helper method
 	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
 	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');

--- a/settings/ajax/installapp.php
+++ b/settings/ajax/installapp.php
@@ -7,7 +7,7 @@ if (!array_key_exists('appid', $_POST)) {
 	exit;
 }
 
-$appId = $_POST['appid'];
+$appId = (string)$_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
 $result = OC_App::installApp($appId);

--- a/settings/ajax/navigationdetect.php
+++ b/settings/ajax/navigationdetect.php
@@ -3,7 +3,7 @@
 OC_Util::checkAdminUser();
 OCP\JSON::callCheck();
 
-$app = $_GET['app'];
+$app = (string)$_GET['app'];
 $app = OC_App::cleanAppId($app);
 
 $navigation = OC_App::getAppNavigationEntries($app);

--- a/settings/ajax/removeRootCertificate.php
+++ b/settings/ajax/removeRootCertificate.php
@@ -2,6 +2,6 @@
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 
-$name = $_POST['cert'];
+$name = (string)$_POST['cert'];
 $certificateManager = \OC::$server->getCertificateManager();
 $certificateManager->removeCertificate($name);

--- a/settings/ajax/setlanguage.php
+++ b/settings/ajax/setlanguage.php
@@ -9,7 +9,7 @@ OCP\JSON::callCheck();
 // Get data
 if( isset( $_POST['lang'] ) ) {
 	$languageCodes=OC_L10N::findAvailableLanguages();
-	$lang=$_POST['lang'];
+	$lang = (string)$_POST['lang'];
 	if(array_search($lang, $languageCodes) or $lang === 'en') {
 		\OC::$server->getConfig()->setUserValue( OC_User::getUser(), 'core', 'lang', $lang );
 		OC_JSON::success(array("data" => array( "message" => $l->t("Language changed") )));

--- a/settings/ajax/setquota.php
+++ b/settings/ajax/setquota.php
@@ -8,7 +8,7 @@
 OC_JSON::checkSubAdminUser();
 OCP\JSON::callCheck();
 
-$username = isset($_POST["username"])?$_POST["username"]:'';
+$username = isset($_POST["username"]) ? (string)$_POST["username"] : '';
 
 if(($username === '' && !OC_User::isAdminUser(OC_User::getUser()))
 	|| (!OC_User::isAdminUser(OC_User::getUser())
@@ -19,7 +19,7 @@ if(($username === '' && !OC_User::isAdminUser(OC_User::getUser()))
 }
 
 //make sure the quota is in the expected format
-$quota=$_POST["quota"];
+$quota= (string)$_POST["quota"];
 if($quota !== 'none' and $quota !== 'default') {
 	$quota= OC_Helper::computerFileSize($quota);
 	$quota=OC_Helper::humanFileSize($quota);

--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -4,8 +4,8 @@ OC_JSON::checkSubAdminUser();
 OCP\JSON::callCheck();
 
 $success = true;
-$username = $_POST["username"];
-$group = $_POST["group"];
+$username = (string)$_POST['username'];
+$group = (string)$_POST['group'];
 
 if($username === OC_User::getUser() && $group === "admin" &&  OC_User::isAdminUser($username)) {
 	$l = \OC::$server->getL10N('core');

--- a/settings/ajax/togglesubadmins.php
+++ b/settings/ajax/togglesubadmins.php
@@ -3,8 +3,8 @@
 OC_JSON::checkAdminUser();
 OCP\JSON::callCheck();
 
-$username = $_POST["username"];
-$group = $_POST["group"];
+$username = (string)$_POST['username'];
+$group = (string)$_POST['group'];
 
 // Toggle group
 if(OC_SubAdmin::isSubAdminofGroup($username, $group)) {

--- a/settings/ajax/uninstallapp.php
+++ b/settings/ajax/uninstallapp.php
@@ -7,7 +7,7 @@ if (!array_key_exists('appid', $_POST)) {
 	exit;
 }
 
-$appId = $_POST['appid'];
+$appId = (string)$_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
 $result = OC_App::removeApp($appId);

--- a/settings/ajax/updateapp.php
+++ b/settings/ajax/updateapp.php
@@ -15,7 +15,7 @@ if (!array_key_exists('appid', $_POST)) {
 	return;
 }
 
-$appId = $_POST['appid'];
+$appId = (string)$_POST['appid'];
 
 if (!is_numeric($appId)) {
 	$appId = \OC::$server->getAppConfig()->getValue($appId, 'ocsid', null);


### PR DESCRIPTION
This enforces proper types on POST and GET arguments where I considered it sensible. I didn't update some as I don't know what kind of values they would support :see_no_evil:

Proper solution would be to use the AppFramework instead such static files as the AppFramework supports this type casting already using annotations…

Fixes https://github.com/owncloud/core/issues/14196 for core – master only.
