### PR TITLE
Also cache files with no tags

### DIFF
--- a/lib/private/connector/sabre/tagsplugin.php
+++ b/lib/private/connector/sabre/tagsplugin.php
@@ -213,6 +213,11 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin
 			$tags = $this->getTagger()->getTagsForObjects($fileIds);
 			if ($tags) {
 				$this->cachedTags = $tags;
+				$emptyFileIds = array_diff($fileIds, array_keys($tags));
+				// also cache the ones that were not found
+				foreach ($emptyFileIds as $fileId) {
+					$this->cachedTags[$fileId] = [];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This prevents requerying the tags for the files for which we already
know that there are no tags.

Only affects PROPFINDs that explicitly ask for "oc:favorite" or "oc:tags".

Avoids "132" extra queries in my test set that have 70 files.

@icewind1991 @LukasReschke @DeepDiver1975 @nickvergessen 

Candidate for backport to stable8 (quick performance win) @karlitschek 
Note that this would only affect clients that explicitly work with favorites and tags.
