### PR TITLE
Use occ to install ownCloud in autotest.sh

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -4,7 +4,7 @@
 #
 # @author Thomas Müller
 # @author Morris Jobke
-# @copyright 2012, 2013 Thomas Müller thomas.mueller@tmit.eu
+# @copyright 2012-2015 Thomas Müller thomas.mueller@tmit.eu
 # @copyright 2014 Morris Jobke hey@morrisjobke.de
 #
 
@@ -90,67 +90,6 @@ fi
 
 echo "Using database $DATABASENAME"
 
-# create autoconfig for sqlite, mysql and postgresql
-cat > ./tests/autoconfig-sqlite.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'sqlite',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-);
-DELIM
-
-cat > ./tests/autoconfig-mysql.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'mysql',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASEUSER',
-  'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
-cat > ./tests/autoconfig-pgsql.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'pgsql',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASEUSER',
-  'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
-cat > ./tests/autoconfig-oci.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'oci',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASENAME',
-  'dbname' => 'XE',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
 function execute_tests {
 	echo "Setup environment for $1 testing ..."
 	# back to root folder
@@ -197,15 +136,16 @@ EOF
 			to $DATABASENAME;
 			exit;
 EOF
+		DATABASEUSER=$DATABASENAME
+		DATABASENAME='XE'
 	fi
 
 	# copy autoconfig
 	cp "$BASEDIR/tests/autoconfig-$1.php" "$BASEDIR/config/autoconfig.php"
 
 	# trigger installation
-	echo "INDEX"
-	php -f index.php | grep -i -C9999 error && echo "Error during setup" && exit 101
-	echo "END INDEX"
+	echo "Installing ...."
+	./occ maintenance:install --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --database-table-prefix=oc_ --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
 
 	#test execution
 	echo "Testing with $1 ..."

--- a/autotest-hhvm.sh
+++ b/autotest-hhvm.sh
@@ -2,8 +2,14 @@
 #
 # ownCloud
 #
+# @author Vincent Petry
+# @author Morris Jobke
+# @author Robin McCorkell
 # @author Thomas Müller
-# @copyright 2012, 2013 Thomas Müller thomas.mueller@tmit.eu
+# @author Andreas Fischer
+# @author Joas Schilling
+# @author Lukas Reschke
+# @copyright 2012-2015 Thomas Müller thomas.mueller@tmit.eu
 #
 
 set -e
@@ -95,67 +101,6 @@ fi
 
 echo "Using database $DATABASENAME"
 
-# create autoconfig for sqlite, mysql and postgresql
-cat > ./tests/autoconfig-sqlite.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'sqlite',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-);
-DELIM
-
-cat > ./tests/autoconfig-mysql.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'mysql',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASEUSER',
-  'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
-cat > ./tests/autoconfig-pgsql.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'pgsql',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASEUSER',
-  'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
-cat > ./tests/autoconfig-oci.php <<DELIM
-<?php
-\$AUTOCONFIG = array (
-  'installed' => false,
-  'dbtype' => 'oci',
-  'dbtableprefix' => 'oc_',
-  'adminlogin' => '$ADMINLOGIN',
-  'adminpass' => 'admin',
-  'directory' => '$DATADIR',
-  'dbuser' => '$DATABASENAME',
-  'dbname' => 'XE',
-  'dbhost' => 'localhost',
-  'dbpass' => 'owncloud',
-);
-DELIM
-
 function execute_tests {
 	echo "Setup environment for $1 testing ..."
 	# back to root folder
@@ -202,15 +147,16 @@ EOF
 			to $DATABASENAME;
 			exit;
 EOF
+		DATABASEUSER=$DATABASENAME
+		DATABASENAME='XE'
 	fi
 
 	# copy autoconfig
 	cp "$BASEDIR/tests/autoconfig-$1.php" "$BASEDIR/config/autoconfig.php"
 
 	# trigger installation
-	echo "INDEX"
-	hhvm -f index.php | grep -i -C9999 error && echo "Error during setup" && exit 101
-	echo "END INDEX"
+	echo "Installing ...."
+	hhvm ./occ maintenance:install --database=$1 --database-name=$DATABASENAME --database-host=localhost --database-user=$DATABASEUSER --database-pass=owncloud --database-table-prefix=oc_ --admin-user=$ADMINLOGIN --admin-pass=admin --data-dir=$DATADIR
 
 	#test execution
 	echo "Testing with $1 ..."

--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -9,42 +9,20 @@
 
 namespace OC\Core\Setup;
 
-use bantu\IniGetWrapper\IniGetWrapper;
-use OCP\IConfig;
-use OCP\IL10N;
+use OC\Setup;
 
 class Controller {
-	/**
-	 * @var \OCP\IConfig
-	 */
-	protected $config;
-	/** @var IniGetWrapper */
-	protected $iniWrapper;
-	/** @var IL10N */
-	protected $l10n;
-	/** @var \OC_Defaults */
-	protected $defaults;
-
-	/**
-	 * @var string
-	 */
+	/** @var Setup */
+	protected $setupHelper;
+	/** @var string */
 	private $autoConfigFile;
 
 	/**
-	 * @param IConfig $config
-	 * @param IniGetWrapper $iniWrapper
-	 * @param IL10N $l10n
-	 * @param \OC_Defaults $defaults
+	 * @param Setup $setupHelper
 	 */
-	function __construct(IConfig $config,
-						 IniGetWrapper $iniWrapper,
-						 IL10N $l10n,
-						 \OC_Defaults $defaults) {
+	function __construct(Setup $setupHelper) {
 		$this->autoConfigFile = \OC::$SERVERROOT.'/config/autoconfig.php';
-		$this->config = $config;
-		$this->iniWrapper = $iniWrapper;
-		$this->l10n = $l10n;
-		$this->defaults = $defaults;
+		$this->setupHelper = $setupHelper;
 	}
 
 	/**
@@ -53,7 +31,7 @@ class Controller {
 	public function run($post) {
 		// Check for autosetup:
 		$post = $this->loadAutoConfig($post);
-		$opts = $this->getSystemInfo();
+		$opts = $this->setupHelper->getSystemInfo();
 
 		// convert 'abcpassword' to 'abcpass'
 		if (isset($post['adminpassword'])) {
@@ -65,7 +43,7 @@ class Controller {
 
 		if(isset($post['install']) AND $post['install']=='true') {
 			// We have to launch the installation process :
-			$e = \OC\Setup::install($post);
+			$e = $this->setupHelper->install($post);
 			$errors = array('errors' => $e);
 
 			if(count($e) > 0) {
@@ -125,86 +103,5 @@ class Controller {
 		$post['directoryIsSet'] = $directoryIsSet;
 
 		return $post;
-	}
-
-	/**
-	 * Gathers system information like database type and does
-	 * a few system checks.
-	 *
-	 * @return array of system info, including an "errors" value
-	 * in case of errors/warnings
-	 */
-	public function getSystemInfo() {
-		$setup = new \OC\Setup($this->config);
-		$databases = $setup->getSupportedDatabases();
-
-		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
-
-		$errors = array();
-
-		// Create data directory to test whether the .htaccess works
-		// Notice that this is not necessarily the same data directory as the one
-		// that will effectively be used.
-		@mkdir($dataDir);
-		$htAccessWorking = true;
-		if (is_dir($dataDir) && is_writable($dataDir)) {
-			// Protect data directory here, so we can test if the protection is working
-			\OC\Setup::protectDataDirectory();
-
-			try {
-				$htAccessWorking = \OC_Util::isHtaccessWorking();
-			} catch (\OC\HintException $e) {
-				$errors[] = array(
-					'error' => $e->getMessage(),
-					'hint' => $e->getHint()
-				);
-				$htAccessWorking = false;
-			}
-		}
-
-
-		if (\OC_Util::runningOnMac()) {
-			$errors[] = array(
-				'error' => $this->l10n->t(
-					'Mac OS X is not supported and %s will not work properly on this platform. ' .
-					'Use it at your own risk! ',
-					$this->defaults->getName()
-				),
-				'hint' => $this->l10n->t('For the best results, please consider using a GNU/Linux server instead.')
-			);
-		}
-
-		if($this->iniWrapper->getString('open_basedir') !== '' && PHP_INT_SIZE === 4) {
-			$errors[] = array(
-				'error' => $this->l10n->t(
-					'It seems that this %s instance is running on a 32-bit PHP environment and the open_basedir has been configured in php.ini. ' .
-					'This will lead to problems with files over 4 GB and is highly discouraged.',
-					$this->defaults->getName()
-				),
-				'hint' => $this->l10n->t('Please remove the open_basedir setting within your php.ini or switch to 64-bit PHP.')
-			);
-		}
-		if(!function_exists('curl_init') && PHP_INT_SIZE === 4) {
-			$errors[] = array(
-				'error' => $this->l10n->t(
-					'It seems that this %s instance is running on a 32-bit PHP environment and cURL is not installed. ' .
-					'This will lead to problems with files over 4 GB and is highly discouraged.',
-					$this->defaults->getName()
-				),
-				'hint' => $this->l10n->t('Please install the cURL extension and restart your webserver.')
-			);
-		}
-
-		return array(
-			'hasSQLite' => isset($databases['sqlite']),
-			'hasMySQL' => isset($databases['mysql']),
-			'hasPostgreSQL' => isset($databases['pgsql']),
-			'hasOracle' => isset($databases['oci']),
-			'hasMSSQL' => isset($databases['mssql']),
-			'databases' => $databases,
-			'directory' => $dataDir,
-			'htaccessWorking' => $htAccessWorking,
-			'errors' => $errors,
-		);
 	}
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -747,7 +747,8 @@ class OC {
 		// Check if ownCloud is installed or in maintenance (update) mode
 		if (!$systemConfig->getValue('installed', false)) {
 			\OC::$server->getSession()->clear();
-			$controller = new OC\Core\Setup\Controller(\OC::$server->getConfig(), \OC::$server->getIniWrapper(), \OC::$server->getL10N('core'), new \OC_Defaults());
+			$setupHelper = new OC\Setup(\OC::$server->getConfig(), \OC::$server->getIniWrapper(), \OC::$server->getL10N('lib'), new \OC_Defaults());
+			$controller = new OC\Core\Setup\Controller($setupHelper);
 			$controller->run($_POST);
 			exit();
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -566,7 +566,7 @@ class OC {
 				} catch(\Exception $e) {
 					echo('Writing to database failed');
 				}
-				exit();
+				exit(1);
 			} else {
 				OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 				OC_Template::printGuestPage('', 'error', array('errors' => $errors));

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -8,19 +8,34 @@
 
 namespace OC;
 
+use bantu\IniGetWrapper\IniGetWrapper;
 use Exception;
-use OC_L10N;
 use OCP\IConfig;
+use OCP\IL10N;
 
 class Setup {
-	/** @var IConfig */
+	/** @var \OCP\IConfig */
 	protected $config;
+	/** @var IniGetWrapper */
+	protected $iniWrapper;
+	/** @var IL10N */
+	protected $l10n;
+	/** @var \OC_Defaults */
+	protected $defaults;
 
 	/**
 	 * @param IConfig $config
+	 * @param IniGetWrapper $iniWrapper
+	 * @param \OC_Defaults $defaults
 	 */
-	function __construct(IConfig $config) {
+	function __construct(IConfig $config,
+						 IniGetWrapper $iniWrapper,
+						 IL10N $l10n,
+						 \OC_Defaults $defaults) {
 		$this->config = $config;
+		$this->iniWrapper = $iniWrapper;
+		$this->l10n = $l10n;
+		$this->defaults = $defaults;
 	}
 
 	static $dbSetupClasses = array(
@@ -31,13 +46,6 @@ class Setup {
 		'sqlite' => '\OC\Setup\Sqlite',
 		'sqlite3' => '\OC\Setup\Sqlite',
 	);
-
-	/**
-	 * @return OC_L10N
-	 */
-	public static function getTrans(){
-		return \OC::$server->getL10N('lib');
-	}
 
 	/**
 	 * Wrapper around the "class_exists" PHP function to be able to mock it
@@ -117,11 +125,90 @@ class Setup {
 	}
 
 	/**
+	 * Gathers system information like database type and does
+	 * a few system checks.
+	 *
+	 * @return array of system info, including an "errors" value
+	 * in case of errors/warnings
+	 */
+	public function getSystemInfo() {
+		$databases = $this->getSupportedDatabases();
+
+		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
+
+		$errors = array();
+
+		// Create data directory to test whether the .htaccess works
+		// Notice that this is not necessarily the same data directory as the one
+		// that will effectively be used.
+		@mkdir($dataDir);
+		$htAccessWorking = true;
+		if (is_dir($dataDir) && is_writable($dataDir)) {
+			// Protect data directory here, so we can test if the protection is working
+			\OC\Setup::protectDataDirectory();
+
+			try {
+				$htAccessWorking = \OC_Util::isHtaccessWorking();
+			} catch (\OC\HintException $e) {
+				$errors[] = array(
+					'error' => $e->getMessage(),
+					'hint' => $e->getHint()
+				);
+				$htAccessWorking = false;
+			}
+		}
+
+		if (\OC_Util::runningOnMac()) {
+			$errors[] = array(
+				'error' => $this->l10n->t(
+					'Mac OS X is not supported and %s will not work properly on this platform. ' .
+					'Use it at your own risk! ',
+					$this->defaults->getName()
+				),
+				'hint' => $this->l10n->t('For the best results, please consider using a GNU/Linux server instead.')
+			);
+		}
+
+		if($this->iniWrapper->getString('open_basedir') !== '' && PHP_INT_SIZE === 4) {
+			$errors[] = array(
+				'error' => $this->l10n->t(
+					'It seems that this %s instance is running on a 32-bit PHP environment and the open_basedir has been configured in php.ini. ' .
+					'This will lead to problems with files over 4 GB and is highly discouraged.',
+					$this->defaults->getName()
+				),
+				'hint' => $this->l10n->t('Please remove the open_basedir setting within your php.ini or switch to 64-bit PHP.')
+			);
+		}
+		if(!function_exists('curl_init') && PHP_INT_SIZE === 4) {
+			$errors[] = array(
+				'error' => $this->l10n->t(
+					'It seems that this %s instance is running on a 32-bit PHP environment and cURL is not installed. ' .
+					'This will lead to problems with files over 4 GB and is highly discouraged.',
+					$this->defaults->getName()
+				),
+				'hint' => $this->l10n->t('Please install the cURL extension and restart your webserver.')
+			);
+		}
+
+		return array(
+			'hasSQLite' => isset($databases['sqlite']),
+			'hasMySQL' => isset($databases['mysql']),
+			'hasPostgreSQL' => isset($databases['pgsql']),
+			'hasOracle' => isset($databases['oci']),
+			'hasMSSQL' => isset($databases['mssql']),
+			'databases' => $databases,
+			'directory' => $dataDir,
+			'htaccessWorking' => $htAccessWorking,
+			'errors' => $errors,
+		);
+	}
+
+	/**
 	 * @param $options
 	 * @return array
 	 */
-	public static function install($options) {
-		$l = self::getTrans();
+	public function install($options) {
+		$l = $this->l10n;
 
 		$error = array();
 		$dbType = $options['dbtype'];
@@ -146,7 +233,7 @@ class Setup {
 
 		$class = self::$dbSetupClasses[$dbType];
 		/** @var \OC\Setup\AbstractDatabase $dbSetup */
-		$dbSetup = new $class(self::getTrans(), 'db_structure.xml');
+		$dbSetup = new $class($l, 'db_structure.xml');
 		$error = array_merge($error, $dbSetup->validate($options));
 
 		// validate the data directory
@@ -186,7 +273,7 @@ class Setup {
 		$secret = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(48);
 
 		//write the config file
-		\OC::$server->getConfig()->setSystemValues([
+		$this->config->setSystemValues([
 			'passwordsalt'		=> $salt,
 			'secret'			=> $secret,
 			'trusted_domains'	=> $trustedDomains,
@@ -281,7 +368,7 @@ class Setup {
 	 * @throws \OC\HintException If .htaccess does not include the current version
 	 */
 	public static function updateHtaccess() {
-		$setupHelper = new \OC\Setup(\OC::$server->getConfig());
+		$setupHelper = new \OC\Setup(\OC::$server->getConfig(), \OC::$server->getIniWrapper(), \OC::$server->getL10N('lib'), new \OC_Defaults());
 		if(!$setupHelper->isCurrentHtaccess()) {
 			throw new \OC\HintException('.htaccess file has the wrong version. Please upload the correct version. Maybe you forgot to replace it after updating?');
 		}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -702,7 +702,7 @@ class OC_Util {
 			);
 		}
 
-		if ($webServerRestart) {
+		if (!\OC::$CLI && $webServerRestart) {
 			$errors[] = array(
 				'error' => $l->t('PHP modules have been installed, but they are still listed as missing?'),
 				'hint' => $l->t('Please ask your server administrator to restart the web server.')

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -497,7 +497,7 @@ class OC_Util {
 		}
 
 		$webServerRestart = false;
-		$setup = new OC\Setup($config);
+		$setup = new \OC\Setup($config, \OC::$server->getIniWrapper(), \OC::$server->getL10N('lib'), new \OC_Defaults());
 		$availableDatabases = $setup->getSupportedDatabases();
 		if (empty($availableDatabases)) {
 			$errors[] = array(

--- a/tests/lib/setup.php
+++ b/tests/lib/setup.php
@@ -10,16 +10,27 @@ use OCP\IConfig;
 
 class Test_OC_Setup extends \Test\TestCase {
 
-	/** @var IConfig */
+	/** @var IConfig | PHPUnit_Framework_MockObject_MockObject */
 	protected $config;
-	/** @var \OC\Setup */
+	/** @var \bantu\IniGetWrapper\IniGetWrapper | PHPUnit_Framework_MockObject_MockObject */
+	private $iniWrapper;
+	/** @var \OCP\IL10N | PHPUnit_Framework_MockObject_MockObject */
+	private $l10n;
+	/** @var \OC_Defaults | PHPUnit_Framework_MockObject_MockObject */
+	private $defaults;
+	/** @var \OC\Setup | PHPUnit_Framework_MockObject_MockObject */
 	protected $setupClass;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->config = $this->getMock('\OCP\IConfig');
-		$this->setupClass = $this->getMock('\OC\Setup', ['class_exists', 'is_callable'], [$this->config]);
+		$this->iniWrapper = $this->getMock('\bantu\IniGetWrapper\IniGetWrapper');
+		$this->l10n = $this->getMock('\OCP\IL10N');
+		$this->defaults = $this->getMock('\OC_Defaults');
+		$this->setupClass = $this->getMock('\OC\Setup',
+			['class_exists', 'is_callable'],
+			[$this->config, $this->iniWrapper, $this->l10n, $this->defaults]);
 	}
 
 	public function testGetSupportedDatabasesWithOneWorking() {


### PR DESCRIPTION
Errors during setup will now be printed to the teriminal

``` sh
 (use-occ-setup-in-autotest-master) ~/Development/ownCloud/master$ ./autotest.sh sqlite
Using database oc_autotest
Setup environment for sqlite testing ...
Installing ....
PHP module GD not installed.
Please ask your server administrator to install the module.

PHP modules have been installed, but they are still listed as missing?
Please ask your server administrator to restart the web server.

Writing to database failedTesting with sqlite ...
PHP Fatal error:  Uncaught exception 'Exception' with message 'Not installed' in /home/deepdiver/Development/ownCloud/master/lib/base.php:241
Stack trace:
#0 /home/deepdiver/Development/ownCloud/master/lib/base.php(543): OC::checkInstalled()
#1 /home/deepdiver/Development/ownCloud/master/lib/base.php(1030): OC::init()
#2 /home/deepdiver/Development/ownCloud/master/tests/bootstrap.php(16): require_once('/home/deepdiver...')
#3 phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php(58): include_once('/home/deepdiver...')
#4 phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php(42): PHPUnit_Util_Fileloader::load('/home/deepdiver...')
#5 phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php(792): PHPUnit_Util_Fileloader::checkAndLoad('/home/deepdiver...')
#6 phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php(622): PHPUnit_TextUI_Command->handleBootstrap('/home/deepdiver...')
#7 phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php(114): PHPUnit_TextUI_Command->handleArguments(Array)
#8 phar:///usr/local/bin/phpu in /home/deepdiver/Development/ownCloud/master/lib/base.php on line 241
```
