### PR TITLE
[stable8.1] allow remote shares for users with email as usernames

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -353,7 +353,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				// allow user to add unknown remote addresses for server-to-server share
 				$backend = \OCP\Share::getBackend((string)$_GET['itemType']);
 				if ($backend->isShareTypeAllowed(\OCP\Share::SHARE_TYPE_REMOTE)) {
-					if (substr_count((string)$_GET['search'], '@') === 1) {
+					if (substr_count((string)$_GET['search'], '@') >= 1) {
 						$shareWith[] = array(
 							'label' => (string)$_GET['search'],
 							'value' => array(


### PR DESCRIPTION
Backport of #17565 to stable8.1
Approval https://github.com/owncloud/core/pull/17565#issuecomment-121237774

sharing dialog was only matching exactly a single '@' in the shareWith field,
but if username is an email you have 2 '@' in that string.

Fixes #14154
Fixes #17492

Please review @schiesbn @nickvergessen @PVince81 @rullzer 
