### PR TITLE
Make command optional

### DIFF
--- a/core/command/maintenance/install.php
+++ b/core/command/maintenance/install.php
@@ -49,7 +49,7 @@ class Install extends Command {
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
-			->addOption('database-pass', null, InputOption::VALUE_REQUIRED, 'Password of the database user', null)
+			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
 			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')


### PR DESCRIPTION
Ok, so apparently required attributes can not be null, follow up fix for #15926 

Should work now I hope (tested locally)

@DeepDiver1975 @MorrisJobke @PVince81 @nickvergessen @LukasReschke
