### PR TITLE
Add whitespace to right of list to prevent accidental deletion when scrolling

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -488,7 +488,7 @@ table td.filename .uploadtext {
 #fileList img.move2trash { display:inline; margin:-8px 0; padding:16px 8px 16px 8px !important; float:right; }
 #fileList a.action.delete {
 	position: absolute;
-	right: 0;
+	right: 15px;
 	padding: 17px 14px;
 }
 

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -99,10 +99,14 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 	display : none;
 }
 
-td.remove { width:1em; padding-right:1em; }
 tr:hover>td.password>span, tr:hover>td.displayName>span { margin:0; cursor:pointer; }
 tr:hover>td.remove>a, tr:hover>td.password>img,tr:hover>td.displayName>img, tr:hover>td.quota>img { visibility:visible; cursor:pointer; }
-tr:hover>td.remove>a { float:right; }
+td.remove {
+	width: 25px;
+}
+tr:hover>td.remove>a {
+	float: left;
+}
 
 div.recoveryPassword { left:50em; display:block; position:absolute; top:-1px; }
 input#recoveryPassword {width:15em;}


### PR DESCRIPTION
This adds a bit of whitespace to the right of the file list (as well as the user list) to prevent accidental deletion when wanting to use the scrollbar with the mouse. Please review @owncloud/designers 

@dragotin @ShamimIslam @Wikinaut I think this will at least partly make you happy. :) Please test.
