### PR TITLE
Keep update page when there are warnings

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -22,6 +22,8 @@
 				return;
 			}
 
+			var hasWarnings = false;
+
 			this.$el = $el;
 
 			this._started = true;
@@ -40,6 +42,7 @@
 			});
 			updateEventSource.listen('notice', function(message) {
 				$('<span>').addClass('error').append(message).append('<br />').appendTo($el);
+				hasWarnings = true;
 			});
 			updateEventSource.listen('error', function(message) {
 				$('<span>').addClass('error').append(message).append('<br />').appendTo($el);
@@ -57,14 +60,23 @@
 				.appendTo($el);
 			});
 			updateEventSource.listen('done', function() {
-				// FIXME: use product name
-				$('<span>').addClass('bold')
-					.append('<br />')
-					.append(t('core', 'The update was successful. Redirecting you to ownCloud now.'))
-					.appendTo($el);
-				setTimeout(function () {
-					OC.redirect(OC.webroot);
-				}, 3000);
+				if (hasWarnings) {
+					$('<span>').addClass('bold')
+						.append('<br />')
+						.append(t('core', 'The update was successful. There were warnings.'))
+						.appendTo($el);
+					var message = t('core', 'Please reload the page.');
+					$('<span>').append('<br />').append(message).append('<br />').appendTo($el);
+				} else {
+					// FIXME: use product name
+					$('<span>').addClass('bold')
+						.append('<br />')
+						.append(t('core', 'The update was successful. Redirecting you to ownCloud now.'))
+						.appendTo($el);
+					setTimeout(function () {
+						OC.redirect(OC.webroot);
+					}, 3000);
+				}
 			});
 		},
 


### PR DESCRIPTION
Whenever there were warnings during an update, the page will not be
redirected any more.

![update-warning](https://cloud.githubusercontent.com/assets/277525/8545320/a2ca647a-24ad-11e5-8645-1b0f8085e5aa.png)

To test:
1. Enable a third party app
2. Increase the version in "version.php" to trigger an update
3. Run the update

Before this PR: redirect didn't leave time to read the warnings.
After this PR: when warnings displayed, the page stays and needs manual reload.
