### PR TITLE
use requesttoken from request when (memory) session does not contain …

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -375,6 +375,8 @@ class Server extends SimpleContainer implements IServerContainer {
 
 			if ($this->getSession()->exists('requesttoken')) {
 				$requestToken = $this->getSession()->get('requesttoken');
+			} else if (isset($_REQUEST['requesttoken'])) {
+				$requestToken = $_REQUEST['requesttoken'];
 			} else {
 				$requestToken = false;
 			}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -377,6 +377,8 @@ class Server extends SimpleContainer implements IServerContainer {
 				$requestToken = $this->getSession()->get('requesttoken');
 			} else if (isset($_REQUEST['requesttoken'])) {
 				$requestToken = $_REQUEST['requesttoken'];
+			} else if (isset($_SERVER['HTTP_REQUESTTOKEN'])) {
+				$requestToken = $_SERVER['HTTP_REQUESTTOKEN'];
 			} else {
 				$requestToken = false;
 			}


### PR DESCRIPTION
:skull: :skull::skull: :skull::skull: :skull: **Insecure, see https://github.com/owncloud/core/pull/16186#issuecomment-100140688** :skull: :skull::skull: :skull::skull: :skull: 

…token, fixes session when using querylog

Current master: when I set `'log_query' => true,` I can no longer use owncloud because the in memory session is stored in the request before the login could be handled.

This may not be the correct fix. but it is too late for me to find a better one.

cc @LukasReschke in case this opens an attack vector...
