### PR TITLE
[app code check] add OC_Search_Provider and _Result

### DIFF
--- a/lib/private/app/codechecker.php
+++ b/lib/private/app/codechecker.php
@@ -71,6 +71,8 @@ class CodeChecker extends BasicEmitter {
 			'OC_Log',
 			'OC_Mail',
 			'OC_Preferences',
+			'OC_Search_Provider',
+			'OC_Search_Result',
 			'OC_Request',
 			'OC_Response',
 			'OC_Template',


### PR DESCRIPTION
Thanks to @libasys for noticing this.

Replaced by `\OCP\Search\...`

cc @nickvergessen @DeepDiver1975 @LukasReschke 
