### PR TITLE
Encode parameters in `OC.generateUrl` by itself

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -116,17 +116,30 @@ var OC={
 
 	/**
 	 * Generates the absolute url for the given relative url, which can contain parameters.
+	 * Parameters will be URL encoded automatically.
 	 * @param {string} url
 	 * @param [params] params
+	 * @param [options] options
+	 * @param {bool} [options.escape=true] enable/disable auto escape of placeholders (by default enabled)
 	 * @return {string} Absolute URL for the given relative URL
 	 */
-	generateUrl: function(url, params) {
+	generateUrl: function(url, params, options) {
+		var defaultOptions = {
+				escape: true
+			},
+			allOptions = options || {};
+		_.defaults(allOptions, defaultOptions);
+
 		var _build = function (text, vars) {
 			var vars = vars || [];
 			return text.replace(/{([^{}]*)}/g,
 				function (a, b) {
-					var r = vars[b];
-					return typeof r === 'string' || typeof r === 'number' ? r : a;
+					var r = (vars[b]);
+					if(allOptions.escape) {
+						return (typeof r === 'string' || typeof r === 'number') ? encodeURIComponent(r) : encodeURIComponent(a);
+					} else {
+						return (typeof r === 'string' || typeof r === 'number') ? r : a;
+					}
 				}
 			);
 		};

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -393,11 +393,20 @@ describe('Core base tests', function() {
 			expect(OC.generateUrl('heartbeat')).toEqual(OC.webroot + '/index.php/heartbeat');
 			expect(OC.generateUrl('/heartbeat')).toEqual(OC.webroot + '/index.php/heartbeat');
 		});
-		it('substitutes parameters', function() {
-			expect(OC.generateUrl('apps/files/download{file}', {file: '/Welcome.txt'})).toEqual(OC.webroot + '/index.php/apps/files/download/Welcome.txt');
+		it('substitutes parameters which are escaped by default', function() {
+			expect(OC.generateUrl('apps/files/download/{file}', {file: '<">ImAnUnescapedString/!'})).toEqual(OC.webroot + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!');
+		});
+		it('substitutes parameters which can also be unescaped via option flag', function() {
+			expect(OC.generateUrl('apps/files/download/{file}', {file: 'subfolder/Welcome.txt'}, {escape: false})).toEqual(OC.webroot + '/index.php/apps/files/download/subfolder/Welcome.txt');
+		});
+		it('substitutes multiple parameters which are escaped by default', function() {
+			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: '<">ImAnUnescapedString/!', id: 5})).toEqual(OC.webroot + '/index.php/apps/files/download/%3C%22%3EImAnUnescapedString%2F!/5');
+		});
+		it('substitutes multiple parameters which can also be unescaped via option flag', function() {
+			expect(OC.generateUrl('apps/files/download/{file}/{id}', {file: 'subfolder/Welcome.txt', id: 5}, {escape: false})).toEqual(OC.webroot + '/index.php/apps/files/download/subfolder/Welcome.txt/5');
 		});
 		it('doesnt error out with no params provided', function  () {
-			expect(OC.generateUrl('apps/files/download{file}')).toEqual(OC.webroot + '/index.php/apps/files/download{file}');
+			expect(OC.generateUrl('apps/files/download{file}')).toEqual(OC.webroot + '/index.php/apps/files/download%7Bfile%7D');
 		});
 	});
 	describe('Main menu mobile toggle', function() {


### PR DESCRIPTION
This function is often used in a wrong and potential dangerous way... Thus we should escape the URL per default and offer developers to disable the automatic escaping via an option parameter if they really want that behaviour.

Might break some things, however, those things are then easy to fix and we really have a ton of bugs caused by this... I went through all usages in core (at least those that PHPStorm found) and I have a strong believe that nonce of these should be affected negatively by this change. There are some problems in files_pdfviewer and gallery though which are addressed with: https://github.com/owncloud/files_pdfviewer/pull/39 and https://github.com/owncloud/gallery/pull/167

Fixes https://github.com/owncloud/core/issues/14228

@DeepDiver1975 @PVince81 Please review
