### PR TITLE
Make controller automatically assemblable

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -63,6 +63,17 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this['AppName'] = $appName;
 		$this['urlParams'] = $urlParams;
 
+		// aliases
+		$this->registerService('appName', function($c) {
+			return $c->query('AppName');
+		});
+		$this->registerService('webRoot', function($c) {
+			return $c->query('WebRoot');
+		});
+		$this->registerService('userId', function($c) {
+			return $c->query('UserId');
+		});
+
 		/**
 		 * Core services
 		 */


### PR DESCRIPTION
This makes it possible to omit the constructor if all you need is the AppName and IRequest instance, see https://github.com/owncloud/core/blob/master/lib/private/appframework/dependencyinjection/dicontainer.php#L63

@DeepDiver1975 @PVince81 @MorrisJobke @nickvergessen 
