### PR TITLE
Add warning to OCC as well in case another PHP version is used there

### DIFF
--- a/console.php
+++ b/console.php
@@ -28,6 +28,14 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 define('OC_CONSOLE', 1);
 
+// Show warning if a PHP version below 5.4.0 is used, this has to happen here
+// because base.php will already use 5.4 syntax.
+if (version_compare(PHP_VERSION, '5.4.0') === -1) {
+	echo 'This version of ownCloud requires at least PHP 5.4.0'.PHP_EOL;
+	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
+	return;
+}
+
 try {
 	require_once 'lib/base.php';
 


### PR DESCRIPTION
In regard to a recent rant on social media where users complained about us to have broken the command line tool. Guess reading the documentation is hard…

cc @blizzz
