### PR TITLE
Remove index on file_target of share table

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -867,13 +867,6 @@
 					<sorting>ascending</sorting>
 				</field>
 			</index>
-			<index>
-				<name>share_file_target</name>
-				<field>
-					<name>file_target</name>
-					<sorting>ascending</sorting>
-				</field>
-			</index>
 		</declaration>
 
 	</table>

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(8, 2, 0, 1);
+$OC_Version=array(8, 2, 0, 2);
 
 // The human readable string
 $OC_VersionString='8.2 pre alpha';


### PR DESCRIPTION
- causes issues on InnoDB because it exceeds the maximal key length
  of an index which is 767 (3-byte charset \* varchar(512) = 1536)
- fixes #17619 

Replaces #17626

cc @karlitschek @DeepDiver1975 @PVince81 
