### PR TITLE
Catch more exceptions in DAV client

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -199,6 +199,8 @@ class Storage extends DAV implements ISharedStorage {
 			$this->manager->removeShare($this->mountPoint);
 			$this->manager->getMountManager()->removeMount($this->mountPoint);
 			throw new StorageInvalidException();
+		} catch (\GuzzleHttp\Exception\ConnectException $e) {
+			throw new StorageNotAvailableException();
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
 			if ($e->getCode() === 503) {
 				throw new StorageNotAvailableException();

--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -248,16 +248,19 @@ class Storage extends DAV implements ISharedStorage {
 
 		// TODO: DI
 		$client = \OC::$server->getHTTPClientService()->newClient();
-		$response = $client->post($url, ['body' => ['password' => $password]]);
-
-		switch ($response->getStatusCode()) {
-			case 401:
-			case 403:
-				throw new ForbiddenException();
-			case 404:
-				throw new NotFoundException();
-			case 500:
-				throw new \Exception();
+		try {
+			$response = $client->post($url, ['body' => ['password' => $password]]);
+		} catch (\GuzzleHttp\Exception\RequestException $e) {
+			switch ($e->getCode()) {
+				case 401:
+				case 403:
+					throw new ForbiddenException();
+				case 404:
+					throw new NotFoundException();
+				case 500:
+					throw new \Exception();
+			}
+			throw $e;
 		}
 
 		return json_decode($response->getBody(), true);


### PR DESCRIPTION
- catch parse errors when remote server returns HTML instead of XML (ex: when EE license expired)
- catch ClientException / ConnectionException when connection was refused when remote server is down / unreachable

@MorrisJobke @icewind1991 @LukasReschke @nickvergessen 

Fixes https://github.com/owncloud/core/issues/15524
Fixes https://github.com/owncloud/core/issues/15430

To test:
- PROPFIND on root (200, list returned)
- PROPFIND on received share (503)
- web UI, access share

combined with:
- with remote server in maintenance mode: share stays
- with remote server with expired/invalid license: share stays
- with no connection to remove server (unplug cable): share stays
- unshare/expire the share on the remote server: accessing the share auto-deletes it for the recipient
