### PR TITLE
Resize filepicker on window size change

### DIFF
--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -78,8 +78,12 @@
 				var pos = self.parent.position();
 				self.$dialog.css({
 					left: pos.left + ($(window).innerWidth() - self.$dialog.outerWidth())/2,
-					top: pos.top + ($(window).innerHeight() - self.$dialog.outerHeight())/2
+					top: pos.top + ($(window).innerHeight() - self.$dialog.outerHeight())/2,
+					width: Math.min(self.options.width, $(window).innerWidth() - 20 ),
+					height: Math.min(self.options.height, $(window).innerHeight() - 20)
 				});
+				// set sizes of content
+				self._setSizes();
 			});
 
 			this._setOptions(this.options);

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -207,7 +207,8 @@ var OCdialogs = {
 
 			self.$filePicker.ocdialog({
 				closeOnEscape: true,
-				width: (4/5)*$(document).width(),
+				// max-width of 600
+				width: Math.min((4/5)*$(document).width(), 600),
 				height: 420,
 				modal: modal,
 				buttons: buttonlist,


### PR DESCRIPTION
- add 20 px space to each direction -> 10px padding to left, right, top and bottom
- fixes #16100 

cc @owncloud/designers 
