### PR TITLE
Use owner when expiring versions, not the logged in user

### DIFF
--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -182,6 +182,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	static protected function logout() {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
+		// needed for fully logout
+		\OC::$server->getUserSession()->setUser(null);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/16334
- [x] fix the issue
- [x] add unit test that makes sure that the job is schedules with the owner, not the logged in user

FYI @icewind1991 
