### PR TITLE
Add info message for upgrade of an 3rdparty app

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -130,6 +130,9 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use($output) {
 				$output->writeln('<info>Disabled 3rd-party app: ' . $app . '</info>');
 			});
+			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use($output) {
+				$output->writeln('<info>Update 3rd-party app: ' . $app . '</info>');
+			});
 			$updater->listen('\OC\Updater', 'repairWarning', function ($app) use($output) {
 				$output->writeln('<error>Repair warning: ' . $app . '</error>');
 			});


### PR DESCRIPTION
cc @nickvergessen @LukasReschke @DeepDiver1975 

This would have helped to debug #16259 

Looks like this:

```
$ ./occ upgrade                     
ownCloud or one of the apps require upgrade - only a limited number of commands are available
Turned on maintenance mode
Checked database schema update
Checked database schema update for apps
Updated database
Disabled 3rd-party app: files_encryption
Update 3rd-party app: files_encryption
App does not provide an info.xml file
Turned off maintenance mode
Update failed
```
