### PR TITLE
Stop executing, when 3rdparty is missing or apps directory is invalid

### DIFF
--- a/tests/preseed-config.php
+++ b/tests/preseed-config.php
@@ -1,23 +1,23 @@
 <?php
-$CONFIG = array (
-	"appstoreenabled" => false,
-	'apps_paths' =>
-		array (
-			0 =>
-				array (
-					'path' => OC::$SERVERROOT.'/apps',
-					'url' => '/apps',
-					'writable' => true,
-				),
-			1 =>
-				array (
-					'path' => OC::$SERVERROOT.'/apps2',
-					'url' => '/apps2',
-					'writable' => false,
-				)
-		),
-);
+$CONFIG = [
+	'appstoreenabled' => false,
+	'apps_paths' => [
+		[
+			'path'		=> OC::$SERVERROOT . '/apps',
+			'url'		=> '/apps',
+			'writable'	=> true,
+		],
+	],
+];
 
-if(substr(strtolower(PHP_OS), 0, 3) == "win") {
-	$CONFIG['openssl'] = array( 'config' => OC::$SERVERROOT.'/tests/data/openssl.cnf');
+if (is_dir(OC::$SERVERROOT.'/apps2')) {
+	$CONFIG['apps_paths'][] = [
+		'path' => OC::$SERVERROOT . '/apps2',
+		'url' => '/apps2',
+		'writable' => false,
+	];
+}
+
+if (substr(strtolower(PHP_OS), 0, 3) === 'win') {
+	$CONFIG['openssl'] = ['config' => OC::$SERVERROOT . '/tests/data/openssl.cnf'];
 }


### PR DESCRIPTION
Replaces #11063

Just making the behaviour consistent when 3rdparty and app path is missing/not valid.

empty `OC::$APPSROOTS` gives a blank page atm, because the exception message is not displayed.

@LukasReschke @MorrisJobke @DeepDiver1975 
