### PR TITLE
Add loginname to user database backend (reborn)

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -944,6 +944,13 @@
 			</field>
 
 			<field>
+				<name>loginname</name>
+				<type>text</type>
+				<default></default>
+				<length>64</length>
+			</field>
+
+			<field>
 				<name>displayname</name>
 				<type>text</type>
 				<default></default>
@@ -963,6 +970,15 @@
 				<primary>true</primary>
 				<field>
 					<name>uid</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>users_loginname</name>
+				<unique>true</unique>
+				<field>
+					<name>loginname</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -38,6 +38,7 @@ use OC\Repair\RemoveGetETagEntries;
 use OC\Repair\SqliteAutoincrement;
 use OC\Repair\DropOldTables;
 use OC\Repair\FillETags;
+use OC\Repair\FixLoginName;
 use OC\Repair\InnoDB;
 use OC\Repair\RepairConfig;
 use OC\Repair\RepairLegacyStorages;
@@ -111,6 +112,7 @@ class Repair extends BasicEmitter {
 			new DropOldTables(\OC_DB::getConnection()),
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC_DB::getConnection()),
+			new FixLoginName(\OC_DB::getConnection()),
 		);
 	}
 

--- a/lib/private/user/manager.php
+++ b/lib/private/user/manager.php
@@ -47,7 +47,7 @@ use OCP\IConfig;
  */
 class Manager extends PublicEmitter implements IUserManager {
 	/**
-	 * @var \OCP\UserInterface [] $backends
+	 * @var \OCP\UserInterface[] $backends
 	 */
 	private $backends = array();
 

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -89,7 +89,7 @@ interface IUserManager {
 	/**
 	 * Check if the password is valid for the user
 	 *
-	 * @param string $loginname
+	 * @param string $loginname The user's login name (not necessarily its UID)
 	 * @param string $password
 	 * @return mixed the User object on success, false otherwise
 	 * @since 8.0.0

--- a/lib/repair/fixloginname.php
+++ b/lib/repair/fixloginname.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Repair;
+
+use OC\DB\Connection;
+use OC\Hooks\BasicEmitter;
+use OC\RepairStep;
+
+class FixLoginName extends BasicEmitter implements RepairStep {
+	/**
+	 * @var \OC\DB\Connection
+	 */
+	private $connection;
+
+	public function __construct(Connection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function getName() {
+		return 'Login name - populate values';
+	}
+
+	public function run() {
+		$qb = $this->connection->createQueryBuilder();
+		$qb->update('`*PREFIX*users`')
+			->set('`loginname`', '`uid`')
+			->where($qb->expr()->isNull('`loginname`'));
+		$affectedRows = $qb->execute();
+
+		$this->emit('OC\Repair', 'info', sprintf('Login name - %d users updated', $affectedRows));
+	}
+}

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -35,16 +35,17 @@ class Controller {
 		\OC_JSON::callCheck();
 		\OC_JSON::checkLoggedIn();
 
-		$username = \OC_User::getUser();
+		$userSession = \OC::$server->getUserSession();
+		$user = $userSession->getUser();
 		$password = isset($_POST['personal-password']) ? $_POST['personal-password'] : null;
 		$oldPassword = isset($_POST['oldpassword']) ? $_POST['oldpassword'] : '';
 
-		if (!\OC_User::checkPassword($username, $oldPassword)) {
+		if (!\OC_User::checkPassword($userSession->getLoginName(), $oldPassword)) {
 			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array("data" => array("message" => $l->t("Wrong password")) ));
 			exit();
 		}
-		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+		if (!is_null($password) && \OC_User::setPassword($user->getUID(), $password)) {
 			\OC_JSON::success();
 		} else {
 			\OC_JSON::error();

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(8, 2, 0, 2);
+$OC_Version=array(8, 2, 0, 3);
 
 // The human readable string
 $OC_VersionString='8.2 pre alpha';


### PR DESCRIPTION
This is a re-birth of @GMTA's PR: #14620, with the interface breakage removed. I spoke to @GMTA before sending this PR, and he is happy with it.

This adds a column to the users table which initially contains the UID. The value contained in this column determines the 'username' part of the credentials used of OC. By changing this value, you effectively
change the username with which a user can login.

Code was/is licensed under MIT as per https://github.com/owncloud/core/pull/14620#issuecomment-76600685, but could @GMTA just confirm that here to be on the safe side? Thanks.

cc @blizzz @DeepDiver1975 @PVince81 @icewind1991 @schiesbn 

Fixes #14476, #6984
