### PR TITLE
Add check for "replace" command in autotest-external

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -32,6 +32,11 @@ if ! [ -x "$PHPUNIT" ]; then
 	exit 3
 fi
 
+if ! which replace > /dev/null 2>&1; then
+	echo "The command 'replace' is not available on this system. Please install it first." >&2
+	exit 5
+fi
+
 PHPUNIT_VERSION=$("$PHPUNIT" --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f2)


### PR DESCRIPTION
@MorrisJobke @Xenopathic 

The "replace" command was not available on my system.
I had to install mariadb-tools-10.0.14-2.3.x86_64 on openSUSE to get it...

This PR adds a warning to avoid running the tests and getting error messages.
