### PR TITLE
Move core apps from OC_Log::write to OCP\Util

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -124,10 +124,10 @@ class OC_Mount_Config {
 			self::addStorageIdToConfig($data['user']);
 			$user = \OC::$server->getUserManager()->get($data['user']);
 			if (!$user) {
-				\OC_Log::write(
+				\OCP\Util::writeLog(
 					'files_external',
 					'Cannot init external mount points for non-existant user "' . $data['user'] . '".',
-					\OC_Log::WARN
+					\OCP\Util::WARN
 				);
 				return;
 			}

--- a/apps/files_sharing/ajax/list.php
+++ b/apps/files_sharing/ajax/list.php
@@ -27,7 +27,7 @@ OCP\JSON::checkAppEnabled('files_sharing');
 
 if(!isset($_GET['t'])){
 	\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
-	\OC_Log::write('core-preview', 'No token parameter was passed', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'No token parameter was passed', \OCP\Util::DEBUG);
 	exit;
 }
 

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -36,20 +36,20 @@ $keepAspect = array_key_exists('a', $_GET) ? true : false;
 
 if($token === ''){
 	\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
-	\OC_Log::write('core-preview', 'No token parameter was passed', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'No token parameter was passed', \OCP\Util::DEBUG);
 	exit;
 }
 
 $linkedItem = \OCP\Share::getShareByToken($token);
 if($linkedItem === false || ($linkedItem['item_type'] !== 'file' && $linkedItem['item_type'] !== 'folder')) {
 	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
-	\OC_Log::write('core-preview', 'Passed token parameter is not valid', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'Passed token parameter is not valid', \OCP\Util::DEBUG);
 	exit;
 }
 
 if(!isset($linkedItem['uid_owner']) || !isset($linkedItem['file_source'])) {
 	\OC_Response::setStatus(\OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	\OC_Log::write('core-preview', 'Passed token seems to be valid, but it does not contain all necessary information . ("' . $token . '")', \OC_Log::WARN);
+	\OCP\Util::writeLog('core-preview', 'Passed token seems to be valid, but it does not contain all necessary information . ("' . $token . '")', \OCP\Util::WARN);
 	exit;
 }
 
@@ -70,7 +70,7 @@ if($linkedItem['item_type'] === 'folder') {
 	$isValid = \OC\Files\Filesystem::isValidPath($file);
 	if(!$isValid) {
 		\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
-		\OC_Log::write('core-preview', 'Passed filename is not valid, might be malicious (file:"' . $file . '";ip:"' . \OC::$server->getRequest()->getRemoteAddress() . '")', \OC_Log::WARN);
+		\OCP\Util::writeLog('core-preview', 'Passed filename is not valid, might be malicious (file:"' . $file . '";ip:"' . \OC::$server->getRequest()->getRemoteAddress() . '")', \OCP\Util::WARN);
 		exit;
 	}
 	$sharedFile = \OC\Files\Filesystem::normalizePath($file);
@@ -89,7 +89,7 @@ if(substr($path, 0, 1) === '/') {
 
 if($maxX === 0 || $maxY === 0) {
 	\OC_Response::setStatus(\OC_Response::STATUS_BAD_REQUEST);
-	\OC_Log::write('core-preview', 'x and/or y set to 0', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'x and/or y set to 0', \OCP\Util::DEBUG);
 	exit;
 }
 
@@ -106,5 +106,5 @@ try{
 	$preview->showPreview();
 } catch (\Exception $e) {
 	\OC_Response::setStatus(\OC_Response::STATUS_INTERNAL_SERVER_ERROR);
-	\OC_Log::write('core', $e->getmessage(), \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);
 }

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -55,13 +55,13 @@ class Helper {
 		$linkItem = \OCP\Share::getShareByToken($token, !$password);
 		if($linkItem === false || ($linkItem['item_type'] !== 'file' && $linkItem['item_type'] !== 'folder')) {
 			\OC_Response::setStatus(404);
-			\OC_Log::write('core-preview', 'Passed token parameter is not valid', \OC_Log::DEBUG);
+			\OCP\Util::writeLog('core-preview', 'Passed token parameter is not valid', \OCP\Util::DEBUG);
 			exit;
 		}
 
 		if(!isset($linkItem['uid_owner']) || !isset($linkItem['file_source'])) {
 			\OC_Response::setStatus(500);
-			\OC_Log::write('core-preview', 'Passed token seems to be valid, but it does not contain all necessary information . ("' . $token . '")', \OC_Log::WARN);
+			\OCP\Util::writeLog('core-preview', 'Passed token seems to be valid, but it does not contain all necessary information . ("' . $token . '")', \OCP\Util::WARN);
 			exit;
 		}
 

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -65,7 +65,7 @@ foreach ($list as $file) {
 	OCA\Files_Trashbin\Trashbin::delete($filename, \OCP\User::getUser(), $timestamp);
 	if (OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
 		$error[] = $filename;
-		OC_Log::write('trashbin','can\'t delete ' . $filename . ' permanently.', OC_Log::ERROR);
+		\OCP\Util::writeLog('trashbin','can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);
 	}
 	// only list deleted files if not deleting everything
 	else if (!$deleteAll) {

--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -36,13 +36,13 @@ $scalingUp = array_key_exists('scalingup', $_GET) ? (bool) $_GET['scalingup'] : 
 
 if($file === '') {
 	\OC_Response::setStatus(400); //400 Bad Request
-	\OC_Log::write('core-preview', 'No file parameter was passed', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'No file parameter was passed', \OCP\Util::DEBUG);
 	exit;
 }
 
 if($maxX === 0 || $maxY === 0) {
 	\OC_Response::setStatus(400); //400 Bad Request
-	\OC_Log::write('core-preview', 'x and/or y set to 0', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core-preview', 'x and/or y set to 0', \OCP\Util::DEBUG);
 	exit;
 }
 
@@ -72,5 +72,5 @@ try{
 	$preview->showPreview();
 }catch(\Exception $e) {
 	\OC_Response::setStatus(500);
-	\OC_Log::write('core', $e->getmessage(), \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);
 }

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -71,7 +71,7 @@ foreach ($list as $file) {
 
 	if ( !OCA\Files_Trashbin\Trashbin::restore($path, $filename, $timestamp) ) {
 		$error[] = $filename;
-		OC_Log::write('trashbin', 'can\'t restore ' . $filename, OC_Log::ERROR);
+		\OCP\Util::writeLog('trashbin', 'can\'t restore ' . $filename, \OCP\Util::ERROR);
 	} else {
 		$success[$i]['filename'] = $file;
 		$success[$i]['timestamp'] = $timestamp;

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -148,7 +148,7 @@ class Trashbin {
 			$query = \OC_DB::prepare("INSERT INTO `*PREFIX*files_trash` (`id`,`timestamp`,`location`,`user`) VALUES (?,?,?,?)");
 			$result = $query->execute(array($ownerFilename, $timestamp, $ownerLocation, $owner));
 			if (!$result) {
-				\OC_Log::write('files_trashbin', 'trash bin database couldn\'t be updated for the files owner', \OC_log::ERROR);
+				\OCP\Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated for the files owner', \OC_log::ERROR);
 			}
 		}
 	}
@@ -195,7 +195,7 @@ class Trashbin {
 			if ($view->file_exists($trashPath)) {
 				$view->deleteAll($trashPath);
 			}
-			\OC_Log::write('files_trashbin', 'Couldn\'t move ' . $file_path . ' to the trash bin', \OC_log::ERROR);
+			\OCP\Util::writeLog('files_trashbin', 'Couldn\'t move ' . $file_path . ' to the trash bin', \OC_log::ERROR);
 		}
 
 		if ($view->file_exists('/files/' . $file_path)) { // failed to delete the original file, abort
@@ -208,7 +208,7 @@ class Trashbin {
 			$query = \OC_DB::prepare("INSERT INTO `*PREFIX*files_trash` (`id`,`timestamp`,`location`,`user`) VALUES (?,?,?,?)");
 			$result = $query->execute(array($filename, $timestamp, $location, $user));
 			if (!$result) {
-				\OC_Log::write('files_trashbin', 'trash bin database couldn\'t be updated', \OC_log::ERROR);
+				\OCP\Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated', \OC_log::ERROR);
 			}
 			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', array('filePath' => \OC\Files\Filesystem::normalizePath($file_path),
 				'trashPath' => \OC\Files\Filesystem::normalizePath($filename . '.d' . $timestamp)));
@@ -294,7 +294,7 @@ class Trashbin {
 		if ($timestamp) {
 			$location = self::getLocation($user, $filename, $timestamp);
 			if ($location === false) {
-				\OC_Log::write('files_trashbin', 'trash bin database inconsistent!', \OC_Log::ERROR);
+				\OCP\Util::writeLog('files_trashbin', 'trash bin database inconsistent!', \OCP\Util::ERROR);
 			} else {
 				// if location no longer exists, restore file in the root directory
 				if ($location !== '/' &&
@@ -635,7 +635,7 @@ class Trashbin {
 			foreach ($files as $file) {
 				if ($availableSpace < 0) {
 					$tmp = self::delete($file['name'], $user, $file['mtime']);
-					\OC_Log::write('files_trashbin', 'remove "' . $file['name'] . '" (' . $tmp . 'B) to meet the limit of trash bin size (50% of available quota)', \OC_log::INFO);
+					\OCP\Util::writeLog('files_trashbin', 'remove "' . $file['name'] . '" (' . $tmp . 'B) to meet the limit of trash bin size (50% of available quota)', \OC_log::INFO);
 					$availableSpace += $tmp;
 					$size += $tmp;
 				} else {
@@ -664,7 +664,7 @@ class Trashbin {
 			if ($timestamp <= $limit) {
 				$count++;
 				$size += self::delete($filename, $user, $timestamp);
-				\OC_Log::write('files_trashbin', 'remove "' . $filename . '" from trash bin because it is older than ' . $retention_obligation, \OC_log::INFO);
+				\OCP\Util::writeLog('files_trashbin', 'remove "' . $filename . '" from trash bin because it is older than ' . $retention_obligation, \OCP\Util::INFO);
 			} else {
 				break;
 			}

--- a/apps/files_versions/ajax/preview.php
+++ b/apps/files_versions/ajax/preview.php
@@ -34,13 +34,13 @@ $scalingUp = array_key_exists('scalingup', $_GET) ? (bool) $_GET['scalingup'] : 
 
 if($file === '' && $version === '') {
 	\OC_Response::setStatus(400); //400 Bad Request
-	\OC_Log::write('versions-preview', 'No file parameter was passed', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('versions-preview', 'No file parameter was passed', \OCP\Util::DEBUG);
 	exit;
 }
 
 if($maxX === 0 || $maxY === 0) {
 	\OC_Response::setStatus(400); //400 Bad Request
-	\OC_Log::write('versions-preview', 'x and/or y set to 0', \OC_Log::DEBUG);
+	\OCP\Util::writeLog('versions-preview', 'x and/or y set to 0', \OCP\Util::DEBUG);
 	exit;
 }
 
@@ -56,5 +56,5 @@ try {
 	$preview->showPreview();
 }catch(\Exception $e) {
 	\OC_Response::setStatus(500);
-	\OC_Log::write('core', $e->getmessage(), \OC_Log::DEBUG);
+	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);
 }

--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -62,7 +62,7 @@ class Groups{
 		// Validate name
 		$groupid = isset($_POST['groupid']) ? $_POST['groupid'] : '';
 		if( preg_match( '/[^a-zA-Z0-9 _\.@\-]/', $groupid ) || empty($groupid)){
-			\OC_Log::write('provisioning_api', 'Attempt made to create group using invalid characters.', \OC_Log::ERROR);
+			\OCP\Util::writeLog('provisioning_api', 'Attempt made to create group using invalid characters.', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}
 		// Check if it exists

--- a/apps/provisioning_api/lib/users.php
+++ b/apps/provisioning_api/lib/users.php
@@ -44,15 +44,15 @@ class Users {
 		$userId = isset($_POST['userid']) ? $_POST['userid'] : null;
 		$password = isset($_POST['password']) ? $_POST['password'] : null;
 		if(OC_User::userExists($userId)) {
-			\OC_Log::write('ocs_api', 'Failed addUser attempt: User already exists.', \OC_Log::ERROR);
+			\OCP\Util::writeLog('ocs_api', 'Failed addUser attempt: User already exists.', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 102, 'User already exists');
 		} else {
 			try {
 				OC_User::createUser($userId, $password);
-				\OC_Log::write('ocs_api', 'Successful addUser call with userid: '.$_POST['userid'], \OC_Log::INFO);
+				\OCP\Util::writeLog('ocs_api', 'Successful addUser call with userid: '.$_POST['userid'], \OCP\Util::INFO);
 				return new OC_OCS_Result(null, 100);
 			} catch (\Exception $e) {
-				\OC_Log::write('ocs_api', 'Failed addUser attempt with exception: '.$e->getMessage(), \OC_Log::ERROR);
+				\OCP\Util::writeLog('ocs_api', 'Failed addUser attempt with exception: '.$e->getMessage(), \OCP\Util::ERROR);
 				return new OC_OCS_Result(null, 101, 'Bad request');
 			}
 		}

--- a/apps/user_webdavauth/user_webdavauth.php
+++ b/apps/user_webdavauth/user_webdavauth.php
@@ -34,27 +34,27 @@ class OC_USER_WEBDAVAUTH extends OC_User_Backend implements \OCP\IUserBackend {
 
 	public function deleteUser($uid) {
 		// Can't delete user
-		OC_Log::write('OC_USER_WEBDAVAUTH', 'Not possible to delete users from web frontend using WebDAV user backend', 3);
+		OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Not possible to delete users from web frontend using WebDAV user backend', 3);
 		return false;
 	}
 
 	public function setPassword ( $uid, $password ) {
 		// We can't change user password
-		OC_Log::write('OC_USER_WEBDAVAUTH', 'Not possible to change password for users from web frontend using WebDAV user backend', 3);
+		OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Not possible to change password for users from web frontend using WebDAV user backend', 3);
 		return false;
 	}
 
 	public function checkPassword( $uid, $password ) {
 		$arr = explode('://', $this->webdavauth_url, 2);
 		if( ! isset($arr) OR count($arr) !== 2) {
-			OC_Log::write('OC_USER_WEBDAVAUTH', 'Invalid Url: "'.$this->webdavauth_url.'" ', 3);
+			OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Invalid Url: "'.$this->webdavauth_url.'" ', 3);
 			return false;
 		}
 		list($webdavauth_protocol, $webdavauth_url_path) = $arr;
 		$url= $webdavauth_protocol.'://'.urlencode($uid).':'.urlencode($password).'@'.$webdavauth_url_path;
 		$headers = get_headers($url);
 		if($headers==false) {
-			OC_Log::write('OC_USER_WEBDAVAUTH', 'Not possible to connect to WebDAV Url: "'.$webdavauth_protocol.'://'.$webdavauth_url_path.'" ', 3);
+			OCP\Util::writeLog('OC_USER_WEBDAVAUTH', 'Not possible to connect to WebDAV Url: "'.$webdavauth_protocol.'://'.$webdavauth_url_path.'" ', 3);
 			return false;
 
 		}


### PR DESCRIPTION
In a lot of places the OC_Log::write was still used. Pretty trivial to review.
Brings us a step closer to #4774 

In the future most of the stuff probably should be migrated to the appframework and then use the ilogger interface. But until that day this seems like a good alternative.
