### PR TITLE
only show connection checks results if there are errors, fix #11476

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -394,14 +394,7 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 
 #postsetupchecks .loading {
 	height: 50px;
-}
-
-#postsetupchecks.section .loading {
 	background-position: left center;
-}
-
-#postsetupchecks .hint {
-	margin-top: 15px;
 }
 
 #admin-tips li {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -140,11 +140,10 @@ $(document).ready(function(){
 		var $errorsEl;
 		$el.find('.loading').addClass('hidden');
 		if (errors.length === 0) {
-			$el.find('.success').removeClass('hidden');
 		} else {
 			$errorsEl = $el.find('.errors');
 			for (var i = 0; i < errors.length; i++ ) {
-				$errorsEl.append('<li class="setupwarning">' + errors[i] + '</li>');
+				$errorsEl.append('<li>' + errors[i] + '</li>');
 			}
 			$errorsEl.removeClass('hidden');
 			$el.find('.hint').removeClass('hidden');

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -172,7 +172,6 @@ if ($_['cronErrors']) {
 
 <div id="postsetupchecks">
 	<div class="loading"></div>
-	<div class="success hidden"><?php p($l->t('No problems found'));?></div>
 	<ul class="errors hidden"></ul>
 	<p class="hint hidden">
 		<?php print_unescaped($l->t('Please double check the <a target="_blank" href="%s">installation guides ↗</a>, and check for any errors or warnings in the <a href="#log-section">log</a>.', link_to_docs('admin-install'))); ?>


### PR DESCRIPTION
This basically just removes the »no problems found« message. Since the »connection checks« section is not separate anymore (https://github.com/owncloud/core/pull/15112), it’s not really needed. When there are no errors, don’t show anything.

Please review @owncloud/designers 
