### PR TITLE
Check for redis to be 2.2.5+

### DIFF
--- a/lib/private/memcache/redis.php
+++ b/lib/private/memcache/redis.php
@@ -151,7 +151,8 @@ class Redis extends Cache implements IMemcache {
 	}
 
 	static public function isAvailable() {
-		return extension_loaded('redis');
+		return extension_loaded('redis')
+			&& version_compare(phpversion('redis'), '2.2.5', '>=');
 	}
 }
 

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -35,6 +35,7 @@ OC_Util::checkAdminUser();
 OC_App::setActiveNavigationEntry("admin");
 
 $template = new OC_Template('settings', 'admin', 'user');
+$l = OC_L10N::get('settings');
 
 $showLog = (\OC::$server->getConfig()->getSystemValue('log_type', 'owncloud') === 'owncloud');
 $numEntriesToLoad = 3;
@@ -128,13 +129,23 @@ $template->assign('getenvServerNotWorking', empty($path));
 // warn if Windows is used
 $template->assign('WindowsWarning', OC_Util::runningOnWindows());
 
-// warn if outdated version of APCu is used
-$template->assign('ApcuOutdatedWarning',
-	extension_loaded('apcu') && version_compare(phpversion('apc'), '4.0.6') === -1);
+// warn if outdated version of a memcache module is used
+$caches = [
+	'apcu'	=> ['name' => $l->t('APCu'), 'version' => '4.0.6'],
+	'redis'	=> ['name' => $l->t('Redis'), 'version' => '2.2.5'],
+];
+
+$outdatedCaches = [];
+foreach ($caches as $php_module => $data) {
+	$isOutdated = extension_loaded($php_module) && version_compare(phpversion($php_module), $data['version'], '<');
+	if ($isOutdated) {
+		$outdatedCaches[$php_module] = $data;
+	}
+}
+$template->assign('OutdatedCacheWarning', $outdatedCaches);
 
 // add hardcoded forms from the template
 $forms = OC_App::getForms('admin');
-$l = OC_L10N::get('settings');
 $formsAndMore = array();
 if ($request->getServerProtocol()  !== 'https' || !OC_Util::isAnnotationsWorking() ||
 	$suggestedOverwriteCliUrl || !OC_Util::isSetLocaleWorking()  ||

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -106,11 +106,11 @@ if ($_['WindowsWarning']) {
 <?php
 }
 
-// APCU Warning if outdated
-if ($_['ApcuOutdatedWarning']) {
+// Warning if memcache is outdated
+foreach ($_['OutdatedCacheWarning'] as $php_module => $data) {
 	?>
 	<li>
-		<?php p($l->t('APCu below version 4.0.6 is installed, for stability and performance reasons we recommend to update to a newer APCu version.')); ?>
+		<?php p($l->t('%1$s below version %2$s is installed, for stability and performance reasons we recommend to update to a newer %1$s version.', $data)); ?>
 	</li>
 <?php
 }


### PR DESCRIPTION
In order to test the output of the warning, when you don't have one of the memcaches installed,
add `$outdatedCaches = $caches;` after the foreach in settings/admin.php

Fix #16113 
Documentation PR: https://github.com/owncloud/documentation/pull/1180

@DeepDiver1975 @jvillafanez 
