### PR TITLE
[sharing] fix addToGroup hook

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -46,12 +46,18 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 */
 	private $recipientView;
 
+	/**
+	 * @var string
+	 */
+	private $user;
+
 	public function __construct($storage, $mountpoint, $arguments = null, $loader = null) {
 		// first update the mount point before creating the parent
 		$this->ownerPropagator = $arguments['propagator'];
-		$this->recipientView = new View('/' . $arguments['user'] . '/files');
+		$this->user = $arguments['user'];
+		$this->recipientView = new View('/' . $this->user . '/files');
 		$newMountPoint = $this->verifyMountPoint($arguments['share']);
-		$absMountPoint = '/' . $arguments['user'] . '/files' . $newMountPoint;
+		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
 		$arguments['ownerView'] = new View('/' . $arguments['share']['uid_owner'] . '/files');
 		parent::__construct($storage, $absMountPoint, $arguments, $loader);
 	}
@@ -90,7 +96,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @param array $share reference to the share which should be modified
 	 * @return bool
 	 */
-	private static function updateFileTarget($newPath, &$share) {
+	private function updateFileTarget($newPath, &$share) {
 		// if the user renames a mount point from a group share we need to create a new db entry
 		// for the unique name
 		if ($share['share_type'] === \OCP\Share::SHARE_TYPE_GROUP && empty($share['unique_name'])) {
@@ -98,7 +104,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 			.' `share_type`, `share_with`, `uid_owner`, `permissions`, `stime`, `file_source`,'
 			.' `file_target`, `token`, `parent`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
 			$arguments = array($share['item_type'], $share['item_source'], $share['item_target'],
-				2, \OCP\User::getUser(), $share['uid_owner'], $share['permissions'], $share['stime'], $share['file_source'],
+				2, $this->user, $share['uid_owner'], $share['permissions'], $share['stime'], $share['file_source'],
 				$newPath, $share['token'], $share['id']);
 		} else {
 			// rename mount point

--- a/lib/base.php
+++ b/lib/base.php
@@ -797,6 +797,7 @@ class OC {
 		if (\OC::$server->getSystemConfig()->getValue('installed')) {
 			OC_Hook::connect('OC_User', 'post_deleteUser', 'OC\Share\Hooks', 'post_deleteUser');
 			OC_Hook::connect('OC_User', 'post_addToGroup', 'OC\Share\Hooks', 'post_addToGroup');
+			OC_Hook::connect('OC_Group', 'pre_addToGroup', 'OC\Share\Hooks', 'pre_addToGroup');
 			OC_Hook::connect('OC_User', 'post_removeFromGroup', 'OC\Share\Hooks', 'post_removeFromGroup');
 			OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC\Share\Hooks', 'post_deleteGroup');
 		}

--- a/tests/lib/share/hooktests.php
+++ b/tests/lib/share/hooktests.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\Tests\Share;
+
+
+use Test\TestCase;
+
+class HookTests extends TestCase {
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	protected function tearDown() {
+		$query = \OC_DB::prepare('DELETE FROM `*PREFIX*share` WHERE `item_type` = ?');
+		$query->execute(array('test'));
+
+		parent::tearDown();
+	}
+
+	public function testPostAddToGroup() {
+
+		/** @var \OC\DB\Connection $connection */
+		$connection = \OC::$server->getDatabaseConnection();
+		$query = $connection->createQueryBuilder();
+		$expr = $query->expr();
+
+		// add some dummy values to the private $updateTargets variable
+		$this->invokePrivate(
+			new \OC\Share\Hooks(),
+			'updateTargets',
+			[
+				[
+					'group1' =>
+						[
+							[
+								'`item_type`' => $expr->literal('test'),
+								'`item_source`' => $expr->literal('42'),
+								'`item_target`' => $expr->literal('42'),
+								'`file_target`' => $expr->literal('test'),
+								'`share_type`' => $expr->literal('2'),
+								'`share_with`' => $expr->literal('group1'),
+								'`uid_owner`' => $expr->literal('owner'),
+								'`permissions`' => $expr->literal('0'),
+								'`stime`' => $expr->literal('676584'),
+								'`file_source`' => $expr->literal('42'),
+							],
+							[
+								'`item_type`' => $expr->literal('test'),
+								'`item_source`' => $expr->literal('42'),
+								'`item_target`' => $expr->literal('42 (2)'),
+								'`share_type`' => $expr->literal('2'),
+								'`share_with`' => $expr->literal('group1'),
+								'`uid_owner`' => $expr->literal('owner'),
+								'`permissions`' => $expr->literal('0'),
+								'`stime`' => $expr->literal('676584'),
+							]
+						],
+					'group2' =>
+						[
+							[
+								'`item_type`' => $expr->literal('test'),
+								'`item_source`' => $expr->literal('42'),
+								'`item_target`' => $expr->literal('42'),
+								'`share_type`' => $expr->literal('2'),
+								'`share_with`' => $expr->literal('group2'),
+								'`uid_owner`' => $expr->literal('owner'),
+								'`permissions`' => $expr->literal('0'),
+								'`stime`' => $expr->literal('676584'),
+							]
+						]
+				]
+			]
+		);
+
+		// add unique targets for group1 to database
+		\OC\Share\Hooks::post_addToGroup(['gid' => 'group1']);
+
+
+		$query->select('`share_with`')->from('`*PREFIX*share`');
+		$result = $query->execute()->fetchAll();
+		$this->assertSame(2, count($result));
+		foreach ($result as $r) {
+			$this->assertSame('group1', $r['share_with']);
+		}
+	}
+
+}


### PR DESCRIPTION
Fix the add to group hook in sharing. This was discovered while working on https://github.com/owncloud/core/pull/17327

We skip this step completely for file shares because for file shares we generate a unique target during the mount operation if needed. Further we make sure that the code gets executed at all. In the old version "$sourcrExists" was always true because we checked it in a post hook. So we always found a share for the user after he was added to the group.

cc @rullzer maybe you have some time to review it? Thanks!
