### PR TITLE
Improve federated cloud sharing activities

### DIFF
--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -170,8 +170,14 @@ class Server2Server {
 			$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*share_external` WHERE `remote_id` = ? AND `share_token` = ?');
 			$query->execute(array($id, $token));
 
+			if ($share['accepted']) {
+				$path = trim($mountpoint, '/');
+			} else {
+				$path = trim($share['name'], '/');
+			}
+
 			\OC::$server->getActivityManager()->publishActivity(
-				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $mountpoint), '', array(),
+				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $path), '', array(),
 				'', '', $user, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_MEDIUM);
 		}
 

--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -71,7 +71,7 @@ class Server2Server {
 				$user = $owner . '@' . $this->cleanupRemote($remote);
 
 				\OC::$server->getActivityManager()->publishActivity(
-					Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_RECEIVED, array($user), '', array(),
+					Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_RECEIVED, array($user, trim($name, '/')), '', array(),
 					'', '', $shareWith, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);
 
 				return new \OC_OCS_Result();

--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -22,6 +22,8 @@
 
 namespace OCA\Files_Sharing\API;
 
+use OCA\Files_Sharing\Activity;
+
 class Server2Server {
 
 	/**
@@ -69,8 +71,8 @@ class Server2Server {
 				$user = $owner . '@' . $this->cleanupRemote($remote);
 
 				\OC::$server->getActivityManager()->publishActivity(
-					'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_RECEIVED, array($user), '', array(),
-					'', '', $shareWith, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_LOW);
+					Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_RECEIVED, array($user), '', array(),
+					'', '', $shareWith, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);
 
 				return new \OC_OCS_Result();
 			} catch (\Exception $e) {
@@ -102,8 +104,8 @@ class Server2Server {
 			list($file, $link) = self::getFile($share['uid_owner'], $share['file_source']);
 
 			\OC::$server->getActivityManager()->publishActivity(
-				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_ACCEPTED, array($share['share_with'], basename($file)), '', array(),
-				$file, $link, $share['uid_owner'], \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_LOW);
+				Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_ACCEPTED, array($share['share_with'], basename($file)), '', array(),
+				$file, $link, $share['uid_owner'], Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);
 		}
 
 		return new \OC_OCS_Result();
@@ -133,8 +135,8 @@ class Server2Server {
 			list($file, $link) = $this->getFile($share['uid_owner'], $share['file_source']);
 
 			\OC::$server->getActivityManager()->publishActivity(
-				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_DECLINED, array($share['share_with'], basename($file)), '', array(),
-				$file, $link, $share['uid_owner'], \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_LOW);
+				Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_DECLINED, array($share['share_with'], basename($file)), '', array(),
+				$file, $link, $share['uid_owner'], Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);
 		}
 
 		return new \OC_OCS_Result();
@@ -177,8 +179,8 @@ class Server2Server {
 			}
 
 			\OC::$server->getActivityManager()->publishActivity(
-				'files_sharing', \OCA\Files_Sharing\Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $path), '', array(),
-				'', '', $user, \OCA\Files_Sharing\Activity::TYPE_REMOTE_SHARE, \OCA\Files_Sharing\Activity::PRIORITY_MEDIUM);
+				Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_UNSHARED, array($owner, $path), '', array(),
+				'', '', $user, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_MEDIUM);
 		}
 
 		return new \OC_OCS_Result();

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -196,13 +196,13 @@ class Activity implements IExtension {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
 				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
-						0 => '',// We can not use 'username' since the user is in a different ownCloud
+						0 => 'federated_cloud_id',
 						//1 => 'file', in theory its a file, but it does not exist yet/anymore
 					);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
 					return array(
-						0 => '',// We can not use 'username' since the user is in a different ownCloud
+						0 => 'federated_cloud_id',
 						1 => 'file',
 					);
 				case self::SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED:
@@ -219,7 +219,7 @@ class Activity implements IExtension {
 				case self::SUBJECT_SHARED_GROUP_SELF:
 					return [
 						0 => 'file',
-						//1 => 'group', Group does not exist yet
+						1 => 'group',
 					];
 			}
 		}

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -150,6 +150,10 @@ class Activity implements IExtension {
 		if ($app === self::FILES_SHARING_APP) {
 			switch ($text) {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
+					if (sizeof($params) === 2) {
+						// New activity ownCloud 8.2+
+						return (string) $l->t('You received a new remote share %2$s from %1$s', $params);
+					}
 					return (string) $l->t('You received a new remote share from %s', $params);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 					return (string) $l->t('%1$s accepted remote share %2$s', $params);
@@ -193,6 +197,7 @@ class Activity implements IExtension {
 				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
 						0 => '',// We can not use 'username' since the user is in a different ownCloud
+						//1 => 'file', in theory its a file, but it does not exist yet/anymore
 					);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -190,12 +190,12 @@ class Activity implements IExtension {
 		if ($app === self::FILES_SHARING_APP) {
 			switch ($text) {
 				case self::SUBJECT_REMOTE_SHARE_RECEIVED:
+				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
 						0 => '',// We can not use 'username' since the user is in a different ownCloud
 					);
 				case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 				case self::SUBJECT_REMOTE_SHARE_DECLINED:
-				case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 					return array(
 						0 => '',// We can not use 'username' since the user is in a different ownCloud
 						1 => 'file',

--- a/apps/files_sharing/lib/activity.php
+++ b/apps/files_sharing/lib/activity.php
@@ -230,7 +230,7 @@ class Activity implements IExtension {
 	 * @return integer|false
 	 */
 	public function getGroupParameter($activity) {
-		if ($activity['app'] === 'files') {
+		if ($activity['app'] === self::FILES_SHARING_APP) {
 			switch ($activity['subject']) {
 				case self::SUBJECT_SHARED_LINK_SELF:
 				case self::SUBJECT_SHARED_WITH_BY:


### PR DESCRIPTION
- Fix grouping activities when multiple shares are shared/unshared
- Do not treat unshares like they point to files (they are non-existant anymore)
- Add the item name to the "you received a federated share" activity

Fixes itself

@schiesbn @rullzer 
