### PR TITLE
Groupmanagers displayNamesInGroup should actually search in displaynames

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -248,7 +248,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				while ($count < 15 && count($users) == $limit) {
 					$limit = 15 - $count;
 					if ($shareWithinGroupOnly) {
-						$users = OC_Group::DisplayNamesInGroups($usergroups, (string)$_GET['search'], $limit, $offset);
+						$users = OC_Group::displayNamesInGroups($usergroups, (string)$_GET['search'], $limit, $offset);
 					} else {
 						$users = OC_User::getDisplayNames((string)$_GET['search'], $limit, $offset);
 					}

--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -247,7 +247,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 			}
 
 			do {
-				$filteredUsers = $this->userManager->search($search, $searchLimit, $searchOffset);
+				$filteredUsers = $this->userManager->searchDisplayName($search, $searchLimit, $searchOffset);
 				foreach($filteredUsers as $filteredUser) {
 					if($group->inGroup($filteredUser)) {
 						$groupUsers[]= $filteredUser;

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -448,7 +448,7 @@ class Manager extends \Test\TestCase {
 		$userBackend = $this->getMock('\OC_User_Backend');
 
 		$userManager->expects($this->any())
-			->method('search')
+			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {
@@ -513,7 +513,7 @@ class Manager extends \Test\TestCase {
 		$userBackend = $this->getMock('\OC_User_Backend');
 
 		$userManager->expects($this->any())
-			->method('search')
+			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {
@@ -580,7 +580,7 @@ class Manager extends \Test\TestCase {
 		$userBackend = $this->getMock('\OC_User_Backend');
 
 		$userManager->expects($this->any())
-			->method('search')
+			->method('searchDisplayName')
 			->with('user3')
 			->will($this->returnCallback(function($search, $limit, $offset) use ($userBackend) {
                                 switch($offset) {


### PR DESCRIPTION
I was looking into #6967.
At first I thought it was a bug in the ajax/share.php however it seems the displayNamesInGroup only searchers uid's. I assume it should search in displayNames.

Lets see how Jenkins feels about this. Probably I can add a few more unit tests. But I'll look into that.

Once we have a clean fix in place this should probably be backported.
