### PR TITLE
Webdav PUT small file lock must be shared during hooks

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1683,12 +1683,14 @@ class View {
 	}
 
 	/**
+	 * Change the lock type
+	 *
 	 * @param string $path the path of the file to lock, relative to the view
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @return bool False if the path is excluded from locking, true otherwise
 	 * @throws \OCP\Lock\LockedException if the path is already locked
 	 */
-	private function changeLock($path, $type) {
+	public function changeLock($path, $type) {
 		$absolutePath = $this->getAbsolutePath($path);
 		if (!$this->shouldLockFile($absolutePath)) {
 			return false;


### PR DESCRIPTION
Fixed code path for Webdav PUT of small files to use shared locks during
hook execution, and exclusive during the file operation

This makes it possible for versions to be copied by accessing the file
in a post_write hook.

Fixes https://github.com/owncloud/core/issues/16900

Please review @icewind1991 @DeepDiver1975 @nickvergessen 
Note that I had to change the hook type from exclusive back to shared to run the post hooks.

Locking during post hooks will also be done for other code paths here: https://github.com/owncloud/core/issues/16829#issuecomment-111502029

I added a unit test. Ideally I'd have wanted to also check the locks during the file operation, but that would require extraordinary gymnastics, so I left it for now. Still, the current test would fail without the fix applied.
