### PR TITLE
Group sharing activities by user/group and file respectively

### DIFF
--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -202,6 +202,7 @@ class Activity implements IExtension {
 		} else if ($app === 'files') {
 			switch ($text) {
 				case self::SUBJECT_SHARED_LINK_SELF:
+					return [0 => 'file'];
 				case self::SUBJECT_SHARED_USER_SELF:
 				case self::SUBJECT_SHARED_WITH_BY:
 					return [0 => 'file', 1 => 'username'];
@@ -225,6 +226,19 @@ class Activity implements IExtension {
 	 * @return integer|false
 	 */
 	public function getGroupParameter($activity) {
+		if ($activity['app'] === 'files') {
+			switch ($activity['subject']) {
+				case self::SUBJECT_SHARED_LINK_SELF:
+				case self::SUBJECT_SHARED_WITH_BY:
+					// Group by file name
+					return 0;
+				case self::SUBJECT_SHARED_USER_SELF:
+				case self::SUBJECT_SHARED_GROUP_SELF:
+					// Group by user/group
+					return 1;
+			}
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
@schiesbn @jancborchardt 

Group by file for "X shared Y with you":

> nickv shared Folder, Folder1, Folder2 and 3 more with you

Group by user/group for "You shared X with Y":

> You shared Folder with user5, user4, user3 and 3 more

Fix owncloud/activity#263

Requires owncloud/activity#265 for the perfect look and feel (otherwise user id is used instead of display name)
