### PR TITLE
Perform the filesize on the file that exists

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -364,8 +364,12 @@ class Encryption extends Wrapper {
 					$encryptionModule = $this->encryptionManager->getEncryptionModule($encryptionModuleId);
 				}
 
-				$size = $this->storage->filesize($path);
-				$unencryptedSize = $this->filesize($path);
+				if ($this->file_exists($path)) {
+					$size = $this->storage->filesize($path);
+					$unencryptedSize = $this->filesize($path);
+				} else {
+					$size = $unencryptedSize = 0;
+				}
 			}
 
 			try {


### PR DESCRIPTION
Caused by the solution of 95602d4069a1eb9a45e1d08edeecc0d5b90e01ca and 9b336765b69bf7b7e2cd67a824862411b249aa4d

We changed the file path in `file_exists()` but still performed the `filesize()` on the original item.
@schiesbn mind having a quick look? The problem seems obvious to me.

cc @th3fallen @DeepDiver1975 

Fix #17247 
