### PR TITLE
Add proper versioning for doc URL

### DIFF
--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -60,7 +60,7 @@ class OC_Defaults {
 		$this->defaultiTunesAppId = '543672169';
 		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
 		$this->defaultDocBaseUrl = 'https://doc.owncloud.org';
-		$this->defaultDocVersion = $version[0] . '.0'; // used to generate doc links
+		$this->defaultDocVersion = $version[0] . '.' . $version[1]; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('web services under your control');
 		$this->defaultLogoClaim = '';
 		$this->defaultMailHeaderColor = '#1d2d44'; /* header color of mail notifications */


### PR DESCRIPTION
As per 8.1 we have docs for minor versions as well so we need to link to `8.1` here instead to `8.0`.

Fixes https://github.com/owncloud/core/issues/16002

cc @MorrisJobke @carlaschroder Please test and review :smile: 
