### PR TITLE
Add async command system to handle asynchronous operations

### DIFF
--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -50,7 +50,7 @@ if (!OC_Config::getValue('maintenance', false)) {
 	OCP\User::logout();
 }
 
-\OC::$server->getAsyncCommandBus()->requireSync('\OC\Command\FileAccess');
+\OC::$server->getCommandBus()->requireSync('\OC\Command\FileAccess');
 
 // Register settings scripts
 OCP\App::registerAdmin('files_encryption', 'settings-admin');

--- a/apps/files_encryption/appinfo/app.php
+++ b/apps/files_encryption/appinfo/app.php
@@ -50,6 +50,8 @@ if (!OC_Config::getValue('maintenance', false)) {
 	OCP\User::logout();
 }
 
+\OC::$server->getAsyncCommandBus()->requireSync('\OC\Command\FileAccess');
+
 // Register settings scripts
 OCP\App::registerAdmin('files_encryption', 'settings-admin');
 OCP\App::registerPersonal('files_encryption', 'settings-personal');

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -979,7 +979,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>2048</length>
+				<length>4000</length>
 			</field>
 
 			<field>

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -979,7 +979,7 @@
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
-				<length>256</length>
+				<length>2048</length>
 			</field>
 
 			<field>

--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -57,6 +57,9 @@ class JobList implements IJobList {
 				$class = $job;
 			}
 			$argument = json_encode($argument);
+			if (strlen($argument) > 2048) {
+				throw new \InvalidArgumentException('Background job arguments cant exceed 2048 characters (json encoded');
+			}
 			$query = $this->conn->prepare('INSERT INTO `*PREFIX*jobs`(`class`, `argument`, `last_run`) VALUES(?, ?, 0)');
 			$query->execute(array($class, $argument));
 		}

--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -58,7 +58,7 @@ class JobList implements IJobList {
 			}
 			$argument = json_encode($argument);
 			if (strlen($argument) > 4000) {
-				throw new \InvalidArgumentException('Background job arguments cant exceed 2048 characters (json encoded');
+				throw new \InvalidArgumentException('Background job arguments can\'t exceed 4000 characters (json encoded)');
 			}
 			$query = $this->conn->prepare('INSERT INTO `*PREFIX*jobs`(`class`, `argument`, `last_run`) VALUES(?, ?, 0)');
 			$query->execute(array($class, $argument));

--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -57,7 +57,7 @@ class JobList implements IJobList {
 				$class = $job;
 			}
 			$argument = json_encode($argument);
