### PR TITLE
Remove \OCP\App::register()

### DIFF
--- a/lib/public/app.php
+++ b/lib/public/app.php
@@ -41,18 +41,6 @@ namespace OCP;
  * @since 4.0.0
  */
 class App {
-	/**
-	 * Makes ownCloud aware of this app
-	 * @param array $data with all information
-	 * @return boolean
-	 *
-	 * @deprecated 4.5.0 This method is deprecated. Do not call it anymore.
-	 * It'll remain in our public API for compatibility reasons.
-	 *
-	 */
-	public static function register( $data ) {
-		return true; // don't do anything
-	}
 
 	/**
 	 * Adds an entry to the navigation


### PR DESCRIPTION
This method can be removed. This isn't used anymore since 4.5.0.

It's deprecated since mid 2012 https://github.com/owncloud/core/commit/e4679770c4d85896bef3e81125e86e272bb6cd64

It doesn't do anything since mid 2012 https://github.com/owncloud/core/commit/8a92cd21d6768fc27c4892583bef327da9a7e5f4

cc @karlitschek @DeepDiver1975 @LukasReschke @PVince81 
