### PR TITLE
Update naturalsort_defaultcollator.php. Fixes #13982

### DIFF
--- a/lib/private/naturalsort.php
+++ b/lib/private/naturalsort.php
@@ -15,6 +15,19 @@ class NaturalSort {
 	private $cache = array();
 
 	/**
+	 * Instantiate a new \OC\NaturalSort instance.
+	 * @param object $injectedCollator
+	 */
+	public function __construct($injectedCollator = null) {
+		// inject an instance of \Collator('en_US') to force using the php5-intl Collator
+		// or inject an instance of \OC\NaturalSort_DefaultCollator to force using Owncloud's default collator
+		if (isset($injectedCollator)) {
+			$this->collator = $injectedCollator;
+			\OC_Log::write('core', 'forced use of '.get_class($injectedCollator), \OC_Log::DEBUG);
+		}
+	}
+
+	/**
 	 * Split the given string in chunks of numbers and strings
 	 * @param string $t string
 	 * @return array of strings and number chunks

--- a/lib/private/naturalsort_defaultcollator.php
+++ b/lib/private/naturalsort_defaultcollator.php
@@ -11,9 +11,10 @@ namespace OC;
 
 class NaturalSort_DefaultCollator {
 	public function compare($a, $b) {
-		if ($a === $b) {
-			return 0;
-		}
-		return ($a < $b) ? -1 : 1;
+		$result = strcasecmp($a, $b); 
+    		if ($result === 0) {
+      			return 0;
+    		}
+    		return ($result < 0) ? -1 : 1;
 	}
 }

--- a/lib/private/naturalsort_defaultcollator.php
+++ b/lib/private/naturalsort_defaultcollator.php
@@ -11,10 +11,13 @@ namespace OC;
 
 class NaturalSort_DefaultCollator {
 	public function compare($a, $b) {
-		$result = strcasecmp($a, $b); 
-    		if ($result === 0) {
-      			return 0;
-    		}
-    		return ($result < 0) ? -1 : 1;
+		$result = strcasecmp($a, $b);
+		if ($result === 0) {
+			if ($a === $b) {
+				return 0;
+			}
+			return ($a > $b) ? -1 : 1;
+		}
+		return ($result < 0) ? -1 : 1;
 	}
 }

--- a/tests/lib/naturalsort.php
+++ b/tests/lib/naturalsort.php
@@ -8,27 +8,32 @@
 
 class Test_NaturalSort extends \Test\TestCase {
 
-	public function setUp() {
-		parent::setUp();
-
-		if(!class_exists('Collator')) {
-			$this->markTestSkipped('The intl module is not available, natural sorting will not work as expected.');
-			return;
-		}
-	}
-
 	/**
 	 * @dataProvider naturalSortDataProvider
 	 */
 	public function testNaturalSortCompare($array, $sorted)
 	{
+		if(!class_exists('Collator')) {
+			$this->markTestSkipped('The intl module is not available, natural sorting might not work as expected.');
+			return;
+		}
 		$comparator = \OC\NaturalSort::getInstance();
 		usort($array, array($comparator, 'compare'));
 		$this->assertEquals($sorted, $array);
 	}
 
 	/**
-	 * Data provider for natural sort.
+	* @dataProvider defaultCollatorDataProvider
+	*/
+	public function testDefaultCollatorCompare($array, $sorted)
+	{
+		$comparator = new \OC\NaturalSort(new \OC\NaturalSort_DefaultCollator());
+		usort($array, array($comparator, 'compare'));
+		$this->assertEquals($sorted, $array);
+	}
+
+	/**
+	 * Data provider for natural sorting with php5-intl's Collator.
 	 * Must provide the same result as in core/js/tests/specs/coreSpec.js
 	 * @return array test cases
 	 */
@@ -177,6 +182,87 @@ class Test_NaturalSort extends \Test\TestCase {
 					'üh.txt',
 					'Üh.txt',
 					'Üh 2.txt',
+				)
+			),
+		);
+	}
+
+	/**
+	* Data provider for natural sorting with \OC\NaturalSort_DefaultCollator.
+	* Must provide the same result as in core/js/tests/specs/coreSpec.js
+	* @return array test cases
+	*/
+	public function defaultCollatorDataProvider()
+	{
+		return array(
+			// different casing
+			array(
+				// unsorted
+				array(
+					'aaa',
+					'bbb',
+					'BBB',
+					'AAA'
+				),
+				// sorted
+				array(
+					'aaa',
+					'AAA',
+					'bbb',
+					'BBB'
+				)
+			),
+			// numbers
+			array(
+				// unsorted
+				array(
+					'124.txt',
+					'abc1',
+					'123.txt',
+					'abc',
+					'abc2',
+					'def (2).txt',
+					'ghi 10.txt',
+					'abc12',
+					'def.txt',
+					'def (1).txt',
+					'ghi 2.txt',
+					'def (10).txt',
+					'abc10',
+					'def (12).txt',
+					'z',
+					'ghi.txt',
+					'za',
+					'ghi 1.txt',
+					'ghi 12.txt',
+					'zz',
+					'15.txt',
+					'15b.txt',
+				),
+				// sorted
+				array(
+					'15.txt',
+					'15b.txt',
+					'123.txt',
+					'124.txt',
+					'abc',
+					'abc1',
+					'abc2',
+					'abc10',
+					'abc12',
+					'def.txt',
+					'def (1).txt',
+					'def (2).txt',
+					'def (10).txt',
+					'def (12).txt',
+					'ghi.txt',
+					'ghi 1.txt',
+					'ghi 2.txt',
+					'ghi 10.txt',
+					'ghi 12.txt',
+					'z',
+					'za',
+					'zz',
 				)
 			),
 		);


### PR DESCRIPTION
This fixes file sorting in environments that can not make use of the php5-intl extension (like some shared hosting). NaturalSort_DefaultCollator now uses `strnatcasecmp()`. See #13982 for details.
