### PR TITLE
Fix the path for users which have an exception for a group share

### DIFF
--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -342,12 +342,15 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 				null, \OCP\Constants::PERMISSION_READ);
 		$this->assertNotNull($result); // returns the token!
 
+		// owner renames after sharing
+		$this->view->rename($this->folder, $this->folder . '_owner_renamed');
+
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$user2View->rename($this->folder, $this->folder . '_renamed');
 
-		$ownerPath = $this->folder;
+		$ownerPath = $this->folder . '_owner_renamed';
 		$owner = self::TEST_FILES_SHARING_API_USER1;
 
 		$result = \OCP\Share::getUsersSharingFile($ownerPath, $owner, $includeOwner, $includePaths);
@@ -421,8 +424,8 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 				true,
 				true,
 				[
-					self::TEST_FILES_SHARING_API_USER1 => self::TEST_FOLDER_NAME,
-					self::TEST_FILES_SHARING_API_USER2 => self::TEST_FOLDER_NAME. '_renamed',
+					self::TEST_FILES_SHARING_API_USER1 => self::TEST_FOLDER_NAME . '_owner_renamed',
+					self::TEST_FILES_SHARING_API_USER2 => self::TEST_FOLDER_NAME . '_renamed',
 					self::TEST_FILES_SHARING_API_USER3 => self::TEST_FOLDER_NAME,
 				],
 			],
@@ -441,8 +444,8 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 				true,
 				true,
 				[
-					self::TEST_FILES_SHARING_API_USER1 => self::TEST_FOLDER_NAME,
-					self::TEST_FILES_SHARING_API_USER2 => self::TEST_FOLDER_NAME. '_renamed',
+					self::TEST_FILES_SHARING_API_USER1 => self::TEST_FOLDER_NAME . '_owner_renamed',
+					self::TEST_FILES_SHARING_API_USER2 => self::TEST_FOLDER_NAME . '_renamed',
 				],
 			],
 		];

--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -65,7 +65,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		parent::tearDown();
 	}
 
