### PR TITLE
[config.sample.php] set correct default value for skeletondirectory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -225,7 +225,7 @@ $CONFIG = array(
  * copied to the data directory of new users. Leave empty to not copy any
  * skeleton files.
  */
-'skeletondirectory' => '',
+'skeletondirectory' => '/path/to/owncloud/core/skeleton',
 
 /**
  * The ``user_backends`` app (which needs to be enabled first) allows you to


### PR DESCRIPTION
The config.sample.php says that this represent the default values, but the truth is, that the default value here is not empty string.

See https://github.com/owncloud/core/blob/1443ff8fd53aaafc383cf863e00bf6f7d1041e94/lib/private/util.php#L275-275

stable8: https://github.com/owncloud/core/blob/stable8/lib/private/util.php#L215
stable7: https://github.com/owncloud/core/blob/stable7/lib/private/util.php#L208

cc @karlitschek I would backport this to stable7 and stable8 because the documentation is generated from this file.
