### PR TITLE
fix issue with previews not being displayed if filename contains apostrophe

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -947,7 +947,7 @@
 						mime: mime,
 						etag: fileData.etag,
 						callback: function(url) {
-							iconDiv.css('background-image', 'url(' + url + ')');
+							iconDiv.css('background-image', 'url("' + url + '")');
 						}
 					});
 				}
@@ -959,7 +959,7 @@
 						};
 					var previewUrl = this.generatePreviewUrl(urlSpec);
 					previewUrl = previewUrl.replace('(', '%28').replace(')', '%29');
-					iconDiv.css('background-image', 'url(' + previewUrl + ')');
+					iconDiv.css('background-image', 'url("' + previewUrl + '")');
 				}
 			}
 			return tr;


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/14149

please review @oparoz @PVince81 

There is no special escaping for an apostrophe (by $.param()).
This leads to issues with background-image: url(...)
Therefore we should wrap the url in double quotes.
This should not introduce new issues with double quotes as:
- we do not allow double quotes in names at all
- double quotes are escaped to %22 anyway
