### PR TITLE
Etc timezones don't exist for .5 and .75 offsets

### DIFF
--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -52,16 +52,31 @@ class Test_Util extends \Test\TestCase {
 		OC_Util::formatDate(1350129205, false, 'Mordor/Barad-dûr');
 	}
 
-	function testFormatDateWithTZFromSession() {
+	public function formatDateWithTZFromSessionData()
+	{
+		return array(
+			array(3, 'October 13, 2012 at 2:53:25 PM GMT+3'),
+			array(15, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+			array(-13, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+			array(3.5, 'October 13, 2012 at 3:23:25 PM GMT+3:30'),
+			array(9.5, 'October 13, 2012 at 9:23:25 PM GMT+9:30'),
+			array(-4.5, 'October 13, 2012 at 7:23:25 AM GMT-4:30'),
+			array(15.5, 'October 13, 2012 at 11:53:25 AM GMT+0'),
+		);
+	}
+
+	/**
+	 * @dataProvider formatDateWithTZFromSessionData
+	 */
+	function testFormatDateWithTZFromSession($offset, $expected) {
 		date_default_timezone_set("UTC");
 
 		$oldDateTimeFormatter = \OC::$server->query('DateTimeFormatter');
-		\OC::$server->getSession()->set('timezone', 3);
+		\OC::$server->getSession()->set('timezone', $offset);
 		$newDateTimeFormatter = new \OC\DateTimeFormatter(\OC::$server->getDateTimeZone()->getTimeZone(), new \OC_L10N('lib', 'en'));
 		$this->setDateFormatter($newDateTimeFormatter);
 
 		$result = OC_Util::formatDate(1350129205, false);
-		$expected = 'October 13, 2012 at 2:53:25 PM GMT+3';
 		$this->assertEquals($expected, $result);
 
 		$this->setDateFormatter($oldDateTimeFormatter);


### PR DESCRIPTION
Fix #14176, #14391 

@phritter @rinchen @bit can you test this please?

cc @LukasReschke 

@DeepDiver1975 should backport
### To test:
1. Change your local Computer timezone to `Asia/Kathmandu`
2. Log in into ownCloud
3. Create a folder to trigger an activity
4. Wait until the activity email is sent, or force it by setting `oc_activity_mq`.`amq_latest_send` to `1` for the entry aswell as `oc_jobs`.`last_run` for `OCA\Activity\BackgroundJob\EmailNotification`
