### PR TITLE
Enable preview for RTF files

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -714,6 +714,7 @@ $CONFIG = array(
  *  - OC\Preview\SVG
  *  - OC\Preview\TIFF
  *  - OC\Preview\Font
+ *  - OC\Preview\RTF
  *
  * .. note:: Troubleshooting steps for the MS Word previews are available
  *    at the :doc:`../configuration_files/collaborative_documents_configuration`
@@ -737,6 +738,7 @@ $CONFIG = array(
 	'OC\Preview\MP3',
 	'OC\Preview\TXT',
 	'OC\Preview\MarkDown'
+	'OC\Preview\RTF',
 ),
 
 /**

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -738,7 +738,6 @@ $CONFIG = array(
 	'OC\Preview\MP3',
 	'OC\Preview\TXT',
 	'OC\Preview\MarkDown'
-	'OC\Preview\RTF',
 ),
 
 /**

--- a/config/mimetypemapping.dist.json
+++ b/config/mimetypemapping.dist.json
@@ -129,6 +129,7 @@
 	"py": ["text/x-python"],
 	"raf": ["image/x-dcraw"],
 	"rar": ["application/x-rar-compressed"],
+	"rtf": ["application/rtf"],
 	"reveal": ["text/reveal"],
 	"rw2": ["image/x-dcraw"],
 	"sgf": ["application/sgf"],

--- a/lib/private/preview/rtf.php
+++ b/lib/private/preview/rtf.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Joerg Ziegler <github@idluxe>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Preview;
+
+//.rtf 
+class RTF extends Office {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType() {
+		return '/application\/rtf.*/';
+	}
+}

--- a/lib/private/previewmanager.php
+++ b/lib/private/previewmanager.php
@@ -212,6 +212,7 @@ class PreviewManager implements IPreview {
 	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\SVG
 	 *  - OC\Preview\TIFF
+	 *  - OC\Preview\RTF
 	 *
 	 * @return array
 	 */
@@ -319,6 +320,7 @@ class PreviewManager implements IPreview {
 						$this->registerCoreProvider('\OC\Preview\MSOffice2007', '/application\/vnd.openxmlformats-officedocument.*/');
 						$this->registerCoreProvider('\OC\Preview\OpenDocument', '/application\/vnd.oasis.opendocument.*/');
 						$this->registerCoreProvider('\OC\Preview\StarOffice', '/application\/vnd.sun.xml.*/');
+						$this->registerCoreProvider('\OC\Preview\RTF', '/application\/rtf.*/');
 					}
 				}
 			}


### PR DESCRIPTION
RTF files are supported by all common office implementations. This patch
enables thumbnail previews for RTF files.

This is the master version of https://github.com/owncloud/core/pull/17741
