### PR TITLE
[encryption2] set size and unencrypted size to zero at the beginning of a write operation

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -223,9 +223,8 @@ class Encryption extends Wrapper {
 			|| $mode === 'wb+'
 		) {
 			// We're writing a new file so start write counter with 0 bytes
-			// TODO can we remove this completely?
-			//$this->unencryptedSize = 0;
-			//$this->size = 0;
+			$this->unencryptedSize = 0;
+			$this->size = 0;
 			$this->readOnly = false;
 		} else {
 			$this->readOnly = true;


### PR DESCRIPTION
only read cache on write operations if fseek is supported by the storage. This improves the performance writing to external storages without fseek support (e.g. ftp) significantly.

In order to test this with a external storage you need to merge this branch with https://github.com/owncloud/core/pull/15445

cc @DeepDiver1975 @jknockaert please have a look if I didn't miss anything. Thanks!
