### PR TITLE
Allow upgrade of not enabled apps

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1162,9 +1162,7 @@ class OC_App {
 			OC_DB::updateDbFromStructure(self::getAppPath($appId) . '/appinfo/database.xml');
 		}
 		unset(self::$appVersion[$appId]);
-		if (!self::isEnabled($appId)) {
-			return false;
-		}
+		// run upgrade code
 		if (file_exists(self::getAppPath($appId) . '/appinfo/update.php')) {
 			self::loadApp($appId, false);
 			include self::getAppPath($appId) . '/appinfo/update.php';
@@ -1173,15 +1171,15 @@ class OC_App {
 		//set remote/public handlers
 		$appData = self::getAppInfo($appId);
 		if (array_key_exists('ocsid', $appData)) {
-			\OC::$server->getAppConfig()->setValue($appId, 'ocsid', $appData['ocsid']);
-		} elseif(\OC::$server->getAppConfig()->getValue($appId, 'ocsid', null) !== null) {
-			\OC::$server->getAppConfig()->deleteKey($appId, 'ocsid');
+			\OC::$server->getConfig()->setAppValue($appId, 'ocsid', $appData['ocsid']);
+		} elseif(\OC::$server->getConfig()->getAppValue($appId, 'ocsid', null) !== null) {
+			\OC::$server->getConfig()->deleteAppValue($appId, 'ocsid');
 		}
 		foreach ($appData['remote'] as $name => $path) {
-			OCP\CONFIG::setAppValue('core', 'remote_' . $name, $appId . '/' . $path);
+			\OC::$server->getConfig()->setAppValue('core', 'remote_' . $name, $appId . '/' . $path);
 		}
 		foreach ($appData['public'] as $name => $path) {
-			OCP\CONFIG::setAppValue('core', 'public_' . $name, $appId . '/' . $path);
+			\OC::$server->getConfig()->setAppValue('core', 'public_' . $name, $appId . '/' . $path);
 		}
 
 		self::setAppTypes($appId);


### PR DESCRIPTION
@PVince81 @karlitschek @schiesbn @icewind1991 please review

This issue basically prevents the upgrade scenario for 3rdparty apps.

To reproduce:
0. Install OC8
1. Install contacts 0.3.0 from https://github.com/owncloud/contacts/releases/download/v8.0.5/contacts-0.3.0.19.tar.gz
2. Enable contacts
3. Upgrade OC8 -> OC8.1
4. Observe contacts being disabled during upgrade
5. Go to apps management and observer the upgrade button on the contacts app within 'disabled' category
6. Click upgrade to 0.4.0

Without this patch the Upgrade will fail because of this check https://github.com/owncloud/core/compare/allow-update-of-disabled-apps?expand=1#diff-4828f39ae4935d14b1dc1a6ffe323725L1165
