### PR TITLE
Add indexes to speedup DB queries

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -471,6 +471,14 @@
 				</field>
 			</index>
 
+			<index>
+				<name>gu_uid_index</name>
+				<field>
+					<name>uid</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
 		</declaration>
 
 	</table>
@@ -856,6 +864,13 @@
 				<name>token_index</name>
 				<field>
 					<name>token</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+			<index>
+				<name>share_file_target</name>
+				<field>
+					<name>file_target</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(8, 2, 0, 0);
+$OC_Version=array(8, 2, 0, 1);
 
 // The human readable string
 $OC_VersionString='8.2 pre alpha';


### PR DESCRIPTION
- file_target is often used in the sharing code in JOIN statements for retrieval of shares

cc @DeepDiver1975 @butonic @PVince81 @icewind1991 @schiesbn 

Fixes #7474

We noticed that adding this two indexes reduced a lot of DB load.

I tested both with sqlite and mysql.
