### PR TITLE
[stable8] Allow multiple whitespace in type hints in AppFramework

### DIFF
--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -56,7 +56,7 @@ class ControllerMethodReflector implements IControllerMethodReflector{
 		$this->annotations = $matches[1];
 
 		// extract type parameter information
-		preg_match_all('/@param (?P<type>\w+) \$(?P<var>\w+)/', $docs, $matches);
+		preg_match_all('/@param\h+(?P<type>\w+)\h+\$(?P<var>\w+)/', $docs, $matches);
 		// this is just a fix for PHP 5.3 (array_combine raises warning if called with
 		// two empty arrays
 		if($matches['var'] === array() && $matches['type'] === array()) {

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -87,6 +87,20 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$this->assertEquals('double', $reader->getType('test'));
 	}
 
+	/**
+	 * @Annotation
+	 * @param 	string  $foo
+	 */
+	public function testReadTypeWhitespaceAnnotations(){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadTypeWhitespaceAnnotations'
+		);
+
+		$this->assertEquals('string', $reader->getType('foo'));
+	}
+
 
 	public function arguments($arg, $arg2='hi') {}
 	public function testReflectParameters() {


### PR DESCRIPTION
Backport of #17056 to stable8

cc @MorrisJobke @Raydiation 
