### PR TITLE
Allow listing of users and groups via OCS API

### DIFF
--- a/apps/files_sharing/api/group.php
+++ b/apps/files_sharing/api/group.php
@@ -39,14 +39,18 @@ class Group {
 			return $group->getGID();
 		}, $groups);
 
+		$url = '';
 		// Set the link (next) header if there is more
 		if ($next_url) {
 			$url = 'ocs/v1.php/apps/files_sharing/api/v1/groups?' .
-			       'limit=' . $limit . '&offset=' . ($offset + $limit);
+			       'limit=' . $limit . '&offset=' . ($offset + $limit) .
+				   '&search=' . $search;
 			$url = $this->urlGenerator->getAbsoluteURL($url);
+			/* Makes unit testing impossible
 			header('Link: <' . $url . '>; rel="next"');
+			*/
 		}
 
-		return new \OC_OCS_Result(['groups' => $groups], 100, 'foo');
+		return new \OC_OCS_Result(['groups' => $groups, 'next' => $url]);
 	}
 }

--- a/apps/files_sharing/api/group.php
+++ b/apps/files_sharing/api/group.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OCA\Files_Sharing\API;
+
+use \OCP\IGroupManager;
+use \OCP\IURLGenerator;
+
+class Group {
+
+	/** @var IGroupManager */
+	var $groupManager;
+
+	/** @var IURLGenerator */
+	var $urlGenerator;
+
+	public function __construct(\OCP\IGroupManager $groupManager,
+	                            \OCP\IURLGenerator $urlGenerator) {
+		$this->groupManager = $groupManager;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	/**
+	 * Return all the groups
+	 * @var array $params Can contain $limit, $offset and $search
+	 * @return \OC_OCS_Result containing a list of matching groups
+	 */
+	public function getGroups($params) {
+		$limit = isset($_GET['limit']) ? intval($_GET['limit']) : 30;
+		$offset = isset($_GET['offset']) ? intval($_GET['offset']) : 0;
+		$search = isset($_GET['search']) ? $_GET['search'] : '';
+
+		$groups = $this->groupManager->search($search, $limit+1, $offset);
+
+		$next_url = count($groups) > $limit;
+		array_splice($groups, $limit);
+
+		//Get the GID for all the groups
+		$groups = array_map(function($group) {
+			return $group->getGID();
+		}, $groups);
+
+		// Set the link (next) header if there is more
+		if ($next_url) {
+			$url = 'ocs/v1.php/apps/files_sharing/api/v1/groups?' .
+			       'limit=' . $limit . '&offset=' . ($offset + $limit);
+			$url = $this->urlGenerator->getAbsoluteURL($url);
+			header('Link: <' . $url . '>; rel="next"');
+		}
+
+		return new \OC_OCS_Result(['groups' => $groups], 100, 'foo');
+	}
+}

--- a/apps/files_sharing/api/group.php
+++ b/apps/files_sharing/api/group.php
@@ -1,5 +1,23 @@
 <?php
-
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 namespace OCA\Files_Sharing\API;
 
 use \OCP\IGroupManager;

--- a/apps/files_sharing/api/user.php
+++ b/apps/files_sharing/api/user.php
@@ -1,5 +1,23 @@
 <?php
-
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 namespace OCA\Files_Sharing\API;
 
 use \OCP\IUserManager;

--- a/apps/files_sharing/api/user.php
+++ b/apps/files_sharing/api/user.php
@@ -44,14 +44,19 @@ class User {
 			];
 		}, $users);
 
+		$url = '';
 		// Set the link (next) header if there is more
 		if ($next_url) {
 			$url = 'ocs/v1.php/apps/files_sharing/api/v1/users?' .
-			       'limit=' . $limit . '&offset=' . ($offset + $limit);
+			       'limit=' . $limit . '&offset=' . ($offset + $limit) .
+				   '&search=' . $search;
 			$url = $this->urlGenerator->getAbsoluteURL($url);
+
+			/* Not possible to unit tests else..
 			header('Link: <' . $url . '>; rel="next"');
+			*/
 		}
 
-		return new \OC_OCS_Result(['users' => $users]);
+		return new \OC_OCS_Result(['users' => $users, 'next' => $url]);
 	}
 }

