### PR TITLE
Properly catch whether a share is `null`

### DIFF
--- a/apps/files_sharing/application.php
+++ b/apps/files_sharing/application.php
@@ -42,7 +42,7 @@ class Application extends App {
 				$server->getAppConfig(),
 				$server->getConfig(),
 				$c->query('URLGenerator'),
-				$server->getUserManager(),
+				$c->query('UserManager'),
 				$server->getLogger(),
 				$server->getActivityManager()
 			);
@@ -64,6 +64,9 @@ class Application extends App {
 		});
 		$container->registerService('URLGenerator', function(SimpleContainer $c) use ($server){
 			return $server->getUrlGenerator();
+		});
+		$container->registerService('UserManager', function(SimpleContainer $c) use ($server){
+			return $server->getUserManager();
 		});
 		$container->registerService('IsIncomingShareEnabled', function(SimpleContainer $c) {
 			return Helper::isIncomingServer2serverShareEnabled();

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -154,6 +154,8 @@ class ShareController extends Controller {
 		if (Filesystem::isReadable($originalSharePath . $path)) {
 			$getPath = Filesystem::normalizePath($path);
 			$originalSharePath .= $path;
+		} else {
+			throw new OCP\Files\NotFoundException();
 		}
 
 		$file = basename($originalSharePath);

--- a/apps/files_sharing/lib/middleware/sharingcheckmiddleware.php
+++ b/apps/files_sharing/lib/middleware/sharingcheckmiddleware.php
@@ -11,6 +11,7 @@
 namespace OCA\Files_Sharing\Middleware;
 
 use OCP\App\IAppManager;
+use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -59,7 +60,7 @@ class SharingCheckMiddleware extends Middleware {
 	 * @return TemplateResponse
 	 */
 	public function afterException($controller, $methodName, \Exception $exception){
-		return new TemplateResponse('core', '404', array(), 'guest');
+		return new NotFoundResponse();
 	}
 
 	/**

--- a/lib/public/appframework/http/notfoundresponse.php
+++ b/lib/public/appframework/http/notfoundresponse.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\AppFramework\Http;
+
+use OCP\AppFramework\Http;
+use OCP\Template;
+
+/**
+ * A generic 404 response showing an 404 error page as well to the end-user
+ */
+class NotFoundResponse extends Response {
+
+	public function __construct() {
+		$this->setStatus(404);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function render() {
+		$template = new Template('core', '404', 'guest');
+		return $template->fetchPage();
+	}
+}


### PR DESCRIPTION
Despite it's PHPDoc the function might return `null` which was not properly catched and thus in some situations the share was resolved to the sharing users root directory.

To test this perform the following steps:
- Share file in owncloud 7 (7.0.4.2)
- Delete the parent folder of the shared file
- The share stays is in the DB and the share via the sharelink is inaccessible. (which is good)
- Upgrade to owncloud 8 (8.0.2) (This step is crucial. The bug is not reproducible without upgrading from 7 to 8)
- Optional Step: Logout, Reset Browser Session, etc.
- Access the share via the old share url: almost empty page, but there is a download button which adds a "/download" to the URL.
- Upon clicking, a download.zip is downloaded which contains EVERYTHING from the owncloud directory (of the user who shared the file)
- No exception is thrown and no error is logged.

This will add a check whether the share is a valid one and also adds unit tests to prevent further regressions in the future. Needs to be backported to ownCloud 8. Will create a backport once this got reviewed and tested to avoid triple the work.

Adding a proper clean-up of the orphaned shares is out-of-scope and would probably require some kind of FK or so.

Fixes https://github.com/owncloud/core/issues/15097

cc @PVince81 @icewind1991 @karlitschek @DeepDiver1975 Please review and test properly.
cc @jnfrmarks Requires a complete retest of whether the sharing still works properly.
