### PR TITLE
[stable8] Do not automatically add "update" permission to shared mounts

### DIFF
--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -182,9 +182,8 @@ class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 		// for the share root we expect:
 		// the shared permissions (1)
 		// the delete permission (8), to enable unshare
-		// the update permission (2), to allow renaming of the mount point
 		$rootInfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$this->assertSame(11, $rootInfo->getPermissions());
+		$this->assertSame(9, $rootInfo->getPermissions());
 
 		// for the file within the shared folder we expect:
 		// the shared permissions (1)

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1010,7 +1010,7 @@ class View {
 		}
 
 		if ($mount instanceof MoveableMount && $internalPath === '') {
-			$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
+			$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
 		}
 
 		$data = \OC_FileProxy::runPostProxies('getFileInfo', $path, $data);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/15063 to stable8.

Backport approved here: https://github.com/owncloud/core/issues/16492#issuecomment-104206246

Please review @icewind1991 @nickvergessen @MorrisJobke @ckamm 
