### PR TITLE
remove 'More apps' link from apps mgmt now that we have support for experimental apps

### DIFF
--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -31,9 +31,6 @@ script(
 
 <?php if(OC_Config::getValue('appstoreenabled', true) === true): ?>
 	<li>
-		<a class="app-external" target="_blank" href="https://apps.owncloud.com/?xsortmode=high"><?php p($l->t('More apps'));?> …</a>
-	</li>
-	<li>
 		<a class="app-external" target="_blank" href="https://owncloud.org/dev"><?php p($l->t('Developer documentation'));?> …</a>
 	</li>
 <?php endif; ?>


### PR DESCRIPTION
Now that we have the »experimental apps« setting, there’s no real reason anymore for a dedicated link to the app store. It’s only confusing since there are not more apps there.

And eventually, all the things which the app store offers (screenshots, comments, and filters for most popular – see https://github.com/owncloud/core/issues/16004) should be in the apps mgmt anyway.

Please review @karlitschek @LukasReschke 
