### PR TITLE
Ignore empty plurals just like with singulars

### DIFF
--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -145,7 +145,7 @@ elsif( $task eq 'write' ){
 			my @js_strings = ();
 			my $plurals;
 
-			foreach my $string ( @{$array} ){
+			TRANSLATIONS: foreach my $string ( @{$array} ){
 				if( $string->msgid() eq '""' ){
 					# Translator information
 					$plurals = getPluralInfo( $string->msgstr());
@@ -157,6 +157,7 @@ elsif( $task eq 'write' ){
 					$identifier =~ s/"/_/g;
 
 					foreach my $variant ( sort { $a <=> $b} keys( %{$string->msgstr_n()} )){
+						next TRANSLATIONS if $string->msgstr_n()->{$variant} eq '""';
 						push( @variants, $string->msgstr_n()->{$variant} );
 					}
 
@@ -165,7 +166,7 @@ elsif( $task eq 'write' ){
 				}
 				else{
 					# singular translations
-					next if $string->msgstr() eq '""';
+					next TRANSLATIONS if $string->msgstr() eq '""';
 					push( @strings, $string->msgid()." => ".$string->msgstr());
 					push( @js_strings, $string->msgid()." : ".$string->msgstr());
 				}

--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -238,7 +238,7 @@ class OC_L10N implements \OCP\IL10N {
 		$this->init();
 		$identifier = "_${text_singular}_::_${text_plural}_";
 		if( array_key_exists($identifier, $this->translations)) {
-			return new OC_L10N_String($this, $identifier, $parameters, $count, array($text_singular, $text_plural));
+			return new OC_L10N_String( $this, $identifier, $parameters, $count );
 		}else{
 			if($count === 1) {
 				return new OC_L10N_String($this, $text_singular, $parameters, $count);

--- a/lib/private/l10n/string.php
+++ b/lib/private/l10n/string.php
@@ -23,11 +23,6 @@ class OC_L10N_String{
 	protected $parameters;
 
 	/**
-	 * @var array
-	 */
-	protected $plurals;
-
-	/**
 	 * @var integer
 	 */
 	protected $count;
@@ -35,12 +30,11 @@ class OC_L10N_String{
 	/**
 	 * @param OC_L10N $l10n
 	 */
-	public function __construct($l10n, $text, $parameters, $count = 1, $plurals = array()) {
+	public function __construct($l10n, $text, $parameters, $count = 1) {
 		$this->l10n = $l10n;
 		$this->text = $text;
 		$this->parameters = $parameters;
 		$this->count = $count;
-		$this->plurals = $plurals;
 	}
 
 	public function __toString() {
@@ -51,19 +45,7 @@ class OC_L10N_String{
 			if(is_array($translations[$this->text])) {
 				$fn = $this->l10n->getPluralFormFunction();
 				$id = $fn($this->count);
-
-				if ($translations[$this->text][$id] !== '') {
-					// The translation of this plural case is not empty, so use it
-					$text = $translations[$this->text][$id];
-				} else {
-					// We didn't find the plural in the language,
-					// so we fall back to english.
-					$id = ($id != 0) ? 1 : 0;
-					if (isset($this->plurals[$id])) {
-						// Fallback to the english plural
-						$text = $this->plurals[$id];
-					}
-				}
+				$text = $translations[$this->text][$id];
 			}
 			else{
 				$text = $translations[$this->text];

--- a/tests/data/l10n/ru.json
+++ b/tests/data/l10n/ru.json
@@ -1,7 +1,6 @@
 {
 	"translations" : {
-		"_%n file_::_%n files_" : ["%n файл", "%n файла", "%n файлов"],
-		"_%n missing plural_::_%n missing plurals_" : ["", "", ""]
+		"_%n file_::_%n files_" : ["%n файл", "%n файла", "%n файлов"]
 	},
 	"pluralForm" :	"nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
 }

--- a/tests/lib/l10n.php
+++ b/tests/lib/l10n.php
@@ -42,24 +42,6 @@ class Test_L10n extends \Test\TestCase {
 		*/
 	}
 
-	public function russianMissingPluralTranslationsData() {
-		return array(
-			array(1, '1 missing plural'),
-			array(2, '2 missing plurals'),
-			array(6, '6 missing plurals'),
-		);
-	}
-
-	/**
-	 * @dataProvider russianMissingPluralTranslationsData
-	 */
-	public function testRussianMissingPluralTranslations($count, $expected) {
-		$l = new OC_L10N('test');
-		$l->load(OC::$SERVERROOT.'/tests/data/l10n/ru.json');
-
-		$this->assertEquals($expected, (string)$l->n('%n missing plural', '%n missing plurals', $count));
-	}
-
 	public function testCzechPluralTranslations() {
 		$l = new OC_L10N('test');
 		$transFile = OC::$SERVERROOT.'/tests/data/l10n/cs.json';


### PR DESCRIPTION
The js and php code of n() has fallbacks for when the key is missing.
However there is no fallback, when the key is defined with an array of empty
strings. So we just don't extract them anymore and use the english language.

See https://github.com/owncloud/administration/pull/31
