### PR TITLE
Update blueimp-md5 to 1.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "blueimp-md5": "~1.0.1",
+    "blueimp-md5": "~1.1.0",
     "handlebars": "~1.3.0",
     "jcrop": "~0.9.12",
     "jquery": "~1.10.0",

--- a/core/vendor/blueimp-md5/.bower.json
+++ b/core/vendor/blueimp-md5/.bower.json
@@ -1,6 +1,6 @@
 {
   "name": "blueimp-md5",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "title": "JavaScript MD5",
   "description": "JavaScript MD5 implementation.",
   "keywords": [
@@ -35,19 +35,20 @@
       "url": "http://www.opensource.org/licenses/MIT"
     }
   ],
-  "devDependencies": {
-    "mocha": "1.11.0",
-    "expect.js": "0.2.0",
-    "uglify-js": "2.3.6"
-  },
   "main": "js/md5.js",
-  "_release": "1.0.3",
+  "ignore": [
+    "/*.*",
+    "css",
+    "js/demo.js",
+    "test"
+  ],
+  "_release": "1.1.0",
   "_resolution": {
     "type": "version",
-    "tag": "1.0.3",
-    "commit": "299407012031ac6f60f832d3b5fa975fcb88b550"
+    "tag": "1.1.0",
+    "commit": "b187bf0abe24bacbca83ea4799978b78829e7914"
   },
   "_source": "git://github.com/blueimp/JavaScript-MD5.git",
-  "_target": "~1.0.1",
+  "_target": "~1.1.0",
   "_originalSource": "blueimp-md5"
 }


### PR DESCRIPTION
Yes this is pretty empty, but it's the truth:

https://github.com/blueimp/JavaScript-MD5/compare/1.0.3...1.1.0

Nobrainer of the week: cc @PVince81 @rullzer @Xenopathic @oparoz @DeepDiver1975
