### PR TITLE
Wrap the entire dav PUT in a read lock

### DIFF
--- a/lib/private/connector/sabre/directory.php
+++ b/lib/private/connector/sabre/directory.php
@@ -30,6 +30,7 @@ namespace OC\Connector\Sabre;
 
 use OC\Connector\Sabre\Exception\InvalidPath;
 use OC\Connector\Sabre\Exception\FileLocked;
+use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Sabre\DAV\Exception\Locked;
 
@@ -110,6 +111,7 @@ class Directory extends \OC\Connector\Sabre\Node
 			// using a dummy FileInfo is acceptable here since it will be refreshed after the put is complete
 			$info = new \OC\Files\FileInfo($path, null, null, array(), null);
 			$node = new \OC\Connector\Sabre\File($this->fileView, $info);
+			$node->acquireLock(ILockingProvider::LOCK_SHARED);
 			return $node->put($data);
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -114,12 +114,6 @@ class File extends Node implements IFile {
 			$partFilePath = $this->path;
 		}
 
-		try {
-			$this->fileView->lockFile($this->path, ILockingProvider::LOCK_SHARED);
-		} catch (LockedException $e) {
-			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
-		}
-
 		// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
 		/** @var \OC\Files\Storage\Storage $partStorage */
 		list($partStorage, $internalPartPath) = $this->fileView->resolvePath($partFilePath);
@@ -176,7 +170,7 @@ class File extends Node implements IFile {
 			}
 
 			try {
-				$this->fileView->changeLock($this->path, ILockingProvider::LOCK_EXCLUSIVE);
+				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
 			} catch (LockedException $e) {
 				if ($needsPartFile) {
 					$partStorage->unlink($internalPartPath);
@@ -202,7 +196,7 @@ class File extends Node implements IFile {
 			}
 
 			try {
-				$this->fileView->changeLock($this->path, ILockingProvider::LOCK_SHARED);
+				$this->changeLock(ILockingProvider::LOCK_SHARED);
 			} catch (LockedException $e) {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
@@ -233,7 +227,6 @@ class File extends Node implements IFile {
 				}
 			}
 			$this->refreshInfo();
-			$this->fileView->unlockFile($this->path, ILockingProvider::LOCK_SHARED);
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
 		}

--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -205,8 +205,11 @@ class File extends Node implements IFile {
 		return '"' . $this->info->getEtag() . '"';
 	}
 
-	private function emitPreHooks($exists) {
-		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($this->path));
+	private function emitPreHooks($exists, $path = null) {
+		if (is_null($path)) {
+			$path = $this->path;
+		}
+		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($path));
 		$run = true;
 
 		if (!$exists) {
@@ -226,8 +229,11 @@ class File extends Node implements IFile {
 		));
 	}
 
