### PR TITLE
Always load authentication apps

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -797,6 +797,9 @@ class OC {
 			self::checkUpgrade();
 		}
 
+		// Always load authentication apps
+		OC_App::loadApps(['authentication']);
+
 		// Load minimum set of apps
 		if (!self::checkUpgrade(false)
 			&& !$systemConfig->getValue('maintenance', false)
@@ -805,8 +808,7 @@ class OC {
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();
 			} else {
-				// For guests: Load only authentication, filesystem and logging
-				OC_App::loadApps(array('authentication'));
+				// For guests: Load only filesystem and logging
 				OC_App::loadApps(array('filesystem', 'logging'));
 				\OC_User::tryBasicAuthLogin();
 			}
@@ -815,7 +817,6 @@ class OC {
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
 				if (!$systemConfig->getValue('maintenance', false) && !\OCP\Util::needUpgrade()) {
-					OC_App::loadApps(array('authentication'));
 					OC_App::loadApps(array('filesystem', 'logging'));
 					OC_App::loadApps();
 				}


### PR DESCRIPTION
The current code path may trigger situations where the LDAP application is not yet loaded and thus problems with the authentication appeared.

In previous versions of ownCloud the authentication mechanism manually loaded these apps which is why this affects ownCloud 8 and master only from my knowledge. (certainly not 6, maybe 7)

Backport to 8 might be something to consider.

Fixes https://github.com/owncloud/core/issues/14469

@blizzz @DeepDiver1975 Please review.
@t0mcat1337 Would be awesome if you could test this and report back whether it works. 
