### PR TITLE
Add login name to users

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -301,6 +301,15 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	}
 
 	/**
+	 * Get login name of the user
+	 * @param string $uid user ID of the user
+	 * @return string The user's login name
+	 */
+	public function getLoginName($uid) {
+		return $uid;
+	}
+
+	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string|false display name

--- a/apps/user_ldap/user_proxy.php
+++ b/apps/user_ldap/user_proxy.php
@@ -188,6 +188,15 @@ class User_Proxy extends lib\Proxy implements \OCP\IUserBackend, \OCP\UserInterf
 	}
 
 	/**
+	 * Get login name of the user
+	 * @param string $uid user ID of the user
+	 * @return string The user's login name
+	 */
+	public function getLoginName($uid) {
+		return $this->handleRequest($uid, 'getLoginName', array($uid));
+	}
+
+	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1019,6 +1019,13 @@
 			</field>
 
 			<field>
+				<name>loginname</name>
+				<type>text</type>
+				<default></default>
+				<length>64</length>
+			</field>
+
+			<field>
 				<name>displayname</name>
 				<type>text</type>
 				<default></default>
@@ -1038,6 +1045,15 @@
 				<primary>true</primary>
 				<field>
 					<name>uid</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>users_loginname</name>
+				<unique>true</unique>
+				<field>
+					<name>loginname</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -15,6 +15,7 @@ use OC\Repair\CleanTags;
 use OC\Repair\Collation;
 use OC\Repair\DropOldTables;
 use OC\Repair\FillETags;
+use OC\Repair\FixLoginName;
 use OC\Repair\InnoDB;
 use OC\Repair\RepairConfig;
 use OC\Repair\RepairLegacyStorages;
