### PR TITLE
force log messages to break to alleviate horizontal scroll on Admin page

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -328,14 +328,12 @@ table.grid td.date{
 .cronlog {
 	margin-left: 10px;
 }
-
 .cronstatus {
 	display: inline-block;
 	height: 16px;
 	width: 16px;
 	vertical-align: text-bottom;
 }
-
 .cronstatus.success {
 	border-radius: 50%;
 }
@@ -347,6 +345,11 @@ table.grid td.date{
 	display: inline-block;
 	height: 36px;
 	padding: 7px 10px
+}
+
+#log .log-message {
+	word-break: break-all;
+	min-width: 180px;
 }
 
 span.success {

--- a/settings/js/log.js
+++ b/settings/js/log.js
@@ -52,6 +52,7 @@ OC.Log = {
 			row.append(appTd);
 
 			var messageTd = $('<td/>');
+			messageTd.addClass('log-message');
 			messageTd.text(entry.message);
 			row.append(messageTd);
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -408,7 +408,7 @@ if ($_['cronErrors']) {
 			<td>
 				<?php p($entry->app);?>
 			</td>
-			<td>
+			<td class="log-message">
 				<?php p($entry->message);?>
 			</td>
 			<td class="date">


### PR DESCRIPTION
Makes it easier to read the log cause the messages will not be too wide, and the time will be visible as well. Fits the width of the viewport now.

Please review @owncloud/designers 
