### PR TITLE
Fix read-only cache

### DIFF
--- a/apps/files_sharing/lib/readonlycache.php
+++ b/apps/files_sharing/lib/readonlycache.php
@@ -28,7 +28,9 @@ use OC\Files\Cache\Cache;
 class ReadOnlyCache extends Cache {
 	public function get($path) {
 		$data = parent::get($path);
-		$data['permissions'] &= (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
+		if ($data !== false) {
+			$data['permissions'] &= (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
+		}
 		return $data;
 	}
 

--- a/apps/files_sharing/tests/readonlycache.php
+++ b/apps/files_sharing/tests/readonlycache.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Olivier Paroz <owncloud@interfasys.ch>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+use OCA\Files_sharing\Tests\TestCase;
+
+class Test_Files_Sharing_ReadOnly_Cache extends TestCase {
+
+	/**
+	 * @type \OC\Files\Storage\Storage
+	 */
+	protected $storage;
+
+	/**
+	 * @type OC\Files\Storage\StorageFactory
+	 */
+	protected $loader;
+
+	/**
+	 * @type OC\Files\Mount\MountPoint
+	 */
+	protected $readOnlyMount;
+
+	/**
+	 * @type \OCA\Files_Sharing\ReadOnlyWrapper
+	 */
+	protected $readOnlyStorage;
+
+	/**
+	 * @type \OC\Files\Cache\Cache
+	 */
+	protected $readOnlyCache;
+
+	protected function setUp() {
+		parent::setUp();
+
+		//error_reporting(E_ERROR | E_PARSE);
+
+		$this->view->mkdir('readonly');
+		$this->view->file_put_contents('readonly/foo.txt', 'foo');
+		$this->view->file_put_contents('readonly/bar.txt', 'bar');
+
+		list($this->storage) = $this->view->resolvePath('');
+		$this->loader = new \OC\Files\Storage\StorageFactory();
+		$this->readOnlyMount = new \OC\Files\Mount\MountPoint($this->storage,
+			'/readonly', [[]], $this->loader);
+		$this->readOnlyStorage = $this->loader->getInstance($this->readOnlyMount,
+			'\OCA\Files_Sharing\ReadOnlyWrapper', ['storage' => $this->storage]);
+
+		$this->readOnlyCache = $this->readOnlyStorage->getCache();
+	}
+
+	protected function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testSetup() {
+		$this->assertTrue($this->view->file_exists('/readonly/foo.txt'));
+
+		$perms = $this->readOnlyStorage->getPermissions('files/readonly/foo.txt');
+		$this->assertEquals(17, $perms);
+
+		$this->assertFalse($this->readOnlyStorage->unlink('files/readonly/foo.txt'));
+		$this->assertTrue($this->readOnlyStorage->file_exists('files/readonly/foo.txt'));
+
+		$this->assertInstanceOf('\OCA\Files_Sharing\ReadOnlyCache', $this->readOnlyCache);
+	}
+
+	public function testGet() {
+		$result = $this->readOnlyCache->get('files/readonly/foo.txt');
+		$this->assertNotEmpty($result);
+
+		$result = $this->readOnlyCache->get('files/readonly/proof does not exist.md');
+		$this->assertFalse($result);
+	}
+
+	public function testGetFolderContents() {
+		$results = $this->readOnlyCache->getFolderContents('files/readonly');
+		$this->assertNotEmpty($results);
+
+		foreach ($results as $result) {
+			$this->assertNotEmpty($result);
+		}
+
+		$results = $this->readOnlyCache->getFolderContents('files/iamaghost');
+		$this->assertEmpty($results);
+	}
+
+}

--- a/apps/files_sharing/tests/readonlycache.php
+++ b/apps/files_sharing/tests/readonlycache.php
@@ -18,39 +18,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-use OCA\Files_sharing\Tests\TestCase;
+namespace OCA\Files_Sharing\Tests;
 
-class Test_Files_Sharing_ReadOnly_Cache extends TestCase {
+class ReadOnlyCache extends TestCase {
 
-	/**
-	 * @type \OC\Files\Storage\Storage
-	 */
+	/** @var \OC\Files\Storage\Storage */
 	protected $storage;
 
-	/**
-	 * @type OC\Files\Storage\StorageFactory
-	 */
+	/** @var \OC\Files\Storage\StorageFactory */
 	protected $loader;
 
-	/**
-	 * @type OC\Files\Mount\MountPoint
-	 */
+	/** @var \OC\Files\Mount\MountPoint */
 	protected $readOnlyMount;
 
-	/**
-	 * @type \OCA\Files_Sharing\ReadOnlyWrapper
-	 */
+	/** @var \OCA\Files_Sharing\ReadOnlyWrapper */
 	protected $readOnlyStorage;
 
-	/**
-	 * @type \OC\Files\Cache\Cache
-	 */
+	/** @var \OC\Files\Cache\Cache */
 	protected $readOnlyCache;
 
 	protected function setUp() {
 		parent::setUp();
-
-		//error_reporting(E_ERROR | E_PARSE);
 
 		$this->view->mkdir('readonly');
 		$this->view->file_put_contents('readonly/foo.txt', 'foo');
@@ -66,10 +54,6 @@ class Test_Files_Sharing_ReadOnly_Cache extends TestCase {
 		$this->readOnlyCache = $this->readOnlyStorage->getCache();
 	}
 
-	protected function tearDown() {
-		parent::tearDown();
-	}
-
 	public function testSetup() {
 		$this->assertTrue($this->view->file_exists('/readonly/foo.txt'));
 
@@ -82,22 +66,26 @@ class Test_Files_Sharing_ReadOnly_Cache extends TestCase {
 		$this->assertInstanceOf('\OCA\Files_Sharing\ReadOnlyCache', $this->readOnlyCache);
 	}
 
-	public function testGet() {
+	public function testGetWhenFileExists() {
 		$result = $this->readOnlyCache->get('files/readonly/foo.txt');
 		$this->assertNotEmpty($result);
+	}
 
+	public function testGetWhenFileDoesNotExist() {
 		$result = $this->readOnlyCache->get('files/readonly/proof does not exist.md');
 		$this->assertFalse($result);
 	}
 
-	public function testGetFolderContents() {
+	public function testGetFolderContentsWhenFolderExists() {
 		$results = $this->readOnlyCache->getFolderContents('files/readonly');
 		$this->assertNotEmpty($results);
 
 		foreach ($results as $result) {
 			$this->assertNotEmpty($result);
 		}
+	}
 
+	public function testGetFolderContentsWhenFolderDoesNotExist() {
 		$results = $this->readOnlyCache->getFolderContents('files/iamaghost');
 		$this->assertEmpty($results);
 	}


### PR DESCRIPTION
Most methods which ask for a cache entry don't explicitly check if the result === false and will happily try to use whatever the cache is sending them.

The problem is that if a share is in read-only mode, all answers to queries about a file or folder's existence will be unreliable: the cache always returns an array which will be interpreted as a valid cache result.

This PR only fixes the result returned by the read-only cache.

Fixes #15551

@icewind1991 @PVince81 @nickvergessen 
