### PR TITLE
Keep fileid when restoring version, using stream copy

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -312,20 +312,7 @@ class Storage {
 		list($storage1, $internalPath1) = $view->resolvePath($path1);
 		list($storage2, $internalPath2) = $view->resolvePath($path2);
 
-		if ($storage1 === $storage2) {
-			return $storage1->rename($internalPath1, $internalPath2);
-		}
-		$source = $storage1->fopen($internalPath1, 'r');
-		$target = $storage2->fopen($internalPath2, 'w');
-		// FIXME: might need to use part file to avoid concurrent writes
-		// (this would be an issue anyway when renaming/restoring cross-storage)
-		list(, $result) = \OC_Helper::streamCopy($source, $target);
-		fclose($source);
-		fclose($target);
-
-		if ($result !== false) {
-			$storage1->unlink($internalPath1);
-		}
+		$result = $storage2->moveFromStorage($storage1, $internalPath1, $internalPath2);
 
 		return ($result !== false);
 	}

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -262,11 +262,16 @@ class Storage {
 	}
 
 	/**
-	 * rollback to an old version of a file.
+	 * Rollback to an old version of a file.
+	 *
+	 * @param string $file file name
+	 * @param int $revision revision timestamp
 	 */
 	public static function rollback($file, $revision) {
 
 		if(\OCP\Config::getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
+			// add expected leading slash
+			$file = '/' . ltrim($file, '/');
 			list($uid, $filename) = self::getUidAndFilename($file);
 			$users_view = new \OC\Files\View('/'.$uid);
 			$files_view = new \OC\Files\View('/'.\OCP\User::getUser().'/files');
@@ -282,12 +287,11 @@ class Storage {
 			}
 
 			// rollback
-			if( @$users_view->rename('files_versions'.$filename.'.v'.$revision, 'files'.$filename) ) {
+			if (self::copyFileContents($users_view, 'files_versions' . $filename . '.v' . $revision, 'files' . $filename)) {
 				$files_view->touch($file, $revision);
 				Storage::scheduleExpire($file);
 				return true;
-
-			}else if ( $versionCreated ) {
+			} else if ($versionCreated) {
 				self::deleteVersion($users_view, $version);
 			}
 		}
@@ -295,6 +299,36 @@ class Storage {
 
 	}
 
+	/**
+	 * Stream copy file contents from $path1 to $path2
+	 *
+	 * @param \OC\Files\View $view view to use for copying
+	 * @param string $path1 source file to copy
+	 * @param string $path2 target file
+	 *
+	 * @return bool true for success, false otherwise
+	 */
+	private static function copyFileContents($view, $path1, $path2) {
+		list($storage1, $internalPath1) = $view->resolvePath($path1);
+		list($storage2, $internalPath2) = $view->resolvePath($path2);
+
+		if ($storage1 === $storage2) {
+			return $storage1->rename($internalPath1, $internalPath2);
+		}
+		$source = $storage1->fopen($internalPath1, 'r');
+		$target = $storage2->fopen($internalPath2, 'w');
+		// FIXME: might need to use part file to avoid concurrent writes
+		// (this would be an issue anyway when renaming/restoring cross-storage)
+		list(, $result) = \OC_Helper::streamCopy($source, $target);
+		fclose($source);
+		fclose($target);
+
+		if ($result !== false) {
+			$storage1->unlink($internalPath1);
+		}
+
+		return ($result !== false);
+	}
 
 	/**
 	 * get a list of all available versions of a file in descending chronological order


### PR DESCRIPTION
Always stream copy when restoring version

This is a workaround to make it possible to keep the file id when restoring a file. Please note that a stream copy would happen anyway when restoring cross-storage.

Please review @icewind1991 @SergioBertolinSG @nickvergessen @MorrisJobke @DeepDiver1975 
