### PR TITLE
add priority to storage wrappers

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -201,11 +201,13 @@ class Filesystem {
 	private static $loader;
 
 	/**
+	 * @param string $wrapperName
 	 * @param callable $wrapper
+	 * @param int $priority
 	 */
-	public static function addStorageWrapper($wrapperName, $wrapper) {
+	public static function addStorageWrapper($wrapperName, $wrapper, $priority = 50) {
 		$mounts = self::getMountManager()->getAll();
-		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper, $mounts)) {
+		if (!self::getLoader()->addStorageWrapper($wrapperName, $wrapper, $priority, $mounts)) {
 			// do not re-wrap if storage with this name already existed
 			return;
 		}

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -37,7 +37,6 @@ namespace OC\Files\Storage;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\Scanner;
-use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OC\Files\Cache\Watcher;
 use OCP\Files\FileNameTooLongException;
@@ -56,7 +55,7 @@ use OCP\Files\ReservedWordException;
  * Some \OC\Files\Storage\Common methods call functions which are first defined
  * in classes which extend it, e.g. $this->stat() .
  */
-abstract class Common implements \OC\Files\Storage\Storage {
+abstract class Common implements Storage {
 	protected $cache;
 	protected $scanner;
 	protected $watcher;
@@ -370,7 +369,7 @@ abstract class Common implements \OC\Files\Storage\Storage {
 			$storage = $this;
 		}
 		if (!isset($this->storageCache)) {
-			$this->storageCache = new Storage($storage);
+			$this->storageCache = new \OC\Files\Cache\Storage($storage);
 		}
 		return $this->storageCache;
 	}


### PR DESCRIPTION
wrappers with the lowerst priority get applied first, meaning they become the most outer wrapper and have the first opportunity to modify the operation.

cc @PVince81 @DeepDiver1975 @schiesbn 
