### PR TITLE
Add the l10n plural function to the core JS

### DIFF
--- a/core/js/l10n.js
+++ b/core/js/l10n.js
@@ -21,10 +21,10 @@ OC.L10N = {
 	_bundles: {},
 
 	/**
-	 * Plural functions, key is app name and value is function.
-	 * @type {Object.<String,Function>}
+	 * Plural function
+	 * @type func
 	 */
-	_pluralFunctions: {},
+	_pluralFunction: '',
 
 	/**
 	 * Load an app's translation bundle if not loaded already.
@@ -63,64 +63,14 @@ OC.L10N = {
 	 *
 	 * @param {String} appName name of the app
 	 * @param {Object<String,String>} bundle
-	 * @param {Function|String} [pluralForm] optional plural function or plural string
+	 * @param {Function} [pluralForm] optional plural function or plural string
 	 */
 	register: function(appName, bundle, pluralForm) {
 		this._bundles[appName] = bundle || {};
 
 		if (_.isFunction(pluralForm)) {
-			this._pluralFunctions[appName] = pluralForm;
-		} else {
-			// generate plural function based on form
-			this._pluralFunctions[appName] = this._generatePluralFunction(pluralForm);
+			this._pluralFunction = pluralForm;
 		}
-	},
-
-	/**
-	 * Generates a plural function based on the given plural form.
-	 * If an invalid form has been given, returns a default function.
-	 *
-	 * @param {String} pluralForm plural form
-	 */
-	_generatePluralFunction: function(pluralForm) {
-		// default func
-		var func = function (n) {
-			var p = (n !== 1) ? 1 : 0;
-			return { 'nplural' : 2, 'plural' : p };
-		};
-
-		if (!pluralForm) {
-			console.warn('Missing plural form in language file');
-			return func;
-		}
-
-		/**
-		 * code below has been taken from jsgettext - which is LGPL licensed
-		 * https://developer.berlios.de/projects/jsgettext/
-		 * http://cvs.berlios.de/cgi-bin/viewcvs.cgi/jsgettext/jsgettext/lib/Gettext.js
-		 */
-		var pf_re = new RegExp('^(\\s*nplurals\\s*=\\s*[0-9]+\\s*;\\s*plural\\s*=\\s*(?:\\s|[-\\?\\|&=!<>+*/%:;a-zA-Z0-9_\\(\\)])+)', 'm');
-		if (pf_re.test(pluralForm)) {
-			//ex english: "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-			//pf = "nplurals=2; plural=(n != 1);";
-			//ex russian: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10< =4 && (n%100<10 or n%100>=20) ? 1 : 2)
-			//pf = "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)";
-			var pf = pluralForm;
-			if (! /;\s*$/.test(pf)) {
-				pf = pf.concat(';');
-			}
-			/* We used to use eval, but it seems IE has issues with it.
-			 * We now use "new Function", though it carries a slightly
-			 * bigger performance hit.
-			var code = 'function (n) { var plural; var nplurals; '+pf+' return { "nplural" : nplurals, "plural" : (plural === true ? 1 : plural ? plural : 0) }; };';
-			Gettext._locale_data[domain].head.plural_func = eval("("+code+")");
-			 */
-			var code = 'var plural; var nplurals; '+pf+' return { "nplural" : nplurals, "plural" : (plural === true ? 1 : plural ? plural : 0) };';
-			func = new Function("n", code);
-		} else {
-			console.warn('Invalid plural form in language file: "' + pluralForm + '"');
-		}
-		return func;
 	},
 
 	/**
@@ -191,7 +141,7 @@ OC.L10N = {
 		if( typeof(value) !== 'undefined' ){
 			var translation = value;
 			if ($.isArray(translation)) {
-				var plural = this._pluralFunctions[app](count);
+				var plural = this._pluralFunction(count);
 				return this.translate(app, translation[plural.plural], vars, count, options);
 			}
 		}

--- a/core/l10n/cs_CZ.js
+++ b/core/l10n/cs_CZ.js
@@ -220,5 +220,10 @@ OC.L10N.register(
     "To avoid timeouts with larger installations, you can instead run the following command from your installation directory:" : "Abyste zabránili vypršení časového limitu u větších instalací, můžete namísto toho spustit následující příkaz v hlavním adresáři:",
     "This %s instance is currently being updated, which may take a while." : "Tato instalace %s je právě aktualizována. Mějte chvíli strpení.",
     "This page will refresh itself when the %s instance is available again." : "Tato stránka se automaticky načte poté, co bude opět dostupná instance %s."
-},
-"nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;");
+}, function(n) {
+		var plural;
+		var nplurals;
+		nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
+		return { "nplural" : nplurals, "plural" : (plural === true ? 1 : plural ? plural : 0) };
+	}
+);

--- a/core/l10n/ru.js
+++ b/core/l10n/ru.js
@@ -219,5 +219,10 @@ OC.L10N.register(
     "To avoid timeouts with larger installations, you can instead run the following command from your installation directory:" : "Чтобы избежать задержек в крупных установках, вы можете выполнить следующую команду в каталоге установки:",
     "This %s instance is currently being updated, which may take a while." : "Этот экземпляр %s в данный момент обновляется. Это может занять некоторое время.",
     "This page will refresh itself when the %s instance is available again." : "Эта страница обновится, когда экземпляр %s снова станет доступен."
-},
-"nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);");
+}, function(n) {
+		var plural;
+		var nplurals;
+		nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);
+		return { "nplural" : nplurals, "plural" : (plural === true ? 1 : plural ? plural : 0) };
+	}
+);


### PR DESCRIPTION
This allows us to get rid of the eval used in the l10n.js code. However, this

As I still don't fully understand what that whole plural thing is for I'm not sure if this works properly. However, russian translation seem to "work". (at least it changes the "Folder" name into something else when selecting multiple things…)

Requires adjustments to Jenkins and discussion if we want to go this route. (as well as unit tests adjustments etc…)

Proposal for https://github.com/owncloud/core/issues/7212

cc @DeepDiver1975 @PVince81 
