### PR TITLE
Add feedback for public page download

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -133,6 +133,9 @@ OCA.Sharing.PublicApp = {
 			img.appendTo('#imgframe');
 		}
 
+		$('#download, #downloadFile').click(function (e) {
+			OC.Notification.showTemporary(t('files_sharing', 'Download started. Please wait …'));
+		});
 		if (this.fileList) {
 			// TODO: move this to a separate PublicFileList class that extends OCA.Files.FileList (+ unit tests)
 			this.fileList.getDownloadUrl = function (filename, dir) {

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -100,7 +100,7 @@ $thumbSize = 1024;
 				<div id="imgframe"></div>
 			<?php endif; ?>
 			<div class="directDownload">
-				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
+				<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
 					<img class="svg" alt="" src="<?php print_unescaped(OCP\image_path("core", "actions/download.svg")); ?>"/>
 					<?php p($l->t('Download %s', array($_['filename'])))?> (<?php p($_['fileSize']) ?>)
 				</a>


### PR DESCRIPTION
- [ ] requires #17159 (already included here)

The issue is, that once somebody click on download and the server needs some time to fetch the file from a storage, there is the possibility that the user think that nothing happens and then click again. This simply adds a feedback for the user. The issue can be simulated by adding `sleep(5);` to the top of `downloadShare()` method in `apps/files_sharing/lib/controllers/sharecontroller.php`. 

Ref owncloud/consulting#14

Does anybody know a way to get notified, once the download actually has started - the response returned from the server? cc @PVince81 @jancborchardt 

cc @owncloud/designers 
