### PR TITLE
Fix language level incompatibilties

### DIFF
--- a/apps/files_external/lib/sftp_key.php
+++ b/apps/files_external/lib/sftp_key.php
@@ -135,11 +135,16 @@ class SFTP_Key extends \OC\Files\Storage\SFTP {
 	}
 
 	public function test() {
-		if (empty($this->getHost())) {
+
+		// FIXME: Use as expression in empty once PHP 5.4 support is dropped
+		$host = $this->getHost();
+		if (empty($host)) {
 			\OC::$server->getLogger()->warning('Hostname has not been specified');
 			return false;
 		}
-		if (empty($this->getUser())) {
+		// FIXME: Use as expression in empty once PHP 5.4 support is dropped
+		$user = $this->getUser();
+		if (empty($user)) {
 			\OC::$server->getLogger()->warning('Username has not been specified');
 			return false;
 		}

--- a/apps/files_external/service/globalstoragesservice.php
+++ b/apps/files_external/service/globalstoragesservice.php
@@ -101,6 +101,7 @@ class GlobalStoragesService extends StoragesService {
 	 * @param string $signal signal to trigger
 	 */
 	protected function triggerHooks(StorageConfig $storage, $signal) {
+		// FIXME: Use as expression in empty once PHP 5.4 support is dropped
 		$applicableUsers = $storage->getApplicableUsers();
 		$applicableGroups = $storage->getApplicableGroups();
 		if (empty($applicableUsers) && empty($applicableGroups)) {
@@ -149,8 +150,11 @@ class GlobalStoragesService extends StoragesService {
 		$groupAdditions = array_diff($newStorage->getApplicableGroups(), $oldStorage->getApplicableGroups());
 		$groupDeletions = array_diff($oldStorage->getApplicableGroups(), $newStorage->getApplicableGroups());
 
+		// FIXME: Use as expression in empty once PHP 5.4 support is dropped
 		// if no applicable were set, raise a signal for "all"
-		if (empty($oldStorage->getApplicableUsers()) && empty($oldStorage->getApplicableGroups())) {
+		$oldApplicableUsers = $oldStorage->getApplicableUsers();
+		$oldApplicableGroups = $oldStorage->getApplicableGroups();
+		if (empty($oldApplicableUsers) && empty($oldApplicableGroups)) {
 			$this->triggerApplicableHooks(
 				Filesystem::signal_delete_mount,
 				$oldStorage->getMountPoint(),
@@ -191,8 +195,11 @@ class GlobalStoragesService extends StoragesService {
 			$groupAdditions
 		);
 
+		// FIXME: Use as expression in empty once PHP 5.4 support is dropped
 		// if no applicable, raise a signal for "all"
-		if (empty($newStorage->getApplicableUsers()) && empty($newStorage->getApplicableGroups())) {
+		$newApplicableUsers = $newStorage->getApplicableUsers();
+		$newApplicableGroups = $newStorage->getApplicableGroups();
+		if (empty($newApplicableUsers) && empty($newApplicableGroups)) {
 			$this->triggerApplicableHooks(
 				Filesystem::signal_create_mount,
 				$newStorage->getMountPoint(),

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -227,8 +227,10 @@ abstract class StoragesService {
 		if (!is_null($storageConfig->getPriority())) {
 			$options['priority'] = $storageConfig->getPriority();
 		}
-		if (!empty($storageConfig->getMountOptions())) {
-			$options['mountOptions'] = $storageConfig->getMountOptions();
+
+		$mountOptions = $storageConfig->getMountOptions();
+		if (!empty($mountOptions)) {
+			$options['mountOptions'] = $mountOptions;
 		}
 
 		$mountPoints[$mountType][$applicable][$rootMountPoint] = $options;


### PR DESCRIPTION
Arbitrary expressions in empty are allowed in PHP 5.5 and upwards. Seems to only affect master.

Fixed https://github.com/owncloud/core/issues/15463
