### PR TITLE
Don't swallow errors in console.php

### DIFF
--- a/console.php
+++ b/console.php
@@ -58,4 +58,5 @@ try {
 } catch (Exception $ex) {
 	echo "An unhandled exception has been thrown:" . PHP_EOL;
 	echo $ex;
+	exit(1);
 }


### PR DESCRIPTION
In the current implementation, console.php swallows unhandled exceptions instead of propagating an error to the calling shell.
This makes error handling in scripts difficult.

I agree to license this commit under the MIT license as well as AGPL as required.
