### PR TITLE
Fix UrlGenerator::imagePath() for app paths

### DIFF
--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -149,6 +149,8 @@ class URLGenerator implements IURLGenerator {
 		//if a theme has a png but not an svg always use the png
 		$basename = substr(basename($image),0,-4);
 
+		$appPath = \OC_App::getAppPath($app);
+
 		// Check if the app is in the app folder
 		$path = '';
 		if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$image")) {
@@ -156,11 +158,11 @@ class URLGenerator implements IURLGenerator {
 		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.svg")
 			&& file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/$app/img/$basename.png")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/apps/$app/img/$basename.png";
-		} elseif (file_exists(\OC_App::getAppPath($app) . "/img/$image")) {
+		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
 			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
-		} elseif (!file_exists(\OC_App::getAppPath($app) . "/img/$basename.svg")
-			&& file_exists(\OC_App::getAppPath($app) . "/img/$basename.png")) {
-			$path =  \OC_App::getAppPath($app) . "/img/$basename.png";
+		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
+			&& file_exists($appPath . "/img/$basename.png")) {
+			$path =  \OC_App::getAppWebPath($app) . "/img/$basename.png";
 		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$image")) {
 			$path =  \OC::$WEBROOT . "/themes/$theme/$app/img/$image";
 		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$theme/$app/img/$basename.svg")


### PR DESCRIPTION
if `getAppPath()` cannot find the app and returns false, the path sent to `file_exists()` is `/img/...`, which causes a log entry about `open_basedir` if it is configured (it will in almost all circumstances return false anyway, which is good, but the log entry is still printed).

In addition, there was a `getAppPath()` where a `getAppWebPath()` should have been.

cc @butonic @LukasReschke @bartv2 

@karlitschek Do we want to backport this? No known bugs relate to this, but it reduces log output and fixes a (potentially) broken case.
