### PR TITLE
split username and server address on the right position

### DIFF
--- a/lib/private/share/exceptions/invalidfederatedcloudidexception.php
+++ b/lib/private/share/exceptions/invalidfederatedcloudidexception.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\Share\Exceptions;
+
+
+use OC\HintException;
+
+class InvalidFederatedCloudIdException extends HintException {
+
+}

--- a/lib/private/share/helper.php
+++ b/lib/private/share/helper.php
@@ -27,6 +27,8 @@
 
 namespace OC\Share;
 
+use OC\Share\Exceptions\InvalidFederatedCloudIdException;
+
 class Helper extends \OC\Share\Constants {
 
 	/**
@@ -243,5 +245,25 @@ class Helper extends \OC\Share\Constants {
 		}
 
 		return rtrim($shareWith, '/');
+	}
+
+	/**
+	 * split user and remote from federated cloud id
+	 *
+	 * @param string $id
+	 * @return array
+	 * @throws InvalidFederatedCloudIdException
+	 */
+	public static function splitUserRemote($id) {
+		$pos = strrpos($id, '@');
+		if ($pos !== false) {
+			$user = substr($id, 0, $pos);
+			$remote = substr($id, $pos + 1);
+			if (!empty($user) && !empty($remote)) {
+				return array($user, $remote);
+			}
+		}
+
+		throw new InvalidFederatedCloudIdException('invalid Federated Cloud ID');
 	}
 }

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2427,7 +2427,7 @@ class Share extends Constants {
 	 */
 	private static function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner) {
 
-		list($user, $remote) = explode('@', $shareWith, 2);
+		list($user, $remote) = Helper::splitUserRemote($shareWith);
 
 		if ($user && $remote) {
 			$url = rtrim($remote, '/') . self::BASE_PATH_TO_SHARE_API . '?format=' . self::RESPONSE_FORMAT;

--- a/tests/lib/share/helper.php
+++ b/tests/lib/share/helper.php
@@ -100,4 +100,43 @@ class Test_Share_Helper extends \Test\TestCase {
 	public function testFixRemoteURLInShareWith($remote, $expected) {
 		$this->assertSame($expected, \OC\Share\Helper::fixRemoteURLInShareWith($remote));
 	}
+
+	/**
+	 * @dataProvider dataTestSplitUserRemoteSuccess
+	 *
+	 * @param string $id
+	 * @param string $expectedUser
+	 * @param string $expectedRemote
+	 */
+	public function testSplitUserRemoteSuccess($id, $expectedUser, $expectedRemote) {
+		list($user, $remote) = \OC\Share\Helper::splitUserRemote($id);
+		$this->assertSame($expectedUser, $user);
+		$this->assertSame($expectedRemote, $remote);
+	}
+
+	public function dataTestSplitUserRemoteSuccess() {
+		return array(
+			array('user@server', 'user', 'server'),
+			array('user@name@server', 'user@name', 'server')
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestSplitUserRemoteError
+	 *
+	 * @param string $id
+	 * @expectedException \OC\Share\Exceptions\InvalidFederatedCloudIdException
+	 */
+	public function testSplitUserRemoteError($id) {
+		\OC\Share\Helper::splitUserRemote($id);
+	}
+
+	public function dataTestSplitUserRemoteError() {
+		return array(
+			array('user@'),
+			array('@server'),
+			array('user'),
+			array(''),
+		);
+	}
 }


### PR DESCRIPTION
make sure that we split user name and server address at the first '@'  from the right to allow usernames containing '@', e.g `user@something@owncloudserver.org`

cc @jnfrmarks maybe this is something we should add to the test plan
cc @nickvergessen maybe also something for a smashbox test?
