### PR TITLE
[stable8] Pass owner to isSystemWideMountPoint to make it work for public links

### DIFF
--- a/apps/files_encryption/lib/hooks.php
+++ b/apps/files_encryption/lib/hooks.php
@@ -478,7 +478,7 @@ class Hooks {
 
 		list($ownerNew, $pathNew) = $util->getUidAndFilename($params['newpath']);
 
-		if ($util->isSystemWideMountPoint($pathNew)) {
+		if ($util->isSystemWideMountPoint($pathNew, $ownerNew)) {
 			$newKeysPath =  'files_encryption/keys/' . $pathNew;
 		} else {
 			$newKeysPath = $ownerNew . '/files_encryption/keys/' . $pathNew;

--- a/apps/files_encryption/lib/keymanager.php
+++ b/apps/files_encryption/lib/keymanager.php
@@ -187,7 +187,7 @@ class Keymanager {
 		$filePath_f = ltrim($filename, '/');
 
 		// in case of system wide mount points the keys are stored directly in the data directory
-		if ($util->isSystemWideMountPoint($filename)) {
+		if ($util->isSystemWideMountPoint($filename, $owner)) {
 			$keyPath = self::$keys_base_dir . $filePath_f . '/';
 		} else {
 			$keyPath = '/' . $owner . self::$keys_base_dir . $filePath_f . '/';

--- a/apps/files_encryption/lib/util.php
+++ b/apps/files_encryption/lib/util.php
@@ -1617,15 +1617,16 @@ class Util {
 	/**
 	 * check if the file is stored on a system wide mount point
 	 * @param string $path relative to /data/user with leading '/'
+	 * @param string $uid
 	 * @return boolean
 	 */
-	public function isSystemWideMountPoint($path) {
+	public function isSystemWideMountPoint($path, $uid) {
 		$normalizedPath = ltrim($path, '/');
 		if (\OCP\App::isEnabled("files_external")) {
 			$mounts = \OC_Mount_Config::getSystemMountPoints();
 			foreach ($mounts as $mount) {
 				if ($mount['mountpoint'] == substr($normalizedPath, 0, strlen($mount['mountpoint']))) {
-					if ($this->isMountPointApplicableToUser($mount)) {
+					if ($this->isMountPointApplicableToUser($mount, $uid)) {
 						return true;
 					}
 				}
@@ -1638,10 +1639,10 @@ class Util {
 	 * check if mount point is applicable to user
 	 *
 	 * @param array $mount contains $mount['applicable']['users'], $mount['applicable']['groups']
+	 * @param string $uid
 	 * @return boolean
 	 */
-	protected function isMountPointApplicableToUser($mount) {
-		$uid = \OCP\User::getUser();
+	protected function isMountPointApplicableToUser($mount, $uid) {
 		$acceptedUids = array('all', $uid);
 		// check if mount point is applicable for the user
 		$intersection = array_intersect($acceptedUids, $mount['applicable']['users']);

--- a/apps/files_encryption/tests/util.php
+++ b/apps/files_encryption/tests/util.php
@@ -587,9 +587,8 @@ class Util extends TestCase {
 	 * @dataProvider dataProviderFortestIsMountPointApplicableToUser
 	 */
 	function testIsMountPointApplicableToUser($mount, $expectedResult) {
-		self::loginHelper(self::TEST_ENCRYPTION_UTIL_USER1);
 		$dummyClass = new DummyUtilClass($this->view, self::TEST_ENCRYPTION_UTIL_USER1);
-		$result = $dummyClass->testIsMountPointApplicableToUser($mount);
+		$result = $dummyClass->testIsMountPointApplicableToUser($mount, self::TEST_ENCRYPTION_UTIL_USER1);
 
 		$this->assertSame($expectedResult, $result);
 	}
@@ -663,7 +662,7 @@ class Util extends TestCase {
  * dummy class extends  \OCA\Files_Encryption\Util to access protected methods for testing
  */
 class DummyUtilClass extends \OCA\Files_Encryption\Util {
-	public function testIsMountPointApplicableToUser($mount) {
-		return $this->isMountPointApplicableToUser($mount);
+	public function testIsMountPointApplicableToUser($mount, $uid) {
+		return $this->isMountPointApplicableToUser($mount, $uid);
 	}
 }

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -299,7 +299,7 @@ class Trashbin {
 			$util = new \OCA\Files_Encryption\Util($rootView, $user);
 
 			$baseDir = '/files_encryption/';
-			if (!$util->isSystemWideMountPoint($ownerPath)) {
+			if (!$util->isSystemWideMountPoint($ownerPath, $owner)) {
 				$baseDir = $owner . $baseDir;
 			}
 
@@ -473,7 +473,7 @@ class Trashbin {
 			$util = new \OCA\Files_Encryption\Util($rootView, $user);
 
 			$baseDir = '/files_encryption/';
-			if (!$util->isSystemWideMountPoint($ownerPath)) {
+			if (!$util->isSystemWideMountPoint($ownerPath, $owner)) {
 				$baseDir = $owner . $baseDir;
 			}
 


### PR DESCRIPTION
Public links did not have the correct owner so could not properly detect
system wide mount points.

This is a manual backport of b25c06f5769fbcd90a780cbce90998a38c112043 from 8.1 (part of fixes from the encryption 2.0 work).

@karlitschek please confirm this backport

Fixes https://github.com/owncloud/core/issues/17507
Steps to reproduce here https://github.com/owncloud/core/issues/17507#issuecomment-121985428

@schiesbn please review
