### PR TITLE
Fix regression in preview height calculation

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -90,7 +90,7 @@ OCA.Sharing.PublicApp = {
 		var token = $('#sharingToken').val();
 		var bottomMargin = 350;
 		var previewWidth = $(window).width() * window.devicePixelRatio;
-		var previewHeight = $(window).height() - bottomMargin * window.devicePixelRatio;
+		var previewHeight = ($(window).height() - bottomMargin) * window.devicePixelRatio;
 		previewHeight = Math.max(200, previewHeight);
 		var params = {
 			x: previewWidth,


### PR DESCRIPTION
8d3f88c introduced some changes to shared image size.
As far as I can understand there is a math error here:

``` javascript
var previewHeight = $(window).height() - bottomMargin * window.devicePixelRatio
```

Should perhaps be(?):

``` javascript
var previewHeight = ($(window).height() - bottomMargin) * window.devicePixelRatio
```

Without the proposed fix the shared images appear like the following screenshot for certain display configurations (200 height): 
https://o.mrfjo.org/s/sIZTGzsvvloOe5P

Please review; @oparoz (Sorry for the ping if you are not the correct person for this)
