### PR TITLE
Proper error handling

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -130,7 +130,8 @@ class Upgrade extends Command {
 				function ($success) use($output, $updateStepEnabled, $self) {
 					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
 					$status = $success ? 'successful' : 'failed' ;
-					$message = "<info>$mode $status</info>";
+					$type = $success ? 'info' : 'error';
+					$message = "<$type>$mode $status</$type>";
 					$output->writeln($message);
 				});
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -39,8 +39,7 @@ class Upgrade extends Command {
 	const ERROR_MAINTENANCE_MODE = 2;
 	const ERROR_UP_TO_DATE = 3;
 	const ERROR_INVALID_ARGUMENTS = 4;
-
-	public $upgradeFailed = false;
+	const ERROR_FAILURE = 5;
 
 	/**
 	 * @var IConfig
@@ -128,9 +127,9 @@ class Upgrade extends Command {
 				$output->writeln('<info>Maintenance mode is kept active</info>');
 			});
 			$updater->listen('\OC\Updater', 'updateEnd',
-				function () use($output, $updateStepEnabled, $self) {
+				function ($success) use($output, $updateStepEnabled, $self) {
 					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
-					$status = $self->upgradeFailed ? 'failed' : 'successful';
+					$status = $success ? 'successful' : 'failed' ;
 					$message = "<info>$mode $status</info>";
 					$output->writeln($message);
 				});
@@ -163,12 +162,15 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'failure', function ($message) use($output, $self) {
 				$output->writeln("<error>$message</error>");
-				$self->upgradeFailed = true;
 			});
 
-			$updater->upgrade();
+			$success = $updater->upgrade();
 
 			$this->postUpgradeCheck($input, $output);
+
+			if(!$success) {
+				return self::ERROR_FAILURE;
+			}
 
 			return self::ERROR_SUCCESS;
 		} else if($this->config->getSystemValue('maintenance', false)) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -382,7 +382,7 @@ class Filesystem {
 
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
-			throw new \OC\User\NoUserException();
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
 		}
 
 		$homeStorage = \OC_Config::getValue('objectstore');

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -200,7 +200,7 @@ class Updater extends BasicEmitter {
 
 		$this->emit('\OC\Updater', 'updateEnd', array($success));
 
-		if(!$wasMaintenanceModeEnabled) {
+		if(!$wasMaintenanceModeEnabled && $success) {
 			$this->config->setSystemValue('maintenance', false);
 			$this->emit('\OC\Updater', 'maintenanceDisabled');
 		} else {

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -189,13 +189,16 @@ class Updater extends BasicEmitter {
 			$this->log->debug('starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, array('app' => 'core'));
 		}
 
+		$success = true;
 		try {
 			$this->doUpgrade($currentVersion, $installedVersion);
 		} catch (\Exception $exception) {
-			$this->emit('\OC\Updater', 'failure', array($exception->getMessage()));
+			\OCP\Util::logException('update', $exception);
+			$this->emit('\OC\Updater', 'failure', array(get_class($exception) . ': ' .$exception->getMessage()));
+			$success = false;
 		}
 
-		$this->emit('\OC\Updater', 'updateEnd');
+		$this->emit('\OC\Updater', 'updateEnd', array($success));
 
 		if(!$wasMaintenanceModeEnabled) {
 			$this->config->setSystemValue('maintenance', false);
@@ -203,6 +206,8 @@ class Updater extends BasicEmitter {
 		} else {
 			$this->emit('\OC\Updater', 'maintenanceActive');
 		}
+
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
- adds the return value, that is described in the PHPDoc of method `upgrade` in `lib/private/updater.php`
- uses this return value to exit with the correct return code
- adds  a proper message to a failure in initMountpoint

cc @nickvergessen @LukasReschke @DeepDiver1975 @VicDeo 

@karlitschek I would like to backport this to stable7, stable8 and master. This is not that urgent and can go into 8.1.1, 8.0.6, 7.0.8 if it is currently too late. cc @cmonteroluque 

Once an exception occurs the exception is now shown properly and also logged. (noticed during a 6->7 upgrade)

Before :

```
$ ./occ upgrade --skip-migration-test
Turned on maintenance mode
Updated database

Turned off maintenance mode
Update successful
```

After:

```
$ ./occ upgrade --skip-migration-test
Turned on maintenance mode
Updated database
\OC\User\NoUserException: 
Turned off maintenance mode
Update failed
```

How to test:
- add `throw new \Exception();' (empty message - then only the empty line is shown) to an apps`appinfo/update.php` (for example files_sharing)
- increase the version number of that app
- run `./occ upgrade`
#### Expected

![bildschirmfoto von 2015-06-23 11-28-15](https://cloud.githubusercontent.com/assets/245432/8303000/fe5c3dd6-199a-11e5-9d7c-f40c2f5f0708.png)
- log lists the exception:

```
{"reqId":"yYe+Yy02TmPZQXX9kwvf","remoteAddr":"","app":"update","message":"Exception: {\"Exception\":\"Exception\",\"Message\":\"\",\"Code\":0,\"Trace\":\"#0 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/lib\\\/private\\\/app.php(1170): include()\\n#1 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/lib\\\/private\\\/updater.php(394): OC_App::updateApp('files_sharing')\\n#2 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/lib\\\/private\\\/updater.php(291): OC\\\\Updater->doAppUpgrade()\\n#3 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/lib\\\/private\\\/updater.php(194): OC\\\\Updater->doUpgrade('8.1.0.7', '8.1.0.7')\\n#4 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/core\\\/command\\\/upgrade.php(167): OC\\\\Updater->upgrade()\\n#5 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/3rdparty\\\/symfony\\\/console\\\/Symfony\\\/Component\\\/Console\\\/Command\\\/Command.php(253): OC\\\\Core\\\\Command\\\\Upgrade->execute(Object(Symfony\\\\Component\\\\Console\\\\Input\\\\ArgvInput), Object(Symfony\\\\Component\\\\Console\\\\Output\\\\ConsoleOutput))\\n#6 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/3rdparty\\\/symfony\\\/console\\\/Symfony\\\/Component\\\/Console\\\/Application.php(874): Symfony\\\\Component\\\\Console\\\\Command\\\\Command->run(Object(Symfony\\\\Component\\\\Console\\\\Input\\\\ArgvInput), Object(Symfony\\\\Component\\\\Console\\\\Output\\\\ConsoleOutput))\\n#7 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/3rdparty\\\/symfony\\\/console\\\/Symfony\\\/Component\\\/Console\\\/Application.php(195): Symfony\\\\Component\\\\Console\\\\Application->doRunCommand(Object(OC\\\\Core\\\\Command\\\\Upgrade), Object(Symfony\\\\Component\\\\Console\\\\Input\\\\ArgvInput), Object(Symfony\\\\Component\\\\Console\\\\Output\\\\ConsoleOutput))\\n#8 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/3rdparty\\\/symfony\\\/console\\\/Symfony\\\/Component\\\/Console\\\/Application.php(126): Symfony\\\\Component\\\\Console\\\\Application->doRun(Object(Symfony\\\\Component\\\\Console\\\\Input\\\\ArgvInput), Object(Symfony\\\\Component\\\\Console\\\\Output\\\\ConsoleOutput))\\n#9 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/lib\\\/private\\\/console\\\/application.php(75): Symfony\\\\Component\\\\Console\\\\Application->run(NULL, NULL)\\n#10 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/console.php(67): OC\\\\Console\\\\Application->run()\\n#11 \\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/occ(11): require_once('\\\/home\\\/mjob\\\/Proj...')\\n#12 {main}\",\"File\":\"\\\/home\\\/mjob\\\/Projekte\\\/owncloud\\\/master\\\/apps\\\/files_sharing\\\/appinfo\\\/update.php\",\"Line\":32}","level":4,"time":"2015-06-23T09:26:53+00:00"}
```
#### Before

![bildschirmfoto von 2015-06-23 11-28-26](https://cloud.githubusercontent.com/assets/245432/8303002/05f5ed12-199b-11e5-815a-90fdea7ccec4.png)
- no entries in log
