### PR TITLE
Introducing media types for yml, yaml, cnf, conf

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -2,17 +2,17 @@
 /**
  * @author Arthur Schiwon <blizzz@owncloud.com>
  * @author Bart Visscher <bartv@thisnet.nl>
- * @author Björn Schießle <schiessle@owncloud.com>
- * @author Christopher Schäpers <kondou@ts.unde.re>
+ * @author BjÃ¶rn SchieÃŸle <schiessle@owncloud.com>
+ * @author Christopher SchÃ¤pers <kondou@ts.unde.re>
  * @author Fabian Henze <flyser42@gmx.de>
  * @author Felix Moeller <mail@felixmoeller.de>
- * @author François Kubler <francois@kubler.org>
+ * @author FranÃ§ois Kubler <francois@kubler.org>
  * @author Frank Karlitschek <frank@owncloud.org>
  * @author Georg Ehrke <georg@owncloud.com>
  * @author Jakob Sack <mail@jakobsack.de>
  * @author Jan-Christoph Borchardt <hey@jancborchardt.net>
  * @author Joas Schilling <nickvergessen@owncloud.com>
- * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author JÃ¶rn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@owncloud.com>
  * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
@@ -22,8 +22,8 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
- * @author Simon Könnecke <simonkoennecke@gmail.com>
- * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Simon KÃ¶nnecke <simonkoennecke@gmail.com>
+ * @author Thomas MÃ¼ller <thomas.mueller@tmit.eu>
  * @author Thomas Tanghus <thomas@tanghus.net>
  * @author Valerio Ponte <valerio.ponte@gmail.com>
  * @author Vincent Petry <pvince81@owncloud.com>
@@ -75,6 +75,7 @@ class OC_Helper {
 		'application/x-perl' => 'text/code',
 		'application/x-php' => 'text/code',
 		'text/x-shellscript' => 'text/code',
+		'application/yaml' => 'text/code',
 		'application/xml' => 'text/html',
 		'text/css' => 'text/code',
 		'application/x-tex' => 'text',

--- a/lib/private/mimetypes.list.php
+++ b/lib/private/mimetypes.list.php
@@ -53,6 +53,8 @@ return array(
 	'cbz' => array('application/x-cbr', null),
 	'cc' => array('text/x-c', null),
 	'cdr' => array('application/coreldraw', null),
+	'cnf' => array('text/plain', null),
+	'conf' => array('text/plain', null),
 	'cpp' => array('text/x-c++src', null),
 	'cr2' => array('image/x-dcraw', null),
 	'css' => array('text/css', null),
@@ -183,5 +185,7 @@ return array(
 	'xltx' => array('application/vnd.openxmlformats-officedocument.spreadsheetml.template', null),
 	'xml' => array('application/xml', 'text/plain'),
 	'xrf' => array('image/x-dcraw', null),
+	'yaml' => array('application/yaml', 'text/plain'),
+	'yml' => array('application/yaml', 'text/plain'),
 	'zip' => array('application/zip', null),
 );

--- a/lib/repair/repairmimetypes.php
+++ b/lib/repair/repairmimetypes.php
@@ -218,6 +218,24 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 		self::updateMimetypes($updatedMimetypes);
 	}
 
+	private function introduceConfMimeType() {
+		$updatedMimetypes = array(
+			'conf' => 'text/plain',
+			'cnf' => 'text/plain',
+		);
+
+		self::updateMimetypes($updatedMimetypes);
+	}
+
+	private function introduceYamlMimeType() {
+		$updatedMimetypes = array(
+			'yaml' => 'application/yaml',
+			'yml' => 'application/yaml',
+		);
+
+		self::updateMimetypes($updatedMimetypes);
+	}
+
 	/**
 	 * Fix mime types
 	 */
@@ -244,6 +262,14 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 
 		if ($this->introduce3dImagesMimeType()) {
 			$this->emit('\OC\Repair', 'info', array('Fixed 3D images mime types'));
+		}
+
+		if ($this->introduceConfMimeType()) {
+			$this->emit('\OC\Repair', 'info', array('Fixed Conf/cnf mime types'));
+		}
+
+		if ($this->introduceYamlMimeType()) {
+			$this->emit('\OC\Repair', 'info', array('Fixed Yaml/Yml mime types'));
 		}
 	}
 }

--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -221,15 +221,52 @@ class RepairMimeTypes extends \Test\TestCase {
 		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
 	}
 
+	/**
+	 * Test renaming the 3D image media type
+	 */
 	public function testRename3dImagesMimeType() {
 		$currentMimeTypes = [
-			['test.eps', 'application/octet-stream'],
-			['test.ps', 'application/octet-stream'],
+			['test.jps', 'application/octet-stream'],
+			['test.mpo', 'application/octet-stream'],
 		];
 
 		$fixedMimeTypes = [
-			['test.eps', 'application/postscript'],
-			['test.ps', 'application/postscript'],
+			['test.jps', 'image/jpeg'],
+			['test.mpo', 'image/jpeg'],
+		];
+
+		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
+	}
+
+	/**
+	 * Test renaming the conf/cnf media type
+	 */
+	public function testRenameConfMimeType() {
+		$currentMimeTypes = [
+			['test.conf', 'application/octet-stream'],
+			['test.cnf', 'application/octet-stream'],
+		];
+
+		$fixedMimeTypes = [
+			['test.conf', 'text/plain'],
+			['test.cnf', 'text/plain'],
+		];
+
+		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
+	}
+
+	/**
+	 * Test renaming the yaml media type
+	 */
+	public function testRenameYamlMimeType() {
+		$currentMimeTypes = [
+			['test.yaml', 'application/octet-stream'],
+			['test.yml', 'application/octet-stream'],
+		];
+
+		$fixedMimeTypes = [
+			['test.yaml', 'application/yaml'],
+			['test.yml', 'application/yaml'],
 		];
 
 		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
@@ -348,6 +385,10 @@ class RepairMimeTypes extends \Test\TestCase {
 			['test.DNG', 'image/x-dcraw'],
 			['test.jps', 'image/jpeg'],
 			['test.MPO', 'image/jpeg'],
+			['test.conf', 'text/plain'],
+			['test.cnf', 'text/plain'],
+			['test.yaml', 'application/yaml'],
+			['test.yml', 'application/yaml'],
 		];
 
 		$fixedMimeTypes = [
@@ -383,6 +424,10 @@ class RepairMimeTypes extends \Test\TestCase {
 			['test.DNG', 'image/x-dcraw'],
 			['test.jps', 'image/jpeg'],
 			['test.MPO', 'image/jpeg'],
+			['test.conf', 'text/plain'],
+			['test.cnf', 'text/plain'],
+			['test.yaml', 'application/yaml'],
+			['test.yml', 'application/yaml'],
 		];
 
 		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);


### PR DESCRIPTION
Those are pretty standard configuration files and formats.

The media type chosen for Yaml is `application/yaml`

It's needed for a new feature of Gallery+ which allows users to [configure albums via yaml config files](https://github.com/interfasys/galleryplus/issues/93).

Would also help if this got reviewed as well: https://github.com/owncloud/files_texteditor/pull/63/files
