### PR TITLE
Fix broken group presentation in selected groups list

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
@@ -158,9 +158,12 @@ OCA = OCA || {};
 		/**
 		 * sets the selected groups
 		 *
-		 * @param {Array} groups
+		 * @param {string} groups
 		 */
 		setGroups: function(groups) {
+			if(typeof groups === 'string') {
+				groups = groups.split("\n");
+			}
 			if(!this.isComplexGroupChooser) {
 				this.setElementValue(this.getGroupsItem().$element, groups);
 				this.getGroupsItem().$element.multiselect('refresh');
@@ -224,10 +227,10 @@ OCA = OCA || {};
 					$selectedGroups, $(this.tabID).find('.ldapManyGroupsSearch')
 				));
 			} else {
-				if(_.isUndefined || only.toLowerCase() === 'available')  {
+				if(only.toLowerCase() === 'available')  {
 					this.filterOnType[0].updateOptions();
 				}
-				if(_.isUndefined || only.toLowerCase() === 'selected')  {
+				if(only.toLowerCase() === 'selected')  {
 					this.filterOnType[1].updateOptions();
 				}
 			}

--- a/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabAbstractFilter.js
@@ -170,6 +170,7 @@ OCA = OCA || {};
 			} else {
 				var $element = $(this.tabID).find('.ldapGroupListSelected');
 				this.equipMultiSelect($element, groups);
+				this.updateFilterOnType('selected');
 			}
 		},
 
@@ -360,7 +361,7 @@ OCA = OCA || {};
 
 			this._saveGroups(selected.concat($available.val()));
 			$available.find('option:selected').prependTo($selected);
-			this.updateFilterOnType();
+			this.updateFilterOnType('available');  // selected groups are not updated yet
 		},
 
 		/**
@@ -373,7 +374,7 @@ OCA = OCA || {};
 
 			this._saveGroups(selected);
 			$selected.find('option:selected').appendTo($available);
-			this.updateFilterOnType();
+			this.updateFilterOnType('available');  // selected groups are not updated yet
 		}
 
 	});


### PR DESCRIPTION
Fixes #15866, see there for reproduction steps.

Also fixes an issue with the type on search in the expended group selector. Previously, the search index was updated too early, so that old state of selected groups was indexed. I.e. if you add a group, do any search, and remove the search string again, then the old, invalid state was shown. Affected the selected groups list only.

please test and review @jvillafanez @MorrisJobke @davitol or others, thx
