### PR TITLE
support `*dbprefix*` in index names

### DIFF
--- a/lib/private/db/mdb2schemareader.php
+++ b/lib/private/db/mdb2schemareader.php
@@ -260,6 +260,8 @@ class MDB2SchemaReader {
 			switch ($child->getName()) {
 				case 'name':
 					$name = (string)$child;
+					$name = str_replace('*dbprefix*', $this->DBTABLEPREFIX, $name);
+					$name = $this->platform->quoteIdentifier($name);
 					break;
 				case 'primary':
 					$primary = $this->asBool($child);


### PR DESCRIPTION
as certain dbms require index names to be unique within the db, it is required to create the index names dynamically as more than one OC instance might be hosted in one db.

thus in index names `*dbprefix*` is replaced by the configured `dbtableprefix` the same way as it is done with the table names.
