### PR TITLE
verify path when getting a node for sabredav

### DIFF
--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -105,6 +105,10 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		}
 
 		$path = trim($path, '/');
+		if ($path) {
+			$this->fileView->verifyPath($path, basename($path));
+		}
+
 		if (isset($this->cache[$path])) {
 			return $this->cache[$path];
 		}


### PR DESCRIPTION
This time with unit tests and tested manually.

Fix #16825 

cc @DeepDiver1975 @PVince81 
