### PR TITLE
Show a text preview instead of a bitmap preview of text

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -32,7 +32,7 @@
 	position: relative;
 	text-align: left;
 	white-space: pre-wrap;
-	overflow-y: auto;
+	overflow-y: hidden;
 	height: auto;
 	min-height: 200px;
 	max-height: 800px;
@@ -42,16 +42,10 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	z-index: 1;
 }
 
-#imgframe .watermark {
-	color: #E3E3E3;
-	font-size: 75pt;
-	position: absolute;
-	width: 80%;
-	top: 100px;
-	z-index: 0;
+#imgframe .ellipsis {
+	font-size: 1.2em;
 }
 
 /* fix multiselect bar offset on shared page */

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -2,7 +2,6 @@
 	background: #fff;
 	text-align: center;
 	margin: 45px auto 0;
-	min-height: 600px;
 }
 
 #preview .notCreatable {
@@ -26,6 +25,22 @@
 #imgframe video {
 	max-height:100%;
 	max-width:100%;
+}
+
+#imgframe .text-preview {
+	display: inline-block;
+	text-align: left;
+	white-space: pre-wrap;
+	overflow-y: auto;
+	height: auto;
+	min-height: 200px;
+	max-height: 800px;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 
 /* fix multiselect bar offset on shared page */

--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -29,6 +29,7 @@
 
 #imgframe .text-preview {
 	display: inline-block;
+	position: relative;
 	text-align: left;
 	white-space: pre-wrap;
 	overflow-y: auto;
