### PR TITLE
fix long group names overlapping in the sidebar, fix #12649

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -76,6 +76,16 @@ table.nostyle td { padding: 0.2em 0; }
 	height: 30px;
 }
 
+.isgroup .groupname {
+	width: 85%;
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.isgroup.active .groupname {
+	width: 65%;
+}
+
 .usercount { float: left; margin: 5px; }
 li.active span.utils .delete {
 	float: left; position: relative; opacity: 0.5;


### PR DESCRIPTION
This introduces the proper width cutoff & ellipsis for long groupnames in user management.

Fix https://github.com/owncloud/core/issues/12649, please review @jnfrmarks @owncloud/designers 
