### PR TITLE
skip user if we don't have a public key

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -94,10 +94,12 @@ class Application extends \OCP\AppFramework\App {
 	public function registerEncryptionModule() {
 		$container = $this->getContainer();
 
+
 		$this->encryptionManager->registerEncryptionModule(
 			Encryption::ID,
 			Encryption::DISPLAY_NAME,
 			function() use ($container) {
+
 			return new Encryption(
 				$container->query('Crypt'),
 				$container->query('KeyManager'),
@@ -105,6 +107,7 @@ class Application extends \OCP\AppFramework\App {
 				$container->getServer()->getLogger()
 			);
 		});
+
 	}
 
 	public function registerServices() {

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -179,8 +179,10 @@ class Encryption implements IEncryptionModule {
 				try {
 					$publicKeys[$uid] = $this->keyManager->getPublicKey($uid);
 				} catch (PublicKeyMissingException $e) {
-					$this->logger->warning('no public key found for user \'' . $uid .
-						'\', user will not be able to read the file', array('app' => 'encryption'));
+					$this->logger->warning(
+						'no public key found for user "{uid}", user will not be able to read the file',
+						['app' => 'encryption', 'uid' => $uid]
+					);
 					// if the public key of the owner is missing we should fail
 					if ($uid === $this->user) {
 						throw $e;

--- a/apps/encryption/tests/lib/crypto/cryptTest.php
+++ b/apps/encryption/tests/lib/crypto/cryptTest.php
@@ -20,7 +20,7 @@
  */
 
 
-namespace OCA\Encryption\Tests\Crypt;
+namespace OCA\Encryption\Tests\lib\Crypto;
 
 
 use OCA\Encryption\Crypto\Crypt;

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Encryption\Tests\Crypto;
 
+use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use Test\TestCase;
 use OCA\Encryption\Crypto\Encryption;
 
@@ -63,6 +64,74 @@ class EncryptionTest extends TestCase {
 			$this->utilMock,
 			$this->loggerMock
 		);
+
+	}
+
+	/**
+	 * test if public key from one of the recipients is missing
+	 */
+	public function testEndUser1() {
+		$this->instance->begin('/foo/bar', 'user1', 'r', array(), array('users' => array('user1', 'user2', 'user3')));
+		$this->endTest();
+	}
+
+	/**
+	 * test if public key from owner is missing
+	 *
+	 * @expectedException \OCA\Encryption\Exceptions\PublicKeyMissingException
+	 */
+	public function testEndUser2() {
+		$this->instance->begin('/foo/bar', 'user2', 'r', array(), array('users' => array('user1', 'user2', 'user3')));
+		$this->endTest();
+	}
+
+	/**
+	 * common part of testEndUser1 and testEndUser2
+	 *
+	 * @throws PublicKeyMissingException
+	 */
+	public function endTest() {
+		// prepare internal variables
+		$class = get_class($this->instance);
+		$module = new \ReflectionClass($class);
+		$isWriteOperation = $module->getProperty('isWriteOperation');
+		$writeCache = $module->getProperty('writeCache');
+		$isWriteOperation->setAccessible(true);
+		$writeCache->setAccessible(true);
+		$isWriteOperation->setValue($this->instance, true);
+		$writeCache->setValue($this->instance, '');
+		$isWriteOperation->setAccessible(false);
+		$writeCache->setAccessible(false);
+
+		$this->keyManagerMock->expects($this->any())
+			->method('getPublicKey')
+			->will($this->returnCallback([$this, 'getPublicKeyCallback']));
+		$this->keyManagerMock->expects($this->any())
+			->method('addSystemKeys')
+			->will($this->returnCallback([$this, 'addSystemKeysCallback']));
+		$this->cryptMock->expects($this->any())
+			->method('multiKeyEncrypt')
+			->willReturn(true);
+		$this->cryptMock->expects($this->any())
+			->method('setAllFileKeys')
+			->willReturn(true);
+
+		$this->instance->end('/foo/bar');
+	}
+
+
+	public function getPublicKeyCallback($uid) {
+		if ($uid === 'user2') {
+			throw new PublicKeyMissingException($uid);
+		}
+		return $uid;
+	}
+
+	public function addSystemKeysCallback($accessList, $publicKeys) {
+		$this->assertSame(2, count($publicKeys));
+		$this->assertArrayHasKey('user1', $publicKeys);
+		$this->assertArrayHasKey('user3', $publicKeys);
+		return $publicKeys;
 	}
 
 	/**

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\Encryption\Tests\Crypto;
+namespace OCA\Encryption\Tests\lib\Crypto;
 
 use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use Test\TestCase;
@@ -92,16 +92,8 @@ class EncryptionTest extends TestCase {
 	 */
 	public function endTest() {
 		// prepare internal variables
-		$class = get_class($this->instance);
-		$module = new \ReflectionClass($class);
-		$isWriteOperation = $module->getProperty('isWriteOperation');
-		$writeCache = $module->getProperty('writeCache');
-		$isWriteOperation->setAccessible(true);
-		$writeCache->setAccessible(true);
-		$isWriteOperation->setValue($this->instance, true);
-		$writeCache->setValue($this->instance, '');
-		$isWriteOperation->setAccessible(false);
-		$writeCache->setAccessible(false);
+		\Test_Helper::invokePrivate($this->instance, 'isWriteOperation', [true]);
+		\Test_Helper::invokePrivate($this->instance, 'writeCache', ['']);
 
 		$this->keyManagerMock->expects($this->any())
 			->method('getPublicKey')

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -523,6 +523,10 @@ class Test_Helper extends \Test\TestCase {
 
 			$property->setAccessible(true);
 
+			if (!empty($parameters)) {
+				$property->setValue($object, array_pop($parameters));
+			}
+
 			return $property->getValue($object);
 		}
 


### PR DESCRIPTION
Steps to test:
- start with a fresh ownCloud
- create two users, user1 and user2
- user1 shares a folder "testFolder" with user2
- enable encryption
- re-login as user1 (don't login as user2)
- upload a file to the shared folder testFolder
  -> Without this PR the file will be broken because we don't have a private key for user2
  -> With this PR the fill will be uploaded succesfully and we will skip user2

cc @PVince81 
