### PR TITLE
Reallow single quote in file names

### DIFF
--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -512,7 +512,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 			}
 		}
 
-		$sanitizedFileName = filter_var($fileName, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW);
+		$sanitizedFileName = filter_var($fileName, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 		if($sanitizedFileName !== $fileName) {
 			throw new InvalidCharacterInPathException();
 		}

--- a/tests/lib/files/pathverificationtest.php
+++ b/tests/lib/files/pathverificationtest.php
@@ -230,4 +230,30 @@ class PathVerification extends \Test\TestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider providesValidPosixPaths
+	 */
+	public function testPathVerificationValidPaths($fileName) {
+		$storage = new Local(['datadir' => '']);
+
+		\Test_Helper::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
+		\Test_Helper::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		// nothing thrown
+		$this->assertTrue(true);
+	}
+
+	public function providesValidPosixPaths() {
+		return [
+			['simple'],
+			['simple.txt'],
+			['\''],
+			['`'],
+			['%'],
+			['()'],
+			['[]'],
+			['!'],
+			['$'],
+			['_'],
+		];
+	}
 }


### PR DESCRIPTION
Regression from stable8, introduced by https://github.com/owncloud/core/commit/2f18a09a20cf62438c742c3020215cab03bc997d

This PR adds a unit test (in the spirit of test first).
Need to look into a solution.

Currently the sanitization block converts "a'b" to "a&#39b" here https://github.com/owncloud/core/commit/2f18a09a20cf62438c742c3020215cab03bc997d#diff-43d02ea7c0da1686b8ca6e343392cff1R508 which fails the final comparison.
- [x] fix the actual bug
- [x] add unit test

@LukasReschke @DeepDiver1975 
