### PR TITLE
[sharing] handle shares of users that aren't available anymore

### DIFF
--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -365,6 +365,7 @@ class Filesystem {
 	 * Initialize system and personal mount points for a user
 	 *
 	 * @param string $user
+	 * @throws \OC\User\NoUserException if the user is not available
 	 */
 	public static function initMountPoints($user = '') {
 		if ($user == '') {


### PR DESCRIPTION
- properly handle the case where an abandoned share is left and
  simply skip it

@karlitschek Should be backported to all stable branches.

How to test this:
- have two LDAP users test1 and test2 (this is not only for LDAP, but for every external user backend, that allows user deletion without notifying ownCloud)
- test1 shares "abc"  to test2
- delete test1 inside of LDAP
- login as test2
### expected
- the share is not available anymore
### actual
- HTTP 500 with a NoUserException in the logs

@butonic @blizzz we discussed this

@schiesbn Or should we delete the share right away?

How should we handle this case? Is this the way to go? Then simply files disappear from users, because of a user deletion. But this is also the case if an ownCloud internal user gets deleted.

cc @nickvergessen @lukasreschke
