### PR TITLE
[OCP] update PHPdoc to contain correct @since tags

### DIFF
--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -420,6 +420,7 @@ interface Storage {
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
+	 * @since 8.1.0
 	 */
 	public function acquireLock($path, $type, ILockingProvider $provider);
 
@@ -427,6 +428,7 @@ interface Storage {
 	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
+	 * @since 8.1.0
 	 */
 	public function releaseLock($path, $type, ILockingProvider $provider);
 
@@ -435,6 +437,7 @@ interface Storage {
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
+	 * @since 8.1.0
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider);
 }

--- a/lib/public/icertificatemanager.php
+++ b/lib/public/icertificatemanager.php
@@ -40,7 +40,7 @@ interface ICertificateManager {
 	 * @param string $name the filename for the certificate
 	 * @return \OCP\ICertificate
 	 * @throws \Exception If the certificate could not get added
-	 * @since 8.0.0
+	 * @since 8.0.0 - since 8.1.0 throws exception instead of returning false
 	 */
 	public function addCertificate($certificate, $name);
 

--- a/lib/public/imemcache.php
+++ b/lib/public/imemcache.php
@@ -42,7 +42,7 @@ interface IMemcache extends ICache {
 	 * @param mixed $value
 	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24
 	 * @return bool
-	 * @since 8.0.0
+	 * @since 8.1.0
 	 */
 	public function add($key, $value, $ttl = 0);
 
@@ -52,7 +52,7 @@ interface IMemcache extends ICache {
 	 * @param string $key
 	 * @param int $step
 	 * @return int | bool
-	 * @since 8.0.0
+	 * @since 8.1.0
 	 */
 	public function inc($key, $step = 1);
 
@@ -62,7 +62,7 @@ interface IMemcache extends ICache {
 	 * @param string $key
 	 * @param int $step
 	 * @return int | bool
-	 * @since 8.0.0
+	 * @since 8.1.0
 	 */
 	public function dec($key, $step = 1);
 
@@ -73,6 +73,7 @@ interface IMemcache extends ICache {
 	 * @param mixed $old
 	 * @param mixed $new
 	 * @return bool
+	 * @since 8.1.0
 	 */
 	public function cas($key, $old, $new);
 }

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -88,7 +88,7 @@ interface IServerContainer {
 	 * Returns the root folder of ownCloud's data directory
 	 *
 	 * @return \OCP\Files\IRootFolder
-	 * @since 6.0.0
+	 * @since 6.0.0 - between 6.0.0 and 8.0.0 this returned \OCP\Files\Folder
 	 */
 	public function getRootFolder();
 

--- a/lib/public/lock/ilockingprovider.php
+++ b/lib/public/lock/ilockingprovider.php
@@ -21,14 +21,27 @@
 
 namespace OCP\Lock;
 
+/**
+ * Interface ILockingProvider
+ *
+ * @package OCP\Lock
+ * @since 8.1.0
+ */
 interface ILockingProvider {
+	/**
+	 * @since 8.1.0
+	 */
 	const LOCK_SHARED = 1;
+	/**
+	 * @since 8.1.0
+	 */
 	const LOCK_EXCLUSIVE = 2;
 
 	/**
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 * @return bool
+	 * @since 8.1.0
 	 */
 	public function isLocked($path, $type);
 
@@ -36,12 +49,14 @@ interface ILockingProvider {
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 * @throws \OCP\Lock\LockedException
+	 * @since 8.1.0
 	 */
 	public function acquireLock($path, $type);
 
 	/**
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @since 8.1.0
 	 */
 	public function releaseLock($path, $type);
 
@@ -51,11 +66,13 @@ interface ILockingProvider {
 	 * @param string $path
 	 * @param int $targetType self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 * @throws \OCP\Lock\LockedException
+	 * @since 8.1.0
 	 */
 	public function changeLock($path, $targetType);
 
 	/**
 	 * release all lock acquired by this instance
+	 * @since 8.1.0
 	 */
 	public function releaseAll();
 }

--- a/lib/public/lock/lockedexception.php
+++ b/lib/public/lock/lockedexception.php
@@ -21,6 +21,12 @@
 
 namespace OCP\Lock;
 
+/**
+ * Class LockedException
+ *
+ * @package OCP\Lock
+ * @since 8.1.0
+ */
 class LockedException extends \Exception {
 	/**
 	 * @var string
@@ -31,6 +37,7 @@ class LockedException extends \Exception {
 	 * LockedException constructor.
 	 *
 	 * @param string $path
+	 * @since 8.1.0
 	 */
 	public function __construct($path) {
 		parent::__construct($path . ' is locked');
@@ -39,6 +46,7 @@ class LockedException extends \Exception {
 
 	/**
 	 * @return string
+	 * @since 8.1.0
 	 */
 	public function getPath() {
 		return $this->path;

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -73,6 +73,7 @@ class Util {
 	/**
 	 * Set current update channel
 	 * @param string $channel
+	 * @since 8.1.0
 	 */
 	public static function setChannel($channel) {
 		//Flush timestamp to reload version.php
@@ -83,6 +84,7 @@ class Util {
 	/**
 	 * Get current update channel
 	 * @return string
+	 * @since 8.1.0
 	 */
 	public static function getChannel() {
 		return \OC_Util::getChannel();


### PR DESCRIPTION
cc @DeepDiver1975 @Raydiation @PVince81 @nickvergessen 

Please always add correct labels for the `@since` tag. This will make the life of developers that want to use the OCP API a lot easier. Loooking at you @schiesbn, @VicDeo  & @icewind1991 ;)
