### PR TITLE
Throw exception if memcache misconfigured or missing

### DIFF
--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -62,11 +62,24 @@ class Factory implements ICacheFactory {
 	{
 		$this->globalPrefix = $globalPrefix;
 
-		if (!($localCacheClass && $localCacheClass::isAvailable())) {
+		if (!$localCacheClass) {
 			$localCacheClass = self::NULL_CACHE;
 		}
-		if (!($distributedCacheClass && $distributedCacheClass::isAvailable())) {
+		if (!$distributedCacheClass) {
 			$distributedCacheClass = $localCacheClass;
+		}
+
+		if (!$localCacheClass::isAvailable()) {
+			throw new \OC\HintException(
+				'Missing memcache class ' . $localCacheClass . ' for local cache',
+				'Is the matching PHP module installed and enabled ?'
+			);
+		}
+		if (!$distributedCacheClass::isAvailable()) {
+			throw new \OC\HintException(
+				'Missing memcache class ' . $distributedCacheClass . ' for distributed cache',
+				'Is the matching PHP module installed and enabled ?'
+			);
 		}
 		if (!($lockingCacheClass && $lockingCacheClass::isAvailable())) {
 			// dont fallback since the fallback might not be suitable for storing lock

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -431,6 +431,10 @@ class Server extends SimpleContainer implements IServerContainer {
 				if (!($memcache instanceof \OC\Memcache\NullCache)) {
 					return new MemcacheLockingProvider($memcache);
 				}
+				throw new HintException(
+					'File locking is enabled but the locking cache class was not found',
+					'Please check the "memcache.locking" setting and make sure the matching PHP module is installed and enabled'
+				);
 			}
 			return new NoopLockingProvider();
 		});


### PR DESCRIPTION
Instead of falling back to null memcache, throw exceptions.
Also throw file locking specific exceptions in case the class is not
available.

Fixes https://github.com/owncloud/core/issues/16696

@DeepDiver1975 @icewind1991 @jnfrmarks 

Note, it is very difficult to control how and where the exception message is displayed because sometimes it happens too early. But at least even with a white page there is something in the log.

So here is the new behavior:
1) If file locking is disabled: no error
2) File locking enabled but missing locking cache class: exception in web UI (full page, app not usable)
3) File locking enabled, locking cache configured, but PHP module missing: white page, exception in web UI (full page, app not usable)
4) All enabled, but redis server not running: app is usable but any file operation will return "500 redis went away".
5) If memcache is configured for "local" and "distributed" but the class is missing: white page, exception in log (because autoloading needs it and cannot work, so there is no way to show a page there)

I hope that is enough. Consequently I removed the "Server status" section in the admin page, as the errors can be inferred through other means.

I didn't want to add an extra redis check for EVERY operation because it means we need to connect to redis even when we don't need to.
