### PR TITLE
[stable8] LDAP: make sure port input box is not getting too small on low width

### DIFF
--- a/apps/user_ldap/css/settings.css
+++ b/apps/user_ldap/css/settings.css
@@ -49,13 +49,15 @@
 }
 
 #ldapWizard1 .hostPortCombinator div span {
-	width: 7%;
-	display: table-cell;
+	width: 14.5%;
+	display: inline-block;
 	text-align: right;
 }
 
 #ldapWizard1 .host {
-	width: 96.5% !important;
+	width: 100%;
+	margin-left: 0;
+	margin-right: 0;
 }
 
 .tableCellInput {


### PR DESCRIPTION
It's a backport picked from refurbished wizard included in master/OC 8.1. Contains CSS format changes only.

@MorrisJobke @Kawohl @karlitschek 
