### PR TITLE
Fix class name conflict

### DIFF
--- a/lib/private/connector/sabre/maintenanceplugin.php
+++ b/lib/private/connector/sabre/maintenanceplugin.php
@@ -27,7 +27,6 @@ namespace OC\Connector\Sabre;
 
 use OCP\IConfig;
 use Sabre\DAV\Exception\ServiceUnavailable;
-use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 
 class MaintenancePlugin extends ServerPlugin {
@@ -61,10 +60,10 @@ class MaintenancePlugin extends ServerPlugin {
 	 *
 	 * This method should set up the required event subscriptions.
 	 *
-	 * @param Server $server
+	 * @param \Sabre\DAV\Server $server
 	 * @return void
 	 */
-	public function initialize(Server $server) {
+	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
 		$this->server->on('beforeMethod', array($this, 'checkMaintenanceMode'), 10);
 	}


### PR DESCRIPTION
Looks like PHP 5.6.x doesn't like name conflicts.

\Sabre\DAV\Server would overlap with \OC\Connector\Sabre\Server.

This fixes this issue on my machine:

```
{"reqId":"XBiGzZSk++g8Zowq\/wkR","remoteAddr":"127.0.0.1","app":"PHP","message":"Cannot use Sabre\\DAV\\Server as Server because the name is already in use at \/srv\/www\/htdocs\/owncloud\/lib\/private\/connector\/sabre\/maintenanceplugin.php#30","level":3,"time":"2015-06-29T15:09:58+00:00","method":"PROPFIND","url":"\/owncloud\/remote.php\/webdav\/"}
```

To reproduce, PUT a file with WebDAV.
Only appears with PHP 5.6+

Please review @nickvergessen @DeepDiver1975 @icewind1991 @LukasReschke 
