### PR TITLE
Use existing IRequest to not read php://input multiple times

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -86,9 +86,9 @@ class OC_API {
 	public static function call($parameters) {
 		// Prepare the request variables
 		if($_SERVER['REQUEST_METHOD'] == 'PUT') {
-			parse_str(file_get_contents("php://input"), $parameters['_put']);
+			$parameters['_put'] = \OC::$server->getRequest()->getParams();
 		} else if($_SERVER['REQUEST_METHOD'] == 'DELETE') {
-			parse_str(file_get_contents("php://input"), $parameters['_delete']);
+			$parameters['_delete'] = \OC::$server->getRequest()->getParams();
 		}
 		$name = $parameters['_route'];
 		// Foreach registered action


### PR DESCRIPTION
Fixes https://github.com/owncloud/client/issues/3204#issuecomment-99427563 and https://github.com/owncloud/firewall/issues/95 - the firewall app has instantiiated an IRequest before and thus broke a lot of stuff on < PHP 5.6.

Requires **proper** testing in all possible scenarios (with CE, with EE, without firewall app, with firewall app, PHP 5.4, PHP 5.5, PHP 5.6 etc…). Master should not be affected as we use a more bullet proof request handling there.

cc @Dianafg76 @ckamm @th3fallen @rullzer @karlitschek @DeepDiver1975 
