### PR TITLE
do not hide exception when ldap server has a hiccup

### DIFF
--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -23,6 +23,7 @@
  */
 
 namespace OCA\Encryption;
+use OC\User\NoUserException;
 
 /**
  * Class for utilities relating to encrypted file storage system
@@ -903,8 +904,14 @@ class Util {
 		) {
 			return true;
 		}
-		$util = new Util($this->view, $user);
-		return $util->ready();
+		try {
+			$util = new Util($this->view, $user);
+			return $util->ready();
+		} catch (NoUserException $e) {
+			\OCP\Util::writeLog('Encryption library',
+				'No User object for '.$user, \OCP\Util::DEBUG);
+			return false;
+		}
 	}
 
 	/**

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -45,7 +45,7 @@ class Connection extends LDAPUtility {
 	//cache handler
 	protected $cache;
 
-	//settings handler
+	/** @var Configuration settings handler **/
 	protected $configuration;
 
 	protected $doNotValidate = false;
@@ -158,7 +158,8 @@ class Connection extends LDAPUtility {
 			$this->establishConnection();
 		}
 		if(is_null($this->ldapConnectionRes)) {
-			\OCP\Util::writeLog('user_ldap', 'Connection could not be established', \OCP\Util::ERROR);
+			\OCP\Util::writeLog('user_ldap', 'No LDAP Connection to server ' . $this->configuration->ldapHost, \OCP\Util::ERROR);
+			throw new \Exception('Connection to LDAP server could not be established');
 		}
 		return $this->ldapConnectionRes;
 	}

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -24,6 +24,8 @@
 namespace OCA\user_ldap\lib;
 
 //magic properties (incomplete)
+use OC\ServerNotAvailableException;
+
 /**
  * responsible for LDAP connections in context with the provided configuration
  *
@@ -159,7 +161,7 @@ class Connection extends LDAPUtility {
 		}
 		if(is_null($this->ldapConnectionRes)) {
 			\OCP\Util::writeLog('user_ldap', 'No LDAP Connection to server ' . $this->configuration->ldapHost, \OCP\Util::ERROR);
-			throw new \Exception('Connection to LDAP server could not be established');
+			throw new ServerNotAvailableException('Connection to LDAP server could not be established');
 		}
 		return $this->ldapConnectionRes;
 	}

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -23,6 +23,8 @@
 
 namespace OCA\user_ldap\lib;
 
+use OC\ServerNotAvailableException;
+
 class LDAP implements ILDAPWrapper {
 	protected $curFunc = '';
 	protected $curArgs = array();
@@ -280,6 +282,8 @@ class LDAP implements ILDAPWrapper {
 					//for now
 				} else if ($errorCode === 10) {
 					//referrals, we switch them off, but then there is AD :)
+				} else if ($errorCode === -1) {
+					throw new ServerNotAvailableException('Lost connection to LDAP server.');
 				} else {
 					\OCP\Util::writeLog('user_ldap',
 										'LDAP error '.$errorMsg.' (' .

--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -173,6 +173,7 @@ class Manager {
 	 * @brief returns a User object by it's DN or ownCloud username
 	 * @param string the DN or username of the user
 	 * @return \OCA\user_ldap\lib\user\User|\OCA\user_ldap\lib\user\OfflineUser|null
+	 * @throws \Exception when connection could not be established
 	 */
 	public function get($id) {
 		$this->checkAccess();
@@ -189,12 +190,7 @@ class Manager {
 			}
 		}
 
-		try {
-			$user = $this->createInstancyByUserName($id);
-			return $user;
-		} catch (\Exception $e) {
-			return null;
-		}
+		return $this->createInstancyByUserName($id);
 	}
 
 }

--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -157,6 +157,11 @@ class Manager {
 			$this->access);
 	}
 
