### PR TITLE
Password set via OCS API should not be double escaped

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1218,7 +1218,7 @@ class Share extends \OC\Share\Constants {
 		$qb->update('`*PREFIX*share`')
 			->set('`share_with`', ':pass')
 			->where('`id` = :shareId')
-			->setParameter(':pass', is_null($password) ? 'NULL' : $qb->expr()->literal(\OC::$server->getHasher()->hash($password)))
+			->setParameter(':pass', is_null($password) ? 'NULL' : \OC::$server->getHasher()->hash($password))
 			->setParameter(':shareId', $shareId);
 
 		$qb->execute();


### PR DESCRIPTION
Should fix #15777

Basically there was to much escaping. So the hash got surrounded by quotes in the database.

This got in since it is very hard to unit test this.
The only real solution I see is to really insert the code in mocked database. Retrieve it and see if the hash verifies correctly. But I need to dive into docterine mocking to get that to work. Any hints/tips are appreciated.

Reviewing should be trivial. However I prefer to have unit tests to make sure it keeps on working. But it should anyways get into 8.1! Hence the overlapping labels.

CC: @PVince81 @LukasReschke @MorrisJobke @DeepDiver1975 
