### PR TITLE
Mute XCache error when trying to clear the opcode cache

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1335,7 +1335,7 @@ class OC_Util {
 			if (ini_get('xcache.admin.enable_auth')) {
 				OC_Log::write('core', 'XCache opcode cache will not be cleared because "xcache.admin.enable_auth" is enabled.', \OC_Log::WARN);
 			} else {
-				xcache_clear_cache(XC_TYPE_PHP, 0);
+				@xcache_clear_cache(XC_TYPE_PHP, 0);
 			}
 		}
 		// Opcache (PHP >= 5.5)


### PR DESCRIPTION
From https://github.com/owncloud/core/issues/16287:

> This is caused by XCache at https://github.com/owncloud/core/blob/8e59d4c64b48ed7daeebb714e11213f7a22b5740/lib/private/util.php#L1276 where we are trying to reset the opcode cache with `XC_TYPE_PHP`.
> 
> I suspect that while XCache is installed its opcode component is not used. Unfortunately, the XCache API is not really properly documented and thus I don't know what API we would have to call to check whether the `XC_TYPE_PHP` cache is populated. In fact, there is an [open XCache bug](http://xcache.lighttpd.net/ticket/176) since 7 years that discusses this problem and is likely to never get fixed since XCache is abandonware.

Fixes https://github.com/owncloud/core/issues/16287

cc @jnfrmarks Please test.
cc @DeepDiver1975 @MorrisJobke Alternative ideas?
