### PR TITLE
Dont lower the mtime of a folder when propagating changes

### DIFF
--- a/lib/private/files/cache/changepropagator.php
+++ b/lib/private/files/cache/changepropagator.php
@@ -59,8 +59,8 @@ class ChangePropagator {
 			list($storage, $internalPath) = $this->view->resolvePath($parent);
 			if ($storage) {
 				$cache = $storage->getCache();
-				$id = $cache->getId($internalPath);
-				$cache->update($id, array('mtime' => $time, 'etag' => $storage->getETag($internalPath)));
+				$entry = $cache->get($internalPath);
+				$cache->update($entry['fileid'], array('mtime' => max($time, $entry['mtime']), 'etag' => $storage->getETag($internalPath)));
 			}
 		}
 	}

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -284,6 +284,7 @@ class UpdaterLegacy extends \Test\TestCase {
 		$time = 1371006070;
 		$barCachedData = $this->cache->get('folder/bar.txt');
 		$folderCachedData = $this->cache->get('folder');
+		$this->cache->put('', ['mtime' => $time - 100]);
 		Filesystem::touch('folder/bar.txt', $time);
 		$cachedData = $this->cache->get('folder/bar.txt');
 		$this->assertInternalType('string', $barCachedData['etag']);
@@ -314,6 +315,7 @@ class UpdaterLegacy extends \Test\TestCase {
 		$fooCachedData = $cache2->get('foo.txt');
 		$cachedData = $cache2->get('foo.txt');
 		$time = 1371006070;
+		$this->cache->put('folder', ['mtime' => $time - 100]);
 		Filesystem::touch('folder/substorage/foo.txt', $time);
 		$cachedData = $cache2->get('foo.txt');
 		$this->assertInternalType('string', $fooCachedData['etag']);


### PR DESCRIPTION
When touching the mtime of a file (such as when uploading trough the sync client) the mtime is propagated to the parent folders.
This changes it to only increase mtimes when propagating to make sure the mtime of a folder is equal to the highest mtime of the files contained in the folder instead of setting it to the mtime of the latest uploaded file.

Fixes #14172

@zocker22  can you verify that this fixes the problem for you

cc @DeepDiver1975 @PVince81 
