### PR TITLE
always open filter tab in raw mode, when 'Manually enter LDAP filters' i...

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
@@ -237,6 +237,7 @@ OCA = OCA || {};
 		 * @inheritdoc
 		 */
 		onActivate: function() {
+			this._super();
 			this.considerFeatureRequests();
 		},
 

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -75,9 +75,13 @@ OCA = OCA || {};
 
 		/**
 		 * this is called by the main view, if the tab is being switched to.
-		 * The concrete tab view can implement this if necessary.
 		 */
-		onActivate: function() { },
+		onActivate: function() {
+			if(!_.isUndefined(this.filterModeKey)
+				&& this.configModel.configuration.ldap_experienced_admin === '1') {
+				this.setFilterMode(this.configModel.FILTER_MODE_RAW);
+			}
+		},
 
 		/**
 		 * updates the tab when the model loaded a configuration and notified

--- a/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
@@ -184,6 +184,7 @@ OCA = OCA || {};
 		 * @inheritdoc
 		 */
 		onActivate: function() {
+			this._super();
 			this.considerFeatureRequests();
 			if(!this.managedItems.ldap_login_filter.$element.val()) {
 				this.configModel.requestWizard('ldap_login_filter');


### PR DESCRIPTION
...s checked

In the moment this is ignored, it caught my attention when working on the test plan.

How to test:
1. Have LDAP enabled
2. Have Basic tab completed correctly
3. “Manually enter LDAP filters” is enabled
4. Move to Users|Login|Group tab
5. The raw filter input field should always be enabled, no matter how the tab was left.

(Without 'Manually enter LDAP filters' checked, the last state is remembered).

@jnfrmarks @jvillafanez @MorrisJobke 
