### PR TITLE
Let buttons hide the sidebar

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1231,7 +1231,7 @@ function initCore() {
 		});
 		// close sidebar when switching navigation entry
 		var $appNavigation = $('#app-navigation');
-		$appNavigation.delegate('a', 'click', function(event) {
+		$appNavigation.delegate('a, :button', 'click', function(event) {
 			var $target = $(event.target);
 			// don't hide navigation when changing settings or adding things
 			if($target.is('.app-navigation-noclose') ||


### PR DESCRIPTION
Currently a click on a link inside the sidebar hides the sidebar on mobile/smaller screens. This should also happen if a button is clicked.

This addition is needed for the mail app. The mail app displays a "new message" button in the sidebar, which, when clicked, should close the sidebar.
![image](https://cloud.githubusercontent.com/assets/1267827/8190177/62d037c0-1461-11e5-9c8a-65b92f4da934.png)

Further info about this issue can be found at owncloud/mail#600
cc @jancborchardt @colmoneill
