### PR TITLE
Check if instance is not yet installed

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -637,6 +637,7 @@ class OC {
 			// \OC\AppFramework\Http\Request::getOverwriteHost public
 			&& self::$server->getConfig()->getSystemValue('overwritehost') === ''
 			&& !\OC::$server->getTrustedDomainHelper()->isTrustedDomain($host)
+			&& self::$server->getConfig()->getSystemValue('installed', false)
 		) {
 			header('HTTP/1.1 400 Bad Request');
 			header('Status: 400 Bad Request');

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -164,7 +164,7 @@ class OC_Setup {
 		    && is_array($options['trusted_domains'])) {
 			$trustedDomains = $options['trusted_domains'];
 		} else {
-			$trustedDomains = [\OCP\Util::getServerHostName()];
+			$trustedDomains = [$request->getInsecureServerHost()];
 		}
 
 		if (OC_Util::runningOnWindows()) {
@@ -187,7 +187,7 @@ class OC_Setup {
 			'secret'			=> $secret,
 			'trusted_domains'	=> $trustedDomains,
 			'datadirectory'		=> $dataDir,
-			'overwrite.cli.url'	=> $request->getServerProtocol() . '://' . $request->getServerHost() . OC::$WEBROOT,
+			'overwrite.cli.url'	=> $request->getServerProtocol() . '://' . $request->getInsecureServerHost() . OC::$WEBROOT,
 			'dbtype'			=> $dbType,
 			'version'			=> implode('.', OC_Util::getVersion()),
 		]);


### PR DESCRIPTION
Due to a security hardening in 8.1 a missing value of empty trusted domains in the config would provoke an error as this was misused by a lot of users.

This caused a problem where the initial installation happened from another domain than 127.0.0.1 as in this case the domain was considered untrusted as no value was defined. However, this special case should not get intercepted.

To test:
- [x] Installing ownCloud on 127.0.0.1 works
- [x]  Installing ownCloud on another domain / IP works
- [x] When setting up ownCloud from 127.0.0.1 and accessing it from the domain above the trusted domain error should be shown if not specified in the config

Fixes https://github.com/owncloud/core/issues/14320

@SergioBertolinSG Please test
