### PR TITLE
webUI to OCS Share API

### DIFF
--- a/core/js/core.json
+++ b/core/js/core.json
@@ -27,6 +27,7 @@
 		"multiselect.js",
 		"oc-requesttoken.js",
 		"setupchecks.js",
-		"../search/js/search.js"
+		"../search/js/search.js",
+		"ocs-share.js"
 	]
 }

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -56,7 +56,7 @@ OC.OCSShare={
 		});
 	},
 
-	publicUpload:function(id, publicUpload, callback) {
+	setPublicUpload:function(id, publicUpload, callback) {
 		var args = {
 			publicUpload: publicUpload
 		};
@@ -75,7 +75,48 @@ OC.OCSShare={
 				}
 			}
 		});
-	}
+	},
 
+	setPassword:function(id, password, callback) {
+		var args = {
+			password: password
+		};
+
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares/' + id + '?format=json',
+			type: 'put',
+			data: args,
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callback) {
+						callback(result.ocs.data);
+					}
+				} else {
+					OC.dialogs.alert(t('core', 'Error while unsharing'), t('core', 'Error'));
+				}
+			}
+		});
+	},
+
+	setPermissions:function(id, permissions, callback) {
+		var args = {
+			permissions: permissions
+		};
+
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares/' + id + '?format=json',
+			type: 'put',
+			data: args,
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callback) {
+						callback(result.ocs.data);
+					}
+				} else {
+					OC.dialogs.alert(t('core', 'Error while unsharing'), t('core', 'Error'));
+				}
+			}
+		});
+	}
 };
 

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -1,0 +1,18 @@
+OC.OCSShare={
+	unshare:function(id, callback) {
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1/shares') + id + '?format=json',
+			type: 'delete',
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callback) {
+						callback();
+					}
+				} else {
+					OC.dialogs.alert(t('core', 'Error while unsharing'), t('core', 'Error'));
+				}
+			}
+		});
+	}
+};
+

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -1,7 +1,48 @@
 OC.OCSShare={
+	share:function(path, shareType, shareWith, permissions, expirationDate, password, callback) {
+		var args = {
+			format: 'json',
+			path: path,
+			shareType: shareType
+		}
+
+		if (shareWith) {
+			args.shareWith = shareWith;
+		}
+		if (permissions) {
+			args.permissions = permissions;
+		}
+		if (expirationDate) {
+			args.expirationDate = expirationDate;
+		}
+		if (password) {
+			args.password = password;
+		}
+
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares?format=json',
+			type: 'post',
+			data: args,
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callback) {
+						callback(result.ocs.data.id);
+					}
+				} else {
+					if (result.ocs.meta.message) {
+						var msg = result.ocs.meta.message;
+					} else {
+						var msg = t('core', 'Error');
+					}
+					OC.dialogs.alert(msg, t('core', 'Error'));
+				}
+			}
+		});
+	},
+
 	unshare:function(id, callback) {
 		$.ajax({
-			url: OC.linkToOCS('apps/files_sharing/api/v1/shares') + id + '?format=json',
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares/' + id + '?format=json',
 			type: 'delete',
 			success: function(result) {
 				if (result.ocs.meta.statuscode === 100) {

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -54,6 +54,28 @@ OC.OCSShare={
 				}
 			}
 		});
+	},
+
+	publicUpload:function(id, publicUpload, callback) {
+		var args = {
+			publicUpload: publicUpload
+		};
+
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares/' + id + '?format=json',
+			type: 'put',
+			data: args,
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callback) {
+						callback(result.ocs.data);
+					}
+				} else {
+					OC.dialogs.alert(t('core', 'Error while unsharing'), t('core', 'Error'));
+				}
+			}
+		});
 	}
