### PR TITLE
Add @deprecated to all methods with a proper method in \OCP

### DIFF
--- a/lib/public/backgroundjob.php
+++ b/lib/public/backgroundjob.php
@@ -80,6 +80,7 @@ class BackgroundJob {
 	/**
 	 * @param string $job
 	 * @param mixed $argument
+	 * @deprecated 8.1.0 Use \OC::$server->getJobList()->add() instead
 	 * @since 6.0.0
 	 */
 	public static function registerJob($job, $argument = null) {

--- a/lib/public/contacts.php
+++ b/lib/public/contacts.php
@@ -46,6 +46,7 @@ namespace OCP {
 	 * For updating it is mandatory to keep the id.
 	 * Without an id a new contact will be created.
 	 *
+	 * @deprecated 8.1.0 use methods of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 	 * @since 5.0.0
 	 */
 	class Contacts {
@@ -91,6 +92,7 @@ namespace OCP {
 		 * @param array $searchProperties defines the properties within the query pattern should match
 		 * @param array $options - for future use. One should always have options!
 		 * @return array an array of contacts which are arrays of key-value-pairs
+		 * @deprecated 8.1.0 use search() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function search($pattern, $searchProperties = array(), $options = array()) {
@@ -104,6 +106,7 @@ namespace OCP {
 		 * @param object $id the unique identifier to a contact
 		 * @param string $address_book_key
 		 * @return bool successful or not
+		 * @deprecated 8.1.0 use delete() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function delete($id, $address_book_key) {
@@ -118,6 +121,7 @@ namespace OCP {
 		 * @param array $properties this array if key-value-pairs defines a contact
 		 * @param string $address_book_key identifier of the address book in which the contact shall be created or updated
 		 * @return array an array representing the contact just created or updated
+		 * @deprecated 8.1.0 use createOrUpdate() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function createOrUpdate($properties, $address_book_key) {
@@ -129,6 +133,7 @@ namespace OCP {
 		 * Check if contacts are available (e.g. contacts app enabled)
 		 *
 		 * @return bool true if enabled, false if not
+		 * @deprecated 8.1.0 use isEnabled() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function isEnabled() {
@@ -138,6 +143,7 @@ namespace OCP {
 
 		/**
 		 * @param \OCP\IAddressBook $address_book
+		 * @deprecated 8.1.0 use registerAddressBook() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function registerAddressBook(\OCP\IAddressBook $address_book) {
@@ -147,6 +153,7 @@ namespace OCP {
 
 		/**
 		 * @param \OCP\IAddressBook $address_book
+		 * @deprecated 8.1.0 use unregisterAddressBook() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function unregisterAddressBook(\OCP\IAddressBook $address_book) {
@@ -156,6 +163,7 @@ namespace OCP {
 
 		/**
 		 * @return array
+		 * @deprecated 8.1.0 use getAddressBooks() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function getAddressBooks() {
@@ -165,6 +173,7 @@ namespace OCP {
 
 		/**
 		 * removes all registered address book instances
+		 * @deprecated 8.1.0 use clear() of \OCP\Contacts\IManager - \OC::$server->getContactsManager();
 		 * @since 5.0.0
 		 */
 		public static function clear() {

--- a/lib/public/db.php
+++ b/lib/public/db.php
@@ -40,6 +40,7 @@ namespace OCP;
 
 /**
  * This class provides access to the internal database system. Use this class exlusively if you want to access databases
+ * @deprecated 8.1.0 use methods of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
  * @since 4.5.0
  */
 class DB {
@@ -51,6 +52,7 @@ class DB {
 	 * @return \OC_DB_StatementWrapper prepared SQL query
 	 *
 	 * SQL query via Doctrine prepare(), needs to be execute()'d!
+	 * @deprecated 8.1.0 use prepare() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 4.5.0
 	 */
 	static public function prepare( $query, $limit=null, $offset=null ) {
@@ -66,6 +68,7 @@ class DB {
 	 *				If this is null or an empty array, all keys of $input will be compared
 	 * @return int number of inserted rows
 	 * @throws \Doctrine\DBAL\DBALException
+	 * @deprecated 8.1.0 use insertIfNotExist() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 5.0.0 - parameter $compare was added in 8.1.0
 	 *
 	 */
@@ -82,6 +85,7 @@ class DB {
 	 *
 	 * Call this method right after the insert command or other functions may
 	 * cause trouble!
+	 * @deprecated 8.1.0 use lastInsertId() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 4.5.0
 	 */
 	public static function insertid($table=null) {
@@ -90,6 +94,7 @@ class DB {
 
 	/**
 	 * Start a transaction
+	 * @deprecated 8.1.0 use beginTransaction() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 4.5.0
 	 */
 	public static function beginTransaction() {
@@ -98,6 +103,7 @@ class DB {
 
 	/**
 	 * Commit the database changes done during a transaction that is in progress
+	 * @deprecated 8.1.0 use commit() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 4.5.0
 	 */
 	public static function commit() {
@@ -106,6 +112,7 @@ class DB {
 
 	/**
 	 * Rollback the database changes done during a transaction that is in progress
+	 * @deprecated 8.1.0 use rollback() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 8.0.0
 	 */
 	public static function rollback() {
@@ -116,6 +123,7 @@ class DB {
 	 * Check if a result is an error, works with Doctrine
 	 * @param mixed $result
 	 * @return bool
+	 * @deprecated 8.1.0 Doctrine returns false on error (and throws an exception)
 	 * @since 4.5.0
 	 */
 	public static function isError($result) {
@@ -126,6 +134,7 @@ class DB {
 	 * returns the error code and message as a string for logging
 	 * works with DoctrineException
 	 * @return string
+	 * @deprecated 8.1.0 use getError() of \OCP\IDBConnection - \OC::$server->getDatabaseConnection()
 	 * @since 6.0.0
 	 */
 	public static function getErrorMessage() {

--- a/lib/public/files.php
+++ b/lib/public/files.php
@@ -91,6 +91,7 @@ class Files {
 	 * @return string
 	 *
 	 * temporary files are automatically cleaned up after the script is finished
+	 * @deprecated 8.1.0 use getTemporaryFile() of \OCP\ITempManager - \OC::$server->getTempManager()
 	 * @since 5.0.0
 	 */
 	public static function tmpFile( $postfix='' ) {
@@ -102,6 +103,7 @@ class Files {
 	 * @return string
 	 *
 	 * temporary files are automatically cleaned up after the script is finished
+	 * @deprecated 8.1.0 use getTemporaryFolder() of \OCP\ITempManager - \OC::$server->getTempManager()
 	 * @since 5.0.0
 	 */
 	public static function tmpFolder() {

--- a/lib/public/iusermanager.php
+++ b/lib/public/iusermanager.php
@@ -43,7 +43,7 @@ interface IUserManager {
 	 * register a user backend
 	 *
 	 * @param \OCP\UserInterface $backend
-		 * @since 8.0.0
+	 * @since 8.0.0
 	 */
 	public function registerBackend($backend);
 

--- a/lib/public/user.php
+++ b/lib/public/user.php
@@ -61,6 +61,7 @@ class User {
 	 * @param int|null $limit
 	 * @param int|null $offset
 	 * @return array an array of all uids
+	 * @deprecated 8.1.0 use method search() of \OCP\IUserManager - \OC::$server->getUserManager()
 	 * @since 5.0.0
 	 */
 	public static function getUsers( $search = '', $limit = null, $offset = null ) {
@@ -71,6 +72,8 @@ class User {
 	 * Get the user display name of the user currently logged in.
 	 * @param string|null $user user id or null for current user
 	 * @return string display name
+	 * @deprecated 8.1.0 fetch \OCP\IUser (has getDisplayName()) by using method
+	 *                   get() of \OCP\IUserManager - \OC::$server->getUserManager()
 	 * @since 5.0.0
 	 */
 	public static function getDisplayName( $user = null ) {
@@ -83,6 +86,7 @@ class User {
 	 * @param int|null $limit
 	 * @param int|null $offset
 	 * @return array an array of all display names (value) and the correspondig uids (key)
+	 * @deprecated 8.1.0 use method searchDisplayName() of \OCP\IUserManager - \OC::$server->getUserManager()
 	 * @since 5.0.0
 	 */
 	public static function getDisplayNames( $search = '', $limit = null, $offset = null ) {
@@ -103,6 +107,7 @@ class User {
 	 * @param string $uid the username
 	 * @param string $excludingBackend (default none)
 	 * @return boolean
+	 * @deprecated 8.1.0 use method userExists() of \OCP\IUserManager - \OC::$server->getUserManager()
 	 * @since 5.0.0
 	 */
 	public static function userExists( $uid, $excludingBackend = null ) {


### PR DESCRIPTION
I added a `@deprecate` tag with the version of deprecation to all methods with a proper method call in `\OCP`

cc @DeepDiver1975 
