### PR TITLE
remove mssql from supported dbs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -100,7 +100,6 @@ $CONFIG = array(
  * 	- mysql (MySQL/MariaDB)
  * 	- pgsql (PostgreSQL)
  * 	- oci (Oracle - Enterprise Edition Only)
- * 	- mssql (Microsoft SQL Server - Enterprise Edition Only)
  */
 'dbtype' => 'sqlite',
 


### PR DESCRIPTION
A simple fix, removing mssql from supported db list

@jnfrmarks 
