### PR TITLE
Check if the key exists, before trying to delete it

### DIFF
--- a/lib/private/encryption/keys/storage.php
+++ b/lib/private/encryption/keys/storage.php
@@ -140,11 +140,11 @@ class Storage implements \OCP\Encryption\Keys\IStorage {
 	 * @param string $uid ID if the user for whom we want to delete the key
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteUserKey($uid, $keyId) {
 		$path = $this->constructUserKeyPath($keyId, $uid);
-		return $this->view->unlink($path);
+		return !$this->view->file_exists($path) || $this->view->unlink($path);
 	}
 
 	/**
@@ -153,22 +153,23 @@ class Storage implements \OCP\Encryption\Keys\IStorage {
 	 * @param string $path path to file
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteFileKey($path, $keyId) {
 		$keyDir = $this->getFileKeyDir($path);
-		return $this->view->unlink($keyDir . $keyId);
+		return !$this->view->file_exists($keyDir . $keyId) || $this->view->unlink($keyDir . $keyId);
 	}
 
 	/**
 	 * delete all file keys for a given file
 	 *
 	 * @param string $path to the file
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteAllFileKeys($path) {
 		$keyDir = $this->getFileKeyDir($path);
-		return $this->view->deleteAll(dirname($keyDir));
+		$path = dirname($keyDir);
+		return !$this->view->file_exists($path) || $this->view->deleteAll($path);
 	}
 
 	/**
@@ -177,11 +178,11 @@ class Storage implements \OCP\Encryption\Keys\IStorage {
 	 *
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteSystemUserKey($keyId) {
 		$path = $this->constructUserKeyPath($keyId);
-		return $this->view->unlink($path);
+		return !$this->view->file_exists($path) || $this->view->unlink($path);
 	}
 
 

--- a/lib/public/encryption/keys/istorage.php
+++ b/lib/public/encryption/keys/istorage.php
@@ -89,7 +89,7 @@ interface IStorage {
 	 * @param string $uid ID if the user for whom we want to delete the key
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteUserKey($uid, $keyId);
 
@@ -99,7 +99,7 @@ interface IStorage {
 	 * @param string $path path to file
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteFileKey($path, $keyId);
 
@@ -107,7 +107,7 @@ interface IStorage {
 	 * delete all file keys for a given file
 	 *
 	 * @param string $path to the file
-	 * @return boolean
+	 * @return boolean False when the keys could not be deleted
 	 */
 	public function deleteAllFileKeys($path);
 
@@ -117,7 +117,7 @@ interface IStorage {
 	 *
 	 * @param string $keyId id of the key
 	 *
-	 * @return boolean
+	 * @return boolean False when the key could not be deleted
 	 */
 	public function deleteSystemUserKey($keyId);
 

--- a/tests/lib/encryption/keys/storage.php
+++ b/tests/lib/encryption/keys/storage.php
@@ -198,6 +198,10 @@ class StorageTest extends TestCase {
 
 	public function testDeleteUserKey() {
 		$this->view->expects($this->once())
+			->method('file_exists')
+			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
+			->willReturn(true);
+		$this->view->expects($this->once())
 			->method('unlink')
 			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
 			->willReturn(true);
@@ -208,6 +212,10 @@ class StorageTest extends TestCase {
 	}
 
 	public function testDeleteSystemUserKey() {
+		$this->view->expects($this->once())
+			->method('file_exists')
+			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
+			->willReturn(true);
 		$this->view->expects($this->once())
 			->method('unlink')
 			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
@@ -229,6 +237,10 @@ class StorageTest extends TestCase {
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
 		$this->view->expects($this->once())
+			->method('file_exists')
+			->with($this->equalTo('/files_encryption/keys/files/foo.txt/encModule/fileKey'))
+			->willReturn(true);
+		$this->view->expects($this->once())
 			->method('unlink')
 			->with($this->equalTo('/files_encryption/keys/files/foo.txt/encModule/fileKey'))
 			->willReturn(true);
@@ -248,6 +260,10 @@ class StorageTest extends TestCase {
 		$this->util->expects($this->any())
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
+		$this->view->expects($this->once())
+			->method('file_exists')
+			->with($this->equalTo('/user1/files_encryption/keys/files/foo.txt/encModule/fileKey'))
+			->willReturn(true);
 		$this->view->expects($this->once())
 			->method('unlink')
 			->with($this->equalTo('/user1/files_encryption/keys/files/foo.txt/encModule/fileKey'))


### PR DESCRIPTION
Currently the activity tests fail, because they delete a user for whome the filesystem was never set up.

```
1) OCA\Activity\Tests\ApiTest::testGet with data set #2 ('activity-api-user1', 0, 1, array(array('link', 'file', null, null, '', 'Subject2 @User #A/B.txt')))
filemtime(): stat failed for /home/travis/build/owncloud/core/data-autotest/activity-api-user1/files_encryption/OC_DEFAULT_MODULE
/home/travis/build/owncloud/core/lib/private/files/storage/local.php:165
/home/travis/build/owncloud/core/lib/private/files/storage/wrapper/wrapper.php:220
/home/travis/build/owncloud/core/lib/private/files/cache/updater.php:186
/home/travis/build/owncloud/core/lib/private/files/cache/updater.php:120
/home/travis/build/owncloud/core/lib/private/files/view.php:989
/home/travis/build/owncloud/core/lib/private/files/view.php:567
/home/travis/build/owncloud/core/lib/private/encryption/keys/storage.php:147
/home/travis/build/owncloud/core/apps/encryption/lib/keymanager.php:456
/home/travis/build/owncloud/core/apps/encryption/hooks/userhooks.php:187
/home/travis/build/owncloud/core/lib/private/hook.php:103
/home/travis/build/owncloud/core/lib/private/server.php:157
/home/travis/build/owncloud/core/lib/private/hooks/basicemitter.php:99
/home/travis/build/owncloud/core/lib/private/hooks/publicemitter.php:32
/home/travis/build/owncloud/core/lib/private/user/user.php:197
/home/travis/build/owncloud/core/lib/private/user.php:224
/home/travis/build/owncloud/core/apps/activity/tests/apitest.php:85
```

Fix owncloud/activity#279

Please review @DeepDiver1975 @schiesbn @th3fallen 
