### PR TITLE
Fix for #17178

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -273,8 +273,15 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				$sharedUsers = [];
 				$sharedGroups = [];
 				if (isset($_GET['itemShares'])) {
-					$sharedUsers = isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) ? $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER] : [];
-					$sharedGroups = isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP]) ? $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP] : [];
+					if (isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]) &&
+					    is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])) {
+						$sharedUsers = $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER];
+					}
+
+					if (isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP]) &&
+					    is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
+						$sharedGroups = isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP]);
+					}
 				}
 
 				$count = 0;


### PR DESCRIPTION
Should fix #17178.

The problem was that the submitted POST arguments when empty were considered as strings. not arrays.

Still pretty crappy that testing these ajax files is near impossible :(

CC: @LukasReschke @nickvergessen @PVince81 
