### PR TITLE
Abort expiration when file is gone

### DIFF
--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -346,7 +346,7 @@ class Storage {
 	 */
 	public static function getVersions($uid, $filename, $userFullPath = '') {
 		$versions = array();
-		if ($filename === '') {
+		if (empty($filename)) {
 			return $versions;
 		}
 		// fetch for old versions
@@ -556,6 +556,10 @@ class Storage {
 		$config = \OC::$server->getConfig();
 		if($config->getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true') {
 			list($uid, $filename) = self::getUidAndFilename($filename);
+			if (empty($filename)) {
+				// file maybe renamed or deleted
+				return false;
+			}
 			$versionsFileview = new \OC\Files\View('/'.$uid.'/files_versions');
 
 			// get available disk space for user

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -552,8 +552,18 @@ class Test_Files_Versioning extends \Test\TestCase {
 	public function testGetVersionsEmptyFile() {
 		// execute copy hook of versions app
 		$versions = \OCA\Files_Versions\Storage::getVersions(self::TEST_VERSIONS_USER, '');
-
 		$this->assertCount(0, $versions);
+
+		$versions = \OCA\Files_Versions\Storage::getVersions(self::TEST_VERSIONS_USER, null);
+		$this->assertCount(0, $versions);
+	}
+
+	public function testExpireNonexistingFile() {
+		$this->logout();
+		// needed to have a FS setup (the background job does this)
+		\OC_Util::setupFS(self::TEST_VERSIONS_USER);
+
+		$this->assertFalse(\OCA\Files_Versions\Storage::expire('/void/unexist.txt'));
 	}
 
 	public function testRestoreSameStorage() {


### PR DESCRIPTION
Sometimes a background job for versions expiration was scheduled for a
file that has been moved or deleted since.

This prevents showing useless warnings in the log and simply bail out.

Fixes https://github.com/owncloud/core/issues/16572

Please review @DeepDiver1975 @icewind1991 @schiesbn @th3fallen @MorrisJobke 

Steps here: https://github.com/owncloud/core/issues/16572#issuecomment-106767636
