### PR TITLE
add recursive copy polyfill for storage backends

### DIFF
--- a/lib/private/files/storage/polyfill/copydirectory.php
+++ b/lib/private/files/storage/polyfill/copydirectory.php
@@ -9,16 +9,44 @@
 namespace OC\Files\Storage\PolyFill;
 
 trait CopyDirectory {
+	/**
+	 * Check if a path is a directory
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
 	abstract public function is_dir($path);
 
+	/**
+	 * Check if a file or folder exists
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
 	abstract public function file_exists($path);
 
-	abstract public function buildPath($path);
-
+	/**
+	 * Delete a file or folder
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
 	abstract public function unlink($path);
 
+	/**
+	 * Open a directory handle for a folder
+	 *
+	 * @param string $path
+	 * @return resource | bool
+	 */
 	abstract public function opendir($path);
 
+	/**
+	 * Create a new folder
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
 	abstract public function mkdir($path);
 
 	public function copy($source, $target) {

--- a/lib/private/files/storage/polyfill/copydirectory.php
+++ b/lib/private/files/storage/polyfill/copydirectory.php
@@ -54,7 +54,7 @@ trait CopyDirectory {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
 			}
-			parent::copy($source, $target);
+			$this->mkdir($target);
 			return $this->copyRecursive($source, $target);
 		} else {
 			return parent::copy($source, $target);

--- a/lib/private/files/storage/polyfill/copydirectory.php
+++ b/lib/private/files/storage/polyfill/copydirectory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace OC\Files\Storage\PolyFill;
+
+trait CopyDirectory {
+	abstract public function is_dir($path);
+
+	abstract public function file_exists($path);
+
+	abstract public function buildPath($path);
+
+	abstract public function unlink($path);
+
+	abstract public function opendir($path);
+
+	abstract public function mkdir($path);
+
+	public function copy($source, $target) {
+		if ($this->is_dir($source)) {
+			if ($this->file_exists($target)) {
+				$this->unlink($target);
+			}
+			parent::copy($source, $target);
+			return $this->copyRecursive($source, $target);
+		} else {
+			return parent::copy($source, $target);
+		}
+	}
+
+	/**
+	 * For adapters that dont support copying folders natively
+	 *
+	 * @param $source
+	 * @param $target
+	 * @return bool
+	 */
+	protected function copyRecursive($source, $target) {
+		$dh = $this->opendir($source);
+		$result = true;
+		while ($file = readdir($dh)) {
+			if ($file !== '.' and $file !== '..') {
+				if ($this->is_dir($source . '/' . $file)) {
+					$this->mkdir($target . '/' . $file);
+					$result = $this->copyRecursive($source . '/' . $file, $target . '/' . $file);
+				} else {
+					$result = parent::copy($source . '/' . $file, $target . '/' . $file);
+				}
+				if (!$result) {
+					break;
+				}
+			}
+		}
+		return $result;
+	}
+}

--- a/tests/lib/files/storage/copydirectory.php
+++ b/tests/lib/files/storage/copydirectory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage;
+
+use OC\Files\Storage\Temporary;
+
+class StorageNoRecursiveCopy extends Temporary {
+	public function copy($path1, $path2) {
+		if ($this->is_dir($path1)) {
+			return false;
+		}
+		return copy($this->getSourcePath($path1), $this->getSourcePath($path2));
+	}
+}
+
+class CopyDirectoryStorage extends StorageNoRecursiveCopy {
+	use \OC\Files\Storage\PolyFill\CopyDirectory;
+}
+
+class CopyDirectory extends Storage {
+
+	protected function setUp() {
+		parent::setUp();
+		$this->instance = new CopyDirectoryStorage([]);
+	}
+}
+


### PR DESCRIPTION
Generic polyfill for recursive copy for storage backends.

Needed to make https://github.com/icewind1991/owncloud_azure work correctly but I figured it would be usefull to have in core for other backends (I know at least the future flysystem ftp backend will need it)

cc @DeepDiver1975 @PVince81 
