### PR TITLE
Better cache usage for previews

### DIFF
--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -53,7 +53,7 @@ if (!$info instanceof OCP\Files\FileInfo || !$always && !\OC::$server->getPrevie
 	\OC_Response::setStatus(404);
 } else {
 	$preview = new \OC\Preview(\OC_User::getUser(), 'files');
-	$preview->setFile($file);
+	$preview->setFile($file, $info);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);
 	$preview->setScalingUp($scalingUp);

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -252,12 +252,13 @@ class Preview {
 	 * Sets the path of the file you want a preview of
 	 *
 	 * @param string $file
+	 * @param \OCP\Files\FileInfo|null $info
 	 *
 	 * @return \OC\Preview
 	 */
-	public function setFile($file) {
+	public function setFile($file, $info = null) {
 		$this->file = $file;
-		$this->info = null;
+		$this->info = $info;
 
 		if ($file !== '') {
 			$this->getFileInfo();

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -536,11 +536,9 @@ class Preview {
 
 		foreach ($allThumbnails as $thumbnail) {
 			$name = $thumbnail['name'];
-			if (strpos($name, 'max')) {
-				list($cachedWidth, $cachedHeight) = $this->getDimensionsFromFilename($name);
-				if ($cachedWidth === $width && $cachedHeight === $height) {
-					return true;
-				}
+			list($cachedWidth, $cachedHeight) = $this->getDimensionsFromFilename($name);
+			if ($cachedWidth === $width && $cachedHeight === $height) {
+				return true;
 			}
 		}
 

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -531,7 +531,7 @@ class Preview {
 	 * @param string $name
 	 * @return bool
 	 */
-	private function thumbnailSizeExists($allThumbnails, $name) {
+	private function thumbnailSizeExists(array $allThumbnails, $name) {
 
 		foreach ($allThumbnails as $thumbnail) {
 			if ($name === $thumbnail->getName()) {

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -479,7 +479,7 @@ class Preview {
 			$preview = $this->buildCachePath($fileId, $previewWidth, $previewHeight);
 
 			// This checks if we have a preview of those exact dimensions in the cache
-			if ($this->thumbnailSizeExists($allThumbnails, $previewWidth, $previewHeight)) {
+			if ($this->thumbnailSizeExists($allThumbnails, basename($preview))) {
 				return $preview;
 			}
 
@@ -528,16 +528,13 @@ class Preview {
 	 * Check if a specific thumbnail size is cached
 	 *
 	 * @param FileInfo[] $allThumbnails the list of all our cached thumbnails
-	 * @param int $width
-	 * @param int $height
+	 * @param string $name
 	 * @return bool
 	 */
-	private function thumbnailSizeExists($allThumbnails, $width, $height) {
+	private function thumbnailSizeExists($allThumbnails, $name) {
 
 		foreach ($allThumbnails as $thumbnail) {
-			$name = $thumbnail['name'];
-			list($cachedWidth, $cachedHeight) = $this->getDimensionsFromFilename($name);
-			if ($cachedWidth === $width && $cachedHeight === $height) {
+			if ($name === $thumbnail->getName()) {
 				return true;
 			}
 		}

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -479,7 +479,7 @@ class Preview {
 			$preview = $this->buildCachePath($fileId, $previewWidth, $previewHeight);
 
 			// This checks if we have a preview of those exact dimensions in the cache
-			if ($this->userView->file_exists($preview)) {
+			if ($this->thumbnailSizeExists($allThumbnails, $previewWidth, $previewHeight)) {
 				return $preview;
 			}
 
@@ -522,6 +522,29 @@ class Preview {
 		}
 
 		return [$maxPreviewX, $maxPreviewY];
+	}
+
+	/**
+	 * Check if a specific thumbnail size is cached
+	 *
+	 * @param FileInfo[] $allThumbnails the list of all our cached thumbnails
+	 * @param int $width
+	 * @param int $height
+	 * @return bool
+	 */
+	private function thumbnailSizeExists($allThumbnails, $width, $height) {
+
+		foreach ($allThumbnails as $thumbnail) {
+			$name = $thumbnail['name'];
+			if (strpos($name, 'max')) {
+				list($cachedWidth, $cachedHeight) = $this->getDimensionsFromFilename($name);
+				if ($cachedWidth === $width && $cachedHeight === $height) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -375,7 +375,7 @@ class Preview {
 			return false;
 		}
 
-		if (!$this->fileView->file_exists($file)) {
+		if (!$this->getFileInfo() instanceof FileInfo) {
 			\OCP\Util::writeLog('core', 'File:"' . $file . '" not found', \OCP\Util::DEBUG);
 
 			return false;

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -22,7 +22,15 @@
 
 namespace Test;
 
+use OC\Files\FileInfo;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
+use Test\Traits\MountProviderTrait;
+use Test\Traits\UserTrait;
+
 class Preview extends TestCase {
+	use UserTrait;
+	use MountProviderTrait;
 
 	const TEST_PREVIEW_USER1 = "test-preview-user1";
 
@@ -59,11 +67,7 @@ class Preview extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$userManager = \OC::$server->getUserManager();
-		$userManager->clearBackends();
-		$backend = new \Test\Util\User\Dummy();
-		$userManager->registerBackend($backend);
-		$backend->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
+		$this->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
 		$this->loginAsUser(self::TEST_PREVIEW_USER1);
 
 		$storage = new \OC\Files\Storage\Temporary([]);
@@ -75,13 +79,13 @@ class Preview extends TestCase {
 
 		// We simulate the max dimension set in the config
 		\OC::$server->getConfig()
-					->setSystemValue('preview_max_x', $this->configMaxWidth);
+			->setSystemValue('preview_max_x', $this->configMaxWidth);
 		\OC::$server->getConfig()
-					->setSystemValue('preview_max_y', $this->configMaxHeight);
+			->setSystemValue('preview_max_y', $this->configMaxHeight);
 		// Used to test upscaling
 		$this->maxScaleFactor = 2;
 		\OC::$server->getConfig()
-					->setSystemValue('preview_max_scale_factor', $this->maxScaleFactor);
+			->setSystemValue('preview_max_scale_factor', $this->maxScaleFactor);
 
 		// We need to enable the providers we're going to use in the tests
 		$providers = [
@@ -92,7 +96,7 @@ class Preview extends TestCase {
 			'OC\\Preview\\Postscript'
 		];
 		\OC::$server->getConfig()
-					->setSystemValue('enabledPreviewProviders', $providers);
+			->setSystemValue('enabledPreviewProviders', $providers);
 
 		// Sample is 1680x1050 JPEG
 		$this->prepareSample('testimage.jpg', 1680, 1050);
@@ -161,7 +165,7 @@ class Preview extends TestCase {
 		$fileId = $fileInfo['fileid'];
 
 		$thumbCacheFolder = '/' . self::TEST_PREVIEW_USER1 . '/' . \OC\Preview::THUMBNAILS_FOLDER .
-							'/' . $fileId . '/';
+			'/' . $fileId . '/';
 
 		$this->assertSame(true, $this->rootView->is_dir($thumbCacheFolder), "$thumbCacheFolder \n");
 
@@ -318,7 +322,7 @@ class Preview extends TestCase {
 
 		// There should be no cached thumbnails
 		$thumbnailFolder = '/' . self::TEST_PREVIEW_USER1 . '/' . \OC\Preview::THUMBNAILS_FOLDER .
-						   '/' . $sampleFileId;
+			'/' . $sampleFileId;
 		$this->assertSame(false, $this->rootView->is_dir($thumbnailFolder));
 
 		$image = $preview->getPreview();
@@ -611,7 +615,7 @@ class Preview extends TestCase {
 		// Need to take care of special postfix added to the dimensions
 		$postfix = '';
 		$isMaxPreview = ($width === $this->maxPreviewWidth
-						 && $height === $this->maxPreviewHeight) ? true : false;
+			&& $height === $this->maxPreviewHeight) ? true : false;
 		if ($isMaxPreview) {
 			$postfix = '-max';
 		}
@@ -731,7 +735,7 @@ class Preview extends TestCase {
 		}
 
 		return $userPath . \OC\Preview::THUMBNAILS_FOLDER . '/' . $fileId
-			   . '/' . $width . '-' . $height . $postfix . '.png';
+		. '/' . $width . '-' . $height . $postfix . '.png';
 	}
 
 	/**
@@ -752,11 +756,11 @@ class Preview extends TestCase {
 
 		$this->samples[] =
 			[
-				'sampleFileId'     => $fileInfo['fileid'],
-				'sampleFileName'   => $fileName,
-				'sampleWidth'      => $sampleWidth,
-				'sampleHeight'     => $sampleHeight,
-				'maxPreviewWidth'  => $maxPreviewWidth,
+				'sampleFileId' => $fileInfo['fileid'],
+				'sampleFileName' => $fileName,
+				'sampleWidth' => $sampleWidth,
+				'sampleHeight' => $sampleHeight,
+				'maxPreviewWidth' => $maxPreviewWidth,
 				'maxPreviewHeight' => $maxPreviewHeight
 			];
 	}
@@ -914,5 +918,39 @@ class Preview extends TestCase {
 
 		$this->assertGreaterThanOrEqual(150, $image->width());
 		$this->assertGreaterThanOrEqual(150, $image->height());
+	}
+
+	public function testSetFileWithInfo() {
+		$info = new FileInfo('/foo', null, '/foo', ['mimetype' => 'foo/bar'], null);
+		$preview = new \OC\Preview();
+		$preview->setFile('/foo', $info);
+		$this->assertEquals($info, $this->invokePrivate($preview, 'getFileInfo'));
+	}
+
+	public function testIsCached() {
+		$sourceFile = __DIR__ . '/../data/testimage.png';
+		$userId = $this->getUniqueID();
+		$this->createUser($userId, 'pass');
+
+		$storage = new Temporary();
+		$storage->mkdir('files');
+		$this->registerMount($userId, $storage, '/' . $userId);
+
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($userId);
+		$preview = new \OC\Preview($userId, 'files');
+		$view = new View('/' . $userId . '/files');
+		$view->file_put_contents('test.png', file_get_contents($sourceFile));
+		$info = $view->getFileInfo('test.png');
+		$preview->setFile('test.png', $info);
+
+		$preview->setMaxX(64);
+		$preview->setMaxY(64);
+
+		$this->assertFalse($preview->isCached($info->getId()));
+
+		$preview->getPreview();
+
+		$this->assertEquals('thumbnails/' . $info->getId() . '/64-64.png', $preview->isCached($info->getId()));
 	}
 }


### PR DESCRIPTION
Use cache data we already have instead of making filesystem calls for significant speed improvements when working with external storages

cc @DeepDiver1975 @PVince81 @georgehrke 
