### PR TITLE
[upgrade] show timestamp for output during upgrade

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -232,8 +232,11 @@ class Upgrade extends Command {
 	protected function writeln(OutputInterface $output, $line) {
 		$t = '';
 		if($this->showTimestamp) {
-			$time = new \DateTime();
-			$t = $time->format(\DateTime::ISO8601) . ' ';
+			$timeZone = $this->config->getSystemValue('logtimezone', null);
+			$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
+
+			$time = new \DateTime('now', $timeZone);
+			$t = $time->format($this->config->getSystemValue('logdateformat', 'c')) . ' ';
 		}
 		$output->writeln($t . $line);
 	}

--- a/lib/private/console/timestampformatter.php
+++ b/lib/private/console/timestampformatter.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Console;
+
+
+use OCP\IConfig;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
+
+class TimestampFormatter implements OutputFormatterInterface {
+	/** @var IConfig */
+	protected $config;
+
+	/**
+	 * @param IConfig $config
+	 * @param OutputFormatterInterface $formatter
+	 */
+	public function __construct(IConfig $config, OutputFormatterInterface $formatter) {
+		$this->config = $config;
+		$this->formatter = $formatter;
+	}
+
+	/**
+	 * Sets the decorated flag.
+	 *
+	 * @param bool $decorated Whether to decorate the messages or not
+	 */
+	public function setDecorated($decorated) {
+		$this->formatter->setDecorated($decorated);
+	}
+
+	/**
+	 * Gets the decorated flag.
+	 *
+	 * @return bool true if the output will decorate messages, false otherwise
+	 */
+	public function isDecorated() {
+		return $this->formatter->isDecorated();
+	}
+
+	/**
+	 * Sets a new style.
+	 *
+	 * @param string $name The style name
+	 * @param OutputFormatterStyleInterface $style The style instance
+	 */
+	public function setStyle($name, OutputFormatterStyleInterface $style) {
+		$this->formatter->setStyle($name, $style);
+	}
+
+	/**
+	 * Checks if output formatter has style with specified name.
+	 *
+	 * @param string $name
+	 * @return bool
+	 */
+	public function hasStyle($name) {
+		$this->formatter->hasStyle($name);
+	}
+
+	/**
+	 * Gets style options from style with specified name.
+	 *
+	 * @param string $name
+	 * @return OutputFormatterStyleInterface
+	 */
+	public function getStyle($name) {
+		return $this->formatter->getStyle($name);
+	}
+
+	/**
+	 * Formats a message according to the given styles.
+	 *
+	 * @param string $message The message to style
+	 * @return string The styled message, prepended with a timestamp using the
+	 * log timezone and dateformat, e.g. "2015-06-23T17:24:37+02:00"
+	 */
+	public function format($message) {
+
+		$timeZone = $this->config->getSystemValue('logtimezone', null);
+		$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
+
+		$time = new \DateTime('now', $timeZone);
+		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', 'c'));
+
+		return $timestampInfo . ' ' . $this->formatter->format($message);
+	}
+}


### PR DESCRIPTION
- added -v option to show timestamp

cc @LukasReschke @DeepDiver1975 @nickvergessen @rullzer @Xenopathic 

```
./occ upgrade -v
ownCloud or one of the apps require upgrade - only a limited number of commands are available
2015-06-23T09:06:15+0000 Turned on maintenance mode
2015-06-23T09:06:15+0000 Checked database schema update
2015-06-23T09:06:15+0000 Checked database schema update for apps
2015-06-23T09:06:15+0000 Updated database
2015-06-23T09:06:15+0000 Updated <files_sharing> to 0.6.6
2015-06-23T09:06:15+0000 Update successful
2015-06-23T09:06:15+0000 Turned off maintenance mode
```

```
$ ./occ upgrade
ownCloud or one of the apps require upgrade - only a limited number of commands are available
Turned on maintenance mode
Checked database schema update
Checked database schema update for apps
Updated database
Updated <files_sharing> to 0.6.5
Update successful
Turned off maintenance mode
```
