### PR TITLE
[stable8.1] Throw StorageNotAvailable if propfind on root failed

### DIFF
--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -760,7 +760,11 @@ class DAV extends Common {
 				return $remoteMtime > $time;
 			}
 		} catch (ClientHttpException $e) {
-			if ($e->getHttpStatus() === 404) {
+			if ($e->getHttpStatus() === 404 || $e->getHttpStatus() === 405) {
+				if ($path === '') {
+					// if root is gone it means the storage is not available
+					throw new StorageNotAvailableException(get_class($e).': '.$e->getMessage());
+				}
 				return false;
 			}
 			$this->convertException($e);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/17620 to stable 8.1

If PROPFIND fails with 404 or 405 on the remote share root, it means the
storage is not available. Throw StorageNotAvailable is such case.

Please review @MorrisJobke @icewind1991 @karlitschek 
