### PR TITLE
Check if array

### DIFF
--- a/apps/files_external/3rdparty/Dropbox/OAuth/Curl.php
+++ b/apps/files_external/3rdparty/Dropbox/OAuth/Curl.php
@@ -75,11 +75,13 @@ class Dropbox_OAuth_Curl extends Dropbox_OAuth {
 
  			//if (is_array($arguments))
  			//	$arguments=http_build_query($arguments);
- 			foreach ($arguments as $key => $value) {
- 				if($value[0] === '@') {
-					exit();
-				}
-			}
+            if(is_array($arguments)) {
+                foreach ($arguments as $key => $value) {
+                    if ($value[0] === '@') {
+                        exit();
+                    }
+                }
+            }
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $arguments);
 // 			$httpHeaders['Content-Length']=strlen($arguments);
 		} else {


### PR DESCRIPTION
The great library that we use apparently uses mixed types for everything because :see_no_evil:

Fixes https://github.com/owncloud/core/issues/16679 for stable8
(For easier review: https://github.com/owncloud/core/pull/16680/files?w=1)
