### PR TITLE
remove slow fade animation for tipsy tooltip

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1142,16 +1142,16 @@ function initCore() {
 	});
 
 	// all the tipsy stuff needs to be here (in reverse order) to work
-	$('.displayName .action').tipsy({gravity:'se', fade:true, live:true});
-	$('.password .action').tipsy({gravity:'se', fade:true, live:true});
-	$('#upload').tipsy({gravity:'w', fade:true});
-	$('.selectedActions a').tipsy({gravity:'s', fade:true, live:true});
-	$('a.action.delete').tipsy({gravity:'e', fade:true, live:true});
-	$('a.action').tipsy({gravity:'s', fade:true, live:true});
-	$('td .modified').tipsy({gravity:'s', fade:true, live:true});
-	$('td.lastLogin').tipsy({gravity:'s', fade:true, html:true});
-	$('input').tipsy({gravity:'w', fade:true});
-	$('.extra-data').tipsy({gravity:'w', fade:true, live:true});
+	$('.displayName .action').tipsy({gravity:'se', live:true});
+	$('.password .action').tipsy({gravity:'se', live:true});
+	$('#upload').tipsy({gravity:'w'});
+	$('.selectedActions a').tipsy({gravity:'s', live:true});
+	$('a.action.delete').tipsy({gravity:'e', live:true});
+	$('a.action').tipsy({gravity:'s', live:true});
+	$('td .modified').tipsy({gravity:'s', live:true});
+	$('td.lastLogin').tipsy({gravity:'s', html:true});
+	$('input').tipsy({gravity:'w'});
+	$('.extra-data').tipsy({gravity:'w', live:true});
 
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function(event) {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -162,7 +162,7 @@ var UserList = {
 		//original title. We use a temporary div to get back the html that we
 		//can pass later. It is also required to initialise tipsy.
 		var tooltip = $('<div>').html($($tdLastLogin.attr('original-title')).text(lastLoginAbs)).html();
-		$tdLastLogin.tipsy({gravity:'s', fade:true, html:true});
+		$tdLastLogin.tipsy({gravity:'s', html:true});
 		$tdLastLogin.attr('title', tooltip);
 
 		/**


### PR DESCRIPTION
The animation is a tad slow and also glitchy as it doesn’t seem to be very performant. Without it the tooltips and the overall experience seems a lot snappier.

Please review @owncloud/designers 
