### PR TITLE
High level file locking

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -31,6 +31,9 @@ namespace OC\Files\Storage;
 
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\ISharedStorage;
+use OCA\Files_Sharing\Propagator;
+use OCA\Files_Sharing\SharedMount;
+use OCP\Lock\ILockingProvider;
 
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
@@ -607,5 +610,28 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		/** @var \OCP\Files\Storage $targetStorage */
 		list($targetStorage, $targetInternalPath) = $this->resolvePath($targetInternalPath);
 		return $targetStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider) {
+		/** @var \OCP\Files\Storage $targetStorage */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
+		$targetStorage->acquireLock($targetInternalPath, $type, $provider);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider) {
+		/** @var \OCP\Files\Storage $targetStorage */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
+		$targetStorage->releaseLock($targetInternalPath, $type, $provider);
 	}
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -634,4 +634,15 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
 		$targetStorage->releaseLock($targetInternalPath, $type, $provider);
 	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider) {
+		/** @var \OCP\Files\Storage $targetStorage */
+		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
+		$targetStorage->changeLock($targetInternalPath, $type, $provider);
+	}
 }

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1026,6 +1026,19 @@ $CONFIG = array(
  */
 'max_filesize_animated_gifs_public_sharing' => 10,
 
+
+/**
+ * Enables the EXPERIMENTAL file locking.
+ * This is disabled by default as it is experimental.
+ *
+ * Prevents concurrent processes to access the same files
+ * at the same time. Can help prevent side effects that would
+ * be caused by concurrent operations.
+ *
+ * WARNING: EXPERIMENTAL
+ */
+'filelocking.enabled' => false,
+
 /**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1040,6 +1040,12 @@ $CONFIG = array(
 'filelocking.enabled' => false,
 
 /**
+ * Memory caching backend for file locking
+ * Because most memcache backends can clean values without warning using redis is recommended
+ */
+'memcache.locking' => '\OC\Memcache\Redis',
+
+/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *

--- a/lib/base.php
+++ b/lib/base.php
@@ -666,6 +666,8 @@ class OC {
 		//make sure temporary files are cleaned up
 		$tmpManager = \OC::$server->getTempManager();
 		register_shutdown_function(array($tmpManager, 'clean'));
+		$lockProvider = \OC::$server->getLockingProvider();
+		register_shutdown_function(array($lockProvider, 'releaseAll'));
 
 		if ($systemConfig->getValue('installed', false) && !self::checkUpgrade(false)) {
 			if (\OC::$server->getConfig()->getAppValue('core', 'backgroundjobs_mode', 'ajax') == 'ajax') {

--- a/lib/private/connector/sabre/exception/filelocked.php
+++ b/lib/private/connector/sabre/exception/filelocked.php
@@ -42,6 +42,6 @@ class FileLocked extends \Sabre\DAV\Exception {
 	 */
 	public function getHTTPCode() {
 
-		return 503;
+		return 423;
 	}
 }

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -45,6 +45,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\LockNotAcquiredException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\ILockingProvider;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\Forbidden;
@@ -109,6 +110,8 @@ class File extends Node implements IFile {
 			// upload file directly as the final path
 			$partFilePath = $this->path;
 		}
+
+		$this->fileView->lockFile($this->path, ILockingProvider::LOCK_EXCLUSIVE);
 
 		// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
 		/** @var \OC\Files\Storage\Storage $partStorage */
@@ -231,6 +234,8 @@ class File extends Node implements IFile {
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
 		}
+
+		$this->fileView->unlockFile($this->path, ILockingProvider::LOCK_EXCLUSIVE);
 
 		return '"' . $this->info->getEtag() . '"';
 	}

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -46,6 +46,7 @@ use OCP\Files\LockNotAcquiredException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\Forbidden;
@@ -80,6 +81,7 @@ class File extends Node implements IFile {
 	 * @throws Exception
 	 * @throws EntityTooLarge
 	 * @throws ServiceUnavailable
+	 * @throws FileLocked
 	 * @return string|null
 	 */
 	public function put($data) {
@@ -111,7 +113,11 @@ class File extends Node implements IFile {
 			$partFilePath = $this->path;
 		}
 
-		$this->fileView->lockFile($this->path, ILockingProvider::LOCK_EXCLUSIVE);
+		try {
+			$this->fileView->lockFile($this->path, ILockingProvider::LOCK_EXCLUSIVE);
+		} catch (LockedException $e) {
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
+		}
 
 		// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
 		/** @var \OC\Files\Storage\Storage $partStorage */
@@ -257,6 +263,8 @@ class File extends Node implements IFile {
 			throw new ServiceUnavailable("Encryption not ready: " . $e->getMessage());
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to open file: " . $e->getMessage());
+		} catch (LockedException $e) {
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -278,6 +286,8 @@ class File extends Node implements IFile {
 			}
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to unlink: " . $e->getMessage());
+		} catch (LockedException $e) {
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 	}
 
@@ -383,6 +393,8 @@ class File extends Node implements IFile {
 				return $info->getEtag();
 			} catch (StorageNotAvailableException $e) {
 				throw new ServiceUnavailable("Failed to put file: " . $e->getMessage());
+			} catch (LockedException $e) {
+				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
 		}
 

--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -89,6 +89,12 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		$this->server->on('afterBind', array($this, 'sendFileIdHeader'));
 		$this->server->on('afterWriteContent', array($this, 'sendFileIdHeader'));
 		$this->server->on('afterMethod:GET', [$this,'httpGet']);
+		$this->server->on('afterResponse', function($request, ResponseInterface $response) {
+			$body = $response->getBody();
+			if (is_resource($body)) {
+				fclose($body);
+			}
+		});
 	}
 
 	/**

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -26,10 +26,12 @@
 namespace OC\Connector\Sabre;
 
 use OC\Connector\Sabre\Exception\InvalidPath;
+use OC\Connector\Sabre\Exception\FileLocked;
 use OC\Files\FileInfo;
 use OC\Files\Mount\MoveableMount;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\LockedException;
 
 class ObjectTree extends \Sabre\DAV\Tree {
 
@@ -221,8 +223,10 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			if (!$renameOkay) {
 				throw new \Sabre\DAV\Exception\Forbidden('');
 			}
-		} catch (\OCP\Files\StorageNotAvailableException $e) {
+		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+		} catch (LockedException $e) {
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 
 		$this->markDirty($sourceDir);
@@ -258,7 +262,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 
 		try {
 			$this->fileView->copy($source, $destination);
-		} catch (\OCP\Files\StorageNotAvailableException $e) {
+		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		}
 

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -264,6 +264,8 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			$this->fileView->copy($source, $destination);
 		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+		} catch (LockedException $e) {
+			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
 
 		list($destinationDir,) = \Sabre\HTTP\URLUtil::splitPath($destination);

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -641,4 +641,13 @@ abstract class Common implements Storage {
 	public function releaseLock($path, $type, ILockingProvider $provider) {
 		$provider->releaseLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
 	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider) {
+		$provider->changeLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
+	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -630,7 +630,7 @@ abstract class Common implements Storage {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type, ILockingProvider $provider) {
-		$provider->acquireLock($this->getId() . '::' . $path, $type);
+		$provider->acquireLock(md5($this->getId() . '::' . $path), $type);
 	}
 
 	/**
@@ -639,6 +639,6 @@ abstract class Common implements Storage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider) {
-		$provider->releaseLock($this->getId() . '::' . $path, $type);
+		$provider->releaseLock(md5($this->getId() . '::' . $path), $type);
 	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -43,6 +43,7 @@ use OCP\Files\FileNameTooLongException;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\ReservedWordException;
+use OCP\Lock\ILockingProvider;
 
 /**
  * Storage backend class for providing common filesystem operation methods
@@ -620,5 +621,24 @@ abstract class Common implements Storage {
 		$data['permissions'] = $this->getPermissions($path);
 
 		return $data;
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider) {
+		$provider->acquireLock($this->getId() . '::' . $path, $type);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider) {
+		$provider->releaseLock($this->getId() . '::' . $path, $type);
 	}
 }

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -630,7 +630,7 @@ abstract class Common implements Storage {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type, ILockingProvider $provider) {
-		$provider->acquireLock(md5($this->getId() . '::' . $path), $type);
+		$provider->acquireLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
 	}
 
 	/**
@@ -639,6 +639,6 @@ abstract class Common implements Storage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider) {
-		$provider->releaseLock(md5($this->getId() . '::' . $path), $type);
+		$provider->releaseLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
 	}
 }

--- a/lib/private/files/storage/storage.php
+++ b/lib/private/files/storage/storage.php
@@ -21,6 +21,7 @@
  */
 
 namespace OC\Files\Storage;
+use OCP\Lock\ILockingProvider;
 
 /**
  * Provide a common interface to all different storage options
@@ -76,4 +77,18 @@ interface Storage extends \OCP\Files\Storage {
 	 */
 	public function getMetaData($path);
 
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider);
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider);
 }

--- a/lib/private/files/storage/storage.php
+++ b/lib/private/files/storage/storage.php
@@ -78,7 +78,7 @@ interface Storage extends \OCP\Files\Storage {
 	public function getMetaData($path);
 
 	/**
-	 * @param string $path
+	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
@@ -86,7 +86,7 @@ interface Storage extends \OCP\Files\Storage {
 	public function acquireLock($path, $type, ILockingProvider $provider);
 
 	/**
-	 * @param string $path
+	 * @param string $path The path of the file to release the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */

--- a/lib/private/files/storage/storage.php
+++ b/lib/private/files/storage/storage.php
@@ -91,4 +91,12 @@ interface Storage extends \OCP\Files\Storage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider);
+
+	/**
+	 * @param string $path The path of the file to change the lock for
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider);
 }

--- a/lib/private/files/storage/wrapper/jail.php
+++ b/lib/private/files/storage/wrapper/jail.php
@@ -23,6 +23,7 @@
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Cache\Wrapper\CacheJail;
+use OCP\Lock\ILockingProvider;
 
 /**
  * Jail to a subdirectory of the wrapped storage
@@ -423,5 +424,24 @@ class Jail extends Wrapper {
 	 */
 	public function getETag($path) {
 		return $this->storage->getETag($this->getSourcePath($path));
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider) {
+		$this->storage->acquireLock($this->getSourcePath($path), $type, $provider);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider) {
+		$this->storage->releaseLock($this->getSourcePath($path), $type, $provider);
 	}
 }

