### PR TITLE
Show time difference of last cron run instead of absolute time

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -39,6 +39,8 @@ $(document).ready(function(){
 		} );
 	});
 
+	$('#backgroundjobs span.crondate').tipsy({fade: true, gravity: 's', live: true});
+
 	$('#backgroundjobs input').change(function(){
 		if($(this).attr('checked')){
 			var mode = $(this).val();

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -237,13 +237,18 @@ if ($_['suggestedOverwriteCliUrl']) {
 	<p class="cronlog inlineblock">
 		<?php if ($_['lastcron'] !== false):
 			$human_time = relative_modified_date($_['lastcron']);
+			$absolute_time = OC_Util::formatDate($_['lastcron']);
 			if (time() - $_['lastcron'] <= 3600): ?>
 				<span class="cronstatus success"></span>
-				<?php p($l->t("Last cron was executed %s.", array($human_time)));
-			else: ?>
+				<span class="crondate" original-title="<?php p($absolute_time);?>">
+					<?php p($l->t("Last cron was executed %s.", array($human_time)));?>
+				</span>
+			<?php else: ?>
 				<span class="cronstatus error"></span>
-				<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($human_time)));
-			endif;
+				<span class="crondate" original-title="<?php p($absolute_time);?>">
+					<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($human_time)));?>
+				</span>
+			<?php endif;
 		else: ?>
 			<span class="cronstatus error"></span>
 			<?php p($l->t("Cron was not executed yet!"));

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -236,13 +236,13 @@ if ($_['suggestedOverwriteCliUrl']) {
 	<?php if ($_['cron_log']): ?>
 	<p class="cronlog inlineblock">
 		<?php if ($_['lastcron'] !== false):
-			$human_time = OC_Util::formatDate($_['lastcron']);
+			$human_time = relative_modified_date($_['lastcron']);
 			if (time() - $_['lastcron'] <= 3600): ?>
 				<span class="cronstatus success"></span>
-				<?php p($l->t("Last cron was executed at %s.", array($human_time)));
+				<?php p($l->t("Last cron was executed %s.", array($human_time)));
 			else: ?>
 				<span class="cronstatus error"></span>
-				<?php p($l->t("Last cron was executed at %s. This is more than an hour ago, something seems wrong.", array($human_time)));
+				<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($human_time)));
 			endif;
 		else: ?>
 			<span class="cronstatus error"></span>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -236,17 +236,17 @@ if ($_['suggestedOverwriteCliUrl']) {
 	<?php if ($_['cron_log']): ?>
 	<p class="cronlog inlineblock">
 		<?php if ($_['lastcron'] !== false):
-			$human_time = relative_modified_date($_['lastcron']);
+			$relative_time = relative_modified_date($_['lastcron']);
 			$absolute_time = OC_Util::formatDate($_['lastcron']);
 			if (time() - $_['lastcron'] <= 3600): ?>
 				<span class="cronstatus success"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron was executed %s.", array($human_time)));?>
+					<?php p($l->t("Last cron was executed %s.", array($relative_time)));?>
 				</span>
 			<?php else: ?>
 				<span class="cronstatus error"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($human_time)));?>
+					<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($relative_time)));?>
 				</span>
 			<?php endif;
 		else: ?>

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -241,12 +241,12 @@ if ($_['suggestedOverwriteCliUrl']) {
 			if (time() - $_['lastcron'] <= 3600): ?>
 				<span class="cronstatus success"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron was executed %s.", array($relative_time)));?>
+					<?php p($l->t("Last cron job execution: %s.", array($relative_time)));?>
 				</span>
 			<?php else: ?>
 				<span class="cronstatus error"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron was executed %s. Something seems wrong.", array($relative_time)));?>
+					<?php p($l->t("Last cron job execution: %s. Something seems wrong.", array($relative_time)));?>
 				</span>
 			<?php endif;
 		else: ?>


### PR DESCRIPTION
When checking the state of the background jobs the page now shows you "Last cron was executed 3 minutes ago" instead of "Last cron was executed at $somedate". For those interested in the exact time a hover tip has been implemented.
