### PR TITLE
fix #16356

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -341,8 +341,8 @@ class Encryption extends Wrapper {
 			} else {
 				$data = '';
 			}
+			$this->unencryptedSize = max($this->unencryptedSize, $this->position);
 		}
-		$this->unencryptedSize = max($this->unencryptedSize, $this->position);
 		return $length;
 	}
 


### PR DESCRIPTION
Updating `$this->unencryptedSize` should happen after writing each (partial) block such that the tests in `readCache()` work properly and avoid reading overhead.
