### PR TITLE
Remove hard dependency on cURL for 8.0

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -59,6 +59,11 @@
 							t('core', 'Your data directory and your files are probably accessible from the internet. The .htaccess file is not working. We strongly suggest that you configure your webserver in a way that the data directory is no longer accessible or you move the data directory outside the webserver document root.')
 						);
 					}
+					if(!data.hasCurlInstalled) {
+						messages.push(
+							t('core', 'cURL is not installed, some functionality might not work. Please install the PHP cURL extension. Future versions will require installed cURL.')
+						);
+					}
 				} else {
 					messages.push(t('core', 'Error occurred while checking server setup'));
 				}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -587,7 +587,6 @@ class OC_Util {
 				'iconv' => 'iconv',
 				'simplexml_load_string' => 'SimpleXML',
 				'hash' => 'HASH Message Digest Framework',
-				'curl_init' => 'cURL',
 			],
 			'defined' => array(
 				'PDO::ATTR_DRIVER_NAME' => 'PDO'

--- a/settings/ajax/checksetup.php
+++ b/settings/ajax/checksetup.php
@@ -19,6 +19,7 @@ if (OC_Util::isInternetConnectionEnabled()) {
 OCP\JSON::success(
 	array (
 		'serverHasInternetConnection' => $hasInternet,
-		'dataDirectoryProtected' => OC_Util::isHtaccessWorking()
+		'dataDirectoryProtected' => OC_Util::isHtaccessWorking(),
+		'hasCurlInstalled' => function_exists('curl_init'),
 	)
 );


### PR DESCRIPTION
This removes the recently introduced hard dependency on cURL for 8.0, for 8.1 it will still stay there.

Instead a warning will now be shown to the user asking to install the PHP cURL extension within the administrative interface of ownCloud.

cc @jnweiger Can we add cURL to our package dependencies?
cc @karlitschek As discussed.
