### PR TITLE
fix PHP warnings when using occ with some LDAP commands

### DIFF
--- a/apps/user_ldap/appinfo/register_command.php
+++ b/apps/user_ldap/appinfo/register_command.php
@@ -25,11 +25,11 @@ $deletedUsersIndex = new DeletedUsersIndex(
 	$ocConfig, $dbConnection, $userMapping
 );
 
-$application->add(new OCA\user_ldap\Command\ShowConfig());
+$application->add(new OCA\user_ldap\Command\ShowConfig($helper));
 $application->add(new OCA\user_ldap\Command\SetConfig());
 $application->add(new OCA\user_ldap\Command\TestConfig());
-$application->add(new OCA\user_ldap\Command\CreateEmptyConfig());
-$application->add(new OCA\user_ldap\Command\DeleteConfig());
+$application->add(new OCA\user_ldap\Command\CreateEmptyConfig($helper));
+$application->add(new OCA\user_ldap\Command\DeleteConfig($helper));
 $application->add(new OCA\user_ldap\Command\Search($ocConfig));
 $application->add(new OCA\user_ldap\Command\ShowRemnants(
 	$deletedUsersIndex, \OC::$server->getDateTimeFormatter())

--- a/apps/user_ldap/command/createemptyconfig.php
+++ b/apps/user_ldap/command/createemptyconfig.php
@@ -17,6 +17,16 @@ use \OCA\user_ldap\lib\Helper;
 use \OCA\user_ldap\lib\Configuration;
 
 class CreateEmptyConfig extends Command {
+	/** @var \OCA\User_LDAP\lib\Helper */
+	protected $helper;
+
+	/**
+	 * @param Helper $helper
+	 */
+	public function __construct(Helper $helper) {
+		$this->helper = $helper;
+		parent::__construct();
+	}
 
 	protected function configure() {
 		$this
@@ -24,7 +34,6 @@ class CreateEmptyConfig extends Command {
 			->setDescription('creates an empty LDAP configuration')
 		;
 	}
-
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$configPrefix = $this->getNewConfigurationPrefix();
@@ -35,7 +44,7 @@ class CreateEmptyConfig extends Command {
 	}
 
 	protected function getNewConfigurationPrefix() {
-		$serverConnections = Helper::getServerConfigurationPrefixes();
+		$serverConnections = $this->helper->getServerConfigurationPrefixes();
 
 		// first connection uses no prefix
 		if(sizeof($serverConnections) == 0) {

--- a/apps/user_ldap/command/deleteconfig.php
+++ b/apps/user_ldap/command/deleteconfig.php
@@ -11,11 +11,20 @@ namespace OCA\user_ldap\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use \OCA\user_ldap\lib\Helper;
 
 class DeleteConfig extends Command {
+	/** @var \OCA\User_LDAP\lib\Helper */
+	protected $helper;
+
+	/**
+	 * @param Helper $helper
+	 */
+	public function __construct(Helper $helper) {
+		$this->helper = $helper;
+		parent::__construct();
+	}
 
 	protected function configure() {
 		$this
@@ -31,9 +40,9 @@ class DeleteConfig extends Command {
 
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$configPrefix = $input->getArgument('configID');;
+		$configPrefix = $input->getArgument('configID');
 
-		$success = Helper::deleteServerConfiguration($configPrefix);
+		$success = $this->helper->deleteServerConfiguration($configPrefix);
 
 		if($success) {
 			$output->writeln("Deleted configuration with configID '{$configPrefix}'");

--- a/apps/user_ldap/command/showconfig.php
+++ b/apps/user_ldap/command/showconfig.php
@@ -17,6 +17,16 @@ use \OCA\user_ldap\lib\Helper;
 use \OCA\user_ldap\lib\Configuration;
 
 class ShowConfig extends Command {
+	/** @var \OCA\User_LDAP\lib\Helper */
+	protected $helper;
+
+	/**
+	 * @param Helper $helper
+	 */
+	public function __construct(Helper $helper) {
+		$this->helper = $helper;
+		parent::__construct();
+	}
 
 	protected function configure() {
 		$this
@@ -37,8 +47,7 @@ class ShowConfig extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$helper = new Helper();
-		$availableConfigs = $helper->getServerConfigurationPrefixes();
+		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if(!is_null($configID)) {
 			$configIDs[] = $configID;


### PR DESCRIPTION
Helper is not static anymore, old usage will throw PHP Warnings into the log file.

@Xenopathic @MorrisJobke
