### PR TITLE
Remove unrequired backtick removal

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -245,9 +245,6 @@ class Cache {
 			$queryParts[] = '`storage`';
 			$params[] = $this->getNumericStorageId();
 
-			$params = array_map(function($item) {
-				return trim($item, "`");
-			}, $params);
 			$queryParts = array_map(function($item) {
 				return trim($item, "`");
 			}, $queryParts);

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -260,6 +260,28 @@ class Cache extends \Test\TestCase {
 		$this->assertEquals(\OC\Files\Cache\Cache::COMPLETE, $this->cache->getStatus('foo'));
 	}
 
+	public function putWithAllKindOfQuotesData() {
+		return [
+			['`backtick`'],
+			['´forward´'],
+			['\'single\''],
+		];
+	}
+
+	/**
+	 * @dataProvider putWithAllKindOfQuotesData
+	 * @param $fileName
+	 */
+	public function testPutWithAllKindOfQuotes($fileName) {
+
+		$this->assertEquals(\OC\Files\Cache\Cache::NOT_FOUND, $this->cache->get($fileName));
+		$this->cache->put($fileName, array('size' => 20, 'mtime' => 25, 'mimetype' => 'foo/file', 'etag' => $fileName));
+
+		$cacheEntry = $this->cache->get($fileName);
+		$this->assertEquals($fileName, $cacheEntry['etag']);
+		$this->assertEquals($fileName, $cacheEntry['path']);
+	}
+
 	function testSearch() {
 		$file1 = 'folder';
 		$file2 = 'folder/foobar';


### PR DESCRIPTION
Without this files with a `(backtick) in the beginning of the filenames where simply not correctly referenced as the` got removed. This can lead to all possible havoc situations.

Should get backported to stable8 and in future we might consider if it is really worth to backport such changes  (https://github.com/owncloud/core/pull/14734) when it is just for SQLite :see_no_evil: – Just for clarity: The bug affects all DBs!

Regression of https://github.com/owncloud/core/pull/14734

@PVince81 Can you add some failing tests? :angel: 
@DeepDiver1975 @karlitschek FYI