+
 };
 

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -26,7 +26,7 @@ OC.OCSShare={
 			success: function(result) {
 				if (result.ocs.meta.statuscode === 100) {
 					if (callback) {
-						callback(result.ocs.data.id);
+						callback(result.ocs.data);
 					}
 				} else {
 					if (result.ocs.meta.message) {

--- a/core/js/ocs-share.js
+++ b/core/js/ocs-share.js
@@ -117,6 +117,30 @@ OC.OCSShare={
 				}
 			}
 		});
+	},
+
+	setExpireDate:function(id, expireDate, callbackSuccess, callbackFailure) {
+		var args = {
+			expireDate: expireDate
+		};
+
+		$.ajax({
+			url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares/' + id + '?format=json',
+			type: 'put',
+			data: args,
+			success: function(result) {
+				if (result.ocs.meta.statuscode === 100) {
+					if (callbackSuccess) {
+						callbackSuccess(result.ocs.data);
+					}
+				} else {
+					OC.dialogs.alert(t('core', 'Error while unsharing'), t('core', 'Error'));
+					if (callbackFailure) {
+						callbackFailure(meta);
+					}
+				}
+			}
+		});
 	}
 };
 

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -1117,12 +1117,8 @@ $(document).ready(function() {
 		if (this.checked) {
 			OC.Share.showExpirationDate('');
 		} else {
-			var itemType = $('#dropdown').data('item-type');
-			var itemSource = $('#dropdown').data('item-source');
-			$.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'setExpirationDate', itemType: itemType, itemSource: itemSource, date: '' }, function(result) {
-				if (!result || result.status !== 'success') {
-					OC.dialogs.alert(t('core', 'Error unsetting expiration date'), t('core', 'Error'));
-				}
+			var shareId = $('#link').data('share-id');
+			OC.OCSShare.setExpireDate(shareId, '', function(data) {
 				$('#expirationDate').slideUp(OC.menuSpeed);
 				if (oc_appconfig.core.defaultExpireDateEnforced === false) {
 					$('#defaultExpireMessage').slideDown(OC.menuSpeed);
@@ -1134,27 +1130,28 @@ $(document).ready(function() {
 	$(document).on('change', '#dropdown #expirationDate', function() {
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
+		var shareId = $('#link').data('share-id');
 
 		$(this).tipsy('hide');
 		$(this).removeClass('error');
 
-		$.post(OC.filePath('core', 'ajax', 'share.php'), { action: 'setExpirationDate', itemType: itemType, itemSource: itemSource, date: $(this).val() }, function(result) {
-			if (!result || result.status !== 'success') {
+		OC.OCSShare.setExpireDate(shareId, $(this).val(), function(data) {
+				if (oc_appconfig.core.defaultExpireDateEnforced === 'no') {
+					$('#defaultExpireMessage').slideUp(OC.menuSpeed);
+				}
+			},
+			function(meta) {
 				var expirationDateField = $('#dropdown #expirationDate');
-				if (!result.data.message) {
+				if (!meta.message) {
 					expirationDateField.attr('original-title', t('core', 'Error setting expiration date'));
 				} else {
-					expirationDateField.attr('original-title', result.data.message);
+					expirationDateField.attr('original-title', meta.message);
 				}
 				expirationDateField.tipsy({gravity: 'n'});
 				expirationDateField.tipsy('show');
 				expirationDateField.addClass('error');
-			} else {
-				if (oc_appconfig.core.defaultExpireDateEnforced === 'no') {
-					$('#defaultExpireMessage').slideUp(OC.menuSpeed);
-				}
 			}
-		});
+		);
 	});
 
 

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -562,14 +562,20 @@ OC.Share={
 				$input.val(t('core', 'Adding user...'));
 				$input.prop('disabled', true);
 
-				OC.Share.share(itemType, itemSource, shareType, shareWith, permissions, itemSourceName, expirationDate, function() {
+				if (FileList.getCurrentDirectory() === '/') {
+					var path = itemSourceName;
+				} else {
+					var path = FileList.getCurrentDirectory() + '/' + itemSourceName;
+				}
+
+				OC.OCSShare.share(path, shareType, shareWith, permissions, expirationDate, undefined, function(shareId) {
 					$input.prop('disabled', false);
 					$loading.addClass('hidden');
 					var posPermissions = possiblePermissions;
 					if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 						posPermissions = permissions;
 					}
-					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, posPermissions, undefined, undefined, -1);
+					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, posPermissions, undefined, undefined, shareId);
 					$('#shareWith').val('');
 					$('#dropdown').trigger(new $.Event('sharesChanged', {shares: OC.Share.currentShares}));
 					OC.Share.updateIcon(itemType, itemSource);
@@ -934,6 +940,8 @@ $(document).ready(function() {
 		var $li = $(this).closest('li');
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
+		var shareType = $li.data('share-type');
+		var shareWith = $li.attr('data-share-with');
 		var shareId = $li.attr('data-share-id');
 		var $button = $(this);
 

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -489,12 +489,12 @@ OC.Share={
 						}
 					} else {
 						if (share.collection) {
-							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, share.collection);
+							OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, share.collection, share.id);
 						} else {
 							if (share.share_type === OC.Share.SHARE_TYPE_REMOTE) {
-								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE, share.mail_send, false);
+								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE, share.mail_send, false, share.id);
 							} else {
-								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, false);
+								OC.Share.addShareWith(share.share_type, share.share_with, share.share_with_displayname, share.permissions, possiblePermissions, share.mail_send, false, share.id);
 							}
 						}
 					}
@@ -569,7 +569,7 @@ OC.Share={
 					if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 						posPermissions = permissions;
 					}
-					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, posPermissions);
+					OC.Share.addShareWith(shareType, shareWith, selected.item.label, permissions, posPermissions, undefined, undefined, -1);
 					$('#shareWith').val('');
 					$('#dropdown').trigger(new $.Event('sharesChanged', {shares: OC.Share.currentShares}));
 					OC.Share.updateIcon(itemType, itemSource);
@@ -645,7 +645,7 @@ OC.Share={
 			}
 		});
 	},
-	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, mailSend, collection) {
+	addShareWith:function(shareType, shareWith, shareWithDisplayName, permissions, possiblePermissions, mailSend, collection, shareId) {
 		var shareItem = {
 			share_type: shareType,
 			share_with: shareWith,
@@ -692,7 +692,7 @@ OC.Share={
 			if (permissions & OC.PERMISSION_SHARE) {
 				shareChecked = 'checked="checked"';
 			}
-			var html = '<li style="clear: both;" data-share-type="'+escapeHTML(shareType)+'" data-share-with="'+escapeHTML(shareWith)+'" title="' + escapeHTML(shareWith) + '">';
+			var html = '<li style="clear: both;" data-share-type="'+escapeHTML(shareType)+'" data-share-with="'+escapeHTML(shareWith)+'" title="' + escapeHTML(shareWith) + '" data-share-id="' + escapeHTML(shareId) + '">';
 			var showCrudsButton;
 			html += '<a href="#" class="unshare"><img class="svg" alt="'+t('core', 'Unshare')+'" title="'+t('core', 'Unshare')+'" src="'+OC.imagePath('core', 'actions/delete')+'"/></a>';
 			if (oc_config.enable_avatars === true) {
@@ -934,8 +934,7 @@ $(document).ready(function() {
 		var $li = $(this).closest('li');
 		var itemType = $('#dropdown').data('item-type');
 		var itemSource = $('#dropdown').data('item-source');
-		var shareType = $li.data('share-type');
-		var shareWith = $li.attr('data-share-with');
+		var shareId = $li.attr('data-share-id');
 		var $button = $(this);
 
 		if (!$button.is('a')) {
@@ -948,7 +947,7 @@ $(document).ready(function() {
 		}
 		$button.empty().addClass('icon-loading-small');
 
-		OC.Share.unshare(itemType, itemSource, shareType, shareWith, function() {
+		OC.OCSShare.unshare(shareId, function() {
 			$li.remove();
 			var index = OC.Share.itemShares[shareType].indexOf(shareWith);
 			OC.Share.itemShares[shareType].splice(index, 1);

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -1091,34 +1091,20 @@ $(document).ready(function() {
 		// Gather data
 		var $dropDown = $('#dropdown');
 		var allowPublicUpload = $(this).is(':checked');
-		var itemType = $dropDown.data('item-type');
-		var itemSource = $dropDown.data('item-source');
-		var itemSourceName = $dropDown.data('item-source-name');
-		var expirationDate = '';
-		if ($('#expirationCheckbox').is(':checked') === true) {
-			expirationDate = $( "#expirationDate" ).val();
-		}
-		var permissions = 0;
 		var $button = $(this);
 		var $loading = $dropDown.find('#allowPublicUploadWrapper .icon-loading-small');
+		var shareId = $('#link').data('share-id');
 
 		if (!$loading.hasClass('hidden')) {
 			// already in progress
 			return false;
 		}
 
-		// Calculate permissions
-		if (allowPublicUpload) {
-			permissions = OC.PERMISSION_UPDATE + OC.PERMISSION_CREATE + OC.PERMISSION_READ;
-		} else {
-			permissions = OC.PERMISSION_READ;
-		}
-
 		// Update the share information
 		$button.addClass('hidden');
 		$button.prop('disabled', true);
 		$loading.removeClass('hidden');
-		OC.Share.share(itemType, itemSource, OC.Share.SHARE_TYPE_LINK, '', permissions, itemSourceName, expirationDate, function(data) {
+		OC.OCSShare.publicUpload(shareId, allowPublicUpload, function(data) {
 			$loading.addClass('hidden');
 			$button.removeClass('hidden');
 			$button.prop('disabled', false);

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -136,15 +136,18 @@ describe('OC.Share tests', function() {
 				$('#dropdown #linkPassText').val('foo');
 				$('#dropdown #linkPassText').focusout();
 
-				expect(fakeServer.requests[1].method).toEqual('POST');
+				expect(fakeServer.requests[1].method).toEqual('PUT');
 				var body = OC.parseQueryString(fakeServer.requests[1].requestBody);
-				expect(body['shareWith']).toEqual('foo');
+				expect(body['password']).toEqual('foo');
 
 				// Set password response
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100}, 
+						data: { }
+					}})
 				);
 
 				expect($('#dropdown #linkPassText').val()).toEqual('');
@@ -176,15 +179,18 @@ describe('OC.Share tests', function() {
 				$('#dropdown #linkPassText').val('foo');
 				$('#dropdown #linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
 
-				expect(fakeServer.requests[1].method).toEqual('POST');
+				expect(fakeServer.requests[1].method).toEqual('PUT');
 				var body = OC.parseQueryString(fakeServer.requests[1].requestBody);
-				expect(body['shareWith']).toEqual('foo');
+				expect(body['password']).toEqual('foo');
 
 				// Set password response
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100},
+						data: {}
+					}})
 				);
 
 				expect($('#dropdown #linkPassText').val()).toEqual('');
@@ -238,7 +244,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 
 				// Remove link
@@ -246,7 +255,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100},
+						data: {}
+					}})
 				);
 
 				/*
@@ -290,7 +302,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 				expect($('#dropdown #linkPassText').attr('placeholder')).toEqual('**********');
 
@@ -299,7 +314,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 
 				// Try to share again
@@ -322,7 +340,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { id: 1}
+					}})
 				);
 
 				//Password protection should be unchecked and password field not visible
@@ -333,10 +354,14 @@ describe('OC.Share tests', function() {
 				$('#dropdown [name=showPassword]').click();
 				$('#dropdown #linkPassText').val('foo');
 				$('#dropdown #linkPassText').trigger(new $.Event('keyup', {keyCode: 13}));
+
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz2'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100},
+						data: {}
+					}})
 				);
 
 				// Unshare
@@ -344,7 +369,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[2].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 
 				// Toggle share again
@@ -352,9 +380,11 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[3].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz3'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { id: 2}
+					}})
 				);
-
 
 				// Password checkbox should be unchecked
 				expect($('#dropdown [name=showPassword]').prop('checked')).toEqual(false);
@@ -374,14 +404,17 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { id: 1}
+					}})
 				);
 
 				//Expiration should be unchecked and expiration field not visible
 				expect($('#dropdown [name=expirationCheckbox]').prop('checked')).toEqual(false);
 				expect($('#dropdown #expirationDate').is(":visible")).toEqual(false);
 
-				// Toggle and set password
+				// Toggle and set expire date
 				$('#dropdown [name=expirationCheckbox]').click();
 				d = new Date();
 				d.setDate(d.getDate() + 1);
@@ -391,7 +424,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz2'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100},
+						data: {}
+					}})
 				);
 
 				// Unshare
@@ -399,7 +435,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[2].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { }
+					}})
 				);
 
 				// Toggle share again
@@ -407,7 +446,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[3].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({data: {token: 'xyz3'}, status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100},
+						data: { id: 2 }
+					}})
 				);
 
 				// Recheck expire visibility
@@ -876,7 +918,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { id: 1 }
+					}})
 				);
 				expect(handler.calledOnce).toEqual(true);
 				var shares = handler.getCall(0).args[0].shares;
@@ -890,7 +935,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 				expect(handler.calledOnce).toEqual(true);
 				var shares = handler.getCall(0).args[0].shares;
@@ -904,7 +952,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[0].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success', data: { token: 'abc' }})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: { id: 1 }
+					}})
 				);
 				expect(handler.calledOnce).toEqual(true);
 				var shares = handler.getCall(0).args[0].shares;
@@ -919,7 +970,10 @@ describe('OC.Share tests', function() {
 				fakeServer.requests[1].respond(
 					200,
 					{ 'Content-Type': 'application/json' },
-					JSON.stringify({status: 'success'})
+					JSON.stringify({ocs: {
+						meta: { statuscode: 100 },
+						data: {}
+					}})
 				);
 
 				expect(handler.calledOnce).toEqual(true);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -83,6 +83,7 @@ class Share extends Constants {
 				);
 				if(count(self::$backendTypes) === 1) {
 					\OC_Util::addScript('core', 'share');
+					\OC_Util::addScript('core', 'ocs-share');
 					\OC_Util::addStyle('core', 'share');
 				}
 				return true;


### PR DESCRIPTION
Currently the web interface uses the ajax/share.php endpoint to do all its sharing magic. Of course this should also use the OCS Share API so there is only 1 code path to maintain.

This PR aims to move the webUI to the OCS Share API. Most stuff is done

Done:
- [x] Create share
- [x] Unshare
- [x] Modify share
- [x] Link sharing stuff

Todo:
- [ ] Port remaining calls to share.php to OCSShare (retrival of share list
- [ ] Fix unit tests to also return token
- [ ] Extend unit tests (check for correct url etc)
- [ ] Less code duplication in ocs-share.js

Currently I created a new file ocs-share.js to make share.js a bit less messy. If desired this can of coursed trivially be merged with share.js

Lets see what jenkins has to say at the moment.