@@ -41,6 +42,16 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	z-index: 1;
+}
+
+#imgframe .watermark {
+	color: #E3E3E3;
+	font-size: 75pt;
+	position: absolute;
+	width: 80%;
+	top: 100px;
+	z-index: 0;
 }
 
 /* fix multiselect bar offset on shared page */

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -87,6 +87,7 @@ OCA.Sharing.PublicApp = {
 
 
 		// dynamically load image previews
+		var token = $('#sharingToken').val();
 		var bottomMargin = 350;
 		var previewWidth = $(window).width() * window.devicePixelRatio;
 		var previewHeight = $(window).height() - bottomMargin * window.devicePixelRatio;
@@ -96,7 +97,7 @@ OCA.Sharing.PublicApp = {
 			y: previewHeight,
 			a: 'true',
 			file: encodeURIComponent(this.initialDir + $('#filename').val()),
-			t: $('#sharingToken').val(),
+			t: token,
 			scalingup: 0
 		};
 
@@ -144,7 +145,6 @@ OCA.Sharing.PublicApp = {
 					filename = JSON.stringify(filename);
 				}
 				var path = dir || FileList.getCurrentDirectory();
-				var token = $('#sharingToken').val();
 				var params = {
 					path: path,
 					files: filename
@@ -154,12 +154,11 @@ OCA.Sharing.PublicApp = {
 
 			this.fileList.getAjaxUrl = function (action, params) {
 				params = params || {};
-				params.t = $('#sharingToken').val();
+				params.t = token;
 				return OC.filePath('files_sharing', 'ajax', action + '.php') + '?' + OC.buildQueryString(params);
 			};
 
 			this.fileList.linkTo = function (dir) {
-				var token = $('#sharingToken').val();
 				var params = {
 					dir: dir
 				};

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -112,26 +112,15 @@ OCA.Sharing.PublicApp = {
 			img.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text') {
 			// Undocumented Url to public WebDAV endpoint
-			var url = parent.location.protocol + '//' +
-				token + '@' + location.host + OC.linkTo('', 'public.php/webdav');
+			var url = parent.location.protocol + '//' + location.host + OC.linkTo('', 'public.php/webdav');
 			$.ajax({
 				url: url,
-				headers: {Range: "bytes=0-1000"}
+				headers: {
+					Authorization: 'Basic ' + btoa(token + ':'),
+					Range: 'bytes=0-1000'
+				}
 			}).then(function (data) {
-				var textDiv = $('<div/>').addClass('text-preview');
-				textDiv.text(data);
-				textDiv.appendTo('#imgframe');
-				var divHeight = textDiv.height();
-				if (data.length > 999) {
-					textDiv.append('</br></br><strong>(...)</strong>');
-					divHeight += 50;
-				}
-				if (divHeight > previewHeight) {
-					textDiv.height(previewHeight);
-				}
-				var watermark = $('<div/>').addClass('watermark');
-				watermark.text('SAMPLE');
-				watermark.appendTo('#imgframe');
+				self._showTextPreview(data, previewHeight);
 			});
 		} else if (previewSupported === 'true' ||
 			mimetype.substr(0, mimetype.indexOf('/')) === 'image' &&
@@ -155,7 +144,7 @@ OCA.Sharing.PublicApp = {
 					path: path,
 					files: filename
 				};
-				return OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString(params);
+				return OC.generateUrl('/s/' + token + '/download', params);
 			};
 
 			this.fileList.getAjaxUrl = function (action, params) {
@@ -165,10 +154,7 @@ OCA.Sharing.PublicApp = {
 			};
 
 			this.fileList.linkTo = function (dir) {
-				var params = {
-					dir: dir
-				};
-				return OC.generateUrl('/s/' + token + '') + '?' + OC.buildQueryString(params);
+				return OC.generateUrl('/s/' + token + '', {dir: dir});
 			};
 
 			this.fileList.generatePreviewUrl = function (urlSpec) {
@@ -238,6 +224,23 @@ OCA.Sharing.PublicApp = {
 
 		// legacy
 		window.FileList = this.fileList;
+	},
+
+	_showTextPreview: function (data, previewHeight) {
+		var textDiv = $('<div/>').addClass('text-preview');
+		textDiv.text(data);
+		textDiv.appendTo('#imgframe');
+		var divHeight = textDiv.height();
+		if (data.length > 999) {
+			textDiv.append('</br></br><strong>(&#133;)</strong>');
+			divHeight += 50;
+		}
+		if (divHeight > previewHeight) {
+			textDiv.height(previewHeight);
+		}
+		var watermark = $('<div/>').addClass('watermark');
+		watermark.text('SAMPLE');
+		watermark.appendTo('#imgframe');
 	},
 
 	_onDirectoryChanged: function (e) {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -118,7 +118,7 @@ OCA.Sharing.PublicApp = {
 				url: url,
 				headers: {Range: "bytes=0-1000"}
 			}).then(function (data) {
-				var textDiv = $('<span/>').addClass('text-preview');
+				var textDiv = $('<div/>').addClass('text-preview');
 				textDiv.text(data);
 				textDiv.appendTo('#imgframe');
 				var divHeight = textDiv.height();
@@ -129,6 +129,9 @@ OCA.Sharing.PublicApp = {
 				if (divHeight > previewHeight) {
 					textDiv.height(previewHeight);
 				}
+				var watermark = $('<div/>').addClass('watermark');
+				watermark.text('SAMPLE');
+				watermark.appendTo('#imgframe');
 			});
 		} else if (previewSupported === 'true' ||
 			mimetype.substr(0, mimetype.indexOf('/')) === 'image' &&

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -111,8 +111,11 @@ OCA.Sharing.PublicApp = {
 			img.attr('src', $('#downloadURL').val());
 			img.appendTo('#imgframe');
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text') {
+			// Undocumented Url to public WebDAV endpoint
+			var url = parent.location.protocol + '//' +
+				token + '@' + location.host + OC.linkTo('', 'public.php/webdav');
 			$.ajax({
-				url: $('#downloadURL').val(),
+				url: url,
 				headers: {Range: "bytes=0-1000"}
 			}).then(function (data) {
 				var textDiv = $('<span/>').addClass('text-preview');

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -87,9 +87,13 @@ OCA.Sharing.PublicApp = {
 
 
 		// dynamically load image previews
+		var bottomMargin = 350;
+		var previewWidth = $(window).width() * window.devicePixelRatio;
+		var previewHeight = $(window).height() - bottomMargin * window.devicePixelRatio;
+		previewHeight = Math.max(200, previewHeight);
 		var params = {
-			x: $(document).width() * window.devicePixelRatio,
-			y: $(document).height() * window.devicePixelRatio,
+			x: previewWidth,
+			y: previewHeight,
 			a: 'true',
 			file: encodeURIComponent(this.initialDir + $('#filename').val()),
 			t: $('#sharingToken').val(),
@@ -105,6 +109,23 @@ OCA.Sharing.PublicApp = {
 			(maxGifSize === -1 || fileSize <= (maxGifSize * 1024 * 1024))) {
 			img.attr('src', $('#downloadURL').val());
 			img.appendTo('#imgframe');
+		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text') {
+			$.ajax({
+				url: $('#downloadURL').val(),
+				headers: {Range: "bytes=0-1000"}
+			}).then(function (data) {
+				var textDiv = $('<span/>').addClass('text-preview');
+				textDiv.text(data);
+				textDiv.appendTo('#imgframe');
+				var divHeight = textDiv.height();
+				if (data.length > 999) {
+					textDiv.append('</br></br><strong>(...)</strong>');
+					divHeight += 50;
+				}
+				if (divHeight > previewHeight) {
+					textDiv.height(previewHeight);
+				}
+			});
 		} else if (previewSupported === 'true' ||
 			mimetype.substr(0, mimetype.indexOf('/')) === 'image' &&
 			mimetype !== 'image/svg+xml') {
@@ -128,7 +149,7 @@ OCA.Sharing.PublicApp = {
 					path: path,
 					files: filename
 				};
-				return OC.generateUrl('/s/'+token+'/download') + '?' + OC.buildQueryString(params);
+				return OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString(params);
 			};
 
 			this.fileList.getAjaxUrl = function (action, params) {
@@ -142,7 +163,7 @@ OCA.Sharing.PublicApp = {
 				var params = {
 					dir: dir
 				};
-				return OC.generateUrl('/s/'+token+'') + '?' + OC.buildQueryString(params);
+				return OC.generateUrl('/s/' + token + '') + '?' + OC.buildQueryString(params);
 			};
 
 			this.fileList.generatePreviewUrl = function (urlSpec) {
@@ -225,7 +246,7 @@ OCA.Sharing.PublicApp = {
 		this.fileList.changeDirectory(params.path || params.dir, false, true);
 	},
 
-	_saveToOwnCloud: function(remote, token, owner, name, isProtected) {
+	_saveToOwnCloud: function (remote, token, owner, name, isProtected) {
 		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
 
 		var url = remote + '/index.php/apps/files#' + 'remote=' + encodeURIComponent(location) // our location is the remote for the other server

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -232,15 +232,13 @@ OCA.Sharing.PublicApp = {
 		textDiv.appendTo('#imgframe');
 		var divHeight = textDiv.height();
 		if (data.length > 999) {
-			textDiv.append('</br></br><strong>(&#133;)</strong>');
-			divHeight += 50;
+			var ellipsis = $('<div/>').addClass('ellipsis');
+			ellipsis.html('(&#133;)');
+			ellipsis.appendTo('#imgframe');
 		}
 		if (divHeight > previewHeight) {
 			textDiv.height(previewHeight);
 		}
-		var watermark = $('<div/>').addClass('watermark');
-		watermark.text('SAMPLE');
-		watermark.appendTo('#imgframe');
 	},
 
 	_onDirectoryChanged: function (e) {


### PR DESCRIPTION
### A fix for
- Add public preview for text files https://github.com/owncloud/files_texteditor/issues/13
- Scale up the font on larger previews https://github.com/owncloud/core/issues/15635
- File preview is in way too small of a font https://github.com/owncloud/core/issues/11469
- Public page asks for previews of the wrong dimension https://github.com/owncloud/core/issues/15653

The text can now be seen with a standard font, without magnification or size problems.

**Bonus**: the preview size is fixed so that this page works on smaller devices.
