### PR TITLE
improved admin settings

### DIFF
--- a/apps/encryption/css/settings-admin.css
+++ b/apps/encryption/css/settings-admin.css
@@ -1,0 +1,23 @@
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+#encryptionAPI input[type=password] {
+	width: 300px;
+}

--- a/apps/encryption/js/settings-admin.js
+++ b/apps/encryption/js/settings-admin.js
@@ -8,37 +8,51 @@
  */
 
 $(document).ready(function () {
+	
+	$('input:button[name="enableRecoveryKey"]').click(function () {
 
-	$('input:radio[name="adminEnableRecovery"]').change(
-		function () {
-			var recoveryStatus = $(this).val();
-			var oldStatus = (1 + parseInt(recoveryStatus)) % 2;
-			var recoveryPassword = $('#encryptionRecoveryPassword').val();
-			var confirmPassword = $('#repeatEncryptionRecoveryPassword').val();
-			OC.msg.startSaving('#encryptionSetRecoveryKey .msg');
-			$.post(
-				OC.generateUrl('/apps/encryption/ajax/adminRecovery'),
-				{
-					adminEnableRecovery: recoveryStatus,
-					recoveryPassword: recoveryPassword,
-					confirmPassword: confirmPassword
+		var recoveryStatus = $(this).attr('status');
+		var newRecoveryStatus = (1 + parseInt(recoveryStatus)) % 2;
+		var buttonValue = $(this).attr('value');
+
+		var recoveryPassword = $('#encryptionRecoveryPassword').val();
+		var confirmPassword = $('#repeatEncryptionRecoveryPassword').val();
+		OC.msg.startSaving('#encryptionSetRecoveryKey .msg');
+		$.post(
+			OC.generateUrl('/apps/encryption/ajax/adminRecovery'),
+			{
+				adminEnableRecovery: newRecoveryStatus,
+				recoveryPassword: recoveryPassword,
+				confirmPassword: confirmPassword
+			}
+		).done(function (data) {
+				OC.msg.finishedSuccess('#encryptionSetRecoveryKey .msg', data.data.message);
+
+				if (newRecoveryStatus === 0) {
+					$('p[name="changeRecoveryPasswordBlock"]').addClass("hidden");
+					$('input:button[name="enableRecoveryKey"]').attr('value', 'Enable recovery key');
+					$('input:button[name="enableRecoveryKey"]').attr('status', '0');
+				} else {
+					$('input:password[name="changeRecoveryPassword"]').val("");
+					$('p[name="changeRecoveryPasswordBlock"]').removeClass("hidden");
+					$('input:button[name="enableRecoveryKey"]').attr('value', 'Disable recovery key');
+					$('input:button[name="enableRecoveryKey"]').attr('status', '1');
 				}
-			).done(function (data) {
-					OC.msg.finishedSuccess('#encryptionSetRecoveryKey .msg', data.data.message);
+			})
+			.fail(function (jqXHR) {
+				$('input:button[name="enableRecoveryKey"]').attr('value', buttonValue);
+				$('input:button[name="enableRecoveryKey"]').attr('status', recoveryStatus);
+				OC.msg.finishedError('#encryptionSetRecoveryKey .msg', JSON.parse(jqXHR.responseText).data.message);
+			});
 
-					if (recoveryStatus === "0") {
-						$('p[name="changeRecoveryPasswordBlock"]').addClass("hidden");
-					} else {
-						$('input:password[name="changeRecoveryPassword"]').val("");
-						$('p[name="changeRecoveryPasswordBlock"]').removeClass("hidden");
-					}
-				})
-				.fail(function (jqXHR) {
-					$('input:radio[name="adminEnableRecovery"][value="' + oldStatus.toString() + '"]').attr("checked", "true");
-					OC.msg.finishedError('#encryptionSetRecoveryKey .msg', JSON.parse(jqXHR.responseText).data.message);
-				});
+
+	});
+
+	$("#repeatEncryptionRecoveryPassword").keyup(function (event) {
+		if (event.keyCode == 13) {
+			$("#enableRecoveryKey").click();
 		}
-	);
+	});
 
 	// change recovery password
 

--- a/apps/encryption/templates/settings-admin.php
+++ b/apps/encryption/templates/settings-admin.php
@@ -3,13 +3,14 @@
 /** @var OC_L10N $l */
 script('encryption', 'settings-admin');
 script('core', 'multiselect');
+style('encryption', 'settings-admin');
 ?>
 <form id="ocDefaultEncryptionModule" class="sub-section">
 	<?php if(!$_["initStatus"]): ?>
 		<?php p($l->t("Encryption App is enabled but your keys are not initialized, please log-out and log-in again")); ?>
 	<?php else: ?>
 	<p id="encryptionSetRecoveryKey">
-		<?php p($l->t('Enable recovery key: ')); ?>
+		<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>
 		<span class="msg"></span>
 		<br/>
 		<em>
@@ -17,54 +18,43 @@ script('core', 'multiselect');
 		to encrypt files. It allows recovery of a user's files if the user forgets their password.")) ?>
 		</em>
 		<br/>
-		<input type="password" name="encryptionRecoveryPassword" id="encryptionRecoveryPassword"/>
-		<label for="recoveryPassword"><?php p($l->t("Recovery key password")); ?></label>
-		<br/>
-		<input type="password" name="encryptionRecoveryPassword" id="repeatEncryptionRecoveryPassword"/>
-		<label for="repeatEncryptionRecoveryPassword"><?php p($l->t("Repeat Recovery key password")); ?></label>
-		<br/>
-		<input
-			type='radio'
-			id='adminEnableRecovery'
-			name='adminEnableRecovery'
-			value='1'
-			<?php echo($_["recoveryEnabled"] === '1' ? 'checked="checked"' : ''); ?> />
-		<label for="adminEnableRecovery"><?php p($l->t("Enable recovery key")); ?></label>
-		<br/>
-
-		<input
-			type='radio'
-			id='adminDisableRecovery'
-			name='adminEnableRecovery'
-			value='0'
-			<?php echo($_["recoveryEnabled"] === '0' ? 'checked="checked"' : ''); ?> />
-		<label for="adminDisableRecovery"><?php p($l->t("Disable recovery key")); ?></label>
+		<input type="password"
+			   name="encryptionRecoveryPassword"
+			   id="encryptionRecoveryPassword"
+			   placeholder="<?php p($l->t("Recovery key password")); ?>"/>
+		<input type="password"
+			   name="encryptionRecoveryPassword"
+			   id="repeatEncryptionRecoveryPassword"
+			   placeholder="<?php p($l->t("Repeat recovery key password")); ?>"/>
+		<input type="button"
+			   name="enableRecoveryKey"
+			   id="enableRecoveryKey"
+			   status="<?php p($_["recoveryEnabled"]) ?>"
+			   value="<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>"/>
 	</p>
 	<br/><br/>
 
-	<p name="changeRecoveryPasswordBlock" id="encryptionChangeRecoveryKey" <?php if ($_['recoveryEnabled'] === '0') print_unescaped('class="hidden"');?>>
-		<strong><?php p($l->t("Change recovery key password:")); ?></strong>
+	<p name="changeRecoveryPasswordBlock" id="encryptionChangeRecoveryKey" <?php if($_['recoveryEnabled'] === '0') print_unescaped('class="hidden"');?>>
+		<?php p($l->t("Change recovery key password:")); ?>
 		<span class="msg"></span>
-		<br/><br/>
-		<input
-			type="password"
-			name="changeRecoveryPassword"
-			id="oldEncryptionRecoveryPassword" />
-		<label for="oldEncryptionRecoveryPassword"><?php p($l->t("Old Recovery key password")); ?></label>
-		<br/>
 		<br/>
 		<input
 			type="password"
 			name="changeRecoveryPassword"
-			id="newEncryptionRecoveryPassword" />
-		<label for="newEncryptionRecoveryPassword"><?php p($l->t("New Recovery key password")); ?></label>
-		<br/>
+			id="oldEncryptionRecoveryPassword"
+			placeholder="<?php p($l->t("Old recovery key password")); ?>"/>
+		<br />
 		<input
 			type="password"
 			name="changeRecoveryPassword"
-			id="repeatedNewEncryptionRecoveryPassword" />
-		<label for="repeatEncryptionRecoveryPassword"><?php p($l->t("Repeat New Recovery key password")); ?></label>
-		<br/>
+			id="newEncryptionRecoveryPassword"
+			placeholder="<?php p($l->t("New recovery key password")); ?>"/>
+		<input
+			type="password"
+			name="changeRecoveryPassword"
+			id="repeatedNewEncryptionRecoveryPassword"
+			placeholder="<?php p($l->t("Repeat new recovery key password")); ?>"/>
+
 		<button
 			type="button"
 			name="submitChangeRecoveryKey">


### PR DESCRIPTION
Some UX changes we discussed here: https://github.com/owncloud/core/pull/16034

This is now how the admin settings look like if no recovery key was enabled

![1](https://cloud.githubusercontent.com/assets/1589737/7514001/97f774d0-f4b9-11e4-8e29-4f25cb688e7d.png)

This is how the admin settings look if the recovery key is enabled:

![2](https://cloud.githubusercontent.com/assets/1589737/7514005/a40288c8-f4b9-11e4-98f0-129ae5fb9328.png)

Maybe in the second screenshot we need a clear indicator that the recovery key is enabled. Just having the top button now labeled as "Disable recovery key" is probably not obvious enough. But I don't have a good idea at the moment.

I also tried to make "Change recovery key password" a link and only show the input fields if the admin click on the link. But in my opinion it was really hard to discover that you can click on the text. Further we don't have a similar behavior anywhere else in the admin settings. So it would be a quite unique concept hard to discover. That's why I decided to keep it for now always visible _if_ the recovery key is enabled. 

cc @jancborchardt please have a look?
cc @MorrisJobke 
