### PR TITLE
use normal font weight instead of bold for image placeholders

### DIFF
--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -59,7 +59,7 @@
 
 		// CSS rules
 		this.css('color', '#fff');
-		this.css('font-weight', 'bold');
+		this.css('font-weight', 'normal');
 		this.css('text-align', 'center');
 
 		// calculate the height


### PR DESCRIPTION
We use bold sparingly for focus, so we shouldn’t bold every single placeholder. Please review @owncloud/designers 

Before:
![capture du 2015-05-22 03 19 34](https://cloud.githubusercontent.com/assets/925062/7762291/7c75764c-0032-11e5-833d-024edad92645.png)

After:
![capture du 2015-05-22 03 19 06](https://cloud.githubusercontent.com/assets/925062/7762292/7c91c662-0032-11e5-903b-89d101e598d9.png)
