### PR TITLE
allow configuring oracle session mode, needed when using oracle wallet

### DIFF
--- a/lib/private/db/connectionfactory.php
+++ b/lib/private/db/connectionfactory.php
@@ -178,6 +178,11 @@ class ConnectionFactory {
 		if ($driverOptions) {
 			$connectionParams['driverOptions'] = $driverOptions;
 		}
+		// allow setting oracle session mode parameter, eg OCI_CRED_EXT when using oracle wallet
+		$sessionMode = $config->getValue('dbsessionmode', null);
+		if ($sessionMode) {
+			$connectionParams['sessionMode'] = $sessionMode;
+		}
 
 		return $connectionParams;
 	}


### PR DESCRIPTION
@bboule can you test this in the lab? It seems without it oracle wallet cannot be used. In config.php set 

``` php
  'dbsessionmode' => OCI_CRED_EXT,
  'dbuser' => '/',
  'dbpass' => '',
  'dbname' => 'YOUR_WALLET_NAME',
```

Followup tasks:
- [ ] installer ui to allow using wallet during installation.
- [ ] add option to the console setup command
- [ ] sample documentation
- [ ] report upstream bug regarding upgrade issue @butonic 

see http://stackoverflow.com/a/11644451

cc @CaptionF 
