### PR TITLE
Do not use digits in random index names

### DIFF
--- a/lib/private/db/migrator.php
+++ b/lib/private/db/migrator.php
@@ -169,7 +169,7 @@ class Migrator {
 				$indexName = $index->getName();
 			} else {
 				// avoid conflicts in index names
-				$indexName = $this->config->getSystemValue('dbtableprefix', 'oc_') . $this->random->generate(13, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+				$indexName = $this->config->getSystemValue('dbtableprefix', 'oc_') . $this->random->generate(13, ISecureRandom::CHAR_LOWER);
 			}
 			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/16779
`An exception occurred while executing 'CREATE UNIQUE INDEX 8akwc7hk08qq5 ON file_map_1uhwdnl37ygqj`
