### PR TITLE
don't update identical values

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -306,7 +306,8 @@ class Cache {
 		}
 
 		list($queryParts, $params) = $this->buildParts($data);
-
+		// duplicate $params because we need the parts twice in the SQL statement
+		// once for the SET part, once in the WHERE clause
 		$params = array_merge($params, $params);
 		$params[] = $id;
 

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -306,10 +306,16 @@ class Cache {
 		}
 
 		list($queryParts, $params) = $this->buildParts($data);
+
+		$params = array_merge($params, $params);
 		$params[] = $id;
 
-		$sql = 'UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=? WHERE `fileid` = ?';
+		// don't update if the data we try to set is the same as the one in the record
+		// some databases (Postgres) don't like superfluous updates
+		$sql = 'UPDATE `*PREFIX*filecache` SET ' . implode(' = ?, ', $queryParts) . '=? ' .
+			'WHERE (' . implode(' <> ? OR ', $queryParts) . ' <> ? ) AND `fileid` = ? ';
 		\OC_DB::executeAudited($sql, $params);
+
 	}
 
 	/**


### PR DESCRIPTION
The UPDATE oc_filecache statement blindly overwrites identical data.
Databases like Postgres that create a new row on an update
and mark the old one as dead will suffer from the previous
behaviour, as millions of "new" rows are created in the database.

This patch changes the WHERE clause to test for identical
values and not updating if the values in the DB are identical
to the ones being passed.
