### PR TITLE
fix avconv cmd line arguments for movie thumbnails

### DIFF
--- a/lib/private/preview/movie.php
+++ b/lib/private/preview/movie.php
@@ -83,7 +83,7 @@ class Movie extends Provider {
 		$tmpPath = \OC_Helper::tmpFile();
 
 		if (self::$avconvBinary) {
-			$cmd = self::$avconvBinary . ' -an -y -ss ' . escapeshellarg($second) .
+			$cmd = self::$avconvBinary . ' -y -ss ' . escapeshellarg($second) .
 				' -i ' . escapeshellarg($absPath) .
 				' -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
 				' > /dev/null 2>&1';


### PR DESCRIPTION
partial fix for #17726:
the -an cmdline argument causes the call to avconv to fail, silently because of the "> /dev/null".
It is used for suppressing audio but this is not applicable in thumbnail creation
and hence can be safely removed.

verified with all movie types from http://camendesign.com/code/video_for_everybody/test.html
