### PR TITLE
Add missing loading indicator for enabled apps

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -321,8 +321,10 @@ OC.Settings.Apps = OC.Settings.Apps || {
 						var img= $('<img class="app-icon"/>').attr({ src: entry.icon});
 						var a=$('<a></a>').attr('href', entry.href);
 						var filename=$('<span></span>');
+						var loading = $('<div class="icon-loading-dark"></div>').css('display', 'none');
 						filename.text(entry.name);
 						a.prepend(filename);
+						a.prepend(loading);
 						a.prepend(img);
 						li.append(a);
 


### PR DESCRIPTION
- happened when an app gets activated, because the
  new appended HTML doesn't contain the loading
  image
- fixes #15806 (there are also the steps to reproduce)

cc @owncloud/designers 
