### PR TITLE
Fix: user login filter does not take username into account

### DIFF
--- a/apps/user_ldap/ajax/getNewServerConfigPrefix.php
+++ b/apps/user_ldap/ajax/getNewServerConfigPrefix.php
@@ -41,6 +41,7 @@ if(isset($_POST['copyConfig'])) {
 	$newConfig->setConfiguration($originalConfig->getConfiguration());
 } else {
 	$configuration = new \OCA\user_ldap\lib\Configuration($nk, false);
+	$newConfig->setConfiguration($configuration->getDefaults());
 	$resultData['defaults'] = $configuration->getDefaults();
 }
 $newConfig->saveConfiguration();

--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -207,7 +207,6 @@ OCA = OCA || {};
 		 */
 		onNewConfiguration: function(view, result) {
 			if(result.isSuccess === true) {
-				console.log('new config');
 				var nthServer = view._configChooserNextServerNumber;
 				view.$configChooser.find('option:selected').removeAttr('selected');
 				var html = '<option value="'+result.configPrefix+'" selected="selected">'+t('user_ldap','{nthServer}. Server', {nthServer: nthServer})+'</option>';

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -958,7 +958,6 @@ class Wizard extends LDAPUtility {
 				$userAttributes = array_change_key_case(array_flip($userAttributes));
 				$parts = 0;
 
-				$x = $this->configuration->ldapLoginFilterUsername;
 				if($this->configuration->ldapLoginFilterUsername === '1') {
 					$attr = '';
 					if(isset($userAttributes['uid'])) {


### PR DESCRIPTION
A just initialized configuration is totally unconfigured i.e. empty, but we sent back default values to the wizard. This effects bugs as #15933. Now, we save the configuration with the defaults for the wizard. See original bug for reproduction steps.

Please review and test @davitol @MorrisJobke @jvillafanez @Xenopathic 
