### PR TITLE
Disable OCS api when in maintenance mode

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -27,7 +27,7 @@
 
 require_once '../lib/base.php';
 
-if (\OCP\Util::needUpgrade()) {
+if (\OCP\Util::needUpgrade() || \OC::$server->getSystemConfig()->getValue('maintenance', false)) {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);


### PR DESCRIPTION
Fix #15456, #15436

@MorrisJobke @PVince81 @jvillafanez 

@DeepDiver1975 should backport all the way down to 7 I think?
