### PR TITLE
OCA\Files_Encryption\Proxy::shouldEncrypt() should query the storage if possible

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -78,14 +78,16 @@ class Proxy extends \OC_FileProxy {
 			$normalizedPath = dirname($normalizedPath);
 		}
 
-		// we don't encrypt server-to-server shares
-		list($storage, ) = \OC\Files\Filesystem::resolvePath($normalizedPath);
+		// we don't encrypt for SecureStorage or server-to-server shares
+		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath($normalizedPath);
 		/**
 		 * @var \OCP\Files\Storage $storage
 		 */
 		if ($storage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
 			return true;
-		}
+		} elseif ($storage->instanceOfStorage('OCP\Files\SecureStorage')) {
+            return $storage->shouldEncrypt($internalPath);
+        }
 
 		return false;
 	}

--- a/lib/public/files/securestorage.php
+++ b/lib/public/files/securestorage.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Dagan Henderson
+ * @copyright 2015 Dagan Henderson dagan@techdagan.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Files/SecureStorage interface
+ */
+
+namespace OCP\Files;
+
+
+interface SecureStorage extends Storage {
+
+    /**
+     * Indicates Whether a Path Should be Encrypted by ownCloud
+     *
+     * Used by OCA\Files_Encryption\Proxy to determine whether or not to
+     * encrypt the given file. If the storage returns false, it must monitor
+     * and respects share of the given path, ensuring all users the file is
+     * shared with maintain access. The storage must also ensure the file is
+     * stored securely.
+     *
+     * @param $path
+     * @return bool
+     */
+    public function shouldEncrypt($path);
+}


### PR DESCRIPTION
In at least one case the encryption app deliberately skips encryption for a storage (i.e. if `::instanceOfStorage('OCA\Files_Sharing\External\Storage')` returns true, regardless of the actual storage class), however if the storage were able to declare itself as secure, new secure storage classes could be added without necessitating either a change to the encryption app or a dishonest return value for `::instanceOfStorage()`. 
