### PR TITLE
Fix browser compatibility issue for element.closest()

### DIFF
--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -58,7 +58,7 @@
 				if (!area.is(':animated')) {
 
 					// button toggles the area
-					if (button === event.target.closest('[data-apps-slide-toggle]')) {
+					if ($(button).is($(event.target).closest('[data-apps-slide-toggle]'))) {
 						if (area.is(':visible')) {
 							hideArea();
 						} else {


### PR DESCRIPTION
element.closest() is only supported by modern browsers (Chrome 41+, Firefox 35+).
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Browser_compatibility

Instead JQuery's closest() should be used.

This impacts for example the settings menu and throws the following error in older browsers:

``` javascript
TypeError: event.target.closest is not a function
    if (button === event.target.closest('[data-apps-slide-toggle]')) {
```

This bug was described by @raimund-schluessler in owncloud/tasks#215
