### PR TITLE
OCS Share API link shares now always have an url

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -70,6 +70,10 @@ class Local {
 					}
 					$share['icon'] = substr(\OC_Helper::mimetypeIcon($share['mimetype']), 0, -3) . 'svg';
 				}
+
+				if (!is_null($share['token'])) {
+					$share['url'] = \OC::$server->getURLGenerator()->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share['token']]);
+				}
 			}
 			return new \OC_OCS_Result($shares);
 		}
@@ -142,6 +146,12 @@ class Local {
 		if ($shares === null || empty($shares)) {
 			return new \OC_OCS_Result(null, 404, 'share doesn\'t exist');
 		} else {
+			foreach ($shares as &$share) {
+				if (!is_null($share['token'])) {
+					$share['url'] = \OC::$server->getURLGenerator()->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share['token']]);
+				}
+			}
+
 			return new \OC_OCS_Result($shares);
 		}
 	}

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -311,6 +311,51 @@ class Test_Files_Sharing_Api extends TestCase {
 	 * @medium
 	 * @depends testCreateShare
 	 */
+	function testPublicLinkUrl() {
+		// simulate a post request
+		$_POST['path'] = $this->folder;
+		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+
+		// check if we have a token
+		$this->assertTrue(is_string($data['token']));
+		$id = $data['id'];
+
+		// check for correct link
+		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);
+		$this->assertEquals($url, $data['url']);
+
+		// check for link in getall shares
+		$result = \OCA\Files_Sharing\API\Local::getAllShares([]);
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals($url, current($data)['url']);
+
+		// check for path
+		$_GET['path'] = $this->folder;
+		$result = \OCA\Files_Sharing\API\Local::getAllShares([]);
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals($url, current($data)['url']);
+
+		// check in share id
+		$result = \OCA\Files_Sharing\API\Local::getShare(['id' => $id]);
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals($url, current($data)['url']);
+
+		//Clean up share
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+	}
+
+	/**
+	 * @medium
+	 * @depends testCreateShare
+	 */
 	function testGetShareFromSource() {
 
 		$fileInfo = $this->view->getFileInfo($this->filename);


### PR DESCRIPTION
Implementation of #16488

To make sure clients have the correct and latest link add an url field
to all OCS Share API return statements on public link shares.
- Added unit tests

CC: @LukasReschke @schiesbn @PVince81 @MorrisJobke @DeepDiver1975 
