### PR TITLE
No more leaking of mounttype via metadata or icon in public shares.

### DIFF
--- a/apps/files_sharing/ajax/list.php
+++ b/apps/files_sharing/ajax/list.php
@@ -71,6 +71,9 @@ foreach ($files as $file) {
 	unset($entry['directory']);
 	// do not disclose share owner
 	unset($entry['shareOwner']);
+	// do not disclose if something is a remote shares
+	unset($entry['mountType']);
+	unset($entry['icon']);
 	$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
 	$formattedFiles[] = $entry;
 }


### PR DESCRIPTION
Patch for #13789

There are no unit tests. I could not find unit tests for the ajax/list.php stuf, which makes sense since it is far from trivial to test. 