-			if (strlen($argument) > 2048) {
+			if (strlen($argument) > 4000) {
 				throw new \InvalidArgumentException('Background job arguments cant exceed 2048 characters (json encoded');
 			}
 			$query = $this->conn->prepare('INSERT INTO `*PREFIX*jobs`(`class`, `argument`, `last_run`) VALUES(?, ?, 0)');

--- a/lib/private/backgroundjob/queuedjob.php
+++ b/lib/private/backgroundjob/queuedjob.php
@@ -35,7 +35,7 @@ abstract class QueuedJob extends Job {
 	 * @param \OC\Log $logger
 	 */
 	public function execute($jobList, $logger = null) {
-		$jobList->remove($this);
+		$jobList->remove($this, $this->argument);
 		parent::execute($jobList, $logger);
 	}
 }

--- a/lib/private/command/asyncbus.php
+++ b/lib/private/command/asyncbus.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OCP\Command\IBus;
+use OCP\Command\ICommand;
+use SuperClosure\Serializer;
+
+/**
+ * Asynchronous command bus that uses the background job system as backend
+ */
+class AsyncBus implements IBus {
+	/**
+	 * @var \OCP\BackgroundJob\IJobList
+	 */
+	private $jobList;
+
+	/**
+	 * @param \OCP\BackgroundJob\IJobList $jobList
+	 */
+	function __construct($jobList) {
+		$this->jobList = $jobList;
+	}
+
+	/**
+	 * Schedule a command to be fired
+	 *
+	 * @param \OCP\Command\ICommand | callable $command
+	 */
+	public function push($command) {
+		$this->jobList->add($this->getJobClass($command), $this->serializeCommand($command));
+	}
+
+	/**
+	 * @param \OCP\Command\ICommand | callable $command
+	 * @return string
+	 */
+	private function getJobClass($command) {
+		if ($command instanceof \Closure) {
+			return 'OC\Command\ClosureJob';
+		} else if (is_callable($command)) {
+			return 'OC\Command\CallableJob';
+		} else if ($command instanceof ICommand) {
+			return 'OC\Command\CommandJob';
+		} else {
+			throw new \InvalidArgumentException('Invalid command');
+		}
+	}
+
+	/**
+	 * @param \OCP\Command\ICommand | callable $command
+	 * @return string
+	 */
+	private function serializeCommand($command) {
+		if ($command instanceof \Closure) {
+			$serializer = new Serializer();
+			return $serializer->serialize($command);
+		} else if (is_callable($command) or $command instanceof ICommand) {
+			return serialize($command);
+		} else {
+			throw new \InvalidArgumentException('Invalid command');
+		}
+	}
+}

--- a/lib/private/command/callablejob.php
+++ b/lib/private/command/callablejob.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OC\BackgroundJob\QueuedJob;
+
+class CallableJob extends QueuedJob {
+	protected function run($serializedCallable) {
+		$callable = unserialize($serializedCallable);
+		if (is_callable($callable)) {
+			$callable();
+		} else {
+			throw new \InvalidArgumentException('Invalid serialized callable');
+		}
+	}
+}

--- a/lib/private/command/closurejob.php
+++ b/lib/private/command/closurejob.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OC\BackgroundJob\QueuedJob;
+use SuperClosure\Serializer;
+
+class ClosureJob extends QueuedJob {
+	protected function run($serializedCallable) {
+		$serializer = new Serializer();
+		$callable = $serializer->unserialize($serializedCallable);
+		if (is_callable($callable)) {
+			$callable();
+		} else {
+			throw new \InvalidArgumentException('Invalid serialized callable');
+		}
+	}
+}

--- a/lib/private/command/commandjob.php
+++ b/lib/private/command/commandjob.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OC\BackgroundJob\QueuedJob;
+use OCP\Command\ICommand;
+
+/**
+ * Wrap a command in the background job interface
+ */
+class CommandJob extends QueuedJob {
+	protected function run($serializedCommand) {
+		$command = unserialize($serializedCommand);
+		if ($command instanceof ICommand) {
+			$command->handle();
+		} else {
+			throw new \InvalidArgumentException('Invalid serialized command');
+		}
+	}
+}

--- a/lib/private/command/fileaccess.php
+++ b/lib/private/command/fileaccess.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OCP\IUser;
+
+trait FileAccess {
+	protected function getUserFolder(IUser $user) {
+		\OC_Util::setupFS($user->getUID());
+		return \OC::$server->getUserFolder($user->getUID());
+	}
+}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -785,7 +785,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	/**
 	 * @return \OCP\Command\IBus
 	 */
-	function getAsyncCommandBus(){
+	function getCommandBus(){
 		return $this->query('AsyncCommandBus');
 	}
 

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -38,6 +38,7 @@ use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\Cache\UserCache;
+use OC\Command\AsyncBus;
 use OC\Diagnostics\NullQueryLogger;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
@@ -290,6 +291,10 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('IniWrapper', function ($c) {
 			return new IniGetWrapper();
+		});
+		$this->registerService('AsyncCommandBus', function (Server $c) {
+			$jobList = $c->getJobList();
+			return new AsyncBus($jobList);
 		});
 		$this->registerService('TrustedDomainHelper', function ($c) {
 			return new TrustedDomainHelper($this->getConfig());
@@ -775,6 +780,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getIniWrapper() {
 		return $this->query('IniWrapper');
+	}
+
+	/**
+	 * @return \OCP\Command\IBus
+	 */
+	function getAsyncCommandBus(){
+		return $this->query('AsyncCommandBus');
 	}
 
 	/**

--- a/lib/public/command/ibus.php
+++ b/lib/public/command/ibus.php
@@ -15,4 +15,11 @@ interface IBus {
 	 * @param \OCP\Command\ICommand | callable $command
 	 */
 	public function push($command);
+
+	/**
+	 * Require all commands using a trait to be run synchronous
+	 *
+	 * @param string $trait
+	 */
+	public function requireSync($trait);
 }

--- a/lib/public/command/ibus.php
+++ b/lib/public/command/ibus.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\Command;
+
+interface IBus {
+	/**
+	 * Schedule a command to be fired
+	 *
+	 * @param \OCP\Command\ICommand | callable $command
+	 */
+	public function push($command);
+}

--- a/lib/public/command/icommand.php
+++ b/lib/public/command/icommand.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCP\Command;
+
+interface ICommand {
+	/**
+	 * Run the command
+	 */
+	public function handle();
+}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -317,4 +317,9 @@ interface IServerContainer {
 	 * @return \bantu\IniGetWrapper\IniGetWrapper
 	 */
 	 function getIniWrapper();
+
+	/**
+	 * @return \OCP\Command\IBus
+	 */
+	function getAsyncCommandBus();
 }

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -321,5 +321,5 @@ interface IServerContainer {
 	/**
 	 * @return \OCP\Command\IBus
 	 */
-	function getAsyncCommandBus();
+	function getCommandBus();
 }

--- a/tests/lib/backgroundjob/dummyjoblist.php
+++ b/tests/lib/backgroundjob/dummyjoblist.php
@@ -21,13 +21,18 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 
 	private $last = 0;
 
-	public function __construct(){}
+	public function __construct() {
+	}
 
 	/**
 	 * @param \OC\BackgroundJob\Job|string $job
 	 * @param mixed $argument
 	 */
 	public function add($job, $argument = null) {
+		if (is_string($job)) {
+			/** @var \OC\BackgroundJob\Job $job */
+			$job = new $job;
+		}
 		$job->setArgument($argument);
 		if (!$this->has($job, null)) {
 			$this->jobs[] = $job;

--- a/tests/lib/command/asyncbus.php
+++ b/tests/lib/command/asyncbus.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Command;
+
+use OCP\Command\ICommand;
+use Test\BackgroundJob\DummyJobList;
+use Test\TestCase;
+
+class SimpleCommand implements ICommand {
+	public function handle() {
+		AsyncBus::$lastCommand = 'SimpleCommand';
+	}
+}
+
+class StateFullCommand implements ICommand {
+	private $state;
+
+	function __construct($state) {
+		$this->state = $state;
+	}
+
+	public function handle() {
+		AsyncBus::$lastCommand = $this->state;
+	}
+}
+
+function basicFunction() {
+	AsyncBus::$lastCommand = 'function';
+}
+
+class AsyncBus extends TestCase {
+	/**
+	 * Basic way to check output from a command
+	 *
+	 * @var string
+	 */
+	public static $lastCommand;
+
+	/**
+	 * @var \OCP\BackgroundJob\IJobList
+	 */
+	private $jobList;
+
+	/**
+	 * @var \OCP\Command\IBus
+	 */
+	private $bus;
+
+	public static function DummyCommand() {
+		self::$lastCommand = 'static';
+	}
+
+	public function setUp() {
+		$this->jobList = new DummyJobList();
+		$this->bus = new \OC\Command\AsyncBus($this->jobList);
+		self::$lastCommand = '';
+	}
+
+	public function testSimpleCommand() {
+		$command = new SimpleCommand();
+		$this->bus->push($command);
+		$this->runJobs();
+		$this->assertEquals('SimpleCommand', self::$lastCommand);
+	}
+
+	public function testStateFullCommand() {
+		$command = new StateFullCommand('foo');
+		$this->bus->push($command);
+		$this->runJobs();
+		$this->assertEquals('foo', self::$lastCommand);
+	}
+
+	public function testStaticCallable() {
+		$this->bus->push(['\Test\Command\AsyncBus', 'DummyCommand']);
+		$this->runJobs();
+		$this->assertEquals('static', self::$lastCommand);
+	}
+
+	public function testMemberCallable() {
+		$command = new StateFullCommand('bar');
+		$this->bus->push([$command, 'handle']);
+		$this->runJobs();
+		$this->assertEquals('bar', self::$lastCommand);
+	}
+
+	public function testFunctionCallable() {
+		$this->bus->push('\Test\Command\BasicFunction');
+		$this->runJobs();
+		$this->assertEquals('function', self::$lastCommand);
+	}
+
+	public function testClosure() {
+		$this->bus->push(function () {
+			AsyncBus::$lastCommand = 'closure';
+		});
+		$this->runJobs();
+		$this->assertEquals('closure', self::$lastCommand);
+	}
+
+	public function testClosureSelf() {
+		$this->bus->push(function () {
+			self::$lastCommand = 'closure-self';
+		});
+		$this->runJobs();
+		$this->assertEquals('closure-self', self::$lastCommand);
+	}
+
+	private function privateMethod() {
+		self::$lastCommand = 'closure-this';
+	}
+
+	public function testClosureThis() {
+		$this->bus->push(function () {
+			$this->privateMethod();
+		});
+		$this->runJobs();
+		$this->assertEquals('closure-this', self::$lastCommand);
+	}
+
+	public function testClosureBind() {
+		$state = 'bar';
+		$this->bus->push(function () use ($state) {
+			self::$lastCommand = 'closure-' . $state;
+		});
+		$this->runJobs();
+		$this->assertEquals('closure-bar', self::$lastCommand);
+	}
+
+
+	private function runJobs() {
+		$jobs = $this->jobList->getAll();
+		foreach ($jobs as $job) {
+			$job->execute($this->jobList);
+		}
+	}
+}

--- a/tests/lib/command/asyncbus.php
+++ b/tests/lib/command/asyncbus.php
@@ -9,6 +9,7 @@
 
 namespace Test\Command;
 
+use OC\Command\FileAccess;
 use OCP\Command\ICommand;
 use Test\BackgroundJob\DummyJobList;
 use Test\TestCase;
@@ -28,6 +29,14 @@ class StateFullCommand implements ICommand {
 
 	public function handle() {
 		AsyncBus::$lastCommand = $this->state;
+	}
+}
+
+class FilesystemCommand implements ICommand {
+	use FileAccess;
+
+	public function handle() {
+		AsyncBus::$lastCommand = 'FileAccess';
 	}
 }
 
@@ -131,6 +140,22 @@ class AsyncBus extends TestCase {
 		});
 		$this->runJobs();
 		$this->assertEquals('closure-bar', self::$lastCommand);
+	}
+
+	public function testFileFileAccessCommand() {
+		$this->bus->push(new FilesystemCommand());
+		$this->assertEquals('', self::$lastCommand);
+		$this->runJobs();
+		$this->assertEquals('FileAccess', self::$lastCommand);
+	}
+
+	public function testFileFileAccessCommandSync() {
+		$this->bus->requireSync('\OC\Command\FileAccess');
+		$this->bus->push(new FilesystemCommand());
+		$this->assertEquals('FileAccess', self::$lastCommand);
+		self::$lastCommand = '';
+		$this->runJobs();
+		$this->assertEquals('', self::$lastCommand);
 	}
 
 

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(8, 0, 0, 9);
+$OC_Version=array(8, 0, 0, 10);
 
 // The human readable string
 $OC_VersionString='8.0';


### PR DESCRIPTION
This provides a new API for working with asynchronous tasks, async operations are wrapped in a `Command` and pushed on the command bus to be executed.

A `Command` holds all state needed to run the task (file path, user id, etc) and a `handle` method to do the actual work.

Usage example:

``` php
function postFileWriteHook($path){
    $user = \OC::$server->getUserSession()->getUser();
    $bus = \OC::$server->getAsyncCommandBus();
    $bus->push(new ThumbnailerCommand($user, $path));
}
```

``` php
class ThumbnailerCommand implements \OCP\Command\ICommand{
    private $user;
    private $path;
    public function __construct($user, $path){
        $this->user=$user;
        $this->path=$path;
    }
    public function handle(){
        $this->setupFileSystemForUser($this->user);
        $this->generateNewThumbnail($this->path)
    }
}
```

Or for simple commands a callable can be pushed on the bus instead:

``` php
function postFileWriteHook($path){
    $bus = \OC::$server->getAsyncCommandBus();
    $bus->push(function() use ($path){
        $fh = fopen('writelog.txt');
        fwrite($fh, $path . "\n");
    });
}
```

The current bus implementation re-uses the BackgroundJob system but can easily be changed to support the various jobqueue systems in the future.

Requires: https://github.com/owncloud/3rdparty/pull/163

TODO:
- [x] Handle commands that require access to the filesystem when encryption is enabled, maybe a `FilesystemCommand` interface that gets executed sync when encryption is enabled

(Additionally this PR increases the max length for background job arguments to 2048 and throws a exception when a job tries to get over that)

cc @DeepDiver1975 @PVince81 @MorrisJobke 
