### PR TITLE
Add an option to get the output in plain, json or print_r syntax

### DIFF
--- a/core/command/app/listapps.php
+++ b/core/command/app/listapps.php
@@ -39,8 +39,7 @@ class ListApps extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$apps = \OC_App::getAllApps();
-		$enabledApps = array();
-		$disabledApps = array();
+		$enabledApps = $disabledApps = [];
 		$versions = \OC_App::getAppVersions();
 
 		//sort enabled apps above disabled apps
@@ -52,39 +51,38 @@ class ListApps extends Base {
 			}
 		}
 
-		sort($enabledApps);
-		sort($disabledApps);
 		$apps = ['enabled' => [], 'disabled' => []];
+
+		sort($enabledApps);
 		foreach ($enabledApps as $app) {
-			if (isset($versions[$app])) {
-				$apps['enabled'][$app] = $versions[$app];
-			} else {
-				$apps['enabled'][$app] = true;
-			}
+			$apps['enabled'][$app] = (isset($versions[$app])) ? $versions[$app] : '';
 		}
 
+		sort($disabledApps);
 		foreach ($disabledApps as $app) {
-			if (isset($versions[$app])) {
-				$apps['disabled'][$app] = $versions[$app];
-			} else {
-				$apps['disabled'][$app] = false;
-			}
+			$apps['disabled'][$app] = (isset($versions[$app])) ? $versions[$app] : '';
 		}
-		$this->writeArrayInOutputFormat($input, $output, $apps);
+
+		$this->writeAppList($input, $output, $apps);
 	}
 
