### PR TITLE
don't let the the user disable encryption once it was activated

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -224,6 +224,10 @@ textarea:disabled {
 	color: #999;
 	cursor: default;
 }
+input:disabled+label, input:disabled:hover+label, input:disabled:focus+label {
+	color: #999 !important;
+	cursor: default;
+}
 
 /* Primary action button, use sparingly */
 .primary, input[type="submit"].primary, input[type="button"].primary, button.primary, .button.primary {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -494,3 +494,7 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 #encryptionModules {
 	padding: 10px;
 }
+
+#warning {
+	color: red;
+}

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -55,6 +55,7 @@ $(document).ready(function(){
 	});
 
 	$('#encryptionEnabled').change(function() {
+		$('#encryptionAPI div#EncryptionWarning').toggleClass('hidden');
 		$('#encryptionAPI div#EncryptionSettingsArea').toggleClass('hidden');
 	});
 

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -54,21 +54,15 @@ $(document).ready(function(){
 		$('#shareAPI p:not(#enable)').toggleClass('hidden', !this.checked);
 	});
 
-	$('#encryptionEnabled').change(function() {
+	$('#enableEncryption').change(function() {
 		$('#encryptionAPI div#EncryptionWarning').toggleClass('hidden');
-		$('#encryptionAPI div#EncryptionSettingsArea').toggleClass('hidden');
 	});
 
-	$('#encryptionAPI input').change(function() {
-		var value = $(this).val();
-		if ($(this).attr('type') === 'checkbox') {
-			if (this.checked) {
-				value = 'yes';
-			} else {
-				value = 'no';
-			}
-		}
-		OC.AppConfig.setValue('core', $(this).attr('name'), value);
+	$('#reallyEnableEncryption').click(function() {
+		$('#encryptionAPI div#EncryptionWarning').toggleClass('hidden');
+		$('#encryptionAPI div#EncryptionSettingsArea').toggleClass('hidden');
+		OC.AppConfig.setValue('core', 'encryption_enabled', 'yes');
+		$('#enableEncryption').attr('disabled', 'disabled');
 	});
 
 	$('#startmigration').click(function(event){

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -319,15 +319,21 @@ if ($_['cronErrors']) {
 		href="<?php p(link_to_docs('admin-encryption')); ?>"></a>
 
 	<p id="enable">
-		<input type="checkbox" name="encryption_enabled"
-			   id="encryptionEnabled"
+		<input type="checkbox"
+			   id="enableEncryption"
 			   value="1" <?php if ($_['encryptionEnabled']) print_unescaped('checked="checked" disabled="disabled"'); ?> />
 		<label
 			for="encryptionEnabled"><?php p($l->t('Enable server-side encryption')); ?> <span id="startmigration_msg" class="msg"></span> </label><br/>
 	</p>
 
 	<div id="EncryptionWarning" class="warning hidden">
-		<?php p($l->t('Once encryption is enabled there is no way to disable it again. This is your last chance to disable it again.')) ?>
+		<?php p($l->t('Encryption is a one way process. Once encryption is enabled,
+		all files from that point forward will be encrypted on the server and it
+		will not be possible to disable encryption at a later date. This is the final warning:
+		Do you really want to enable encryption?')) ?>
+		<input type="button"
+			   id="reallyEnableEncryption"
+			   value="<?php p($l->t("Enable encryption")); ?>" />
 	</div>
 
 	<div id="EncryptionSettingsArea" class="<?php if (!$_['encryptionEnabled']) p('hidden'); ?>">

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -321,10 +321,14 @@ if ($_['cronErrors']) {
 	<p id="enable">
 		<input type="checkbox" name="encryption_enabled"
 			   id="encryptionEnabled"
-			   value="1" <?php if ($_['encryptionEnabled']) print_unescaped('checked="checked"'); ?> />
+			   value="1" <?php if ($_['encryptionEnabled']) print_unescaped('checked="checked" disabled="disabled"'); ?> />
 		<label
 			for="encryptionEnabled"><?php p($l->t('Enable server-side encryption')); ?> <span id="startmigration_msg" class="msg"></span> </label><br/>
 	</p>
+
+	<div id="EncryptionWarning" class="warning hidden">
+		<?php p($l->t('Once encryption is enabled there is no way to disable it again. This is your last chance to disable it again.')) ?>
+	</div>
 
 	<div id="EncryptionSettingsArea" class="<?php if (!$_['encryptionEnabled']) p('hidden'); ?>">
 		<div id='selectEncryptionModules' class="<?php if (!$_['encryptionReady']) p('hidden'); ?>">

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -323,7 +323,7 @@ if ($_['cronErrors']) {
 			   id="enableEncryption"
 			   value="1" <?php if ($_['encryptionEnabled']) print_unescaped('checked="checked" disabled="disabled"'); ?> />
 		<label
-			for="encryptionEnabled"><?php p($l->t('Enable server-side encryption')); ?> <span id="startmigration_msg" class="msg"></span> </label><br/>
+			for="enableEncryption"><?php p($l->t('Enable server-side encryption')); ?> <span id="startmigration_msg" class="msg"></span> </label><br/>
 	</p>
 
 	<div id="EncryptionWarning" class="warning hidden">


### PR DESCRIPTION
part of https://github.com/owncloud/core/issues/16021

We don't want to allow the user to disable encryption again after encryption was enabled, see also this discussion https://github.com/owncloud/core/pull/15880#discussion_r29142909

This is how it looks at the beginning, nothing changed:

![1](https://cloud.githubusercontent.com/assets/1589737/7452489/50d11ea6-f25e-11e4-9cea-ea30c0c98684.png)

After the admin enabled encryption he will see:

![2](https://cloud.githubusercontent.com/assets/1589737/7452492/5c44e4e8-f25e-11e4-83fa-b4bb56e7d648.png)

At this point the admin can decide to disable encryption again if he checked the checkbox by accident. If he decide to keep it and leave the page and come back later the setting will look like this

![3](https://cloud.githubusercontent.com/assets/1589737/7452503/80555f5c-f25e-11e4-9b65-1677519259d0.png)

Now the checkbox is disabled and it is no longer possible to disable encryption

cc @DeepDiver1975 @MTRichards @jancborchardt 
