### PR TITLE
[autotest] timeout oracle docker startup after 2 minutes

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -167,8 +167,8 @@ function execute_tests {
 
 		echo "Waiting for Oracle initialization ... "
 
-		# grep exits on the first match and then the script continues
-		docker logs -f "$DOCKER_CONTAINER_ID" 2>&1 | grep -q "Grant succeeded."
+		# grep exits on the first match and then the script continues - times out after 2 minutes
+		timeout 120 docker logs -f "$DOCKER_CONTAINER_ID" 2>&1 | grep -q "Grant succeeded."
 
 		DATABASEUSER=autotest
 		DATABASENAME='XE'


### PR DESCRIPTION
Followup of #17660 because on some test runs the startup hangs.

This kills the "waiting for startup" after 2 minutes.

cc @DeepDiver1975 @rullzer 
