### PR TITLE
Do not register JS share plugin if core sharing API is disabled

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -25,6 +25,10 @@
 		 * @param {OCA.Files.FileList} fileList file list to be extended
 		 */
 		attach: function(fileList) {
+			// core sharing is disabled/not loaded
+			if (!OC.Share) {
+				return;
+			}
 			if (fileList.id === 'trashbin' || fileList.id === 'files.public') {
 				return;
 			}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/15186

To test: disable sharing API in the admin page, but leave the files_sharing app enabled.

Please review @MorrisJobke @nickvergessen @icewind1991 @schiesbn 
