### PR TITLE
Improve error messge text for app upgrade try (#15375)

### DIFF
--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -263,6 +263,7 @@ class OCSClient {
 
 		$tmp = $data->data->content;
 		if (is_null($tmp)) {
+			\OC_Log::write('core', 'No update found at the ownCloud appstore for app ' . $id, \OC_Log::INFO);
 			return null;
 		}
 


### PR DESCRIPTION
This PR fixes an error message text and the error level when owncloud queries for possible app upgrades but there are non present. See corresponding issue: https://github.com/owncloud/core/issues/15375

old: "Fatal" "core" "Invalid OCS content returned for app"
new: "Info" "core" "No update found at the ownCloud appstore for app"

The app queried is added to the text automaticaly (like before)
