### PR TITLE
Checks if getenv returns proper system environment variable results

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -118,6 +118,9 @@ $databaseOverload = (strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !==
 $template->assign('databaseOverload', $databaseOverload);
 $template->assign('cronErrors', $appConfig->getValue('core', 'cronErrors'));
 
+// warn if php is not setup properly to get system variables with getenv
+$template->assign('getenvServerNotWorking', empty(getenv('PATH')));
+
 // warn if Windows is used
 $template->assign('WindowsWarning', OC_Util::runningOnWindows());
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -67,6 +67,16 @@ if ($_['mail_smtpmode'] == 'qmail') {
 	<h2><?php p($l->t('Security & setup warnings'));?></h2>
 	<ul>
 <?php
+// is php setup properly to query system environment variables like getenv('PATH')
+if ($_['getenvServerNotWorking']) {
+?>
+	<li>
+		<?php p($l->t('php does not seem to be setup properly to query system environment variables. The test with getenv("PATH") only returns an empty response.')); ?><br>
+		<?php p($l->t('Please check the installation documentation for php configuration notes and the php configuration of your server, especially when using php-fpm.')); ?>
+	</li>
+<?php
+}
+
 // is read only config enabled
 if ($_['readOnlyConfigEnabled']) {
 ?>


### PR DESCRIPTION
In addition to:
#15597 (Adding a final fallback for findBinaryPath)
#15546 (SMB is broken - gone from the list of available external storages)

It checks if getenv('PATH') returns empty or a result. In case of empty, a warning is printed in the `Security and Setup` section of the admin page because php is not properly setup to return system environment variables.

It is also needed to update the documentation, will be done in an seperate PR.
