### PR TITLE
Fix the avatarcontroller cache needing the cache dir

### DIFF
--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -95,6 +95,10 @@ class AvatarControllerTest extends \Test\TestCase {
 		\OC_User::setUserId($this->user);
 		\OC_Util::setupFS($this->user);
 
+		// Create Cache dir
+		$view = new \OC\Files\View('/'.$this->user);
+		$view->mkdir('cache');
+
 		// Configure userMock
 		$this->userMock->method('getDisplayName')->willReturn($this->user);
 		$this->userMock->method('getUID')->willReturn($this->user);
@@ -275,7 +279,6 @@ class AvatarControllerTest extends \Test\TestCase {
 
 	/**
 	 * Check what happens when we upload a GIF
-	 * TODO: Finish
 	 */
 	public function testPostAvatarFileGif() {
 		//Create temp file


### PR DESCRIPTION
Automatic cache dir was removed in 82254ad5efb65e8650567f49343ec37eb55e2f3e (if I'm not mistaken) and
unfortunately missed by jenkins before mering into master.
