### PR TITLE
[stable8] fall back to absolute path for pipelined assets (#14940)

### DIFF
--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -238,7 +238,11 @@ class OC_TemplateLayout extends OC_Template {
 
 	private static function hashFileNames($files) {
 		foreach($files as $i => $file) {
-			$files[$i] = self::convertToRelativePath($file[0]).'/'.$file[2];
+			try {
+				$files[$i] = self::convertToRelativePath($file[0]).'/'.$file[2];
+			} catch (\Exception $e) {
+				$files[$i] = $file[0].'/'.$file[2];
+			}
 		}
 
 		sort($files);


### PR DESCRIPTION
If the asset is, for example, in an apps directory that is
outside the $SERVERROOT, we won't be able to get a relative
path. We shouldn't just fail hard in this case. Fall back to
using the absolute path instead (as we used to).

Backport of #14941 
Approval: https://github.com/owncloud/core/pull/14941#issuecomment-108872571

cc @adamwill @DeepDiver1975 

I had a smoke test and all still works.
