### PR TITLE
[Stable7] fix deleted users during upgrade migration

### DIFF
--- a/apps/files_sharing/appinfo/update.php
+++ b/apps/files_sharing/appinfo/update.php
@@ -87,8 +87,14 @@ function removeSharedFolder($mkdirs = true, $chunkSize = 99) {
 		// create folder Shared for each user
 
 		if ($mkdirs) {
+			$logger = \OC::$server->getLogger();
 			foreach ($unique_users as $user) {
-				\OC\Files\Filesystem::initMountPoints($user);
+				try {
+					\OC\Files\Filesystem::initMountPoints($user);
+				} catch(\OC\User\NoUserException $e) {
+					$logger->warning("Update: removeSharedFolder - user '$user' is not present anymore" , array('app' => 'files_sharing'));
+					continue;
+				}
 				if (!$view->file_exists('/' . $user . '/files/Shared')) {
 					$view->mkdir('/' . $user . '/files/Shared');
 				}


### PR DESCRIPTION
- have a stable6 instance
- have two users (test1 and test2)
- share a file `abc` from user test1 to test2
- remove the entry of test2 from DB table `*PREFIX*users` (this happens in real world, when you have a LDAP setup and delete a user from the LDAP - then somehow the deletion isn't properly propagated and some zombie entries are left in the DB)
- upgrade to stable7 via `./occ upgrade`
### expected
- update just finishes fine
### actual
- it looks like the upgrade finishes fine, but it crashes (see #17095 for a fix of this silent failure) and you will get presented the upgrade web page once you try to browse your ownCloud

@cmonteroluque I rated this as high and would like to get this into 7.0.7

This only applies to stable7. In stable8 this code isn't there anymore.

cc @LukasReschke @schiesbn @nickvergessen @PVince81 

This patch simply ignores the users, that aren't available anymore.
