### PR TITLE
make sure that encrypted private keys always have a header

### DIFF
--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -140,7 +140,8 @@ class KeyManager {
 
 			// Encrypt private key empty passphrase
 			$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'], '');
-			$this->keyStorage->setSystemUserKey($this->publicShareKeyId . '.privateKey', $encryptedKey);
+			$header = $this->crypt->generateHeader();
+			$this->setSystemPrivateKey($this->publicShareKeyId, $header . $encryptedKey);
 		}
 
 		$this->keyId = $userSession && $userSession->isLoggedIn() ? $userSession->getUser()->getUID() : false;

--- a/apps/encryption/lib/recovery.php
+++ b/apps/encryption/lib/recovery.php
@@ -135,8 +135,9 @@ class Recovery {
 		$recoveryKey = $this->keyManager->getSystemPrivateKey($this->keyManager->getRecoveryKeyId());
 		$decryptedRecoveryKey = $this->crypt->decryptPrivateKey($recoveryKey, $oldPassword);
 		$encryptedRecoveryKey = $this->crypt->symmetricEncryptFileContent($decryptedRecoveryKey, $newPassword);
+		$header = $this->crypt->generateHeader();
 		if ($encryptedRecoveryKey) {
-			$this->keyManager->setSystemPrivateKey($this->keyManager->getRecoveryKeyId(), $encryptedRecoveryKey);
+			$this->keyManager->setSystemPrivateKey($this->keyManager->getRecoveryKeyId(), $header . $encryptedRecoveryKey);
 			return true;
 		}
 		return false;


### PR DESCRIPTION
add a header to every private key, otherwise we will not be able to decrypt it if the admin changed the encryption cipher at some point in time

cc @DeepDiver1975 @th3fallen
