### PR TITLE
LDAP tests: switch var_dump to exception

### DIFF
--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -275,7 +275,7 @@ class Test_Wizard extends \Test\TestCase {
 				} else if($filter === 'mailPrimaryAddress') {
 					return 17;
 				}
-				var_dump($filter);
+				throw new \Exception('Untested filter: ' . $filter);
 			}));
 
 		$result = $wizard->detectEmailAttribute()->getResultArray();
@@ -314,7 +314,7 @@ class Test_Wizard extends \Test\TestCase {
 				} else if($filter === 'mailPrimaryAddress') {
 					return 17;
 				}
-				var_dump($filter);
+				throw new \Exception('Untested filter: ' . $filter);
 			}));
 
 		$result = $wizard->detectEmailAttribute()->getResultArray();
@@ -353,7 +353,7 @@ class Test_Wizard extends \Test\TestCase {
 				} else if($filter === 'mailPrimaryAddress') {
 					return 0;
 				}
-				var_dump($filter);
+				throw new \Exception('Untested filter: ' . $filter);
 			}));
 
 		$result = $wizard->detectEmailAttribute();


### PR DESCRIPTION
Noticed while read through scrutinizer.

Should have no impact (because only affects tests), but removes scrutinizer warnings.

cc @blizzz @DeepDiver1975 @nickvergessen @LukasReschke 
