### PR TITLE
Do not automatically add "update" permission to shared mounts

### DIFF
--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -182,9 +182,8 @@ class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 		// for the share root we expect:
 		// the shared permissions (1)
 		// the delete permission (8), to enable unshare
-		// the update permission (2), to allow renaming of the mount point
 		$rootInfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$this->assertSame(11, $rootInfo->getPermissions());
+		$this->assertSame(9, $rootInfo->getPermissions());
 
 		// for the file within the shared folder we expect:
 		// the shared permissions (1)

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1133,7 +1133,7 @@ class View {
 		}
 
 		if ($mount instanceof MoveableMount && $internalPath === '') {
-			$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
+			$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
 		$data = \OC_FileProxy::runPostProxies('getFileInfo', $path, $data);


### PR DESCRIPTION
In the past it seems the update permission was needed to be able to
rename shared mounts, but it doesn't seem to be the case any more.

Removing the "update" permission that used to be added automatically
fixes the read-only permission check when trying to overwrite a
read-only file over WebDAV.

Fixes https://github.com/owncloud/core/issues/15026

Please review @schiesbn @icewind1991 @nickvergessen @MorrisJobke 
#### Tests
- [x] overwrite read-only shared file with WebDAV returns 403 (no more 500)
- [x] overwrite read-write shared file with WebDAV still works
- [x] can rename/move read-write shared file as recipient
- [x] can rename/move read-only  shared file as recipient
- [x] can rename/move read-write shared folder as recipient
- [x] can rename/move read-only  shared folder as recipient
- [x] can still reshare all of the above
