### PR TITLE
Fix invalid `ini_set` directives

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -253,7 +253,7 @@ class OC {
 				$header .= '; includeSubDomains';
 			}
 			header($header);
-			ini_set('session.cookie_secure', 'on');
+			ini_set('session.cookie_secure', true);
 
 			if ($request->getServerProtocol() <> 'https' && !OC::$CLI) {
 				$url = 'https://' . $request->getServerHost() . $request->getRequestUri();
@@ -405,7 +405,7 @@ class OC {
 
 	public static function initSession() {
 		// prevents javascript from accessing php session cookies
-		ini_set('session.cookie_httponly', '1;');
+		ini_set('session.cookie_httponly', true);
 
 		// set the cookie path to the ownCloud directory
 		$cookie_path = OC::$WEBROOT ? : '/';


### PR DESCRIPTION
Somehow they got messed up. Because PHP does automatic type juggling this has worked before as well however it's not guaranteed that this might work in the future as well.

@th3fallen @nickvergessen Easy one. :smile: 
