### PR TITLE
Get a 96x96 preview for file conflict resolution

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -389,7 +389,7 @@ var OCdialogs = {
 				forceIcon:	0
 			};
 			var previewpath = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
-			$originalDiv.find('.icon').css('background-image','url('+previewpath+')');
+			$originalDiv.find('.icon').css({"background-image":   "url('" + previewpath + "')"});
 			getCroppedPreview(replacement).then(
 				function(path){
 					$replacementDiv.find('.icon').css('background-image','url(' + path + ')');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -381,9 +381,15 @@ var OCdialogs = {
 				$replacementDiv.find('.mtime').text(formatDate(replacement.lastModifiedDate));
 			}
 			var path = original.directory + '/' +original.name;
-			Files.lazyLoadPreview(path, original.mimetype, function(previewpath){
-				$originalDiv.find('.icon').css('background-image','url('+previewpath+')');
-			}, 96, 96, original.etag);
+			var urlSpec = {
+				file:		path,
+				x:		96,
+				y:		96,
+				c:		original.etag,
+				forceIcon:	0
+			};
+			var previewpath = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
+			$originalDiv.find('.icon').css('background-image','url('+previewpath+')');
 			getCroppedPreview(replacement).then(
 				function(path){
 					$replacementDiv.find('.icon').css('background-image','url(' + path + ')');

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -389,6 +389,8 @@ var OCdialogs = {
 				forceIcon:	0
 			};
 			var previewpath = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
+			// Escaping single quotes
+			previewpath = previewpath.replace(/'/g, "%27")
 			$originalDiv.find('.icon').css({"background-image":   "url('" + previewpath + "')"});
 			getCroppedPreview(replacement).then(
 				function(path){


### PR DESCRIPTION
Fix for "Wrong preview size is used for the conflict resolution modal window" #16616

The method currently used doesn't support width and height parameters.
### Before

![compare_before](https://cloud.githubusercontent.com/assets/323220/7881847/a496bcaa-0607-11e5-9e67-53d3baf95b23.png)
### After

![compare_after](https://cloud.githubusercontent.com/assets/323220/7881850/b5badcfa-0607-11e5-8186-4f04e4e96438.png)

@jancborchardt @georgehrke
