### PR TITLE
[stable8] fix IE8 & IE9

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -62,6 +62,7 @@ select {
 
 /* fix installation screen rendering issue for IE8+9 */
 .lte9 #body-login {
+	min-height: 100%;
 	height: auto !important;
 }
 

--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -60,6 +60,11 @@ select {
 	visibility: hidden;
 }
 
+/* fix installation screen rendering issue for IE8+9 */
+.lte9 #body-login {
+	height: auto !important;
+}
+
 /* oc-dialog only uses box shadow which is not supported by ie8 */
 .ie8 .oc-dialog {
 	border: 1px solid #888888;


### PR DESCRIPTION
Reverts #16416 (same as #16703 for stable8)
Fixes #15413 for stable8

@DeepDiver1975 @karlitschek @cmonteroluque Do we want this minor change in 8.0.4? Otherwise the setup page in 8.0.4 isn't scrollable with IE8 and IE9.

@owncloud/designers @SergioBertolinSG Please review
