### PR TITLE
[stable7] make sure to get the right list of users with access to the file when deleting a shared file

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -97,6 +97,7 @@ class Trashbin {
 	 * move file to the trash bin
 	 *
 	 * @param string $file_path path to the deleted file/directory relative to the files root directory
+	 * @return bool
 	 */
 	public static function move2trash($file_path) {
 		$user = \OCP\User::getUser();
@@ -109,6 +110,9 @@ class Trashbin {
 		}
 
 		self::setUpTrash($user);
+		if ($owner !== $user) {
+			self::setUpTrash($owner);
+		}
 
 		$view = new \OC\Files\View('/' . $user);
 		$path_parts = pathinfo($file_path);
@@ -279,7 +283,7 @@ class Trashbin {
 				$rootView->rename($sharekeys, $user . '/files_trashbin/share-keys/' . $filename . '.d' . $timestamp);
 			} else {
 				// handle share-keys
-				$matches = \OCA\Encryption\Helper::findShareKeys($ownerPath, $sharekeys, $rootView);
+				$matches = \OCA\Encryption\Helper::findShareKeys($file_path, $sharekeys, $rootView);
 				foreach ($matches as $src) {
 					// get source file parts
 					$pathinfo = pathinfo($src);


### PR DESCRIPTION
Fix for 7.0.6 maintenance release, as discussed with @cmonteroluque 

make sure to get the right list of users with access to the file, including the owner

fix https://github.com/owncloud/core/issues/14588

Don't get irritated by the high number of line changes, most are unit tests.

cc @PVince81 please review, thanks!
