### PR TITLE
Increase timeout again

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,4 +21,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 7200    # Timeout in seconds. 60 minutes
+        timeout: 7200    # Timeout in seconds. 120 minutes

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,4 +21,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 3600    # Timeout in seconds. 60 minutes
+        timeout: 7200    # Timeout in seconds. 60 minutes


### PR DESCRIPTION
Our test execution is terribly slow and now also exceeds more than one hour on our CI system. This means that Scrutinizer fails hard on a lot of PRs such as https://github.com/owncloud/core/pull/17217#issuecomment-116252420

@DeepDiver1975 @MorrisJobke 
