### PR TITLE
Move the helpful invokePrivate method to the TestCase class

### DIFF
--- a/apps/encryption/tests/lib/HookManagerTest.php
+++ b/apps/encryption/tests/lib/HookManagerTest.php
@@ -43,7 +43,7 @@ class HookManagerTest extends TestCase {
 			$this->getMock('NotIHook')
 		]);
 
-		$hookInstances = \Test_Helper::invokePrivate(self::$instance, 'hookInstances');
+		$hookInstances = self::invokePrivate(self::$instance, 'hookInstances');
 		// Make sure our type checking works
 		$this->assertCount(2, $hookInstances);
 	}
@@ -66,7 +66,7 @@ class HookManagerTest extends TestCase {
 		$mock = $this->getMockBuilder('OCA\Encryption\Hooks\Contracts\IHook')->disableOriginalConstructor()->getMock();
 		self::$instance->registerHook($mock);
 
-		$hookInstances = \Test_Helper::invokePrivate(self::$instance, 'hookInstances');
+		$hookInstances = self::invokePrivate(self::$instance, 'hookInstances');
 		$this->assertCount(3, $hookInstances);
 
 	}

--- a/apps/encryption/tests/lib/KeyManagerTest.php
+++ b/apps/encryption/tests/lib/KeyManagerTest.php
@@ -285,7 +285,7 @@ class KeyManagerTest extends TestCase {
 			->with('user1', 'privateKey')
 			->willReturn(true);
 
-		$this->assertTrue(\Test_Helper::invokePrivate($this->instance,
+		$this->assertTrue(self::invokePrivate($this->instance,
 			'deletePrivateKey',
 			[$this->userId]));
 	}
@@ -329,8 +329,8 @@ class KeyManagerTest extends TestCase {
 			});
 
 		// set key IDs
-		\Test_Helper::invokePrivate($this->instance, 'publicShareKeyId', [$publicShareKeyId]);
-		\Test_Helper::invokePrivate($this->instance, 'recoveryKeyId', [$recoveryKeyId]);
+		self::invokePrivate($this->instance, 'publicShareKeyId', [$publicShareKeyId]);
+		self::invokePrivate($this->instance, 'recoveryKeyId', [$recoveryKeyId]);
 
 		$result = $this->instance->addSystemKeys($accessList, $publicKeys, $uid);
 

--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -292,7 +292,7 @@ class MigrationTest extends \Test\TestCase {
 	public function testUpdateFileCache() {
 		$this->prepareFileCache();
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection());
-		\Test_Helper::invokePrivate($m, 'updateFileCache');
+		self::invokePrivate($m, 'updateFileCache');
 
 		// check results
 

--- a/apps/encryption/tests/lib/RecoveryTest.php
+++ b/apps/encryption/tests/lib/RecoveryTest.php
@@ -180,7 +180,7 @@ class RecoveryTest extends TestCase {
 		$this->keyManagerMock->expects($this->once())
 			->method('setAllFileKeys');
 
-		$this->assertNull(\Test_Helper::invokePrivate($this->instance,
+		$this->assertNull(self::invokePrivate($this->instance,
 			'recoverFile',
 			['/', 'testkey', 'admin']));
 	}

--- a/apps/encryption/tests/lib/crypto/cryptTest.php
+++ b/apps/encryption/tests/lib/crypto/cryptTest.php
@@ -70,7 +70,7 @@ class cryptTest extends TestCase {
 			->with($this->equalTo('openssl'), $this->equalTo([]))
 			->willReturn(array());
 
-		$result = \Test_Helper::invokePrivate($this->crypt, 'getOpenSSLConfig');
+		$result = self::invokePrivate($this->crypt, 'getOpenSSLConfig');
 		$this->assertSame(1, count($result));
 		$this->assertArrayHasKey('private_key_bits', $result);
 		$this->assertSame(4096, $result['private_key_bits']);
@@ -86,7 +86,7 @@ class cryptTest extends TestCase {
 			->with($this->equalTo('openssl'), $this->equalTo([]))
 			->willReturn(array('foo' => 'bar', 'private_key_bits' => 1028));
 
-		$result = \Test_Helper::invokePrivate($this->crypt, 'getOpenSSLConfig');
+		$result = self::invokePrivate($this->crypt, 'getOpenSSLConfig');
 		$this->assertSame(2, count($result));
 		$this->assertArrayHasKey('private_key_bits', $result);
 		$this->assertArrayHasKey('foo', $result);
@@ -146,7 +146,7 @@ class cryptTest extends TestCase {
 	 */
 	public function testConcatIV() {
 
-		$result = \Test_Helper::invokePrivate(
+		$result = self::invokePrivate(
 			$this->crypt,
 			'concatIV',
 			array('content', 'my_iv'));
@@ -161,7 +161,7 @@ class cryptTest extends TestCase {
 	 */
 	public function testSplitIV() {
 		$data = 'encryptedContent00iv001234567890123456';
-		$result = \Test_Helper::invokePrivate($this->crypt, 'splitIV', array($data));
+		$result = self::invokePrivate($this->crypt, 'splitIV', array($data));
 		$this->assertTrue(is_array($result));
 		$this->assertSame(2, count($result));
 		$this->assertArrayHasKey('encrypted', $result);
@@ -174,7 +174,7 @@ class cryptTest extends TestCase {
 	 * test addPadding()
 	 */
 	public function testAddPadding() {
-		$result = \Test_Helper::invokePrivate($this->crypt, 'addPadding', array('data'));
+		$result = self::invokePrivate($this->crypt, 'addPadding', array('data'));
 		$this->assertSame('dataxx', $result);
 	}
 
@@ -186,7 +186,7 @@ class cryptTest extends TestCase {
 	 * @param $expected
 	 */
 	public function testRemovePadding($data, $expected) {
-		$result = \Test_Helper::invokePrivate($this->crypt, 'removePadding', array($data));
+		$result = self::invokePrivate($this->crypt, 'removePadding', array($data));
 		$this->assertSame($expected, $result);
 	}
 
@@ -208,7 +208,7 @@ class cryptTest extends TestCase {
 	public function testParseHeader() {
 
 		$header= 'HBEGIN:foo:bar:cipher:AES-256-CFB:HEND';
-		$result = \Test_Helper::invokePrivate($this->crypt, 'parseHeader', array($header));
+		$result = self::invokePrivate($this->crypt, 'parseHeader', array($header));
 
 		$this->assertTrue(is_array($result));
 		$this->assertSame(2, count($result));
@@ -227,12 +227,12 @@ class cryptTest extends TestCase {
 
 		$decrypted = 'content';
 		$password = 'password';
-		$iv = \Test_Helper::invokePrivate($this->crypt, 'generateIv');
+		$iv = self::invokePrivate($this->crypt, 'generateIv');
 
 		$this->assertTrue(is_string($iv));
 		$this->assertSame(16, strlen($iv));
 
-		$result = \Test_Helper::invokePrivate($this->crypt, 'encrypt', array($decrypted, $iv, $password));
+		$result = self::invokePrivate($this->crypt, 'encrypt', array($decrypted, $iv, $password));
 
 		$this->assertTrue(is_string($result));
 
@@ -251,7 +251,7 @@ class cryptTest extends TestCase {
 	 */
 	public function testDecrypt($data) {
 
-		$result = \Test_Helper::invokePrivate(
+		$result = self::invokePrivate(
 			$this->crypt,
 			'decrypt',
 			array($data['encrypted'], $data['iv'], $data['password']));

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -103,8 +103,8 @@ class EncryptionTest extends TestCase {
 	 */
 	public function endTest() {
 		// prepare internal variables
-		\Test_Helper::invokePrivate($this->instance, 'isWriteOperation', [true]);
-		\Test_Helper::invokePrivate($this->instance, 'writeCache', ['']);
+		self::invokePrivate($this->instance, 'isWriteOperation', [true]);
+		self::invokePrivate($this->instance, 'writeCache', ['']);
 
 		$this->keyManagerMock->expects($this->any())
 			->method('getPublicKey')
@@ -142,7 +142,7 @@ class EncryptionTest extends TestCase {
 	 */
 	public function testGetPathToRealFile($path, $expected) {
 		$this->assertSame($expected,
-			\Test_Helper::invokePrivate($this->instance, 'getPathToRealFile', array($path))
+			self::invokePrivate($this->instance, 'getPathToRealFile', array($path))
 		);
 	}
 
@@ -184,9 +184,9 @@ class EncryptionTest extends TestCase {
 		$this->assertArrayHasKey('cipher', $result);
 		$this->assertSame($expected, $result['cipher']);
 		if ($mode === 'w') {
-			$this->assertTrue(\Test_Helper::invokePrivate($this->instance, 'isWriteOperation'));
+			$this->assertTrue(self::invokePrivate($this->instance, 'isWriteOperation'));
 		} else {
-			$this->assertFalse(\Test_Helper::invokePrivate($this->instance, 'isWriteOperation'));
+			$this->assertFalse(self::invokePrivate($this->instance, 'isWriteOperation'));
 		}
 	}
 

--- a/apps/files_sharing/tests/external/managertest.php
+++ b/apps/files_sharing/tests/external/managertest.php
@@ -76,7 +76,7 @@ class ManagerTest extends TestCase {
 		$this->assertCount(1, $openShares);
 		$this->assertExternalShareEntry($shareData1, $openShares[0], 1, '{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertNotMount('SharedFolder');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 
@@ -88,7 +88,7 @@ class ManagerTest extends TestCase {
 		// New share falls back to "-1" appendix, because the name is already taken
 		$this->assertExternalShareEntry($shareData2, $openShares[1], 2, '{{TemporaryMountPointName#' . $shareData2['name'] . '}}-1');
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertNotMount('SharedFolder');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
@@ -101,7 +101,7 @@ class ManagerTest extends TestCase {
 		$this->manager->acceptShare($openShares[0]['id']);
 
 		// Check remaining shares - Accepted
-		$acceptedShares = \Test_Helper::invokePrivate($this->manager, 'getShares', [true]);
+		$acceptedShares = self::invokePrivate($this->manager, 'getShares', [true]);
 		$this->assertCount(1, $acceptedShares);
 		$shareData1['accepted'] = true;
 		$this->assertExternalShareEntry($shareData1, $acceptedShares[0], 1, $shareData1['name']);
@@ -110,7 +110,7 @@ class ManagerTest extends TestCase {
 		$this->assertCount(1, $openShares);
 		$this->assertExternalShareEntry($shareData2, $openShares[0], 2, '{{TemporaryMountPointName#' . $shareData2['name'] . '}}-1');
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
@@ -123,7 +123,7 @@ class ManagerTest extends TestCase {
 		// New share falls back to the original name (no "-\d", because the name is not taken)
 		$this->assertExternalShareEntry($shareData3, $openShares[1], 3, '{{TemporaryMountPointName#' . $shareData3['name'] . '}}');
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
@@ -135,13 +135,13 @@ class ManagerTest extends TestCase {
 		// Decline the third share
 		$this->manager->declineShare($openShares[1]['id']);
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
 
 		// Check remaining shares - Accepted
-		$acceptedShares = \Test_Helper::invokePrivate($this->manager, 'getShares', [true]);
+		$acceptedShares = self::invokePrivate($this->manager, 'getShares', [true]);
 		$this->assertCount(1, $acceptedShares);
 		$shareData1['accepted'] = true;
 		$this->assertExternalShareEntry($shareData1, $acceptedShares[0], 1, $shareData1['name']);
@@ -150,7 +150,7 @@ class ManagerTest extends TestCase {
 		$this->assertCount(1, $openShares);
 		$this->assertExternalShareEntry($shareData2, $openShares[0], 2, '{{TemporaryMountPointName#' . $shareData2['name'] . '}}-1');
 
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
@@ -163,10 +163,10 @@ class ManagerTest extends TestCase {
 			->with($this->stringStartsWith('http://localhost/ocs/v1.php/cloud/shares/' . $acceptedShares[0]['remote_id'] . '/decline'), $this->anything());
 
 		$this->manager->removeUserShares($this->uid);
-		$this->assertEmpty(\Test_Helper::invokePrivate($this->manager, 'getShares', [null]), 'Asserting all shares for the user have been deleted');
+		$this->assertEmpty(self::invokePrivate($this->manager, 'getShares', [null]), 'Asserting all shares for the user have been deleted');
 
 		$this->mountManager->clear();
-		\Test_Helper::invokePrivate($this->manager, 'setupMounts');
+		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertNotMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');

--- a/apps/files_sharing/tests/middleware/sharingcheckmiddleware.php
+++ b/apps/files_sharing/tests/middleware/sharingcheckmiddleware.php
@@ -58,7 +58,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 			->with('core', 'shareapi_allow_links', 'yes')
 			->will($this->returnValue('yes'));
 
-		$this->assertTrue(\Test_Helper::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
+		$this->assertTrue(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
 
 	public function testIsSharingEnabledWithAppDisabled() {
@@ -68,7 +68,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 			->with('files_sharing')
 			->will($this->returnValue(false));
 
-		$this->assertFalse(\Test_Helper::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
+		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
 
 	public function testIsSharingEnabledWithSharingDisabled() {
@@ -84,6 +84,6 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 			->with('core', 'shareapi_allow_links', 'yes')
 			->will($this->returnValue('no'));
 
-		$this->assertFalse(\Test_Helper::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
+		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
 }

--- a/tests/core/command/encryption/disabletest.php
+++ b/tests/core/command/encryption/disabletest.php
@@ -80,6 +80,6 @@ class DisableTest extends TestCase {
 				->with('core', 'encryption_enabled', 'no');
 		}
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 }

--- a/tests/core/command/encryption/enabletest.php
+++ b/tests/core/command/encryption/enabletest.php
@@ -114,6 +114,6 @@ class EnableTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains($expectedDefaultModuleString));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 }

--- a/tests/core/command/encryption/setdefaultmoduletest.php
+++ b/tests/core/command/encryption/setdefaultmoduletest.php
@@ -87,6 +87,6 @@ class SetDefaultModuleTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains($expectedString));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 }

--- a/tests/core/command/user/deletetest.php
+++ b/tests/core/command/user/deletetest.php
@@ -83,7 +83,7 @@ class DeleteTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains($expectedString));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
 	public function testInvalidUser() {
@@ -101,6 +101,6 @@ class DeleteTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains('User does not exist'));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 }

--- a/tests/core/command/user/lastseentest.php
+++ b/tests/core/command/user/lastseentest.php
@@ -82,7 +82,7 @@ class LastSeenTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains($expectedString));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
 	public function testInvalidUser() {
@@ -100,6 +100,6 @@ class LastSeenTest extends TestCase {
 			->method('writeln')
 			->with($this->stringContains('User does not exist'));
 
-		\Test_Helper::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 }

--- a/tests/lib/activitymanager.php
+++ b/tests/lib/activitymanager.php
@@ -156,7 +156,7 @@ class Test_ActivityManager extends \Test\TestCase {
 	 */
 	public function testGetUserFromTokenThrowInvalidToken($token, $users) {
 		$this->mockRSSToken($token, $token, $users);
-		\Test_Helper::invokePrivate($this->activityManager, 'getUserFromToken');
+		self::invokePrivate($this->activityManager, 'getUserFromToken');
 	}
 
 	public function getUserFromTokenData() {

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -797,7 +797,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertNull(\Test_Helper::invokePrivate($request, 'getOverwriteHost'));
+		$this->assertNull(self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
 	public function testGetOverwriteHostWithOverwrite() {
@@ -824,7 +824,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertSame('www.owncloud.org', \Test_Helper::invokePrivate($request, 'getOverwriteHost'));
+		$this->assertSame('www.owncloud.org', self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
 	public function testGetPathInfoWithSetEnv() {

--- a/tests/lib/encryption/keys/storage.php
+++ b/tests/lib/encryption/keys/storage.php
@@ -382,7 +382,7 @@ class StorageTest extends TestCase {
 			'/user1/files_encryption',
 			'/user1');
 
-		\Test_Helper::invokePrivate($this->storage, 'keySetPreparation', array('/user1/files_encryption/keys/foo'));
+		self::invokePrivate($this->storage, 'keySetPreparation', array('/user1/files_encryption/keys/foo'));
 	}
 
 	public function mkdirCallback() {

--- a/tests/lib/encryption/managertest.php
+++ b/tests/lib/encryption/managertest.php
@@ -127,7 +127,7 @@ class ManagerTest extends TestCase {
 		$en0 = $this->manager->getEncryptionModule('ID0');
 		$this->assertEquals('ID0', $en0->getId());
 
-		$en0 = \Test_Helper::invokePrivate($this->manager, 'getDefaultEncryptionModule');
+		$en0 = self::invokePrivate($this->manager, 'getDefaultEncryptionModule');
 		$this->assertEquals('ID0', $en0->getId());
 
 		$this->assertEquals('ID0', $this->manager->getDefaultEncryptionModuleId());

--- a/tests/lib/files/pathverificationtest.php
+++ b/tests/lib/files/pathverificationtest.php
@@ -94,7 +94,7 @@ class PathVerification extends \Test\TestCase {
 		$storage = new Local(['datadir' => '']);
 
 		$fileName = " 123{$fileName}456 ";
-		\Test_Helper::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
 	}
 
 	public function providesInvalidCharsWindows() {
@@ -151,7 +151,7 @@ class PathVerification extends \Test\TestCase {
 		$storage = new Local(['datadir' => '']);
 
 		$fileName = " 123{$fileName}456 ";
-		\Test_Helper::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
 	}
 
 	public function providesInvalidCharsPosix() {
@@ -200,7 +200,7 @@ class PathVerification extends \Test\TestCase {
 	public function testPathVerificationReservedNamesWindows($fileName) {
 		$storage = new Local(['datadir' => '']);
 
-		\Test_Helper::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
 	}
 
 	public function providesReservedNamesWindows() {
@@ -236,8 +236,8 @@ class PathVerification extends \Test\TestCase {
 	public function testPathVerificationValidPaths($fileName) {
 		$storage = new Local(['datadir' => '']);
 
-		\Test_Helper::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
-		\Test_Helper::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
+		self::invokePrivate($storage, 'verifyWindowsPath', [$fileName]);
 		// nothing thrown
 		$this->assertTrue(true);
 	}

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -355,7 +355,7 @@ class Encryption extends \Test\Files\Storage\Storage {
 		}
 
 		$this->assertSame($expected,
-			\Test_Helper::invokePrivate($this->instance, 'copyKeys', ['/source', '/target'])
+			self::invokePrivate($this->instance, 'copyKeys', ['/source', '/target'])
 		);
 	}
 

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -509,28 +509,9 @@ class Test_Helper extends \Test\TestCase {
 	 * @param $methodName
 	 * @param array $parameters
 	 * @return mixed
+	 * @deprecated Please extend \Test\TestCase and use self::invokePrivate() then
 	 */
 	public static function invokePrivate($object, $methodName, array $parameters = array()) {
-		$reflection = new ReflectionClass(get_class($object));
-
-		if ($reflection->hasMethod($methodName)) {
-			$method = $reflection->getMethod($methodName);
-
-			$method->setAccessible(true);
-
-			return $method->invokeArgs($object, $parameters);
-		} elseif ($reflection->hasProperty($methodName)) {
-			$property = $reflection->getProperty($methodName);
-
-			$property->setAccessible(true);
-
-			if (!empty($parameters)) {
-				$property->setValue($object, array_pop($parameters));
-			}
-
-			return $property->getValue($object);
-		}
-
-		return false;
+		return parent::invokePrivate($object, $methodName, $parameters);
 	}
 }

--- a/tests/lib/http/client/clienttest.php
+++ b/tests/lib/http/client/clienttest.php
@@ -47,7 +47,7 @@ class ClientTest extends \Test\TestCase {
 			->method('getSystemValue')
 			->with('proxyuserpwd', null)
 			->willReturn(null);
-		$this->assertSame('', \Test_Helper::invokePrivate($this->client, 'getProxyUri'));
+		$this->assertSame('', self::invokePrivate($this->client, 'getProxyUri'));
 	}
 
 	public function testGetProxyUriProxyHostEmptyPassword() {
@@ -61,7 +61,7 @@ class ClientTest extends \Test\TestCase {
 			->method('getSystemValue')
 			->with('proxyuserpwd', null)
 			->willReturn(null);
-		$this->assertSame('foo', \Test_Helper::invokePrivate($this->client, 'getProxyUri'));
+		$this->assertSame('foo', self::invokePrivate($this->client, 'getProxyUri'));
 	}
 
 	public function testGetProxyUriProxyHostWithPassword() {
@@ -75,7 +75,7 @@ class ClientTest extends \Test\TestCase {
 			->method('getSystemValue')
 			->with('proxyuserpwd', null)
 			->willReturn('username:password');
-		$this->assertSame('username:password@foo', \Test_Helper::invokePrivate($this->client, 'getProxyUri'));
+		$this->assertSame('username:password@foo', self::invokePrivate($this->client, 'getProxyUri'));
 	}
 
 	public function testGet() {

--- a/tests/lib/mail/mailer.php
+++ b/tests/lib/mail/mailer.php
@@ -35,7 +35,7 @@ class MailerTest extends TestCase {
 	}
 
 	public function testGetMailInstance() {
-		$this->assertEquals(\Swift_MailTransport::newInstance(), \Test_Helper::invokePrivate($this->mailer, 'getMailinstance'));
+		$this->assertEquals(\Swift_MailTransport::newInstance(), self::invokePrivate($this->mailer, 'getMailinstance'));
 	}
 
 	public function testGetSendMailInstanceSendMail() {
@@ -45,7 +45,7 @@ class MailerTest extends TestCase {
 			->with('mail_smtpmode', 'sendmail')
 			->will($this->returnValue('sendmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs'), \Test_Helper::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetSendMailInstanceSendMailQmail() {
@@ -55,11 +55,11 @@ class MailerTest extends TestCase {
 			->with('mail_smtpmode', 'sendmail')
 			->will($this->returnValue('qmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -bs'), \Test_Helper::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetInstanceDefault() {
-		$this->assertInstanceOf('\Swift_MailTransport', \Test_Helper::invokePrivate($this->mailer, 'getInstance'));
+		$this->assertInstanceOf('\Swift_MailTransport', self::invokePrivate($this->mailer, 'getInstance'));
 	}
 
 	public function testGetInstancePhp() {
@@ -68,7 +68,7 @@ class MailerTest extends TestCase {
 			->method('getSystemValue')
 			->will($this->returnValue('php'));
 
-		$this->assertInstanceOf('\Swift_MailTransport', \Test_Helper::invokePrivate($this->mailer, 'getInstance'));
+		$this->assertInstanceOf('\Swift_MailTransport', self::invokePrivate($this->mailer, 'getInstance'));
 	}
 
 	public function testGetInstanceSendmail() {
@@ -77,7 +77,7 @@ class MailerTest extends TestCase {
 			->method('getSystemValue')
 			->will($this->returnValue('sendmail'));
 
-		$this->assertInstanceOf('\Swift_SendmailTransport', \Test_Helper::invokePrivate($this->mailer, 'getInstance'));
+		$this->assertInstanceOf('\Swift_SendmailTransport', self::invokePrivate($this->mailer, 'getInstance'));
 	}
 
 	public function testCreateMessage() {

--- a/tests/lib/mail/message.php
+++ b/tests/lib/mail/message.php
@@ -42,7 +42,7 @@ class MessageTest extends TestCase {
 	 * @dataProvider mailAddressProvider
 	 */
 	public function testConvertAddresses($unconverted, $expected) {
-		$this->assertSame($expected, \Test_Helper::invokePrivate($this->message, 'convertAddresses', array($unconverted)));
+		$this->assertSame($expected, self::invokePrivate($this->message, 'convertAddresses', array($unconverted)));
 	}
 
 	public function testSetFrom() {

--- a/tests/lib/ocsclienttest.php
+++ b/tests/lib/ocsclienttest.php
@@ -76,7 +76,7 @@ class OCSClientTest extends \Test\TestCase {
 			->method('getSystemValue')
 			->with('appstoreurl', 'https://api.owncloud.com/v1')
 			->will($this->returnValue('https://api.owncloud.com/v1'));
-		$this->assertSame('https://api.owncloud.com/v1', Test_Helper::invokePrivate($this->ocsClient, 'getAppStoreUrl'));
+		$this->assertSame('https://api.owncloud.com/v1', self::invokePrivate($this->ocsClient, 'getAppStoreUrl'));
 	}
 
 	public function testGetCategoriesDisabledAppStore() {

--- a/tests/lib/repair/cleantags.php
+++ b/tests/lib/repair/cleantags.php
@@ -64,15 +64,15 @@ class CleanTags extends \Test\TestCase {
 		$this->assertEntryCount('*PREFIX*vcategory_to_object', 4, 'Assert tag entries count before repair step');
 		$this->assertEntryCount('*PREFIX*vcategory', 4, 'Assert tag categories count before repair step');
 
-		\Test_Helper::invokePrivate($this->repair, 'deleteOrphanFileEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanFileEntries');
 		$this->assertEntryCount('*PREFIX*vcategory_to_object', 3, 'Assert tag entries count after cleaning file entries');
 		$this->assertEntryCount('*PREFIX*vcategory', 4, 'Assert tag categories count after cleaning file entries');
 
-		\Test_Helper::invokePrivate($this->repair, 'deleteOrphanTagEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanTagEntries');
 		$this->assertEntryCount('*PREFIX*vcategory_to_object', 2, 'Assert tag entries count after cleaning tag entries');
 		$this->assertEntryCount('*PREFIX*vcategory', 4, 'Assert tag categories count after cleaning tag entries');
 
-		\Test_Helper::invokePrivate($this->repair, 'deleteOrphanCategoryEntries');
+		self::invokePrivate($this->repair, 'deleteOrphanCategoryEntries');
 		$this->assertEntryCount('*PREFIX*vcategory_to_object', 2, 'Assert tag entries count after cleaning category entries');
 		$this->assertEntryCount('*PREFIX*vcategory', 2, 'Assert tag categories count after cleaning category entries');
 	}

--- a/tests/lib/security/hasher.php
+++ b/tests/lib/security/hasher.php
@@ -11,7 +11,7 @@ use OC\Security\Hasher;
 /**
  * Class HasherTest
  */
-class HasherTest extends \PHPUnit_Framework_TestCase {
+class HasherTest extends \Test\TestCase {
 
 	/**
 	 * @return array
@@ -70,14 +70,15 @@ class HasherTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-
-
 	/** @var Hasher */
 	protected $hasher;
+
 	/** @var \OCP\IConfig */
 	protected $config;
 
 	protected function setUp() {
+		parent::setUp();
+
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
 
@@ -93,7 +94,7 @@ class HasherTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider versionHashProvider
 	 */
 	function testSplitHash($hash, $expected) {
-		$relativePath = \Test_Helper::invokePrivate($this->hasher, 'splitHash', array($hash));
+		$relativePath = self::invokePrivate($this->hasher, 'splitHash', array($hash));
 		$this->assertSame($expected, $relativePath);
 	}
 

--- a/tests/lib/setup.php
+++ b/tests/lib/setup.php
@@ -120,7 +120,7 @@ class Test_OC_Setup extends \Test\TestCase {
 	 * If it hasn't this test will fail.
 	 */
 	public function testHtaccessIsCurrent() {
-		$result = Test_Helper::invokePrivate(
+		$result = self::invokePrivate(
 			$this->setupClass,
 			'isCurrentHtaccess'
 		);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1051,7 +1051,7 @@ class Test_Share extends \Test\TestCase {
 	 */
 	function testRemoveProtocolFromUrl($url, $expectedResult) {
 		$share = new \OC\Share\Share();
-		$result = \Test_Helper::invokePrivate($share, 'removeProtocolFromUrl', array($url));
+		$result = self::invokePrivate($share, 'removeProtocolFromUrl', array($url));
 		$this->assertSame($expectedResult, $result);
 	}
 

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -154,7 +154,7 @@ class TempManager extends \Test\TestCase {
 
 	public function testBuildFileNameWithPostfix() {
 		$logger = $this->getMock('\Test\NullLogger');
-		$tmpManager = \Test_Helper::invokePrivate(
+		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 			'buildFileNameWithSuffix',
 			['/tmp/myTemporaryFile', 'postfix']
@@ -165,7 +165,7 @@ class TempManager extends \Test\TestCase {
 
 	public function testBuildFileNameWithoutPostfix() {
 		$logger = $this->getMock('\Test\NullLogger');
-		$tmpManager = \Test_Helper::invokePrivate(
+		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 					'buildFileNameWithSuffix',
 			['/tmp/myTemporaryFile', '']
@@ -176,7 +176,7 @@ class TempManager extends \Test\TestCase {
 
 	public function testBuildFileNameWithSuffixPathTraversal() {
 		$logger = $this->getMock('\Test\NullLogger');
-		$tmpManager = \Test_Helper::invokePrivate(
+		$tmpManager = self::invokePrivate(
 			$this->getManager($logger),
 			'buildFileNameWithSuffix',
 			['foo', '../Traversal\\../FileName']

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -50,6 +50,38 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Allows us to test private methods/properties
+	 *
+	 * @param $object
+	 * @param $methodName
+	 * @param array $parameters
+	 * @return mixed
+	 */
+	protected static function invokePrivate($object, $methodName, array $parameters = array()) {
+		$reflection = new \ReflectionClass(get_class($object));
+
+		if ($reflection->hasMethod($methodName)) {
+			$method = $reflection->getMethod($methodName);
+
+			$method->setAccessible(true);
+
+			return $method->invokeArgs($object, $parameters);
+		} elseif ($reflection->hasProperty($methodName)) {
+			$property = $reflection->getProperty($methodName);
+
+			$property->setAccessible(true);
+
+			if (!empty($parameters)) {
+				$property->setValue($object, array_pop($parameters));
+			}
+
+			return $property->getValue($object);
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns a unique identifier as uniqid() is not reliable sometimes
 	 *
 	 * @param string $prefix

--- a/tests/settings/controller/CheckSetupControllerTest.php
+++ b/tests/settings/controller/CheckSetupControllerTest.php
@@ -81,7 +81,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(false));
 
 		$this->assertFalse(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isInternetConnectionWorking'
 			)
@@ -109,7 +109,7 @@ class CheckSetupControllerTest extends TestCase {
 
 
 		$this->assertTrue(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isInternetConnectionWorking'
 			)
@@ -134,7 +134,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue($client));
 
 		$this->assertFalse(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isInternetConnectionWorking'
 			)
@@ -162,7 +162,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue($client));
 
 		$this->assertFalse(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isInternetConnectionWorking'
 			)
@@ -176,7 +176,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(null));
 
 		$this->assertFalse(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isMemcacheConfigured'
 			)
@@ -190,7 +190,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue('SomeProvider'));
 
 		$this->assertTrue(
-			\Test_Helper::invokePrivate(
+			self::invokePrivate(
 				$this->checkSetupController,
 				'isMemcacheConfigured'
 			)
@@ -239,7 +239,7 @@ class CheckSetupControllerTest extends TestCase {
 				'dataDirectoryProtected' => true,
 				'isMemcacheConfigured' => true,
 				'memcacheDocs' => 'http://doc.owncloud.org/server/go.php?to=admin-performance',
-				'isUrandomAvailable' => \Test_Helper::invokePrivate($this->checkSetupController, 'isUrandomAvailable'),
+				'isUrandomAvailable' => self::invokePrivate($this->checkSetupController, 'isUrandomAvailable'),
 				'securityDocs' => 'https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/hardening.html',
 			]
 		);

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -1290,7 +1290,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		list($user, $expectedResult) = $this->mockUser();
 
-		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -1327,7 +1327,7 @@ class UsersControllerTest extends \Test\TestCase {
 			)
 			->will($this->returnValue('1'));
 
-		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -1345,7 +1345,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$expectedResult['isRestoreDisabled'] = true;
 
-		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
 		$this->assertEquals($expectedResult, $result);
 	}
 
@@ -1384,7 +1384,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$expectedResult['isRestoreDisabled'] = true;
 
-		$result = \Test_Helper::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
+		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
 		$this->assertEquals($expectedResult, $result);
 	}
 


### PR DESCRIPTION
Easy one @MorrisJobke @LukasReschke @schiesbn 

We shouldn't call a static method on a phpunit test, when we can have it on the same class easily...
