### PR TITLE
always create a new instance of the encryption module

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -27,6 +27,7 @@ namespace OCA\Encryption\AppInfo;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\Crypto\Encryption;
 use OCA\Encryption\HookManager;
 use OCA\Encryption\Hooks\UserHooks;
 use OCA\Encryption\KeyManager;
@@ -90,14 +91,17 @@ class Application extends \OCP\AppFramework\App {
 
 	public function registerEncryptionModule() {
 		$container = $this->getContainer();
-		$container->registerService('EncryptionModule', function (IAppContainer $c) {
-			return new \OCA\Encryption\Crypto\Encryption(
-				$c->query('Crypt'),
-				$c->query('KeyManager'),
-				$c->query('Util'));
+
+		$this->encryptionManager->registerEncryptionModule(
+			Encryption::ID,
+			Encryption::DISPLAY_NAME,
+			function() use ($container) {
+			return new Encryption(
+				$container->query('Crypt'),
+				$container->query('KeyManager'),
+				$container->query('Util')
+			);
 		});
-		$module = $container->query('EncryptionModule');
-		$this->encryptionManager->registerEncryptionModule($module);
 	}
 
 	public function registerServices() {

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -32,6 +32,7 @@ use OCA\Encryption\KeyManager;
 class Encryption implements IEncryptionModule {
 
 	const ID = 'OC_DEFAULT_MODULE';
+	const DISPLAY_NAME = 'ownCloud Default Encryption';
 
 	/**
 	 * @var Crypt
@@ -90,7 +91,7 @@ class Encryption implements IEncryptionModule {
 	 * @return string
 	 */
 	public function getDisplayName() {
-		return 'ownCloud Default Encryption';
+		return self::DISPLAY_NAME;
 	}
 
 	/**

--- a/lib/public/encryption/imanager.php
+++ b/lib/public/encryption/imanager.php
@@ -40,26 +40,28 @@ interface IManager {
 	function isEnabled();
 
 	/**
-	 * Registers an encryption module
+	 * Registers an callback function which must return an encryption module instance
 	 *
-	 * @param IEncryptionModule $module
+	 * @param string $id
+	 * @param string $displayName
+	 * @param callable $callback
 	 * @throws ModuleAlreadyExistsException
 	 * @since 8.1.0
 	 */
-	function registerEncryptionModule(IEncryptionModule $module);
+	function registerEncryptionModule($id, $displayName, callable $callback);
 
 	/**
 	 * Unregisters an encryption module
 	 *
-	 * @param IEncryptionModule $module
+	 * @param string $moduleId
 	 * @since 8.1.0
 	 */
-	function unregisterEncryptionModule(IEncryptionModule $module);
+	function unregisterEncryptionModule($moduleId);
 
 	/**
 	 * get a list of all encryption modules
 	 *
-	 * @return array
+	 * @return array [id => ['id' => $id, 'displayName' => $displayName, 'callback' => callback]]
 	 * @since 8.1.0
 	 */
 	function getEncryptionModules();

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -96,10 +96,10 @@ try {
 }
 $encModulues = array();
 foreach ($encryptionModules as $module) {
-	$encModulues[$module->getId()]['displayName'] = $module->getDisplayName();
-	$encModulues[$module->getId()]['default'] = false;
-	if ($defaultEncryptionModule && $module->getId() === $defaultEncryptionModuleId) {
-		$encModulues[$module->getId()]['default'] = true;
+	$encModulues[$module['id']]['displayName'] = $module['displayName'];
+	$encModulues[$module['id']]['default'] = false;
+	if ($defaultEncryptionModule && $module['id'] === $defaultEncryptionModuleId) {
+		$encModulues[$module['id']]['default'] = true;
 	}
 }
 $template->assign('encryptionModules', $encModulues);

--- a/tests/lib/encryption/managertest.php
+++ b/tests/lib/encryption/managertest.php
@@ -36,9 +36,9 @@ class ManagerTest extends TestCase {
 	public function testManagerIsDisabledIfDisabledButModules() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(false);
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function() use ($em) {return $em;});
 		$this->assertFalse($this->manager->isEnabled());
 	}
 
@@ -50,29 +50,32 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @expectedException \OC\Encryption\Exceptions\ModuleAlreadyExistsException
-	 * @expectedExceptionMessage Id "0" already used by encryption module "TestDummyModule0"
+	 * @expectedExceptionMessage Id "id" already used by encryption module "TestDummyModule0"
 	 */
 	public function testModuleRegistration() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn('yes');
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 		$this->assertSame(1, count($this->manager->getEncryptionModules()));
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 	}
 
 	public function testModuleUnRegistration() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 		$this->assertSame(1,
 			count($this->manager->getEncryptionModules())
 		);
-		$this->manager->unregisterEncryptionModule($em);
+
+		$this->manager->unregisterEncryptionModule('id');
 		$this->assertEmpty($this->manager->getEncryptionModules());
+
 	}
 
 	/**
@@ -82,9 +85,9 @@ class ManagerTest extends TestCase {
 	public function testGetEncryptionModuleUnknown() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 		$this->assertSame(1, count($this->manager->getEncryptionModules()));
 		$this->manager->getEncryptionModule('unknown');
 	}
@@ -92,23 +95,23 @@ class ManagerTest extends TestCase {
 	public function testGetEncryptionModule() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 		$this->assertSame(1, count($this->manager->getEncryptionModules()));
-		$en0 = $this->manager->getEncryptionModule(0);
-		$this->assertEquals(0, $en0->getId());
+		$en0 = $this->manager->getEncryptionModule('id');
+		$this->assertEquals('id', $en0->getId());
 	}
 
 	public function testGetDefaultEncryptionModule() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
 		$em = $this->getMock('\OCP\Encryption\IEncryptionModule');
-		$em->expects($this->any())->method('getId')->willReturn(0);
+		$em->expects($this->any())->method('getId')->willReturn('id');
 		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-		$this->manager->registerEncryptionModule($em);
+		$this->manager->registerEncryptionModule('id', 'TestDummyModule0', function () use ($em) { return $em;});
 		$this->assertSame(1, count($this->manager->getEncryptionModules()));
-		$en0 = $this->manager->getEncryptionModule(0);
-		$this->assertEquals(0, $en0->getId());
+		$en0 = $this->manager->getEncryptionModule('id');
+		$this->assertEquals('id', $en0->getId());
 	}
 
 //	/**


### PR DESCRIPTION
make sure that we have two differnt instances of the encryption module if we do a stream_copy and read and write a encrypted stream at the same file. This was solved by regitsering a closure instead of a instance of the encryption module so  that we can create a new instance on every getEncryptionModule() call.

cc @DeepDiver1975 @PVince81 @th3fallen 
