### PR TITLE
[stable8] Properly return fileid when scanFile() did not find differences

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -155,6 +155,8 @@ class Scanner extends BasicEmitter {
 					$data['fileid'] = $this->addToCache($file, $newData);
 					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
 					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
+				} else if (!empty($cacheData)) {
+					$data['fileid'] = $cacheData['fileid'];
 				}
 			} else {
 				$this->removeFromCache($file);

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -181,6 +181,14 @@ class Scanner extends \Test\TestCase {
 		$this->assertEquals($oldData['size'], $newData['size']);
 	}
 
+	public function testReuseIdentical() {
+		$this->storage->file_put_contents('file.txt', 'contents');
+		$data = $this->scanner->scanFile('file.txt', \OC\Files\Cache\Scanner::REUSE_ETAG);
+		$this->assertTrue(isset($data['fileid']));
+		$data = $this->scanner->scanFile('file.txt', \OC\Files\Cache\Scanner::REUSE_ETAG);
+		$this->assertTrue(isset($data['fileid']));
+	}
+
 	public function testRemovedFile() {
 		$this->fillTestFolders();
 


### PR DESCRIPTION
@icewind1991 see unit test.

Not sure if the fix is adequate or could have side effects.
I basically just copied over this two lines into one: https://github.com/owncloud/core/commit/4242dd0d9d3c11a67511ec21c50e5d3a91f66f7f#diff-a53613a10fd8e2a0bb19c40f83baeaf0R145

Fixes https://github.com/owncloud/core/issues/16659 
