### PR TITLE
Only use quota stream wrapper on "files"

### DIFF
--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -141,10 +141,12 @@ class Quota extends Wrapper {
 		$source = $this->storage->fopen($path, $mode);
 		$free = $this->free_space('');
 		if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
-			return \OC\Files\Stream\Quota::wrap($source, $free);
-		} else {
-			return $source;
+			// only apply quota for files, not metadata, trash or others
+			if (strpos(ltrim($path, '/'), 'files/') === 0) {
+				return \OC\Files\Stream\Quota::wrap($source, $free);
+			}
 		}
+		return $source;
 	}
 
 	/**

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -35,20 +35,21 @@ class Quota extends \Test\Files\Storage\Storage {
 	 */
 	protected function getLimitedStorage($limit) {
 		$storage = new \OC\Files\Storage\Local(array('datadir' => $this->tmpDir));
+		$storage->mkdir('files');
 		$storage->getScanner()->scan('');
 		return new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => $limit));
 	}
 
 	public function testFilePutContentsNotEnoughSpace() {
 		$instance = $this->getLimitedStorage(3);
-		$this->assertFalse($instance->file_put_contents('foo', 'foobar'));
+		$this->assertFalse($instance->file_put_contents('files/foo', 'foobar'));
 	}
 
 	public function testCopyNotEnoughSpace() {
 		$instance = $this->getLimitedStorage(9);
-		$this->assertEquals(6, $instance->file_put_contents('foo', 'foobar'));
+		$this->assertEquals(6, $instance->file_put_contents('files/foo', 'foobar'));
 		$instance->getScanner()->scan('');
-		$this->assertFalse($instance->copy('foo', 'bar'));
+		$this->assertFalse($instance->copy('files/foo', 'files/bar'));
 	}
 
 	public function testFreeSpace() {
@@ -92,17 +93,17 @@ class Quota extends \Test\Files\Storage\Storage {
 
 	public function testFWriteNotEnoughSpace() {
 		$instance = $this->getLimitedStorage(9);
-		$stream = $instance->fopen('foo', 'w+');
+		$stream = $instance->fopen('files/foo', 'w+');
 		$this->assertEquals(6, fwrite($stream, 'foobar'));
 		$this->assertEquals(3, fwrite($stream, 'qwerty'));
 		fclose($stream);
-		$this->assertEquals('foobarqwe', $instance->file_get_contents('foo'));
+		$this->assertEquals('foobarqwe', $instance->file_get_contents('files/foo'));
 	}
 
 	public function testStreamCopyWithEnoughSpace() {
 		$instance = $this->getLimitedStorage(16);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
-		$outputStream = $instance->fopen('foo', 'w+');
+		$outputStream = $instance->fopen('files/foo', 'w+');
 		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
 		$this->assertEquals(12, $count);
 		$this->assertTrue($result);
@@ -113,7 +114,7 @@ class Quota extends \Test\Files\Storage\Storage {
 	public function testStreamCopyNotEnoughSpace() {
 		$instance = $this->getLimitedStorage(9);
 		$inputStream = fopen('data://text/plain,foobarqwerty', 'r');
-		$outputStream = $instance->fopen('foo', 'w+');
+		$outputStream = $instance->fopen('files/foo', 'w+');
 		list($count, $result) = \OC_Helper::streamCopy($inputStream, $outputStream);
 		$this->assertEquals(9, $count);
 		$this->assertFalse($result);
@@ -139,16 +140,27 @@ class Quota extends \Test\Files\Storage\Storage {
 		$instance = $this->getLimitedStorage(9);
 
 		// create test file first
-		$stream = $instance->fopen('foo', 'w+');
+		$stream = $instance->fopen('files/foo', 'w+');
 		fwrite($stream, 'blablacontent');
 		fclose($stream);
 
-		$stream = $instance->fopen('foo', 'r');
+		$stream = $instance->fopen('files/foo', 'r');
 		$meta = stream_get_meta_data($stream);
 		$this->assertEquals('plainfile', $meta['wrapper_type']);
 		fclose($stream);
 
-		$stream = $instance->fopen('foo', 'rb');
+		$stream = $instance->fopen('files/foo', 'rb');
+		$meta = stream_get_meta_data($stream);
+		$this->assertEquals('plainfile', $meta['wrapper_type']);
+		fclose($stream);
+	}
+
+	public function testReturnRegularStreamWhenOutsideFiles() {
+		$instance = $this->getLimitedStorage(9);
+		$instance->mkdir('files_other');
+
+		// create test file first
+		$stream = $instance->fopen('files_other/foo', 'w+');
 		$meta = stream_get_meta_data($stream);
 		$this->assertEquals('plainfile', $meta['wrapper_type']);
 		fclose($stream);
@@ -156,7 +168,7 @@ class Quota extends \Test\Files\Storage\Storage {
 
 	public function testReturnQuotaStreamOnWrite() {
 		$instance = $this->getLimitedStorage(9);
-		$stream = $instance->fopen('foo', 'w+');
+		$stream = $instance->fopen('files/foo', 'w+');
 		$meta = stream_get_meta_data($stream);
 		$expected_type = defined('HHVM_VERSION') ? 'File' : 'user-space';
 		$this->assertEquals($expected_type, $meta['wrapper_type']);


### PR DESCRIPTION
Prevent using the quota stream wrapper on trashbin folders and other
metadata folders

Fixes https://github.com/owncloud/core/issues/16187

Please review @icewind1991 @schiesbn @nickvergessen 

Note: this fix is a bit ugly because it assumes that we only ever wrap the HomeStorage with the Quota storage wrapper. External storage is never wrapped with the quota storage wrapper, so this will work.

If you guys have better ideas, let me know.
