### PR TITLE
Restore min-height for single previews

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -2,6 +2,7 @@
 	background: #fff;
 	text-align: center;
 	margin: 45px auto 0;
+	min-height: 200px;
 }
 
 #preview .notCreatable {


### PR DESCRIPTION
The height of the preview element is automagically calculated but in case someone shares an empty folder, the message shown to the user would collapse due to the missing height.

Fixes #16335 

Tested with txt, gif, jpg and empty
