### PR TITLE
Fix typo in PHPDoc

### DIFF
--- a/lib/public/app/iappmanager.php
+++ b/lib/public/app/iappmanager.php
@@ -88,7 +88,7 @@ interface IAppManager {
 	 * List all installed apps
 	 *
 	 * @return string[]
-	 * @since 8.0.0
+	 * @since 8.1.0
 	 */
 	public function getInstalledApps();
 


### PR DESCRIPTION
cc @LukasReschke @nickvergessen 

added in 8.1 with 2b58e8489fcb5eff0e2312209beca038bfe9b40a
