### PR TITLE
[stable7] block cron.php and OCS API when in single user mode or maintenance mode

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -57,6 +57,11 @@ try {
 		exit;
 	}
 
+	if (\OCP\Config::getSystemValue('singleuser', false)) {
+		\OCP\Util::writeLog('cron', 'We are in admin only mode, skipping cron', \OCP\Util::DEBUG);
+		exit;
+	}
+
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -254,26 +254,32 @@ class OC {
 			header('Retry-After: 120');
 
 			// render error page
-			$tmpl = new OC_Template('', 'update.user', 'guest');
-			$tmpl->printPage();
+			$template = new OC_Template('', 'update.user', 'guest');
+			$template->printPage();
 			die();
 		}
 	}
 
 	public static function checkSingleUserMode() {
-		$user = OC_User::getUserSession()->getUser();
-		$group = OC_Group::getManager()->get('admin');
-		if ($user && OC_Config::getValue('singleuser', false) && !$group->inGroup($user)) {
-			// send http status 503
-			header('HTTP/1.1 503 Service Temporarily Unavailable');
-			header('Status: 503 Service Temporarily Unavailable');
-			header('Retry-After: 120');
-
-			// render error page
-			$tmpl = new OC_Template('', 'singleuser.user', 'guest');
-			$tmpl->printPage();
-			die();
+		if (!\OCP\Config::getSystemValue('singleuser', false)) {
+			return;
 		}
+		$user = OC_User::getUserSession()->getUser();
+		if ($user) {
+			$group = \OC::$server->getGroupManager()->get('admin');
+			if ($group->inGroup($user)) {
+				return;
+			}
+		}
+		// send http status 503
+		header('HTTP/1.1 503 Service Temporarily Unavailable');
+		header('Status: 503 Service Temporarily Unavailable');
+		header('Retry-After: 120');
+
+		// render error page
+		$template = new OC_Template('', 'singleuser.user', 'guest');
+		$template->printPage();
+		die();
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -260,7 +260,7 @@ class OC {
 		}
 	}
 
-	public static function checkSingleUserMode() {
+	public static function checkSingleUserMode($lockIfNoUserLoggedIn = false) {
 		if (!\OCP\Config::getSystemValue('singleuser', false)) {
 			return;
 		}
@@ -268,6 +268,10 @@ class OC {
 		if ($user) {
 			$group = \OC::$server->getGroupManager()->get('admin');
 			if ($group->inGroup($user)) {
+				return;
+			}
+		} else {
+			if(!$lockIfNoUserLoggedIn) {
 				return;
 			}
 		}

--- a/lib/private/connector/sabre/maintenanceplugin.php
+++ b/lib/private/connector/sabre/maintenanceplugin.php
@@ -45,6 +45,9 @@ class OC_Connector_Sabre_MaintenancePlugin extends \Sabre\DAV\ServerPlugin
 	 * @return bool
 	 */
 	public function checkMaintenanceMode() {
+		if (\OCP\Config::getSystemValue('singleuser', false)) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable();
+		}
 		if (OC_Config::getValue('maintenance', false)) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable();
 		}

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -23,7 +23,7 @@
 
 require_once '../lib/base.php';
 
-if (\OCP\Util::needUpgrade()) {
+if (\OCP\Util::needUpgrade() || \OCP\Config::getSystemValue('maintenance', false)) {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -23,7 +23,9 @@
 
 require_once '../lib/base.php';
 
-if (\OCP\Util::needUpgrade() || \OCP\Config::getSystemValue('maintenance', false)) {
+if (\OCP\Util::needUpgrade()
+	|| \OCP\Config::getSystemValue('maintenance', false)
+	|| \OCP\Config::getSystemValue('singleuser', false)) {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);

--- a/public.php
+++ b/public.php
@@ -12,7 +12,7 @@ try {
 	}
 
 	OC::checkMaintenanceMode();
-	OC::checkSingleUserMode();
+	OC::checkSingleUserMode(true);
 	$pathInfo = OC_Request::getPathInfo();
 	if (!$pathInfo && !isset($_GET['service'])) {
 		header('HTTP/1.0 404 Not Found');


### PR DESCRIPTION
This is the backport of #15510 and #15465

Fixes #15436

cc @nickvergessen @DeepDiver1975 @LukasReschke

@karlitschek 

Ref #15456

Approval https://github.com/owncloud/core/pull/15510#issuecomment-92145032

How to test:
- OCS: `curl -u mjob:mjob -X POST http://localhost/master/ocs/v1.php/cloud/users -d userid=foo -d password=11111`
- Webdav: use cadaver
- Web UI
