### PR TITLE
Move away from private static function OC_Util::getUrlContent

### DIFF
--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -56,71 +56,76 @@ $externalManager = new \OCA\Files_Sharing\External\Manager(
 );
 
 // check for ssl cert
-if (substr($remote, 0, 5) === 'https' and !OC_Util::getUrlContent($remote)) {
-	\OCP\JSON::error(array('data' => array('message' => $l->t('Invalid or untrusted SSL certificate'))));
-	exit;
-} else {
-	$mount = $externalManager->addShare($remote, $token, $password, $name, $owner, true);
-
-	/**
-	 * @var \OCA\Files_Sharing\External\Storage $storage
-	 */
-	$storage = $mount->getStorage();
+if (substr($remote, 0, 5) === 'https') {
 	try {
-		// check if storage exists
-		$storage->checkStorageAvailability();
+		\OC::$server->getHTTPClientService()->newClient()->get($remote)->getBody();
+	} catch (\Exception $e) {
+		\OCP\JSON::error(array('data' => array('message' => $l->t('Invalid or untrusted SSL certificate'))));
+		exit;
+	}
+}
+
+$mount = $externalManager->addShare($remote, $token, $password, $name, $owner, true);
+
+/**
+ * @var \OCA\Files_Sharing\External\Storage $storage
+ */
+$storage = $mount->getStorage();
+try {
+	// check if storage exists
+	$storage->checkStorageAvailability();
+} catch (\OCP\Files\StorageInvalidException $e) {
+	// note: checkStorageAvailability will already remove the invalid share
+	\OCP\Util::writeLog(
+		'files_sharing',
+		'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+		\OCP\Util::DEBUG
+	);
+	\OCP\JSON::error(
+		array(
+			'data' => array(
+				'message' => $l->t('Could not authenticate to remote share, password might be wrong')
+			)
+		)
+	);
+	exit();
+} catch (\Exception $e) {
+	\OCP\Util::writeLog(
+		'files_sharing',
+		'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
+		\OCP\Util::DEBUG
+	);
+	$externalManager->removeShare($mount->getMountPoint());
+	\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
+	exit();
+}
+$result = $storage->file_exists('');
+if ($result) {
+	try {
+		$storage->getScanner()->scanAll();
+		\OCP\JSON::success();
 	} catch (\OCP\Files\StorageInvalidException $e) {
-		// note: checkStorageAvailability will already remove the invalid share
 		\OCP\Util::writeLog(
 			'files_sharing',
 			'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
 			\OCP\Util::DEBUG
 		);
-		\OCP\JSON::error(
-			array(
-				'data' => array(
-					'message' => $l->t('Could not authenticate to remote share, password might be wrong')
-				)
-			)
-		);
-		exit();
+		\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
 	} catch (\Exception $e) {
 		\OCP\Util::writeLog(
 			'files_sharing',
 			'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
 			\OCP\Util::DEBUG
 		);
-		$externalManager->removeShare($mount->getMountPoint());
-		\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
-		exit();
-	}
-	$result = $storage->file_exists('');
-	if ($result) {
-		try {
-			$storage->getScanner()->scanAll();
-			\OCP\JSON::success();
-		} catch (\OCP\Files\StorageInvalidException $e) {
-			\OCP\Util::writeLog(
-				'files_sharing',
-				'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
-				\OCP\Util::DEBUG
-			);
-			\OCP\JSON::error(array('data' => array('message' => $l->t('Storage not valid'))));
-		} catch (\Exception $e) {
-			\OCP\Util::writeLog(
-				'files_sharing',
-				'Invalid remote storage: ' . get_class($e) . ': ' . $e->getMessage(),
-				\OCP\Util::DEBUG
-			);
-			\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t add remote share'))));
-		}
-	} else {
-		$externalManager->removeShare($mount->getMountPoint());
-		\OCP\Util::writeLog(
-			'files_sharing',
-			'Couldn\'t add remote share',
-			\OCP\Util::DEBUG
-		);
 		\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t add remote share'))));
 	}
+} else {
+	$externalManager->removeShare($mount->getMountPoint());
+	\OCP\Util::writeLog(
+		'files_sharing',
+		'Couldn\'t add remote share',
+		\OCP\Util::DEBUG
+	);
+	\OCP\JSON::error(array('data' => array('message' => $l->t('Couldn\'t add remote share'))));
 }
+

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1234,6 +1234,7 @@ class OC_Util {
 	 * @return string of the response or false on error
 	 * This function get the content of a page via curl, if curl is enabled.
 	 * If not, file_get_contents is used.
+	 * @deprecated Use \OCP\Http\Client\IClientService
 	 */
 	public static function getUrlContent($url) {
 		try {


### PR DESCRIPTION
As described in #4774
- This moves the files_sharing app away from OC_Util::getUrlContent.
- Deprecates OC_Util::getUrlContent, it is just a wrapper around a deprecated function. So it should go.
