### PR TITLE
If the execute method on the mapper receives an assoc array, it binds by...

### DIFF
--- a/tests/lib/appframework/db/mappertest.php
+++ b/tests/lib/appframework/db/mappertest.php
@@ -47,6 +47,7 @@ class ExampleMapper extends Mapper {
 	public function findOneEntity($table, $id){ return $this->findEntity($table, $id); }
 	public function findAllEntities($table){ return $this->findEntities($table); }
 	public function mapRow($row){ return $this->mapRowToEntity($row); }
+	public function execSql($sql, $params){ return $this->execute($sql, $params); }
 }
 
 
@@ -184,6 +185,15 @@ class MapperTest extends MapperTestUtility {
 		$result = $this->mapper->insert($entity);
 
 		$this->assertEquals(3, $result->getId());
+	}
+
+
+	public function testAssocParameters() {
+		$sql = 'test';
+		$params = [':test' => 1, ':a' => 2];
+
+		$this->setMapperResult($sql, $params);
+		$this->mapper->execSql($sql, $params);
 	}
 
 

--- a/tests/lib/appframework/db/mappertestutility.php
+++ b/tests/lib/appframework/db/mappertestutility.php
@@ -56,7 +56,30 @@ abstract class MapperTestUtility extends \Test\TestCase {
 		$this->fetchAt = 0;
 	}
 
+	/**
+	 * Checks if an array is associative
+	 * @param array $array
+	 * @return bool true if associative
+	 */
+	private function isAssocArray(array $array) {
+		return array_values($array) !== $array;
+	}
 
+	/**
+	 * Returns the correct PDO constant based on the value type
+	 * @param $value
+	 * @return PDO constant
+	 */
+	private function getPDOType($value) {
+		switch (gettype($value)) {
+			case 'integer':
+				return \PDO::PARAM_INT;
+			case 'boolean':
+				return \PDO::PARAM_BOOL;
+			default:
+				return \PDO::PARAM_STR;
+		}
+	}
 
 	/**
 	 * Create mocks and set expected results for database queries
@@ -117,32 +140,28 @@ abstract class MapperTestUtility extends \Test\TestCase {
 				}
 			));
 
-		$index = 1;
-		foreach($arguments as $argument) {
-			switch (gettype($argument)) {
-				case 'integer':
-					$pdoConstant = \PDO::PARAM_INT;
-					break;
-
-				case 'NULL':
-					$pdoConstant = \PDO::PARAM_NULL;
-					break;
-
-				case 'boolean':
-					$pdoConstant = \PDO::PARAM_BOOL;
-					break;
-
-				default:
-					$pdoConstant = \PDO::PARAM_STR;
-					break;
+		if ($this->isAssocArray($arguments)) {
+			foreach($arguments as $key => $argument) {
+				$pdoConstant = $this->getPDOType($argument);
+				$this->query->expects($this->at($this->queryAt))
+					->method('bindValue')
+					->with($this->equalTo($key),
+						$this->equalTo($argument),
+						$this->equalTo($pdoConstant));
+				$this->queryAt++;
 			}
-			$this->query->expects($this->at($this->queryAt))
-				->method('bindValue')
-				->with($this->equalTo($index),
-					$this->equalTo($argument),
-					$this->equalTo($pdoConstant));
-			$index++;
-			$this->queryAt++;
+		} else {
+			$index = 1;
+			foreach($arguments as $argument) {
+				$pdoConstant = $this->getPDOType($argument);
+				$this->query->expects($this->at($this->queryAt))
+					->method('bindValue')
+					->with($this->equalTo($index),
+						$this->equalTo($argument),
+						$this->equalTo($pdoConstant));
+				$index++;
+				$this->queryAt++;
+			}
 		}
 
 		$this->query->expects($this->at($this->queryAt))


### PR DESCRIPTION
... value instead of index

e.g.: you can now do the following inside a mapper 

``` php
$this->execute('SELECT * FROM table WHERE column = :test', [':test' => 1]);
```

Previously only binding by index was possible which is sometimes hard to read:

``` php
$this->execute('SELECT * FROM table WHERE column = ?', [1]);
```

Needs to be rebased on https://github.com/owncloud/core/pull/14986 first

@MorrisJobke @PVince81 @LukasReschke @LEDfan @georgehrke @jbtbnl @DeepDiver1975 
