### PR TITLE
Catch more error codes thrown by federated shares

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -191,7 +191,7 @@ class Storage extends DAV implements ISharedStorage {
 				throw new StorageInvalidException();
 			} else {
 				// ownCloud instance is gone, likely to be a temporary server configuration error
-				throw $e;
+				throw new StorageNotAvailableException();
 			}
 		} catch (ForbiddenException $e) {
 			// auth error, remove share for now (provide a dialog in the future)
@@ -201,10 +201,7 @@ class Storage extends DAV implements ISharedStorage {
 		} catch (\GuzzleHttp\Exception\ConnectException $e) {
 			throw new StorageNotAvailableException();
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
-			if ($e->getCode() === 503) {
-				throw new StorageNotAvailableException();
-			}
-			throw $e;
+			throw new StorageNotAvailableException();
 		} catch (\Exception $e) {
 			throw $e;
 		}
@@ -250,16 +247,13 @@ class Storage extends DAV implements ISharedStorage {
 		try {
 			$response = $client->post($url, ['body' => ['password' => $password]]);
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
-			switch ($e->getCode()) {
-				case 401:
-				case 403:
+			if ($e->getCode() === 401 || $e->getCode() === 403) {
 					throw new ForbiddenException();
-				case 404:
-					throw new NotFoundException();
-				case 500:
-					throw new \Exception();
 			}
-			throw $e;
+			// throw this to be on the safe side: the share will still be visible
+			// in the UI in case the failure is intermittent, and the user will
+			// be able to decide whether to remove it if it's really gone
+			throw new NotFoundException();
 		}
 
 		return json_decode($response->getBody(), true);


### PR DESCRIPTION
Most of the time it doesn't make sense to forward Guzzle's
RequestException, so we convert it to StorageNotAvailable instead.

This prevents unpredictable error codes to block access to unrelated
folders needlessly.

Fixes https://github.com/owncloud/core/issues/17272

@schiesbn @nickvergessen @LukasReschke @icewind1991 

Setting to 8.2 first
