### PR TITLE
[stable8] Verify if path exists

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -46,6 +46,11 @@ $view = new \OC\Files\View('/' . $userId . '/files');
 
 $pathId = $linkedItem['file_source'];
 $path = $view->getPath($pathId);
+
+if($path === null) {
+	throw new \OCP\Files\NotFoundException();
+}
+
 $pathInfo = $view->getFileInfo($path);
 $sharedFile = null;
 

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -48,7 +48,9 @@ $pathId = $linkedItem['file_source'];
 $path = $view->getPath($pathId);
 
 if($path === null) {
-	throw new \OCP\Files\NotFoundException();
+	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
+	\OC_Log::write('core-preview', 'Could not resolve file for shared item', OC_Log::WARN);
+	exit;
 }
 
 $pathInfo = $view->getFileInfo($path);


### PR DESCRIPTION
We need to verify if the specified path exists to gracefully prevent errors. To test this please ensure that in all legitim cases the public preview (i.e. the one you see when you have public shared folders / files) does still work.
