### PR TITLE
Remote shares should be uique

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -781,6 +781,19 @@ class Share extends Constants {
 			\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName), \OCP\Util::ERROR);
 			throw new \Exception($message_t);
 		} else if ($shareType === self::SHARE_TYPE_REMOTE) {
+
+			/*
+			 * Check if file is not already shared with the remote user
+			 */
+			if ($checkExists = self::getItems($itemType, $itemSource, self::SHARE_TYPE_REMOTE,
+				$shareWith, $uidOwner, self::FORMAT_NONE, null, 1, true, true)) {
+					$message = 'Sharing %s failed, because this item is already shared with %s';
+					$message_t = $l->t('Sharing %s failed, because this item is already shared with %s', array($itemSourceName, $shareWith));
+					\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::ERROR);
+					throw new \Exception($message_t);
+			}
+
+
 			$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(self::TOKEN_LENGTH, \OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
 				\OCP\Security\ISecureRandom::CHAR_DIGITS);
 


### PR DESCRIPTION
Fix for #17183

Right now it is possible for a user A to create multiple remote shares to a user B. This is weird behaviour.
- [x] Check for existing shares from user A to user B
- [ ] Check for existing shares of the same stuff from a user C to user B (and what do we do then)
- [x] Try to tests this

Probably this PR won't get it a 100% right since it it complex material. But it should fix the most common issues.
