### PR TITLE
remove duplicate ID in HTML template for public shares

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -100,7 +100,7 @@ $thumbSize = 1024;
 				<div id="imgframe"></div>
 			<?php endif; ?>
 			<div class="directDownload">
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
+				<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
 					<img class="svg" alt="" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>"/>
 					<?php p($l->t('Download %s', array($_['filename'])))?> (<?php p($_['fileSize']) ?>)
 				</a>


### PR DESCRIPTION
- fixes itself
- see line 80 for the other usage, which is actually use within the JS code.

cc @owncloud/designers

@karlitschek I would like to backport this to all stable branches, because it is invalid HTML (duplicate use of IDs is not allowed)
