### PR TITLE
Fix file move/copy when storage space is not enough

### DIFF
--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -99,6 +99,28 @@ class Quota extends \Test\Files\Storage\Storage {
 		$this->assertEquals('foobarqwe', $instance->file_get_contents('foo'));
 	}
 
+	public function testStreamCopyWithEnoughSpace() {
+		$instance = $this->getLimitedStorage(16);
+		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
+		$outputStream = $instance->fopen('foo', 'w+');
+		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
+		$this->assertEquals(12, $count);
+		$this->assertTrue($result);
+		fclose($inputStream);
+		fclose($outputStream);
+	}
+
+	public function testStreamCopyNotEnoughSpace() {
+		$instance = $this->getLimitedStorage(9);
+		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
+		$outputStream = $instance->fopen('foo', 'w+');
+		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
+		$this->assertEquals(9, $count);
+		$this->assertFalse($result);
+		fclose($inputStream);
+		fclose($outputStream);
+	}
+
 	public function testReturnFalseWhenFopenFailed() {
 		$failStorage = $this->getMock(
 			'\OC\Files\Storage\Local',


### PR DESCRIPTION
- properly detect streamCopy errors
- when a streamCopy failed, delete the partially written target file

This applies for both "rename" and "copy"

@icewind1991 @DeepDiver1975 @schiesbn 
