### PR TITLE
Reset share dialog values - more

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -986,6 +986,11 @@ $(document).ready(function() {
 			$('#linkPassText').attr('placeholder', t('core', 'Choose a password for the public link'));
 			// Reset link
 			$('#linkText').val('');
+			$('#showPassword').prop('checked', false);
+			$('#linkPass').hide();
+			$('#sharingDialogAllowPublicUpload').prop('checked', false);
+			$('#expirationCheckbox').prop('checked', false);
+			$('#expirationDate').hide();
 			var expireDateString = '';
 			if (oc_appconfig.core.defaultExpireDateEnabled) {
 				var date = new Date().getTime();

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -228,6 +228,112 @@ describe('OC.Share tests', function() {
 
 				oc_appconfig.core.enforcePasswordForPublicLink = old;
 			});
+			it('reset password on toggle of share', function() {
+				$('#allowShareWithLink').val('yes');
+				OC.Share.showDropDown(
+					'file',
+					123,
+					$container,
+					true,
+					31,
+					'shared_file_name.txt'
+				);
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+				);
+
+				//Password protection should be unchecked and password field not visible
+				expect($('#dropdown [name=showPassword]').prop('checked')).toEqual(false);
+				expect($('#dropdown #linkPass').is(":visible")).toEqual(false);
+
+				// Toggle and set password
+				$('#dropdown [name=showPassword]').click();
+				$('#dropdown #linkPassText').val('foo');
+				$('#dropdown #linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
+				fakeServer.requests[1].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz2'}, status: 'success'})
+				);
+
+				// Unshare
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[2].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({status: 'success'})
+				);
+
+				// Toggle share again
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[3].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz3'}, status: 'success'})
+				);
+
+
+				// Password checkbox should be unchecked
+				expect($('#dropdown [name=showPassword]').prop('checked')).toEqual(false);
+				expect($('#dropdown #linkPass').is(":visible")).toEqual(false);
+			});
+			it('reset expiration on toggle of share', function() {
+				$('#allowShareWithLink').val('yes');
+				OC.Share.showDropDown(
+					'file',
+					123,
+					$container,
+					true,
+					31,
+					'shared_file_name.txt'
+				);
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+				);
+
+				//Expiration should be unchecked and expiration field not visible
+				expect($('#dropdown [name=expirationCheckbox]').prop('checked')).toEqual(false);
+				expect($('#dropdown #expirationDate').is(":visible")).toEqual(false);
+
+				// Toggle and set password
+				$('#dropdown [name=expirationCheckbox]').click();
+				d = new Date();
+				d.setDate(d.getDate() + 1);
+				date=d.getDate() + '-' + (d.getMonth()+1) + '-' + d.getFullYear();
+				$('#dropdown #expirationDate').val(date);
+				$('#dropdown #expirationDate').change();
+				fakeServer.requests[1].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz2'}, status: 'success'})
+				);
+
+				// Unshare
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[2].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({status: 'success'})
+				);
+
+				// Toggle share again
+				$('#dropdown [name=linkCheckbox]').click();
+				fakeServer.requests[3].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({data: {token: 'xyz3'}, status: 'success'})
+				);
+
+				// Recheck expire visibility
+				expect($('#dropdown [name=expirationCheckbox]').prop('checked')).toEqual(false);
+				expect($('#dropdown #expirationDate').is(":visible")).toEqual(false);
+			});
 			it('shows populated link share when a link share exists', function() {
 				loadItemStub.returns({
 					reshare: [],


### PR DESCRIPTION
Fix for #15812 but also for the other available checkboxes.
In general the share dialog box remains open we do not reset the state after an unshare and a share after that.

All the fields should be reset now.
However the javascript unit test fails (more will follow when this one is fixed). @PVince81 could you help out?
