### PR TITLE
Deprecate unused `\OCP\Response::sendFile`

### DIFF
--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -212,9 +212,10 @@ class OC_Response {
 	}
 
 	/**
-	* Send file as response, checking and setting caching headers
-	* @param string $filepath of file to send
-	*/
+	 * Send file as response, checking and setting caching headers
+	 * @param string $filepath of file to send
+	 * @deprecated Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
+	 */
 	static public function sendFile($filepath) {
 		$fp = fopen($filepath, 'rb');
 		if ($fp) {

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -214,7 +214,7 @@ class OC_Response {
 	/**
 	 * Send file as response, checking and setting caching headers
 	 * @param string $filepath of file to send
-	 * @deprecated Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
+	 * @deprecated 8.1.0 - Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
 	 */
 	static public function sendFile($filepath) {
 		$fp = fopen($filepath, 'rb');

--- a/lib/public/response.php
+++ b/lib/public/response.php
@@ -37,6 +37,7 @@ namespace OCP;
 /**
  * This class provides convenient functions to send the correct http response headers
  * @since 4.0.0
+ * @deprecated Use AppFramework controllers instead and modify the response object
  */
 class Response {
 	/**
@@ -103,6 +104,7 @@ class Response {
 	 * Send file as response, checking and setting caching headers
 	 * @param string $filepath of file to send
 	 * @since 4.0.0
+	 * @deprecated Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
 	 */
 	static public function sendFile( $filepath ) {
 		\OC_Response::sendFile( $filepath );

--- a/lib/public/response.php
+++ b/lib/public/response.php
@@ -37,7 +37,7 @@ namespace OCP;
 /**
  * This class provides convenient functions to send the correct http response headers
  * @since 4.0.0
- * @deprecated Use AppFramework controllers instead and modify the response object
+ * @deprecated 8.1.0 - Use AppFramework controllers instead and modify the response object
  */
 class Response {
 	/**
@@ -104,7 +104,7 @@ class Response {
 	 * Send file as response, checking and setting caching headers
 	 * @param string $filepath of file to send
 	 * @since 4.0.0
-	 * @deprecated Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
+	 * @deprecated 8.1.0 - Use \OCP\AppFramework\Http\StreamResponse or another AppFramework controller instead
 	 */
 	static public function sendFile( $filepath ) {
 		\OC_Response::sendFile( $filepath );


### PR DESCRIPTION
This function is unused in our own code and can be better achieved using the AppFramework. Also very easy to do grave mistakes using this function.

cc @MorrisJobke 
