### PR TITLE
Move core apps from private to public functions (trivial part)

### DIFF
--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -14,7 +14,7 @@
 				<h2>
 					<label for="webdavurl"><?php p($l->t('WebDAV'));?></label>
 				</h2>
-				<input id="webdavurl" type="text" readonly="readonly" value="<?php p(OC_Helper::linkToRemote('webdav')); ?>" />
+				<input id="webdavurl" type="text" readonly="readonly" value="<?php p(\OCP\Util::linkToRemote('webdav')); ?>" />
 				<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank">access your Files via WebDAV</a>', array(link_to_docs('user-webdav'))));?></em>
 		</div>
 	</div>

--- a/apps/files_encryption/lib/helper.php
+++ b/apps/files_encryption/lib/helper.php
@@ -395,7 +395,7 @@ class Helper {
 			}
 		}
 
-		$location = \OC_Helper::linkToAbsolute('apps/files_encryption/files', 'error.php');
+		$location = \OCP\Util::linkToAbsolute('apps/files_encryption/files', 'error.php');
 		$post = 0;
 		if(count($_POST) > 0) {
 			$post = 1;

--- a/apps/files_encryption/settings-personal.php
+++ b/apps/files_encryption/settings-personal.php
@@ -26,7 +26,7 @@
  */
 
 // Add CSS stylesheet
-\OC_Util::addStyle('files_encryption', 'settings-personal');
+\OCP\Util::addStyle('files_encryption', 'settings-personal');
 
 $tmpl = new OCP\Template('files_encryption', 'settings-personal');
 

--- a/apps/files_encryption/templates/invalid_private_key.php
+++ b/apps/files_encryption/templates/invalid_private_key.php
@@ -1,6 +1,6 @@
 <ul>
 	<li class='error'>
-		<?php $location = \OC_Helper::linkToRoute( "settings_personal" ).'#changePKPasswd' ?>
+		<?php $location = \OCP\Util::linkToRoute( "settings_personal" ).'#changePKPasswd' ?>
 
 		<?php p($_['message']); ?>
 		<br/>

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -118,7 +118,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 			$permissions |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
-		if (\OC_Util::isSharingDisabledForUser()) {
+		if (\OCP\Util::isSharingDisabledForUser()) {
 			$permissions &= ~\OCP\Constants::PERMISSION_SHARE;
 		}
 

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -990,6 +990,6 @@ class Trashbin {
 	 * @return string
 	 */
 	public static function preview_icon($path) {
-		return \OC_Helper::linkToRoute('core_ajax_trashbin_preview', array('x' => 36, 'y' => 36, 'file' => $path));
+		return \OCP\Util::linkToRoute('core_ajax_trashbin_preview', array('x' => 36, 'y' => 36, 'file' => $path));
 	}
 }

--- a/apps/user_webdavauth/appinfo/app.php
+++ b/apps/user_webdavauth/appinfo/app.php
@@ -33,6 +33,6 @@ OC_User::useBackend( "WEBDAVAUTH" );
 $entry = array(
 	'id' => "user_webdavauth_settings",
 	'order'=>1,
-	'href' => OC_Helper::linkTo( "user_webdavauth", "settings.php" ),
+	'href' => \OCP\Util::linkTo( "user_webdavauth", "settings.php" ),
 	'name' => 'WEBDAVAUTH'
 );


### PR DESCRIPTION
See #4774

This commit just moves the apps to already available public functions in \OCP\Util. Sometimes even some calls in the apps were to the OCP ones while other still were to the OC_ ones.

Anyway, trivial fix.

CC: @DeepDiver1975 @butonic @LukasReschke @MorrisJobke 
