### PR TITLE
Expire files from the trash in the background

### DIFF
--- a/apps/files_trashbin/command/expire.php
+++ b/apps/files_trashbin/command/expire.php
@@ -49,6 +49,7 @@ class Expire implements ICommand {
 	}
 
 	public function handle() {
+		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($this->user);
 		Trashbin::expire($this->trashBinSize, $this->user);
 	}

--- a/apps/files_trashbin/command/expire.php
+++ b/apps/files_trashbin/command/expire.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ownCloud - trash bin
+ *
+ * @author Robin Appelman
+ * @copyright 2015 Robin Appelman icewind@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Trashbin\Command;
+
+use OC\Command\FileAccess;
+use OCA\Files_Trashbin\Trashbin;
+use OCP\Command\ICommand;
+
+class Expire implements ICommand {
+	use FileAccess;
+
+	/**
+	 * @var string
+	 */
+	private $user;
+
+	/**
+	 * @var int
+	 */
+	private $trashBinSize;
+
+	/**
+	 * @param string $user
+	 * @param int $trashBinSize
+	 */
+	function __construct($user, $trashBinSize) {
+		$this->user = $user;
+		$this->trashBinSize = $trashBinSize;
+	}
+
+	public function handle() {
+		\OC_Util::setupFS($this->user);
+		Trashbin::expire($this->trashBinSize, $this->user);
+	}
+}

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -210,6 +210,8 @@ class Test_Trashbin extends \Test\TestCase {
 
 		\OC\Files\Filesystem::unlink($folder . 'user1-4.txt');
 
+		$this->runCommands();
+
 		$filesInTrashUser2AfterDelete = OCA\Files_Trashbin\Helper::getTrashFiles('/', self::TEST_TRASHBIN_USER2);
 
 		// user2-1.txt should have been expired

--- a/lib/private/command/queuebus.php
+++ b/lib/private/command/queuebus.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Command;
+
+use OCP\Command\IBus;
+use OCP\Command\ICommand;
+
+class QueueBus implements IBus {
+	/**
+	 * @var (ICommand|callable)[]
+	 */
+	private $queue;
+
+	/**
+	 * Schedule a command to be fired
+	 *
+	 * @param \OCP\Command\ICommand | callable $command
+	 */
+	public function push($command) {
+		$this->queue[] = $command;
+	}
+
+	/**
+	 * Require all commands using a trait to be run synchronous
+	 *
+	 * @param string $trait
+	 */
+	public function requireSync($trait) {
+	}
+
+	/**
+	 * @param \OCP\Command\ICommand | callable $command
+	 */
+	private function runCommand($command) {
+		if ($command instanceof ICommand) {
+			$command->handle();
+		} else {
+			$command();
+		}
+	}
+
+	public function run() {
+		while ($command = array_shift($this->queue)) {
+			$this->runCommand($command);
+		}
+	}
+}


### PR DESCRIPTION
Move expiring the trash to the async command bus and add some generic logic to allow unit tests to work with the command bus.

Note that this is only a minimal set of changes to make it async, the trash app could use some further cleanup.

cc @DeepDiver1975 @PVince81 @schiesbn 
