### PR TITLE
add whitespace to bottom of files list to correctly show dropdowns

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -602,18 +602,19 @@ a.action>img {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
 	filter: alpha(opacity=30);
 	opacity: .3;
-	height: 60px;
+	/* add whitespace to bottom of files list to correctly show dropdowns */
+	height: 300px;
 }
-
 .summary:hover,
 .summary:focus,
 .summary,
 table tr.summary td {
 	background-color: transparent;
 }
-
 .summary td {
 	border-bottom: none;
+	vertical-align: top;
+	padding-top: 20px;
 }
 .summary .info {
 	margin-left: 40px;


### PR DESCRIPTION
Fix #15801, please review @donniezazen @nickvergessen @owncloud/designers 

Who removed that whitespace in the first place? cc @MorrisJobke @PVince81 do you know? Did it have something to do with lazy loading? Seems to work fine.
