### PR TITLE
Use OCP classes as much as possible in files_external

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -373,7 +373,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				self::$tmpFiles[$tmpFile] = $path;
 
 				try {
@@ -405,7 +405,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');

--- a/apps/files_external/lib/api.php
+++ b/apps/files_external/lib/api.php
@@ -71,7 +71,7 @@ class Api {
 	 */
 	public static function getUserMounts($params) {
 		$entries = array();
-		$user = \OC_User::getUser();
+		$user = \OC::$server->getUserSession()->getUser()->getUID();
 
 		$mounts = \OC_Mount_Config::getAbsoluteMountPoints($user);
 		foreach($mounts as $mountPoint => $mount) {

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -243,7 +243,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				try {
 					$data = $this->dropbox->getFile($path);
 					file_put_contents($tmpFile, $data);
@@ -269,7 +269,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -428,7 +428,7 @@ class Google extends \OC\Files\Storage\Common {
 						$request = new \Google_Http_Request($downloadUrl, 'GET', null, null);
 						$httpRequest = $this->client->getAuth()->authenticatedRequest($request);
 						if ($httpRequest->getResponseHttpCode() == 200) {
-							$tmpFile = \OC_Helper::tmpFile($ext);
+							$tmpFile = \OCP\Files::tmpFile($ext);
 							$data = $httpRequest->getResponseBody();
 							file_put_contents($tmpFile, $data);
 							return fopen($tmpFile, $mode);
@@ -448,7 +448,7 @@ class Google extends \OC\Files\Storage\Common {
 			case 'x+':
 			case 'c':
 			case 'c+':
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'rb');

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -310,7 +310,7 @@ class Swift extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				self::$tmpFiles[$tmpFile] = $path;
 				try {
 					$object = $this->getContainer()->getObject($path);
@@ -348,7 +348,7 @@ class Swift extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -306,7 +306,7 @@ abstract class StoragesService {
 	 */
 	protected function triggerApplicableHooks($signal, $mountPoint, $mountType, $applicableArray) {
 		foreach ($applicableArray as $applicable) {
-			\OC_Hook::emit(
+			\OCP\Util::emitHook(
 				Filesystem::CLASSNAME,
 				$signal,
 				[

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -16,7 +16,7 @@
 		<tbody>
 		<?php $_['mounts'] = array_merge($_['mounts'], array('' => array('id' => ''))); ?>
 		<?php foreach ($_['mounts'] as $mount): ?>
-			<tr <?php print_unescaped(isset($mount['mountpoint']) ? 'class="'.OC_Util::sanitizeHTML($mount['class']).'"' : 'id="addMountPoint"'); ?> data-id="<?php p($mount['id']) ?>">
+			<tr <?php print_unescaped(isset($mount['mountpoint']) ? 'class="'.\OCP\Util::sanitizeHTML($mount['class']).'"' : 'id="addMountPoint"'); ?> data-id="<?php p($mount['id']) ?>">
 				<td class="status">
 					<span></span>
 				</td>


### PR DESCRIPTION
To progress towards #4774 , I've modified files_external so that it uses OCP as much as is possible with the current public interfaces.

Also makes the code slightly cleaner and easier to work with in unit tests.

cc @DeepDiver1975 @rullzer @PVince81 @icewind1991 
