### PR TITLE
Add a notification when no search provider is found

### DIFF
--- a/core/search/ajax/search.php
+++ b/core/search/ajax/search.php
@@ -52,9 +52,15 @@ if (isset($_GET['size'])) {
 } else {
 	$size = 30;
 }
+
 if($query) {
-	$result = \OC::$server->getSearch()->searchPaged($query, $inApps, $page, $size);
-	OC_JSON::encodedPrint($result);
+	try {
+		$result = \OC::$server->getSearch()->searchPaged($query, $inApps, $page, $size);
+		OC_JSON::encodedPrint($result);
+	} catch (\OCP\Search\NoProviderException $e) {
+		$l = \OC_L10N::get('core');
+		OC_JSON::error(['message' => $l->t('No search provider registered for the current location')]);
+	}
 }
 else {
 	echo 'false';

--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -130,11 +130,15 @@
 
 						// do the actual search query
 						$.getJSON(OC.generateUrl('core/search'), {query:query, inApps:inApps, page:page, size:size }, function(results) {
-							lastResults = results;
-							if (page === 1) {
-								showResults(results);
+							if (results instanceof Array) {
+								lastResults = results;
+								if (page === 1) {
+									showResults(results);
+								} else {
+									addResults(results);
+								}
 							} else {
-								addResults(results);
+								OC.Notification.showTemporary(results.message);
 							}
 						});
 					}, 500);

--- a/lib/public/search/noproviderexception.php
+++ b/lib/public/search/noproviderexception.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Search;
+
+/**
+ * @since 8.1.0
+ */
+class NoProviderException extends \UnexpectedValueException {
+
+}


### PR DESCRIPTION
@jancborchardt you never answered what the expected result is nowerdays:

When there is no search provider in charge of the current page, I now display a temporary notification:
![bildschirmfoto vom 2015-05-20 18 38 56](https://cloud.githubusercontent.com/assets/213943/7731357/250ddef2-ff20-11e4-9f37-0f306473507c.png)

But then I as a user would wonder why the search box is even there, if it does nothing outside the settings/apps and the files list.

Fix #15297
