### PR TITLE
Fix unit tests

### DIFF
--- a/tests/lib/encryption/managertest.php
+++ b/tests/lib/encryption/managertest.php
@@ -81,7 +81,7 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @expectedException \OC\Encryption\Exceptions\ModuleDoesNotExistsException
-	 * @expectedExceptionMessage Module with id: unknown does not exists.
+	 * @expectedExceptionMessage Module with id: unknown does not exist.
 	 */
 	public function testGetEncryptionModuleUnknown() {
 		$this->config->expects($this->any())->method('getAppValue')->willReturn(true);
@@ -195,7 +195,7 @@ class ManagerTest extends TestCase {
 //
 //	/**
 //	 * @expectedException \OC\Encryption\Exceptions\ModuleDoesNotExistsException
-//	 * @expectedExceptionMessage Module with id: unknown does not exists.
+//	 * @expectedExceptionMessage Module with id: unknown does not exist.
 //	 */
 //	public function testGetEncryptionModuleUnknown() {
 //		$config = $this->getMock('\OCP\IConfig');


### PR DESCRIPTION
Regression caused by https://github.com/owncloud/core/pull/16721

Failed the unit tests as per https://ci.owncloud.org/job/server-master-linux/database=sqlite,label=SLAVE/1994/testReport/junit/(root)/Test_Encryption_ManagerTest/testGetEncryptionModuleUnknown/:

```
Test\Encryption\ManagerTest::testGetEncryptionModuleUnknown
Failed asserting that exception message 'Module with id: unknown does not exist.' contains 'Module with id: unknown does not exists.'
```

@DeepDiver1975 @th3fallen Please review. THX.
