### PR TITLE
DAV authentication: use Owncloud's internal user instead of HTTP auth one

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -52,7 +52,7 @@ class OC_Connector_Sabre_Auth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 	 */
 	protected function validateUserPass($username, $password) {
 		if (OC_User::isLoggedIn() &&
-			$this->isDavAuthenticated($username)
+			$this->isDavAuthenticated(OC_User::getUser())
 		) {
 			OC_Util::setupFS(OC_User::getUser());
 			\OC::$server->getSession()->close();

--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -60,8 +60,11 @@ class OC_Connector_Sabre_Auth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 		} else {
 			OC_Util::setUpFS(); //login hooks may need early access to the filesystem
 			if(OC_User::login($username, $password)) {
-				OC_Util::setUpFS(OC_User::getUser());
-				\OC::$server->getSession()->set(self::DAV_AUTHENTICATED, $username);
+			        // make sure we use owncloud's internal username here
+			        // and not the HTTP auth supplied one, see issue #14048
+			        $ocUser = OC_User::getUser();
+				OC_Util::setUpFS($ocUser);
+				\OC::$server->getSession()->set(self::DAV_AUTHENTICATED, $ocUser);
 				\OC::$server->getSession()->close();
 				return true;
 			} else {


### PR DESCRIPTION
Fixes: #14048, #14104, calendar#712
