### PR TITLE
Properly add trailing slash to mount point

### DIFF
--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -144,14 +144,20 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		\OC\Files\Filesystem::rename($this->filename, "newFileName");
+		\OC\Files\Filesystem::rename($this->filename, $this->filename . '_renamed');
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('newFileName'));
+		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
 		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename));
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists("newFileName"));
+		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
+
+		// rename back to original name
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		\OC\Files\Filesystem::rename($this->filename . '_renamed', $this->filename);
+		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
+		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
 
 		//cleanup
 		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);

--- a/lib/private/files/mount/mountpoint.php
+++ b/lib/private/files/mount/mountpoint.php
@@ -113,10 +113,12 @@ class MountPoint implements IMountPoint {
 	}
 
 	/**
+	 * Sets the mount point path, relative to data/
+	 *
 	 * @param string $mountPoint new mount point
 	 */
 	public function setMountPoint($mountPoint) {
-		$this->mountPoint = $mountPoint;
+		$this->mountPoint = $this->formatPath($mountPoint);
 	}
 
 	/**

--- a/tests/lib/files/mount/mountpoint.php
+++ b/tests/lib/files/mount/mountpoint.php
@@ -31,6 +31,10 @@ class MountPoint extends \Test\TestCase {
 
 		$this->assertEquals($storage, $mountPoint->getStorage());
 		$this->assertEquals(123, $mountPoint->getStorageId());
+		$this->assertEquals('/mountpoint/', $mountPoint->getMountPoint());
+
+		$mountPoint->setMountPoint('another');
+		$this->assertEquals('/another/', $mountPoint->getMountPoint());
 	}
 
 	public function testInvalidStorage() {


### PR DESCRIPTION
Fixes resolving mount points when shared mount point's target name has
the same prefix as the source name

Fixes https://github.com/owncloud/core/issues/15340 where the original folder would disappear completely

Please review @icewind1991 @schiesbn @nickvergessen @MorrisJobke @rullzer 
