### PR TITLE
Make it possible to pass empty database passwords to install command

### DIFF
--- a/core/command/maintenance/install.php
+++ b/core/command/maintenance/install.php
@@ -49,7 +49,7 @@ class Install extends Command {
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
-			->addOption('database-pass', null, InputOption::VALUE_REQUIRED, 'Password of the database user')
+			->addOption('database-pass', null, InputOption::VALUE_REQUIRED, 'Password of the database user', null)
 			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
@@ -101,6 +101,9 @@ class Install extends Command {
 		if ($input->hasParameterOption('--database-table-prefix')) {
 			$dbTablePrefix = (string) $input->getOption('database-table-prefix');
 			$dbTablePrefix = trim($dbTablePrefix);
+		}
+		if ($input->hasParameterOption('--database-pass')) {
+			$dbPass = (string) $input->getOption('database-pass');
 		}
 		$adminLogin = $input->getOption('admin-user');
 		$adminPassword = $input->getOption('admin-pass');


### PR DESCRIPTION
The install command does not allow empty passwords for databases which are widely used for CI however.

@DeepDiver1975 @MorrisJobke @PVince81 @nickvergessen @LukasReschke 
