### PR TITLE
Cleanup OCS code

### DIFF
--- a/lib/private/ocs.php
+++ b/lib/private/ocs.php
@@ -32,71 +32,15 @@ use OCP\API;
 
 /**
  * Class to handle open collaboration services API requests
- *
  */
 class OC_OCS {
-
 	/**
-	* reads input data from get/post and converts the date to a special data-type
-	*
-	* @param string $method HTTP method to read the key from
-	* @param string $key Parameter to read
-	* @param string $type Variable type to format data
-	* @param string $default Default value to return if the key is not found
-	* @return string Data or if the key is not found and no default is set it will exit with a 400 Bad request
-	*/
-	public static function readData($method, $key, $type = 'raw', $default = null) {
-		$data = false;
-		if ($method == 'get') {
-			if (isset($_GET[$key])) {
-				$data = $_GET[$key];
-			} else if (isset($default)) {
-				return $default;
-			} else {
-				$data = false;
-			}
-		} else if ($method == 'post') {
-			if (isset($_POST[$key])) {
-				$data = $_POST[$key];
-			} else if (isset($default)) {
-				return $default;
-			} else {
-				$data = false;
-			}
-		}
-		if ($data === false) {
-			throw new \OC\OCS\Exception(new OC_OCS_Result(null, 400, 'Bad request. Please provide a valid '.$key));
-		} else {
-			// NOTE: Is the raw type necessary? It might be a little risky without sanitization
-			if ($type == 'raw') return $data;
-			elseif ($type == 'text') return OC_Util::sanitizeHTML($data);
-			elseif ($type == 'int')  return (int) $data;
-			elseif ($type == 'float') return (float) $data;
-			elseif ($type == 'array') return OC_Util::sanitizeHTML($data);
-			else return OC_Util::sanitizeHTML($data);
-		}
-	}
-
+	 * Called when a not existing OCS endpoint has been called
+	 */
 	public static function notFound() {
-		$format = OC_API::requestedFormat();
+		$format = \OC::$server->getRequest()->getParam('format', 'xml');
 		$txt='Invalid query, please check the syntax. API specifications are here:'
-		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:'."\n";
-		$txt.=OC_OCS::getDebugOutput();
+			.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:'."\n";
+		OC_API::respond(new OC_OCS_Result(null, API::RESPOND_UNKNOWN_ERROR, $txt), $format);	}
 
-		OC_API::respond(new OC_OCS_Result(null, API::RESPOND_UNKNOWN_ERROR, $txt), $format);
-	}
-
-	/**
-	* generated some debug information to make it easier to find failed API calls
-	* @return string data
-	*/
-	private static function getDebugOutput() {
-		$txt='';
-		$txt.="debug output:\n";
-		if(isset($_SERVER['REQUEST_METHOD'])) $txt.='http request method: '.$_SERVER['REQUEST_METHOD']."\n";
-		if(isset($_SERVER['REQUEST_URI'])) $txt.='http request uri: '.$_SERVER['REQUEST_URI']."\n";
-		if(isset($_GET)) foreach($_GET as $key=>$value) $txt.='get parameter: '.$key.'->'.$value."\n";
-		if(isset($_POST)) foreach($_POST as $key=>$value) $txt.='post parameter: '.$key.'->'.$value."\n";
-		return($txt);
-	}
 }

--- a/lib/private/ocs/privatedata.php
+++ b/lib/private/ocs/privatedata.php
@@ -69,7 +69,7 @@ class OC_OCS_Privatedata {
 		$user = OC_User::getUser();
 		$app = addslashes(strip_tags($parameters['app']));
 		$key = addslashes(strip_tags($parameters['key']));
-		$value = OC_OCS::readData('post', 'value', 'text');
+		$value = (string)$_POST['value'];
 
 		// update in DB
 		$query = \OCP\DB::prepare('UPDATE `*PREFIX*privatedata` SET `value` = ?  WHERE `user` = ? AND `app` = ? AND `key` = ?');

--- a/lib/public/appframework/http/ocsresponse.php
+++ b/lib/public/appframework/http/ocsresponse.php
@@ -29,8 +29,6 @@ namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
 
-use OC_OCS;
-
 /**
  * A renderer for OCS responses
  * @since 8.1.0


### PR DESCRIPTION
This removes unused code from `OC_OCS` which nobody understood what it really was for anyways. To test just ensure that `/ocs/v1.php/cloud/users/?format=json` and  `/ocs/v1.php/cloud/users/?format=xml` will still throw a valid formatted error. This code was just used for displaying that error. 

Still not where I want to be with it but a nice step forward.