+	/**
+	 * @brief returns a User object by it's ownCloud username
+	 * @param string the DN or username of the user
+	 * @return \OCA\user_ldap\lib\user\User|\OCA\user_ldap\lib\user\OfflineUser|null
+	 */
 	protected function createInstancyByUserName($id) {
 		//most likely a uid. Check whether it is a deleted user
 		if($this->isDeletedUser($id)) {
@@ -166,12 +171,12 @@ class Manager {
 		if($dn !== false) {
 			return $this->createAndCache($dn, $id);
 		}
-		throw new \Exception('Could not create User instance');
+		return null;
 	}
 
 	/**
 	 * @brief returns a User object by it's DN or ownCloud username
-	 * @param string the DN or username of the user
+	 * @param string the username of the user
 	 * @return \OCA\user_ldap\lib\user\User|\OCA\user_ldap\lib\user\OfflineUser|null
 	 * @throws \Exception when connection could not be established
 	 */

--- a/apps/user_ldap/tests/user/manager.php
+++ b/apps/user_ldap/tests/user/manager.php
@@ -142,8 +142,6 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
         $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
         $manager->setLdapAccess($access);
         $user = $manager->get($inputDN);
-
-        $this->assertNull($user);
     }
 
     public function testGetByUidExisting() {
@@ -191,8 +189,6 @@ class Test_User_Manager extends \PHPUnit_Framework_TestCase {
         $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
         $manager->setLdapAccess($access);
         $user = $manager->get($uid);
-
-        $this->assertNull($user);
     }
 
 }

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -176,6 +176,7 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 	 * check if a user exists
 	 * @param string $uid the username
 	 * @return boolean
+	 * @throws \Exception when connection could not be established
 	 */
 	public function userExists($uid) {
 		if($this->access->connection->isCached('userExists'.$uid)) {
@@ -194,17 +195,12 @@ class USER_LDAP extends BackendUtility implements \OCP\UserInterface {
 			return true;
 		}
 
-		try {
-			$result = $this->userExistsOnLDAP($user);
-			$this->access->connection->writeToCache('userExists'.$uid, $result);
-			if($result === true) {
-				$user->update();
-			}
-			return $result;
-		} catch (\Exception $e) {
-			\OCP\Util::writeLog('user_ldap', $e->getMessage(), \OCP\Util::WARN);
-			return false;
+		$result = $this->userExistsOnLDAP($user);
+		$this->access->connection->writeToCache('userExists'.$uid, $result);
+		if($result === true) {
+			$user->update();
 		}
+		return $result;
 	}
 
 	/**

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -455,6 +455,10 @@ OC.Share={
 					} else {
 						response();
 					}
+				}).fail(function(){
+					$('#dropdown').find('.shareWithLoading').addClass('hidden');
+					OC.Notification.show(t('core', 'An error occured. Please try again'));
+					window.setTimeout(OC.Notification.hide, 5000);
 				});
 			},
 			focus: function(event, focused) {

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -12,6 +12,12 @@
 				<small><?php p($l->t('Please contact your administrator.')); ?></small>
 			</div>
 		<?php endif; ?>
+		<?php if (isset($_['internalexception']) && ($_['internalexception'])): ?>
+			<div class="warning">
+				<?php p($l->t('An internal error occured.')); ?><br>
+				<small><?php p($l->t('Please try again or contact your administrator.')); ?></small>
+			</div>
+		<?php endif; ?>
 		<p id="message" class="hidden">
 			<img class="float-spinner" src="<?php p(\OCP\Util::imagePath('core', 'loading-dark.gif'));?>"/>
 			<span id="messageText"></span>

--- a/lib/base.php
+++ b/lib/base.php
@@ -829,15 +829,21 @@ class OC {
 		OC_App::loadApps(array('prelogin'));
 		$error = array();
 
-		// auth possible via apache module?
-		if (OC::tryApacheAuth()) {
-			$error[] = 'apacheauthfailed';
-		} // remember was checked after last login
-		elseif (OC::tryRememberLogin()) {
-			$error[] = 'invalidcookie';
-		} // logon via web form
-		elseif (OC::tryFormLogin()) {
-			$error[] = 'invalidpassword';
+		try {
+			// auth possible via apache module?
+			if (OC::tryApacheAuth()) {
+				$error[] = 'apacheauthfailed';
+			} // remember was checked after last login
+			elseif (OC::tryRememberLogin()) {
+				$error[] = 'invalidcookie';
+			} // logon via web form
+			elseif (OC::tryFormLogin()) {
+				$error[] = 'invalidpassword';
+			}
+		} catch (\Exception $ex) {
+			\OCP\Util::logException('handleLogin', $ex);
+			// do not disclose information. show generic error
+			$error[] = 'internalexception';
 		}
 
 		OC_Util::displayLoginPage(array_unique($error));

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -329,41 +329,41 @@ class Filesystem {
 
 		$userObject = \OC_User::getManager()->get($user);
 
-		if (!is_null($userObject)) {
-			$homeStorage = \OC_Config::getValue( 'objectstore' );
-			if (!empty($homeStorage)) {
-				// sanity checks
-				if (empty($homeStorage['class'])) {
-					\OCP\Util::writeLog('files', 'No class given for objectstore', \OCP\Util::ERROR);
-				}
-				if (!isset($homeStorage['arguments'])) {
-					$homeStorage['arguments'] = array();
-				}
-				// instantiate object store implementation
-				$homeStorage['arguments']['objectstore'] = new $homeStorage['class']($homeStorage['arguments']);
-				// mount with home object store implementation
-				$homeStorage['class'] = '\OC\Files\ObjectStore\HomeObjectStoreStorage';
-			} else {
-				$homeStorage = array(
-					//default home storage configuration:
-					'class' => '\OC\Files\Storage\Home',
-					'arguments' => array()
-				);
-			}
-			$homeStorage['arguments']['user'] = $userObject;
-
-			// check for legacy home id (<= 5.0.12)
-			if (\OC\Files\Cache\Storage::exists('local::' . $root . '/')) {
-				$homeStorage['arguments']['legacy'] = true;
-			}
-
-			self::mount($homeStorage['class'], $homeStorage['arguments'], $user);
-
-			$home = \OC\Files\Filesystem::getStorage($user);
+		if (is_null($userObject)) {
+			\OCP\Util::writeLog('files', ' Backends provided no user object for '.$user, \OCP\Util::ERROR);
+			throw new \OC\User\NoUserException();
 		}
-		else {
-			self::mount('\OC\Files\Storage\Local', array('datadir' => $root), $user);
+
+		$homeStorage = \OC_Config::getValue( 'objectstore' );
+		if (!empty($homeStorage)) {
+			// sanity checks
+			if (empty($homeStorage['class'])) {
+				\OCP\Util::writeLog('files', 'No class given for objectstore', \OCP\Util::ERROR);
+			}
+			if (!isset($homeStorage['arguments'])) {
+				$homeStorage['arguments'] = array();
+			}
+			// instantiate object store implementation
+			$homeStorage['arguments']['objectstore'] = new $homeStorage['class']($homeStorage['arguments']);
+			// mount with home object store implementation
+			$homeStorage['class'] = '\OC\Files\ObjectStore\HomeObjectStoreStorage';
+		} else {
+			$homeStorage = array(
+				//default home storage configuration:
+				'class' => '\OC\Files\Storage\Home',
+				'arguments' => array()
+			);
 		}
+		$homeStorage['arguments']['user'] = $userObject;
+
+		// check for legacy home id (<= 5.0.12)
+		if (\OC\Files\Cache\Storage::exists('local::' . $root . '/')) {
+			$homeStorage['arguments']['legacy'] = true;
+		}
+
+		self::mount($homeStorage['class'], $homeStorage['arguments'], $user);
+
+		$home = \OC\Files\Filesystem::getStorage($user);
 
 		self::mountCacheDir($user);
 

--- a/lib/private/hook.php
+++ b/lib/private/hook.php
@@ -80,6 +80,9 @@ class OC_Hook{
 				OC_Log::write('hook',
 					'error while running hook (' . $i["class"] . '::' . $i["name"] . '): '.$e->getMessage(),
 					OC_Log::ERROR);
+				if($e instanceof \OC\ServerNotAvailableException && $signalclass === 'OC_Filesystem' && $signalname === 'setup') {
+					throw $e;
+				}
 			}
 		}
 

--- a/lib/private/servernotavailableexception.php
+++ b/lib/private/servernotavailableexception.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC;
+
+
+class ServerNotAvailableException extends \Exception {
+
+}

--- a/lib/private/user/nouserexception.php
+++ b/lib/private/user/nouserexception.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * ownCloud
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING-AGPL file.
+ *
+ * @author Jörn Friedrich Dreyer <jfd@owncloud.com>
+ * @copyright Jörn Friedrich Dreyer 2015
+ */
+
+namespace OC\User;
+
+class NoUserException extends \Exception {}

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -191,19 +191,14 @@ class Filesystem extends \Test\TestCase {
 	}
 
 	/**
-	 * Tests that a local storage mount is used when passed user
-	 * does not exist.
+	 * Tests that an exception is thrown when passed user does not exist.
+	 * @expectedException \OC\User\NoUserException
 	 */
 	public function testLocalMountWhenUserDoesNotExist() {
 		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 		$userId = uniqid('user_');
 
 		\OC\Files\Filesystem::initMountPoints($userId);
-
-		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
-
-		$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\Storage\Local'));
-		$this->assertEquals('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
 	}
 
 	/**


### PR DESCRIPTION
this PR allows connection related exceptions in user_ldap to bubble up. When triggered by the filecache post write hook the following message will now show up in tho oc log.

```
{"reqId":"551a86144fa46","app":"hook","message":"error while running hook (\\OC\\Files\\Cache\\Shared_Updater::writeHook): No LDAP Connection to server localhost","level":3,"
```

When a user tries to login and the ldap server is not available he will now see
![bildschirmfoto von 2015-03-31 13 47 16](https://cloud.githubusercontent.com/assets/956847/6918270/9e5b2486-d7ac-11e4-83b6-0f3ce509dffa.png)

instead of

![bildschirmfoto von 2015-03-31 13 50 53](https://cloud.githubusercontent.com/assets/956847/6918297/fed98bfe-d7ac-11e4-872c-fe5a4ab02c66.png)

Fixes #13862
