### PR TITLE
Show hidden files (dot files) in gray

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -743,8 +743,12 @@
 			// from here work on the display name
 			name = fileData.displayName || name;
 
+			// show hidden files (starting with a dot) completely in gray
+			if(name.indexOf('.') === 0) {
+				basename = '';
+				extension = name;
 			// split extension from filename for non dirs
-			if (type !== 'dir' && name.indexOf('.') !== -1) {
+			} else if (type !== 'dir' && name.indexOf('.') !== -1) {
 				basename = name.substr(0, name.lastIndexOf('.'));
 				extension = name.substr(name.lastIndexOf('.'));
 			} else {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -359,6 +359,25 @@ describe('OCA.Files.FileList tests', function() {
 			expect($('#emptycontent').hasClass('hidden')).toEqual(true);
 			expect(fileList.isEmpty).toEqual(false);
 		});
+		it('correctly adds the extension markup and show hidden files completely in gray', function() {
+			var $tr;
+			var testDataAndExpectedResult = [
+				{file: {type: 'file', name: 'ZZZ.txt'}, extension: '.txt'},
+				{file: {type: 'file', name: 'ZZZ.tar.gz'}, extension: '.gz'},
+				{file: {type: 'file', name: 'test.with.some.dots.in.it.txt'}, extension: '.txt'},
+				// we render hidden files completely in gray
+				{file: {type: 'file', name: '.test.with.some.dots.in.it.txt'}, extension: '.test.with.some.dots.in.it.txt'},
+				{file: {type: 'file', name: '.hidden'}, extension: '.hidden'},
+			];
+			fileList.setFiles(testFiles);
+
+			for(var i = 0; i < testDataAndExpectedResult.length; i++) {
+				var testSet = testDataAndExpectedResult[i];
+				var fileData = testSet['file'];
+				$tr = fileList.add(fileData);
+				expect($tr.find('.nametext .extension').text()).toEqual(testSet['extension']);
+			}
+		});
 	});
 	describe('Removing files from the list', function() {
 		it('Removes file from list when calling remove() and updates summary', function() {


### PR DESCRIPTION
Was requested in https://github.com/owncloud/apps/issues/2038

Now it shows dot files in a light gray. ref #4369 #8438 #2589

cc @owncloud/designers @peterpablo

Before:
![hidden-files-before](https://cloud.githubusercontent.com/assets/245432/6843426/285202d0-d3a3-11e4-96ee-c9c595053ec7.png)

After:
![hidden-files-after](https://cloud.githubusercontent.com/assets/245432/6843428/29c027d2-d3a3-11e4-9cb2-462e6e82530d.png)
