### PR TITLE
Workaround for empty dir deletion for SFTP

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -251,7 +251,11 @@ class SFTP extends \OC\Files\Storage\Common {
 	 */
 	public function rmdir($path) {
 		try {
-			return $this->getConnection()->delete($this->absPath($path), true);
+			$result = $this->getConnection()->delete($this->absPath($path), true);
+			// workaround: stray stat cache entry when deleting empty folders
+			// see https://github.com/phpseclib/phpseclib/issues/706
+			$this->getConnection()->clearStatCache();
+			return $result;
 		} catch (\Exception $e) {
 			return false;
 		}

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -380,6 +380,13 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertFalse($this->instance->file_exists('folder'));
 	}
 
+	public function testRmdirEmptyFolder() {
+		$this->assertTrue($this->instance->mkdir('empty'));
+		$this->wait();
+		$this->assertTrue($this->instance->rmdir('empty'));
+		$this->assertFalse($this->instance->file_exists('empty'));
+	}
+
 	public function testRecursiveUnlink() {
 		$this->instance->mkdir('folder');
 		$this->instance->mkdir('folder/bar');


### PR DESCRIPTION
Explicitly clear the stat cache after deleting an empty folder to make
sure it is properly detected as deleted in subsequent requests.

This works around a problem with phpseclib where the folder is properly
deleted remotely but the stat cache was not updated.

Fixes https://github.com/owncloud/core/issues/17019
phpseclib bug raised here https://github.com/phpseclib/phpseclib/issues/706

Please review @nickvergessen @icewind1991 @LukasReschke @DeepDiver1975 @bantu 
