### PR TITLE
Revert "fix layout for multiline buttons which are <a class='button'>"

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -213,10 +213,6 @@ input[type="submit"] img, input[type="button"] img, button img, .button img { cu
 	border: none;
 	box-shadow: none;
 }
-/* fix layout for multiline buttons which are <a class="button"> */
-.button {
-	display: inline-block;
-}
 
 /* disabled input fields and buttons */
 input:disabled, input:disabled:hover, input:disabled:focus,
@@ -1065,3 +1061,4 @@ fieldset.warning legend + p, fieldset.update legend + p {
 @-ms-viewport {
 	width: device-width;
 }
+


### PR DESCRIPTION
Reverts owncloud/core#15875, fix https://github.com/owncloud/core/issues/15916

Will just revert this until we come up with a better solution. For now the only button where the issue appeared is on the »Add example.com to trusted domains« and that arguably is less important than not breaking anything else.

Please review @owncloud/designers @nickvergessen 
