### PR TITLE
Encryption improve handling of empty and unencrypted files

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -101,7 +101,8 @@ class Application extends \OCP\AppFramework\App {
 			return new Encryption(
 				$container->query('Crypt'),
 				$container->query('KeyManager'),
-				$container->query('Util')
+				$container->query('Util'),
+				$container->getServer()->getLogger()
 			);
 		});
 	}

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -410,7 +410,7 @@ class Crypt {
 	 * @return string
 	 * @throws \Exception
 	 */
-	public static function generateFileKey() {
+	public function generateFileKey() {
 		// Generate key
 		$key = base64_encode(openssl_random_pseudo_bytes(32, $strong));
 		if (!$key || !$strong) {


### PR DESCRIPTION
- Only update files if a file key exists

Steps to test:
1. create a file in a subfolder while encryption is disabled
2. enable encryption
3. re-login
4. share the folder which contain the unencrypted file
5. will create a error because the share-keys of the unencrypted file can't be adjusted. -> with this PR sharing should work
- Also create file keys if a empty file was written

Steps to test:
1. enable encryption
2. upload a empty file (file needs to be uploaded, creating a new empty file in the web interface doesn't trigger the same error)
3. empty file will have a encryption header but no keys, with this pr keys will exists

cc @DeepDiver1975 This should fix the problems we discussed on IRC.

cc @th3fallen maybe you can review it? Thanks!
