### PR TITLE
Use "off" and "off" instead of true booleans

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,7 +14,7 @@ php_value memory_limit 512M
 php_value mbstring.func_overload 0
 php_value always_populate_raw_post_data -1
 php_value default_charset 'UTF-8'
-php_value output_buffering false
+php_value output_buffering off
 <IfModule mod_env.c>
   SetEnv htaccessWorking true
 </IfModule>

--- a/.user.ini
+++ b/.user.ini
@@ -4,4 +4,4 @@ memory_limit=512M
 mbstring.func_overload=0
 always_populate_raw_post_data=-1
 default_charset='UTF-8'
-output_buffering=false
+output_buffering=off

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -638,8 +638,11 @@ class OC_Util {
 			$webServerRestart = true;
 		}
 		foreach($invalidIniSettings as $setting) {
+			if(is_bool($setting[1])) {
+				$setting[1] = ($setting[1]) ? 'on' : 'off';
+			}
 			$errors[] = [
-				'error' => $l->t('PHP setting "%s" is not set to "%s".', [$setting[0], $setting[1]]),
+				'error' => $l->t('PHP setting "%s" is not set to "%s".', [$setting[0], var_export($setting[1], true)]),
 				'hint' =>  $l->t('Adjusting this setting in php.ini will make ownCloud run again')
 			];
 			$webServerRestart = true;


### PR DESCRIPTION
Apparently a boolean in php.ini is according to the documentation "on" or "off"…

Fixes itself.

(that said… it magically worked for me :see_no_evil:)

@jmaciasportela @andyknownasabu Please test.
