### PR TITLE
Share dropdown: fix checkbox alignment, more whitespace

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -87,6 +87,7 @@
 
 #dropdown input[type="checkbox"] {
 	margin:0 3px 0 8px;
+	vertical-align: middle;
 }
 
 a.showCruds {

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -127,8 +127,10 @@ a.unshare {
 	width:12px;
 }
 
-.reshare,#link label,#expiration label {
-	padding-left:8px;
+.reshare,#link label,
+#expiration label {
+	display: inline-block;
+	padding: 6px 4px;
 }
 
 a.showCruds:hover,a.unshare:hover {


### PR DESCRIPTION
- fix checkbox alignment in share dialog, fix #11515 cc @PVince81 
- add more whitespace to share link options in dropdown for better clickability and look

Please review @owncloud/designers 
