### PR TITLE
Check whether the user exists before trying to set up his file system

### DIFF
--- a/apps/files_trashbin/command/expire.php
+++ b/apps/files_trashbin/command/expire.php
@@ -49,6 +49,12 @@ class Expire implements ICommand {
 	}
 
 	public function handle() {
+		$userManager = \OC::$server->getUserManager();
+		if (!$userManager->userExists($this->user)) {
+			// User has been deleted already
+			return;
+		}
+
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($this->user);
 		Trashbin::expire($this->trashBinSize, $this->user);

--- a/apps/files_trashbin/tests/command/expiretest.php
+++ b/apps/files_trashbin/tests/command/expiretest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Trashbin\Tests\Command;
+
+use OCA\Files_Trashbin\Command\Expire;
+use Test\TestCase;
+
+class ExpireTest extends TestCase {
+	public function testExpireNonExistingUser() {
+		$command = new Expire('test', 0);
+		$command->handle();
+
+		$this->assertTrue(true);
+	}
+}

--- a/apps/files_versions/command/expire.php
+++ b/apps/files_versions/command/expire.php
@@ -50,6 +50,12 @@ class Expire implements ICommand {
 
 
 	public function handle() {
+		$userManager = \OC::$server->getUserManager();
+		if (!$userManager->userExists($this->user)) {
+			// User has been deleted already
+			return;
+		}
+
 		\OC_Util::setupFS($this->user);
 		Storage::expire($this->fileName, $this->versionsSize, $this->neededSpace);
 		\OC_Util::tearDownFS();

--- a/apps/files_versions/tests/command/expiretest.php
+++ b/apps/files_versions/tests/command/expiretest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Versions\Tests\Command;
+
+use OCA\Files_Versions\Command\Expire;
+use Test\TestCase;
+
+class ExpireTest extends TestCase {
+	public function testExpireNonExistingUser() {
+		$command = new Expire('test', '');
+		$command->handle();
+
+		$this->assertTrue(true);
+	}
+}


### PR DESCRIPTION
Fix #16752 

Due to our architecture that stores serialized objects in the database, we can not use DI without breaking existing jobs:
https://github.com/owncloud/core/blob/9a6d253af39dba49a1397416fb448e922df8a7a1/apps/files_versions/lib/storage.php#L543-L544
https://github.com/owncloud/core/blob/b585d87d9d6ccf964d10cd2e2cb1d465eb537a25/lib/private/command/asyncbus.php#L58-58
https://github.com/owncloud/core/blob/b585d87d9d6ccf964d10cd2e2cb1d465eb537a25/lib/private/command/asyncbus.php#L105-L107

My suggestion would be to fix the architectural problem asap in 8.2, so we store the classname and arguments, instead of the object.

@PVince81 @schiesbn @icewind1991 @DeepDiver1975 
