### PR TITLE
Consistent behaviour and error reporting when changing full name, password or email in users page. Fixes #14955

### DIFF
--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -56,10 +56,10 @@ class Controller {
 		\OC_JSON::callCheck();
 		\OC_JSON::checkLoggedIn();
 
+		$l = new \OC_L10n('settings');
 		if (isset($_POST['username'])) {
 			$username = $_POST['username'];
 		} else {
-			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array('data' => array('message' => $l->t('No user supplied')) ));
 			exit();
 		}
@@ -72,7 +72,6 @@ class Controller {
 		} elseif (\OC_SubAdmin::isUserAccessible(\OC_User::getUser(), $username)) {
 			$userstatus = 'subadmin';
 		} else {
-			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array('data' => array('message' => $l->t('Authentication error')) ));
 			exit();
 		}
@@ -116,7 +115,6 @@ class Controller {
 				$validRecoveryPassword = $keyManager->checkRecoveryPassword($recoveryPassword);
 				$recoveryEnabledForUser = $recovery->isRecoveryEnabledForUser($username);
 			}
-			$l = new \OC_L10n('settings');
 
 			if ($recoveryEnabledForUser && $recoveryPassword === '') {
 				\OC_JSON::error(array('data' => array(


### PR DESCRIPTION
Fixes #14955. For one, it looks like a lot of duplicated code, but since it's a bug fix that may/can/should go back to OC 8 and 7 I just fixed it as it was.

Basic issue: it was not clear when a change was saved, and when not. Also, if e.g. a display name change could not be done, an error was not reported, it looked like all was fine.

What happens now:
- If you change a Full Name, Password or Email address, pressing Enter will save (just like before). If a change failed, an error message is shown (new for Full Name) and the original/valid value is shown again (new for Full Name and Email, not shown for Password anyway).
- If you change  a Full Name, Password or Email address, clicking away with the mouse will cancel the action (just like before) and the original/valid value is shown again (new for Full Name and Email, not shown for Password anyway).
- If you change a Full Name, Password or Email address, pressing ESC will cancel the action (new for all) and the original/valid value is shown again (new for Full Name and Email, not shown for Password anyway).

There are two hackish lines where Firefox requires one method call to be placed twice to happen once (OK with Chromium). No idea way, maybe someone sees something obvious that I did wrongly? Lines 727 and 770. Also see https://github.com/owncloud/core/issues/14955#issuecomment-114876998, has a link to a JS Fiddle where the issue is isolated.

Please test and review, also confirmation from designers is appreciated. @PVince81 @MorrisJobke @jancborchardt @rperezb 

@karlitschek okay to backport? Affects OC 7 and 8.
