### PR TITLE
make private key handling backward compatible

### DIFF
--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -200,9 +200,10 @@ class KeyManager {
 
 		$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'],
 			$password);
+		$header = $this->crypt->generateHeader();
 
 		if ($encryptedKey) {
-			$this->setPrivateKey($uid, $encryptedKey);
+			$this->setPrivateKey($uid, $header . $encryptedKey);
 			return true;
 		}
 		return false;
@@ -219,9 +220,10 @@ class KeyManager {
 
 		$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'],
 			$password);
+		$header = $this->crypt->generateHeader();
 
 		if ($encryptedKey) {
-			$this->setSystemPrivateKey($this->getRecoveryKeyId(), $encryptedKey);
+			$this->setSystemPrivateKey($this->getRecoveryKeyId(), $header . $encryptedKey);
 			return true;
 		}
 		return false;

--- a/apps/encryption/lib/recovery.php
+++ b/apps/encryption/lib/recovery.php
@@ -129,6 +129,7 @@ class Recovery {
 	 *
 	 * @param string $newPassword
 	 * @param string $oldPassword
+	 * @return bool
 	 */
 	public function changeRecoveryKeyPassword($newPassword, $oldPassword) {
 		$recoveryKey = $this->keyManager->getSystemPrivateKey($this->keyManager->getRecoveryKeyId());


### PR DESCRIPTION
new private keys should always have a header which defines a cipher, if no header exists we need to fall back to the old default cipher (aes-128)

cc @DeepDiver1975 @th3fallen 
