### PR TITLE
[HHVM] \OC\Connector\Sabre\CopyEtagHeaderPlugin constructor does not take any arguments

### DIFF
--- a/tests/lib/connector/sabre/copyetagheaderplugintest.php
+++ b/tests/lib/connector/sabre/copyetagheaderplugintest.php
@@ -18,7 +18,7 @@ class CopyEtagPluginTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->server = new \Sabre\DAV\Server();
-		$this->plugin = new \OC\Connector\Sabre\CopyEtagHeaderPlugin($this->tree);
+		$this->plugin = new \OC\Connector\Sabre\CopyEtagHeaderPlugin();
 		$this->plugin->initialize($this->server);
 	}
 


### PR DESCRIPTION
This should fix

```
02:06:58 1) Tests\Connector\Sabre\CopyEtagPluginTest::testCopyEtag
02:06:58 Undefined property: Tests\Connector\Sabre\CopyEtagPluginTest::$tree
02:06:58 
02:06:58 /var/lib/jenkins/jobs/server-master-linux-hhvm/workspace/database/sqlite/label/master/tests/lib/connector/sabre/copyetagheaderplugintest.php:21
02:06:58 
02:06:58 2) Tests\Connector\Sabre\CopyEtagPluginTest::testNoopWhenEmpty
02:06:58 Undefined property: Tests\Connector\Sabre\CopyEtagPluginTest::$tree
02:06:58 
02:06:58 /var/lib/jenkins/jobs/server-master-linux-hhvm/workspace/database/sqlite/label/master/tests/lib/connector/sabre/copyetagheaderplugintest.php:21
```

on HHVM.

Also see https://github.com/owncloud/core/blob/master/apps/files/appinfo/remote.php#L79
