### PR TITLE
Handle returned null value in app level code

### DIFF
--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -173,7 +173,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}
@@ -189,7 +189,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}


### PR DESCRIPTION
- getApplication on OCSClient can also return null (see https://github.com/owncloud/core/blob/e55e0ee945628fac297bf69cf5d67b3bfe75dbb0/lib/private/ocsclient.php#L238-238) this is now handled properly
- fixes #17587

@shiznix Please test this :)

cc @rullzer @Xenopathic @nickvergessen @karlitschek 

@karlitschek I would like to backport this to stable8.1
