### PR TITLE
Minor update to the description of the root variable

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -72,7 +72,7 @@ class View {
 	protected $updater;
 
 	/**
-	 * @param string $root
+	 * @param string $root the folder to use for this view. No ending slash!
 	 * @throws \Exception If $root contains an invalid path
 	 */
 	public function __construct($root = '') {


### PR DESCRIPTION
After having lost time trying to get search() working, I thought it would be good to mention that the root variable should never end with a slash.
It's not something which can be solved via code.

@PVince81 @MorrisJobke  
