### PR TITLE
Truncate preview resolution

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1173,8 +1173,10 @@
 			if (!urlSpec.y) {
 				urlSpec.y = this.$table.data('preview-y') || 36;
 			}
-			urlSpec.y *= window.devicePixelRatio;
 			urlSpec.x *= window.devicePixelRatio;
+			urlSpec.y *= window.devicePixelRatio;
+			urlSpec.x = Math.floor(urlSpec.x);
+			urlSpec.y = Math.floor(urlSpec.y);
 			urlSpec.forceIcon = 0;
 			return OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
 		},


### PR DESCRIPTION
This prevents having float numbers appear in the URL

@oparoz @georgehrke @MorrisJobke please review

On my laptop I noticed that the preview URL had float values before this fix.
