### PR TITLE
Filter potential dangerous characters in path name

### DIFF
--- a/lib/private/tempmanager.php
+++ b/lib/private/tempmanager.php
@@ -54,10 +54,15 @@ class TempManager implements ITempManager {
 		$this->log = $logger;
 	}
 
+	/**
+	 * @param string $postFix
+	 * @return string
+	 */
 	protected function generatePath($postFix) {
 		if ($postFix) {
 			$postFix = '.' . ltrim($postFix, '.');
 		}
+		$postFix = str_replace(['\\', '/'], '', $postFix);
 		return $this->tmpBaseDir . '/oc_tmp_' . md5(time() . rand()) . $postFix;
 	}
 

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -151,4 +151,17 @@ class TempManager extends \Test\TestCase {
 			->with($this->stringContains('Can not create a temporary folder in directory'));
 		$this->assertFalse($manager->getTemporaryFolder());
 	}
+
+	public function testGeneratePathTraversal() {
+		$logger = $this->getMock('\Test\NullLogger');
+		$tmpManager = \Test_Helper::invokePrivate(
+			$this->getManager($logger),
+			'generatePath',
+			['../Traversal\\../FileName']
+		);
+
+		$this->assertStringEndsNotWith('./Traversal\\../FileName', $tmpManager);
+		$this->assertStringEndsWith('.Traversal..FileName', $tmpManager);
+
+	}
 }


### PR DESCRIPTION
We should not allow / or \ in the postfix here.

@nickvergessen As discussed.
