### PR TITLE
End processing when file is not found

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -138,6 +138,7 @@ class OC_Files {
 				header("HTTP/1.0 404 Not Found");
 				$tmpl = new OC_Template('', '404', 'guest');
 				$tmpl->printPage();
+				exit();
 			} else {
 				header("HTTP/1.0 403 Forbidden");
 				die('403 Forbidden');


### PR DESCRIPTION
We have to end the processing when a file is not found or otherwise the method is proceeding and even sending invalid file paths to the sendfile methods.

Due to nginx preventing directory traversals this is luckily not immediately exploitable. We should for hardening purposes however quit the script execution just as we do for 403 cases and others as well.

@icewind1991 @PVince81 Thoughts?
