### PR TITLE
Validate path in getChild

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -150,9 +150,12 @@ class Directory extends \OC\Connector\Sabre\Node
 		$path = $this->path . '/' . $name;
 		if (is_null($info)) {
 			try {
+				$this->fileView->verifyPath($this->path, $name);
 				$info = $this->fileView->getFileInfo($path);
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
 				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			} catch (\OCP\Files\InvalidPathException $ex) {
+				throw new InvalidPath($ex->getMessage());
 			}
 		}
 

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -70,8 +70,15 @@ class Directory extends \OC\Connector\Sabre\Node
 	 *
 	 * @param string $name Name of the file
 	 * @param resource|string $data Initial payload
-	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @return null|string
+	 * @throws Exception\EntityTooLarge
+	 * @throws Exception\UnsupportedMediaType
+	 * @throws FileLocked
+	 * @throws InvalidPath
+	 * @throws \Sabre\DAV\Exception
+	 * @throws \Sabre\DAV\Exception\BadRequest
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function createFile($name, $data = null) {
 
@@ -115,8 +122,10 @@ class Directory extends \OC\Connector\Sabre\Node
 	 * Creates a new subdirectory
 	 *
 	 * @param string $name
+	 * @throws FileLocked
+	 * @throws InvalidPath
 	 * @throws \Sabre\DAV\Exception\Forbidden
-	 * @return void
+	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function createDirectory($name) {
 		try {
@@ -143,8 +152,10 @@ class Directory extends \OC\Connector\Sabre\Node
 	 *
 	 * @param string $name
 	 * @param \OCP\Files\FileInfo $info
-	 * @throws \Sabre\DAV\Exception\FileNotFound
 	 * @return \Sabre\DAV\INode
+	 * @throws InvalidPath
+	 * @throws \Sabre\DAV\Exception\NotFound
+	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
 	public function getChild($name, $info = null) {
 		$path = $this->path . '/' . $name;
@@ -214,6 +225,7 @@ class Directory extends \OC\Connector\Sabre\Node
 	 * Deletes all files in this directory, and then itself
 	 *
 	 * @return void
+	 * @throws FileLocked
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 */
 	public function delete() {

--- a/tests/lib/connector/sabre/directory.php
+++ b/tests/lib/connector/sabre/directory.php
@@ -140,7 +140,33 @@ class Test_OC_Connector_Sabre_Directory extends \Test\TestCase {
 
 		// calling a second time just returns the cached values,
 		// does not call getDirectoryContents again
-		$nodes = $dir->getChildren();
+		$dir->getChildren();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\ServiceUnavailable
+	 */
+	public function testGetChildThrowStorageNotAvailableException() {
+		$this->view->expects($this->once())
+			->method('getFileInfo')
+			->willThrowException(new \OCP\Files\StorageNotAvailableException());
+
+		$dir = new \OC\Connector\Sabre\Directory($this->view, $this->info);
+		$dir->getChild('.');
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\InvalidPath
+	 */
+	public function testGetChildThrowInvalidPath() {
+		$this->view->expects($this->once())
+			->method('verifyPath')
+			->willThrowException(new \OCP\Files\InvalidPathException());
+		$this->view->expects($this->never())
+			->method('getFileInfo');
+
+		$dir = new \OC\Connector\Sabre\Directory($this->view, $this->info);
+		$dir->getChild('.');
 	}
 
 	public function testGetQuotaInfo() {


### PR DESCRIPTION
Returns the correct error message when trying to create a folder called "\":
`curl -v -X MKCOL "http://user:password@host/remote.php/webdav/\\"`
or
`curl -v -X MKCOL 'http://user:password@host/remote.php/webdav/%5C'`

@SergioBertolinSG @icewind1991 @nickvergessen 

Fixes https://github.com/owncloud/core/issues/16618
