### PR TITLE
Fix the mount point name before creating the activities

### DIFF
--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -170,8 +170,14 @@ class Server2Server {
 			$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*share_external` WHERE `remote_id` = ? AND `share_token` = ?');
 			$query->execute(array($id, $token));
 
+			if ($share['accepted']) {
+				$path = trim($mountpoint, '/');
+			} else {
+				$path = trim($share['name'], '/');
+			}
+
 			\OC::$server->getActivityManager()->publishActivity(
-				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $mountpoint), '', array(),
+				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $path), '', array(),
 				'', '', $user, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_MEDIUM);
 		}
 

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -190,12 +190,12 @@ class Activity implements IExtension {
 		if ($app === self::FILES_SHARING_APP) {
 			switch ($text) {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
+				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
 						0 => '',// We can not use 'username' since the user is in a different ownCloud
 					);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
-				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
 						0 => '',// We can not use 'username' since the user is in a different ownCloud
 						1 => 'file',


### PR DESCRIPTION
### Steps to reproduce
1. Make sure to have activities for remote shares enabled:
   
   > A file or folder was shared from another server
2. Remote share an item (do **NOT** accept)
3. Delete the remote share
4. Check activities on the remote instance:
   1. You received a new remote share from admin@localhost/ownCloud/eightOne/core
   2. _admin@localhost/ownCloud/eightOne/core_ unshared `Tooltip: "in {{TemporaryMountPointName#` **test}}** from you 

With patch step 4 shows:
1. You received a new remote share from admin@localhost/ownCloud/eightOne/core
2. _admin@localhost/ownCloud/eightOne/core_ unshared `No Tooltip` **test** from you 

@schiesbn @rullzer @DeepDiver1975 

Backport of the important part from #17335
