### PR TITLE
fix link for Preview documentation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -671,8 +671,8 @@ $CONFIG = array(
  *  - OC\Preview\TIFF
  * 
  * .. note:: Troubleshooting steps for the MS Word previews are available
- *    at the :doc:`collaborative_documents_configuration` section
- *    of the Administrators Manual.
+ *    at the :doc:`../configuration_files/collaborative_documents_configuration`
+ *    section of the Administrators Manual.
  *
  * The following providers are not available in Microsoft Windows:
  *


### PR DESCRIPTION
cc @carlaschroder @LukasReschke @nickvergessen 

No brainer. It just fixes a link for the documentation.
