### PR TITLE
Use non-zero exit code when app is not compliant (so CIs can detect t…

### DIFF
--- a/core/command/app/checkcode.php
+++ b/core/command/app/checkcode.php
@@ -73,6 +73,7 @@ class CheckCode extends Command {
 			$output->writeln('<info>App is compliant - awesome job!</info>');
 		} else {
 			$output->writeln('<error>App is not compliant</error>');
+			return 1;
 		}
 	}
 }


### PR DESCRIPTION
…he status)

@MorrisJobke @LukasReschke 

@DeepDiver1975 can we have this before 8.1 :see_no_evil: 
