### PR TITLE
Move UTF-8 check to setup

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -651,6 +651,7 @@ class OC_Util {
 			'ini' => [
 				'mbstring.func_overload' => 0,
 				'output_buffering' => false,
+				'default_charset' => 'UTF-8',
 			],
 		);
 		$missingDependencies = array();
@@ -681,6 +682,11 @@ class OC_Util {
 			}
 			if(is_int($expected)) {
 				if($iniWrapper->getNumeric($setting) !== $expected) {
+					$invalidIniSettings[] = [$setting, $expected];
+				}
+			}
+			if(is_string($expected)) {
+				if(strtolower($iniWrapper->getString($setting)) !== strtolower($expected)) {
 					$invalidIniSettings[] = [$setting, $expected];
 				}
 			}
@@ -1509,15 +1515,6 @@ class OC_Util {
 		} else {
 			return false;
 		}
-	}
-
-	/**
-	 * Check if PhpCharset config is UTF-8
-	 *
-	 * @return string
-	 */
-	public static function isPhpCharSetUtf8() {
-		return strtoupper(ini_get('default_charset')) === 'UTF-8';
 	}
 
 }

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -65,7 +65,6 @@ $template->assign('doesLogFileExist', $doesLogFileExist);
 $template->assign('showLog', $showLog);
 $template->assign('readOnlyConfigEnabled', OC_Helper::isReadOnlyConfigEnabled());
 $template->assign('isLocaleWorking', OC_Util::isSetLocaleWorking());
-$template->assign('isPhpCharSetUtf8', OC_Util::isPhpCharSetUtf8());
 $template->assign('isAnnotationsWorking', OC_Util::isAnnotationsWorking());
 $template->assign('has_fileinfo', OC_Util::fileInfoLoaded());
 $template->assign('backgroundjobs_mode', $appConfig->getValue('core', 'backgroundjobs_mode', 'ajax'));
@@ -116,7 +115,7 @@ $forms = OC_App::getForms('admin');
 $l = OC_L10N::get('settings');
 $formsAndMore = array();
 if ($request->getServerProtocol()  !== 'https' || !OC_Util::isAnnotationsWorking() ||
-	$suggestedOverwriteCliUrl || !OC_Util::isSetLocaleWorking() || !OC_Util::isPhpCharSetUtf8() ||
+	$suggestedOverwriteCliUrl || !OC_Util::isSetLocaleWorking()  ||
 	!OC_Util::fileInfoLoaded() || $databaseOverload
 ) {
 	$formsAndMore[] = array('anchor' => 'security-warning', 'section-name' => $l->t('Security & Setup Warnings'));

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -175,20 +175,6 @@ if (!$_['has_fileinfo']) {
 <?php
 }
 
-// is PHP charset set to UTF8?
-if (!$_['isPhpCharSetUtf8']) {
-	?>
-	<div class="section">
-		<h2><?php p($l->t('PHP charset is not set to UTF-8'));?></h2>
-
-		<span class="connectionwarning">
-		<?php p($l->t("PHP charset is not set to UTF-8. This can cause major issues with non-ASCII characters in file names. We highly recommend to change the value of 'default_charset' php.ini to 'UTF-8'.")); ?>
-	</span>
-
-	</div>
-<?php
-}
-
 // is locale working ?
 if (!$_['isLocaleWorking']) {
 	?>


### PR DESCRIPTION
Nobody reads the warnings anyways and so we should enforce it at installation time... I mean: Honestly, we show only a warning when it can cause "Major issues"?!?

To test change the `default_charset` to something other than `utf-8` or `UTF-8`, both should work fine with that change here. An error should then get shown.

We already set those default charsets in the shipped .user.ini and .htaccess

@nickvergessen @th3fallen Please review.
