### PR TITLE
Use OC.Notification for update notifications

### DIFF
--- a/core/js/update-notification.js
+++ b/core/js/update-notification.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015 ownCloud Inc
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+/**
+ * this gets only loaded if an update is available and then shows a temporary notification
+ */
+$(document).ready(function(){
+	var head = $('html > head'),
+		version = head.data('update-version'),
+		docLink = head.data('update-link'),
+		text = t('core', '{version} is available. Get more information on how to update.', {version: version}),
+		element = $('<a>').attr('href', docLink).text(text);
+
+	OC.Notification.showTemporary(
+		element,
+		{
+			isHTML: true
+		}
+	);
+});
+

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -2,7 +2,11 @@
 <!--[if lte IE 8]><html class="ng-csp ie ie8 lte9 lte8" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><![endif]-->
 <!--[if IE 9]><html class="ng-csp ie ie9 lte9" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--><html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><!--<![endif]-->
-	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
+	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>"
+		<?php if ($_['updateAvailable']): ?>
+			data-update-version="<?php print($_['updateVersion']); ?>" data-update-link="<?php print_unescaped($_['updateLink']); ?>"
+		<?php endif; ?>
+		>
 		<meta charset="utf-8">
 		<title>
 			<?php
@@ -31,9 +35,6 @@
 	<?php include('layout.noscript.warning.php'); ?>
 	<div id="notification-container">
 		<div id="notification"></div>
-		<?php if ($_['updateAvailable']): ?>
-			<div id="update-notification" style="display: inline;"><a href="<?php print_unescaped($_['updateLink']); ?>"><?php p($l->t('%s is available. Get more information on how to update.', array($_['updateVersion']))); ?></a></div>
-		<?php endif; ?>
 	</div>
 	<header role="banner"><div id="header">
 			<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -85,6 +85,7 @@ class OC_TemplateLayout extends OC_Template {
 					$this->assign('updateAvailable', true);
 					$this->assign('updateVersion', $data['versionstring']);
 					$this->assign('updateLink', $data['web']);
+					\OCP\Util::addScript('core', 'update-notification');
 				} else {
 					$this->assign('updateAvailable', false); // No update available or not an admin user
 				}


### PR DESCRIPTION
- instead of a static rendering inside PHP use the JS OC.Notification.showTemporary to hide the  notification after 7 seconds automatically
- fixes #14811 

For testing add following lines to https://github.com/owncloud/core/blob/6bd861910bbc8e1af383109ae1c8f220cded2b9c/lib/private/templatelayout.php#L83 to invoke the update notification:

``` php
$data['version'] = [8, 0, 4, 0];
$data['versionstring'] = '8.0.4';
$data['web'] = 'http://owncloud.org';
```

cc @owncloud/designers @pascalBokBok @deMattin @rullzer @Xenopathic 
