### PR TITLE
Add detection for invalid CLI configuration for settings page

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -575,15 +575,30 @@ class OC {
 		$errors = OC_Util::checkServer(\OC::$server->getConfig());
 		if (count($errors) > 0) {
 			if (self::$CLI) {
+				// Convert l10n string into regular string for usage in database
+				$staticErrors = [];
+				$i = 0;
 				foreach ($errors as $error) {
 					echo $error['error'] . "\n";
 					echo $error['hint'] . "\n\n";
+					$staticErrors[$i]['error'] = (string) $error['error'];
+					$staticErrors[$i]['hint'] = (string) $error['hint'];
+					$i++;
 				}
+
+				try {
+					\OC::$server->getConfig()->setAppValue('core', 'cronErrors', json_encode($staticErrors));
+				} catch(\Exception $e) {
+					echo('Writing to database failed');
+				}
+				exit();
 			} else {
 				OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 				OC_Template::printGuestPage('', 'error', array('errors' => $errors));
+				exit;
 			}
-			exit;
+		} elseif(self::$CLI && \OC::$server->getConfig()->getSystemValue('installed', false)) {
+				\OC::$server->getConfig()->deleteAppValue('core', 'cronErrors');
 		}
 
 		//try to set the session lifetime

--- a/lib/base.php
+++ b/lib/base.php
@@ -577,13 +577,13 @@ class OC {
 			if (self::$CLI) {
 				// Convert l10n string into regular string for usage in database
 				$staticErrors = [];
-				$i = 0;
 				foreach ($errors as $error) {
 					echo $error['error'] . "\n";
 					echo $error['hint'] . "\n\n";
-					$staticErrors[$i]['error'] = (string) $error['error'];
-					$staticErrors[$i]['hint'] = (string) $error['hint'];
-					$i++;
+					$staticErrors[] = [
+						'error' => (string) $error['error'],
+						'hint' => (string) $error['hint'],
+					];
 				}
 
 				try {

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -80,6 +80,7 @@ $template->assign('allowMailNotification', $appConfig->getValue('core', 'shareap
 $template->assign('onlyShareWithGroupMembers', \OC\Share\Share::shareWithGroupMembersOnly());
 $databaseOverload = (strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !== false);
 $template->assign('databaseOverload', $databaseOverload);
+$template->assign('cronErrors', $appConfig->getValue('core', 'cronErrors'));
 
 // warn if Windows is used
 $template->assign('WindowsWarning', OC_Util::runningOnWindows());

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -212,7 +212,29 @@ if ($_['suggestedOverwriteCliUrl']) {
 	</div>
 <?php
 }
+
+if ($_['cronErrors']) {
+	?>
+	<div class="section">
+		<h2><?php p($l->t('Cronjob encountered misconfiguration'));?></h2>
+
+		<span class="connectionwarning">
+			<?php p($l->t('It was not possible to execute the cronjob via CLI. The following technical errors have appeared:')); ?>
+			<br/>
+			<ol>
+				<?php foreach(json_decode($_['cronErrors']) as $error) { if(isset($error->error)) {?>
+					<li><?php p($error->error) ?></li>
+					<ul><li><?php p($error->hint) ?></li></ul>
+
+				<?php }};?>
+			</ol>
+		</span>
+
+	</div>
+<?php
+}
 ?>
+
 <div id="postsetupchecks" class="section">
 	<h2><?php p($l->t('Configuration Checks'));?></h2>
 	<div class="loading"></div>


### PR DESCRIPTION
This change will log all failures that prevent the CLI cronjob from happening to the database and display a warning to administrators when an error happened. – Ugly base.php hack :see_no_evil: 

To test:
1. Configure some invalid CLI php.ini settings
2. Enable the CLI cronjob and run php cron.php
3. See the errors printed and also in the admin page
4. Configure the CLI settings correctly
5. Errors should be gone.

Fixes https://github.com/owncloud/core/issues/13994

@karlitschek @DeepDiver1975 @RealRancor
