### PR TITLE
only try to determine unencrypted size if a encrypted file is read

### DIFF
--- a/apps/files_encryption/lib/proxy.php
+++ b/apps/files_encryption/lib/proxy.php
@@ -299,7 +299,10 @@ class Proxy extends \OC_FileProxy {
 	public function postGetFileInfo($path, $data) {
 
 		// if path is a folder do nothing
-		if (\OCP\App::isEnabled('files_encryption') && $data !== false && array_key_exists('size', $data)) {
+		if (\OCP\App::isEnabled('files_encryption') &&
+			$data !== false &&
+			array_key_exists('size', $data) &&
+			$this->shouldEncrypt($path)) {
 
 			// Disable encryption proxy to prevent recursive calls
 			$proxyStatus = \OC_FileProxy::$enabled;
@@ -330,7 +333,8 @@ class Proxy extends \OC_FileProxy {
 		// if encryption is no longer enabled or if the files aren't migrated yet
 		// we return the default file size
 		if(!\OCP\App::isEnabled('files_encryption') ||
-				$util->getMigrationStatus() !== Util::MIGRATION_COMPLETED) {
+				$util->getMigrationStatus() !== Util::MIGRATION_COMPLETED ||
+				!$this->shouldEncrypt($path)) {
 			return $size;
 		}
 


### PR DESCRIPTION
steps to test:
- install ownCloud 8.0 and the news app
- enable encryption
- run cron.php
  -> without this patch you will see "Error while running background job: Could not determine user" in your owncloud.log
  -> with this patch the error message should be gone

fix #15664 

Tested: master (upcoming oC 8.1) is not affected
