### PR TITLE
Fix OCP PHPDoc

### DIFF
--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -315,11 +315,11 @@ interface IServerContainer {
 	/**
 	 * Get the certificate manager for the user
 	 *
-	 * @param \OCP\IUser $user (optional) if not specified the current loggedin user is used
+	 * @param string $userId (optional) if not specified the current loggedin user is used
 	 * @return \OCP\ICertificateManager
 	 * @since 8.0.0
 	 */
-	public function getCertificateManager($user = null);
+	public function getCertificateManager($userId = null);
 
 	/**
 	 * Create a new event source


### PR DESCRIPTION
- was always a string instead of \OCP\IUser

Compare: https://github.com/owncloud/core/blob/3898b8c9b89609a199b87d4d3ce1c7fe95026c1c/lib/public/iservercontainer.php#L318 <-> https://github.com/owncloud/core/blob/3898b8c9b89609a199b87d4d3ce1c7fe95026c1c/lib/private/server.php#L788

cc @DeepDiver1975 @LukasReschke 

@karlitschek Should also be backported to stable8
