### PR TITLE
[stable8] Fix totally broken AppStore code…

### DIFF
--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -161,6 +161,36 @@ class AllConfig implements \OCP\IConfig {
 		\OC::$server->getAppConfig()->deleteApp($appName);
 	}
 
+	/**
+	 * Determines the apps that have the set the value for the specified
+	 * keys
+	 *
+	 * @param string $value the value to get the app for
+	 * @param string $key the key too lookup
+	 * @return array of app IDs
+	 */
+	public function getAppsForKeyValue($key, $value) {
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$qb = $this->connection->createQueryBuilder();
+		$qb
+			->select('appid')
+			->from('`*PREFIX*appconfig`')
+			->where('configvalue = ?')
+			->andWhere('configkey = ?')
+			->setParameter(0, $value)
+			->setParameter(1, $key)
+		;
+		$result = $qb->execute();
+
+		$appIDs = [];
+		while ($row = $result->fetch()) {
+			$appIDs[] = $row['appid'];
+		}
+
+		return $appIDs;
+	}
 
 	/**
 	 * Set a user defined value

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -189,6 +189,7 @@ class AllConfig implements \OCP\IConfig {
 			$appIDs[] = $row['appid'];
 		}
 
+		sort($appIDs);
 		return $appIDs;
 	}
 

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -109,6 +109,15 @@ interface IConfig {
 	 */
 	public function deleteAppValues($appName);
 
+	/**
+	 * Determines the apps that have the set the value for the specified
+	 * keys
+	 *
+	 * @param string $value the value to get the app for
+	 * @param string $key the key too lookup
+	 * @return array of app IDs
+	 */
+	public function getAppsForKeyValue($key, $value);
 
 	/**
 	 * Set a user defined value

--- a/settings/ajax/disableapp.php
+++ b/settings/ajax/disableapp.php
@@ -11,8 +11,7 @@ $appId = $_POST['appid'];
 $appId = OC_App::cleanAppId($appId);
 
 // FIXME: Clear the cache - move that into some sane helper method
-\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
-\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
+\OC::$server->getMemCacheFactory()->create('settings')->clear('listApps-');
 
 OC_App::disable($appId);
 OC_JSON::success();

--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -8,8 +8,7 @@ $groups = isset($_POST['groups']) ? $_POST['groups'] : null;
 try {
 	OC_App::enable(OC_App::cleanAppId($_POST['appid']), $groups);
 	// FIXME: Clear the cache - move that into some sane helper method
-	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-0');
-	\OC::$server->getMemCacheFactory()->create('settings')->remove('listApps-1');
+	\OC::$server->getMemCacheFactory()->create('settings')->clear('listApps-');
 	OC_JSON::success();
 } catch (Exception $e) {
 	OC_Log::write('core', $e->getMessage(), OC_Log::ERROR);

--- a/tests/lib/allconfig.php
+++ b/tests/lib/allconfig.php
@@ -26,6 +26,33 @@ class TestAllConfig extends \Test\TestCase {
 		return new \OC\AllConfig($systemConfig, $connection);
 	}
 
+	// FIXME: Actually an integration test... – Shouldn't be in the unit test at all.
+	public function testGetAppsForKeyValue() {
+		$config = $this->getConfig();
+
+		// preparation - add something to the database
+		$data = [
+			['myFirstApp', 'key1', 'value1'],
+			['mySecondApp', 'key1', 'value2'],
+			['mySecondApp', 'key3', 'value2'],
+			['myThirdApp', 'key3', 'value3'],
+			['myThirdApp', 'key3', 'value2'],
+		];
+		foreach ($data as $entry) {
+			$config->setAppValue($entry[0], $entry[1], $entry[2]);
+		}
+
+		$this->assertEquals(['mySecondApp'], $config->getAppsForKeyValue('key1', 'value2'));
+		$this->assertEquals(['mySecondApp', 'myThirdApp'], $config->getAppsForKeyValue('key3', 'value2'));
+		$this->assertEquals([], $config->getAppsForKeyValue('NotExisting', 'NotExistingValue'));
+
+		// cleanup
+		foreach ($data as $entry) {
+			$config->deleteAppValue($entry[0], $entry[1]);
+
+		}
+	}
+
 	public function testDeleteUserValue() {
 		$config = $this->getConfig();
 


### PR DESCRIPTION
As it turned out the AppStore code was completely broken when it came from apps delivered from the appstore, this meant:
1. You could not disable and then re-enable an application that was installed from the AppStore. It simply failed hard.
2. You could not disable apps from the categories but only from the "Activated" page
3. It did not show the activation state from any category page

This code is completely static and thus testing it is impossible. We really have to stop with "let's add yet another feature in already existing static code". Such stuff has to get refactored first.

That said, this code works from what I can say when clicking around in the AppStore page GUI. However, it may easily be that it does not work with updates or whatsever as I have no chance to test that since the AppStore code is not open-source and it is impossible to write unit-tests for that.

Fixes https://github.com/owncloud/core/issues/14711

<hr/>

**Disclaimer:** All the fame belongs to @PVince81 and @nickvergessen . I only fixed the bug, they pointed out the actual problem… So this goes to their :beer:-count.
