### PR TITLE
Add --show-password option to ldap:show-config

### DIFF
--- a/apps/user_ldap/command/showconfig.php
+++ b/apps/user_ldap/command/showconfig.php
@@ -27,6 +27,12 @@ class ShowConfig extends Command {
 					InputArgument::OPTIONAL,
 					'will show the configuration of the specified id'
 				     )
+			->addOption(
+					'show-password',
+					null,
+					InputOption::VALUE_NONE,
+					'show ldap bind password'
+				     )
 		;
 	}
 
@@ -44,15 +50,16 @@ class ShowConfig extends Command {
 			$configIDs = $availableConfigs;
 		}
 
-		$this->renderConfigs($configIDs, $output);
+		$this->renderConfigs($configIDs, $output, $input->getOption('show-password'));
 	}
 
 	/**
 	 * prints the LDAP configuration(s)
 	 * @param string[] configID(s)
 	 * @param OutputInterface $output
+	 * @param bool $withPassword      Set to TRUE to show plaintext passwords in output
 	 */
-	protected function renderConfigs($configIDs, $output) {
+	protected function renderConfigs($configIDs, $output, $withPassword) {
 		foreach($configIDs as $id) {
 			$configHolder = new Configuration($id);
 			$configuration = $configHolder->getConfiguration();
@@ -62,7 +69,7 @@ class ShowConfig extends Command {
 			$table->setHeaders(array('Configuration', $id));
 			$rows = array();
 			foreach($configuration as $key => $value) {
-				if($key === 'ldapAgentPassword') {
+				if($key === 'ldapAgentPassword' && !$withPassword) {
 					$value = '***';
 				}
 				if(is_array($value)) {


### PR DESCRIPTION
This commits adds a --show-password option to the ldap:show-config command line method.

The goal of this change is to enable configuration checking of all ldap configuration options. Without this change one cannot compare the current ldap password with the desired one: although one could blindly configure the desired password, it would be impossible to determine whether a change occurred.

This commit does not create any new security risks: The default option is to not show the password, so inadvertent  exposure is not possible. Any adversary with access to the owncloud command line will by definition also have access to the database credentials, and therefore to the ldap password: this commit therefore does not expose any new information.
