### PR TITLE
OCS Fixes to allow setting of password without removing additional settings

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1167,7 +1167,8 @@ class Share extends \OC\Share\Constants {
 
 		$qb->select('`uid_owner`')
 			->from('`*PREFIX*share`')
-			->where($qb->expr()->eq('`id`', $shareId));
+			->where('`id` = :shareId')
+			->setParameter(':shareId', $shareId);
 		$result = $qb->execute();
 		$result = $result->fetch();
 
@@ -1215,8 +1216,11 @@ class Share extends \OC\Share\Constants {
 
 		$qb = $connection->createQueryBuilder();
 		$qb->update('`*PREFIX*share`')
-			->set('`share_with`', is_null($password) ? 'NULL' : $qb->expr()->literal(\OC::$server->getHasher()->hash($password)))
-			->where($qb->expr()->eq('`id`', $shareId));
+			->set('`share_with`', ':pass')
+			->where('`id` = :shareId')
+			->setParameter(':pass', is_null($password) ? 'NULL' : $qb->expr()->literal(\OC::$server->getHasher()->hash($password)))
+			->setParameter(':shareId', $shareId);
+
 		$qb->execute();
 
 		return true;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -318,6 +318,20 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
+	 * Set expiration date for a share
+	 * @param int $shareId
+	 * @param string $password
+	 * @return boolean
+	 */
+	public static function setPassword($shareId, $password) {
+		$userSession = \OC::$server->getUserSession();
+		$connection = \OC::$server->getDatabaseConnection();
+		$config = \OC::$server->getConfig();
+		return \OC\Share\Share::setPassword($userSession, $connection, $config, $shareId, $password);
+	}
+
+
+	/**
 	 * Get the backend class for the specified item type
 	 * @param string $itemType
 	 * @return Share_Backend

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1128,6 +1128,236 @@ class Test_Share extends \Test\TestCase {
 		\OC_Appconfig::deleteKey('core', 'shareapi_expire_after_n_days');
 		\OC_Appconfig::deleteKey('core', 'shareapi_enforce_expire_date');
 	}
+
+	/**
+	 * Cannot set password is there is no user
+	 *
+	 * @expectedException Exception
+	 * @expectedExceptionMessage User not logged in
+	 */
+	public function testSetPasswordNoUser() {
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+
+		$connection  = $this->getMockBuilder('\OC\DB\Connection')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+		               ->getMock();
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 1, 'pass');
+	}
+
+	/**
+	 * Test setting a password when everything is fine
+	 */
+	public function testSetPassword() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+		             ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('select')->will($this->returnSelf());
+		$qb->method('from')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
+		            ->disableOriginalConstructor()
+					->getMock();
+		$ret->method('fetch')->willReturn(['uid_owner' => 'user']);
+		$qb->method('execute')->willReturn($ret);
+
+
+		$connection  = $this->getMockBuilder('\OC\DB\Connection')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+		               ->getMock();
+
+
+		$res = \OC\Share\Share::setPassword($userSession, $connection, $config, 1, 'pass');
+
+		$this->assertTrue($res);
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Cannot remove password
+	 *
+	 * Test removing a password when password is enforced
+	 */
+	public function testSetPasswordRemove() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+		             ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('select')->will($this->returnSelf());
+		$qb->method('from')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
+		            ->disableOriginalConstructor()
+					->getMock();
+		$ret->method('fetch')->willReturn(['uid_owner' => 'user']);
+		$qb->method('execute')->willReturn($ret);
+
+
+		$connection  = $this->getMockBuilder('\OC\DB\Connection')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+		               ->getMock();
+		$config->method('getAppValue')->willReturn('yes');
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 1, '');
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Share not found
+	 *
+	 * Test modification of invaid share
+	 */
+	public function testSetPasswordInvalidShare() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+		             ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('select')->will($this->returnSelf());
+		$qb->method('from')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
+		            ->disableOriginalConstructor()
+					->getMock();
+		$ret->method('fetch')->willReturn([]);
+		$qb->method('execute')->willReturn($ret);
+
+
+		$connection  = $this->getMockBuilder('\OC\DB\Connection')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+		               ->getMock();
+
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 1, 'pass');
+	}
+
+	/**
+	 * @expectedException Exception
+	 * @expectedExceptionMessage Cannot update share of a different user
+	 *
+	 * Test modification of share of another user
+	 */
+	public function testSetPasswordShareOtherUser() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+		             ->disableOriginalConstructor()
+		             ->getMock();
+		$user->method('getUID')->willReturn('user');
+
+		$userSession = $this->getMockBuilder('\OCP\IUserSession')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$userSession->method('getUser')->willReturn($user);
+
+
+		$ex = $this->getMockBuilder('\Doctrine\DBAL\Query\Expression\ExpressionBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb = $this->getMockBuilder('\Doctrine\DBAL\Query\QueryBuilder')
+		           ->disableOriginalConstructor()
+		           ->getMock();
+		$qb->method('update')->will($this->returnSelf());
+		$qb->method('set')->will($this->returnSelf());
+		$qb->method('where')->will($this->returnSelf());
+		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('select')->will($this->returnSelf());
+		$qb->method('from')->will($this->returnSelf());
+		$qb->method('expr')->willReturn($ex);
+
+		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
+		            ->disableOriginalConstructor()
+					->getMock();
+		$ret->method('fetch')->willReturn(['uid_owner' => 'user2']);
+		$qb->method('execute')->willReturn($ret);
+
+
+		$connection  = $this->getMockBuilder('\OC\DB\Connection')
+		                    ->disableOriginalConstructor()
+		                    ->getMock();
+		$connection->method('createQueryBuilder')->willReturn($qb);
+
+		$config = $this->getMockBuilder('\OCP\IConfig')
+		               ->disableOriginalConstructor()
+		               ->getMock();
+
+
+		\OC\Share\Share::setPassword($userSession, $connection, $config, 1, 'pass');
+	}
+
 }
 
 class DummyShareClass extends \OC\Share\Share {

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1178,6 +1178,7 @@ class Test_Share extends \Test\TestCase {
 		$qb->method('andWhere')->will($this->returnSelf());
 		$qb->method('select')->will($this->returnSelf());
 		$qb->method('from')->will($this->returnSelf());
+		$qb->method('setParameter')->will($this->returnSelf());
 		$qb->method('expr')->willReturn($ex);
 
 		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
@@ -1232,6 +1233,7 @@ class Test_Share extends \Test\TestCase {
 		$qb->method('set')->will($this->returnSelf());
 		$qb->method('where')->will($this->returnSelf());
 		$qb->method('andWhere')->will($this->returnSelf());
+		$qb->method('setParameter')->will($this->returnSelf());
 		$qb->method('expr')->willReturn($ex);
 
 		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
@@ -1284,6 +1286,7 @@ class Test_Share extends \Test\TestCase {
 		$qb->method('andWhere')->will($this->returnSelf());
 		$qb->method('select')->will($this->returnSelf());
 		$qb->method('from')->will($this->returnSelf());
+		$qb->method('setParameter')->will($this->returnSelf());
 		$qb->method('expr')->willReturn($ex);
 
 		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')
@@ -1336,6 +1339,7 @@ class Test_Share extends \Test\TestCase {
 		$qb->method('andWhere')->will($this->returnSelf());
 		$qb->method('select')->will($this->returnSelf());
 		$qb->method('from')->will($this->returnSelf());
+		$qb->method('setParameter')->will($this->returnSelf());
 		$qb->method('expr')->willReturn($ex);
 
 		$ret = $this->getMockBuilder('\Doctrine\DBAL\Driver\ResultStatement')


### PR DESCRIPTION
Redo of #14868 but only for the OCS API.

What has been done:
- Added setPassword to share.php
- Fixed OCS API call
- Added unit tests

Related issues #10671 and #14826 

No work has been done in the web frontend since we need to switch that to the OCS API anyway. And the patch did not fix it completely anyway.

Might be a good idea to backport this fix as well. Since the clients use the OCS API.
