### PR TITLE
Do not restrict permissions for the original owner

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -356,7 +356,7 @@ OC.Share={
 		var data = OC.Share.loadItem(itemType, itemSource);
 		var dropDownEl;
 		var html = '<div id="dropdown" class="drop shareDropDown" data-item-type="'+itemType+'" data-item-source="'+itemSource+'">';
-		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined) {
+		if (data !== false && data.reshare !== false && data.reshare.uid_owner !== undefined && data.reshare.uid_owner !== OC.currentUser) {
 			html += '<span class="reshare">';
 			if (oc_config.enable_avatars === true) {
 				html += '<div class="avatar"></div> ';

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -29,6 +29,7 @@ describe('OC.Share tests', function() {
 		var oldEnableAvatars;
 		var avatarStub;
 		var placeholderStub;
+		var oldCurrentUser;
 
 		beforeEach(function() {
 			$('#testArea').append($('<div id="shareContainer"></div>'));
@@ -62,8 +63,12 @@ describe('OC.Share tests', function() {
 			oc_config.enable_avatars = false;
 			avatarStub = sinon.stub($.fn, 'avatar');
 			placeholderStub = sinon.stub($.fn, 'imageplaceholder');
+
+			oldCurrentUser = OC.currentUser;
+			OC.currentUser = 'user0';
 		});
 		afterEach(function() {
+			OC.currentUser = oldCurrentUser;
 			/* jshint camelcase:false */
 			oc_appconfig.core = oldAppConfig;
 			loadItemStub.restore();
@@ -863,6 +868,26 @@ describe('OC.Share tests', function() {
 						'shared_file_name.txt'
 					);
 					expect($('#dropdown #shareWithList').length).toEqual(0);
+				});
+				it('allows owner to share their own share when they are also the recipient', function() {
+					OC.currentUser = 'user1';
+					loadItemStub.returns({
+						reshare: {
+							permissions: OC.PERMISSION_READ,
+							uid_owner: 'user1'
+						},
+						shares: []
+					});
+					OC.Share.showDropDown(
+						'file',
+						123,
+						$container,
+						true,
+						OC.PERMISSION_ALL,
+						'shared_file_name.txt'
+					);
+					// sharing still allowed
+					expect($('#dropdown #shareWithList').length).toEqual(1);
 				});
 			});
 		});

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2100,7 +2100,9 @@ class Share extends Constants {
 				\OC_Log::write('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OC_Log::ERROR);
 				throw new \Exception($message_t);
 			}
+		}
 
+		if ($checkReshare && $checkReshare['uid_owner'] !== \OC_User::getUser()) {
 			// Check if share permissions is granted
 			if (self::isResharingAllowed() && (int)$checkReshare['permissions'] & \OCP\Constants::PERMISSION_SHARE) {
 				if (~(int)$checkReshare['permissions'] & $permissions) {

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -333,15 +333,15 @@ class Share extends Constants {
 		$shares = array();
 		$fileDependent = false;
 
+		$where = 'WHERE';
+		$fileDependentWhere = '';
 		if ($itemType === 'file' || $itemType === 'folder') {
 			$fileDependent = true;
 			$column = 'file_source';
-			$where = 'INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` ';
-			$where .= 'INNER JOIN `*PREFIX*storages` ON `numeric_id` = `*PREFIX*filecache`.`storage` ';
-			$where .= ' WHERE';
+			$fileDependentWhere = 'INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` ';
+			$fileDependentWhere .= 'INNER JOIN `*PREFIX*storages` ON `numeric_id` = `*PREFIX*filecache`.`storage` ';
 		} else {
 			$column = 'item_source';
-			$where = 'WHERE';
 		}
 
 		$select = self::createSelectStatement(self::FORMAT_NONE, $fileDependent);
@@ -364,7 +364,7 @@ class Share extends Constants {
 			$arguments[] = $owner;
 		}
 
-		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` '. $where);
+		$query = \OC_DB::prepare('SELECT ' . $select . ' FROM `*PREFIX*share` '. $fileDependentWhere . $where);
 
 		$result = \OC_DB::executeAudited($query, $arguments);
 
@@ -380,7 +380,7 @@ class Share extends Constants {
 			$groups = \OC_Group::getUserGroups($user);
 
 			if (!empty($groups)) {
-				$where = 'WHERE `' . $column . '` = ? AND `item_type` = ? AND `share_with` in (?)';
+				$where = $fileDependentWhere . ' WHERE `' . $column . '` = ? AND `item_type` = ? AND `share_with` in (?)';
 				$arguments = array($itemSource, $itemType, $groups);
 				$types = array(null, null, \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
 
@@ -394,7 +394,7 @@ class Share extends Constants {
 				// class isn't static anymore...
 				$conn = \OC_DB::getConnection();
 				$result = $conn->executeQuery(
-					'SELECT * FROM `*PREFIX*share` ' . $where,
+					'SELECT ' . $select . ' FROM `*PREFIX*share` ' . $where,
 					$arguments,
 					$types
 				);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -495,6 +495,38 @@ class Test_Share extends \Test\TestCase {
 
 	}
 
+	public function testSharingAFolderThatIsSharedWithAGroupOfTheOwner() {
+		OC_User::setUserId($this->user1);
+		$view = new \OC\Files\View('/' . $this->user1 . '/');
+		$view->mkdir('files/test');
+		$view->mkdir('files/test/sub1');
+		$view->mkdir('files/test/sub1/sub2');
+
+		$fileInfo = $view->getFileInfo('files/test/sub1');
+		$fileId = $fileInfo->getId();
+
+		$this->assertTrue(
+			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_GROUP, $this->group1, \OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_CREATE),
+			'Failed asserting that user 1 successfully shared "test/sub1" with group 1.'
+		);
+
+		$result = OCP\Share::getItemShared('folder', $fileId, Test_Share_Backend::FORMAT_SOURCE);
+		$this->assertNotEmpty($result);
+		$this->assertEquals(\OCP\Constants::PERMISSION_READ + \OCP\Constants::PERMISSION_CREATE, $result['permissions']);
+
+		$fileInfo = $view->getFileInfo('files/test/sub1/sub2');
+		$fileId = $fileInfo->getId();
+
+		$this->assertTrue(
+			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_USER, $this->user4, \OCP\Constants::PERMISSION_READ),
+			'Failed asserting that user 1 successfully shared "test/sub1/sub2" with user 4.'
+		);
+
+		$result = OCP\Share::getItemShared('folder', $fileId, Test_Share_Backend::FORMAT_SOURCE);
+		$this->assertNotEmpty($result);
+		$this->assertEquals(\OCP\Constants::PERMISSION_READ, $result['permissions']);
+	}
+
 	protected function shareUserOneTestFileWithGroupOne() {
 		OC_User::setUserId($this->user1);
 		$this->assertTrue(
@@ -760,6 +792,7 @@ class Test_Share extends \Test\TestCase {
 
 	/**
 	 * @param boolean|string $token
+	 * @return array
 	 */
 	protected function getShareByValidToken($token) {
 		$row = OCP\Share::getShareByToken($token);


### PR DESCRIPTION
Fix #15771 

``` js
            // reduce possible permissions to what the original share allowed
            possiblePermissions = possiblePermissions & data.reshare.permissions;
```

was wrongly called for the owner.

We should write a test for this, if someone can help me through the shareSpec.js that would be nice
