### PR TITLE
Delete temp files after testing encryption stream wrapper

### DIFF
--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -148,6 +148,8 @@ class Encryption extends \Test\TestCase {
 		$stream = $this->getStream($fileName, 'r', 6);
 		$this->assertEquals('foobar', fread($stream, 100));
 		fclose($stream);
+
+		unlink($fileName);
 	}
 
 	public function testSeek() {
@@ -161,6 +163,8 @@ class Encryption extends \Test\TestCase {
 		$stream = $this->getStream($fileName, 'r', 9);
 		$this->assertEquals('foofoobar', fread($stream, 100));
 		fclose($stream);
+
+		unlink($fileName);
 	}
 
 	function dataFilesProvider() {
@@ -198,6 +202,8 @@ class Encryption extends \Test\TestCase {
 		fclose($stream);
 
 		$this->assertEquals($expectedData, $data);
+
+		unlink($fileName);
 	}
 
 	/**


### PR DESCRIPTION
I wasn't happy to see all these remaining "/tmp/FOO*" files after running the tests.

This PR fixes that.

Note: tempnam doesn't take care of cleaning up temp files at the end of the PHP process

@schiesbn @th3fallen @DeepDiver1975 
