### PR TITLE
Skip directory entry in S3 opendir

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -274,6 +274,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			), array('return_prefixes' => true));
 
 			foreach ($result as $object) {
+				if (isset($object['Key']) && $object['Key'] === $path) {
+					// it's the directory itself, skip
+					continue;
+				}
 				$file = basename(
 					isset($object['Key']) ? $object['Key'] : $object['Prefix']
 				);


### PR DESCRIPTION
The result set contains the directory itself, so skip it to avoid
scanning a non-existing directory

Fixes https://github.com/owncloud/core/issues/16937

@icewind1991 @butonic @DeepDiver1975 @MorrisJobke 
