### PR TITLE
fix app menu not showing on mobile, fix #16844

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -21,8 +21,8 @@
 	box-align: center;
 }
 
-/* on mobile, show only the icon of the logo, hide the text */
-#header .header-appname-container {
+/* on mobile public share, show only the icon of the logo, hide the text */
+#body-public #header .header-appname-container {
 	display: none;
 }
 


### PR DESCRIPTION
Fix https://github.com/owncloud/core/issues/16844 – now the app menu should be shown on mobile again. The purpose of this line of code is to only hide the »ownCloud« text on mobile in the header where the space is needed for the buttons.

Please review @owncloud/designers @Raydiation 
