### PR TITLE
Pass current user to sharing calls in shared storage/cache

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -40,7 +40,14 @@ use OCP\Share_Backend_Collection;
  */
 class Shared_Cache extends Cache {
 
+	/**
+	 * @var \OC\Files\Storage\Shared
+	 */
 	private $storage;
+
+	/**
+	 * @var array
+	 */
 	private $files = array();
 
 	/**
@@ -60,7 +67,12 @@ class Shared_Cache extends Cache {
 		if ($target === false || $target === $this->storage->getMountPoint()) {
 			$target = '';
 		}
-		$source = \OC_Share_Backend_File::getSource($target, $this->storage->getMountPoint(), $this->storage->getItemType());
+		$source = \OC_Share_Backend_File::getSource(
+			$target,
+			$this->storage->getMountPoint(),
+			$this->storage->getItemType(),
+			$this->storage->getUser()
+		);
 		if (isset($source['path']) && isset($source['fileOwner'])) {
 			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
 			$mounts = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
@@ -242,7 +254,12 @@ class Shared_Cache extends Cache {
 	 */
 	protected function getMoveInfo($path) {
 		$cache = $this->getSourceCache($path);
-		$file = \OC_Share_Backend_File::getSource($path, $this->storage->getMountPoint(), $this->storage->getItemType());
+		$file = \OC_Share_Backend_File::getSource(
+			$path,
+			$this->storage->getMountPoint(),
+			$this->storage->getItemType(),
+			$this->storage->getUser()
+		);
 		return [$cache->getNumericStorageId(), $file['path']];
 	}
 

--- a/apps/files_sharing/lib/share/file.php
+++ b/apps/files_sharing/lib/share/file.php
@@ -205,21 +205,38 @@ class OC_Share_Backend_File implements OCP\Share_Backend_File_Dependent {
 	}
 
 	/**
-	 * @param string $target
-	 * @param string $mountPoint
-	 * @param string $itemType
+	 * Returns the share entry matching the given mount point
+	 *
+	 * @param string $target target path inside the share
+	 * @param string $mountPoint mount point path
+	 * @param string $itemType share item type
+	 * @param string $user user receiving the share
 	 * @return array|false source item
 	 */
-	public static function getSource($target, $mountPoint, $itemType) {
+	public static function getSource($target, $mountPoint, $itemType, $user = null) {
 		if ($itemType === 'folder') {
-			$source = \OCP\Share::getItemSharedWith('folder', $mountPoint, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+			$source = \OCP\Share::getItemSharedWith(
+				'folder',
+				$mountPoint,
+				\OC_Share_Backend_File::FORMAT_SHARED_STORAGE,
+				null,
+				false,
+				$user
+			);
 			if ($source && $target !== '') {
 				// note: in case of ext storage mount points the path might be empty
 				// which would cause a leading slash to appear
 				$source['path'] = ltrim($source['path'] . '/' . $target, '/');
 			}
 		} else {
-			$source = \OCP\Share::getItemSharedWith('file', $mountPoint, \OC_Share_Backend_File::FORMAT_SHARED_STORAGE);
+			$source = \OCP\Share::getItemSharedWith(
+				'file',
+				$mountPoint,
+				\OC_Share_Backend_File::FORMAT_SHARED_STORAGE,
+				null,
+				false,
+				$user
+			);
 		}
 		if ($source) {
 			return self::resolveReshares($source);

--- a/apps/files_versions/command/expire.php
+++ b/apps/files_versions/command/expire.php
@@ -72,7 +72,7 @@ class Expire implements ICommand {
 		}
 
 		\OC_Util::setupFS($this->user);
-		Storage::expire($this->fileName, $this->versionsSize, $this->neededSpace);
+		Storage::expire($this->user, $this->fileName, $this->versionsSize, $this->neededSpace);
 		\OC_Util::tearDownFS();
 	}
 }

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -281,12 +281,32 @@ class Share extends Constants {
 	 * @param mixed $parameters (optional)
 	 * @param int $limit Number of items to return (optional) Returns all by default
 	 * @param boolean $includeCollections (optional)
+	 * @param string $recipientUser id of the recipient user (optional), defaults
+	 * to the currently logged in user
 	 * @return mixed Return depends on format
 	 */
-	public static function getItemsSharedWith($itemType, $format = self::FORMAT_NONE,
-											  $parameters = null, $limit = -1, $includeCollections = false) {
-		return self::getItems($itemType, null, self::$shareTypeUserAndGroups, \OC_User::getUser(), null, $format,
-			$parameters, $limit, $includeCollections);
+	public static function getItemsSharedWith(
+		$itemType,
+		$format = self::FORMAT_NONE,
+		$parameters = null,
+		$limit = -1,
+		$includeCollections = false,
+		$recipientUser = null
+	) {
+		if ($recipientUser === null) {
+			$recipientUser = self::getLoggedInUser();
+		}
+		return self::getItems(
+			$itemType,
+			null,
+			self::$shareTypeUserAndGroups,
+			$recipientUser,
+			null,
+			$format,
+			$parameters,
+			$limit,
+			$includeCollections
+		);
 	}
 
 	/**
@@ -312,12 +332,32 @@ class Share extends Constants {
 	 * @param int $format (optional) Format type must be defined by the backend
 	 * @param mixed $parameters (optional)
 	 * @param boolean $includeCollections (optional)
+	 * @param string $recipientUser id of the recipient user (optional), defaults
+	 * to the currently logged in user
 	 * @return mixed Return depends on format
 	 */
-	public static function getItemSharedWith($itemType, $itemTarget, $format = self::FORMAT_NONE,
-											 $parameters = null, $includeCollections = false) {
-		return self::getItems($itemType, $itemTarget, self::$shareTypeUserAndGroups, \OC_User::getUser(), null, $format,
-			$parameters, 1, $includeCollections);
+	public static function getItemSharedWith(
+		$itemType,
+		$itemTarget,
+		$format = self::FORMAT_NONE,
+		$parameters = null,
+		$includeCollections = false,
+		$recipientUser = null
+	) {
+		if ($recipientUser === null) {
+			$recipientUser = self::getLoggedInUser();
+		}
+		return self::getItems(
+			$itemType,
+			$itemTarget,
+			self::$shareTypeUserAndGroups,
+			$recipientUser,
+			null,
+			$format,
+			$parameters,
+			1,
+			$includeCollections
+		);
 	}
 
 	/**
@@ -329,7 +369,13 @@ class Share extends Constants {
 	 * @param int $shareType only look for a specific share type
 	 * @return array Return list of items with file_target, permissions and expiration
 	 */
-	public static function getItemSharedWithUser($itemType, $itemSource, $user, $owner = null, $shareType = null) {
+	public static function getItemSharedWithUser(
+		$itemType,
+		$itemSource,
+		$user,
+		$owner = null,
+		$shareType = null
+	) {
 		$shares = array();
 		$fileDependent = false;
 
@@ -435,8 +481,14 @@ class Share extends Constants {
 	 * @param string $shareWith (optional) define against which user should be checked, default: current user
 	 * @return array
 	 */
-	public static function getItemSharedWithBySource($itemType, $itemSource, $format = self::FORMAT_NONE,
-													 $parameters = null, $includeCollections = false, $shareWith = null) {
+	public static function getItemSharedWithBySource(
+		$itemType,
+		$itemSource,
+		$format = self::FORMAT_NONE,
+		$parameters = null,
+		$includeCollections = false,
+		$shareWith = null
+	) {
 		$shareWith = ($shareWith === null) ? \OC_User::getUser() : $shareWith;
 		return self::getItems($itemType, $itemSource, self::$shareTypeUserAndGroups, $shareWith, null, $format,
 			$parameters, 1, $includeCollections, true);
@@ -2585,5 +2637,20 @@ class Share extends Constants {
 		$query = 'SELECT * FROM `*PREFIX*share` WHERE `file_source` = ?';
 		$result = \OC::$server->getDatabaseConnection()->executeQuery($query, [$id]);
 		return $result->fetchAll();
+	}
+
+	/**
+	 * Returns the currently logged in user id.
+	 *
+	 * @return string|bool currently logged in user id or false
+	 * if none
+	 */
+	private static function getLoggedInUser() {
+		$user = \OC::$server->getUserSession()->getUser();
+		if ($user) {
+			return $user->getUID();
+		} else {
+			return false;
+		}
 	}
 }

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -12,6 +12,7 @@
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Sam Tuke <mail@samtuke.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -96,13 +97,27 @@ class Share extends \OC\Share\Constants {
 	 * @param mixed $parameters (optional)
 	 * @param int $limit Number of items to return (optional) Returns all by default
 	 * @param bool $includeCollections (optional)
+	 * @param string $recipientUser id of the recipient user (optional), defaults
+	 * to the currently logged in user
 	 * @return mixed Return depends on format
 	 * @since 5.0.0
 	 */
-	public static function getItemsSharedWith($itemType, $format = self::FORMAT_NONE,
-		$parameters = null, $limit = -1, $includeCollections = false) {
-
-		return \OC\Share\Share::getItemsSharedWith($itemType, $format, $parameters, $limit, $includeCollections);
+	public static function getItemsSharedWith(
+		$itemType,
+		$format = self::FORMAT_NONE,
+		$parameters = null,
+		$limit = -1,
+		$includeCollections = false,
+		$recipientUser = null
+	) {
+		return \OC\Share\Share::getItemsSharedWith(
+			$itemType,
+			$format,
+			$parameters,
+			$limit,
+			$includeCollections,
+			$recipientUser
+		);
 	}
 
 	/**
@@ -129,13 +144,27 @@ class Share extends \OC\Share\Constants {
 	 * @param int $format (optional) Format type must be defined by the backend
 	 * @param mixed $parameters (optional)
 	 * @param bool $includeCollections (optional)
+	 * @param string $recipientUser id of the recipient user (optional), defaults
+	 * to the currently logged in user
 	 * @return mixed Return depends on format
 	 * @since 5.0.0
 	 */
-	public static function getItemSharedWith($itemType, $itemTarget, $format = self::FORMAT_NONE,
-		$parameters = null, $includeCollections = false) {
-
-		return \OC\Share\Share::getItemSharedWith($itemType, $itemTarget, $format, $parameters, $includeCollections);
+	public static function getItemSharedWith(
+		$itemType,
+		$itemTarget,
+		$format = self::FORMAT_NONE,
+		$parameters = null,
+		$includeCollections = false,
+		$recipientUser = null
+	) {
+		return \OC\Share\Share::getItemSharedWith(
+			$itemType,
+			$itemTarget,
+			$format,
+			$parameters,
+			$includeCollections,
+			$recipientUser
+		);
 	}
 
 	/**


### PR DESCRIPTION
In some situations like when running background jobs, there is no logged
in user. However the filesystem has been setup for a given user to
perform operations on it. That user must be used when calling the Share
API instead of letting it rely on the logged in user.

Fixes https://github.com/owncloud/core/issues/15852
- [x] TODO: add unit tests
- [x] requires https://github.com/owncloud/core/issues/15867 to be fixed to be able to check if expiry is done properly after move

@schiesbn @icewind1991 
