### PR TITLE
widen displayName input field

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -29,10 +29,19 @@ input#openid, input#webdav { width:20em; }
 	font-weight: bold;
 }
 
-#displaynameerror { display:none; }
-#displaynamechanged { display:none; }
-input#identity { width:20em; }
-#email { width: 17em; }
+#displaynameerror {
+	display: none;
+}
+#displaynamechanged {
+	display: none;
+}
+input#identity {
+	width: 20em;
+}
+#displayName,
+#email {
+	width: 17em;
+}
 
 #avatar .warning {
 	width: 350px;


### PR DESCRIPTION
Currently the »full name« input field is very narrow. This fixes that and makes it as wide as the email field.

Please review @owncloud/designers 
