### PR TITLE
Persist the state of the maintenance after an upgrade

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -44,11 +44,14 @@ if (OC::checkUpgrade(false)) {
 	$incompatibleApps = [];
 	$disabledThirdPartyApps = [];
 
-	$updater->listen('\OC\Updater', 'maintenanceStart', function () use ($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'maintenanceEnabled', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Turned on maintenance mode'));
 	});
-	$updater->listen('\OC\Updater', 'maintenanceEnd', function () use ($eventSource, $l) {
+	$updater->listen('\OC\Updater', 'maintenanceDisabled', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Turned off maintenance mode'));
+	});
+	$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Maintenance mode is kept active'));
 	});
 	$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updated database'));

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -107,12 +107,17 @@ class Upgrade extends Command {
 			$updater->setSimulateStepEnabled($simulateStepEnabled);
 			$updater->setUpdateStepEnabled($updateStepEnabled);
 
-			$updater->listen('\OC\Updater', 'maintenanceStart', function () use($output) {
+			$updater->listen('\OC\Updater', 'maintenanceEnabled', function () use($output) {
 				$output->writeln('<info>Turned on maintenance mode</info>');
 			});
-			$updater->listen('\OC\Updater', 'maintenanceEnd',
+			$updater->listen('\OC\Updater', 'maintenanceDisabled', function () use($output) {
+				$output->writeln('<info>Turned off maintenance mode</info>');
+			});
+			$updater->listen('\OC\Updater', 'maintenanceActive', function () use($output) {
+				$output->writeln('<info>Maintenance mode is kept active</info>');
+			});
+			$updater->listen('\OC\Updater', 'updateEnd',
 				function () use($output, $updateStepEnabled, $self) {
-					$output->writeln('<info>Turned off maintenance mode</info>');
 					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
 					$status = $self->upgradeFailed ? 'failed' : 'successful';
 					$message = "<info>$mode $status</info>";

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -163,14 +163,18 @@ class Updater extends BasicEmitter {
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
 	public function upgrade() {
-		$this->config->setSystemValue('maintenance', true);
+		$wasMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
+
+		if(!$wasMaintenanceModeEnabled) {
+			$this->config->setSystemValue('maintenance', true);
+			$this->emit('\OC\Updater', 'maintenanceEnabled');
+		}
 
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
 		$currentVersion = implode('.', \OC_Util::getVersion());
 		if ($this->log) {
 			$this->log->debug('starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, array('app' => 'core'));
 		}
-		$this->emit('\OC\Updater', 'maintenanceStart');
 
 		try {
 			$this->doUpgrade($currentVersion, $installedVersion);
@@ -178,8 +182,14 @@ class Updater extends BasicEmitter {
 			$this->emit('\OC\Updater', 'failure', array($exception->getMessage()));
 		}
 
-		$this->config->setSystemValue('maintenance', false);
-		$this->emit('\OC\Updater', 'maintenanceEnd');
+		$this->emit('\OC\Updater', 'updateEnd');
+
+		if(!$wasMaintenanceModeEnabled) {
+			$this->config->setSystemValue('maintenance', false);
+			$this->emit('\OC\Updater', 'maintenanceDisabled');
+		} else {
+			$this->emit('\OC\Updater', 'maintenanceActive');
+		}
 	}
 
 	/**


### PR DESCRIPTION
- if maintenance mode was enabled before an upgrade
  it will be enabled afterwards too
- fixes #16429 

cc @nickvergessen @DeepDiver1975 @danimo 
