### PR TITLE
Make getLanguageCode() return the current language when it's being forced

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -358,23 +358,14 @@ class OC_L10N implements \OCP\IL10N {
 		self::$language = $lang;
 	}
 
-
 	/**
-	 * find the best language
+	 * The code (en, de, ...) of the language that is used for this OC_L10N object
 	 *
-	 * @param array|string $app details below
-	 *
-	 * If $app is an array, ownCloud assumes that these are the available
-	 * languages. Otherwise ownCloud tries to find the files in the l10n
-	 * folder.
-	 *
-	 * If nothing works it returns 'en'
 	 * @return string language
 	 */
-	public function getLanguageCode($app=null) {
-		return self::findLanguage($app);
+	public function getLanguageCode() {
+		return $this->lang ? $this->lang : self::findLanguage();
 	}
-
 
 	/**
 	 * find the best language
@@ -515,7 +506,7 @@ class OC_L10N implements \OCP\IL10N {
 	 * @throws \Punic\Exception\ValueNotInList
 	 */
 	public function getDateFormat() {
-		$locale = self::findLanguage();
+		$locale = $this->getLanguageCode();
 		return Punic\Calendar::getDateFormat('short', $locale);
 	}
 
@@ -523,7 +514,7 @@ class OC_L10N implements \OCP\IL10N {
 	 * @return int
 	 */
 	public function getFirstWeekDay() {
-		$locale = self::findLanguage();
+		$locale = $this->getLanguageCode();
 		return Punic\Calendar::getFirstWeekday($locale);
 	}
 }

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -396,8 +396,7 @@ class OC_Util {
 	 */
 	public static function addTranslations($application, $languageCode = null) {
 		if (is_null($languageCode)) {
-			$l = new \OC_L10N($application);
-			$languageCode = $l->getLanguageCode($application);
+			$languageCode = \OC_L10N::findLanguage($application);
 		}
 		if (!empty($application)) {
 			$path = "$application/l10n/$languageCode";

--- a/lib/public/il10n.php
+++ b/lib/public/il10n.php
@@ -75,15 +75,9 @@ interface IL10N {
 
 
 	/**
-	 * find the best language
-	 * @param array|string $app details below
+	 * The code (en, de, ...) of the language that is used for this OC_L10N object
+	 *
 	 * @return string language
-	 *
-	 * If $app is an array, ownCloud assumes that these are the available
-	 * languages. Otherwise ownCloud tries to find the files in the l10n
-	 * folder.
-	 *
-	 * If nothing works it returns 'en'
 	 */
-	public function getLanguageCode($app=null);
+	public function getLanguageCode();
 }

--- a/tests/lib/l10n.php
+++ b/tests/lib/l10n.php
@@ -173,4 +173,20 @@ class Test_L10n extends \Test\TestCase {
 			array(null, null, 'en'),
 		);
 	}
+
+	public function testGetLanguageCode() {
+		$l = OC_L10N::get('lib', 'de');
+		$this->assertEquals('de', $l->getLanguageCode());
+	}
+
+	public function testFactoryGetLanguageCode() {
+		$factory = new \OC\L10N\Factory();
+		$l = $factory->get('lib', 'de');
+		$this->assertEquals('de', $l->getLanguageCode());
+	}
+
+	public function testServiceGetLanguageCode() {
+		$l = \OC::$server->getL10N('lib', 'de');
+		$this->assertEquals('de', $l->getLanguageCode());
+	}
 }


### PR DESCRIPTION
The method has fooled me more then once already. The name implies behavior that is not given.

3 Examples of what you would think:

``` php
'de' === OC_L10N::get('lib', 'de')->getLanguageCode();
'de' === (new \OC\L10N\Factory())->get('lib', 'de')->getLanguageCode();
'de' === \OC::$server->getL10N('lib', 'de')->getLanguageCode();
```

However the old `getLanguageCode()` was more a `tryToFindTheCorrectLanguageForThisUserAndAGivenApp()` (always returns the personal language of the user instead of the one set via the constructor)
The only method that was using it in this way was `Util::addTranslations()`. I changed that method to use OC_L10N::findLanguage() directly, instead of creating an object and then call a method on the object which then calls `findLanguage()`.

@DeepDiver1975 can we have this please? Otherwise I need to create a new method with a name that is close to similar which reflects the correct behaviour. No one should manually rely on this method in it's old way anyhow, since they can just keep `null` in the constructor and will have the old behaviour.

Fix owncloud/activity#145
