### PR TITLE
Introducing OC.Preview

### DIFF
--- a/core/js/core.json
+++ b/core/js/core.json
@@ -29,6 +29,7 @@
 		"setupchecks.js",
 		"../search/js/search.js",
 		"mimetype.js",
-		"mimetypelist.js"
+		"mimetypelist.js",
+		"preview.js"
 	]
 }

--- a/core/js/preview.js
+++ b/core/js/preview.js
@@ -1,0 +1,17 @@
+OC.Preview = {
+	previewAvailable: function(mimetype) {
+		var res = OC.Preview._Providers.map( function(provider) {
+			var match = mimetype.match(new RegExp(provider));
+			if (match && match.indexOf(mimetype) !== -1) {
+				return true;
+			}
+			return false;
+		});
+
+		if (res.indexOf(true) !== -1) {
+			return true;
+		}
+		return false;
+	}
+};
+

--- a/core/js/previewproviders.php
+++ b/core/js/previewproviders.php
@@ -1,0 +1,11 @@
+<?php
+
+$providers = \OC::$server->getPreviewManager()->getProviders();
+
+$types = array_keys($providers);
+
+$types = array_map(function($type) {
+	return substr($type, 1, -1);
+}, $types);
+
+echo 'OC.Preview._Providers = ' . json_encode($types, JSON_PRETTY_PRINT) . ';';

--- a/core/js/tests/specs/previewSpec.js
+++ b/core/js/tests/specs/previewSpec.js
@@ -1,0 +1,60 @@
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+describe('Preview', function() {
+	var _providers;
+
+	beforeAll(function() {
+		_providers = OC.Preview._Providers;
+
+		OC.Preview._Providers = [
+			"image\\\/png"
+		];
+	});
+
+	afterAll(function() {
+		OC.Preview._Providers = _providers;
+	});
+
+	describe('previewAvailable', function() {
+
+		it('match for image/png', function() {
+			var res = OC.Preview.previewAvailable('image/png');
+			expect(res).toEqual(true);
+		});
+
+		it('no match for image/png2', function() {
+			var res = OC.Preview.previewAvailable('image/png2');
+			expect(res).toEqual(false);
+		});
+
+		it('no match on image', function() {
+			var res = OC.Preview.previewAvailable('image');
+			expect(res).toEqual(false);
+		});
+
+		it('no match on png', function() {
+			var res = OC.Preview.previewAvailable('png');
+			expect(res).toEqual(false);
+		});
+
+	});
+
+});

--- a/core/routes.php
+++ b/core/routes.php
@@ -98,6 +98,9 @@ $this->create('core_tags_delete', '/tags/{type}/delete')
 // oC JS config
 $this->create('js_config', '/core/js/oc.js')
 	->actionInclude('core/js/config.php');
+// oC JS previewproviders
+$this->create('js_previewproviders', '/core/js/previewproviders.js')
+	->actionInclude('core/js/previewproviders.php');
 // Routing
 $this->create('core_ajax_preview', '/core/preview')
 	->actionInclude('core/ajax/preview.php');

--- a/lib/base.php
+++ b/lib/base.php
@@ -408,6 +408,7 @@ class OC {
 		OC_Util::addScript("apps");
 		OC_Util::addScript('mimetype');
 		OC_Util::addScript('mimetypelist');
+		OC_Util::addScript('preview');
 		OC_Util::addVendorScript('snapjs/dist/latest/snap');
 
 		// avatars

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -144,6 +144,7 @@ class OC_TemplateLayout extends OC_Template {
 		$useAssetPipeline = self::isAssetPipelineEnabled();
 		if ($useAssetPipeline) {
 			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config', array('v' => self::$versionHash)));
+			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_previewproviders', array('v' => self::$versionHash)));
 			$this->generateAssets();
 		} else {
 			// Add the js files
@@ -157,6 +158,8 @@ class OC_TemplateLayout extends OC_Template {
 				$file = $info[2];
 				$this->append( 'jsfiles', $web.'/'.$file . '?v=' . self::$versionHash);
 			}
+
+			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_previewproviders', array('v' => self::$versionHash)));
 
 			// Add the css files
 			$cssFiles = self::findStylesheetFiles(OC_Util::$styles);


### PR DESCRIPTION
The new webdav js stuff no longer has access to isPreviewavailable. This introduces a simple function to find out if the instance can generate previews for a given mimetype.

I'm not really happy with the way this is loaded. Feels even more hacky than base.php does.

TODO:
- [ ] Lazy loading? (maybe different PR)
- [ ] More tests

CC: @PVince81 @oparoz 
