### PR TITLE
Add repair step for outdated OCS IDs

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -656,6 +656,12 @@ class OC_App {
 		if (is_array($data)) {
 			$data = OC_App::parseAppInfo($data);
 		}
+		if(isset($data['ocsid'])) {
+			$storedId = \OC::$server->getConfig()->getAppValue($appId, 'ocsid');
+			if($storedId !== '' && $storedId !== $data['ocsid']) {
+				$data['ocsid'] = $storedId;
+			}
+		}
 
 		self::$appInfo[$appId] = $data;
 

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -43,6 +43,7 @@ use OC\Repair\RepairConfig;
 use OC\Repair\RepairLegacyStorages;
 use OC\Repair\RepairMimeTypes;
 use OC\Repair\SearchLuceneTables;
+use OC\Repair\UpdateOutdatedOcsIds;
 
 class Repair extends BasicEmitter {
 	/**
@@ -101,7 +102,7 @@ class Repair extends BasicEmitter {
 	 * @return array of RepairStep instances
 	 */
 	public static function getRepairSteps() {
-		return array(
+		return [
 			new RepairMimeTypes(),
 			new RepairLegacyStorages(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new RepairConfig(),
@@ -111,7 +112,8 @@ class Repair extends BasicEmitter {
 			new DropOldTables(\OC::$server->getDatabaseConnection()),
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),
-		);
+			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
+		];
 	}
 
 	/**

--- a/lib/repair/updateoutdatedocsids.php
+++ b/lib/repair/updateoutdatedocsids.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Lukas Reschke <l8kas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+use OC\RepairStep;
+use OCP\IConfig;
+
+/**
+ * Class UpdateOutdatedOcsIds is used to update invalid outdated OCS IDs, this is
+ * for example the case when an application has had another OCS ID in the past such
+ * as for contacts and calendar when apps.owncloud.com migrated to a unified identifier
+ * for multiple versions.
+ *
+ * @package OC\Repair
+ */
+class UpdateOutdatedOcsIds extends BasicEmitter implements RepairStep {
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getName() {
+		return 'Repair outdated OCS IDs';
+	}
+
+	/**
+	 * @param string $appName
+	 * @param string $oldId
+	 * @param string $newId
+	 * @return bool True if updated, false otherwise
+	 */
+	public function fixOcsId($appName, $oldId, $newId) {
+		$existingId = $this->config->getAppValue($appName, 'ocsid');
+
+		if($existingId === $oldId) {
+			$this->config->setAppValue($appName, 'ocsid', $newId);
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function run() {
+		$appsToUpdate = [
+			'contacts' => [
+				'old' => '166044',
+				'new' => '168708',
+			],
+			'calendar' => [
+				'old' => '166043',
+				'new' => '168707',
+			],
+			'bookmarks' => [
+				'old' => '166042',
+				'new' => '168710',
+			],
+			'search_lucene' => [
+				'old' => '166057',
+				'new' => '168709',
+			],
+			'documents' => [
+				'old' => '166045',
+				'new' => '168711',
+			]
+		];
+
+		foreach($appsToUpdate as $appName => $ids) {
+			if ($this->fixOcsId($appName, $ids['old'], $ids['new'])) {
+				$this->emit(
+					'\OC\Repair',
+					'info',
+					[sprintf('Fixed invalid %s OCS id', $appName)]
+				);
+			}
+		}
+	}
+}

--- a/tests/lib/repair/updateoutdatedocsids.php
+++ b/tests/lib/repair/updateoutdatedocsids.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Lukas Reschke <l8kas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Repair;
+
+use OCP\IConfig;
+use Test\TestCase;
+
+/**
+ * Class UpdateOutdatedOcsIds
+ *
+ * @package Test\Repair
+ */
+class UpdateOutdatedOcsIds extends TestCase {
+	/** @var IConfig */
+	private $config;
+	/** @var \OC\Repair\UpdateOutdatedOcsIds */
+	private $updateOutdatedOcsIds;
+
+	public function setUp() {
+		parent::setUp();
+		$this->config = $this->getMockBuilder('\\OCP\\IConfig')->getMock();
+		$this->updateOutdatedOcsIds = new \OC\Repair\UpdateOutdatedOcsIds($this->config);
+	}
+
+	public function testGetName() {
+		$this->assertSame('Repair outdated OCS IDs', $this->updateOutdatedOcsIds->getName());
+	}
+
+	public function testFixOcsIdNoOcsId() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('MyNotInstalledApp', 'ocsid')
+			->will($this->returnValue(''));
+		$this->assertFalse($this->updateOutdatedOcsIds->fixOcsId('MyNotInstalledApp', '1337', '0815'));
+	}
+
+	public function testFixOcsIdUpdateOcsId() {
+		$this->config
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('MyInstalledApp', 'ocsid')
+			->will($this->returnValue('1337'));
+		$this->config
+			->expects($this->at(1))
+			->method('setAppValue')
+			->with('MyInstalledApp', 'ocsid', '0815');
+
+		$this->assertTrue($this->updateOutdatedOcsIds->fixOcsId('MyInstalledApp', '1337', '0815'));
+	}
+
+	public function testFixOcsIdAlreadyFixed() {
+		$this->config
+			->expects($this->once())
+			->method('getAppValue')
+			->with('MyAlreadyFixedAppId', 'ocsid')
+			->will($this->returnValue('0815'));
+
+		$this->assertFalse($this->updateOutdatedOcsIds->fixOcsId('MyAlreadyFixedAppId', '1337', '0815'));
+	}
+}


### PR DESCRIPTION
There is the case where OCs IDs might become outdated such as it has been with the calendar and contacts app which refer to the old dummy entry. This means that users with the old OCS id can't update updates as well will receive invalid state flags. (e.g. "experimental" instead of "approved")

To allow instances to properly update the applications in the future we need to migrate the OCS IDs for now manually.
# Testplan

Install one of the affected applications and run the repair steps and verify that the OCS id in the DB has been updated.
# Todo
- [x] Backport this PR to stable8.1 (https://github.com/owncloud/core/pull/17690)
- [x] Fix contacts OCS id (https://github.com/owncloud/contacts/pull/989 + https://github.com/owncloud/contacts/pull/990)
  - [x] Push update to appstore
- [x] Fix calendar OCS id (https://github.com/owncloud/calendar/pull/858 + https://github.com/owncloud/calendar/pull/859)
  - [x] Push update to appstore
- [x] Fix bookmarks OCS id (https://github.com/owncloud/bookmarks/pull/174 + https://github.com/owncloud/bookmarks/pull/175)
  - [x] Push update to appstore
- [x] Fix search_lucene OCS id (https://github.com/owncloud/search_lucene/pull/92 + https://github.com/owncloud/search_lucene/pull/93) 
  - [x] Push update to appstore
- [x] Fix documents OCS id
  - [x] Push update to appstore

<hr/>

@karlitschek As discussed.
