### PR TITLE
[stable7] Proper error handling

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -21,6 +21,7 @@ class Upgrade extends Command {
 	const ERROR_MAINTENANCE_MODE = 2;
 	const ERROR_UP_TO_DATE = 3;
 	const ERROR_INVALID_ARGUMENTS = 4;
+	const ERROR_FAILURE = 5;
 
 	protected function configure() {
 		$this
@@ -83,15 +84,17 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'maintenanceStart', function () use($output) {
 				$output->writeln('<info>Turned on maintenance mode</info>');
 			});
-			$updater->listen('\OC\Updater', 'maintenanceEnd', function () use($output, $updateStepEnabled) {
-				$output->writeln('<info>Turned off maintenance mode</info>');
-				if (!$updateStepEnabled) {
-					$output->writeln('<info>Update simulation successful</info>');
-				}
-				else {
-					$output->writeln('<info>Update successful</info>');
-				}
-			});
+			$updater->listen('\OC\Updater', 'maintenanceEnd',
+				function () use($output) {
+					$output->writeln('<info>Turned off maintenance mode</info>');
+				});
+			$updater->listen('\OC\Updater', 'updateEnd',
+				function ($success) use($output, $updateStepEnabled, $self) {
+					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
+					$status = $success ? 'successful' : 'failed' ;
+					$message = "<info>$mode $status</info>";
+					$output->writeln($message);
+				});
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {
 				$output->writeln('<info>Updated database</info>');
 			});
@@ -106,13 +109,17 @@ class Upgrade extends Command {
 			});
 
 			$updater->listen('\OC\Updater', 'failure', function ($message) use($output) {
-				$output->writeln($message);
+				$output->writeln("<error>$message</error>");
 				\OC_Config::setValue('maintenance', false);
 			});
 
-			$updater->upgrade();
+			$success = $updater->upgrade();
 
 			$this->postUpgradeCheck($input, $output);
+
+			if(!$success) {
+				return self::ERROR_FAILURE;
+			}
 
 			return self::ERROR_SUCCESS;
 		} else if(\OC_Config::getValue('maintenance', false)) {

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -92,7 +92,8 @@ class Upgrade extends Command {
 				function ($success) use($output, $updateStepEnabled, $self) {
 					$mode = $updateStepEnabled ? 'Update' : 'Update simulation';
 					$status = $success ? 'successful' : 'failed' ;
-					$message = "<info>$mode $status</info>";
+					$type = $success ? 'info' : 'error';
+					$message = "<$type>$mode $status</$type>";
 					$output->writeln($message);
 				});
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {

--- a/lib/private/files/filesystem.php
+++ b/lib/private/files/filesystem.php
@@ -331,7 +331,7 @@ class Filesystem {
 
 		if (is_null($userObject)) {
 			\OCP\Util::writeLog('files', ' Backends provided no user object for '.$user, \OCP\Util::ERROR);
-			throw new \OC\User\NoUserException();
+			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
 		}
 
 		$homeStorage = \OC_Config::getValue( 'objectstore' );

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -136,14 +136,20 @@ class Updater extends BasicEmitter {
 		}
 		$this->emit('\OC\Updater', 'maintenanceStart');
 
+		$success = true;
 		try {
 			$this->doUpgrade($currentVersion, $installedVersion);
 		} catch (\Exception $exception) {
-			$this->emit('\OC\Updater', 'failure', array($exception->getMessage()));
+			\OCP\Util::logException('update', $exception);
+			$this->emit('\OC\Updater', 'failure', array(get_class($exception) . ': ' .$exception->getMessage()));
+			$success = false;
 		}
 
 		\OC_Config::setValue('maintenance', false);
 		$this->emit('\OC\Updater', 'maintenanceEnd');
+		$this->emit('\OC\Updater', 'updateEnd', array($success));
+
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
adjusted backport of #17095 to stable7

I tested this with an added `throw new Exception('boom');` within `apps/files_sharing/appinfo/update.php`.

I tested a failed upgrade and a successful upgrade.

cc @DeepDiver1975 @nickvergessen @LukasReschke 
