### PR TITLE
Encode requesttoken

### DIFF
--- a/core/js/eventsource.js
+++ b/core/js/eventsource.js
@@ -49,7 +49,7 @@ OC.EventSource=function(src,data){
 			dataStr+=name+'='+encodeURIComponent(data[name])+'&';
 		}
 	}
-	dataStr+='requesttoken='+oc_requesttoken;
+	dataStr+='requesttoken='+encodeURIComponent(oc_requesttoken);
 	if(!this.useFallBack && typeof EventSource !== 'undefined'){
 		joinChar = '&';
 		if(src.indexOf('?') === -1) {


### PR DESCRIPTION
One cannot make any assumptions about the requesttoken content. Thus we need to encode it.
![59252147](https://cloud.githubusercontent.com/assets/1005065/6218120/2905147e-b61b-11e4-98cf-33b5406623c3.jpg)
