### PR TITLE
fix search results from other places, account for margin-bottom in files list

### DIFF
--- a/core/search/css/results.css
+++ b/core/search/css/results.css
@@ -3,12 +3,14 @@
  See the COPYING-README file. */
 
 #searchresults {
-	background-color:#fff;
-	overflow-x:hidden;
-	text-overflow:ellipsis;
+	background-color: #fff;
+	overflow-x: hidden;
+	text-overflow: ellipsis;
 	padding-top: 65px;
 	box-sizing: border-box;
-	z-index:75;
+	z-index: 75;
+	/* account for margin-bottom in files list */
+	margin-top: -250px;
 }
 
 #searchresults.hidden {


### PR DESCRIPTION
Previously there was a bunch of free space between the files list and the »Search results from other places« when searching. That was due to me re-adding the bottom margin in the files list. This fixes that.

Please review @owncloud/designers @butonic 
