### PR TITLE
Allow configuring background job mode from the console

### DIFF
--- a/core/command/background/ajax.php
+++ b/core/command/background/ajax.php
@@ -1,0 +1,33 @@
+<?php
+/**
+* The MIT License (MIT)
+*
+* Copyright (c) 2015 Christian Kampka <christian@kampka.net>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace OC\Core\Command\Background;
+
+class Ajax extends Base {
+
+	protected function getMode() {
+		return 'ajax';
+	}
+}

--- a/core/command/background/base.php
+++ b/core/command/background/base.php
@@ -1,0 +1,77 @@
+<?php
+/**
+* The MIT License (MIT)
+*
+* Copyright (c) 2015 Christian Kampka <christian@kampka.net>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace OC\Core\Command\Background;
+
+use \OCP\IConfig;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+* An abstract base class for configuring the background job mode
+* from the command line interface.
+* Subclasses will override the getMode() function to specify the mode to configure.
+*/
+abstract class Base extends Command {
+
+
+	abstract protected function getMode();
+
+	/**
+	* @var \OCP\IConfig
+	*/
+	protected $config;
+
+	/**
+	* @param \OCP\IConfig $config
+	*/
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$mode = $this->getMode();
+		$this
+			->setName("background:$mode")
+			->setDescription("Use $mode to run background jobs");
+	}
+
+	/**
+	* Executing this command will set the background job mode for owncloud.
+	* The mode to set is specified by the concrete sub class by implementing the
+	* getMode() function.
+	*
+	* @param InputInterface $input
+	* @param OutputInterface $output
+	*/
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$mode = $this->getMode();
+		$this->config->setAppValue( 'core', 'backgroundjobs_mode', $mode );
+		$output->writeln("Set mode for background jobs to '$mode'");
+	}
+}

--- a/core/command/background/cron.php
+++ b/core/command/background/cron.php
@@ -1,0 +1,33 @@
+<?php
+/**
+* The MIT License (MIT)
+*
+* Copyright (c) 2015 Christian Kampka <christian@kampka.net>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace OC\Core\Command\Background;
+
+class Cron extends Base {
+
+	protected function getMode() {
+		return 'cron';
+	}
+}

--- a/core/command/background/webcron.php
+++ b/core/command/background/webcron.php
@@ -1,0 +1,33 @@
+<?php
+/**
+* The MIT License (MIT)
+*
+* Copyright (c) 2015 Christian Kampka <christian@kampka.net>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace OC\Core\Command\Background;
+
+class WebCron extends Base {
+
+	protected function getMode() {
+		return 'webcron';
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -27,6 +27,9 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen());
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\L10n\CreateJs());
+	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
 } else {
 	$application->add(new OC\Core\Command\Maintenance\Install(\OC::$server->getConfig()));
 }

--- a/tests/lib/command/background.php
+++ b/tests/lib/command/background.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* The MIT License (MIT)
+*
+* Copyright (c) 2015 Christian Kampka <christian@kampka.net>
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace Test\Command;
+
+use Test\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+use OC\Core\Command\Background\Cron;
+use OC\Core\Command\Background\WebCron;
+use OC\Core\Command\Background\Ajax;
+
+class BackgroundJobs extends TestCase {
+
+	public function testCronCommand() {
+		$config = \OC::$server->getConfig();
+		$job = new Cron($config);
+		$job->run(new StringInput(''), new NullOutput());
+		$this->assertEquals('cron', $config->getAppValue('core', 'backgroundjobs_mode'));
+	}
+
+	public function testAjaxCommand() {
+		$config = \OC::$server->getConfig();
+		$job = new Ajax($config);
+		$job->run(new StringInput(''), new NullOutput());
+		$this->assertEquals('ajax', $config->getAppValue('core', 'backgroundjobs_mode'));
+	}
+
+	public function testWebCronCommand() {
+		$config = \OC::$server->getConfig();
+		$job = new WebCron($config);
+		$job->run(new StringInput(''), new NullOutput());
+		$this->assertEquals('webcron', $config->getAppValue('core', 'backgroundjobs_mode'));
+	}
+}


### PR DESCRIPTION
When installing owncloud from the console, it is inconvenient to configure the background mode from the WebUI.
Setting it using SQL by writing it into the appconfig table is possible but screams broken upgrade path.
This commit adds the possibility to configure the background mode through the occ command line tool.

I agree to license this commit under the MIT license.
