### PR TITLE
Fix scanFile signature warnings

### DIFF
--- a/apps/files_sharing/lib/external/scanner.php
+++ b/apps/files_sharing/lib/external/scanner.php
@@ -33,7 +33,7 @@ class Scanner extends \OC\Files\Cache\Scanner {
 	 * @param int $reuseExisting
 	 * @return array an array of metadata of the scanned file
 	 */
-	public function scanFile($file, $reuseExisting = 0) {
+	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null) {
 		try {
 			return parent::scanFile($file, $reuseExisting);
 		} catch (ForbiddenException $e) {


### PR DESCRIPTION
@icewind1991 @schiesbn @DeepDiver1975 @nickvergessen @LukasReschke 

Fixes annoying warning about signature mismatch of `scanFile()`
