### PR TITLE
Don't use placeholder for password in IE8 & 9

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -989,6 +989,11 @@ $(document).ready(function() {
 				});
 			} else {
 				$('#linkPass').slideToggle(OC.menuSpeed);
+				// TODO drop with IE8 drop
+				if(html.hasClass('ie8')) {
+					$('#linkPassText').attr('placeholder', null);
+					$('#linkPassText').val('');
+				}
 				$('#linkPassText').focus();
 			}
 			if (expireDateString !== '') {

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -172,7 +172,13 @@ $(document).ready(function () {
 		$('#pass2').showPassword().keyup();
 	}
 	$("#passwordbutton").click(function () {
-		if ($('#pass1').val() !== '' && $('#pass2').val() !== '') {
+		var isIE8or9 = html.hasClass('lte9');
+		// FIXME - TODO - once support for IE8 and IE9 is dropped
+		// for IE8 and IE9 this will check additionally if the typed in password
+		// is different from the placeholder, because in IE8/9 the placeholder
+		// is simply set as the value to look like a placeholder
+		if ($('#pass1').val() !== '' && $('#pass2').val() !== ''
+			&& !(isIE8or9 && $('#pass2').val() === $('#pass2').attr('placeholder'))) {
 			// Serialize the data
 			var post = $("#passwordform").serialize();
 			$('#passwordchanged').hide();


### PR DESCRIPTION
- the placeholder is in IE 8 and 9 just set as text and
  styled a bit grey. If the form is then serialized without
  typing something in the placeholder is sent as value
- this fixes that behaviour for the password field and
  properly detects empyt passwords
- fixes #14912 
- [x] I'm really sorry to say that. There is also a problem when sharing a link, if password enforcement is activated. If you click on the checkbox "share link", the password field appears. But in IE9, you are NOT forced to enter a password. After one second you can directly send a mail and set an expiration date. If you then uncheck the checkbox and directly check it again, the password field is filled with "*******". Then you are forced to enter a password.

cc @PVince81 @jancborchardt @norahy
