### PR TITLE
do not show update notification on mobile, fix overlapping of header menus

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -54,6 +54,11 @@
 	display: none;
 }
 
+/* do not show update notification on mobile */
+#update-notification {
+	display: none !important;
+}
+
 /* position share dropdown */
 #dropdown {
 	margin-right: 10% !important;


### PR DESCRIPTION
Fix #10544, please review @tomneedham @owncloud/designers 

You are not very likely to perform an ownCloud-update from your mobile phone anyway. Hence it’s not really relevant there.

We should also most probably backport this since it obstructs the mobile interface.
