### PR TITLE
Allow updating of password on public share

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -487,13 +487,7 @@ class Local {
 		}
 
 		try {
-			$result = \OCP\Share::shareItem(
-					$itemType,
-					$itemSource,
-					\OCP\Share::SHARE_TYPE_LINK,
-					$shareWith,
-					$permissions
-					);
+			$result = \OCP\Share::setPassword($itemType, $itemSource, $shareWith);
 		} catch (\Exception $e) {
 			return new \OC_OCS_Result(null, 403, $e->getMessage());
 		}

--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -478,7 +478,6 @@ class Local {
 		foreach ($items as $item) {
 			if($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
 				$checkExists = true;
-				$permissions = $item['permissions'];
 			}
 		}
 

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -90,6 +90,16 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				}
 			}
 			break;
+		case 'setPassword':
+			if (isset($_POST['shareWith'])) {
+				try {
+					$return = OCP\Share::setPassword((string)$_POST['itemType'], (string)$_POST['itemSource'], (string)$_POST['shareWith']);
+					($return) ? OC_JSON::success() : OC_JSON::error();
+				} catch (\Exception $e) {
+					OC_JSON::error(array('data' => array('message' => $e->getMessage())));
+				}
+			}
+			break;
 		case 'informRecipients':
 			$l = \OC::$server->getL10N('core');
 			$shareType = (int) $_POST['shareType'];

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -1080,10 +1080,17 @@ $(document).ready(function() {
 			}
 
 			$loading.removeClass('hidden');
-			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', permissions, itemSourceName).then(function() {
-				$loading.addClass('hidden');
-				$('#linkPassText').attr('placeholder', t('core', 'Choose a password for the public link'));
-			});
+			$.post(OC.filePath('core', 'ajax', 'share.php'), 
+				{ 
+					action: 'setPassword', 
+					itemType: itemType, 
+					itemSource: itemSource,
+					shareWith: '' 
+				},
+				function() {
+					$loading.addClass('hidden');
+					$('#linkPassText').attr('placeholder', t('core', 'Choose a password for the public link'));
+				});
 		} else {
 			$('#linkPassText').focus();
 		}
