### PR TITLE
[sqlite] Use an atomic implementation on sqlite for insertIfNotExist() + use it in the file cache ...

### DIFF
--- a/lib/private/db/connection.php
+++ b/lib/private/db/connection.php
@@ -79,8 +79,6 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 		if (!is_null($limit)) {
 			$platform = $this->getDatabasePlatform();
 			$statement = $platform->modifyLimitQuery($statement, $limit, $offset);
-		} else {
-			$origStatement = $statement;
 		}
 		$statement = $this->replaceTablePrefix($statement);
 		$statement = $this->adapter->fixupStatement($statement);
@@ -92,17 +90,19 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	}
 
 	/**
-	 * Executes an, optionally parameterized, SQL query.
+	 * Executes an, optionally parametrized, SQL query.
 	 *
-	 * If the query is parameterized, a prepared statement is used.
+	 * If the query is parametrized, a prepared statement is used.
 	 * If an SQLLogger is configured, the execution is logged.
 	 *
-	 * @param string $query The SQL query to execute.
-	 * @param string[] $params The parameters to bind to the query, if any.
-	 * @param array $types The types the previous parameters are in.
-	 * @param QueryCacheProfile $qcp
+	 * @param string                                      $query  The SQL query to execute.
+	 * @param array                                       $params The parameters to bind to the query, if any.
+	 * @param array                                       $types  The types the previous parameters are in.
+	 * @param \Doctrine\DBAL\Cache\QueryCacheProfile|null $qcp    The query cache profile, optional.
+	 *
 	 * @return \Doctrine\DBAL\Driver\Statement The executed statement.
-	 * @internal PERF: Directly prepares a driver statement, not a wrapper.
+	 *
+	 * @throws \Doctrine\DBAL\DBALException
 	 */
 	public function executeQuery($query, array $params = array(), $types = array(), QueryCacheProfile $qcp = null)
 	{
@@ -117,11 +117,13 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 *
 	 * This method supports PDO binding types as well as DBAL mapping types.
 	 *
-	 * @param string $query The SQL query.
-	 * @param array $params The query parameters.
-	 * @param array $types The parameter types.
+	 * @param string $query  The SQL query.
+	 * @param array  $params The query parameters.
+	 * @param array  $types  The parameter types.
+	 *
 	 * @return integer The number of affected rows.
-	 * @internal PERF: Directly prepares a driver statement, not a wrapper.
+	 *
+	 * @throws \Doctrine\DBAL\DBALException
 	 */
 	public function executeUpdate($query, array $params = array(), array $types = array())
 	{

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -243,13 +243,19 @@ class Cache {
 			list($queryParts, $params) = $this->buildParts($data);
 			$queryParts[] = '`storage`';
 			$params[] = $this->getNumericStorageId();
-			$valuesPlaceholder = array_fill(0, count($queryParts), '?');
 
-			$sql = 'INSERT INTO `*PREFIX*filecache` (' . implode(', ', $queryParts) . ')'
-				. ' VALUES (' . implode(', ', $valuesPlaceholder) . ')';
-			\OC_DB::executeAudited($sql, $params);
+			$params = array_map(function($item) {
+				return trim($item, "`");
+			}, $params);
+			$queryParts = array_map(function($item) {
+				return trim($item, "`");
+			}, $queryParts);
+			$values = array_combine($queryParts, $params);
+			if (\OC::$server->getDatabaseConnection()->insertIfNotExist('*PREFIX*filecache', $values)) {
+				return (int)\OC_DB::insertid('*PREFIX*filecache');
+			}
 
-			return (int)\OC_DB::insertid('*PREFIX*filecache');
+			return $this->getId($file);
 		}
 	}
 


### PR DESCRIPTION
@dragotin can you put this on your failing instance? THX

@PVince81 @icewind1991 please review 

insertIfNotExist() is now used in the file cache to avoid integrity constraint violations. Let's see ...
