### PR TITLE
Correctly get array of groups and send OCP\IGroup objects to enable meth...

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -269,7 +269,15 @@ class OC_App {
 
 		$appManager = \OC::$server->getAppManager();
 		if (!is_null($groups)) {
-			$appManager->enableAppForGroups($app, $groups);
+			$groupManager = \OC::$server->getGroupManager();
+			$groupsList = [];
+			foreach ($groups as $group) {
+				$groupItem = $groupManager->get($group);
+				if ($groupItem instanceof \OCP\IGroup) {
+					$groupsList[] = $groupManager->get($group);
+				}
+			}
+			$appManager->enableAppForGroups($app, $groupsList);
 		} else {
 			$appManager->enableApp($app);
 		}

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -406,7 +406,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			var element = $(this).parent().find('input.enable');
 			var groups = $(this).val();
 			if (groups && groups !== '') {
-				groups = groups.split(',');
+				groups = groups.split('|');
 			} else {
 				groups = [];
 			}


### PR DESCRIPTION
...od
- [x] `$appManager->enableAppForGroups()` takes an array of `\OCP\IGroup`, not strings
- [x] The array is split incorrectly on `,` instead of `|` in js

@LukasReschke @MorrisJobke @icewind1991 
