### PR TITLE
[stable8.1] Do not show static share owner if not available

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -151,7 +151,7 @@
 				var permissions = $tr.data('permissions');
 				var hasLink = !!(shareStatus && shareStatus.link);
 				OC.Share.markFileAsShared($tr, true, hasLink);
-				if ((permissions & OC.PERMISSION_SHARE) === 0) {
+				if ((permissions & OC.PERMISSION_SHARE) === 0 && $tr.attr('data-share-owner')) {
 					// if no share action exists because the admin disabled sharing for this user
 					// we create a share notification action to inform the user about files
 					// shared with him otherwise we just update the existing share action.

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -206,6 +206,23 @@ describe('OCA.Sharing.Util tests', function() {
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 			expect($action.find('img').length).toEqual(1);
 		});
+		it('do not show static share text when share exists but neither permission nor owner is available', function() {
+			var $action, $tr;
+			fileList.setFiles([{
+				id: 1,
+				type: 'dir',
+				name: 'One',
+				path: '/subdir',
+				mimetype: 'text/plain',
+				size: 12,
+				permissions: OC.PERMISSION_CREATE,
+				etag: 'abc'
+			}]);
+			$tr = fileList.$el.find('tbody tr:first');
+			expect($tr.find('.action-share').length).toEqual(0);
+			$action = $tr.find('.action-share-notification');
+			expect($action.length).toEqual(0);
+		});
 	});
 	describe('Share action', function() {
 		var showDropDownStub;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/17349 to stable8.1.

Do not merge before 8.1.1.

Please review @MorrisJobke @nickvergessen @schiesbn 
