### PR TITLE
Deprecate functions (OC_Helper + OCP\Util) that only call the urlgenerator anyway

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -132,6 +132,7 @@ class OC_Helper {
 	 * @return
 	 * @internal param array $args with param=>value, will be appended to the returned url
 	 * @return string the url
+	 * @deprecated Use \OC::$server->getURLGenerator()->linkToRoute($route, $parameters)
 	 *
 	 * Returns a url to the given app and file.
 	 */
@@ -146,6 +147,7 @@ class OC_Helper {
 	 * @param array $args array with param=>value, will be appended to the returned url
 	 *    The value of $args will be urlencoded
 	 * @return string the url
+	 * @deprecated Use \OC::$server->getURLGenerator()->linkTo($app, $file, $args)
 	 *
 	 * Returns a url to the given app and file.
 	 */
@@ -156,6 +158,7 @@ class OC_Helper {
 	/**
 	 * @param string $key
 	 * @return string url to the online documentation
+	 * @deprecated Use \OC::$server->getURLGenerator()->linkToDocs($key)
 	 */
 	public static function linkToDocs($key) {
 		return OC::$server->getURLGenerator()->linkToDocs($key);
@@ -181,6 +184,7 @@ class OC_Helper {
 	 * Makes an $url absolute
 	 * @param string $url the url
 	 * @return string the absolute url
+	 * @deprecated Use \OC::$server->getURLGenerator()->getAbsoluteURL($url)
 	 *
 	 * Returns a absolute url to the given app and file.
 	 */
@@ -236,6 +240,7 @@ class OC_Helper {
 	 * @param string $app app
 	 * @param string $image image name
 	 * @return string the url
+	 * @deprecated Use \OC::$server->getURLGenerator()->imagePath($app, $image)
 	 *
 	 * Returns the path to the image.
 	 */

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -260,6 +260,7 @@ class Util {
 	 * @param array $parameters
 	 * @internal param array $args with param=>value, will be appended to the returned url
 	 * @return string the url
+	 * @deprecated Use \OC::$server->getURLGenerator()->linkToRoute($route, $parameters)
 	 */
 	public static function linkToRoute( $route, $parameters = array() ) {
 		return \OC_Helper::linkToRoute($route, $parameters);
@@ -272,6 +273,7 @@ class Util {
 	* @param array $args array with param=>value, will be appended to the returned url
 	* 	The value of $args will be urlencoded
 	* @return string the url
+	* @deprecated Use \OC::$server->getURLGenerator()->linkTo($app, $file, $args)
 	*/
 	public static function linkTo( $app, $file, $args = array() ) {
 		return(\OC_Helper::linkTo( $app, $file, $args ));
@@ -362,6 +364,7 @@ class Util {
 	 * @param string $app app
 	 * @param string $image image name
 	 * @return string the url
+	 * @deprecated Use \OC::$server->getURLGenerator()->imagePath($app, $image)
 	 */
 	public static function imagePath( $app, $image ) {
 		return(\OC_Helper::imagePath( $app, $image ));


### PR DESCRIPTION
Several function in OCP\Util only call functions in OC_Helper which in turn call the urlgenerator.
This PR deprecates the trivial cases so people that touch related code will get warnings to use the urlgenerator directly.

This should make this easier in the long run ;)

---

Note that this PR is only for the trivial cases. There are several functions (for example linkToPublic) that do not have a counter part in the urlgenerator yet. We should discus what we want to do there. But thats is something for a different PR
