### PR TITLE
bring back border in host input field for consistency

### DIFF
--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -66,7 +66,6 @@
 	width: 100%;
 	margin-left: 0;
 	margin-right: 0;
-	border: 0;
 }
 
 .tableCellInput {


### PR DESCRIPTION
Fixes #15764 

Makes the border of the Host field in the LDAP Wizard look like the other text input fields.

Small changesets: gets rid of just a line of css. 

@jnfrmarks @MorrisJobke @nickvergessen or others, thx :)
