### PR TITLE
Soft fail in CustomPropertiesBackend whenever storage not available

### DIFF
--- a/lib/private/connector/sabre/custompropertiesbackend.php
+++ b/lib/private/connector/sabre/custompropertiesbackend.php
@@ -30,6 +30,7 @@ use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
 use Sabre\DAV\Tree;
 use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Exception\ServiceUnavailable;
 
 class CustomPropertiesBackend implements BackendInterface {
 
@@ -100,6 +101,9 @@ class CustomPropertiesBackend implements BackendInterface {
 			if (!($node instanceof Node)) {
 				return;
 			}
+		} catch (ServiceUnavailable $e) {
+			// might happen for unavailable mount points, skip
+			return;
 		} catch (NotFound $e) {
 			// in some rare (buggy) cases the node might not be found,
 			// we catch the exception to prevent breaking the whole list with a 404

--- a/tests/lib/connector/sabre/custompropertiesbackend.php
+++ b/tests/lib/connector/sabre/custompropertiesbackend.php
@@ -105,10 +105,15 @@ class CustomPropertiesBackend extends \Test\TestCase {
 	 * Test that propFind on a missing file soft fails
 	 */
 	public function testPropFindMissingFileSoftFail() {
-		$this->tree->expects($this->any())
+		$this->tree->expects($this->at(0))
 			->method('getNodeForPath')
 			->with('/dummypath')
 			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
+
+		$this->tree->expects($this->at(1))
+			->method('getNodeForPath')
+			->with('/dummypath')
+			->will($this->throwException(new \Sabre\DAV\Exception\ServiceUnavailable()));
 
 		$propFind = new \Sabre\DAV\PropFind(
 			'/dummypath',
@@ -118,6 +123,11 @@ class CustomPropertiesBackend extends \Test\TestCase {
 				'unsetprop',
 			),
 			0
+		);
+
+		$this->plugin->propFind(
+			'/dummypath',
+			$propFind
 		);
 
 		$this->plugin->propFind(


### PR DESCRIPTION
When a storage is not available, it will not fail the whole call any
more but still return a usable file list.

Similar to https://github.com/owncloud/core/pull/14994 but for unavailable storages.

Steps:
1. Mount an s2s share in "/mount"
2. Enable maintanance mode in the remote OC
3. PROPFIND on the root

Before: get 503 without any result
After: get 200 with a proper file list when PROPFIND on "/". PROPFIND on "/mount" will give 503.

Please review @LukasReschke @nickvergessen @DeepDiver1975 @icewind1991
