### PR TITLE
Hint for remote sharing syntax

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -37,8 +37,12 @@
 	display: none !important;
 }
 
+#dropdown .shareWithRemoteInfo {
+	padding: 11px 20px;
+}
+
 #dropdown .avatar {
-	margin-right: 2px;
+	margin-right: 8px;
 	display: inline-block;
 	overflow: hidden;
 	vertical-align: middle;
@@ -108,7 +112,8 @@ a.unshare {
 }
 
 #dropdown input[type="text"],#dropdown input[type="password"] {
-	width:90%;
+	width: 86%;
+	margin-left: 7px;
 }
 
 #dropdown form {

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -50,17 +50,16 @@ foreach(OC_App::getEnabledApps() as $app) {
 	$apps_paths[$app] = OC_App::getAppWebPath($app);
 }
 
-$value = \OCP\Config::getAppValue('core', 'shareapi_default_expire_date', 'no');
+$config = \OC::$server->getConfig();
+$value = $config->getAppValue('core', 'shareapi_default_expire_date', 'no');
 $defaultExpireDateEnabled = ($value === 'yes') ? true :false;
 $defaultExpireDate = $enforceDefaultExpireDate = null;
 if ($defaultExpireDateEnabled) {
-	$defaultExpireDate = (int)\OCP\Config::getAppValue('core', 'shareapi_expire_after_n_days', '7');
-	$value = \OCP\Config::getAppValue('core', 'shareapi_enforce_expire_date', 'no');
+	$defaultExpireDate = (int) $config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
+	$value = $config->getAppValue('core', 'shareapi_enforce_expire_date', 'no');
 	$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
 }
-$appConfig = \OC::$server->getAppConfig();
-$result = $appConfig->getValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-$outgoingServer2serverShareEnabled = ($result === 'yes') ? true : false;
+$outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
 $array = array(
 	"oc_debug" => (defined('DEBUG') && DEBUG) ? 'true' : 'false',

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -112,7 +112,8 @@ $array = array(
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
-				'remoteShareAllowed' =>  $outgoingServer2serverShareEnabled
+				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
+				'federatedCloudShareDoc' => \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated')
 				)
 			)
 	),

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -58,6 +58,9 @@ if ($defaultExpireDateEnabled) {
 	$value = \OCP\Config::getAppValue('core', 'shareapi_enforce_expire_date', 'no');
 	$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
 }
+$appConfig = \OC::$server->getAppConfig();
+$result = $appConfig->getValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
+$outgoingServer2serverShareEnabled = ($result === 'yes') ? true : false;
 
 $array = array(
 	"oc_debug" => (defined('DEBUG') && DEBUG) ? 'true' : 'false',
@@ -110,6 +113,7 @@ $array = array(
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
+				'remoteShareAllowed' =>  $outgoingServer2serverShareEnabled
 				)
 			)
 	),

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -399,7 +399,7 @@ OC.Share={
 			html += '<label for="shareWith" class="hidden-visually">'+t('core', 'Share')+'</label>';
 			html += '<input id="shareWith" type="text" placeholder="' + sharePlaceholder + '" />';
 			if(oc_appconfig.core.remoteShareAllowed) {
-				html += '<a target="_blank" class="icon-info shareWithRemoteInfo" '
+				html += '<a target="_blank" class="icon-info svg shareWithRemoteInfo" '
 					+ 'title="'+t('core', 'Share with people on other ownClouds using the syntax username@example.com/owncloud')+'" '
 					+ 'href="https://doc.owncloud.org/server/8.0/user_manual/files/federated_cloud_sharing.html"></a>';
 			}

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -393,7 +393,7 @@ OC.Share={
 
 			var sharePlaceholder = t('core', 'Share with users or groups …');
 			if(oc_appconfig.core.remoteShareAllowed) {
-				sharePlaceholder = t('core', 'Share with users, groups or remote (user@domain) …');
+				sharePlaceholder = t('core', 'Share with users, groups or remote users …');
 			}
 
 			html += '<label for="shareWith" class="hidden-visually">'+t('core', 'Share')+'</label>';

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -399,9 +399,9 @@ OC.Share={
 			html += '<label for="shareWith" class="hidden-visually">'+t('core', 'Share')+'</label>';
 			html += '<input id="shareWith" type="text" placeholder="' + sharePlaceholder + '" />';
 			if(oc_appconfig.core.remoteShareAllowed) {
-				html += '<a target="_blank" class="icon-info svg shareWithRemoteInfo" '
-					+ 'title="'+t('core', 'Share with people on other ownClouds using the syntax username@example.com/owncloud')+'" '
-					+ 'href="https://doc.owncloud.org/server/8.0/user_manual/files/federated_cloud_sharing.html"></a>';
+				var federatedCloudSharingDoc = '<a target="_blank" class="icon-info svg shareWithRemoteInfo" href="{docLink}" '
+					+ 'title="' + t('core', 'Share with people on other ownClouds using the syntax username@example.com/owncloud') + '"></a>';
+				html += federatedCloudSharingDoc.replace('{docLink}', oc_appconfig.core.federatedCloudShareDoc);
 			}
 			html += '<span class="shareWithLoading icon-loading-small hidden"></span>';
 			html += '<ul id="shareWithList">';

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -398,6 +398,11 @@ OC.Share={
 
 			html += '<label for="shareWith" class="hidden-visually">'+t('core', 'Share')+'</label>';
 			html += '<input id="shareWith" type="text" placeholder="' + sharePlaceholder + '" />';
+			if(oc_appconfig.core.remoteShareAllowed) {
+				html += '<a target="_blank" class="icon-info shareWithRemoteInfo" '
+					+ 'title="'+t('core', 'Share with people on other ownClouds using the syntax username@example.com/owncloud')+'" '
+					+ 'href="https://doc.owncloud.org/server/8.0/user_manual/files/federated_cloud_sharing.html"></a>';
+			}
 			html += '<span class="shareWithLoading icon-loading-small hidden"></span>';
 			html += '<ul id="shareWithList">';
 			html += '</ul>';
@@ -447,6 +452,11 @@ OC.Share={
 			html += '</div>';
 			dropDownEl = $(html);
 			dropDownEl = dropDownEl.appendTo(appendTo);
+
+			// trigger remote share info tooltip
+			if(oc_appconfig.core.remoteShareAllowed) {
+				$('.shareWithRemoteInfo').tipsy({gravity: 'e'});
+			}
 
 			//Get owner avatars
 			if (oc_config.enable_avatars === true && data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -391,8 +391,13 @@ OC.Share={
 				}
 			});
 
+			var sharePlaceholder = t('core', 'Share with users or groups …');
+			if(oc_appconfig.core.remoteShareAllowed) {
+				sharePlaceholder = t('core', 'Share with users, groups or remote (user@domain) …');
+			}
+
 			html += '<label for="shareWith" class="hidden-visually">'+t('core', 'Share')+'</label>';
-			html += '<input id="shareWith" type="text" placeholder="'+t('core', 'Share with user or group …')+'" />';
+			html += '<input id="shareWith" type="text" placeholder="' + sharePlaceholder + '" />';
 			html += '<span class="shareWithLoading icon-loading-small hidden"></span>';
 			html += '<ul id="shareWithList">';
 			html += '</ul>';


### PR DESCRIPTION
This adds a hint for the remote sharing syntax to the Share dropdown.

The normal hint is: `Share with users or groups …`
And with Federated Cloud Sharing enabled: `Share with users, groups or remote (user@domain) …`

Please review @owncloud/designers @schiesbn @karlitschek 
