### PR TITLE
Backport of #17723 to stable7

### DIFF
--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -117,8 +117,8 @@ class Manager {
 		$user = new User($uid, $dn, $this->access, $this->ocConfig,
 			$this->ocFilesystem, clone $this->image, $this->ocLog,
 			$this->avatarManager);
-		$users['byDN'][$dn]   = $user;
-		$users['byUid'][$uid] = $user;
+		$this->users['byDN'][$dn]   = $user;
+		$this->users['byUid'][$uid] = $user;
 		return $user;
 	}
 

--- a/apps/user_ldap/tests/user/manager.php
+++ b/apps/user_ldap/tests/user/manager.php
@@ -1,24 +1,24 @@
 <?php
 /**
-* ownCloud
-*
-* @author Arthur Schiwon
-* @copyright 2014 Arthur Schiwon blizzz@owncloud.com
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * ownCloud
+ *
+ * @author Arthur Schiwon
+ * @copyright 2014 Arthur Schiwon blizzz@owncloud.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 namespace OCA\user_ldap\tests;
 
@@ -26,169 +26,177 @@ use OCA\user_ldap\lib\user\Manager;
 
 class Test_User_Manager extends \PHPUnit_Framework_TestCase {
 
-    private function getTestInstances() {
-        $access  = $this->getMock('\OCA\user_ldap\lib\user\IUserTools');
-        $config  = $this->getMock('\OCP\IConfig');
-        $filesys = $this->getMock('\OCA\user_ldap\lib\FilesystemHelper');
-        $log     = $this->getMock('\OCA\user_ldap\lib\LogWrapper');
-        $avaMgr  = $this->getMock('\OCP\IAvatarManager');
-        $image   = $this->getMock('\OCP\Image');
+	private function getTestInstances() {
+		$access = $this->getMock('\OCA\user_ldap\lib\user\IUserTools');
+		$config = $this->getMock('\OCP\IConfig');
+		$filesys = $this->getMock('\OCA\user_ldap\lib\FilesystemHelper');
+		$log = $this->getMock('\OCA\user_ldap\lib\LogWrapper');
+		$avaMgr = $this->getMock('\OCP\IAvatarManager');
+		$image = $this->getMock('\OCP\Image');
 
-        return array($access, $config, $filesys, $image, $log, $avaMgr);
-    }
+		return array($access, $config, $filesys, $image, $log, $avaMgr);
+	}
 
-    public function testGetByDNExisting() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
+	public function testGetByDNExisting() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
 
-        $inputDN = 'cn=foo,dc=foobar,dc=bar';
-        $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
-
-		$access->expects($this->once())
-            ->method('stringResemblesDN')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(true));
-
-        $access->expects($this->once())
-            ->method('dn2username')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue($uid));
-
-        $access->expects($this->never())
-            ->method('username2dn');
-
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($inputDN);
-
-        $this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
-    }
-
-    public function testGetByEDirectoryDN() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
-
-        $inputDN = 'uid=foo,o=foobar,c=bar';
-        $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
+		$inputDN = 'cn=foo,dc=foobar,dc=bar';
+		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
 		$access->expects($this->once())
-            ->method('stringResemblesDN')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(true));
-
-        $access->expects($this->once())
-            ->method('dn2username')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue($uid));
-
-        $access->expects($this->never())
-            ->method('username2dn');
-
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($inputDN);
-
-        $this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
-    }
-
-    public function testGetByExoticDN() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
-
-        $inputDN = 'ab=cde,f=ghei,mno=pq';
-        $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
+			->method('stringResemblesDN')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(true));
 
 		$access->expects($this->once())
-            ->method('stringResemblesDN')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(true));
+			->method('dn2username')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue($uid));
 
-        $access->expects($this->once())
-            ->method('dn2username')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue($uid));
+		$access->expects($this->never())
+			->method('username2dn');
 
-        $access->expects($this->never())
-            ->method('username2dn');
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($inputDN);
 
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($inputDN);
+		// Now we fetch the user again. If this leads to a failing test,
+		// runtime caching the manager is broken.
+		$user = $manager->get($inputDN);
 
-        $this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
-    }
+		$this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
+	}
 
-    public function testGetByDNNotExisting() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
+	public function testGetByEDirectoryDN() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
 
-        $inputDN = 'cn=gone,dc=foobar,dc=bar';
+		$inputDN = 'uid=foo,o=foobar,c=bar';
+		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
 		$access->expects($this->once())
-            ->method('stringResemblesDN')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(true));
+			->method('stringResemblesDN')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(true));
 
-        $access->expects($this->once())
-            ->method('dn2username')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(false));
+		$access->expects($this->once())
+			->method('dn2username')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue($uid));
 
-        $access->expects($this->once())
-            ->method('username2dn')
-            ->with($this->equalTo($inputDN))
-            ->will($this->returnValue(false));
+		$access->expects($this->never())
+			->method('username2dn');
 
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($inputDN);
-    }
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($inputDN);
 
-    public function testGetByUidExisting() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
+		$this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
+	}
 
-        $dn = 'cn=foo,dc=foobar,dc=bar';
-        $uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
+	public function testGetByExoticDN() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
 
-        $access->expects($this->never())
-            ->method('dn2username');
+		$inputDN = 'ab=cde,f=ghei,mno=pq';
+		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
-        $access->expects($this->once())
-            ->method('username2dn')
-            ->with($this->equalTo($uid))
-            ->will($this->returnValue($dn));
+		$access->expects($this->once())
+			->method('stringResemblesDN')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(true));
 
-        $access->expects($this->once())
-            ->method('stringResemblesDN')
-            ->with($this->equalTo($uid))
-            ->will($this->returnValue(false));
+		$access->expects($this->once())
+			->method('dn2username')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue($uid));
 
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($uid);
+		$access->expects($this->never())
+			->method('username2dn');
 
-        $this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
-    }
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($inputDN);
 
-    public function testGetByUidNotExisting() {
-        list($access, $config, $filesys, $image, $log, $avaMgr) =
-            $this->getTestInstances();
+		$this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
+	}
 
-        $dn = 'cn=foo,dc=foobar,dc=bar';
-        $uid = 'gone';
+	public function testGetByDNNotExisting() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
 
-        $access->expects($this->never())
-            ->method('dn2username');
+		$inputDN = 'cn=gone,dc=foobar,dc=bar';
 
-        $access->expects($this->exactly(1))
-            ->method('username2dn')
-            ->with($this->equalTo($uid))
-            ->will($this->returnValue(false));
+		$access->expects($this->once())
+			->method('stringResemblesDN')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(true));
 
-        $manager = new Manager($config, $filesys, $log, $avaMgr, $image);
-        $manager->setLdapAccess($access);
-        $user = $manager->get($uid);
-    }
+		$access->expects($this->once())
+			->method('dn2username')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(false));
+
+		$access->expects($this->once())
+			->method('username2dn')
+			->with($this->equalTo($inputDN))
+			->will($this->returnValue(false));
+
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($inputDN);
+	}
+
+	public function testGetByUidExisting() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
+
+		$dn = 'cn=foo,dc=foobar,dc=bar';
+		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
+
+		$access->expects($this->never())
+			->method('dn2username');
+
+		$access->expects($this->once())
+			->method('username2dn')
+			->with($this->equalTo($uid))
+			->will($this->returnValue($dn));
+
+		$access->expects($this->once())
+			->method('stringResemblesDN')
+			->with($this->equalTo($uid))
+			->will($this->returnValue(false));
+
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($uid);
+
+		// Now we fetch the user again. If this leads to a failing test,
+		// runtime caching the manager is broken.
+		$user = $manager->get($uid);
+
+		$this->assertInstanceOf('\OCA\user_ldap\lib\user\User', $user);
+	}
+
+	public function testGetByUidNotExisting() {
+		list($access, $config, $filesys, $image, $log, $avaMgr) =
+			$this->getTestInstances();
+
+		$dn = 'cn=foo,dc=foobar,dc=bar';
+		$uid = 'gone';
+
+		$access->expects($this->never())
+			->method('dn2username');
+
+		$access->expects($this->exactly(1))
+			->method('username2dn')
+			->with($this->equalTo($uid))
+			->will($this->returnValue(false));
+
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image);
+		$manager->setLdapAccess($access);
+		$user = $manager->get($uid);
+	}
 
 }


### PR DESCRIPTION
See original issue for reproduction steps: #17723, but mind that manual testing is more complicated, because there is a fall-back cache that catches the misbehaviour elsewhere. The unit-tests do fine.

(Hint: adding ?w=1 to the files URL hides whitespace changes. )

Please check @benwilliams @johansmitsnl @Nick-Lock @nickvergessen @MorrisJobke @rperezb
