### PR TITLE
make sure that we keep the correct encrypted-flag and the (unencrypted)size

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -252,6 +252,7 @@ class Encryption extends Wrapper {
 	 */
 	public function copy($path1, $path2) {
 		$fullPath1 = $this->getFullPath($path1);
+		$fullPath2 = $this->getFullPath($path2);
 		if ($this->util->isExcluded($fullPath1)) {
 			return $this->storage->copy($path1, $path2);
 		}
@@ -267,6 +268,9 @@ class Encryption extends Wrapper {
 			) {
 				$this->update->update($target);
 			}
+			$data = $this->getMetaData($path1);
+			$this->getCache()->put($path2, ['encrypted' => $data['encrypted']]);
+			$this->updateUnencryptedSize($fullPath2, $data['size']);
 		}
 
 		return $result;


### PR DESCRIPTION
make sure that we keep the correct encrypted-flag and the (unencrypted)size if a file gets copied

should fix https://github.com/owncloud/core/issues/15970

cc @PVince81 

steps to test:
1. enable encryption
2. upload a file
3. copy it, e.g. with a webdav client
4. check the file cache

-> without the patch the copy will have "encrypted" set to "0" and as "size" the encrypted size (different size then the source file).

-> with this patch "encrypted" flag will be set to '1' and the 'size' will be the correct unencrypted size (same size as the source file)

Second test:
1. enable encryption
2. upload a file
3. edit it multiple times so that ownCloud create some versions
4. check the file cache

-> without the patch the file_versions will have "encrypted" set to "0" and as "size" the encrypted size (different size then the source file).

-> with this patch "encrypted" flag will be set to '1' and the 'size' will be the correct unencrypted size (same size as the source file)

cc @th3fallen @nickvergessen maybe you can review it? Thanks!