-	function testUnshareFromSelf() {
+	public function testUnshareFromSelf() {
 
 		\OC_Group::createGroup('testGroup');
 		\OC_Group::addToGroup(self::TEST_FILES_SHARING_API_USER2, 'testGroup');
@@ -103,7 +103,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 	/**
 	 * if a file was shared as group share and as individual share they should be grouped
 	 */
-	function testGroupingOfShares() {
+	public function testGroupingOfShares() {
 
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
@@ -171,7 +171,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 	 * single user share to user2. If he re-shares the file to user2 the same target
 	 * then the group share should be used to group the item
 	 */
-	function testShareAndUnshareFromSelf() {
+	public function testShareAndUnshareFromSelf() {
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
 		// share the file to group1 (user2 is a member of this group) and explicitely to user2
@@ -217,7 +217,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 
 	}
 
-	function verifyDirContent($content, $expected) {
+	public function verifyDirContent($content, $expected) {
 		foreach ($content as $c) {
 			if (!in_array($c['name'], $expected)) {
 				$this->assertTrue(false, "folder should only contain '" . implode(',', $expected) . "', found: " .$c['name']);
@@ -225,7 +225,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		}
 	}
 
-	function testShareWithDifferentShareFolder() {
+	public function testShareWithDifferentShareFolder() {
 
 		$fileinfo = $this->view->getFileInfo($this->filename);
 		$folderinfo = $this->view->getFileInfo($this->folder);
@@ -249,7 +249,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		\OC::$server->getConfig()->deleteSystemValue('share_folder');
 	}
 
-	function testShareWithGroupUniqueName() {
+	public function testShareWithGroupUniqueName() {
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		\OC\Files\Filesystem::file_put_contents('test.txt', 'test');
 
@@ -283,9 +283,9 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 
 	/**
 	 * shared files should never have delete permissions
-	 * @dataProvider  DataProviderTestFileSharePermissions
+	 * @dataProvider dataProviderTestFileSharePermissions
 	 */
-	function testFileSharePermissions($permission, $expectedPermissions) {
+	public function testFileSharePermissions($permission, $expectedPermissions) {
 
 		$fileinfo = $this->view->getFileInfo($this->filename);
 
@@ -305,7 +305,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		$this->assertSame($expectedPermissions, $share['permissions']);
 	}
 
-	function DataProviderTestFileSharePermissions() {
+	public function dataProviderTestFileSharePermissions() {
 		$permission1 = \OCP\Constants::PERMISSION_ALL;
 		$permission3 = \OCP\Constants::PERMISSION_READ;
 		$permission4 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE;
@@ -329,7 +329,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 	 * @param bool $includePaths whether to include paths in the result
 	 * @param array $expectedResult expected result of the API call
 	 */
-	function testGetUsersSharingFile($groupName, $includeOwner, $includePaths, $expectedResult) {
+	public function testGetUsersSharingFile($groupName, $includeOwner, $includePaths, $expectedResult) {
 
 		$fileinfo = $this->view->getFileInfo($this->folder);
 
@@ -368,7 +368,7 @@ class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 		);
 	}
 
-	function dataProviderGetUsersSharingFile() {
+	public function dataProviderGetUsersSharingFile() {
 		// note: "group" contains user1 (the owner), user2 and user3
 		// and self::TEST_FILES_SHARING_API_GROUP1 contains only user2
 		return [

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -253,9 +253,6 @@ class Share extends Constants {
 		// Include owner in list of users, if requested
 		if ($includeOwner) {
 			$shares[] = $ownerUser;
-			if ($returnUserPaths) {
-				$sharePaths[$ownerUser] = $path;
-			}
 		}
 
 		if ($returnUserPaths) {
@@ -281,6 +278,12 @@ class Share extends Constants {
 						}
 					}
 				}
+			}
+
+			if ($includeOwner) {
+				$sharePaths[$ownerUser] = $path;
+			} else {
+				unset($sharePaths[$ownerUser]);
 			}
 
 			return $sharePaths;

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -142,15 +142,25 @@ class Share extends Constants {
 
 		while ($source !== -1) {
 			// Fetch all shares with another user
-			$query = \OC_DB::prepare(
-				'SELECT `share_with`, `file_source`, `file_target`
+			if (!$returnUserPaths) {
+				$query = \OC_DB::prepare(
+					'SELECT `share_with`, `file_source`, `file_target`
+					FROM
+					`*PREFIX*share`
+					WHERE
+					`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
+				);
+				$result = $query->execute(array($source, self::SHARE_TYPE_USER));
+			} else {
+				$query = \OC_DB::prepare(
+					'SELECT `share_with`, `file_source`, `file_target`
 				FROM
 				`*PREFIX*share`
 				WHERE
-				`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
-			);
-
-			$result = $query->execute(array($source, self::SHARE_TYPE_USER));
+				`item_source` = ? AND `share_type` IN (?, ?) AND `item_type` IN (\'file\', \'folder\')'
+				);
+				$result = $query->execute(array($source, self::SHARE_TYPE_USER, self::$shareTypeGroupUserUnique));
+			}
 
 			if (\OCP\DB::isError($result)) {
 				\OCP\Util::writeLog('OCP\Share', \OC_DB::getErrorMessage(), \OC_Log::ERROR);
@@ -182,7 +192,12 @@ class Share extends Constants {
 					$shares = array_merge($shares, $usersInGroup);
 					if ($returnUserPaths) {
 						foreach ($usersInGroup as $user) {
-							$fileTargets[(int) $row['file_source']][$user] = $row;
+							if (!isset($fileTargets[(int) $row['file_source']][$user])) {
+								// When the user already has an entry for this file source
+								// the file is either shared directly with him as well, or
+								// he has an exception entry (because of naming conflict).
+								$fileTargets[(int) $row['file_source']][$user] = $row;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Steps to reproduce
1. User1 is member of Group1
2. User1 creates folder test
3. User2 creates folder test
4. User2 shares folder test with Group1
5. User2 creates a file in test
6. User1 has test and the shared "test (2)"
### Expected

User1 has activity "User2 created `Tooltip: in test (2)` test.txt
### Actual

User1 has activity "User2 created `Tooltip: in test` test.txt

Activity app is the only code using the `$returnUserPaths === true` method.

@rullzer @schiesbn 
