### PR TITLE
Fix files_external l10n

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -32,6 +32,16 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'	</div>' +
 	'</div>';
 
+	/* TODO the current l10n extrator can't handle JS functions within handlebar
+	   templates therefore they are duplicated here
+	t("files_external", "Enable encryption")
+	t("files_external", "Enable previews")
+	t("files_external", "Check for changes")
+	t("files_external", "Never")
+	t("files_external", "Once every direct access")
+	t("files_external", "Every time the filesystem is used")
+	 */
+
 /**
  * Returns the selection of applicable users in the given configuration row
  *


### PR DESCRIPTION
- current l10n..pl script can't extract JS functions that are within a handlebars
  template - therefore they are duplicated until the script is fixed
- fixes #16559 

cc @DeepDiver1975 

Maybe we should use something like https://github.com/vialink/handlebars-xgettext to be able to extract from handlebar templates. Or we try to patch xgettext and provide this upstream.
