### PR TITLE
Tear down FS after running trash expire

### DIFF
--- a/apps/files_trashbin/command/expire.php
+++ b/apps/files_trashbin/command/expire.php
@@ -52,5 +52,6 @@ class Expire implements ICommand {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($this->user);
 		Trashbin::expire($this->trashBinSize, $this->user);
+		\OC_Util::tearDownFS();
 	}
 }


### PR DESCRIPTION
We certainly do not want to risk mixing up FS for the subsequent commands that are run within the same cron.php call...

@icewind1991 @LukasReschke @DeepDiver1975 
