### PR TITLE
Add a test to update a column from text (255) to clob

### DIFF
--- a/tests/data/db_text_clob.xml
+++ b/tests/data/db_text_clob.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<database>
+	<name>*dbname*</name>
+	<create>true</create>
+	<overwrite>false</overwrite>
+	<charset>utf8</charset>
+
+	<table>
+		<name>*dbprefix*ctvt_test</name>
+
+		<declaration>
+			<field>
+				<name>test_column</name>
+				*COLUMNDETAILS*
+				<default></default>
+				<notnull>false</notnull>
+			</field>
+		</declaration>
+	</table>
+</database>

--- a/tests/data/db_text_notnull.xml
+++ b/tests/data/db_text_notnull.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<database>
+	<name>*dbname*</name>
+	<create>true</create>
+	<overwrite>false</overwrite>
+	<charset>utf8</charset>
+
+	<table>
+		<name>*dbprefix*ctvt2_test</name>
+
+		<declaration>
+			<field>
+				<name>test_column</name>
+				<type>text</type>
+				<length>64</length>
+				<notnull>*COLUMNDETAILS*</notnull>
+			</field>
+		</declaration>
+	</table>
+</database>

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -261,6 +261,44 @@ class Test_DB extends \Test\TestCase {
 		$this->assertSame($expected, $actual);
 	}
 
+	public function testTypeChangeData() {
+		$outFile = 'static://test_db_text_clob.xml';
+		$prefix = strtolower($this->getUniqueID('', 4) . '_');
+		$tableName = '*PREFIX*' . $prefix . 'ctvt_test';
+		$content = file_get_contents(OC::$SERVERROOT . '/tests/data/db_text_clob.xml');
+		$content = str_replace('*dbprefix*', '*dbprefix*' . $prefix, $content);
+
+		$testString = 'Öäüß\'Ћö雙喜\xE2\x80\xA2';
+
+		$contentText = str_replace('*COLUMNDETAILS*', '<type>text</type><length>255</length>', $content);
+		file_put_contents($outFile, $contentText);
+		OC_DB::createDbFromStructure($outFile);
+
+		$query = OC_DB::prepare("INSERT INTO `{$tableName}` (`test_column`) VALUES (?)");
+		$result = $query->execute(array($testString));
+		$this->assertEquals(1, $result);
+
+		$actual = OC_DB::prepare("SELECT `test_column` FROM `{$tableName}`")->execute()->fetchOne();
+		$this->assertSame($testString, $actual);
+
+		$contentText = str_replace('*COLUMNDETAILS*', '<type>text</type><length>4000</length>', $content);
+		file_put_contents($outFile, $contentText);
+		OC_DB::updateDbFromStructure($outFile);
+
+		$actual = OC_DB::prepare("SELECT `test_column` FROM `{$tableName}`")->execute()->fetchOne();
+		$this->assertSame($testString, $actual);
+
+		$contentText = str_replace('*COLUMNDETAILS*', '<type>clob</type>', $content);
+		file_put_contents($outFile, $contentText);
+		OC_DB::updateDbFromStructure($outFile);
+
+		$actual = OC_DB::prepare("SELECT `test_column` FROM `{$tableName}`")->execute()->fetchOne();
+		$this->assertSame($testString, $actual);
+
+		OC_DB::removeDBStructure($outFile);
+		unlink($outFile);
+	}
+
 	/**
 	 * Insert, select and delete decimal(12,2) values
 	 * @dataProvider decimalData


### PR DESCRIPTION
Adds a unit test which changes the type of a string column from text to clob, as required in https://github.com/owncloud/activity/pull/255

Passed on mysql and sqlite locally
@DeepDiver1975 please run on oracle? :)
