### PR TITLE
Search address book for federated cloud id

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -352,7 +352,23 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 							)
 						);
 					}
+					$contactManager = \OC::$server->getContactsManager();
+					$addressBookContacts = $contactManager->search($_GET['search'], ['CLOUD', 'FN']);
+					foreach ($addressBookContacts as $contact) {
+						if (isset($contact['CLOUD'])) {
+							foreach ($contact['CLOUD'] as $cloudId) {
+								$shareWith[] = array(
+									'label' => $contact['FN'] . ' (' . $cloudId . ')',
+									'value' => array(
+										'shareType' => \OCP\Share::SHARE_TYPE_REMOTE,
+										'shareWith' => $cloudId
+									)
+								);
+							}
+						}
+					}
 				}
+
 
 				$sorter = new \OC\Share\SearchResultSorter((string)$_GET['search'],
 														   'label',

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1703,11 +1703,20 @@ class Share extends Constants {
 				$row['permissions'] &= ~\OCP\Constants::PERMISSION_SHARE;
 			}
 			// Add display names to result
+			$row['share_with_displayname'] = $row['share_with'];
 			if ( isset($row['share_with']) && $row['share_with'] != '' &&
 				isset($row['share_with']) && $row['share_type'] === self::SHARE_TYPE_USER) {
 				$row['share_with_displayname'] = \OCP\User::getDisplayName($row['share_with']);
-			} else {
-				$row['share_with_displayname'] = $row['share_with'];
+			} else if(isset($row['share_with']) && $row['share_with'] != '' &&
+				$row['share_type'] === self::SHARE_TYPE_REMOTE) {
+				$addressBookEntries = \OC::$server->getContactsManager()->search($row['share_with'], ['CLOUD']);
+				foreach ($addressBookEntries as $entry) {
+					foreach ($entry['CLOUD'] as $cloudID) {
+						if ($cloudID === $row['share_with']) {
+							$row['share_with_displayname'] = $entry['FN'];
+						}
+					}
+				}
 			}
 			if ( isset($row['uid_owner']) && $row['uid_owner'] != '') {
 				$row['displayname_owner'] = \OCP\User::getDisplayName($row['uid_owner']);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1705,7 +1705,7 @@ class Share extends Constants {
 			// Add display names to result
 			$row['share_with_displayname'] = $row['share_with'];
 			if ( isset($row['share_with']) && $row['share_with'] != '' &&
-				isset($row['share_with']) && $row['share_type'] === self::SHARE_TYPE_USER) {
+				$row['share_type'] === self::SHARE_TYPE_USER) {
 				$row['share_with_displayname'] = \OCP\User::getDisplayName($row['share_with']);
 			} else if(isset($row['share_with']) && $row['share_with'] != '' &&
 				$row['share_type'] === self::SHARE_TYPE_REMOTE) {


### PR DESCRIPTION
Search the address book for federated cloud IDs and use it for auto completion in the share dialog. In order to work you need the contacts app from master (was added to contacts here: https://github.com/owncloud/contacts/pull/924) and add a "Federated Cloud ID" to your contact.

This is how auto completion looks like (we search for the full name and the cloud id)

![1](https://cloud.githubusercontent.com/assets/1589737/8352491/d02bad2e-1b35-11e5-9a2e-bc4f880cbeef.png)

After the file was shared successfully and you re-open the share dialog you will see:

![2](https://cloud.githubusercontent.com/assets/1589737/8352505/e3abd7b6-1b35-11e5-9126-f207491804d5.png)

The display name is the full name stored in the address book, on hover we show the federated cloud id of the user.

cc @jancborchardt what do you think from the design point of view. Anything we could/should improve?
