### PR TITLE
keep a read lock while scanning a file or folder

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -55,6 +55,15 @@ class Trashbin {
 	 */
 	private static $scannedVersions = false;
 
+	/**
+	 * Ensure we dont need to scan the file during the move to trash
+	 *
+	 * @param array $params
+	 */
+	public static function ensureFileScannedHook($params) {
+		self::getUidAndFilename($params['path']);
+	}
+
 	public static function getUidAndFilename($filename) {
 		$uid = \OC\Files\Filesystem::getOwner($filename);
 		\OC\Files\Filesystem::initMountPoints($uid);
@@ -870,6 +879,7 @@ class Trashbin {
 		//Listen to post write hook
 		\OCP\Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Files_Trashbin\Hooks', 'post_write_hook');
 		// pre and post-rename, disable trash logic for the copy+unlink case
+		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Trashbin\Trashbin', 'ensureFileScannedHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
 		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
 	}

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -57,6 +57,7 @@ class Trashbin {
 
 	/**
 	 * Ensure we dont need to scan the file during the move to trash
+	 * by triggering the scan in the pre-hook
 	 *
 	 * @param array $params
 	 */

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -216,14 +216,14 @@ class File extends Node implements IFile {
 				}
 			}
 
-			// since we skipped the view we need to scan and emit the hooks ourselves
-			$partStorage->getScanner()->scanFile($internalPath);
-
 			try {
 				$this->fileView->changeLock($this->path, ILockingProvider::LOCK_SHARED);
 			} catch (LockedException $e) {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
+
+			// since we skipped the view we need to scan and emit the hooks ourselves
+			$partStorage->getScanner()->scanFile($internalPath);
 
 			if ($view) {
 				$this->fileView->getUpdater()->propagate($hookPath);
@@ -249,11 +249,10 @@ class File extends Node implements IFile {
 				}
 			}
 			$this->refreshInfo();
+			$this->fileView->unlockFile($this->path, ILockingProvider::LOCK_SHARED);
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
 		}
-
-		$this->fileView->unlockFile($this->path, ILockingProvider::LOCK_SHARED);
 
 		return '"' . $this->info->getEtag() . '"';
 	}

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -999,7 +999,7 @@ class View {
 					throw $e;
 				}
 
-				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && $operation !== 'fopen') {
+				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {
 					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
 				}
 
@@ -1013,7 +1013,7 @@ class View {
 					$this->updater->update($path, $extraParam);
 				}
 
-				if ($operation === 'fopen' and $result) {
+				if ($operation === 'fopen' and is_resource($result)) {
 					$result = CallbackWrapper::wrap($result, null, null, function () use ($hooks, $path) {
 						if (in_array('write', $hooks)) {
 							$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -771,9 +771,12 @@ class View {
 				} else {
 					$result = $storage2->copyFromStorage($storage1, $internalPath1, $internalPath2);
 				}
+
+				$this->changeLock($path2, ILockingProvider::LOCK_SHARED);
+
 				$this->updater->update($path2);
 
-				$this->unlockFile($path2, ILockingProvider::LOCK_EXCLUSIVE);
+				$this->unlockFile($path2, ILockingProvider::LOCK_SHARED);
 				$this->unlockFile($path1, ILockingProvider::LOCK_SHARED);
 
 				if ($this->shouldEmitHooks() && $result !== false) {
@@ -996,6 +999,10 @@ class View {
 					throw $e;
 				}
 
+				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && $operation !== 'fopen') {
+					$this->changeLock($path, ILockingProvider::LOCK_SHARED);
+				}
+
 				if (in_array('delete', $hooks) and $result) {
 					$this->updater->remove($path);
 				}
@@ -1014,12 +1021,8 @@ class View {
 							$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 						}
 					});
-				} else {
-					if (in_array('write', $hooks) || in_array('delete', $hooks)) {
-						$this->unlockFile($path, ILockingProvider::LOCK_EXCLUSIVE);
-					} else if (in_array('read', $hooks)) {
-						$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
-					}
+				} else if (in_array('write', $hooks) || in_array('delete', $hooks) || in_array('read', $hooks)) {
+					$this->unlockFile($path, ILockingProvider::LOCK_SHARED);
 				}
 
 

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1694,6 +1694,7 @@ class View {
 	 * @throws \OCP\Lock\LockedException if the path is already locked
 	 */
 	public function changeLock($path, $type) {
+		$path = Filesystem::normalizePath($path);
 		$absolutePath = $this->getAbsolutePath($path);
 		if (!$this->shouldLockFile($absolutePath)) {
 			return false;


### PR DESCRIPTION
Note that this does **not** prevent concurrent scanners, only stops the file or folder being changed while scanning

For #16664

cc @DeepDiver1975 @PVince81 
