### PR TITLE
exclude directories from beeing processed

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -61,6 +61,15 @@ if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
 	exit();
 }
 
+if (\OC\Files\Filesystem::isForbiddenFileOrDir($fileName)) {
+	$result['data'] = array('message' => $l10n->t(
+			'The name %s has been excluded by the admin for files and directories. Please choose a different name.',
+			$fileName)
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 $target = $dir.'/'.$fileName;
 
 if (\OC\Files\Filesystem::file_exists($target)) {

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -53,6 +53,15 @@ try {
 	return;
 }
 
+if (\OC\Files\Filesystem::isForbiddenFileOrDir($folderName)) {
+	$result['data'] = array('message' => $l10n->t(
+			'The name %s has been excluded by the admin for files and directories. Please choose a different name.',
+			$folderName)
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
 	$result['data'] = array('message' => (string)$l10n->t(
 			'The target folder has been moved or deleted.'),

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -978,6 +978,20 @@ $CONFIG = array(
 'blacklisted_files' => array('.htaccess'),
 
 /**
+ * Exclude specific directory names and disallow scanning, creating and renaming
+ * using these names. Case insensitive.
+ * Excluded directory names are queried at any path part like at the beginning, 
+ * in the middle or at the end and will not be further processed if found.
+ * Please see the documentation for details and examples.
+ * Use when the storage backend supports eg snapshot directories to be excluded.
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'excluded_directories' =>
+	array (
+		'.snapshot',
+		'~snapshot',
+	),
+/**
  * Define a default folder for shared files and folders other than root.
  */
 'share_folder' => '/',

--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -151,7 +151,7 @@ class AvatarController extends Controller {
 			if (
 				$files['error'][0] === 0 &&
 				 is_uploaded_file($files['tmp_name'][0]) &&
-				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
+				!\OC\Files\Filesystem::isForbiddenFileOrDir($files['tmp_name'][0])
 			) {
 				if ($files['size'][0] > 20*1024*1024) {
 					return new DataResponse(['data' => ['message' => $this->l->t('File is too big')]],

--- a/lib/base.php
+++ b/lib/base.php
@@ -790,8 +790,8 @@ class OC {
 	 */
 	public static function registerFilesystemHooks() {
 		// Check for blacklisted files
-		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isBlacklisted');
-		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isBlacklisted');
+		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
+		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
 	}
 
 	/**

--- a/lib/private/connector/sabre/custompropertiesbackend.php
+++ b/lib/private/connector/sabre/custompropertiesbackend.php
@@ -105,6 +105,9 @@ class CustomPropertiesBackend implements BackendInterface {
 		} catch (ServiceUnavailable $e) {
 			// might happen for unavailable mount points, skip
 			return;
+		} catch (Forbidden $e) {
+			// might happen for excluded mount points, skip
+			return;
 		} catch (NotFound $e) {
 			// in some rare (buggy) cases the node might not be found,
 			// we catch the exception to prevent breaking the whole list with a 404

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -85,13 +85,13 @@ class Directory extends \OC\Connector\Sabre\Node
 	 */
 	public function createFile($name, $data = null) {
 
-		# the check here is necessary, because createFile uses put covered in sabre/file.php 
-		# and not touch covered in files/view.php
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
-		}
-
 		try {
+			# the check here is necessary, because createFile uses put covered in sabre/file.php 
+			# and not touch covered in files/view.php
+			if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
+
 			// for chunked upload also updating a existing file is a "createFile"
 			// because we create all the chunks before re-assemble them to the existing file.
 			if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
@@ -138,13 +138,12 @@ class Directory extends \OC\Connector\Sabre\Node
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function createDirectory($name) {
-
-		# the check here is necessary, because createDirectory does not use the methods in files/view.php
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
-		}
-
 		try {
+			# the check here is necessary, because createDirectory does not use the methods in files/view.php
+			if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+				throw new \Sabre\DAV\Exception\Forbidden();
+			}
+
 			if (!$this->info->isCreatable()) {
 				throw new \Sabre\DAV\Exception\Forbidden();
 			}

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -85,6 +85,12 @@ class Directory extends \OC\Connector\Sabre\Node
 	 */
 	public function createFile($name, $data = null) {
 
+		# the check here is necessary, because createFile uses put covered in sabre/file.php 
+		# and not touch covered in files/view.php
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		try {
 			// for chunked upload also updating a existing file is a "createFile"
 			// because we create all the chunks before re-assemble them to the existing file.
@@ -132,6 +138,12 @@ class Directory extends \OC\Connector\Sabre\Node
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function createDirectory($name) {
+
+		# the check here is necessary, because createDirectory does not use the methods in files/view.php
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		try {
 			if (!$this->info->isCreatable()) {
 				throw new \Sabre\DAV\Exception\Forbidden();

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -245,6 +245,10 @@ abstract class Node implements \Sabre\DAV\INode {
 	}
 
 	protected function verifyPath() {
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($this->info->getPath())) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		try {
 			$fileName = basename($this->info->getPath());
 			$this->fileView->verifyPath($this->path, $fileName);

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -97,16 +97,12 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 * @param string $path
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 * @throws \Sabre\DAV\Exception\NotFound
+	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @return \Sabre\DAV\INode
 	 */
 	public function getNodeForPath($path) {
 		if (!$this->fileView) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
-		}
-
-		// check the path, also called when the path has been entered manually eg via a file explorer
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
 		$path = trim($path, '/');
@@ -116,6 +112,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			} catch (\OCP\Files\InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
+		}
+
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
 		if (isset($this->cache[$path])) {

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -104,6 +104,11 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		$path = trim($path, '/');
 		if ($path) {
 			try {
@@ -185,7 +190,15 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
+		# check the destination path, for source see below
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($destinationPath)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		$targetNodeExists = $this->nodeExists($destinationPath);
+
+		// at getNodeForPath we also check the path for isForbiddenFileOrDir
+		// with that we have covered both source and destination
 		$sourceNode = $this->getNodeForPath($sourcePath);
 		if ($sourceNode instanceof \Sabre\DAV\ICollection && $targetNodeExists) {
 			throw new \Sabre\DAV\Exception\Forbidden('Could not copy directory ' . $sourceNode . ', target exists');
@@ -260,7 +273,13 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
-		// this will trigger existence check
+		# check the destination path, for source see below
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($destination)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		// at getNodeForPath we also check the path for isForbiddenFileOrDir
+		// with that we have covered both source and destination
 		$this->getNodeForPath($source);
 
 		list($destinationDir, $destinationName) = \Sabre\HTTP\URLUtil::splitPath($destination);

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -299,7 +299,7 @@ class Scanner extends BasicEmitter {
 		if ($dh = $this->storage->opendir($folder)) {
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if (!Filesystem::isIgnoredDir($file)) {
+					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 						$children[] = $file;
 					}
 				}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -582,29 +582,26 @@ class Filesystem {
 	 *
 	 * @param array $data from hook
 	 */
-	static public function isBlacklisted($data) {
+	static public function isForbiddenFileOrDir_Hook($data) {
 		if (isset($data['path'])) {
 			$path = $data['path'];
 		} else if (isset($data['newpath'])) {
 			$path = $data['newpath'];
 		}
 		if (isset($path)) {
-			if (self::isFileBlacklisted($path)) {
+			if (self::isForbiddenFileOrDir($path)) {
 				$data['run'] = false;
 			}
 		}
 	}
 
 	/**
+	 * depriciated, replaced by isForbiddenFileOrDir
 	 * @param string $filename
-	 * @return bool
+	 * @return boolean
 	 */
 	static public function isFileBlacklisted($filename) {
-		$filename = self::normalizePath($filename);
-
-		$blacklist = \OC_Config::getValue('blacklisted_files', array('.htaccess'));
-		$filename = strtolower(basename($filename));
-		return in_array($filename, $blacklist);
+		return self::isForbiddenFileOrDir($filename);
 	}
 
 	/**
@@ -616,6 +613,54 @@ class Filesystem {
 	 */
 	static public function isIgnoredDir($dir) {
 		if ($dir === '.' || $dir === '..') {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	* Check if the directory path / file name contains a Blacklisted or Excluded name
+	* config.php parameter arrays can contain file names to be blacklisted or directory names to be excluded
+	* Blacklist ... files that may harm the owncloud environment like a foreign .htaccess file
+	* Excluded  ... directories that are excluded from beeing further processed, like snapshot directories
+	* The parameter $ed is only used in conjunction with unit tests as we handover here the excluded
+	* directory name to be tested against. $ed and the query with can be redesigned if filesystem.php will get 
+	* a constructor where it is then possible to define the excluded directory names for unit tests.
+	* @param string $FileOrDir
+	* @param array $ed
+	* @return boolean
+	*/
+	static public function isForbiddenFileOrDir($FileOrDir, $ed = array()) {
+		$excluded = array();
+		$blacklist = array();
+		$path_parts = array();
+		$ppx = array();
+		$blacklist = \OC::$server->getSystemConfig()->getValue('blacklisted_files', array('.htaccess'));
+		if ($ed) {
+			$excluded = $ed;
+		} else {
+			$excluded = \OC::$server->getSystemConfig()->getValue('excluded_directories', $ed);
+		}
+		// explode '/'
+		$ppx = array_filter(explode('/', $FileOrDir), 'strlen');
+		$ppx = array_map('strtolower', $ppx);
+		// further explode each array element with '\' and add to result array if found  
+		foreach($ppx as $pp) {
+			// only add an array element if strlen != 0
+			$path_parts = array_merge($path_parts, array_filter(explode('\\', $pp), 'strlen'));
+		}
+		if ($excluded) {
+			$excluded = array_map('trim', $excluded);
+			$excluded = array_map('strtolower', $excluded);
+			$match = array_intersect($path_parts, $excluded);
+			if ($match) {
+				return true;
+			}
+		}
+		$blacklist = array_map('trim', $blacklist);
+		$blacklist = array_map('strtolower', $blacklist);
+		$match = array_intersect($path_parts, $blacklist);
+		if ($match) {
 			return true;
 		}
 		return false;

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -203,7 +203,7 @@ abstract class Common implements Storage {
 			$dir = $this->opendir($path1);
 			$this->mkdir($path2);
 			while ($file = readdir($dir)) {
-				if (!Filesystem::isIgnoredDir($file)) {
+				if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 					if (!$this->copy($path1 . '/' . $file, $path2 . '/' . $file)) {
 						return false;
 					}
@@ -551,7 +551,7 @@ abstract class Common implements Storage {
 			$result = $this->mkdir($targetInternalPath);
 			if (is_resource($dh)) {
 				while ($result and ($file = readdir($dh)) !== false) {
-					if (!Filesystem::isIgnoredDir($file)) {
+					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
 						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);
 					}
 				}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -534,7 +534,7 @@ class View {
 		if (is_resource($data)) { //not having to deal with streams in file_put_contents makes life easier
 			$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 			if (Filesystem::isValidPath($path)
-				and !Filesystem::isFileBlacklisted($path)
+				and !Filesystem::isForbiddenFileOrDir($path)
 			) {
 				$path = $this->getRelativePath($absolutePath);
 
@@ -623,7 +623,7 @@ class View {
 		if (
 			Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and !Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isForbiddenFileOrDir($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -747,7 +747,7 @@ class View {
 		if (
 			Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and !Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isForbiddenFileOrDir($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -981,7 +981,7 @@ class View {
 		$postFix = (substr($path, -1, 1) === '/') ? '/' : '';
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (Filesystem::isValidPath($path)
-			and !Filesystem::isFileBlacklisted($path)
+			and !Filesystem::isForbiddenFileOrDir($path)
 		) {
 			$path = $this->getRelativePath($absolutePath);
 			if ($path == null) {

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1293,7 +1293,10 @@ class View {
 				if (\OCP\Util::isSharingDisabledForUser()) {
 					$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 				}
-				$files[] = new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content, $mount);
+				// do not add forbidden files or directories to the list of visible elements
+				if (!\OC\Files\Filesystem::isForbiddenFileOrDir($content['path'])) {
+					$files[] = new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content, $mount);
+				}
 			}
 
 			//add a folder for any mountpoint in this directory and add the sizes of other mountpoints to the folders

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -330,7 +330,7 @@ class OC_Helper {
 					self::copyr("$src/$file", "$dest/$file");
 				}
 			}
-		} elseif (file_exists($src) && !\OC\Files\Filesystem::isFileBlacklisted($src)) {
+		} elseif (file_exists($src) && !\OC\Files\Filesystem::isForbiddenFileOrDir($src)) {
 			copy($src, $dest);
 		}
 	}

--- a/lib/private/security/certificatemanager.php
+++ b/lib/private/security/certificatemanager.php
@@ -124,7 +124,7 @@ class CertificateManager implements ICertificateManager {
 	 * @throws \Exception If the certificate could not get added
 	 */
 	public function addCertificate($certificate, $name) {
-		if (!Filesystem::isValidPath($name) or Filesystem::isFileBlacklisted($name)) {
+		if (!Filesystem::isValidPath($name) or Filesystem::isForbiddenFileOrDir($name)) {
 			throw new \Exception('Filename is not valid');
 		}
 

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -225,7 +225,7 @@ class Filesystem extends \Test\TestCase {
 			array('.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess/', true),
-			array('/etc/foo\bar/.htaccess/foo', false),
+			array('/etc/foo\bar/.htaccess/foo', true),
 			array('//foo//bar/\.htaccess/', true),
 			array('\foo\bar\.HTAccess', true),
 		);
@@ -235,7 +235,30 @@ class Filesystem extends \Test\TestCase {
 	 * @dataProvider isFileBlacklistedData
 	 */
 	public function testIsFileBlacklisted($path, $expected) {
-		$this->assertSame($expected, \OC\Files\Filesystem::isFileBlacklisted($path));
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path));
+	}
+
+	public function isExcludedData() {
+		return array(
+			array('.snapshot', true),
+			array('.snapshot/', true),
+			array('.snapshot\\', true),
+			array('/etc/foo/bar/foo.txt', false),
+			array('/.snapshot/etc/foo/bar/foo.txt', true),
+			array('/.snapShot/etc/foo/bar/foo.txt', true),
+			array('\.snapshot\etc\foo/bar\foo.txt', true),
+			array('/etc/foo/.snapshot', true),
+			array('/etc/foo/.snapshot/bar', true),
+		);
+	}
+
+	/**
+	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to 
+	 * define the excluded directories for unit tests
+	 * @dataProvider isExcludedData
+	 */
+	public function testIsExcluded($path, $expected) {
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path, array('.snapshot')));
 	}
 
 	public function normalizePathWindowsAbsolutePathData() {


### PR DESCRIPTION
Summary:
1. Enterprise Storage Systems are capable of Snapshots. These Snapshots are directories with a particular name and keep point in time views of the data. Usually, these snapshot directories are present in each directory
2. There is no common naming for these directories and will never be. NetApp uses `.snapshot` and `~snapshot`, EMC eg `.ckpt`, HDS eg `.latest` and `~latest` and so on
3. Viewing and scanning of these directories does not make any sense as these directories are used to restore files from an OS point of view
4. You can also have hardlinks to backups with the same background as described in #15385
5. Scanning a huge datastore containing snapshots does mean that for each snapshot taken ALL files of the datastore are imported into the database again. Example: a datastore containing 200K files, having 15 snapshots means scanning of 3M files where 2.8M are worthless to be imported

There are for sure more resons, but I tried to keep it short.

With this PR, you can define a array of directory names in config.php which are further excluded from beeing processed.

These excluded directory names are not scanned, not viewed, can not be created or renamed (or deleted) or accessed via direct path input from a file explorer.

Access methods covered: webdav, webgui and client.

Following test have been made creating either a file or directory having once a allowed and once a excluded name. The results were the same independent of the storage type (tested on user home and SMB).

The functions shown in the table are except one all triggered and covered by the access methods used in lib/private/files/view.php

For WebDav, CyberDuck and native WebDav access was used on a W7 client.
The IOS client ran the latest available version (3.4.1)

All access tests made passed well.

The table shows the covered methods for all storage types using it:

|  | webdav | webgui | client IOS |
| --- | --- | --- | --- |
| directory create | mkdir | mkdir | mkdir |
| directory rename | rename | rename | rename |
| directory delete | rmdir | rmdir | rmdir |
|  |  |  |  |
| file create | put(*) | touch | n.a. |
| file rename | rename | rename | rename |
| file delete | unlink | unlink | unlink |

n.a. ... function not available
(*) put ... this function is not handled in lib/private/files/view.php but in lib/private/connector/sabre/directory.php which points to ../sabre/file.php

The case manually defining the path in a file explorer to access a excluded directory via a webdav connected client is also covered. (lib/private/connector/sabre/objecttree.php and ../sabre/custompropertiesbackend.php)

Adding a new external storage and let it scan also worked well, excluded directories are not further processed.

@DeepDiver1975 @karlitschek @nickvergessen @Aesculapius  @icewind1991 @LukasReschke 

(sorry to create another PR, but a rebase messed everything up badly...)
