### PR TITLE
Add support for Raw files previews

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -701,6 +701,10 @@ $CONFIG = array(
  *    at the :doc:`../configuration_files/collaborative_documents_configuration`
  *    section of the Administrators Manual.
  *
+ * .. note:: You need to make sure that your ImageMagick installation supports
+ *    the Raw file format before enabling it in the configuration. This usually
+ *    involves installing the ufraw-batch application
+ *
  * The following providers are not available in Microsoft Windows:
  *
  *  - OC\Preview\Movie

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -695,6 +695,7 @@ $CONFIG = array(
  *  - OC\Preview\SVG
  *  - OC\Preview\TIFF
  *  - OC\Preview\Font
+ *  - OC\Preview\Raw
  *
  * .. note:: Troubleshooting steps for the MS Word previews are available
  *    at the :doc:`../configuration_files/collaborative_documents_configuration`

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -64,7 +64,7 @@ class OC_Helper {
 		'application/coreldraw' => 'image',
 		'application/x-gimp' => 'image',
 		'application/x-photoshop' => 'image',
-		'application/x-dcraw' => 'image',
+		'image/x-dcraw' => 'image',
 
 		'application/font-sfnt' => 'font',
 		'application/x-font' => 'font',

--- a/lib/private/preview/raw.php
+++ b/lib/private/preview/raw.php
@@ -29,4 +29,15 @@ class Raw extends Bitmap {
 	public function getMimeType() {
 		return '/image\/x-dcraw/';
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
+		$converter = \OC_Helper::findBinaryPath('ufraw-batch');
+		if (empty($converter)) {
+			return false;
+		}
+		return parent::getThumbnail($path, $maxX, $maxY, $scalingup, $fileview);
+	}
 }

--- a/lib/private/preview/raw.php
+++ b/lib/private/preview/raw.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Olivier Paroz 2015 <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Preview;
+
+// Supports many file extensions linked to the Raw media type
+class Raw extends Bitmap {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType() {
+		return '/image\/x-dcraw/';
+	}
+}

--- a/lib/private/previewmanager.php
+++ b/lib/private/previewmanager.php
@@ -211,6 +211,7 @@ class PreviewManager implements IPreview {
 	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\SVG
 	 *  - OC\Preview\TIFF
+	 *  - OC\Preview\Raw
 	 *
 	 * @return array
 	 */
@@ -284,6 +285,7 @@ class PreviewManager implements IPreview {
 				'PSD'	=> ['mimetype' => '/application\/x-photoshop/', 'class' => '\OC\Preview\Photoshop'],
 				'EPS'	=> ['mimetype' => '/application\/postscript/', 'class' => '\OC\Preview\Postscript'],
 				'TTF'	=> ['mimetype' => '/application\/(?:font-sfnt|x-font$)/', 'class' => '\OC\Preview\Font'],
+				'CR2'	=> ['mimetype' => '/image\/x-dcraw/', 'class' => '\OC\Preview\Raw'],
 			];
 
 			foreach ($imagickProviders as $queryFormat => $provider) {


### PR DESCRIPTION
## Replaces #13652
### Solution for

https://github.com/owncloud/core/issues/13650
https://github.com/owncloud/apps/issues/439
https://github.com/owncloud/apps/issues/1113

Including media type migration and tests
### Supported formats:
- Sony Alpha RAW .arw
- Canon RAW 2 .cr2
- Digital Camera Raw .dcr
- Digital Negative .dng
- EPSON RAW .erf
- Intelligent Image Quality RAW .iiq
- Kodak DC40/DC50 RAW .kdc
- Kodak DC25 RAW .k25
- Nikon RAW .nef
- Mamiya RAW .mef
- Olympus RAW .orf
- Panasonic RAW .rw2
- PENTAX RAW .pef
- Fujifilm RAW .raf
- Sony RAW File .srf .sr2
- SIGMA RAW .xrf
### Requirements
- ImageMagick
- ufraw as an ImageMagick delegate for DNG
- ufraw-batch must be reachable from PHP
- PR https://github.com/owncloud/core/pull/13654, which is a fix for https://github.com/owncloud/core/issues/12282
- A gallery app which supports all media types supported by ownCloud
