### PR TITLE
some encryption fixes

### DIFF
--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -483,7 +483,7 @@ class KeyManager {
 	}
 
 	public function deleteAllFileKeys($path) {
-		return $this->keyStorage->deleteAllFileKeys($path, Encryption::ID);
+		return $this->keyStorage->deleteAllFileKeys($path);
 	}
 
 	/**

--- a/lib/private/encryption/keys/storage.php
+++ b/lib/private/encryption/keys/storage.php
@@ -125,10 +125,9 @@ class Storage implements IStorage {
 	/**
 	 * @inheritdoc
 	 */
-	public function deleteAllFileKeys($path, $encryptionModuleId) {
-		$keyDir = $this->getFileKeyDir($encryptionModuleId, $path);
-		$path = dirname($keyDir);
-		return !$this->view->file_exists($path) || $this->view->deleteAll($path);
+	public function deleteAllFileKeys($path) {
+		$keyDir = $this->getFileKeyDir('', $path);
+		return !$this->view->file_exists($keyDir) || $this->view->deleteAll($keyDir);
 	}
 
 	/**
@@ -208,17 +207,10 @@ class Storage implements IStorage {
 	 * @param string $encryptionModuleId
 	 * @param string $path path to the file, relative to data/
 	 * @return string
-	 * @throws GenericEncryptionException
-	 * @internal param string $keyId
 	 */
 	private function getFileKeyDir($encryptionModuleId, $path) {
 
-		if ($this->view->is_dir($path)) {
-			throw new GenericEncryptionException("file was expected but directory was given: $path");
-		}
-
 		list($owner, $filename) = $this->util->getUidAndFilename($path);
-		$filename = $this->util->stripPartialFileExtension($filename);
 
 		// in case of system wide mount points the keys are stored directly in the data directory
 		if ($this->util->isSystemWideMountPoint($filename, $owner)) {

--- a/lib/public/encryption/keys/istorage.php
+++ b/lib/public/encryption/keys/istorage.php
@@ -129,12 +129,11 @@ interface IStorage {
 	 * delete all file keys for a given file
 	 *
 	 * @param string $path to the file
-	 * @param string $encryptionModuleId
 	 *
 	 * @return boolean False when the keys could not be deleted
 	 * @since 8.1.0
 	 */
-	public function deleteAllFileKeys($path, $encryptionModuleId);
+	public function deleteAllFileKeys($path);
 
 	/**
 	 * delete system-wide encryption keys not related to a specific user,


### PR DESCRIPTION
Some changes which should fix (most) litmus tests.
- delete all file keys doesn't need the encryption module as parameter
- implement rmdir
- getFileKeyDir should also work for part files and complete directories

@DeepDiver1975 please test this. 1-2 litmus tests still fail on my system randomly ( :fearful: ) but also without encryption. Let's hope that something is wrong on my setup.