--- a/apps/files_sharing/api/user.php
+++ b/apps/files_sharing/api/user.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OCA\Files_Sharing\API;
+
+use \OCP\IUserManager;
+use \OCP\IURLGenerator;
+
+class User {
+
+	/** @var IGroupManager */
+	var $userManager;
+
+	/** @var IURLGenerator */
+	var $urlGenerator;
+
+	public function __construct(\OCP\IUserManager $userManager,
+	                            \OCP\IURLGenerator $urlGenerator) {
+		$this->userManager = $userManager;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	/**
+	 * Return all the users
+	 * @var array $params Can contain $limit, $offset and $search
+	 * @return \OC_OCS_Result containing a list of matching users
+	 */
+	public function getUsers($params) {
+		$limit = isset($_GET['limit']) ? intval($_GET['limit']) : 30;
+		$offset = isset($_GET['offset']) ? intval($_GET['offset']) : 0;
+		$search = isset($_GET['search']) ? $_GET['search'] : '';
+
+		$users = $this->userManager->searchDisplayName($search, $limit+1, $offset);
+
+		$next_url = count($users) > $limit;
+		array_splice($users, $limit);
+
+		$users = array_values($users);
+
+		//Get the UID for all the users
+		$users = array_map(function($user) {
+			return [
+				'uid' => $user->getUID(),
+				'displayName' => $user->getDisplayName()
+			];
+		}, $users);
+
+		// Set the link (next) header if there is more
+		if ($next_url) {
+			$url = 'ocs/v1.php/apps/files_sharing/api/v1/users?' .
+			       'limit=' . $limit . '&offset=' . ($offset + $limit);
+			$url = $this->urlGenerator->getAbsoluteURL($url);
+			header('Link: <' . $url . '>; rel="next"');
+		}
+
+		return new \OC_OCS_Result(['users' => $users]);
+	}
+}

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -102,3 +102,12 @@ API::register('get',
 		'/cloud/capabilities',
 		array('OCA\Files_Sharing\Capabilities', 'getCapabilities'),
 		'files_sharing', API::USER_AUTH);
+
+
+$groups = new \OCA\Files_Sharing\API\Group(\OC::$server->getGroupManager(),
+                                           \OC::$server->getURLGenerator());
+API::Register('get',
+		'/apps/files_sharing/api/v1/groups',
+		[$groups, 'getGroups'],
+		'files_sharing',
+		API::USER_AUTH);

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -111,3 +111,11 @@ API::Register('get',
 		[$groups, 'getGroups'],
 		'files_sharing',
 		API::USER_AUTH);
+
+$users = new \OCA\Files_Sharing\API\User(\OC::$server->getUserManager(),
+                                         \OC::$server->getURLGenerator());
+API::Register('get',
+		'/apps/files_sharing/api/v1/users',
+		[$users, 'getUsers'],
+		'files_sharing',
+		API::USER_AUTH);

--- a/apps/files_sharing/tests/group.php
+++ b/apps/files_sharing/tests/group.php
@@ -1,5 +1,23 @@
 <?php
-
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 use OCA\Files_Sharing\API\Group;
 use OCA\Files_Sharing\Tests\TestCase;
 

--- a/apps/files_sharing/tests/group.php
+++ b/apps/files_sharing/tests/group.php
@@ -1,0 +1,121 @@
+<?php
+
+use OCA\Files_Sharing\API\Group;
+use OCA\Files_Sharing\Tests\TestCase;
+
+/**
+ * Class Test_Files_Sharing_Api
+ */
+class TestGroupListingApi extends TestCase {
+
+	/**
+	 * @param string $gid GID of the group
+	 * @param bool $called Will this mock be actually called
+	 */
+	private function mockGroup($gid, $called) {
+		$group = $this->getMockBuilder('\OCP\IGroup')
+			->disableOriginalConstructor()
+			->getMock();
+
+		if ($called) {
+			$group->expects($this->once())
+				->method('getGID')
+				->willReturn($gid);
+		} else {
+			$group->expects($this->never())->method($this->anything());
+		}
+
+		return $group;
+	}
+
+	public function testGetGroupEmpty() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$groupManager->expects($this->once())
+			->method('search')
+			->willReturn([]);
+
+		$groupListing = new Group($groupManager, $urlGenerator);
+
+		$res = $groupListing->getGroups([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('groups', $res->getData());
+		$this->assertEmpty($res->getData()['groups']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEmpty($res->getData()['next']);
+	}
+
+	public function testGetGroupDefault() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Mock group list
+		$groups = array_map(function($i) {
+			$gid = 'group' . $i;
+			return $this->mockGroup($gid, true);
+		}, range(1, 10));
+
+		$groupManager->expects($this->once())
+			->method('search')
+			->willReturn($groups);
+
+		$groupListing = new Group($groupManager, $urlGenerator);
+
+		$res = $groupListing->getGroups([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('groups', $res->getData());
+		$this->assertCount(10, $res->getData()['groups']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEmpty($res->getData()['next']);
+	}
+
+	public function testGetGroupLimitOffsetSearch() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+		$urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->will($this->returnArgument(0));
+
+		$groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Mock group list
+		$groups = array_map(function($i) {
+			$uid = 'group' . $i;
+			return $this->mockGroup($uid, $i <= 2);
+		}, range(1, 3));
+
+		$groupManager->expects($this->once())
+			->method('search')
+			->willReturn($groups);
+
+		$groupListing = new Group($groupManager, $urlGenerator);
+
+		// Set limit
+		$_GET['limit'] = 2;
+		$_GET['offset'] = 1;
+		$_GET['search'] = 'group';
+
+		$res = $groupListing->getGroups([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('groups', $res->getData());
+		$this->assertCount(2, $res->getData()['groups']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEquals('ocs/v1.php/apps/files_sharing/api/v1/groups?limit=2&offset=3&search=group', $res->getData()['next']);
+	}
+}

--- a/apps/files_sharing/tests/user.php
+++ b/apps/files_sharing/tests/user.php
@@ -1,0 +1,125 @@
+<?php
+
+use OCA\Files_Sharing\API\User;
+use OCA\Files_Sharing\Tests\TestCase;
+
+/**
+ * Class Test_Files_Sharing_Api
+ */
+class TestUserListingApi extends TestCase {
+
+	/**
+	 * @param string $uid Uid of the mock
+	 * @param string $displayName Displayname of the mock
+	 * @param bool $called Will this mock be actually called
+	 */
+	private function mockUser($uid, $displayName, $called) {
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
+
+		if ($called) {
+			$user->expects($this->once())
+				->method('getUID')
+				->willReturn($uid);
+			$user->expects($this->once())
+				->method('getDisplayName')
+				->willReturn($uid);
+		} else {
+			$user->expects($this->never())->method($this->anything());
+		}
+
+		return $user;
+	}
+
+	public function testGetUserEmpty() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$userManager = $this->getMockBuilder('\OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$userManager->expects($this->once())
+			->method('searchDisplayName')
+			->willReturn([]);
+
+		$userListing = new User($userManager, $urlGenerator);
+
+		$res = $userListing->getUsers([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('users', $res->getData());
+		$this->assertEmpty($res->getData()['users']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEmpty($res->getData()['next']);
+	}
+
+	public function testGetUserDefault() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$userManager = $this->getMockBuilder('\OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Mock user list
+		$users = array_map(function($i) {
+			$uid = 'user' . $i;
+			return $this->mockUser($uid, $uid, true);
+		}, range(1, 10));
+
+		$userManager->expects($this->once())
+			->method('searchDisplayName')
+			->willReturn($users);
+
+		$userListing = new User($userManager, $urlGenerator);
+
+		$res = $userListing->getUsers([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('users', $res->getData());
+		$this->assertCount(10, $res->getData()['users']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEmpty($res->getData()['next']);
+	}
+
+	public function testGetUserLimitOffsetSearch() {
+		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+			->disableOriginalConstructor()
+			->getMock();
+		$urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->will($this->returnArgument(0));
+
+		$userManager = $this->getMockBuilder('\OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Mock user list
+		$users = array_map(function($i) {
+			$uid = 'user' . $i;
+			return $this->mockUser($uid, $uid, $i <= 2);
+		}, range(1, 3));
+
+		$userManager->expects($this->once())
+			->method('searchDisplayName')
+			->willReturn($users);
+
+		$userListing = new User($userManager, $urlGenerator);
+
+		// Set limit
+		$_GET['limit'] = 2;
+		$_GET['offset'] = 1;
+		$_GET['search'] = 'user';
+
+		$res = $userListing->getUsers([]);
+		$this->assertEquals(100, $res->getStatusCode());
+		$this->assertArrayHasKey('users', $res->getData());
+		$this->assertCount(2, $res->getData()['users']);
+
+		$this->assertArrayHasKey('next', $res->getData());
+		$this->assertEquals('ocs/v1.php/apps/files_sharing/api/v1/users?limit=2&offset=3&search=user', $res->getData()['next']);
+	}
+}

--- a/apps/files_sharing/tests/user.php
+++ b/apps/files_sharing/tests/user.php
@@ -1,5 +1,23 @@
 <?php
-
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 use OCA\Files_Sharing\API\User;
 use OCA\Files_Sharing\Tests\TestCase;
 


### PR DESCRIPTION
As described in #16646

This allows listing of users and groups so clients can also implement user/group sharing (with completion).

Original I had the Link header. But that breaks unit testing.

TODO:
- [ ] shareable option (to only list who we can share with) (default?, no other reason to list)
- [ ] Maybe direct avatar link .../users/<uid>/avatar (separate PR).

Comments are welcome: @DeepDiver1975 @LukasReschke @PVince81 @MorrisJobke 

@dragotin: Can you think of any additional stuff we need in the client besides the uid/displayname and maybe an avatar?
