### PR TITLE
wait with copying the skeleton untill login and setupfs are done

### DIFF
--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -78,10 +78,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		\OC_User::createUser($this->user, $this->user);
 		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
-		Filesystem::tearDown();
-		\OC_User::setUserId($this->user);
-		\OC_Util::setupFS($this->user);
+		$this->loginAsUser($this->user);
 
 		// Create a dummy shared file
 		$view = new View('/'. $this->user . '/files');

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -153,6 +153,7 @@ abstract class TestCase extends \Test\TestCase {
 		\OC::$server->getUserSession()->setUser(null);
 		\OC\Files\Filesystem::tearDown();
 		\OC::$server->getUserSession()->login($user, $password);
+		\OC::$server->getUserFolder($user);
 
 		\OC_Util::setupFS($user);
 	}

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -646,6 +646,7 @@ class Test_Trashbin extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
+		\OC::$server->getUserFolder($user);
 	}
 }
 

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -753,6 +753,7 @@ class Test_Files_Versioning extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
+		\OC::$server->getUserFolder($user);
 	}
 
 }

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -44,7 +44,7 @@ class AppsTest extends TestCase {
 
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 
 		$result = \OCA\provisioning_API\Apps::getApps(array());
 

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -27,7 +27,7 @@ class GroupsTest extends TestCase {
 	public function testGetGroupAsUser() {
 
 		$users = $this->generateUsers(2);
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
@@ -46,7 +46,7 @@ class GroupsTest extends TestCase {
 	public function testGetGroupAsSubadmin() {
 
 		$users = $this->generateUsers(2);
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
@@ -75,7 +75,7 @@ class GroupsTest extends TestCase {
 	public function testGetGroupAsIrrelevantSubadmin() {
 
 		$users = $this->generateUsers(2);
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
@@ -99,7 +99,7 @@ class GroupsTest extends TestCase {
 	public function testGetGroupAsAdmin() {
 
 		$users = $this->generateUsers(2);
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
@@ -120,7 +120,7 @@ class GroupsTest extends TestCase {
 	public function testGetSubAdminsOfGroup() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -135,7 +135,7 @@ class GroupsTest extends TestCase {
 		\OC_Group::deleteGroup($group1);
 
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$result = \OCA\provisioning_api\Groups::getSubAdminsOfGroup(array(
 			'groupid' => $this->getUniqueID(),

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -81,7 +81,7 @@ class UsersTest extends TestCase {
 
 	public function testGetUserOnSelf() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$params['userid'] = $user;
 		$result = \OCA\provisioning_API\Users::getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
@@ -92,7 +92,7 @@ class UsersTest extends TestCase {
 	public function testGetUserOnNonExistingUser() {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$params = array();
 		$params['userid'] = $this->getUniqueID();
 		while(\OC_User::userExists($params['userid'])) {
@@ -108,7 +108,7 @@ class UsersTest extends TestCase {
 	public function testGetUserOnOtherUser() {
 		$users = $this->generateUsers(2);
 		$params['userid'] = $users[0];
-		\OC_User::setUserId($users[1]);
+		self::loginAsUser($users[1]);
 		$result = \OCA\provisioning_API\Users::getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertFalse($result->succeeded());
@@ -116,8 +116,10 @@ class UsersTest extends TestCase {
 		// Now as as admin
 		$users = $this->generateUsers(2);
 		$params['userid'] = $users[0];
+		// login to generate home
+		self::loginAsUser($users[0]);
 		\OC_Group::addToGroup($users[1], 'admin');
-		\OC_User::setUserId($users[1]);
+		self::loginAsUser($users[1]);
 		$result = \OCA\provisioning_API\Users::getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
@@ -129,7 +131,7 @@ class UsersTest extends TestCase {
 
 		// Test editing own name
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
 				'userid' => $user,
@@ -150,7 +152,7 @@ class UsersTest extends TestCase {
 		// Test admin editing users name
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
@@ -171,7 +173,7 @@ class UsersTest extends TestCase {
 
 		// Test editing other users name
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
@@ -195,7 +197,7 @@ class UsersTest extends TestCase {
 	public function testEditOwnQuota($expected, $quota) {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::editUser(
 			[
 				'userid' => $user,
@@ -222,7 +224,7 @@ class UsersTest extends TestCase {
 	public function testAdminEditOwnQuota() {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
 				'userid' => $user,
@@ -239,7 +241,7 @@ class UsersTest extends TestCase {
 	public function testAdminEditOtherUserQuota() {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
@@ -256,7 +258,7 @@ class UsersTest extends TestCase {
 
 	public function testUserEditOtherUserQuota() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
@@ -274,7 +276,7 @@ class UsersTest extends TestCase {
 	public function testUserEditOwnEmail() {
 		$user = $this->generateUsers();
 		$email = 'test@example.com';
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
 				'userid' => $user,
@@ -292,7 +294,7 @@ class UsersTest extends TestCase {
 	public function testUserEditOtherUserEmailAsUser() {
 		$users = $this->generateUsers(2);
 		$email = 'test@example.com';
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
 				'userid' => $users[1],
@@ -309,7 +311,7 @@ class UsersTest extends TestCase {
 	public function testUserEditOtherUserEmailAsAdmin() {
 		$users = $this->generateUsers(2);
 		$email = 'test@example.com';
-		\OC_User::setUserId($users[0]);
+		self::loginAsUser($users[0]);
 		\OC_Group::addToGroup($users[0], 'admin');
 		$result = \OCA\provisioning_API\Users::editUser(
 			array(
@@ -327,7 +329,7 @@ class UsersTest extends TestCase {
 
 	public function testDeleteSelf() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::deleteUser(array(
 			'userid' => $user,
 			));
@@ -337,7 +339,7 @@ class UsersTest extends TestCase {
 
 	public function testDeleteOtherAsUser() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::deleteUser(array(
 			'userid' => $user2,
@@ -348,7 +350,7 @@ class UsersTest extends TestCase {
 
 	public function testDeleteOtherAsSubAdmin() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
@@ -365,7 +367,7 @@ class UsersTest extends TestCase {
 
 	public function testDeleteOtherAsIrelevantSubAdmin() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$group = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
@@ -386,7 +388,7 @@ class UsersTest extends TestCase {
 	public function testDeleteOtherAsAdmin() {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$user2 = $this->generateUsers();
 		$result = \OCA\provisioning_API\Users::deleteUser(array(
 			'userid' => $user2,
@@ -398,7 +400,7 @@ class UsersTest extends TestCase {
 	public function testDeleteSelfAsAdmin() {
 		$user = $this->generateUsers();
 		\OC_Group::addToGroup($user, 'admin');
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$result = \OCA\provisioning_API\Users::deleteUser(array(
 			'userid' => $user,
 			));
@@ -408,7 +410,7 @@ class UsersTest extends TestCase {
 
 	public function testGetUsersGroupsOnSelf() {
 		$user = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
 		\OC_Group::addToGroup($user, $group);
@@ -426,7 +428,7 @@ class UsersTest extends TestCase {
 	public function testGetUsersGroupOnOther() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
 		\OC_Group::addToGroup($user2, $group);
@@ -442,7 +444,7 @@ class UsersTest extends TestCase {
 		$user1 = $this->generateUsers();
 		\OC_Group::addToGroup($user1, 'admin');
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
 		\OC_Group::addToGroup($user2, $group);
@@ -460,7 +462,7 @@ class UsersTest extends TestCase {
 	public function testGetUsersGroupsOnOtherAsSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -484,7 +486,7 @@ class UsersTest extends TestCase {
 	public function testGetUsersGroupsOnOtherAsIrelevantSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -505,7 +507,7 @@ class UsersTest extends TestCase {
 		$user = $this->generateUsers();
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$_POST['groupid'] = $group;
 		$result = \OCA\provisioning_API\Users::addToGroup(array(
 			'userid' => $user,
@@ -522,7 +524,7 @@ class UsersTest extends TestCase {
 		$group = $this->getUniqueID();
 		\OC_Group::createGroup($group);
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user);
+		self::loginAsUser($user);
 		$_POST['groupid'] = $group;
 		$result = \OCA\provisioning_API\Users::addToGroup(array(
 			'userid' => $user2,
@@ -536,7 +538,7 @@ class UsersTest extends TestCase {
 	public function testAddToGroupAsSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
 		\OC_SubAdmin::createSubAdmin($user1, $group1);
@@ -553,7 +555,7 @@ class UsersTest extends TestCase {
 	public function testAddToGroupAsIrelevantSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -573,7 +575,7 @@ class UsersTest extends TestCase {
 	// test delete /cloud/users/{userid}/groups
 	public function testRemoveFromGroupAsSelf() {
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
 		\OC_Group::addToGroup($user1, $group1);
@@ -592,7 +594,7 @@ class UsersTest extends TestCase {
 	public function testRemoveFromGroupAsAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
 		\OC_Group::addToGroup($user2, $group1);
@@ -611,7 +613,7 @@ class UsersTest extends TestCase {
 
 	public function testRemoveFromGroupAsSubAdmin() {
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$user2 = $this->generateUsers();
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -632,7 +634,7 @@ class UsersTest extends TestCase {
 
 	public function testRemoveFromGroupAsIrelevantSubAdmin() {
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		$user2 = $this->generateUsers();
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
@@ -657,7 +659,7 @@ class UsersTest extends TestCase {
 	public function testCreateSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -674,7 +676,7 @@ class UsersTest extends TestCase {
 
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$_POST['groupid'] = 'admin';
 		$result = \OCA\provisioning_api\Users::addSubAdmin(array(
@@ -687,7 +689,7 @@ class UsersTest extends TestCase {
 		$this->resetParams();
 
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -704,7 +706,7 @@ class UsersTest extends TestCase {
 	public function testRemoveSubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -721,7 +723,7 @@ class UsersTest extends TestCase {
 		\OC_Group::deleteGroup($group1);
 
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$result = \OCA\provisioning_api\Users::removeSubAdmin(array(
 			'userid' => $this->getUniqueID(),
@@ -737,7 +739,7 @@ class UsersTest extends TestCase {
 
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -757,7 +759,7 @@ class UsersTest extends TestCase {
 	public function testGetSubAdminGroups() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);
@@ -772,7 +774,7 @@ class UsersTest extends TestCase {
 		\OC_Group::deleteGroup($group1);
 
 		$user1 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		$result = \OCA\provisioning_api\Users::getUserSubAdminGroups(array(
@@ -786,7 +788,7 @@ class UsersTest extends TestCase {
 	public function testSubAdminOfGroupAlreadySubAdmin() {
 		$user1 = $this->generateUsers();
 		$user2 = $this->generateUsers();
-		\OC_User::setUserId($user1);
+		self::loginAsUser($user1);
 		\OC_Group::addToGroup($user1, 'admin');
 		$group1 = $this->getUniqueID();
 		\OC_Group::createGroup($group1);

--- a/lib/private/log/errorhandler.php
+++ b/lib/private/log/errorhandler.php
@@ -64,10 +64,16 @@ class ErrorHandler {
 		}
 	}
 
-	// Uncaught exception handler
+	/**
+	 * 	Uncaught exception handler
+	 *
+	 * @param \Exception $exception
+	 */
 	public static function onException($exception) {
-		$msg = $exception->getMessage() . ' at ' . $exception->getFile() . '#' . $exception->getLine();
-		self::$logger->critical(self::removePassword($msg), array('app' => 'PHP'));
+		$class = get_class($exception);
+		$msg = $exception->getMessage();
+		$msg = "$class: $msg at " . $exception->getFile() . '#' . $exception->getLine();
+		self::$logger->critical(self::removePassword($msg), ['app' => 'PHP']);
 	}
 
 	//Recoverable errors handler

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -241,7 +241,10 @@ class OC_User {
 		$result = self::getUserSession()->login($loginname, $password);
 		if ($result) {
 			//we need to pass the user name, which may differ from login name
-			OC_Util::setupFS(self::getUserSession()->getUser()->getUID());
+			$user = self::getUserSession()->getUser()->getUID();
+			OC_Util::setupFS($user);
+			//trigger creation of user home and /files folder
+			\OC::$server->getUserFolder($user);
 		}
 		return $result;
 	}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -189,9 +189,6 @@ class OC_Util {
 			//jail the user into his "home" directory
 			\OC\Files\Filesystem::init($user, $userDir);
 
-			//trigger creation of user home and /files folder
-			\OC::$server->getUserFolder($user);
-
 			OC_Hook::emit('OC_Filesystem', 'setup', array('user' => $user, 'user_dir' => $userDir));
 		}
 		\OC::$server->getEventLogger()->end('setup_fs');

--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -88,11 +88,7 @@ class AvatarControllerTest extends \Test\TestCase {
 		$this->user = $this->getUniqueID('user');
 
 		OC::$server->getUserManager()->createUser($this->user, $this->user);
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
-		Filesystem::tearDown();
-		\OC_User::setUserId($this->user);
-		\OC_Util::setupFS($this->user);
+		$this->loginAsUser($this->user);
 
 		// Create Cache dir
 		$view = new \OC\Files\View('/'.$this->user);

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -174,6 +174,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
+		\OC::$server->getUserFolder($user);
 	}
 
 	/**

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -174,7 +174,9 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
-		\OC::$server->getUserFolder($user);
+		if (\OC_User::userExists($user)) {
+			\OC::$server->getUserFolder($user);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #15981

Moves creating the skeleton outside setupfs and call it manually after the entire login process is done.

The problem was caused by encryption calling setupfs from it's login hook (which it shouldn't but that's for another time)

cc @DeepDiver1975 @PVince81  @schiesbn  
