### PR TITLE
[WIP] Experiment with moving the share dropdown to a sidebar

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -69,8 +69,8 @@
 
 /* position share dropdown */
 #dropdown {
-	margin-right: 10% !important;
 	width: 80% !important;
+	max-width: 400px;
 }
 
 

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -1066,3 +1066,15 @@ fieldset.warning legend + p, fieldset.update legend + p {
 	width: device-width;
 }
 
+
+#dropdown.drop {
+	position: fixed;
+	right: 0;
+	left: initial;
+	top: 45px;
+	height: 100%;
+	box-sizing: border-box;
+	width: 400px;
+	border-radius: 0;
+	box-shadow: 0 0 20px rgba(100, 100, 100, .3);
+}

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -609,9 +609,8 @@ OC.Share={
 			dropDownEl.appendTo(appendTo);
 		}
 		dropDownEl.attr('data-item-source-name', filename);
-		$('#dropdown').slideDown(OC.menuSpeed, function() {
-			OC.Share.droppedDown = true;
-		});
+		$('#dropdown').show('slide', { direction: 'left' }, 1000);
+		OC.Share.droppedDown = true;
 		if ($('html').hasClass('lte9')){
 			$('#dropdown input[placeholder]').placeholder();
 		}
@@ -619,16 +618,15 @@ OC.Share={
 	},
 	hideDropDown:function(callback) {
 		OC.Share.currentShares = null;
-		$('#dropdown').slideUp(OC.menuSpeed, function() {
-			OC.Share.droppedDown = false;
-			$('#dropdown').remove();
-			if (typeof FileActions !== 'undefined') {
-				$('tr').removeClass('mouseOver');
-			}
-			if (callback) {
-				callback.call();
-			}
-		});
+		$('#dropdown').hide();
+		OC.Share.droppedDown = false;
+		$('#dropdown').remove();
+		if (typeof FileActions !== 'undefined') {
+			$('tr').removeClass('mouseOver');
+		}
+		if (callback) {
+			callback.call();
+		}
 	},
 	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, mailSend, collection) {
 		var shareItem = {


### PR DESCRIPTION
**IMPORTANT** This is only to be understood as a stupid mockup. To make this work nicely we need some deep underlying code changes. cc @DeepDiver1975 

First testing of a sidebar instead of dropdown. Some things missing:
- [x] VERY IMPORTANT: Add file thumbnail & name on top so you know which file this is about
- [x] we could even make the thumbnail a bit bigger, especially useful for pictures and to make @dragotin happy ;D 
- [x] animations to slide it in nicely from the right and slide it out again
- [ ] a switcher on top for Versions & Sharing. For folders no switcher is needed as there are no versions.
- [x] add a close button on the top right
- [x] on clicking outside it, close it instead of performing any other action
- [ ] add a menu for the actions: https://github.com/owncloud/core/issues/12081

In the future:
- [x] show more info about the file https://github.com/owncloud/core/issues/16308
- [x] include the activity stream for the file
- [ ] in that activity stream, integrate the versions directly
- [ ] also in the activity stream, integrate the ability to leave and read comments on the file. Ref https://github.com/owncloud/core/issues/16328

Before:
![capture du 2015-05-18 15 46 31](https://cloud.githubusercontent.com/assets/925062/7682040/1bc0fa8e-fd75-11e4-88fc-dbf67e6496a6.png)
After:
![capture du 2015-05-18 15 46 08](https://cloud.githubusercontent.com/assets/925062/7682039/1bbfcea2-fd75-11e4-9fc8-0a0eff92ae3b.png)

What do you think @MTRichards @karlitschek @owncloud/designers?
