### PR TITLE
Check if response could get generated

### DIFF
--- a/lib/public/appframework/http/jsonresponse.php
+++ b/lib/public/appframework/http/jsonresponse.php
@@ -61,9 +61,16 @@ class JSONResponse extends Response {
 	 * Returns the rendered json
 	 * @return string the rendered json
 	 * @since 6.0.0
+	 * @throws \Exception If data could not get encoded
 	 */
-	public function render(){
-		return json_encode($this->data);
+	public function render() {
+		$response = json_encode($this->data);
+		if($response === false) {
+			throw new \Exception(sprintf('Could not json_encode due to invalid ' .
+				'non UTF-8 characters in the array: %s', var_export($this->data, true)));
+		}
+
+		return $response;
 	}
 
 	/**

--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -76,6 +76,17 @@ class JSONResponseTest extends \Test\TestCase {
 		$this->assertEquals($expected, $this->json->render());
 	}
 
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage Could not json_encode due to invalid non UTF-8 characters in the array: array (
+	 * @requires PHP 5.5
+	 */
+	public function testRenderWithNonUtf8Encoding() {
+		$params = ['test' => hex2bin('e9')];
+		$this->json->setData($params);
+		$this->json->render();
+	}
+
 	public function testConstructorAllowsToSetData() {
 		$data = array('hi');
 		$code = 300;


### PR DESCRIPTION
`json_encode` fails hard on PHP >= 5.5 if a non UTF-8 value is specified by returning false. Older PHP versions just nullify the value which makes it at least somewhat usable.

This leads to very confusing errors which are very hard to debug since developers are usually not aware of this. In this case I'd consider throwing a fatal exception – since it arguably is an error situation – is a fair solution since this makes developers and administrators aware of any occurence of the problem so that these bugs can get fixed.

Fixes https://github.com/owncloud/core/issues/17265

@DeepDiver1975 @Raydiation Thoughts?
