### PR TITLE
make sure that there is a space between user- and admin-documentation

### DIFF
--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -82,13 +82,13 @@ script(
 			<?php p($l->t("Documentation:"));?>
 			{{#if documentation.user}}
 			<span class="userDocumentation">
-			<a id='userDocumentation' class="appslink" href='{{documentation.user}}' target="_blank"><?php p($l->t("User Documentation"));?></a>
+			<a id="userDocumentation" class="appslink" href="{{documentation.user}}" target="_blank"><?php p($l->t('User documentation'));?> ↗</a>
 			</span>
 			{{/if}}
 
 			{{#if documentation.admin}}
 			<span class="adminDocumentation">
-			<a id='adminDocumentation' class="appslink" href='{{documentation.admin}}' target="_blank"><?php p($l->t("Admin Documentation"));?></a>
+			<a id="adminDocumentation" class="appslink" href="{{documentation.admin}}" target="_blank"><?php p($l->t('Admin documentation'));?> ↗</a>
 			</span>
 			{{/if}}
 		</p>

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -81,14 +81,14 @@ script(
 		<p class="documentation">
 			<?php p($l->t("Documentation:"));?>
 			{{#if documentation.user}}
-			<span class="userDocumentation appslink">
-			<a id='userDocumentation' href='{{documentation.user}}' target="_blank"><?php p($l->t("User Documentation"));?></a>
+			<span class="userDocumentation">
+			<a id='userDocumentation' class="appslink" href='{{documentation.user}}' target="_blank"><?php p($l->t("User Documentation"));?></a>
 			</span>
 			{{/if}}
 
 			{{#if documentation.admin}}
-			<span class="adminDocumentation appslink">
-			<a id='adminDocumentation' href='{{documentation.admin}}' target="_blank"><?php p($l->t("Admin Documentation"));?></a>
+			<span class="adminDocumentation">
+			<a id='adminDocumentation' class="appslink" href='{{documentation.admin}}' target="_blank"><?php p($l->t("Admin Documentation"));?></a>
 			</span>
 			{{/if}}
 		</p>


### PR DESCRIPTION
make sure that there is a space between user- and admin-documentation in the apps menu.

Before (no space between user and admin documentation, one continuous underline) :

![1](https://cloud.githubusercontent.com/assets/1589737/8824924/bad6e9a2-307a-11e5-88fe-568581e10545.png)

After (with a space):

![2](https://cloud.githubusercontent.com/assets/1589737/8824926/c042efd0-307a-11e5-958d-822e9982bcd0.png)

cc @jancborchardt 
