### PR TITLE
Update search.js

### DIFF
--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -104,14 +104,6 @@
 					if (typeof size !== 'number') {
 						size = 30;
 					}
-					if (typeof inApps !== 'object') {
-						var currentApp = getCurrentApp();
-						if(currentApp) {
-							inApps = [currentApp];
-						} else {
-							inApps = [];
-						}
-					}
 					// prevent double pages
 					if ($searchResults && query === lastQuery && page === lastPage && size === lastSize) {
 						return;
@@ -128,14 +120,27 @@
 						$status.html(t('core', 'Searching other places')+'<img class="spinner" alt="search in progress" src="'+OC.webroot+'/core/img/loading.gif" />');
 
 						// do the actual search query
-						$.getJSON(OC.generateUrl('core/search'), {query:query, inApps:inApps, page:page, size:size }, function(results) {
-							lastResults = results;
-							if (page === 1) {
-								showResults(results);
-							} else {
-								addResults(results);
-							}
-						});
+						// only pass inApps when set
+						if (typeof inApps === 'object') {
+							$.getJSON(OC.generateUrl('core/search'), {query:query, inApps:inApps, page:page, size:size }, function(results) {
+								lastResults = results;
+								if (page === 1) {
+									showResults(results);
+								} else {
+									addResults(results);
+								}
+							});
+						}
+						else {
+							$.getJSON(OC.generateUrl('core/search'), {query:query, page:page, size:size }, function(results) {
+								lastResults = results;
+								if (page === 1) {
+									showResults(results);
+								} else {
+									addResults(results);
+								}
+							});	
+						}
 					}, 500);
 				}
 			};


### PR DESCRIPTION
OCP\ISearch says $inApps is optional, but passing an empty string defaults to currentApp on line 110. Therefore not showing search results from other places in apps. In my case I apdapted the trashbin in my app and it won't show search results from "files" because of this. Perhaps adapting cores search.js and including it in each app would be a solution, but that's too much for me. Further it would be nice to use code which is already written.
