### PR TITLE
[stable8] Properly log out test users in unit tests

### DIFF
--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -168,5 +168,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	static protected function logout() {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
+		// needed for fully logout
+		\OC::$server->getUserSession()->setUser(null);
 	}
 }


### PR DESCRIPTION
So far only to test Jenkins, but that call should be useful (it's on master too)