--- a/lib/private/files/storage/wrapper/jail.php
+++ b/lib/private/files/storage/wrapper/jail.php
@@ -444,4 +444,13 @@ class Jail extends Wrapper {
 	public function releaseLock($path, $type, ILockingProvider $provider) {
 		$this->storage->releaseLock($this->getSourcePath($path), $type, $provider);
 	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider) {
+		$this->storage->changeLock($this->getSourcePath($path), $type, $provider);
+	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -25,6 +25,7 @@
 namespace OC\Files\Storage\Wrapper;
 
 use OCP\Files\InvalidPathException;
+use OCP\Lock\ILockingProvider;
 
 class Wrapper implements \OC\Files\Storage\Storage {
 	/**
@@ -540,5 +541,24 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	 */
 	public function getMetaData($path) {
 		return $this->storage->getMetaData($path);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider) {
+		$this->storage->acquireLock($path, $type, $provider);
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider) {
+		$this->storage->releaseLock($path, $type, $provider);
 	}
 }

--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -561,4 +561,13 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	public function releaseLock($path, $type, ILockingProvider $provider) {
 		$this->storage->releaseLock($path, $type, $provider);
 	}
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider) {
+		$this->storage->changeLock($path, $type, $provider);
+	}
 }

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1639,14 +1639,26 @@ class View {
 	private function lockPath($path, $type) {
 		$mount = $this->getMount($path);
 		if ($mount) {
-			$mount->getStorage()->acquireLock($mount->getInternalPath($this->getAbsolutePath($path)), $type, $this->lockingProvider);
+			$mount->getStorage()->acquireLock(
+				$mount->getInternalPath(
+					$this->getAbsolutePath($path)
+				),
+				$type,
+				$this->lockingProvider
+			);
 		}
 	}
 
 	private function unlockPath($path, $type) {
 		$mount = $this->getMount($path);
 		if ($mount) {
-			$mount->getStorage()->releaseLock($mount->getInternalPath($this->getAbsolutePath($path)), $type, $this->lockingProvider);
+			$mount->getStorage()->releaseLock(
+				$mount->getInternalPath(
+					$this->getAbsolutePath($path)
+				),
+				$type,
+				$this->lockingProvider
+			);
 		}
 	}
 

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1618,11 +1618,11 @@ class View {
 	 * @return string[]
 	 */
 	private function getParents($path) {
+		$path = trim($path, '/');
 		if (!$path) {
 			return [];
 		}
 
-		$path = trim($path, '/');
 		$parts = explode('/', $path);
 
 		// remove the single file

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1621,9 +1621,11 @@ class View {
 		if (!$path) {
 			return [];
 		}
+
+		$path = trim($path, '/');
 		$parts = explode('/', $path);
 
-		// remove the singe file
+		// remove the single file
 		array_pop($parts);
 		$result = array('/');
 		$resultPath = '';

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -960,7 +960,7 @@ class View {
 			if ($run and $storage) {
 				if (in_array('write', $hooks) || in_array('delete', $hooks)) {
 					$this->lockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-				} else {
+				} else if (in_array('read', $hooks)) {
 					$this->lockFile($path, ILockingProvider::LOCK_SHARED);
 				}
 				try {
@@ -972,7 +972,7 @@ class View {
 				} catch (\Exception $e) {
 					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} else {
+					} else if (in_array('read', $hooks)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 					}
 					throw $e;
@@ -992,14 +992,14 @@ class View {
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-						} else {
+						} else if (in_array('read', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						}
 					});
 				} else {
 					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} else {
+					} else if (in_array('read', $hooks)) {
 						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 					}
 				}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -971,9 +971,9 @@ class View {
 					}
 				} catch (\Exception $e) {
 					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
-						$this->lockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
+						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
 					} else {
-						$this->lockFile($path, ILockingProvider::LOCK_SHARED);
+						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 					}
 					throw $e;
 				}
@@ -1638,6 +1638,10 @@ class View {
 		return $result;
 	}
 
+	/**
+	 * @param string $path the path of the file to lock, relative to the view
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 */
 	private function lockPath($path, $type) {
 		$mount = $this->getMount($path);
 		if ($mount) {
@@ -1651,6 +1655,10 @@ class View {
 		}
 	}
 
+	/**
+	 * @param string $path the path of the file to unlock, relative to the view
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 */
 	private function unlockPath($path, $type) {
 		$mount = $this->getMount($path);
 		if ($mount) {
@@ -1665,13 +1673,13 @@ class View {
 	}
 
 	/**
-	 * Lock a path and all it's parents
+	 * Lock a path and all its parents up to the root of the view
 	 *
-	 * @param string $path
-	 * @param int $type
+	 * @param string $path the path of the file to lock relative to the view
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 */
 	public function lockFile($path, $type) {
-		$path = rtrim($path, '/');
+		$path = '/' . trim($path, '/');
 		$this->lockPath($path, $type);
 
 		$parents = $this->getParents($path);
@@ -1681,10 +1689,10 @@ class View {
 	}
 
 	/**
-	 * Unlock a path and all it's parents
+	 * Unlock a path and all its parents up to the root of the view
 	 *
-	 * @param string $path
-	 * @param int $type
+	 * @param string $path the path of the file to lock relative to the view
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 */
 	public function unlockFile($path, $type) {
 		$path = rtrim($path, '/');

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -49,6 +49,7 @@ use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\ReservedWordException;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
 
 /**
  * Class to provide access to ownCloud filesystem via a "view", and methods for
@@ -638,7 +639,12 @@ class View {
 				$internalPath2 = $mount2->getInternalPath($absolutePath2);
 
 				$this->lockFile($path1, ILockingProvider::LOCK_EXCLUSIVE);
-				$this->lockFile($path2, ILockingProvider::LOCK_EXCLUSIVE);
+				try {
+					$this->lockFile($path2, ILockingProvider::LOCK_EXCLUSIVE);
+				} catch (LockedException $e) {
+					$this->unlockFile($path1, ILockingProvider::LOCK_EXCLUSIVE);
+					throw $e;
+				}
 
 				if ($internalPath1 === '' and $mount1 instanceof MoveableMount) {
 					if ($this->isTargetAllowed($absolutePath2)) {

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -988,7 +988,7 @@ class View {
 					$this->updater->update($path, $extraParam);
 				}
 
-				if ($operation === 'fopen') {
+				if ($operation === 'fopen' and $result) {
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -664,6 +664,11 @@ class View {
 				$this->unlockFile($path1, ILockingProvider::LOCK_EXCLUSIVE);
 				$this->unlockFile($path2, ILockingProvider::LOCK_EXCLUSIVE);
 
+				if ($internalPath1 === '' and $mount1 instanceof MoveableMount) {
+					// since $path2 now points to a different storage we need to unlock the path on the old storage separately
+					$storage2->releaseLock($internalPath2, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
+				}
+
 				if ((Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false) {
 					// if it was a rename from a part file to a regular file it was a write and not a rename operation
 					$this->updater->update($path2);

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -88,8 +88,10 @@ class MemcacheLockingProvider implements ILockingProvider {
 	 */
 	public function releaseLock($path, $type) {
 		if ($type === self::LOCK_SHARED) {
-			$this->memcache->dec($path);
-			$this->acquiredLocks['shared'][$path]--;
+			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
+				$this->memcache->dec($path);
+				$this->acquiredLocks['shared'][$path]--;
+			}
 		} else if ($type === self::LOCK_EXCLUSIVE) {
 			$this->memcache->cas($path, 'exclusive', 0);
 			unset($this->acquiredLocks['exclusive'][$path]);

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -111,6 +111,9 @@ class MemcacheLockingProvider implements ILockingProvider {
 				throw new LockedException($path);
 			}
 			unset($this->acquiredLocks['exclusive'][$path]);
+			if (!isset($this->acquiredLocks['shared'][$path])) {
+				$this->acquiredLocks['shared'][$path] = 0;
+			}
 			$this->acquiredLocks['shared'][$path]++;
 		} else if ($targetType === self::LOCK_EXCLUSIVE) {
 			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -110,11 +110,15 @@ class MemcacheLockingProvider implements ILockingProvider {
 			if (!$this->memcache->cas($path, 'exclusive', 1)) {
 				throw new LockedException($path);
 			}
+			unset($this->acquiredLocks['exclusive'][$path]);
+			$this->acquiredLocks['shared'][$path]++;
 		} else if ($targetType === self::LOCK_EXCLUSIVE) {
 			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock
 			if (!$this->memcache->cas($path, 1, 'exclusive')) {
 				throw new LockedException($path);
 			}
+			$this->acquiredLocks['exclusive'][$path] = true;
+			$this->acquiredLocks['shared'][$path]--;
 		}
 	}
 

--- a/lib/private/lock/nooplockingprovider.php
+++ b/lib/private/lock/nooplockingprovider.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Lock;
+
+use OCP\Lock\ILockingProvider;
+
+/**
+ * Locking provider that does nothing.
+ *
+ * To be used when locking is disabled.
+ */
+class NoopLockingProvider implements ILockingProvider {
+
+    /**
+     * {@inheritdoc}
+     */
+	public function isLocked($path, $type) {
+		return false;
+	}
+
+    /**
+     * {@inheritdoc}
+     */
+	public function acquireLock($path, $type) {
+		// do nothing
+	}
+
+	/**
+     * {@inheritdoc}
+	 */
+	public function releaseLock($path, $type) {
+		// do nothing
+	}
+
+	/**
+	 * release all lock acquired by this instance
+	 */
+	public function releaseAll() {
+		// do nothing
+	}
+}

--- a/lib/private/lock/nooplockingprovider.php
+++ b/lib/private/lock/nooplockingprovider.php
@@ -51,10 +51,17 @@ class NoopLockingProvider implements ILockingProvider {
 		// do nothing
 	}
 
-	/**
-	 * release all lock acquired by this instance
+	/**1
+	 * {@inheritdoc}
 	 */
 	public function releaseAll() {
+		// do nothing
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function changeLock($path, $targetType) {
 		// do nothing
 	}
 }

--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -47,12 +47,18 @@ class Factory implements ICacheFactory {
 	private $distributedCacheClass;
 
 	/**
+	 * @var string $lockingCacheClass
+	 */
+	private $lockingCacheClass;
+
+	/**
 	 * @param string $globalPrefix
 	 * @param string|null $localCacheClass
 	 * @param string|null $distributedCacheClass
+	 * @param string|null $lockingCacheClass
 	 */
 	public function __construct($globalPrefix,
-		$localCacheClass = null, $distributedCacheClass = null)
+		$localCacheClass = null, $distributedCacheClass = null, $lockingCacheClass = null)
 	{
 		$this->globalPrefix = $globalPrefix;
 
@@ -62,8 +68,23 @@ class Factory implements ICacheFactory {
 		if (!($distributedCacheClass && $distributedCacheClass::isAvailable())) {
 			$distributedCacheClass = $localCacheClass;
 		}
+		if (!($lockingCacheClass && $lockingCacheClass::isAvailable())) {
+			// dont fallback since the fallback might not be suitable for storing lock
+			$lockingCacheClass = '\OC\Memcache\Null';
+		}
 		$this->localCacheClass = $localCacheClass;
 		$this->distributedCacheClass = $distributedCacheClass;
+		$this->lockingCacheClass = $lockingCacheClass;
+	}
+
+	/**
+	 * create a cache instance for storing locks
+	 *
+	 * @param string $prefix
+	 * @return \OCP\IMemcache
+	 */
+	public function createLocking($prefix = '') {
+		return new $this->lockingCacheClass($this->globalPrefix . '/' . $prefix);
 	}
 
 	/**

--- a/lib/private/memcache/null.php
+++ b/lib/private/memcache/null.php
@@ -22,7 +22,7 @@
 
 namespace OC\Memcache;
 
-class Null extends Cache {
+class Null extends Cache implements \OCP\IMemcache {
 	public function get($key) {
 		return null;
 	}
@@ -39,11 +39,15 @@ class Null extends Cache {
 		return true;
 	}
 
-	public function inc($key) {
+	public function add($key, $value, $ttl = 0) {
 		return true;
 	}
 
-	public function dec($key) {
+	public function inc($key, $step = 1) {
+		return true;
+	}
+
+	public function dec($key, $step = 1) {
 		return true;
 	}
 

--- a/lib/private/memcache/null.php
+++ b/lib/private/memcache/null.php
@@ -39,6 +39,18 @@ class Null extends Cache {
 		return true;
 	}
 
+	public function inc($key) {
+		return true;
+	}
+
+	public function dec($key) {
+		return true;
+	}
+
+	public function cas($key, $old, $new) {
+		return true;
+	}
+
 	public function clear($prefix = '') {
 		return true;
 	}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -43,6 +43,7 @@ use OC\Command\AsyncBus;
 use OC\Diagnostics\NullQueryLogger;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
+use OC\Lock\MemcacheLockingProvider;
 use OC\Mail\Mailer;
 use OC\Memcache\ArrayCache;
 use OC\Http\Client\ClientService;
@@ -418,6 +419,13 @@ class Server extends SimpleContainer implements IServerContainer {
 				$this->getHTTPClientService(),
 				$this->getConfig(),
 				$this->getLogger()
+			);
+		});
+		$this->registerService('LockingProvider', function (Server $c) {
+			/** @var \OC\Memcache\Factory $memcacheFactory */
+			$memcacheFactory = $c->getMemCacheFactory();
+			return new MemcacheLockingProvider(
+				$memcacheFactory->createDistributed('lock')
 			);
 		});
 	}
@@ -907,5 +915,15 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getTrustedDomainHelper() {
 		return $this->query('TrustedDomainHelper');
+	}
+
+	/**
+	 * Get the locking provider
+	 *
+	 * @return \OCP\Lock\ILockingProvider
+	 * @since 8.1.0
+	 */
+	public function getLockingProvider() {
+		return $this->query('LockingProvider');
 	}
 }

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -224,7 +224,7 @@ class Server extends SimpleContainer implements IServerContainer {
 		$this->registerService('MemCacheFactory', function (Server $c) {
 			$config = $c->getConfig();
 
-			if($config->getSystemValue('installed', false)) {
+			if($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$v = \OC_App::getAppVersions();
 				$v['core'] = implode('.', \OC_Util::getVersion());
 				$version = implode(',', $v);

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -234,7 +234,8 @@ class Server extends SimpleContainer implements IServerContainer {
 				$prefix = md5($instanceId.'-'.$version.'-'.$path);
 				return new \OC\Memcache\Factory($prefix,
 					$config->getSystemValue('memcache.local', null),
-					$config->getSystemValue('memcache.distributed', null)
+					$config->getSystemValue('memcache.distributed', null),
+					$config->getSystemValue('memcache.locking', null)
 				);
 			}
 
@@ -426,7 +427,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			if ($c->getConfig()->getSystemValue('filelocking.enabled', false) or (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				/** @var \OC\Memcache\Factory $memcacheFactory */
 				$memcacheFactory = $c->getMemCacheFactory();
-				$memcache = $memcacheFactory->createDistributed('lock');
+				$memcache = $memcacheFactory->createLocking('lock');
 				if (!($memcache instanceof \OC\Memcache\Null)) {
 					return new MemcacheLockingProvider($memcache);
 				}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -241,6 +241,7 @@ class Server extends SimpleContainer implements IServerContainer {
 
 			return new \OC\Memcache\Factory('',
 				new ArrayCache(),
+				new ArrayCache(),
 				new ArrayCache()
 			);
 		});

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -423,7 +423,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			);
 		});
 		$this->registerService('LockingProvider', function (Server $c) {
-			if ($c->getConfig()->getSystemValue('filelocking.enabled', false)) {
+			if ($c->getConfig()->getSystemValue('filelocking.enabled', false) or (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				/** @var \OC\Memcache\Factory $memcacheFactory */
 				$memcacheFactory = $c->getMemCacheFactory();
 				$memcache = $memcacheFactory->createDistributed('lock');

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -33,6 +33,7 @@
 // This means that they should be used by apps instead of the internal ownCloud classes
 namespace OCP\Files;
 use OCP\Files\InvalidPathException;
+use OCP\Lock\ILockingProvider;
 
 /**
  * Provide a common interface to all different storage options
@@ -413,4 +414,19 @@ interface Storage {
 	 * @since 8.1.0
 	 */
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath);
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function acquireLock($path, $type, ILockingProvider $provider);
+
+	/**
+	 * @param string $path
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 */
+	public function releaseLock($path, $type, ILockingProvider $provider);
 }

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -416,7 +416,7 @@ interface Storage {
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath);
 
 	/**
-	 * @param string $path
+	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
@@ -424,7 +424,7 @@ interface Storage {
 	public function acquireLock($path, $type, ILockingProvider $provider);
 
 	/**
-	 * @param string $path
+	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -429,4 +429,12 @@ interface Storage {
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider);
+
+	/**
+	 * @param string $path The path of the file to change the lock for
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function changeLock($path, $type, ILockingProvider $provider);
 }

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -413,4 +413,12 @@ interface IServerContainer {
 	 * @since 8.1.0
 	 */
 	public function getMailer();
+
+	/**
+	 * Get the locking provider
+	 *
+	 * @return \OCP\Lock\ILockingProvider
+	 * @since 8.1.0
+	 */
+	public function getLockingProvider();
 }

--- a/lib/public/lock/ilockingprovider.php
+++ b/lib/public/lock/ilockingprovider.php
@@ -44,4 +44,9 @@ interface ILockingProvider {
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 */
 	public function releaseLock($path, $type);
+
+	/**
+	 * release all lock acquired by this instance
+	 */
+	public function releaseAll();
 }

--- a/lib/public/lock/ilockingprovider.php
+++ b/lib/public/lock/ilockingprovider.php
@@ -46,6 +46,15 @@ interface ILockingProvider {
 	public function releaseLock($path, $type);
 
 	/**
+	 * Change the type of an existing lock
+	 *
+	 * @param string $path
+	 * @param int $targetType self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @throws \OCP\Lock\LockedException
+	 */
+	public function changeLock($path, $targetType);
+
+	/**
 	 * release all lock acquired by this instance
 	 */
 	public function releaseAll();

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -29,6 +29,8 @@
  *
  */
 
+use OC\Lock\NoopLockingProvider;
+
 OC_Util::checkAdminUser();
 OC_App::setActiveNavigationEntry("admin");
 
@@ -175,6 +177,11 @@ $template->assign('fileSharingSettings', $fileSharingSettings);
 $template->assign('filesExternal', $filesExternal);
 $template->assign('updaterAppPanel', $updaterAppPanel);
 $template->assign('ocDefaultEncryptionModulePanel', $ocDefaultEncryptionModulePanel);
+if (\OC::$server->getLockingProvider() instanceof NoopLockingProvider) {
+	$template->assign('fileLockingEnabled', false);
+} else {
+	$template->assign('fileLockingEnabled', true);
+}
 
 $formsMap = array_map(function ($form) {
 	if (preg_match('%(<h2[^>]*>.*?</h2>)%i', $form, $regs)) {
@@ -200,6 +207,7 @@ $formsAndMore = array_merge($formsAndMore, $formsMap);
 $formsAndMore[] = ['anchor' => 'backgroundjobs', 'section-name' => $l->t('Cron')];
 $formsAndMore[] = ['anchor' => 'mail_general_settings', 'section-name' => $l->t('Email server')];
 $formsAndMore[] = ['anchor' => 'log-section', 'section-name' => $l->t('Log')];
+$formsAndMore[] = ['anchor' => 'server-status', 'section-name' => $l->t('Server Status')];
 $formsAndMore[] = ['anchor' => 'admin-tips', 'section-name' => $l->t('Tips & tricks')];
 if ($updaterAppPanel) {
 	$formsAndMore[] = ['anchor' => 'updater', 'section-name' => $l->t('Updates')];

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -7,6 +7,7 @@
 /**
  * @var array $_
  * @var \OCP\IL10N $l
+ * @var OC_Defaults $theme
  */
 
 style('settings', 'settings');
@@ -15,32 +16,32 @@ script('core', ['multiselect', 'setupchecks']);
 vendor_script('select2/select2');
 vendor_style('select2/select2');
 
-$levels = array('Debug', 'Info', 'Warning', 'Error', 'Fatal');
-$levelLabels = array(
+$levels = ['Debug', 'Info', 'Warning', 'Error', 'Fatal'];
+$levelLabels = [
 	$l->t( 'Everything (fatal issues, errors, warnings, info, debug)' ),
 	$l->t( 'Info, warnings, errors and fatal issues' ),
 	$l->t( 'Warnings, errors and fatal issues' ),
 	$l->t( 'Errors and fatal issues' ),
 	$l->t( 'Fatal issues only' ),
-);
+];
 
-$mail_smtpauthtype = array(
+$mail_smtpauthtype = [
 	''	=> $l->t('None'),
 	'LOGIN'	=> $l->t('Login'),
 	'PLAIN'	=> $l->t('Plain'),
 	'NTLM'	=> $l->t('NT LAN Manager'),
-);
+];
 
-$mail_smtpsecure = array(
+$mail_smtpsecure = [
 	''		=> $l->t('None'),
 	'ssl'	=> $l->t('SSL'),
 	'tls'	=> $l->t('TLS'),
-);
+];
 
-$mail_smtpmode = array(
+$mail_smtpmode = [
 	'php',
 	'smtp',
-);
+];
 if ($_['sendmail_is_available']) {
 	$mail_smtpmode[] = 'sendmail';
 }
@@ -137,7 +138,7 @@ if (!$_['isLocaleWorking']) {
 		?>
 			<br>
 			<?php
-			p($l->t('We strongly suggest installing the required packages on your system to support one of the following locales: %s.', array($locales)));
+			p($l->t('We strongly suggest installing the required packages on your system to support one of the following locales: %s.', [$locales]));
 			?>
 	</li>
 <?php
@@ -266,12 +267,12 @@ if ($_['cronErrors']) {
 			if (time() - $_['lastcron'] <= 3600): ?>
 				<span class="cronstatus success"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron job execution: %s.", array($relative_time)));?>
+					<?php p($l->t("Last cron job execution: %s.", [$relative_time]));?>
 				</span>
 			<?php else: ?>
 				<span class="cronstatus error"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
-					<?php p($l->t("Last cron job execution: %s. Something seems wrong.", array($relative_time)));?>
+					<?php p($l->t("Last cron job execution: %s. Something seems wrong.", [$relative_time]));?>
 				</span>
 			<?php endif;
 		else: ?>
@@ -525,6 +526,18 @@ if ($_['cronErrors']) {
 		<li><a target="_blank" href="<?php p(link_to_docs('admin-config')); ?>"><?php p($l->t('Improving the config.php'));?> ↗</a></li>
 		<li><a target="_blank" href="<?php p(link_to_docs('developer-theming')); ?>"><?php p($l->t('Theming'));?> ↗</a></li>
 		<li><a target="_blank" href="<?php p(link_to_docs('admin-security')); ?>"><?php p($l->t('Hardening and security guidance'));?> ↗</a></li>
+	</ul>
+</div>
+<div class="section" id="server-status">
+	<h2><?php p($l->t('Server Status'));?></h2>
+	<ul>
+		<li>
+			<?php if ($_['fileLockingEnabled']) {
+				p($l->t('Experimental File Lock is enabled.'));
+			} else {
+				p($l->t('Experimental File Lock is disabled.'));
+			} ?>
+		</li>
 	</ul>
 </div>
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1090,7 +1090,7 @@ class View extends \Test\TestCase {
 	public function testReadFromWriteLockedPath() {
 		$view = new \OC\Files\View();
 		$storage = new Temporary(array());
-		Filesystem::mount($storage, [], '/');
+		\OC\Files\Filesystem::mount($storage, [], '/');
 		$view->lockFile('/foo/bar', ILockingProvider::LOCK_EXCLUSIVE);
 		$view->lockFile('/foo/bar/asd', ILockingProvider::LOCK_SHARED);
 	}
@@ -1103,7 +1103,7 @@ class View extends \Test\TestCase {
 	public function testWriteToReadLockedFile() {
 		$view = new \OC\Files\View();
 		$storage = new Temporary(array());
-		Filesystem::mount($storage, [], '/');
+		\OC\Files\Filesystem::mount($storage, [], '/');
 		$view->lockFile('/foo/bar', ILockingProvider::LOCK_SHARED);
 		$view->lockFile('/foo/bar', ILockingProvider::LOCK_EXCLUSIVE);
 	}

--- a/tests/lib/lock/lockingprovider.php
+++ b/tests/lib/lock/lockingprovider.php
@@ -107,6 +107,30 @@ abstract class LockingProvider extends TestCase {
 		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
+	public function testReleaseAll() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->acquireLock('bar', ILockingProvider::LOCK_SHARED);
+		$this->instance->acquireLock('asd', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->instance->releaseAll();
+
+		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance->isLocked('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance->isLocked('asd', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	public function testReleaseAfterReleaseAll() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->instance->releaseAll();
+
+		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+	}
+
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException

--- a/tests/lib/lock/lockingprovider.php
+++ b/tests/lib/lock/lockingprovider.php
@@ -158,4 +158,57 @@ abstract class LockingProvider extends TestCase {
 			$this->assertEquals('foo', $e->getPath());
 		}
 	}
+
+	public function testChangeLockToExclusive() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	public function testChangeLockToShared() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testChangeLockToExclusiveDoubleShared() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testChangeLockToExclusiveNoShared() {
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testChangeLockToExclusiveFromExclusive() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testChangeLockToSharedNoExclusive() {
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testChangeLockToSharedFromShared() {
+		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
+	}
 }

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	protected function tearDown() {
 		$hookExceptions = \OC_Hook::$thrownExceptions;
 		\OC_Hook::$thrownExceptions = [];
+		\OC::$server->getLockingProvider()->releaseAll();
 		if(!empty($hookExceptions)) {
 			throw $hookExceptions[0];
 		}


### PR DESCRIPTION
~~Currently explodes share unit tests.~~

~~From what I can tell they explode because the view lock the files, call the shared storage, which in turn calls the view, causing the locking logic to be called again.~~
~~#12086 Should fix that but is not something we can do for 8.1~~

cc @PVince81 @DeepDiver1975 
