### PR TITLE
fix layout for multiline buttons which are <a class='button'>

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -213,6 +213,10 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 	border: none;
 	box-shadow: none;
 }
+/* fix layout for multiline buttons which are <a class="button"> */
+.button {
+	display: inline-block;
+}
 
 /* disabled input fields and buttons */
 input:disabled, input:disabled:hover, input:disabled:focus,
@@ -1061,4 +1065,3 @@ fieldset.warning legend + p, fieldset.update legend + p {
 @-ms-viewport {
 	width: device-width;
 }
-


### PR DESCRIPTION
Before
![capture du 2015-04-26 11 06 38](https://cloud.githubusercontent.com/assets/925062/7336570/42d3b494-ec05-11e4-9f76-34c105dd827b.png)
After
![capture du 2015-04-26 11 06 50](https://cloud.githubusercontent.com/assets/925062/7336569/42b7b80c-ec05-11e4-82ae-cbf4184012f5.png)

Normal buttons are all inline-block already, so this just fixes the case for any non input/button elements which are class="button". Please review @owncloud/designers 
