### PR TITLE
[stable8.1] Fix preview of old file on public upload conflicts

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -158,9 +158,18 @@ OCA.Sharing.PublicApp = {
 			};
 
 			this.fileList.generatePreviewUrl = function (urlSpec) {
+				urlSpec = urlSpec || {};
+				if (!urlSpec.x) {
+					urlSpec.x = 36;
+				}
+				if (!urlSpec.y) {
+					urlSpec.y = 36;
+				}
+				urlSpec.x *= window.devicePixelRatio;
+				urlSpec.y *= window.devicePixelRatio;
+				urlSpec.x = Math.floor(urlSpec.x);
+				urlSpec.y = Math.floor(urlSpec.y);
 				urlSpec.t = $('#dirToken').val();
-				urlSpec.y = Math.floor(36 * window.devicePixelRatio);
-				urlSpec.x = Math.floor(36 * window.devicePixelRatio);
 				return OC.generateUrl('/apps/files_sharing/ajax/publicpreview.php?') + $.param(urlSpec);
 			};
 
@@ -292,15 +301,8 @@ $(document).ready(function () {
 
 	if (window.Files) {
 		// HACK: for oc-dialogs previews that depends on Files:
-		Files.lazyLoadPreview = function (path, mime, ready, width, height, etag) {
-			return App.fileList.lazyLoadPreview({
-				path: path,
-				mime: mime,
-				callback: ready,
-				width: width,
-				height: height,
-				etag: etag
-			});
+		Files.generatePreviewUrl = function (urlSpec) {
+			return App.fileList.generatePreviewUrl(urlSpec);
 		};
 	}
 });

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -388,9 +388,9 @@ var OCdialogs = {
 				c:		original.etag,
 				forceIcon:	0
 			};
-			var previewpath = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
+			var previewpath = Files.generatePreviewUrl(urlSpec);
 			// Escaping single quotes
-			previewpath = previewpath.replace(/'/g, "%27")
+			previewpath = previewpath.replace(/'/g, "%27");
 			$originalDiv.find('.icon').css({"background-image":   "url('" + previewpath + "')"});
 			getCroppedPreview(replacement).then(
 				function(path){


### PR DESCRIPTION
Partial fix for https://github.com/owncloud/core/issues/17618

@PVince81 If you follow the steps you've added to your issue, you should be getting a preview on the right side of the dialogue.

The left side of the dialogue can't be shown due to the current CSP configuration of ownCloud 8.1
