### PR TITLE
Convert 'abcpassword' to 'abcpass' during setup

### DIFF
--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -55,6 +55,14 @@ class Controller {
 		$post = $this->loadAutoConfig($post);
 		$opts = $this->getSystemInfo();
 
+		// convert 'abcpassword' to 'abcpass'
+		if (isset($post['adminpassword'])) {
+			$post['adminpass'] = $post['adminpassword'];
+		}
+		if (isset($post['dbpassword'])) {
+			$post['dbpass'] = $post['dbpassword'];
+		}
+
 		if(isset($post['install']) AND $post['install']=='true') {
 			// We have to launch the installation process :
 			$e = \OC\Setup::install($post);


### PR DESCRIPTION
This allows autoconfig files to use 'dbpassword' instead of 'dbpass', which is more consistent with config.php. It's a mechanism to avoid confusion for new admins, who expect 'dbpassword' to work.

Fixes #7786

cc @ideaship @ser72 @PVince81 @DeepDiver1975 
