### PR TITLE
Serve all files with a Content-Disposition of 'attachment' via WebDAV

### DIFF
--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -99,7 +99,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	function httpGet(RequestInterface $request, ResponseInterface $response) {
 		// Only handle valid files
-		$node = $this->tree->getNodeForPath($request->getPath(), 0);
+		$node = $this->tree->getNodeForPath($request->getPath());
 		if (!($node instanceof IFile)) return;
 
 		$response->addHeader('Content-Disposition', 'attachment');


### PR DESCRIPTION
As an additional security hardening it's sensible to serve these files with a Content-Disposition of 'attachment'. Currently they are served 'inline' and get a "secure mimetype" assigned in case of potential dangerous files.

To test this change ensure that:
- [x] Syncing with the Desktop client still works
- [x] Syncing with the Android client still works
- [x] Syncing with the iOS client still works
- [x] litmus tests (https://github.com/owncloud/core/pull/14488#issuecomment-86672236)

I verified that the 1.8 OS X and iOS client still work with this change.

@DeepDiver1975 @PVince81 Please review.
