### PR TITLE
correctly align file list summary when the list has the favorite feature

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -582,6 +582,9 @@ table tr.summary td {
 .summary .info {
 	margin-left: 40px;
 }
+.has-favorites .summary .info {
+	margin-left: 90px;
+}
 
 #scanning-message{ top:40%; left:40%; position:absolute; display:none; }
 


### PR DESCRIPTION
This properly left-aligns the file list summary with the filenames above. Previously it was too much to the left (aligned with the file thumbnail) when the list had the favorite feature.

Please review @owncloud/designers 
