### PR TITLE
Convert error and hint to string before writing to the output

### DIFF
--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -52,8 +52,8 @@ class Application {
 			$errors = \OC_Util::checkServer(\OC::$server->getConfig());
 			if (!empty($errors)) {
 				foreach ($errors as $error) {
-					$output->writeln($error['error']);
-					$output->writeln($error['hint']);
+					$output->writeln((string)$error['error']);
+					$output->writeln((string)$error['hint']);
 					$output->writeln('');
 				}
 				throw new \Exception("Environment not properly prepared.");


### PR DESCRIPTION
 fixes https://mailman.owncloud.org/pipermail/devel/2015-April/001184.html
