### PR TITLE
remove part file extension before we read a filekey

### DIFF
--- a/lib/private/encryption/keys/storage.php
+++ b/lib/private/encryption/keys/storage.php
@@ -70,7 +70,8 @@ class Storage implements IStorage {
 	 * @inheritdoc
 	 */
 	public function getFileKey($path, $keyId, $encryptionModuleId) {
-		$keyDir = $this->getFileKeyDir($encryptionModuleId, $path);
+		$realFile = $this->util->stripPartialFileExtension($path);
+		$keyDir = $this->getFileKeyDir($encryptionModuleId, $realFile);
 		return $this->getKey($keyDir . $keyId);
 	}
 

--- a/tests/lib/encryption/keys/storage.php
+++ b/tests/lib/encryption/keys/storage.php
@@ -76,7 +76,9 @@ class StorageTest extends TestCase {
 		$this->util->expects($this->any())
 			->method('getUidAndFilename')
 			->willReturn(array('user1', '/files/foo.txt'));
-		$this->util->expects($this->any())
+		// we need to strip away the part file extension in order to reuse a
+		// existing key if it exists, otherwise versions will break
+		$this->util->expects($this->once())
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
 		$this->util->expects($this->any())

--- a/tests/lib/encryption/utiltest.php
+++ b/tests/lib/encryption/utiltest.php
@@ -174,4 +174,24 @@ class UtilTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider dataTestStripPartialFileExtension
+	 *
+	 * @param string $path
+	 * @param string $expected
+	 */
+	public function testStripPartialFileExtension($path, $expected) {
+		$this->assertSame($expected,
+			$this->util->stripPartialFileExtension($path));
+	}
+
+	public function dataTestStripPartialFileExtension() {
+		return array(
+			array('/foo/test.txt', '/foo/test.txt'),
+			array('/foo/test.txt.part', '/foo/test.txt'),
+			array('/foo/test.txt.ocTransferId7567846853.part', '/foo/test.txt'),
+			array('/foo/test.txt.ocTransferId7567.part', '/foo/test.txt'),
+		);
+	}
+
 }


### PR DESCRIPTION
remove part file extension before we read a filekey to reuse a existing key if possible, otherwise stuff like versioning will break

fix https://github.com/owncloud/core/issues/16373

cc @nickvergessen @SergioBertolinSG 
