### PR TITLE
Graceful fail in case of error in fileActionsReady handler

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -597,7 +597,7 @@
 
 			// trigger event for newly added rows
 			if (newTrs.length > 0) {
-				this.$fileList.trigger($.Event('fileActionsReady', {fileList: this, $files: newTrs}));
+				this._triggerFileActionsReady({fileList: this, $files: newTrs});
 			}
 
 			if (animate) {
@@ -625,8 +625,22 @@
 			$files.each(function() {
 				self.fileActions.display($(this).find('td.filename'), false, self);
 			});
-			this.$fileList.trigger($.Event('fileActionsReady', {fileList: this, $files: $files}));
+			this._triggerFileActionsReady({fileList: this, $files: $files});
 
+		},
+
+		/**
+		 * Triggers event "fileActionsReady" with graceful failing.
+		 * In case of exception, the exception is logged.
+		 *
+		 * @param {Object} options event options
+		 */
+		_triggerFileActionsReady: function(options) {
+			try {
+				this.$fileList.trigger($.Event('fileActionsReady', options || {}));
+			} catch (e) {
+				console.error('Exception occurred in "fileActionsReady" event handler', e);
+			}
 		},
 
 		/**
@@ -1502,7 +1516,7 @@
 								self.files.splice(tr.index(), 1);
 								tr.remove();
 								tr = self.add(fileInfo, {updateSummary: false, silent: true});
-								self.$fileList.trigger($.Event('fileActionsReady', {fileList: self, $files: $(tr)}));
+								self._triggerFileActionsReady({fileList: self, $files: $(tr)});
 							}
 						});
 					} else {
@@ -1510,7 +1524,7 @@
 						self.files.splice(tr.index(), 1);
 						tr.remove();
 						tr = self.add(oldFileInfo, {updateSummary: false, silent: true});
-						self.$fileList.trigger($.Event('fileActionsReady', {fileList: self, $files: $(tr)}));
+						self._triggerFileActionsReady({fileList: self, $files: $(tr)});
 					}
 				} catch (error) {
 					input.attr('title', error);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -899,6 +899,20 @@ describe('OCA.Files.FileList tests', function() {
 			expect(handler.calledOnce).toEqual(true);
 			expect(handler.getCall(0).args[0].$files.length).toEqual(fileList.pageSize());
 		});
+		it('continues processing even if "fileActionsReady" handler threw an exception', function() {
+			var clock = sinon.useFakeTimers();
+			var handler = function() {
+				throw "Failure";
+			};
+			fileList.setFiles(generateFiles(0, 64));
+			fileList.$fileList.on('fileActionsReady', handler);
+			fileList._nextPage(true);
+			expect(fileList.$fileList.find('.appear.transparent').length).toBeGreaterThan(0);
+			// finish animation
+			clock.tick(10);
+			expect(fileList.$fileList.find('.appear.transparent').length).toEqual(0);
+			clock.restore();
+		});
 		it('does not trigger "fileActionsReady" event after single add with silent argument', function() {
 			var handler = sinon.stub();
 			fileList.setFiles(testFiles);


### PR DESCRIPTION
This is mostly to avoid breaking the file list if the fileActionsReady
handler fails for some reason.

Makes the file list more robust here https://github.com/owncloud/core/issues/15856
Root cause still needs to be investigated there, likely to be related to sharing.
