### PR TITLE
Add some closeCursor functions to file cache to avoid database locks.

### DIFF
--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -139,6 +139,13 @@ class OC_DB {
 		self::raiseExceptionOnError($stmt, 'Could not prepare statement');
 		if ($stmt instanceof OC_DB_StatementWrapper) {
 			$result = $stmt->execute($parameters);
+			if( is_int($result) ) {
+                                // If the result is an int, this was a data manipulation statement
+				// and the statement should be closed here. In the case of query 
+				// statements, the statement object is returned as the calling function 
+				// might still want to deal with the statement. So it can not be closed here.
+                                $stmt->closeCursor();
+                        }
 			self::raiseExceptionOnError($result, 'Could not execute statement');
 		} else {
 			if (is_object($stmt)) {

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -101,7 +101,7 @@ class Cache {
 				self::$mimetypeIds[$row['mimetype']] = $row['id'];
 				self::$mimetypes[$row['id']] = $row['mimetype'];
 			}
-            $result->closeCursor();
+                        $result->closeCursor();
 		}
 	}
 
@@ -127,7 +127,7 @@ class Cache {
 				FROM `*PREFIX*filecache` ' . $where;
 		$result = \OC_DB::executeAudited($sql, $params);
 		$data = $result->fetchRow();
-        $result->closeCursor();
+                $result->closeCursor();
         
 		//FIXME hide this HACK in the next database layer, or just use doctrine and get rid of MDB2 and PDO
 		//PDO returns false, MDB2 returns null, oracle always uses MDB2, so convert null to false
@@ -184,7 +184,7 @@ class Cache {
 					FROM `*PREFIX*filecache` WHERE `parent` = ? ORDER BY `name` ASC';
 			$result = \OC_DB::executeAudited($sql, array($fileId));
 			$files = $result->fetchAll();
-            $result->closeCursor();
+	                $result->closeCursor();
 			foreach ($files as &$file) {
 				$file['mimetype'] = $this->getMimetype($file['mimetype']);
 				$file['mimepart'] = $this->getMimetype($file['mimepart']);
@@ -328,8 +328,8 @@ class Cache {
 
 		$sql = 'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?';
 		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $pathHash));
-        $row = $result->fetchRow();
-        $result->closeCursor();
+                $row = $result->fetchRow();
+                $result->closeCursor();
 		if ($row ) {
 			return $row['fileid'];
 		} else {
@@ -415,7 +415,7 @@ class Cache {
 			$sql = 'SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?';
 			$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $source . '/%'));
 			$childEntries = $result->fetchAll();
-            $result->closeCursor();
+                        $result->closeCursor();
 			$sourceLength = strlen($source);
 			\OC_DB::beginTransaction();
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `path` = ?, `path_hash` = ? WHERE `fileid` = ?');
@@ -454,8 +454,8 @@ class Cache {
 		$pathHash = md5($file);
 		$sql = 'SELECT `size` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path_hash` = ?';
 		$result = \OC_DB::executeAudited($sql, array($this->getNumericStorageId(), $pathHash));
-        $row = $result->fetchRow();
-        $result->closeCursor();
+                $row = $result->fetchRow();
+                $result->closeCursor();
                 
 		if ($row) {
 			if ((int)$row['size'] === -1) {
@@ -490,8 +490,8 @@ class Cache {
 				`unencrypted_size`, `etag`, `permissions`
 			FROM `*PREFIX*filecache`
 			WHERE `storage` = ? AND `name` ILIKE ?';
-		$result = \OC_DB::executeAudited($sql,
-			array($this->getNumericStorageId(), $pattern)
+		        $result = \OC_DB::executeAudited($sql,
+			    array($this->getNumericStorageId(), $pattern)
 		);
 
 		$files = array();
@@ -500,7 +500,7 @@ class Cache {
 			$row['mimepart'] = $this->getMimetype($row['mimepart']);
 			$files[] = $row;
 		}
-        $result->closeCursor();
+                $result->closeCursor();
 		return $files;
 	}
 
@@ -526,7 +526,7 @@ class Cache {
 			$row['mimepart'] = $this->getMimetype($row['mimepart']);
 			$files[] = $row;
 		}
-        $result->closeCursor();
+                $result->closeCursor();
 		return $files;
 	}
 
@@ -572,7 +572,7 @@ class Cache {
 		while ($row = $result->fetchRow()) {
 			$files[] = $row;
 		}
-        $result->closeCursor();
+                $result->closeCursor();
 		return $files;
 	}
 
@@ -655,7 +655,7 @@ class Cache {
 		while ($row = $result->fetchRow()) {
 			$ids[] = $row['fileid'];
 		}
-        $result->closeCursor();
+                $result->closeCursor();
 		return $ids;
 	}
 
@@ -672,8 +672,8 @@ class Cache {
 		$query = \OC_DB::prepare('SELECT `path` FROM `*PREFIX*filecache`'
 			. ' WHERE `storage` = ? AND `size` = -1 ORDER BY `fileid` DESC', 1);
 		$result = \OC_DB::executeAudited($query, array($this->getNumericStorageId()));
-        $row = $result->fetchRow();
-        $result->closeCursor();
+                $row = $result->fetchRow();
+                $result->closeCursor();
 		if ($row) {
 			return $row['path'];
 		} else {
@@ -690,8 +690,8 @@ class Cache {
 	public function getPathById($id) {
 		$sql = 'SELECT `path` FROM `*PREFIX*filecache` WHERE `fileid` = ? AND `storage` = ?';
 		$result = \OC_DB::executeAudited($sql, array($id, $this->getNumericStorageId()));
-        $row = $result->fetchRow();
-        $result->closeCursor();
+                $row = $result->fetchRow();
+                $result->closeCursor();
                 
 		if ($row) {
 			// Oracle stores empty strings as null...
@@ -715,8 +715,8 @@ class Cache {
 	static public function getById($id) {
 		$sql = 'SELECT `storage`, `path` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
 		$result = \OC_DB::executeAudited($sql, array($id));
-        $row = $result->fetchRow();
-        $result->closeCursor();
+                $row = $result->fetchRow();
+                $result->closeCursor();
 		if ($row) {
 			$numericId = $row['storage'];
 			$path = $row['path'];

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -75,7 +75,6 @@ class Cache {
 		if (!isset(self::$mimetypeIds[$mime])) {
 			try {
 				$result = \OC_DB::executeAudited('INSERT INTO `*PREFIX*mimetypes`(`mimetype`) VALUES(?)', array($mime));
-                $result->closeCursor();
 				self::$mimetypeIds[$mime] = \OC_DB::insertid('*PREFIX*mimetypes');
 				self::$mimetypes[self::$mimetypeIds[$mime]] = $mime;
 			} catch (\Doctrine\DBAL\DBALException $e) {


### PR DESCRIPTION
I'd recommend to add the call to **closeCursor()** on _every_ sql statement object that is not longer used. I took some time to dig through the sources of doctrine and pdo and the sqlite implementation in particular and it turns out that the sqlite3_finalize() function, that frees the database statement, is only called in the destructor (for the C++ implementation). I don't know _when_ that is called by the PHP engine, but obviously that can be done any time later. 

As especially SQLite has a very interesting locking method it can easily happen that a writing operation on a table (INSERT, UPDATE) keeps an lock also for reads as long as the writing operation statement was not closed. The subsequent read operations easily can time out or see a lock because of that.

Apart from that, I think it would be good to set a busy handler timeout explicitely:
<code type="php">
$PDO->setAttribute( PDO::ATTR_TIMEOUT, 5 /\* Timeout in seconds */ );
</code>
but I am not sure where to set that.

This submit request is just one step, I think the closeCursor() functions should be added wherever database interaction happens.

Note: This is **not** a SQLite only problem, it's just pretty visible there.
