### PR TITLE
Properly detect streamCopy errors

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -109,7 +109,7 @@ class Quota extends Wrapper {
 		if ($free < 0 or $this->getSize($source) < $free) {
 			return $this->storage->copy($source, $target);
 		} else {
-			return false;
+			throw new \OCP\Files\NotEnoughSpaceException();
 		}
 	}
 

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -574,13 +574,23 @@ class OC_Helper {
 		if (!$source or !$target) {
 			return array(0, false);
 		}
+		$bufSize = 8192;
 		$result = true;
 		$count = 0;
 		while (!feof($source)) {
-			if (($c = fwrite($target, fread($source, 8192))) === false) {
+			$buf = fread($source, $bufSize);
+			$bytesWritten = fwrite($target, $buf);
+			if ($bytesWritten !== false) {
+				$count += $bytesWritten;
+			}
+			// note: strlen is expensive so only use it when necessary,
+			// on the last block
+			if ($bytesWritten === false
+				|| ($bytesWritten < $bufSize && $bytesWritten < strlen($buf))
+			) {
+				// write error, could be disk full ?
 				$result = false;
-			} else {
-				$count += $c;
+				break;
 			}
 		}
 		return array($count, $result);

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -99,6 +99,28 @@ class Quota extends \Test\Files\Storage\Storage {
 		$this->assertEquals('foobarqwe', $instance->file_get_contents('foo'));
 	}
 
+	public function testStreamCopyWithEnoughSpace() {
+		$instance = $this->getLimitedStorage(16);
+		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
+		$outputStream = $instance->fopen('foo', 'w+');
+		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
+		$this->assertEquals(12, $count);
+		$this->assertTrue($result);
+		fclose($inputStream);
+		fclose($outputStream);
+	}
+
+	public function testStreamCopyNotEnoughSpace() {
+		$instance = $this->getLimitedStorage(9);
+		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
+		$outputStream = $instance->fopen('foo', 'w+');
+		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
+		$this->assertEquals(9, $count);
+		$this->assertFalse($result);
+		fclose($inputStream);
+		fclose($outputStream);
+	}
+
 	public function testReturnFalseWhenFopenFailed() {
 		$failStorage = $this->getMock(
 			'\OC\Files\Storage\Local',


### PR DESCRIPTION
Now checking whether the written bytes match the number of read bytes.

Fixes https://github.com/owncloud/core/issues/14284

Additional work needed:
- [ ] properly delete target file on failed move
