### PR TITLE
[stable8.1] Remove OCS IDs

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -19,5 +19,4 @@ Turning the feature off removes shared files and folders on the server for all s
 		<files>public.php</files>
 		<webdav>publicwebdav.php</webdav>
 	</public>
-	<ocsid>166050</ocsid>
 </info>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -18,5 +18,4 @@ To prevent a user from running out of disk space, the ownCloud Deleted files app
 	<documentation>
 		<user>user-trashbin</user>
 	</documentation>
-	<ocsid>166052</ocsid>
 </info>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -18,5 +18,4 @@ In addition to the expiry of versions, ownCloud’s versions app makes certain n
 		<user>user-versions</user>
 	</documentation>
 	<default_enable/>
-	<ocsid>166053</ocsid>
 </info>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -17,7 +17,6 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	<documentation>
 		<admin>admin-ldap</admin>
 	</documentation>
-	<ocsid>166061</ocsid>
 	<dependencies>
 		<lib>ldap</lib>
 	</dependencies>

--- a/apps/user_webdavauth/appinfo/info.xml
+++ b/apps/user_webdavauth/appinfo/info.xml
@@ -12,5 +12,4 @@
 	<types>
 		<authentication/>
 	</types>
-	<ocsid>166062</ocsid>
 </info>


### PR DESCRIPTION
While making the AppStore ready for 8.1 I also deleted some dummy entries which means that these IDs do not resolve anymore. We should remove them to prevent errors such as https://github.com/owncloud/core/issues/17307

Ref https://github.com/owncloud/activity/issues/320#issuecomment-117691867

@karlitschek I would love to have this in the 8.1 final
