### PR TITLE
allow remote shares for users with email as usernames

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -296,7 +296,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				// allow user to add unknown remote addresses for server-to-server share
 				$backend = \OCP\Share::getBackend((string)$_GET['itemType']);
 				if ($backend->isShareTypeAllowed(\OCP\Share::SHARE_TYPE_REMOTE)) {
-					if (substr_count((string)$_GET['search'], '@') === 1) {
+					if (substr_count((string)$_GET['search'], '@') >= 1) {
 						$shareWith[] = array(
 							'label' => (string)$_GET['search'],
 							'value' => array(


### PR DESCRIPTION
sharing dialog was only matching exactly a single '@' in the shareWith field,
but if username is an email you have 2 '@' in that string.

Fixes #14154 
Fixes #17492
