### PR TITLE
Check if imageflip is available

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -391,7 +391,7 @@ class OC_Image {
 				$rotate = 90;
 				break;
 		}
-		if($flip) {
+		if($flip && function_exists('imageflip')) {
 			imageflip($this->resource, IMG_FLIP_HORIZONTAL);
 		}
 		if ($rotate) {


### PR DESCRIPTION
- imageflip() isn't available in PHP < 5.5
- fixes #14130 

Backport of #14138
