### PR TITLE
Check for relative datadirectory path

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -886,17 +886,23 @@ class OC_Util {
 	 * checking the existence of the ".ocdata" file.
 	 *
 	 * @param string $dataDirectory data directory path
-	 * @return bool true if the data directory is valid, false otherwise
+	 * @return array errors found
 	 */
 	public static function checkDataDirectoryValidity($dataDirectory) {
 		$l = \OC::$server->getL10N('lib');
-		$errors = array();
+		$errors = [];
+		if (!self::runningOnWindows() && $dataDirectory[0] !== '/') {
+			$errors[] = [
+				'error' => $l->t('Data directory (%s) must be an absolute path', [$dataDirectory]),
+				'hint' => $l->t('Check the value of "datadirectory" in your configuration')
+			];
+		}
 		if (!file_exists($dataDirectory . '/.ocdata')) {
-			$errors[] = array(
-				'error' => $l->t('Data directory (%s) is invalid', array($dataDirectory)),
+			$errors[] = [
+				'error' => $l->t('Data directory (%s) is invalid', [$dataDirectory]),
 				'hint' => $l->t('Please check that the data directory contains a file' .
 					' ".ocdata" in its root.')
-			);
+			];
 		}
 		return $errors;
 	}

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -419,6 +419,25 @@ class Test_Util extends \Test\TestCase {
 
 		$this->assertFalse(\OCP\Util::needUpgrade());
 	}
+
+	public function testCheckDataDirectoryValidity() {
+		$dataDir = \OCP\Files::tmpFolder();
+		touch($dataDir . '/.ocdata');
+		$errors = \OC_Util::checkDataDirectoryValidity($dataDir);
+		$this->assertEmpty($errors);
+		\OCP\Files::rmdirr($dataDir);
+
+		$dataDir = \OCP\Files::tmpFolder();
+		// no touch
+		$errors = \OC_Util::checkDataDirectoryValidity($dataDir);
+		$this->assertNotEmpty($errors);
+		\OCP\Files::rmdirr($dataDir);
+
+		if (!\OC_Util::runningOnWindows()) {
+			$errors = \OC_Util::checkDataDirectoryValidity('relative/path');
+			$this->assertNotEmpty($errors);
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Relative data directory paths are not supported. Also, more test coverage! The new check only works on non-Windows though.

Fixes #11251

cc @DeepDiver1975 @LukasReschke @PVince81 @karlitschek @AW-UC