-	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items) {
-		$outputFormat = $input->getOption('output');
-		switch ($outputFormat) {
-			case 'json':
-			case 'print':
-				parent::writeArrayInOutputFormat($input, $output, $items);
-			break;
-			default:
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @param array $items
+	 */
+	protected function writeAppList(InputInterface $input, OutputInterface $output, $items) {
+		switch ($input->getOption('output')) {
+			case 'plain':
 				$output->writeln('Enabled:');
 				parent::writeArrayInOutputFormat($input, $output, $items['enabled']);
+
 				$output->writeln('Disabled:');
 				parent::writeArrayInOutputFormat($input, $output, $items['disabled']);
+			break;
+
+			default:
+				parent::writeArrayInOutputFormat($input, $output, $items);
 			break;
 		}
 	}

--- a/core/command/app/listapps.php
+++ b/core/command/app/listapps.php
@@ -23,15 +23,18 @@
 
 namespace OC\Core\Command\App;
 
-use Symfony\Component\Console\Command\Command;
+use OC\Core\Command\Base;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListApps extends Command {
+class ListApps extends Base {
 	protected function configure() {
+		parent::configure();
+
 		$this
 			->setName('app:list')
-			->setDescription('List all available apps');
+			->setDescription('List all available apps')
+		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -51,13 +54,38 @@ class ListApps extends Command {
 
 		sort($enabledApps);
 		sort($disabledApps);
-		$output->writeln('Enabled:');
+		$apps = ['enabled' => [], 'disabled' => []];
 		foreach ($enabledApps as $app) {
-			$output->writeln(' - ' . $app . (isset($versions[$app]) ? ' (' . $versions[$app] . ')' : ''));
+			if (isset($versions[$app])) {
+				$apps['enabled'][$app] = $versions[$app];
+			} else {
+				$apps['enabled'][$app] = true;
+			}
 		}
-		$output->writeln('Disabled:');
+
 		foreach ($disabledApps as $app) {
-			$output->writeln(' - ' . $app . (isset($versions[$app]) ? ' (' . $versions[$app] . ')' : ''));
+			if (isset($versions[$app])) {
+				$apps['disabled'][$app] = $versions[$app];
+			} else {
+				$apps['disabled'][$app] = false;
+			}
+		}
+		$this->writeArrayInOutputFormat($input, $output, $apps);
+	}
+
+	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items) {
+		$outputFormat = $input->getOption('output');
+		switch ($outputFormat) {
+			case 'json':
+			case 'print':
+				parent::writeArrayInOutputFormat($input, $output, $items);
+			break;
+			default:
+				$output->writeln('Enabled:');
+				parent::writeArrayInOutputFormat($input, $output, $items['enabled']);
+				$output->writeln('Disabled:');
+				parent::writeArrayInOutputFormat($input, $output, $items['disabled']);
+			break;
 		}
 	}
 }

--- a/core/command/base.php
+++ b/core/command/base.php
@@ -39,6 +39,11 @@ class Base extends Command {
 		;
 	}
 
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @param array $items
+	 */
 	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items) {
 		switch ($input->getOption('output')) {
 			case 'json':

--- a/core/command/base.php
+++ b/core/command/base.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * @author Bart Visscher <bartv@thisnet.nl>
- * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Joas Schilling <nickvergessen@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -22,27 +21,40 @@
 
 namespace OC\Core\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Status extends Base {
+class Base extends Command {
 	protected function configure() {
-		parent::configure();
-
 		$this
-			->setName('status')
-			->setDescription('show some status information')
+			->addOption(
+				'output',
+				null,
+				InputOption::VALUE_OPTIONAL,
+				'Output format (plain, print or json, default is plain)',
+				'plain'
+			)
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
-		$values = array(
-			'installed' => \OC_Config::getValue('installed') ? 'true' : 'false',
-			'version' => implode('.', \OC_Util::getVersion()),
-			'versionstring' => \OC_Util::getVersionString(),
-			'edition' => \OC_Util::getEditionString(),
-		);
-
-		$this->writeArrayInOutputFormat($input, $output, $values);
+	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items) {
+		$outputFormat = $input->getOption('output');
+		switch ($outputFormat) {
+			case 'json':
+			case 'print':
+				if ($outputFormat === 'json') {
+					$output->writeln(json_encode($items));
+				} else {
+					print_r($items);
+				}
+				break;
+			default:
+				foreach ($items as $key => $item) {
+					$output->writeln(' - ' . (!is_int($key) ? $key . ': ' : '') . $item);
+				}
+				break;
+		}
 	}
 }

--- a/core/command/base.php
+++ b/core/command/base.php
@@ -33,22 +33,19 @@ class Base extends Command {
 				'output',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'Output format (plain, print or json, default is plain)',
+				'Output format (plain, json or json_pretty, default is plain)',
 				'plain'
 			)
 		;
 	}
 
 	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items) {
-		$outputFormat = $input->getOption('output');
-		switch ($outputFormat) {
+		switch ($input->getOption('output')) {
 			case 'json':
-			case 'print':
-				if ($outputFormat === 'json') {
-					$output->writeln(json_encode($items));
-				} else {
-					print_r($items);
-				}
+				$output->writeln(json_encode($items));
+				break;
+			case 'json_pretty':
+				$output->writeln(json_encode($items, JSON_PRETTY_PRINT));
 				break;
 			default:
 				foreach ($items as $key => $item) {

--- a/core/command/check.php
+++ b/core/command/check.php
@@ -3,11 +3,10 @@
 namespace OC\Core\Command;
 
 use OCP\IConfig;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Check extends Command {
+class Check extends Base {
 	/**
 	 * @var IConfig
 	 */
@@ -19,6 +18,8 @@ class Check extends Command {
 	}
 
 	protected function configure() {
+		parent::configure();
+
 		$this
 			->setName('check')
 			->setDescription('check dependencies of the server environment')
@@ -28,10 +29,11 @@ class Check extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$errors = \OC_Util::checkServer($this->config);
 		if (!empty($errors)) {
-			$errors = array_map( function($items) {
-				return (string)$items['error'];
+			$errors = array_map(function($item) {
+				return (string) $item['error'];
 			}, $errors);
-			echo json_encode($errors);
+
+			$this->writeArrayInOutputFormat($input, $output, $errors);
 			return 1;
 		}
 		return 0;


### PR DESCRIPTION
Follow up for #15448 

@DeepDiver1975 @MorrisJobke @jnweiger 
### ./occ check

```
nickv@nickv-lt-mint $ ./occ check
 - Setting locale to en_US.UTF-8/fr_FR.UTF-8/es_ES.UTF-8/de_DE.UTF-8/ru_RU.UTF-8/pt_BR.UTF-8/it_IT.UTF-8/ja_JP.UTF-8/zh_CN.UTF-8 failed

nickv@nickv-lt-mint $ ./occ check --output=print
Array
(
    [0] => Setting locale to en_US.UTF-8/fr_FR.UTF-8/es_ES.UTF-8/de_DE.UTF-8/ru_RU.UTF-8/pt_BR.UTF-8/it_IT.UTF-8/ja_JP.UTF-8/zh_CN.UTF-8 failed
)

nickv@nickv-lt-mint $ ./occ check --output=json
["Setting locale to en_US.UTF-8\/fr_FR.UTF-8\/es_ES.UTF-8\/de_DE.UTF-8\/ru_RU.UTF-8\/pt_BR.UTF-8\/it_IT.UTF-8\/ja_JP.UTF-8\/zh_CN.UTF-8 failed"]
```
### ./occ status

```
nickv@nickv-lt-mint $ ./occ status
 - installed: true
 - version: 8.1.0.1
 - versionstring: 8.1 pre alpha
 - edition: Enterprise
nickv@nickv-lt-mint $ ./occ status --output=print
Array
(
    [installed] => true
    [version] => 8.1.0.1
    [versionstring] => 8.1 pre alpha
    [edition] => Enterprise
)

nickv@nickv-lt-mint $ ./occ status --output=json
{"installed":"true","version":"8.1.0.1","versionstring":"8.1 pre alpha","edition":"Enterprise"}
```
### ./occ app:list

```
nickv@nickv-lt-mint ~/ownCloud/master/core {master*}:
$ ./occ app:list
Enabled:
 - files: 1.1.9
 - files_external: 0.2.3
 - files_sharing: 0.6.1
 - files_texteditor: 0.4
 - files_trashbin: 0.6.2
 - files_versions: 1.0.5
 - provisioning_api: 0.2
Disabled:
 - activity: 1.2.3
 - encryption: 
 - encryption_dummy: 
nickv@nickv-lt-mint ~/ownCloud/master/core {master*}:
$ ./occ app:list --output=print
Array
(
    [enabled] => Array
        (
            [files] => 1.1.9
            [files_external] => 0.2.3
            [files_sharing] => 0.6.1
            [files_texteditor] => 0.4
            [files_trashbin] => 0.6.2
            [files_versions] => 1.0.5
            [provisioning_api] => 0.2
        )

    [disabled] => Array
        (
            [activity] => 1.2.3
            [encryption] => 
            [encryption_dummy] => 
        )

)
nickv@nickv-lt-mint ~/ownCloud/master/core {master*}:
$ ./occ app:list --output=json
{"enabled":{"files":"1.1.9","files_external":"0.2.3","files_sharing":"0.6.1","files_texteditor":"0.4","files_trashbin":"0.6.2","files_versions":"1.0.5","provisioning_api":"0.2"},"disabled":{"activity":"1.2.3","encryption":"","encryption_dummy":false}}

```
