### PR TITLE
Fix OC.joinPaths with empty arguments

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -340,13 +340,23 @@ var OC={
 			return '';
 		}
 		var path = '';
-		var lastArg = arguments[arguments.length - 1];
-		var leadingSlash = arguments[0].charAt(0) === '/';
+		// convert to array
+		var args = Array.prototype.slice.call(arguments);
+		// discard empty arguments
+		args = _.filter(args, function(arg) {
+			return arg.length > 0;
+		});
+		if (args.length < 1) {
+			return '';
+		}
+
+		var lastArg = args[args.length - 1];
+		var leadingSlash = args[0].charAt(0) === '/';
 		var trailingSlash = lastArg.charAt(lastArg.length - 1) === '/';
 		var sections = [];
 		var i;
-		for (i = 0; i < arguments.length; i++) {
-			sections = sections.concat(arguments[i].split('/'));
+		for (i = 0; i < args.length; i++) {
+			sections = sections.concat(args[i].split('/'));
 		}
 		var first = !leadingSlash;
 		for (i = 0; i < sections.length; i++) {

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -147,11 +147,15 @@ describe('Core base tests', function() {
 		});
 		it('keeps leading slashes', function() {
 			expect(OC.joinPaths('/abc')).toEqual('/abc');
+			expect(OC.joinPaths('/abc', '')).toEqual('/abc');
+			expect(OC.joinPaths('', '/abc')).toEqual('/abc');
 			expect(OC.joinPaths('/abc', 'def')).toEqual('/abc/def');
 			expect(OC.joinPaths('/abc', 'def', 'ghi')).toEqual('/abc/def/ghi');
 		});
 		it('keeps trailing slashes', function() {
+			expect(OC.joinPaths('', 'abc/')).toEqual('abc/');
 			expect(OC.joinPaths('abc/')).toEqual('abc/');
+			expect(OC.joinPaths('abc/', '')).toEqual('abc/');
 			expect(OC.joinPaths('abc', 'def/')).toEqual('abc/def/');
 			expect(OC.joinPaths('abc', 'def', 'ghi/')).toEqual('abc/def/ghi/');
 		});


### PR DESCRIPTION
When empty arguments are given, the leading or trailing slash was not
detected properly.

Please review @icewind1991 @rullzer @oparoz 

See the unit test to see what case was broken :smile: 
