### PR TITLE
Fix return type of the getRootFolder() method

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -492,7 +492,7 @@ class Server extends SimpleContainer implements IServerContainer {
 	/**
 	 * Returns the root folder of ownCloud's data directory
 	 *
-	 * @return \OCP\Files\Folder
+	 * @return \OCP\Files\IRootFolder
 	 */
 	public function getRootFolder() {
 		return $this->query('RootFolder');

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -87,7 +87,7 @@ interface IServerContainer {
 	/**
 	 * Returns the root folder of ownCloud's data directory
 	 *
-	 * @return \OCP\Files\Folder
+	 * @return \OCP\Files\IRootFolder
 	 * @since 6.0.0
 	 */
 	public function getRootFolder();


### PR DESCRIPTION
Fix #15899 

@MorrisJobke @LukasReschke @dagan
