### PR TITLE
Avoid loading CSS and JS files in app.php

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -20,7 +20,6 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-use OCA\Files\Appinfo\Application;
 
 // Check if we are a user
 OCP\User::checkLoggedIn();
@@ -42,8 +41,11 @@ OCP\Util::addscript('files', 'search');
 \OCP\Util::addScript('files', 'favoritesfilelist');
 \OCP\Util::addScript('files', 'tagsplugin');
 \OCP\Util::addScript('files', 'favoritesplugin');
-
 \OC_Util::addVendorScript('core', 'handlebars/handlebars');
+
+$resourceLoader = \OC::$server->getTemplateResourceLoader();
+$resourceLoader->loadResources('files', 'index');
+
 
 OCP\App::setActiveNavigationEntry('files_index');
 
@@ -134,6 +136,7 @@ OCP\Util::addscript('files', 'fileactions');
 OCP\Util::addscript('files', 'files');
 OCP\Util::addscript('files', 'navigation');
 OCP\Util::addscript('files', 'keyboardshortcuts');
+
 $tmpl = new OCP\Template('files', 'index', 'user');
 $tmpl->assign('usedSpacePercent', (int)$storageInfo['relative']);
 $tmpl->assign('isPublic', false);

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -179,6 +179,10 @@ class ShareController extends Controller {
 		$shareTmpl['nonHumanFileSize'] = $nonHumanFileSize;
 		$shareTmpl['fileSize'] = \OCP\Util::humanFileSize($nonHumanFileSize);
 
+		// Load all resources for a file list and file list actions
+		$resourceLoader = \OC::$server->getTemplateResourceLoader();
+		$resourceLoader->loadResources('files', 'index');
+
 		// Show file list
 		if (Filesystem::is_dir($originalSharePath)) {
 			$shareTmpl['dir'] = $getPath;

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -20,6 +20,7 @@ use OC\Security\Hasher;
 use OC\Security\SecureRandom;
 use OC\Diagnostics\NullEventLogger;
 use OC\Security\TrustedDomainHelper;
+use OC\Template\DelayedResourceLoader;
 use OCP\IServerContainer;
 use OCP\ISession;
 use OC\Tagging\TagMapper;
@@ -329,6 +330,16 @@ class Server extends SimpleContainer implements IServerContainer {
 				new \OC_Defaults()
 			);
 		});
