### PR TITLE
Keep shares when deleting shared folders

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -33,7 +33,6 @@ class Helper {
 		\OCP\Util::connectHook('OC_Filesystem', 'setup', '\OC\Files\Storage\Shared', 'setup');
 		\OCP\Util::connectHook('OC_Filesystem', 'setup', '\OCA\Files_Sharing\External\Manager', 'setup');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_write', '\OC\Files\Cache\Shared_Updater', 'writeHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OC\Files\Cache\Shared_Updater', 'postDeleteHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'delete', '\OC\Files\Cache\Shared_Updater', 'deleteHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OC\Files\Cache\Shared_Updater', 'renameHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -82,25 +82,6 @@ class Shared_Updater {
 	}
 
 	/**
-	 * remove all shares for a given file if the file was deleted
-	 *
-	 * @param string $path
-	 */
-	private static function removeShare($path) {
-		$fileSource = self::$toRemove[$path];
-
-		if (!\OC\Files\Filesystem::file_exists($path)) {
-			$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share` WHERE `file_source`=?');
-			try	{
-				\OC_DB::executeAudited($query, array($fileSource));
-			} catch (\Exception $e) {
-				\OCP\Util::writeLog('files_sharing', "can't remove share: " . $e->getMessage(), \OCP\Util::WARN);
-			}
-		}
-		unset(self::$toRemove[$path]);
-	}
-
-	/**
 	 * @param array $params
 	 */
 	static public function writeHook($params) {
@@ -122,19 +103,6 @@ class Shared_Updater {
 	static public function deleteHook($params) {
 		$path = $params['path'];
 		self::correctFolders($path);
-
-		$fileInfo = \OC\Files\Filesystem::getFileInfo($path);
-
-		// mark file as deleted so that we can clean up the share table if
-		// the file was deleted successfully
-		self::$toRemove[$path] =  $fileInfo['fileid'];
-	}
-
-	/**
-	 * @param array $params
-	 */
-	static public function postDeleteHook($params) {
-		self::removeShare($params['path']);
 	}
 
 	/**

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -27,9 +27,6 @@ namespace OC\Files\Cache;
 
 class Shared_Updater {
 
-	// shares which can be removed from oc_share after the delete operation was successful
-	static private $toRemove = array();
-
 	/**
 	 * walk up the users file tree and update the etags
 	 * @param string $user

--- a/apps/files_sharing/tests/deleteorphanedsharesjobtest.php
+++ b/apps/files_sharing/tests/deleteorphanedsharesjobtest.php
@@ -55,6 +55,9 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		$appManager = \OC::$server->getAppManager();
 		self::$trashBinStatus = $appManager->isEnabledForUser('files_trashbin');
 		$appManager->disableApp('files_trashbin');
+
+		// just in case...
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 	}
 
 	public static function tearDownAfterClass() {


### PR DESCRIPTION
The share entries will be linked with the fileid while they are kept in
the trashbin.

In the future a background just will scrape orphaned shares and delete
them.

(implementing a "new" feature by just deleting code!)
- [x] Needs https://github.com/owncloud/core/pull/14676 first
- [x] fix unit test
