### PR TITLE
[WIP] OCS to appframework

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -101,6 +101,7 @@ class Local {
 		if ($itemSource !== null) {
 			$shares = \OCP\Share::getItemShared($itemType, $itemSource);
 			$receivedFrom = \OCP\Share::getItemSharedWithBySource($itemType, $itemSource);
+
 			// if a specific share was specified only return this one
 			if ($getSpecificShare === true) {
 				foreach ($shares as $share) {

--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -175,7 +175,7 @@ class Local {
 	/**
 	 * get share from all files in a given folder (non-recursive)
 	 * @param array $params contains 'path' to the folder
-	 * @return \OC_OCS_Result
+	 * @return array
 	 */
 	private static function getSharesFromFolder($params) {
 		$path = $params['path'];
@@ -209,7 +209,7 @@ class Local {
 
 	/**
 	 * get files shared with the user
-	 * @return \OC_OCS_Result
+	 * @return array
 	 */
 	private static function getFilesSharedWithMe() {
 		try	{
@@ -234,7 +234,7 @@ class Local {
 	/**
 	 * create a new share
 	 * @param array $params
-	 * @return \OC_OCS_Result
+	 * @return arra
 	 */
 	public static function createShare($params) {
 

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -12,6 +12,9 @@ $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'o_c_s_api#getShare', 'url' => 'ocs/v1/shares/{shareId}', 'verb' => 'GET'],
 		['name' => 'o_c_s_api#getAllShares', 'url' => 'ocs/v1/shares', 'verb' => 'GET'],
+		['name' => 'o_c_s_api#deleteShare', 'url' => 'ocs/v1/shares/{shareId}', 'verb' => 'DELETE'],
+		['name' => 'o_c_s_api#createShare', 'url' => 'ocs/v1/shares', 'verb' => 'POST'],
+		['name' => 'o_c_s_api#updateShare', 'url' => 'ocs/v1/shares/{shareId}', 'verb' => 'PUT'],
 	]
 ]);
 

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -8,6 +8,10 @@ $application = new Application();
 $application->registerRoutes($this, [
 	'resources' => [
 		'ExternalShares' => ['url' => '/api/externalShares'],
+	],
+	'routes' => [
+		['name' => 'o_c_s_api#getShare', 'url' => 'ocs/v1/shares/{shareId}', 'verb' => 'GET'],
+		['name' => 'o_c_s_api#getAllShares', 'url' => 'ocs/v1/shares', 'verb' => 'GET'],
 	]
 ]);
 

--- a/apps/files_sharing/application.php
+++ b/apps/files_sharing/application.php
@@ -60,9 +60,9 @@ class Application extends App {
 			return new OCSApiController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$server->getUserSession(),
-				$server->getLogger(),
-				$c->query('DatabaseConnection')
+				$c->query('Logger'),
+				$c->query('DatabaseConnection'),
+				$c->query('Config')
 			);
 		});
 
@@ -92,6 +92,13 @@ class Application extends App {
 		$container->registerService('DatabaseConnection', function(SimpleContainer $c) use ($server){
 			return $server->getDatabaseConnection();
 		});
+		$container->registerService('Logger', function(SimpleContainer $c) use ($server){
+			return $server->getLogger();
+		});
+		$container->registerService('Config', function(SimpleContainer $c) use ($server){
+			return $server->getConfig();
+		});
+
 
 		/**
 		 * Middleware

--- a/apps/files_sharing/application.php
+++ b/apps/files_sharing/application.php
@@ -14,6 +14,7 @@ use OC\AppFramework\Utility\SimpleContainer;
 use OCA\Files_Sharing\Controllers\ExternalSharesController;
 use OCA\Files_Sharing\Controllers\ShareController;
 use OCA\Files_Sharing\Middleware\SharingCheckMiddleware;
+use OCA\Files_Sharing\Controllers\OCSApiController;
 use \OCP\AppFramework\App;
 
 /**
@@ -55,6 +56,15 @@ class Application extends App {
 				$c->query('ExternalManager')
 			);
 		});
+		$container->registerService('OCSApiController', function(SimpleContainer $c) use ($server) {
+			return new OCSApiController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$server->getUserSession(),
+				$server->getLogger(),
+				$c->query('DatabaseConnection')
+			);
+		});
 
 		/**
 		 * Core class wrappers
@@ -78,6 +88,9 @@ class Application extends App {
 					$server->getHTTPHelper(),
 					$uid
 			);
+		});
+		$container->registerService('DatabaseConnection', function(SimpleContainer $c) use ($server){
+			return $server->getDatabaseConnection();
 		});
 
 		/**

--- a/apps/files_sharing/lib/controllers/ocsapicontroller.php
+++ b/apps/files_sharing/lib/controllers/ocsapicontroller.php
@@ -1,0 +1,664 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Controllers;
+
+use OC;
+use OC\Files\Filesystem;
+use OC_Files;
+use OC_Util;
+use OCP;
+use OCP\Template;
+use OCP\JSON;
+use OCP\Share;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OC\URLGenerator;
+use OC\AppConfig;
+use OCP\ILogger;
+use OCA\Files_Sharing\Helper;
+use OCP\User;
+use OCP\Util;
+use OCA\Files_Sharing\Activity;
+use OCP\IDBConnection;
+
+/**
+ * Class OCSApiController
+ *
+ * @package OCA\Files_Sharing\Controllers
+ */
+class OCSApiController extends OCSController {
+
+	/** @var \OC\User\Session */
+	protected $userSession;
+	/** @var \OC\AppConfig */
+	protected $appConfig;
+	/** @var \OCP\IConfig */
+	protected $config;
+	/** @var \OC\URLGenerator */
+	protected $urlGenerator;
+	/** @var \OC\User\Manager */
+	protected $userManager;
+	/** @var \OCP\ILogger */
+	protected $logger;
+	/** @var OCP\Activity\IManager */
+	protected $activityManager;
+	/** @var IDBConnection */
+	protected $dbconnection;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param OC\User\Session $userSession
+	 * @param AppConfig $appConfig
+	 * @param OCP\IConfig $config
+	 * @param URLGenerator $urlGenerator
+	 * @param OC\User\Manager $userManager
+	 * @param ILogger $logger
+	 * @param OCP\Activity\IManager $activityManager
+	 * @param IDBConnection $dbconnection
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								OC\User\Session $userSession,
+								ILogger $logger,
+								IDBConnection $dbconnection) {
+		parent::__construct($appName, $request);
+
+		$this->logger = $logger;
+		$this->dbconnection = $dbconnection;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * Get share information for a given share
+	 * 
+	 * @param int $shareId
+	 */
+	public function getShare($shareId) {
+		$share = $this->getShareFromId($shareId);
+		return $this->collectShares($shareId, $share['file_source'], $share['item_type'], true, null);
+	}
+
+	/**
+	 * get some information from a given share
+	 * @param int $shareId
+	 * @return array|null with: item_source, share_type, share_with, item_type, permissions
+	 */
+	private function getShareFromId($shareId) {
+		$qb = $this->dbconnection->createQueryBuilder();
+
+		$qb->select('file_source')
+		   ->addSelect('share_type')
+		   ->addSelect('share_with')
+		   ->addSelect('item_type')
+		   ->addSelect('permissions')
+		   ->addSelect('stime')
+		   ->from('*PREFIX*share')
+		   ->where($qb->expr()->eq('id', $shareId));
+	
+		$result = $qb->execute();
+
+		if ($share = $result->fetch()) {
+			return $share;
+		}
+
+		return null;
+	}
+
+	/**
+	 * collect all share information, either of a specific share or all
+	 *        shares for a given path
+	 * @param int $shareId
+	 * @param int $itemSource
+	 * @param string $itemType
+	 * @param bool $getSpecificShare
+	 * @param string $path
+	 */
+	private function collectShares($shareId, $itemSource, $itemType, $getSpecificShare, $path) {
+
+		if ($itemSource) {
+			$shares = \OCP\Share::getItemShared($itemType, $itemSource);
+			$receivedFrom = \OCP\Share::getItemSharedWithBySource($itemType, $itemSource);
+
+			if ($getSpecificShare) {
+				foreach ($shares as $share) {
+					if ($share['id'] === $shareId) {
+						$shares = ['element' => $share];
+						break;
+					}
+				}
+			} else {
+				foreach ($shares as $key => $share) {
+					$shares[$key]['path'] = $path;
+				}
+			}
+
+			// include also reshares in the lists. This means that the result
+			// will contain every user with access to the file.
+			if (isset($params['reshares']) && $params['reshares'] === true) {
+				$shares = self::addReshares($shares, $itemSource);
+			}
+
+			if ($receivedFrom) {
+				foreach ($shares as $key => $share) {
+					$shares[$key]['received_from'] = $receivedFrom['uid_owner'];
+					$shares[$key]['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
+				}
+			}
+		} else {
+			$shares = null;
+		}
+
+		if ($shares === null || empty($shares)) {
+			return ['statuscode' => 404,
+				'message' => 'share doesn\'t exists'
+			];
+		} else {
+			return ['data' => $shares];
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * get all shares
+	 *
+	 * @param string $path limit the result to a specific file/folder
+	 * @param bool $reshares return now only share from current user but all shares for a given file
+	 * @param bool $subfiles returns all shares within a folder ($path has to be a folder)
+	 *
+	 * @return \OC_OCS_Result share information
+	 */
+	public function getAllShares($path, $reshares, $subfiles) {
+		if (isset($path)) {
+			$itemSource = self::getFileId($path);
+			$itemType = self::getItemType($path);
+
+			if (isset($subfiles) && $subfiles) {
+				return self::getSharesFromFolder($params);
+			}
+			return $this->collectShares(null, $itemSource, $itemType, false, $path);
+		}
+
+		$shares = \OCP\Share::getItemShared('file', null);
+
+		if ($shares === false) {
+			return new \OC_OCS_Result(null, 404, 'could not get shares');
+		} else {
+			foreach ($shares as &$share) {
+				if ($share['item_type'] === 'file' && isset($share['path'])) {
+					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['path']);
+					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
+						$share['isPreviewAvailable'] = true;
+					}
+				}
+			}
+			return new \OC_OCS_Result($shares);
+		}
+
+	}
+
+	/**
+	 * add reshares to a array of shares
+	 * @param array $shares array of shares
+	 * @param int $itemSource item source ID
+	 * @return array new shares array which includes reshares
+	 */
+	private static function addReshares($shares, $itemSource) {
+
+		// if there are no shares than there are also no reshares
+		$firstShare = reset($shares);
+		if ($firstShare) {
+			$path = $firstShare['path'];
+		} else {
+			return $shares;
+		}
+
+		$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `file_source`, `path` , `*PREFIX*share`.`permissions`, `stime`, `expiration`, `token`, `storage`, `mail_send`, `mail_send`';
+		$getReshares = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` WHERE `*PREFIX*share`.`file_source` = ? AND `*PREFIX*share`.`item_type` IN (\'file\', \'folder\') AND `uid_owner` != ?');
+		$reshares = $getReshares->execute(array($itemSource, \OCP\User::getUser()))->fetchAll();
+
+		foreach ($reshares as $key => $reshare) {
+			if (isset($reshare['share_with']) && $reshare['share_with'] !== '') {
+				$reshares[$key]['share_with_displayname'] = \OCP\User::getDisplayName($reshare['share_with']);
+			}
+			// add correct path to the result
+			$reshares[$key]['path'] = $path;
+		}
+
+		return array_merge($shares, $reshares);
+	}
+
+	/**
+	 * get share from all files in a given folder (non-recursive)
+	 * @param array $params contains 'path' to the folder
+	 * @return \OC_OCS_Result
+	 */
+	private static function getSharesFromFolder($params) {
+		$path = $params['path'];
+		$view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
+
+		if(!$view->is_dir($path)) {
+			return new \OC_OCS_Result(null, 400, "not a directory");
+		}
+
+		$content = $view->getDirectoryContent($path);
+
+		$result = array();
+		foreach ($content as $file) {
+			// workaround because folders are named 'dir' in this context
+			$itemType = $file['type'] === 'file' ? 'file' : 'folder';
+			$share = \OCP\Share::getItemShared($itemType, $file['fileid']);
+			if($share) {
+				$receivedFrom =  \OCP\Share::getItemSharedWithBySource($itemType, $file['fileid']);
+				reset($share);
+				$key = key($share);
+				if ($receivedFrom) {
+					$share[$key]['received_from'] = $receivedFrom['uid_owner'];
+					$share[$key]['received_from_displayname'] = \OCP\User::getDisplayName($receivedFrom['uid_owner']);
+				}
+				$result = array_merge($result, $share);
+			}
+		}
+
+		return new \OC_OCS_Result($result);
+	}
+
+	/**
+	 * get files shared with the user
+	 * @return \OC_OCS_Result
+	 */
+	private static function getFilesSharedWithMe() {
+		try	{
+			$shares = \OCP\Share::getItemsSharedWith('file');
+			foreach ($shares as &$share) {
+				if ($share['item_type'] === 'file') {
+					$share['mimetype'] = \OC_Helper::getFileNameMimeType($share['file_target']);
+					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
+						$share['isPreviewAvailable'] = true;
+					}
+				}
+			}
+			$result = new \OC_OCS_Result($shares);
+		} catch (\Exception $e) {
+			$result = new \OC_OCS_Result(null, 403, $e->getMessage());
+		}
+
+		return $result;
+
+	}
+
+	/**
+	 * create a new share
+	 * @param array $params
+	 * @return \OC_OCS_Result
+	 */
+	public static function createShare($params) {
+
+		$path = isset($_POST['path']) ? $_POST['path'] : null;
+
+		if($path === null) {
+			return new \OC_OCS_Result(null, 400, "please specify a file or folder path");
+		}
+		$itemSource = self::getFileId($path);
+		$itemType = self::getItemType($path);
+
+		if($itemSource === null) {
+			return new \OC_OCS_Result(null, 404, "wrong path, file/folder doesn't exist.");
+		}
+
+		$shareWith = isset($_POST['shareWith']) ? $_POST['shareWith'] : null;
+		$shareType = isset($_POST['shareType']) ? (int)$_POST['shareType'] : null;
+
+		switch($shareType) {
+			case \OCP\Share::SHARE_TYPE_USER:
+				$permissions = isset($_POST['permissions']) ? (int)$_POST['permissions'] : 31;
+				break;
+			case \OCP\Share::SHARE_TYPE_GROUP:
+				$permissions = isset($_POST['permissions']) ? (int)$_POST['permissions'] : 31;
+				break;
+			case \OCP\Share::SHARE_TYPE_LINK:
+				//allow password protection
+				$shareWith = isset($_POST['password']) ? $_POST['password'] : null;
+				//check public link share
+				$publicUploadEnabled = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
+				if(isset($_POST['publicUpload']) && $publicUploadEnabled !== 'yes') {
+					return new \OC_OCS_Result(null, 403, "public upload disabled by the administrator");
+				}
+				$publicUpload = isset($_POST['publicUpload']) ? $_POST['publicUpload'] : 'false';
+				// read, create, update (7) if public upload is enabled or
+				// read (1) if public upload is disabled
+				$permissions = $publicUpload === 'true' ? 7 : 1;
+				break;
+			default:
+				return new \OC_OCS_Result(null, 400, "unknown share type");
+		}
+
+		if (($permissions & \OCP\Constants::PERMISSION_READ) === 0) {
+			return new \OC_OCS_Result(null, 400, 'invalid permissions');
+		}
+
+		try	{
+			$token = \OCP\Share::shareItem(
+					$itemType,
+					$itemSource,
+					$shareType,
+					$shareWith,
+					$permissions
+					);
+		} catch (\Exception $e) {
+			return new \OC_OCS_Result(null, 403, $e->getMessage());
+		}
+
+		if ($token) {
+			$data = array();
+			$data['id'] = 'unknown';
+			$shares = \OCP\Share::getItemShared($itemType, $itemSource);
+			if(is_string($token)) { //public link share
+				foreach ($shares as $share) {
+					if ($share['token'] === $token) {
+						$data['id'] = $share['id'];
+						break;
+					}
+				}
+				$url = \OCP\Util::linkToPublic('files&t='.$token);
+				$data['url'] = $url; // '&' gets encoded to $amp;
+				$data['token'] = $token;
+
+			} else {
+				foreach ($shares as $share) {
+					if ($share['share_with'] === $shareWith && $share['share_type'] === $shareType) {
+						$data['id'] = $share['id'];
+						break;
+					}
+				}
+			}
+			return new \OC_OCS_Result($data);
+		} else {
+			return new \OC_OCS_Result(null, 404, "couldn't share file");
+		}
+	}
+
+	/**
+	 * update shares, e.g. password, permissions, etc
+	 * @param array $params shareId 'id' and the parameter we want to update
+	 *                      currently supported: permissions, password, publicUpload
+	 * @return \OC_OCS_Result
+	 */
+	public static function updateShare($params) {
+
+		$share = self::getShareFromId($params['id']);
+
+		if(!isset($share['file_source'])) {
+			return new \OC_OCS_Result(null, 404, "wrong share Id, share doesn't exist.");
+		}
+
+		try {
+			if(isset($params['_put']['permissions'])) {
+				return self::updatePermissions($share, $params);
+			} elseif (isset($params['_put']['password'])) {
+				return self::updatePassword($share, $params);
+			} elseif (isset($params['_put']['publicUpload'])) {
+				return self::updatePublicUpload($share, $params);
+			} elseif (isset($params['_put']['expireDate'])) {
+				return self::updateExpireDate($share, $params);
+			}
+		} catch (\Exception $e) {
+
+			return new \OC_OCS_Result(null, 400, $e->getMessage());
+		}
+
+		return new \OC_OCS_Result(null, 400, "Wrong or no update parameter given");
+	}
+
+	/**
+	 * update permissions for a share
+	 * @param array $share information about the share
+	 * @param array $params contains 'permissions'
+	 * @return \OC_OCS_Result
+	 */
+	private static function updatePermissions($share, $params) {
+
+		$itemSource = $share['item_source'];
+		$itemType = $share['item_type'];
+		$shareWith = $share['share_with'];
+		$shareType = $share['share_type'];
+		$permissions = isset($params['_put']['permissions']) ? (int)$params['_put']['permissions'] : null;
+
+		$publicUploadStatus = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
+		$publicUploadEnabled = ($publicUploadStatus === 'yes') ? true : false;
+
+
+		// only change permissions for public shares if public upload is enabled
+		// and we want to set permissions to 1 (read only) or 7 (allow upload)
+		if ( (int)$shareType === \OCP\Share::SHARE_TYPE_LINK ) {
+			if ($publicUploadEnabled === false || ($permissions !== 7 && $permissions !== 1)) {
+				return new \OC_OCS_Result(null, 400, "can't change permission for public link share");
+			}
+		}
+
+		if (($permissions & \OCP\Constants::PERMISSION_READ) === 0) {
+			return new \OC_OCS_Result(null, 400, 'invalid permissions');
+		}
+
+		try {
+			$return = \OCP\Share::setPermissions(
+					$itemType,
+					$itemSource,
+					$shareType,
+					$shareWith,
+					$permissions
+					);
+		} catch (\Exception $e) {
+			return new \OC_OCS_Result(null, 404, $e->getMessage());
+		}
+
+		if ($return) {
+			return new \OC_OCS_Result();
+		} else {
+			return new \OC_OCS_Result(null, 404, "couldn't set permissions");
+		}
+	}
+
+	/**
+	 * enable/disable public upload
+	 * @param array $share information about the share
+	 * @param array $params contains 'publicUpload' which can be 'yes' or 'no'
+	 * @return \OC_OCS_Result
+	 */
+	private static function updatePublicUpload($share, $params) {
+
+		$publicUploadEnabled = \OC::$server->getAppConfig()->getValue('core', 'shareapi_allow_public_upload', 'yes');
+		if($publicUploadEnabled !== 'yes') {
+			return new \OC_OCS_Result(null, 403, "public upload disabled by the administrator");
+		}
+
+		if ($share['item_type'] !== 'folder' ||
+				(int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK ) {
+			return new \OC_OCS_Result(null, 400, "public upload is only possible for public shared folders");
+		}
+
+		// read, create, update (7) if public upload is enabled or
+		// read (1) if public upload is disabled
+		$params['_put']['permissions'] = $params['_put']['publicUpload'] === 'true' ? 7 : 1;
+
+		return self::updatePermissions($share, $params);
+
+	}
+
+	/**
+	 * set expire date for public link share
+	 * @param array $share information about the share
+	 * @param array $params contains 'expireDate' which needs to be a well formated date string, e.g DD-MM-YYYY
+	 * @return \OC_OCS_Result
+	 */
+	private static function updateExpireDate($share, $params) {
+		// only public links can have a expire date
+		if ((int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK ) {
+			return new \OC_OCS_Result(null, 400, "expire date only exists for public link shares");
+		}
+
+		try {
+			$expireDateSet = \OCP\Share::setExpirationDate($share['item_type'], $share['item_source'], $params['_put']['expireDate'], (int)$share['stime']);
+			$result = ($expireDateSet) ? new \OC_OCS_Result() : new \OC_OCS_Result(null, 404, "couldn't set expire date");
+		} catch (\Exception $e) {
+			$result = new \OC_OCS_Result(null, 404, $e->getMessage());
+		}
+
+		return $result;
+
+	}
+
+	/**
+	 * update password for public link share
+	 * @param array $share information about the share
+	 * @param array $params 'password'
+	 * @return \OC_OCS_Result
+	 */
+	private static function updatePassword($share, $params) {
+
+		$itemSource = $share['item_source'];
+		$itemType = $share['item_type'];
+
+		if( (int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK) {
+			return  new \OC_OCS_Result(null, 400, "password protection is only supported for public shares");
+		}
+
+		$shareWith = isset($params['_put']['password']) ? $params['_put']['password'] : null;
+
+		if($shareWith === '') {
+			$shareWith = null;
+		}
+
+		$items = \OCP\Share::getItemShared($itemType, $itemSource);
+
+		$checkExists = false;
+		foreach ($items as $item) {
+			if($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$checkExists = true;
+				$permissions = $item['permissions'];
+			}
+		}
+
+		if (!$checkExists) {
+			return  new \OC_OCS_Result(null, 404, "share doesn't exists, can't change password");
+		}
+
+		try {
+			$result = \OCP\Share::shareItem(
+					$itemType,
+					$itemSource,
+					\OCP\Share::SHARE_TYPE_LINK,
+					$shareWith,
+					$permissions
+					);
+		} catch (\Exception $e) {
+			return new \OC_OCS_Result(null, 403, $e->getMessage());
+		}
+
+		if($result) {
+			return new \OC_OCS_Result();
+		}
+
+		return new \OC_OCS_Result(null, 404, "couldn't set password");
+	}
+
+	/**
+	 * unshare a file/folder
+	 * @param array $params contains the shareID 'id' which should be unshared
+	 * @return \OC_OCS_Result
+	 */
+	public static function deleteShare($params) {
+
+		$share = self::getShareFromId($params['id']);
+		$fileSource = isset($share['file_source']) ? $share['file_source'] : null;
+		$itemType = isset($share['item_type']) ? $share['item_type'] : null;;
+
+		if($fileSource === null) {
+			return new \OC_OCS_Result(null, 404, "wrong share ID, share doesn't exist.");
+		}
+
+		$shareWith = isset($share['share_with']) ? $share['share_with'] : null;
+		$shareType = isset($share['share_type']) ? (int)$share['share_type'] : null;
+
+		if( $shareType === \OCP\Share::SHARE_TYPE_LINK) {
+			$shareWith = null;
+		}
+
+		try {
+			$return = \OCP\Share::unshare(
+					$itemType,
+					$fileSource,
+					$shareType,
+					$shareWith);
+		} catch (\Exception $e) {
+			return new \OC_OCS_Result(null, 404, $e->getMessage());
+		}
+
+		if ($return) {
+			return new \OC_OCS_Result();
+		} else {
+			$msg = "Unshare Failed";
+			return new \OC_OCS_Result(null, 404, $msg);
+		}
+	}
+
+	/**
+	 * get file ID from a given path
+	 * @param string $path
+	 * @return string fileID or null
+	 */
+	private static function getFileId($path) {
+
+		$view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
+		$fileId = null;
+		$fileInfo = $view->getFileInfo($path);
+		if ($fileInfo) {
+			$fileId = $fileInfo['fileid'];
+		}
+
+		return $fileId;
+	}
+
+	/**
+	 * get itemType
+	 * @param string $path
+	 * @return string type 'file', 'folder' or null of file/folder doesn't exists
+	 */
+	private static function getItemType($path) {
+		$view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
+		$itemType = null;
+
+		if ($view->is_dir($path)) {
+			$itemType = "folder";
+		} elseif ($view->is_file($path)) {
+			$itemType = "file";
+		}
+
+		return $itemType;
+	}
+
+}

--- a/apps/files_sharing/tests/controller/ocsapicontrollertest.php
+++ b/apps/files_sharing/tests/controller/ocsapicontrollertest.php
@@ -10,14 +10,9 @@
 
 namespace OCA\Files_Sharing\Controllers;
 
-use OC\Files\Filesystem;
 use OCA\Files_Sharing\Application;
 use OCP\AppFramework\IAppContainer;
 use OCP\Files;
-use OCP\AppFramework\Http\RedirectResponse;
-use OCP\AppFramework\Http\TemplateResponse;
-use OCP\Security\ISecureRandom;
-use OC\Files\View;
 use OCP\Share;
 use OCA\Files_sharing\Tests\TestCase;
 
@@ -28,17 +23,8 @@ class OCSApiControllerTest extends TestCase {
 
 	/** @var IAppContainer */
 	private $container;
-	/** @var string */
-	private $user;
-	/** @var string */
-	private $token;
-	/** @var string */
-	private $oldUser;
 	/** @var OCSApiController */
 	private $OCSApiController;
-	/** @var URLGenerator */
-	private $urlGenerator;
-
 	/** @var \Doctrine\DBAL\Query\QueryBuilder */
 	private $qb;
 
@@ -167,7 +153,7 @@ class OCSApiControllerTest extends TestCase {
 	}
 
 
-	function testEnfoceLinkPassword() {
+	public function testEnfoceLinkPassword() {
 		$appConfig = \OC::$server->getAppConfig();
 		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'yes');
 
@@ -205,7 +191,7 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * @medium
 	*/
-	function testSharePermissions() {
+	public function testSharePermissions() {
 
 		// sharing file to a user should work if shareapi_exclude_groups is set
 		// to no
@@ -268,7 +254,7 @@ class OCSApiControllerTest extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testGetAllShares() {
+	public function testGetAllShares() {
 
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
@@ -289,7 +275,7 @@ class OCSApiControllerTest extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testGetShareFromSource() {
+	public function testGetShareFromSource() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
@@ -299,7 +285,7 @@ class OCSApiControllerTest extends TestCase {
 		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
 				null, 1);
 
-		$result = $this->OCSApiController->getAllShares($this->filename, null, null, null);
+		$result = $this->OCSApiController->getAllShares($this->filename, null, null);
 		$this->assertArrayHasKey('data', $result);
 
 		$this->assertTrue(count($result['data']) === 2);
@@ -315,7 +301,7 @@ class OCSApiControllerTest extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testGetShareFromSourceWithReshares() {
+	public function testGetShareFromSourceWithReshares() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
@@ -332,7 +318,7 @@ class OCSApiControllerTest extends TestCase {
 		// login as user1 again
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
-		$result = $this->OCSApiController->getAllShares($this->filename, null, null, null);
+		$result = $this->OCSApiController->getAllShares($this->filename, null, null);
 		$this->assertArrayHasKey('data', $result);
 
 		// test should return one share
@@ -361,7 +347,7 @@ class OCSApiControllerTest extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testGetShareFromId() {
+	public function testGetShareFromId() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
@@ -379,16 +365,12 @@ class OCSApiControllerTest extends TestCase {
 		// get first element
 		$share = reset($result);
 
-		/* TODO: Mock DB
-
 		// call getShare() with share ID
 		$result = $this->OCSApiController->getShare($share['id']);
 		$this->assertArrayHasKey('data', $result);
 
 		// test should return one share created from testCreateShare()
 		$this->assertEquals(1, count($result['data']));
-
-		*/
 
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
 			self::TEST_FILES_SHARING_API_USER2);
@@ -398,7 +380,7 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * @medium
 	 */
-	function testGetShareFromFolder() {
+	public function testGetShareFromFolder() {
 
 		$fileInfo1 = $this->view->getFileInfo($this->filename);
 		$fileInfo2 = $this->view->getFileInfo($this->folder.'/'.$this->filename);
@@ -432,7 +414,7 @@ class OCSApiControllerTest extends TestCase {
 	 * share a folder, than reshare a file within the shared folder and check if we construct the correct path
 	 * @medium
 	 */
-	function testGetShareFromFolderReshares() {
+	public function testGetShareFromFolderReshares() {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
@@ -489,7 +471,7 @@ class OCSApiControllerTest extends TestCase {
 	 * reshare a sub folder and check if we get the correct path
 	 * @medium
 	 */
-	function testGetShareFromSubFolderReShares() {
+	public function testGetShareFromSubFolderReShares() {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
@@ -534,7 +516,7 @@ class OCSApiControllerTest extends TestCase {
 	 * test re-re-share of folder if the path gets constructed correctly
 	 * @medium
 	 */
-	function testGetShareFromFolderReReShares() {
+	public function testGetShareFromFolderReReShares() {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
@@ -593,7 +575,7 @@ class OCSApiControllerTest extends TestCase {
 	 * test multiple shared folder if the path gets constructed correctly
 	 * @medium
 	 */
-	function testGetShareMultipleSharedFolder() {
+	public function testGetShareMultipleSharedFolder() {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
@@ -669,7 +651,7 @@ class OCSApiControllerTest extends TestCase {
 	 * test re-re-share of folder if the path gets constructed correctly
 	 * @medium
 	 */
-	function testGetShareFromFileReReShares() {
+	public function testGetShareFromFileReReShares() {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
@@ -726,23 +708,17 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * @medium
 	 */
-	function testGetShareFromUnknownId() {
-
-		/* TODO: Finish mock db
+	public function testGetShareFromUnknownId() {
 		$result = $this->OCSApiController->getShare(0);
-		print_r($result);
-
-		$this->assertEquals(404, $result->getStatusCode());
-		$meta = $result->getMeta();
-		$this->assertEquals('share doesn\'t exist', $meta['message']);
-		*/
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(404, $result['statuscode']);
 	}
 
 	/**
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testUpdateShare() {
+	public function testUpdateShare() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
@@ -875,7 +851,7 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * @medium
 	 */
-	function testUpdateShareUpload() {
+	public function testUpdateShareUpload() {
 		//Allow public uploads
 		$this->container['Config']->method('getAppValue')->willReturn('yes');
 
@@ -929,7 +905,7 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * @medium
 	 */
-	function testUpdateShareExpireDate() {
+	public function testUpdateShareExpireDate() {
 
 		$fileInfo = $this->view->getFileInfo($this->folder);
 		$config = \OC::$server->getConfig();
@@ -991,7 +967,7 @@ class OCSApiControllerTest extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
-	function testDeleteShare() {
+	public function testDeleteShare() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);
 
@@ -1019,7 +995,7 @@ class OCSApiControllerTest extends TestCase {
 	/**
 	 * test unshare of a reshared file
 	 */
-	function testDeleteReshare() {
+	public function testDeleteReshare() {
 
 		// user 1 shares a folder with user2
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -1108,6 +1084,8 @@ class OCSApiControllerTest extends TestCase {
 
 	/**
 	 * Post init mount points hook for mounting simulated ext storage
+	 *
+	 * @param array $data
 	 */
 	public static function initTestMountPointsHook($data) {
 		if ($data['user'] === self::TEST_FILES_SHARING_API_USER1) {

--- a/apps/files_sharing/tests/controller/ocsapicontrollertest.php
+++ b/apps/files_sharing/tests/controller/ocsapicontrollertest.php
@@ -1,0 +1,1232 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ * @copyright 2014 Lukas Reschke
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OCA\Files_Sharing\Controllers;
+
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\Application;
+use OCP\AppFramework\IAppContainer;
+use OCP\Files;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Security\ISecureRandom;
+use OC\Files\View;
+use OCP\Share;
+use OCA\Files_sharing\Tests\TestCase;
+
+/**
+ * @package OCA\Files_Sharing\Controllers
+ */
+class OCSApiControllerTest extends TestCase {
+
+	/** @var IAppContainer */
+	private $container;
+	/** @var string */
+	private $user;
+	/** @var string */
+	private $token;
+	/** @var string */
+	private $oldUser;
+	/** @var OCSApiController */
+	private $OCSApiController;
+	/** @var URLGenerator */
+	private $urlGenerator;
+
+	/** @var \Doctrine\DBAL\Query\QueryBuilder */
+	private $qb;
+
+	//OLD
+	const TEST_FOLDER_NAME = '/folder_share_api_test';
+
+	private static $tempStorage;
+
+
+	protected function setUp() {
+		parent::setUp();
+
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_expire_after_n_days', '7');
+
+		$this->folder = self::TEST_FOLDER_NAME;
+		$this->subfolder  = '/subfolder_share_api_test';
+		$this->subsubfolder = '/subsubfolder_share_api_test';
+
+		$this->filename = '/share-api-test.txt';
+
+		// save file with content
+		$this->view->file_put_contents($this->filename, $this->data);
+		$this->view->mkdir($this->folder);
+		$this->view->mkdir($this->folder . $this->subfolder);
+		$this->view->mkdir($this->folder . $this->subfolder . $this->subsubfolder);
+		$this->view->file_put_contents($this->folder.$this->filename, $this->data);
+		$this->view->file_put_contents($this->folder . $this->subfolder . $this->filename, $this->data);
+
+		//NEW
+		$app = new Application();
+		$this->container = $app->getContainer();
+		$this->container['AppName'] = 'files_sharing';
+		$this->container['Logger'] = $this->getMockBuilder('\OCP\ILogger')
+			->disableOriginalConstructor()->getMock();
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+			->disableOriginalConstructor()->getMock();
+		$this->qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+			->disableOriginalConstructor()->getMock();
+
+		$this->qb->method('update')->will($this->returnSelf());
+		$this->qb->method('set')->will($this->returnSelf());
+		$this->qb->method('where')->will($this->returnSelf());
+		$this->qb->method('andWhere')->will($this->returnSelf());
+		$this->qb->method('select')->will($this->returnSelf());
+		$this->qb->method('addSelect')->will($this->returnSelf());
+		$this->qb->method('from')->will($this->returnSelf());
+		$this->qb->method('expr')->willReturn($ex);
+
+		$this->container['DatabaseConnection'] = $this->getMockBuilder('\OCP\IDBConnection')
+			->disableOriginalConstructor()->getMock();
+		$this->container['DatabaseConnection']->method('createQueryBuilder')->willReturn($this->qb);
+		$this->container['Config'] = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()->getMock();
+	
+		$this->OCSApiController = $this->container['OCSApiController'];
+	}
+
+	protected function tearDown() {
+		if($this->view instanceof \OC\Files\View) {
+			$this->view->unlink($this->filename);
+			$this->view->deleteAll($this->folder);
+		}
+
+		self::$tempStorage = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @medium
+	 */
+	function testCreateShare() {
+
+		// share to user
+		$result = $this->OCSApiController->createShare($this->filename, Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, null, null, null);
+
+		$this->assertArrayHasKey('data', $result);
+		$this->assertArrayHasKey('id', $result['data']);
+
+		$share = $this->getShareFromId($result['data']['id']);
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
+
+		// share link
+		$result = $this->OCSApiController->createShare($this->folder, Share::SHARE_TYPE_LINK, null, null, null, null);
+
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+		$this->assertArrayHasKey('id', $data);
+		$this->assertArrayHasKey('url', $data);
+		$this->assertArrayHasKey('token', $data);
+
+		// check if we have a token
+		$this->assertTrue(is_string($data['token']));
+		$share = $this->getShareFromId($data['id']);
+
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+	}
+
+	/**
+	 * @medium
+	 */
+	public function testCreateShareInvalidPermissions() {
+
+		// simulate a post request
+		$result = $this->OCSApiController->createShare($this->filename, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, null, null, \OCP\Constants::PERMISSION_SHARE);
+
+		$this->assertEquals(400, $result['statuscode']);
+
+		$shares = \OCP\Share::getItemShared('file', null);
+		$this->assertCount(0, $shares);
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+	}
+
+
+	function testEnfoceLinkPassword() {
+		$appConfig = \OC::$server->getAppConfig();
+		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'yes');
+
+		// don't allow to share link without a password
+		$result = $this->OCSApiController->createShare($this->folder, \OCP\Share::SHARE_TYPE_LINK, null ,null, null, null);
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(403, $result['statuscode']);
+
+		// don't allow to share link without a empty password
+		$result = $this->OCSApiController->createShare($this->folder, \OCP\Share::SHARE_TYPE_LINK, null, null, '', null);
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(403, $result['statuscode']);
+
+		// share with password should succeed
+		$result = $this->OCSApiController->createShare($this->folder, \OCP\Share::SHARE_TYPE_LINK, null, null, 'foo', null);
+		$this->assertArrayHasKey('data', $result);
+
+		$data = $result['data'];
+
+		// setting new password should succeed
+		$result = $this->OCSApiController->updateShare($data['id'], null, 'bar', null, null);
+		$this->assertEmpty($result);
+
+		// removing password should fail
+		$result = $this->OCSApiController->updateShare($data['id'], null, '', null, null);
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(403, $result['statuscode']);
+
+		// cleanup
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'no');
+	}
+
+	/**
+	 * @medium
+	*/
+	function testSharePermissions() {
+
+		// sharing file to a user should work if shareapi_exclude_groups is set
+		// to no
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
+
+		$result = $this->OCSApiController->createShare($this->filename, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, null, null, null);
+
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+
+		$share = $this->getShareFromId($data['id']);
+
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+
+		$result = \OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		$this->assertTrue($result);
+
+		// exclude groups, but not the group the user belongs to. Sharing should still work
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'yes');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group1,group2');
+
+		$result = $this->OCSApiController->createShare($this->filename, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, null, null, null);
+
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+
+		$share = $this->getShareFromId($data['id']);
+
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+
+		$result = \OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		$this->assertTrue($result);
+
+		// now we exclude the group the user belongs to ('group'), sharing should fail now
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', 'admin,group');
+
+		$result = $this->OCSApiController->createShare($this->filename, \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, null, null, null);
+
+		$this->assertEquals(403, $result['statuscode']);
+
+		// cleanup
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups', 'no');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_exclude_groups_list', '');
+	}
+
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testGetAllShares() {
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+
+		\OCP\Share::shareItem('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+		self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$result = $this->OCSApiController->getAllShares(null, null, null);
+		$this->assertArrayHasKey('data', $result);
+
+		// test should return one share 
+		$this->assertTrue(count($result['data']) === 1);
+
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testGetShareFromSource() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		$result = $this->OCSApiController->getAllShares($this->filename, null, null, null);
+		$this->assertArrayHasKey('data', $result);
+
+		$this->assertTrue(count($result['data']) === 2);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testGetShareFromSourceWithReshares() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		// share the file as user1 to user2
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// login as user2 and reshare the file to user3
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3, 31);
+
+		// login as user1 again
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$result = $this->OCSApiController->getAllShares($this->filename, null, null, null);
+		$this->assertArrayHasKey('data', $result);
+
+		// test should return one share
+		$this->assertTrue(count($result['data']) === 1);
+
+		// now also ask for the reshares
+		$result = $this->OCSApiController->getAllShares($this->filename, true, null);
+		$this->assertArrayHasKey('data', $result);
+
+		// now we should get two shares, the initial share and the reshare
+		$this->assertTrue(count($result['data']) === 2);
+
+		// unshare files again
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testGetShareFromId() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// get item to determine share ID
+		$result = \OCP\Share::getItemShared('file', $fileInfo['fileid']);
+
+		$this->assertEquals(1, count($result));
+
+		// get first element
+		$share = reset($result);
+
+		/* TODO: Mock DB
+
+		// call getShare() with share ID
+		$result = $this->OCSApiController->getShare($share['id']);
+		$this->assertArrayHasKey('data', $result);
+
+		// test should return one share created from testCreateShare()
+		$this->assertEquals(1, count($result['data']));
+
+		*/
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+
+	}
+
+	/**
+	 * @medium
+	 */
+	function testGetShareFromFolder() {
+
+		$fileInfo1 = $this->view->getFileInfo($this->filename);
+		$fileInfo2 = $this->view->getFileInfo($this->folder.'/'.$this->filename);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$result = $this->OCSApiController->getAllShares($this->folder, null, true);
+		$this->assertArrayHasKey('data', $result);
+
+		// test should return one share within $this->folder
+		$this->assertTrue(count($result['data']) === 1);
+
+		\OCP\Share::unshare('file', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * share a folder, than reshare a file within the shared folder and check if we construct the correct path
+	 * @medium
+	 */
+	function testGetShareFromFolderReshares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder.'/'.$this->filename);
+		$fileInfo3 = $this->view->getFileInfo($this->folder.'/' . $this->subfolder . '/' .$this->filename);
+
+		// share root folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// share file in root folder
+		$result = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		// share file in subfolder
+		$result = \OCP\Share::shareItem('file', $fileInfo3['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$testValues=array(
+			array('query' => $this->folder,
+				'expectedResult' => $this->folder . $this->filename),
+			array('query' => $this->folder . $this->subfolder,
+				'expectedResult' => $this->folder . $this->subfolder . $this->filename),
+		);
+		foreach ($testValues as $value) {
+			$result = $this->OCSApiController->getAllShares($value['query'], null, true);
+			$this->assertArrayHasKey('data', $result);
+			$this->assertCount(1, $result['data']);
+			$this->assertEquals($value['expectedResult'], $result['data'][0]['path']);
+		}
+
+		// cleanup
+
+		\OCP\Share::unshare('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		\OCP\Share::unshare('file', $fileInfo3['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+	}
+
+	/**
+	 * reshare a sub folder and check if we get the correct path
+	 * @medium
+	 */
+	function testGetShareFromSubFolderReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo = $this->view->getFileInfo($this->folder . $this->subfolder);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subfolder
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$result = $this->OCSApiController->getAllShares('/', null, true);
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+		$this->assertCount(1, $data);
+
+		$expectedPath = $this->subfolder;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
+	 * test re-re-share of folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareFromFolderReReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder . $this->subfolder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder . $this->subfolder . $this->subsubfolder);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subsubfolder
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3, 31);
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user3
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$result = $this->OCSApiController->getAllShares('/', null, true);
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+		$this->assertCount(1, $data);
+
+		$expectedPath = $this->subsubfolder;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
+	 * test multiple shared folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareMultipleSharedFolder() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder . $this->subfolder);
+
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// share folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+
+		// ask for subfolder
+		$expectedPath1 = $this->subfolder;
+
+		$result1 = $this->OCSApiController->getAllShares($expectedPath1, null, null);
+		$this->assertArrayHasKey('data', $result1);
+		$data1 = $result1['data'];
+		$this->assertCount(1, $data1);
+		$share1 = reset($data1);
+
+		// ask for folder/subfolder
+		$expectedPath2 = $this->folder . $this->subfolder;
+
+		$result2 = $this->OCSApiController->getAllShares($expectedPath2, null, null);
+		$this->assertArrayHasKey('data', $result2);
+		$data2 = $result2['data'];
+		$this->assertCount(1, $data2);
+		$share2 = reset($data2);
+
+		// validate results
+		// we should get exactly one result each time
+		$this->assertEquals(1, count($data1));
+		$this->assertEquals(1, count($data2));
+
+		$this->assertEquals($expectedPath1, $share1['path']);
+		$this->assertEquals($expectedPath2, $share2['path']);
+
+
+		// cleanup
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+		$result = \OCP\Share::unshare('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
+	 * test re-re-share of folder if the path gets constructed correctly
+	 * @medium
+	 */
+	function testGetShareFromFileReReShares() {
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder . $this->subfolder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder. $this->subfolder . $this->filename);
+
+		// share sub-folder to user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		// reshare subsubfolder
+		$result = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3, 31);
+		// share was successful?
+		$this->assertTrue($result);
+
+		// login as user3
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$result = $this->OCSApiController->getAllShares('/', null, true);
+		$this->assertArrayHasKey('data', $result);
+		$data = $result['data'];
+		$this->assertCount(1, $data);
+
+		$expectedPath = $this->filename;
+		$this->assertEquals($expectedPath, $data[0]['path']);
+
+		// cleanup
+		$result = \OCP\Share::unshare('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$result = \OCP\Share::unshare('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER3);
+		$this->assertTrue($result);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+
+	}
+
+	/**
+	 * @medium
+	 */
+	function testGetShareFromUnknownId() {
+
+		/* TODO: Finish mock db
+		$result = $this->OCSApiController->getShare(0);
+		print_r($result);
+
+		$this->assertEquals(404, $result->getStatusCode());
+		$meta = $result->getMeta();
+		$this->assertEquals('share doesn\'t exist', $meta['message']);
+		*/
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testUpdateShare() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$items = \OCP\Share::getItemShared('file', null);
+
+		// make sure that we found a link share and a user share
+		$this->assertEquals(count($items), 2);
+
+		$linkShare = null;
+		$userShare = null;
+
+		foreach ($items as $item) {
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$linkShare = $item;
+			}
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_USER) {
+				$userShare = $item;
+			}
+		}
+
+		// make sure that we found a link share and a user share
+		$this->assertTrue(is_array($linkShare));
+		$this->assertTrue(is_array($userShare));
+
+		// check if share have expected permissions, single shared files never have
+		// delete permissions
+		$this->assertEquals(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_DELETE, $userShare['permissions']);
+
+		//no elements
+		$pdo = $this->getMock('mockPDOStatement', ['fetch']);
+		$this->qb->method('execute')->willReturn($pdo);
+
+		// update permissions
+		$result = $this->OCSApiController->updateShare($userShare['id'], 1, null, null, null);
+		$this->assertEmpty($result);
+
+		$items = \OCP\Share::getItemShared('file', $userShare['file_source']);
+
+		$newUserShare = null;
+		foreach ($items as $item) {
+			if ($item['share_with'] === self::TEST_FILES_SHARING_API_USER2) {
+				$newUserShare = $item;
+				break;
+			}
+		}
+
+		$this->assertTrue(is_array($newUserShare));
+
+		$this->assertEquals('1', $newUserShare['permissions']);
+
+		// update password for link share
+
+		$this->assertTrue(empty($linkShare['share_with']));
+
+		$result = $this->OCSApiController->updateShare($linkShare['id'], null, 'foo', null, null);
+		$this->assertEmpty($result);
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+
+		$newLinkShare = null;
+		foreach ($items as $item) {
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$newLinkShare = $item;
+				break;
+			}
+		}
+
+		$this->assertTrue(is_array($newLinkShare));
+		$this->assertTrue(!empty($newLinkShare['share_with']));
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	public function testUpdateShareInvalidPermissions() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		$result = \OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, \OCP\Constants::PERMISSION_ALL);
+
+		// share was successful?
+		$this->assertTrue($result);
+
+		$share = \OCP\Share::getItemShared('file', null);
+		$this->assertCount(1, $share);
+		$share = reset($share);
+
+		// check if share have expected permissions, single shared files never have
+		// delete permissions
+		$this->assertEquals(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_DELETE, $share['permissions']);
+
+		// update permissions
+		$result = $this->OCSApiController->updateShare($share['id'], \OCP\Constants::PERMISSION_SHARE, null, null, null);
+
+		//Updating should fail with 400
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(400, $result['statuscode']);
+
+		$share = \OCP\Share::getItemShared('file', $share['file_source']);
+		$share = reset($share);
+
+		//Permissions should not have changed!
+		$this->assertEquals(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_DELETE, $share['permissions']);
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+	}
+
+
+	/**
+	 * @medium
+	 */
+	function testUpdateShareUpload() {
+		//Allow public uploads
+		$this->container['Config']->method('getAppValue')->willReturn('yes');
+
+		$fileInfo = $this->view->getFileInfo($this->folder);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$items = \OCP\Share::getItemShared('file', null);
+
+		// make sure that we found a link share and a user share
+		$this->assertEquals(1, count($items));
+
+		$linkShare = null;
+
+		foreach ($items as $item) {
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$linkShare = $item;
+			}
+		}
+
+		// make sure that we found a link share
+		$this->assertTrue(is_array($linkShare));
+
+		// update public upload
+		$result = $this->OCSApiController->updateShare($linkShare['id'], null, null, true, null);
+		$this->assertEmpty($result);
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+
+		$updatedLinkShare = null;
+		foreach ($items as $item) {
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$updatedLinkShare = $item;
+				break;
+			}
+		}
+
+		$this->assertTrue(is_array($updatedLinkShare));
+		$this->assertEquals(7, $updatedLinkShare['permissions']);
+
+		// cleanup
+
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * @medium
+	 */
+	function testUpdateShareExpireDate() {
+
+		$fileInfo = $this->view->getFileInfo($this->folder);
+		$config = \OC::$server->getConfig();
+
+		// enforce expire date, by default 7 days after the file was share
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'yes');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
+
+		$dateWithinRange = new \DateTime();
+		$dateWithinRange->add(new \DateInterval('P5D'));
+		$dateOutOfRange = new \DateTime();
+		$dateOutOfRange->add(new \DateInterval('P8D'));
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		// share was successful?
+		$this->assertTrue(is_string($result));
+
+		$items = \OCP\Share::getItemShared('file', null);
+
+		// make sure that we found a link share
+		$this->assertEquals(1, count($items));
+
+		$linkShare = reset($items);
+
+		// update expire date to a valid value
+		$result = $this->OCSApiController->updateShare($linkShare['id'], null, null, null, $dateWithinRange->format('Y-m-d'));
+		$this->assertEmpty($result);
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+		$updatedLinkShare = reset($items);
+
+		// date should be changed
+		$this->assertTrue(is_array($updatedLinkShare));
+		$this->assertEquals($dateWithinRange->format('Y-m-d') . ' 00:00:00', $updatedLinkShare['expiration']);
+
+		// update expire date to a value out of range
+		$result = $this->OCSApiController->updateShare($linkShare['id'], null, null, null, $dateOutOfRange->format('Y-m-d'));
+		$this->assertArrayHasKey('statuscode', $result);
+		$this->assertEquals(404, $result['statuscode']);
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+
+		$updatedLinkShare = reset($items);
+
+		// date shouldn't be changed
+		$this->assertTrue(is_array($updatedLinkShare));
+		$this->assertEquals($dateWithinRange->format('Y-m-d') . ' 00:00:00', $updatedLinkShare['expiration']);
+
+		// cleanup
+		$config->setAppValue('core', 'shareapi_default_expire_date', 'no');
+		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'no');
+		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
+	function testDeleteShare() {
+
+		$fileInfo = $this->view->getFileInfo($this->filename);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		\OCP\Share::shareItem('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_LINK,
+				null, 1);
+
+		$items = \OCP\Share::getItemShared('file', null);
+
+		$this->assertEquals(2, count($items));
+
+		foreach ($items as $item) {
+			$result = $this->OCSApiController->deleteShare($item['id']);
+			$this->assertEmpty($result);
+		}
+
+		$itemsAfterDelete = \OCP\Share::getItemShared('file', null);
+
+		$this->assertTrue(empty($itemsAfterDelete));
+
+	}
+
+	/**
+	 * test unshare of a reshared file
+	 */
+	function testDeleteReshare() {
+
+		// user 1 shares a folder with user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo1 = $this->view->getFileInfo($this->folder);
+		$fileInfo2 = $this->view->getFileInfo($this->folder.'/'.$this->filename);
+
+		$result1 = \OCP\Share::shareItem('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$this->assertTrue($result1);
+
+		// user2 shares a file from the folder as link
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$result2 = \OCP\Share::shareItem('file', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_LINK, null, 1);
+
+		$this->assertTrue(is_string($result2));
+
+		// test if we can unshare the link again
+		$items = \OCP\Share::getItemShared('file', null);
+		$this->assertEquals(1, count($items));
+
+		$item = reset($items);
+		$result3 = $this->OCSApiController->deleteShare($item['id']);
+		$this->assertEmpty($result3);
+
+		// cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$result = \OCP\Share::unshare('folder', $fileInfo1['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * share a folder which contains a share mount point, should be forbidden
+	 */
+	public function testShareFolderWithAMountPoint() {
+		// user 1 shares a folder with user2
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo = $this->view->getFileInfo($this->folder);
+
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$this->assertTrue($result);
+
+		// user2 shares a file from the folder as link
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view->mkdir("localDir");
+
+		// move mount point to the folder "localDir"
+		$result = $view->rename($this->folder, 'localDir/'.$this->folder);
+		$this->assertTrue($result !== false);
+
+		// try to share "localDir"
+		$fileInfo2 = $view->getFileInfo('localDir');
+
+		$this->assertTrue($fileInfo2 instanceof \OC\Files\FileInfo);
+
+		try {
+			$result2 = \OCP\Share::shareItem('folder', $fileInfo2['fileid'], \OCP\Share::SHARE_TYPE_USER,
+					self::TEST_FILES_SHARING_API_USER3, 31);
+		} catch (\Exception $e) {
+			$result2 = false;
+		}
+
+		$this->assertFalse($result2);
+
+		//cleanup
+
+		$result = $view->rename('localDir/' . $this->folder, $this->folder);
+		$this->assertTrue($result !== false);
+		$view->unlink('localDir');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2);
+	}
+
+	/**
+	 * Post init mount points hook for mounting simulated ext storage
+	 */
+	public static function initTestMountPointsHook($data) {
+		if ($data['user'] === self::TEST_FILES_SHARING_API_USER1) {
+			\OC\Files\Filesystem::mount(self::$tempStorage, array(), '/' . self::TEST_FILES_SHARING_API_USER1 . '/files' . self::TEST_FOLDER_NAME);
+		}
+	}
+
+	/**
+	 * Tests mounting a folder that is an external storage mount point.
+	 */
+	public function testShareStorageMountPoint() {
+		self::$tempStorage = new \OC\Files\Storage\Temporary(array());
+		self::$tempStorage->file_put_contents('test.txt', 'abcdef');
+		self::$tempStorage->getScanner()->scan('');
+
+		// needed because the sharing code sometimes switches the user internally and mounts the user's
+		// storages. In our case the temp storage isn't mounted automatically, so doing it in the post hook
+		// (similar to how ext storage works)
+		\OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', 'self', 'initTestMountPointsHook');
+
+		// logging in will auto-mount the temp storage for user1 as well
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$fileInfo = $this->view->getFileInfo($this->folder);
+
+		// user 1 shares the mount point folder with user2
+		$result = \OCP\Share::shareItem('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				self::TEST_FILES_SHARING_API_USER2, 31);
+
+		$this->assertTrue($result);
+
+		// user2: check that mount point name appears correctly
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+
+		$this->assertTrue($view->file_exists($this->folder));
+		$this->assertTrue($view->file_exists($this->folder . '/test.txt'));
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::unshare('folder', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+			self::TEST_FILES_SHARING_API_USER2);
+
+		\OC_Hook::clear('OC_Filesystem', 'post_initMountPoints', 'self', 'initTestMountPointsHook');
+	}
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testShareNonExisting() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$id = PHP_INT_MAX - 1;
+		\OCP\Share::shareItem('file', $id, \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+	}
+
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testShareNotOwner() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		\OC\Files\Filesystem::file_put_contents('foo.txt', 'bar');
+		$info = \OC\Files\Filesystem::getFileInfo('foo.txt');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		\OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, self::TEST_FILES_SHARING_API_USER2, 31);
+	}
+
+	public function testDefaultExpireDate() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_default_expire_date', 'yes');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_enforce_expire_date', 'yes');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_expire_after_n_days', '2');
+
+		// default expire date is set to 2 days
+		// the time when the share was created is set to 3 days in the past
+		// user defined expire date is set to +2 days from now on
+		// -> link should be already expired by the default expire date but the user
+		//    share should still exists.
+		$now = time();
+		$dateFormat = 'Y-m-d H:i:s';
+		$shareCreated = $now - 3 * 24 * 60 * 60;
+		$expireDate = date($dateFormat, $now + 2 * 24 * 60 * 60);
+
+		$info = \OC\Files\Filesystem::getFileInfo($this->filename);
+		$this->assertTrue($info instanceof \OC\Files\FileInfo);
+
+		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_LINK, null, \OCP\Constants::PERMISSION_READ);
+		$this->assertTrue(is_string($result));
+
+		$result = \OCP\Share::shareItem('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
+		$this->assertTrue($result);
+
+		$result = \OCP\Share::setExpirationDate('file', $info->getId() , $expireDate, $now);
+		$this->assertTrue($result);
+
+		//manipulate stime so that both shares are older then the default expire date
+		$statement = "UPDATE `*PREFIX*share` SET `stime` = ? WHERE `share_type` = ?";
+		$query = \OCP\DB::prepare($statement);
+		$result = $query->execute(array($shareCreated, \OCP\Share::SHARE_TYPE_LINK));
+		$this->assertSame(1, $result);
+		$query = \OCP\DB::prepare($statement);
+		$result = $query->execute(array($shareCreated, \OCP\Share::SHARE_TYPE_USER));
+		$this->assertSame(1, $result);
+
+		// now the link share should expire because of enforced default expire date
+		// the user share should still exist
+		$result = \OCP\Share::getItemShared('file', $info->getId());
+		$this->assertTrue(is_array($result));
+		$this->assertSame(1, count($result));
+		$share = reset($result);
+		$this->assertSame(\OCP\Share::SHARE_TYPE_USER, $share['share_type']);
+
+		//cleanup
+		$result = \OCP\Share::unshare('file', $info->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue($result);
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_default_expire_date', 'no');
+		\OC::$server->getAppConfig()->setValue('core', 'shareapi_enforce_expire_date', 'no');
+
+	}
+}

--- a/lib/public/idbconnection.php
+++ b/lib/public/idbconnection.php
@@ -174,4 +174,12 @@ interface IDBConnection {
 	 * @return bool
 	 */
 	public function tableExists($table);
+
+
+	/**
+	 * Gets the QueryBuilder
+	 *
+	 * @return \Doctrine\DBAL\Query\QueryBuilder
+	 */
+	public function createQueryBuilder();
 }


### PR DESCRIPTION
It is about time we moved the OCS stuff to the appframework (#12454). To allow all the fancy features it offers.

Todo:
- [x] Move api/local.php to appframework
- [ ] Run trough the analyzers etc to see where I did not pay attention -- (probably tomorrow)
- [ ] Get all unit tests working again
- [ ] Move towards QueryBuilder

Feature Work:
- [ ] More injections
- [ ] Remove all global stuff from unit tests
- [ ] Make share.php properly injectable/mockable

Discussion points:
- [ ] What to do about the routes?
- [ ] Currently the return is just an array. Maybe add extra functions to do better/more structured unit test testing.

Probably more is needed. Since this is a pretty invasive change.
All feedback (and help) is welcome!
