### PR TITLE
[stable8] Proper error handling

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -111,7 +111,8 @@ class Upgrade extends Command {
 				function ($success) use($output, $updateStepEnabled, $self) {
 					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
 					$status = $success ? 'successful' : 'failed' ;
-					$message = "<info>$mode $status</info>";
+					$type = $success ? 'info' : 'error';
+					$message = "<$type>$mode $status</$type>";
 					$output->writeln($message);
 				});
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -344,7 +344,7 @@ class Filesystem {
 
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for '.$user, \OCP\Util::ERROR);
-			throw new \OC\User\NoUserException();
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
 		}
 
 		$homeStorage = \OC_Config::getValue( 'objectstore' );

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -159,14 +159,20 @@ class Updater extends BasicEmitter {
 		}
 		$this->emit('\OC\Updater', 'maintenanceStart');
 
+		$success = true;
 		try {
 			$this->doUpgrade($currentVersion, $installedVersion);
 		} catch (\Exception $exception) {
-			$this->emit('\OC\Updater', 'failure', array($exception->getMessage()));
+			\OCP\Util::logException('update', $exception);
+			$this->emit('\OC\Updater', 'failure', array(get_class($exception) . ': ' .$exception->getMessage()));
+			$success = false;
 		}
 
 		$this->config->setSystemValue('maintenance', false);
 		$this->emit('\OC\Updater', 'maintenanceEnd');
+		$this->emit('\OC\Updater', 'updateEnd', array($success));
+
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
adjusted backport of #17095

I tested this with an added `throw new Exception('boom');` within `apps/files_sharing/appinfo/update.php`.

I tested a failed upgrade and a successful upgrade.

cc @DeepDiver1975 @nickvergessen @LukasReschke 
