### PR TITLE
Only clean up if migration finished succesfully

### DIFF
--- a/apps/encryption/command/migratekeys.php
+++ b/apps/encryption/command/migratekeys.php
@@ -115,5 +115,7 @@ class MigrateKeys extends Command {
 			}
 		}
 
+		$migration->finalCleanUp();
+
 	}
 }

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -406,19 +406,36 @@ class KeyManager {
 	}
 
 	/**
-	 * @param $userId
+	 * check if user has a private and a public key
+	 *
+	 * @param string $userId
 	 * @return bool
+	 * @throws PrivateKeyMissingException
+	 * @throws PublicKeyMissingException
 	 */
 	public function userHasKeys($userId) {
+		$privateKey = $publicKey = true;
+
 		try {
 			$this->getPrivateKey($userId);
-			$this->getPublicKey($userId);
 		} catch (PrivateKeyMissingException $e) {
-			return false;
-		} catch (PublicKeyMissingException $e) {
-			return false;
+			$privateKey = false;
+			$exception = $e;
 		}
-		return true;
+		try {
+			$this->getPublicKey($userId);
+		} catch (PublicKeyMissingException $e) {
+			$publicKey = false;
+			$exception = $e;
+		}
+
+		if ($privateKey && $publicKey) {
+			return true;
+		} elseif (!$privateKey && !$publicKey) {
+			return false;
+		} else {
+			throw $exception;
+		}
 	}
 
 	/**

--- a/apps/encryption/lib/migration.php
+++ b/apps/encryption/lib/migration.php
@@ -50,7 +50,7 @@ class Migration {
 		$this->config = $config;
 	}
 
-	public function __destruct() {
+	public function finalCleanUp() {
 		$this->view->deleteAll('files_encryption/public_keys');
 		$this->updateFileCache();
 		$this->config->deleteAppValue('files_encryption', 'installed_version');

--- a/settings/controller/encryptioncontroller.php
+++ b/settings/controller/encryptioncontroller.php
@@ -102,6 +102,8 @@ class EncryptionController extends Controller {
 				} while (count($users) >= $limit);
 			}
 
+			$migration->finalCleanUp();
+
 		} catch (\Exception $e) {
 			return array(
 				'data' => array(


### PR DESCRIPTION
- Move the final clean up from the destructor to a separate method. If the migration fails it can happen that the destructor gets called to early. This way we make sure that we really clean up the remaining keys and config settings only at the end of the migration process.
- only create new key pair if both keys, private and public, are missing

Fixes issues like described here https://github.com/owncloud/core/issues/16928
