### PR TITLE
owner is stored as 'uid_owner', not as 'owner' in the oc_share table

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -150,6 +150,8 @@ class Server extends SimpleContainer implements IServerContainer {
 			});
 			$groupManager->listen('\OC\Group', 'postAddUser', function (\OC\Group\Group $group, \OC\User\User $user) {
 				\OC_Hook::emit('OC_Group', 'post_addToGroup', array('uid' => $user->getUID(), 'gid' => $group->getGID()));
+				//Minimal fix to keep it backward compatible TODO: clean up all the GroupManager hooks
+				\OC_Hook::emit('OC_User', 'post_addToGroup', array('uid' => $user->getUID(), 'gid' => $group->getGID()));
 			});
 			return $groupManager;
 		});

--- a/lib/private/share/hooks.php
+++ b/lib/private/share/hooks.php
@@ -63,12 +63,12 @@ class Hooks extends \OC\Share\Constants {
 				$itemTarget = $sourceExists['item_target'];
 			} else {
 				$itemTarget = Helper::generateTarget($item['item_type'], $item['item_source'], self::SHARE_TYPE_USER, $arguments['uid'],
-					$item['owner'], null, $item['parent']);
+					$item['uid_owner'], null, $item['parent']);
 
 				// do we also need a file target
 				if ($item['item_type'] === 'file' || $item['item_type'] === 'folder') {
 					$fileTarget = Helper::generateTarget('file', $item['file_target'], self::SHARE_TYPE_USER, $arguments['uid'],
-							$item['owner'], null, $item['parent']);
+							$item['uid_owner'], null, $item['parent']);
 				} else {
 					$fileTarget = null;
 				}


### PR DESCRIPTION
Make suer that we access the owner correctly. Owner is stored as 'uid_owner', not as 'owner' in the oc_share table.

fix #16740

cc @karlitschek also affects 8.1, 8.0 and 7.0. I would suggest to backport it.
