### PR TITLE
Use the new IteratorDirectory instead of the fakedir wrapper

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -40,6 +40,7 @@ require 'aws-autoloader.php';
 
 use Aws\S3\S3Client;
 use Aws\S3\Exception\S3Exception;
+use Icewind\Streams\IteratorDirectory;
 
 class AmazonS3 extends \OC\Files\Storage\Common {
 
@@ -284,9 +285,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				$files[] = $file;
 			}
 
-			\OC\Files\Stream\Dir::register('amazons3' . $path, $files);
-
-			return opendir('fakedir://amazons3' . $path);
+			return IteratorDirectory::wrap($files);
 		} catch (S3Exception $e) {
 			\OCP\Util::logException('files_external', $e);
 			return false;

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -29,6 +29,8 @@
 
 namespace OC\Files\Storage;
 
+use Icewind\Streams\IteratorDirectory;
+
 require_once __DIR__ . '/../3rdparty/Dropbox/autoload.php';
 
 class Dropbox extends \OC\Files\Storage\Common {
@@ -156,8 +158,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 			foreach ($contents as $file) {
 				$files[] = basename($file['path']);
 			}
-			\OC\Files\Stream\Dir::register('dropbox'.$path, $files);
-			return opendir('fakedir://dropbox'.$path);
+			return IteratorDirectory::wrap($files);
 		}
 		return false;
 	}

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -32,6 +32,8 @@
 
 namespace OC\Files\Storage;
 
+use Icewind\Streams\IteratorDirectory;
+
 set_include_path(get_include_path().PATH_SEPARATOR.
 	\OC_App::getAppPath('files_external').'/3rdparty/google-api-php-client/src');
 require_once 'Google/Client.php';
@@ -291,8 +293,7 @@ class Google extends \OC\Files\Storage\Common {
 				}
 				$pageToken = $children->getNextPageToken();
 			}
-			\OC\Files\Stream\Dir::register('google'.$path, $files);
-			return opendir('fakedir://google'.$path);
+			return IteratorDirectory::wrap($files);
 		} else {
 			return false;
 		}

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -29,6 +29,7 @@
  *
  */
 namespace OC\Files\Storage;
+use Icewind\Streams\IteratorDirectory;
 
 /**
 * Uses phpseclib's Net_SFTP class and the Net_SFTP_Stream stream wrapper to
@@ -278,8 +279,7 @@ class SFTP extends \OC\Files\Storage\Common {
 					$dirStream[] = $file;
 				}
 			}
-			\OC\Files\Stream\Dir::register($id, $dirStream);
-			return opendir('fakedir://' . $id);
+			return IteratorDirectory::wrap($dirStream);
 		} catch(\Exception $e) {
 			return false;
 		}

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -32,6 +32,7 @@
 namespace OC\Files\Storage;
 
 use Guzzle\Http\Exception\ClientErrorResponseException;
+use Icewind\Streams\IteratorDirectory;
 use OpenCloud;
 use OpenCloud\Common\Exceptions;
 use OpenCloud\OpenStack;
@@ -222,8 +223,7 @@ class Swift extends \OC\Files\Storage\Common {
 				}
 			}
 
-			\OC\Files\Stream\Dir::register('swift' . $path, $files);
-			return opendir('fakedir://swift' . $path);
+			return IteratorDirectory::wrap($files);
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 			return false;

--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -24,6 +24,7 @@
 
 namespace OC\Files\ObjectStore;
 
+use Icewind\Streams\IteratorDirectory;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class ObjectStoreStorage extends \OC\Files\Storage\Common {
@@ -216,9 +217,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				$files[] = $file['name'];
 			}
 
-			\OC\Files\Stream\Dir::register('objectstore' . $path . '/', $files);
-
-			return opendir('fakedir://objectstore' . $path . '/');
+			return IteratorDirectory::wrap($files);
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog('objectstore', $e->getMessage(), \OCP\Util::ERROR);
 			return false;

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -38,7 +38,7 @@ namespace OC\Files\Storage;
 use Exception;
 use OC\Files\Filesystem;
 use OC\Files\Stream\Close;
-use OC\Files\Stream\Dir;
+use Icewind\Streams\IteratorDirectory;
 use OC\MemCache\ArrayCache;
 use OCP\Constants;
 use OCP\Files;
@@ -211,8 +211,7 @@ class DAV extends Common {
 				$file = basename($file);
 				$content[] = $file;
 			}
-			Dir::register($id, $content);
-			return opendir('fakedir://' . $id);
+			return IteratorDirectory::wrap($content);
 		} catch (ClientHttpException $e) {
 			if ($e->getHttpStatus() === 404) {
 				$this->statCache->clear($path . '/');

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -35,7 +35,6 @@
  */
 
 namespace OC\Files\Storage;
-
 /**
  * for local filestore, we only have to map the paths
  */


### PR DESCRIPTION
Saves "leaking" memory by having to set the directory content in a static member.

cc @PVince81 @DeepDiver1975 
