### PR TITLE
ajax/share.php should return correct list of suggestions

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -241,6 +241,14 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					$usergroups = OC_Group::getUserGroups(OC_User::getUser());
 					$groups = array_intersect($groups, $usergroups);
 				}
+
+				$sharedUsers = [];
+				$sharedGroups = [];
+				if (isset($_GET['itemShares'])) {
+					$sharedUsers = isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) ? $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER] : [];
+					$sharedGroups = isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP]) ? $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP] : [];
+				}
+
 				$count = 0;
 				$users = array();
 				$limit = 0;
@@ -252,8 +260,13 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					} else {
 						$users = OC_User::getDisplayNames((string)$_GET['search'], $limit, $offset);
 					}
+
 					$offset += $limit;
 					foreach ($users as $uid => $displayName) {
+						if (in_array($uid, $sharedUsers)) {
+							continue;
+						}
+
 						if ((!isset($_GET['itemShares'])
 							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])
 							|| !in_array($uid, (string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]))
@@ -274,6 +287,10 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$l = \OC::$server->getL10N('core');
 
 				foreach ($groups as $group) {
+					if (in_array($group, $sharedGroups)) {
+						continue;
+					}
+
 					if ($count < 15) {
 						if (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])


### PR DESCRIPTION
Partial solves #8231

We should take advantage of the provided list of users and groups we already share with to filter the suggestions. This makes it harder to do double shares with the same users wich leads to bad UX.

Note to self: This should probably also be done in #13587
