### PR TITLE
Get etag from remote OC server

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -682,7 +682,7 @@ class DAV extends Common {
 	public function getPermissions($path) {
 		$this->init();
 		$path = $this->cleanPath($path);
-		$response = $this->client->propfind($this->encodePath($path), array('{http://owncloud.org/ns}permissions'));
+		$response = $this->propfind($path);
 		if (isset($response['{http://owncloud.org/ns}permissions'])) {
 			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
 		} else if ($this->is_dir($path)) {
@@ -692,6 +692,17 @@ class DAV extends Common {
 		} else {
 			return 0;
 		}
+	}
+
+	/** {@inheritdoc} */
+	public function getETag($path) {
+		$this->init();
+		$path = $this->cleanPath($path);
+		$response = $this->propfind($path);
+		if (isset($response['{DAV:}getetag'])) {
+			return trim($response['{DAV:}getetag'], '"');
+		}
+		return parent::getEtag($path);
 	}
 
 	/**
@@ -733,8 +744,11 @@ class DAV extends Common {
 			$response = $this->propfind($path);
 			if (isset($response['{DAV:}getetag'])) {
 				$cachedData = $this->getCache()->get($path);
-				$etag = trim($response['{DAV:}getetag'], '"');
-				if ($cachedData['etag'] !== $etag) {
+				$etag = null;
+				if (isset($response['{DAV:}getetag'])) {
+					$etag = trim($response['{DAV:}getetag'], '"');
+				}
+				if (!empty($etag) && $cachedData['etag'] !== $etag) {
 					return true;
 				} else if (isset($response['{http://owncloud.org/ns}permissions'])) {
 					$permissions = $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -22,6 +22,8 @@
 
 namespace Test\Files\Storage;
 
+use OC\Files\Cache\Watcher;
+
 abstract class Storage extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Storage instance
@@ -307,6 +309,19 @@ abstract class Storage extends \Test\TestCase {
 
 		$this->instance->unlink('/lorem.txt');
 		$this->assertTrue($this->instance->hasUpdated('/', $mtimeStart - 5));
+	}
+
+	/**
+	 * Test whether checkUpdate properly returns false when there was
+	 * no change.
+	 */
+	public function testCheckUpdate() {
+		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
+		$watcher = $this->instance->getWatcher();
+		$watcher->setPolicy(Watcher::CHECK_ALWAYS);
+		$this->instance->file_put_contents('/lorem.txt', file_get_contents($textFile));
+		$this->assertTrue($watcher->checkUpdate('/lorem.txt'), 'Update detected');
+		$this->assertFalse($watcher->checkUpdate('/lorem.txt'), 'No update');
 	}
 
 	public function testUnlink() {

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -316,6 +316,9 @@ abstract class Storage extends \Test\TestCase {
 	 * no change.
 	 */
 	public function testCheckUpdate() {
+		if ($this->instance instanceof \OC\Files\Storage\Wrapper\Wrapper) {
+			$this->markTestSkipped('Cannot test update check on wrappers');
+		}
 		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
 		$watcher = $this->instance->getWatcher();
 		$watcher->setPolicy(Watcher::CHECK_ALWAYS);


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/15125

~~BUT this will break syncing with DAV servers that do not return any etags.~~
- ~~find a good solution for regular DAV servers, maybe differentiate between DAV and ownCloud backends (and use ownCloud backend for s2s too)~~ syncing should not break, it will fallback to use mtime for update detection

@icewind1991 