@@ -1109,17 +1116,23 @@ $(document).ready(function() {
 			}
 
 			$loading.removeClass('hidden');
-			OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, $('#linkPassText').val(), permissions, itemSourceName, function(data) {
-				$loading.addClass('hidden');
-				linkPassText.val('');
-				linkPassText.attr('placeholder', t('core', 'Password protected'));
+			$.post(OC.filePath('core', 'ajax', 'share.php'), 
+				{ 
+					action: 'setPassword', 
+					itemType: itemType, 
+					itemSource: itemSource,
+					shareWith: $('#linkPassText').val() 
+				},
+				function(data) {
+					$loading.addClass('hidden');
+					linkPassText.val('');
+					linkPassText.attr('placeholder', t('core', 'Password protected'));
 
-				if (oc_appconfig.core.enforcePasswordForPublicLink) {
-					OC.Share.showLink(data.token, "password set", itemSource);
-					OC.Share.updateIcon(itemType, itemSource);
-				}
-			});
-
+					if (oc_appconfig.core.enforcePasswordForPublicLink) {
+						OC.Share.showLink(data.token, "password set", itemSource);
+						OC.Share.updateIcon(itemType, itemSource);
+					}
+				});
 		}
 	});
 

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1148,7 +1148,7 @@ class Share extends \OC\Share\Constants {
 
 		$qb = \OC::$server->getDatabaseConnection()->createQueryBuilder();
 		$qb->update('*PREFIX*share')
-		      ->set('share_with', is_null($password) ? null : $qb->expr()->literal(\OC::$server->getHasher()->hash($password)))
+		      ->set('share_with', is_null($password) ? 'NULL' : $qb->expr()->literal(\OC::$server->getHasher()->hash($password)))
 			  ->where($qb->expr()->eq('item_type', $qb->expr()->literal($itemType)))
 			  ->andWhere($qb->expr()->eq('item_source', $qb->expr()->literal($itemSource)))
 			  ->andWhere($qb->expr()->eq('uid_owner', $qb->expr()->literal($user)))

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -24,6 +24,7 @@ namespace OC\Share;
 
 use OCP\IUserSession;
 use OCP\IDBConnection;
+use OCP\IConfig;
 
 /**
  * This class provides the ability for apps to share their content between users.
@@ -1117,6 +1118,7 @@ class Share extends \OC\Share\Constants {
 	 *
 	 * @param IUserSession $userSession
 	 * @param IDBConnection $connection
+	 * @param IConfig $config
 	 * @param string $itemType
 	 * @param string $itemSource
 	 * @param string $password
@@ -1125,6 +1127,7 @@ class Share extends \OC\Share\Constants {
 	 */
 	public static function setPassword(IUserSession $userSession, 
 	                                   IDBConnection $connection, 
+									   IConfig $config,
 									   $itemType, $itemSource, $password) {
 		$user = $userSession->getUser();
 		if (is_null($user)) {
@@ -1137,7 +1140,7 @@ class Share extends \OC\Share\Constants {
 		}
 
 		//If passwords are enforced the password can't be null
-		if (self::enforcePassword() && is_null($password)) {
+		if (self::enforcePassword($config) && is_null($password)) {
 			throw new \Exception('Cannot remove password');
 		}
 
@@ -2399,8 +2402,12 @@ class Share extends \OC\Share\Constants {
 		return (int)\OCP\Config::getAppValue('core', 'shareapi_expire_after_n_days', '7');
 	}
 
-	public static function enforcePassword() {
-		$enforcePassword = \OCP\Config::getAppValue('core', 'shareapi_enforce_links_password', 'no');
+	/**
+     * @param IConfig $config
+	 * @return bool 
+	 */
+	public static function enforcePassword(IConfig $config) {
+		$enforcePassword = $config->getAppValue('core', 'shareapi_enforce_links_password', 'no');
 		return ($enforcePassword === "yes") ? true : false;
 	}
 }

--- a/lib/public/idbconnection.php
+++ b/lib/public/idbconnection.php
@@ -174,4 +174,11 @@ interface IDBConnection {
 	 * @return bool
 	 */
 	public function tableExists($table);
+
+	/**
+	 * Gets the QueryBuilder
+	 *
+	 * @return \Doctrine\DBAL\Query\QueryBuilder
+	 */
+	public function createQueryBuilder();
 }

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -309,6 +309,18 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
+	 * Set expiration date for a share
+	 * @param string $itemType
+	 * @param string $itemSource
+	 * @param string $password
+	 * @return boolean
+	 */
+	public static function setPassword($itemType, $itemSource, $password) {
+		return \OC\Share\Share::setPassword($itemType, $itemSource, $password);
+	}
+
+
+	/**
 	 * Get the backend class for the specified item type
 	 * @param string $itemType
 	 * @return Share_Backend

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -316,7 +316,9 @@ class Share extends \OC\Share\Constants {
 	 * @return boolean
 	 */
 	public static function setPassword($itemType, $itemSource, $password) {
-		return \OC\Share\Share::setPassword($itemType, $itemSource, $password);
+		$userSession = \OC::$server->getUserSession();
+		$connection = \OC::$server->getDatabaseConnection();
+		return \OC\Share\Share::setPassword($userSession, $connection, $itemType, $itemSource, $password);
 	}
 
 

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -318,7 +318,8 @@ class Share extends \OC\Share\Constants {
 	public static function setPassword($itemType, $itemSource, $password) {
 		$userSession = \OC::$server->getUserSession();
 		$connection = \OC::$server->getDatabaseConnection();
-		return \OC\Share\Share::setPassword($userSession, $connection, $itemType, $itemSource, $password);
+		$config = \OC::$server->getConfig();
+		return \OC\Share\Share::setPassword($userSession, $connection, $config, $itemType, $itemSource, $password);
 	}
 
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1051,6 +1051,116 @@ class Test_Share extends \Test\TestCase {
 				),
 		);
 	}
+
+	/**
+	 * Cannot set password is there is no user
+	 *
+	 * @expectedException Exception
+	 * @expectedExceptionMessage User not logged in
+	 */
+	public function testSetPasswordNoUser() {
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+							->getMock();
+
+		$connection  = $this->getMockBuilder('\OCP\IDBConnection')
+		                    ->disableOriginalConstructor()
+							->getMock();
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+					   ->getMock();
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 'a', 'b', 'c');
+	}
+
+	/**
+	 * Test setting a password when everything is fine
+	 */
+	public function testSetPassword() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+					 ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+							->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+				   ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+				   ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+
+		$connection  = $this->getMockBuilder('\OCP\IDBConnection')
+		                    ->disableOriginalConstructor()
+							->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+					   ->getMock();
+
+
+		$res = \OC\Share\Share::setPassword($userSession, $connection, $config, 'a', 'b', 'c');
+
+		$this->assertTrue($res);
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Cannot remove password
+	 *
+	 * Test removing a password when password is enforced
+	 */
+	public function testSetPasswordRemove() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+					 ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+							->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+				   ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+				   ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+
+		$connection  = $this->getMockBuilder('\OCP\IDBConnection')
+		                    ->disableOriginalConstructor()
+							->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+					   ->getMock();
+		$config->method('getAppValue')->willReturn('yes');
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 'a', 'b', '');
+	}
+
 }
 
 class DummyShareClass extends \OC\Share\Share {


### PR DESCRIPTION
PR to resolve #10671 and #14826 (and possibly others).

currently we cannot update passwords on public shares. What happens is that a new share is created. This leads to problems with the expiration date being not properly propagated and the share getting a new id. Several things have to happen:
- [x] Add setPassword function to share.php
- [x] Update OCS call
- [x] Update ajax/share.php call
- [x] Update share.js
- [x] Cleanup share.php code for links
- [ ] More JS unit test
- [ ] Fix issue with allow upload
