### PR TITLE
Sort apps by level, then by name

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -86,17 +86,25 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}), {
 			type:'GET',
 			success: function (apps) {
-				OC.Settings.Apps.State.apps = _.indexBy(apps.apps, 'id');
+				var appList = _.map(_.indexBy(apps.apps, 'id'), function(app) {
+					// default values for missing fields
+					return _.extend({level: 0}, app);
+				});
+				OC.Settings.Apps.State.apps = appList;
 				var source   = $("#app-template").html();
 				var template = Handlebars.compile(source);
 
-				if (apps.apps.length) {
-					apps.apps.sort(function(a,b) {
-						return b.level - a.level;
+				if (appList.length) {
+					appList.sort(function(a,b) {
+						var levelDiff = b.level - a.level;
+						if (levelDiff === 0) {
+							return OC.Util.naturalSortCompare(a.name, b.name);
+						}
+						return levelDiff;
 					});
 
 					var firstExperimental = false;
-					_.each(apps.apps, function(app) {
+					_.each(appList, function(app) {
 						if(app.level === 0 && firstExperimental === false) {
 							firstExperimental = true;
 							OC.Settings.Apps.renderApp(app, template, null, true);

--- a/settings/tests/js/appsSpec.js
+++ b/settings/tests/js/appsSpec.js
@@ -130,14 +130,26 @@ describe('OC.Settings.Apps tests', function() {
 					apps: [
 						{
 							id: 'foo',
+							name: 'Foo app',
 							level: 0
 						},
 						{
 							id: 'alpha',
+							name: 'Alpha app',
 							level: 300
 						},
 						{
+							id: 'nolevel',
+							name: 'No level'
+						},
+						{
+							id: 'zork',
+							name: 'Some famous adventure game',
+							level: 200
+						},
+						{
 							id: 'delta',
+							name: 'Mathematical symbol',
 							level: 200
 						}
 					]
@@ -145,10 +157,8 @@ describe('OC.Settings.Apps tests', function() {
 			);
 
 			var results = getResultsFromDom();
-			expect(results.length).toEqual(3);
-			expect(results[0]).toEqual('alpha');
-			expect(results[1]).toEqual('delta');
-			expect(results[2]).toEqual('foo');
+			expect(results.length).toEqual(5);
+			expect(results).toEqual(['alpha', 'delta', 'zork', 'foo', 'nolevel']);
 		});
 	});
 


### PR DESCRIPTION
Also properly initialize the level to 0 when no level was returned
This means that now experimental apps (level 0) are at the bottom of the list instead of the top, this is because we were comparing "undefined" levels.

Fixes https://github.com/owncloud/core/issues/16295

Please review @LukasReschke @DeepDiver1975 @jancborchardt @MorrisJobke 
