### PR TITLE
also log the class for dav exceptions

### DIFF
--- a/lib/private/connector/sabre/exceptionloggerplugin.php
+++ b/lib/private/connector/sabre/exceptionloggerplugin.php
@@ -95,6 +95,7 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 
 		$exception = [
 			'Message' => $message,
+			'Exception' => $exceptionClass,
 			'Code' => $ex->getCode(),
 			'Trace' => $ex->getTraceAsString(),
 			'File' => $ex->getFile(),


### PR DESCRIPTION
Make it consistent with the rest of our exception logging.

cc @DeepDiver1975 @PVince81 
