### PR TITLE
Fix regression of button at public download page

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -72,7 +72,7 @@ thead {
 }
 
 /* keep long file names in one line to not overflow download button on mobile */
-.directDownload #download {
+.directDownload #downloadFile {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
- introduced with #17159

The direct download button on a single file public share was wrapped on very small screens. This fixes that broken behaviour.

cc @Henni @PVince81 @owncloud/designers  
