### PR TITLE
fix cron errors to only appear in one line instead of introducing another list

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -158,9 +158,7 @@ if ($_['cronErrors']) {
 			<br>
 			<ol>
 				<?php foreach(json_decode($_['cronErrors']) as $error) { if(isset($error->error)) {?>
-					<li><?php p($error->error) ?></li>
-					<ul><li><?php p($error->hint) ?></li></ul>
-
+					<li><?php p($error->error) ?> <?php p($error->hint) ?></li>
 				<?php }};?>
 			</ol>
 	</li>


### PR DESCRIPTION
Please review @schiesbn @owncloud/designers 

Before (see second bullet point)
![capture du 2015-05-07 16 19 57](https://cloud.githubusercontent.com/assets/925062/7517379/fefa19f6-f4d4-11e4-87d7-91f10451a532.png)
After 
![capture du 2015-05-07 16 20 15](https://cloud.githubusercontent.com/assets/925062/7517378/fef7d088-f4d4-11e4-8fad-2426c7a5466d.png)
