### PR TITLE
catch unallowed anonymous auth attempt and show specific error

### DIFF
--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -34,16 +34,21 @@ $ldapWrapper = new OCA\user_ldap\lib\LDAP();
 $connection = new \OCA\user_ldap\lib\Connection($ldapWrapper, '', null);
 //needs to be true, otherwise it will also fail with an irritating message
 $_POST['ldap_configuration_active'] = 1;
-if($connection->setConfiguration($_POST)) {
-	//Configuration is okay
-	if($connection->bind()) {
-		OCP\JSON::success(array('message'
+
+try {
+	if ($connection->setConfiguration($_POST)) {
+		//Configuration is okay
+		if ($connection->bind()) {
+			OCP\JSON::success(array('message'
 			=> $l->t('The configuration is valid and the connection could be established!')));
+		} else {
+			OCP\JSON::error(array('message'
+			=> $l->t('The configuration is valid, but the Bind failed. Please check the server settings and credentials.')));
+		}
 	} else {
 		OCP\JSON::error(array('message'
-			=> $l->t('The configuration is valid, but the Bind failed. Please check the server settings and credentials.')));
-	}
-} else {
-	OCP\JSON::error(array('message'
 		=> $l->t('The configuration is invalid. Please have a look at the logs for further details.')));
+	}
+} catch (\Exception $e) {
+	OCP\JSON::error(array('message' => $e->getMessage()));
 }

--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -165,6 +165,12 @@ OCA = OCA || {};
 		 * @inheritdoc
 		 */
 		overrideErrorMessage: function(message, key) {
+			var original = message;
+			message = this._super(message, key);
+			if(original !== message) {
+				// we pass the parents change
+				return message;
+			}
 			switch(key) {
 				case 'ldap_port':
 					if (message === 'Invalid credentials') {
@@ -267,7 +273,8 @@ OCA = OCA || {};
 						message = t('user_ldap', objectsFound + ' entries available within the provided Base DN');
 					}
 				} else {
-					message = t('user_ldap', 'An error occurred. Please check the Base DN, as well as connection settings and credentials.');
+					message = view.overrideErrorMessage(payload.data.message);
+					message = message || t('user_ldap', 'An error occurred. Please check the Base DN, as well as connection settings and credentials.');
 					if(payload.data.message) {
 						console.warn(payload.data.message);
 					}

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -70,6 +70,11 @@ OCA = OCA || {};
 		 * @returns {string}
 		 */
 		overrideErrorMessage: function(message, key) {
+			if(message === 'LDAP authentication method rejected'
+				&& !this.configModel.configuration.ldap_dn)
+			{
+				message = t('user_ldap', 'Anonymous bind is not allowed. Please provide a User DN and Password.');
+			}
 			return message;
 		},
 

--- a/apps/user_ldap/js/wizard/wizardTabGeneric.js
+++ b/apps/user_ldap/js/wizard/wizardTabGeneric.js
@@ -74,7 +74,13 @@ OCA = OCA || {};
 				&& !this.configModel.configuration.ldap_dn)
 			{
 				message = t('user_ldap', 'Anonymous bind is not allowed. Please provide a User DN and Password.');
+			} else if (message === 'LDAP Operations error'
+				&& !this.configModel.configuration.ldap_dn
+				&& !this.configModel.configuration.ldap_agent_password)
+			{
+				message = t('user_ldap', 'LDAP Operations error. Anonymous bind might not be allowed.');
 			}
+
 			return message;
 		},
 

--- a/apps/user_ldap/js/wizard/wizardTabUserFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabUserFilter.js
@@ -122,6 +122,12 @@ OCA = OCA || {};
 		 * @inheritdoc
 		 */
 		overrideErrorMessage: function(message, key) {
+			var original = message;
+			message = this._super(message, key);
+			if(original !== message) {
+				// we pass the parents change
+				return message;
+			}
 			if(   key === 'ldap_userfilter_groups'
 			   && message === 'memberOf is not supported by the server'
 			) {

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -289,6 +289,8 @@ class LDAP implements ILDAPWrapper {
 					throw new ServerNotAvailableException('Lost connection to LDAP server.');
 				} else if ($errorCode === 48) {
 					throw new \Exception('LDAP authentication method rejected');
+				} else if ($errorCode === 1) {
+					throw new \Exception('LDAP Operations error', $errorCode);
 				} else {
 					\OCP\Util::writeLog('user_ldap',
 										'LDAP error '.$errorMsg.' (' .

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -287,6 +287,8 @@ class LDAP implements ILDAPWrapper {
 					//referrals, we switch them off, but then there is AD :)
 				} else if ($errorCode === -1) {
 					throw new ServerNotAvailableException('Lost connection to LDAP server.');
+				} else if ($errorCode === 48) {
+					throw new \Exception('LDAP authentication method rejected');
 				} else {
 					\OCP\Util::writeLog('user_ldap',
 										'LDAP error '.$errorMsg.' (' .

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -288,7 +288,7 @@ class LDAP implements ILDAPWrapper {
 				} else if ($errorCode === -1) {
 					throw new ServerNotAvailableException('Lost connection to LDAP server.');
 				} else if ($errorCode === 48) {
-					throw new \Exception('LDAP authentication method rejected');
+					throw new \Exception('LDAP authentication method rejected', $errorCode);
 				} else if ($errorCode === 1) {
 					throw new \Exception('LDAP Operations error', $errorCode);
 				} else {


### PR DESCRIPTION
Fixes #15982 

When an anonymous bind is attempted although not allowed, the users sees a specific message now:

![shiny new message](https://cloud.githubusercontent.com/assets/2184312/7523706/975ffe72-f4fd-11e4-8c6e-5c175ee57a7c.jpg)

For reproduction steps, please see original issue.

@jvillafanez please test with AD. So far I tried with OpenLDAP, but if the LDAP error codes are followed, it should behave the same.

Please test and review @MorrisJobke @Xenopathic @ryno83 or others
