### PR TITLE
[stable6] make sure that the versions array contains the correct path

### DIFF
--- a/apps/files_versions/lib/versions.php
+++ b/apps/files_versions/lib/versions.php
@@ -280,7 +280,7 @@ class Storage {
 		$pathinfo = pathinfo($filename);
 		$versionedFile = $pathinfo['basename'];
 
-		$dir = self::VERSIONS_ROOT . '/' . $pathinfo['dirname'];
+		$dir = \OC\Files\Filesystem::normalizePath(self::VERSIONS_ROOT . '/' . $pathinfo['dirname']);
 
 		$dirContent = false;
 		if ($view->is_dir($dir)) {
@@ -308,7 +308,7 @@ class Storage {
 						} else {
 							$versions[$key]['preview'] = \OCP\Util::linkToRoute('core_ajax_versions_preview', array('file' => $userFullPath, 'version' => $timestamp));
 						}
-						$versions[$key]['path'] = $filename;
+						$versions[$key]['path'] = $pathinfo['dirname'] . '/' . $filename;
 						$versions[$key]['name'] = $versionedFile;
 						$versions[$key]['size'] = $view->filesize($dir . '/' . $entryName);
 					}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/10186 to stable6

Fixes https://github.com/owncloud/core/issues/14728

@DeepDiver1975 @MorrisJobke @cdamken as discussed

@karlitschek please confirm
