### PR TITLE
Use default timezone for logs if logtimezone unset

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -491,7 +491,6 @@ class OC {
 			ini_set('display_errors', 1);
 		}
 
-		date_default_timezone_set('UTC');
 		ini_set('arg_separator.output', '&amp;');
 
 		//try to configure php to enable big file uploads.

--- a/lib/private/datetimezone.php
+++ b/lib/private/datetimezone.php
@@ -46,14 +46,14 @@ class DateTimeZone implements IDateTimeZone {
 			if ($this->session->exists('timezone')) {
 				return $this->guessTimeZoneFromOffset($this->session->get('timezone'));
 			}
-			$timeZone = $this->getDefaultTimeZone();
+			return $this->getServerTimeZone();
 		}
 
 		try {
 			return new \DateTimeZone($timeZone);
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog('datetimezone', 'Failed to created DateTimeZone "' . $timeZone . "'", \OCP\Util::DEBUG);
-			return new \DateTimeZone($this->getDefaultTimeZone());
+			return $this->getServerTimeZone();
 		}
 	}
 
@@ -91,7 +91,7 @@ class DateTimeZone implements IDateTimeZone {
 
 			// No timezone found, fallback to UTC
 			\OCP\Util::writeLog('datetimezone', 'Failed to find DateTimeZone for offset "' . $offset . "'", \OCP\Util::DEBUG);
-			return new \DateTimeZone($this->getDefaultTimeZone());
+			return $this->getServerTimeZone();
 		}
 	}
 
@@ -100,10 +100,14 @@ class DateTimeZone implements IDateTimeZone {
 	 *
 	 * Falls back to UTC if it is not yet set.
 	 * 
-	 * @return string
+	 * @return \DateTimeZone
 	 */
-	protected function getDefaultTimeZone() {
-		$serverTimeZone = date_default_timezone_get();
-		return $serverTimeZone ?: 'UTC';
+	public function getServerTimeZone() {
+		try {
+			$serverTimeZone = date_default_timezone_get();
+			return new \DateTimeZone($serverTimeZone);
+		} catch (\Exception $e) {
+			return new \DateTimeZone('UTC');
+		}
 	}
 }

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -61,11 +61,11 @@ class OC_Log_Owncloud {
 		if($level>=$minLevel) {
 			// default to ISO8601
 			$format = OC_Config::getValue('logdateformat', 'c');
-			$logtimezone=OC_Config::getValue( "logtimezone", 'UTC' );
+			$logtimezone = OC_Config::getValue("logtimezone");
 			try {
 				$timezone = new DateTimeZone($logtimezone);
 			} catch (Exception $e) {
-				$timezone = new DateTimeZone('UTC');
+				$timezone = \OC::$server->getDateTimeZone()->getServerTimeZone();
 			}
 			$time = new DateTime(null, $timezone);
 			$request = \OC::$server->getRequest();

--- a/lib/public/idatetimezone.php
+++ b/lib/public/idatetimezone.php
@@ -15,7 +15,16 @@ namespace OCP;
 
 interface IDateTimeZone {
 	/**
+	 * Get the timezone of the current user
+	 *
 	 * @return \DateTimeZone
 	 */
 	public function getTimeZone();
+
+	/**
+	 * Get the timezone of the server
+	 *
+	 * @return \DateTimeZone
+	 */
+	public function getServerTimeZone();
 }

--- a/tests/lib/datetimezone.php
+++ b/tests/lib/datetimezone.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+class DateTimeZone extends TestCase {
+	protected $config;
+	protected $session;
+
+	protected function setUp() {
+		date_default_timezone_set('UTC');
+		$this->config = $this->getMockBuilder('\OCP\IConfig')
+			->getMock();
+		$this->session = $this->getMockBuilder('\OCP\ISession')
+			->getMock();
+	}
+
+	public function testServerTimeZone() {
+		$dateTimeZone = new \OC\DateTimeZone($this->config, $this->session);
+
+		date_default_timezone_set('UTC');
+		$this->assertEquals($dateTimeZone->getServerTimeZone()->getName(), 'UTC');
+
+		date_default_timezone_set('Europe/Berlin');
+		$this->assertEquals($dateTimeZone->getServerTimeZone()->getName(), 'Europe/Berlin');
+	}
+
+	public function userTimeZoneProvider() {
+		return [
+			[null, 'UTC'],
+			['Europe/Berlin', 'Europe/Berlin'],
+			['Mars/OlympusMons', 'UTC']
+		];
+	}
+
+	/**
+	 * @dataProvider userTimeZoneProvider
+	 */
+	public function testUserTimeZone($timezone, $expectedTimezone) {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('user_id')
+			->willReturn('foobar');
+		$this->session->method('exists')
+			->with('timezone')
+			->willReturn(false);
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('foobar', 'core', 'timezone', null)
+			->willReturn($timezone);
+
+		$dateTimeZone = new \OC\DateTimeZone($this->config, $this->session);
+
+		$this->assertEquals($expectedTimezone, $dateTimeZone->getTimeZone()->getName());
+	}
+}
+


### PR DESCRIPTION
Augmentation of \OC\DateTimeZone with the `getSystemTimeZone()` method, which returns the system timezone (`date_default_timezone_get()`). This is then used if `logtimezone` is unset for the log timezone, instead of the default of UTC.

This does mean however that the setting of UTC as the default timezone in base.php has been removed. I don't know the implications of this, but hopefully our code is robust enough to cope. (that line was introduced in December 2012 in 7d811e57e6c7942964d6937a8cc1113839e25968)

Fixes #8212

cc @PVince81 @DeepDiver1975 @LukasReschke @MorrisJobke 
