### PR TITLE
Remove transaction from file scanner for better parallel execution

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -47,7 +47,11 @@ class Scanner extends BasicEmitter {
 	/**
 	 * @var bool $useTransactions whether to use transactions
 	 */
-	protected $useTransactions = true;
+	// FIXME Instead of using a transaction we should lock the table.
+	// FIXME Transactions cause a problem, if two scanChildren() calls run.
+	// FIXME Then insertIfNotExists() of the second one fails to insert, but the
+	// FIXME select can not find the value, because it still has the old state.
+	protected $useTransactions = false;// FIXME true;
 
 	const SCAN_RECURSIVE = true;
 	const SCAN_SHALLOW = false;

--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -131,9 +131,14 @@ class Scanner extends PublicEmitter {
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);
 			$this->attachListener($mount);
-			$this->db->beginTransaction();
+
+			// FIXME Instead of using a transaction we should lock the table.
+			// FIXME Transactions cause a problem, if two scanChildren() calls run.
+			// FIXME Then insertIfNotExists() of the second one fails to insert, but the
+			// FIXME select can not find the value, because it still has the old state.
+			// FIXME $this->db->beginTransaction();
 			$scanner->scan($relativePath, \OC\Files\Cache\Scanner::SCAN_RECURSIVE, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
-			$this->db->commit();
+			// FIXME $this->db->commit();
 		}
 		$this->propagator->propagateChanges(time());
 	}


### PR DESCRIPTION
Transactions cause a problem, if two scanChildren() calls run.
Then insertIfNotExists() of the second one fails to insert, but the
select can not find the value, because it still has the old state.

6871a150bd1309af0ca22e45487043d9640bb356 + 644755df663e8dc295e92700da208a28c13cbaab

@icewind1991 @DeepDiver1975 

@jnfrmarks please run smashbox against this branch
#15337
