### PR TITLE
If no link text has been set for the navigation show the link nonetheless

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -74,6 +74,7 @@
 	display: block;
 	width: 100%;
 	line-height: 44px;
+	min-height: 44px;
 	padding: 0 12px;
 	overflow: hidden;
 	-moz-box-sizing: border-box; box-sizing: border-box;


### PR DESCRIPTION
Fixes https://github.com/owncloud/notes/issues/63

@jancborchardt @LukasReschke @MorrisJobke 
