### PR TITLE
Move mimetypealiases.json to mimetypealiases.dist.json

### DIFF
--- a/config/mimetypealiases.dist.json
+++ b/config/mimetypealiases.dist.json
@@ -1,7 +1,11 @@
 {
-	"_comment" : "When this file is changed make sure to run",
-	"_comment2": "./occ maintenance:mimetypesjs",
-	"_comment3": "Otherwise your update won't propagate through the system",
+	"_comment" : "Array of mimetype aliases.",
+	"_comment2": "Any changes you make here will be overwritten on an update of ownCloud.",
+	"_comment3": "Put any custom aliases in a new file mimetypealiases.json in this directory",
+
+	"_comment4": "After any change to mimetypealiases.json run:",
+	"_comment5": "./occ maintenance:mimetypesjs",
+	"_comment6": "Otherwise your update won't propagate through the system.",
 
 
 	"application/coreldraw": "image",

--- a/core/command/maintenance/mimetypesjs.php
+++ b/core/command/maintenance/mimetypesjs.php
@@ -33,7 +33,12 @@ class MimeTypesJS extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		// Fetch all the aliases
-		$aliases = json_decode(file_get_contents(dirname(__DIR__) . '/../../config/mimetypealiases.json'), true);
+		$aliases = json_decode(file_get_contents(\OC::$SERVERROOT . '/config/mimetypealiases.dist.json'), true);
+
+		if (file_exists(\OC::$SERVERROOT . '/config/mimetypealiases.json')) {
+			$custom = get_object_vars(json_decode(file_get_contents(\OC::$SERVERROOT . '/config/mimetypealiases.json')));
+			$aliases = array_merge($aliases, $custom);
+		}
 
 		// Remove comments
 		$keys = array_filter(array_keys($aliases), function($k) {

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -188,8 +188,13 @@ class OC_Helper {
 
 		// On first access load the list of mimetype aliases
 		if (empty(self::$mimeTypeAlias)) {
-			$file = file_get_contents(OC::$SERVERROOT . '/config/mimetypealiases.json');
+			$file = file_get_contents(OC::$SERVERROOT . '/config/mimetypealiases.dist.json');
 			self::$mimeTypeAlias = get_object_vars(json_decode($file));
+
+			if (file_exists(\OC::$SERVERROOT . '/config/mimetypealiases.json')) {
+				$custom = get_object_vars(json_decode(file_get_contents(\OC::$SERVERROOT . '/config/mimetypealiases.json')));
+				self::$mimeTypeAlias = array_merge(self::$mimeTypeAlias, $custom);
+			}
 		}
 
 		if (isset(self::$mimeTypeAlias[$mimetype])) {


### PR DESCRIPTION
Make sure that users can keep their changes in mimetypealiases.json so we can override mimetypealiases.dist.json.
Similar to the last commit in #17481

This way they'll know not to touch the file we distribute.

CC: @PVince81 @Xenopathic @oparoz @MorrisJobke 
