### PR TITLE
[stable8] Add cURL as hard-dependency

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -577,7 +577,7 @@ class OC_Util {
 				'DOMDocument' => 'dom',
 				'XMLWriter' => 'XMLWriter'
 			),
-			'functions' => array(
+			'functions' => [
 				'xml_parser_create' => 'libxml',
 				'mb_detect_encoding' => 'mb multibyte',
 				'ctype_digit' => 'ctype',
@@ -586,8 +586,9 @@ class OC_Util {
 				'gzencode' => 'zlib',
 				'iconv' => 'iconv',
 				'simplexml_load_string' => 'SimpleXML',
-				'hash' => 'HASH Message Digest Framework'
-			),
+				'hash' => 'HASH Message Digest Framework',
+				'curl_init' => 'cURL',
+			],
 			'defined' => array(
 				'PDO::ATTR_DRIVER_NAME' => 'PDO'
 			)


### PR DESCRIPTION
It is required by other functionalities such as S2S anyways and ownCloud will fail hard at a lot of places without it.

Backport of https://github.com/owncloud/core/pull/14838
