### PR TITLE
FIX for webdav.mediencenter.t-online.de

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -602,6 +602,11 @@ class DAV extends \OC\Files\Storage\Common {
 					return false;
 				}
 			} else {
+				// This resolves issues that are flooding the log file due to some malformed
+				// WebDAV response e.g. T-Mobile's cloud named "Mediencenter"
+				if (!isset($response['{DAV:}getlastmodified']))
+					return false;
+				
 				$remoteMtime = strtotime($response['{DAV:}getlastmodified']);
 				return $remoteMtime > $time;
 			}


### PR DESCRIPTION
https://webdav.mediencenter.t-online.de returns invalid response code.

e.g.
{"reqId":"f9a1c394b98108e4e5ca62bf47829c64","remoteAddr":"81.189.45.224","app":"PHP","message":"Undefined offset: 2 at \/var\/www\/owncloud\/3rdparty\/sabre\/dav\/lib\/Sabre\/DAV\/Client.php#569","level":3,"time":"2015-03-25T18:25:48+00:00","method":"GET","url":"\/index.php\/apps\/files\/ajax\/getstoragestats.php?dir=External%2FT-Cloud%2FTests"}

e.g.
{"reqId":"3407d66672b3cef206b0af883e49bff4","remoteAddr":"46.74.125.245","app":"PHP","message":"Undefined index: {DAV:}getlastmodified at \/var\/www\/owncloud\/lib\/private\/files\/storage\/dav.php#563","level":3,"time":"2015-03-25T16:33:21+00:00"}
