### PR TITLE
add disabled state to primary action button

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -233,12 +233,13 @@ textarea:disabled {
 }
 	.primary:hover, input[type="submit"].primary:hover, input[type="button"].primary:hover, button.primary:hover, .button.primary:hover,
 	.primary:focus, input[type="submit"].primary:focus, input[type="button"].primary:focus, button.primary:focus, .button.primary:focus {
-		border: 1px solid #1d2d44;
 		background-color: #304d76;
 		color: #fff;
 	}
-	.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active {
-		border: 1px solid #1d2d44;
+	.primary:active, input[type="submit"].primary:active, input[type="button"].primary:active, button.primary:active, .button.primary:active,
+	.primary:disabled, input[type="submit"].primary:disabled, input[type="button"].primary:disabled, button.primary:disabled, .button.primary:disabled,
+	.primary:disabled:hover, input[type="submit"].primary:disabled:hover, input[type="button"].primary:disabled:hover, button.primary:disabled:hover, .button.primary:disabled:hover,
+	.primary:disabled:focus, input[type="submit"].primary:disabled:focus, input[type="button"].primary:disabled:focus, button.primary:disabled:focus, .button.primary:disabled:focus {
 		background-color: #1d2d44;
 		color: #bbb;
 	}


### PR DESCRIPTION
The primary action button was missing a disabled state. That made it impossible to notice if it was disabled or not. This fixes that issue.

Please review @owncloud/designers @wurstchristoph
