### PR TITLE
Strip public webdav info about sharing and mount points

### DIFF
--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -45,7 +45,7 @@ $defaults = new OC_Defaults();
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
 // FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 $server->addPlugin(new \OC\Connector\Sabre\DummyGetResponsePlugin());
-$server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree));
+$server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree, true));
 $server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
 $server->addPlugin(new \OC\Connector\Sabre\ExceptionLoggerPlugin('webdav', \OC::$server->getLogger()));
 

--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -56,10 +56,19 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	private $tree;
 
 	/**
+	 * Whether this is public webdav.
+	 * If true, some returned information will be stripped off.
+	 *
+	 * @var bool
+	 */
+	private $isPublic;
+
+	/**
 	 * @param \Sabre\DAV\Tree $tree
 	 */
-	public function __construct(\Sabre\DAV\Tree $tree) {
+	public function __construct(\Sabre\DAV\Tree $tree, $isPublic = false) {
 		$this->tree = $tree;
+		$this->isPublic = $isPublic;
 	}
 
 	/**
@@ -129,7 +138,12 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 			});
 
 			$propFind->handle(self::PERMISSIONS_PROPERTYNAME, function() use ($node) {
-				return $node->getDavPermissions();
+				$perms = $node->getDavPermissions();
+				if ($this->isPublic) {
+					// remove mount information
+					$perms = str_replace(['S', 'M'], '', $perms);
+				}
+				return $perms;
 			});
 
 			$propFind->handle(self::GETETAG_PROPERTYNAME, function() use ($node) {

--- a/tests/lib/connector/sabre/filesplugin.php
+++ b/tests/lib/connector/sabre/filesplugin.php
@@ -62,7 +62,7 @@ class FilesPlugin extends \Test\TestCase {
 			->will($this->returnValue('"abc"'));
 		$node->expects($this->any())
 			->method('getDavPermissions')
-			->will($this->returnValue('R'));
+			->will($this->returnValue('DWCKMSR'));
 
 		return $node;
 	}
@@ -98,9 +98,34 @@ class FilesPlugin extends \Test\TestCase {
 		$this->assertEquals('"abc"', $propFind->get(self::GETETAG_PROPERTYNAME));
 		$this->assertEquals(123, $propFind->get(self::FILEID_PROPERTYNAME));
 		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
-		$this->assertEquals('R', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
+		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals('http://example.com/', $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
 		$this->assertEquals(array(self::SIZE_PROPERTYNAME), $propFind->get404Properties());
+	}
+
+	public function testGetPublicPermissions() {
+		$this->plugin = new \OC\Connector\Sabre\FilesPlugin($this->tree, true);
+		$this->plugin->initialize($this->server);
+
+		$propFind = new \Sabre\DAV\PropFind(
+			'/dummyPath',
+			[
+				self::PERMISSIONS_PROPERTYNAME,
+			],
+			0
+		);
+
+		$node = $this->createTestNode('\OC\Connector\Sabre\File');
+		$node->expects($this->any())
+			->method('getDavPermissions')
+			->will($this->returnValue('DWCKMSR'));
+
+		$this->plugin->handleGetProperties(
+			$propFind,
+			$node
+		);
+
+		$this->assertEquals('DWCKR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 	}
 
 	public function testGetPropertiesForDirectory() {
@@ -132,7 +157,7 @@ class FilesPlugin extends \Test\TestCase {
 		$this->assertEquals('"abc"', $propFind->get(self::GETETAG_PROPERTYNAME));
 		$this->assertEquals(123, $propFind->get(self::FILEID_PROPERTYNAME));
 		$this->assertEquals(1025, $propFind->get(self::SIZE_PROPERTYNAME));
-		$this->assertEquals('R', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
+		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals(null, $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
 		$this->assertEquals(array(self::DOWNLOADURL_PROPERTYNAME), $propFind->get404Properties());
 	}


### PR DESCRIPTION
Remove information about whether a file is an incoming share or mount
point when requested over public webdav.

@rullzer @icewind1991 @DeepDiver1975 @schiesbn @LukasReschke 
