### PR TITLE
include base dn test in functionality test

### DIFF
--- a/apps/user_ldap/js/wizard/view.js
+++ b/apps/user_ldap/js/wizard/view.js
@@ -168,6 +168,26 @@ OCA = OCA || {};
 		},
 
 		/**
+		 * Base DN test results will arrive here
+		 *
+		 * @param {WizardTabElementary} view
+		 * @param {FeaturePayload} payload
+		 */
+		onDetectionTestCompleted: function(view, payload) {
+			if(payload.feature === 'TestBaseDN') {
+				if(payload.data.status === 'success') {
+					var objectsFound = parseInt(payload.data.changes.ldap_test_base, 10);
+					if(objectsFound > 0) {
+						view._updateStatusIndicator(view.STATUS_SUCCESS);
+						return;
+					}
+				}
+				view._updateStatusIndicator(view.STATUS_ERROR);
+				OC.Notification.showTemporary(t('user_ldap', 'The Base DN appears to be wrong'));
+			}
+		},
+
+		/**
 		 * updates the status indicator based on the configuration test result
 		 *
 		 * @param {WizardView} [view]
@@ -176,7 +196,7 @@ OCA = OCA || {};
 		 */
 		onTestCompleted: function(view, result) {
 			if(result.isSuccess) {
-				view._updateStatusIndicator(view.STATUS_SUCCESS);
+				view.configModel.requestWizard('ldap_test_base');
 			} else {
 				view._updateStatusIndicator(view.STATUS_ERROR);
 			}
@@ -272,6 +292,7 @@ OCA = OCA || {};
 			this.configModel.on('setRequested', this.onSetRequested, this);
 			this.configModel.on('setCompleted', this.onSetRequestDone, this);
 			this.configModel.on('configurationTested', this.onTestCompleted, this);
+			this.configModel.on('receivedLdapFeature', this.onDetectionTestCompleted, this);
 		},
 
 		/**

--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -17,6 +17,8 @@ OCA = OCA || {};
 		/** @property {number} */
 		_configChooserNextServerNumber: 1,
 
+		baseDNTestTriggered: false,
+
 		/**
 		 * initializes the instance. Always call it after initialization.
 		 *
@@ -192,8 +194,8 @@ OCA = OCA || {};
 		 * @param {Object} configuration
 		 */
 		onConfigSwitch: function(view, configuration) {
+			this.baseDNTestTriggered = false;
 			view.disableElement(view.managedItems.ldap_port.$relatedElements);
-
 			view.onConfigLoaded(view, configuration);
 		},
 
@@ -255,7 +257,8 @@ OCA = OCA || {};
 		 * @param {FeaturePayload} payload
 		 */
 		onTestResultReceived: function(view, payload) {
-			if(payload.feature === 'TestBaseDN') {
+			if(view.baseDNTestTriggered && payload.feature === 'TestBaseDN') {
+				view.enableElement(view.managedItems.ldap_base.$testButton);
 				var message;
 				if(payload.data.status === 'success') {
 					var objectsFound = parseInt(payload.data.changes.ldap_test_base, 10);
@@ -303,7 +306,9 @@ OCA = OCA || {};
 		 */
 		onBaseDNTestButtonClick: function(event) {
 			event.preventDefault();
+			this.baseDNTestTriggered = true;
 			this.configModel.requestWizard('ldap_test_base');
+			this.disableElement(this.managedItems.ldap_base.$testButton);
 		},
 
 		/**


### PR DESCRIPTION
Fixes #16192 

Caveeat: Functionality check now takes much longer. That is the cost for this test. Try it out or check this video:

https://s3.owncloud.com/owncloud/index.php/s/LCiyRvTfw5irgr2

Have it or leave it?

Personally, it takes too long for me. Also, when base dn does not work, you cannot configure other stuff (given, it does not keep you from breaking your config afterwards, if you don't use the test buttons). 

Also, it's rather enhancement than bug, as the criticised behaviour was there as it is since always(:tm:).
