### PR TITLE
Correctly create the expected key for plurals with quotes

### DIFF
--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -153,8 +153,11 @@ elsif( $task eq 'write' ){
 				elsif( defined( $string->msgstr_n() )){
 					# plural translations
 					my @variants = ();
-					my $identifier = $string->msgid()."::".$string->msgid_plural();
-					$identifier =~ s/"/_/g;
+					my $msgid = $string->msgid();
+					$msgid =~ s/^"(.*)"$/$1/;
+					my $msgid_plural = $string->msgid_plural();
+					$msgid_plural =~ s/^"(.*)"$/$1/;
+					my $identifier = "_" . $msgid."_::_".$msgid_plural . "_";
 
 					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
 						push( @variants, $string->msgstr_n()->{$variant} );


### PR DESCRIPTION
Ported from the administration repo:
https://github.com/owncloud/administration/commit/c67eaa11c04d0989ee9331c97788a0225a82e7f5
and
https://github.com/owncloud/administration/commit/41b0f9fa3a9c6183972f971eea3875b98e22217a

@DeepDiver1975 
