### PR TITLE
Fix differences between php and php-fpm for scriptname

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -522,8 +522,18 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 */
 	public function getRequestUri() {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
+
+		$script_name = $_SERVER['SCRIPT_NAME'];
+		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
+			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
+			if ($pos === false) {
+			} else {
+				$script_name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
+			}
+		}
+
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
-			$uri = $this->getScriptName() . substr($uri, strlen($this->server['SCRIPT_NAME']));
+			$uri = $this->getScriptName() . substr($uri, strlen($script_name));
 		}
 		return $uri;
 	}
@@ -548,6 +558,15 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		$scriptName = $this->server['SCRIPT_NAME'];
+
+		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
+			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
+			if ($pos === false) {
+			} else {
+				$scriptName = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
+			}
+		}
+
 		$pathInfo = $requestUri;
 
 		// strip off the script name's dir and file name
@@ -604,6 +623,14 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 */
 	public function getScriptName() {
 		$name = $this->server['SCRIPT_NAME'];
+		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
+			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
+			if ($pos === false) {
+			} else {
+				$name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
+			}
+		}
+
 		$overwriteWebRoot =  $this->config->getSystemValue('overwritewebroot');
 		if ($overwriteWebRoot !== '' && $this->isOverwriteCondition()) {
 			// FIXME: This code is untestable due to __DIR__, also that hardcoded path is really dangerous

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -530,14 +530,15 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	}
 
         /**
-         * Returns the actual scriptname. In some version of php there is a bug
-         * which causes PATH_INFO to also be part of SCRIPT_NAME.
+         * Returns the actual scriptname. This is a workaround for https://bugs.php.net/bug.php?id=65641
+         * which was fixed in php 5.5.18. RHEL 7 and Ubuntu 14.04 have not backported this fix yet.
+         * The problem is that PATH_INFO is also part of SCRIPT_NAME.
          * @return string
          */
         private function getRawScriptName() {
             $ScriptName = $this->server['SCRIPT_NAME'];
 
-            if (array_key_exists('PATH_INFO', $_SERVER) === true) {
+            if (array_key_exists('PATH_INFO', $this->server) === true) {
                 $pos = strpos($this->server['SCRIPT_NAME'], rawurldecode($this->server['PATH_INFO']));
 
                 if ($pos !== false) {

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -524,7 +524,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
-			$uri = $this->getScriptName() . substr($uri, strlen(getRawScriptName()));
+			$uri = $this->getScriptName() . substr($uri, strlen($this->getRawScriptName()));
 		}
 		return $uri;
 	}
@@ -535,17 +535,17 @@ class Request implements \ArrayAccess, \Countable, IRequest {
          * @return string
          */
         private function getRawScriptName() {
-            $script_name = $_SERVER['SCRIPT_NAME'];
+            $ScriptName = $this->server['SCRIPT_NAME'];
 
-            if (array_key_exists('PATH_INFO', $_SERVER) == true) {
-                $pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
+            if (array_key_exists('PATH_INFO', $_SERVER) === true) {
+                $pos = strpos($this->server['SCRIPT_NAME'], rawurldecode($this->server['PATH_INFO']));
 
                 if ($pos !== false) {
-                    $script_name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
+                    $ScriptName = substr($this->server['SCRIPT_NAME'], 0, $pos);
                 }
             }
 
-            return $script_name;
+            return $ScriptName;
         }
 
 	/**
@@ -567,7 +567,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			$requestUri = substr($requestUri, 0, $pos);
 		}
 
-		$scriptName = getRawScriptName();
+		$scriptName = $this->getRawScriptName();
 		$pathInfo = $requestUri;
 
 		// strip off the script name's dir and file name
@@ -623,7 +623,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string the script name
 	 */
 	public function getScriptName() {
-		$name = getRawScriptName();
+		$name = $this->getRawScriptName();
 
 		$overwriteWebRoot =  $this->config->getSystemValue('overwritewebroot');
 		if ($overwriteWebRoot !== '' && $this->isOverwriteCondition()) {

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -523,20 +523,30 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	public function getRequestUri() {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 
-		$script_name = $_SERVER['SCRIPT_NAME'];
-		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
-			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
-			if ($pos === false) {
-			} else {
-				$script_name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
-			}
-		}
-
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
-			$uri = $this->getScriptName() . substr($uri, strlen($script_name));
+			$uri = $this->getScriptName() . substr($uri, strlen(getRawScriptName()));
 		}
 		return $uri;
 	}
+
+        /**
+         * Returns the actual scriptname. In some version of php there is a bug
+         * which causes PATH_INFO to also be part of SCRIPT_NAME.
+         * @return string
+         */
+        private function getRawScriptName() {
+            $script_name = $_SERVER['SCRIPT_NAME'];
+
+            if (array_key_exists('PATH_INFO', $_SERVER) == true) {
+                $pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
+
+                if ($pos !== false) {
+                    $script_name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
+                }
+            }
+
+            return $script_name;
+        }
 
 	/**
 	 * Get raw PathInfo from request (not urldecoded)
@@ -557,16 +567,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			$requestUri = substr($requestUri, 0, $pos);
 		}
 
-		$scriptName = $this->server['SCRIPT_NAME'];
-
-		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
-			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
-			if ($pos === false) {
-			} else {
-				$scriptName = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
-			}
-		}
-
+		$scriptName = getRawScriptName();
 		$pathInfo = $requestUri;
 
 		// strip off the script name's dir and file name
@@ -622,14 +623,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string the script name
 	 */
 	public function getScriptName() {
-		$name = $this->server['SCRIPT_NAME'];
-		if (array_key_exists('PATH_INFO', $_SERVER) === true) {
-			$pos = strpos($_SERVER['SCRIPT_NAME'], rawurldecode($_SERVER['PATH_INFO']));
-			if ($pos === false) {
-			} else {
-				$name = substr($_SERVER['SCRIPT_NAME'], 0, $pos);
-			}
-		}
+		$name = getRawScriptName();
 
 		$overwriteWebRoot =  $this->config->getSystemValue('overwritewebroot');
 		if ($overwriteWebRoot !== '' && $this->isOverwriteCondition()) {


### PR DESCRIPTION
Originally done by @niobos in #7719. If you want to run owncloud with
php-fpm on RHEL 7, you need this. There is a bug in php that causes
$_SERVER['SCRIPT_NAME'] to also contains the PATH_INFO. This works
around that issue.

I need this patch to get owncloud to work on RHEL7 with apache 2.4 and php-fpm.
