### PR TITLE
Install command should not require table prefix

### DIFF
--- a/core/command/maintenance/install.php
+++ b/core/command/maintenance/install.php
@@ -30,7 +30,7 @@ class Install extends Command {
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
 			->addOption('database-pass', null, InputOption::VALUE_REQUIRED, 'Password of the database user')
-			->addOption('database-table-prefix', null, InputOption::VALUE_REQUIRED, 'Prefix for all tables', 'oc_')
+			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
 			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to data directory', \OC::$SERVERROOT."/data");
@@ -80,7 +80,11 @@ class Install extends Command {
 		$dbPass = $input->getOption('database-pass');
 		$dbName = $input->getOption('database-name');
 		$dbHost = $input->getOption('database-host');
-		$dbTablePrefix = $input->getOption('database-table-prefix');
+		$dbTablePrefix = 'oc_';
+		if ($input->hasParameterOption('--database-table-prefix')) {
+			$dbTablePrefix = (string) $input->getOption('database-table-prefix');
+			$dbTablePrefix = trim($dbTablePrefix);
+		}
 		$adminLogin = $input->getOption('admin-user');
 		$adminPassword = $input->getOption('admin-pass');
 		$dataDir = $input->getOption('data-dir');


### PR DESCRIPTION
The maintenance:install occ command currently requires the table prefix to be provided.
This requirement is not mandated by the software. 
As a matter of fact, I would argue that most people installing Owncloud from the CLI do not care about table prefixing anyways as it is a setting that is geared towards shared databases.
That use case I imagine is very uncommon for installations where an admin has command line access to the server.

I agree to license this contribution under the MIT license.
