### PR TITLE
Add ability to encrypt e-mails from owncloud

### DIFF
--- a/lib/public/ignupg.php
+++ b/lib/public/ignupg.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Interface IGnuPG
+ *
+ * @package OCP
+ * @since 8.2.0
+ */
+interface IGnuPG {
+	/**
+	 * Add a public key to the keyring
+	 *
+	 * @param string $key The public key to add
+	 * @return string Fingerprint of added $key
+	 * @since 8.2.0
+	 */
+	public function addPublicKey($key);
+
+	/**
+	 * Remove public key with $fingerprint from the keyring
+	 *
+	 * @param string $fingerprint The fingerprint of the public key to remove
+	 * @return bool Was the key removed succesfully
+	 * @since 8.2.0
+	 */
+	public function removePublicKey($fingerprint);
+
+	/**
+	 * Encrtypt a message
+	 *
+	 * @param string $message The message to encrypt
+	 * @param string $fingerprint The fingerprint of the key to use for encryption
+	 * @return string The encrypted message
+	 * @since 8.2.0
+	 */
+	public function encryptMessage($message, $fingerprint);
+}


### PR DESCRIPTION
PR for #16813 

This is the first attempt at an Interface for GnuPG.
- Since signing is only possible with passwordless keys I did not add this to the interface.

There are some open questions here.
### Manager

Do we in the future want to have users be able to mange their own keyring? Apps that mail could use this then. If that is the case we should probably add an IGnuPGManager right away.
### Location

Where will we store the keyring?
### App

Should this just be an app? The functionality feels like something that should be an app. However I'm not sure we can easily hook this functionality into our mailing setup.

CC: @schiesbn @oparoz @DeepDiver1975 
