### PR TITLE
Lock file during download

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -43,6 +43,7 @@
 // TODO: get rid of this using proper composer packages
 require_once 'mcnetic/phpzipstreamer/ZipStreamer.php';
 
+use OC\Lock\NoopLockingProvider;
 use OCP\Lock\ILockingProvider;
 
 /**
@@ -86,10 +87,13 @@ class OC_Files {
 	public static function get($dir, $files, $only_header = false) {
 		$view = \OC\Files\Filesystem::getView();
 		$xsendfile = false;
-		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) ||
-			isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
-			isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])) {
-			$xsendfile = true;
+		if (\OC::$server->getLockingProvider() instanceof NoopLockingProvider) {
+			if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) ||
+				isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
+				isset($_SERVER['MOD_X_ACCEL_REDIRECT_ENABLED'])
+			) {
+				$xsendfile = true;
+			}
 		}
 
 		if (is_array($files) && count($files) === 1) {

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -43,6 +43,8 @@
 // TODO: get rid of this using proper composer packages
 require_once 'mcnetic/phpzipstreamer/ZipStreamer.php';
 
+use OCP\Lock\ILockingProvider;
+
 /**
  * Class for file server access
  *
@@ -82,6 +84,7 @@ class OC_Files {
 	 * @param boolean $only_header ; boolean to only send header of the request
 	 */
 	public static function get($dir, $files, $only_header = false) {
+		$view = \OC\Files\Filesystem::getView();
 		$xsendfile = false;
 		if (isset($_SERVER['MOD_X_SENDFILE_ENABLED']) ||
 			isset($_SERVER['MOD_X_SENDFILE2_ENABLED']) ||
@@ -131,7 +134,9 @@ class OC_Files {
 		OC_Util::obEnd();
 
 		try {
-
+			if ($get_type === self::FILE) {
+				$view->lockFile($filename, ILockingProvider::LOCK_SHARED);
+			}
 			if ($zip or \OC\Files\Filesystem::isReadable($filename)) {
 				self::sendHeaders($filename, $name, $zip);
 			} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
@@ -168,7 +173,6 @@ class OC_Files {
 				set_time_limit($executionTime);
 			} else {
 				if ($xsendfile) {
-					$view = \OC\Files\Filesystem::getView();
 					/** @var $storage \OC\Files\Storage\Storage */
 					list($storage) = $view->resolvePath($filename);
 					if ($storage->isLocal()) {
@@ -180,6 +184,13 @@ class OC_Files {
 					\OC\Files\Filesystem::readfile($filename);
 				}
 			}
+			if ($get_type === self::FILE) {
+				$view->unlockFile($filename, ILockingProvider::LOCK_SHARED);
+			}
+		} catch (\OCP\Lock\LockedException $ex) {
+			$l = \OC::$server->getL10N('core');
+			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
+			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint);
 		} catch (\Exception $ex) {
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';


### PR DESCRIPTION
Put a shared lock on a file before download it, and free it at the end of the transfer.

My worries here:
1) Shared lock during download will prevent other users to update/overwrite that file in the time being. Ideal would be able to deliver an older copy of the file
2) What happens if the download takes too long and PHP times out, will the lock stay forever ?

@DeepDiver1975 @icewind1991 what do you think ?

A similar approach will be needed for zip files, see https://github.com/owncloud/core/issues/16960#issuecomment-112482247
