### PR TITLE
Update fileinfo.php

### DIFF
--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -116,7 +116,7 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals('abcdef', $result['data']['etag']);
 		$this->assertFalse(isset($result['data']['tags']));
 		$this->assertEquals('/', $result['data']['path']);
-		$icon = \OC_Helper::mimetypeIcon('dir');
+		$icon = \OC_Helper::mimetypeIcon('dir-external');
 		$icon = substr($icon, 0, -3) . 'svg';
 		$this->assertEquals($icon, $result['data']['icon']);
 	}

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -252,7 +252,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		$sid = $this->getStorage()->getId();
 		if (!is_null($sid)) {
 			$sid = explode(':', $sid);
-			return ($sid[0] !== 'local' and $sid[0] !== 'home' and $sid[0] !== 'shared');
+			return ($sid[0] !== 'home' and $sid[0] !== 'shared');
 		}
 
 		return false;


### PR DESCRIPTION
Edits isMounted() to remove the check for 'local' prefix (since ownCloud 8 converts old personal storage deisgnations), so that folder icons are displayed correctly (see issue #10712)
