### PR TITLE
Retrieve user home folder before deleting a user

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -72,3 +72,7 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
+#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
+
+ErrorDocument 403 //core/templates/403.php
+ErrorDocument 404 //core/templates/404.php

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -197,6 +197,9 @@ class User implements IUser {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
 		}
+		// homeDir needs to be retrieved before the user is deleted - otherwise it isn't correct and the fallback is used
+		$homeDir = $this->getHome();
+
 		$result = $this->backend->deleteUser($this->uid);
 		if ($result) {
 
@@ -210,7 +213,7 @@ class User implements IUser {
 			\OC::$server->getConfig()->deleteAllUserValues($this->uid);
 
 			// Delete user files in /data/
-			\OC_Helper::rmdirr($this->getHome());
+			\OC_Helper::rmdirr($homeDir);
 
 			// Delete the users entry in the storage table
 			Storage::remove('home::' . $this->uid);


### PR DESCRIPTION
A first try to fix #16588

@blizzz Somehow this doesn't retrieve the correct home folders if a different folder name is used by LDAP. I always get the user home dir with UUID instead of the specified attribute.
- set the home dir naming schema to `cn`
- everything works, but once I delete a user from LDAP, list it via the ldap:show-remnants command and delete the user the wrong folder is choosen - could this e related to the homeFoldersToKill attribute in the ldap backend?
