### PR TITLE
Get the real protocol behind several proxies

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -480,8 +480,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	}
 
 	/**
-	 * Returns the server protocol. It respects reverse proxy servers and load
-	 * balancers.
+	 * Returns the server protocol. It respects one or more reverse proxies servers
+	 * and load balancers
 	 * @return string Server protocol (http or https)
 	 */
 	public function getServerProtocol() {
@@ -491,7 +491,13 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		if (isset($this->server['HTTP_X_FORWARDED_PROTO'])) {
-			$proto = strtolower($this->server['HTTP_X_FORWARDED_PROTO']);
+			if (strpos($this->server['HTTP_X_FORWARDED_PROTO'], ',') !== false) {
+				$parts = explode(',', $this->server['HTTP_X_FORWARDED_PROTO']);
+				$proto = strtolower(trim(current($parts)));
+			} else {
+				$proto = strtolower($this->server['HTTP_X_FORWARDED_PROTO']);
+			}
+
 			// Verify that the protocol is always HTTP or HTTPS
 			// default to http if an invalid value is provided
 			return $proto === 'https' ? 'https' : 'http';

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -493,7 +493,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		if (isset($this->server['HTTP_X_FORWARDED_PROTO'])) {
 			if (strpos($this->server['HTTP_X_FORWARDED_PROTO'], ',') !== false) {
 				$parts = explode(',', $this->server['HTTP_X_FORWARDED_PROTO']);
-				$proto = strtolower(trim(current($parts)));
+				$proto = strtolower(trim($parts[0]));
 			} else {
 				$proto = strtolower($this->server['HTTP_X_FORWARDED_PROTO']);
 			}

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -593,6 +593,27 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('http', $request->getServerProtocol());
 	}
 
+	public function testGetServerProtocolBehindLoadBalancers() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('overwriteprotocol')
+			->will($this->returnValue(''));
+
+		$request = new Request(
+			[
+				'server' => [
+					'HTTP_X_FORWARDED_PROTO' => 'https,http,http'
+				],
+			],
+			$this->secureRandom,
+			$this->config,
+			$this->stream
+		);
+
+		$this->assertSame('https', $request->getServerProtocol());
+	}
+
 	/**
 	 * @dataProvider userAgentProvider
 	 * @param string $testAgent


### PR DESCRIPTION
X-Forwarded-Proto contains a list of protocols if ownCloud is behind multiple reverse proxies.

This is a revival of https://github.com/owncloud/core/pull/11157 using the new IRequest public API.

@nickvergessen @Romua1d Please review.
