### PR TITLE
Add a public method to get the mimetype from the file name

### DIFF
--- a/lib/public/files.php
+++ b/lib/public/files.php
@@ -64,6 +64,16 @@ class Files {
 	}
 
 	/**
+	 * Get the mimetype form a file name
+	 * @param string $path
+	 * @return string
+	 * @since 8.2.0
+	 */
+	static function getMimeTypeByFileName($path) {
+		return \OC_Helper::getFileNameMimeType($path);
+	}
+
+	/**
 	 * Search for files by mimetype
 	 * @param string $mimetype
 	 * @return array


### PR DESCRIPTION
The problem with `getMimeType()` is that it calls `\OC_Helper::getMimeType()` which opens the files.
However the other method `\OC_Helper::getFileNameMimeType()` also works without the file.

So it would be nice to have a wrapper for that method. (It is also the method that is used by all apps (versions, trashbin, sharing, storages, ...)

@DeepDiver1975 @enoch85 
