### PR TITLE
always write file, if fseek doesn't work we write the whole file

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -412,14 +412,16 @@ class Encryption extends Wrapper {
 			// we are handling that separately here and we don't want to
 			// get into an infinite loop
 			$encrypted = $this->encryptionModule->encrypt($this->cache);
-			parent::stream_write($encrypted);
+			$bytesWritten = parent::stream_write($encrypted);
 			$this->writeFlag = false;
-			// If the write concerns the last block then then update the encrypted filesize
+			// Check whether the write concerns the last block
+			// If so then update the encrypted filesize
 			// Note that the unencrypted pointer and filesize are NOT yet updated when flush() is called
 			// We recalculate the encrypted filesize as we do not know the context of calling flush()
-			if ((int)floor($this->unencryptedSize/$this->unencryptedBlockSize) === (int)floor($this->position/$this->unencryptedBlockSize)) {
-				$this->size = $this->util->getBlockSize() * (int)floor($this->unencryptedSize/$this->unencryptedBlockSize);
-				$this->size += strlen($encrypted);
+			$completeBlocksInFile=(int)floor($this->unencryptedSize/$this->unencryptedBlockSize);
+			if ($completeBlocksInFile === (int)floor($this->position/$this->unencryptedBlockSize)) {
+				$this->size = $this->util->getBlockSize() * $completeBlocksInFile;
+				$this->size += $bytesWritten;
 				$this->size += $this->headerSize;
 			}
 		}

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -273,7 +273,7 @@ class Encryption extends Wrapper {
 
 		$result = '';
 
-//		$count = min($count, $this->unencryptedSize - $this->position);
+		$count = min($count, $this->unencryptedSize - $this->position);
 		while ($count > 0) {
 			$remainingLength = $count;
 			// update the cache of the current block

--- a/tests/lib/files/stream/dummyencryptionwrapper.php
+++ b/tests/lib/files/stream/dummyencryptionwrapper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\Files\Stream;
+
+class DummyEncryptionWrapper extends \OC\Files\Stream\Encryption {
+
+	/**
+	 * simulate a non-seekable stream wrapper by always return false
+	 *
+	 * @param int $position
+	 * @return bool
+	 */
+	protected function parentStreamSeek($position) {
+		return false;
+	}
+
+}


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/16356

@jknockaert please have a look. I have the feeling that this is to simple and fear that I missed something.

The problem is that if we upload a large file to a storage which doesn't support fseek and ftell, which is the case for some ftp storages, we don't get the correct size after the first write. So  $positionInFile will no longer be equal to $this->size and fseek will be false. This means that we will stop writing after the first block.

My assumption: Either we write in the middle of the file and fseek works, or fseek failed because it is not supported by the storage back-end in this case we always write the complete file and we don't need a additional check, which lead us to 

```
if (!($this->readOnly) && ($resultFseek || !$resultFseek || $positionInFile === $this->size)) {
```

which again lead us to 

```
if (!$this->readOnly) {
```

All tests pass with this changes and the issue above is fixed.
