### PR TITLE
Add endpoint with list of OCS providers

### DIFF
--- a/ocs-provider/index.php
+++ b/ocs-provider/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require_once('../lib/base.php');
+require_once(__DIR__ . '/provider.php');
+
+header('Content-Type: application/json');
+
+$server = \OC::$server;
+
+$controller = new Provider(
+	'ocs_provider',
+	$server->getRequest(),
+	$server->getAppManager()
+);
+echo $controller->buildProviderList()->render();

--- a/ocs-provider/provider.php
+++ b/ocs-provider/provider.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+class Provider extends \OCP\AppFramework\Controller {
+	/** @var \OCP\App\IAppManager */
+	private $appManager;
+
+	/**
+	 * @param string $appName
+	 * @param \OCP\IRequest $request
+	 * @param \OCP\App\IAppManager $appManager
+	 */
+	public function __construct($appName,
+								\OCP\IRequest $request,
+								\OCP\App\IAppManager $appManager) {
+		parent::__construct($appName, $request);
+		$this->appManager = $appManager;
+	}
+
+	/**
+	 * @return \OCP\AppFramework\Http\JSONResponse
+	 */
+	public function buildProviderList() {
+		$services = [
+			'version' => 2,
+			'PRIVATE_DATA' => [
+				'version' => 1,
+				'endpoints' => [
+					'store' => '/ocs/v1.php/privatedata/setattribute',
+					'read' => '/ocs/v1.php/privatedata/getattribute',
+					'delete' => '/ocs/v1.php/privatedata/deleteattribute',
+				],
+			],
+		];
+
+		if($this->appManager->isEnabledForUser('files_sharing')) {
+			$services['SHARING'] = [
+				'version' => 1,
+				'endpoints' => [
+					'share' => '/ocs/v1.php/apps/files_sharing/api/v1/shares',
+				],
+			];
+			$services['FEDERATED_SHARING'] = [
+				'version' => 1,
+				'endpoints' => [
+					'share' => '/ocs/v1.php/cloud/shares',
+					'webdav' => '/public.php/webdav/',
+				],
+			];
+		}
+
+		if($this->appManager->isEnabledForUser('activity')) {
+			$services['ACTIVITY'] = [
+				'version' => 1,
+				'endpoints' => [
+					'list' => '/ocs/v1.php/cloud/activity',
+				],
+			];
+		}
+
+		if($this->appManager->isEnabledForUser('provisioning_api')) {
+			$services['PROVISIONING'] = [
+				'version' => 1,
+				'endpoints' => [
+					'user' => '/ocs/v1.php/cloud/users',
+					'groups' => '/ocs/v1.php/cloud/groups',
+					'apps' => '/ocs/v1.php/cloud/apps',
+				],
+			];
+		}
+
+		return new \OCP\AppFramework\Http\JSONResponse($services);
+	}
+}

