### PR TITLE
Fix URL generation

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -277,6 +277,11 @@ OCA.Sharing.PublicApp = {
 };
 
 $(document).ready(function () {
+	// FIXME: replace with OC.Plugins.register()
+	if (window.TESTING) {
+		return;
+	}
+
 	var App = OCA.Sharing.PublicApp;
 	// defer app init, to give a chance to plugins to register file actions
 	_.defer(function () {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -144,7 +144,7 @@ OCA.Sharing.PublicApp = {
 					path: path,
 					files: filename
 				};
-				return OC.generateUrl('/s/' + token + '/download', params);
+				return OC.generateUrl('/s/' + token + '/download') + '?' + OC.buildQueryString(params);
 			};
 
 			this.fileList.getAjaxUrl = function (action, params) {

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -1,0 +1,107 @@
+/**
+* ownCloud
+*
+* @author Vincent Petry
+* @copyright 2015 Vincent Petry <pvince81@owncloud.com>
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+describe('OCA.Sharing.PublicApp tests', function() {
+	var App = OCA.Sharing.PublicApp;
+	var $preview;
+	var fileListIn;
+	var fileListOut;
+
+	beforeEach(function() {
+		$preview = $('<div id="preview"></div>');
+		$('#testArea').append($preview);
+		$preview.append(
+			'<div id="mimetype"></div>' +
+			'<div id="mimetypeIcon"></div>' +
+			'<input type="hidden" id="sharingToken" value="sh4tok"></input>'
+		);
+	});
+
+	describe('File list', function() {
+		// TODO: this should be moved to a separate file once the PublicFileList is extracted from public.js
+		beforeEach(function() {
+			$preview.append(
+				'<div id="app-content-files">' +
+				// init horrible parameters
+				'<input type="hidden" id="dir" value="/subdir"/>' +
+				'<input type="hidden" id="permissions" value="31"/>' +
+				// dummy controls
+				'<div id="controls">' +
+				'   <div class="actions creatable"></div>' +
+				'   <div class="notCreatable"></div>' +
+				'</div>' +
+				// uploader
+				'<input type="file" id="file_upload_start" name="files[]" multiple="multiple">' +
+				// dummy table
+				// TODO: at some point this will be rendered by the fileList class itself!
+				'<table id="filestable">' +
+				'<thead><tr>' +
+				'<th id="headerName" class="hidden column-name">' +
+				'<input type="checkbox" id="select_all_files" class="select-all">' +
+				'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
+				'<span class="selectedActions hidden">' +
+				'<a href class="download">Download</a>' +
+				'</th>' +
+				'<th class="hidden column-size"><a class="columntitle" data-sort="size"><span class="sort-indicator"></span></a></th>' +
+				'<th class="hidden column-mtime"><a class="columntitle" data-sort="mtime"><span class="sort-indicator"></span></a></th>' +
+				'</tr></thead>' +
+				'<tbody id="fileList"></tbody>' +
+				'<tfoot></tfoot>' +
+				'</table>' +
+				// TODO: move to handlebars template
+				'<div id="emptycontent"><h2>Empty content message</h2><p class="uploadmessage">Upload message</p></div>' +
+				'<div class="nofilterresults hidden"></div>' +
+				'</div>'
+			);
+
+			App.initialize($('#preview'));
+		});
+		afterEach(function() {
+			App._initialized = false;
+		});
+
+		describe('Download Url', function() {
+			var fileList;
+
+			beforeEach(function() {
+				fileList = App.fileList;
+			});
+
+			it('returns correct download URL for single files', function() {
+				expect(fileList.getDownloadUrl('some file.txt'))
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=some%20file.txt');
+				expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fanotherpath%2Fabc&files=some%20file.txt');
+				fileList.changeDirectory('/');
+				expect(fileList.getDownloadUrl('some file.txt'))
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2F&files=some%20file.txt');
+			});
+			it('returns correct download URL for multiple files', function() {
+				expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=%5B%22a%20b%20c.txt%22%2C%22d%20e%20f.txt%22%5D');
+			});
+			it('returns the correct ajax URL', function() {
+				expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))
+					.toEqual(OC.webroot + '/index.php/apps/files_sharing/ajax/test.php?a=1&b=x%20y&t=sh4tok');
+			});
+		});
+	});
+});

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -54,7 +54,8 @@ module.exports = function(config) {
 					'apps/files_sharing/js/app.js',
 					'apps/files_sharing/js/sharedfilelist.js',
 					'apps/files_sharing/js/share.js',
-					'apps/files_sharing/js/external.js'
+					'apps/files_sharing/js/external.js',
+					'apps/files_sharing/js/public.js'
 				],
 				testFiles: ['apps/files_sharing/tests/js/*.js']
 			},


### PR DESCRIPTION
`params` in the `OC.generateUrl` function call only replaces all specified occurences of a key just like the l10n PHP functionality does.

This means that to build a query string we have to use `OC.buildQueryString` instead of the params parameters.

Fixes https://github.com/owncloud/core/issues/16336 which is a regression introduced with https://github.com/owncloud/core/commit/58a87d0babcb91aab75b45e630d2fc2fee15691e of https://github.com/owncloud/core/pull/15652.

Without this fix downloading single files from a public shared folder is not possible.

<hr/>
# Testplan
1. Share a folder on master publicly
2. Access the public link and downloading single files does download the whole folder as a ZIP
3. Apply the patch, clear your cache, downloading single files and all works again
