### PR TITLE
Activity/225 sharing extension

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -28,7 +28,10 @@ OCP\Util::addScript('files_sharing', 'external');
 OC_FileProxy::register(new OCA\Files\Share\Proxy());
 
 \OC::$server->getActivityManager()->registerExtension(function() {
-		return new \OCA\Files_Sharing\Activity();
+		return new \OCA\Files_Sharing\Activity(
+			\OC::$server->query('L10NFactory'),
+			\OC::$server->getURLGenerator()
+		);
 });
 
 $config = \OC::$server->getConfig();

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -84,22 +84,6 @@ class Activity implements IExtension {
 	}
 
 	/**
-	 * The extension can filter the types based on the filter if required.
-	 * In case no filter is to be applied false is to be returned unchanged.
-	 *
-	 * @param array $types
-	 * @param string $filter
-	 * @return array|false
-	 */
-	public function filterNotificationTypes($types, $filter) {
-		switch ($filter) {
-			case self::FILTER_SHARES:
-				return array_intersect([self::TYPE_SHARED], $types);
-		}
-		return false;
-	}
-
-	/**
 	 * For a given method additional types to be displayed in the settings can be returned.
 	 * In case no additional types are to be added false is to be returned.
 	 *
@@ -117,6 +101,25 @@ class Activity implements IExtension {
 		}
 
 		return $defaultTypes;
+	}
+
+	/**
+	 * A string naming the css class for the icon to be used can be returned.
+	 * If no icon is known for the given type false is to be returned.
+	 *
+	 * @param string $type
+	 * @return string|false
+	 */
+	public function getTypeIcon($type) {
+		switch ($type) {
+			case self::TYPE_SHARED:
+			case self::TYPE_REMOTE_SHARE:
+				return 'icon-share';
+			case self::TYPE_PUBLIC_LINKS:
+				return 'icon-download';
+		}
+
+		return false;
 	}
 
 	/**
@@ -215,25 +218,6 @@ class Activity implements IExtension {
 	}
 
 	/**
-	 * A string naming the css class for the icon to be used can be returned.
-	 * If no icon is known for the given type false is to be returned.
-	 *
-	 * @param string $type
-	 * @return string|false
-	 */
-	public function getTypeIcon($type) {
-		switch ($type) {
-			case self::TYPE_SHARED:
-			case self::TYPE_REMOTE_SHARE:
-				return 'icon-share';
-			case self::TYPE_PUBLIC_LINKS:
-				return 'icon-download';
-		}
-
-		return false;
-	}
-
-	/**
 	 * The extension can define the parameter grouping by returning the index as integer.
 	 * In case no grouping is required false is to be returned.
 	 *
@@ -276,6 +260,22 @@ class Activity implements IExtension {
 	}
 
 	/**
+	 * The extension can filter the types based on the filter if required.
+	 * In case no filter is to be applied false is to be returned unchanged.
+	 *
+	 * @param array $types
+	 * @param string $filter
+	 * @return array|false
+	 */
+	public function filterNotificationTypes($types, $filter) {
+		switch ($filter) {
+			case self::FILTER_SHARES:
+				return array_intersect([self::TYPE_SHARED, self::TYPE_REMOTE_SHARE], $types);
+		}
+		return false;
+	}
+
+	/**
 	 * For a given filter the extension can specify the sql query conditions including parameters for that query.
 	 * In case the extension does not know the filter false is to be returned.
 	 * The query condition and the parameters are to be returned as array with two elements.
@@ -287,14 +287,8 @@ class Activity implements IExtension {
 	public function getQueryForFilter($filter) {
 		if ($filter === self::FILTER_SHARES) {
 			return [
-				'('
-					. '`app` = ? and `type` = ? or '
-					. '`app` = ? and `type` = ?'
-				. ')',
-				[
-					'files_sharing', self::TYPE_REMOTE_SHARE,
-					'files', self::TYPE_SHARED,
-				],
+				'(`app` = ? or `app` = ?)',
+				['files_sharing', 'files'],
 			];
 		}
 		return false;

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -1,37 +1,70 @@
 <?php
 /**
- * ownCloud - publish activities
+ * ownCloud - Sharing Activity Extension
  *
  * @copyright (c) 2014, ownCloud Inc.
  *
  * @author Bjoern Schiessle <schiessle@owncloud.com>
+ * @author Joas Schilling <nickvergessen@owncloud.com>
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
  */
 
 namespace OCA\Files_Sharing;
 
