### PR TITLE
add admin documentation hints to Federated Cloud Sharing and cron

### DIFF
--- a/apps/files_sharing/js/settings-admin.js
+++ b/apps/files_sharing/js/settings-admin.js
@@ -8,4 +8,5 @@ $(document).ready(function() {
 		OC.AppConfig.setValue('files_sharing', $(this).attr('name'), value);
 	});
 
+	$('.section .icon-info').tipsy({gravity: 'w'});
 });

--- a/apps/files_sharing/templates/settings-admin.php
+++ b/apps/files_sharing/templates/settings-admin.php
@@ -4,6 +4,9 @@
 ?>
 <div id="fileSharingSettings">
 	<h3><?php p($l->t('Federated Cloud Sharing'));?></h3>
+	<a target="_blank" class="icon-info svg"
+		title="<?php p($l->t('Open documentation'));?>"
+		href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
 
 	<p>
 		<input type="checkbox" name="outgoing_server2server_share_enabled" id="outgoingServer2serverShareEnabled"

--- a/core/js/backgroundjobs.js
+++ b/core/js/backgroundjobs.js
@@ -22,4 +22,6 @@
 // start worker once page has loaded
 $(document).ready(function(){
 	$.get( OC.webroot+'/cron.php' );
+
+	$('.section .icon-info').tipsy({gravity: 'w'});
 });

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -350,6 +350,7 @@ table.grid td.date{
 	margin: 10px 0;
 	color: #ce3702;
 }
+
 #shareAPI p { padding-bottom: 0.8em; }
 #shareAPI input#shareapiExpireAfterNDays {width: 25px;}
 #shareAPI .indent {
@@ -357,6 +358,13 @@ table.grid td.date{
 }
 #shareAPI .double-indent {
 	padding-left: 56px;
+}
+#fileSharingSettings h3 {
+	display: inline-block;
+}
+
+.icon-info {
+	padding: 11px 20px;
 }
 
 .mail_settings p label:first-child {

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -269,6 +269,10 @@ if ($_['cronErrors']) {
 		endif; ?>
 	</p>
 	<?php endif; ?>
+	<a target="_blank" class="icon-info svg"
+		title="<?php p($l->t('Open documentation'));?>"
+		href="<?php p(link_to_docs('admin-background-jobs')); ?>"></a>
+
 	<p>
 				<input type="radio" name="mode" value="ajax"
 					   id="backgroundjobs_ajax" <?php if ($_['backgroundjobs_mode'] === "ajax") {


### PR DESCRIPTION
As discussed @karlitschek 

Please review @owncloud/designers 

The documentation links have already been added via https://github.com/owncloud/documentation/pull/1052
If we want to add the inline docs link to more admin settings, it just has to be done the same way – add the `a class="icon-info"` with the link, start the tipsy, and add the link to the docs.
