### PR TITLE
[stable7] [config.sample.php] set correct default value for skeletondirectory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -211,7 +211,7 @@ $CONFIG = array(
  * copied to the data directory of new users. Leave empty to not copy any
  * skeleton files.
  */
-'skeletondirectory' => '',
+'skeletondirectory' => '/path/to/owncloud/core/skeleton',
 
 /**
  * The ``user_backends`` app (which needs to be enabled first) allows you to


### PR DESCRIPTION
This is a backport of #17026 which only addresses documentation within the config.sample.php

cc @nickvergessen @LukasReschke 
