### PR TITLE
Files thumbnail fix

### DIFF
--- a/apps/files/appinfo/application.php
+++ b/apps/files/appinfo/application.php
@@ -8,7 +8,6 @@
 
 namespace OCA\Files\Appinfo;
 
-use OC\AppFramework\Utility\SimpleContainer;
 use OCA\Files\Controller\ApiController;
 use OCP\AppFramework\App;
 use \OCA\Files\Service\TagService;
@@ -18,15 +17,17 @@ class Application extends App {
 	public function __construct(array $urlParams=array()) {
 		parent::__construct('files', $urlParams);
 		$container = $this->getContainer();
+		$server = $container->getServer();
 
 		/**
 		 * Controllers
 		 */
-		$container->registerService('APIController', function (IContainer $c) {
+		$container->registerService('APIController', function (IContainer $c) use ($server) {
 			return new ApiController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('TagService')
+				$c->query('TagService'),
+				$server->getPreviewManager()
 			);
 		});
 


### PR DESCRIPTION
Using OC_Image->show() already sends headers. So don't use that if more headers are required.

Related issues #12712 and #14378
- The DataDisplayResponse is now used.
- IPreview is injected
- Some unit tests
