### PR TITLE
Disable the cache updater when doing the encryption migration

### DIFF
--- a/apps/files_encryption/lib/migration.php
+++ b/apps/files_encryption/lib/migration.php
@@ -221,7 +221,7 @@ class Migration {
 						$extension = $this->getExtension($file, $trash);
 						$targetDir = $this->getTargetDir($user, $filePath, $filename, $extension, $trash);
 						$this->createPathForKeys($targetDir);
-						$this->view->copy($path . '/' . $file, $targetDir . '/fileKey');
+						$this->view->rename($path . '/' . $file, $targetDir . '/fileKey');
 						$this->renameShareKeys($user, $filePath, $filename, $targetDir, $trash);
 					}
 				}
@@ -267,7 +267,7 @@ class Migration {
 						if (substr($file, 0, strlen($filename) + 1) === $filename . '.') {
 
 							$uid = $this->getUidFromShareKey($file, $filename, $trash);
-							$this->view->copy($oldShareKeyPath . '/' . $file, $target . '/' . $uid . '.shareKey');
+							$this->view->rename($oldShareKeyPath . '/' . $file, $target . '/' . $uid . '.shareKey');
 						}
 					}
 

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -13,6 +13,11 @@ namespace OC\Files\Cache;
  */
 class Updater {
 	/**
+	 * @var bool
+	 */
+	protected $enabled = true;
+
+	/**
 	 * @var \OC\Files\View
 	 */
 	protected $view;
@@ -30,6 +35,14 @@ class Updater {
 		$this->propagator = new ChangePropagator($view);
 	}
 
+	public function disable() {
+		$this->enabled = false;
+	}
+
+	public function enable() {
+		$this->enabled = true;
+	}
+
 	public function propagate($path, $time = null) {
 		if (Scanner::isPartialFile($path)) {
 			return;
@@ -45,7 +58,7 @@ class Updater {
 	 * @param int $time
 	 */
 	public function update($path, $time = null) {
-		if (Scanner::isPartialFile($path)) {
+		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
 		/**
@@ -70,7 +83,7 @@ class Updater {
 	 * @param string $path
 	 */
 	public function remove($path) {
-		if (Scanner::isPartialFile($path)) {
+		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
 		/**
@@ -97,7 +110,7 @@ class Updater {
 	 * @param string $target
 	 */
 	public function rename($source, $target) {
-		if (Scanner::isPartialFile($source) or Scanner::isPartialFile($target)) {
+		if (!$this->enabled or Scanner::isPartialFile($source) or Scanner::isPartialFile($target)) {
 			return;
 		}
 		/**

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1528,4 +1528,11 @@ class View {
 			$mount
 		);
 	}
+
+	/**
+	 * @return Updater
+	 */
+	public function getUpdater(){
+		return $this->updater;
+	}
 }

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -146,4 +146,34 @@ class Updater extends \Test\TestCase {
 		$this->assertEquals($cached['size'], $cachedTarget['size']);
 		$this->assertEquals($cached['fileid'], $cachedTarget['fileid']);
 	}
+
+	public function testNewFileDisabled() {
+		$this->storage->file_put_contents('foo.txt', 'bar');
+		$this->assertFalse($this->cache->inCache('foo.txt'));
+
+		$this->updater->disable();
+		$this->updater->update('/foo.txt');
+
+		$this->assertFalse($this->cache->inCache('foo.txt'));
+	}
+
+	public function testMoveDisabled() {
+		$this->storage->file_put_contents('foo.txt', 'qwerty');
+		$this->updater->update('foo.txt');
+
+		$this->assertTrue($this->cache->inCache('foo.txt'));
+		$this->assertFalse($this->cache->inCache('bar.txt'));
+		$cached = $this->cache->get('foo.txt');
+
+		$this->storage->rename('foo.txt', 'bar.txt');
+
+		$this->assertTrue($this->cache->inCache('foo.txt'));
+		$this->assertFalse($this->cache->inCache('bar.txt'));
+
+		$this->updater->disable();
+		$this->updater->rename('foo.txt', 'bar.txt');
+
+		$this->assertTrue($this->cache->inCache('foo.txt'));
+		$this->assertFalse($this->cache->inCache('bar.txt'));
+	}
 }


### PR DESCRIPTION
For #14012

Brings the time to do the migration in the unit tests down to <2s from ~11s on my local machine

cc @PVince81 @DeepDiver1975 @schiesbn 
