### PR TITLE
[stable7] Add "Reply-To" support for sharing notifications

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -104,7 +104,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			// don't send a mail to the user who shared the file
 			$recipientList = array_diff($recipientList, array(\OCP\User::getUser()));
 
-			$mailNotification = new OC\Share\MailNotifications();
+			$mailNotification = new OC\Share\MailNotifications(\OCP\User::getUser());
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
 
 			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
@@ -136,7 +136,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			$file = $_POST['file'];
 			$to_address = $_POST['toaddress'];
 
-			$mailNotification = new \OC\Share\MailNotifications();
+			$mailNotification = new \OC\Share\MailNotifications(\OCP\User::getUser());
 
 			$expiration = null;
 			if (isset($_POST['expiration']) && $_POST['expiration'] !== '') {

--- a/lib/private/mail.php
+++ b/lib/private/mail.php
@@ -28,10 +28,11 @@ class OC_Mail {
 	 * @param string $ccaddress
 	 * @param string $ccname
 	 * @param string $bcc
+	 * @param string $replyTo
 	 * @throws Exception
 	 */
 	public static function send($toaddress, $toname, $subject, $mailtext, $fromaddress, $fromname,
-		$html=0, $altbody='', $ccaddress='', $ccname='', $bcc='') {
+		$html=0, $altbody='', $ccaddress='', $ccname='', $bcc='', $replyTo='') {
 
 		$SMTPMODE = OC_Config::getValue( 'mail_smtpmode', 'sendmail' );
 		$SMTPHOST = OC_Config::getValue( 'mail_smtphost', '127.0.0.1' );
@@ -78,7 +79,9 @@ class OC_Mail {
 			if($ccaddress<>'') $mailo->AddCC($ccaddress, $ccname);
 			if($bcc<>'') $mailo->AddBCC($bcc);
 
-			$mailo->AddReplyTo($fromaddress, $fromname);
+			if($replyTo !== '') {
+				$mailo->addReplyTo($replyTo);
+			}
 
 			$mailo->WordWrap = 50;
 			if($html==1) $mailo->IsHTML(true); else $mailo->IsHTML(false);

--- a/lib/private/share/mailnotifications.php
+++ b/lib/private/share/mailnotifications.php
@@ -37,6 +37,9 @@ class MailNotifications {
 	 */
 	private $from;
 
+	/** @var string Mail address used for reply to */
+	private $replyTo;
+
 	/**
 	 * @var string
 	 */
@@ -49,20 +52,16 @@ class MailNotifications {
 
 	/**
 	 *
-	 * @param string $sender user id (if nothing is set we use the currently logged-in user)
+	 * @param string $sender user id
 	 */
-	public function __construct($sender = null) {
+	public function __construct($sender) {
 		$this->l = \OC::$server->getL10N('lib');
 
 		$this->senderId = $sender;
 
 		$this->from = \OCP\Util::getDefaultEmailAddress('sharing-noreply');
-		if ($this->senderId) {
-			$this->from = \OCP\Config::getUserValue($this->senderId, 'settings', 'email', $this->from);
-			$this->senderDisplayName = \OCP\User::getDisplayName($this->senderId);
-		} else {
-			$this->senderDisplayName = \OCP\User::getDisplayName();
-		}
+		$this->replyTo = \OCP\Config::getUserValue($this->senderId, 'settings', 'email', $this->from);
+		$this->senderDisplayName = \OCP\User::getDisplayName($this->senderId);
 	}
 
 	/**
@@ -118,7 +117,7 @@ class MailNotifications {
 
 			// send it out now
 			try {
-				\OCP\Util::sendMail($to, $recipientDisplayName, $subject, $htmlMail, $this->from, $this->senderDisplayName, 1, $alttextMail);
+				\OC_MAIL::send($to, $recipientDisplayName, $subject, $htmlMail, $this->from, $this->senderDisplayName, 1, $alttextMail, '', '', '', $this->replyTo);
 			} catch (\Exception $e) {
 				\OCP\Util::writeLog('sharing', "Can't send mail to inform the user about an internal share: " . $e->getMessage() , \OCP\Util::ERROR);
 				$noMail[] = $recipientDisplayName;
@@ -145,7 +144,7 @@ class MailNotifications {
 		$failed = array();
 		foreach ($rs as $r) {
 			try {
-				\OCP\Util::sendMail($r, $r, $subject, $htmlMail, $this->from, $this->senderDisplayName, 1, $alttextMail);
+				\OC_MAIL::send($r, $r, $subject, $htmlMail, $this->from, $this->senderDisplayName, 1, $alttextMail, '', '', '', $this->replyTo);
 			} catch (\Exception $e) {
 				\OCP\Util::writeLog('sharing', "Can't send mail with public link to $r: " . $e->getMessage(), \OCP\Util::ERROR);
 				$failed[] = $r;


### PR DESCRIPTION
Very hacky backport of https://github.com/owncloud/core/pull/15541 - I changed the code path to use OC_Mail instead the OCP pendant since I didn't want to modify the public API. (OCP\Util::sendMail() is anyways deprecated with 8.1)

@jcfischer Too late ;-)
