### PR TITLE
Fix etag propagation for single file shares

### DIFF
--- a/apps/files_sharing/lib/propagation/changewatcher.php
+++ b/apps/files_sharing/lib/propagation/changewatcher.php
@@ -48,6 +48,8 @@ class ChangeWatcher {
 		}
 		$info = $this->baseView->getFileInfo($path);
 		if ($info) {
+			// trigger propagation if the subject of the write hook is shared.
+			// if a parent folder of $path is shared the propagation will be triggered from the change propagator hooks
 			$this->recipientPropagator->propagateById($info->getId());
 		}
 	}

--- a/apps/files_sharing/lib/propagation/changewatcher.php
+++ b/apps/files_sharing/lib/propagation/changewatcher.php
@@ -25,10 +25,17 @@ class ChangeWatcher {
 	private $baseView;
 
 	/**
-	 * @param \OC\Files\View $baseView the view for the logged in user
+	 * @var RecipientPropagator
 	 */
-	public function __construct(View $baseView) {
+	private $recipientPropagator;
+
+	/**
+	 * @param \OC\Files\View $baseView the view for the logged in user
+	 * @param RecipientPropagator $recipientPropagator
+	 */
+	public function __construct(View $baseView, RecipientPropagator $recipientPropagator) {
 		$this->baseView = $baseView;
+		$this->recipientPropagator = $recipientPropagator;
 	}
 
 
@@ -38,6 +45,10 @@ class ChangeWatcher {
 		$mount = $this->baseView->getMount($path);
 		if ($mount instanceof SharedMount) {
 			$this->propagateForOwner($mount->getShare(), $mount->getInternalPath($fullPath), $mount->getOwnerPropagator());
+		}
+		$info = $this->baseView->getFileInfo($path);
+		if ($info) {
+			$this->recipientPropagator->propagateById($info->getId());
 		}
 	}
 

--- a/apps/files_sharing/lib/propagation/propagationmanager.php
+++ b/apps/files_sharing/lib/propagation/propagationmanager.php
@@ -75,7 +75,7 @@ class PropagationManager {
 		if (isset($this->sharePropagators[$user])) {
 			return $this->sharePropagators[$user];
 		}
-		$this->sharePropagators[$user] = new RecipientPropagator($user, $this->getChangePropagator($user), $this->config);
+		$this->sharePropagators[$user] = new RecipientPropagator($user, $this->getChangePropagator($user), $this->config, $this);
 		return $this->sharePropagators[$user];
 	}
 
@@ -101,7 +101,8 @@ class PropagationManager {
 		if (!$user) {
 			return;
 		}
-		$watcher = new ChangeWatcher(Filesystem::getView());
+		$recipientPropagator = $this->getSharePropagator($user->getUID());
+		$watcher = new ChangeWatcher(Filesystem::getView(), $recipientPropagator);
 
 		// for marking shares owned by the active user as dirty when a file inside them changes
 		$this->listenToOwnerChanges($user->getUID(), $user->getUID());

--- a/apps/files_sharing/tests/etagpropagation.php
+++ b/apps/files_sharing/tests/etagpropagation.php
@@ -69,9 +69,12 @@ class EtagPropagation extends TestCase {
 		$view1->mkdir('/directReshare');
 		$view1->mkdir('/sub1/sub2/folder/other');
 		$view1->mkdir('/sub1/sub2/folder/other');
+		$view1->file_put_contents('/foo.txt', 'foobar');
 		$view1->file_put_contents('/sub1/sub2/folder/file.txt', 'foobar');
 		$view1->file_put_contents('/sub1/sub2/folder/inside/file.txt', 'foobar');
 		$folderInfo = $view1->getFileInfo('/sub1/sub2/folder');
+		$fileInfo = $view1->getFileInfo('/foo.txt');
+		\OCP\Share::shareItem('file', $fileInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
 		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2, 31);
 		\OCP\Share::shareItem('folder', $folderInfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER3, 31);
 		$folderInfo = $view1->getFileInfo('/directReshare');
@@ -175,6 +178,15 @@ class EtagPropagation extends TestCase {
 		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER4]);
 		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3]);
+
+		$this->assertAllUnchaged();
+	}
+
+	public function testOwnerWritesToSingleFileShare() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
+		Filesystem::file_put_contents('/foo.txt', 'bar');
+		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER4, self::TEST_FILES_SHARING_API_USER3]);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2]);
 
 		$this->assertAllUnchaged();
 	}


### PR DESCRIPTION
To test:
- create 2 users user1 and user2
- create a text file as user1 and share it with user2
- check the root etag for user2
- update the text file as user1
- check if the root etag for user2 has been changed

cc @DeepDiver1975 @PVince81 
