### PR TITLE
Make OC_SubAdmin non static

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -71,11 +71,13 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	private $cachedUserGroups = array();
 
+	/** @var \OC\SubAdmin */
+	private $subAdmin = null;
 
 	/**
 	 * @param \OC\User\Manager $userManager
 	 */
-	public function __construct($userManager) {
+	public function __construct(\OC\User\Manager $userManager) {
 		$this->userManager = $userManager;
 		$cachedGroups = & $this->cachedGroups;
 		$cachedUserGroups = & $this->cachedUserGroups;
@@ -313,5 +315,20 @@ class Manager extends PublicEmitter implements IGroupManager {
 			$matchingUsers[$groupUser->getUID()] = $groupUser->getDisplayName();
 		}
 		return $matchingUsers;
+	}
+
+	/**
+	 * @return \OC\SubAdmin
+	 */
+	public function getSubAdmin() {
+		if (!$this->subAdmin) {
+			$this->subAdmin = new \OC\SubAdmin(
+				$this->userManager,
+				$this,
+				\OC::$server->getDatabaseConnection()
+			);
+		}
+
+		return $this->subAdmin;
 	}
 }

--- a/lib/private/legacy/subadmin.php
+++ b/lib/private/legacy/subadmin.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Georg Ehrke <georg@owncloud.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Lukas Reschke <lukas@owncloud.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+OC_Hook::connect('OC_User', 'post_deleteUser', 'OC_SubAdmin', 'post_deleteUser');
+OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC_SubAdmin', 'post_deleteGroup');
+/**
+ * This class provides all methods needed for managing groups.
+ *
+ * Hooks provided:
+ *   post_createSubAdmin($gid)
+ *   post_deleteSubAdmin($gid)
+ */
+class OC_SubAdmin{
+
+	/**
+	 * add a SubAdmin
+	 * @param string $uid uid of the SubAdmin
+	 * @param string $gid gid of the group
+	 * @return boolean
+	 */
+	public static function createSubAdmin($uid, $gid) {
+		$stmt = OC_DB::prepare('INSERT INTO `*PREFIX*group_admin` (`gid`,`uid`) VALUES(?,?)');
+		$stmt->execute(array($gid, $uid));
+		OC_Hook::emit( "OC_SubAdmin", "post_createSubAdmin", array( "gid" => $gid ));
+		return true;
+	}
+
+	/**
+	 * delete a SubAdmin
+	 * @param string $uid uid of the SubAdmin
+	 * @param string $gid gid of the group
+	 * @return boolean
+	 */
+	public static function deleteSubAdmin($uid, $gid) {
+		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `gid` = ? AND `uid` = ?');
+		$stmt->execute(array($gid, $uid));
+		OC_Hook::emit( "OC_SubAdmin", "post_deleteSubAdmin", array( "gid" => $gid ));
+		return true;
+	}
+
+	/**
+	 * get groups of a SubAdmin
+	 * @param string $uid uid of the SubAdmin
+	 * @return array
+	 */
+	public static function getSubAdminsGroups($uid) {
+		$stmt = OC_DB::prepare('SELECT `gid` FROM `*PREFIX*group_admin` WHERE `uid` = ?');
+		$result = $stmt->execute(array($uid));
+		$gids = array();
+		while($row = $result->fetchRow()) {
+			$gids[] = $row['gid'];
+		}
+		return $gids;
+	}
+
+	/**
+	 * get SubAdmins of a group
+	 * @param string $gid gid of the group
+	 * @return array
+	 */
+	public static function getGroupsSubAdmins($gid) {
+		$stmt = OC_DB::prepare('SELECT `uid` FROM `*PREFIX*group_admin` WHERE `gid` = ?');
+		$result = $stmt->execute(array($gid));
+		$uids = array();
+		while($row = $result->fetchRow()) {
+			$uids[] = $row['uid'];
+		}
+		return $uids;
+	}
+
+	/**
+	 * get all SubAdmins
+	 * @return array
+	 */
+	public static function getAllSubAdmins() {
+		$stmt = OC_DB::prepare('SELECT * FROM `*PREFIX*group_admin`');
+		$result = $stmt->execute();
+		$subadmins = array();
+		while($row = $result->fetchRow()) {
+			$subadmins[] = $row;
+		}
+		return $subadmins;
+	}
+
+	/**
+	 * checks if a user is a SubAdmin of a group
+	 * @param string $uid uid of the subadmin
+	 * @param string $gid gid of the group
+	 * @return bool
+	 */
+	public static function isSubAdminofGroup($uid, $gid) {
+		$stmt = OC_DB::prepare('SELECT COUNT(*) AS `count` FROM `*PREFIX*group_admin` WHERE `uid` = ? AND `gid` = ?');
+		$result = $stmt->execute(array($uid, $gid));
+		$result = $result->fetchRow();
+		if($result['count'] >= 1) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * checks if a user is a SubAdmin
+	 * @param string $uid uid of the subadmin
+	 * @return bool
+	 */
+	public static function isSubAdmin($uid) {
+		// Check if the user is already an admin
+		if(OC_Group::inGroup($uid, 'admin' )) {
+			return true;
+		}
+
+		$stmt = OC_DB::prepare('SELECT COUNT(*) AS `count` FROM `*PREFIX*group_admin` WHERE `uid` = ?');
+		$result = $stmt->execute(array($uid));
+		$result = $result->fetchRow();
+		if($result['count'] > 0) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * checks if a user is a accessible by a subadmin
+	 * @param string $subadmin uid of the subadmin
+	 * @param string $user uid of the user
+	 * @return bool
+	 */
+	public static function isUserAccessible($subadmin, $user) {
+		if(!self::isSubAdmin($subadmin)) {
+			return false;
+		}
+		if(OC_User::isAdminUser($user)) {
+			return false;
+		}
+		$accessiblegroups = self::getSubAdminsGroups($subadmin);
+		foreach($accessiblegroups as $accessiblegroup) {
+			if(OC_Group::inGroup($user, $accessiblegroup)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/*
+	 * alias for self::isSubAdminofGroup()
+	 */
+	public static function isGroupAccessible($subadmin, $group) {
+		return self::isSubAdminofGroup($subadmin, $group);
+	}
+
+	/**
+	 * delete all SubAdmins by uid
+	 * @param array $parameters
+	 * @return boolean
+	 */
+	public static function post_deleteUser($parameters) {
+		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `uid` = ?');
+		$stmt->execute(array($parameters['uid']));
+		return true;
+	}
+
+	/**
+	 * delete all SubAdmins by gid
+	 * @param array $parameters
+	 * @return boolean
+	 */
+	public static function post_deleteGroup($parameters) {
+		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `gid` = ?');
+		$stmt->execute(array($parameters['gid']));
+		return true;
+	}
+}

--- a/lib/private/subadmin.php
+++ b/lib/private/subadmin.php
@@ -2,10 +2,9 @@
 /**
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Georg Ehrke <georg@owncloud.com>
- * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@owncloud.com>
  * @author Morris Jobke <hey@morrisjobke.de>
- * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
@@ -24,171 +23,235 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-OC_Hook::connect('OC_User', 'post_deleteUser', 'OC_SubAdmin', 'post_deleteUser');
-OC_Hook::connect('OC_User', 'post_deleteGroup', 'OC_SubAdmin', 'post_deleteGroup');
-/**
- * This class provides all methods needed for managing groups.
- *
- * Hooks provided:
- *   post_createSubAdmin($gid)
- *   post_deleteSubAdmin($gid)
- */
-class OC_SubAdmin{
+
+namespace OC;
+
+use OC\Hooks\PublicEmitter;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IDBConnection;
+
+class SubAdmin extends PublicEmitter {
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var IGroupManager */
+	private $groupManager;
+
+	/** @var IDBConnection */
+	private $dbConn;
+
+	public function __construct(IUserManager $userManager,
+	                            IGroupManager $groupManager,
+								IDBConnection $dbConn) {
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->dbConn = $dbConn;
+
+		$this->userManager->listen('\OC\User', 'postDelete', function($user) {
+			$this->post_deleteUser($user);
+		});
+		$this->groupManager->listen('\OC\Group', 'postDelete', function($group) {
+			$this->post_deleteGroup($group);	
+		});
+	}
 
 	/**
 	 * add a SubAdmin
-	 * @param string $uid uid of the SubAdmin
-	 * @param string $gid gid of the group
-	 * @return boolean
+	 * @param IUser $user user to be SubAdmin
+	 * @param IGroup $group group $user becomes subadmin of
+	 * @return bool
 	 */
-	public static function createSubAdmin($uid, $gid) {
-		$stmt = OC_DB::prepare('INSERT INTO `*PREFIX*group_admin` (`gid`,`uid`) VALUES(?,?)');
-		$stmt->execute(array($gid, $uid));
-		OC_Hook::emit( "OC_SubAdmin", "post_createSubAdmin", array( "gid" => $gid ));
+	public function createSubAdmin(IUser $user, IGroup $group) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->insert('group_admin')
+			->values([
+				'gid' => $qb->createNamedParameter($group->getGID()),
+				'uid' => $qb->createNamedParameter($user->getUID())
+			])
+			->execute();
+
+		$this->emit('\OC\SubAdmin', 'postCreateSubAdmin', [$user, $group]);
+		\OC_Hook::emit("OC_SubAdmin", "post_createSubAdmin", ["gid" => $group->getGID()]);
 		return true;
 	}
 
 	/**
 	 * delete a SubAdmin
-	 * @param string $uid uid of the SubAdmin
-	 * @param string $gid gid of the group
-	 * @return boolean
+	 * @param IUser $user the user that is the SubAdmin
+	 * @param IGroup $group the group
+	 * @return bool
 	 */
-	public static function deleteSubAdmin($uid, $gid) {
-		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `gid` = ? AND `uid` = ?');
-		$stmt->execute(array($gid, $uid));
-		OC_Hook::emit( "OC_SubAdmin", "post_deleteSubAdmin", array( "gid" => $gid ));
+	public function deleteSubAdmin(IUser $user, IGroup $group) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->delete('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
+			->execute();
+
+		$this->emit('\OC\SubAdmin', 'postDeleteSubAdmin', [$user, $group]);
+		\OC_Hook::emit("OC_SubAdmin", "post_deleteSubAdmin", ["gid" => $group->getGID()]);
 		return true;
 	}
 
 	/**
 	 * get groups of a SubAdmin
-	 * @param string $uid uid of the SubAdmin
-	 * @return array
+	 * @param IUser $user the SubAdmin
+	 * @return IGroup[]
 	 */
-	public static function getSubAdminsGroups($uid) {
-		$stmt = OC_DB::prepare('SELECT `gid` FROM `*PREFIX*group_admin` WHERE `uid` = ?');
-		$result = $stmt->execute(array($uid));
-		$gids = array();
-		while($row = $result->fetchRow()) {
-			$gids[] = $row['gid'];
+	public function getSubAdminsGroups(IUser $user) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->select('gid')
+			->from('group_admin')
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
+			->execute();
+
+		$groups = [];
+		while($row = $result->fetch()) {
+			$groups[] = $this->groupManager->get($row['gid']);
 		}
-		return $gids;
+
+		return $groups;
 	}
 
 	/**
 	 * get SubAdmins of a group
-	 * @param string $gid gid of the group
-	 * @return array
+	 * @param IGroup $group the group
+	 * @return IUser[]
 	 */
-	public static function getGroupsSubAdmins($gid) {
-		$stmt = OC_DB::prepare('SELECT `uid` FROM `*PREFIX*group_admin` WHERE `gid` = ?');
-		$result = $stmt->execute(array($gid));
-		$uids = array();
-		while($row = $result->fetchRow()) {
-			$uids[] = $row['uid'];
+	public function getGroupsSubAdmins(IGroup $group) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->select('uid')
+			->from('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
+			->execute();
+
+		$users = [];
+		while($row = $result->fetch()) {
+			$users[] = $this->userManager->get($row['uid']);
 		}
-		return $uids;
+
+		return $users;
 	}
 
 	/**
 	 * get all SubAdmins
 	 * @return array
 	 */
-	public static function getAllSubAdmins() {
-		$stmt = OC_DB::prepare('SELECT * FROM `*PREFIX*group_admin`');
-		$result = $stmt->execute();
-		$subadmins = array();
-		while($row = $result->fetchRow()) {
-			$subadmins[] = $row;
+	public function getAllSubAdmins() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->select('*')
+			->from('group_admin')
+			->execute();
+
+		$subadmins = [];
+		while($row = $result->fetch()) {
+			$subadmins[] = [
+				'user'  => $this->userManager->get($row['uid']),
+				'group' => $this->groupManager->get($row['gid'])
+			];
 		}
 		return $subadmins;
 	}
 
 	/**
 	 * checks if a user is a SubAdmin of a group
-	 * @param string $uid uid of the subadmin
-	 * @param string $gid gid of the group
+	 * @param IUser $user 
+	 * @param IGroup $group
 	 * @return bool
 	 */
-	public static function isSubAdminofGroup($uid, $gid) {
-		$stmt = OC_DB::prepare('SELECT COUNT(*) AS `count` FROM `*PREFIX*group_admin` WHERE `uid` = ? AND `gid` = ?');
-		$result = $stmt->execute(array($uid, $gid));
-		$result = $result->fetchRow();
-		if($result['count'] >= 1) {
-			return true;
-		}
-		return false;
+	public function isSubAdminofGroup(IUser $user, IGroup $group) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->select('*')
+			->from('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
+			->execute();
+
+		return !empty($result->fetch()) ? true : false;
 	}
 
 	/**
 	 * checks if a user is a SubAdmin
-	 * @param string $uid uid of the subadmin
+	 * @param IUser $user 
 	 * @return bool
 	 */
-	public static function isSubAdmin($uid) {
+	public function isSubAdmin(IUser $user) {
 		// Check if the user is already an admin
-		if(OC_Group::inGroup($uid, 'admin' )) {
+		if ($this->groupManager->isAdmin($user->getUID())) {
 			return true;
 		}
 
-		$stmt = OC_DB::prepare('SELECT COUNT(*) AS `count` FROM `*PREFIX*group_admin` WHERE `uid` = ?');
-		$result = $stmt->execute(array($uid));
-		$result = $result->fetchRow();
-		if($result['count'] > 0) {
-			return true;
-		}
-		return false;
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->select('gid')
+			->from('group_admin')
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
+			->setMaxResults(1)
+			->execute()
+			->fetch();
+
+		return $result === false ? false : true;
 	}
 
 	/**
 	 * checks if a user is a accessible by a subadmin
-	 * @param string $subadmin uid of the subadmin
-	 * @param string $user uid of the user
+	 * @param IUser $subadmin
+	 * @param IUser $user
 	 * @return bool
 	 */
-	public static function isUserAccessible($subadmin, $user) {
-		if(!self::isSubAdmin($subadmin)) {
+	public function isUserAccessible($subadmin, $user) {
+		if(!$this->isSubAdmin($subadmin)) {
 			return false;
 		}
-		if(OC_User::isAdminUser($user)) {
+		if($this->groupManager->isAdmin($user->getUID())) {
 			return false;
 		}
-		$accessiblegroups = self::getSubAdminsGroups($subadmin);
+		$accessiblegroups = $this->getSubAdminsGroups($subadmin);
 		foreach($accessiblegroups as $accessiblegroup) {
-			if(OC_Group::inGroup($user, $accessiblegroup)) {
+			if($accessiblegroup->inGroup($user)) {
 				return true;
 			}
 		}
 		return false;
 	}
 
-	/*
-	 * alias for self::isSubAdminofGroup()
-	 */
-	public static function isGroupAccessible($subadmin, $group) {
-		return self::isSubAdminofGroup($subadmin, $group);
-	}
-
 	/**
-	 * delete all SubAdmins by uid
-	 * @param array $parameters
+	 * delete all SubAdmins by $user
+	 * @param IUser $user
 	 * @return boolean
 	 */
-	public static function post_deleteUser($parameters) {
-		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `uid` = ?');
-		$stmt->execute(array($parameters['uid']));
+	private function post_deleteUser($user) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->delete('group_admin')
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
+			->execute();
+
 		return true;
 	}
 
 	/**
-	 * delete all SubAdmins by gid
-	 * @param array $parameters
+	 * delete all SubAdmins by $group
+	 * @param IGroup $group
 	 * @return boolean
 	 */
-	public static function post_deleteGroup($parameters) {
-		$stmt = OC_DB::prepare('DELETE FROM `*PREFIX*group_admin` WHERE `gid` = ?');
-		$stmt->execute(array($parameters['gid']));
+	private function post_deleteGroup($group) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$result = $qb->delete('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
+			->execute();
+
 		return true;
 	}
 }

--- a/tests/lib/subadmin.php
+++ b/tests/lib/subadmin.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test;
+
+class SubAdmin extends \Test\TestCase {
+
+	/** @var \OCP\IUserManager */
+	private $userManager;
+
+	/** @var \OCP\IGroupManager */
+	private $groupManager;
+
+	/** @var \OCP\IDBConnection */
+	private $dbConn;
+
+	/** @var \OCP\IUser[] */
+	private $users;
+
+	/** @var \OCP\IGroup[] */
+	private $groups;
+	
+	public function setup() {
+		$this->users = [];
+		$this->groups = [];
+
+		$this->userManager = \OC::$server->getUserManager();
+		$this->groupManager = \OC::$server->getGroupManager();
+		$this->dbConn = \OC::$server->getDatabaseConnection();
+
+		// Create 3 users and 3 groups
+		for ($i = 0; $i < 3; $i++) {
+			$this->users[] = $this->userManager->createUser('user'.$i, 'user');
+			$this->groups[] = $this->groupManager->createGroup('group'.$i);
+		}
+
+		// Create admin group
+		if (!$this->groupManager->groupExists('admin')) {
+			$this->groupManager->createGroup('admin');
+		}
+	}
+
+	public function tearDown() {
+		foreach($this->users as $user) {
+			$user->delete();
+		}
+
+		foreach($this->groups as $group) {
+			$group->delete();
+		}
+	}
+
+	public function testCreateSubAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+
+		// Look for subadmin in the database
+		$qb = $this->dbConn->getQueryBuilder();
+		$result = $qb->select(['gid', 'uid'])
+			->from('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
+			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
+			->execute()
+			->fetch();
+		$this->assertEquals(
+			[
+				'gid' => $this->groups[0]->getGID(), 
+				'uid' => $this->users[0]->getUID()
+			], $result);
+
+		// Delete subadmin
+		$result = $qb->delete('*PREFIX*group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
+			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
+			->execute();
+	}
+
+	public function testDeleteSubAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+
+		// DB query should be empty
+		$qb = $this->dbConn->getQueryBuilder();
+		$result = $qb->select(['gid', 'uid'])
+			->from('group_admin')
+			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
+			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
+			->execute()
+			->fetch();
+		$this->assertEmpty($result);
+	}
+
+	public function testGetSubAdminsGroups() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[1]));
+
+		$result = $subAdmin->getSubAdminsGroups($this->users[0]);
+		
+		$this->assertContains($this->groups[0], $result);
+		$this->assertContains($this->groups[1], $result);
+		$this->assertNotContains($this->groups[2], $result);
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[1]));
+	}
+
+	public function testGetGroupsSubAdmins() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[1], $this->groups[0]));
+
+		$result = $subAdmin->getGroupsSubAdmins($this->groups[0]);
+		
+		$this->assertContains($this->users[0], $result);
+		$this->assertContains($this->users[1], $result);
+		$this->assertNotContains($this->users[2], $result);
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[1], $this->groups[0]));
+	}
+
+	public function testGetAllSubAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[1], $this->groups[1]));
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[2], $this->groups[1]));
+
+		$result = $subAdmin->getAllSubAdmins();
+
+		$this->assertContains(['user' => $this->users[0], 'group' => $this->groups[0]], $result);
+		$this->assertContains(['user' => $this->users[1], 'group' => $this->groups[1]], $result);
+		$this->assertContains(['user' => $this->users[2], 'group' => $this->groups[1]], $result);
+	}
+
+	public function testIsSubAdminofGroup() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+
+		$this->assertTrue($subAdmin->isSubAdminOfGroup($this->users[0], $this->groups[0]));
+		$this->assertFalse($subAdmin->isSubAdminOfGroup($this->users[0], $this->groups[1]));
+		$this->assertFalse($subAdmin->isSubAdminOfGroup($this->users[1], $this->groups[0]));
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+	}
+
+	public function testIsSubAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+
+		$this->assertTrue($subAdmin->isSubAdmin($this->users[0]));
+		$this->assertFalse($subAdmin->isSubAdmin($this->users[1]));
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+	}
+
+	public function testIsSubAdminAsAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->groupManager->get('admin')->addUser($this->users[0]);
+
+		$this->assertTrue($subAdmin->isSubAdmin($this->users[0]));
+	}
+
+	public function testIsUserAccessible() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->groups[0]->addUser($this->users[1]);
+		$this->groups[1]->addUser($this->users[1]);
+		$this->groups[1]->addUser($this->users[2]);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[2], $this->groups[2]));
+
+		$this->assertTrue($subAdmin->isUserAccessible($this->users[0], $this->users[1]));
+		$this->assertFalse($subAdmin->isUserAccessible($this->users[0], $this->users[2]));
+		$this->assertFalse($subAdmin->isUserAccessible($this->users[2], $this->users[0]));
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[0], $this->groups[0]));
+		$this->assertTrue($subAdmin->deleteSubAdmin($this->users[2], $this->groups[2]));
+	}
+
+	public function testIsUserAccessibleAsUser() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertFalse($subAdmin->isUserAccessible($this->users[0], $this->users[1]));
+	}
+
+	public function testIsUserAccessibleAdmin() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+		$this->assertTrue($subAdmin->createSubAdmin($this->users[0], $this->groups[0]));
+		$this->groupManager->get('admin')->addUser($this->users[1]);
+
+		$this->assertFalse($subAdmin->isUserAccessible($this->users[0], $this->users[1]));
+
+	}
+
+	public function testPostDeleteUser() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+
+		$user = array_shift($this->users);
+		foreach($this->groups as $group) {
+			$this->assertTrue($subAdmin->createSubAdmin($user, $group));
+		}
+
+		$user->delete();
+		$this->assertEmpty($subAdmin->getAllSubAdmins());
+	}
+
+	public function testPostDeleteGroup() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+
+		$group = array_shift($this->groups);
+		foreach($this->users as $user) {
+			$this->assertTrue($subAdmin->createSubAdmin($user, $group));
+		}
+
+		$group->delete();
+		$this->assertEmpty($subAdmin->getAllSubAdmins());
+	}
+
+	public function testHooks() {
+		$subAdmin = new \OC\SubAdmin($this->userManager, $this->groupManager, $this->dbConn);
+
+		$test = $this;
+		$u = $this->users[0];
+		$g = $this->groups[0];
+		$count = 0;
+
+		$subAdmin->listen('\OC\SubAdmin', 'postCreateSubAdmin', function ($user, $group) use ($test, $u, $g, &$count) {
+			$test->assertEquals($u->getUID(), $user->getUID());
+			$test->assertEquals($g->getGID(), $group->getGID());
+			$count++;
+		});
+
+		$subAdmin->listen('\OC\SubAdmin', 'postDeleteSubAdmin', function ($user, $group) use ($test, $u, $g, &$count) {
+			$test->assertEquals($u->getUID(), $user->getUID());
+			$test->assertEquals($g->getGID(), $group->getGID());
+			$count++;
+		});
+
+		$this->assertTrue($subAdmin->createSubAdmin($u, $g));
+		$this->assertEquals(1, $count);
+
+		$this->assertTrue($subAdmin->deleteSubAdmin($u, $g));
+		$this->assertEquals(2, $count);
+	}
+
+}


### PR DESCRIPTION
While trying to get the core apps more compliant I can across OC_SubAdmin. Which is not only static in its current form (so no proper testing :( ) but also lacks an OCP interface. So no change in passing the tests in its current form.

First commit moves from a static OC_SubAdmin to OC\SubAdmin.

Lot of files are modified to still pass the unit tests. But even after that grep still showed a lot of occurences of OC_SubAdmin :( (so we have still to much untested code...)

TODO:
- [x] DI
- [ ] ~~OCP Interface~~
- [x] Add unit tests
- [x] Still fire original hooks
- [x] Move out of servercontainer

CC: @LukasReschke @DeepDiver1975
