### PR TITLE
Clear memcache keys after unlock

### DIFF
--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -91,9 +91,10 @@ class MemcacheLockingProvider implements ILockingProvider {
 			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
 				$this->memcache->dec($path);
 				$this->acquiredLocks['shared'][$path]--;
+				$this->memcache->cad($path, 0);
 			}
 		} else if ($type === self::LOCK_EXCLUSIVE) {
-			$this->memcache->cas($path, 'exclusive', 0);
+			$this->memcache->cad($path, 'exclusive');
 			unset($this->acquiredLocks['exclusive'][$path]);
 		}
 	}

--- a/lib/private/memcache/apc.php
+++ b/lib/private/memcache/apc.php
@@ -31,6 +31,8 @@ class APC extends Cache implements IMemcache {
 		cas as casEmulated;
 	}
 
+	use CADTrait;
+
 	public function get($key) {
 		$result = apc_fetch($this->getPrefix() . $key, $success);
 		if (!$success) {

--- a/lib/private/memcache/arraycache.php
+++ b/lib/private/memcache/arraycache.php
@@ -28,6 +28,8 @@ class ArrayCache extends Cache implements IMemcache {
 	/** @var array Array with the cached data */
 	protected $cachedData = array();
 
+	use CADTrait;
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/lib/private/memcache/cadtrait.php
+++ b/lib/private/memcache/cadtrait.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * @author Morris Jobke <hey@morrisjobke.de>
- * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ * @author Robin Appelman <icewind@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -22,48 +21,33 @@
 
 namespace OC\Memcache;
 
-class Null extends Cache implements \OCP\IMemcache {
-	public function get($key) {
-		return null;
-	}
+trait CADTrait {
+	abstract public function get($key);
 
-	public function set($key, $value, $ttl = 0) {
-		return true;
-	}
+	abstract public function remove($key);
 
-	public function hasKey($key) {
-		return false;
-	}
+	abstract public function add($key, $value, $ttl = 0);
 
-	public function remove($key) {
-		return true;
-	}
-
-	public function add($key, $value, $ttl = 0) {
-		return true;
-	}
-
-	public function inc($key, $step = 1) {
-		return true;
-	}
-
-	public function dec($key, $step = 1) {
-		return true;
-	}
-
-	public function cas($key, $old, $new) {
-		return true;
-	}
-
+	/**
+	 * Compare and delete
+	 *
+	 * @param string $key
+	 * @param mixed $old
+	 * @return bool
+	 */
 	public function cad($key, $old) {
-		return true;
-	}
-
-	public function clear($prefix = '') {
-		return true;
-	}
-
-	static public function isAvailable() {
-		return true;
+		//no native cas, emulate with locking
+		if ($this->add($key . '_lock', true)) {
+			if ($this->get($key) === $old) {
+				$this->remove($key);
+				$this->remove($key . '_lock');
+				return true;
+			} else {
+				$this->remove($key . '_lock');
+				return false;
+			}
+		} else {
+			return false;
+		}
 	}
 }

--- a/lib/private/memcache/memcached.php
+++ b/lib/private/memcache/memcached.php
@@ -34,6 +34,8 @@ class Memcached extends Cache implements IMemcache {
 	 */
 	private static $cache = null;
 
+	use CADTrait;
+
 	public function __construct($prefix = '') {
 		parent::__construct($prefix);
 		if (is_null(self::$cache)) {

--- a/lib/private/memcache/xcache.php
+++ b/lib/private/memcache/xcache.php
@@ -34,6 +34,8 @@ use OCP\IMemcache;
 class XCache extends Cache implements IMemcache {
 	use CASTrait;
 
+	use CADTrait;
+
 	/**
 	 * entries in XCache gets namespaced to prevent collisions between ownCloud instances and users
 	 */

--- a/lib/public/imemcache.php
+++ b/lib/public/imemcache.php
@@ -76,4 +76,14 @@ interface IMemcache extends ICache {
 	 * @since 8.1.0
 	 */
 	public function cas($key, $old, $new);
+
+	/**
+	 * Compare and delete
+	 *
+	 * @param string $key
+	 * @param mixed $old
+	 * @return bool
+	 * @since 8.1.0
+	 */
+	public function cad($key, $old);
 }

--- a/tests/lib/memcache/cache.php
+++ b/tests/lib/memcache/cache.php
@@ -103,6 +103,18 @@ abstract class Cache extends \Test_Cache {
 		$this->assertEquals('bar1', $this->instance->get('foo'));
 	}
 
+	public function testCadNotChanged() {
+		$this->instance->set('foo', 'bar');
+		$this->assertTrue($this->instance->cad('foo', 'bar'));
+		$this->assertFalse($this->instance->hasKey('foo'));
+	}
+
+	public function testCadChanged() {
+		$this->instance->set('foo', 'bar1');
+		$this->assertFalse($this->instance->cad('foo', 'bar'));
+		$this->assertTrue($this->instance->hasKey('foo'));
+	}
+
 
 	protected function tearDown() {
 		if ($this->instance) {


### PR DESCRIPTION
This adds compare-and-delete to the memcache backend (emulated for everything but redis atm)

For redis cad and cas are implemented using [eval](http://redis.io/commands/EVAL) which allows running lua scripts atomically on the server.

cc @DeepDiver1975 @PVince81 
