### PR TITLE
Do not try to make user subadmin of group twice

### DIFF
--- a/apps/provisioning_api/lib/users.php
+++ b/apps/provisioning_api/lib/users.php
@@ -292,6 +292,10 @@ class Users {
 		if(strtolower($group) == 'admin') {
 			return new OC_OCS_Result(null, 103, 'Cannot create subadmins for admin group');
 		}
+		// We cannot be subadmin twice
+		if (OC_Subadmin::isSubAdminOfGroup($user, $group)) {
+			return new OC_OCS_Result(null, 100);
+		}
 		// Go
 		if(OC_Subadmin::createSubAdmin($user, $group)) {
 			return new OC_OCS_Result(null, 100);

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -766,4 +766,29 @@ class UsersTest extends TestCase {
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(101, $result->getStatusCode());
 	}
+
+	public function testSubAdminOfGroupAlreadySubAdmin() {
+		$user1 = $this->generateUsers();
+		$user2 = $this->generateUsers();
+		\OC_User::setUserId($user1);
+		\OC_Group::addToGroup($user1, 'admin');
+		$group1 = $this->getUniqueID();
+		\OC_Group::createGroup($group1);
+
+		//Make user2 subadmin of group1
+		$_POST['groupid'] = $group1;
+		$result = \OCA\provisioning_api\Users::addSubAdmin([
+			'userid' => $user2,
+		]);
+		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertTrue($result->succeeded());
+
+		//Make user2 subadmin of group1 again
+		$_POST['groupid'] = $group1;
+		$result = \OCA\provisioning_api\Users::addSubAdmin([
+			'userid' => $user2,
+		]);
+		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertTrue($result->succeeded());
+	}
 }


### PR DESCRIPTION
As stated in #13709

If the provisioning api is used to make a user subadmin of a group that user is already a subadmin just return success. In my opinion returning success is better than returning an error since the desired outcome is already in place. 

Added unit test to ensure things keep working.

Probably best to get this into 8.1

@karlitschek probably a good idea to backport to 8.0 as well

CC: @DeepDiver1975 @LukasReschke @MorrisJobke 
