### PR TITLE
Only load commands of enabled apps

### DIFF
--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -35,7 +35,7 @@ class Application {
 		if ($this->config->getSystemValue('installed', false)) {
 			if (!\OCP\Util::needUpgrade()) {
 				OC_App::loadApps();
-				foreach (OC_App::getAllApps() as $app) {
+				foreach (\OC::$server->getAppManager()->getInstalledApps() as $app) {
 					$file = OC_App::getAppPath($app) . '/appinfo/register_command.php';
 					if (file_exists($file)) {
 						require $file;


### PR DESCRIPTION
- add some syntax errors to `appinfo/register_command.php` of a disabled app (like `user_ldap`)
- run `./occ`
### Expected

Command runs fine
### Actual

```
PHP Parse error:  syntax error, unexpected '$dbConnection' (T_VARIABLE) in /home/mjob/Projekte/owncloud/master/apps/user_ldap/appinfo/register_command.php on line 30
PHP Stack trace:
PHP   1. {main}() /home/mjob/Projekte/owncloud/master/occ:0
PHP   2. require_once() /home/mjob/Projekte/owncloud/master/occ:11
PHP   3. OC\Console\Application->loadCommands() /home/mjob/Projekte/owncloud/master/console.php:66
```

cc @nickvergessen @DeepDiver1975 @LukasReschke @rullzer @Xenopathic 

@karlitschek I would like to backport this to stable8 once it is merged.
