### PR TITLE
Fix for thumbnail creation on File upload OC version 81.beta

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -833,7 +833,8 @@ class Preview {
 	private function storeMaxPreview($previewPath) {
 		$maxPreview = false;
 		$preview = $this->preview;
-
+		$this->keepAspect = true;
+		
 		$allThumbnails = $this->userView->getDirectoryContent($previewPath);
 		// This is so that the cache doesn't need emptying when upgrading
 		// Can be replaced by an upgrade script...


### PR DESCRIPTION
If you upload an image that is greater than the config value of preview_max_x/preview_max_y (2048) you run in an issue that the big image also get cropped to 2048 x 2048 cause the first small thumb creation is square 36/36 so the keepAspect is false. with this addition you ge sure the aspect ratio is set to true!
