### PR TITLE
[stable8] backport 13740 and 15606

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -251,7 +251,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * returns a filter for a "users in primary group" search or count operation
 	 *
-	 * @param $groupDN
+	 * @param string $groupDN
 	 * @param string $search
 	 * @return string
 	 * @throws \Exception
@@ -281,7 +281,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return \string[]
+	 * @return string[]
 	 */
 	public function getUsersInPrimaryGroup($groupDN, $search = '', $limit = -1, $offset = 0) {
 		try {
@@ -300,7 +300,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	/**
 	 * returns the number of users that have the given group as primary group
 	 *
-	 * @param $groupDN
+	 * @param string $groupDN
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
@@ -310,7 +310,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		try {
 			$filter = $this->prepareFilterForUsersInPrimaryGroup($groupDN, $search);
 			$users = $this->access->countUsers($filter, array('dn'), $limit, $offset);
-			return (is_int($users)) ? $users : 0;
+			return (int)$users;
 		} catch (\Exception $e) {
 			return 0;
 		}

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -444,6 +444,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!$this->groupExists($gid)) {
 			return array();
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$cacheKey = 'usersInGroup-'.$gid.'-'.$search.'-'.$limit.'-'.$offset;
 		// check for cache of the exact query
 		$groupUsers = $this->access->connection->getFromCache($cacheKey);
@@ -557,6 +558,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			$this->access->connection->writeToCache($cacheKey, $groupUsers);
 			return $groupUsers;
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$isMemberUid =
 			(strtolower($this->access->connection->ldapGroupMemberAssocAttr)
 			=== 'memberuid');
@@ -663,6 +665,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(!$this->enabled) {
 			return array();
 		}
+		$search = $this->access->escapeFilterPart($search, true);
 		$pagingSize = $this->access->connection->ldapPagingSize;
 		if ((! $this->access->connection->hasPagedResultSupport)
 		   	|| empty($pagingSize)) {

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -510,10 +510,11 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			}
 		}
 
+		$groupUsers = array_unique(array_merge($groupUsers, $primaryUsers));
 		natsort($groupUsers);
 		$this->access->connection->writeToCache('usersInGroup-'.$gid.'-'.$search, $groupUsers);
 		$groupUsers = array_slice($groupUsers, $offset, $limit);
-		$groupUsers = array_unique(array_merge($groupUsers, $primaryUsers));
+
 
 		$this->access->connection->writeToCache($cacheKey, $groupUsers);
 

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -286,12 +286,13 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	public function getUsersInPrimaryGroup($groupDN, $search = '', $limit = -1, $offset = 0) {
 		try {
 			$filter = $this->prepareFilterForUsersInPrimaryGroup($groupDN, $search);
-			return $this->access->fetchListOfUsers(
+			$users = $this->access->fetchListOfUsers(
 				$filter,
 				array($this->access->connection->ldapUserDisplayName, 'dn'),
 				$limit,
 				$offset
 			);
+			return $this->access->ownCloudUserNames($users);
 		} catch (\Exception $e) {
 			return array();
 		}
@@ -470,8 +471,9 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			return array();
 		}
 
+		$primaryUsers = $this->getUsersInPrimaryGroup($groupDN, $search, $limit, $offset);
 		$members = array_keys($this->_groupMembers($groupDN));
-		if(!$members) {
+		if(!$members && empty($primaryUsers)) {
 			//in case users could not be retrieved, return empty result set
 			$this->access->connection->writeToCache($cacheKey, array());
 			return array();
@@ -511,9 +513,6 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		natsort($groupUsers);
 		$this->access->connection->writeToCache('usersInGroup-'.$gid.'-'.$search, $groupUsers);
 		$groupUsers = array_slice($groupUsers, $offset, $limit);
-
-		//and get users that have the group as primary
-		$primaryUsers = $this->getUsersInPrimaryGroup($groupDN, $search, $limit, $offset);
 		$groupUsers = array_unique(array_merge($groupUsers, $primaryUsers));
 
 		$this->access->connection->writeToCache($cacheKey, $groupUsers);
@@ -545,16 +544,15 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		}
 
 		$members = array_keys($this->_groupMembers($groupDN));
-		if(!$members) {
+		$primaryUserCount = $this->countUsersInPrimaryGroup($groupDN, '');
+		if(!$members && $primaryUserCount === 0) {
 			//in case users could not be retrieved, return empty result set
 			$this->access->connection->writeToCache($cacheKey, false);
 			return false;
 		}
 
 		if(empty($search)) {
-			$primaryUsers = $this->countUsersInPrimaryGroup($groupDN, '');
-			$groupUsers = count($members) + $primaryUsers;
-
+			$groupUsers = count($members) + $primaryUserCount;
 			$this->access->connection->writeToCache($cacheKey, $groupUsers);
 			return $groupUsers;
 		}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -958,7 +958,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	/**
 	* escapes (user provided) parts for LDAP filter
 	* @param string $input, the provided value
-	* @param bool $allowAsterisk wether in * at the beginning should be preserved
+	* @param bool $allowAsterisk whether in * at the beginning should be preserved
 	* @return string the escaped string
 	*/
 	public function escapeFilterPart($input, $allowAsterisk = false) {

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -34,6 +34,7 @@ use OC\ServerNotAvailableException;
  * @property boolean hasPagedResultSupport
  * @property string[] ldapBaseUsers
  * @property int|string ldapPagingSize holds an integer
+ * @property bool|mixed|void ldapGroupMemberAssocAttr
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -852,13 +852,23 @@ class Wizard extends LDAPUtility {
 						}
 						$base = $this->configuration->ldapBase[0];
 						foreach($cns as $cn) {
-							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn'));
+							$rr = $this->ldap->search($cr, $base, 'cn=' . $cn, array('dn', 'primaryGroupToken'));
 							if(!$this->ldap->isResource($rr)) {
 								continue;
 							}
 							$er = $this->ldap->firstEntry($cr, $rr);
+							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
-							$filter .= '(memberof=' . $dn . ')';
+							if(empty($dn)) {
+								continue;
+							}
+							$filterPart = '(memberof=' . $dn . ')';
+							if(isset($attrs['primaryGroupToken'])) {
+								$pgt = $attrs['primaryGroupToken'][0];
+								$primaryFilterPart = '(primaryGroupID=' . $pgt .')';
+								$filterPart = '(|' . $filterPart . $primaryFilterPart . ')';
+							}
+							$filter .= $filterPart;
 						}
 						$filter .= ')';
 					}

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -76,10 +76,15 @@ class Test_Group_Ldap extends \Test\TestCase {
 			->method('readAttribute')
 			->will($this->returnValue(array('u11', 'u22', 'u33', 'u34')));
 
+		// for primary groups
+		$access->expects($this->once())
+			->method('countUsers')
+			->will($this->returnValue(2));
+
 		$groupBackend = new GroupLDAP($access);
 		$users = $groupBackend->countUsersInGroup('group');
 
-		$this->assertSame(4, $users);
+		$this->assertSame(6, $users);
 	}
 
 	public function testCountWithSearchString() {

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -312,4 +312,74 @@ class Test_Group_Ldap extends \Test\TestCase {
 		$this->assertSame(2, count($groups));
 	}
 
+	/**
+	 * tests that a user listing is complete, if all it's members have the group
+	 * as their primary.
+	 */
+	public function  testUsersInGroupPrimaryMembersOnly() {
+		$access = $this->getAccessMock();
+		$this->enableGroups($access);
+
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->will($this->returnValue(null));
+
+		$access->expects($this->any())
+			->method('readAttribute')
+			->will($this->returnCallback(function($dn, $attr) {
+				if($attr === 'primaryGroupToken') {
+					return array(1337);
+				}
+				return array();
+			}));
+
+		$access->expects($this->any())
+			->method('groupname2dn')
+			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
+
+		$access->expects($this->once())
+			->method('ownCloudUserNames')
+			->will($this->returnValue(array('lisa', 'bart', 'kira', 'brad')));
+
+		$groupBackend = new GroupLDAP($access);
+		$users = $groupBackend->usersInGroup('foobar');
+
+		$this->assertSame(4, count($users));
+	}
+
+	/**
+	 * tests that a user counting is complete, if all it's members have the group
+	 * as their primary.
+	 */
+	public function  testCountUsersInGroupPrimaryMembersOnly() {
+		$access = $this->getAccessMock();
+		$this->enableGroups($access);
+
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->will($this->returnValue(null));
+
+		$access->expects($this->any())
+			->method('readAttribute')
+			->will($this->returnCallback(function($dn, $attr) {
+				if($attr === 'primaryGroupToken') {
+					return array(1337);
+				}
+				return array();
+			}));
+
+		$access->expects($this->any())
+			->method('groupname2dn')
+			->will($this->returnValue('cn=foobar,dc=foo,dc=bar'));
+
+		$access->expects($this->once())
+			->method('countUsers')
+			->will($this->returnValue(4));
+
+		$groupBackend = new GroupLDAP($access);
+		$users = $groupBackend->countUsersInGroup('foobar');
+
+		$this->assertSame(4, $users);
+	}
+
 }


### PR DESCRIPTION
Backport of #13740 and #15606 (because the latter is a followup of the previous one)

Fixes #12190 and fixes #13533
### How to test?
- configure User Filter in the LDAP Wizard and select a group
- on AD, the resulting filter should look like `(&(|(objectclass=person))(|(|((memberof=CN=Domain Users,CN=Users,DC=madder,DC=owncloud,DC=bzoc)(primaryGroupID=513)))(|((memberof=CN=Wolfpack 8,OU=packs,DC=madder,DC=owncloud,DC=bzoc)(primaryGroupID=968988)`(2 selected groups)
- on OpenLDAP the `(primaryGroupID=XXX)` part should not show up!
- in the User list: users should appear, that have the selected group  as primary, but are not regular member of any of those selected
- in the User list: Before: empty count, no users when selecting the group. Now: proper count with users.

@craigpg @sbelov1 @bboule @jnfrmarks @plastilincheg @rjaeckel @gig13 Please test. I tested this with an LDAP instance and all works like before and no errors are logged.

This is my :+1: for this, because I only cherry picked the commits of @blizzz who is on vacation.
