### PR TITLE
Add an occ command to get the status of encryption

### DIFF
--- a/core/command/encryption/status.php
+++ b/core/command/encryption/status.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Encryption;
+
+use OC\Core\Command\Base;
+use OCP\Encryption\IManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Status extends Base {
+	/** @var IManager */
+	protected $encryptionManager;
+
+	/**
+	 * @param IManager $encryptionManager
+	 */
+	public function __construct(IManager $encryptionManager) {
+		parent::__construct();
+		$this->encryptionManager = $encryptionManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('encryption:status')
+			->setDescription('Lists the current status of encryption')
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->writeArrayInOutputFormat($input, $output, [
+			'enabled' => $this->encryptionManager->isEnabled(),
+			'defaultModule' => $this->encryptionManager->getDefaultEncryptionModuleId(),
+		]);
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -54,6 +54,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager()));
 	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager()));
+	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
 } else {
 	$application->add(new OC\Core\Command\Maintenance\Install(\OC::$server->getConfig()));
 }


### PR DESCRIPTION
@DeepDiver1975 @schiesbn @jnfrmarks 

Fix #15977 

```
./occ encryption:status --output=json_pretty
{
    "enabled": true,
    "defaultModule": "OC_DUMMY_MODULE"
}
```

```
./occ encryption:status
 - enabled: true
 - defaultModule: OC_DUMMY_MODULE
```
