### PR TITLE
Fix root request path for Dropbox

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -100,7 +100,12 @@ class Dropbox extends \OC\Files\Storage\Common {
 				return $contents;
 			} else {
 				try {
-					$response = $this->dropbox->getMetaData($path, 'false');
+					$requestPath = $path;
+					if ($path === '.') {
+						$requestPath = '';
+					}
+
+					$response = $this->dropbox->getMetaData($requestPath, 'false');
 					if (!isset($response['is_deleted']) || !$response['is_deleted']) {
 						$this->metaData[$path] = $response;
 						return $response;


### PR DESCRIPTION
It looks like so far the request with "." worked, maybe the API itself has changed.

This fix converts "." to "" when requesting info from the Dropbox root.

Seems to fix the intermittent 401 errors.
