### PR TITLE
always fall back to default share folder

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -283,8 +283,21 @@ class Helper {
 	 */
 	public static function getShareFolder() {
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
+		$shareFolder = \OC\Files\Filesystem::normalizePath($shareFolder);
 
-		return \OC\Files\Filesystem::normalizePath($shareFolder);
+		if (!\OC\Files\Filesystem::file_exists($shareFolder)) {
+			$dir = '';
+			$subdirs = explode('/', $shareFolder);
+			foreach ($subdirs as $subdir) {
+				$dir = $dir . '/' . $subdir;
+				if (!\OC\Files\Filesystem::is_dir($dir)) {
+					\OC\Files\Filesystem::mkdir($dir);
+				}
+			}
+		}
+
+		return $shareFolder;
+
 	}
 
 	/**

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -50,8 +50,8 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$mountPoint = basename($share['file_target']);
 		$parent = dirname($share['file_target']);
 
-		while (!\OC\Files\Filesystem::is_dir($parent)) {
-			$parent = dirname($parent);
+		if (!\OC\Files\Filesystem::is_dir($parent)) {
+			$parent = Helper::getShareFolder();
 		}
 
 		$newMountPoint = \OCA\Files_Sharing\Helper::generateUniqueTarget(

--- a/apps/files_sharing/tests/helper.php
+++ b/apps/files_sharing/tests/helper.php
@@ -52,9 +52,11 @@ class Test_Files_Sharing_Helper extends TestCase {
 	function testSetGetShareFolder() {
 		$this->assertSame('/', \OCA\Files_Sharing\Helper::getShareFolder());
 
-		\OCA\Files_Sharing\Helper::setShareFolder('/Shared');
+		\OCA\Files_Sharing\Helper::setShareFolder('/Shared/Folder');
 
-		$this->assertSame('/Shared', \OCA\Files_Sharing\Helper::getShareFolder());
+		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder();
+		$this->assertSame('/Shared/Folder', \OCA\Files_Sharing\Helper::getShareFolder());
+		$this->assertTrue(\OC\Files\Filesystem::is_dir($sharedFolder));
 
 		// cleanup
 		\OC::$server->getConfig()->deleteSystemValue('share_folder');


### PR DESCRIPTION
@MorrisJobke @PVince81 @felixboehm as discussed. Fall back to the default share folder if the parent no longer exists.

Steps to test:
- create two users
- define a default share folder in config.php
- share file from user1 to user2
- check if share is mounted in the default share folder for user2
- logout
- delete default share folder from user2
- login as user2 -> default share folder should be re-created