-class Activity implements \OCP\Activity\IExtension {
+use OC\L10N\Factory;
+use OCP\Activity\IExtension;
+use OCP\IURLGenerator;
 
-	const TYPE_REMOTE_SHARE = 'remote_share';
+class Activity implements IExtension {
+	/**
+	 * Filter with all sharing related activities
+	 */
+	const FILTER_SHARES = 'shares';
+
+	/**
+	 * Activity types known to this extension
+	 */
 	const TYPE_PUBLIC_LINKS = 'public_links';
-	const SUBJECT_REMOTE_SHARE_RECEIVED = 'remote_share_received';
-	const SUBJECT_REMOTE_SHARE_ACCEPTED = 'remote_share_accepted';
-	const SUBJECT_REMOTE_SHARE_DECLINED = 'remote_share_declined';
-	const SUBJECT_REMOTE_SHARE_UNSHARED = 'remote_share_unshared';
+	const TYPE_REMOTE_SHARE = 'remote_share';
+	const TYPE_SHARED = 'shared';
+
+	/**
+	 * Subject keys for translation of the subjections
+	 */
 	const SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED = 'public_shared_file_downloaded';
 	const SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED = 'public_shared_folder_downloaded';
+
+	const SUBJECT_REMOTE_SHARE_ACCEPTED = 'remote_share_accepted';
+	const SUBJECT_REMOTE_SHARE_DECLINED = 'remote_share_declined';
+	const SUBJECT_REMOTE_SHARE_RECEIVED = 'remote_share_received';
+	const SUBJECT_REMOTE_SHARE_UNSHARED = 'remote_share_unshared';
+
+	const SUBJECT_SHARED_GROUP_SELF = 'shared_group_self';
+	const SUBJECT_SHARED_LINK_SELF = 'shared_link_self';
+	const SUBJECT_SHARED_USER_SELF = 'shared_user_self';
+	const SUBJECT_SHARED_WITH_BY = 'shared_with_by';
+
+	/** @var Factory */
+	protected $languageFactory;
+
+	/** @var IURLGenerator */
+	protected $URLGenerator;
+
+	/**
+	 * @param Factory $languageFactory
+	 * @param IURLGenerator $URLGenerator
+	 */
+	public function __construct(Factory $languageFactory, IURLGenerator $URLGenerator) {
+		$this->languageFactory = $languageFactory;
+		$this->URLGenerator = $URLGenerator;
+	}
+
+	protected function getL10N($languageCode = null) {
+		return $this->languageFactory->get('files_sharing', $languageCode);
+	}
 
 	/**
 	 * The extension can return an array of additional notification types.
@@ -41,10 +74,12 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return array|false
 	 */
 	public function getNotificationTypes($languageCode) {
-		$l = \OC::$server->getL10N('files_sharing', $languageCode);
+		$l = $this->getL10N($languageCode);
+
 		return array(
-			self::TYPE_REMOTE_SHARE => $l->t('A file or folder was shared from <strong>another server</strong>'),
-			self::TYPE_PUBLIC_LINKS => $l->t('A public shared file or folder was <strong>downloaded</strong>'),
+			self::TYPE_SHARED => (string) $l->t('A file or folder has been <strong>shared</strong>'),
+			self::TYPE_REMOTE_SHARE => (string) $l->t('A file or folder was shared from <strong>another server</strong>'),
+			self::TYPE_PUBLIC_LINKS => (string) $l->t('A public shared file or folder was <strong>downloaded</strong>'),
 		);
 	}
 
@@ -57,7 +92,11 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return array|false
 	 */
 	public function filterNotificationTypes($types, $filter) {
-		return $types;
+		switch ($filter) {
+			case self::FILTER_SHARES:
+				return array_intersect([self::TYPE_SHARED], $types);
+		}
+		return false;
 	}
 
 	/**
@@ -68,18 +107,16 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return array|false
 	 */
 	public function getDefaultTypes($method) {
-		switch ($method) {
-			case 'email':
-				$result = array(self::TYPE_REMOTE_SHARE);
-				break;
-			case 'stream':
-				$result = array(self::TYPE_REMOTE_SHARE, self::TYPE_PUBLIC_LINKS);
-				break;
-			default:
-				$result = false;
+		$defaultTypes = [
+			self::TYPE_SHARED,
+			self::TYPE_REMOTE_SHARE,
+		];
+
+		if ($method === 'stream') {
+			$defaultTypes[] = self::TYPE_PUBLIC_LINKS;
 		}
 
-		return $result;
+		return $defaultTypes;
 	}
 
 	/**
@@ -95,23 +132,33 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return string|false
 	 */
 	public function translate($app, $text, $params, $stripPath, $highlightParams, $languageCode) {
-
-		$l = \OC::$server->getL10N('files_sharing', $languageCode);
+		$l = $this->getL10N($languageCode);
 
 		if ($app === 'files_sharing') {
 			switch ($text) {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
-					return $l->t('You received a new remote share from %s', $params)->__toString();
+					return (string) $l->t('You received a new remote share from %s', $params);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
-					return $l->t('%1$s accepted remote share %2$s', $params)->__toString();
+					return (string) $l->t('%1$s accepted remote share %2$s', $params);
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
-					return $l->t('%1$s declined remote share %2$s', $params)->__toString();
+					return (string) $l->t('%1$s declined remote share %2$s', $params);
 				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
-					return $l->t('%1$s unshared %2$s from you', $params)->__toString();
+					return (string) $l->t('%1$s unshared %2$s from you', $params);
 				case self::SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED:
-					return $l->t('Public shared folder %1$s was downloaded', $params)->__toString();
+					return (string) $l->t('Public shared folder %1$s was downloaded', $params);
 				case self::SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED:
-					return $l->t('Public shared file %1$s was downloaded', $params)->__toString();
+					return (string) $l->t('Public shared file %1$s was downloaded', $params);
+			}
+		} else if ($app === 'files') {
+			switch ($text) {
+				case self::SUBJECT_SHARED_USER_SELF:
+					return (string) $l->t('You shared %1$s with %2$s', $params);
+				case self::SUBJECT_SHARED_GROUP_SELF:
+					return (string) $l->t('You shared %1$s with group %2$s', $params);
+				case self::SUBJECT_SHARED_WITH_BY:
+					return (string) $l->t('%2$s shared %1$s with you', $params);
+				case self::SUBJECT_SHARED_LINK_SELF:
+					return (string) $l->t('You shared %1$s via link', $params);
 			}
 		}
 
@@ -149,6 +196,19 @@ class Activity implements \OCP\Activity\IExtension {
 						0 => 'file',
 					);
 			}
+		} else if ($app === 'files') {
+			switch ($text) {
+				case self::SUBJECT_SHARED_LINK_SELF:
+				case self::SUBJECT_SHARED_USER_SELF:
+				case self::SUBJECT_SHARED_WITH_BY:
+					return [0 => 'file', 1 => 'username'];
+
+				case self::SUBJECT_SHARED_GROUP_SELF:
+					return [
+						0 => 'file',
+						//1 => 'group', Group does not exist yet
+					];
+			}
 		}
 
 		return false;
@@ -163,6 +223,7 @@ class Activity implements \OCP\Activity\IExtension {
 	 */
 	public function getTypeIcon($type) {
 		switch ($type) {
+			case self::TYPE_SHARED:
 			case self::TYPE_REMOTE_SHARE:
 				return 'icon-share';
 			case self::TYPE_PUBLIC_LINKS:
@@ -191,7 +252,17 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return array|false
 	 */
 	public function getNavigation() {
-		return false;
+		$l = $this->getL10N();
+		return [
+			'apps' => [],
+			'top' => [
+				self::FILTER_SHARES => [
+					'id' => self::FILTER_SHARES,
+					'name' => (string) $l->t('Shares'),
+					'url' => $this->URLGenerator->linkToRoute('activity.Activities.showList', ['filter' => self::FILTER_SHARES]),
+				],
+			],
+		];
 	}
 
 	/**
@@ -201,7 +272,7 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return boolean
 	 */
 	public function isFilterValid($filterValue) {
-		return false;
+		return $filterValue === self::FILTER_SHARES;
 	}
 
 	/**
@@ -214,8 +285,17 @@ class Activity implements \OCP\Activity\IExtension {
 	 * @return array|false
 	 */
 	public function getQueryForFilter($filter) {
-		if ($filter === 'shares') {
-			return array('`app` = ? and `type` = ?', array('files_sharing', self::TYPE_REMOTE_SHARE));
+		if ($filter === self::FILTER_SHARES) {
+			return [
+				'('
+					. '`app` = ? and `type` = ? or '
+					. '`app` = ? and `type` = ?'
+				. ')',
+				[
+					'files_sharing', self::TYPE_REMOTE_SHARE,
+					'files', self::TYPE_SHARED,
+				],
+			];
 		}
 		return false;
 	}

--- a/apps/files_sharing/tests/activity.php
+++ b/apps/files_sharing/tests/activity.php
@@ -34,7 +34,12 @@ class Activity extends \OCA\Files_Sharing\Tests\TestCase{
 
 	protected function setUp() {
 		parent::setUp();
-		$this->activity = new \OCA\Files_Sharing\Activity();
+		$this->activity = new \OCA\Files_Sharing\Activity(
+			$this->getMock('\OC\L10N\Factory'),
+			$this->getMockBuilder('\OC\URLGenerator')
+				->disableOriginalConstructor()
+				->getMock()
+		);
 	}
 
 	/**
@@ -56,9 +61,8 @@ class Activity extends \OCA\Files_Sharing\Tests\TestCase{
 
 	public function dataTestGetDefaultType() {
 		return array(
-			array('email', array(\OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE)),
-			array('stream', array(\OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::TYPE_PUBLIC_LINKS)),
-			array('foo', false)
+			array('email', array(\OCA\Files_Sharing\Activity::TYPE_SHARED, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE)),
+			array('stream', array(\OCA\Files_Sharing\Activity::TYPE_SHARED, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::TYPE_PUBLIC_LINKS)),
 		);
 	}
 


### PR DESCRIPTION
This is only the output component.
Input is still done by the activity app itself and will be extracted later.

Part 2.1 of owncloud/activity#225

@DeepDiver1975 @schiesbn 
### Testplan
1. Perform some actions that trigger activities (share file via link and to a user, receive share as a user (group is broken due to https://github.com/owncloud/core/pull/13979 )
2. Checkout activity branch `issue/225-sharing-extension-moved`
3. Remove the settings (`notify_stream_shared` and `notify_email_shared`) from oc_preferences 
4. Visit personal settings: check that `A file or folder has been shared` still exists and check whether both columns are still checked
5. Visit stream and "Shares" filter and see that the activities still have the `<` icon, are useful sentences and the filter displays sharing activities only.
