### PR TITLE
encryption improvements

### DIFF
--- a/apps/encryption/lib/migration.php
+++ b/apps/encryption/lib/migration.php
@@ -54,6 +54,7 @@ class Migration {
 	public function __destruct() {
 		$this->view->deleteAll('files_encryption/public_keys');
 		$this->updateFileCache();
+		$this->config->deleteAppValue('files_encryption', 'installed_version');
 	}
 
 	/**
@@ -139,7 +140,6 @@ class Migration {
 	public function updateDB() {
 
 		// delete left-over from old encryption which is no longer needed
-		$this->config->deleteAppValue('files_encryption', 'installed_version');
 		$this->config->deleteAppValue('files_encryption', 'ocsid');
 		$this->config->deleteAppValue('files_encryption', 'types');
 		$this->config->deleteAppValue('files_encryption', 'enabled');

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -349,7 +349,8 @@ class Encryption extends Wrapper {
 		if ($this->util->isExcluded($fullPath) === false) {
 
 			$size = $unencryptedSize = 0;
-			$targetExists = $this->file_exists($path);
+			$realFile = $this->util->stripPartialFileExtension($path);
+			$targetExists = $this->file_exists($realFile);
 			$targetIsEncrypted = false;
 			if ($targetExists) {
 				// in case the file exists we require the explicit module as
@@ -605,8 +606,9 @@ class Encryption extends Wrapper {
 	 */
 	protected function getHeader($path) {
 		$header = '';
-		if ($this->storage->file_exists($path)) {
-			$handle = $this->storage->fopen($path, 'r');
+		$realFile = $this->util->stripPartialFileExtension($path);
+		if ($this->storage->file_exists($realFile)) {
+			$handle = $this->storage->fopen($realFile, 'r');
 			$firstBlock = fread($handle, $this->util->getHeaderSize());
 			fclose($handle);
 			if (substr($firstBlock, 0, strlen(Util::HEADER_START)) === Util::HEADER_START) {


### PR DESCRIPTION
- remove files_encryption from database at the end of the migration process (as long as files_encryption is in the database the new module will not be loaded, this should block all possible file operations on encrypted files until the migration finished)

improvements from https://github.com/owncloud/core/issues/17035
