### PR TITLE
Request approved state for disabled apps with ocsid

### DIFF
--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -284,6 +284,7 @@ class OCSClient {
 		$app['description'] = (string)$tmp->description;
 		$app['detailpage'] = (string)$tmp->detailpage;
 		$app['score'] = (int)$tmp->score;
+		$app['level'] = (int)$tmp->approved;
 
 		return $app;
 	}

--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -176,6 +176,15 @@ class AppSettingsController extends Controller {
 					$apps = array_filter($apps, function ($app) {
 						return !$app['active'];
 					});
+					foreach($apps as $key => $app) {
+						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
+							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid']);
+
+							if(array_key_exists('level', $remoteAppEntry)) {
+								$apps[$key]['level'] = $remoteAppEntry['level'];
+							}
+						}
+					}
 					usort($apps, function ($a, $b) {
 						$a = (string)$a['name'];
 						$b = (string)$b['name'];

--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -169,6 +169,15 @@ class AppSettingsController extends Controller {
 						}
 						return ($a < $b) ? -1 : 1;
 					});
+					foreach($apps as $key => $app) {
+						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
+							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid']);
+
+							if(array_key_exists('level', $remoteAppEntry)) {
+								$apps[$key]['level'] = $remoteAppEntry['level'];
+							}
+						}
+					}
 					break;
 				// not-installed apps
 				case 1:

--- a/tests/lib/ocsclienttest.php
+++ b/tests/lib/ocsclienttest.php
@@ -732,6 +732,7 @@ class OCSClientTest extends \Test\TestCase {
 			   <downloadpackagename1></downloadpackagename1>
 			   <downloadrepository1></downloadrepository1>
 			   <downloadsize1>1</downloadsize1>
+			   <approved>200</approved>
 			  </content>
 			 </data>
 			</ocs>
@@ -770,6 +771,7 @@ class OCSClientTest extends \Test\TestCase {
 			'changed' => 1404743680,
 			'description' => 'Placeholder for future updates',
 			'score' => 50,
+			'level' => 200,
 		];
 		$this->assertSame($expected, $this->ocsClient->getApplication('MyId'));
 	}


### PR DESCRIPTION
In case an application gets disabled the level is set to "experimental" if it does not contain a `shipped` tag. This can for example be reproduced by installing the documents app from the appstore and then disabling it. Or cloning an app from git.

With this change the controller will now load the level of the application from the appstore if a valid OCSID has been provided.

Fixes https://github.com/owncloud/core/issues/17003

<hr/>

@karlitschek This requires that the app store returns the approved state for single applications as well. Thus my last mail to you. Would be great to have this :smile: 
