### PR TITLE
Fix the mount point name before creating the activities

### DIFF
--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -164,7 +164,7 @@ class Server2Server {
 			$remote = $this->cleanupRemote($share['remote']);
 
 			$owner = $share['owner'] . '@' . $remote;
-			$mountpoint = $share['mountpoint'];
+			$mountpoint = $this->getMountPointFromTemporaryName($share['mountpoint']);
 			$user = $share['user'];
 
 			$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*share_external` WHERE `remote_id` = ? AND `share_token` = ?');
@@ -176,6 +176,24 @@ class Server2Server {
 		}
 
 		return new \OC_OCS_Result();
+	}
+
+	/**
+	 * Extract the mountpoint name from the temporary name
+	 *
+	 * Not accepted external shares have  `{{TemporaryMountPointName#/foobar}}`
+	 * as a name, to make sure they get a unique name when they are being accepted:
+	 *  =>
+	 *
+	 * @param string $mountpoint E.g. `{{TemporaryMountPointName#/foobar}}`
+	 * @return string Cleaned name as `/foobar`
+	 */
+	private function getMountPointFromTemporaryName($mountpoint) {
+		if (strpos($mountpoint, '{{TemporaryMountPointName#') === 0 && substr($mountpoint, -2) === '}}') {
+			return substr($mountpoint, strlen('{{TemporaryMountPointName#'), -2);
+		}
+
+		return $mountpoint;
 	}
 
 	private function cleanupRemote($remote) {


### PR DESCRIPTION
### Steps to reproduce
1. Make sure to have activities for remote shares enabled:
   
   > A file or folder was shared from another server
2. Remote share an item (do **NOT** accept)
3. Delete the remote share
4. Check activities on the remote instance:
   1. You received a new remote share from admin@localhost/ownCloud/eightOne/core
   2. _admin@localhost/ownCloud/eightOne/core_ unshared `Tooltip: "in {{TemporaryMountPointName#` **test}}** from you 

With patch step 4 shows:
1. You received a new remote share from admin@localhost/ownCloud/eightOne/core
2. _admin@localhost/ownCloud/eightOne/core_ unshared `No Tooltip` **test** from you 

@schiesbn @DeepDiver1975 
