### PR TITLE
add admin documentation links for Sharing, Encryption and Email server

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -368,8 +368,15 @@ table.grid td.date{
 	display: inline-block;
 }
 
+/* correctly display help icons next to headings */
 .icon-info {
 	padding: 11px 20px;
+	vertical-align: text-bottom;
+}
+#shareAPI h2,
+#encryptionAPI h2,
+#mail_general_settings h2 {
+	display: inline-block;
 }
 
 .mail_settings p label:first-child {

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -180,6 +180,9 @@ if ($_['cronErrors']) {
 
 	<div class="section" id="shareAPI">
 		<h2><?php p($l->t('Sharing'));?></h2>
+		<a target="_blank" class="icon-info svg"
+			title="<?php p($l->t('Open documentation'));?>"
+			href="<?php p(link_to_docs('admin-sharing')); ?>"></a>
 		<p id="enable">
 			<input type="checkbox" name="shareapi_enabled" id="shareAPIEnabled"
 				   value="1" <?php if ($_['shareAPIEnabled'] === 'yes') print_unescaped('checked="checked"'); ?> />
@@ -310,7 +313,10 @@ if ($_['cronErrors']) {
 </div>
 
 <div class="section" id='encryptionAPI'>
-	<h2><?php p($l->t('Server-side encryption')); ?> </h2>
+	<h2><?php p($l->t('Server-side encryption')); ?></h2>
+	<a target="_blank" class="icon-info svg"
+		title="<?php p($l->t('Open documentation'));?>"
+		href="<?php p(link_to_docs('admin-encryption')); ?>"></a>
 
 	<p id="enable">
 		<input type="checkbox" name="encryption_enabled"
@@ -359,6 +365,9 @@ if ($_['cronErrors']) {
 <div class="section" id="mail_general_settings">
 	<form id="mail_general_settings_form" class="mail_settings">
 		<h2><?php p($l->t('Email server'));?></h2>
+		<a target="_blank" class="icon-info svg"
+			title="<?php p($l->t('Open documentation'));?>"
+			href="<?php p(link_to_docs('admin-email')); ?>"></a>
 
 		<p><?php p($l->t('This is used for sending out notifications.')); ?> <span id="mail_settings_msg" class="msg"></span></p>
 


### PR DESCRIPTION
Please review @owncloud/designers @karlitschek @schiesbn 

Requires https://github.com/owncloud/documentation/pull/1095 for the documentation links to work.
