### PR TITLE
Fix undefined offset

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -658,11 +658,6 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string Server host
 	 */
 	public function getServerHost() {
-		// FIXME: Ugly workaround that we need to get rid of
-		if (\OC::$CLI && defined('PHPUNIT_RUN')) {
-			return 'localhost';
-		}
-
 		// overwritehost is always trusted
 		$host = $this->getOverwriteHost();
 		if ($host !== null) {
@@ -680,7 +675,11 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			return $host;
 		} else {
 			$trustedList = $this->config->getSystemValue('trusted_domains', []);
-			return $trustedList[0];
+			if(!empty($trustedList)) {
+				return $trustedList[0];
+			} else {
+				return '';
+			}
 		}
 	}
 


### PR DESCRIPTION
There are cases where no trusted host is specified such as when installing the instance, this lead to an undefined offset warning in the log right after installing. (when another domain than localhost or 127.0.0.1 was used)

Fixes https://github.com/owncloud/core/issues/16685

To test:
1. Install ownCloud from another domain than localhost or 127.0.0.1
2. `Undefined offset: 0 at \/srv\/www\/htdocs\/owncloud\/lib\/private\/appframework\/http\/request.php#683` should not appear in the log after install

@PVince81 FYI
