### PR TITLE
exclude directories from beeing processed

### DIFF
--- a/apps/files/ajax/newfile.php
+++ b/apps/files/ajax/newfile.php
@@ -62,6 +62,15 @@ if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
 	exit();
 }
 
+if (\OC\Files\Filesystem::isForbiddenFileOrDir($fileName)) {
+	$result['data'] = array('message' => $l10n->t(
+			'The name %s has been excluded by the admin for files and directories. Please choose a different name.',
+			$fileName)
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 $target = $dir.'/'.$fileName;
 
 if (\OC\Files\Filesystem::file_exists($target)) {

--- a/apps/files/ajax/newfolder.php
+++ b/apps/files/ajax/newfolder.php
@@ -54,6 +54,15 @@ try {
 	return;
 }
 
+if (\OC\Files\Filesystem::isForbiddenFileOrDir($folderName)) {
+	$result['data'] = array('message' => $l10n->t(
+			'The name %s has been excluded by the admin for files and directories. Please choose a different name.',
+			$folderName)
+		);
+	OCP\JSON::error($result);
+	exit();
+}
+
 if (!\OC\Files\Filesystem::file_exists($dir . '/')) {
 	$result['data'] = array('message' => (string)$l10n->t(
 			'The target folder has been moved or deleted.'),

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -803,6 +803,19 @@ $CONFIG = array(
 'blacklisted_files' => array('.htaccess'),
 
 /**
+ * Exclude specific directory names and disallow 
+ * scanning, creating and renaming using these names. Case insensitive.
+ * Excluded directories will not show up.
+ * Use when the storage backend supports eg snapshot directories to be excluded.
+ * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
+ */
+'excluded_directories' =>
+	array (
+		'.snapshot',
+		'~snapshot',
+	),
+
+/**
  * Define a default folder for shared files and folders other than root.
  */
 'share_folder' => '/',

--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -137,7 +137,7 @@ class AvatarController extends Controller {
 			if (
 				$files['error'][0] === 0 &&
 				 is_uploaded_file($files['tmp_name'][0]) &&
-				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
+				!\OC\Files\Filesystem::isForbiddenFileOrDir($files['tmp_name'][0])
 			) {
 				$this->cache->set('avatar_upload', file_get_contents($files['tmp_name'][0]), 7200);
 				$view = new \OC\Files\View('/'.$userId.'/cache');

--- a/lib/base.php
+++ b/lib/base.php
@@ -767,8 +767,8 @@ class OC {
 	 */
 	public static function registerFilesystemHooks() {
 		// Check for blacklisted files
-		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isBlacklisted');
-		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isBlacklisted');
+		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
+		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
 	}
 
 	/**

--- a/lib/private/connector/sabre/custompropertiesbackend.php
+++ b/lib/private/connector/sabre/custompropertiesbackend.php
@@ -103,6 +103,9 @@ class CustomPropertiesBackend implements BackendInterface {
 		} catch (ServiceUnavailable $e) {
 			// might happen for unavailable mount points, skip
 			return;
+		} catch (Forbidden $e) {
+			// might happen for excluded mount points, skip
+			return;
 		} catch (NotFound $e) {
 			// in some rare (buggy) cases the node might not be found,
 			// we catch the exception to prevent breaking the whole list with a 404

--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -83,6 +83,12 @@ class Directory extends \OC\Connector\Sabre\Node
 	 */
 	public function createFile($name, $data = null) {
 
+		# the check here is necessary, because createFile uses put covered in sabre/file.php 
+		# and not touch covered in files/view.php
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($name)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
 		try {
 			// for chunked upload also updating a existing file is a "createFile"
 			// because we create all the chunks before re-assemble them to the existing file.

--- a/lib/private/connector/sabre/objecttree.php
+++ b/lib/private/connector/sabre/objecttree.php
@@ -103,6 +103,10 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		if (!$this->fileView) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
+		// if the path has been entered manually and eg not via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
 
 		$path = trim($path, '/');
 		if ($path) {

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -299,8 +299,8 @@ class Scanner extends BasicEmitter {
 		if ($dh = $this->storage->opendir($folder)) {
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if (!Filesystem::isIgnoredDir($file)) {
-						$children[] = $file;
+					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
+							$children[] = $file;
 					}
 				}
 			}

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -583,29 +583,26 @@ class Filesystem {
 	 *
 	 * @param array $data from hook
 	 */
-	static public function isBlacklisted($data) {
+	static public function isForbiddenFileOrDir_Hook($data) {
 		if (isset($data['path'])) {
 			$path = $data['path'];
 		} else if (isset($data['newpath'])) {
 			$path = $data['newpath'];
 		}
 		if (isset($path)) {
-			if (self::isFileBlacklisted($path)) {
+			if (self::isForbiddenFileOrDir($path)) {
 				$data['run'] = false;
 			}
 		}
 	}
 
 	/**
+	 * depriciated, replaced by isForbiddenFileOrDir
 	 * @param string $filename
-	 * @return bool
+	 * @return boolean
 	 */
 	static public function isFileBlacklisted($filename) {
-		$filename = self::normalizePath($filename);
-
-		$blacklist = \OC_Config::getValue('blacklisted_files', array('.htaccess'));
-		$filename = strtolower(basename($filename));
-		return in_array($filename, $blacklist);
+		return self::isForbiddenFileOrDir($filename);
 	}
 
 	/**
@@ -617,6 +614,52 @@ class Filesystem {
 	 */
 	static public function isIgnoredDir($dir) {
 		if ($dir === '.' || $dir === '..') {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	* Check if the directory path / file name contains a Blacklisted or Excluded name
+	* config.php parameter arrays can contain file names to be blacklisted or directory names to be excluded
+	* Blacklist ... files that may harm the owncloud environment like a foreign .htaccess file
+	* Excluded  ... directories that are excluded from beeing further processed, like snapshot directories
+	* $ed and the query can be redesigned if filesystem.php will get a constructor where it is possible to 
+	* define the excluded directories for unit tests
+	* @param String $dir
+	* @param array $ed
+	* @return boolean
+	*/
+	static public function isForbiddenFileOrDir($FileOrDir, $ed = array()) {
+		$excluded = array();
+		$blacklist = array();
+		$path_parts = array();
+		$ppx = array();
+		$blacklist = \OC::$server->getSystemConfig()->getValue('blacklisted_files', array('.htaccess'));
+		if ($ed) {
+			$excluded = $ed;
+		} else {
+			$excluded = \OC::$server->getSystemConfig()->getValue('excluded_directories', $ed);
+		}
+		// explode '/'
+		$ppx = array_filter(explode('/', $FileOrDir), 'strlen');
+		$ppx = array_map('strtolower', $ppx);
+		// explode each array element with '\' and add to result array  
+		foreach($ppx as $pp) {
+			$path_parts = array_merge($path_parts, array_filter(explode('\\', $pp), 'strlen'));
+		}
+		if ($excluded) {
+			$excluded = array_map('trim', $excluded);
+			$excluded = array_map('strtolower', $excluded);
+			$match = array_intersect($path_parts, $excluded);
+			if ($match) {
+				return true;
+			}
+		}
+		$blacklist = array_map('trim', $blacklist);
+		$blacklist = array_map('strtolower', $blacklist);
+		$match = array_intersect($path_parts, $blacklist);
+		if ($match) {
 			return true;
 		}
 		return false;

--- a/lib/private/files/mapper.php
+++ b/lib/private/files/mapper.php
@@ -282,7 +282,7 @@ class Mapper
 		// trim ending dots (for security reasons and win compatibility)
 		$text = preg_replace('~\.+$~', '', $text);
 
-		if (empty($text) || \OC\Files\Filesystem::isFileBlacklisted($text)) {
+		if (empty($text) || \OC\Files\Filesystem::isForbiddenFileOrDir($text)) {
 			/**
 			 * Item slug would be empty. Previously we used uniqid() here.
 			 * However this means that the behaviour is not reproducible, so

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -531,7 +531,7 @@ class View {
 		if (is_resource($data)) { //not having to deal with streams in file_put_contents makes life easier
 			$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 			if (Filesystem::isValidPath($path)
-				and !Filesystem::isFileBlacklisted($path)
+				and !Filesystem::isForbiddenFileOrDir($path)
 			) {
 				$path = $this->getRelativePath($absolutePath);
 
@@ -618,7 +618,7 @@ class View {
 		if (
 			Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and !Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isForbiddenFileOrDir($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -740,7 +740,7 @@ class View {
 		if (
 			Filesystem::isValidPath($path2)
 			and Filesystem::isValidPath($path1)
-			and !Filesystem::isFileBlacklisted($path2)
+			and !Filesystem::isForbiddenFileOrDir($path2)
 		) {
 			$path1 = $this->getRelativePath($absolutePath1);
 			$path2 = $this->getRelativePath($absolutePath2);
@@ -978,7 +978,7 @@ class View {
 		$postFix = (substr($path, -1, 1) === '/') ? '/' : '';
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (Filesystem::isValidPath($path)
-			and !Filesystem::isFileBlacklisted($path)
+			and !Filesystem::isForbiddenFileOrDir($path)
 		) {
 			$path = $this->getRelativePath($absolutePath);
 			if ($path == null) {

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -442,7 +442,7 @@ class OC_Helper {
 					self::copyr("$src/$file", "$dest/$file");
 				}
 			}
-		} elseif (file_exists($src) && !\OC\Files\Filesystem::isFileBlacklisted($src)) {
+		} elseif (file_exists($src) && !\OC\Files\Filesystem::isForbiddenFileOrDir($src)) {
 			copy($src, $dest);
 		}
 	}

--- a/lib/private/security/certificatemanager.php
+++ b/lib/private/security/certificatemanager.php
@@ -111,7 +111,7 @@ class CertificateManager implements ICertificateManager {
 	 * @throws \Exception If the certificate could not get added
 	 */
 	public function addCertificate($certificate, $name) {
-		if (!Filesystem::isValidPath($name) or Filesystem::isFileBlacklisted($name)) {
+		if (!Filesystem::isValidPath($name) or Filesystem::isForbiddenFileOrDir($name)) {
 			throw new \Exception('Filename is not valid');
 		}
 

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -225,7 +225,7 @@ class Filesystem extends \Test\TestCase {
 			array('.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess\\', true),
 			array('/etc/foo\bar/.htaccess/', true),
-			array('/etc/foo\bar/.htaccess/foo', false),
+			array('/etc/foo\bar/.htaccess/foo', true),
 			array('//foo//bar/\.htaccess/', true),
 			array('\foo\bar\.HTAccess', true),
 		);
@@ -235,7 +235,30 @@ class Filesystem extends \Test\TestCase {
 	 * @dataProvider isFileBlacklistedData
 	 */
 	public function testIsFileBlacklisted($path, $expected) {
-		$this->assertSame($expected, \OC\Files\Filesystem::isFileBlacklisted($path));
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path));
+	}
+
+	public function isExcludedData() {
+		return array(
+			array('.snapshot', true),
+			array('.snapshot/', true),
+			array('.snapshot\\', true),
+			array('/etc/foo/bar/foo.txt', false),
+			array('/.snapshot/etc/foo/bar/foo.txt', true),
+			array('/.snapShot/etc/foo/bar/foo.txt', true),
+			array('\.snapshot\etc\foo/bar\foo.txt', true),
+			array('/etc/foo/.snapshot', true),
+			array('/etc/foo/.snapshot/bar', true),
+		);
+	}
+
+	/**
+	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to 
+	 * define the excluded directories for unit tests
+	 * @dataProvider isExcludedData
+	 */
+	public function testIsExcluded($path, $expected) {
+		$this->assertSame($expected, \OC\Files\Filesystem::isForbiddenFileOrDir($path, array('.snapshot')));
 	}
 
 	public function normalizePathWindowsAbsolutePathData() {


### PR DESCRIPTION
Because issues on Jenkins and the recommandation to create a new PR, here it is (attempt No 4...)

Summary:
1. Enterprise Storage Systems are capable of Snapshots. These Snapshots are directories with a particular name and keep point in time views of the data. Usually, these snapshot directories are present in each directory
2. There is no common naming for these directories and will never be. NetApp uses `.snapshot` and `~snapshot`, EMC eg `.ckpt`, HDS eg `.latest` and `~latest` and so on
3. Viewing and scanning of these directories does not make any sense as these directories are used to restore files from an OS point of view
4. You can also have hardlinks to backups with the same background as described in #15385
5. Scanning a huge datastore containing snapshots does mean that for each snapshot taken ALL files of the datastore are imported into the database again. Example: a datastore containing 200K files, having 15 snapshots means scanning of 3M files where 2.8M are worthless to be imported

There are for sure more resons, but I tried to keep it short.

With this PR, you can define a array of directory names in config.php which are further excluded from beeing processed.

These excluded directory names are not scanned, not viewed, can not be created or renamed (or deleted) or accessed via direct path input from a file explorer.

Access methods covered: webdav, webgui and client.

Following test have been made creating either a file or directory having once a allowed and once a excluded name. The results were the same independent of the storage type (tested on user home and SMB).

The functions shown in the table are except one all triggered and covered by the access methods used in lib/private/files/view.php

For WebDav, CyberDuck and native WebDav access was used on a W7 client.
The IOS client ran the latest available version (3.4.1)

All access tests made passed well.

The table shows the covered methods for all storage types using it:

|  | webdav | webgui | client IOS |
| --- | --- | --- | --- |
| directory create | mkdir | mkdir | mkdir |
| directory rename | rename | rename | rename |
| directory delete | rmdir | rmdir | rmdir |
|  |  |  |  |
| file create | put(*) | touch | n.a. |
| file rename | rename | rename | rename |
| file delete | unlink | unlink | unlink |

n.a. ... function not available
(*) put ... this function is not handled in lib/private/files/view.php but in lib/private/connector/sabre/directory.php which points to ../sabre/file.php

The case manually defining the path in a file explorer to access a excluded directory via a webdav connected client is also covered. (lib/private/connector/sabre/objecttree.php and ../sabre/custompropertiesbackend.php)

Adding a new external storage and let it scan also worked well, excluded directories are not further processed.

Example assumtion: excluded directory name is `.snapshot`

**allowed:**
my.snapshot
my.snapshot.name
.snapshot.name
/dir/my.snapshot
/dir/my.snapshot/subsubdir
...

**excluded:**
`.snapshot`
/dir/`.snapshot`
/dir/`.snapshot`/nightly.0

**Differences between Blacklisted Files and Excluded Directories**
Blacklist ... files that may harm the owncloud environment like a foreign .htaccess file
Excluded  ... directories that are excluded from beeing further processed, like snapshot directories

Unit tests included
Note: as there is no constructor in filesystem.php available, and I did not wanted to change all existing calls to do mockups, the excluded directory name to be tested against can be handed over as parameter and is only used by the unit test.

There is only one App (contacts) that is using `isFileBlacklisted`. Therefore I have left `isFileBlacklisted` with a depriciation note and forwarded the call to the new routine `isForbiddenFileOrDir`.

If the PR gets merged, I will take care on the contacts app and replace the function call name accordingly.

I will file a documentation PR in the next days to describe the behaviour and difference between Blacklist and Excluded properly.

@DeepDiver1975 @karlitschek @nickvergessen @Aesculapius  @icewind1991 @LukasReschke 
