### PR TITLE
Add OCS API to send, get, accept and decline remote shares

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -270,9 +270,9 @@ class Local {
 		$shareType = isset($_POST['shareType']) ? (int)$_POST['shareType'] : null;
 
 		switch($shareType) {
+			case \OCP\Share::SHARE_TYPE_REMOTE:
+				$shareWith = rtrim($shareWith, '/');
 			case \OCP\Share::SHARE_TYPE_USER:
-				$permissions = isset($_POST['permissions']) ? (int)$_POST['permissions'] : 31;
-				break;
 			case \OCP\Share::SHARE_TYPE_GROUP:
 				$permissions = isset($_POST['permissions']) ? (int)$_POST['permissions'] : 31;
 				break;

--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -260,6 +260,7 @@ class Local {
 			return new \OC_OCS_Result(null, 400, "please specify a file or folder path");
 		}
 		$itemSource = self::getFileId($path);
+		$itemSourceName = $itemSource;
 		$itemType = self::getItemType($path);
 
 		if($itemSource === null) {
@@ -272,6 +273,7 @@ class Local {
 		switch($shareType) {
 			case \OCP\Share::SHARE_TYPE_REMOTE:
 				$shareWith = rtrim($shareWith, '/');
+				$itemSourceName = basename($path);
 			case \OCP\Share::SHARE_TYPE_USER:
 			case \OCP\Share::SHARE_TYPE_GROUP:
 				$permissions = isset($_POST['permissions']) ? (int)$_POST['permissions'] : 31;
@@ -303,7 +305,8 @@ class Local {
 					$itemSource,
 					$shareType,
 					$shareWith,
-					$permissions
+					$permissions,
+					$itemSourceName
 					);
 		} catch (HintException $e) {
 			return new \OC_OCS_Result(null, 400, $e->getHint());

--- a/apps/files_sharing/api/remote.php
+++ b/apps/files_sharing/api/remote.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\API;
+
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\External\Manager;
+
+class Remote {
+
+	/**
+	 * Accept a remote share
+	 *
+	 * @param array $params contains the shareID 'id' which should be accepted
+	 * @return \OC_OCS_Result
+	 */
+	public static function getOpenShares($params) {
+		$externalManager = new Manager(
+			\OC::$server->getDatabaseConnection(),
+			Filesystem::getMountManager(),
+			Filesystem::getLoader(),
+			\OC::$server->getHTTPHelper(),
+			\OC_User::getUser()
+		);
+
+		return new \OC_OCS_Result($externalManager->getOpenShares());
+	}
+
+	/**
+	 * Accept a remote share
+	 *
+	 * @param array $params contains the shareID 'id' which should be accepted
+	 * @return \OC_OCS_Result
+	 */
+	public static function acceptShare($params) {
+		$externalManager = new Manager(
+			\OC::$server->getDatabaseConnection(),
+			Filesystem::getMountManager(),
+			Filesystem::getLoader(),
+			\OC::$server->getHTTPHelper(),
+			\OC_User::getUser()
+		);
+
+		if ($externalManager->acceptShare($params['id'])) {
+			return new \OC_OCS_Result();
+		}
+
+		return new \OC_OCS_Result(null, 404, "wrong share ID, share doesn't exist.");
+	}
+
+	/**
+	 * Decline a remote share
+	 *
+	 * @param array $params contains the shareID 'id' which should be declined
+	 * @return \OC_OCS_Result
+	 */
+	public static function declineShare($params) {
+		$externalManager = new Manager(
+			\OC::$server->getDatabaseConnection(),
+			Filesystem::getMountManager(),
+			Filesystem::getLoader(),
+			\OC::$server->getHTTPHelper(),
+			\OC_User::getUser()
+		);
+
+		if ($externalManager->declineShare($params['id'])) {
+			return new \OC_OCS_Result();
+		}
+
+		return new \OC_OCS_Result(null, 404, "wrong share ID, share doesn't exist.");
+	}
+
+}

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -82,6 +82,21 @@ API::register('delete',
 		array('\OCA\Files_Sharing\API\Local', 'deleteShare'),
 		'files_sharing');
 
+API::register('get',
+		'/apps/files_sharing/api/v1/remote_shares',
+		array('\OCA\Files_Sharing\API\Remote', 'getOpenShares'),
+		'files_sharing');
+
+API::register('post',
+		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		array('\OCA\Files_Sharing\API\Remote', 'acceptShare'),
+		'files_sharing');
+
+API::register('delete',
+		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		array('\OCA\Files_Sharing\API\Remote', 'declineShare'),
+		'files_sharing');
+
 // Register with the capabilities API
 API::register('get',
 		'/cloud/capabilities',

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -186,6 +186,7 @@ class Manager {
 	 * accept server-to-server share
 	 *
 	 * @param int $id
+	 * @return bool True if the share could be accepted, false otherwise
 	 */
 	public function acceptShare($id) {
 
@@ -204,13 +205,18 @@ class Manager {
 				WHERE `id` = ? AND `user` = ?');
 			$acceptShare->execute(array(1, $mountPoint, $hash, $id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
+
+			return true;
 		}
+
+		return false;
 	}
 
 	/**
 	 * decline server-to-server share
 	 *
 	 * @param int $id
+	 * @return bool True if the share could be declined, false otherwise
 	 */
 	public function declineShare($id) {
 
@@ -221,7 +227,11 @@ class Manager {
 				DELETE FROM `*PREFIX*share_external` WHERE `id` = ? AND `user` = ?');
 			$removeShare->execute(array($id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+
+			return true;
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This is required so we can manage remote shares via the pyoc client for smashbox

Replace #14668
Fix #13627
