### PR TITLE
Remove hard-dependency on disabled output_buffering

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -30,6 +30,8 @@
 // no php execution timeout for webdav
 set_time_limit(0);
 
+// Turn off output buffering to prevent memory problems
+\OC_Util::obEnd();
 
 // Backends
 $authBackend = new \OC\Connector\Sabre\Auth();

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -672,7 +672,6 @@ class OC_Util {
 			),
 			'ini' => [
 				'mbstring.func_overload' => 0,
-				'output_buffering' => false,
 				'default_charset' => 'UTF-8',
 			],
 		);


### PR DESCRIPTION
This removes the hard-dependency on output buffering as requested at https://github.com/owncloud/core/issues/16013 since a lot of distributions such as Debian and Ubuntu decided to use `4096` instead of the PHP recommended and documented default value of `off`.

However, we still should encourage disabling this setting for improved performance and reliability thus the setting switches in `.user.ini` and `.htaccess` are remaining there. It is very likely that we in other cases also should disable the output buffering but aren't doing it everywhere and thus causing memory problems.

Fixes https://github.com/owncloud/core/issues/16013

cc @karlitschek @DeepDiver1975 
