### PR TITLE
Prefer scalar type hints over phpdoc annotation

### DIFF
--- a/lib/private/appframework/utility/controllermethodreflector.php
+++ b/lib/private/appframework/utility/controllermethodreflector.php
@@ -60,16 +60,18 @@ class ControllerMethodReflector implements IControllerMethodReflector{
 
 		// extract type parameter information
 		preg_match_all('/@param\h+(?P<type>\w+)\h+\$(?P<var>\w+)/', $docs, $matches);
-		// this is just a fix for PHP 5.3 (array_combine raises warning if called with
-		// two empty arrays
-		if($matches['var'] === array() && $matches['type'] === array()) {
-			$this->types = array();
-		} else {
-			$this->types = array_combine($matches['var'], $matches['type']);
-		}
+		$this->types = array_combine($matches['var'], $matches['type']);
 
-		// get method parameters
 		foreach ($reflection->getParameters() as $param) {
+			// extract type information from PHP 7 scalar types and prefer them
+			// over phpdoc annotations
+			if (method_exists($param, 'getType')) {
+				$type = $param->getType();
+				if ($type !== null) {
+					$this->types[$param->getName()] = (string) $type;
+				}
+			}
+
 			if($param->isOptional()) {
 				$default = $param->getDefaultValue();
 			} else {
@@ -82,9 +84,9 @@ class ControllerMethodReflector implements IControllerMethodReflector{
 
 	/**
 	 * Inspects the PHPDoc parameters for types
-	 * @param string $parameter the parameter whose type comments should be 
+	 * @param string $parameter the parameter whose type comments should be
 	 * parsed
-	 * @return string|null type in the type parameters (@param int $something) 
+	 * @return string|null type in the type parameters (@param int $something)
 	 * would return int or null if not existing
 	 */
 	public function getType($parameter) {

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -104,6 +104,25 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$this->assertEquals('int', $reader->getType('test'));
 	}
 
+	/**
+	 * @Annotation
+	 * @param int $a
+	 * @param int $b
+	 * @requires PHP 7
+	 */
+	public function testReadTypeIntAnnotationsScalarTypes($a, float $b, int $c, $d){
+		$reader = new ControllerMethodReflector();
+		$reader->reflect(
+			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
+			'testReadTypeIntAnnotationsScalarTypes'
+		);
+
+		$this->assertEquals('int', $reader->getType('a'));
+		$this->assertEquals('float', $reader->getType('b'));
+		$this->assertEquals('int', $reader->getType('c'));
+		$this->assertNull($reader->getType('d'));
+	}
+
 
 	/**
 	 * @Annotation

--- a/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/appframework/utility/ControllerMethodReflectorTest.php
@@ -108,13 +108,17 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 	 * @Annotation
 	 * @param int $a
 	 * @param int $b
+	 */
+	public function arguments3($a, float $b, int $c, $d){}
+
+	/**
 	 * @requires PHP 7
 	 */
-	public function testReadTypeIntAnnotationsScalarTypes($a, float $b, int $c, $d){
+	public function testReadTypeIntAnnotationsScalarTypes(){
 		$reader = new ControllerMethodReflector();
 		$reader->reflect(
 			'\OC\AppFramework\Utility\ControllerMethodReflectorTest',
-			'testReadTypeIntAnnotationsScalarTypes'
+			'arguments3'
 		);
 
 		$this->assertEquals('int', $reader->getType('a'));


### PR DESCRIPTION
First stab at fixing #17076 

Still needs testing on PHP 7

@LukasReschke @DeepDiver1975 @MorrisJobke @ChristophWurst @Xenopathic @PVince81
