### PR TITLE
Ocs respect enforced date

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -1079,6 +1079,24 @@ class Test_Files_Sharing_Api extends TestCase {
 		$this->assertTrue(is_array($updatedLinkShare));
 		$this->assertEquals($dateWithinRange->format('Y-m-d') . ' 00:00:00', $updatedLinkShare['expiration']);
 
+
+		// Try to remove expire date
+		$params = array();
+		$params['id'] = $linkShare['id'];
+		$params['_put'] = ['expireDate' => ''];
+
+		$result = \OCA\Files_Sharing\API\Local::updateShare($params);
+
+		$this->assertFalse($result->succeeded());
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+
+		$updatedLinkShare = reset($items);
+
+		// date shouldn't be changed
+		$this->assertTrue(is_array($updatedLinkShare));
+		$this->assertEquals($dateWithinRange->format('Y-m-d') . ' 00:00:00', $updatedLinkShare['expiration']);
+
 		// cleanup
 		$config->setAppValue('core', 'shareapi_default_expire_date', 'no');
 		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'no');

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1097,9 +1097,17 @@ class Share extends \OC\Share\Constants {
 	 */
 	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null) {
 		$user = \OC_User::getUser();
+		$l = \OC::$server->getL10N('lib');
 
 		if ($date == '') {
-			$date = null;
+			if (\OCP\Util::isDefaultExpireDateEnforced()) {
+				$warning = 'Cannot clear expiration date. Shares are required to have an expiration date.';
+				$warning_t = $l->t('Cannot clear expiration date. Shares are required to have an expiration date.');
+				\OCP\Util::writeLog('OCP\Share', $warning, \OCP\Util::WARN);
+				throw new \Exception($warning_t);
+			} else {
+				$date = null;
+			}
 		} else {
 			$date = self::validateExpireDate($date, $shareTime, $itemType, $itemSource);
 		}


### PR DESCRIPTION
Fix for #15021

If the expiration date is enforced it should not be possible to delete it.
Of course new tests are added.
