### PR TITLE
add createQueryBuilder() to the interface

### DIFF
--- a/lib/private/appframework/db/db.php
+++ b/lib/private/appframework/db/db.php
@@ -240,4 +240,13 @@ class Db implements IDb {
 		return $this->connection->tableExists($table);
 	}
 
+	/**
+	 * Creates a new instance of a SQL query builder.
+	 *
+	 * @return \Doctrine\DBAL\Query\QueryBuilder
+	 */
+	public function createQueryBuilder() {
+		return $this->connection->createQueryBuilder();
+	}
+
 }

--- a/lib/public/idbconnection.php
+++ b/lib/public/idbconnection.php
@@ -190,4 +190,13 @@ interface IDBConnection {
 	 * @since 8.0.0
 	 */
 	public function tableExists($table);
+
+	/**
+	 * Creates a new instance of a SQL query builder.
+	 *
+	 * @return \Doctrine\DBAL\Query\QueryBuilder
+	 * @since 8.2.0
+	 */
+	public function createQueryBuilder();
+
 }


### PR DESCRIPTION
add createQueryBuilder() to the interface so that it can be auto-completed without always re-declare the variable, like:

```
/** @var \OC\DB\Connection $db */
$db = \OC::$server->getDatabaseConnection();
```

@nickvergessen I think we already discussed this in the past.

cc @DeepDiver1975 
