### PR TITLE
Add owner to the storage stats to enable better notifications

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -138,6 +138,8 @@ OCP\Util::addscript('files', 'navigation');
 OCP\Util::addscript('files', 'keyboardshortcuts');
 $tmpl = new OCP\Template('files', 'index', 'user');
 $tmpl->assign('usedSpacePercent', (int)$storageInfo['relative']);
+$tmpl->assign('owner', $storageInfo['owner']);
+$tmpl->assign('ownerDisplayName', $storageInfo['ownerDisplayName']);
 $tmpl->assign('isPublic', false);
 $tmpl->assign("mailNotificationEnabled", $config->getAppValue('core', 'shareapi_allow_mail_notification', 'no'));
 $tmpl->assign("mailPublicNotificationEnabled", $config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -63,6 +63,8 @@
 				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('original-title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
+				$('#owner').val(response.data.owner);
+				$('#ownerDisplayName').val(response.data.ownerDisplayName);
 				Files.displayStorageWarnings();
 			}
 			if (response[0] === undefined) {
@@ -109,12 +111,24 @@
 				return;
 			}
 
-			var usedSpacePercent = $('#usedSpacePercent').val();
+			var usedSpacePercent = $('#usedSpacePercent').val(),
+				owner = $('#owner').val(),
+				ownerDisplayName = $('#ownerDisplayName').val();
 			if (usedSpacePercent > 98) {
+				if (owner !== oc_current_user) {
+					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
+						{ owner: ownerDisplayName }));
+					return;
+				}
 				OC.Notification.show(t('files', 'Your storage is full, files can not be updated or synced anymore!'));
 				return;
 			}
 			if (usedSpacePercent > 90) {
+				if (owner !== oc_current_user) {
+					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
+						{ usedSpacePercent: usedSpacePercent,  owner: ownerDisplayName }));
+					return;
+				}
 				OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',
 					{usedSpacePercent: usedSpacePercent}));
 			}

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -52,7 +52,9 @@ class Helper {
 			'uploadMaxFilesize' => $maxUploadFileSize,
 			'maxHumanFilesize'  => $maxHumanFileSize,
 			'freeSpace' => $storageInfo['free'],
-			'usedSpacePercent'  => (int)$storageInfo['relative']
+			'usedSpacePercent'  => (int)$storageInfo['relative'],
+			'owner' => $storageInfo['owner'],
+			'ownerDisplayName' => $storageInfo['ownerDisplayName'],
 		];
 	}
 

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -11,6 +11,8 @@
 <!-- config hints for javascript -->
 <input type="hidden" name="filesApp" id="filesApp" value="1" />
 <input type="hidden" name="usedSpacePercent" id="usedSpacePercent" value="<?php p($_['usedSpacePercent']); ?>" />
+<input type="hidden" name="owner" id="owner" value="<?php p($_['owner']); ?>" />
+<input type="hidden" name="ownerDisplayName" id="ownerDisplayName" value="<?php p($_['ownerDisplayName']); ?>" />
 <?php if (!$_['isPublic']) :?>
 <input type="hidden" name="mailNotificationEnabled" id="mailNotificationEnabled" value="<?php p($_['mailNotificationEnabled']) ?>" />
 <input type="hidden" name="mailPublicNotificationEnabled" id="mailPublicNotificationEnabled" value="<?php p($_['mailPublicNotificationEnabled']) ?>" />

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -1008,7 +1008,21 @@ class OC_Helper {
 			$relative = 0;
 		}
 
-		return array('free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative);
+		$ownerId = $storage->getOwner($path);
+		$ownerDisplayName = '';
+		$owner = \OC::$server->getUserManager()->get($ownerId);
+		if($owner) {
+			$ownerDisplayName = $owner->getDisplayName();
+		}
+
+		return [
+			'free' => $free,
+			'used' => $used,
+			'total' => $total,
+			'relative' => $relative,
+			'owner' => $ownerId,
+			'ownerDisplayName' => $ownerDisplayName,
+		];
 	}
 
 	/**


### PR DESCRIPTION
- getstoragestats.php returns now the owner and it's display name
- show proper storage stats notifications for shared folders
- fixes #16651

@PVince81 I hope this is the way you want to have this solved.

cc @michaelstingl @LukasReschke 
