### PR TITLE
locking for chunked dav upload

### DIFF
--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -379,12 +379,13 @@ class File extends Node implements IFile {
 				$this->emitPreHooks($exists, $targetPath);
 
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
+				/** @var \OC\Files\Storage\Storage $targetStorage */
+				list($targetStorage, $targetInternalPath) = $this->fileView->resolvePath($targetPath);
 
 				if ($needsPartFile) {
 					// we first assembly the target file as a part file
 					$partFile = $path . '/' . $info['name'] . '.ocTransferId' . $info['transferid'] . '.part';
-
-
+					/** @var \OC\Files\Storage\Storage $targetStorage */
 					list($partStorage, $partInternalPath) = $this->fileView->resolvePath($partFile);
 
 
@@ -392,8 +393,7 @@ class File extends Node implements IFile {
 
 					// here is the final atomic rename
 					$renameOkay = $targetStorage->moveFromStorage($partStorage, $partInternalPath, $targetInternalPath);
-
-					$fileExists = $this->fileView->file_exists($targetPath);
+					$fileExists = $targetStorage->file_exists($targetInternalPath);
 					if ($renameOkay === false || $fileExists === false) {
 						\OCP\Util::writeLog('webdav', '\OC\Files\Filesystem::rename() failed', \OCP\Util::ERROR);
 						// only delete if an error occurred and the target file was already created
@@ -427,6 +427,9 @@ class File extends Node implements IFile {
 				$this->emitPostHooks($exists, $targetPath);
 
 				$info = $this->fileView->getFileInfo($targetPath);
+
+				$this->fileView->unlockFile($targetPath, ILockingProvider::LOCK_SHARED);
+
 				return $info->getEtag();
 			} catch (\Exception $e) {
 				if ($partFile !== null) {

--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -350,12 +350,8 @@ class File extends Node implements IFile {
 			throw new NotImplemented('Invalid chunk name');
 		}
 
-		$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
-
 		$chunk_handler = new \OC_FileChunking($info);
 		$bytesWritten = $chunk_handler->store($info['index'], $data);
-
-		$this->changeLock(ILockingProvider::LOCK_SHARED);
 
 		//detect aborted upload
 		if (isset ($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'PUT') {

--- a/apps/dav/lib/connector/sabre/lockplugin.php
+++ b/apps/dav/lib/connector/sabre/lockplugin.php
@@ -62,7 +62,7 @@ class LockPlugin extends ServerPlugin {
 	public function getLock(RequestInterface $request) {
 		// we cant listen on 'beforeMethod:PUT' due to order of operations with setting up the tree
 		// so instead we limit ourselves to the PUT method manually
-		if ($request->getMethod() !== 'PUT') {
+		if ($request->getMethod() !== 'PUT' || isset($_SERVER['HTTP_OC_CHUNKED'])) {
 			return;
 		}
 		try {
@@ -80,7 +80,7 @@ class LockPlugin extends ServerPlugin {
 	}
 
 	public function releaseLock(RequestInterface $request) {
-		if ($request->getMethod() !== 'PUT') {
+		if ($request->getMethod() !== 'PUT' || isset($_SERVER['HTTP_OC_CHUNKED'])) {
 			return;
 		}
 		try {

--- a/apps/dav/tests/unit/connector/sabre/file.php
+++ b/apps/dav/tests/unit/connector/sabre/file.php
@@ -200,7 +200,9 @@ class File extends \Test\TestCase {
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
 		// put first chunk
+		$file->acquireLock(ILockingProvider::LOCK_SHARED);
 		$this->assertNull($file->put('test data one'));
+		$file->releaseLock(ILockingProvider::LOCK_SHARED);
 
 		$info = new \OC\Files\FileInfo('/test.txt-chunking-12345-2-1', null, null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL
@@ -443,12 +445,12 @@ class File extends \Test\TestCase {
 		$thrown = false;
 		try {
 			// beforeMethod locks
-			$view->lockFile('/test.txt', ILockingProvider::LOCK_SHARED);
+			$file->acquireLock(ILockingProvider::LOCK_SHARED);
 
 			$file->put($this->getStream('test data'));
 
 			// afterMethod unlocks
-			$view->unlockFile('/test.txt', ILockingProvider::LOCK_SHARED);
+			$file->releaseLock(ILockingProvider::LOCK_SHARED);
 		} catch (\Sabre\DAV\Exception\BadRequest $e) {
 			$thrown = true;
 		}
@@ -505,7 +507,9 @@ class File extends \Test\TestCase {
 			'permissions' => \OCP\Constants::PERMISSION_ALL
 		], null);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file->acquireLock(ILockingProvider::LOCK_SHARED);
 		$this->assertNull($file->put('test data one'));
+		$file->releaseLock(ILockingProvider::LOCK_SHARED);
 
 		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt-chunking-12345-2-1', null, null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL
@@ -515,7 +519,9 @@ class File extends \Test\TestCase {
 		// action
 		$thrown = false;
 		try {
+			$file->acquireLock(ILockingProvider::LOCK_SHARED);
 			$file->put($this->getStream('test data'));
+			$file->releaseLock(ILockingProvider::LOCK_SHARED);
 		} catch (\OCA\DAV\Connector\Sabre\Exception\FileLocked $e) {
 			$thrown = true;
 		}

--- a/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
+++ b/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
@@ -8,7 +8,9 @@
 
 namespace OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest;
 
-use OC\AppFramework\Http;
+use OC\Connector\Sabre\Exception\FileLocked;
+use OCP\AppFramework\Http;
+use OCP\Lock\ILockingProvider;
 
 class UploadTest extends RequestTest {
 	public function testBasicUpload() {
@@ -41,6 +43,34 @@ class UploadTest extends RequestTest {
 		$info = $view->getFileInfo('foo.txt');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
 		$this->assertEquals(3, $info->getSize());
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 */
+	public function testUploadOverWriteReadLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'bar');
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_SHARED);
+
+		$this->request($view, $user, 'pass', 'PUT', '/foo.txt', 'asd');
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 */
+	public function testUploadOverWriteWriteLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'bar');
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->request($view, $user, 'pass', 'PUT', '/foo.txt', 'asd');
 	}
 
 	public function testChunkedUpload() {
@@ -106,5 +136,55 @@ class UploadTest extends RequestTest {
 		$info = $view->getFileInfo('foo.txt');
 		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
 		$this->assertEquals(6, $info->getSize());
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 */
+	public function testChunkedUploadOutOfOrderReadLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$this->assertFalse($view->file_exists('foo.txt'));
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_SHARED);
+
+		try {
+			$response = $this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-1', 'bar', ['OC-Chunked' => '1']);
+		} catch (FileLocked $e) {
+			$this->fail('Didn\'t expect locked error for the first chunk on read lock');
+			return;
+		}
+
+		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertFalse($view->file_exists('foo.txt'));
+
+		// last chunk should trigger the locked error since it tries to assemble
+		$this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-0', 'asd', ['OC-Chunked' => '1']);
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 */
+	public function testChunkedUploadOutOfOrderWriteLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$this->assertFalse($view->file_exists('foo.txt'));
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		try {
+			$response = $this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-1', 'bar', ['OC-Chunked' => '1']);
+		} catch (FileLocked $e) {
+			$this->fail('Didn\'t expect locked error for the first chunk on write lock'); // maybe forbid this in the future for write locks only?
+			return;
+		}
+
+		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertFalse($view->file_exists('foo.txt'));
+
+		// last chunk should trigger the locked error since it tries to assemble
+		$this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-0', 'asd', ['OC-Chunked' => '1']);
 	}
 }

--- a/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
+++ b/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
@@ -46,7 +46,7 @@ class UploadTest extends RequestTest {
 	}
 
 	/**
-	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\FileLocked
 	 */
 	public function testUploadOverWriteReadLocked() {
 		$user = $this->getUniqueID();
@@ -60,7 +60,7 @@ class UploadTest extends RequestTest {
 	}
 
 	/**
-	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\FileLocked
 	 */
 	public function testUploadOverWriteWriteLocked() {
 		$user = $this->getUniqueID();
@@ -139,7 +139,7 @@ class UploadTest extends RequestTest {
 	}
 
 	/**
-	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\FileLocked
 	 */
 	public function testChunkedUploadOutOfOrderReadLocked() {
 		$user = $this->getUniqueID();
@@ -151,7 +151,7 @@ class UploadTest extends RequestTest {
 
 		try {
 			$response = $this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-1', 'bar', ['OC-Chunked' => '1']);
-		} catch (FileLocked $e) {
+		} catch (\OCA\DAV\Connector\Sabre\Exception\FileLocked $e) {
 			$this->fail('Didn\'t expect locked error for the first chunk on read lock');
 			return;
 		}
@@ -164,7 +164,7 @@ class UploadTest extends RequestTest {
 	}
 
 	/**
-	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\FileLocked
 	 */
 	public function testChunkedUploadOutOfOrderWriteLocked() {
 		$user = $this->getUniqueID();
@@ -176,7 +176,7 @@ class UploadTest extends RequestTest {
 
 		try {
 			$response = $this->request($view, $user, 'pass', 'PUT', '/foo.txt-chunking-123-2-1', 'bar', ['OC-Chunked' => '1']);
-		} catch (FileLocked $e) {
+		} catch (\OCA\DAV\Connector\Sabre\Exception\FileLocked $e) {
 			$this->fail('Didn\'t expect locked error for the first chunk on write lock'); // maybe forbid this in the future for write locks only?
 			return;
 		}


### PR DESCRIPTION
Change the locking handler code to work directly on the storage and lock the upload target while we're assembling the chunks.

cc @DeepDiver1975 @PVince81 
