### PR TITLE
Use individual timers for separate config rows

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -412,7 +412,7 @@ MountConfigListView.prototype = {
 	/**
 	 * Flag whether the list is about user storage configs (true)
 	 * or global storage configs (false)
-	 * 
+	 *
 	 * @type bool
 	 */
 	_isPersonal: false,
@@ -488,35 +488,12 @@ MountConfigListView.prototype = {
 	_initEvents: function() {
 		var self = this;
 
-		this.$el.on('paste', 'td input', function() {
-			var $me = $(this);
-			var $tr = $me.closest('tr');
-			setTimeout(function() {
-				highlightInput($me);
-				self.saveStorageConfig($tr);
-			}, 20);
-		});
-
-		var timer;
-
-		this.$el.on('keyup', 'td input', function() {
-			clearTimeout(timer);
-			var $tr = $(this).closest('tr');
-			highlightInput($(this));
-			if ($(this).val) {
-				timer = setTimeout(function() {
-					self.saveStorageConfig($tr);
-				}, 2000);
-			}
-		});
-
-		this.$el.on('change', 'td input:checkbox', function() {
-			self.saveStorageConfig($(this).closest('tr'));
-		});
-
-		this.$el.on('change', '.applicable', function() {
-			self.saveStorageConfig($(this).closest('tr'));
-		});
+		var onChangeHandler = _.bind(this._onChange, this);
+		//this.$el.on('input', 'td input', onChangeHandler);
+		this.$el.on('keyup', 'td input', onChangeHandler);
+		this.$el.on('paste', 'td input', onChangeHandler);
+		this.$el.on('change', 'td input:checkbox', onChangeHandler);
+		this.$el.on('change', '.applicable', onChangeHandler);
 
 		this.$el.on('click', '.status>span', function() {
 			self.recheckStorageConfig($(this).closest('tr'));
@@ -527,6 +504,20 @@ MountConfigListView.prototype = {
 		});
 
 		this.$el.on('change', '.selectBackend', _.bind(this._onSelectBackend, this));
+	},
+
+	_onChange: function(event) {
+		var self = this;
+		var $target = $(event.target);
+		highlightInput($target);
+		var $tr = $target.closest('tr');
+
+		var timer = $tr.data('save-timer');
+		clearTimeout(timer);
+		timer = setTimeout(function() {
+			self.saveStorageConfig($tr);
+		}, 2000);
+		$tr.data('save-timer', timer);
 	},
 
 	_onSelectBackend: function(event) {


### PR DESCRIPTION
Tabbing out of a storage row into a new one (or the empty selectBackend one) will no longer cancel the save timer for that row, allowing it to save correctly. This also fixes the potential issue where a user modifies multiple storages very quickly - with the old system of a single timer this would quickly break down, with only the most recently edited config being saved. With this PR each row has an individual timer, and so all get saved.

Re-incarnation of #14904 with IE8 support

Fixes #11216 

cc @DeepDiver1975 @PVince81 @MorrisJobke @karlitschek 
