### PR TITLE
fix filepicker

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -196,10 +196,11 @@ class Helper {
 	 * @param string $dir path to the directory
 	 * @param string $sortAttribute attribute to sort on
 	 * @param bool $sortDescending true for descending sort, false otherwise
+	 * @param string $mimetypeFilter limit returned content to this mimetype or mimepart
 	 * @return \OCP\Files\FileInfo[] files
 	 */
-	public static function getFiles($dir, $sortAttribute = 'name', $sortDescending = false) {
-		$content = \OC\Files\Filesystem::getDirectoryContent($dir);
+	public static function getFiles($dir, $sortAttribute = 'name', $sortDescending = false, $mimetypeFilter = '') {
+		$content = \OC\Files\Filesystem::getDirectoryContent($dir, $mimetypeFilter);
 
 		return self::sortFiles($content, $sortAttribute, $sortDescending);
 	}

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -138,7 +138,7 @@ var OCdialogs = {
 	 * @param title dialog title
 	 * @param callback which will be triggered when user presses Choose
 	 * @param multiselect whether it should be possible to select multiple files
-	 * @param mimetypeFilter mimetype to filter by
+	 * @param mimetypeFilter mimetype to filter by - directories will always be included
 	 * @param modal make the dialog modal
 	*/
 	filepicker:function(title, callback, multiselect, mimetypeFilter, modal) {


### PR DESCRIPTION
- add ability to filter for mimetype
- fixes #15526
- fixes #11563 

cc @libasys @PVince81 @LukasReschke @DeepDiver1975 

This feature of filtering by mimetype was removed with 0be9de5df558232e12e2f582af5d08e1f488ba90 (see https://github.com/owncloud/core/commit/0be9de5df558232e12e2f582af5d08e1f488ba90#diff-1401cb5335f4cec60bed20bac7ae768eL22 and following lines)

I simplyfied the logic linked above.
