### PR TITLE
Allow ajax requests on public webdav interface

### DIFF
--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -46,7 +46,8 @@ $serverFactory = new \OC\Connector\Sabre\ServerFactory(
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
 $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, function () use ($authBackend) {
-	if (OCA\Files_Sharing\Helper::isOutgoingServer2serverShareEnabled() === false) {
+	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest');
+	if (OCA\Files_Sharing\Helper::isOutgoingServer2serverShareEnabled() === false && !$isAjax) {
 		// this is what is thrown when trying to access a non-existing share
 		throw new \Sabre\DAV\Exception\NotAuthenticated();
 	}


### PR DESCRIPTION
Whenever outgoing shares are disabled, still allow ajax requests to make
it possible to use the Webdav interface in the public link page.

Please note that disabling outgoing shares isn't strong anyway as
someone could abuse the ajax endpoints to access files anyway. To
properly disable remote sharing, public link sharing must be disabled
too.

@oparoz that would also fix the text preview, was it still using Webdav ?

This will be required when the files UI uses Webdav.

Please review @LukasReschke @icewind1991 @MorrisJobke @schiesbn @th3fallen 
