### PR TITLE
Do not use OC*::mb_*_replace(), they are useless

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -518,8 +518,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			if($isMemberUid) {
 				//we got uids, need to get their DNs to 'translate' them to user names
 				$filter = $this->access->combineFilterWithAnd(array(
-					\OCP\Util::mb_str_replace('%uid', $member,
-						$this->access->connection->ldapLoginFilter, 'UTF-8'),
+					str_replace('%uid', $member, $this->access->connection->ldapLoginFilter),
 					$this->access->getFilterPartForUserSearch($search)
 				));
 				$ldap_users = $this->access->fetchListOfUsers($filter, 'dn');
@@ -608,8 +607,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			if($isMemberUid) {
 				//we got uids, need to get their DNs to 'translate' them to user names
 				$filter = $this->access->combineFilterWithAnd(array(
-					\OCP\Util::mb_str_replace('%uid', $member,
-						$this->access->connection->ldapLoginFilter, 'UTF-8'),
+					str_replace('%uid', $member, $this->access->connection->ldapLoginFilter),
 					$this->access->getFilterPartForUserSearch($search)
 				));
 				$ldap_users = $this->access->fetchListOfUsers($filter, 'dn');

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -605,8 +605,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 */
 	public function fetchUsersByLoginName($loginName, $attributes = array('dn')) {
 		$loginName = $this->escapeFilterPart($loginName);
-		$filter = \OCP\Util::mb_str_replace(
-			'%uid', $loginName, $this->connection->ldapLoginFilter, 'UTF-8');
+		$filter = str_replace('%uid', $loginName, $this->connection->ldapLoginFilter);
 		$users = $this->fetchListOfUsers($filter, $attributes);
 		return $users;
 	}
@@ -985,7 +984,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$name = iconv('UTF-8', 'ASCII//TRANSLIT', $name);
 
 		// Replacements
-		$name = \OCP\Util::mb_str_replace(' ', '_', $name, 'UTF-8');
+		$name = str_replace(' ', '_', $name);
 
 		// Every remaining disallowed characters will be removed
 		$name = preg_replace('/[^a-zA-Z0-9_.@-]/u', '', $name);

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -630,8 +630,7 @@ class Wizard extends LDAPUtility {
 		if($this->ldap->errno($cr) !== 0) {
 			throw new \Exception($this->ldap->error($cr));
 		}
-		$filter = \OCP\Util::mb_str_replace(
-			'%uid', $loginName, $this->access->connection->ldapLoginFilter, 'UTF-8');
+		$filter = str_replace('%uid', $loginName, $this->access->connection->ldapLoginFilter);
 		$this->result->addChange('ldap_test_loginname', count($users));
 		$this->result->addChange('ldap_test_effective_filter', $filter);
 		return $this->result;

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -770,17 +770,11 @@ class OC_Helper {
 	 * @param int $start If start is positive, the replacing will begin at the start'th offset into string. If start is negative, the replacing will begin at the start'th character from the end of string.
 	 * @param int $length Length of the part to be replaced
 	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
-	 * @internal param string $input The input string. .Opposite to the PHP build-in function does not accept an array.
 	 * @return string
+	 * @deprecated 8.2.0 Use substr_replace() instead.
 	 */
-	public static function mb_substr_replace($string, $replacement, $start, $length = null, $encoding = 'UTF-8') {
-		$start = intval($start);
-		$length = intval($length);
-		$string = mb_substr($string, 0, $start, $encoding) .
-			$replacement .
-			mb_substr($string, $start + $length, mb_strlen($string, 'UTF-8') - $start, $encoding);
-
-		return $string;
+	public static function mb_substr_replace($string, $replacement, $start, $length = 0, $encoding = 'UTF-8') {
+		return substr_replace($string, $replacement, $start, $length);
 	}
 
 	/**
@@ -792,17 +786,11 @@ class OC_Helper {
 	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
 	 * @param int $count If passed, this will be set to the number of replacements performed.
 	 * @return string
+	 * @deprecated 8.2.0 Use str_replace() instead.
 	 *
 	 */
 	public static function mb_str_replace($search, $replace, $subject, $encoding = 'UTF-8', &$count = null) {
-		$offset = -1;
-		$length = mb_strlen($search, $encoding);
-		while (($i = mb_strrpos($subject, $search, $offset, $encoding)) !== false) {
-			$subject = OC_Helper::mb_substr_replace($subject, $replace, $i, $length);
-			$offset = $i - mb_strlen($subject, $encoding);
-			$count++;
-		}
-		return $subject;
+		return str_replace($search, $replace, $subject, $count);
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -542,6 +542,7 @@ class Util {
 	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
 	 * @return string
 	 * @since 4.5.0
+	 * @deprecated 8.2.0 Use substr_replace() instead.
 	 */
 	public static function mb_substr_replace($string, $replacement, $start, $length = null, $encoding = 'UTF-8') {
 		return(\OC_Helper::mb_substr_replace($string, $replacement, $start, $length, $encoding));
@@ -557,6 +558,7 @@ class Util {
 	 * @param int $count If passed, this will be set to the number of replacements performed.
 	 * @return string
 	 * @since 4.5.0
+	 * @deprecated 8.2.0 Use str_replace() instead.
 	 */
 	public static function mb_str_replace($search, $replace, $subject, $encoding = 'UTF-8', &$count = null) {
 		return(\OC_Helper::mb_str_replace($search, $replace, $subject, $encoding, $count));


### PR DESCRIPTION
As stated in https://github.com/owncloud/core/issues/16654#issuecomment-113481612,
the `mb_(sub)str_replace` wrappers/utils are useless. String replacement is encoding safe. OC should just use the PHP native `(sub)str_replace` functions and get rid of the `mb_*_replace` implementations.
