### PR TITLE
Missing memcache should not cause occ hard-fail

### DIFF
--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -29,6 +29,7 @@
 namespace OC\Memcache;
 
 use \OCP\ICacheFactory;
+use \OCP\ILogger;
 
 class Factory implements ICacheFactory {
 	const NULL_CACHE = '\\OC\\Memcache\\NullCache';
@@ -37,6 +38,11 @@ class Factory implements ICacheFactory {
 	 * @var string $globalPrefix
 	 */
 	private $globalPrefix;
+
+	/**
+	 * @var ILogger $logger
+	 */
+	private $logger;
 
 	/**
 	 * @var string $localCacheClass
@@ -55,13 +61,15 @@ class Factory implements ICacheFactory {
 
 	/**
 	 * @param string $globalPrefix
+	 * @param ILogger $logger
 	 * @param string|null $localCacheClass
 	 * @param string|null $distributedCacheClass
 	 * @param string|null $lockingCacheClass
 	 */
-	public function __construct($globalPrefix,
+	public function __construct($globalPrefix, ILogger $logger,
 		$localCacheClass = null, $distributedCacheClass = null, $lockingCacheClass = null)
 	{
+		$this->logger = $logger;
 		$this->globalPrefix = $globalPrefix;
 
 		if (!$localCacheClass) {
@@ -71,22 +79,43 @@ class Factory implements ICacheFactory {
 			$distributedCacheClass = $localCacheClass;
 		}
 
+		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
+		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
 		if (!$localCacheClass::isAvailable()) {
-			throw new \OC\HintException(
-				'Missing memcache class ' . $localCacheClass . ' for local cache',
-				'Is the matching PHP module installed and enabled ?'
-			);
+			if (\OC::$CLI) {
+				// CLI should not hard-fail on broken memcache
+				$this->logger->info($missingCacheMessage, [
+					'class' => $localCacheClass,
+					'use' => 'local',
+					'app' => 'cli'
+				]);
+				$localCacheClass = self::NULL_CACHE;
+			} else {
+				throw new \OC\HintException(strtr($missingCacheMessage, [
+					'{class}' => $localCacheClass, '{use}' => 'local'
+				]), $missingCacheHint);
+			}
 		}
 		if (!$distributedCacheClass::isAvailable()) {
-			throw new \OC\HintException(
-				'Missing memcache class ' . $distributedCacheClass . ' for distributed cache',
-				'Is the matching PHP module installed and enabled ?'
-			);
+			if (\OC::$CLI) {
+				// CLI should not hard-fail on broken memcache
+				$this->logger->info($missingCacheMessage, [
+					'class' => $distributedCacheClass,
+					'use' => 'distributed',
+					'app' => 'cli'
+				]);
+				$distributedCacheClass = self::NULL_CACHE;
+			} else {
+				throw new \OC\HintException(strtr($missingCacheMessage, [
+					'{class}' => $distributedCacheClass, '{use}' => 'distributed'
+				]), $missingCacheHint);
+			}
 		}
 		if (!($lockingCacheClass && $lockingCacheClass::isAvailable())) {
 			// dont fallback since the fallback might not be suitable for storing lock
-			$lockingCacheClass = '\OC\Memcache\NullCache';
+			$lockingCacheClass = self::NULL_CACHE;
 		}
+
 		$this->localCacheClass = $localCacheClass;
 		$this->distributedCacheClass = $distributedCacheClass;
 		$this->lockingCacheClass = $lockingCacheClass;

--- a/lib/private/memcache/factory.php
+++ b/lib/private/memcache/factory.php
@@ -82,7 +82,7 @@ class Factory implements ICacheFactory {
 		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
 		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
 		if (!$localCacheClass::isAvailable()) {
-			if (\OC::$CLI) {
+			if (\OC::$CLI && !defined('PHPUNIT_RUN')) {
 				// CLI should not hard-fail on broken memcache
 				$this->logger->info($missingCacheMessage, [
 					'class' => $localCacheClass,
@@ -97,7 +97,7 @@ class Factory implements ICacheFactory {
 			}
 		}
 		if (!$distributedCacheClass::isAvailable()) {
-			if (\OC::$CLI) {
+			if (\OC::$CLI && !defined('PHPUNIT_RUN')) {
 				// CLI should not hard-fail on broken memcache
 				$this->logger->info($missingCacheMessage, [
 					'class' => $distributedCacheClass,

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -50,7 +50,6 @@ use OC\Http\Client\ClientService;
 use OC\Lock\MemcacheLockingProvider;
 use OC\Lock\NoopLockingProvider;
 use OC\Mail\Mailer;
-use OC\Memcache\ArrayCache;
 use OC\Memcache\NullCache;
 use OC\Security\CertificateManager;
 use OC\Security\Crypto;
@@ -242,9 +241,9 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 
 			return new \OC\Memcache\Factory('', $c->getLogger(),
-				new ArrayCache(),
-				new ArrayCache(),
-				new ArrayCache()
+				'\\OC\\Memcache\\ArrayCache',
+				'\\OC\\Memcache\\ArrayCache',
+				'\\OC\\Memcache\\ArrayCache'
 			);
 		});
 		$this->registerService('ActivityManager', function (Server $c) {

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -234,14 +234,14 @@ class Server extends SimpleContainer implements IServerContainer {
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
 				$prefix = md5($instanceId.'-'.$version.'-'.$path);
-				return new \OC\Memcache\Factory($prefix,
+				return new \OC\Memcache\Factory($prefix, $c->getLogger(),
 					$config->getSystemValue('memcache.local', null),
 					$config->getSystemValue('memcache.distributed', null),
 					$config->getSystemValue('memcache.locking', null)
 				);
 			}
 
-			return new \OC\Memcache\Factory('',
+			return new \OC\Memcache\Factory('', $c->getLogger(),
 				new ArrayCache(),
 				new ArrayCache(),
 				new ArrayCache()

--- a/tests/lib/memcache/factory.php
+++ b/tests/lib/memcache/factory.php
@@ -114,7 +114,8 @@ class Test_Factory extends \Test\TestCase {
 	 */
 	public function testCacheAvailability($localCache, $distributedCache, $lockingCache,
 		$expectedLocalCache, $expectedDistributedCache, $expectedLockingCache) {
-		$factory = new \OC\Memcache\Factory('abc', $localCache, $distributedCache, $lockingCache);
+		$logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		$factory = new \OC\Memcache\Factory('abc', $logger, $localCache, $distributedCache, $lockingCache);
 		$this->assertTrue(is_a($factory->createLocal(), $expectedLocalCache));
 		$this->assertTrue(is_a($factory->createDistributed(), $expectedDistributedCache));
 		$this->assertTrue(is_a($factory->createLocking(), $expectedLockingCache));
@@ -125,6 +126,7 @@ class Test_Factory extends \Test\TestCase {
 	 * @expectedException \OC\HintException
 	 */
 	public function testCacheNotAvailableException($localCache, $distributedCache) {
-		new \OC\Memcache\Factory('abc', $localCache, $distributedCache);
+		$logger = $this->getMockBuilder('\OCP\ILogger')->getMock();
+		new \OC\Memcache\Factory('abc', $logger, $localCache, $distributedCache);
 	}
 }


### PR DESCRIPTION
Warning is now printed to logs, but occ will still work. The memcache factory is primed with `null` memcaches in this case, so no caching will be performed.

Fixes #17329 

cc @MorrisJobke @DeepDiver1975 @RealRancor @rullzer @MightyCreak

BTW, I noticed something a little strange... in case the ownCloud instance isn't installed yet, or debug is enabled, we fall back to using ArrayCache, but the Factory is constructed using ArrayCache instances, while the factory itself needs class names (it initialises the caches itself when required). I think this is a bug? cc @LukasReschke 
