### PR TITLE
[encryption] fix moving files to a shared folder

### DIFF
--- a/lib/private/encryption/file.php
+++ b/lib/private/encryption/file.php
@@ -36,7 +36,7 @@ class File implements \OCP\Encryption\IFile {
 	 * get list of users with access to the file
 	 *
 	 * @param string $path to the file
-	 * @return array
+	 * @return array  ['users' => $uniqueUserIds, 'public' => $public]
 	 */
 	public function getAccessList($path) {
 
@@ -46,7 +46,7 @@ class File implements \OCP\Encryption\IFile {
 		// always add owner to the list of users with access to the file
 		$userIds = array($owner);
 
-		if (!$this->util->isFile($ownerPath)) {
+		if (!$this->util->isFile($owner . '/' . $ownerPath)) {
 			return array('users' => $userIds, 'public' => false);
 		}
 

--- a/lib/private/encryption/keys/storage.php
+++ b/lib/private/encryption/keys/storage.php
@@ -235,6 +235,7 @@ class Storage implements IStorage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @return boolean
 	 */
 	public function renameKeys($source, $target) {
 
@@ -253,7 +254,11 @@ class Storage implements IStorage {
 		if ($this->view->file_exists($sourcePath)) {
 			$this->keySetPreparation(dirname($targetPath));
 			$this->view->rename($sourcePath, $targetPath);
+
+			return true;
 		}
+
+		return false;
 	}
 
 	/**
@@ -261,6 +266,7 @@ class Storage implements IStorage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @return boolean
 	 */
 	public function copyKeys($source, $target) {
 
@@ -279,7 +285,10 @@ class Storage implements IStorage {
 		if ($this->view->file_exists($sourcePath)) {
 			$this->keySetPreparation(dirname($targetPath));
 			$this->view->copy($sourcePath, $targetPath);
+			return true;
 		}
+
+		return false;
 	}
 
 	/**

--- a/lib/private/encryption/manager.php
+++ b/lib/private/encryption/manager.php
@@ -22,6 +22,7 @@
 
 namespace OC\Encryption;
 
+use OC\Files\Filesystem;
 use OC\Files\Storage\Shared;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
@@ -222,7 +223,24 @@ class Manager implements IManager {
 				$uid = $user ? $user->getUID() : null;
 				$fileHelper = \OC::$server->getEncryptionFilesHelper();
 				$keyStorage = \OC::$server->getEncryptionKeyStorage();
-				return new Encryption($parameters, $manager, $util, $logger, $fileHelper, $uid, $keyStorage);
+				$update = new Update(
+					new View(),
+					$util,
+					Filesystem::getMountManager(),
+					$manager,
+					$fileHelper,
+					$uid
+				);
+				return new Encryption(
+					$parameters,
+					$manager,
+					$util,
+					$logger,
+					$fileHelper,
+					$uid,
+					$keyStorage,
+					$update
+				);
 			} else {
 				return $storage;
 			}

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -23,15 +23,15 @@
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
-use OC\Encryption\File;
-use OC\Encryption\Manager;
 use OC\Encryption\Update;
 use OC\Encryption\Util;
 use OC\Files\Filesystem;
 use OC\Files\Storage\LocalTempFileTrait;
-use OC\Log;
+use OCP\Encryption\IFile;
+use OCP\Encryption\IManager;
 use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Mount\IMountPoint;
+use OCP\ILogger;
 
 class Encryption extends Wrapper {
 
@@ -43,10 +43,10 @@ class Encryption extends Wrapper {
 	/** @var \OC\Encryption\Util */
 	private $util;
 
-	/** @var \OC\Encryption\Manager */
+	/** @var \OCP\Encryption\IManager */
 	private $encryptionManager;
 
-	/** @var \OC\Log */
+	/** @var \OCP\ILogger */
 	private $logger;
 
 	/** @var string */
@@ -55,7 +55,7 @@ class Encryption extends Wrapper {
 	/** @var array */
 	private $unencryptedSize;
 
-	/** @var File */
+	/** @var \OCP\Encryption\IFile */
 	private $fileHelper;
 
 	/** @var IMountPoint */
@@ -69,20 +69,20 @@ class Encryption extends Wrapper {
 
 	/**
 	 * @param array $parameters
-	 * @param \OC\Encryption\Manager $encryptionManager
+	 * @param \OCP\Encryption\IManager $encryptionManager
 	 * @param \OC\Encryption\Util $util
-	 * @param \OC\Log $logger
-	 * @param File $fileHelper
+	 * @param \OCP\ILogger $logger
+	 * @param \OCP\Encryption\IFile $fileHelper
 	 * @param string $uid user who perform the read/write operation (null for public access)
 	 * @param IStorage $keyStorage
 	 * @param Update $update
 	 */
 	public function __construct(
 			$parameters,
-			Manager $encryptionManager = null,
+			IManager $encryptionManager = null,
 			Util $util = null,
-			Log $logger = null,
-			File $fileHelper = null,
+			ILogger $logger = null,
+			IFile $fileHelper = null,
 			$uid = null,
 			IStorage $keyStorage = null,
 			Update $update = null

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -256,9 +256,9 @@ class Encryption extends Wrapper {
 		$result = $this->storage->copy($path1, $path2);
 		if ($result) {
 			$target = $this->getFullPath($path2);
-			$encryptionModule = $this->getEncryptionModule($path2);
-			if ($encryptionModule) {
-				$this->keyStorage->copyKeys($source, $target);
+			$this->keyStorage->copyKeys($source, $target);
+			if (dirname($source) !== dirname($target) && $this->util->isFile($target)) {
+				$this->update->update($target);
 			}
 		}
 

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -230,8 +230,11 @@ class Encryption extends Wrapper {
 			if (isset($this->unencryptedSize[$source])) {
 				$this->unencryptedSize[$target] = $this->unencryptedSize[$source];
 			}
-			$this->keyStorage->renameKeys($source, $target);
-			if (dirname($source) !== dirname($target) && $this->util->isFile($target)) {
+			$keysRenamed = $this->keyStorage->renameKeys($source, $target);
+			if ($keysRenamed &&
+				dirname($source) !== dirname($target) &&
+				$this->util->isFile($target)
+			) {
 				$this->update->update($target);
 			}
 		}
@@ -256,8 +259,11 @@ class Encryption extends Wrapper {
 		$result = $this->storage->copy($path1, $path2);
 		if ($result) {
 			$target = $this->getFullPath($path2);
-			$this->keyStorage->copyKeys($source, $target);
-			if (dirname($source) !== dirname($target) && $this->util->isFile($target)) {
+			$keysCopied = $this->keyStorage->copyKeys($source, $target);
+			if ($keysCopied &&
+				dirname($source) !== dirname($target) &&
+				$this->util->isFile($target)
+			) {
 				$this->update->update($target);
 			}
 		}

--- a/lib/public/encryption/keys/istorage.php
+++ b/lib/public/encryption/keys/istorage.php
@@ -153,6 +153,7 @@ interface IStorage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @return boolean
 	 * @since 8.1.0
 	 */
 	public function renameKeys($source, $target);
@@ -162,6 +163,7 @@ interface IStorage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @retrun boolean
 	 * @since 8.1.0
 	 */
 	public function copyKeys($source, $target);

--- a/lib/public/encryption/keys/istorage.php
+++ b/lib/public/encryption/keys/istorage.php
@@ -163,7 +163,7 @@ interface IStorage {
 	 *
 	 * @param string $source
 	 * @param string $target
-	 * @retrun boolean
+	 * @return boolean
 	 * @since 8.1.0
 	 */
 	public function copyKeys($source, $target);

--- a/tests/lib/encryption/updatetest.php
+++ b/tests/lib/encryption/updatetest.php
@@ -52,7 +52,7 @@ class UpdateTest extends TestCase {
 	/** @var \OC\Encryption\File | \PHPUnit_Framework_MockObject_MockObject */
 	private $fileHelper;
 
-	public function setUp() {
+	protected function setUp() {
 		parent::setUp();
 
 		$this->view = $this->getMockBuilder('\OC\Files\View')

--- a/tests/lib/encryption/updatetest.php
+++ b/tests/lib/encryption/updatetest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\Encryption;
+
+
+use OC\Encryption\Update;
+use Test\TestCase;
+
+class UpdateTest extends TestCase {
+
+	/** @var \OC\Encryption\Update */
+	private $update;
+
+	/** @var string */
+	private $uid;
+
+	/** @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject */
+	private $view;
+
+	/** @var \OC\Encryption\Util | \PHPUnit_Framework_MockObject_MockObject */
+	private $util;
+
+	/** @var \OC\Files\Mount\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	private $mountManager;
+
+	/** @var \OC\Encryption\Manager | \PHPUnit_Framework_MockObject_MockObject */
+	private $encryptionManager;
+
+	/** @var \OCP\Encryption\IEncryptionModule | \PHPUnit_Framework_MockObject_MockObject */
+	private $encryptionModule;
+
+	/** @var \OC\Encryption\File | \PHPUnit_Framework_MockObject_MockObject */
+	private $fileHelper;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->view = $this->getMockBuilder('\OC\Files\View')
+			->disableOriginalConstructor()->getMock();
+		$this->util = $this->getMockBuilder('\OC\Encryption\Util')
+			->disableOriginalConstructor()->getMock();
+		$this->mountManager = $this->getMockBuilder('\OC\Files\Mount\Manager')
+			->disableOriginalConstructor()->getMock();
+		$this->encryptionManager = $this->getMockBuilder('\OC\Encryption\Manager')
+			->disableOriginalConstructor()->getMock();
+		$this->fileHelper = $this->getMockBuilder('\OC\Encryption\File')
+			->disableOriginalConstructor()->getMock();
+		$this->encryptionModule = $this->getMockBuilder('\OCP\Encryption\IEncryptionModule')
+			->disableOriginalConstructor()->getMock();
+
+		$this->encryptionManager->expects($this->once())
+			->method('getDefaultEncryptionModule')
+			->willReturn($this->encryptionModule);
+
+		$this->uid = 'testUser1';
+
+		$this->update = new Update(
+			$this->view,
+			$this->util,
+			$this->mountManager,
+			$this->encryptionManager,
+			$this->fileHelper,
+			$this->uid);
+	}
+
+	/**
+	 * @dataProvider dataTestUpdate
+	 *
+	 * @param string $path
+	 * @param boolean $isDir
+	 * @param array $allFiles
+	 * @param integer $numberOfFiles
+	 */
+	public function testUpdate($path, $isDir, $allFiles, $numberOfFiles) {
+
+		$this->view->expects($this->once())
+			->method('is_dir')
+			->willReturn($isDir);
+
+		if($isDir) {
+			$this->util->expects($this->once())
+				->method('getAllFiles')
+				->willReturn($allFiles);
+		}
+
+		$this->fileHelper->expects($this->exactly($numberOfFiles))
+			->method('getAccessList')
+			->willReturn(['users' => [], 'public' => false]);
+
+		$this->encryptionModule->expects($this->exactly($numberOfFiles))
+			->method('update')
+			->willReturn(true);
+
+		$this->update->update($path);
+	}
+
+	/**
+	 * data provider for testUpdate()
+	 *
+	 * @return array
+	 */
+	public function dataTestUpdate() {
+		return array(
+			array('/user/files/foo', true, ['/user/files/foo/file1.txt', '/user/files/foo/file1.txt'], 2),
+			array('/user/files/test.txt', false, [], 1),
+		);
+	}
+
+}

--- a/tests/lib/encryption/utiltest.php
+++ b/tests/lib/encryption/utiltest.php
@@ -152,4 +152,25 @@ class UtilTest extends TestCase {
 		return false;
 	}
 
+	/**
+	 * @dataProvider dataTestIsFile
+	 */
+	public function testIsFile($path, $expected) {
+		$this->assertSame($expected,
+			$this->util->isFile($path)
+		);
+	}
+
+	public function dataTestIsFile() {
+		return array(
+			array('/user/files/test.txt', true),
+			array('/user/files', true),
+			array('/user/files_versions/test.txt', false),
+			array('/user/foo/files/test.txt', false),
+			array('/files/foo/files/test.txt', false),
+			array('/user', false),
+			array('/user/test.txt', false),
+		);
+	}
+
 }

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -44,7 +44,7 @@ class Encryption extends \Test\Files\Storage\Storage {
 	 */
 	private $update;
 
-	public function setUp() {
+	protected function setUp() {
 
 		parent::setUp();
 
@@ -127,7 +127,7 @@ class Encryption extends \Test\Files\Storage\Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestRename
+	 * @dataProvider dataTestCopyAndRename
 	 *
 	 * @param string $source
 	 * @param string $target
@@ -154,25 +154,13 @@ class Encryption extends \Test\Files\Storage\Storage {
 	}
 
 	/**
-	 * data provider for testRename()
-	 *
-	 * @return array
-	 */
-	public function dataTestRename() {
-		return array(
-			array('source', 'target', false),
-			array('source', '/subFolder/target', true),
-		);
-	}
-
-	/**
-	 * @dataProvider dataTestCopy
+	 * @dataProvider dataTestCopyAndRename
 	 *
 	 * @param string $source
 	 * @param string $target
 	 * @param boolean $shouldUpdate
 	 */
-	public function testCopy($source, $target, $shouldUpdate) {
+	public function testCopyTesting($source, $target, $shouldUpdate) {
 		$this->keyStore
 			->expects($this->once())
 			->method('copyKeys')
@@ -193,12 +181,20 @@ class Encryption extends \Test\Files\Storage\Storage {
 	}
 
 	/**
-	 * data provider for testRename()
+	 * @dataProvider copyAndMoveProvider
+	 */
+	public function testCopy($source, $target) {
+		$this->assertTrue(true, 'Replaced by testCopyTesting()');
+	}
+
+	/**
+	 * data provider for testCopyTesting() and dataTestCopyAndRename()
 	 *
 	 * @return array
 	 */
-	public function dataTestCopy() {
+	public function dataTestCopyAndRename() {
 		return array(
+			array('source', 'target', false),
 			array('source', 'target', false),
 			array('source', '/subFolder/target', true),
 		);

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -131,13 +131,14 @@ class Encryption extends \Test\Files\Storage\Storage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @param boolean $renameKeysReturn
 	 * @param boolean $shouldUpdate
 	 */
-	public function testRename($source, $target, $shouldUpdate) {
+	public function testRename($source, $target, $renameKeysReturn, $shouldUpdate) {
 		$this->keyStore
 			->expects($this->once())
 			->method('renameKeys')
-			->willReturn(true);
+			->willReturn($renameKeysReturn);
 		$this->util->expects($this->any())
 			->method('isFile')->willReturn(true);
 		if ($shouldUpdate) {
@@ -158,13 +159,14 @@ class Encryption extends \Test\Files\Storage\Storage {
 	 *
 	 * @param string $source
 	 * @param string $target
+	 * @param boolean $copyKeysReturn
 	 * @param boolean $shouldUpdate
 	 */
-	public function testCopyTesting($source, $target, $shouldUpdate) {
+	public function testCopyTesting($source, $target, $copyKeysReturn, $shouldUpdate) {
 		$this->keyStore
 			->expects($this->once())
 			->method('copyKeys')
-			->willReturn(true);
+			->willReturn($copyKeysReturn);
 		$this->util->expects($this->any())
 			->method('isFile')->willReturn(true);
 		if ($shouldUpdate) {
@@ -194,9 +196,10 @@ class Encryption extends \Test\Files\Storage\Storage {
 	 */
 	public function dataTestCopyAndRename() {
 		return array(
-			array('source', 'target', false),
-			array('source', 'target', false),
-			array('source', '/subFolder/target', true),
+			array('source', 'target', false, false),
+			array('source', 'target', true, false),
+			array('source', '/subFolder/target', false, false),
+			array('source', '/subFolder/target', true, true),
 		);
 	}
 

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -136,7 +136,8 @@ class Encryption extends \Test\Files\Storage\Storage {
 	public function testRename($source, $target, $shouldUpdate) {
 		$this->keyStore
 			->expects($this->once())
-			->method('renameKeys');
+			->method('renameKeys')
+			->willReturn(true);
 		$this->util->expects($this->any())
 			->method('isFile')->willReturn(true);
 		if ($shouldUpdate) {
@@ -174,7 +175,8 @@ class Encryption extends \Test\Files\Storage\Storage {
 	public function testCopy($source, $target, $shouldUpdate) {
 		$this->keyStore
 			->expects($this->once())
-			->method('copyKeys');
+			->method('copyKeys')
+			->willReturn(true);
 		$this->util->expects($this->any())
 			->method('isFile')->willReturn(true);
 		if ($shouldUpdate) {


### PR DESCRIPTION
Update share-keys if a file was moved to a shared folder.

Steps to test:
- user1 creates a folder called "folder1"
- user1 shares folder1 with user2
- user1 uploads a file "test.txt"
- the file will have one share-key for user1
- user1 moves test.txt fo folder1
- now test.txt should have two share-keys, one for user1 and one for user2 (doesn't work on master)
- repeat the same steps with webdav copy.

cc @PVince81 @th3fallen @DeepDiver1975 
