### PR TITLE
Allow Remote avatars

### DIFF
--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -90,14 +90,18 @@ class AvatarController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @PublicPage
 	 *
 	 * @param string $userId
 	 * @param int $size
 	 * @return DataResponse|DataDisplayResponse
 	 */
 	public function getAvatar($userId, $size) {
+		if (!$this->userManager->userExists($userId)) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
 		if ($size > 2048) {
 			$size = 2048;
 		} elseif ($size <= 0) {


### PR DESCRIPTION
PR for #14564 

Added a function to the avatar controller to deal with remote avatar calls. This function takes as input the userId, size and the share token.

This share token is used to retrieve the share, It is then matched against the userId. There are two possible scenario's.

If userA (on instance A) shares with userB (on instance B).
- userB can request the avatar from userA, but user A cannot yet request the avatar from userB.
- if userB has accepted the share userA can also request the avatar from userB.

Still todo:
- [ ] Some new js logic is required to properly fetch remote avatars.
- [ ] UserA should check if the share is accepted before sending the request

Future work:
- [ ] Cacheing
