### PR TITLE
handle rmdir on files for ftp storages

### DIFF
--- a/apps/files_external/lib/streamwrapper.php
+++ b/apps/files_external/lib/streamwrapper.php
@@ -40,8 +40,11 @@ abstract class StreamWrapper extends Common {
 	}
 
 	public function rmdir($path) {
-		if ($this->file_exists($path) && $this->isDeletable($path)) {
+		if ($this->is_dir($path) && $this->isDeletable($path)) {
 			$dh = $this->opendir($path);
+			if (!is_resource($dh)) {
+				return false;
+			}
 			while (($file = readdir($dh)) !== false) {
 				if ($this->is_dir($path . '/' . $file)) {
 					$this->rmdir($path . '/' . $file);


### PR DESCRIPTION
Prevents error message spam from trying to readdir on a non dir-handle

cc @PVince81 @MorrisJobke 
