### PR TITLE
Fixes returns of group memberships and counting if all members have the ...

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -516,10 +516,11 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			}
 		}
 
+		$groupUsers = array_unique(array_merge($groupUsers, $primaryUsers));
 		natsort($groupUsers);
 		$this->access->connection->writeToCache('usersInGroup-'.$gid.'-'.$search, $groupUsers);
 		$groupUsers = array_slice($groupUsers, $offset, $limit);
-		$groupUsers = array_unique(array_merge($groupUsers, $primaryUsers));
+
 
 		$this->access->connection->writeToCache($cacheKey, $groupUsers);
 

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -313,4 +313,74 @@ class Test_Group_Ldap extends \Test\TestCase {
 		$this->assertSame(2, count($groups));
 	}
 
+	/**
+	 * tests that a user listing is complete, if all it's members have the group
+	 * as their primary.
+	 */
+	public function  testUsersInGroupPrimaryMembersOnly() {
+		$access = $this->getAccessMock();
+		$this->enableGroups($access);
+
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->will($this->returnValue(null));
+
+		$access->expects($this->any())
+			->method('readAttribute')
+			->will($this->returnCallback(function($dn, $attr) {
+				if($attr === 'primaryGroupToken') {
+					return array(1337);
+				}
+				return array();
+			}));
+
+		$access->expects($this->any())
+			->method('groupname2dn')
+			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
+
+		$access->expects($this->once())
+			->method('ownCloudUserNames')
+			->will($this->returnValue(array('lisa', 'bart', 'kira', 'brad')));
+
+		$groupBackend = new GroupLDAP($access);
+		$users = $groupBackend->usersInGroup('foobar');
+
+		$this->assertSame(4, count($users));
+	}
+
+	/**
+	 * tests that a user counting is complete, if all it's members have the group
+	 * as their primary.
+	 */
+	public function  testCountUsersInGroupPrimaryMembersOnly() {
+		$access = $this->getAccessMock();
+		$this->enableGroups($access);
+
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->will($this->returnValue(null));
+
+		$access->expects($this->any())
+			->method('readAttribute')
+			->will($this->returnCallback(function($dn, $attr) {
+				if($attr === 'primaryGroupToken') {
+					return array(1337);
+				}
+				return array();
+			}));
+
+		$access->expects($this->any())
+			->method('groupname2dn')
+			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
+
+		$access->expects($this->once())
+			->method('countUsers')
+			->will($this->returnValue(4));
+
+		$groupBackend = new GroupLDAP($access);
+		$users = $groupBackend->countUsersInGroup('foobar');
+
+		$this->assertSame(4, $users);
+	}
+
 }


### PR DESCRIPTION
...specific groups as primary set.

Finally fixes #13533 

How to reproduce:
1. Have an AD
2. Have a group where all available users have it set as primary group
3. I.e. no other (ownCloud available) users should be there as usual member
4. Go to users page. Before: empty count, no users when selecting the group. Now: proper count with users.

Kindof follow up to #13740

Includes unit tests :turtle: 

Please test and review @MorrisJobke @jnfrmarks @plastilincheg @rjaeckel @LukasReschke  or others
