### PR TITLE
Acquire read lock when getting file or directory info

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -30,6 +30,7 @@ namespace OC\Connector\Sabre;
 use OC\Connector\Sabre\Exception\InvalidPath;
 use OC\Connector\Sabre\Exception\FileLocked;
 use OCP\Lock\LockedException;
+use Sabre\DAV\Exception\Locked;
 
 class Directory extends \OC\Connector\Sabre\Node
 	implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuota {
@@ -191,7 +192,11 @@ class Directory extends \OC\Connector\Sabre\Node
 		if (!is_null($this->dirContent)) {
 			return $this->dirContent;
 		}
-		$folderContent = $this->fileView->getDirectoryContent($this->path);
+		try {
+			$folderContent = $this->fileView->getDirectoryContent($this->path);
+		} catch (LockedException $e) {
+			throw new Locked();
+		}
 
 		$nodes = array();
 		foreach ($folderContent as $info) {

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -150,6 +150,8 @@ class ObjectTree extends \Sabre\DAV\Tree {
 				throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage not available');
 			} catch (StorageInvalidException $e) {
 				throw new \Sabre\DAV\Exception\NotFound('Storage ' . $path . ' is invalid');
+			} catch (LockedException $e) {
+				throw new \Sabre\DAV\Exception\Locked();
 			}
 		}
 

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1166,6 +1166,7 @@ class View {
 				// if the file is not in the cache or needs to be updated, trigger the scanner and reload the data
 				if (!$data) {
 					if (!$storage->file_exists($internalPath)) {
+						$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);
 						return false;
 					}
 					$scanner = $storage->getScanner($internalPath);
@@ -1251,6 +1252,7 @@ class View {
 				$watcher = $storage->getWatcher($internalPath);
 				if (!$data or $data['size'] === -1) {
 					if (!$storage->file_exists($internalPath)) {
+						$this->unlockFile($directory, ILockingProvider::LOCK_SHARED);
 						return array();
 					}
 					$scanner = $storage->getScanner($internalPath);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1826,8 +1826,6 @@ class View {
 	 * @return bool False if the path is excluded from locking, true otherwise
 	 */
 	public function unlockFile($path, $type) {
-		$path = '/' . trim($path, '/');
-
 		$absolutePath = $this->getAbsolutePath($path);
 		$absolutePath = Filesystem::normalizePath($absolutePath);
 		if (!$this->shouldLockFile($absolutePath)) {


### PR DESCRIPTION
Prevents cache data being changed while a file is being written or a folder is being renamed.

For #13391

cc @DeepDiver1975 @PVince81 
