### PR TITLE
[stable8] Return null when requesting tags for null user

### DIFF
--- a/lib/private/tagmanager.php
+++ b/lib/private/tagmanager.php
@@ -76,6 +76,11 @@ class TagManager implements \OCP\ITagManager {
 	*/
 	public function load($type, $defaultTags = array(), $includeShared = false, $userId = null) {
 		if (is_null($userId)) {
+			$user = $this->userSession->getUser();
+			if ($user === null) {
+				// nothing we can do without a user
+				return null;
+			}
 			$userId = $this->userSession->getUser()->getUId();
 		}
 		return new Tags($this->mapper, $userId, $type, $defaultTags, $includeShared);

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -62,6 +62,16 @@ class Test_Tags extends \Test\TestCase {
 		parent::tearDown();
 	}
 
+	public function testTagManagerWithoutUserReturnsNull() {
+		$this->userSession = $this->getMock('\OCP\IUserSession');
+		$this->userSession
+			->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue(null));
+		$this->tagMgr = new OC\TagManager($this->tagMapper, $this->userSession);
+		$this->assertNull($this->tagMgr->load($this->objectType));
+	}
+
 	public function testInstantiateWithDefaults() {
 		$defaultTags = array('Friends', 'Family', 'Work', 'Other');
 


### PR DESCRIPTION
The TagManager->load() now returns null if the user is not authenticated
instead of failing with an error.

Backport of https://github.com/owncloud/core/pull/14508 from master

Please review @LukasReschke @rullzer @DeepDiver1975 

Thanks.
