### PR TITLE
Only update the htaccess ErrorDocument links when they are not set yet

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -402,10 +402,20 @@ class Setup {
 			throw new \OC\HintException('.htaccess file has the wrong version. Please upload the correct version. Maybe you forgot to replace it after updating?');
 		}
 
-		$content = "\n";
-		$content.= "ErrorDocument 403 ".\OC::$WEBROOT."/core/templates/403.php\n";//custom 403 error page
-		$content.= "ErrorDocument 404 ".\OC::$WEBROOT."/core/templates/404.php";//custom 404 error page
-		@file_put_contents($setupHelper->pathToHtaccess(), $content, FILE_APPEND); //suppress errors in case we don't have permissions for it
+		$htaccessContent = file_get_contents($setupHelper->pathToHtaccess());
+		$content = '';
+		if (strpos($htaccessContent, 'ErrorDocument 403') === false) {
+			//custom 403 error page
+			$content.= "\nErrorDocument 403 ".\OC::$WEBROOT."/core/templates/403.php";
+		}
+		if (strpos($htaccessContent, 'ErrorDocument 404') === false) {
+			//custom 404 error page
+			$content.= "\nErrorDocument 404 ".\OC::$WEBROOT."/core/templates/404.php";
+		}
+		if ($content !== '') {
+			//suppress errors in case we don't have permissions for it
+			@file_put_contents($setupHelper->pathToHtaccess(), $content . "\n", FILE_APPEND);
+		}
 	}
 
 	public static function protectDataDirectory() {


### PR DESCRIPTION
``` diff
diff --git a/.htaccess b/.htaccess
index 115a024..5663762 100644
--- a/.htaccess
+++ b/.htaccess
@@ -58,3 +58,22 @@ Options -Indexes
 </IfModule>
ErrorDocument 403 /../notowncloud/templates/403.php
ErrorDocument 404 /../notowncloud/templates/404.php
+
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
+ErrorDocument 403 /core/templates/403.php
+ErrorDocument 404 /core/templates/404.php
```

This is really not, what we intended.

@MorrisJobke @LukasReschke 
