### PR TITLE
brighten header color a bit

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -38,7 +38,7 @@
 	z-index: 2000;
 	height: 45px;
 	line-height: 2.5em;
-	background-color: #1d2d44;
+	background-color: #294160;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
@@ -306,7 +306,7 @@
 		margin-bottom: -3px;
 		margin-right: 6px;
 	}
-	#expanddiv a:hover, #expanddiv a:focus, #expanddiv a:active {
+	#expanddiv a:hover, #expanddiv a:focus, #expanddiv a.active {
 		-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 		filter: alpha(opacity=100);
 		opacity: 1;


### PR DESCRIPTION
Another approach similar to https://github.com/owncloud/core/pull/14731 & https://github.com/owncloud/core/pull/14958 to make the header and dropdowns look less strange together.

This time I brightened the header color. It’s the tone which is in the middle of the fade on the log in screen. Having it brighter is good in general since our blue is really quite dark on displays.

Please test @karlitschek @owncloud/designers 
