### PR TITLE
only apply then encryption wrappen when encryption is enabled

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -746,7 +746,9 @@ class OC {
 	}
 
 	private static function registerEncryptionWrapper() {
-		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OC\Encryption\Manager', 'setupStorage');
+		if (\OC::$server->getEncryptionManager()->isEnabled()) {
+			\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OC\Encryption\Manager', 'setupStorage');
+		}
 	}
 
 	private static function registerEncryptionHooks() {


### PR DESCRIPTION
even without any encryption module in use the wrapper has a significant overhead (esp on external storages)

cc @DeepDiver1975 @PVince81 @schiesbn 
