### PR TITLE
LDAP: when checking group for matching filter, also take base DN into…

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -382,7 +382,12 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			if (is_array($groupDNs)) {
 				$groupDNs = $this->access->groupsMatchFilter($groupDNs);
 				foreach ($groupDNs as $dn) {
-					$groups[] = $this->access->dn2groupname($dn);
+					$groupName = $this->access->dn2groupname($dn);
+					if(is_string($groupName)) {
+						// be sure to never return false if the dn could not be
+						// resolved to a name, for whatever reason.
+						$groups[] = $groupName;
+					}
 				}
 			}
 			if($primaryGroup !== false) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -365,10 +365,21 @@ class Access extends LDAPUtility implements user\IUserTools {
 				continue;
 			}
 
+			// Check the base DN first. If this is not met already, we don't
+			// need to ask the server at all.
+			if(!$this->isDNPartOfBase($dn, $this->connection->ldapBaseGroups)) {
+				$this->connection->writeToCache($cacheKey, false);
+				continue;
+			}
+
 			$result = $this->readAttribute($dn, 'cn', $this->connection->ldapGroupFilter);
 			if(is_array($result)) {
+				$this->connection->writeToCache($cacheKey, true);
 				$validGroupDNs[] = $dn;
+			} else {
+				$this->connection->writeToCache($cacheKey, false);
 			}
+
 		}
 		return $validGroupDNs;
 	}

--- a/apps/user_ldap/tests/integration/setup-scripts/createExplicitGroupsDifferentOU.php
+++ b/apps/user_ldap/tests/integration/setup-scripts/createExplicitGroupsDifferentOU.php
@@ -1,0 +1,52 @@
+<?php
+
+if(php_sapi_name() !== 'cli') {
+	print('Only via CLI, please.');
+	exit(1);
+}
+
+include __DIR__ . '/config.php';
+
+$cr = ldap_connect($host, $port);
+ldap_set_option($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
+$ok = ldap_bind($cr, $adn, $apwd);
+
+if (!$ok) {
+	die(ldap_error($cr));
+}
+
+$ouName = 'SpecialGroups';
+$ouDN = 'ou=' . $ouName . ',' . $bdn;
+
+//creates an OU
+if (true) {
+	$entry = [];
+	$entry['objectclass'][] = 'top';
+	$entry['objectclass'][] = 'organizationalunit';
+	$entry['ou'] = $ouName;
+	$b = ldap_add($cr, $ouDN, $entry);
+	if (!$b) {
+		die(ldap_error($cr));
+	}
+}
+
+$groups = ['SquareGroup', 'CircleGroup', 'TriangleGroup', 'SquaredCircleGroup'];
+// groupOfNames requires groups to have at least one member
+// the member used is created by createExplicitUsers.php script
+$omniMember = 'uid=alice,ou=Users,' . $bdn;
+
+foreach ($groups as $cn) {
+	$newDN = 'cn=' . $cn . ',' . $ouDN;
+
+	$entry = [];
+	$entry['cn'] = $cn;
+	$entry['objectclass'][] = 'groupOfNames';
+	$entry['member'][] = $omniMember;
+
+	$ok = ldap_add($cr, $newDN, $entry);
+	if ($ok) {
+		echo('created group ' . ': ' . $entry['cn'] . PHP_EOL);
+	} else {
+		die(ldap_error($cr));
+	}
+}


### PR DESCRIPTION
… consideration. Fixes #17516 

Integration test extended.

How to test:
1. LDAP Server must support memberOf.
2. Have an LDAP user with groups of different bases. 
3. Have Group base limited so that some groups are ruled out.
4. Log in with the LDAP user and go to Personal settings.

Before this patch: WPoD
After: Page load properly and all valid groups are shown.

Please test and review @MorrisJobke @giancarlobi @Xenopathic @11mariom or others

@karlitschek: this will require backport to stable8.1. Granted?
