### PR TITLE
Add OC_Response::setContentLengthHeader() for Apache PHP SAPI workaround...

### DIFF
--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -39,7 +39,7 @@ $ftype=\OC_Helper::getSecureMimeType(\OC\Files\Filesystem::getMimeType( $filenam
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');
 OCP\Response::disableCaching();
-header('Content-Length: '.\OC\Files\Filesystem::filesize($filename));
+OCP\Response::setContentLengthHeader(\OC\Files\Filesystem::filesize($filename));
 
 OC_Util::obEnd();
 \OC\Files\Filesystem::readfile( $filename );

--- a/apps/files_versions/download.php
+++ b/apps/files_versions/download.php
@@ -38,7 +38,7 @@ $ftype = $view->getMimeType('/'.$uid.'/files/'.$filename);
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');
 OCP\Response::disableCaching();
-header('Content-Length: '.$view->filesize($versionName));
+OCP\Response::setContentLengthHeader($view->filesize($versionName));
 
 OC_Util::obEnd();
 

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -48,7 +48,7 @@ class OC_Files {
 			$filesize = \OC\Files\Filesystem::filesize($filename);
 			header('Content-Type: '.\OC_Helper::getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename)));
 			if ($filesize > -1) {
-				header("Content-Length: ".$filesize);
+				OC_Response::setContentLengthHeader($filesize);
 			}
 		}
 	}

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -172,6 +172,27 @@ class OC_Response {
 	}
 
 	/**
+	 * Sets the content length header (with possible workarounds)
+	 * @param string|int|float $length Length to be sent
+	 */
+	static public function setContentLengthHeader($length) {
+		if (PHP_INT_SIZE === 4) {
+			if ($length > PHP_INT_MAX && stripos(PHP_SAPI, 'apache') === 0) {
+				// Apache PHP SAPI casts Content-Length headers to PHP integers.
+				// This enforces a limit of PHP_INT_MAX (2147483647 on 32-bit
+				// platforms). So, if the length is greater than PHP_INT_MAX,
+				// we just do not send a Content-Length header to prevent
+				// bodies from being received incompletely.
+				return;
+			}
+			// Convert signed integer or float to unsigned base-10 string.
+			$lfh = new \OC\LargeFileHelper;
+			$length = $lfh->formatUnsignedInteger($length);
+		}
+		header('Content-Length: '.$length);
+	}
+
+	/**
 	* Send file as response, checking and setting caching headers
 	* @param string $filepath of file to send
 	*/
@@ -181,7 +202,7 @@ class OC_Response {
 			self::setLastModifiedHeader(filemtime($filepath));
 			self::setETagHeader(md5_file($filepath));
 
-			header('Content-Length: '.filesize($filepath));
+			self::setContentLengthHeader(filesize($filepath));
 			fpassthru($fp);
 		}
 		else {

--- a/lib/public/response.php
+++ b/lib/public/response.php
@@ -64,6 +64,14 @@ class Response {
 	}
 
 	/**
+	 * Sets the content length header (with possible workarounds)
+	 * @param string|int|float $length Length to be sent
+	 */
+	static public function setContentLengthHeader($length) {
+		\OC_Response::setContentLengthHeader($length);
+	}
+
+	/**
 	 * Disable browser caching
 	 * @see enableCaching with cache_time = 0
 	 */


### PR DESCRIPTION
Fixes #11270

Do not send Content-Length headers with a value larger than PHP_INT_MAX (2147483647 on 32-bit) on Apache PHP SAPI. PHP will eat them and send 2147483647 instead.

When X-Sendfile is enabled, Apache will send a correct Content-Length header, even for files larger than 2147483647 bytes. When X-Sendfile is not enabled, ownCloud will not send a Content-Length header anymore, which prevents progress bars from working but allows the actual transfer to work properly.
