### PR TITLE
Fixing issue #15322 - showing Settings button next to gear icon

### DIFF
--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -7,7 +7,7 @@
 	<div id="app-settings">
 		<div id="app-settings-header">
 			<button class="settings-button" data-apps-slide-toggle="#app-settings-content">
-				<span class="hidden-visually"><?php p($l->t('Settings'));?></span>
+				<span><?php p($l->t('Settings'));?></span>
 			</button>
 		</div>
 		<div id="app-settings-content">


### PR DESCRIPTION
Removed span class which caused Settings text to fail to appear.
