### PR TITLE
Move console application to it's own class - allows reuse in the web shell

### DIFF
--- a/console.php
+++ b/console.php
@@ -23,8 +23,8 @@
  *
  */
 
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
+use OC\Console\Application;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 define('OC_CONSOLE', 1);
 
@@ -54,36 +54,8 @@ try {
 		}
 	}
 
-	$defaults = new OC_Defaults;
-	$application = new Application($defaults->getName(), \OC_Util::getVersionString());
-	require_once 'core/register_command.php';
-	if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
-		if (!\OCP\Util::needUpgrade()) {
-			OC_App::loadApps();
-			foreach (OC_App::getAllApps() as $app) {
-				$file = OC_App::getAppPath($app) . '/appinfo/register_command.php';
-				if (file_exists($file)) {
-					require $file;
-				}
-			}
-		} else {
-			echo "ownCloud or one of the apps require upgrade - only a limited number of commands are available" . PHP_EOL;
-		}
-	} else {
-		echo "ownCloud is not installed - only a limited number of commands are available" . PHP_EOL;
-	}
-	$input = new ArgvInput();
-	if ($input->getFirstArgument() !== 'check') {
-		$errors = \OC_Util::checkServer(\OC::$server->getConfig());
-		if (!empty($errors)) {
-			foreach ($errors as $error) {
-				echo $error['error'] . "\n";
-				echo $error['hint'] . "\n\n";
-			}
-			exit(1);
-		}
-	}
-
+	$application = new Application(\OC::$server->getConfig());
+	$application->loadCommands(new ConsoleOutput());
 	$application->run();
 } catch (Exception $ex) {
 	echo "An unhandled exception has been thrown:" . PHP_EOL;

--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace OC\Console;
+
+use OC_App;
+use OC_Defaults;
+use OCP\IConfig;
+use Symfony\Component\Console\Application as SymfonyApplication;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Application {
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$defaults = new OC_Defaults;
+		$this->config = $config;
+		$this->application = new SymfonyApplication($defaults->getName(), \OC_Util::getVersionString());
+	}
+
+	/**
+	 * @param OutputInterface $output
+	 */
+	public function loadCommands(OutputInterface $output) {
+		// $application is required to be defined in the register_command scripts
+		$application = $this->application;
+		require_once \OC::$SERVERROOT . '/core/register_command.php';
+		if ($this->config->getSystemValue('installed', false)) {
+			if (!\OCP\Util::needUpgrade()) {
+				OC_App::loadApps();
+				foreach (OC_App::getAllApps() as $app) {
+					$file = OC_App::getAppPath($app) . '/appinfo/register_command.php';
+					if (file_exists($file)) {
+						require $file;
+					}
+				}
+			} else {
+				$output->writeln("ownCloud or one of the apps require upgrade - only a limited number of commands are available");
+			}
+		} else {
+			$output->writeln("ownCloud is not installed - only a limited number of commands are available");
+		}
+		$input = new ArgvInput();
+		if ($input->getFirstArgument() !== 'check') {
+			$errors = \OC_Util::checkServer(\OC::$server->getConfig());
+			if (!empty($errors)) {
+				foreach ($errors as $error) {
+					$output->writeln($error['error']);
+					$output->writeln($error['hint']);
+					$output->writeln('');
+				}
+			}
+		}
+	}
+
+	public function setAutoExit($boolean) {
+		$this->application->setAutoExit($boolean);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 * @throws \Exception
+	 */
+	public function run(InputInterface $input = null, OutputInterface $output = null) {
+		return $this->application->run($input, $output);
+	}
+}

--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -56,6 +56,7 @@ class Application {
 					$output->writeln($error['hint']);
 					$output->writeln('');
 				}
+				throw new \Exception("Environment not properly prepared.");
 			}
 		}
 	}


### PR DESCRIPTION
This introduces an app for admins to execute console commands in the browser - might be helpful for people running ownCloud at a shared hoster without terminal access.

Inspired by https://github.com/owncloud/core/pull/15445#issuecomment-90749219

The app lives now here: https://github.com/DeepDiver1975/web_shell
