### PR TITLE
[stable8] Closes "New" dropdown when switching category

### DIFF
--- a/apps/files/js/navigation.js
+++ b/apps/files/js/navigation.js
@@ -124,7 +124,7 @@
 			var $target = $(ev.target);
 			var itemId = $target.closest('li').attr('data-id');
 			this.setActiveItem(itemId);
-			return false;
+			ev.preventDefault();
 		}
 	};
 


### PR DESCRIPTION
- fixes #16394
- return false - stops all following event callbacks

cc @nickvergessen @jancborchardt @davitol 

@karlitschek Please approve the backport. This is an easy fix :)
