### PR TITLE
[stable7] Add min-height to login page for IE8 and IE9

### DIFF
--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -62,6 +62,7 @@ select {
 
 /* fix installation screen rendering issue for IE8+9 */
 .lte9 #body-login {
+	min-height: 100%;
 	height: auto !important;
 }
 


### PR DESCRIPTION
same as #16703 for stable7 (without the revert, because the PR wasn't merged for stable7)
Fixes #15413 for stable7

@owncloud/designers @SergioBertolinSG Please review
