### PR TITLE
Allow setting expire on user / group shares via API

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -452,13 +452,9 @@ class Local {
 	 * @return \OC_OCS_Result
 	 */
 	private static function updateExpireDate($share, $params) {
-		// only public links can have a expire date
-		if ((int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK ) {
-			return new \OC_OCS_Result(null, 400, "expire date only exists for public link shares");
-		}
 
 		try {
-			$expireDateSet = \OCP\Share::setExpirationDate($share['item_type'], $share['item_source'], $params['_put']['expireDate'], (int)$share['stime']);
+			$expireDateSet = \OCP\Share::setExpirationDate($share['item_type'], $share['item_source'], $params['_put']['expireDate'], (int)$share['stime'], (int)$share['id']);
 			$result = ($expireDateSet) ? new \OC_OCS_Result() : new \OC_OCS_Result(null, 404, "couldn't set expire date");
 		} catch (\Exception $e) {
 			$result = new \OC_OCS_Result(null, 404, $e->getMessage());
@@ -578,7 +574,7 @@ class Local {
 	 * @return array with: item_source, share_type, share_with, item_type, permissions
 	 */
 	private static function getShareFromId($shareID) {
-		$sql = 'SELECT `file_source`, `item_source`, `share_type`, `share_with`, `item_type`, `permissions`, `stime` FROM `*PREFIX*share` WHERE `id` = ?';
+		$sql = 'SELECT `id`, `file_source`, `item_source`, `share_type`, `share_with`, `item_type`, `permissions`, `stime` FROM `*PREFIX*share` WHERE `id` = ?';
 		$args = array($shareID);
 		$query = \OCP\DB::prepare($sql);
 		$result = $query->execute($args);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1168,10 +1168,11 @@ class Share extends Constants {
 	 * @param string $itemSource
 	 * @param string $date expiration date
 	 * @param int $shareTime timestamp from when the file was shared
+	 * @param int $id share id (optional, set it to set expiration for user or group shares)
 	 * @return boolean
 	 * @throws \Exception when the expire date is not set, in the past or further in the future then the enforced date
 	 */
-	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null) {
+	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null, $id = null) {
 		$user = \OC_User::getUser();
 		$l = \OC::$server->getL10N('lib');
 
@@ -1187,16 +1188,24 @@ class Share extends Constants {
 		} else {
 			$date = self::validateExpireDate($date, $shareTime, $itemType, $itemSource);
 		}
-		$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `expiration` = ? WHERE `item_type` = ? AND `item_source` = ?  AND `uid_owner` = ? AND `share_type` = ?');
-		$query->bindValue(1, $date, 'datetime');
-		$query->bindValue(2, $itemType);
-		$query->bindValue(3, $itemSource);
-		$query->bindValue(4, $user);
-		$query->bindValue(5, \OCP\Share::SHARE_TYPE_LINK);
+		if (!is_null($id)) {
+			$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `expiration` = ? WHERE `id` = ? AND `uid_owner` = ?');
+			$query->bindValue(1, $date, 'datetime');
+			$query->bindValue(2, $id);
+			$query->bindValue(3, $user);
+		} else {
+			$query = \OC_DB::prepare('UPDATE `*PREFIX*share` SET `expiration` = ? WHERE `item_type` = ? AND `item_source` = ?  AND `uid_owner` = ? AND `share_type` = ?');
+			$query->bindValue(1, $date, 'datetime');
+			$query->bindValue(2, $itemType);
+			$query->bindValue(3, $itemSource);
+			$query->bindValue(4, $user);
+			$query->bindValue(5, \OCP\Share::SHARE_TYPE_LINK);
+		}
 
 		$query->execute();
 
 		\OC_Hook::emit('OCP\Share', 'post_set_expiration_date', array(
+			'id' => $id,
 			'itemType' => $itemType,
 			'itemSource' => $itemSource,
 			'date' => $date,

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -336,11 +336,12 @@ class Share extends \OC\Share\Constants {
 	 * @param string $itemSource
 	 * @param string $date expiration date
 	 * @param int $shareTime timestamp from when the file was shared
+	 * @param int $id share id (optional, set it to set expiration for user or group shares)
 	 * @return boolean
 	 * @since 5.0.0 - parameter $shareTime was added in 8.0.0
 	 */
-	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null) {
-		return \OC\Share\Share::setExpirationDate($itemType, $itemSource, $date, $shareTime);
+	public static function setExpirationDate($itemType, $itemSource, $date, $shareTime = null, $id = null) {
+		return \OC\Share\Share::setExpirationDate($itemType, $itemSource, $date, $shareTime, $id);
 	}
 
 	/**


### PR DESCRIPTION
We have users that have been using the API since OC5 to set expire dates on user shares. This PR restores that functionality. no change is made in the web ui. That is tracked in https://github.com/owncloud/core/issues/11642
