### PR TITLE
use the preSetup hook to ensure the encryption wrapper is applied correctly

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -712,7 +712,7 @@ class OC {
 	}
 
 	private static function registerEncryptionWrapper() {
-		\OCP\Util::connectHook('OC_Filesystem', 'setup', 'OC\Encryption\Manager', 'setupStorage');
+		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OC\Encryption\Manager', 'setupStorage');
 	}
 
 	private static function registerEncryptionHooks() {


### PR DESCRIPTION
Fixes #15640

cc @PVince81 @DeepDiver1975 @schiesbn 
