### PR TITLE
Non-blocking use of set_time_limit()

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -25,7 +25,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-set_time_limit(0);
+@set_time_limit(0);
 require_once '../../lib/base.php';
 
 \OCP\JSON::callCheck();


### PR DESCRIPTION
Using `set_time_limit()` on some hosting provider which have `set_time_limit()` disabled will cause an incomplete update.
A more elegant solution could be the use of `function_exists('set_time_limit')`.
