### PR TITLE
Fix childs of slideToggle not sliding the target

### DIFF
--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -12,7 +12,7 @@
 	<div id="app-settings">
 		<div id="app-settings-header">
 			<button class="settings-button" data-apps-slide-toggle="#app-settings-content">
-				<span><?php p($l->t('Settings'));?></span>
+				<?php p($l->t('Settings'));?>
 			</button>
 		</div>
 		<div id="app-settings-content">

--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -58,7 +58,7 @@
 				if (!area.is(':animated')) {
 
 					// button toggles the area
-					if (button === event.target) {
+					if (button === event.target.closest('[data-apps-slide-toggle]')) {
 						if (area.is(':visible')) {
 							hideArea();
 						} else {


### PR DESCRIPTION
If the slideToggle, which is used for the settings in the navigation sidebar, contains a child element, this child element doesn't trigger the show or hide animation.
This problem occurs on the current master of the files and tasks app.

**Example**:

```
<button data-apps-slide-toggle=".slide-area"><span>Click me</span></button>
<div class=".slide-area" class="hidden">Slide Area</div>
```

If you click on "Click me" the _Slide Area_ isn't shown, whereas a click somewhere else within the button shows the _Slide Area_.
