### PR TITLE
Fix bugs in ownCloud external storage

### DIFF
--- a/apps/files_external/lib/owncloud.php
+++ b/apps/files_external/lib/owncloud.php
@@ -49,13 +49,13 @@ class OwnCloud extends \OC\Files\Storage\DAV{
 			$host = substr($host, 0, $hostSlashPos);
 		}
 
-		if (substr($contextPath , 1) !== '/'){
+		if (substr($contextPath, -1) !== '/'){
 			$contextPath .= '/';
 		}
 
 		if (isset($params['root'])){
 			$root = $params['root'];
-			if (substr($root, 1) !== '/'){
+			if (substr($root, 0, 1) !== '/'){
 				$root = '/' . $root;
 			}
 		}

--- a/apps/files_external/tests/owncloudfunctions.php
+++ b/apps/files_external/tests/owncloudfunctions.php
@@ -81,6 +81,14 @@ class OwnCloudFunctions extends \Test\TestCase {
 				),
 				'http://testhost/testroot/remote.php/webdav/subdir/',
 			),
+			array(
+				array(
+					'host' => 'http://testhost/testroot/',
+					'root' => '/subdir',
+					'secure' => false
+				),
+				'http://testhost/testroot/remote.php/webdav/subdir/',
+			),
 		);
 	}
 


### PR DESCRIPTION
I noticed these errors while browsing through the code of the ownCloud external storage type. This was the intended behaviour, from what I can gather. The original code didn't visibly break, as ultimately these checks are a bit redundant (but nice to have for sane variables and nice URLs)

cc @PVince81 @LukasReschke @icewind1991 
