### PR TITLE
Return null when requesting tags for null user

### DIFF
--- a/lib/private/tagmanager.php
+++ b/lib/private/tagmanager.php
@@ -65,6 +65,11 @@ class TagManager implements \OCP\ITagManager {
 	*/
 	public function load($type, $defaultTags = array(), $includeShared = false, $userId = null) {
 		if (is_null($userId)) {
+			$user = $this->userSession->getUser();
+			if ($user === null) {
+				// nothing we can do without a user
+				return null;
+			}
 			$userId = $this->userSession->getUser()->getUId();
 		}
 		return new Tags($this->mapper, $userId, $type, $defaultTags, $includeShared);

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -62,6 +62,16 @@ class Test_Tags extends \Test\TestCase {
 		parent::tearDown();
 	}
 
+	public function testTagManagerWithoutUserReturnsNull() {
+		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession
+			->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue(null));
+		$this->tagMgr = new OC\TagManager($this->tagMapper, $this->userSession);
+		$this->assertNull($this->tagMgr->load($this->objectType));
+	}
+
 	public function testInstantiateWithDefaults() {
 		$defaultTags = array('Friends', 'Family', 'Work', 'Other');
 


### PR DESCRIPTION
The TagManager->load() now returns null if the user is not authenticated
instead of failing with an error.

Fixes https://github.com/owncloud/core/issues/14029

To test:
`curl -D - http://localhost/owncloud/index.php/apps/files/api/v1/thumbnail/2/3/welcome.txt`

Before the fix: error page is returned,error in log
After the fix: 401 returned

@rullzer @LukasReschke @icewind1991 @nickvergessen please review
