### PR TITLE
Check `mbstring.func_overload` only if the mb module is installed.

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -739,15 +739,6 @@ class OC_Util {
 			$webServerRestart = true;
 		}
 
-		if (version_compare(phpversion(), '5.4.0', '<')) {
-			$errors[] = array(
-				'error' => $l->t('PHP %s or higher is required.', '5.4.0'),
-				'hint' => $l->t('Please ask your server administrator to update PHP to the latest version.'
-					. ' Your PHP version is no longer supported by ownCloud and the PHP community.')
-			);
-			$webServerRestart = true;
-		}
-
 		/**
 		 * PHP 5.6 ships with a PHP setting which throws notices by default for a
 		 * lot of endpoints. Thus we need to ensure that the value is set to -1

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -671,7 +671,6 @@ class OC_Util {
 				'PDO::ATTR_DRIVER_NAME' => 'PDO'
 			),
 			'ini' => [
-				'mbstring.func_overload' => 0,
 				'default_charset' => 'UTF-8',
 			],
 		);
@@ -685,6 +684,7 @@ class OC_Util {
 		 *        approach to check for these values we should re-enable those
 		 *        checks.
 		 */
+		$iniWrapper = \OC::$server->getIniWrapper();
 		if (!self::runningOnHhvm()) {
 			foreach ($dependencies['classes'] as $class => $module) {
 				if (!class_exists($class)) {
@@ -702,7 +702,6 @@ class OC_Util {
 				}
 			}
 			foreach ($dependencies['ini'] as $setting => $expected) {
-				$iniWrapper = \OC::$server->getIniWrapper();
 				if (is_bool($expected)) {
 					if ($iniWrapper->getBool($setting) !== $expected) {
 						$invalidIniSettings[] = [$setting, $expected];
@@ -737,6 +736,22 @@ class OC_Util {
 				'hint' =>  $l->t('Adjusting this setting in php.ini will make ownCloud run again')
 			];
 			$webServerRestart = true;
+		}
+
+		/**
+		 * The mbstring.func_overload check can only be performed if the mbstring
+		 * module is installed as it will return null if the checking setting is
+		 * not available and thus a check on the boolean value fails.
+		 *
+		 * TODO: Should probably be implemented in the above generic dependency
+		 *       check somehow in the long-term.
+		 */
+		if($iniWrapper->getBool('mbstring.func_overload') !== null &&
+			$iniWrapper->getBool('mbstring.func_overload') === true) {
+			$errors[] = array(
+				'error' => $l->t('mbstring.func_overload is set to "%s" instead to the expected value "0"', [$iniWrapper->getString('mbstring.func_overload')]),
+				'hint' => $l->t('To fix this issue set <code>mbstring.func_overload</code> to <code>0</code> in your php.ini')
+			);
 		}
 
 		/**


### PR DESCRIPTION
Fixes #14670

cc @Raydiation Please test and review.
cc @karlitschek 
