### PR TITLE
adjust controls bar width to not overlay scrollbar

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -635,6 +635,8 @@
 		 * @param filesArray array of file data (map)
 		 */
 		setFiles: function(filesArray) {
+			var self = this;
+
 			// detach to make adding multiple rows faster
 			this.files = filesArray;
 
@@ -655,7 +657,10 @@
 			this.updateSelectionSummary();
 			$(window).scrollTop(0);
 
-			this.$fileList.trigger(jQuery.Event("updated"));
+			this.$fileList.trigger(jQuery.Event('updated'));
+			_.defer(function() {
+				self.$el.closest('#app-content').trigger(jQuery.Event('apprendered'));
+			});
 		},
 		/**
 		 * Creates a new table row element using the given file data.

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1261,6 +1261,32 @@ function initCore() {
 		// initial call
 		toggleSnapperOnSize();
 
+		// adjust controls bar width
+		var adjustControlsWidth = function() {
+			if($('#controls').length) {
+				// if there is a scrollbar …
+				if($('#app-content').get(0).scrollHeight > $('#app-content').height()) {
+					if($(window).width() > 768) {
+						var controlsWidth = $('#content').width() - $('#app-navigation').width() - getScrollBarWidth();
+					} else {
+						var controlsWidth = $('#content').width() - getScrollBarWidth();
+					}
+				} else { // if there is none
+					if($(window).width() > 768) {
+						var controlsWidth = $('#content').width() - $('#app-navigation').width();
+					} else {
+						var controlsWidth = $('#content').width();
+					}
+				}
+				$('#controls').css('width', controlsWidth);
+				$('#controls').css('min-width', controlsWidth);
+			}
+		};
+
+		$(window).resize(_.debounce(adjustControlsWidth, 250));
+
+		$('body').delegate('#app-content', 'apprendered', adjustControlsWidth);
+
 	}
 
 }
@@ -1684,4 +1710,30 @@ jQuery.fn.selectRange = function(start, end) {
  */
 jQuery.fn.exists = function(){
 	return this.length > 0;
+};
+
+function getScrollBarWidth() {
+	var inner = document.createElement('p');
+	inner.style.width = "100%";
+	inner.style.height = "200px";
+
+	var outer = document.createElement('div');
+	outer.style.position = "absolute";
+	outer.style.top = "0px";
+	outer.style.left = "0px";
+	outer.style.visibility = "hidden";
+	outer.style.width = "200px";
+	outer.style.height = "150px";
+	outer.style.overflow = "hidden";
+	outer.appendChild (inner);
+
+	document.body.appendChild (outer);
+	var w1 = inner.offsetWidth;
+	outer.style.overflow = 'scroll';
+	var w2 = inner.offsetWidth;
+	if (w1 == w2) w2 = outer.clientWidth;
+
+	document.body.removeChild (outer);
+
+	return (w1 - w2);
 };

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1264,18 +1264,19 @@ function initCore() {
 		// adjust controls bar width
 		var adjustControlsWidth = function() {
 			if($('#controls').length) {
+				var controlsWidth;
 				// if there is a scrollbar …
 				if($('#app-content').get(0).scrollHeight > $('#app-content').height()) {
 					if($(window).width() > 768) {
-						var controlsWidth = $('#content').width() - $('#app-navigation').width() - getScrollBarWidth();
+						controlsWidth = $('#content').width() - $('#app-navigation').width() - getScrollBarWidth();
 					} else {
-						var controlsWidth = $('#content').width() - getScrollBarWidth();
+						controlsWidth = $('#content').width() - getScrollBarWidth();
 					}
 				} else { // if there is none
 					if($(window).width() > 768) {
-						var controlsWidth = $('#content').width() - $('#app-navigation').width();
+						controlsWidth = $('#content').width() - $('#app-navigation').width();
 					} else {
-						var controlsWidth = $('#content').width();
+						controlsWidth = $('#content').width();
 					}
 				}
 				$('#controls').css('width', controlsWidth);
@@ -1731,9 +1732,11 @@ function getScrollBarWidth() {
 	var w1 = inner.offsetWidth;
 	outer.style.overflow = 'scroll';
 	var w2 = inner.offsetWidth;
-	if (w1 == w2) w2 = outer.clientWidth;
+	if(w1 === w2) {
+		w2 = outer.clientWidth;
+	}
 
 	document.body.removeChild (outer);
 
 	return (w1 - w2);
-};
+}


### PR DESCRIPTION
Crazy JS-fu incoming

![](http://replygif.net/i/168.gif)

Currently the controls bar extends all the way to the right to overlay the scrollbar. When you have a lot of files, your complete scrollbar could vanish. This fixes that with _a lot_ of JS.

Check it out @owncloud/designers @PVince81 
