### PR TITLE
Add loading feedback for email change in user management

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -194,6 +194,14 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 	color: #000000;
 }
 
+#userlist .mailAddress .loading-small {
+	width: 16px;
+	height: 16px;
+	margin-left: -26px;
+	position: relative;
+	top: 3px;
+}
+
 tr:hover>td.password>span, tr:hover>td.displayName>span { margin:0; cursor:pointer; }
 tr:hover>td.remove>a, tr:hover>td.password>img,tr:hover>td.displayName>img, tr:hover>td.quota>img { visibility:visible; cursor:pointer; }
 td.remove {

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -34,7 +34,7 @@
 				src="<?php print_unescaped(image_path('core', 'actions/rename.svg'))?>"
 				alt="<?php p($l->t("set new password"))?>" title="<?php p($l->t("set new password"))?>"/>
 			</td>
-			<td class="mailAddress"><span></span> <img class="svg action"
+			<td class="mailAddress"><span></span><div class="loading-small hidden"></div> <img class="svg action"
 				src="<?php p(image_path('core', 'actions/rename.svg'))?>"
 				alt="<?php p($l->t('change email address'))?>" title="<?php p($l->t('change email address'))?>"/>
 			</td>


### PR DESCRIPTION
- show loading indicator while the request is running
- change value after the request succeed - not before and
  undo maybe wrong changes

The loading indicator is to the right of the input field

![bildschirmfoto am 2015-04-20 um 14 36 14](https://cloud.githubusercontent.com/assets/245432/7230064/b4d93d24-e76a-11e4-8948-17d265924e7a.png)

cc @LukasReschke @jancborchardt
