### PR TITLE
also call generateTarget for group shares

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1678,7 +1678,8 @@ class Share extends \OC\Share\Constants {
 			}
 			$groupItemTarget = Helper::generateTarget($itemType, $itemSource, $shareType, $shareWith['group'],
 					$uidOwner, $suggestedItemTarget);
-			$groupFileTarget = $filePath;
+			$groupFileTarget = Helper::generateTarget($itemType, $itemSource, $shareType, $shareWith['group'],
+					$uidOwner, $filePath);
 
 			// add group share to table and remember the id as parent
 			$queriesToExecute['groupShare'] = array(
@@ -1691,7 +1692,7 @@ class Share extends \OC\Share\Constants {
 				'permissions'		=> $permissions,
 				'shareTime'			=> time(),
 				'fileSource'		=> $fileSource,
-				'fileTarget'		=> $filePath,
+				'fileTarget'		=> $groupFileTarget,
 				'token'				=> $token,
 				'parent'			=> $parent,
 				'expiration'		=> $expirationDate,


### PR DESCRIPTION
also call generateTarget for group shares to add the correct prefix if share_folder is defined in config.php

cc @felixboehm @MorrisJobke this should solve the problem we discussed early today. Please give it a try, thanks!
