### PR TITLE
Move files sharing app (mostly) to OCP\DB

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -163,7 +163,7 @@ class Local {
 		}
 
 		$select = '`*PREFIX*share`.`id`, `item_type`, `*PREFIX*share`.`parent`, `share_type`, `share_with`, `file_source`, `path` , `*PREFIX*share`.`permissions`, `stime`, `expiration`, `token`, `storage`, `mail_send`, `mail_send`';
-		$getReshares = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` WHERE `*PREFIX*share`.`file_source` = ? AND `*PREFIX*share`.`item_type` IN (\'file\', \'folder\') AND `uid_owner` != ?');
+		$getReshares = \OCP\DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` WHERE `*PREFIX*share`.`file_source` = ? AND `*PREFIX*share`.`item_type` IN (\'file\', \'folder\') AND `uid_owner` != ?');
 		$reshares = $getReshares->execute(array($itemSource, \OCP\User::getUser()))->fetchAll();
 
 		foreach ($reshares as $key => $reshare) {
@@ -572,7 +572,7 @@ class Local {
 		$result = $query->execute($args);
 
 		if (\OCP\DB::isError($result)) {
-			\OCP\Util::writeLog('files_sharing', \OC_DB::getErrorMessage(), \OCP\Util::ERROR);
+			\OCP\Util::writeLog('files_sharing', \OCP\DB::getErrorMessage(), \OCP\Util::ERROR);
 			return null;
 		}
 		if ($share = $result->fetchRow()) {

--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -120,7 +120,7 @@ class Shared_Cache extends Cache {
 			if (!is_int($sourceId) || $sourceId === 0) {
 				$sourceId = $this->storage->getSourceId();
 			}
-			$query = \OC_DB::prepare(
+			$query = \OCP\DB::prepare(
 				'SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`,'
 				. ' `size`, `mtime`, `encrypted`, `storage_mtime`, `etag`, `permissions`'
 				. ' FROM `*PREFIX*filecache` WHERE `fileid` = ?');
@@ -499,7 +499,7 @@ class Shared_Cache extends Cache {
 	 */
 	private function getParentInfo($id) {
 		$sql = 'SELECT `parent`, `name` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
-		$query = \OC_DB::prepare($sql);
+		$query = \OCP\DB::prepare($sql);
 		$result = $query->execute(array($id));
 		if ($row = $result->fetchRow()) {
 			return array((int)$row['parent'], $row['name']);

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -183,7 +183,7 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 		if (isset($source['parent'])) {
 			$parent = $source['parent'];
 			while (isset($parent)) {
-				$query = \OC_DB::prepare('SELECT `parent`, `uid_owner` FROM `*PREFIX*share` WHERE `id` = ?', 1);
+				$query = \OCP\DB::prepare('SELECT `parent`, `uid_owner` FROM `*PREFIX*share` WHERE `id` = ?', 1);
 				$item = $query->execute(array($parent))->fetchRow();
 				if (isset($item['parent'])) {
 					$parent = $item['parent'];

--- a/apps/files_sharing/lib/share/folder.php
+++ b/apps/files_sharing/lib/share/folder.php
@@ -64,7 +64,7 @@ class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share
 	 * @return mixed parent ID or null
 	 */
 	private function getParentId($child) {
-		$query = \OC_DB::prepare('SELECT `parent` FROM `*PREFIX*filecache` WHERE `fileid` = ?');
+		$query = \OCP\DB::prepare('SELECT `parent` FROM `*PREFIX*filecache` WHERE `fileid` = ?');
 		$result = $query->execute(array($child));
 		$row = $result->fetchRow();
 		$parent = ($row) ? $row['parent'] : null;
@@ -75,7 +75,7 @@ class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share
 	public function getChildren($itemSource) {
 		$children = array();
 		$parents = array($itemSource);
-		$query = \OC_DB::prepare('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?');
+		$query = \OCP\DB::prepare('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?');
 		$result = $query->execute(array('httpd/unix-directory'));
 		if ($row = $result->fetchRow()) {
 			$mimetype = $row['id'];
@@ -84,7 +84,7 @@ class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share
 		}
 		while (!empty($parents)) {
 			$parents = "'".implode("','", $parents)."'";
-			$query = OC_DB::prepare('SELECT `fileid`, `name`, `mimetype` FROM `*PREFIX*filecache`'
+			$query = \OCP\DB::prepare('SELECT `fileid`, `name`, `mimetype` FROM `*PREFIX*filecache`'
 				.' WHERE `parent` IN ('.$parents.')');
 			$result = $query->execute();
 			$parents = array();

--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -87,7 +87,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		// if the user renames a mount point from a group share we need to create a new db entry
 		// for the unique name
 		if ($share['share_type'] === \OCP\Share::SHARE_TYPE_GROUP && empty($share['unique_name'])) {
-			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`, `item_target`,'
+			$query = \OCP\DB::prepare('INSERT INTO `*PREFIX*share` (`item_type`, `item_source`, `item_target`,'
 			.' `share_type`, `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
 			.' `file_target`, `token`, `parent`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
 			$arguments = array($share['item_type'], $share['item_source'], $share['item_target'],
@@ -95,7 +95,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 				$newPath, $share['token'], $share['id']);
 		} else {
 			// rename mount point
-			$query = \OC_DB::prepare(
+			$query = \OCP\DB::prepare(
 					'Update `*PREFIX*share`
 						SET `file_target` = ?
 						WHERE `id` = ?'

--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -138,7 +138,7 @@ class Shared_Updater {
 	 */
 	static public function fixBrokenSharesOnAppUpdate() {
 		// delete all shares where the original file no longer exists
-		$findAndRemoveShares = \OC_DB::prepare('DELETE FROM `*PREFIX*share` ' .
+		$findAndRemoveShares = \OCP\DB::prepare('DELETE FROM `*PREFIX*share` ' .
 			'WHERE `item_type` IN (\'file\', \'folder\') ' .
 			'AND `file_source` NOT IN (SELECT `fileid` FROM `*PREFIX*filecache`)'
 		);

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -61,11 +61,11 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 			self::TEST_FILES_SHARING_API_USER2, 31);
 
 		$statement = "UPDATE `*PREFIX*share` SET `file_target` = ? where `share_with` = ?";
-		$query = \OC_DB::prepare($statement);
+		$query = \OCP\DB::prepare($statement);
 		$arguments = array('/foo/bar' . $this->folder, self::TEST_FILES_SHARING_API_USER2);
 		$query->execute($arguments);
 
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share`');
+		$query = \OCP\DB::prepare('SELECT * FROM `*PREFIX*share`');
 		$result = $query->execute();
 
 		$shares = $result->fetchAll();
@@ -79,7 +79,7 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 
 		// share should have moved up
 
-		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share`');
+		$query = \OCP\DB::prepare('SELECT * FROM `*PREFIX*share`');
 		$result = $query->execute();
 
 		$shares = $result->fetchAll();


### PR DESCRIPTION
A part of #13779 while trying to fix more for #4774.

Trivially moving \OC_DB calls to \OCP\DB.

Only the two at https://github.com/owncloud/core/blob/master/apps/files_sharing/lib/updater.php#L93-L95 remain since executeAudited is used and there is no function for that in OCP\DB. So that should probably be rewritten.
