### PR TITLE
Display app names in update page for app updates

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -672,6 +672,13 @@ label.infield {
 	color: #ccc;
 }
 
+#body-login .update .appList {
+	list-style: disc;
+	text-align: left;
+	margin-left: 25px;
+	margin-right: 25px;
+}
+
 #body-login .v-align {
 	width: inherit;
 }

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -1,13 +1,14 @@
 <div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
 	<div class="updateOverview">
 		<?php if ($_['isAppsOnlyUpgrade']) { ?>
-		<h2 class="title bold"><?php p($l->t('The following apps will be updated:')); ?></h2>
+		<h2 class="title bold"><?php p($l->t('Apps update required.')); ?></h2>
 		<?php } else { ?>
 		<h2 class="title bold"><?php p($l->t('%s will be updated to version %s.',
 			array($_['productName'], $_['version']))); ?></h2>
 		<?php } ?>
 		<?php if (!empty($_['appsToUpgrade'])) { ?>
 		<div class="infogroup">
+			<span class="bold"><?php p($l->t('These apps will be updated:')); ?></span>
 			<ul class="content appList">
 				<?php foreach ($_['appsToUpgrade'] as $appInfo) { ?>
 				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
@@ -15,11 +16,11 @@
 			</ul>
 		</div>
 		<?php } ?>
-		<?php if (!empty($_['appList'])) { ?>
+		<?php if (!empty($_['incompatibleAppsList'])) { ?>
 		<div class="infogroup">
-			<span class="bold"><?php p($l->t('The following apps will be disabled:')) ?></span>
+			<span class="bold"><?php p($l->t('These incompatible apps will be disabled:')) ?></span>
 			<ul class="content appList">
-				<?php foreach ($_['appList'] as $appInfo) { ?>
+				<?php foreach ($_['incompatibleAppsList'] as $appInfo) { ?>
 				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
 				<?php } ?>
 			</ul>
@@ -30,11 +31,9 @@
 			<?php p($l->t('The theme %s has been disabled.', array($_['oldTheme']))) ?>
 		</div>
 		<?php } ?>
-		<?php if (!$_['isAppsOnlyUpgrade']) { ?>
 		<div class="infogroup bold">
 			<?php p($l->t('Please make sure that the database, the config folder and the data folder have been backed up before proceeding.')) ?>
 		</div>
-		<?php } ?>
 		<input class="updateButton" type="button" value="<?php p($l->t('Start update')) ?>">
 		<div class="infogroup">
 			<?php p($l->t('To avoid timeouts with larger installations, you can instead run the following command from your installation directory:')) ?>

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -1,7 +1,20 @@
 <div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
 	<div class="updateOverview">
+		<?php if ($_['isAppsOnlyUpgrade']) { ?>
+		<h2 class="title bold"><?php p($l->t('The following apps will be updated:')); ?></h2>
+		<?php } else { ?>
 		<h2 class="title bold"><?php p($l->t('%s will be updated to version %s.',
 			array($_['productName'], $_['version']))); ?></h2>
+		<?php } ?>
+		<?php if (!empty($_['appsToUpgrade'])) { ?>
+		<div class="infogroup">
+			<ul class="content appList">
+				<?php foreach ($_['appsToUpgrade'] as $appInfo) { ?>
+				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
+				<?php } ?>
+			</ul>
+		</div>
+		<?php } ?>
 		<?php if (!empty($_['appList'])) { ?>
 		<div class="infogroup">
 			<span class="bold"><?php p($l->t('The following apps will be disabled:')) ?></span>
@@ -17,9 +30,11 @@
 			<?php p($l->t('The theme %s has been disabled.', array($_['oldTheme']))) ?>
 		</div>
 		<?php } ?>
+		<?php if (!$_['isAppsOnlyUpgrade']) { ?>
 		<div class="infogroup bold">
 			<?php p($l->t('Please make sure that the database, the config folder and the data folder have been backed up before proceeding.')) ?>
 		</div>
+		<?php } ?>
 		<input class="updateButton" type="button" value="<?php p($l->t('Start update')) ?>">
 		<div class="infogroup">
 			<?php p($l->t('To avoid timeouts with larger installations, you can instead run the following command from your installation directory:')) ?>

--- a/lib/base.php
+++ b/lib/base.php
@@ -346,33 +346,47 @@ class OC {
 		if (\OCP\Util::needUpgrade()) {
 			$systemConfig = \OC::$server->getSystemConfig();
 			if ($showTemplate && !$systemConfig->getValue('maintenance', false)) {
-				$version = OC_Util::getVersion();
-				$oldTheme = $systemConfig->getValue('theme');
-				$systemConfig->setValue('theme', '');
-				OC_Util::addScript('config'); // needed for web root
-				OC_Util::addScript('update');
-				$tmpl = new OC_Template('', 'update.admin', 'guest');
-				$tmpl->assign('version', OC_Util::getVersionString());
-
-				// get third party apps
-				$apps = OC_App::getEnabledApps();
-				$incompatibleApps = array();
-				foreach ($apps as $appId) {
-					$info = OC_App::getAppInfo($appId);
-					if(!OC_App::isAppCompatible($version, $info)) {
-						$incompatibleApps[] = $info;
-					}
-				}
-				$tmpl->assign('appList', $incompatibleApps);
-				$tmpl->assign('productName', 'ownCloud'); // for now
-				$tmpl->assign('oldTheme', $oldTheme);
-				$tmpl->printPage();
+				self::printUpgradePage();
 				exit();
 			} else {
 				return true;
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Prints the upgrade page
+	 */
+	private static function printUpgradePage() {
+		$systemConfig = \OC::$server->getSystemConfig();
+		$oldTheme = $systemConfig->getValue('theme');
+		$systemConfig->setValue('theme', '');
+		\OCP\Util::addScript('config'); // needed for web root
+		\OCP\Util::addScript('update');
+
+		// check whether this is a core update or apps update
+		$installedVersion = $systemConfig->getValue('version', '0.0.0');
+		$currentVersion = implode('.', OC_Util::getVersion());
+
+		$appManager = \OC::$server->getAppManager();
+
+		$tmpl = new OC_Template('', 'update.admin', 'guest');
+		$tmpl->assign('version', OC_Util::getVersionString());
+
+		// if not a core upgrade, then it's apps upgrade
+		if (version_compare($currentVersion, $installedVersion, '=')) {
+			$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade());
+			$tmpl->assign('isAppsOnlyUpgrade', true);
+		} else {
+			// get third party apps
+			$version = OC_Util::getVersion();
+			$tmpl->assign('appList', $appManager->getIncompatibleApps($version));
+			$tmpl->assign('isAppsOnlyUpgrade', false);
+		}
+		$tmpl->assign('productName', 'ownCloud'); // for now
+		$tmpl->assign('oldTheme', $oldTheme);
+		$tmpl->printPage();
 	}
 
 	public static function initTemplateEngine() {

--- a/lib/base.php
+++ b/lib/base.php
@@ -376,14 +376,15 @@ class OC {
 
 		// if not a core upgrade, then it's apps upgrade
 		if (version_compare($currentVersion, $installedVersion, '=')) {
-			$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade());
 			$tmpl->assign('isAppsOnlyUpgrade', true);
 		} else {
-			// get third party apps
-			$version = OC_Util::getVersion();
-			$tmpl->assign('appList', $appManager->getIncompatibleApps($version));
 			$tmpl->assign('isAppsOnlyUpgrade', false);
 		}
+
+		// get third party apps
+		$ocVersion = OC_Util::getVersion();
+		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
+		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
 		$tmpl->assign('productName', 'ownCloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/app/appmanager.php
+++ b/lib/private/app/appmanager.php
@@ -213,11 +213,12 @@ class AppManager implements IAppManager {
 	/**
 	 * Returns a list of apps that need upgrade
 	 *
+	 * @param array $version ownCloud version as array of version components
 	 * @return array list of app info from apps that need an upgrade
 	 *
 	 * @internal
 	 */
-	public function getAppsNeedingUpgrade() {
+	public function getAppsNeedingUpgrade($ocVersion) {
 		$appsToUpgrade = [];
 		$apps = $this->getInstalledApps();
 		foreach ($apps as $appId) {
@@ -226,6 +227,7 @@ class AppManager implements IAppManager {
 			if ($appDbVersion
 				&& isset($appInfo['version'])
 				&& version_compare($appInfo['version'], $appDbVersion, '>')
+				&& \OC_App::isAppCompatible($ocVersion, $appInfo)
 			) {
 				$appsToUpgrade[] = $appInfo;
 			}
@@ -258,7 +260,7 @@ class AppManager implements IAppManager {
 	/**
 	 * Returns a list of apps incompatible with the given version
 	 *
-	 * @param array $version version as array of version components
+	 * @param array $version ownCloud version as array of version components
 	 *
 	 * @return array list of app info from incompatible apps
 	 *

--- a/lib/private/app/appmanager.php
+++ b/lib/private/app/appmanager.php
@@ -209,4 +209,71 @@ class AppManager implements IAppManager {
 		$settingsMemCache = $this->memCacheFactory->create('settings');
 		$settingsMemCache->clear('listApps');
 	}
+
+	/**
+	 * Returns a list of apps that need upgrade
+	 *
+	 * @return array list of app info from apps that need an upgrade
+	 *
+	 * @internal
+	 */
+	public function getAppsNeedingUpgrade() {
+		$appsToUpgrade = [];
+		$apps = $this->getInstalledApps();
+		foreach ($apps as $appId) {
+			$appInfo = $this->getAppInfo($appId);
+			$appDbVersion = $this->appConfig->getValue($appId, 'installed_version');
+			if ($appDbVersion
+				&& isset($appInfo['version'])
+				&& version_compare($appInfo['version'], $appDbVersion, '>')
+			) {
+				$appsToUpgrade[] = $appInfo;
+			}
+		}
+
+		return $appsToUpgrade;
+	}
+
+	/**
+	 * Returns the app information from "appinfo/info.xml".
+	 *
+	 * If no version was present in "appinfo/info.xml", reads it
+	 * from the external "appinfo/version" file instead.
+	 *
+	 * @param string $appId app id
+	 *
+	 * @return array app iinfo
+	 *
+	 * @internal
+	 */
+	public function getAppInfo($appId) {
+		$appInfo = \OC_App::getAppInfo($appId);
+		if (!isset($appInfo['version'])) {
+			// read version from separate file
+			$appInfo['version'] = \OC_App::getAppVersion($appId);
+		}
+		return $appInfo;
+	}
+
+	/**
+	 * Returns a list of apps incompatible with the given version
+	 *
+	 * @param array $version version as array of version components
+	 *
+	 * @return array list of app info from incompatible apps
+	 *
+	 * @internal
+	 */
+	public function getIncompatibleApps($version) {
+		$apps = $this->getInstalledApps();
+		$incompatibleApps = array();
+		foreach ($apps as $appId) {
+			$info = $this->getAppInfo($appId);
+			if (!\OC_App::isAppCompatible($version, $info)) {
+				$incompatibleApps[] = $info;
+			}
+		}
+		return $incompatibleApps;
+	}
+
 }

--- a/tests/lib/app/manager.php
+++ b/tests/lib/app/manager.php
@@ -212,9 +212,10 @@ class Manager extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$appInfos = [
-			'test1' => ['id' => 'test1', 'version' => '1.0.1', 'requiremax' => '8.0.0'],
+			'test1' => ['id' => 'test1', 'version' => '1.0.1', 'requiremax' => '9.0.0'],
 			'test2' => ['id' => 'test2', 'version' => '1.0.0', 'requiremin' => '8.2.0'],
 			'test3' => ['id' => 'test3', 'version' => '1.2.4', 'requiremin' => '9.0.0'],
+			'test4' => ['id' => 'test4', 'version' => '3.0.0', 'requiremin' => '8.1.0'],
 			'testnoversion' => ['id' => 'testnoversion', 'requiremin' => '8.2.0'],
 		];
 
@@ -232,12 +233,14 @@ class Manager extends \PHPUnit_Framework_TestCase {
 		$this->appConfig->setValue('test2', 'installed_version', '1.0.0');
 		$this->appConfig->setValue('test3', 'enabled', 'yes');
 		$this->appConfig->setValue('test3', 'installed_version', '1.0.0');
+		$this->appConfig->setValue('test4', 'enabled', 'yes');
+		$this->appConfig->setValue('test4', 'installed_version', '2.4.0');
 
-		$apps = $this->manager->getAppsNeedingUpgrade();
+		$apps = $this->manager->getAppsNeedingUpgrade('8.2.0');
 
 		$this->assertCount(2, $apps);
 		$this->assertEquals('test1', $apps[0]['id']);
-		$this->assertEquals('test3', $apps[1]['id']);
+		$this->assertEquals('test4', $apps[1]['id']);
 	}
 
 	public function testGetIncompatibleApps() {


### PR DESCRIPTION
Whenever the update page is displayed for apps, show app names instead
of the core update text.

Fixes https://github.com/owncloud/core/issues/16272
- [x] TODO: add unit test
- [x] To discuss: should we move `getIncompatibleApps` and `getAppsNeedingUpgrade` to the `IAppManager` interface ? I'd rather keep them private but "apps.php" is horribly static... @icewind1991 @MorrisJobke @nickvergessen @oparoz what do you think ?
