### PR TITLE
only request encryption module for files which are not excluded

### DIFF
--- a/settings/controller/encryptioncontroller.php
+++ b/settings/controller/encryptioncontroller.php
@@ -82,11 +82,12 @@ class EncryptionController extends Controller {
 	public function startMigration() {
         // allow as long execution on the web server as possible
 		set_time_limit(0);
-		$migration = new Migration($this->config, $this->view, $this->connection);
-		$migration->reorganizeSystemFolderStructure();
-		$migration->updateDB();
 
 		try {
+
+			$migration = new Migration($this->config, $this->view, $this->connection);
+			$migration->reorganizeSystemFolderStructure();
+			$migration->updateDB();
 
 			foreach ($this->userManager->getBackends() as $backend) {
 


### PR DESCRIPTION
Only try to load encryption module if the file isn't excluded. This should make the migration step more robust.

Steps to test:
1. setup ownCloud 8.0
2. enable files-encryption
3. re-login so that the user has his private/public keys and at least the welcome.txt is encrypted
4. move to this branch
5. login
6. enable the downCloud default encryption module in the app settings but _don't_ enable encryption in the admin settings.
7. call .occ encryption:migrate

Without this patch you will get a error that the default encryption module doesn't exists. With this patch the error should be gone.
