### PR TITLE
Replace originalStorage in tests with a proper teardown

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -38,21 +38,15 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 	 */
 	private $files;
 
-	private $originalStorage;
-
 	protected function setUp() {
 		parent::setUp();
-
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 
 		// mock OC_L10n
 		if (!self::$user) {
 			self::$user = uniqid();
 		}
 		\OC_User::createUser(self::$user, 'password');
-		\OC_User::setUserId(self::$user);
-
-		\OC\Files\Filesystem::init(self::$user, '/' . self::$user . '/files');
+		$this->loginAsUser(self::$user);
 
 		$l10nMock = $this->getMock('\OC_L10N', array('t'), array(), '', false);
 		$l10nMock->expects($this->any())
@@ -72,9 +66,8 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 	protected function tearDown() {
 		$result = \OC_User::deleteUser(self::$user);
 		$this->assertTrue($result);
-		\OC\Files\Filesystem::tearDown();
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -35,11 +35,6 @@ class Storage extends \Test\TestCase {
 	private $user;
 
 	/**
-	 * @var \OC\Files\Storage\Storage
-	 **/
-	private $originalStorage;
-
-	/**
 	 * @var \OC\Files\View
 	 */
 	private $rootView;
@@ -61,8 +56,6 @@ class Storage extends \Test\TestCase {
 		// this will setup the FS
 		$this->loginAsUser($this->user);
 
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-
 		\OCA\Files_Trashbin\Storage::setupStorage();
 
 		$this->rootView = new \OC\Files\View('/');
@@ -73,7 +66,6 @@ class Storage extends \Test\TestCase {
 
 	protected function tearDown() {
 		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 		$this->logout();
 		\OC_User::deleteUser($this->user);
 		\OC_Hook::clear();

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -33,16 +33,12 @@ class Updater extends \Test\TestCase {
 	 */
 	protected $updater;
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	protected function setUp() {
 		parent::setUp();
 
-		$this->originalStorage = Filesystem::getStorage('/');
+		$this->loginAsUser();
 
 		$this->storage = new Temporary(array());
-		Filesystem::clearMounts();
 		Filesystem::mount($this->storage, array(), '/');
 		$this->view = new View('');
 		$this->updater = new \OC\Files\Cache\Updater($this->view);
@@ -51,8 +47,8 @@ class Updater extends \Test\TestCase {
 
 	protected function tearDown() {
 		Filesystem::clearMounts();
-		Filesystem::mount($this->originalStorage, array(), '/');
 
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -27,9 +27,6 @@ class UpdaterLegacy extends \Test\TestCase {
 	 */
 	private $cache;
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	private static $user;
 
 	protected function setUp() {
@@ -48,14 +45,12 @@ class UpdaterLegacy extends \Test\TestCase {
 		$this->scanner->scan('');
 		$this->cache = $this->storage->getCache();
 
-		$this->originalStorage = Filesystem::getStorage('/');
-		Filesystem::tearDown();
 		if (!self::$user) {
 			self::$user = $this->getUniqueID();
 		}
 
 		\OC_User::createUser(self::$user, 'password');
-		\OC_User::setUserId(self::$user);
+		$this->loginAsUser(self::$user);
 
 		Filesystem::init(self::$user, '/' . self::$user . '/files');
 
@@ -71,9 +66,8 @@ class UpdaterLegacy extends \Test\TestCase {
 		}
 		$result = \OC_User::deleteUser(self::$user);
 		$this->assertTrue($result);
-		Filesystem::tearDown();
-		Filesystem::mount($this->originalStorage, array(), '/');
 
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -15,14 +15,10 @@ class Watcher extends \Test\TestCase {
 	 */
 	private $storages = array();
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	protected function setUp() {
 		parent::setUp();
 
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC\Files\Filesystem::clearMounts();
+		$this->loginAsUser();
 	}
 
 	protected function tearDown() {
@@ -32,9 +28,7 @@ class Watcher extends \Test\TestCase {
 			$cache->clear();
 		}
 
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
-
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -16,15 +16,10 @@ class EtagTest extends \Test\TestCase {
 
 	private $tmpDir;
 
-	private $uid;
-
 	/**
 	 * @var \OC_User_Dummy $userBackend
 	 */
 	private $userBackend;
-
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
 
 	protected function setUp() {
 		parent::setUp();
@@ -37,21 +32,15 @@ class EtagTest extends \Test\TestCase {
 		$this->datadir = \OC_Config::getValue('datadirectory');
 		$this->tmpDir = \OC_Helper::tmpFolder();
 		\OC_Config::setValue('datadirectory', $this->tmpDir);
-		$this->uid = \OC_User::getUser();
-		\OC_User::setUserId(null);
 
 		$this->userBackend = new \OC_User_Dummy();
 		\OC_User::useBackend($this->userBackend);
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC_Util::tearDownFS();
 	}
 
 	protected function tearDown() {
 		\OC_Config::setValue('datadirectory', $this->datadir);
-		\OC_User::setUserId($this->uid);
-		\OC_Util::setupFS($this->uid);
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 
+		$this->logout();
 		parent::tearDown();
 	}
 
@@ -59,9 +48,7 @@ class EtagTest extends \Test\TestCase {
 		$user1 = $this->getUniqueID('user_');
 		$this->userBackend->createUser($user1, '');
 
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId($user1);
-		\OC_Util::setupFS($user1);
+		$this->loginAsUser($user1);
 		Filesystem::mkdir('/folder');
 		Filesystem::mkdir('/folder/subfolder');
 		Filesystem::file_put_contents('/foo.txt', 'asd');

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -28,9 +28,6 @@ class Filesystem extends \Test\TestCase {
 	 */
 	private $tmpDirs = array();
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	/**
 	 * @return array
 	 */
@@ -42,20 +39,15 @@ class Filesystem extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC_User::setUserId('');
-		\OC\Files\Filesystem::clearMounts();
+		$this->loginAsUser();
 	}
 
 	protected function tearDown() {
 		foreach ($this->tmpDirs as $dir) {
 			\OC_Helper::rmdirr($dir);
 		}
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
-		\OC_User::setUserId('');
 
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -20,9 +20,6 @@ class IntegrationTests extends \Test\TestCase {
 	 */
 	private $root;
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	/**
 	 * @var \OC\Files\Storage\Storage[]
 	 */
@@ -36,9 +33,6 @@ class IntegrationTests extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
-		\OC\Files\Filesystem::init('', '');
-		\OC\Files\Filesystem::clearMounts();
 		$manager = \OC\Files\Filesystem::getMountManager();
 
 		\OC_Hook::clear('OC_Filesystem');
@@ -49,7 +43,8 @@ class IntegrationTests extends \Test\TestCase {
 		\OC_Hook::connect('OC_Filesystem', 'post_touch', '\OC\Files\Cache\Updater', 'touchHook');
 
 		$user = new User($this->getUniqueID('user'), new \OC_User_Dummy);
-		\OC_User::setUserId($user->getUID());
+		$this->loginAsUser($user->getUID());
+
 		$this->view = new View();
 		$this->root = new Root($manager, $this->view, $user);
 		$storage = new Temporary(array());
@@ -64,9 +59,8 @@ class IntegrationTests extends \Test\TestCase {
 		foreach ($this->storages as $storage) {
 			$storage->getCache()->clear();
 		}
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
 
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -39,18 +39,14 @@ class TestScanner extends \OC\Files\Utils\Scanner {
 }
 
 class Scanner extends \Test\TestCase {
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	protected function setUp() {
 		parent::setUp();
 
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+		$this->loginAsUser();
 	}
 
 	protected function tearDown() {
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
-
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -27,9 +27,6 @@ class View extends \Test\TestCase {
 	/** @var \OC\Files\Storage\Storage */
 	private $tempStorage;
 
-	/** @var \OC\Files\Storage\Storage */
-	private $originalStorage;
-
 	protected function setUp() {
 		parent::setUp();
 
@@ -39,9 +36,10 @@ class View extends \Test\TestCase {
 		//login
 		\OC_User::createUser('test', 'test');
 		$this->user = \OC_User::getUser();
-		\OC_User::setUserId('test');
 
-		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
+		$this->loginAsUser('test');
+		// clear mounts but somehow keep the root storage
+		// that was initialized above...
 		\OC\Files\Filesystem::clearMounts();
 
 		$this->tempStorage = null;
@@ -59,9 +57,7 @@ class View extends \Test\TestCase {
 			system('rm -rf ' . escapeshellarg($this->tempStorage->getDataDir()));
 		}
 
-		\OC\Files\Filesystem::clearMounts();
-		\OC\Files\Filesystem::mount($this->originalStorage, array(), '/');
-
+		$this->logout();
 		parent::tearDown();
 	}
 

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -26,6 +26,8 @@ class Preview extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
+		// FIXME: use proper tearDown with $this->loginAsUser() and $this->logout()
+		// (would currently break the tests for some reason)
 		$this->originalStorage = \OC\Files\Filesystem::getStorage('/');
 
 		// create a new user with his own filesystem view

--- a/tests/lib/streamwrappers.php
+++ b/tests/lib/streamwrappers.php
@@ -72,6 +72,8 @@ class Test_StreamWrappers extends \Test\TestCase {
 	}
 
 	public function testOC() {
+		// FIXME: use proper tearDown with $this->loginAsUser() and $this->logout()
+		// (would currently break the tests for some reason)
 		$originalStorage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::clearMounts();
 

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -167,9 +167,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 * Login and setup FS as a given user,
 	 * sets the given user as the current user.
 	 *
-	 * @param string $user user id
+	 * @param string $user user id or empty for a generic FS
 	 */
-	static protected function loginAsUser($user) {
+	static protected function loginAsUser($user = '') {
 		self::logout();
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);


### PR DESCRIPTION
The purpose of $originalStorage in unit tests was to remount the old
root.
However that storage itself is already wrapped by storage wrapper, so
remounting it would rewrap the storage several times.

This fix makes use of "loginAsUser()" and "logout()" from the TestCase
class to properly initialize and cleanup the FS as expected.

Please review @icewind1991 @MorrisJobke @nickvergessen @LukasReschke 

Note that the original failing can be reproduced only by letting `xdebug.max_nesting_level` on its default value of 100.

Fixes https://github.com/owncloud/core/issues/15326

Also it seems to magically fix the "OCA\Files_Encryption\Tests\Share::testRemoteShareFile" fail from https://github.com/owncloud/core/issues/15326#issue-65396123 I used to see.
