### PR TITLE
Replace `_method` requirement by {g,s}etMethods()

### DIFF
--- a/lib/private/route/route.php
+++ b/lib/private/route/route.php
@@ -37,7 +37,7 @@ class Route extends SymfonyRoute implements IRoute {
 	 * @return \OC\Route\Route
 	 */
 	public function method($method) {
-		$this->setRequirement('_method', strtoupper($method));
+		$this->setMethods($method);
 		return $this;
 	}
 
@@ -109,7 +109,7 @@ class Route extends SymfonyRoute implements IRoute {
 	 * @return \OC\Route\Route
 	 */
 	public function requirements($requirements) {
-		$method = $this->getRequirement('_method');
+		$method = $this->getMethods();
 		$this->setRequirements($requirements);
 		if (isset($requirements['_method'])) {
 			$method = $requirements['_method'];


### PR DESCRIPTION
Make the call compatible with future Symfony version, and avoid
E_USER_DEPRECATED as thrown by the current 2.7.0-beta1:

The "_method" requirement is deprecated since version 2.2 and will be
removed in 3.0. Use getMethods() instead. at
…/Symfony/Component/Routing/Route.php#554

The "_method" requirement is deprecated since version 2.2 and will be
removed in 3.0. Use the setMethods() method instead or the "methods"
option in the route definition. at
…/Symfony/Component/Routing/Route.php#662
