### PR TITLE
Enable file icons & previews in "Shared ..." categories

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -950,7 +950,8 @@
 			if (fileData.isPreviewAvailable) {
 				var iconDiv = filenameTd.find('.thumbnail');
 				// lazy load / newly inserted td ?
-				if (options.animate) {
+				// the typeof check ensures that the default value of animate is true
+				if (typeof(options.animate) === 'undefined' || !!options.animate) {
 					this.lazyLoadPreview({
 						path: path + '/' + fileData.name,
 						mime: mime,

--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -68,6 +68,7 @@ class Local {
 					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
 						$share['isPreviewAvailable'] = true;
 					}
+					$share['icon'] = substr(\OC_Helper::mimetypeIcon($share['mimetype']), 0, -3) . 'svg';
 				}
 			}
 			return new \OC_OCS_Result($shares);

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -176,6 +176,7 @@
 				.map(function(share) {
 					var file = {
 						id: share.file_source,
+						icon: share.icon,
 						mimetype: share.mimetype
 					};
 					if (share.item_type === 'folder') {


### PR DESCRIPTION
- sharing API returns now the mimetype icon path
- file previews are now lazyloaded by default (as the doc says)
- fixes #16086

cc @schiesbn @rullzer Is it okay to add the mime icon to the sharing API?

@PVince81 You're the master of file list - I fixed the lazyload of preview by default thing. The doc said, that this is the case, but it wasn't.

cc @LukasReschke @nickvergessen @rullzer @Xenopathic 
