### PR TITLE
don't return null for not existing group id's

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -156,7 +156,10 @@ class Manager extends PublicEmitter implements IGroupManager {
 		foreach ($this->backends as $backend) {
 			$groupIds = $backend->getGroups($search, $limit, $offset);
 			foreach ($groupIds as $groupId) {
-				$groups[$groupId] = $this->get($groupId);
+				$group = $this->get($groupId);
+				if (!is_null($group)) {
+					$groups[$groupId] = $group;
+				}
 			}
 			if (!is_null($limit) and $limit <= 0) {
 				return array_values($groups);


### PR DESCRIPTION
@blizzz @MorrisJobke We have a problem like this:

```
{"app":"PHP","message":"Argument 1 passed to OC\\Group\\MetaData::generateGroupMetaData() must be an instance of OC\\Group\\Group, null given, called in \/srv\/www\/htdocs\/lib\/private\/group\/metadata.php on line 80 and defined at \/srv\/www\/htdocs\/lib\/private\/group\/metadata.php#142","level":3,"time":"2015-04-07T11:19:43+00:00"}
{"app":"PHP","message":"Call to a member function getGID() on a non-object at \/srv\/www\/htdocs\/lib\/private\/group\/metadata.php#144","level":3,"time":"2015-04-07T11:19:43+00:00"}

{"app":"PHP","message":"Allowed memory size of 536870912 bytes exhausted (tried to allocate 369364992 bytes) at \/srv\/www\/htdocs\/lib\/private\/template\/functions.php#14","level":3,"time":"2015-04-07T11:24:43+00:00"}
```

This PR fixes a problem when a backend does not resolve a group id. Will submit PR for stable8 / master if this makes sense.
