### PR TITLE
Add version and path to cache prefix

### DIFF
--- a/lib/private/memcache/cache.php
+++ b/lib/private/memcache/cache.php
@@ -21,6 +21,9 @@ abstract class Cache implements \ArrayAccess, \OCP\ICache {
 		$this->prefix = $prefix;
 	}
 
+	/**
+	 * @return string Prefix used for caching purposes
+	 */
 	public function getPrefix() {
 		return $this->prefix;
 	}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -157,8 +157,13 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('MemCacheFactory', function ($c) {
 			$config = $c->getConfig();
+			$v = \OC_App::getAppVersions();
+			$v['core'] = implode('.', \OC_Util::getVersion());
+			$version = implode(',', $v);
 			$instanceId = \OC_Util::getInstanceId();
-			return new \OC\Memcache\Factory($instanceId,
+			$path = \OC::$SERVERROOT;
+			$prefix = md5($instanceId.'-'.$version.'-'.$path);
+			return new \OC\Memcache\Factory($prefix,
 				$config->getSystemValue('memcache.local', null),
 				$config->getSystemValue('memcache.distributed', null)
 			);


### PR DESCRIPTION
Prevents to have the cache reused by other instances on the server which have possible the same instance ID and also invalidates older cache entries after an upgrade which can cause unwanted side-effects.

Impact for deployment: The same cache will only get used if ownCloud is installed with the same version and under the same path. But this should be a basic requirement anyways.

cc @MorrisJobke @DeepDiver1975 
