### PR TITLE
Use `input` event for triggering external storage configuration saving

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -388,26 +388,15 @@ $(document).ready(function() {
 		return defaultMountPoint+append;
 	}
 
-	$externalStorage.on('paste', 'td input', function() {
-		var $me = $(this);
-		var $tr = $me.closest('tr');
-		setTimeout(function() {
-			highlightInput($me);
-			OC.MountConfig.saveStorage($tr);
-		}, 20);
-	});
-
 	var timer;
 
-	$externalStorage.on('keyup', 'td input', function() {
+	$externalStorage.on('input', 'td input', function() {
 		clearTimeout(timer);
 		var $tr = $(this).closest('tr');
 		highlightInput($(this));
-		if ($(this).val) {
-			timer = setTimeout(function() {
-				OC.MountConfig.saveStorage($tr);
-			}, 2000);
-		}
+		timer = setTimeout(function() {
+			OC.MountConfig.saveStorage($tr);
+		}, 2000);
 	});
 
 	$externalStorage.on('change', 'td input:checkbox', function() {


### PR DESCRIPTION
Using `keyup` results in certain keys not working properly, as it gets the context of the result of the key press instead of the element the keypress occurred in. This is most notably seen when tabbing through the inputs - tabbing past the last input triggers a `keyup`, but in the context of the next row, so nothing gets saved. `input` is much more robust with this. Also means that a separate `paste` handler is unnecessary.

In addition, the original code never actually worked correctly. `$(...).val` is a function (`.val()`), not a property.

Fixes #11216

cc @PVince81 @DeepDiver1975 @icewind1991 

Backport to stable8? This requires IE 9 to work properly, so I don't think it is suitable for stable7 or stable6.
