### PR TITLE
adjust list of errors, more compact and readable

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -339,6 +339,12 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 	background-position: left center;
 }
 
-#postsetupchecks .hint, #postsetupchecks .setupwarning {
+#postsetupchecks .hint {
 	margin-top: 15px;
+}
+
+#postsetupchecks .setupwarning {
+	list-style: initial;
+	font-weight: normal;
+	margin-top: 5px;
 }

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -144,7 +144,7 @@ $(document).ready(function(){
 		} else {
 			$errorsEl = $el.find('.errors');
 			for (var i = 0; i < errors.length; i++ ) {
-				$errorsEl.append('<div class="setupwarning">' + errors[i] + '</div>');
+				$errorsEl.append('<li class="setupwarning">' + errors[i] + '</li>');
 			}
 			$errorsEl.removeClass('hidden');
 			$el.find('.hint').removeClass('hidden');

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -225,7 +225,7 @@ if ($_['cronErrors']) {
 	<h2><?php p($l->t('Configuration Checks'));?></h2>
 	<div class="loading"></div>
 	<div class="success hidden"><?php p($l->t('No problems found'));?></div>
-	<div class="errors hidden"></div>
+	<ul class="errors hidden"></ul>
 	<div class="hint hidden">
 		<span class="setupwarning"><?php
 			print_unescaped($l->t('Please double check the <a href=\'%s\'>installation guides</a>.', \OC_Helper::linkToDocs('admin-install')));


### PR DESCRIPTION
Improves the error list on the admin page:
- more readable by formatting as list
- removing bold style
- reducing the whitespace

Please review @owncloud/designers @karlitschek 
