### PR TITLE
Check if cURL supports the desired features

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -346,8 +346,12 @@ class DAV extends Common {
 				curl_setopt($curl, CURLOPT_URL, $this->createBaseUri() . $this->encodePath($path));
 				curl_setopt($curl, CURLOPT_FILE, $fp);
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-				curl_setopt($curl, CURLOPT_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
-				curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS,  CURLPROTO_HTTP | CURLPROTO_HTTPS);
+				if(defined('CURLOPT_PROTOCOLS')) {
+					curl_setopt($curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+				}
+				if(defined('CURLOPT_REDIR_PROTOCOLS')) {
+					curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+				}
 				if ($this->secure === true) {
 					curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
 					curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);


### PR DESCRIPTION
Older versions of cURL that are unfortunately still bundled by distributors don't support these features which will result in errors and other possibly unpredictable behaviour.

Fixes https://github.com/owncloud/core/issues/16179 for master – stable8 requires another patch. This is the same approach as I used for SabreDAV in https://github.com/fruux/sabre-http/commit/59179fd8bc62cdb0eede412957797e6d005710a2

cc @MorrisJobke @nickvergessen  Please review and test. 
