### PR TITLE
Fix the config.php owner check for console.php

### DIFF
--- a/console.php
+++ b/console.php
@@ -54,7 +54,7 @@ try {
 			exit(0);
 		}
 		$user = posix_getpwuid(posix_getuid());
-		$configUser = posix_getpwuid(fileowner(OC::$SERVERROOT . '/config/config.php'));
+		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
 		if ($user['name'] !== $configUser['name']) {
 			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
 			echo "Current user: " . $user['name'] . PHP_EOL;


### PR DESCRIPTION
The config directory must be taken from OC::$configDir

Minor fix
- Remove uneeded slash in the configdir path.

This is only for the jenkins run. The actual review already happened in the original PR in #16917
