### PR TITLE
Fix error message when wrong user on console

### DIFF
--- a/console.php
+++ b/console.php
@@ -47,9 +47,9 @@ try {
 		$user = posix_getpwuid(posix_getuid());
 		$configUser = posix_getpwuid(fileowner(OC::$SERVERROOT . '/config/config.php'));
 		if ($user['name'] !== $configUser['name']) {
-			echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
+			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 			echo "Current user: " . $user['name'] . PHP_EOL;
-			echo "Web server user: " . $configUser['name'] . PHP_EOL;
+			echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
 			exit(0);
 		}
 	}


### PR DESCRIPTION
Owncloud complains if the user runs a shell script with a user other than the user that owns `config/config.php`. The error message does not reflect this, and instead speaks about the web server user. Related issue: #15920 .
