### PR TITLE
Allow iframes from same domain in share view

### DIFF
--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -203,7 +203,12 @@ class ShareController extends Controller {
 		$shareTmpl['downloadURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadShare', array('token' => $token));
 		$shareTmpl['maxSizeAnimateGif'] = $this->config->getSystemValue('max_filesize_animated_gifs_public_sharing', 10);
 
-		return new TemplateResponse($this->appName, 'public', $shareTmpl, 'base');
+		$csp = new OCP\AppFramework\Http\ContentSecurityPolicy();
+		$csp->addAllowedFrameDomain('\'self\'');
+		$response = new TemplateResponse($this->appName, 'public', $shareTmpl, 'base');
+		$response->setContentSecurityPolicy($csp);
+
+		return $response;
 	}
 
 	/**

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -159,7 +159,12 @@ class ShareControllerTest extends \Test\TestCase {
 			'nonHumanFileSize' => 33,
 			'maxSizeAnimateGif' => 10,
 		);
+
+		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new TemplateResponse($this->container['AppName'], 'public', $sharedTmplParams, 'base');
+		$expectedResponse->setContentSecurityPolicy($csp);
+
 		$this->assertEquals($expectedResponse, $response);
 	}
 


### PR DESCRIPTION
This is required because the PDF Viewer itself is embedded using an iframe from the same domain. The default policy is blocking this.

Going on further, we have to come up with a solution in the future how to handle previews by applications, one example might be that they call their own endpoint and not the generic share page to allow applications to have full control over how to display previews.

**How to test?**
Anyways, to test this behaviour use a decent newer browser (such as Chrome 41) and share a PDF file, obviously the PDF viewer needs to be enabled as well. Without this patch publicly shared PDF files should not get previewed and an error is thrown. (if it isn't then your browser is probably not obeying our Content-Security-Policy and you might consider switching to another one ;))

cc @DeepDiver1975 @PVince81 Please review. This only affects master.
