### PR TITLE
Reduce call of legacy wrapper by call the OCP directly

### DIFF
--- a/lib/public/db.php
+++ b/lib/public/db.php
@@ -85,7 +85,7 @@ class DB {
 	 * @since 4.5.0
 	 */
 	public static function insertid($table=null) {
-		return(\OC_DB::insertid($table));
+		return \OC::$server->getDatabaseConnection()->lastInsertId($table);
 	}
 
 	/**
@@ -93,7 +93,7 @@ class DB {
 	 * @since 4.5.0
 	 */
 	public static function beginTransaction() {
-		\OC_DB::beginTransaction();
+		\OC::$server->getDatabaseConnection()->beginTransaction();
 	}
 
 	/**
@@ -101,7 +101,7 @@ class DB {
 	 * @since 4.5.0
 	 */
 	public static function commit() {
-		\OC_DB::commit();
+		\OC::$server->getDatabaseConnection()->commit();
 	}
 
 	/**
@@ -109,7 +109,7 @@ class DB {
 	 * @since 8.0.0
 	 */
 	public static function rollback() {
-		\OC_DB::rollback();
+		\OC::$server->getDatabaseConnection()->rollback();
 	}
 
 	/**
@@ -119,7 +119,8 @@ class DB {
 	 * @since 4.5.0
 	 */
 	public static function isError($result) {
-		return(\OC_DB::isError($result));
+		// Doctrine returns false on error (and throws an exception)
+		return $result === false;
 	}
 
 	/**
@@ -129,7 +130,7 @@ class DB {
 	 * @since 6.0.0
 	 */
 	public static function getErrorMessage() {
-		return(\OC_DB::getErrorMessage());
+		return \OC::$server->getDatabaseConnection()->getError();
 	}
 
 }

--- a/lib/public/files.php
+++ b/lib/public/files.php
@@ -94,7 +94,7 @@ class Files {
 	 * @since 5.0.0
 	 */
 	public static function tmpFile( $postfix='' ) {
-		return(\OC_Helper::tmpFile( $postfix ));
+		return \OC::$server->getTempManager()->getTemporaryFile($postfix);
 	}
 
 	/**
@@ -105,7 +105,7 @@ class Files {
 	 * @since 5.0.0
 	 */
 	public static function tmpFolder() {
-		return(\OC_Helper::tmpFolder());
+		return \OC::$server->getTempManager()->getTemporaryFolder();
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -395,7 +395,7 @@ class Util {
 	 * @since 4.0.0
 	 */
 	public static function imagePath( $app, $image ) {
-		return(\OC_Helper::imagePath( $app, $image ));
+		return \OC::$server->getURLGenerator()->imagePath($app, $image);
 	}
 
 	/**


### PR DESCRIPTION
- ref #15734
- reduces the call depth, because the private methods just call OCP stuff

cc @rullzer @DeepDiver1975 
