### PR TITLE
Use `getParam` instead of `server`

### DIFF
--- a/public.php
+++ b/public.php
@@ -15,11 +15,12 @@ try {
 	OC::checkSingleUserMode();
 	$request = \OC::$server->getRequest();
 	$pathInfo = $request->getPathInfo();
-	if (!$pathInfo && !isset($request->server['service'])) {
+
+	if (!$pathInfo && $request->getParam('service', '') === '') {
 		header('HTTP/1.0 404 Not Found');
 		exit;
-	} elseif (isset($request->server['service'])) {
-		$service = $request->server['service'];
+	} elseif ($request->getParam('service', '')) {
+		$service = $request->getParam('service', '');
 	} else {
 		$pathInfo = trim($pathInfo, '/');
 		list($service) = explode('/', $pathInfo);


### PR DESCRIPTION
`server` is completely wrong here and this will not work on master. With `getParam` it will work fine though.

Testplan:
- [ ] Without patch: Share a file and try to access `http://localhost/public.php?service=files&t=THESHAREDTOKEN` => Fails
- [ ] With patch: Try the same => Works

Master only. Fixes itself.

@nickvergessen @th3fallen Please test.
