### PR TITLE
use hooks to update encryption keys

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -727,6 +727,8 @@ class OC {
 		if ($enabled) {
 			\OCP\Util::connectHook('OCP\Share', 'post_shared', 'OC\Encryption\HookManager', 'postShared');
 			\OCP\Util::connectHook('OCP\Share', 'post_unshare', 'OC\Encryption\HookManager', 'postUnshared');
+			\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OC\Encryption\HookManager', 'postRename');
+			\OCP\Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', 'OC\Encryption\HookManager', 'postRestore');
 		}
 	}
 

--- a/lib/private/encryption/hookmanager.php
+++ b/lib/private/encryption/hookmanager.php
@@ -37,6 +37,14 @@ class HookManager {
 		self::getUpdate()->postUnshared($params);
 	}
 
+	public static function postRename($params) {
+		self::getUpdate()->postRename($params);
+	}
+
+	public static function postRestore($params) {
+		self::getUpdate()->postRestore($params);
+	}
+
 	/**
 	 * @return Update
 	 */

--- a/lib/private/encryption/update.php
+++ b/lib/private/encryption/update.php
@@ -108,13 +108,45 @@ class Update {
 	}
 
 	/**
+	 * inform encryption module that a file was restored from the trash bin,
+	 * e.g. to update the encryption keys
+	 *
+	 * @param array $params
+	 */
+	public function postRestore($params) {
+		if ($this->encryptionManager->isEnabled()) {
+			$path = Filesystem::normalizePath('/' . $this->uid . '/files/' . $params['filePath']);
+			$this->update($path);
+		}
+	}
+
+	/**
+	 * inform encryption module that a file was renamed,
+	 * e.g. to update the encryption keys
+	 *
+	 * @param array $params
+	 */
+	public function postRename($params) {
+		$source = $params['oldpath'];
+		$target = $params['newpath'];
+		if(
+			$this->encryptionManager->isEnabled() &&
+			dirname($source) !== dirname($target)
+		) {
+				list($owner, $ownerPath) = $this->getOwnerPath($target);
+				$absPath = '/' . $owner . '/files/' . $ownerPath;
+				$this->update($absPath);
+		}
+	}
+
+	/**
 	 * get owner and path relative to data/<owner>/files
 	 *
 	 * @param string $path path to file for current user
 	 * @return array ['owner' => $owner, 'path' => $path]
 	 * @throw \InvalidArgumentException
 	 */
-	private function getOwnerPath($path) {
+	protected function getOwnerPath($path) {
 		$info = Filesystem::getFileInfo($path);
 		$owner = Filesystem::getOwner($path);
 		$view = new View('/' . $owner . '/files');

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -231,13 +231,7 @@ class Encryption extends Wrapper {
 				if (isset($this->unencryptedSize[$source])) {
 					$this->unencryptedSize[$target] = $this->unencryptedSize[$source];
 				}
-				$keysRenamed = $this->keyStorage->renameKeys($source, $target);
-				if ($keysRenamed &&
-					dirname($source) !== dirname($target) &&
-					$this->util->isFile($target)
-				) {
-					$this->update->update($target);
-				}
+				$this->keyStorage->renameKeys($source, $target);
 			}
 		}
 

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -157,13 +157,11 @@ class Encryption extends \Test\Files\Storage\Storage {
 	 * @param string $target
 	 * @param $encryptionEnabled
 	 * @param boolean $renameKeysReturn
-	 * @param boolean $shouldUpdate
 	 */
 	public function testRename($source,
 							   $target,
 							   $encryptionEnabled,
-							   $renameKeysReturn,
-							   $shouldUpdate) {
+							   $renameKeysReturn) {
 		if ($encryptionEnabled) {
 			$this->keyStore
 				->expects($this->once())
@@ -177,13 +175,6 @@ class Encryption extends \Test\Files\Storage\Storage {
 			->method('isFile')->willReturn(true);
 		$this->encryptionManager->expects($this->once())
 			->method('isEnabled')->willReturn($encryptionEnabled);
-		if ($shouldUpdate) {
-			$this->update->expects($this->once())
-				->method('update');
-		} else {
-			$this->update->expects($this->never())
-				->method('update');
-		}
 
 		$this->instance->mkdir($source);
 		$this->instance->mkdir(dirname($target));


### PR DESCRIPTION
use hooks to update encryption keys instead of the storage wrapper if a file gets renamed/restored, as long as we are in the storage wrapper the file cache isn't up-to-date

fix https://github.com/owncloud/core/issues/16199
