### PR TITLE
fix wrong typeface being used for some buttons

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -71,7 +71,14 @@ body {
 }
 
 
+
 /* INPUTS */
+
+/* specifically override browser styles */
+input, textarea, select, button {
+	font-family: 'Open Sans', Frutiger, Calibri, 'Myriad Pro', Myriad, sans-serif;
+}
+
 input[type="text"],
 input[type="password"],
 input[type="search"],


### PR DESCRIPTION
The `Settings` text in files and the `Change password` button in the Personal settings used Arial. This change specifically overrides the browser styles which caused that.

You can test this for example in Chrome, looking at the text mentioned above. @owncloud/designers 
