### PR TITLE
explicitly set z-index on app-content, fix overlap from navigation

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -410,6 +410,7 @@
 	position: relative;
 	height: 100%;
 	overflow-y: auto;
+	z-index: 100;
 }
 
 #app-content-wrapper {
@@ -555,4 +556,3 @@ em {
 	z-index:500;
 	padding:16px;
 }
-


### PR DESCRIPTION
This prevents elements from the navigation with a set z-index (lower than 100) from overlapping the content. Review please @owncloud/designers 

You can test this with the Mail app for example: Prior to this change, the »New message« button from the sidebar will overlap the content. Or with any app, just set an element in the sidebar to have a `z-index:1;` for example.

We also need to backport this fix to stable8 and stable7 cc @karlitschek 
