### PR TITLE
Use internally \OCP\ILogger instead of \OC\Log

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -354,7 +354,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 
 				$sorter = new \OC\Share\SearchResultSorter((string)$_GET['search'],
 														   'label',
-														   new \OC\Log());
+														   \OC::$server->getLogger());
 				usort($shareWith, array($sorter, 'sort'));
 				OC_JSON::success(array('data' => $shareWith));
 			}

--- a/lib/private/backgroundjob/job.php
+++ b/lib/private/backgroundjob/job.php
@@ -24,6 +24,7 @@
 namespace OC\BackgroundJob;
 
 use OCP\BackgroundJob\IJob;
+use OCP\ILogger;
 
 abstract class Job implements IJob {
 	/**
@@ -43,9 +44,9 @@ abstract class Job implements IJob {
 
 	/**
 	 * @param JobList $jobList
-	 * @param \OC\Log $logger
+	 * @param ILogger $logger
 	 */
-	public function execute($jobList, $logger = null) {
+	public function execute($jobList, ILogger $logger = null) {
 		$jobList->setLastRun($this);
 		try {
 			$this->run($this->argument);

--- a/lib/private/backgroundjob/queuedjob.php
+++ b/lib/private/backgroundjob/queuedjob.php
@@ -21,6 +21,7 @@
  */
 
 namespace OC\BackgroundJob;
+use OCP\ILogger;
 
 /**
  * Class QueuedJob
@@ -34,9 +35,9 @@ abstract class QueuedJob extends Job {
 	 * run the job, then remove it from the joblist
 	 *
 	 * @param JobList $jobList
-	 * @param \OC\Log $logger
+	 * @param ILogger $logger
 	 */
-	public function execute($jobList, $logger = null) {
+	public function execute($jobList, ILogger $logger = null) {
 		$jobList->remove($this, $this->argument);
 		parent::execute($jobList, $logger);
 	}

--- a/lib/private/backgroundjob/timedjob.php
+++ b/lib/private/backgroundjob/timedjob.php
@@ -21,6 +21,7 @@
  */
 
 namespace OC\BackgroundJob;
+use OCP\ILogger;
 
 /**
  * Class QueuedJob
@@ -45,9 +46,9 @@ abstract class TimedJob extends Job {
 	 * run the job if
 	 *
 	 * @param JobList $jobList
-	 * @param \OC\Log $logger
+	 * @param ILogger $logger
 	 */
-	public function execute($jobList, $logger = null) {
+	public function execute($jobList, ILogger $logger = null) {
 		if ((time() - $this->lastRun) > $this->interval) {
 			parent::execute($jobList, $logger);
 		}

--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -23,10 +23,10 @@
 
 namespace OC\Log;
 
-use OC\Log as LoggerInterface;
+use OCP\ILogger;
 
 class ErrorHandler {
-	/** @var LoggerInterface */
+	/** @var ILogger */
 	private static $logger;
 
 	/**
@@ -50,7 +50,7 @@ class ErrorHandler {
 		set_exception_handler(array($handler, 'onException'));
 	}
 
-	public static function setLogger(LoggerInterface $logger) {
+	public static function setLogger(ILogger $logger) {
 		self::$logger = $logger;
 	}
 

--- a/lib/private/share/searchresultsorter.php
+++ b/lib/private/share/searchresultsorter.php
@@ -23,6 +23,8 @@
  */
 namespace OC\Share;
 
+use OCP\ILogger;
+
 class SearchResultSorter {
 	private $search;
 	private $encoding;
@@ -34,9 +36,9 @@ class SearchResultSorter {
 	 * @param string $key the array key containing the value that should be compared
 	 * against
 	 * @param string $encoding optional, encoding to use, defaults to UTF-8
-	 * @param \OC\Log $log optional
+	 * @param ILogger $log optional
 	 */
-	public function __construct($search, $key, \OC\Log $log = null, $encoding = 'UTF-8') {
+	public function __construct($search, $key, ILogger $log = null, $encoding = 'UTF-8') {
 		$this->encoding = $encoding;
 		$this->key = $key;
 		$this->log = $log;

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -37,6 +37,7 @@ use OC_Installer;
 use OC_Util;
 use OCP\IConfig;
 use OC\Setup;
+use OCP\ILogger;
 
 /**
  * Class that handles autoupdating of ownCloud
@@ -49,7 +50,7 @@ use OC\Setup;
  */
 class Updater extends BasicEmitter {
 
-	/** @var \OC\Log $log */
+	/** @var ILogger $log */
 	private $log;
 	
 	/** @var \OC\HTTPHelper $helper */
@@ -67,9 +68,9 @@ class Updater extends BasicEmitter {
 	/**
 	 * @param HTTPHelper $httpHelper
 	 * @param IConfig $config
-	 * @param \OC\Log $log
+	 * @param ILogger $log
 	 */
-	public function __construct(HTTPHelper $httpHelper, IConfig $config, $log = null) {
+	public function __construct(HTTPHelper $httpHelper, IConfig $config, ILogger $log = null) {
 		$this->httpHelper = $httpHelper;
 		$this->log = $log;
 		$this->config = $config;

--- a/lib/public/backgroundjob/ijob.php
+++ b/lib/public/backgroundjob/ijob.php
@@ -22,6 +22,7 @@
  */
 
 namespace OCP\BackgroundJob;
+use OCP\ILogger;
 
 /**
  * Interface IJob
@@ -34,11 +35,11 @@ interface IJob {
 	 * Run the background job with the registered argument
 	 *
 	 * @param \OCP\BackgroundJob\IJobList $jobList The job list that manages the state of this job
-	 * @param \OC\Log $logger
+	 * @param ILogger $logger
 	 * @return void
 	 * @since 7.0.0
 	 */
-	public function execute($jobList, $logger = null);
+	public function execute($jobList, ILogger $logger = null);
 
 	/**
 	 * Get the id of the background job


### PR DESCRIPTION
- this is the preparation for some upcoming logger related changes
- also fixes an issue in the public interface where we request
  an internal class as parameter

cc @nickvergessen @DeepDiver1975 @PVince81 @rullzer @Xenopathic

@DeepDiver1975 please choose from one of the following milestones ;) 8.1 or 8.2
