### PR TITLE
[stable8] emit hooks from a view as long as the path is inside the default root

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -898,7 +898,8 @@ class View {
 		if ($this->fakeRoot === $defaultRoot) {
 			return true;
 		}
-		return (strlen($this->fakeRoot) > strlen($defaultRoot)) && (substr($this->fakeRoot, 0, strlen($defaultRoot) + 1) === $defaultRoot . '/');
+		$fullPath = $this->getAbsolutePath($path);
+		return (strlen($fullPath) > strlen($defaultRoot)) && (substr($fullPath, 0, strlen($defaultRoot) + 1) === $defaultRoot . '/');
 	}
 
 	/**

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -909,10 +909,11 @@ class View {
 	 * @return bool
 	 */
 	private function runHooks($hooks, $path, $post = false) {
+		$relativePath = $path;
 		$path = $this->getHookPath($path);
 		$prefix = ($post) ? 'post_' : '';
 		$run = true;
-		if ($this->shouldEmitHooks($path)) {
+		if ($this->shouldEmitHooks($relativePath)) {
 			foreach ($hooks as $hook) {
 				if ($hook != 'read') {
 					\OC_Hook::emit(


### PR DESCRIPTION
Backport of #16657
