### PR TITLE
Cache \OC\URLGenerator::imagePath

### DIFF
--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -10,7 +10,7 @@
 
 // This file is just used to redirect the legacy sharing URLs (< ownCloud 8) to the new ones
 
-$urlGenerator = new \OC\URLGenerator(\OC::$server->getConfig());
+$urlGenerator = \OC::$server->getURLGenerator();
 $token = isset($_GET['t']) ? $_GET['t'] : '';
 $route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadShare' : 'files_sharing.sharecontroller.showShare';
 

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -147,7 +147,11 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('URLGenerator', function (Server $c) {
 			$config = $c->getConfig();
-			return new \OC\URLGenerator($config);
+			$cacheFactory = $c->getMemCacheFactory();
+			return new \OC\URLGenerator(
+				$config,
+				$cacheFactory
+			);
 		});
 		$this->registerService('AppHelper', function ($c) {
 			return new \OC\AppHelper();

--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -117,14 +117,14 @@ class URLGenerator implements IURLGenerator {
 	 * Returns the path to the image.
 	 */
 	public function imagePath($app, $image) {
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
-
 		$cache = $this->cacheFactory->create('imagePath');
 		$cacheKey = $app.'-'.$image;
 		if($cache->hasKey($cacheKey)) {
 			return $cache->get($cacheKey);
 		}
+
+		// Read the selected theme from the config file
+		$theme = \OC_Util::getTheme();
 
 		//if a theme has a png but not an svg always use the png
 		$basename = substr(basename($image),0,-4);

--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -119,8 +119,8 @@ class URLGenerator implements IURLGenerator {
 	public function imagePath($app, $image) {
 		$cache = $this->cacheFactory->create('imagePath');
 		$cacheKey = $app.'-'.$image;
-		if($cache->hasKey($cacheKey)) {
-			return $cache->get($cacheKey);
+		if($key = $cache->get($cacheKey)) {
+			return $key;
 		}
 
 		// Read the selected theme from the config file

--- a/tests/lib/urlgenerator.php
+++ b/tests/lib/urlgenerator.php
@@ -16,7 +16,8 @@ class Test_Urlgenerator extends \Test\TestCase {
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '';
 		$config = $this->getMock('\OCP\IConfig');
-		$urlGenerator = new \OC\URLGenerator($config);
+		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkTo($app, $file, $args);
 
 		$this->assertEquals($expectedResult, $result);
@@ -30,7 +31,8 @@ class Test_Urlgenerator extends \Test\TestCase {
 	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
 		\OC::$WEBROOT = '/owncloud';
 		$config = $this->getMock('\OCP\IConfig');
-		$urlGenerator = new \OC\URLGenerator($config);
+		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkTo($app, $file, $args);
 
 		$this->assertEquals($expectedResult, $result);
@@ -42,7 +44,8 @@ class Test_Urlgenerator extends \Test\TestCase {
 	public function testLinkToRouteAbsolute($route, $expected) {
 		\OC::$WEBROOT = '/owncloud';
 		$config = $this->getMock('\OCP\IConfig');
-		$urlGenerator = new \OC\URLGenerator($config);
+		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->linkToRouteAbsolute($route);
 		$this->assertEquals($expected, $result);
 
@@ -79,7 +82,9 @@ class Test_Urlgenerator extends \Test\TestCase {
 	function testGetAbsoluteURLDocRoot($url, $expectedResult) {
 
 		\OC::$WEBROOT = '';
-		$urlGenerator = new \OC\URLGenerator(null);
+		$config = $this->getMock('\OCP\IConfig');
+		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->getAbsoluteURL($url);
 
 		$this->assertEquals($expectedResult, $result);
@@ -93,7 +98,9 @@ class Test_Urlgenerator extends \Test\TestCase {
 	function testGetAbsoluteURLSubDir($url, $expectedResult) {
 
 		\OC::$WEBROOT = '/owncloud';
-		$urlGenerator = new \OC\URLGenerator(null);
+		$config = $this->getMock('\OCP\IConfig');
+		$cacheFactory = $this->getMock('\OCP\ICacheFactory');
+		$urlGenerator = new \OC\URLGenerator($config, $cacheFactory);
 		$result = $urlGenerator->getAbsoluteURL($url);
 
 		$this->assertEquals($expectedResult, $result);


### PR DESCRIPTION
\OC\URLGenerator::imagePath is a really expensive operation due to all the I/O handling and can really benefit from caching. 

To test this:

``` php
    $before = microtime(true);

    for ($i=0 ; $i < 100000 ; $i++) {
        OCP\Util::imagePath("core", "places/files.svg");
    }

    $after = microtime(true);
    echo ($after-$before)." sec\n";
```

On master on my SSD machine: 6.4791729450226 sec
On this branch (with enabled APCu cache as per config.php): ~~2.801265001297~~ ~~1.7592339515686~~ 1.5740730762482 sec

For a single run on this branch: ~~8.702278137207E-5~~ ~~7.7962875366211E~~ 6.7949295043945E sec
For a single run on master: 0.00012588500976562 sec

Requires https://github.com/owncloud/core/pull/14948 so that it gets invalidated after application updates.
