### PR TITLE
Make version check work on the lowest common version denominator

### DIFF
--- a/lib/private/app/dependencyanalyzer.php
+++ b/lib/private/app/dependencyanalyzer.php
@@ -82,6 +82,14 @@ class DependencyAnalyzer {
 		return [implode('.', $first), implode('.', $second)];
 	}
 
+	/**
+	 * Parameters will be normalized and then passed into version_compare
+	 * in the same order they are specified in the method header
+	 * @param string $first
+	 * @param string $second
+	 * @param string $operator
+	 * @return bool result similar to version_compare
+	 */
 	private function compare($first, $second, $operator) {
 		// we cant normalize versions if one of the given parameters is not a
 		// version string but null. In case one parameter is null normalization
@@ -93,10 +101,22 @@ class DependencyAnalyzer {
 		return version_compare($first, $second, $operator);
 	}
 
+	/**
+	 * Checks if a version is bigger than another version
+	 * @param string $first
+	 * @param string $second
+	 * @return bool true if the first version is bigger than the second
+	 */
 	private function compareBigger($first, $second) {
 		return $this->compare($first, $second, '>');
 	}
 
+	/**
+	 * Checks if a version is smaller than another version
+	 * @param string $first
+	 * @param string $second
+	 * @return bool true if the first version is smaller than the second
+	 */
 	private function compareSmaller($first, $second) {
 		return $this->compare($first, $second, '<');
 	}

--- a/tests/lib/app/dependencyanalyzer.php
+++ b/tests/lib/app/dependencyanalyzer.php
@@ -52,7 +52,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			}));
 		$this->platformMock->expects($this->any())
 			->method('getOcVersion')
-			->will( $this->returnValue('8.0.1'));
+			->will( $this->returnValue('8.0.2'));
 
 		$this->l10nMock = $this->getMockBuilder('\OCP\IL10N')
 			->disableOriginalConstructor()
@@ -183,8 +183,12 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 		return array(
 			// no version -> no missing dependency
 			array(array(), null),
+			array(array(), array('@attributes' => array('min-version' => '8', 'max-version' => '8'))),
+			array(array(), array('@attributes' => array('min-version' => '8.0', 'max-version' => '8.0'))),
+			array(array(), array('@attributes' => array('min-version' => '8.0.2', 'max-version' => '8.0.2'))),
+			array(array('ownCloud 8.0.3 or higher is required.'), array('@attributes' => array('min-version' => '8.0.3'))),
 			array(array('ownCloud 9 or higher is required.'), array('@attributes' => array('min-version' => '9'))),
-			array(array('ownCloud with a version lower than 5.1.2 is required.'), array('@attributes' => array('max-version' => '5.1.2'))),
+			array(array('ownCloud with a version lower than 8.0.1 is required.'), array('@attributes' => array('max-version' => '8.0.1'))),
 		);
 	}
 
@@ -208,7 +212,17 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 				array(array('@attributes' => array('min-version' => '100.0'), '@value' => 'curl'))),
 			// curl in version 100.0 does not exist
 			array(array('Library curl with a version lower than 1.0.0 is required - available version 2.3.4.'),
-				array(array('@attributes' => array('max-version' => '1.0.0'), '@value' => 'curl')))
+				array(array('@attributes' => array('max-version' => '1.0.0'), '@value' => 'curl'))),
+			array(array('Library curl with a version lower than 2.3.3 is required - available version 2.3.4.'),
+				array(array('@attributes' => array('max-version' => '2.3.3'), '@value' => 'curl'))),
+			array(array('Library curl with a version higher than 2.3.5 is required - available version 2.3.4.'),
+				array(array('@attributes' => array('min-version' => '2.3.5'), '@value' => 'curl'))),
+			array(array(),
+				array(array('@attributes' => array('min-version' => '2.3.4', 'max-version' => '2.3.4'), '@value' => 'curl'))),
+			array(array(),
+				array(array('@attributes' => array('min-version' => '2.3', 'max-version' => '2.3'), '@value' => 'curl'))),
+			array(array(),
+				array(array('@attributes' => array('min-version' => '2', 'max-version' => '2'), '@value' => 'curl'))),
 		);
 	}
 
@@ -244,6 +258,7 @@ class DependencyAnalyzer extends \PHPUnit_Framework_TestCase {
 			array(array(), '5.4', '5.5'),
 			array(array('PHP 5.4.4 or higher is required.'), '5.4.4', null),
 			array(array('PHP with a version lower than 5.4.2 is required.'), null, '5.4.2'),
+			array(array(), '5.4', '5.4'),
 		);
 	}
 }


### PR DESCRIPTION
See https://github.com/owncloud/core/issues/14392

The idea is to ignore patch releases if they are not specifically required as a dependency, e.g. the following app would require PHP 5 (5.0, 5.1, 5.2.3, etc) but not PHP 6

``` xml
<php min-version="5" max-version="5" />
```

The current implementation would just compare 5.5 with 5 and see that 5.5 is bigger than 5 and fail. This is not really intuitive and helpful.

As for requiring specific path versions, you can specify the version more, e.g. if you want to limit the version to maximum of 5.5 (as in 5.6 is not supported), you can do the following

``` xml
<php max-version="5.5" />
```

You still define the patch level accurately, e.g.: if you rely on versions bigger than 5.3.2 (because a fix is in 5.3.3 that you need) you can do the following

``` xml
<php min-version="5.3.3"/>
```

@DeepDiver1975 @MorrisJobke @jbtbnl @PVince81 
