### PR TITLE
Add "Reply-To" support for sharing mails as well as refactor code and add unit-tests

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -119,7 +119,14 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			// don't send a mail to the user who shared the file
 			$recipientList = array_diff($recipientList, array(\OCP\User::getUser()));
 
-			$mailNotification = new OC\Share\MailNotifications();
+			$mailNotification = new \OC\Share\MailNotifications(
+				\OC::$server->getUserSession()->getUser()->getUID(),
+				\OC::$server->getConfig(),
+				\OC::$server->getL10N('lib'),
+				\OC::$server->getMailer(),
+				\OC::$server->getLogger(),
+				$defaults
+			);
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
 
 			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
@@ -151,7 +158,14 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$file = (string)$_POST['file'];
 			$to_address = (string)$_POST['toaddress'];
 
-			$mailNotification = new \OC\Share\MailNotifications();
+			$mailNotification = new \OC\Share\MailNotifications(
+				\OC::$server->getUserSession()->getUser()->getUID(),
+				\OC::$server->getConfig(),
+				\OC::$server->getL10N('lib'),
+				\OC::$server->getMailer(),
+				\OC::$server->getLogger(),
+				$defaults
+			);
 
 			$expiration = null;
 			if (isset($_POST['expiration']) && $_POST['expiration'] !== '') {

--- a/lib/private/mail/message.php
+++ b/lib/private/mail/message.php
@@ -93,6 +93,28 @@ class Message {
 	}
 
 	/**
+	 * Set the Reply-To address of this message
+	 *
+	 * @param array $addresses
+	 * @return $this
+	 */
+	public function setReplyTo(array $addresses) {
+		$addresses = $this->convertAddresses($addresses);
+
+		$this->swiftMessage->setReplyTo($addresses);
+		return $this;
+	}
+
+	/**
+	 * Returns the Reply-To address of this message
+	 *
+	 * @return array
+	 */
+	public function getReplyTo() {
+		return $this->swiftMessage->getReplyTo();
+	}
+
+	/**
 	 * Set the to addresses of this message.
 	 *
 	 * @param array $recipients Example: array('recipient@domain.org', 'other@domain.org' => 'A name')

--- a/tests/lib/mail/message.php
+++ b/tests/lib/mail/message.php
@@ -62,6 +62,23 @@ class MessageTest extends TestCase {
 		$this->assertSame(array('lukas@owncloud.com'), $this->message->getFrom());
 	}
 
+	public function testSetReplyTo() {
+		$this->swiftMessage
+			->expects($this->once())
+			->method('setReplyTo')
+			->with(['lukas@owncloud.com']);
+		$this->message->setReplyTo(['lukas@owncloud.com']);
+	}
+
+	public function testGetReplyTo() {
+		$this->swiftMessage
+			->expects($this->once())
+			->method('getReplyTo')
+			->will($this->returnValue(['lukas@owncloud.com']));
+
+		$this->assertSame(['lukas@owncloud.com'], $this->message->getReplyTo());
+	}
+
 	public function testSetTo() {
 		$this->swiftMessage
 			->expects($this->once())

--- a/tests/lib/share/MailNotificationsTest.php
+++ b/tests/lib/share/MailNotificationsTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use OC\Share\MailNotifications;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\Mail\IMailer;
+use OCP\ILogger;
+use OCP\Defaults;
+
+/**
+ * Class MailNotificationsTest
+ */
+class MailNotificationsTest extends \Test\TestCase {
+	/** @var IConfig */
+	private $config;
+	/** @var IL10N */
+	private $l10n;
+	/** @var IMailer */
+	private $mailer;
+	/** @var ILogger */
+	private $logger;
+	/** @var Defaults */
+	private $defaults;
+
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+			->disableOriginalConstructor()->getMock();
+		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')
+			->disableOriginalConstructor()->getMock();
+		$this->logger = $this->getMockBuilder('\OCP\ILogger')
+			->disableOriginalConstructor()->getMock();
+		$this->defaults = $this->getMockBuilder('\OCP\Defaults')
+			->disableOriginalConstructor()->getMock();
+
+		$this->l10n->expects($this->any())
+			->method('t')
+			->will($this->returnCallback(function($text, $parameters = array()) {
+				return vsprintf($text, $parameters);
+			}));
+	}
+
+	public function testSendLinkShareMailWithoutReplyTo() {
+		$message = $this->getMockBuilder('\OC\Mail\Message')
+			->disableOriginalConstructor()->getMock();
+
+		$message
+			->expects($this->once())
+			->method('setSubject')
+			->with('TestUser shared »MyFile« with you');
+		$message
+			->expects($this->once())
+			->method('setTo')
+			->with(['lukas@owncloud.com']);
+		$message
+			->expects($this->once())
+			->method('setHtmlBody');
+		$message
+			->expects($this->once())
+			->method('setPlainBody');
+		$message
+			->expects($this->once())
+			->method('setFrom')
+			->with([\OCP\Util::getDefaultEmailAddress('sharing-noreply') => 'TestUser via UnitTestCloud']);
+
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->will($this->returnValue($message));
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message)
+			->will($this->returnValue([]));
+
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->will($this->returnValue('UnitTestCloud'));
+
+		$this->config
+			->expects($this->at(0))
+			->method('getUserValue')
+			->with('TestUser', 'settings', 'email', null)
+			->will($this->returnValue('sharer@owncloud.com'));
+
+		$mailNotifications = new MailNotifications(
+			'TestUser',
+			$this->config,
+			$this->l10n,
+			$this->mailer,
+			$this->logger,
+			$this->defaults
+		);
+
+		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
+	}
+
+	public function testSendLinkShareMailWithReplyTo() {
+		$message = $this->getMockBuilder('\OC\Mail\Message')
+			->disableOriginalConstructor()->getMock();
+
+		$message
+			->expects($this->once())
+			->method('setSubject')
+			->with('TestUser shared »MyFile« with you');
+		$message
+			->expects($this->once())
+			->method('setTo')
+			->with(['lukas@owncloud.com']);
+		$message
+			->expects($this->once())
+			->method('setHtmlBody');
+		$message
+			->expects($this->once())
+			->method('setPlainBody');
+		$message
+			->expects($this->once())
+			->method('setFrom')
+			->with([\OCP\Util::getDefaultEmailAddress('sharing-noreply') => 'TestUser via UnitTestCloud']);
+		$message
+			->expects($this->once())
+			->method('setReplyTo')
+			->with(['sharer@owncloud.com']);
+
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->will($this->returnValue($message));
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message)
+			->will($this->returnValue([]));
+
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->will($this->returnValue('UnitTestCloud'));
+
+		$this->config
+			->expects($this->at(0))
+			->method('getUserValue')
+			->with('TestUser', 'settings', 'email', null)
+			->will($this->returnValue('sharer@owncloud.com'));
+
+		$mailNotifications = new MailNotifications(
+			'TestUser',
+			$this->config,
+			$this->l10n,
+			$this->mailer,
+			$this->logger,
+			$this->defaults
+		);
+		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
+	}
+
+	public function testSendLinkShareMailException() {
+		$message = $this->getMockBuilder('\OC\Mail\Message')
+			->disableOriginalConstructor()->getMock();
+
+		$message
+			->expects($this->once())
+			->method('setSubject')
+			->with('TestUser shared »MyFile« with you');
+		$message
+			->expects($this->once())
+			->method('setTo')
+			->with(['lukas@owncloud.com']);
+		$message
+			->expects($this->once())
+			->method('setHtmlBody');
+		$message
+			->expects($this->once())
+			->method('setPlainBody');
+		$message
+			->expects($this->once())
+			->method('setFrom')
+			->with([\OCP\Util::getDefaultEmailAddress('sharing-noreply') => 'TestUser via UnitTestCloud']);
+
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->will($this->returnValue($message));
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message)
+			->will($this->throwException(new Exception('Some Exception Message')));
+
+		$this->defaults
+			->expects($this->once())
+			->method('getName')
+			->will($this->returnValue('UnitTestCloud'));
+
+		$this->config
+			->expects($this->at(0))
+			->method('getUserValue')
+			->with('TestUser', 'settings', 'email', null)
+			->will($this->returnValue('sharer@owncloud.com'));
+
+		$mailNotifications = new MailNotifications(
+			'TestUser',
+			$this->config,
+			$this->l10n,
+			$this->mailer,
+			$this->logger,
+			$this->defaults
+		);
+
+		$this->assertSame(['lukas@owncloud.com'], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
+	}
+
+}


### PR DESCRIPTION
Current sharing mails set no "Reply-To" header, this means that when a sharing mail is sent and somebody clicks reply it will end-up in /dev/null and this has lead to multiple complaints.

Thus this pull request does:
1. Add "Reply-To" support to mailer class 
2. Refactored the sharing notification mail class a bit and added unit-tests for it where possible
3. When a sharing notification mail is sent and the user has specified a mail address it it set as "Reply-To" header, so when somebody clicks "Reply" in their mail program the reply will be sent to the actual user.
4. The "From" field displayname is now "$user via ownCloud" (where ownCloud uses the name from the theme), this is what most other providers do as well and at least I find it way easier to filter for mails then etc…

@karlitschek @DeepDiver1975 Please sort out for which releases we want this. That said, for me this is a new feature and not a bug fix and thus I'd advise against any kind of hacky backport. (which with the old API will also not be able easily)

@MTRichards @gig13 @karlitschek 

Replaces https://github.com/owncloud/core/pull/13855, fixes https://github.com/owncloud/core/issues/10545 and probably some other issues
