### PR TITLE
Verify CSRF token already in update.php and not the EventSource code

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -2,6 +2,8 @@
 set_time_limit(0);
 require_once '../../lib/base.php';
 
+\OCP\JSON::callCheck();
+
 if (OC::checkUpgrade(false)) {
 	// if a user is currently logged in, their session must be ignored to
 	// avoid side effects


### PR DESCRIPTION
Issue report:

> Hum, well I upgraded the package then visited the web interface to
> trigger the update and it failed; the UI would say there was a
> possible CSRF attack and after that it'd be stuck in maintenance mode.
> Tried a few times (by editing maintenance to false in owncloud.conf)
> and same result each time.

That smells partially like an issue caused by our EventSource implementation, due to legacy concerns the CSRF verification happens within the EventSource handling and not when the actual endpoint is called, what happens here then is:
1. User has somehow an invalid CSRF token in session (or none at all)
2. User clicks the update button
3. Invalid CSRF token is sent to update.php - no CSRF check there => Instance gets set in maintenance mode
4. Invalid CSRF token is processed by the EventSource code => Code Execution is stopped and ownCloud is stuck in maintenance mode

I have a work-around for this problem, basically it verifies the CSRF token already in step 3 and cancels execution then. The same error will be shown to the user however he can work around it by refreshing the page – as stated by the error. I think that’s an acceptable behaviour for now: https://github.com/owncloud/core/pull/14753

To verify this test:
1. Delete your ownCloud cookies
2. Increment the version in version.php
3. Try to upgrade
   => Before the patch: Instance shows an error, is set to upgrade mode and a refresh does not help
   => After the patch: Instance shows an error, a refresh helps though.

This is not really the best fix as a better solution would be to catch such situations when bootstrapping ownCloud, however, I don’t dare to touch base.php for this sake only, you never know what breaks then…

That said: There might be other bugs as well, especially the stacktrace is somewhat confusing but then again it is installing ownCloud under /usr/share/owncloud/ and I bet that is part of the whole issue ;-)

cc @adamwill @karlitschek 
