### PR TITLE
Move Provisioning API to OCP

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -21,30 +21,39 @@
  *
  */
 
-// Users
+namespace OCA\Provisioning_API\AppInfo;
+
 use OCP\API;
 
-API::register('get', '/cloud/users', array('OCA\Provisioning_API\Users', 'getUsers'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('post', '/cloud/users', array('OCA\Provisioning_API\Users', 'addUser'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/users/{userid}', array('OCA\Provisioning_API\Users', 'getUser'), 'provisioning_api', API::USER_AUTH);
-API::register('put', '/cloud/users/{userid}', array('OCA\Provisioning_API\Users', 'editUser'), 'provisioning_api', API::USER_AUTH);
-API::register('delete', '/cloud/users/{userid}', array('OCA\Provisioning_API\Users', 'deleteUser'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('get', '/cloud/users/{userid}/groups', array('OCA\Provisioning_API\Users', 'getUsersGroups'), 'provisioning_api', API::USER_AUTH);
-API::register('post', '/cloud/users/{userid}/groups', array('OCA\Provisioning_API\Users', 'addToGroup'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('delete', '/cloud/users/{userid}/groups', array('OCA\Provisioning_API\Users', 'removeFromGroup'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('post', '/cloud/users/{userid}/subadmins', array('OCA\Provisioning_API\Users', 'addSubAdmin'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('delete', '/cloud/users/{userid}/subadmins', array('OCA\Provisioning_API\Users', 'removeSubAdmin'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/users/{userid}/subadmins', array('OCA\Provisioning_API\Users', 'getUserSubAdminGroups'), 'provisioning_api', API::ADMIN_AUTH);
+// Users
+$users = new \OCA\Provisioning_API\Users(
+	\OC::$server->getUserManager(),
+	\OC::$server->getConfig(),
+	\OC::$server->getGroupManager()
+);
+API::register('get', '/cloud/users', [$users, 'getUsers'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('post', '/cloud/users', [$users, 'addUser'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/users/{userid}', [$users, 'getUser'], 'provisioning_api', API::USER_AUTH);
+API::register('put', '/cloud/users/{userid}', [$users, 'editUser'], 'provisioning_api', API::USER_AUTH);
+API::register('delete', '/cloud/users/{userid}', [$users, 'deleteUser'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('get', '/cloud/users/{userid}/groups', [$users, 'getUsersGroups'], 'provisioning_api', API::USER_AUTH);
+API::register('post', '/cloud/users/{userid}/groups', [$users, 'addToGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('delete', '/cloud/users/{userid}/groups', [$users, 'removeFromGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('post', '/cloud/users/{userid}/subadmins', [$users, 'addSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('delete', '/cloud/users/{userid}/subadmins', [$users, 'removeSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::ADMIN_AUTH);
 
 // Groups
-API::register('get', '/cloud/groups', array('OCA\Provisioning_API\Groups', 'getGroups'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('post', '/cloud/groups', array('OCA\Provisioning_API\Groups', 'addGroup'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('get', '/cloud/groups/{groupid}', array('OCA\Provisioning_API\Groups', 'getGroup'), 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('delete', '/cloud/groups/{groupid}', array('OCA\Provisioning_API\Groups', 'deleteGroup'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/groups/{groupid}/subadmins', array('OCA\Provisioning_API\Groups', 'getSubAdminsOfGroup'), 'provisioning_api', API::ADMIN_AUTH);
+$groups = new \OCA\Provisioning_API\Groups();
+API::register('get', '/cloud/groups', [$groups, 'getGroups'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('post', '/cloud/groups', [$groups, 'addGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('get', '/cloud/groups/{groupid}', [$groups, 'getGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
+API::register('delete', '/cloud/groups/{groupid}', [$groups, 'deleteGroup'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/groups/{groupid}/subadmins', [$groups, 'getSubAdminsOfGroup'], 'provisioning_api', API::ADMIN_AUTH);
 
 // Apps
-API::register('get', '/cloud/apps', array('OCA\Provisioning_API\Apps', 'getApps'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/apps/{appid}', array('OCA\Provisioning_API\Apps', 'getAppInfo'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('post', '/cloud/apps/{appid}', array('OCA\Provisioning_API\Apps', 'enable'), 'provisioning_api', API::ADMIN_AUTH);
-API::register('delete', '/cloud/apps/{appid}', array('OCA\Provisioning_API\Apps', 'disable'), 'provisioning_api', API::ADMIN_AUTH);
+$apps = new \OCA\Provisioning_API\Apps();
+API::register('get', '/cloud/apps', [$apps, 'getApps'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/apps/{appid}', [$apps, 'getAppInfo'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('post', '/cloud/apps/{appid}', [$apps, 'enable'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('delete', '/cloud/apps/{appid}', [$apps, 'disable'], 'provisioning_api', API::ADMIN_AUTH);

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -56,7 +56,9 @@ API::register('delete', '/cloud/groups/{groupid}', [$groups, 'deleteGroup'], 'pr
 API::register('get', '/cloud/groups/{groupid}/subadmins', [$groups, 'getSubAdminsOfGroup'], 'provisioning_api', API::ADMIN_AUTH);
 
 // Apps
-$apps = new \OCA\Provisioning_API\Apps();
+$apps = new \OCA\Provisioning_API\Apps(
+	\OC::$server->getAppManager()
+);
 API::register('get', '/cloud/apps', [$apps, 'getApps'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('get', '/cloud/apps/{appid}', [$apps, 'getAppInfo'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('post', '/cloud/apps/{appid}', [$apps, 'enable'], 'provisioning_api', API::ADMIN_AUTH);

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -44,7 +44,9 @@ API::register('delete', '/cloud/users/{userid}/subadmins', [$users, 'removeSubAd
 API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::ADMIN_AUTH);
 
 // Groups
-$groups = new \OCA\Provisioning_API\Groups();
+$groups = new \OCA\Provisioning_API\Groups(
+	\OC::$server->getGroupManager()
+);
 API::register('get', '/cloud/groups', [$groups, 'getGroups'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('post', '/cloud/groups', [$groups, 'addGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('get', '/cloud/groups/{groupid}', [$groups, 'getGroup'], 'provisioning_api', API::SUBADMIN_AUTH);

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -29,7 +29,8 @@ use OCP\API;
 $users = new \OCA\Provisioning_API\Users(
 	\OC::$server->getUserManager(),
 	\OC::$server->getConfig(),
-	\OC::$server->getGroupManager()
+	\OC::$server->getGroupManager(),
+	\OC::$server->getUserSession()
 );
 API::register('get', '/cloud/users', [$users, 'getUsers'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('post', '/cloud/users', [$users, 'addUser'], 'provisioning_api', API::ADMIN_AUTH);
@@ -45,7 +46,8 @@ API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdmi
 
 // Groups
 $groups = new \OCA\Provisioning_API\Groups(
-	\OC::$server->getGroupManager()
+	\OC::$server->getGroupManager(),
+	\OC::$server->getUserSession()
 );
 API::register('get', '/cloud/groups', [$groups, 'getGroups'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('post', '/cloud/groups', [$groups, 'addGroup'], 'provisioning_api', API::SUBADMIN_AUTH);

--- a/apps/provisioning_api/lib/apps.php
+++ b/apps/provisioning_api/lib/apps.php
@@ -28,7 +28,14 @@ use \OC_App;
 
 class Apps {
 
-	public static function getApps($parameters){
+	/** @var \OCP\App\IAppManager */
+	private $appManager;
+
+	public function __construct(\OCP\App\IAppManager $appManager) {
+		$this->appManager = $appManager;
+	}
+
+	public function getApps($parameters){
 		$apps = OC_App::listAllApps();
 		$list = array();
 		foreach($apps as $app) {
@@ -55,9 +62,9 @@ class Apps {
 		}
 	}
 
-	public static function getAppInfo($parameters){
+	public function getAppInfo($parameters){
 		$app = $parameters['appid'];
-		$info = OC_App::getAppInfo($app);
+		$info = \OCP\App::getAppInfo($app);
 		if(!is_null($info)) {
 			return new OC_OCS_Result(OC_App::getAppInfo($app));
 		} else {
@@ -65,15 +72,15 @@ class Apps {
 		}
 	}
 
-	public static function enable($parameters){
+	public function enable($parameters){
 		$app = $parameters['appid'];
-		OC_App::enable($app);
+		$this->appManager->enableApp($app);
 		return new OC_OCS_Result(null, 100);
 	}
 
-	public static function disable($parameters){
+	public function disable($parameters){
 		$app = $parameters['appid'];
-		OC_App::disable($app);
+		$this->appManager->disableApp($app);
 		return new OC_OCS_Result(null, 100);
 	}
 

--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -31,11 +31,17 @@ class Groups{
 	/** @var \OCP\IGroupManager */
 	private $groupManager;
 
+	/** @var \OCP\IUserSession */
+	private $userSession;
+
 	/**
 	 * @param \OCP\IGroupManager $groupManager
+	 * @param \OCP\IUserSession $userSession
 	 */
-	public function __construct(\OCP\IGroupManager $groupManager) {
+	public function __construct(\OCP\IGroupManager $groupManager,
+	                            \OCP\IUserSession $userSession) {
 		$this->groupManager = $groupManager;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -63,8 +69,8 @@ class Groups{
 			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested group could not be found');
 		}
 		// Check subadmin has access to this group
-		if($this->groupManager->isAdmin(\OC_User::getUser())
-			|| in_array($parameters['groupid'], \OC_SubAdmin::getSubAdminsGroups(\OC_User::getUser()))){
+		if($this->groupManager->isAdmin($this->userSession->getUser()->getUID())
+			|| in_array($parameters['groupid'], \OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID()))){
 			$users = $this->groupManager->get($parameters['groupid'])->getUsers();
 			$users =  array_map(function($user) {
 				return $user->getUID();

--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -102,9 +102,9 @@ class Groups{
 
 	public function deleteGroup($parameters){
 		// Check it exists
-		if(!$this->groupManager->grouExists($parameters['groupid'])){
+		if(!$this->groupManager->groupExists($parameters['groupid'])){
 			return new OC_OCS_Result(null, 101);
-		} else if($parameters['groupid'] === 'admin' || !$this->groupManger->get($parameters['groupid'])->delete()){
+		} else if($parameters['groupid'] === 'admin' || !$this->groupManager->get($parameters['groupid'])->delete()){
 			// Cannot delete admin group
 			return new OC_OCS_Result(null, 102);
 		} else {

--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -63,14 +63,20 @@ class Groups{
 	/**
 	 * returns an array of users in the group specified
 	 */
-	public function getGroup($parameters){
+	public function getGroup($parameters) {
+		// Check if user is logged in
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
+		}
+
 		// Check the group exists
 		if(!$this->groupManager->groupExists($parameters['groupid'])){
 			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'The requested group could not be found');
 		}
 		// Check subadmin has access to this group
-		if($this->groupManager->isAdmin($this->userSession->getUser()->getUID())
-			|| in_array($parameters['groupid'], \OC_SubAdmin::getSubAdminsGroups($this->userSession->getUser()->getUID()))){
+		if($this->groupManager->isAdmin($user->getUID())
+		   || in_array($parameters['groupid'], \OC_SubAdmin::getSubAdminsGroups($user->getUID()))){
 			$users = $this->groupManager->get($parameters['groupid'])->getUsers();
 			$users =  array_map(function($user) {
 				return $user->getUID();

--- a/apps/provisioning_api/lib/users.php
+++ b/apps/provisioning_api/lib/users.php
@@ -184,7 +184,7 @@ class Users {
 					if (is_numeric($quota)) {
 						$quota = floatval($quota);
 					} else {
-						$quota = OC_Helper::computerFileSize($quota);
+						$quota = \OCP\Util::computerFileSize($quota);
 					}
 					if ($quota === false) {
 						return new OC_OCS_Result(null, 103, "Invalid quota value {$parameters['_put']['value']}");
@@ -194,7 +194,7 @@ class Users {
 					}else if($quota === -1){
 						$quota = 'none';
 					} else {
-						$quota = OC_Helper::humanFileSize($quota);
+						$quota = \OCP\Util::humanFileSize($quota);
 					}
 				}
 				$this->config->setUserValue($userId, 'files', 'quota', $quota);

--- a/apps/provisioning_api/lib/users.php
+++ b/apps/provisioning_api/lib/users.php
@@ -130,7 +130,7 @@ class Users {
 		$data = self::fillStorageInfo($userId, $data);
 		$data['enabled'] = $this->config->getUserValue($userId, 'core', 'enabled', 'true');
 		$data['email'] = $this->config->getUserValue($userId, 'settings', 'email');
-		$data['displayname'] = $this->userManager->get($parameters['userid']);
+		$data['displayname'] = $this->userManager->get($parameters['userid'])->getDisplayName();
 
 		// Return the appropriate data
 		$responseData = array();

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -87,6 +87,12 @@ class AppsTest extends TestCase {
 		}
 		$disabled = array_diff($list, \OC_App::getEnabledApps());
 		$this->assertEquals(count($disabled), count($data['apps']));
+	}
 
+	public function testGetAppsInvalidFilter() {
+		$_GET['filter'] = 'foo';
+		$result = $this->api->getApps([]);
+		$this->assertFalse($result->succeeded());
+		$this->assertEquals(101, $result->getStatusCode());
 	}
 }

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -29,6 +29,8 @@ class AppsTest extends TestCase {
 	public function setup() {
 		parent::setup();
 		$this->appManager = \OC::$server->getAppManager();
+		$this->groupManager = \OC::$server->getGroupManager();
+		$this->userSession = \OC::$server->getUserSession();
 		$this->api = new \OCA\Provisioning_API\Apps($this->appManager);
 	}
 
@@ -51,8 +53,8 @@ class AppsTest extends TestCase {
 	public function testGetApps() {
 
 		$user = $this->generateUsers();
-		\OC_Group::addToGroup($user, 'admin');
-		self::loginAsUser($user);
+		$this->groupManager->get('admin')->addUser($user);
+		$this->userSession->setUser($user);
 
 		$result = $this->api->getApps([]);
 

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -25,8 +25,15 @@
 namespace OCA\Provisioning_API\Tests;
 
 class AppsTest extends TestCase {
+	
+	public function setup() {
+		parent::setup();
+		$this->appManager = \OC::$server->getAppManager();
+		$this->api = new \OCA\Provisioning_API\Apps($this->appManager);
+	}
+
 	public function testGetAppInfo() {
-		$result = \OCA\provisioning_API\Apps::getAppInfo(array('appid' => 'provisioning_api'));
+		$result = $this->api->getAppInfo(['appid' => 'provisioning_api']);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
 
@@ -34,7 +41,7 @@ class AppsTest extends TestCase {
 
 	public function testGetAppInfoOnBadAppID() {
 
-		$result = \OCA\provisioning_API\Apps::getAppInfo(array('appid' => 'not_provisioning_api'));
+		$result = $this->api->getAppInfo(['appid' => 'not_provisioning_api']);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertFalse($result->succeeded());
 		$this->assertEquals(\OCP\API::RESPOND_NOT_FOUND, $result->getStatusCode());
@@ -47,7 +54,7 @@ class AppsTest extends TestCase {
 		\OC_Group::addToGroup($user, 'admin');
 		self::loginAsUser($user);
 
-		$result = \OCA\provisioning_API\Apps::getApps(array());
+		$result = $this->api->getApps([]);
 
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
@@ -58,7 +65,7 @@ class AppsTest extends TestCase {
 	public function testGetAppsEnabled() {
 
 		$_GET['filter'] = 'enabled';
-		$result = \OCA\provisioning_API\Apps::getApps(array('filter' => 'enabled'));
+		$result = $this->api->getApps(['filter' => 'enabled']);
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
 		$this->assertEquals(count(\OC_App::getEnabledApps()), count($data['apps']));
@@ -68,7 +75,7 @@ class AppsTest extends TestCase {
 	public function testGetAppsDisabled() {
 
 		$_GET['filter'] = 'disabled';
-		$result = \OCA\provisioning_API\Apps::getApps(array('filter' => 'disabled'));
+		$result = $this->api->getApps(['filter' => 'disabled']);
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
 		$apps = \OC_App::listAllApps();

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -31,7 +31,11 @@ class GroupsTest extends TestCase {
 
 		$this->userManager = \OC::$server->getUserManager();
 		$this->groupManager = \OC::$server->getGroupManager();
-		$this->api = new \OCA\Provisioning_API\Groups($this->groupManager);
+		$this->userSession = \OC::$server->getUserSession();
+		$this->api = new \OCA\Provisioning_API\Groups(
+			$this->groupManager,
+			$this->userSession
+		);
 	}
 
 	public function testGetGroupAsUser() {

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -63,7 +63,7 @@ class GroupsTest extends TestCase {
 		$result = $this->api->getGroups([]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
-		$this->assertCount(11, $result->getData()['groups']);
+		$this->assertCount(count($this->groupManager->search('')), $result->getData()['groups']);
 		$this->assertContains('admin', $result->getData()['groups']);
 		foreach ($groups as $group) {
 			$this->assertContains($group->getGID(), $result->getData()['groups']);

--- a/apps/provisioning_api/tests/testcase.php
+++ b/apps/provisioning_api/tests/testcase.php
@@ -22,8 +22,17 @@
 
 namespace OCA\Provisioning_API\Tests;
 
+use OCP\IUserManager;
+use OCP\IGroupManager;
+
 abstract class TestCase extends \Test\TestCase {
 	protected $users = array();
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IGroupManager */
+	protected $groupManager;
 
 	protected function setUp() {
 		parent::setUp();

--- a/apps/provisioning_api/tests/testcase.php
+++ b/apps/provisioning_api/tests/testcase.php
@@ -27,7 +27,10 @@ abstract class TestCase extends \Test\TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		\OC_Group::createGroup('admin');
+
+		$this->userManager = \OC::$server->getUserManager();
+		$this->groupManager = \OC::$server->getGroupManager();
+		$this->groupManager->createGroup('admin');
 	}
 
 	/**
@@ -38,8 +41,7 @@ abstract class TestCase extends \Test\TestCase {
 	protected function generateUsers($num = 1) {
 		$users = array();
 		for ($i = 0; $i < $num; $i++) {
-			$user = $this->getUniqueID();
-			\OC_User::createUser($user, 'password');
+			$user = $this->userManager->createUser($this->getUniqueID(), 'password');
 			$this->users[] = $user;
 			$users[] = $user;
 		}
@@ -48,11 +50,10 @@ abstract class TestCase extends \Test\TestCase {
 
 	protected function tearDown() {
 		foreach($this->users as $user) {
-			\OC_User::deleteUser($user);
+			$user->delete();
 		}
 
-		\OC_Group::deleteGroup('admin');
-
+		$this->groupManager->get('admin')->delete();
 		parent::tearDown();
 	}
 }

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -602,7 +602,7 @@ class UsersTest extends TestCase {
 		$userSession = $this->getMockBuilder('\OCP\IUserSession')
 			->disableOriginalConstructor()
 			->getMock();
-		$userSession->expects($this->exactly(2))
+		$userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user2);
 	

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -38,10 +38,13 @@ class UsersTest extends TestCase {
 		$this->userManager = \OC::$server->getUserManager();
 		$this->config = \OC::$server->getConfig();
 		$this->groupManager = \OC::$server->getGroupManager();
+		$this->userSession = \OC::$server->getUserSession();
 		$this->api = new \OCA\Provisioning_Api\Users(
 			$this->userManager, 
 			$this->config, 
-			$this->groupManager);
+			$this->groupManager,
+			$this->userSession
+		);
 	}
 
 	// Test getting the list of users

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -162,12 +162,15 @@ class UsersTest extends TestCase {
 
 	public function testGetUserOnSelf() {
 		$user = $this->generateUsers();
+		$user->setDisplayName('foobar');
 		$this->userSession->setUser($user);
 		$params['userid'] = $user->getUID();
 		$result = $this->api->getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
+		
+		$this->assertEquals('foobar', $data['displayname']);
 	}
 
 	public function testGetUserOnNonExistingUser() {


### PR DESCRIPTION
Our quest to only use OCP for core apps is still on going! #4774

This PR reduces the number of calls to OC significantly. It also opens up the ability for the provisioning API to be unit tested instead of just integration tests. 

For the apps part of the provisioning API we might need to introduce new OCP calls. But I'll look into that.

TODO:
- [ ] Convert tests of user to use only OCP
- [ ] Convert tests of groups to use only OCP
- [ ] Convert Apps part of the provisioning app
- [ ] Convert tests of Apps part to use only OCP
