### PR TITLE
fix encryption header error

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author Björn Schießle <schiessle@owncloud.com>
- * @author jknockaert <jasper@knockaert.nl>
+ * @author Jasper Knockaert <jasper@knockaert.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -237,7 +237,6 @@ class Encryption extends Wrapper {
 		$accessList = $this->file->getAccessList($sharePath);
 		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $this->header, $accessList);
 
-		if (!($path==='')){
 		if (
 			$mode === 'w'
 			|| $mode === 'w+'
@@ -249,9 +248,9 @@ class Encryption extends Wrapper {
 			$this->writeHeader();
 			$this->size = $this->util->getHeaderSize();
 		} else {
-			parent::stream_read($this->util->getHeaderSize());
+			$this->skipHeader();
 		}
-		}
+
 		return true;
 
 	}
@@ -432,9 +431,16 @@ class Encryption extends Wrapper {
 	 * @return integer
 	 * @throws EncryptionHeaderKeyExistsException if header key is already in use
 	 */
-	private function writeHeader() {
+	protected function writeHeader() {
 		$header = $this->util->createHeader($this->newHeader, $this->encryptionModule);
 		return parent::stream_write($header);
+	}
+
+	/**
+	 * read first block to skip the header
+	 */
+	protected function skipHeader() {
+		parent::stream_read($this->util->getHeaderSize());
 	}
 
 }

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -229,6 +229,14 @@ class Encryption extends Wrapper {
 			$this->readOnly = true;
 		}
 
+		$sharePath = $this->fullPath;
+		if (!$this->storage->file_exists($this->internalPath)) {
+			$sharePath = dirname($sharePath);
+		}
+
+		$accessList = $this->file->getAccessList($sharePath);
+		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $this->header, $accessList);
+
 		if (
 			$mode === 'w'
 			|| $mode === 'w+'
@@ -242,14 +250,6 @@ class Encryption extends Wrapper {
 		} else {
 			parent::stream_read($this->util->getHeaderSize());
 		}
-
-		$sharePath = $this->fullPath;
-		if (!$this->storage->file_exists($this->internalPath)) {
-			$sharePath = dirname($sharePath);
-		}
-
-		$accessList = $this->file->getAccessList($sharePath);
-		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $this->header, $accessList);
 
 		return true;
 

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -237,6 +237,7 @@ class Encryption extends Wrapper {
 		$accessList = $this->file->getAccessList($sharePath);
 		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $this->header, $accessList);
 
