### PR TITLE
[WIP] Check checksum of all files of a app when installing it

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1149,6 +1149,29 @@ class OC_App {
 				);
 			}
 
+			$appPath =self::getAppPath($app);
+			if(is_file( $appPath. '/appinfo/checksum.json')) {
+				$checksums = file_get_contents($appPath.'/appinfo/checksum.json');
+				$checksums = json_decode($checksums);
+				foreach ($checksums as $file=>$checksum) {
+					$filePath = $appPath . '/' . $file;
+					if (file_exists($filePath)){
+						if(md5_file($filePath) !== $checksum){
+							throw new \Exception(
+								$l->t('App \"%s\" cannot be installed because the checksum of following file is no correct: %s',
+									array($info['name'], $file)
+								)
+							);
+						}
+					} else {
+						throw new \Exception(
+							$l->t('App \"%s\" cannot be installed because the following file is not found on the filesystem: %s',
+								array($info['name'], $file)
+							)
+						);
+					}
+				}
+			}
 			$config->setAppValue($app, 'enabled', 'yes');
 			if (isset($appData['id'])) {
 				$config->setAppValue($app, 'ocsid', $appData['id']);


### PR DESCRIPTION
Refs  #14616
This currently works when:
- enabling an app via the web interface
- enabling an app via the CLI
- when the app is available on the filesystem
- or when the app is downloaded via the AppStore ~~(not sure if so. I'll upload an app to the appstore which should fail when installing)~~ I checked this. The checksums are checked.
- and when it has never been installed before (so the SQL tables aren't in the DB and in the oc_appconfig table)

cc @Raydiation @LukasReschke

(please also review the error messages)
TODO:
- [ ] documentation for developers
- [ ] documentation for end-users and administrators
- [ ] improve errors
- [ ] log when there is no checksum.json file
- [x] also call the checksum stuff in the updateApp method
- [ ] replace copyr with rename
- [ ] add unit tests
