### PR TITLE
Remove check for RAW_POPULATE_POST_DATA for unit tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,13 +6,6 @@ if ($configDir) {
 	define('PHPUNIT_CONFIG_DIR', $configDir);
 }
 
-if (!defined('HHVM_VERSION')) {
-	if(version_compare(phpversion(), '5.6.0', '>=') &&
-		ini_get('always_populate_raw_post_data') !== '-1') {
-		throw new Exception("'always_populate_raw_post_data' has to be set to '-1' in your php.ini");
-	}
-}
-
 require_once __DIR__ . '/../lib/base.php';
 
 // load minimum set of apps


### PR DESCRIPTION
We do have a work around meanwhile and for CLI this is not relevant at all. Can be removedWe do have a work around meanwhile and for CLI this is not relevant at all. Can be removed.

@DeepDiver1975 As discussed. You were right. We already have another workaround in base.php so even for web interface it is not required anymore and has already been removed…
