### PR TITLE
Don't use pcre/pcre8 patterns to validate email addresses 

### DIFF
--- a/lib/private/mail.php
+++ b/lib/private/mail.php
@@ -5,6 +5,7 @@
  * later.
  * See the COPYING-README file.
  */
+use OC\Mailer;
 
 /**
  * OC_Mail
@@ -46,7 +47,7 @@ class OC_Mail {
 		$SMTPSECURE   = OC_Config::getValue( 'mail_smtpsecure', '' );
 
 
-		$mailo = new PHPMailer(true);
+		$mailo = new Mailer(true);
 		if($SMTPMODE=='sendmail') {
 			$mailo->IsSendmail();
 		}elseif($SMTPMODE=='smtp') {
@@ -133,7 +134,7 @@ class OC_Mail {
 			return false;
 		}
 		$emailAddress = self::buildAsciiEmail($emailAddress);
-		return PHPMailer::ValidateAddress($emailAddress);
+		return Mailer::ValidateAddress($emailAddress);
 	}
 
 	/**

--- a/lib/private/mailer.php
+++ b/lib/private/mailer.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC;
+
+use PHPMailer;
+
+class Mailer extends PHPMailer {
+
+	public static function validateAddress($address, $patternSelect = 'php') {
+		return parent::validateAddress($address, $patternSelect);
+	}
+}

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -147,7 +147,7 @@ class Test_Util extends \Test\TestCase {
 
 	function testGetDefaultEmailAddress() {
 		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
-		$this->assertEquals('no-reply@localhost', $email);
+		$this->assertEquals('no-reply@localhost.localdomain', $email);
 	}
 
 	function testGetDefaultEmailAddressFromConfig() {


### PR DESCRIPTION
fixes #16720

@kkretsch please test if this fixes the issue for you - THX
