### PR TITLE
The external directories should get the correct icon in filelist

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -685,6 +685,10 @@
 
 			if (type === 'dir') {
 				mime = mime || 'httpd/unix-directory';
+
+				if (fileData.mountType && fileData.mountType.indexOf('external') === 0) {
+					icon = OC.MimeType.getIconUrl('dir-external');
+				}
 			}
 
 			//containing tr


### PR DESCRIPTION
Fix for #17696 

When moving to OC.Mimetype the external folder case was missed. Since this is not reflected in the mimetype.

@PVince81 does it make sense to add unit tests for those cases to the files app? Or should I wait till your webdav move is ready?

Easy to review.

CC: @MorrisJobke @Xenopathic 
