### PR TITLE
Revert z-index changes

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -410,7 +410,6 @@
 	position: relative;
 	height: 100%;
 	overflow-y: auto;
-	z-index: 100;
 }
 
 #app-content-wrapper {
@@ -556,3 +555,4 @@ em {
 	z-index:500;
 	padding:16px;
 }
+

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -161,7 +161,6 @@ a.showCruds:hover,a.unshare:hover {
 	max-height:103px;
 	overflow-y:auto;
 	overflow-x:hidden;
-	z-index: 101 !important;
 }
 
 .notCreatable {


### PR DESCRIPTION
This reverts PRs https://github.com/owncloud/core/pull/17105 and https://github.com/owncloud/core/pull/17203 as the original issue wasn’t as grave as all the stuff these changes caused.

Please review @owncloud/designers 
- fix https://github.com/owncloud/core/issues/17292 @Raydiation 
- fix https://github.com/owncloud/contacts/issues/950 @thfree
- replace https://github.com/owncloud/core/pull/17278 & https://github.com/owncloud/core/pull/17279 @libasys

We _need_ to backport this to stable8.1 before release. @karlitschek 

What we learned today: Never ever again will we do z-index changes so early before the release …
