### PR TITLE
use `dbtableprefix` for temp table and index names

### DIFF
--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -100,7 +100,7 @@ class Migrator {
 	 * @return string
 	 */
 	protected function generateTemporaryTableName($name) {
-		return 'oc_' . $name . '_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+		return $this->config->getSystemValue('dbtableprefix', 'oc_') . $name . '_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 	}
 
 	/**
@@ -151,7 +151,7 @@ class Migrator {
 				$indexName = $index->getName();
 			} else {
 				// avoid conflicts in index names
-				$indexName = 'oc_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+				$indexName = $this->config->getSystemValue('dbtableprefix', 'oc_') . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 			}
 			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}


### PR DESCRIPTION
replace `oc_` with `dbtableprefix` form config for temporary table and index names.

(i know it is not absolutely necessary since the names include a random component. but it is still cleaner that way. and in case an update is aborted and multiple oc instances are hosted in one single db, then it is clear where the temp table came from.)
