### PR TITLE
Adding a final fallback for findBinaryPath

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -931,7 +931,12 @@ class OC_Helper {
 			// Returns null if nothing is found
 			$result = $exeSniffer->find($program);
 			if (empty($result)) {
-				$paths = str_replace(':','/ ',getenv('PATH'));
+				$paths = getenv('PATH');
+				if (empty($paths)) {
+					$paths = '/usr/local/bin /usr/bin /opt/bin /bin';
+				} else {
+					$paths = str_replace(':',' ',getenv('PATH'));
+				}
 				$command = 'find ' . $paths . ' -name ' . escapeshellarg($program) . ' 2> /dev/null';
 				exec($command, $output, $returnCode);
 				if (count($output) > 0) {


### PR DESCRIPTION
oC can't find executables on systems using PHP-FPM and which have not been configured to receive environment variables.

Fix for #15546
