### PR TITLE
Only get encryption status when logged in

### DIFF
--- a/apps/encryption/js/encryption.js
+++ b/apps/encryption/js/encryption.js
@@ -15,7 +15,7 @@ if (!OC.Encryption) {
  */
 OC.Encryption = {
 	displayEncryptionWarning: function () {
-		if (!OC.Notification.isHidden()) {
+		if (!OC.currentUser || !OC.Notification.isHidden()) {
 			return;
 		}
 


### PR DESCRIPTION
This removes useless warnings in the logs.

Fixes https://github.com/owncloud/core/issues/15827

@schiesbn @th3fallen @nickvergessen @DeepDiver1975 
