### PR TITLE
[AppFramework] DI add userFolder to alias to getUserFolder

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -220,6 +220,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getUserSession();
 		});
 
+		$this->registerService('userFolder', function($c) {
+			return $this->getServer()->getUserFolder();
+		});
+
 		$this->registerService('ServerContainer', function ($c) {
 			return $this->getServer();
 		});


### PR DESCRIPTION
- enables auto loading of user folder

With this you can inject the user folder via `$userFolder` in the constructor of a class. See #12830

cc @DeepDiver1975 @LukasReschke @Raydiation 
