### PR TITLE
Allow app:check-code and l10n:createjs commands when not installed

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -26,6 +26,8 @@
 
 /** @var $application Symfony\Component\Console\Application */
 $application->add(new OC\Core\Command\Status);
+$application->add(new OC\Core\Command\App\CheckCode());
+$application->add(new OC\Core\Command\L10n\CreateJs());
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$repair = new \OC\Repair(\OC\Repair::getRepairSteps());
@@ -35,7 +37,6 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\SingleUser());
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\App\CheckCode());
 	$application->add(new OC\Core\Command\App\Disable());
 	$application->add(new OC\Core\Command\App\Enable());
 	$application->add(new OC\Core\Command\App\ListApps());
@@ -45,7 +46,6 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen());
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\L10n\CreateJs());
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));


### PR DESCRIPTION
These commands don't require ownCloud to be installed to work.

cc @DeepDiver1975 @MorrisJobke 
