### PR TITLE
[stable8] Verify CSRF token already in update.php and not the EventSource code

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -2,6 +2,8 @@
 set_time_limit(0);
 require_once '../../lib/base.php';
 
+\OCP\JSON::callCheck();
+
 if (OC::checkUpgrade(false)) {
 	// if a user is currently logged in, their session must be ignored to
 	// avoid side effects


### PR DESCRIPTION
Proposed backport of https://github.com/owncloud/core/pull/14753
