### PR TITLE
Lock correct paths when moving mount

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -357,6 +357,11 @@ class Scanner extends BasicEmitter {
 				// log and ignore
 				\OC_Log::write('core', 'Exception while scanning file "' . $child . '": ' . $ex->getMessage(), \OC_Log::DEBUG);
 				$exceptionOccurred = true;
+			} catch (\OCP\Lock\LockedException $e) {
+				if ($this->useTransactions) {
+					\OC_DB::rollback();
+				}
+				throw $e;
 			}
 		}
 		$removedChildren = \array_diff(array_keys($existingChildren), $newChildren);


### PR DESCRIPTION
This will make tests fail, for example:

```
1) Test_Files_Sharing_Api::testShareFolderWithAMountPoint
Exception: Tried to unlock a path that was not exclusively locked

/srv/www/htdocs/owncloud/lib/private/lock/memcachelockingprovider.php:100
/srv/www/htdocs/owncloud/lib/private/files/storage/common.php:642
/srv/www/htdocs/owncloud/lib/private/files/view.php:1793
/srv/www/htdocs/owncloud/lib/private/files/view.php:1837
/srv/www/htdocs/owncloud/lib/private/files/view.php:696
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:1213

2) Test_Files_Sharing_Api::testShareStorageMountPoint
OCP\Lock\LockedException: "folder_share_api_test" is locked

/srv/www/htdocs/owncloud/lib/private/files/view.php:1727
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

Caused by
OCP\Lock\LockedException: "files/3b7bfb765164b2cb4ba35323f1f4d5e0" is locked

/srv/www/htdocs/owncloud/lib/private/lock/memcachelockingprovider.php:70
/srv/www/htdocs/owncloud/lib/private/files/storage/common.php:633
/srv/www/htdocs/owncloud/lib/private/files/view.php:1724
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

3) Test_Files_Sharing_Api::testShareNonExisting
OCP\Lock\LockedException: "folder_share_api_test" is locked

/srv/www/htdocs/owncloud/lib/private/files/view.php:1727
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

Caused by
OCP\Lock\LockedException: "files/3b7bfb765164b2cb4ba35323f1f4d5e0" is locked

/srv/www/htdocs/owncloud/lib/private/lock/memcachelockingprovider.php:70
/srv/www/htdocs/owncloud/lib/private/files/storage/common.php:633
/srv/www/htdocs/owncloud/lib/private/files/view.php:1724
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

4) Test_Files_Sharing_Api::testShareNotOwner
OCP\Lock\LockedException: "folder_share_api_test" is locked

/srv/www/htdocs/owncloud/lib/private/files/view.php:1727
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

Caused by
OCP\Lock\LockedException: "files/3b7bfb765164b2cb4ba35323f1f4d5e0" is locked

/srv/www/htdocs/owncloud/lib/private/lock/memcachelockingprovider.php:70
/srv/www/htdocs/owncloud/lib/private/files/storage/common.php:633
/srv/www/htdocs/owncloud/lib/private/files/view.php:1724
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

5) Test_Files_Sharing_Api::testDefaultExpireDate
OCP\Lock\LockedException: "folder_share_api_test" is locked

/srv/www/htdocs/owncloud/lib/private/files/view.php:1727
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

Caused by
OCP\Lock\LockedException: "files/3b7bfb765164b2cb4ba35323f1f4d5e0" is locked

/srv/www/htdocs/owncloud/lib/private/lock/memcachelockingprovider.php:70
/srv/www/htdocs/owncloud/lib/private/files/storage/common.php:633
/srv/www/htdocs/owncloud/lib/private/files/view.php:1724
/srv/www/htdocs/owncloud/lib/private/files/view.php:1813
/srv/www/htdocs/owncloud/lib/private/files/view.php:993
/srv/www/htdocs/owncloud/lib/private/files/view.php:243
/srv/www/htdocs/owncloud/apps/files_sharing/tests/api.php:55

FAILURES!
Tests: 26, Assertions: 129, Errors: 5.

```

We seem to have a path mismatch issue when moving mount points.
CC @icewind1991 this is the problem I mentioned to you

Might explain the failure in https://github.com/owncloud/core/pull/17030#issuecomment-114059014
