### PR TITLE
Reset sharedialog values

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -982,6 +982,10 @@ $(document).ready(function() {
 		}
 
 		if (this.checked) {
+			// Reset password placeholder
+			$('#linkPassText').attr('placeholder', t('core', 'Choose a password for the public link'));
+			// Reset link
+			$('#linkText').val('');
 			var expireDateString = '';
 			if (oc_appconfig.core.defaultExpireDateEnabled) {
 				var date = new Date().getTime();

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -1013,7 +1013,7 @@ $(document).ready(function() {
 			} else {
 				$('#linkPass').slideToggle(OC.menuSpeed);
 				// TODO drop with IE8 drop
-				if(html.hasClass('ie8')) {
+				if($('html').hasClass('ie8')) {
 					$('#linkPassText').attr('placeholder', null);
 					$('#linkPassText').val('');
 				}
@@ -1120,7 +1120,6 @@ $(document).ready(function() {
 	$(document).on('focusout keyup', '#dropdown #linkPassText', function(event) {
 		var linkPassText = $('#linkPassText');
 		if ( linkPassText.val() != '' && (event.type == 'focusout' || event.keyCode == 13) ) {
-
 			var allowPublicUpload = $('#sharingDialogAllowPublicUpload').is(':checked');
 			var dropDown = $('#dropdown');
 			var itemType = dropDown.data('item-type');

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -129,6 +129,100 @@ describe('OC.Share tests', function() {
 				);
 				expect($('#dropdown #linkCheckbox').length).toEqual(0);
 			});
+			it('Reset link when password is enforced and link is toggled', function() { 
+				var old = oc_appconfig.core.enforcePasswordForPublicLink;
+				oc_appconfig.core.enforcePasswordForPublicLink = true;
+				$('#allowShareWithLink').val('yes');
+
+				OC.Share.showDropDown(
+					'file',
+					123,
+					$container,
+					true,
+					31,
+					'shared_file_name.txt'
+				);
+
+				// Toggle linkshare
+				$('#dropdown [name=linkCheckbox]').click();
+				expect($('#dropdown #linkText').val()).toEqual('');
+
+				// Set password
+				$('#dropdown #linkPassText').val('foo');
+				$('#dropdown #linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+				);
+
+				// Remove link
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[1].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({status: 'success'})
+				);
+
+				/*
+				 * Try to share again
+				 * The linkText should be emptied
+				 */
+				$('#dropdown [name=linkCheckbox]').click();
+				expect($('#dropdown #linkText').val()).toEqual('');
+
+				/*
+				 * Do not set password but untoggle
+				 * Since there is no share this should not result in another request to the server
+				 */
+				$('#dropdown [name=linkCheckbox]').click();
+				expect(fakeServer.requests.length).toEqual(2);
+
+				oc_appconfig.core.enforcePasswordForPublicLink = old;
+			});
+
+			it('Reset password placeholder when password is enforced and link is toggled', function() { 
+				var old = oc_appconfig.core.enforcePasswordForPublicLink;
+				oc_appconfig.core.enforcePasswordForPublicLink = true;
+				$('#allowShareWithLink').val('yes');
+
+				OC.Share.showDropDown(
+					'file',
+					123,
+					$container,
+					true,
+					31,
+					'shared_file_name.txt'
+				);
+
+				// Toggle linkshare
+				$('#dropdown [name=linkCheckbox]').click();
+				expect($('#dropdown #linkPassText').attr('placeholder')).toEqual('Choose a password for the public link');
+
+				// Set password
+				$('#dropdown #linkPassText').val('foo');
+				$('#dropdown #linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+				);
+				expect($('#dropdown #linkPassText').attr('placeholder')).toEqual('**********');
+
+				// Remove link
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[1].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({status: 'success'})
+				);
+
+				// Try to share again
+				$('#dropdown [name=linkCheckbox]').click();
+				expect($('#dropdown #linkPassText').attr('placeholder')).toEqual('Choose a password for the public link');
+
+				oc_appconfig.core.enforcePasswordForPublicLink = old;
+			});
 			it('shows populated link share when a link share exists', function() {
 				loadItemStub.returns({
 					reshare: [],


### PR DESCRIPTION
By not resetting the sharedialog values stuff breaks! See #15368

This resets the values to the correct state so the code works as expected again.

No unit tests yet as the IE8 check at https://github.com/owncloud/core/blob/master/core/js/share.js#L1012 breaks my unit tests. I already called in the help of @PVince81 about that.

Other than the unit test this can be tested already
