### PR TITLE
Add helper to check for `ini` values in `OC_Util::checkServer`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,6 +14,7 @@ php_value memory_limit 512M
 php_value mbstring.func_overload 0
 php_value always_populate_raw_post_data -1
 php_value default_charset 'UTF-8'
+php_value output_buffering false
 <IfModule mod_env.c>
   SetEnv htaccessWorking true
 </IfModule>

--- a/.user.ini
+++ b/.user.ini
@@ -4,3 +4,4 @@ memory_limit=512M
 mbstring.func_overload=0
 always_populate_raw_post_data=-1
 default_charset='UTF-8'
+output_buffering=false


### PR DESCRIPTION
This allows to check for specific values in the PHP.ini that ownCloud requires for full compatibility.

`mbstring.func_overload`: https://github.com/owncloud/core/issues/14372
`output_buffering`: http://doc.owncloud.org/server/8.0/admin_manual/configuration/big_file_upload_configuration.html#configuring-php

The `always_populate_raw_post_data` check is not included here since we don't check it on HHVM because of a HHVM incompatibility…

Fixes https://github.com/owncloud/core/issues/14372 and https://github.com/owncloud/core/issues/14412

@DeepDiver1975 @RealRancor @Raydiation Please review. – Likely to let Jenkins explode if wrong php.ini settings are existent there as well :see_no_evil: 
