### PR TITLE
Check if the part files has keys when the original file does not

### DIFF
--- a/lib/private/encryption/keys/storage.php
+++ b/lib/private/encryption/keys/storage.php
@@ -72,7 +72,17 @@ class Storage implements IStorage {
 	public function getFileKey($path, $keyId, $encryptionModuleId) {
 		$realFile = $this->util->stripPartialFileExtension($path);
 		$keyDir = $this->getFileKeyDir($encryptionModuleId, $realFile);
-		return $this->getKey($keyDir . $keyId);
+		$key = $this->getKey($keyDir . $keyId);
+
+		if ($key === '' && $realFile !== $path) {
+			// Check if the part file has keys and use them, if no normal keys
+			// exist. This is required to fix copyBetweenStorage() when we
+			// rename a .part file over storage borders.
+			$keyDir = $this->getFileKeyDir($encryptionModuleId, $path);
+			$key = $this->getKey($keyDir . $keyId);
+		}
+
+		return $key;
 	}
 
 	/**


### PR DESCRIPTION
All existing tests pass, and the failing smashbox test passes as well.
However, I'd like to add some unit tests to core which fail without this patch.

Fix #16801 
Fix owncloud/smashbox#105

cc @schiesbn @th3fallen 
