### PR TITLE
LDAP: reset paged search on null limit [stable7]

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -1541,6 +1541,17 @@ class Access extends LDAPUtility implements user\IUserTools {
 				}
 
 			}
+		} else if($this->connection->hasPagedResultSupport && intval($limit) === 0) {
+			// a search without limit was requested. However, if we do use
+			// Paged Search once, we always must do it. This requires us to
+			// initialize it with the configured page size.
+			$this->abandonPagedSearch();
+			// in case someone set it to 0 … use 500, otherwise no results will
+			// be returned.
+			$pageSize = intval($this->connection->ldapPagingSize) > 0 ? intval($this->connection->ldapPagingSize) : 500;
+			$pagedSearchOK = $this->ldap->controlPagedResult(
+				$this->connection->getConnectionResource(), $pageSize, false, ''
+			);
 		}
 
 		return $pagedSearchOK;


### PR DESCRIPTION
Fixes an issues found in https://github.com/owncloud/core/issues/13533#issuecomment-76092306 ff

OC 7 version

Thing is, the issue is hard to reproduce. I wrote a test script, but was never able to reproduce the issue on my system against AD 2008 nor 2012.  On the system of the ticket however, it was reproducible, the test worked and the fix also.

I don't expect side effects.
