### PR TITLE
Fix grammar of search results phrase

### DIFF
--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -213,7 +213,7 @@
 					$status.addClass('emptycontent').removeClass('status');
 					$status.html('');
 					$status.append('<div class="icon-search"></div>');
-					$status.append('<h2>' + t('core', 'No search result in other places') + '</h2>');
+					$status.append('<h2>' + t('core', 'No search results in other places') + '</h2>');
 				} else {
 					$status.removeClass('emptycontent').addClass('status');
 					$status.text(n('core', '{count} search result in other places', '{count} search results in other places', count, {count:count}));


### PR DESCRIPTION
When searching for files, and there are no results in other places, a message is shown to the user.

Currently it reads: 'No search result in other places' whereas it should read 'No search results in other places'.

Other native speaker @MTRichards ?
