### PR TITLE
Fix occ user:add failure return codes

### DIFF
--- a/core/command/user/add.php
+++ b/core/command/user/add.php
@@ -81,7 +81,7 @@ class Add extends Command {
 		$uid = $input->getArgument('uid');
 		if ($this->userManager->userExists($uid)) {
 			$output->writeln('<error>The user "' . $uid . '" already exists.</error>');
-			return;
+			return 1;
 		}
 
 		$password = $input->getOption('password');
@@ -103,6 +103,7 @@ class Add extends Command {
 			$output->writeln('The user "' . $user->getUID() . '" was created successfully');
 		} else {
 			$output->writeln('<error>An error occurred while creating the user</error>');
+			return 1;
 		}
 
 		if ($input->getOption('display-name')) {


### PR DESCRIPTION
This commit fixes two failure paths of the `occ user:add` command:
1. When a user already exists, the command returned a 0 return value. This is contrary to best practices, which dicate that a 0 return value should only be used to indicate success. This commit changes the return value in this situation to 1.
2. When an error occurs during account creation, the code displayed a warning but did not bail out, continuing to (attempt to) set a display name and add groups. This commit instead makes the code return as soon as the error is detected, giving a return value of 1.

This contribution is MIT licenced.
