### PR TITLE
[stable8] Replace static dbtableprefix with config dbtableprefix

### DIFF
--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -100,7 +100,7 @@ class Migrator {
 	 * @return string
 	 */
 	protected function generateTemporaryTableName($name) {
-		return 'oc_' . $name . '_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+		return $this->config->getSystemValue('dbtableprefix', 'oc_') . $name . '_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 	}
 
 	/**
@@ -151,7 +151,7 @@ class Migrator {
 				$indexName = $index->getName();
 			} else {
 				// avoid conflicts in index names
-				$indexName = 'oc_' . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+				$indexName = $this->config->getSystemValue('dbtableprefix', 'oc_') . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 			}
 			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -26,11 +26,17 @@ class Migrator extends \Test\TestCase {
 	 */
 	private $manager;
 
+	/**
+	 * @var IConfig
+	 **/
+	private $config;
+
 	private $tableName;
 
 	protected function setUp() {
 		parent::setUp();
 
+		$this->config = \OC::$server->getConfig();
 		$this->connection = \OC_DB::getConnection();
 		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
 			$this->markTestSkipped('DB migration tests are not supported on OCI');
@@ -39,7 +45,7 @@ class Migrator extends \Test\TestCase {
 			$this->markTestSkipped('DB migration tests are not supported on MSSQL');
 		}
 		$this->manager = new \OC\DB\MDB2SchemaManager($this->connection);
-		$this->tableName = strtolower($this->getUniqueID('oc_test_'));
+		$this->tableName = strtolower($this->getUniqueID($this->config->getSystemValue('dbtableprefix', 'oc_') . 'test_'));
 	}
 
 	protected function tearDown() {
@@ -107,6 +113,27 @@ class Migrator extends \Test\TestCase {
 		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 		$this->assertTrue(true);
+	}
+
+	public function testUpgradeDifferentPrefix() {
+		$oldTablePrefix = $this->config->getSystemValue('dbtableprefix', 'oc_');
+
+		$this->config->setSystemValue('dbtableprefix', 'ownc_');
+		$this->tableName = strtolower($this->getUniqueID($this->config->getSystemValue('dbtableprefix') . 'test_'));
+
+		list($startSchema, $endSchema) = $this->getDuplicateKeySchemas();
+		$migrator = $this->manager->getMigrator();
+		$migrator->migrate($startSchema);
+
+		$this->connection->insert($this->tableName, array('id' => 1, 'name' => 'foo'));
+		$this->connection->insert($this->tableName, array('id' => 2, 'name' => 'bar'));
+		$this->connection->insert($this->tableName, array('id' => 3, 'name' => 'qwerty'));
+
+		$migrator->checkMigrate($endSchema);
+		$migrator->migrate($endSchema);
+		$this->assertTrue(true);
+
+		$this->config->setSystemValue('dbtableprefix', $oldTablePrefix);
 	}
 
 	public function testInsertAfterUpgrade() {


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/14660 to stable8.
Also brings in the matching unit tests from https://github.com/owncloud/core/issues/16420

@karlitschek please confirm this backport
