### PR TITLE
[avatar] add error handlers for avatar setup

### DIFF
--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -134,6 +134,10 @@ class AvatarController extends Controller {
 		if (isset($path)) {
 			$path = stripslashes($path);
 			$view = new \OC\Files\View('/'.$userId.'/files');
+			if ($view->filesize($path) > 20*1024*1024) {
+				return new DataResponse(['data' => ['message' => $this->l->t('File is too big')]],
+					Http::STATUS_BAD_REQUEST);
+			}
 			$fileName = $view->getLocalFile($path);
 		} elseif (!is_null($files)) {
 			if (
@@ -141,6 +145,10 @@ class AvatarController extends Controller {
 				 is_uploaded_file($files['tmp_name'][0]) &&
 				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
 			) {
+				if ($files['size'][0] > 20*1024*1024) {
+					return new DataResponse(['data' => ['message' => $this->l->t('File is too big')]],
+						Http::STATUS_BAD_REQUEST);
+				}
 				$this->cache->set('avatar_upload', file_get_contents($files['tmp_name'][0]), 7200);
 				$view = new \OC\Files\View('/'.$userId.'/cache');
 				$fileName = $view->getLocalFile('avatar_upload');

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -234,6 +234,20 @@ $(document).ready(function () {
 	var uploadparms = {
 		done: function (e, data) {
 			avatarResponseHandler(data.result);
+		},
+		fail: function (e, data){
+			var msg = data.jqXHR.statusText + ' (' + data.jqXHR.status + ')';
+			if (!_.isUndefined(data.jqXHR.responseJSON) &&
+				!_.isUndefined(data.jqXHR.responseJSON.data) &&
+				!_.isUndefined(data.jqXHR.responseJSON.data.message)
+			) {
+				msg = data.jqXHR.responseJSON.data.message;
+			}
+			avatarResponseHandler({
+			data: {
+					message: t('settings', 'An error occurred: {message}', { message: msg })
+				}
+			});
 		}
 	};
 
@@ -247,7 +261,25 @@ $(document).ready(function () {
 		OC.dialogs.filepicker(
 			t('settings', "Select a profile picture"),
 			function (path) {
-				$.post(OC.generateUrl('/avatar/'), {path: path}, avatarResponseHandler);
+				$.ajax({
+					type: "POST",
+					url: OC.generateUrl('/avatar/'),
+					data: { path: path }
+				}).done(avatarResponseHandler)
+					.fail(function(jqXHR, status){
+						var msg = jqXHR.statusText + ' (' + jqXHR.status + ')';
+						if (!_.isUndefined(jqXHR.responseJSON) &&
+							!_.isUndefined(jqXHR.responseJSON.data) &&
+							!_.isUndefined(jqXHR.responseJSON.data.message)
+						) {
+							msg = jqXHR.responseJSON.data.message;
+						}
+						avatarResponseHandler({
+							data: {
+								message: t('settings', 'An error occurred: {message}', { message: msg })
+							}
+						});
+					});
 			},
 			false,
 			["image/png", "image/jpeg"]

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -159,7 +159,7 @@ if($_['passwordChangeSupported']) {
 		<input type="file" class="hidden" name="files[]" id="uploadavatar">
 		<div class="inlineblock button" id="selectavatar"><?php p($l->t('Select new from Files')); ?></div>
 		<div class="inlineblock button" id="removeavatar"><?php p($l->t('Remove image')); ?></div><br>
-		<?php p($l->t('Either png or jpg. Ideally square but you will be able to crop it.')); ?>
+		<?php p($l->t('Either png or jpg. Ideally square but you will be able to crop it. The file is not allowed to exceed the maximum size of 20 MB.')); ?>
 		<?php else: ?>
 		<?php p($l->t('Your avatar is provided by your original account.')); ?>
 		<?php endif; ?>

--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -23,7 +23,6 @@ namespace OC\Core\Avatar;
 use OC;
 use OC\Core\Application;
 use OCP\AppFramework\IAppContainer;
-use OCP\Security\ISecureRandom;
 use OC\Files\Filesystem;
 use OCP\AppFramework\Http;
 use OCP\Image;
@@ -264,7 +263,7 @@ class AvatarControllerTest extends \Test\TestCase {
 		$view->file_put_contents('avatar_upload', file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.jpg'));
 
 		//Create request return
-		$reqRet = ['error' => [0], 'tmp_name' => [$fileName]];
+		$reqRet = ['error' => [0], 'tmp_name' => [$fileName], 'size' => [filesize(OC::$SERVERROOT.'/tests/data/testimage.jpg')]];
 		$this->container['Request']->method('getUploadedFile')->willReturn($reqRet);
 
 		$response = $this->avatarController->postAvatar(null);
@@ -303,7 +302,7 @@ class AvatarControllerTest extends \Test\TestCase {
 		$view->file_put_contents('avatar_upload', file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.gif'));
 
 		//Create request return
-		$reqRet = ['error' => [0], 'tmp_name' => [$fileName]];
+		$reqRet = ['error' => [0], 'tmp_name' => [$fileName], 'size' => filesize(OC::$SERVERROOT.'/tests/data/testimage.gif')];
 		$this->container['Request']->method('getUploadedFile')->willReturn($reqRet);
 
 		$response = $this->avatarController->postAvatar(null);
@@ -330,7 +329,7 @@ class AvatarControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * Test invalid crop argment
+	 * Test invalid crop argument
 	 */
 	public function testPostCroppedAvatarInvalidCrop() {
 		$response = $this->avatarController->postCroppedAvatar([]);
@@ -370,6 +369,20 @@ class AvatarControllerTest extends \Test\TestCase {
 
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 		$this->assertEquals('success', $response->getData()['status']);
+	}
+
+	/**
+	 * Check for proper reply on proper crop argument
+	 */
+	public function testFileTooBig() {
+		$fileName = OC::$SERVERROOT.'/tests/data/testimage.jpg';
+		//Create request return
+		$reqRet = ['error' => [0], 'tmp_name' => [$fileName], 'size' => [21*1024*1024]];
+		$this->container['Request']->method('getUploadedFile')->willReturn($reqRet);
+
+		$response = $this->avatarController->postAvatar(null);
+
+		$this->assertEquals('File is too big', $response->getData()['data']['message']);
 	}
 
 }


### PR DESCRIPTION
Steps to reproduce:
- upload a huge image (i.e. https://commons.wikimedia.org/wiki/File:Bath_from_alexandra_park.jpg )
- upload it directly as avatar in the personal settings
- before: no error message, afterwards: error message
- upload the same file to files app
- go to personal settings
- click "Choose from files"
- choose the image
- before: no error message, afterwards: error message

cc @DeepDiver1975 @CaptionF @Kawohl @Henni @rullzer @Xenopathic @LukasReschke @oparoz 
