### PR TITLE
Remove custom `arg_separator.output`

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -504,7 +504,6 @@ class OC {
 		}
 
 		date_default_timezone_set('UTC');
-		ini_set('arg_separator.output', '&amp;');
 
 		//try to configure php to enable big file uploads.
 		//this doesn´t work always depending on the webserver and php configuration.


### PR DESCRIPTION
This seems unrequired nowadays and likely a legacy fragment. It should be safe to remove.

Fixes https://github.com/owncloud/core/issues/14782
