### PR TITLE
Adding BPG media type

### DIFF
--- a/lib/private/mimetypes.list.php
+++ b/lib/private/mimetypes.list.php
@@ -45,6 +45,7 @@ return array(
 	'blend' => array('application/x-blender', null),
 	'bin' => array('application/x-bin', null),
 	'bmp' => array('image/bmp', null),
+	'bpg' => array('image/bpg', null),
 	'cb7' => array('application/x-cbr', null),
 	'cba' => array('application/x-cbr', null),
 	'cbr' => array('application/x-cbr', null),


### PR DESCRIPTION
This is to add support for the BPG media type so that apps can start experimenting with the format. Without that, they can't identify those files.

`image/bpg` has not been approved yet, but I don't think it's an issue as the format is so new.
No repair is necessary as it's unlikely people have large collections of images in that format.
#### Information on the format

BPG (Better Portable Graphics) is a new image format. Its purpose is to replace the JPEG image format when quality or file size is an issue. Its main advantages are:
- High compression ratio. Files are much smaller than JPEG for similar quality.
- Supported by most Web browsers with a small Javascript decoder (gzipped size: 56 KB).
- Based on a subset of the HEVC open video compression standard.
- Supports the same chroma formats as JPEG (grayscale, YCbCr 4:2:0, 4:2:2, 4:4:4) to reduce the losses during the conversion. An alpha channel is supported. The RGB, YCgCo and CMYK color spaces are also supported.
- Native support of 8 to 14 bits per channel for a higher dynamic range.
- Lossless compression is supported.
- Various metadata (such as EXIF, ICC profile, XMP) can be included.
- Animation support.

Source: http://bellard.org/bpg/

Online converter: http://webencoder.libbpg.org/
