### PR TITLE
Make blacklisted_files really case insensitive

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -539,6 +539,7 @@ class Filesystem {
 		$filename = self::normalizePath($filename);
 
 		$blacklist = \OC_Config::getValue('blacklisted_files', array('.htaccess'));
+		$blacklist = array_map('strtolower', $blacklist);
 		$filename = strtolower(basename($filename));
 		return in_array($filename, $blacklist);
 	}


### PR DESCRIPTION
Applying strtolower to blacklisted_files config value to make it really case insensitive. Before if you use uppercase in the config it will never match, because of strtolower on the filename parameter.
