### PR TITLE
[upgrade] add verbosity check and show repair info & steps

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -168,6 +168,15 @@ class Upgrade extends Command {
 				$output->writeln("<error>$message</error>");
 			});
 
+			if(OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
+				$updater->listen('\OC\Updater', 'repairInfo', function ($message) use($output) {
+					$output->writeln('<info>Repair info: ' . $message . '</info>');
+				});
+				$updater->listen('\OC\Updater', 'repairStep', function ($message) use($output) {
+					$output->writeln('<info>Repair step: ' . $message . '</info>');
+				});
+			}
+
 			$success = $updater->upgrade();
 
 			$this->postUpgradeCheck($input, $output);

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -238,6 +238,12 @@ class Updater extends BasicEmitter {
 		$repair->listen('\OC\Repair', 'error', function ($description) {
 			$this->emit('\OC\Updater', 'repairError', array($description));
 		});
+		$repair->listen('\OC\Repair', 'info', function ($description) {
+			$this->emit('\OC\Updater', 'repairInfo', array($description));
+		});
+		$repair->listen('\OC\Repair', 'step', function ($description) {
+			$this->emit('\OC\Updater', 'repairStep', array($description));
+		});
 	}
 
 	/**

--- a/lib/repair/collation.php
+++ b/lib/repair/collation.php
@@ -60,6 +60,7 @@ class Collation extends BasicEmitter implements \OC\RepairStep {
 
 		$tables = $this->getAllNonUTF8BinTables($this->connection);
 		foreach ($tables as $table) {
+			$this->emit('\OC\Repair', 'info', array("Change collation for $table ..."));
 			$query = $this->connection->prepare('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;');
 			$query->execute();
 		}


### PR DESCRIPTION
cc @LukasReschke @DeepDiver1975 @nickvergessen @PVince81 

I would like to have this at least in 8.1.x. This help to find issues during a upgrade more easiely. I'm also open to backport this to older branches, but that decision is up to @karlitschek 
- [x] add documentation once this is merged

Now you can add the `-v` option and it will be more verbose (shows repair info and repair steps):

```
$ ./occ upgrade -v
ownCloud or one of the apps require upgrade - only a limited number of commands are available
Turned on maintenance mode
Repair step: Repair MySQL database engine
Repair info: Not a mysql database -> nothing to do
Repair step: Repair MySQL collation
Repair info: Not a mysql database -> nothing to no
Repair step: Repair SQLite autoincrement
Repair step: Repair duplicate entries in oc_lucene_status
Repair info: lucene_status table does not exist -> nothing to do
Repair step: Repair config
Checked database schema update
Checked database schema update for apps
Updated database
Repair step: Repair mime types
Repair step: Repair legacy storages
Repair step: Repair config
Repair step: Clear asset cache after upgrade
Repair info: Asset pipeline disabled -> nothing to do
Repair step: Generate ETags for file where no ETag is present.
Repair info: ETags have been fixed for 0 files/folders.
Repair step: Clean tags and favorites
Repair info: 0 tags for delete files have been removed.
Repair info: 0 tag entries for deleted tags have been removed.
Repair info: 0 tags with no entries have been removed.
Repair step: Drop old database tables
Repair step: Drop old background jobs
Update successful
Turned off maintenance mode
```

Also the old way works:

```
$ ./occ upgrade       
ownCloud or one of the apps require upgrade - only a limited number of commands are available
Turned on maintenance mode
Checked database schema update
Checked database schema update for apps
Updated database
Update successful
Turned off maintenance mode
```
