### PR TITLE
Enable preview/thumbnail generation for RTF files

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -648,6 +648,7 @@ $CONFIG = array(
  *  - OC\Preview\PDF
  *  - OC\Preview\StarOffice
  *  - OC\Preview\SVG
+ *  - OC\Preview\RTF
  *
  * .. note:: Troubleshooting steps for the MS Word previews are available
  *    at the :doc:`collaborative_documents_configuration` section

--- a/lib/private/mimetypes.list.php
+++ b/lib/private/mimetypes.list.php
@@ -122,6 +122,7 @@ return array(
 	'py' => array('text/x-python', null),
 	'rar' => array('application/x-rar-compressed', null),
 	'reveal' => array('text/reveal', null),
+	'rtf' => array('application/rtf', null),
 	'sgf' => array('application/sgf', null),
 	'sh-lib' => array('text/x-shellscript', null),
 	'sh' => array('text/x-shellscript', null),

--- a/lib/private/preview/office-cl.php
+++ b/lib/private/preview/office-cl.php
@@ -135,4 +135,15 @@ if (!\OC_Util::runningOnWindows()) {
 	}
 
 	\OC\Preview::registerProvider('OC\Preview\StarOffice');
+
+	// RTF
+	class RTF extends Office {
+
+		public function getMimeType() {
+			return '/application\/rtf.*/';
+		}
+
+	}
+
+	\OC\Preview::registerProvider('OC\Preview\RTF');
 }


### PR DESCRIPTION
(this is my first merge request - I'd appreciate your feedback if the presentation or workflow can be improved)

By default, preview generation for documents is disabled. 
For those users who wish to use them and explicitly enable them in the config, there is no obvious reason why it should be possible to generate a thumbnail for docs/odt's and not for rtf files.

this patch enables preview generation for RTF files.
