### PR TITLE
[POC] Store file id in extended attributes where possible

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -100,7 +100,7 @@ class Cache {
 			try {
 				$connection = \OC_DB::getConnection();
 				$connection->insertIfNotExist('*PREFIX*mimetypes', [
-					'mimetype'	=> $mime,
+					'mimetype' => $mime,
 				]);
 				$this->loadMimetypes();
 			} catch (\Doctrine\DBAL\DBALException $e) {
@@ -236,10 +236,11 @@ class Cache {
 	 *
 	 * @param string $file
 	 * @param array $data
-	 *
+	 * @param bool | int $fileId
 	 * @return int file id
+	 * @throws \OC\DatabaseException
 	 */
-	public function put($file, array $data) {
+	public function put($file, array $data, $fileId = false) {
 		if (($id = $this->getId($file)) > -1) {
 			$this->update($id, $data);
 			return $id;
@@ -267,6 +268,10 @@ class Cache {
 			list($queryParts, $params) = $this->buildParts($data);
 			$queryParts[] = '`storage`';
 			$params[] = $this->getNumericStorageId();
+			if ($fileId) {
+				$queryParts[] = 'fileid';
+				$params[] = $fileId;
+			}
 			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
 
 			$sql = 'INSERT INTO `*PREFIX*filecache` (' . implode(', ', $queryParts) . ')'

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -34,6 +34,8 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\Files\Storage\IAttribute;
+
 if (\OC_Util::runningOnWindows()) {
 	class Local extends MappedLocal {
 
@@ -43,7 +45,7 @@ if (\OC_Util::runningOnWindows()) {
 	/**
 	 * for local filestore, we only have to map the paths
 	 */
-	class Local extends \OC\Files\Storage\Common {
+	class Local extends \OC\Files\Storage\Common implements IAttribute {
 		protected $datadir;
 
 		public function __construct($arguments) {
@@ -337,6 +339,34 @@ if (\OC_Util::runningOnWindows()) {
 				);
 			} else {
 				return parent::getETag($path);
+			}
+		}
+
+		/**
+		 * Set an attribute on a file
+		 *
+		 * @param string $path
+		 * @param string $name
+		 * @param string $value
+		 */
+		public function setAttribute($path, $name, $value) {
+			if (function_exists('xattr_set')) {
+				xattr_set($this->getSourcePath($path), $name, $value);
+			}
+		}
+
+		/**
+		 * Get an attribute from a file
+		 *
+		 * @param string $path
+		 * @param string $name
+		 * @return string | bool
+		 */
+		public function getAttribute($path, $name) {
+			if (function_exists('xattr_get')) {
+				return xattr_get($this->getSourcePath($path), $name);
+			} else {
+				return false;
 			}
 		}
 	}

--- a/lib/public/files/storage/iattribute.php
+++ b/lib/public/files/storage/iattribute.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Files\Storage;
+
+interface IAttribute {
+	/**
+	 * Set an attribute on a file
+	 *
+	 * @param string $path
+	 * @param string $name
+	 * @param string $value
+	 */
+	public function setAttribute($path, $name, $value);
+
+	/**
+	 * Get an attribute from a file
+	 *
+	 * @param string $path
+	 * @param string $name
+	 * @return string | bool
+	 */
+	public function getAttribute($path, $name);
+}


### PR DESCRIPTION
Requires http://pecl.php.net/package/xattr to be installed and the filesystem to support user extended attributes (default on btrfs, mount option for ext(3|4) iirc)

To test:
- upload a new file to a folder
- share the file
- delete the cache entry for the file
- check that the file is no longer shown in the web interface
- run the filescanner
- check that the file is back in the web interface and still shared

cc @PVince81 @DeepDiver1975 
