### PR TITLE
Backport of #15592 to stable8

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -184,8 +184,10 @@ class Manager extends PublicEmitter implements IGroupManager {
 		$groups = array();
 		foreach ($this->backends as $backend) {
 			$groupIds = $backend->getUserGroups($uid);
-			foreach ($groupIds as $groupId) {
-				$groups[$groupId] = $this->get($groupId);
+			if (is_array($groupIds)) {
+				foreach ($groupIds as $groupId) {
+					$groups[$groupId] = $this->get($groupId);
+				}
 			}
 		}
 		$this->cachedUserGroups[$uid] = $groups;

--- a/tests/lib/group/manager.php
+++ b/tests/lib/group/manager.php
@@ -846,4 +846,26 @@ class Manager extends \Test\TestCase {
 		$groups = $manager->getUserGroups($user1);
 		$this->assertEquals(array(), $groups);
 	}
+
+	public function testGetUserIdGroups() {
+		/**
+		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC_Group_Backend $backend
+		 */
+		$backend = $this->getMock('\OC_Group_Database');
+		$backend->expects($this->any())
+			->method('getUserGroups')
+			->with('user1')
+			->will($this->returnValue(null));
+
+		/**
+		 * @var \OC\User\Manager $userManager
+		 */
+		$userManager = $this->getMock('\OC\User\Manager');
+		$manager = new \OC\Group\Manager($userManager);
+		$manager->addBackend($backend);
+
+		$groups = $manager->getUserIdGroups('user1');
+		$this->assertEquals([], $groups);
+	}
+
 }


### PR DESCRIPTION
Fixes #15590 on stable8. I have no reproduction steps for the original issue, but the unit test works quite fine (i.e. throws error without actual fix and is happy with it), and also Users page is good afterwards.

Please review and test @DeepDiver1975 @MorrisJobke @nickvergessen @icewind1991 

It's basically a backport, do you confirm @karlitschek ?
