### PR TITLE
Revert "Deprecated \OCP\IAppConfig - add missing methods to IConfig"

### DIFF
--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -26,8 +26,6 @@
  */
 
 namespace OC;
-
-use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
 
@@ -40,9 +38,6 @@ class AllConfig implements \OCP\IConfig {
 
 	/** @var IDBConnection */
 	private $connection;
-
-	/** @var IAppConfig */
-	private $appConfig;
 
 	/**
 	 * 3 dimensional array with the following structure:
@@ -85,16 +80,10 @@ class AllConfig implements \OCP\IConfig {
 	 *
 	 * otherwise a SQLite database is created in the wrong directory
 	 * because the database connection was created with an uninitialized config
-	 *
-	 * The same applies for the app config, because it uses the database
-	 * connection itself
 	 */
 	private function fixDIInit() {
 		if($this->connection === null) {
 			$this->connection = \OC::$server->getDatabaseConnection();
-		}
-		if ($this->appConfig === null) {
-			$this->appConfig = \OC::$server->getAppConfig();
 		}
 	}
 
@@ -145,10 +134,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string[] the keys stored for the app
 	 */
 	public function getAppKeys($appName) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		return $this->appConfig->getKeys($appName);
+		return \OC::$server->getAppConfig()->getKeys($appName);
 	}
 
 	/**
@@ -159,24 +145,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $value the value that should be stored
 	 */
 	public function setAppValue($appName, $key, $value) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		$this->appConfig->setValue($appName, $key, $value);
-	}
-
-	/**
-	 * Checks if a key is set in the apps config
-	 *
-	 * @param string $appName the appName tto look a key up
-	 * @param string $key the key to look up
-	 * @return bool
-	 */
-	public function hasAppKey($appName, $key) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		$this->appConfig->hasKey($appName, $key);
+		\OC::$server->getAppConfig()->setValue($appName, $key, $value);
 	}
 
 	/**
@@ -188,49 +157,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string the saved value
 	 */
 	public function getAppValue($appName, $key, $default = '') {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		return $this->appConfig->getValue($appName, $key, $default);
-	}
-
-	/**
-	 * Get all app values that are stored
-	 *
-	 * @param string $appName the appName
-	 * @return array with key - value pair as they are saved previously
-	 */
-	public function getAppValuesByApp($appName) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		return $this->appConfig->getValues($appName, false);
-	}
-
-	/**
-	 * Get all app values that use the same key
-	 *
-	 * @param string $key the appName
-	 * @return array with key - value pair as they are saved previously with the
-	 *                 app name as key
-	 */
-	public function getAppValuesByKey($key) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		return $this->appConfig->getValues(false, $key);
-	}
-
-	/**
-	 * Get all apps that have at least one value saved
-	 *
-	 * @return array containing app names
-	 */
-	public function getApps() {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		return $this->appConfig->getApps();
+		return \OC::$server->getAppConfig()->getValue($appName, $key, $default);
 	}
 
 	/**
@@ -240,10 +167,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 */
 	public function deleteAppValue($appName, $key) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		$this->appConfig->deleteKey($appName, $key);
+		\OC::$server->getAppConfig()->deleteKey($appName, $key);
 	}
 
 	/**
@@ -252,10 +176,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @param string $appName the appName the configs are stored under
 	 */
 	public function deleteAppValues($appName) {
-		// TODO - FIXME
-		$this->fixDIInit();
-
-		$this->appConfig->deleteApp($appName);
+		\OC::$server->getAppConfig()->deleteApp($appName);
 	}
 
 

--- a/lib/private/legacy/appconfig.php
+++ b/lib/private/legacy/appconfig.php
@@ -27,7 +27,7 @@
  * This class provides an easy way for apps to store config values in the
  * database.
  *
- * @deprecated use \OC::$server->getConfig() to get an \OCP\IConfig instance
+ * @deprecated use \OC::$server->getAppConfig() to get an \OCP\IAppConfig instance
  */
 class OC_Appconfig {
 	/**

--- a/lib/public/iappconfig.php
+++ b/lib/public/iappconfig.php
@@ -27,10 +27,6 @@ namespace OCP;
 /**
  * This class provides an easy way for apps to store config values in the
  * database.
- *
- * @deprecated This interface will be dropped with ownCloud 10.1 which will be
- *             released in the first quarter of 2017. Use the methods of
- *             \OCP\IConfig instead
  */
 interface IAppConfig {
 	/**
@@ -38,7 +34,6 @@ interface IAppConfig {
 	 * @param string $app
 	 * @param string $key
 	 * @return bool
-	 * @deprecated use method hasAppKey of \OCP\IConfig
 	 */
 	public function hasKey($app, $key);
 
@@ -81,7 +76,6 @@ interface IAppConfig {
 	 * @param string|false $key
 	 * @param string|false $app
 	 * @return array|false
-	 * @deprecated use method getAppValuesByApp or getAppValuesByKey of \OCP\IConfig
 	 */
 	public function getValues($app, $key);
 
@@ -100,7 +94,6 @@ interface IAppConfig {
 	/**
 	 * Get all apps using the config
 	 * @return array an array of app ids
-	 * @deprecated use method getApps of \OCP\IConfig
 	 *
 	 * This function returns a list of all apps that have at least one
 	 * entry in the appconfig table.

--- a/lib/public/iconfig.php
+++ b/lib/public/iconfig.php
@@ -90,16 +90,6 @@ interface IConfig {
 	public function setAppValue($appName, $key, $value);
 
 	/**
-	 * Checks if a key is set in the apps config
-	 *
-	 * @param string $appName the appName tto look a key up
-	 * @param string $key the key to look up
-	 * @return bool
-	 * @since 8.1.0
-	 */
-	public function hasAppKey($appName, $key);
-
-	/**
 	 * Looks up an app wide defined value
 	 *
 	 * @param string $appName the appName that we stored the value under
@@ -108,33 +98,6 @@ interface IConfig {
 	 * @return string the saved value
 	 */
 	public function getAppValue($appName, $key, $default = '');
-
-	/**
-	 * Get all app values that are stored
-	 *
-	 * @param string $appName the appName
-	 * @return array with key - value pair as they are saved previously
-	 * @since 8.1.0
-	 */
-	public function getAppValuesByApp($appName);
-
-	/**
-	 * Get all app values that use the same key
-	 *
-	 * @param string $key the appName
-	 * @return array with key - value pair as they are saved previously with the
-	 * 	             app name as key
-	 * @since 8.1.0
-	 */
-	public function getAppValuesByKey($key);
-
-	/**
-	 * Get all apps that have at least one value saved
-	 *
-	 * @return array containing app names
-	 * @since 8.1.0
-	 */
-	public function getApps();
 
 	/**
 	 * Delete an app wide defined value


### PR DESCRIPTION
This reverts commit 012016d3311a13c3c1e9d60778dc6fbd6be0204e.

@MorrisJobke seems the last test run was quite old and didn't match the new code.

We need to revert this to have tests pass on master

@icewind1991 @schiesbn 
