### PR TITLE
Allow sub-locking with acquired exclusive lock

### DIFF
--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -32,8 +32,15 @@ class MemcacheLockingProvider implements ILockingProvider {
 	private $memcache;
 
 	private $acquiredLocks = [
-		'shared' => [],
-		'exclusive' => []
+		'memcache' => [
+			'shared' => [],
+			'exclusive' => [],
+		],
+		// Local locks are used, when we already have an exclusive lock
+		'local' => [
+			'shared' => [],
+			'exclusive' => [],
+		],
 	];
 
 	/**
@@ -65,20 +72,25 @@ class MemcacheLockingProvider implements ILockingProvider {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type) {
+		if (isset($this->acquiredLocks['memcache']['exclusive'][$path])) {
+			$this->acquireLocalLock($path, $type);
+			return;
+		}
+
 		if ($type === self::LOCK_SHARED) {
 			if (!$this->memcache->inc($path)) {
 				throw new LockedException($path);
 			}
-			if (!isset($this->acquiredLocks['shared'][$path])) {
-				$this->acquiredLocks['shared'][$path] = 0;
+			if (!isset($this->acquiredLocks['memcache']['shared'][$path])) {
+				$this->acquiredLocks['memcache']['shared'][$path] = 0;
 			}
-			$this->acquiredLocks['shared'][$path]++;
+			$this->acquiredLocks['memcache']['shared'][$path]++;
 		} else {
 			$this->memcache->add($path, 0);
 			if (!$this->memcache->cas($path, 0, 'exclusive')) {
 				throw new LockedException($path);
 			}
-			$this->acquiredLocks['exclusive'][$path] = true;
+			$this->acquiredLocks['memcache']['exclusive'][$path] = true;
 		}
 	}
 
@@ -86,17 +98,75 @@ class MemcacheLockingProvider implements ILockingProvider {
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
 	 */
-	public function releaseLock($path, $type) {
+	protected function acquireLocalLock($path, $type) {
 		if ($type === self::LOCK_SHARED) {
-			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
+			if (!isset($this->acquiredLocks['local']['shared'][$path])) {
+				$this->acquiredLocks['local']['shared'][$path] = 0;
+			}
+			$this->acquiredLocks['local']['shared'][$path]++;
+		} else {
+			if (!isset($this->acquiredLocks['local']['exclusive'][$path])) {
+				$this->acquiredLocks['local']['exclusive'][$path] = 0;
+			}
+			$this->acquiredLocks['local']['exclusive'][$path]++;
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @param bool $ignoreLocalLocks Release the memcache locks directly
+	 */
+	public function releaseLock($path, $type, $ignoreLocalLocks = false) {
+		if (isset($this->acquiredLocks['memcache']['exclusive'][$path]) && !$ignoreLocalLocks) {
+			// If we acquired locks while we had an exclusive lock we have to unlock them
+			// Only if we didn't have a sub-lock, we release the real memcache lock
+			if ($this->releaseLocalLock($path, $type)) {
+				return;
+			}
+		}
+
+		if ($type === self::LOCK_SHARED) {
+			if (isset($this->acquiredLocks['memcache']['shared'][$path]) and $this->acquiredLocks['memcache']['shared'][$path] > 0) {
 				$this->memcache->dec($path);
-				$this->acquiredLocks['shared'][$path]--;
+				$this->acquiredLocks['memcache']['shared'][$path]--;
 				$this->memcache->cad($path, 0);
 			}
 		} else if ($type === self::LOCK_EXCLUSIVE) {
+			if (!$ignoreLocalLocks) {
+				if ((isset($this->acquiredLocks['local']['shared'][$path]) && $this->acquiredLocks['local']['shared'][$path] > 0)
+				 || (isset($this->acquiredLocks['local']['exclusive'][$path]) && $this->acquiredLocks['local']['exclusive'][$path] > 0)) {
+					// Can not unlock the exclusive lock, when we still have local share locks
+					throw new LockedException($path);
+				}
+			}
 			$this->memcache->cad($path, 'exclusive');
-			unset($this->acquiredLocks['exclusive'][$path]);
+			unset($this->acquiredLocks['local']['shared'][$path]);
+			unset($this->acquiredLocks['local']['exclusive'][$path]);
+			unset($this->acquiredLocks['memcache']['exclusive'][$path]);
 		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @return bool True if a local lock was released, false otherwise
+	 */
+	protected function releaseLocalLock($path, $type) {
+		if ($type === self::LOCK_SHARED) {
+			if (isset($this->acquiredLocks['local']['shared'][$path]) && $this->acquiredLocks['local']['shared'][$path] > 0) {
+				$this->acquiredLocks['local']['shared'][$path]--;
+				return true;
+			}
+			unset($this->acquiredLocks['local']['shared'][$path]);
+		} else {
+			if (isset($this->acquiredLocks['local']['exclusive'][$path]) && $this->acquiredLocks['local']['exclusive'][$path] > 0) {
+				$this->acquiredLocks['local']['exclusive'][$path]--;
+				return true;
+			}
+			unset($this->acquiredLocks['local']['exclusive'][$path]);
+		}
+		return false;
 	}
 
 	/**
@@ -107,37 +177,82 @@ class MemcacheLockingProvider implements ILockingProvider {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function changeLock($path, $targetType) {
+		if (isset($this->acquiredLocks['memcache']['exclusive'][$path])) {
+			// If we acquired locks while we had an exclusive lock we have to unlock them
+			// Only if we didn't have a sub-lock, we release the real memcache lock
+			if ($this->changeLocalLock($path, $targetType)) {
+				return;
+			}
+		}
+
 		if ($targetType === self::LOCK_SHARED) {
+			if ((isset($this->acquiredLocks['local']['shared'][$path]) && $this->acquiredLocks['local']['shared'][$path] > 0)
+				|| (isset($this->acquiredLocks['local']['exclusive'][$path]) && $this->acquiredLocks['local']['exclusive'][$path] > 0)) {
+				// Can not change the exclusive lock, when we still have local locks
+				throw new LockedException($path);
+			}
+
 			if (!$this->memcache->cas($path, 'exclusive', 1)) {
 				throw new LockedException($path);
 			}
-			unset($this->acquiredLocks['exclusive'][$path]);
-			if (!isset($this->acquiredLocks['shared'][$path])) {
-				$this->acquiredLocks['shared'][$path] = 0;
+			unset($this->acquiredLocks['memcache']['exclusive'][$path]);
+			if (!isset($this->acquiredLocks['memcache']['shared'][$path])) {
+				$this->acquiredLocks['memcache']['shared'][$path] = 0;
 			}
-			$this->acquiredLocks['shared'][$path]++;
+			$this->acquiredLocks['memcache']['shared'][$path]++;
 		} else if ($targetType === self::LOCK_EXCLUSIVE) {
 			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock
 			if (!$this->memcache->cas($path, 1, 'exclusive')) {
 				throw new LockedException($path);
 			}
-			$this->acquiredLocks['exclusive'][$path] = true;
-			$this->acquiredLocks['shared'][$path]--;
+			$this->acquiredLocks['memcache']['exclusive'][$path] = true;
+			$this->acquiredLocks['memcache']['shared'][$path]--;
 		}
+	}
+
+	/**
+	 * Change the type of an existing local lock
+	 *
+	 * @param string $path
+	 * @param int $targetType self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @return bool True if a local lock was changed, false otherwise
+	 */
+	protected function changeLocalLock($path, $targetType) {
+		if ($targetType === self::LOCK_SHARED) {
+			if (isset($this->acquiredLocks['local']['exclusive'][$path]) && $this->acquiredLocks['local']['exclusive'][$path] > 0) {
+				if (!isset($this->acquiredLocks['local']['shared'][$path])) {
+					$this->acquiredLocks['local']['shared'][$path] = 0;
+				}
+				$this->acquiredLocks['local']['shared'][$path]++;
+				$this->acquiredLocks['local']['exclusive'][$path]--;
+				return true;
+			}
+
+		} else if ($targetType === self::LOCK_EXCLUSIVE) {
+			if (isset($this->acquiredLocks['local']['shared'][$path]) && $this->acquiredLocks['local']['shared'][$path] > 0) {
+				if (!isset($this->acquiredLocks['local']['exclusive'][$path])) {
+					$this->acquiredLocks['local']['exclusive'][$path] = 0;
+				}
+				$this->acquiredLocks['local']['exclusive'][$path]++;
+				$this->acquiredLocks['local']['shared'][$path]--;
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
 	 * release all lock acquired by this instance
 	 */
 	public function releaseAll() {
-		foreach ($this->acquiredLocks['shared'] as $path => $count) {
+		foreach ($this->acquiredLocks['memcache']['shared'] as $path => $count) {
 			for ($i = 0; $i < $count; $i++) {
-				$this->releaseLock($path, self::LOCK_SHARED);
+				$this->releaseLock($path, self::LOCK_SHARED, true);
 			}
 		}
 
-		foreach ($this->acquiredLocks['exclusive'] as $path => $hasLock) {
-			$this->releaseLock($path, self::LOCK_EXCLUSIVE);
+		foreach ($this->acquiredLocks['memcache']['exclusive'] as $path => $hasLock) {
+			$this->releaseLock($path, self::LOCK_EXCLUSIVE, true);
 		}
 	}
 }

--- a/lib/private/lock/nooplockingprovider.php
+++ b/lib/private/lock/nooplockingprovider.php
@@ -37,6 +37,13 @@ class NoopLockingProvider implements ILockingProvider {
 		return false;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isLockOwned($path, $type) {
+		return false;
+	}
+
     /**
      * {@inheritdoc}
      */

--- a/lib/public/lock/ilockingprovider.php
+++ b/lib/public/lock/ilockingprovider.php
@@ -45,6 +45,15 @@ interface ILockingProvider {
 	 */
 	public function isLocked($path, $type);
 
+
+	/**
+	 * @param string $path
+	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE
+	 * @return bool
+	 * @since 8.1.0
+	 */
+	public function isLockOwned($path, $type);
+
 	/**
 	 * @param string $path
 	 * @param int $type self::LOCK_SHARED or self::LOCK_EXCLUSIVE

--- a/tests/lib/lock/lockingprovider.php
+++ b/tests/lib/lock/lockingprovider.php
@@ -29,7 +29,11 @@ abstract class LockingProvider extends TestCase {
 	/**
 	 * @var \OCP\Lock\ILockingProvider
 	 */
-	protected $instance;
+	protected $instance1;
+	/**
+	 * @var \OCP\Lock\ILockingProvider
+	 */
+	protected $instance2;
 
 	/**
 	 * @return \OCP\Lock\ILockingProvider
@@ -38,97 +42,98 @@ abstract class LockingProvider extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->instance = $this->getInstance();
+		$this->instance1 = $this->getInstance();
+		$this->instance2 = $this->getInstance();
 	}
 
 	public function testExclusiveLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testSharedLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testDoubleSharedLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testReleaseSharedLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testDoubleExclusiveLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	public function testReleaseExclusiveLock() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->instance->releaseLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testExclusiveLockAfterShared() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	public function testExclusiveLockAfterSharedReleased() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
 	public function testReleaseAll() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('bar', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('asd', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('bar', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('asd', ILockingProvider::LOCK_EXCLUSIVE);
 
-		$this->instance->releaseAll();
+		$this->instance1->releaseAll();
 
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->assertFalse($this->instance->isLocked('bar', ILockingProvider::LOCK_SHARED));
-		$this->assertFalse($this->instance->isLocked('asd', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLocked('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLocked('asd', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
 	public function testReleaseAfterReleaseAll() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 
-		$this->instance->releaseAll();
+		$this->instance1->releaseAll();
 
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 
-		$this->instance->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 
 
@@ -136,9 +141,9 @@ abstract class LockingProvider extends TestCase {
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testSharedLockAfterExclusive() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 
 	public function testLockedExceptionHasPathForShared() {
@@ -160,55 +165,55 @@ abstract class LockingProvider extends TestCase {
 	}
 
 	public function testChangeLockToExclusive() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
 	public function testChangeLockToShared() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->assertFalse($this->instance->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
-		$this->assertTrue($this->instance->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToExclusiveDoubleShared() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToExclusiveNoShared() {
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToExclusiveFromExclusive() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToSharedNoExclusive() {
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 
 	/**
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToSharedFromShared() {
-		$this->instance->acquireLock('foo', ILockingProvider::LOCK_SHARED);
-		$this->instance->changeLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 }

--- a/tests/lib/lock/lockingprovider.php
+++ b/tests/lib/lock/lockingprovider.php
@@ -50,12 +50,22 @@ abstract class LockingProvider extends TestCase {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testSharedLock() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testDoubleSharedLock() {
@@ -64,6 +74,9 @@ abstract class LockingProvider extends TestCase {
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testReleaseSharedLock() {
@@ -72,10 +85,17 @@ abstract class LockingProvider extends TestCase {
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	/**
@@ -84,14 +104,26 @@ abstract class LockingProvider extends TestCase {
 	public function testDoubleExclusiveLock() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
 		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	public function testReleaseExclusiveLock() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
 		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
@@ -101,15 +133,25 @@ abstract class LockingProvider extends TestCase {
 	public function testExclusiveLockAfterShared() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
 	public function testExclusiveLockAfterSharedReleased() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
 	public function testReleaseAll() {
@@ -118,22 +160,45 @@ abstract class LockingProvider extends TestCase {
 		$this->instance1->acquireLock('bar', ILockingProvider::LOCK_SHARED);
 		$this->instance1->acquireLock('asd', ILockingProvider::LOCK_EXCLUSIVE);
 
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($this->instance1->isLockOwned('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertTrue($this->instance1->isLockOwned('asd', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('asd', ILockingProvider::LOCK_EXCLUSIVE));
+
 		$this->instance1->releaseAll();
 
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 		$this->assertFalse($this->instance2->isLocked('bar', ILockingProvider::LOCK_SHARED));
 		$this->assertFalse($this->instance2->isLocked('asd', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance1->isLockOwned('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('bar', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance1->isLockOwned('asd', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('asd', ILockingProvider::LOCK_EXCLUSIVE));
 	}
 
 	public function testReleaseAfterReleaseAll() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance1->releaseAll();
 
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance1->releaseLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 
@@ -143,6 +208,10 @@ abstract class LockingProvider extends TestCase {
 	public function testSharedLockAfterExclusive() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
 		$this->instance2->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 
@@ -166,16 +235,38 @@ abstract class LockingProvider extends TestCase {
 
 	public function testChangeLockToExclusive() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	public function testChangeLockToShared() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->assertFalse($this->instance2->isLocked('foo', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->assertTrue($this->instance2->isLocked('foo', ILockingProvider::LOCK_SHARED));
+
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
+		$this->assertFalse($this->instance2->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 	}
 
 	/**
@@ -184,6 +275,8 @@ abstract class LockingProvider extends TestCase {
 	public function testChangeLockToExclusiveDoubleShared() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
@@ -191,6 +284,8 @@ abstract class LockingProvider extends TestCase {
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToExclusiveNoShared() {
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
@@ -199,6 +294,7 @@ abstract class LockingProvider extends TestCase {
 	 */
 	public function testChangeLockToExclusiveFromExclusive() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_EXCLUSIVE);
 	}
 
@@ -206,6 +302,8 @@ abstract class LockingProvider extends TestCase {
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testChangeLockToSharedNoExclusive() {
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_EXCLUSIVE));
+		$this->assertFalse($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 
@@ -214,6 +312,7 @@ abstract class LockingProvider extends TestCase {
 	 */
 	public function testChangeLockToSharedFromShared() {
 		$this->instance1->acquireLock('foo', ILockingProvider::LOCK_SHARED);
+		$this->assertTrue($this->instance1->isLockOwned('foo', ILockingProvider::LOCK_SHARED));
 		$this->instance1->changeLock('foo', ILockingProvider::LOCK_SHARED);
 	}
 }

--- a/tests/lib/lock/memcachelockingprovider.php
+++ b/tests/lib/lock/memcachelockingprovider.php
@@ -31,15 +31,27 @@ class MemcacheLockingProvider extends LockingProvider {
 	private $memcache;
 
 	/**
+	 * @return \OCP\IMemcache
+	 */
+	protected function getMemcache() {
+		if ($this->memcache instanceof \OCP\IMemcache) {
+			return $this->memcache;
+		}
+		$this->memcache = new ArrayCache();
+		return $this->memcache;
+	}
+
+	/**
 	 * @return \OCP\Lock\ILockingProvider
 	 */
 	protected function getInstance() {
-		$this->memcache = new ArrayCache();
-		return new \OC\Lock\MemcacheLockingProvider($this->memcache);
+		return new \OC\Lock\MemcacheLockingProvider($this->getMemcache());
 	}
 
 	public function tearDown() {
-		$this->memcache->clear();
+		if ($this->memcache instanceof \OCP\IMemcache) {
+			$this->memcache->clear();
+		}
 		parent::tearDown();
 	}
 }


### PR DESCRIPTION
We need a way so that subcalls of the same process can try to get locks.
This is required because storage wrappers and hooks are within the parent lock,
but currently fail to be allowed to get locks, because the file is already locked.

So I added local lock tracking, if we have an exclusive lock already. The memcache lock
can only be released when we have no more local locks. This allows subsequent calls of the
same process to lock and release files just normally.
This thereby fixes the problem of the encryption storage wrapper that makes smashbox fail, see #17029 for more details.

Fixes #17029 

@PVince81 @icewind1991 @DeepDiver1975 @schiesbn 
