### PR TITLE
Deprecate useless helper class

### DIFF
--- a/lib/private/apphelper.php
+++ b/lib/private/apphelper.php
@@ -23,7 +23,8 @@
 namespace OC;
 
 /**
- * TODO: Description
+ * Class AppHelper
+ * @deprecated 8.1.0
  */
 class AppHelper implements \OCP\IHelper {
 	/**
@@ -31,6 +32,7 @@ class AppHelper implements \OCP\IHelper {
 	 * installed
 	 * @param string $url the url that should be fetched
 	 * @return string the content of the webpage
+	 * @deprecated 8.1.0 Use \OCP\IServerContainer::getHTTPClientService
 	 */
 	public function getUrlContent($url) {
 		return \OC_Util::getUrlContent($url);

--- a/lib/public/ihelper.php
+++ b/lib/public/ihelper.php
@@ -33,6 +33,7 @@ namespace OCP;
 /**
  * Functions that don't have any specific interface to place
  * @since 6.0.0
+ * @deprecated 8.1.0
  */
 interface IHelper {
 	/**
@@ -41,6 +42,7 @@ interface IHelper {
 	 * @param string $url the url that should be fetched
 	 * @return string the content of the webpage
 	 * @since 6.0.0
+	 * @deprecated 8.1.0 Use \OCP\IServerContainer::getHTTPClientService
 	 */
 	public function getUrlContent($url);
 }


### PR DESCRIPTION
The helper class has no real reason anymore with 8.1.0 as we now have better public APIs. No need for an `IHelper` class like that from my opinion. Better to recommend directly the proper API to users.

cc @karlitschek @DeepDiver1975 Please review.
