### PR TITLE
Suggest to include php_flag display_errors in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -22,6 +22,7 @@
   </FilesMatch>
 </IfModule>
 <IfModule mod_php5.c>
+php_flag display_errors 0
 php_value upload_max_filesize 513M
 php_value post_max_size 513M
 php_value memory_limit 512M


### PR DESCRIPTION
so that users know how to make error messages visible. 
Maybe even default, to make them visible?
