### PR TITLE
Fix parsing of sharetime as string

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -820,6 +820,21 @@ OC.Share={
 		return path.replace(/\\/g,'/').replace(/\/[^\/]*$/, '');
 	},
 	/**
+	 * Parses a string to an valid integer (unix timestamp)
+	 * @param time
+	 * @returns {*}
+	 * @internal Only used to work around a bug in the backend
+	 */
+	_parseTime: function(time) {
+		if (_.isString(time)) {
+			time = parseInt(time, 10);
+			if(isNaN(time)) {
+				time = null;
+			}
+		}
+		return time;
+	},
+	/**
 	 * Displays the expiration date field
 	 *
 	 * @param {Date} date current expiration date
@@ -834,6 +849,8 @@ OC.Share={
 			minDate: minDate,
 			maxDate: null
 		};
+		// TODO: hack: backend returns string instead of integer
+		shareTime = OC.Share._parseTime(shareTime);
 		if (_.isNumber(shareTime)) {
 			shareTime = new Date(shareTime * 1000);
 		}

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -827,6 +827,10 @@ OC.Share={
 	 */
 	_parseTime: function(time) {
 		if (_.isString(time)) {
+			// skip empty strings and hex values
+			if (time === '' || (time.length > 1 && time[0] === '0' && time[1] === 'x')) {
+				return null;
+			}
 			time = parseInt(time, 10);
 			if(isNaN(time)) {
 				time = null;

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -1324,6 +1324,8 @@ describe('OC.Share tests', function() {
 				[  123456 , 123456],
 				['0123456', 123456],
 				['abcdefg',   null],
+				['0x12345',   null],
+				[       '',   null],
 			], function(value) {
 				expect(OC.Share._parseTime(value[0])).toEqual(value[1]);
 			});

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -1316,5 +1316,19 @@ describe('OC.Share tests', function() {
 			});
 		});
 	});
+	describe('OC.Share utils', function() {
+		it('parseTime should properly parse strings', function() {
+
+			_.each([
+				[ '123456', 123456],
+				[  123456 , 123456],
+				['0123456', 123456],
+				['abcdefg',   null],
+			], function(value) {
+				expect(OC.Share._parseTime(value[0])).toEqual(value[1]);
+			});
+
+		});
+	});
 });
 


### PR DESCRIPTION
In some cases the ajax/share.php will return the share time as string.
If this is the case it would get parsed completely wrong and cause the
share dropdown to not work anymore. This change will properly cast the
string to an interger and also fallback if this is not possible.

There are just some very rare cases, where the share table is modified in a way that it will cause this. I couldn't find the reproduction steps. I also don't want to fight against the 400 line monster of sharing method that returns the string: https://github.com/owncloud/core/blob/fix-share-time-as-string/lib/private/share/share.php#L1488-L1877

cc @rullzer @schiesbn @PVince81 
