### PR TITLE
Support for print stylesheets

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -15,7 +15,10 @@
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path('', 'favicon-touch.png')); ?>">
 		<link rel="mask-icon" sizes="any" href="<?php print_unescaped(image_path('', 'favicon-mask.svg')); ?>" color="#1d2d44">
 		<?php foreach ($_['cssfiles'] as $cssfile): ?>
-			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="screen">
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>">
+		<?php endforeach; ?>
+		<?php foreach($_['printcssfiles'] as $cssfile): ?>
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
 		<?php foreach ($_['jsfiles'] as $jsfile): ?>
 			<script src="<?php print_unescaped($jsfile); ?>"></script>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -16,7 +16,10 @@
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path('', 'favicon-touch.png')); ?>">
 		<link rel="mask-icon" sizes="any" href="<?php print_unescaped(image_path('', 'favicon-mask.svg')); ?>" color="#1d2d44">
 		<?php foreach($_['cssfiles'] as $cssfile): ?>
-			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="screen">
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>">
+		<?php endforeach; ?>
+		<?php foreach($_['printcssfiles'] as $cssfile): ?>
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
 		<?php foreach($_['jsfiles'] as $jsfile): ?>
 			<script src="<?php print_unescaped($jsfile); ?>"></script>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -27,7 +27,10 @@
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path($_['appid'], 'favicon-touch.png')); ?>">
 		<link rel="mask-icon" sizes="any" href="<?php print_unescaped(image_path($_['appid'], 'favicon-mask.svg')); ?>" color="#1d2d44">
 		<?php foreach($_['cssfiles'] as $cssfile): ?>
-			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="screen">
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>">
+		<?php endforeach; ?>
+		<?php foreach($_['printcssfiles'] as $cssfile): ?>
+			<link rel="stylesheet" href="<?php print_unescaped($cssfile); ?>" media="print">
 		<?php endforeach; ?>
 		<?php foreach($_['jsfiles'] as $jsfile): ?>
 			<script src="<?php print_unescaped($jsfile); ?>"></script>

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -182,7 +182,11 @@ class TemplateLayout extends \OC_Template {
 				$web = $info[1];
 				$file = $info[2];
 
-				$this->append( 'cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
+			if (substr($file, -strlen('print.css')) === 'print.css') {
+					$this->append( 'printcssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
+				} else {
+					$this->append( 'cssfiles', $web.'/'.$file . '?v=' . self::$versionHash);
+				}
 			}
 		}
 	}
@@ -249,10 +253,35 @@ class TemplateLayout extends \OC_Template {
 		}
 
 		$cssFiles = self::findStylesheetFiles(\OC_Util::$styles);
-		$cssHash = self::hashFileNames($cssFiles);
 
-		if (!file_exists("$assetDir/assets/$cssHash.css")) {
-			$cssFiles = array_map(function ($item) {
+		// differentiate between screen stylesheets and printer stylesheets
+		$screenCssFiles = array_filter($cssFiles, function($cssFile) {
+			return substr_compare($cssFile[2], 'print.css', -strlen('print.css')) !== 0;
+		});
+		$screenCssAsset = $this->generateCssAsset($screenCssFiles);
+
+		$printCssFiles = array_filter($cssFiles, function($cssFile) {
+			return substr_compare($cssFile[2], 'print.css', -strlen('print.css')) === 0;
+		});
+		$printCssAsset = $this->generateCssAsset($printCssFiles);
+
+		$this->append('jsfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$jsHash.js"));
+		$this->append('cssfiles', $screenCssAsset);
+		$this->append('printcssfiles', $printCssAsset);
+	}
+
+	/**
+	 * generates a single css asset file from an array of css files if at least one of them has changed
+	 * otherwise it just returns the path to the old asset file
+	 * @param $files
+	 * @return string
+	 */
+	private function generateCssAsset($files) {
+		$assetDir = \OC::$server->getConfig()->getSystemValue('assetdirectory', \OC::$SERVERROOT);
+		$hash = self::hashFileNames($files);
+
+		if (!file_exists("$assetDir/assets/$hash.css")) {
+			$files = array_map(function ($item) {
 				$root = $item[0];
 				$file = $item[2];
 				$assetPath = $root . '/' . $file;
@@ -268,16 +297,17 @@ class TemplateLayout extends \OC_Template {
 					$sourceRoot,
 					$sourcePath
 				);
-			}, $cssFiles);
-			$cssCollection = new AssetCollection($cssFiles);
-			$cssCollection->setTargetPath("assets/$cssHash.css");
+			}, $files);
+
+			$cssCollection = new AssetCollection($files);
+			$cssCollection->setTargetPath("assets/$hash.css");
 
 			$writer = new AssetWriter($assetDir);
 			$writer->writeAsset($cssCollection);
+
 		}
 
-		$this->append('jsfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$jsHash.js"));
-		$this->append('cssfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$cssHash.css"));
+		return \OC::$server->getURLGenerator()->linkTo('assets', "$hash.css");
 	}
 
 	/**


### PR DESCRIPTION
I removed the restriction `media="screen"` for all stylesheets and added the restriction `media="print"` to all stylesheets with the name `print.css`.

Maybe the restriction `media="screen"` could be added to all stylesheets with the name `screen.css` and similar for `projection.css`

This prepares the core for owncloud/tasks#119 and owncloud/mail#717.

Feedback is especially welcome for environments with the AssetPipeline enabled.
