### PR TITLE
Avoid the log entry with the ModuleAlreadyExists exception when enabl…

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -385,7 +385,13 @@ class OC_App {
 	public static function getAppNavigationEntries($app) {
 		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
 			OC::$server->getNavigationManager()->clear();
-			require $app . '/appinfo/app.php';
+			try {
+				require $app . '/appinfo/app.php';
+			} catch (\OC\Encryption\Exceptions\ModuleAlreadyExistsException $e) {
+				// FIXME we should avoid getting this exception in first place,
+				// For now we just catch it, since we don't care about encryption modules
+				// when trying to find out, whether the app has a navigation entry.
+			}
 			return OC::$server->getNavigationManager()->getAll();
 		}
 		return array();


### PR DESCRIPTION
…ing the app

Fix #16103

@DeepDiver1975 @schiesbn 

The only other idea would be to refactor how the enable app works:
#### old
1. Enable app
2. In case of success gather navigation data
3. In case of success add data from step2 to navigation
#### new
1. Gather navigation data
2. Enable app
3. In case of success add data from step1 to navigation

=> The risc of changing this is we might execute code of the app, before it is enabled, etc.
