### PR TITLE
Enforce string as passed type

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -3,6 +3,7 @@
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -49,7 +50,6 @@ class Application extends \OCP\AppFramework\App {
 	private $config;
 
 	/**
-	 * @param $appName
 	 * @param array $urlParams
 	 */
 	public function __construct($urlParams = array()) {
@@ -59,9 +59,6 @@ class Application extends \OCP\AppFramework\App {
 		$this->registerServices();
 	}
 
-	/**
-	 *
-	 */
 	public function registerHooks() {
 		if (!$this->config->getSystemValue('maintenance', false)) {
 
@@ -89,9 +86,6 @@ class Application extends \OCP\AppFramework\App {
 		}
 	}
 
-	/**
-	 *
-	 */
 	public function registerEncryptionModule() {
 		$container = $this->getContainer();
 		$container->registerService('EncryptionModule', function (IAppContainer $c) {
@@ -104,9 +98,6 @@ class Application extends \OCP\AppFramework\App {
 		$this->encryptionManager->registerEncryptionModule($module);
 	}
 
-	/**
-	 *
-	 */
 	public function registerServices() {
 		$container = $this->getContainer();
 
@@ -131,7 +122,6 @@ class Application extends \OCP\AppFramework\App {
 					$c->query('Util')
 				);
 			});
-
 
 		$container->registerService('Recovery',
 			function (IAppContainer $c) {
@@ -181,9 +171,6 @@ class Application extends \OCP\AppFramework\App {
 
 	}
 
-	/**
-	 *
-	 */
 	public function registerSettings() {
 		// Register settings scripts
 		App::registerAdmin('encryption', 'settings/settings-admin');

--- a/apps/encryption/controller/recoverycontroller.php
+++ b/apps/encryption/controller/recoverycontroller.php
@@ -52,7 +52,11 @@ class RecoveryController extends Controller {
 	 * @param IL10N $l10n
 	 * @param Recovery $recovery
 	 */
-	public function __construct($AppName, IRequest $request, IConfig $config, IL10N $l10n, Recovery $recovery) {
+	public function __construct($AppName,
+								IRequest $request,
+								IConfig $config,
+								IL10N $l10n,
+								Recovery $recovery) {
 		parent::__construct($AppName, $request);
 		$this->config = $config;
 		$this->l = $l10n;
@@ -145,6 +149,9 @@ class RecoveryController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 *
+	 * @param string $userEnableRecovery
+	 * @return DataResponse
 	 */
 	public function userSetRecovery($userEnableRecovery) {
 		if ($userEnableRecovery === '0' || $userEnableRecovery === '1') {

--- a/apps/encryption/controller/recoverycontroller.php
+++ b/apps/encryption/controller/recoverycontroller.php
@@ -2,6 +2,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -28,7 +29,6 @@ use OCP\AppFramework\Controller;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\JSON;
 use OCP\AppFramework\Http\DataResponse;
 
 class RecoveryController extends Controller {
@@ -59,6 +59,12 @@ class RecoveryController extends Controller {
 		$this->recovery = $recovery;
 	}
 
+	/**
+	 * @param string $recoveryPassword
+	 * @param string $confirmPassword
+	 * @param string $adminEnableRecovery
+	 * @return DataResponse
+	 */
 	public function adminRecovery($recoveryPassword, $confirmPassword, $adminEnableRecovery) {
 		// Check if both passwords are the same
 		if (empty($recoveryPassword)) {
@@ -89,6 +95,12 @@ class RecoveryController extends Controller {
 		}
 	}
 
+	/**
+	 * @param string $newPassword
+	 * @param string $oldPassword
+	 * @param string $confirmPassword
+	 * @return DataResponse
+	 */
 	public function changeRecoveryPassword($newPassword, $oldPassword, $confirmPassword) {
 		//check if both passwords are the same
 		if (empty($oldPassword)) {

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -3,6 +3,7 @@
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -327,6 +328,10 @@ class Encryption implements IEncryptionModule {
 		return 6126;
 	}
 
+	/**
+	 * @param string $path
+	 * @return string
+	 */
 	protected function getPathToRealFile($path) {
 		$realPath = $path;
 		$parts = explode('/', $path);

--- a/apps/encryption/lib/hookmanager.php
+++ b/apps/encryption/lib/hookmanager.php
@@ -2,6 +2,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -49,9 +50,6 @@ class HookManager {
 		return true;
 	}
 
-	/**
-	 *
-	 */
 	public function fireHooks() {
 		foreach ($this->hookInstances as $instance) {
 			/**

--- a/apps/encryption/lib/session.php
+++ b/apps/encryption/lib/session.php
@@ -2,6 +2,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -33,6 +34,9 @@ class Session {
 	const INIT_EXECUTED = '1';
 	const INIT_SUCCESSFUL = '2';
 
+	/**
+	 * @param ISession $session
+	 */
 	public function __construct(ISession $session) {
 		$this->session = $session;
 	}

--- a/apps/encryption/lib/users/setup.php
+++ b/apps/encryption/lib/users/setup.php
@@ -2,6 +2,7 @@
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Lukas Reschke <lukas@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -53,7 +54,10 @@ class Setup {
 	 * @param Crypt $crypt
 	 * @param KeyManager $keyManager
 	 */
-	public function __construct(ILogger $logger, IUserSession $userSession, Crypt $crypt, KeyManager $keyManager) {
+	public function __construct(ILogger $logger,
+								IUserSession $userSession,
+								Crypt $crypt,
+								KeyManager $keyManager) {
 		$this->logger = $logger;
 		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser()->getUID() : false;
 		$this->crypt = $crypt;
@@ -61,8 +65,8 @@ class Setup {
  	}
 
 	/**
-	 * @param $uid userid
-	 * @param $password user password
+	 * @param string $uid userid
+	 * @param string $password user password
 	 * @return bool
 	 */
 	public function setupUser($uid, $password) {
@@ -70,8 +74,8 @@ class Setup {
 	}
 
 	/**
-	 * @param $uid userid
-	 * @param $password user password
+	 * @param string $uid userid
+	 * @param string $password user password
 	 * @return bool
 	 */
 	public function setupServerSide($uid, $password) {


### PR DESCRIPTION
@th3fallen @schiesbn The AppFramework supports enforcing the string type, please use the PHPDocs as annotations where sensible. Can prevent bad bugs.

cc @MorrisJobke 
