### PR TITLE
Use APCu only if available in version 4.0.6 and higher

### DIFF
--- a/lib/private/memcache/apcu.php
+++ b/lib/private/memcache/apcu.php
@@ -14,6 +14,8 @@ class APCu extends APC {
 			return false;
 		} elseif (!ini_get('apc.enable_cli') && \OC::$CLI) {
 			return false;
+		} elseif (version_compare(phpversion('apc'), '4.0.6') === -1) {
+			return false;
 		} else {
 			return true;
 		}

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -85,6 +85,10 @@ $template->assign('databaseOverload', $databaseOverload);
 // warn if Windows is used
 $template->assign('WindowsWarning', OC_Util::runningOnWindows());
 
+// warn if outdated version of APCu is used
+$template->assign('ApcuOutdatedWarning',
+	extension_loaded('apcu') && version_compare(phpversion('apc'), '4.0.6') === -1);
+
 // add hardcoded forms from the template
 $forms = OC_App::getForms('admin');
 $l = OC_L10N::get('settings');

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -143,9 +143,24 @@ if ($_['WindowsWarning']) {
 	</p>
 
 </div>
+
 <?php
 }
 
+// APCU Warning if outdated
+if ($_['ApcuOutdatedWarning']) {
+	?>
+	<div class="section">
+		<h2><?php p($l->t('APCu below version 4.0.6 installed'));?></h2>
+
+		<p class="securitywarning">
+			<?php p($l->t('APCu below version 4.0.6 is installed, for stability and performance reasons we recommend to update to a newer APCu version.')); ?>
+		</p>
+
+	</div>
+
+<?php
+}
 // if module fileinfo available?
 if (!$_['has_fileinfo']) {
 	?>


### PR DESCRIPTION
APCu before 4.0.6 is unbelievable buggy and tend to segfault the PHP process (i.e. the whole webserver)

This potentially fixes https://github.com/owncloud/core/issues/14175

Requires a backport to stable8, and possibly some documentation update… Though I doubt that we have documentation about that.  (and APCu is anyways only nice-to-have as we use it only for caching things)
