### PR TITLE
Use OC.webroot instead of calculating the URL

### DIFF
--- a/core/js/maintenance-check.js
+++ b/core/js/maintenance-check.js
@@ -3,10 +3,7 @@ window.setInterval(checkStatus, 20000);
 
 function checkStatus() {
 	var request = new XMLHttpRequest();
-	var ocroot = location.pathname.substr(
-		0, location.pathname.indexOf('index.php')
-	);
-	request.open("GET", ocroot+'status.php', true);
+	request.open("GET", OC.webroot+'/status.php', true);
 	request.onreadystatechange = function() {
 		if (request.readyState === 4) {
 			var response = request.responseText;


### PR DESCRIPTION
Calculating the URL is error-prone as it doesn't work when for example `public.php` is requested and might even be harmful as it could leak sensitive information. (i.e. the requesttoken)

Since `oc.js` is even available when maintenance mode is available it is better to use the global `OC.webroot` that is not controlled by any user.

cc @MorrisJobke @nickvergessen Please review and test.