@@ -86,6 +87,7 @@ class Repair extends BasicEmitter {
 			new FillETags(\OC_DB::getConnection()),
 			new CleanTags(\OC_DB::getConnection()),
 			new DropOldTables(\OC_DB::getConnection()),
+			new FixLoginName(\OC_DB::getConnection()),
 		);
 	}
 

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -530,7 +530,7 @@ class OC_User {
 	 * returns the user id or false
 	 */
 	public static function checkPassword($loginname, $password) {
-		$manager = \OC::$server->getUserManager();
+		$manager = self::getManager();
 		$username = $manager->checkPassword($loginname, $password);
 		if ($username !== false) {
 			return $username->getUID();

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -522,16 +522,16 @@ class OC_User {
 	/**
 	 * Check if the password is correct
 	 *
-	 * @param string $uid The username
+	 * @param string $loginname The login name of the user
 	 * @param string $password The password
 	 * @return string|false user id a string on success, false otherwise
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
 	 */
-	public static function checkPassword($uid, $password) {
-		$manager = self::getManager();
-		$username = $manager->checkPassword($uid, $password);
+	public static function checkPassword($loginname, $password) {
+		$manager = \OC::$server->getUserManager();
+		$username = $manager->checkPassword($loginname, $password);
 		if ($username !== false) {
 			return $username->getUID();
 		}

--- a/lib/private/user/backend.php
+++ b/lib/private/user/backend.php
@@ -154,6 +154,15 @@ abstract class OC_User_Backend implements OC_User_Interface {
 	}
 
 	/**
+	 * Get login name of the user
+	 * @param string $uid user ID of the user
+	 * @return string The user's login name
+	 */
+	public function getLoginName($uid) {
+		return $uid;
+	}
+
+	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name

--- a/lib/private/user/database.php
+++ b/lib/private/user/database.php
@@ -50,8 +50,8 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 	 */
 	public function createUser($uid, $password) {
 		if (!$this->userExists($uid)) {
-			$query = OC_DB::prepare('INSERT INTO `*PREFIX*users` ( `uid`, `password` ) VALUES( ?, ? )');
-			$result = $query->execute(array($uid, \OC::$server->getHasher()->hash($password)));
+			$query = OC_DB::prepare('INSERT INTO `*PREFIX*users` ( `uid`, `loginname`, `password` ) VALUES( ?, ?, ? )');
+			$result = $query->execute(array($uid, $uid, \OC::$server->getHasher()->hash($password)));
 
 			return $result ? true : false;
 		}
@@ -118,6 +118,16 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 	}
 
 	/**
+	 * Get login name of the user
+	 * @param string $uid user ID of the user
+	 * @return string The user's login name
+	 */
+	public function getLoginName($uid) {
+		$this->loadUser($uid);
+		return $this->cache[$uid]['loginname'];
+	}
+
+	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name
@@ -148,28 +158,28 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 
 	/**
 	 * Check if the password is correct
-	 * @param string $uid The username
+	 * @param string $loginname The user's login name
 	 * @param string $password The password
 	 * @return string
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
 	 */
-	public function checkPassword($uid, $password) {
-		$query = OC_DB::prepare('SELECT `uid`, `password` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
-		$result = $query->execute(array($uid));
+	public function checkPassword($loginname, $password) {
+		$query = OC_DB::prepare('SELECT `uid`, `password` FROM `*PREFIX*users` WHERE LOWER(`loginname`) = LOWER(?)');
+		$result = $query->execute(array($loginname));
 
 		$row = $result->fetchRow();
 		if ($row) {
+			$uid = $row['uid'];
 			$storedHash = $row['password'];
 			$newHash = '';
-			if(\OC::$server->getHasher()->verify($password, $storedHash, $newHash)) {
-				if(!empty($newHash)) {
+			if (\OC::$server->getHasher()->verify($password, $storedHash, $newHash)) {
+				if (!empty($newHash)) {
 					$this->setPassword($uid, $password);
 				}
 				return $row['uid'];
 			}
-
 		}
 
 		return false;
@@ -182,7 +192,7 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 	 */
 	private function loadUser($uid) {
 		if (empty($this->cache[$uid])) {
-			$query = OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
+			$query = OC_DB::prepare('SELECT `uid`, `loginname`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
 			$result = $query->execute(array($uid));
 
 			if (OC_DB::isError($result)) {
@@ -192,6 +202,7 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 
 			while ($row = $result->fetchRow()) {
 				$this->cache[$uid]['uid'] = $row['uid'];
+				$this->cache[$uid]['loginname'] = $row['loginname'];
 				$this->cache[$uid]['displayname'] = $row['displayname'];
 			}
 		}

--- a/lib/private/user/interface.php
+++ b/lib/private/user/interface.php
@@ -56,13 +56,6 @@ interface OC_User_Interface {
 	public function userExists($uid);
 
 	/**
-	 * Get login name of the user
-	 * @param string $uid user ID of the user
-	 * @return string The user's login name
-	 */
-	public function getLoginName($uid);
-
-	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name

--- a/lib/private/user/interface.php
+++ b/lib/private/user/interface.php
@@ -56,6 +56,13 @@ interface OC_User_Interface {
 	public function userExists($uid);
 
 	/**
+	 * Get login name of the user
+	 * @param string $uid user ID of the user
+	 * @return string The user's login name
+	 */
+	public function getLoginName($uid);
+
+	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
 	 * @return string display name

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -28,7 +28,7 @@ use OCP\IConfig;
  */
 class Manager extends PublicEmitter implements IUserManager {
 	/**
-	 * @var \OCP\UserInterface [] $backends
+	 * @var \OCP\UserInterface[] $backends
 	 */
 	private $backends = array();
 

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -186,19 +186,19 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * try to login with the provided credentials
 	 *
-	 * @param string $uid
+	 * @param string $loginname
 	 * @param string $password
 	 * @return boolean|null
 	 * @throws LoginException
 	 */
-	public function login($uid, $password) {
-		$this->manager->emit('\OC\User', 'preLogin', array($uid, $password));
-		$user = $this->manager->checkPassword($uid, $password);
+	public function login($loginname, $password) {
+		$this->manager->emit('\OC\User', 'preLogin', array($loginname, $password));
+		$user = $this->manager->checkPassword($loginname, $password);
 		if ($user !== false) {
 			if (!is_null($user)) {
 				if ($user->isEnabled()) {
 					$this->setUser($user);
-					$this->setLoginName($uid);
+					$this->setLoginName($loginname);
 					$this->manager->emit('\OC\User', 'postLogin', array($user, $password));
 					if ($this->isLoggedIn()) {
 						return true;

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -85,6 +85,13 @@ class User implements IUser {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getLoginName() {
+		return $this->backend->getLoginName($this->uid);
+	}
+
+	/**
 	 * get the displayname for the user, if no specific displayname is set it will fallback to the user id
 	 *
 	 * @return string

--- a/lib/public/iuser.php
+++ b/lib/public/iuser.php
@@ -18,6 +18,13 @@ interface IUser {
 	public function getUID();
 
 	/**
+	 * Get the login name, which is used as part of the user's credentials
+	 *
+	 * @return string
+	 */
+	public function getLoginName();
+
+	/**
 	 * get the display name for the user, if no specific display name is set it will fallback to the user id
 	 *
 	 * @return string

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -68,7 +68,7 @@ interface IUserManager {
 	/**
 	 * Check if the password is valid for the user
 	 *
-	 * @param string $loginname
+	 * @param string $loginname The user's login name (not necessarily its UID)
 	 * @param string $password
 	 * @return mixed the User object on success, false otherwise
 	 */

--- a/lib/repair/fixloginname.php
+++ b/lib/repair/fixloginname.php
@@ -28,7 +28,7 @@ class FixLoginName extends BasicEmitter implements RepairStep {
 	public function run() {
 		$qb = $this->connection->createQueryBuilder();
 		$qb->update('`*PREFIX*users`')
-			->set('`loginname`', '`UID`')
+			->set('`loginname`', '`uid`')
 			->where($qb->expr()->isNull('`loginname`'));
 		$affectedRows = $qb->execute();
 

--- a/lib/repair/fixloginname.php
+++ b/lib/repair/fixloginname.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Repair;
+
+use OC\DB\Connection;
+use OC\Hooks\BasicEmitter;
+use OC\RepairStep;
+
+class FixLoginName extends BasicEmitter implements RepairStep {
+	/**
+	 * @var \OC\DB\Connection
+	 */
+	private $connection;
+
+	public function __construct(Connection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function getName() {
+		return 'Login name - populate values';
+	}
+
+	public function run() {
+		$qb = $this->connection->createQueryBuilder();
+		$qb->update('`*PREFIX*users`')
+			->set('`loginname`', '`UID`')
+			->where($qb->expr()->isNull('`loginname`'));
+		$affectedRows = $qb->execute();
+
+		$this->emit('OC\Repair', 'info', sprintf('Login name - %d users updated', $affectedRows));
+	}
+}

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -8,16 +8,16 @@ class Controller {
 		\OC_JSON::callCheck();
 		\OC_JSON::checkLoggedIn();
 
-		$username = \OC_User::getUser();
+		$user = \OC::$server->getUserSession()->getUser();
 		$password = isset($_POST['personal-password']) ? $_POST['personal-password'] : null;
 		$oldPassword = isset($_POST['oldpassword']) ? $_POST['oldpassword'] : '';
 
-		if (!\OC_User::checkPassword($username, $oldPassword)) {
+		if (!\OC_User::checkPassword($user->getLoginName(), $oldPassword)) {
 			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+		if (!is_null($password) && \OC_User::setPassword($user->getUID(), $password)) {
 			\OC_JSON::success();
 		} else {
 			\OC_JSON::error();

--- a/tests/lib/contacts/localadressbook.php
+++ b/tests/lib/contacts/localadressbook.php
@@ -49,11 +49,16 @@ class SimpleUserForTesting implements \OCP\IUser {
 	public function __construct($uid, $displayName) {
 
 		$this->uid = $uid;
+		$this->loginName = $uid;
 		$this->displayName = $displayName;
 	}
 
 	public function getUID() {
 		return $this->uid;
+	}
+
+	public function getLoginName() {
+		return $this->loginName;
 	}
 
 	public function getDisplayName() {


### PR DESCRIPTION
This adds a column to the users table which initially contains the UID. The value contained in this column determines the 'username' part of the credentials used for OC. By changing this value, you effectively change the username with which a user can login. This only works for the database backend.

Notes:
- Login name renaming is not supported in either the backends or UI yet, but this is easily added by adding a new backend capability
- The OC upgrade system does not allow for new unique NOT NULL columns to be added to a table. To cope with this, a nullable column is added and populated afterwards by a new repair step. This repair step is not executed on install, but as a new install does not yet have any users, there are no rows that need to be populated.
- If an app always calls ::checkPassword() with the UID of the user instead of his username, this becomes a backward incompatible change. However, the parameter is called $loginname instead of $uid, so you could say the app was already breaking the API contract.
