### PR TITLE
Return correct user count when the group has none

### DIFF
--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -36,7 +36,11 @@ GroupList = {
 	},
 
 	getUserCount: function ($groupLiElement) {
-		return parseInt($groupLiElement.data('usercount'), 10);
+		var $userCount = parseInt($groupLiElement.data('usercount'), 10);
+		if (isNaN($userCount)) {
+			$userCount = 0;
+		}
+		return $userCount;
 	},
 
 	modEveryoneCount: function(diff) {


### PR DESCRIPTION
@PVince81 @davitol 

@DeepDiver1975 @karlitschek please rate if we should fix this on stable7

Fix #17260 
