### PR TITLE
Check target name on rename with web UI

### DIFF
--- a/apps/files/lib/app.php
+++ b/apps/files/lib/app.php
@@ -74,6 +74,17 @@ class App {
 			'data'		=> NULL
 		);
 
+		try {
+			// check if the new name is conform to file name restrictions
+			$this->view->verifyPath($dir, $newname);
+		} catch (\OCP\Files\InvalidPathException $ex) {
+			$result['data'] = array(
+				'message'	=> $this->l10n->t($ex->getMessage()),
+				'code' => 'invalidname',
+			);
+			return $result;
+		}
+
 		$normalizedOldPath = \OC\Files\Filesystem::normalizePath($dir . '/' . $oldname);
 		$normalizedNewPath = \OC\Files\Filesystem::normalizePath($dir . '/' . $newname);
 

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -222,36 +222,17 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 	}
 
 	/**
-	 * Test move to a folder that doesn't exist any more
+	 * Test move to invalid name
 	 */
-	function testRenameToNonExistingFolder() {
+	function testRenameToInvalidName() {
 		$dir = '/';
 		$oldname = 'oldname';
-		$newname = '/unexist/newname';
-
-		$this->viewMock->expects($this->any())
-			->method('file_exists')
-			->with($this->anything())
-			->will($this->returnValueMap(array(
-				array('/oldname', true),
-				array('/unexist', false)
-				)));
-
-		$this->viewMock->expects($this->any())
-			->method('getFileInfo')
-			->will($this->returnValue(array(
-				'fileid' => 123,
-				'type' => 'dir',
-				'mimetype' => 'httpd/unix-directory',
-				'size' => 18,
-				'etag' => 'abcdef',
-				'directory' => '/unexist',
-				'name' => 'new_name',
-			)));
+		$newname = 'abc\\';
 
 		$result = $this->files->rename($dir, $oldname, $newname);
 
 		$this->assertFalse($result['success']);
-		$this->assertEquals('targetnotfound', $result['data']['code']);
+		$this->assertEquals('File name contains at least one invalid character', $result['data']['message']);
+		$this->assertEquals('invalidname', $result['data']['code']);
 	}
 }


### PR DESCRIPTION
When renaming over the web UI, check early that the target name is
valid.

This prevents nonsensical error messages when renaming to a name with a
trailing backslash.

Fixes https://github.com/owncloud/core/issues/16401

Test by renaming either to "*" or to a file name with a trailing backslash.

Please review @LukasReschke @icewind1991 @DeepDiver1975 @davitol @nickvergessen 
