### PR TITLE
Throw storage not available on guzzle error

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -253,7 +253,7 @@ class Storage extends DAV implements ISharedStorage {
 			// throw this to be on the safe side: the share will still be visible
 			// in the UI in case the failure is intermittent, and the user will
 			// be able to decide whether to remove it if it's really gone
-			throw new NotFoundException();
+			throw new StorageNotAvailableException();
 		}
 
 		return json_decode($response->getBody(), true);


### PR DESCRIPTION
If the remote server is in maintenance mode, we must throw storage not
available exception instead of not found which might auto-remove the
share.

Fixes regression from https://github.com/owncloud/core/pull/17273.
The wrong exception type was used.

Please review @schiesbn @nickvergessen @LukasReschke @icewind1991 @MorrisJobke 

@karlitschek I'll add this to the backport PR from https://github.com/owncloud/core/pull/17273
