### PR TITLE
Only run some preview unit tets if imagemagick is available

### DIFF
--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -287,6 +287,7 @@ class Preview extends TestCase {
 	/**
 	 * Tests if a preview of max dimensions gets created
 	 *
+	 * @requires extension imagick
 	 * @dataProvider dimensionsDataProvider
 	 *
 	 * @param int $sampleId
@@ -358,6 +359,7 @@ class Preview extends TestCase {
 	/**
 	 * Tests if the second preview will be based off the cached max preview
 	 *
+	 * @requires extension imagick
 	 * @dataProvider dimensionsDataProvider
 	 *
 	 * @param int $sampleId
@@ -443,6 +445,7 @@ class Preview extends TestCase {
 	 * so we should be getting either the max preview or a preview the size
 	 * of the dimensions set in the config
 	 *
+	 * @requires extension imagick
 	 * @dataProvider aspectDataProvider
 	 *
 	 * @param int $sampleId
@@ -499,6 +502,7 @@ class Preview extends TestCase {
 	 * 200-200    ✓
 	 * 300-188-with-aspect
 	 *
+	 * @requires extension imagick
 	 * @dataProvider aspectDataProvider
 	 *
 	 * @param int $sampleId

--- a/tests/lib/preview/provider.php
+++ b/tests/lib/preview/provider.php
@@ -85,6 +85,7 @@ abstract class Provider extends \Test\TestCase {
 	 * Launches all the tests we have
 	 *
 	 * @dataProvider dimensionsDataProvider
+	 * @requires extension imagick
 	 *
 	 * @param int $widthAdjustment
 	 * @param int $heightAdjustment


### PR DESCRIPTION
I did not have imagemagick installed on my server so a lot of unit tests started failing.

This PR skips some of the tests if the imagick module is not available. Which makes everything work again. 

However you still need to make sure that imagemagick has support for JPEG/GIF/PNG/EPS. We could use \Imagick::queryformats(); to verify that the formats are supported. Only how to let people know not all samples are used because not everything was available?

CC: @oparoz @LukasReschke @MorrisJobke 
