### PR TITLE
IUrlGenerator - document linkTo properly

### DIFF
--- a/lib/public/iurlgenerator.php
+++ b/lib/public/iurlgenerator.php
@@ -59,10 +59,12 @@ interface IURLGenerator {
 	 * Returns an URL for an image or file
 	 * @param string $appName the name of the app
 	 * @param string $file the name of the file
+	 * @param array $args array with param=>value, will be appended to the returned url
+	 *    The value of $args will be urlencoded
 	 * @return string the url
 	 * @since 6.0.0
 	 */
-	public function linkTo($appName, $file);
+	public function linkTo($appName, $file, $args = array());
 
 	/**
 	 * Returns the link to an image, like linkTo but only with prepending img/


### PR DESCRIPTION
- parameter $args was there since 6.0.0
- see 61a9098b7d88656d0297a18c1b7685c04d1c64dc

Should fix some scrutinizer warnings

cc @DeepDiver1975 @LukasReschke 
