### PR TITLE
Add check for availability of /dev/urandom

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -64,6 +64,11 @@
 							t('core', 'cURL is not installed, some functionality might not work. Please install the PHP cURL extension. Future versions will require installed cURL.')
 						);
 					}
+					if(!data.isUrandomAvailable) {
+						messages.push(
+							t('core', '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.securityDocs})
+						);
+					}
 				} else {
 					messages.push(t('core', 'Error occurred while checking server setup'));
 				}

--- a/settings/ajax/checksetup.php
+++ b/settings/ajax/checksetup.php
@@ -10,6 +10,22 @@ OCP\JSON::callCheck();
 
 \OC::$server->getSession()->close();
 
+/**
+ * Whether /dev/urandom is available to the PHP controller
+ *
+ * @return bool
+ */
+function isUrandomAvailable() {
+	if(@file_exists('/dev/urandom')) {
+		$file = fopen('/dev/urandom', 'rb');
+		if($file) {
+			fclose($file);
+			return true;
+		}
+	}
+	return false;
+}
+
 // no warning when has_internet_connection is false in the config
 $hasInternet = true;
 if (OC_Util::isInternetConnectionEnabled()) {
@@ -21,5 +37,7 @@ OCP\JSON::success(
 		'serverHasInternetConnection' => $hasInternet,
 		'dataDirectoryProtected' => OC_Util::isHtaccessWorking(),
 		'hasCurlInstalled' => function_exists('curl_init'),
+		'isUrandomAvailable' => isUrandomAvailable(),
+		'securityDocs' => \OC::$server->getURLGenerator()->linkToDocs('admin-security'),
 	)
 );


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/16565 to stable8 – no unit test since the code has been refactored to be testable only with 8.1
