### PR TITLE
add occ tool to delete versions

### DIFF
--- a/apps/files_versions/appinfo/register_command.php
+++ b/apps/files_versions/appinfo/register_command.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+use OCA\Files_Versions\Command\CleanUp;
+
+$userManager = OC::$server->getUserManager();
+$rootFolder = \OC::$server->getRootFolder();
+/** @var Symfony\Component\Console\Application $application */
+$application->add(new CleanUp($rootFolder, $userManager));

--- a/apps/files_versions/command/cleanup.php
+++ b/apps/files_versions/command/cleanup.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Versions\Command;
+
+
+use OCP\Files\IRootFolder;
+use OCP\IUserBackend;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanUp extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IRootFolder */
+	protected $rootFolder;
+
+	/**
+	 * @param IRootFolder $rootFolder
+	 * @param IUserManager $userManager
+	 */
+	function __construct(IRootFolder $rootFolder, IUserManager $userManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+		$this->rootFolder = $rootFolder;
+	}
+
+	protected function configure() {
+		$this
+			->setName('versions:cleanup')
+			->setDescription('Delete versions')
+			->addArgument(
+				'user_id',
+				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				'delete versions of the given user(s), if no user is given all versions will be deleted'
+			);
+	}
+
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$users = $input->getArgument('user_id');
+		if (!empty($users)) {
+			foreach ($users as $user) {
+				if ($this->userManager->userExists($user)) {
+					$output->writeln("Delete versions of   <info>$user</info>");
+					$this->deleteVersions($user);
+				} else {
+					$output->writeln("<error>Unknown user $user</error>");
+				}
+			}
+		} else {
+			$output->writeln('Delete all versions');
+			foreach ($this->userManager->getBackends() as $backend) {
+				$name = get_class($backend);
+
+				if ($backend instanceof IUserBackend) {
+					$name = $backend->getBackendName();
+				}
+
+				$output->writeln("Delete versions for users on backend <info>$name</info>");
+
+				$limit = 500;
+				$offset = 0;
+				do {
+					$users = $backend->getUsers('', $limit, $offset);
+					foreach ($users as $user) {
+						$output->writeln("   <info>$user</info>");
+						$this->deleteVersions($user);
+					}
+					$offset += $limit;
+				} while (count($users) >= $limit);
+			}
+		}
+	}
+
+
+	/**
+	 * delete versions for the given user
+	 *
+	 * @param string $user
+	 */
+	protected function deleteVersions($user) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($user);
+		if ($this->rootFolder->nodeExists('/' . $user . '/files_versions')) {
+			$this->rootFolder->get('/' . $user . '/files_versions')->delete();
+		}
+	}
+
+}

--- a/apps/files_versions/tests/command/cleanuptest.php
+++ b/apps/files_versions/tests/command/cleanuptest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Files_Versions\Tests\Command;
+
+
+use OCA\Files_Versions\Command\CleanUp;
+use Test\TestCase;
+use OC\User\Manager;
+use OCP\Files\IRootFolder;
+
+class CleanupTest extends TestCase {
+
+	/** @var  CleanUp */
+	protected $cleanup;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | Manager */
+	protected $userManager;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IRootFolder */
+	protected $rootFolder;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')
+			->disableOriginalConstructor()->getMock();
+		$this->userManager = $this->getMockBuilder('OC\User\Manager')
+			->disableOriginalConstructor()->getMock();
+
+
+		$this->cleanup = new CleanUp($this->rootFolder, $this->userManager);
+	}
+
+	/**
+	 * @dataProvider dataTestDeleteVersions
+	 * @param boolean $nodeExists
+	 */
+	public function testDeleteVersions($nodeExists) {
+
+		$this->rootFolder->expects($this->once())
+			->method('nodeExists')
+			->with('/testUser/files_versions')
+			->willReturn($nodeExists);
+
+
+		if($nodeExists) {
+			$this->rootFolder->expects($this->once())
+				->method('get')
+				->with('/testUser/files_versions')
+				->willReturn($this->rootFolder);
+			$this->rootFolder->expects($this->once())
+				->method('delete');
+		} else {
+			$this->rootFolder->expects($this->never())
+				->method('get');
+			$this->rootFolder->expects($this->never())
+				->method('delete');
+		}
+
+		$this->invokePrivate($this->cleanup, 'deleteVersions', ['testUser']);
+	}
+
+	public function dataTestDeleteVersions() {
+		return array(
+			array(true),
+			array(false)
+		);
+	}
+
+
+	/**
+	 * test delete versions from users given as parameter
+	 */
+	public function testExecuteDeleteListOfUsers() {
+		$userIds = ['user1', 'user2', 'user3'];
+
+		$instance = $this->getMockBuilder('OCA\Files_Versions\Command\CleanUp')
+			->setMethods(['deleteVersions'])
+			->setConstructorArgs([$this->rootFolder, $this->userManager])
+			->getMock();
+		$instance->expects($this->exactly(count($userIds)))
+			->method('deleteVersions')
+			->willReturnCallback(function ($user) use ($userIds) {
+				$this->assertTrue(in_array($user, $userIds));
+			});
+
+		$this->userManager->expects($this->exactly(count($userIds)))
+			->method('userExists')->willReturn(true);
+
+		$inputInterface = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+			->disableOriginalConstructor()->getMock();
+		$inputInterface->expects($this->once())->method('getArgument')
+			->with('user_id')
+			->willReturn($userIds);
+
+		$outputInterface = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+			->disableOriginalConstructor()->getMock();
+
+		$this->invokePrivate($instance, 'execute', [$inputInterface, $outputInterface]);
+	}
+
+	/**
+	 * test delete versions of all users
+	 */
+	public function testExecuteAllUsers() {
+		$userIds = [];
+		$backendUsers = ['user1', 'user2'];
+
+		$instance = $this->getMockBuilder('OCA\Files_Versions\Command\CleanUp')
+			->setMethods(['deleteVersions'])
+			->setConstructorArgs([$this->rootFolder, $this->userManager])
+			->getMock();
+
+		$backend = $this->getMockBuilder('OC_User_Interface')
+			->disableOriginalConstructor()->getMock();
+		$backend->expects($this->once())->method('getUsers')
+			->with('', 500, 0)
+			->willReturn($backendUsers);
+
+		$instance->expects($this->exactly(count($backendUsers)))
+			->method('deleteVersions')
+			->willReturnCallback(function ($user) use ($backendUsers) {
+				$this->assertTrue(in_array($user, $backendUsers));
+			});
+
+		$inputInterface = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+			->disableOriginalConstructor()->getMock();
+		$inputInterface->expects($this->once())->method('getArgument')
+			->with('user_id')
+			->willReturn($userIds);
+
+		$outputInterface = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+			->disableOriginalConstructor()->getMock();
+
+		$this->userManager->expects($this->once())
+				->method('getBackends')
+				->willReturn([$backend]);
+
+		$this->invokePrivate($instance, 'execute', [$inputInterface, $outputInterface]);
+	}
+
+}


### PR DESCRIPTION
occ tool to delete versions.

```
$ ./occ help versions:cleanup
Usage:
 versions:cleanup [user_id1] ... [user_idN]

Arguments:
 user_id               delete versions of the given user(s), if no user is given all versions will be deleted
```

part of https://github.com/owncloud/core/issues/9652
