### PR TITLE
Throw StorageNotAvailable if propfind on root failed

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -760,7 +760,11 @@ class DAV extends Common {
 				return $remoteMtime > $time;
 			}
 		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
+			if ($e->getHttpStatus() === 404 || $e->getHttpStatus() === 405) {
+				if ($path === '') {
+					// if root is gone it means the storage is not available
+					throw new StorageNotAvailableException(get_class($e).': '.$e->getMessage());
+				}
 				return false;
 			}
 			$this->convertException($e);


### PR DESCRIPTION
If PROPFIND fails with 404 or 405 on the remote share root, it means the
storage is not available. Throw StorageNotAvailable is such case.
### Steps to test
1. Setup two instances "oclocal" (this branch) and "ocremote" (I used 8.0.2)
2. Login in "ocremote"
3. Share a non-empty "tests" folder with "root@oclocal/owncloud"
4. On the disk, rename the folder of "ocremote" to "ocremote_side" to make it unavailable
5. Do a PROPFIND on "oclocal" on the "tests" folder
### Before this PR

PROPFIND succeeds and shows the contents of the folder, even though it's not available
(also happens on OC 8.0.5 and OC 8.1, not a regression)
### After this PR

PROPFIND fails with 503 Storage Not Available.

This is yet another one of the million of possible "not available" cases to catch.

Please review @icewind1991 @MorrisJobke @nickvergessen 
