### PR TITLE
Fix fileglobalgc unlink parameter warnings

### DIFF
--- a/lib/private/cache/fileglobalgc.php
+++ b/lib/private/cache/fileglobalgc.php
@@ -6,6 +6,9 @@ use OC\BackgroundJob\Job;
 use OCP\IConfig;
 
 class FileGlobalGC extends Job {
+	// only do cleanup every 5 minutes
+	const CLEANUP_TTL_SEC = 300;
+
 	public function run($argument) {
 		$this->gc(\OC::$server->getConfig(), $this->getCacheDir());
 	}
@@ -39,8 +42,7 @@ class FileGlobalGC extends Job {
 	public function gc(IConfig $config, $cacheDir) {
 		$lastRun = $config->getAppValue('core', 'global_cache_gc_lastrun', 0);
 		$now = time();
-		if (($now - $lastRun) < 300) {
-			// only do cleanup every 5 minutes
+		if (($now - $lastRun) < self::CLEANUP_TTL_SEC) {
 			return;
 		}
 		$config->setAppValue('core', 'global_cache_gc_lastrun', $now);

--- a/lib/private/cache/fileglobalgc.php
+++ b/lib/private/cache/fileglobalgc.php
@@ -48,6 +48,8 @@ class FileGlobalGC extends Job {
 			return;
 		}
 		$paths = $this->getExpiredPaths($cacheDir, $now);
-		array_walk($paths, 'unlink');
+		array_walk($paths, function($file) {
+			unlink($file);
+		});
 	}
 }


### PR DESCRIPTION
From the documentation (http://php.net/manual/en/function.array-walk.php):

>    Typically, callback takes on two parameters. The array parameter's value being the first, and the key/index second. 
> Many internal functions (for example strtolower()) will throw a warning if more than the expected number of argument are passed in and are not usable directly as a callback. 

`unlink` has an optional second parameter, a resource, which prints a warning when passed an integer as per `array_walk`.

Fixes #14932

@karlitschek This affects stable8, backport?
