### PR TITLE
Wrap cache entries removal in a transaction

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -464,12 +464,14 @@ class Cache {
 	 * @param string $file
 	 */
 	public function remove($file) {
+		\OC_DB::beginTransaction();
 		$entry = $this->get($file);
 		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
 		\OC_DB::executeAudited($sql, array($entry['fileid']));
 		if ($entry['mimetype'] === 'httpd/unix-directory') {
 			$this->removeChildren($entry);
 		}
+		\OC_DB::commit();
 	}
 
 	/**
@@ -540,24 +542,24 @@ class Cache {
 		list($sourceStorageId, $sourcePath) = $sourceCache->getMoveInfo($sourcePath);
 		list($targetStorageId, $targetPath) = $this->getMoveInfo($targetPath);
 
+		\OC_DB::beginTransaction();
 		if ($sourceData['mimetype'] === 'httpd/unix-directory') {
 			//find all child entries
 			$sql = 'SELECT `path`, `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ? AND `path` LIKE ?';
 			$result = \OC_DB::executeAudited($sql, [$sourceStorageId, $sourcePath . '/%']);
 			$childEntries = $result->fetchAll();
 			$sourceLength = strlen($sourcePath);
-			\OC_DB::beginTransaction();
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*filecache` SET `storage` = ?, `path` = ?, `path_hash` = ? WHERE `fileid` = ?');
 
 			foreach ($childEntries as $child) {
 				$newTargetPath = $targetPath . substr($child['path'], $sourceLength);
 				\OC_DB::executeAudited($query, [$targetStorageId, $newTargetPath, md5($newTargetPath), $child['fileid']]);
 			}
-			\OC_DB::commit();
 		}
 
 		$sql = 'UPDATE `*PREFIX*filecache` SET `storage` =  ?, `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?';
 		\OC_DB::executeAudited($sql, [$targetStorageId, $targetPath, md5($targetPath), basename($targetPath), $newParentId, $sourceId]);
+		\OC_DB::commit();
 	}
 
 	/**

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -338,7 +338,13 @@ class Scanner extends BasicEmitter {
 		$removedChildren = \array_diff(array_keys($existingChildren), $newChildren);
 		foreach ($removedChildren as $childName) {
 			$child = ($path) ? $path . '/' . $childName : $childName;
-			$this->removeFromCache($child);
+			try {
+				$this->removeFromCache($child);
+			} catch (\Doctrine\DBAL\DBALException $ex) {
+				// might happen if another process is currently updating (renaming)
+				// the entries in a separate transaction
+				\OC_Log::write('core', 'Cannot remove entry "' . $child . '" from cache: ' . $ex->getMessage(), \OC_Log::DEBUG);
+			}
 		}
 		if ($this->useTransactions) {
 			\OC_DB::commit();


### PR DESCRIPTION
In case there is a rename transaction in progress, the scanner will not
be able to delete the affected entries in case it detects the discrepancy
on disk.

Also fixed scanner to fail gracefully in case an error occurs during the
removal of a cache entry.

Steps to reproduce here: https://github.com/owncloud/core/issues/13391#issuecomment-105525369
Fixes https://github.com/owncloud/core/issues/13391

This helps preventing the data loss, but might not be the optimal solution in case the race condition happens outside of the DB code. But the DB code seems to be the most likely to cause the cache entries to disappear.

Note: we'll still need to invest some time to handle the failure cases https://github.com/owncloud/core/issues/16445.

Please review @icewind1991 @MorrisJobke @karlitschek @DeepDiver1975 @nickvergessen @LukasReschke 
