### PR TITLE
offset needs to be considered in computed limit

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -673,7 +673,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		}
 		$maxGroups = 100000; // limit max results (just for safety reasons)
 		if ($limit > -1) {
-		   $overallLimit = min($limit, $maxGroups);
+		   $overallLimit = min($limit + $offset, $maxGroups);
 		} else {
 		   $overallLimit = $maxGroups;
 		}

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -298,4 +298,18 @@ class Test_Group_Ldap extends \Test\TestCase {
 		$groupBackend->inGroup($uid, $gid);
 	}
 
+	public function testGetGroupsWithOffset() {
+		$access = $this->getAccessMock();
+		$this->enableGroups($access);
+
+		$access->expects($this->once())
+			->method('ownCloudGroupNames')
+			->will($this->returnValue(array('group1', 'group2')));
+
+		$groupBackend = new GroupLDAP($access);
+		$groups = $groupBackend->getGroups('', 2, 2);
+
+		$this->assertSame(2, count($groups));
+	}
+
 }


### PR DESCRIPTION
Fixes #14098

To reproduce: have LDAP configured with groups and run from command line as web user: ./occ ldap:search --group --offset=3 --limit=3 ''

Before: no result. No: with result. 

Includes  a unit test.

Please review: @jvillafanez @jnfrmarks @Xenopathic @MorrisJobke 
