### PR TITLE
Add support for http range

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -67,6 +67,7 @@ class OC_Files {
 			isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
 			$xsendfile = true;
 		}
+		$httpRange = getenv('HTTP_RANGE');
 
 		if (is_array($files) && count($files) === 1) {
 			$files = $files[0];
@@ -101,8 +102,9 @@ class OC_Files {
 
 		if ($get_type === self::FILE) {
 			$zip = false;
-			if ($xsendfile && OC_App::isEnabled('files_encryption')) {
+			if (($xsendfile || $httpRange) && OC_App::isEnabled('files_encryption')) {
 				$xsendfile = false;
+				$httpRange = false;
 			}
 		} else {
 			$zip = new ZipStreamer(false);
@@ -152,6 +154,10 @@ class OC_Files {
 					\OC\Files\Filesystem::readfile($filename);
 				}
 			} else {
+				if ($httpRange) {
+					\OC\Files\Filesystem::setFileRange($filename, $httpRange);
+				}
+				
 				\OC\Files\Filesystem::readfile($filename);
 			}
 		}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -598,6 +598,10 @@ class Filesystem {
 	static public function readfile($path) {
 		return self::$defaultInstance->readfile($path);
 	}
+	
+	static public function setFileRange($path, $httpRange) {
+		return self::$defaultInstance->setFileRange($path, $httpRange);
+	}
 
 	static public function isCreatable($path) {
 		return self::$defaultInstance->isCreatable($path);


### PR DESCRIPTION
OC does not currently offer native support the HTTP_RANGE header.  This header allows for pause/resume of downloads and time skipping of streaming videos (from the video app).

OC does offer partial support by allowing the use of the xsendfile apache module, but in addition to requiring the additional module, it has limited use.  OC's xsendfile implementation only supports local files and doesn't seem to work properly in Firefox and IE (likely due to issues in xsendfile).  XSendFile is also difficult to get working with OC when PHP is run in CGI mode.

The provided patch adds native support for the HTTP_RANGE header.  It supports local files and it also seems to support files supplied by the external storage app.  I say "seems to" because I have only tested a few.

This code released under MIT license, some code ported from CakePHP (MIT License).
