### PR TITLE
Allow verification of public shares in core

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -120,8 +120,6 @@ class Helper {
 	public static function authenticate($linkItem, $password = null) {
 		if ($password !== null) {
 			if ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_LINK) {
-				// Check Password
-				$newHash = '';
 				if(\OC::$server->getHasher()->verify($password, $linkItem['share_with'], $newHash)) {
 					// Save item id in session for future requests
 					\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -120,25 +120,9 @@ class Helper {
 	public static function authenticate($linkItem, $password = null) {
 		if ($password !== null) {
 			if ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_LINK) {
-				if(\OC::$server->getHasher()->verify($password, $linkItem['share_with'], $newHash)) {
+				if (\OCP\Share::verify($linkItem['id'], $password)) {
 					// Save item id in session for future requests
 					\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);
-
-					/**
-					 * FIXME: Migrate old hashes to new hash format
-					 * Due to the fact that there is no reasonable functionality to update the password
-					 * of an existing share no migration is yet performed there.
-					 * The only possibility is to update the existing share which will result in a new
-					 * share ID and is a major hack.
-					 *
-					 * In the future the migration should be performed once there is a proper method
-					 * to update the share's password. (for example `$share->updatePassword($password)`
-					 *
-					 * @link https://github.com/owncloud/core/issues/10671
-					 */
-					if(!empty($newHash)) {
-
-					}
 				} else {
 					return false;
 				}

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1247,6 +1247,33 @@ class Share extends Constants {
 	}
 
 	/**
+	 * Return share information for a given id
+	 *
+	 * @param Connection $connection
+	 * @param int $shareId The id of the share
+	 * @return array the share info
+	 * @throws \OCP\Share\NotFoundException
+	 *
+	 */
+	public static function getShareById(Connection $connection,
+	                                    $shareId) {
+		$qb = $connection->createQueryBuilder();
+		$qb->select('*')
+		   ->from('`*PREFIX*share`')
+		   ->where('`id` = :id')
+		   ->setParameter(':id', $shareId);
+
+		$result = $qb->execute();
+		$result = $result->fetchAll();
+
+		if (count($result) !== 1) {
+			throw new \OCP\Share\NotFoundException;
+		}
+
+		return current($result);
+	}
+
+	/**
 	 * Checks whether a share has expired, calls unshareItem() if yes.
 	 * @param array $item Share data (usually database row)
 	 * @return boolean True if item was expired, false otherwise.

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1274,6 +1274,49 @@ class Share extends Constants {
 	}
 
 	/**
+	 * Verify the password of a share
+	 * And upgrade the hash if required
+	 *
+	 * @param int $shareId The id of the share
+	 * @param string $password The password to verify
+	 * @return bool If the password is correct
+	 * @throws \OCP\Share\NotFoundException
+	 * @throws \OCP\Share\NotPasswordProtectedException
+	 * @throws \OCP\Share\NoLinkShareException
+	 */
+	public static function verify($shareId, $password) {
+		//Get share
+		$share = \OCP\Share::getShareById($shareId);
+
+		if ((int)$share['share_type'] !== \OCP\Share::SHARE_TYPE_LINK) {
+			throw new \OCP\Share\NoLinkShareException;
+		}
+
+		if (empty($share['share_with'])) {
+			throw new \OCP\Share\NotPAsswordProtectedException;
+		}
+
+		//Verify password
+		$newHash = '';
+		if (!\OC::$server->getHasher()->verify($password, $share['share_with'], $newHash)) {
+			return false;
+		}
+
+		//If we need a newhash update the password in the database
+		if (!empty($newHash)) {
+			$qb = \OC::$server->getDatabaseConnection()->createQueryBuilder();
+			$qb->update('`*PREFIX*share`')
+			   ->set('`share_with`', ':pass')
+			   ->where('`id` = :id')
+			   ->setParameter(':id', $shareId)
+			   ->setParameter(':pass', $newHash);
+			$qb->execute();
+		}
+
+		return true;
+	}
+
+	/**
 	 * Checks whether a share has expired, calls unshareItem() if yes.
 	 * @param array $item Share data (usually database row)
 	 * @return boolean True if item was expired, false otherwise.

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -190,6 +190,19 @@ class Share extends \OC\Share\Constants {
 	}
 
 	/**
+	 * Retrieve the share for a given id
+	 *
+	 * @param int $id The id of the share
+	 * @return array The share
+	 * @throws \OCP\Share\NotFoundException
+	 * @since 8.2.0
+	 */
+	public static function getShareById($shareId) {
+		$connection = \OC::$server->getDatabaseConnection();
+		return \OC\Share\Share::getShareById($connection, $shareId);
+	}
+
+	/**
 	 * resolves reshares down to the last real share
 	 * @param array $linkItem
 	 * @return array file owner

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -370,6 +370,22 @@ class Share extends \OC\Share\Constants {
 		return \OC\Share\Share::setPassword($userSession, $connection, $config, $shareId, $password);
 	}
 
+	/**
+	 * Verify the password of a share
+	 * Update the password in the database if required
+	 *
+	 * @param int $shareId The id of the share
+	 * @param string $password The password to verify
+	 * @return bool If the password is correct
+	 * @throws \OCP\Share\NotFoundException
+	 * @throws \OCP\Share\NotPasswordProtectedException
+	 * @throws \OCP\Share\NoPublicShareException
+	 * @since 8.2.0
+	 */
+	public static function verify($shareId, $password) {
+		return \OC\Share\Share::verify($shareId, $password);
+	}
+
 
 	/**
 	 * Get the backend class for the specified item type

--- a/lib/public/share/nolinkshareexception.php
+++ b/lib/public/share/nolinkshareexception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Share\NoLinkShareException class
+ */
+
+namespace OCP\Share;
+
+/**
+ * Exception for operations that can only be performed on link shares
+ * @since 8.2.0
+ */
+class NoLinkShareException extends \Exception {}

--- a/lib/public/share/notfoundexception.php
+++ b/lib/public/share/notfoundexception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Share\NotFoundException class
+ */
+
+namespace OCP\Share;
+
+/**
+ * Exception for unkown shares
+ * @since 8.2.0
+ */
+class NotFoundException extends \Exception {}

--- a/lib/public/share/notpasswordprotectedexception.php
+++ b/lib/public/share/notpasswordprotectedexception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Share\NotPasswordProtectedException class
+ */
+
+namespace OCP\Share;
+
+/**
+ * Exception if a password is expected
+ * @since 8.2.0
+ */
+class NotPasswordProtectedException extends \Exception {}

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1,23 +1,37 @@
 <?php
 /**
-* ownCloud
-*
-* @author Michael Gapczynski
-* @copyright 2012 Michael Gapczynski mtgap@owncloud.com
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * @author Andreas Fischer <bantu@owncloud.com>
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author ben-denham <bend@catalyst.net.nz>
+ * @author Björn Schießle <schiessle@owncloud.com>
+ * @author Felix Moeller <mail@felixmoeller.de>
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Michael Gapczynski <GapczynskiM@gmail.com>
+ * @author Michael Kuhn <suraia@ikkoku.de>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Scrutinizer Auto-Fixer <auto-fixer@scrutinizer-ci.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Thomas Tanghus <thomas@tanghus.net>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 class Test_Share extends \Test\TestCase {
 
@@ -1530,6 +1544,44 @@ class Test_Share extends \Test\TestCase {
 
 		\OC\Share\Share::setPassword($userSession, $connection, $config, 1, 'pass');
 	}
+
+	public function testGetShareById() {
+		OC_User::setUserId($this->user1);
+		OCP\Share::shareItem(
+			'test',
+			'test.txt',
+			OCP\Share::SHARE_TYPE_USER,
+			$this->user2,
+			\OCP\Constants::PERMISSION_ALL
+		);
+
+		$res = OCP\Share::getItemShared('test', 'test.txt');
+		$this->assertInternalType('array', $res);
+		$this->assertCount(1, $res);
+
+		$id = array_keys($res)[0];
+		$res = $res[$id];
+		$this->assertInternalType('array', $res);
+		$this->assertArrayHasKey('id', $res);
+
+		$res2 = OCP\Share::getShareById($res['id']);
+		$this->assertInternalType('array', $res2);
+
+		OCP\Share::unshare(
+			'test',
+			'test.txt',
+			OCP\Share::SHARE_TYPE_USER,
+			$this->user2
+		);
+	}
+
+	/**
+      * @expectedException \OCP\Share\NotFoundException
+      */
+	public function testGetShareByIdException() {
+		OCP\Share::getShareById(-1);
+	}
+
 
 }
 


### PR DESCRIPTION
The password checks for shares was handled outside OC\Share. Now it is handled internally.
This also allows updating of the password hash (#16594).

I know we want to modernize the sharing code. But that still might take a while... and this should be easy enough to port along side.

CC: @MorrisJobke @LukasReschke @DeepDiver1975 @schiesbn 
