### PR TITLE
Soft fail in custom properties backend

### DIFF
--- a/tests/lib/connector/sabre/custompropertiesbackend.php
+++ b/tests/lib/connector/sabre/custompropertiesbackend.php
@@ -102,6 +102,34 @@ class CustomPropertiesBackend extends \Test\TestCase {
 	}
 
 	/**
+	 * Test that propFind on a missing file soft fails
+	 */
+	public function testPropFindMissingFileSoftFail() {
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/dummypath')
+			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
+
+		$propFind = new \Sabre\DAV\PropFind(
+			'/dummypath',
+			array(
+				'customprop',
+				'customprop2',
+				'unsetprop',
+			),
+			0
+		);
+
+		$this->plugin->propFind(
+			'/dummypath',
+			$propFind
+		);
+
+		// no exception, soft fail
+		$this->assertTrue(true);
+	}
+
+	/**
 	 * Test setting/getting properties
 	 */
 	public function testSetGetPropertiesForFile() {


### PR DESCRIPTION
This makes it possible for clients to still receive a file list (minus
the broken files) instead of getting no list at all

Steps:
1. Create a file "`backtickfront.txt" with the web UI
2. Try a PROPFIND on the file list

Before this fix: no list returned, big 404
After this fix: file list returned, minus the broken file (which is better than no list at all)

@LukasReschke @nickvergessen @DeepDiver1975 @icewind1991
