### PR TITLE
Check whether the file id is valid, before using it to delete the previews

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -14,6 +14,7 @@
 namespace OC;
 
 use OC\Preview\Provider;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 
 class Preview {
@@ -327,21 +328,21 @@ class Preview {
 	 * deletes all previews of a file
 	 */
 	public function deleteAllPreviews() {
-		$file = $this->getFile();
-
-		$fileInfo = $this->getFileInfo($file);
-
 		$toDelete = $this->getChildren();
-		$toDelete[] = $fileInfo;
+		$toDelete[] = $this->getFileInfo();
 
 		foreach ($toDelete as $delete) {
-			if ($delete !== null && $delete !== false) {
+			if ($delete instanceof FileInfo) {
 				/** @var \OCP\Files\FileInfo $delete */
 				$fileId = $delete->getId();
 
-				$previewPath = $this->getPreviewPath($fileId);
-				$this->userView->deleteAll($previewPath);
-				$this->userView->rmdir($previewPath);
+				// getId() might return null, e.g. when the file is a
+				// .ocTransferId*.part file from chunked file upload.
+				if (!empty($fileId)) {
+					$previewPath = $this->getPreviewPath($fileId);
+					$this->userView->deleteAll($previewPath);
+					$this->userView->rmdir($previewPath);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix #14671 

@oparoz @jmit79 @LukasReschke @MorrisJobke 
