### PR TITLE
Failing mysql master tests

### DIFF
--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -36,7 +36,7 @@ use OC\URLGenerator;
 /**
  * @package OCA\Files_Sharing\Controllers
  */
-class ShareControllerTest extends \PHPUnit_Framework_TestCase {
+class ShareControllerTest extends \Test\TestCase {
 
 	/** @var IAppContainer */
 	private $container;

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -65,7 +65,7 @@ abstract class TestCase extends \Test\TestCase {
 
 		// reset backend
 		\OC_User::clearBackends();
-		\OC_User::useBackend('database');
+		\OC_Group::clearBackends();
 
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
@@ -129,6 +129,12 @@ abstract class TestCase extends \Test\TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		Filesystem::tearDown();
+
+		// reset backend
+		\OC_User::clearBackends();
+		\OC_User::useBackend('database');
+		\OC_Group::clearBackends();
+		\OC_Group::useBackend(new \OC_Group_Database());
 
 		parent::tearDownAfterClass();
 	}

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -59,7 +59,14 @@ class GroupsTest extends TestCase {
 
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
-		$this->assertEquals(array('users' => $users), $result->getData());
+		$this->assertEquals(1, sizeof($result->getData()), 'Asserting the result data array only has the "users" key');
+		$this->assertArrayHasKey('users', $result->getData());
+		$resultData = $result->getData();
+		$resultData = $resultData['users'];
+
+		sort($users);
+		sort($resultData);
+		$this->assertEquals($users, $resultData);
 
 	}
 

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -106,6 +106,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	public function clearBackends() {
 		$this->backends = array();
 		$this->cachedGroups = array();
+		$this->cachedUserGroups = array();
 	}
 
 	/**

--- a/tests/lib/connector/sabre/objecttree.php
+++ b/tests/lib/connector/sabre/objecttree.php
@@ -11,7 +11,6 @@ namespace Test\OC\Connector\Sabre;
 
 use OC\Files\FileInfo;
 use OC\Connector\Sabre\Directory;
-use PHPUnit_Framework_TestCase;
 
 class TestDoubleFileView extends \OC\Files\View {
 

--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -23,8 +23,6 @@ namespace OCA\ObjectStore\Tests\Unit;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\ObjectStore\Swift as ObjectStoreToTest;
 
-use PHPUnit_Framework_TestCase;
-
 //class Swift extends PHPUnit_Framework_TestCase {
 class Swift extends \Test\Files\Storage\Storage {
 


### PR DESCRIPTION
@DeepDiver1975 @LukasReschke 

Fixes multiple failures that each on itself can cause the tests to fail.
At least the group/manager.php change should probably be backported.
