### PR TITLE
use arrow icon for external link to Apps dev docs, like in Help section

### DIFF
--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -31,7 +31,7 @@ script(
 
 <?php if(OC_Config::getValue('appstoreenabled', true) === true): ?>
 	<li>
-		<a class="app-external" target="_blank" href="https://owncloud.org/dev"><?php p($l->t('Developer documentation'));?> …</a>
+		<a class="app-external" target="_blank" href="https://owncloud.org/dev"><?php p($l->t('Developer documentation'));?> ↗</a>
 	</li>
 <?php endif; ?>
 </script>


### PR DESCRIPTION
Just a small detail. Previously we used `…` at the end of the apps dev docs sidebar link:
![capture du 2015-05-22 01 20 12](https://cloud.githubusercontent.com/assets/925062/7760978/e5ee905c-0020-11e5-8e1a-0d49b831201f.png)
Now we use the external arrow icon:
![capture du 2015-05-22 01 20 46](https://cloud.githubusercontent.com/assets/925062/7760977/e5e8618c-0020-11e5-89b0-787dc50babea.png)
Just like in the Help / Documentation section:
![capture du 2015-05-22 01 18 56](https://cloud.githubusercontent.com/assets/925062/7760979/e6426bdc-0020-11e5-9d31-2862971493f4.png)

Please review @owncloud/designers :)
