### PR TITLE
Fix for CLI installation with mysql

### DIFF
--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -107,8 +107,8 @@ class Setup {
 				'name' => 'SQLite'
 			),
 			'mysql' => array(
-				'type' => 'function',
-				'call' => 'mysql_connect',
+				'type' => 'class',
+				'call' => 'MySQLi',
 				'name' => 'MySQL/MariaDB'
 			),
 			'pgsql' => array(


### PR DESCRIPTION
`mysql_connect` is deprecated in PHP 5.5 and modern systems likely will not be automated relying on this old function, so lets better check for MySQLi presence.

Alternative way is to allow arrays in `call` element, so that we can check for either `mysql_connect` or `mysqli_connect`.
