### PR TITLE
Allow multiple whitespace in type hints in AppFramework

### DIFF
--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -59,7 +59,7 @@ class ControllerMethodReflector implements IControllerMethodReflector{
 		$this->annotations = $matches[1];
 
 		// extract type parameter information
-		preg_match_all('/@param (?P<type>\w+) \$(?P<var>\w+)/', $docs, $matches);
+		preg_match_all('/@param\h+(?P<type>\w+)\h+\$(?P<var>\w+)/', $docs, $matches);
 		// this is just a fix for PHP 5.3 (array_combine raises warning if called with
 		// two empty arrays
 		if($matches['var'] === array() && $matches['type'] === array()) {

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -119,6 +119,20 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$this->assertEquals('double', $reader->getType('test'));
 	}
 
+	/**
+	 * @Annotation
+	 * @param 	string  $foo
+	 */
+	public function testReadTypeWhitespaceAnnotations(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadTypeWhitespaceAnnotations'
+		);
+
+		$this->assertEquals('string', $reader->getType('foo'));
+	}
+
 
 	public function arguments($arg, $arg2='hi') {}
 	public function testReflectParameters() {


### PR DESCRIPTION
Type hints such as `@param bool     $doSomething` will now correctly get parsed, allowing for alignment of docblock parameters if the app developer so wishes. Also allows for using non-space characters in the docblock, for example tabs (but limited to horizontal whitespace, so no funky newlines)

Note, I do not condone the use of multiple whitespace characters in docblocks, but some app developers may want to use the style, and the issue produced from a tiny bit of broken whitespace can be awkward to debug.

Ref: owncloud/mail#813 owncloud/mail#815

cc @jancborchardt @LukasReschke @ChristophWurst 
