### PR TITLE
Allow files app nav entries to have a different icon class

### DIFF
--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -3,7 +3,7 @@
 		<?php foreach ($_['navigationItems'] as $item) { ?>
 		<li data-id="<?php p($item['id']) ?>" class="nav-<?php p($item['id']) ?>">
 			<a href="<?php p(isset($item['href']) ? $item['href'] : '#') ?>"
-				class="nav-icon-<?php p($item['id']) ?> svg">
+				class="nav-icon-<?php p($item['icon'] !== '' ? $item['icon'] : $item['id']) ?> svg">
 				<?php p($item['name']);?>
 			</a>
 		</li>


### PR DESCRIPTION
Replacement for #15602

cc @DeepDiver1975 @jancborchardt 

This reuses the currently unused icon entry of the navigation to pass in the css class to use with `nav-icon-...`

I will create the fixing PRs in the corresponding apps.
