### PR TITLE
[encryption] only try to delete file keys if it is a valid path

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -245,8 +245,12 @@ class Encryption extends Wrapper {
 	 */
 	public function rmdir($path) {
 		$result = $this->storage->rmdir($path);
-		if ($result && $this->encryptionManager->isEnabled()) {
-			$this->keyStorage->deleteAllFileKeys($this->getFullPath($path));
+		$fullPath = $this->getFullPath($path);
+		if ($result &&
+			$this->util->isExcluded($fullPath) === false &&
+			$this->encryptionManager->isEnabled()
+		) {
+			$this->keyStorage->deleteAllFileKeys($fullPath);
 		}
 
 		return $result;


### PR DESCRIPTION
only try to delete file keys if it is a valid path

This are some tests steps which are affected by the bug and which are fixed with this PR https://github.com/owncloud/core/issues/16358

fix https://github.com/owncloud/core/issues/16358
