### PR TITLE
show a better error message when trying to create a user that already exists

### DIFF
--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -286,6 +286,15 @@ class UsersController extends Controller {
 			}
 		}
 
+		if ($this->userManager->userExists($username)) {
+			return new DataResponse(
+				array(
+					'message' => (string)$this->l10n->t('A user with that name already exists.')
+				),
+				Http::STATUS_CONFLICT
+			);
+		}
+
 		try {
 			$user = $this->userManager->createUser($username, $password);
 		} catch (\Exception $exception) {


### PR DESCRIPTION
Fixes #14965
