### PR TITLE
fall back to mimeicon if no preview available

### DIFF
--- a/apps/files_versions/ajax/preview.php
+++ b/apps/files_versions/ajax/preview.php
@@ -53,7 +53,21 @@ try {
 	$preview->setMaxY($maxY);
 	$preview->setScalingUp($scalingUp);
 
-	$preview->showPreview();
+	$image = $preview->getPreview();
+	if ($image->valid()) {
+		$image->show();
+	} else {
+		$image = new \OC_Image();
+		$mimeIconWebPath = \OC_Helper::mimetypeIcon($mimetype);
+		if (empty(\OC::$WEBROOT)) {
+			$mimeIconServerPath = \OC::$SERVERROOT . $mimeIconWebPath;
+		} else {
+			$mimeIconServerPath = str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
+		}
+		$image->loadFromFile($mimeIconServerPath);
+		$image->show();
+	}
+
 }catch(\Exception $e) {
 	\OC_Response::setStatus(500);
 	\OC_Log::write('core', $e->getmessage(), \OC_Log::DEBUG);


### PR DESCRIPTION
fall back to mimeicon if we can't show a preview in the versions drop down.

Not my preferred solution but probably the only feasible solution for 8.1 and I really want to fix this one. A few weeks ago I even saw a article about one of the largest ownCloud installations with a screenshot which showed unintentional the broken icons.

fix https://github.com/owncloud/core/issues/14106

cc @karlitschek This also affect oc8 and oc7. Should we backport it? It's just a visual bug, but a really annoying one.
