### PR TITLE
take share target into account when updating recipient etags

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -77,10 +77,10 @@ class Shared_Updater {
 			$shareType = $params['shareType'];
 
 			if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
-				self::correctUsersFolder($shareWith, '/');
+				self::correctUsersFolder($shareWith, $params['fileTarget']);
 			} elseif ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
 				foreach (\OC_Group::usersInGroup($shareWith) as $user) {
-					self::correctUsersFolder($user, '/');
+					self::correctUsersFolder($user, $params['fileTarget']);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #16505

To test:
- change the config value of `'share_folder'` to something other than `'/'`
- create two users user1 and user2
- check the etag of the folder defined as `share_folder`
- share a file from user1 to user2
- check if the etag of the `share_folder` has changed

cc @DeepDiver1975 @PVince81 
