### PR TITLE
Remove 3rd party text for disabled apps on update

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -93,7 +93,7 @@ if (OC::checkUpgrade(false)) {
 	}
 	if (!empty($disabledThirdPartyApps)) {
 		$eventSource->send('notice',
-			(string)$l->t('Following 3rd party apps have been disabled: %s', implode(', ', $disabledThirdPartyApps)));
+			(string)$l->t('Following apps have been disabled: %s', implode(', ', $disabledThirdPartyApps)));
 	}
 
 	$eventSource->send('done', '');


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/17437

@jancborchardt I cannot remove the container because it's the container for warnings, and that message is produced as a warning/notice during the update.

If we really want this it will need some restructuring.
Let me know.