-	private function emitPostHooks($exists) {
-		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($this->path));
+	private function emitPostHooks($exists, $path = null) {
+		if (is_null($path)) {
+			$path = $this->path;
+		}
+		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($path));
 		if (!$exists) {
 			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_create, array(
 				\OC\Files\Filesystem::signal_param_path => $hookPath
@@ -362,7 +368,7 @@ class File extends Node implements IFile {
 			$exists = $this->fileView->file_exists($targetPath);
 
 			try {
-				$this->emitPreHooks($exists);
+				$this->emitPreHooks($exists, $targetPath);
 
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
 
@@ -408,9 +414,9 @@ class File extends Node implements IFile {
 				$this->changeLock(ILockingProvider::LOCK_SHARED);
 
 				// since we skipped the view we need to scan and emit the hooks ourselves
-				$this->fileView->getUpdater()->update($this->path);
+				$this->fileView->getUpdater()->update($targetPath);
 
-				$this->emitPostHooks($exists);
+				$this->emitPostHooks($exists, $targetPath);
 
 				$info = $this->fileView->getFileInfo($targetPath);
 				return $info->getEtag();

--- a/lib/private/connector/sabre/lockplugin.php
+++ b/lib/private/connector/sabre/lockplugin.php
@@ -85,7 +85,11 @@ class LockPlugin extends ServerPlugin {
 		if ($request->getMethod() !== 'PUT') {
 			return;
 		}
-		$node = $this->tree->getNodeForPath($request->getPath());
+		try {
+			$node = $this->tree->getNodeForPath($request->getPath());
+		} catch (NotFound $e) {
+			return;
+		}
 		if ($node instanceof Node) {
 			$node->releaseLock(ILockingProvider::LOCK_SHARED);
 		}

--- a/lib/private/connector/sabre/lockplugin.php
+++ b/lib/private/connector/sabre/lockplugin.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Connector\Sabre;
+
+use OC\Connector\Sabre\Exception\FileLocked;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use Sabre\DAV\Exception\NotFound;
+use \Sabre\DAV\PropFind;
+use \Sabre\DAV\PropPatch;
+use Sabre\DAV\ServerPlugin;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class LockPlugin extends ServerPlugin {
+	/**
+	 * Reference to main server object
+	 *
+	 * @var \Sabre\DAV\Server
+	 */
+	private $server;
+
+	/**
+	 * @var \Sabre\DAV\Tree
+	 */
+	private $tree;
+
+	/**
+	 * @param \Sabre\DAV\Tree $tree tree
+	 */
+	public function __construct(Tree $tree) {
+		$this->tree = $tree;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function initialize(\Sabre\DAV\Server $server) {
+		$this->server = $server;
+		$this->server->on('beforeMethod', [$this, 'getLock'], 50);
+		$this->server->on('afterMethod', [$this, 'releaseLock'], 50);
+	}
+
+	public function getLock(RequestInterface $request) {
+		// we cant listen on 'beforeMethod:PUT' due to order of operations with setting up the tree
+		// so instead we limit ourselves to the PUT method manually
+		if ($request->getMethod() !== 'PUT') {
+			return;
+		}
+		try {
+			$node = $this->tree->getNodeForPath($request->getPath());
+		} catch (NotFound $e) {
+			return;
+		}
+		if ($node instanceof Node) {
+			try {
+				$node->acquireLock(ILockingProvider::LOCK_SHARED);
+			} catch (LockedException $e) {
+				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
+			}
+		}
+	}
+
+	public function releaseLock(RequestInterface $request) {
+		if ($request->getMethod() !== 'PUT') {
+			return;
+		}
+		$node = $this->tree->getNodeForPath($request->getPath());
+		if ($node instanceof Node) {
+			$node->releaseLock(ILockingProvider::LOCK_SHARED);
+		}
+	}
+}

--- a/lib/private/connector/sabre/node.php
+++ b/lib/private/connector/sabre/node.php
@@ -67,6 +67,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	/**
 	 * Sets up the node, expects a full path name
+	 *
 	 * @param \OC\Files\View $view
 	 * @param \OCP\Files\FileInfo $info
 	 */
@@ -82,6 +83,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	/**
 	 *  Returns the name of the node
+	 *
 	 * @return string
 	 */
 	public function getName() {
@@ -99,6 +101,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	/**
 	 * Renames the node
+	 *
 	 * @param string $name The new name
 	 * @throws \Sabre\DAV\Exception\BadRequest
 	 * @throws \Sabre\DAV\Exception\Forbidden
@@ -131,6 +134,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	/**
 	 * Returns the last modification time, as a unix timestamp
+	 *
 	 * @return int timestamp as integer
 	 */
 	public function getLastModified() {
@@ -212,7 +216,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	 * @return string|null
 	 */
 	public function getDavPermissions() {
-		$p ='';
+		$p = '';
 		if ($this->info->isShared()) {
 			$p .= 'S';
 		}
@@ -247,5 +251,26 @@ abstract class Node implements \Sabre\DAV\INode {
 		} catch (\OCP\Files\InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
 		}
+	}
+
+	/**
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 */
+	public function acquireLock($type) {
+		$this->fileView->lockFile($this->path, $type);
+	}
+
+	/**
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 */
+	public function releaseLock($type) {
+		$this->fileView->unlockFile($this->path, $type);
+	}
+
+	/**
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 */
+	public function changeLock($type) {
+		$this->fileView->changeLock($this->path, $type);
 	}
 }

--- a/lib/private/connector/sabre/serverfactory.php
+++ b/lib/private/connector/sabre/serverfactory.php
@@ -70,6 +70,7 @@ class ServerFactory {
 		$server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree));
 		$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin($this->config));
 		$server->addPlugin(new \OC\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
+		$server->addPlugin(new \OC\Connector\Sabre\LockPlugin($objectTree));
 
 		// wait with registering these until auth is handled and the filesystem is setup
 		$server->on('beforeMethod', function () use ($server, $objectTree, $viewCallBack) {

--- a/lib/private/filechunking.php
+++ b/lib/private/filechunking.php
@@ -178,27 +178,26 @@ class OC_FileChunking {
 	 * Assembles the chunks into the file specified by the path.
 	 * Also triggers the relevant hooks and proxies.
 	 *
-	 * @param string $path target path
+	 * @param \OC\Files\Storage\Storage $storage
+	 * @param string $path target path relative to the storage
+	 * @param string $absolutePath
+	 * @return bool assembled file size or false if file could not be created
 	 *
-	 * @return boolean assembled file size or false if file could not be created
-	 *
-	 * @throws \OC\InsufficientStorageException when file could not be fully
-	 * assembled due to lack of free space
+	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function file_assemble($path) {
-		$absolutePath = \OC\Files\Filesystem::normalizePath(\OC\Files\Filesystem::getView()->getAbsolutePath($path));
+	public function file_assemble($storage, $path, $absolutePath) {
 		$data = '';
 		// use file_put_contents as method because that best matches what this function does
 		if (\OC\Files\Filesystem::isValidPath($path)) {
-			$path = \OC\Files\Filesystem::getView()->getRelativePath($absolutePath);
-			$exists = \OC\Files\Filesystem::file_exists($path);
+			$exists = $storage->file_exists($path);
 			$run = true;
+			$hookPath = \OC\Files\Filesystem::getView()->getRelativePath($absolutePath);
 			if(!$exists) {
 				OC_Hook::emit(
 					\OC\Files\Filesystem::CLASSNAME,
 					\OC\Files\Filesystem::signal_create,
 					array(
-						\OC\Files\Filesystem::signal_param_path => $path,
+						\OC\Files\Filesystem::signal_param_path => $hookPath,
 						\OC\Files\Filesystem::signal_param_run => &$run
 					)
 				);
@@ -207,14 +206,14 @@ class OC_FileChunking {
 				\OC\Files\Filesystem::CLASSNAME,
 				\OC\Files\Filesystem::signal_write,
 				array(
-					\OC\Files\Filesystem::signal_param_path => $path,
+					\OC\Files\Filesystem::signal_param_path => $hookPath,
 					\OC\Files\Filesystem::signal_param_run => &$run
 				)
 			);
 			if(!$run) {
 				return false;
 			}
-			$target = \OC\Files\Filesystem::fopen($path, 'w');
+			$target = $storage->fopen($path, 'w');
 			if($target) {
 				$count = $this->assemble($target);
 				fclose($target);
@@ -222,13 +221,13 @@ class OC_FileChunking {
 					OC_Hook::emit(
 						\OC\Files\Filesystem::CLASSNAME,
 						\OC\Files\Filesystem::signal_post_create,
-						array( \OC\Files\Filesystem::signal_param_path => $path)
+						array( \OC\Files\Filesystem::signal_param_path => $hookPath)
 					);
 				}
 				OC_Hook::emit(
 					\OC\Files\Filesystem::CLASSNAME,
 					\OC\Files\Filesystem::signal_post_write,
-					array( \OC\Files\Filesystem::signal_param_path => $path)
+					array( \OC\Files\Filesystem::signal_param_path => $hookPath)
 				);
 				return $count > 0;
 			}else{

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -114,7 +114,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->atLeastOnce())
 			->method('resolvePath')
 			->will($this->returnCallback(
-				function($path) use ($storage){
+				function ($path) use ($storage) {
 					return [$storage, $path];
 				}
 			));
@@ -172,7 +172,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->atLeastOnce())
 			->method('resolvePath')
 			->will($this->returnCallback(
-				function($path) use ($storage){
+				function ($path) use ($storage) {
 					return [$storage, $path];
 				}
 			));
@@ -249,7 +249,15 @@ class File extends \Test\TestCase {
 
 		$file = new \OC\Connector\Sabre\File($view, $info);
 
-		return $file->put($this->getStream('test data'));
+		// beforeMethod locks
+		$view->lockFile($path, ILockingProvider::LOCK_SHARED);
+
+		$result = $file->put($this->getStream('test data'));
+
+		// afterMethod unlocks
+		$view->unlockFile($path, ILockingProvider::LOCK_SHARED);
+
+		return $result;
 	}
 
 	/**
@@ -431,7 +439,13 @@ class File extends \Test\TestCase {
 		// action
 		$thrown = false;
 		try {
+			// beforeMethod locks
+			$view->lockFile('/test.txt', ILockingProvider::LOCK_SHARED);
+
 			$file->put($this->getStream('test data'));
+
+			// afterMethod unlocks
+			$view->unlockFile('/test.txt', ILockingProvider::LOCK_SHARED);
 		} catch (\Sabre\DAV\Exception\BadRequest $e) {
 			$thrown = true;
 		}
@@ -458,7 +472,13 @@ class File extends \Test\TestCase {
 		// action
 		$thrown = false;
 		try {
+			// beforeMethod locks
+			$view->lockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
+
 			$file->put($this->getStream('test data'));
+
+			// afterMethod unlocks
+			$view->unlockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
 		} catch (\OC\Connector\Sabre\Exception\FileLocked $e) {
 			$thrown = true;
 		}
@@ -519,7 +539,13 @@ class File extends \Test\TestCase {
 		// action
 		$thrown = false;
 		try {
+			// beforeMethod locks
+			$view->lockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
+
 			$file->put($this->getStream('test data'));
+
+			// afterMethod unlocks
+			$view->unlockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
 		} catch (\OC\Connector\Sabre\Exception\InvalidPath $e) {
 			$thrown = true;
 		}
@@ -577,7 +603,13 @@ class File extends \Test\TestCase {
 		// action
 		$thrown = false;
 		try {
+			// beforeMethod locks
+			$view->lockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
+
 			$file->put($this->getStream('test data'));
+
+			// afterMethod unlocks
+			$view->unlockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
 		} catch (\Sabre\DAV\Exception\BadRequest $e) {
 			$thrown = true;
 		}
@@ -702,7 +734,7 @@ class File extends \Test\TestCase {
 		$eventHandler->expects($this->once())
 			->method('writeCallback')
 			->will($this->returnCallback(
-				function() use ($view, $path, &$wasLockedPre){
+				function () use ($view, $path, &$wasLockedPre) {
 					$wasLockedPre = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
 					$wasLockedPre = $wasLockedPre && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 				}
@@ -710,7 +742,7 @@ class File extends \Test\TestCase {
 		$eventHandler->expects($this->once())
 			->method('postWriteCallback')
 			->will($this->returnCallback(
-				function() use ($view, $path, &$wasLockedPost){
+				function () use ($view, $path, &$wasLockedPost) {
 					$wasLockedPost = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
 					$wasLockedPost = $wasLockedPost && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 				}
@@ -729,7 +761,13 @@ class File extends \Test\TestCase {
 			'postWriteCallback'
 		);
 
+		// beforeMethod locks
+		$view->lockFile($path, ILockingProvider::LOCK_SHARED);
+
 		$this->assertNotEmpty($file->put($this->getStream('test data')));
+
+		// afterMethod unlocks
+		$view->unlockFile($path, ILockingProvider::LOCK_SHARED);
 
 		$this->assertTrue($wasLockedPre, 'File was locked during pre-hooks');
 		$this->assertTrue($wasLockedPost, 'File was locked during post-hooks');

--- a/tests/lib/connector/sabre/file.php
+++ b/tests/lib/connector/sabre/file.php
@@ -210,7 +210,9 @@ class File extends \Test\TestCase {
 		$caughtException = null;
 		try {
 			// last chunk
+			$file->acquireLock(ILockingProvider::LOCK_SHARED);
 			$file->put('test data two');
+			$file->releaseLock(ILockingProvider::LOCK_SHARED);
 		} catch (\Exception $e) {
 			$caughtException = $e;
 		}

--- a/tests/lib/connector/sabre/requesttest/uploadtest.php
+++ b/tests/lib/connector/sabre/requesttest/uploadtest.php
@@ -19,18 +19,26 @@ class UploadTest extends RequestTest {
 		$this->assertEquals(201, $response->getStatus());
 		$this->assertTrue($view->file_exists('foo.txt'));
 		$this->assertEquals('asd', $view->file_get_contents('foo.txt'));
+
+		$info = $view->getFileInfo('foo.txt');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
+		$this->assertEquals(3, $info->getSize());
 	}
 
 	public function testUploadOverWrite() {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
-		$view->file_put_contents('foo.txt', 'bar');
+		$view->file_put_contents('foo.txt', 'foobar');
 
 		$response = $this->request($view, $user, 'pass', 'PUT', '/foo.txt', 'asd');
 
 		$this->assertEquals(204, $response->getStatus());
 		$this->assertEquals('asd', $view->file_get_contents('foo.txt'));
+
+		$info = $view->getFileInfo('foo.txt');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
+		$this->assertEquals(3, $info->getSize());
 	}
 
 	public function testChunkedUpload() {
@@ -49,6 +57,10 @@ class UploadTest extends RequestTest {
 		$this->assertTrue($view->file_exists('foo.txt'));
 
 		$this->assertEquals('asdbar', $view->file_get_contents('foo.txt'));
+
+		$info = $view->getFileInfo('foo.txt');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
+		$this->assertEquals(6, $info->getSize());
 	}
 
 	public function testChunkedUploadOverWrite() {
@@ -66,6 +78,10 @@ class UploadTest extends RequestTest {
 		$this->assertEquals(201, $response->getStatus());
 
 		$this->assertEquals('asdbar', $view->file_get_contents('foo.txt'));
+
+		$info = $view->getFileInfo('foo.txt');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
+		$this->assertEquals(6, $info->getSize());
 	}
 
 	public function testChunkedUploadOutOfOrder() {
@@ -84,5 +100,9 @@ class UploadTest extends RequestTest {
 		$this->assertTrue($view->file_exists('foo.txt'));
 
 		$this->assertEquals('asdbar', $view->file_get_contents('foo.txt'));
+
+		$info = $view->getFileInfo('foo.txt');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $info);
+		$this->assertEquals(6, $info->getSize());
 	}
 }


### PR DESCRIPTION
Acquire a read lock in the beforeMethod hook to ensure we have the file read locked when precondition checks are made.

Fixes #16569

cc @DeepDiver1975 @PVince81 
