### PR TITLE
Help section: fix commercial support link

### DIFF
--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -36,7 +36,7 @@
 	<?php } ?>
 
 	<li>
-		<a href="https://owncloud.com" target="_blank" rel="noreferrer">
+		<a href="https://owncloud.com/subscriptions/" target="_blank" rel="noreferrer">
 			<?php p($l->t( 'Commercial Support' )); ?> ↗
 		</a>
 	</li>

--- a/settings/templates/help.php
+++ b/settings/templates/help.php
@@ -4,25 +4,25 @@
 		<li>
 			<a class="<?php p($_['style1']); ?>"
 				href="<?php print_unescaped($_['url1']); ?>">
-				<?php p($l->t( 'User Documentation' )); ?>
+				<?php p($l->t('User documentation')); ?>
 			</a>
 		</li>
 		<li>
 			<a class="<?php p($_['style2']); ?>"
 				href="<?php print_unescaped($_['url2']); ?>">
-				<?php p($l->t( 'Administrator Documentation' )); ?>
+				<?php p($l->t('Administrator documentation')); ?>
 			</a>
 		</li>
 	<?php } ?>
 
 		<li>
 			<a href="https://owncloud.org/support" target="_blank" rel="noreferrer">
-				<?php p($l->t( 'Online Documentation' )); ?> ↗
+				<?php p($l->t('Online documentation')); ?> ↗
 			</a>
 		</li>
 		<li>
 			<a href="https://forum.owncloud.org" target="_blank" rel="noreferrer">
-				<?php p($l->t( 'Forum' )); ?> ↗
+				<?php p($l->t('Forum')); ?> ↗
 			</a>
 		</li>
 
@@ -30,14 +30,14 @@
 		<li>
 			<a href="https://github.com/owncloud/core/blob/master/CONTRIBUTING.md"
 				target="_blank" rel="noreferrer">
-				<?php p($l->t( 'Bugtracker' )); ?> ↗
+				<?php p($l->t('Issue tracker')); ?> ↗
 			</a>
 		</li>
 	<?php } ?>
 
 	<li>
 		<a href="https://owncloud.com/subscriptions/" target="_blank" rel="noreferrer">
-			<?php p($l->t( 'Commercial Support' )); ?> ↗
+			<?php p($l->t('Commercial support')); ?> ↗
 		</a>
 	</li>
 </div>


### PR DESCRIPTION
Add the proper deep link for the subscriptions. I link to https://owncloud.com/subscriptions/ instead of https://owncloud.com/get-started-standard-subscription/ because the former page has way more understandable info about the subscriptions themselves.

Also some code style and wording fixes. Please review @karlitschek @DeepDiver1975 @MorrisJobke 
