### PR TITLE
Rethrow LockedException with full path

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1659,6 +1659,8 @@ class View {
 	}
 
 	/**
+	 * Lock the given path
+	 *
 	 * @param string $path the path of the file to lock, relative to the view
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @return bool False if the path is excluded from locking, true otherwise
@@ -1672,11 +1674,19 @@ class View {
 
 		$mount = $this->getMount($path);
 		if ($mount) {
-			$mount->getStorage()->acquireLock(
-				$mount->getInternalPath($absolutePath),
-				$type,
-				$this->lockingProvider
-			);
+			try {
+				$mount->getStorage()->acquireLock(
+					$mount->getInternalPath($absolutePath),
+					$type,
+					$this->lockingProvider
+				);
+			} catch (\OCP\Lock\LockedException $e) {
+				// rethrow with the a human-readable path
+				throw new \OCP\Lock\LockedException(
+					$this->getPathRelativeToFiles($absolutePath),
+					$e
+				);
+			}
 		}
 
 		return true;
@@ -1698,17 +1708,27 @@ class View {
 
 		$mount = $this->getMount($path);
 		if ($mount) {
-			$mount->getStorage()->changeLock(
-				$mount->getInternalPath($absolutePath),
-				$type,
-				$this->lockingProvider
-			);
+			try {
+				$mount->getStorage()->changeLock(
+					$mount->getInternalPath($absolutePath),
+					$type,
+					$this->lockingProvider
+				);
+			} catch (\OCP\Lock\LockedException $e) {
+				// rethrow with the a human-readable path
+				throw new \OCP\Lock\LockedException(
+					$this->getPathRelativeToFiles($absolutePath),
+					$e
+				);
+			}
 		}
 
 		return true;
 	}
 
 	/**
+	 * Unlock the given path
+	 *
 	 * @param string $path the path of the file to unlock, relative to the view
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @return bool False if the path is excluded from locking, true otherwise
@@ -1797,5 +1817,30 @@ class View {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Shortens the given absolute path to be relative to
+	 * "$user/files".
+	 *
+	 * @param string $absolutePath absolute path which is under "files"
+	 *
+	 * @return string path relative to "files" with trimmed slashes or null
+	 * if the path was NOT relative to files
+	 *
+	 * @throws \InvalidArgumentException if the given path was not under "files"
+	 * @since 8.1.0
+	 */
+	public function getPathRelativeToFiles($absolutePath) {
+		$path = Filesystem::normalizePath($absolutePath);
+		$parts = explode('/', trim($path, '/'), 3);
+		// "$user", "files", "path/to/dir"
+		if (!isset($parts[1]) || $parts[1] !== 'files') {
+			throw new \InvalidArgumentException('$absolutePath must be relative to "files"');
+		}
+		if (isset($parts[2])) {
+			return $parts[2];
+		}
+		return '';
 	}
 }

--- a/lib/public/lock/lockedexception.php
+++ b/lib/public/lock/lockedexception.php
@@ -28,7 +28,10 @@ namespace OCP\Lock;
  * @since 8.1.0
  */
 class LockedException extends \Exception {
+
 	/**
+	 * Locked path
+	 *
 	 * @var string
 	 */
 	private $path;
@@ -36,11 +39,13 @@ class LockedException extends \Exception {
 	/**
 	 * LockedException constructor.
 	 *
-	 * @param string $path
+	 * @param string $path locked path
+	 * @param \Exception $previous previous exception for cascading
+	 *
 	 * @since 8.1.0
 	 */
-	public function __construct($path) {
-		parent::__construct($path . ' is locked');
+	public function __construct($path, \Exception $previous = null) {
+		parent::__construct('"' . $path . '" is locked', 0, $previous);
 		$this->path = $path;
 	}
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1169,4 +1169,43 @@ class View extends \Test\TestCase {
 			['', '/testuser/{folder}'],
 		];
 	}
+
+	public function pathRelativeToFilesProvider() {
+		return [
+			['admin/files', ''],
+			['admin/files/x', 'x'],
+			['/admin/files', ''],
+			['/admin/files/sub', 'sub'],
+			['/admin/files/sub/', 'sub'],
+			['/admin/files/sub/sub2', 'sub/sub2'],
+			['//admin//files/sub//sub2', 'sub/sub2'],
+		];
+	}
+
+	/**
+	 * @dataProvider pathRelativeToFilesProvider
+	 */
+	public function testGetPathRelativeToFiles($path, $expectedPath) {
+		$view = new \OC\Files\View();
+		$this->assertEquals($expectedPath, $view->getPathRelativeToFiles($path));
+	}
+
+	public function pathRelativeToFilesProviderExceptionCases() {
+		return [
+			[''],
+			['x'],
+			['files'],
+			['/files'],
+			['/admin/files_versions/abc'],
+		];
+	}
+
+	/**
+	 * @dataProvider pathRelativeToFilesProviderExceptionCases
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testGetPathRelativeToFilesWithInvalidArgument($path) {
+		$view = new \OC\Files\View();
+		$view->getPathRelativeToFiles($path);
+	}
 }


### PR DESCRIPTION
Because the path is converted to md5 from the original exception,
rethrow the exception with the correct full path

FYI @icewind1991 @SergioBertolinSG 
- ~~currently returned paths are full paths from the root, for example it says "admin/files/somefile.txt" is locked but it should say "somefile.txt" is locked in the UI. Need to catch the exceptions again higher and strip the path~~
