### PR TITLE
[stable8] Only load commands of enabled apps

### DIFF
--- a/console.php
+++ b/console.php
@@ -51,7 +51,11 @@ try {
 	$application = new Application($defaults->getName(), \OC_Util::getVersionString());
 	require_once 'core/register_command.php';
 	if (!\OCP\Util::needUpgrade()) {
+		$appManager = \OC::$server->getAppManager();
 		foreach(OC_App::getAllApps() as $app) {
+			if(!$appManager->isInstalled($app)) {
+				continue;
+			}
 			$file = OC_App::getAppPath($app).'/appinfo/register_command.php';
 			if(file_exists($file)) {
 				require $file;


### PR DESCRIPTION
Slightly different way to check this, because the method in the interface isn't present.

Backport of #16403

cc @DeepDiver1975 @nickvergessen @LukasReschke @rullzer @Xenopathic 

Tested and works.
