### PR TITLE
fix z-index of share-autocomplete

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -161,6 +161,7 @@ a.showCruds:hover,a.unshare:hover {
 	max-height:103px;
 	overflow-y:auto;
 	overflow-x:hidden;
+	z-index: 101 !important;
 }
 
 .notCreatable {


### PR DESCRIPTION
Fixes an issue caused by https://github.com/owncloud/core/pull/17105 where the autocomplete-popover didn’t show. Please review @owncloud/designers

@schiesbn this is the issue you mentioned in https://github.com/owncloud/contacts/issues/931#issuecomment-115284768
