### PR TITLE
[stable8.1] Handle returned null value in app level code

### DIFF
--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -173,7 +173,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}
@@ -189,7 +189,7 @@ class AppSettingsController extends Controller {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
 							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
 
-							if(array_key_exists('level', $remoteAppEntry)) {
+							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
 							}
 						}


### PR DESCRIPTION
- getApplication on OCSClient can also return null
  this is now handled properly
- fixes #17587 

Backport of #17606 to stable8.1
Approval: https://github.com/owncloud/core/pull/17606#issuecomment-120912453

cc @rullzer @Xenopathic @nickvergessen @karlitschek
