### PR TITLE
Make string 'SFTP with secret key login' translateable

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -227,7 +227,7 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP', [
 ]);
 
 OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP_Key', [
-	'backend' => 'SFTP with secret key login',
+	'backend' => (string)$l->t('SFTP with secret key login'),
 	'priority' => 100,
 	'configuration' => array(
 		'host' => (string)$l->t('Host'),


### PR DESCRIPTION
Refs #16559 (Missing translation in External storage back-end and LDAP wizard)

Makes the string `SFTP with secret key login` translatable
