### PR TITLE
[8.1] lock parent folders for the owner when locking a shared file as recipient

### DIFF
--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -632,7 +632,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		// lock the parent folders of the owner when locking the share as recipient
 		if ($path === '') {
 			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
-			$this->ownerView->lockFile($sourcePath, ILockingProvider::LOCK_SHARED, true);
+			$this->ownerView->lockFile(dirname($sourcePath), ILockingProvider::LOCK_SHARED, true);
 		}
 	}
 
@@ -648,7 +648,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		// unlock the parent folders of the owner when unlocking the share as recipient
 		if ($path === '') {
 			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
-			$this->ownerView->unlockFile($sourcePath, ILockingProvider::LOCK_SHARED, true);
+			$this->ownerView->unlockFile(dirname($sourcePath), ILockingProvider::LOCK_SHARED, true);
 		}
 	}
 

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -45,8 +45,14 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	private $files = array();
 	private static $isInitialized = array();
 
+	/**
+	 * @var \OC\Files\View
+	 */
+	private $ownerView;
+
 	public function __construct($arguments) {
 		$this->share = $arguments['share'];
+		$this->ownerView = $arguments['ownerView'];
 	}
 
 	/**
@@ -623,6 +629,11 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		/** @var \OCP\Files\Storage $targetStorage */
 		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
 		$targetStorage->acquireLock($targetInternalPath, $type, $provider);
+		// lock the parent folders of the owner when locking the share as recipient
+		if ($path === '') {
+			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			$this->ownerView->lockFile($sourcePath, ILockingProvider::LOCK_SHARED, true);
+		}
 	}
 
 	/**
@@ -634,6 +645,11 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		/** @var \OCP\Files\Storage $targetStorage */
 		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
 		$targetStorage->releaseLock($targetInternalPath, $type, $provider);
+		// unlock the parent folders of the owner when unlocking the share as recipient
+		if ($path === '') {
+			$sourcePath = $this->ownerView->getPath($this->share['file_source']);
+			$this->ownerView->unlockFile($sourcePath, ILockingProvider::LOCK_SHARED, true);
+		}
 	}
 
 	/**

--- a/apps/files_sharing/tests/locking.php
+++ b/apps/files_sharing/tests/locking.php
@@ -87,4 +87,15 @@ class Locking extends TestCase {
 
 		$this->assertTrue(Filesystem::rename('/foo', '/asd'));
 	}
+
+	public function testChangeLock() {
+
+		Filesystem::initMountPoints($this->recipientUid);
+		$recipientView = new View('/' . $this->recipientUid . '/files');
+		$recipientView->lockFile('bar.txt', ILockingProvider::LOCK_SHARED);
+		$recipientView->changeLock('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+		$recipientView->unlockFile('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->assertTrue(true);
+	}
 }

--- a/apps/files_sharing/tests/locking.php
+++ b/apps/files_sharing/tests/locking.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_sharing\Tests;
+
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OC\Lock\MemcacheLockingProvider;
+use OCP\Lock\ILockingProvider;
+
+class Locking extends TestCase {
+	/**
+	 * @var \OC_User_Dummy
+	 */
+	private $userBackend;
+
+	private $ownerUid;
+	private $recipientUid;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userBackend = new \OC_User_Dummy();
+		\OC::$server->getUserManager()->registerBackend($this->userBackend);
+
+		$this->ownerUid = $this->getUniqueID('owner_');
+		$this->recipientUid = $this->getUniqueID('recipient_');
+		$this->userBackend->createUser($this->ownerUid, '');
+		$this->userBackend->createUser($this->recipientUid, '');
+
+		$this->loginAsUser($this->ownerUid);
+		Filesystem::mkdir('/foo');
+		Filesystem::file_put_contents('/foo/bar.txt', 'asd');
+		$fileId = Filesystem::getFileInfo('/foo/bar.txt')->getId();
+
+		\OCP\Share::shareItem('file', $fileId, \OCP\Share::SHARE_TYPE_USER, $this->recipientUid, 31);
+
+		$this->loginAsUser($this->recipientUid);
+		$this->assertTrue(Filesystem::file_exists('bar.txt'));
+	}
+
+	public function tearDown() {
+		\OC::$server->getUserManager()->removeBackend($this->userBackend);
+		parent::tearDown();
+	}
+
+	/**
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testLockAsRecipient() {
+		$this->loginAsUser($this->ownerUid);
+
+		Filesystem::initMountPoints($this->recipientUid);
+		$recipientView = new View('/' . $this->recipientUid . '/files');
+		$recipientView->lockFile('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		Filesystem::rename('/foo', '/asd');
+	}
+
+	public function testUnLockAsRecipient() {
+		$this->loginAsUser($this->ownerUid);
+
+		Filesystem::initMountPoints($this->recipientUid);
+		$recipientView = new View('/' . $this->recipientUid . '/files');
+		$recipientView->lockFile('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+		$recipientView->unlockFile('bar.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->assertTrue(Filesystem::rename('/foo', '/asd'));
+	}
+}


### PR DESCRIPTION
Backport of #17246
