### PR TITLE
Add more spacing to the file picker dialog

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -856,7 +856,7 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 	background-image:url('../img/places/home.svg');
 	background-repeat:no-repeat;
 	background-position: left center;
-	width: 26px;
+	width: 30px;
 	display: inline-block;
 }
 #oc-dialog-filepicker-content .dirtree span:not(:last-child) { cursor: pointer; }

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -693,7 +693,7 @@ var OCdialogs = {
 		}
 		$template.octemplate({
 			dir: '',
-			name: '&nbsp;&nbsp;&nbsp;&nbsp;' // Ugly but works ;)
+			name: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' // Ugly but works ;)
 		}, {escapeFunction: null}).addClass('home svg').prependTo(this.$dirTree);
 	},
 	/**


### PR DESCRIPTION
Without this the first `>` looked somewhat off, to test this change go to the personal settings and choose a profile picture in a subfolder.

Tested in newest Chrome and FF on OS X.

Before:
![2015-03-28_14-20-45](https://cloud.githubusercontent.com/assets/878997/6881210/c3f4716a-d555-11e4-8ddd-479eee2eef18.png)

After:
![2015-03-28_14-19-21](https://cloud.githubusercontent.com/assets/878997/6881209/c2baee5a-d555-11e4-876b-105f24541bbc.png)

<hr/>

<small>This patch looks very hacky. If you have a better idea feel free to directly push it here :-)</small>
