### PR TITLE
dont allow using null as view root

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -77,7 +77,7 @@ class View {
 	 */
 	public function __construct($root = '') {
 		if (is_null($root)) {
-			throw new \InvalidArgumentException('Root cant be null');
+			throw new \InvalidArgumentException('Root can\'t be null');
 		}
 		if(!Filesystem::isValidPath($root)) {
 			throw new \Exception();

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -76,6 +76,9 @@ class View {
 	 * @throws \Exception If $root contains an invalid path
 	 */
 	public function __construct($root = '') {
+		if (is_null($root)) {
+			throw new \InvalidArgumentException('Root cant be null');
+		}
 		if(!Filesystem::isValidPath($root)) {
 			throw new \Exception();
 		}
@@ -85,6 +88,9 @@ class View {
 	}
 
 	public function getAbsolutePath($path = '/') {
+		if ($path === null) {
+			return null;
+		}
 		$this->assertPathLength($path);
 		if ($path === '') {
 			$path = '/';

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -30,7 +30,7 @@ class TemporaryNoCross extends \OC\Files\Storage\Temporary {
 
 class TemporaryNoLocal extends \OC\Files\Storage\Temporary {
 	public function instanceOfStorage($className) {
-		if($className === '\OC\Files\Storage\Local') {
+		if ($className === '\OC\Files\Storage\Local') {
 			return false;
 		} else {
 			return parent::instanceOfStorage($className);
@@ -952,7 +952,7 @@ class View extends \Test\TestCase {
 
 		$storage2->expects($this->any())
 			->method('fopen')
-			->will($this->returnCallback(function($path, $mode) use($storage2) {
+			->will($this->returnCallback(function ($path, $mode) use ($storage2) {
 				$source = fopen($storage2->getSourcePath($path), $mode);
 				return \OC\Files\Stream\Quota::wrap($source, 9);
 			}));
@@ -1062,5 +1062,22 @@ class View extends \Test\TestCase {
 		$storage = $mount->getStorage();
 		$watcher = $storage->getWatcher();
 		$this->assertEquals(Watcher::CHECK_NEVER, $watcher->getPolicy());
+	}
+
+	public function testGetAbsolutePathOnNull() {
+		$view = new \OC\Files\View();
+		$this->assertNull($view->getAbsolutePath(null));
+	}
+
+	public function testGetRelativePathOnNull() {
+		$view = new \OC\Files\View();
+		$this->assertNull($view->getRelativePath(null));
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testNullAsRoot() {
+		new \OC\Files\View(null);
 	}
 }


### PR DESCRIPTION
Also changes `getAbsolutePath` to preserve null values

cc @PVince81 @DeepDiver1975 
