### PR TITLE
Show a empty response for GET on non-files instead of the Browser Plugin

### DIFF
--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -48,7 +48,8 @@ $server->setBaseUri($baseuri);
 // Load plugins
 $defaults = new OC_Defaults();
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
-$server->addPlugin(new \Sabre\DAV\Browser\Plugin(false)); // Show something in the Browser, but no upload
+// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
+$server->addPlugin(new \OC\Connector\Sabre\DummyGetResponsePlugin());
 $server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree));
 $server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin());
 $server->addPlugin(new \OC\Connector\Sabre\ExceptionLoggerPlugin('webdav', \OC::$server->getLogger()));


### PR DESCRIPTION
As discussed in https://github.com/owncloud/core/pull/14151, we missed to add this to the `files_sharing` S2S public WebDAV backend though.

cc @DeepDiver1975 @PVince81 