+		if (!($path==='')){
 		if (
 			$mode === 'w'
 			|| $mode === 'w+'
@@ -250,7 +251,7 @@ class Encryption extends Wrapper {
 		} else {
 			parent::stream_read($this->util->getHeaderSize());
 		}
-
+		}
 		return true;
 
 	}

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -167,20 +167,20 @@ class Encryption extends \Test\TestCase {
 //		fclose($stream);
 //	}
 
-//	public function testRewind() {
-//		$fileName = tempnam("/tmp", "FOO");
-//		$stream = $this->getStream($fileName, 'w+', 0);
-//		$this->assertEquals(6, fwrite($stream, 'foobar'));
-//		$this->assertEquals(TRUE, rewind($stream));
-//		$this->assertEquals('foobar', fread($stream, 100));
-//		$this->assertEquals(TRUE, rewind($stream));
-//		$this->assertEquals(3, fwrite($stream, 'bar'));
-//		fclose($stream);
-//
-//		$stream = $this->getStream($fileName, 'r', 6);
-//		$this->assertEquals('barbar', fread($stream, 100));
-//		fclose($stream);
-//	}
+	public function testRewind() {
+		$fileName = tempnam("/tmp", "FOO");
+		$stream = $this->getStream($fileName, 'w+', 0);
+		$this->assertEquals(6, fwrite($stream, 'foobar'));
+		$this->assertEquals(TRUE, rewind($stream));
+		$this->assertEquals('foobar', fread($stream, 100));
+		$this->assertEquals(TRUE, rewind($stream));
+		$this->assertEquals(3, fwrite($stream, 'bar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r', 6);
+		$this->assertEquals('barbar', fread($stream, 100));
+		fclose($stream);
+	}
 
 	public function testSeek() {
 		$fileName = tempnam("/tmp", "FOO");

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -152,20 +152,20 @@ class Encryption extends \Test\TestCase {
 		unlink($fileName);
 	}
 
-	public function testWriteWriteRead() {
-		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
-		$this->assertEquals(6, fwrite($stream, 'foobar'));
-		fclose($stream);
-
-		$stream = $this->getStream($fileName, 'r+', 6);
-		$this->assertEquals(3, fwrite($stream, 'bar'));
-		fclose($stream);
-
-		$stream = $this->getStream($fileName, 'r', 6);
-		$this->assertEquals('barbar', fread($stream, 100));
-		fclose($stream);
-	}
+//	public function testWriteWriteRead() {
+//		$fileName = tempnam("/tmp", "FOO");
+//		$stream = $this->getStream($fileName, 'w+', 0);
+//		$this->assertEquals(6, fwrite($stream, 'foobar'));
+//		fclose($stream);
+//
+//		$stream = $this->getStream($fileName, 'r+', 6);
+//		$this->assertEquals(3, fwrite($stream, 'bar'));
+//		fclose($stream);
+//
+//		$stream = $this->getStream($fileName, 'r', 6);
+//		$this->assertEquals('barbar', fread($stream, 100));
+//		fclose($stream);
+//	}
 
 	public function testRewind() {
 		$fileName = tempnam("/tmp", "FOO");

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -152,6 +152,36 @@ class Encryption extends \Test\TestCase {
 		unlink($fileName);
 	}
 
+	public function testWriteWriteRead() {
+		$fileName = tempnam("/tmp", "FOO");
+		$stream = $this->getStream($fileName, 'w+', 0);
+		$this->assertEquals(6, fwrite($stream, 'foobar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r+', 6);
+		$this->assertEquals(3, fwrite($stream, 'bar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r', 6);
+		$this->assertEquals('barbar', fread($stream, 100));
+		fclose($stream);
+	}
+
+	public function testRewind() {
+		$fileName = tempnam("/tmp", "FOO");
+		$stream = $this->getStream($fileName, 'w+', 0);
+		$this->assertEquals(6, fwrite($stream, 'foobar'));
+		$this->assertEquals(TRUE, rewind($stream));
+		$this->assertEquals('foobar', fread($stream, 100));
+		$this->assertEquals(TRUE, rewind($stream));
+		$this->assertEquals(3, fwrite($stream, 'bar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r', 6);
+		$this->assertEquals('barbar', fread($stream, 100));
+		fclose($stream);
+	}
+
 	public function testSeek() {
 		$fileName = tempnam("/tmp", "FOO");
 		$stream = $this->getStream($fileName, 'w+', 0);

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -167,20 +167,20 @@ class Encryption extends \Test\TestCase {
 //		fclose($stream);
 //	}
 
-	public function testRewind() {
-		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
-		$this->assertEquals(6, fwrite($stream, 'foobar'));
-		$this->assertEquals(TRUE, rewind($stream));
-		$this->assertEquals('foobar', fread($stream, 100));
-		$this->assertEquals(TRUE, rewind($stream));
-		$this->assertEquals(3, fwrite($stream, 'bar'));
-		fclose($stream);
-
-		$stream = $this->getStream($fileName, 'r', 6);
-		$this->assertEquals('barbar', fread($stream, 100));
-		fclose($stream);
-	}
+//	public function testRewind() {
+//		$fileName = tempnam("/tmp", "FOO");
+//		$stream = $this->getStream($fileName, 'w+', 0);
+//		$this->assertEquals(6, fwrite($stream, 'foobar'));
+//		$this->assertEquals(TRUE, rewind($stream));
+//		$this->assertEquals('foobar', fread($stream, 100));
+//		$this->assertEquals(TRUE, rewind($stream));
+//		$this->assertEquals(3, fwrite($stream, 'bar'));
+//		fclose($stream);
+//
+//		$stream = $this->getStream($fileName, 'r', 6);
+//		$this->assertEquals('barbar', fread($stream, 100));
+//		fclose($stream);
+//	}
 
 	public function testSeek() {
 		$fileName = tempnam("/tmp", "FOO");

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -152,20 +152,20 @@ class Encryption extends \Test\TestCase {
 		unlink($fileName);
 	}
 
-//	public function testWriteWriteRead() {
-//		$fileName = tempnam("/tmp", "FOO");
-//		$stream = $this->getStream($fileName, 'w+', 0);
-//		$this->assertEquals(6, fwrite($stream, 'foobar'));
-//		fclose($stream);
-//
-//		$stream = $this->getStream($fileName, 'r+', 6);
-//		$this->assertEquals(3, fwrite($stream, 'bar'));
-//		fclose($stream);
-//
-//		$stream = $this->getStream($fileName, 'r', 6);
-//		$this->assertEquals('barbar', fread($stream, 100));
-//		fclose($stream);
-//	}
+	public function testWriteWriteRead() {
+		$fileName = tempnam("/tmp", "FOO");
+		$stream = $this->getStream($fileName, 'w+', 0);
+		$this->assertEquals(6, fwrite($stream, 'foobar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r+', 6);
+		$this->assertEquals(3, fwrite($stream, 'bar'));
+		fclose($stream);
+
+		$stream = $this->getStream($fileName, 'r', 6);
+		$this->assertEquals('barbar', fread($stream, 100));
+		fclose($stream);
+	}
 
 	public function testRewind() {
 		$fileName = tempnam("/tmp", "FOO");


### PR DESCRIPTION
When moving back the pointer to position 0 (using stream_seek), the pointer on the encrypted stream will be moved to the position immediately after the header. Reading the header again (invoked by stream_read) will cause an error, writing the header again (invoked by stream_write) will corrupt the file. Reading/writing the header should therefore happen when opening the file rather than upon read or write. Note that a side-effect of this PR is that empty files will still get an encryption header; I think that is OK, but it is different from how it was originally implemented.
@schiesbn @PVince81 Could you pls check?
