### PR TITLE
Fallback to picture preview for IE <= 9

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -110,7 +110,7 @@ OCA.Sharing.PublicApp = {
 			(maxGifSize === -1 || fileSize <= (maxGifSize * 1024 * 1024))) {
 			img.attr('src', $('#downloadURL').val());
 			img.appendTo('#imgframe');
-		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text') {
+		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text' && window.btoa) {
 			// Undocumented Url to public WebDAV endpoint
 			var url = parent.location.protocol + '//' + location.host + OC.linkTo('', 'public.php/webdav');
 			$.ajax({


### PR DESCRIPTION
IE 9 and below do not provide window.btoa and there is currently no way
to generate base64 strings without introducting further dependencies.

So for now the solution is to fall back to the ugly picture mode for
text files whenever IE <= 9 is used.

Fixes https://github.com/owncloud/core/issues/16489

This removes the JS error and makes the "Add to ownCloud" button work again.

@davitol @oparoz @jancborchardt @MorrisJobke @icewind1991 
