### PR TITLE
Don't display errors and log them

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -542,12 +542,10 @@ class OC {
 		\OC::$server->getEventLogger()->log('autoloader', 'Autoloader', $loaderStart, $loaderEnd);
 		\OC::$server->getEventLogger()->start('boot', 'Initialize');
 
-		// set some stuff
-		//ob_start();
+		// Don't display errors and log them
 		error_reporting(E_ALL | E_STRICT);
-		if (defined('DEBUG') && DEBUG) {
-			ini_set('display_errors', 1);
-		}
+		@ini_set('display_errors', 0);
+		@ini_set('log_errors', 1);
 
 		date_default_timezone_set('UTC');
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -754,25 +754,6 @@ class OC_Util {
 			);
 		}
 
-		/**
-		 * PHP 5.6 ships with a PHP setting which throws notices by default for a
-		 * lot of endpoints. Thus we need to ensure that the value is set to -1
-		 *
-		 * FIXME: Due to https://github.com/owncloud/core/pull/13593#issuecomment-71178078
-		 * this check is disabled for HHVM at the moment. This should get re-evaluated
-		 * at a later point.
-		 *
-		 * @link https://github.com/owncloud/core/issues/13592
-		 */
-		if(version_compare(phpversion(), '5.6.0', '>=') &&
-			!self::runningOnHhvm() &&
-			\OC::$server->getIniWrapper()->getNumeric('always_populate_raw_post_data') !== -1) {
-			$errors[] = array(
-				'error' => $l->t('PHP is configured to populate raw post data. Since PHP 5.6 this will lead to PHP throwing notices for perfectly valid code.'),
-				'hint' => $l->t('To fix this issue set <code>always_populate_raw_post_data</code> to <code>-1</code> in your php.ini')
-			);
-		}
-
 		if (!self::isAnnotationsWorking()) {
 			$errors[] = array(
 				'error' => $l->t('PHP is apparently setup to strip inline doc blocks. This will make several core apps inaccessible.'),


### PR DESCRIPTION
~~There is a breaking behavioural change in PHP 5.6 that will result in getting valid requests logged as DEPRECATED notice which in some cases can result in broken AJAX requests and other unpredictable havoc.~~

~~As a workaround we can change the error_reporting handler to exclude deprecated notices. The actual fix would be to adjust the ini setting but since this is not possible programmatically due to the fact that user code is executed after this exception is thrown we have to do it this way. Our .htaccess and .user.ini will still contain the correct fix. To sum it up: Huge hack:see_no_evil:~~

New approach at https://github.com/owncloud/core/pull/16050#issuecomment-99018847

Fixes https://github.com/owncloud/core/issues/16014

cc @karlitschek 
