### PR TITLE
prevent error when app store is disabled

### DIFF
--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -173,7 +173,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if($remoteAppEntry && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}
@@ -189,7 +189,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if($remoteAppEntry && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}


### PR DESCRIPTION
I have the app store disabled in my ownCloud installation. Whenever I open the app settings to enable or disable an app, I see the following error in the log:
`array_key_exists() expects parameter 2 to be array, null given at <redacted>\/settings\/controller\/appsettingscontroller.php#176`

This patch fixes the issue for me.
