### PR TITLE
OCS API should return fancy OC url

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -303,8 +303,7 @@ class Local {
 						break;
 					}
 				}
-				$url = \OCP\Util::linkToPublic('files&t='.$token);
-				$data['url'] = $url; // '&' gets encoded to $amp;
+				$data['url'] = \OC::$server->getURLGenerator()->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token]);
 				$data['token'] = $token;
 
 			} else {

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -103,6 +103,11 @@ class Test_Files_Sharing_Api extends TestCase {
 		// check if we have a token
 		$this->assertTrue(is_string($data['token']));
 
+		// check for correct link
+		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);
+		$this->assertEquals($url, $data['url']);
+
+
 		$share = $this->getShareFromId($data['id']);
 
 		$items = \OCP\Share::getItemShared('file', $share['item_source']);


### PR DESCRIPTION
Right now the OCS API still returns the old url for link shares. It should use the fancy new shorter url. 

Pretty trivial fix - just a tiny thing that annoys me way more than it should
