### PR TITLE
don't move keys if the key where already moved in a previous migration run

### DIFF
--- a/apps/encryption/appinfo/register_command.php
+++ b/apps/encryption/appinfo/register_command.php
@@ -26,4 +26,5 @@ $userManager = OC::$server->getUserManager();
 $view = new \OC\Files\View();
 $config = \OC::$server->getConfig();
 $connection = \OC::$server->getDatabaseConnection();
-$application->add(new MigrateKeys($userManager, $view, $connection, $config));
+$logger = \OC::$server->getLogger();
+$application->add(new MigrateKeys($userManager, $view, $connection, $config, $logger));

--- a/apps/encryption/command/migratekeys.php
+++ b/apps/encryption/command/migratekeys.php
@@ -27,6 +27,7 @@ use OC\Files\View;
 use OC\User\Manager;
 use OCA\Encryption\Migration;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IUserBackend;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -44,22 +45,27 @@ class MigrateKeys extends Command {
 	private $connection;
 	/** @var IConfig */
 	private $config;
+	/** @var  ILogger */
+	private $logger;
 
 	/**
 	 * @param Manager $userManager
 	 * @param View $view
 	 * @param Connection $connection
 	 * @param IConfig $config
+	 * @param ILogger $logger
 	 */
 	public function __construct(Manager $userManager,
 								View $view,
 								Connection $connection,
-								IConfig $config) {
+								IConfig $config,
+								ILogger $logger) {
 
 		$this->userManager = $userManager;
 		$this->view = $view;
 		$this->connection = $connection;
 		$this->config = $config;
+		$this->logger = $logger;
 		parent::__construct();
 	}
 
@@ -77,7 +83,7 @@ class MigrateKeys extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
 		// perform system reorganization
-		$migration = new Migration($this->config, $this->view, $this->connection);
+		$migration = new Migration($this->config, $this->view, $this->connection, $this->logger);
 
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {

--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Encryption\Tests;
 
 use OCA\Encryption\Migration;
+use OCP\ILogger;
 
 class MigrationTest extends \Test\TestCase {
 
@@ -36,6 +37,9 @@ class MigrationTest extends \Test\TestCase {
 	private $public_share_key_id = 'share_key_id';
 	private $recovery_key_id = 'recovery_key_id';
 	private $moduleId;
+
+	/** @var  PHPUnit_Framework_MockObject_MockObject | ILogger */
+	private $logger;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -53,6 +57,7 @@ class MigrationTest extends \Test\TestCase {
 
 
 	public function setUp() {
+		$this->logger = $this->getMockBuilder('\OCP\ILogger')->disableOriginalConstructor()->getMock();
 		$this->view = new \OC\Files\View();
 		$this->moduleId = \OCA\Encryption\Crypto\Encryption::ID;
 	}
@@ -142,7 +147,7 @@ class MigrationTest extends \Test\TestCase {
 
 		$this->createDummySystemWideKeys();
 
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection());
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
 		$m->reorganizeFolderStructure();
 
 		$this->assertTrue(
@@ -267,7 +272,7 @@ class MigrationTest extends \Test\TestCase {
 	public function testUpdateDB() {
 		$this->prepareDB();
 
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection());
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
 		$m->updateDB();
 
 		$this->verifyDB('`*PREFIX*appconfig`', 'files_encryption', 0);
@@ -286,7 +291,7 @@ class MigrationTest extends \Test\TestCase {
 		$config->setAppValue('encryption', 'publicShareKeyId', 'wrong_share_id');
 		$config->setUserValue(self::TEST_ENCRYPTION_MIGRATION_USER1, 'encryption', 'recoverKeyEnabled', '9');
 
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection());
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
 		$m->updateDB();
 
 		$this->verifyDB('`*PREFIX*appconfig`', 'files_encryption', 0);
@@ -349,7 +354,7 @@ class MigrationTest extends \Test\TestCase {
 	 */
 	public function testUpdateFileCache() {
 		$this->prepareFileCache();
-		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection());
+		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
 		self::invokePrivate($m, 'updateFileCache');
 
 		// check results

--- a/settings/application.php
+++ b/settings/application.php
@@ -79,7 +79,8 @@ class Application extends App {
 				$c->query('Config'),
 				$c->query('DatabaseConnection'),
 				$c->query('UserManager'),
-				new View()
+				new View(),
+				$c->query('Logger')
 			);
 		});
 		$container->registerService('AppSettingsController', function(IContainer $c) {

--- a/settings/controller/encryptioncontroller.php
+++ b/settings/controller/encryptioncontroller.php
@@ -25,6 +25,7 @@ use OC\Files\View;
 use OCA\Encryption\Migration;
 use OCP\IL10N;
 use OCP\AppFramework\Controller;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IConfig;
 use OC\DB\Connection;
@@ -50,6 +51,9 @@ class EncryptionController extends Controller {
 	/** @var View */
 	private $view;
 
+	/** @var  ILogger */
+	private $logger;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -58,6 +62,7 @@ class EncryptionController extends Controller {
 	 * @param \OC\DB\Connection $connection
 	 * @param IUserManager $userManager
 	 * @param View $view
+	 * @param ILogger $logger
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -65,7 +70,8 @@ class EncryptionController extends Controller {
 								IConfig $config,
 								Connection $connection,
 								IUserManager $userManager,
-								View $view) {
+								View $view,
+								ILogger  $logger) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
 		$this->config = $config;
@@ -85,7 +91,7 @@ class EncryptionController extends Controller {
 
 		try {
 
-			$migration = new Migration($this->config, $this->view, $this->connection);
+			$migration = new Migration($this->config, $this->view, $this->connection, $this->logger);
 			$migration->reorganizeSystemFolderStructure();
 			$migration->updateDB();
 


### PR DESCRIPTION
fix #17564

steps to test:
- setup ownCloud 8.0
- enable encyption
- migrate to this branch
- run multiple times `./occ encryption:migrate`

without this patch keys get moved each time which crates a nested structure of files/files/files/...
with this patch keys get only moved once
