### PR TITLE
fix bug #15973

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -356,22 +356,20 @@ class Encryption extends Wrapper {
 
 		switch ($whence) {
 			case SEEK_SET:
-				if ($offset < $this->unencryptedSize && $offset >= 0) {
-					$newPosition = $offset;
-				}
+				$newPosition = $offset;
 				break;
 			case SEEK_CUR:
-				if ($offset >= 0) {
-					$newPosition = $offset + $this->position;
-				}
+				$newPosition = $this->position + $offset;
 				break;
 			case SEEK_END:
-				if ($this->unencryptedSize + $offset >= 0) {
-					$newPosition = $this->unencryptedSize + $offset;
-				}
+				$newPosition = $this->unencryptedSize + $offset;
 				break;
 			default:
 				return $return;
+		}
+
+		if ($newPosition > $this->unencryptedSize || $newPosition < 0) {
+			return $return;
 		}
 
 		$newFilePosition = floor($newPosition / $this->unencryptedBlockSize)

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -160,15 +160,6 @@ class Encryption extends \Test\TestCase {
 		$this->assertEquals('foobar', fread($stream, 100));
 		fclose($stream);
 
-		unlink($fileName);
-	}
-
-	public function testWriteWriteRead() {
-		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
-		$this->assertEquals(6, fwrite($stream, 'foobar'));
-		fclose($stream);
-
 		$stream = $this->getStream($fileName, 'r+', 6);
 		$this->assertEquals(3, fwrite($stream, 'bar'));
 		fclose($stream);
@@ -176,6 +167,8 @@ class Encryption extends \Test\TestCase {
 		$stream = $this->getStream($fileName, 'r', 6);
 		$this->assertEquals('barbar', fread($stream, 100));
 		fclose($stream);
+
+		unlink($fileName);
 	}
 
 	public function testRewind() {
@@ -191,7 +184,9 @@ class Encryption extends \Test\TestCase {
 		$stream = $this->getStream($fileName, 'r', 6);
 		$this->assertEquals('barbar', fread($stream, 100));
 		fclose($stream);
-	}
+	
+		unlink($fileName);
+}
 
 	public function testSeek() {
 		$fileName = tempnam("/tmp", "FOO");
@@ -203,6 +198,12 @@ class Encryption extends \Test\TestCase {
 
 		$stream = $this->getStream($fileName, 'r', 9);
 		$this->assertEquals('foofoobar', fread($stream, 100));
+		$this->assertEquals(-1, fseek($stream, 10));
+		$this->assertEquals(0, fseek($stream, 9));
+		$this->assertEquals(-1, fseek($stream, -10, 'SEEK_CUR'));
+		$this->assertEquals(0, fseek($stream, -9, 'SEEK_CUR'));
+		$this->assertEquals(-1, fseek($stream, -10, 'SEEK_END'));
+		$this->assertEquals(0, fseek($stream, -9, 'SEEK_END'));
 		fclose($stream);
 
 		unlink($fileName);

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -200,10 +200,10 @@ class Encryption extends \Test\TestCase {
 		$this->assertEquals('foofoobar', fread($stream, 100));
 		$this->assertEquals(-1, fseek($stream, 10));
 		$this->assertEquals(0, fseek($stream, 9));
-		$this->assertEquals(-1, fseek($stream, -10, 'SEEK_CUR'));
-		$this->assertEquals(0, fseek($stream, -9, 'SEEK_CUR'));
-		$this->assertEquals(-1, fseek($stream, -10, 'SEEK_END'));
-		$this->assertEquals(0, fseek($stream, -9, 'SEEK_END'));
+		$this->assertEquals(-1, fseek($stream, -10, SEEK_CUR));
+		$this->assertEquals(0, fseek($stream, -9, SEEK_CUR));
+		$this->assertEquals(-1, fseek($stream, -10, SEEK_END));
+		$this->assertEquals(0, fseek($stream, -9, SEEK_END));
 		fclose($stream);
 
 		unlink($fileName);


### PR DESCRIPTION
Rework of stream_seek handling; there where basically two bugs: 1. seeking to the end of the current file would fail (with SEEK_SET); and 2. if seeking to an undefined position (outside 0,unencryptedSize) then newPosition was not defined. I used the opportunity to simplify the code.
