### PR TITLE
Allow removing of link password in OCS again

### DIFF
--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -888,7 +888,6 @@ class Test_Files_Sharing_Api extends TestCase {
 		$this->assertEquals('1', $newUserShare['permissions']);
 
 		// update password for link share
-
 		$this->assertTrue(empty($linkShare['share_with']));
 
 		$params = array();
@@ -912,6 +911,29 @@ class Test_Files_Sharing_Api extends TestCase {
 
 		$this->assertTrue(is_array($newLinkShare));
 		$this->assertTrue(!empty($newLinkShare['share_with']));
+
+		// Remove password for link share
+		$params = array();
+		$params['id'] = $linkShare['id'];
+		$params['_put'] = array();
+		$params['_put']['password'] = '';
+
+		$result = \OCA\Files_Sharing\API\Local::updateShare($params);
+
+		$this->assertTrue($result->succeeded());
+
+		$items = \OCP\Share::getItemShared('file', $linkShare['file_source']);
+
+		$newLinkShare = null;
+		foreach ($items as $item) {
+			if ($item['share_type'] === \OCP\Share::SHARE_TYPE_LINK) {
+				$newLinkShare = $item;
+				break;
+			}
+		}
+
+		$this->assertTrue(is_array($newLinkShare));
+		$this->assertTrue(empty($newLinkShare['share_with']));
 
 		\OCP\Share::unshare('file', $fileInfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
 				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1220,7 +1220,7 @@ class Share extends Constants {
 		$qb->update('`*PREFIX*share`')
 			->set('`share_with`', ':pass')
 			->where('`id` = :shareId')
-			->setParameter(':pass', is_null($password) ? 'NULL' : \OC::$server->getHasher()->hash($password))
+			->setParameter(':pass', is_null($password) ? null : \OC::$server->getHasher()->hash($password))
 			->setParameter(':shareId', $shareId);
 
 		$qb->execute();


### PR DESCRIPTION
My commit b0aa17b13fe504445a3108e46a56031ca4b73bc6 set no password for a link share to 'NULL' but this should be null. Else it will just be the string 'NULL'.

This commit fixes that and extends the unit tests to make sure that we can actually unset the password of a link share.

CC: @DeepDiver1975 @LukasReschke @schiesbn @MorrisJobke @PVince81
