### PR TITLE
[encryption] handle encrypted files correctly which where encrypted with a old version of ownCloud (<=oc6)

### DIFF
--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -210,6 +210,15 @@ class Crypt {
 	}
 
 	/**
+	 * get legacy cipher
+	 *
+	 * @return string
+	 */
+	public function getLegacyCipher() {
+		return self::LEGACY_CIPHER;
+	}
+
+	/**
 	 * @param string $encryptedContent
 	 * @param string $iv
 	 * @return string

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -72,5 +72,32 @@ class EncryptionTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider dataTestBegin
+	 */
+	public function testBegin($mode, $header, $legacyCipher, $defaultCipher, $expected) {
+
+		$this->cryptMock->expects($this->any())
+			->method('getCipher')
+			->willReturn($defaultCipher);
+		$this->cryptMock->expects($this->any())
+			->method('getLegacyCipher')
+			->willReturn($legacyCipher);
+
+		$result = $this->instance->begin('/user/files/foo.txt', 'user', $mode, $header, []);
+
+		$this->assertArrayHasKey('cipher', $result);
+		$this->assertSame($expected, $result['cipher']);
+	}
+
+	public function dataTestBegin() {
+		return array(
+			array('w', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'myCipher'),
+			array('r', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'myCipher'),
+			array('w', [], 'legacyCipher', 'defaultCipher', 'defaultCipher'),
+			array('r', [], 'legacyCipher', 'defaultCipher', 'legacyCipher'),
+		);
+	}
+
 
 }

--- a/apps/encryption_dummy/lib/dummymodule.php
+++ b/apps/encryption_dummy/lib/dummymodule.php
@@ -53,6 +53,7 @@ class DummyModule implements IEncryptionModule {
 	 *
 	 * @param string $path to the file
 	 * @param string $user who read/write the file (null for public access)
+	 * @param string $mode php stream open mode
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 *
@@ -60,7 +61,7 @@ class DummyModule implements IEncryptionModule {
 	 *                       written to the header, in case of a write operation
 	 *                       or if no additional data is needed return a empty array
 	 */
-	public function begin($path, $user, array $header, array $accessList) {
+	public function begin($path, $user, $mode, array $header, array $accessList) {
 		return array();
 	}
 

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -162,8 +162,9 @@ class Encryption extends Wrapper {
 	public function file_get_contents($path) {
 
 		$encryptionModule = $this->getEncryptionModule($path);
+		$info = $this->getCache()->get($path);
 
-		if ($encryptionModule) {
+		if ($encryptionModule || $info['encrypted'] === true) {
 			$handle = $this->fopen($path, "r");
 			if (!$handle) {
 				return false;
@@ -283,7 +284,8 @@ class Encryption extends Wrapper {
 		$encryptionEnabled = $this->encryptionManager->isEnabled();
 		$shouldEncrypt = false;
 		$encryptionModule = null;
-		$header = $this->getHeader($path);
+		$rawHeader = $this->getHeader($path);
+		$header = $this->util->readHeader($rawHeader);
 		$fullPath = $this->getFullPath($path);
 		$encryptionModuleId = $this->util->getEncryptionModuleId($header);
 
@@ -319,9 +321,17 @@ class Encryption extends Wrapper {
 					$shouldEncrypt = $encryptionModule->shouldEncrypt($fullPath);
 				}
 			} else {
+				$info = $this->getCache()->get($path);
 				// only get encryption module if we found one in the header
+				// or if file should be encrypted according to the file cache
 				if (!empty($encryptionModuleId)) {
 					$encryptionModule = $this->encryptionManager->getEncryptionModule($encryptionModuleId);
+					$shouldEncrypt = true;
+				} else if(empty($encryptionModuleId) && $info['encrypted'] === true) {
+					// we come from a old installation. No header and/or no module defined
+					// but the file is encrypted. In this case we need to use the
+					// OC_DEFAULT_MODULE to read the file
+					$encryptionModule = $this->encryptionManager->getEncryptionModule('OC_DEFAULT_MODULE');
 					$shouldEncrypt = true;
 				}
 			}
@@ -341,7 +351,7 @@ class Encryption extends Wrapper {
 			$source = $this->storage->fopen($path, $mode);
 			$handle = \OC\Files\Stream\Encryption::wrap($source, $path, $fullPath, $header,
 				$this->uid, $encryptionModule, $this->storage, $this, $this->util, $this->fileHelper, $mode,
-				$size, $unencryptedSize);
+				$size, $unencryptedSize, strlen($rawHeader));
 			return $handle;
 		} else {
 			return $this->storage->fopen($path, $mode);
@@ -419,10 +429,13 @@ class Encryption extends Wrapper {
 		$header = '';
 		if ($this->storage->file_exists($path)) {
 			$handle = $this->storage->fopen($path, 'r');
-			$header = fread($handle, $this->util->getHeaderSize());
+			$firstBlock = fread($handle, $this->util->getHeaderSize());
 			fclose($handle);
+			if (substr($firstBlock, 0, strlen(Util::HEADER_START)) === Util::HEADER_START) {
+				$header = $firstBlock;
+			}
 		}
-		return $this->util->readHeader($header);
+		return $header;
 	}
 
 	/**
@@ -435,7 +448,8 @@ class Encryption extends Wrapper {
 	 */
 	protected function getEncryptionModule($path) {
 		$encryptionModule = null;
-		$header = $this->getHeader($path);
+		$rawHeader = $this->getHeader($path);
+		$header = $this->util->readHeader($rawHeader);
 		$encryptionModuleId = $this->util->getEncryptionModuleId($header);
 		if (!empty($encryptionModuleId)) {
 			try {

--- a/lib/public/encryption/iencryptionmodule.php
+++ b/lib/public/encryption/iencryptionmodule.php
@@ -50,6 +50,7 @@ interface IEncryptionModule {
 	 *
 	 * @param string $path to the file
 	 * @param string $user who read/write the file (null for public access)
+	 * @param string $mode php stream open mode
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 *
@@ -58,7 +59,7 @@ interface IEncryptionModule {
 	 *                       or if no additional data is needed return a empty array
 	 * @since 8.1.0
 	 */
-	public function begin($path, $user, array $header, array $accessList);
+	public function begin($path, $user, $mode, array $header, array $accessList);
 
 	/**
 	 * last chunk received. This is the place where you can perform some final

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -44,7 +44,7 @@ class Encryption extends \Test\TestCase {
 
 		return \OC\Files\Stream\Encryption::wrap($source, $internalPath,
 			$fullPath, $header, $uid, $encryptionModule, $storage, $encStorage,
-			$util, $file, $mode, $size, $unencryptedSize);
+			$util, $file, $mode, $size, $unencryptedSize, 8192);
 	}
 
 	/**


### PR DESCRIPTION
fall back to the ownCloud default encryption module and aes128 if we read a encrypted file without a header.

Steps to test:
- enable encryption
- set default cipher to  AES-128-CFB in your config.php (used on old versions)
- upload a test file
- set default cipher back to AES-256-CFB
- edit the uploaded file manually and remove the header (starting with 'HBEGIN' and all the padding '-') Make sure that you editor doesn't add a trailing '\n' if you save the file (this is the file format on old versions)
- try to download the file -> will fail on master and work with this branch
