### PR TITLE
Add check for availability of /dev/urandom

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -64,6 +64,11 @@
 							t('core', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.memcacheDocs})
 						);
 					}
+					if(!data.isUrandomAvailable) {
+						messages.push(
+							t('core', '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.securityDocs})
+						);
+					}
 				} else {
 					messages.push(t('core', 'Error occurred while checking server setup'));
 				}

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -66,7 +66,7 @@ describe('OC.SetupChecks tests', function() {
 				{
 					'Content-Type': 'application/json'
 				},
-				JSON.stringify({serverHasInternetConnection: false, memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance'})
+				JSON.stringify({isUrandomAvailable: true, serverHasInternetConnection: false, memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance'})
 			);
 
 			async.done(function( data, s, x ){
@@ -83,7 +83,7 @@ describe('OC.SetupChecks tests', function() {
 				{
 					'Content-Type': 'application/json'
 				},
-				JSON.stringify({serverHasInternetConnection: false, dataDirectoryProtected: false, memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance'})
+				JSON.stringify({isUrandomAvailable: true, serverHasInternetConnection: false, dataDirectoryProtected: false, memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance'})
 			);
 
 			async.done(function( data, s, x ){
@@ -100,7 +100,7 @@ describe('OC.SetupChecks tests', function() {
 				{
 					'Content-Type': 'application/json',
 				},
-				JSON.stringify({serverHasInternetConnection: false, dataDirectoryProtected: false, isMemcacheConfigured: true})
+				JSON.stringify({isUrandomAvailable: true, serverHasInternetConnection: false, dataDirectoryProtected: false, isMemcacheConfigured: true})
 			);
 
 			async.done(function( data, s, x ){
@@ -109,6 +109,22 @@ describe('OC.SetupChecks tests', function() {
 			});
 		});
 
+		it('should return an error if /dev/urandom is not accessible', function(done) {
+			var async = OC.SetupChecks.checkSetup();
+
+			suite.server.requests[0].respond(
+				200,
+				{
+					'Content-Type': 'application/json',
+				},
+				JSON.stringify({isUrandomAvailable: false, securityDocs: 'https://docs.owncloud.org/myDocs.html', serverHasInternetConnection: true, dataDirectoryProtected: true, isMemcacheConfigured: true})
+			);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual(['/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="https://docs.owncloud.org/myDocs.html">documentation</a>.']);
+				done();
+			});
+		});
 
 		it('should return an error if the response has no statuscode 200', function(done) {
 			var async = OC.SetupChecks.checkSetup();

--- a/settings/controller/checksetupcontroller.php
+++ b/settings/controller/checksetupcontroller.php
@@ -91,6 +91,23 @@ class CheckSetupController extends Controller {
 	}
 
 	/**
+	 * Whether /dev/urandom is available to the PHP controller
+	 *
+	 * @return bool
+	 */
+	private function isUrandomAvailable() {
+		if(@file_exists('/dev/urandom')) {
+			$file = fopen('/dev/urandom', 'rb');
+			if($file) {
+				fclose($file);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @return DataResponse
 	 */
 	public function check() {
@@ -100,6 +117,8 @@ class CheckSetupController extends Controller {
 				'dataDirectoryProtected' => $this->util->isHtaccessWorking($this->config),
 				'isMemcacheConfigured' => $this->isMemcacheConfigured(),
 				'memcacheDocs' => $this->urlGenerator->linkToDocs('admin-performance'),
+				'isUrandomAvailable' => $this->isUrandomAvailable(),
+				'securityDocs' => $this->urlGenerator->linkToDocs('admin-security'),
 			]
 		);
 	}

--- a/tests/settings/controller/CheckSetupControllerTest.php
+++ b/tests/settings/controller/CheckSetupControllerTest.php
@@ -224,10 +224,14 @@ class CheckSetupControllerTest extends TestCase {
 		$this->util->expects($this->once())
 			->method('isHtaccessWorking')
 			->will($this->returnValue(true));
-		$this->urlGenerator->expects($this->once())
+		$this->urlGenerator->expects($this->at(0))
 			->method('linkToDocs')
 			->with('admin-performance')
 			->willReturn('http://doc.owncloud.org/server/go.php?to=admin-performance');
+		$this->urlGenerator->expects($this->at(1))
+			->method('linkToDocs')
+			->with('admin-security')
+			->willReturn('https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/hardening.html');
 
 		$expected = new DataResponse(
 			[
@@ -235,6 +239,8 @@ class CheckSetupControllerTest extends TestCase {
 				'dataDirectoryProtected' => true,
 				'isMemcacheConfigured' => true,
 				'memcacheDocs' => 'http://doc.owncloud.org/server/go.php?to=admin-performance',
+				'isUrandomAvailable' => \Test_Helper::invokePrivate($this->checkSetupController, 'isUrandomAvailable'),
+				'securityDocs' => 'https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/hardening.html',
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->check());


### PR DESCRIPTION
Without /dev/urandom being available to read the medium RNG will rely only on the following components on a Linux system:
1. MicroTime: microtime() . memory_get_usage() as seed and then a garbage collected microtime for loop
2. MTRand: chr((mt_rand() ^ mt_rand()) % 256)
3. Rand: chr((rand() ^ rand()) % 256)
4. UniqId: Plain uniqid()

An adversary with the possibility to predict the seed used by the PHP process may thus be able to predict future tokens which is an unwanted behaviour. – However, the MicroTime check is also seeded using `posix_times` as well as other possibly not exposed values.

One should note that this behaviour [is documented in our documentation](https://doc.owncloud.org/server/8.0/admin_manual/configuration_server/harden_server.html) to ensure that users get aware of this even without reading our documentation this will add a post setup check to the administrative interface. – I'd suggest not to add a hard requirement at this stage as we should better evaluate adding OpenSSL as another medium source for 8.2 (see future steps).

Thanks to David Black from d1b.org (@d1b) for bringing this again to our attention.

<hr/>

Future steps:
1. Evaluate adding OpenSSL as medium random source as well
2. Discuss where to communicate this to stable8 users (backport to 8.0.5? / blog post / advisory / etc…)

<hr/>

@PVince81 Please review. - To test this it's the easiest way to change the `/dev/urandom` path in `checksetupcontroller.php`