+		$this->registerService('TemplateResourceLoader', function() {
+			return new DelayedResourceLoader();
+		});
+	}
+
+	/**
+	 * @return \OCP\Template\IDelayedResourceLoader
+	 */
+	public function getTemplateResourceLoader() {
+		return $this->query('TemplateResourceLoader');
 	}
 
 	/**

--- a/lib/private/template/delayedresourceloader.php
+++ b/lib/private/template/delayedresourceloader.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling
+ * @copyright 2015 Joas Schilling nickvergessen@owncloud.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Template;
+
+use OCP\Template\IDelayedResourceLoader;
+
+class DelayedResourceLoader implements IDelayedResourceLoader {
+	/** @var array */
+	protected $scripts;
+
+	/** @var array */
+	protected $styles;
+
+	/** @var array */
+	protected $vendorScripts;
+
+	/** @var array */
+	protected $vendorStyles;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->scripts = [];
+		$this->styles = [];
+		$this->vendorScripts = [];
+		$this->vendorStyles = [];
+	}
+
+	/**
+	 * Add a script resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $script
+	 */
+	public function addScript($eventApp, $eventName, $app, $script) {
+		if (!isset($this->scripts[$eventApp][$eventName][$app])) {
+			$this->scripts[$eventApp][$eventName][$app] = [];
+		}
+		$this->scripts[$eventApp][$eventName][$app][] = $script;
+	}
+
+	/**
+	 * Add a style resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $style
+	 */
+	public function addStyle($eventApp, $eventName, $app, $style) {
+		if (!isset($this->styles[$eventApp][$eventName][$app])) {
+			$this->styles[$eventApp][$eventName][$app] = [];
+		}
+		$this->styles[$eventApp][$eventName][$app][] = $style;
+	}
+
+	/**
+	 * Add a vendor script resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $script
+	 */
+	public function addVendorScript($eventApp, $eventName, $app, $script) {
+		if (!isset($this->vendorScripts[$eventApp][$eventName][$app])) {
+			$this->vendorScripts[$eventApp][$eventName][$app] = [];
+		}
+		$this->vendorScripts[$eventApp][$eventName][$app][] = $script;
+	}
+
+	/**
+	 * Add a vendor style resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $style
+	 */
+	public function addVendorStyle($eventApp, $eventName, $app, $style) {
+		if (!isset($this->vendorStyles[$eventApp][$eventName][$app])) {
+			$this->vendorStyles[$eventApp][$eventName][$app] = [];
+		}
+		$this->vendorStyles[$eventApp][$eventName][$app][] = $style;
+	}
+
+	/**
+	 * Load the resources that are registered for the event
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 */
+	public function loadResources($eventApp, $eventName) {
+		if (isset($this->scripts[$eventApp][$eventName])) {
+			foreach ($this->scripts[$eventApp][$eventName] as $app => $resources) {
+				foreach ($resources as $resource) {
+					script($app, $resource);
+				}
+			}
+		}
+
+		if (isset($this->styles[$eventApp][$eventName])) {
+			foreach ($this->styles[$eventApp][$eventName] as $app => $resources) {
+				foreach ($resources as $resource) {
+					style($app, $resource);
+				}
+			}
+		}
+
+		if (isset($this->vendorScripts[$eventApp][$eventName])) {
+			foreach ($this->vendorScripts[$eventApp][$eventName] as $app => $resources) {
+				foreach ($resources as $resource) {
+					vendor_script($app, $resource);
+				}
+			}
+		}
+
+		if (isset($this->vendorStyles[$eventApp][$eventName])) {
+			foreach ($this->vendorStyles[$eventApp][$eventName] as $app => $resources) {
+				foreach ($resources as $resource) {
+					vendor_style($app, $resource);
+				}
+			}
+		}
+	}
+}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -294,6 +294,13 @@ interface IServerContainer {
 	function getTempManager();
 
 	/**
+	 * Get the manager for template resource loading
+	 *
+	 * @return \OCP\Template\IDelayedResourceLoader
+	 */
+	public function getTemplateResourceLoader();
+
+	/**
 	 * Get the app manager
 	 *
 	 * @return \OCP\App\IAppManager

--- a/lib/public/template/idelayedresourceloader.php
+++ b/lib/public/template/idelayedresourceloader.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling
+ * @copyright 2015 Joas Schilling nickvergessen@owncloud.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace OCP\Template;
+
+interface IDelayedResourceLoader {
+	/**
+	 * Add a script resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $script
+	 */
+	public function addScript($eventApp, $eventName, $app, $script);
+
+	/**
+	 * Add a style resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $style
+	 */
+	public function addStyle($eventApp, $eventName, $app, $style);
+
+	/**
+	 * Add a vendor script resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $script
+	 */
+	public function addVendorScript($eventApp, $eventName, $app, $script);
+
+	/**
+	 * Add a vendor style resource to the list, that is loaded when the event is triggered
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 * @param string $app
+	 * @param string|array $style
+	 */
+	public function addVendorStyle($eventApp, $eventName, $app, $style);
+
+	/**
+	 * Load the resources that are registered for the event
+	 *
+	 * @param string $eventApp
+	 * @param string $eventName
+	 */
+	public function loadResources($eventApp, $eventName);
+}


### PR DESCRIPTION
One solution to the current mess that apps do.
## The Problem

Some apps use JS and CSS to beautify the file list or extend the functionality of it.

``` php
/** app.php */
// make slideshow available in files and public shares
OCP\Util::addScript('gallery', 'jquery.mousewheel-3.1.1');
OCP\Util::addScript('gallery', 'slideshow');
OCP\Util::addScript('gallery', 'public');
OCP\Util::addStyle('gallery', 'slideshow');
```

If you create an empty controller page with the ocdev tool, in a basic checkout with "recommended" apps, **18 CSS files and 43 JS files are loaded**. I guess the amount could be halfed at least
The goal of this PR is, to reduce the number of files loaded and searched (on disc), to a minimum.
While the actual file loading only makes front facing calls light weighter, the "do not look for a file we wont load anyway" part also makes webdav and ajax requests faster.
## Explanation

Instead of the app registering the resource on each page call, the data is only put into the array of a "DelayedResourceLoader", linked to an event name. We can then provide entry points for points where we see this problem appear. One problem e.g. is the files list.

External storages register multiple JS and CSS, which are only needed on the file list, but currently they are loaded in the app.php and so each ajax/webdav/web request does the "find file"-logic and web requests even load the files.
Sample patch for an app: https://github.com/owncloud/gallery/pull/175/files

There is no need to load those resources in the user/admin settings (CSS/JS for those panels should be added in the respective template file), the activity, calendar, contacts app (no files, no external storage symbols, no gallery slideshow, no pdf viewing), etc.
## Comment
1. Yes, this looks like just a third way for events. However, in opposite to events/hooks, the object allows us to type hint and document correctly how to use it.
2. Having a hardcoded solution for resources is fine imo. Having something like "execute on load of service/route" etc is fine aswell. But note that there is no service for e.g. the file list (so we would need to add an empty fake service) and this way allows to use the same event on multiple routes (files/index + public page)
3. No, we are not looking for the perfect world atm, but for short/simple ways to make the overall usage of owncloud faster.
