### PR TITLE
[stable7] Fix webdav access for public reshare

### DIFF
--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -42,8 +42,8 @@ $server->subscribeEvent('beforeMethod', function () use ($server, $objectTree, $
 	$share = $authBackend->getShare();
 	$rootShare = \OCP\Share::resolveReShare($share);
 	$owner = $rootShare['uid_owner'];
-	$isWritable = $rootShare['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
-	$fileId = $rootShare['file_source'];
+	$isWritable = $share['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
+	$fileId = $share['file_source'];
 
 	if (!$isWritable) {
 		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {

--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -40,9 +40,10 @@ $server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('webdav'));
 // wait with registering these until auth is handled and the filesystem is setup
 $server->subscribeEvent('beforeMethod', function () use ($server, $objectTree, $authBackend) {
 	$share = $authBackend->getShare();
-	$owner = $share['uid_owner'];
-	$isWritable = $share['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
-	$fileId = $share['file_source'];
+	$rootShare = \OCP\Share::resolveReShare($share);
+	$owner = $rootShare['uid_owner'];
+	$isWritable = $rootShare['permissions'] & (\OCP\PERMISSION_UPDATE | \OCP\PERMISSION_CREATE);
+	$fileId = $rootShare['file_source'];
 
 	if (!$isWritable) {
 		\OC\Files\Filesystem::addStorageWrapper('readonly', function ($mountPoint, $storage) {


### PR DESCRIPTION
Backport of #15814

Since `CachePermissionsMask` is not available in stable7 this backport doesnt replace the `ReadonlyWrapper`

cc @PVince81 @DeepDiver1975
