### PR TITLE
Store server timezone before setting to UTC

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -491,6 +491,11 @@ class OC {
 			ini_set('display_errors', 1);
 		}
 
+		try {
+			$serverDateTimeZone = new \DateTimeZone(date_default_timezone_get());
+			\OC::$server->registerParameter('ServerDateTimeZone', $serverDateTimeZone);
+		} catch (\Exception $e) {
+		}
 		date_default_timezone_set('UTC');
 		ini_set('arg_separator.output', '&amp;');
 

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -61,11 +61,16 @@ class OC_Log_Owncloud {
 		if($level>=$minLevel) {
 			// default to ISO8601
 			$format = OC_Config::getValue('logdateformat', 'c');
-			$logtimezone=OC_Config::getValue( "logtimezone", 'UTC' );
+			$timezone = null;
 			try {
-				$timezone = new DateTimeZone($logtimezone);
+				$logtimezone = OC_Config::getValue("logtimezone");
+				if ($logtimezone) {
+					$timezone = new DateTimeZone($logtimezone);
+				}
 			} catch (Exception $e) {
-				$timezone = new DateTimeZone('UTC');
+			}
+			if (!$timezone) {
+				$timezone = \OC::$server->getServerDateTimeZone();
 			}
 			$time = new DateTime(null, $timezone);
 			$request = \OC::$server->getRequest();

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -269,6 +269,7 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getSession()
 			);
 		});
+		$this->registerParameter('ServerDateTimeZone', new \DateTimeZone('UTC'));
 		$this->registerService('DateTimeFormatter', function(Server $c) {
 			$language = $c->getConfig()->getUserValue($c->getSession()->get('user_id'), 'core', 'lang', null);
 
@@ -761,6 +762,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getDateTimeZone() {
 		return $this->query('DateTimeZone');
+	}
+
+	/**
+	 * @return \DateTimeZone
+	 */
+	public function getServerDateTimeZone() {
+		return $this->query('ServerDateTimeZone');
 	}
 
 	/**

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -328,11 +328,6 @@ class Setup {
 				self::protectDataDirectory();
 			}
 
-			//try to write logtimezone
-			if (date_default_timezone_get()) {
-				\OC_Config::setValue('logtimezone', date_default_timezone_get());
-			}
-
 			//and we are done
 			$config->setSystemValue('installed', true);
 		}

--- a/tests/lib/datetimezone.php
+++ b/tests/lib/datetimezone.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+class DateTimeZone extends TestCase {
+	protected $config;
+	protected $session;
+	protected $savedTimezone;
+
+	protected function setUp() {
+		$this->config = $this->getMockBuilder('\OCP\IConfig')
+			->getMock();
+		$this->session = $this->getMockBuilder('\OCP\ISession')
+			->getMock();
+		$this->savedTimezone = \OC::$server->getServerDateTimeZone();
+		\OC::$server->registerParameter('ServerDateTimeZone', new \DateTimeZone('UTC'));
+	}
+
+	protected function tearDown() {
+		\OC::$server->registerParameter('ServerDateTimeZone', $this->savedTimezone);
+	}
+
+	public function userTimeZoneProvider() {
+		return [
+			[null, 'UTC'],
+			['Europe/Berlin', 'Europe/Berlin'],
+			['Mars/OlympusMons', 'UTC']
+		];
+	}
+
+	/**
+	 * @dataProvider userTimeZoneProvider
+	 */
+	public function testUserTimeZone($timezone, $expectedTimezone) {
+		$this->session->expects($this->once())
+			->method('get')
+			->with('user_id')
+			->willReturn('foobar');
+		$this->session->method('exists')
+			->with('timezone')
+			->willReturn(false);
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('foobar', 'core', 'timezone', null)
+			->willReturn($timezone);
+
+		$dateTimeZone = new \OC\DateTimeZone($this->config, $this->session);
+
+		$this->assertEquals($expectedTimezone, $dateTimeZone->getTimeZone()->getName());
+	}
+}


### PR DESCRIPTION
Used for the default log timezone. Fixes #8212

See #14898 for the previous incarnation. This version doesn't remove the default timezone to UTC setting, so it won't break anything.

cc @karlitschek @DeepDiver1975 @PVince81 