--- a/tests/ocs-provider/provider.php
+++ b/tests/ocs-provider/provider.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+class OcsProviderTest extends \Test\TestCase {
+	/** @var \OCP\IRequest */
+	private $request;
+	/** @var \OCP\App\IAppManager */
+	private $appManager;
+	/** @var Provider */
+	private $ocsProvider;
+
+	public function setUp() {
+		parent::setUp();
+
+		require_once '../ocs-provider/provider.php';
+
+		$this->request = $this->getMockBuilder('\\OCP\\IRequest')->getMock();
+		$this->appManager = $this->getMockBuilder('\\OCP\\App\\IAppManager')->getMock();
+		$this->ocsProvider = new Provider('ocs_provider', $this->request, $this->appManager);
+	}
+
+	public function testBuildProviderListWithoutAnythingEnabled() {
+		$this->appManager
+			->expects($this->at(0))
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(1))
+			->method('isEnabledForUser')
+			->with('activity')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(2))
+			->method('isEnabledForUser')
+			->with('provisioning_api')
+			->will($this->returnValue(false));
+
+		$expected = new \OCP\AppFramework\Http\JSONResponse(
+			[
+				'version' => 2,
+				'PRIVATE_DATA' => [
+					'version' => 1,
+					'endpoints' => [
+						'store' => '/ocs/v1.php/privatedata/setattribute',
+						'read' => '/ocs/v1.php/privatedata/getattribute',
+						'delete' => '/ocs/v1.php/privatedata/deleteattribute',
+					],
+				],
+			]
+		);
+
+		$this->assertEquals($expected, $this->ocsProvider->buildProviderList());
+	}
+
+	public function testBuildProviderListWithSharingEnabled() {
+		$this->appManager
+			->expects($this->at(0))
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->will($this->returnValue(true));
+		$this->appManager
+			->expects($this->at(1))
+			->method('isEnabledForUser')
+			->with('activity')
+			->will($this->returnValue(false));
+		$this->appManager
+			->expects($this->at(2))
+			->method('isEnabledForUser')
+			->with('provisioning_api')
+			->will($this->returnValue(false));
+
+		$expected = new \OCP\AppFramework\Http\JSONResponse(
+			[
+				'version' => 2,
+				'PRIVATE_DATA' => [
+					'version' => 1,
+					'endpoints' => [
+						'store' => '/ocs/v1.php/privatedata/setattribute',
+						'read' => '/ocs/v1.php/privatedata/getattribute',
+						'delete' => '/ocs/v1.php/privatedata/deleteattribute',
+					],
+				],
+				'FEDERATED_SHARING' => [
+					'version' => 1,
+					'endpoints' => [
+						'share' => '/ocs/v1.php/cloud/shares',
+						'webdav' => '/public.php/webdav/',
+					],
+				],
+				'SHARING' => [
+					'version' => 1,
+					'endpoints' => [
+						'share' => '/ocs/v1.php/apps/files_sharing/api/v1/shares',
+					],
+				],
+			]
+		);
+
+		$this->assertEquals($expected, $this->ocsProvider->buildProviderList());
+	}
+
+	public function testBuildProviderListWithEverythingEnabled() {
+		$this->appManager
+			->expects($this->any())
+			->method('isEnabledForUser')
+			->will($this->returnValue(true));
+
+		$expected = new \OCP\AppFramework\Http\JSONResponse(
+			[
+				'version' => 2,
+				'PRIVATE_DATA' => [
+					'version' => 1,
+					'endpoints' => [
+						'store' => '/ocs/v1.php/privatedata/setattribute',
+						'read' => '/ocs/v1.php/privatedata/getattribute',
+						'delete' => '/ocs/v1.php/privatedata/deleteattribute',
+					],
+				],
+				'FEDERATED_SHARING' => [
+					'version' => 1,
+					'endpoints' => [
+						'share' => '/ocs/v1.php/cloud/shares',
+						'webdav' => '/public.php/webdav/',
+					],
+				],
+				'SHARING' => [
+					'version' => 1,
+					'endpoints' => [
+						'share' => '/ocs/v1.php/apps/files_sharing/api/v1/shares',
+					],
+				],
+				'ACTIVITY' => [
+					'version' => 1,
+					'endpoints' => [
+						'list' => '/ocs/v1.php/cloud/activity',
+					],
+				],
+				'PROVISIONING' => [
+					'version' => 1,
+					'endpoints' => [
+						'user' => '/ocs/v1.php/cloud/users',
+						'groups' => '/ocs/v1.php/cloud/groups',
+						'apps' => '/ocs/v1.php/cloud/apps',
+					],
+				],
+			]
+		);
+
+		$this->assertEquals($expected, $this->ocsProvider->buildProviderList());
+	}
+}

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -10,6 +10,7 @@
 		<directory suffix='.php'>lib/</directory>
 		<directory suffix='.php'>settings/</directory>
 		<directory suffix='.php'>core/</directory>
+		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<!-- filters for code coverage -->

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -4,6 +4,7 @@
 		<directory suffix='.php'>lib/</directory>
 		<directory suffix='.php'>settings/</directory>
 		<directory suffix='.php'>core/</directory>
+		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<!-- filters for code coverage -->


### PR DESCRIPTION
This adds a OCS provider list at `ocs-provider/` to enable a somewhat autodiscovery of services.

In the moment it is not possible for applications to add own entries and it is basically hard-coded in the controller. I'm aware that this is not an optimal solution and I'm happy for any pragmatic input that won't pollute our public API too much. (and is not a big super hack, this is already hacky enough ;-))
I'd really avoid to add more static stuff to the public API when we can maybe come up with a proper method in the future. (feedback welcome!)

That said, I'd consider it as a first step also feasible to go with this somewhat hard-coded list and see if this gets adopted...

@karlitschek @schiesbn 
