### PR TITLE
Fixing "ImportController::__construct() must implement interface OCP\…

### DIFF
--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -25,9 +25,12 @@ namespace OC\Cache;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\ICache;
 use OCP\Security\ISecureRandom;
 
-class File {
+class File implements ICache {
+
+	/** @var View */
 	protected $storage;
 
 	/**

--- a/tests/lib/server.php
+++ b/tests/lib/server.php
@@ -99,6 +99,7 @@ class Server extends \Test\TestCase {
 			['NavigationManager', '\OC\NavigationManager'],
 			['NavigationManager', '\OCP\INavigationManager'],
 			['UserCache', '\OC\Cache\File'],
+			['UserCache', '\OCP\ICache'],
 
 			['OcsClient', '\OC\OCSClient'],
 


### PR DESCRIPTION
…\ICache, instance of OC\Cache\File given"

@nickvergessen @PVince81 @icewind1991 @MorrisJobke THX
