### PR TITLE
Add a session wrapper to encrypt sessiondata

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1113,6 +1113,36 @@
 	</table>
 
 	<table>
+		<!--
+		Stores the used sessions to reduce the risks of session collisions
+		-->
+		<name>*dbprefix*sessions</name>
+		<declaration>
+			<field>
+				<name>hashed_id</name>
+				<type>string</type>
+				<length>128</length>
+			</field>
+			<field>
+				<name>last_used</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>false</notnull>
+			</field>
+
+			<index>
+				<primary>true</primary>
+				<unique>true</unique>
+				<name>hashed_id_index</name>
+				<field>
+					<name>hashed_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+		</declaration>
+	</table>
+
+	<table>
 
 		<!--
 		Namespaced Key-Value Store for arbitrary data.

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -40,6 +40,7 @@ use bantu\IniGetWrapper\IniGetWrapper;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\SimpleContainer;
+use OC\AppFramework\Utility\TimeFactory;
 use OC\Command\AsyncBus;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\NullEventLogger;
@@ -157,7 +158,10 @@ class Server extends SimpleContainer implements IServerContainer {
 		});
 		$this->registerService('UserSession', function (Server $c) {
 			$manager = $c->getUserManager();
-			$userSession = new \OC\User\Session($manager, new \OC\Session\Memory(''));
+
+			$session = new \OC\Session\Memory('');
+
+			$userSession = new \OC\User\Session($manager, $session);
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', array('run' => true, 'uid' => $uid, 'password' => $password));
 			});
@@ -357,6 +361,9 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getDateTimeZone()->getTimeZone(),
 				$c->getL10N('lib', $language)
 			);
+		});
+		$this->registerService('TimeFactory', function() {
+			return new TimeFactory();
 		});
 		$this->registerService('MountConfigManager', function () {
 			$loader = \OC\Files\Filesystem::getLoader();
@@ -609,6 +616,13 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getConfig() {
 		return $this->query('AllConfig');
+	}
+
+	/**
+	 * @return \OCP\AppFramework\Utility\ITimeFactory
+	 */
+	public function getTimeFactory() {
+		return $this->query('TimeFactory');
 	}
 
 	/**

--- a/lib/private/session/cryptosessionhandler.php
+++ b/lib/private/session/cryptosessionhandler.php
@@ -325,7 +325,7 @@ class CryptoSessionHandler extends \SessionHandler {
 		for ($i = 1; $i <= 10; $i++) {
 			$sessionId = $this->secureRandom->getMediumStrengthGenerator()->generate(
 				64,
-				ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS
+				ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_DIGITS
 			);
 
 			$hashedSessionId = $this->deriveHashedLocalSessionName($sessionId);

--- a/lib/private/session/cryptosessionhandler.php
+++ b/lib/private/session/cryptosessionhandler.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Session;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+
+/**
+ * Class CryptoSessionHandler provides some rough basic level of additional
+ * security by storing the session data in an encrypted form.
+ *
+ * The content of the session is encrypted using it's session ID and the actual
+ * session ID is not stored on the application server. One should note that an
+ * adversary with access to the source code or the system memory is still able
+ * to read the original session ID from the users' request. This thus can not be
+ * considered a strong security measure one should consider it as an additional
+ * small security obfuscation layer to comply with compliance guidelines.
+ *
+ * This class also provides a custom `create_sid` function to provide a generic
+ * protection against potential session collisions which may be experienced on
+ * huge instances where the PHP settings have been configured wrongly. Due to PHP
+ * limitations this is however only applied on instances running at least PHP 5.5.1
+ *
+ * DO NOT CALL METHODS OF THIS CLASS FROM OUTSIDE THIS CLASS. THESE FUNCTIONS ARE
+ * ONLY EXPECTED TO BE CALLED BY PHP AS CALLBACK.
+ *
+ * @package OC\Session
+ */
+class CryptoSessionHandler extends \SessionHandler {
+	/** @var \OCP\Security\ICrypto */
+	protected $crypto;
+	/** @var ISecureRandom */
+	protected $secureRandom;
+	/** @var IDBConnection */
+	protected $connection;
+	/** @var IConfig */
+	protected $config;
+	/** @var ITimeFactory */
+	protected $timeFactory;
+	/** @var ILogger */
+	protected $logger;
+
+	/**
+	 * @param ICrypto $crypto
+	 * @param ISecureRandom $secureRandom
+	 * @param IDBConnection $connection
+	 * @param IConfig $config
+	 * @param ITimeFactory $timeFactory
+	 * @param ILogger $logger
+	 */
+	public function __construct(ICrypto $crypto,
+								ISecureRandom $secureRandom,
+								IDBConnection $connection,
+								IConfig $config,
+								ITimeFactory $timeFactory,
+								ILogger $logger) {
+		$this->crypto = $crypto;
+		$this->secureRandom = $secureRandom;
+		$this->connection = $connection;
+		$this->config = $config;
+		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Derive the hashed name under which the session is stored on the application
+	 * server. Since we don't want to increase the processing time unnecessary
+	 * the session id is only pbkdf2'd using 1 iteration. While this does not provide
+	 * perfect security one should note that the actual session IDs are 64 characters
+	 * long and also using other data such as the secret from config.php as salt.
+	 *
+	 * Since this is not aimed to be a perfect protection, as an admin could likely
+	 * just hijack the server otherwise, this is pretty much adequate to provide
+	 * at least a small level of protection against time-memory trade-offs.
+	 *
+	 * @internal
+	 * @param string $originalId
+	 * @return string Hashed session ID
+	 */
+	public function deriveHashedLocalSessionName($originalId) {
+		return hash_pbkdf2(
+			'sha512',
+			$originalId,
+			$this->config->getSystemValue('secret', ''),
+			1
+		);
+	}
+
+	/**
+	 * Wrapped for unit-test purposes
+	 *
+	 * @internal
+	 * @param int $maxLifeTime
+	 * @return bool
+	 */
+	public function parentGc($maxLifeTime) {
+		return parent::gc($maxLifeTime);
+	}
+
+	/**
+	 * Wrapper around \SessionHandler::gc also cleaning the database from expired
+	 * session IDs.
+	 *
+	 * @internal
+	 * @param int $maxLifeTime
+	 * @return bool
+	 */
+	public function gc($maxLifeTime) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('*PREFIX*sessions')
+			->where($qb->expr()->lte('last_used', $qb->createParameter('timestamp')))
+			->setParameter('timestamp', $this->timeFactory->getTime() - $maxLifeTime)
+			->execute();
+		return $this->parentGc($maxLifeTime);
+	}
+
+	/**
+	 * Wrapped for unit-test purposes
+	 *
+	 * @internal
+	 * @param string $hashedId
+	 * @return bool
+	 */
+	public function parentDestroy($hashedId) {
+		return parent::destroy($hashedId);
+	}
+
+	/**
+	 * Wrapper around the destroy function also marking the session id as unused
+	 * within the database.
+	 *
+	 * @internal
+	 * @param string $originalSessionId
+	 * @return bool
+	 */
+	public function destroy($originalSessionId) {
+		$hashedSessionId = $this->deriveHashedLocalSessionName($originalSessionId);
+		$this->expireSession($hashedSessionId);
+
+		/**
+		 * While \SessionHandler::destroy allows to specify an ID it is actual not
+		 * used meaning that the data does not get decrypted successfully.
+		 *
+		 * To work around this issue the session gets manually set using `session_id`
+		 * to the encrypted value and then changed to the unencrypted ID.
+		 *
+		 * @link https://bugs.php.net/bug.php?id=70133
+		 */
+		session_id($hashedSessionId);
+
+		return $this->parentDestroy($hashedSessionId);
+	}
+
+	/**
+	 * Wrapped for unit-test purposes
+	 *
+	 * @internal
+	 * @param string $hashedSessionId
+	 * @return string
+	 */
+	public function parentRead($hashedSessionId) {
+		return parent::read($hashedSessionId);
+	}
+
+	/**
+	 * Wrapper around \SessionHandler::read decrypting the content and updating
+	 * the last session usage time.
+	 *
+	 * @internal
+	 * @param string $originalSessionId
+	 * @return string
+	 */
+	public function read($originalSessionId) {
+		$hashedSessionId = $this->deriveHashedLocalSessionName($originalSessionId);
+
+		/**
+		 * While \SessionHandler::read allows to specify an ID it is actual not
+		 * used meaning that the data does not get decrypted successfully.
+		 *
+		 * To work around this issue the session gets manually set using `session_id`
+		 * to the encrypted value and then changed to the unencrypted ID.
+		 *
+		 * @link https://bugs.php.net/bug.php?id=70133
+		 */
+		session_id($hashedSessionId);
+		$data = $this->parentRead($hashedSessionId);
+		session_id($originalSessionId);
+		$this->markSessionAsUsed($hashedSessionId);
+
+		if($data === '') {
+			return '';
+		}
+
+		try {
+			return $this->crypto->decrypt($data, $originalSessionId);
+		} catch (\Exception $e) {
+			return '';
+		}
+	}
+
+	/**
+	 * Wrapped for unit-test purposes
+	 *
+	 * @internal
+	 * @param string $hashedSessionId
+	 * @param string $encryptedSessionData
+	 * @return bool
+	 */
+	public function parentWrite($hashedSessionId, $encryptedSessionData) {
+		return parent::write($hashedSessionId, $encryptedSessionData);
+	}
+
+	/**
+	 * Wrapper around \SessionHandler::write encrypting the passed session data
+	 *
+	 * @internal
+	 * @param string $originalSessionId
+	 * @param string $sessionData
+	 * @return bool
+	 */
+	public function write($originalSessionId, $sessionData) {
+		$hashedSessionId = $this->deriveHashedLocalSessionName($originalSessionId);
+		$encryptedSessionData = $this->crypto->encrypt($sessionData, $originalSessionId);
+
+		return $this->parentWrite($hashedSessionId, $encryptedSessionData);
+	}
+
+	/**
+	 * Checks whether a session is already used
+	 *
+	 * @internal
+	 * @param string $hashedSessionId
+	 * @return bool True if session is used, false otherwise
+	 */
+	private function isSessionUsed($hashedSessionId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('hashed_id')
+			->from('*PREFIX*sessions')
+			->where($qb->expr()->eq('hashed_id', $qb->createParameter('hashed_id')))
+			->setParameter(':hashed_id', $hashedSessionId);
+		$result = $qb->execute();
+		$result = $result->fetch();
+		return !empty($result);
+	}
+
+	/**
+	 * Marks a session as used in the database to reduce the risk of potential
+	 * session collisions. If the session is already used it will update its
+	 * time stamp.
+	 *
+	 * @internal
+	 * @param string $hashedSessionId
+	 */
+	private function markSessionAsUsed($hashedSessionId) {
+		$qb = $this->connection->getQueryBuilder();
+
+		if($this->isSessionUsed($hashedSessionId)) {
+			$qb->update('*PREFIX*sessions')
+				->set('last_used', $qb->createParameter('last_used'))
+				->where($qb->expr()->eq('hashed_id', $qb->createParameter('hashed_id')))
+				->setParameter(':last_used', $this->timeFactory->getTime())
+				->setParameter(':hashed_id', $hashedSessionId)
+				->execute();
+		} else {
+			$qb->insert('*PREFIX*sessions')
+				->values([
+					'hashed_id' => $qb->createNamedParameter($hashedSessionId, \PDO::PARAM_STR),
+					'last_used' => $qb->createNamedParameter($this->timeFactory->getTime()),
+				])
+				->execute();
+		}
+	}
+
+	/**
+	 * Removes a used session id from the database
+	 *
+	 * @param string $hashedSessionId
+	 * @internal
+	 */
+	private function expireSession($hashedSessionId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('*PREFIX*sessions')
+			->where($qb->expr()->eq('hashed_id', $qb->createParameter('hashed_id')))
+			->setParameter('hashed_id', $hashedSessionId)
+			->execute();
+	}
+
+	/**
+	 * Custom session handler which also checks whether a session with this ID
+	 * already exists to reduce the potential risk of session collisions. Since
+	 * there is no locking/transactions in place here this may technically still
+	 * happen but an actual chance of having this happen is way smaller than with
+	 * the default PHP session handler. Note that in a proper configured environment
+	 * this should never be the case anyways.
+	 *
+	 * This will only work with >= PHP 5.5.1, older versions will simply ignore
+	 * this and use the default session creation employed by PHP.
+	 *
+	 * @internal
+	 */
+	public function create_sid() {
+		for ($i = 1; $i <= 10; $i++) {
+			$sessionId = $this->secureRandom->getMediumStrengthGenerator()->generate(
+				64,
+				ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS
+			);
+
+			$hashedSessionId = $this->deriveHashedLocalSessionName($sessionId);
+			if (!$this->isSessionUsed($hashedSessionId)) {
+				$this->markSessionAsUsed($hashedSessionId);
+				return $sessionId;
+			}
+		}
+
+		/**
+		 * This should never happen. If an unique session ID could not get created
+		 * within 10 tries it is better to stop the script execution instead of
+		 * returning always the same likely insecure ID.
+		 *
+		 * Since this is deeply integrated within the PHP core we can't throw a
+		 * regular exception here and thus need to stop the execution using this
+		 * approach and inform the user using a white page.
+		 */
+		$errorMsg = 'Critical error encountered. Couldn\'t generate valid session ' .
+			'ID. Please contact the instance administrator.';
+		$this->logger->emergency($errorMsg, ['app' => 'core']);
+		http_response_code(500);
+		die($errorMsg);
+	}
+}

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -365,6 +365,28 @@ class Setup {
 			$config->setSystemValue('installed', true);
 		}
 
+		/**
+		 * Setup the encrypted session handler. This is required here as well as
+		 * in base.php as the session handler has dependencies on the database as
+		 * well as the configuration file.
+		 *
+		 * Without this change here the automatic first login after clicking install
+		 * would not work anymore. While this is a minor issue it is a change in
+		 * behaviour and it makes sense to not confuse the user.
+		 */
+		session_destroy();
+		$handler = new \OC\Session\CryptoSessionHandler(
+				\OC::$server->getCrypto(),
+				\OC::$server->getSecureRandom(),
+				\OC::$server->getDatabaseConnection(),
+				\OC::$server->getConfig(),
+				\OC::$server->getTimeFactory(),
+				\OC::$server->getLogger()
+		);
+		session_set_save_handler($handler, true);
+		session_start();
+		\OC_User::login($username, $password);
+
 		return $error;
 	}
 

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -438,4 +438,10 @@ interface IServerContainer {
 	 * @since 8.2.0
 	 */
 	public function getMimeTypeDetector();
+
+	/**
+	 * @return \OCP\AppFramework\Utility\ITimeFactory
+	 * @since 8.2.0
+	 */
+	public function getTimeFactory();
 }

--- a/tests/lib/session/cryptosessionhandler.php
+++ b/tests/lib/session/cryptosessionhandler.php
@@ -1,0 +1,492 @@
+<?php
+/**
+ * @author Lukas Reschke <lukas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Session;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+
+/**
+ * Class CryptoSessionHandler
+ *
+ * @package Test\Session
+ */
+class CryptoSessionHandler extends \Test\TestCase {
+	/** @var \OC\Session\CryptoSessionHandler */
+	private $cryptoSessionHandler;
+	/** @var ICrypto */
+	private $crypto;
+	/** @var ISecureRandom */
+	private $secureRandom;
+	/** @var IDBConnection */
+	private $connection;
+	/** @var IConfig */
+	private $config;
+	/** @var ITimeFactory */
+	private $timeFactory;
+	/** @var ILogger */
+	private $logger;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->crypto = $this->getMockBuilder('\\OCP\\Security\\ICrypto')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->secureRandom = $this->getMockBuilder('\\OCP\\Security\\ISecureRandom')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->connection = $this->getMockBuilder('\\OCP\\IDBConnection')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->config = $this->getMockBuilder('\\OCP\\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->timeFactory = $this->getMockBuilder('\\OCP\\AppFramework\\Utility\\ITimeFactory')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->logger = $this->getMockBuilder('\\OCP\\ILogger')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->cryptoSessionHandler = $this->getMockBuilder('\\OC\\Session\\CryptoSessionHandler')
+			->setConstructorArgs([
+				$this->crypto,
+				$this->secureRandom,
+				$this->connection,
+				$this->config,
+				$this->timeFactory,
+				$this->logger,
+			])
+			->setMethods([
+				'parentGc',
+				'parentDestroy',
+				'parentRead',
+				'parentWrite',
+			])
+			->getMock();
+	}
+
+	/**
+	 * @return array
+	 */
+	public function hashDataProvider() {
+		return [
+			[
+				'OriginalSecretId',
+				'3326270571368a224a95fa74dbe3b86c6fc96e3c3c51d54306f3618f7f3f8c990249aacef3766d24033f324b652ea73f1bc206be330829c60ff75100e31e3190',
+				'RandomSecret',
+			],
+			[
+				'PAFT3R18I85TE3ajLl62',
+				'7e98e48ea7714edc9eaa899e137c34d6916cd708785ab45193ac8ba77ab342d174ee61283d7294ccdbfb59ea00be1d97f53eee5d9c2390769aeb314ad88b3fb1',
+				'sFQQ0hnT3B9Fzoeh2AbX',
+			],
+			[
+				'ek3tqx28gwyccfzgbyi273tyevvlzjgiok6sc1krv55915nsce9om8ocvnfu0w4u',
+				'21ee1547f147e8fd32f217af112aae968b1327cf67607e2c272ffd74199e47c189acf35e79e66b67b7fd7973626dd30f36f4ced45682ce3f8c5c945214dd8ec3',
+				'rdyoLA+bFUeAydwPg8UV4NGT2RygGLOMgg8HR6rQtKMoyQVL'
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider hashDataProvider
+	 *
+	 * @param string $originalId
+	 * @param string $expectedHashedLocalId
+	 * @param string $secret
+	 */
+	public function testDeriveHashedLocalSessionName($originalId, $expectedHashedLocalId, $secret) {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('secret', '')
+			->will($this->returnValue($secret));
+
+		$hashedId = $this->invokePrivate($this->cryptoSessionHandler, 'deriveHashedLocalSessionName', [$originalId]);
+		$this->assertSame($expectedHashedLocalId, $hashedId);
+	}
+
+	public function testGc() {
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$exp = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection
+			->expects($this->once())
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+
+		$qb->expects($this->once())
+			->method('delete')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('expr')
+			->will($this->returnValue($exp));
+		$exp->expects($this->once())
+			->method('lte')
+			->with('last_used', $qb->createParameter('timestamp'))
+			->will($this->returnValue($exp));
+		$qb->expects($this->once())
+			->method('where')
+			->with($exp)
+			->will($this->returnValue($qb));
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->will($this->returnValue(2000));
+		$qb->expects($this->once())
+			->method('setParameter')
+			->with('timestamp', 663)
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('execute');
+
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentGc')
+			->with(1337)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($this->cryptoSessionHandler->gc(1337));
+	}
+
+	public function testDestroy() {
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$exp = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection
+			->expects($this->once())
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('delete')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('expr')
+			->will($this->returnValue($exp));
+		$exp->expects($this->once())
+			->method('eq')
+			->with('hashed_id')
+			->will($this->returnValue($exp));
+		$qb->expects($this->once())
+			->method('where')
+			->with($exp)
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('setParameter')
+			->with('hashed_id', 'c3d74c512393fa9b93159cd52668463e9b2321e8112baa61c0663531b2c7e10d904601094411625e079f6ff016fbeefc81384a6526e48cc709eba4c54e88c505')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('execute');
+
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentDestroy')
+			->with('c3d74c512393fa9b93159cd52668463e9b2321e8112baa61c0663531b2c7e10d904601094411625e079f6ff016fbeefc81384a6526e48cc709eba4c54e88c505')
+			->will($this->returnValue(true));
+
+		$this->assertTrue($this->cryptoSessionHandler->destroy('MySessionToDestroy'));
+	}
+
+	public function testReadEmpty() {
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$checkExpr = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection
+			->expects($this->exactly(2))
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('select')
+			->with('hashed_id')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('from')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('expr')
+			->will($this->returnValue($checkExpr));
+		$checkExpr->expects($this->exactly(2))
+			->method('eq')
+			->with('hashed_id', $qb->createParameter('hashed_id'))
+			->will($this->returnValue($checkExpr));
+		$qb->expects($this->any())
+			->method('where')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('setParameter')
+			->will($this->returnValue($qb));
+		$statement = $this->getMockBuilder('\\Doctrine\\DBAL\\Driver\\Statement')
+			->disableOriginalConstructor()
+			->getMock();
+		$qb->expects($this->exactly(2))
+			->method('execute')
+			->will($this->returnValue($statement));
+		$statement->expects($this->once())
+			->method('fetch')
+			->will($this->returnValue(['DummyValue']));
+		$qb->expects($this->once())
+			->method('update')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('set')
+			->will($this->returnValue($qb));
+
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentRead')
+			->with('9024f4324c7290ef7a982356436c94542eebe1cf12e8236c4c811eadb7e0c0d2444227abb8379573b2f2461de2d04120165576d6135db5ccf17aa1e0360d9188')
+			->will($this->returnValue(''));
+
+		$this->assertSame('', $this->cryptoSessionHandler->read('MySessionIdToRead'));
+	}
+
+	public function testReadData() {
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$checkExpr = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection
+			->expects($this->exactly(2))
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('select')
+			->with('hashed_id')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('from')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('expr')
+			->will($this->returnValue($checkExpr));
+		$checkExpr->expects($this->exactly(2))
+			->method('eq')
+			->with('hashed_id', $qb->createParameter('hashed_id'))
+			->will($this->returnValue($checkExpr));
+		$qb->expects($this->any())
+			->method('where')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('setParameter')
+			->will($this->returnValue($qb));
+		$statement = $this->getMockBuilder('\\Doctrine\\DBAL\\Driver\\Statement')
+			->disableOriginalConstructor()
+			->getMock();
+		$qb->expects($this->exactly(2))
+			->method('execute')
+			->will($this->returnValue($statement));
+		$statement->expects($this->once())
+			->method('fetch')
+			->will($this->returnValue(['DummyValue']));
+		$qb->expects($this->once())
+			->method('update')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('set')
+			->will($this->returnValue($qb));
+
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentRead')
+			->with('9024f4324c7290ef7a982356436c94542eebe1cf12e8236c4c811eadb7e0c0d2444227abb8379573b2f2461de2d04120165576d6135db5ccf17aa1e0360d9188')
+			->will($this->returnValue('9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948'));
+		$this->crypto
+			->expects($this->once())
+			->method('decrypt')
+			->with('9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948')
+			->will($this->returnValue('ReturnedData'));
+
+		$this->assertSame('ReturnedData', $this->cryptoSessionHandler->read('MySessionIdToRead'));
+	}
+
+	public function testReadDataException() {
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$checkExpr = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection
+			->expects($this->exactly(2))
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('select')
+			->with('hashed_id')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('from')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('expr')
+			->will($this->returnValue($checkExpr));
+		$checkExpr->expects($this->exactly(2))
+			->method('eq')
+			->with('hashed_id', $qb->createParameter('hashed_id'))
+			->will($this->returnValue($checkExpr));
+		$qb->expects($this->any())
+			->method('where')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('setParameter')
+			->will($this->returnValue($qb));
+		$statement = $this->getMockBuilder('\\Doctrine\\DBAL\\Driver\\Statement')
+			->disableOriginalConstructor()
+			->getMock();
+		$qb->expects($this->exactly(2))
+			->method('execute')
+			->will($this->returnValue($statement));
+		$statement->expects($this->once())
+			->method('fetch')
+			->will($this->returnValue(['DummyValue']));
+		$qb->expects($this->once())
+			->method('update')
+			->with('*PREFIX*sessions')
+			->will($this->returnValue($qb));
+		$qb->expects($this->once())
+			->method('set')
+			->will($this->returnValue($qb));
+
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentRead')
+			->with('9024f4324c7290ef7a982356436c94542eebe1cf12e8236c4c811eadb7e0c0d2444227abb8379573b2f2461de2d04120165576d6135db5ccf17aa1e0360d9188')
+			->will($this->returnValue('9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948'));
+		$this->crypto
+			->expects($this->once())
+			->method('decrypt')
+			->with('9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948')
+			->will($this->throwException(new \Exception()));
+
+		$this->assertSame('', $this->cryptoSessionHandler->read('MySessionIdToRead'));
+	}
+
+	public function testWrite() {
+		$this->crypto
+			->expects($this->once())
+			->method('encrypt')
+			->with('RandomData', 'MySessionIdToWrite')
+			->will($this->returnValue('9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948'));
+		$this->cryptoSessionHandler
+			->expects($this->once())
+			->method('parentWrite')
+			->with(
+				'40e7b28ebdbaa02d09d571a656e8aa8db4737ddc3c547245cb5a2ff1d6893b984e494bb0df37c3e991f31ac93392b303e99915690382aaa54b2fe9dadb73b18a',
+				'9b7fe79030f1b2b15b7464a1d849dc72931db954bcc504f04d22fcb33a4eedff|eyUT7om27ZQJ7QZ2|b23bffce7c88bfe8258cd5ee1d792ae1b251ca6cb8c8e4a816dfaf0405a0c29161cd3cd8069f231cca6c03310f32ad8f767431c80ae1ddb5e3f6e01bbbfae948'
+			)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($this->cryptoSessionHandler->write('MySessionIdToWrite', 'RandomData'));
+	}
+
+	public function testCreate_sid() {
+		$this->secureRandom
+			->expects($this->once())
+			->method('getMediumStrengthGenerator')
+			->will($this->returnSelf());
+		$this->secureRandom
+			->expects($this->once())
+			->method('generate')
+			->with(
+				64,
+				'abcdefghijklmnopqrstuvwxyz0123456789'
+			)
+			->will($this->returnValue('MyRandomSessionId'));
+		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$checkExpr = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IExpressionBuilder')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->connection
+			->expects($this->any())
+			->method('getQueryBuilder')
+			->will($this->returnValue($qb));
+		$qb->expects($this->any())
+			->method('select')
+			->with('hashed_id')
+			->will($this->returnSelf());
+		$qb->expects($this->any())
+			->method('from')
+			->with('*PREFIX*sessions')
+			->will($this->returnSelf());
+		$checkExpr->expects($this->any())
+			->method('eq')
+			->with('hashed_id', $qb->createParameter('hashed_id'));
+		$qb->expects($this->any())
+			->method('expr')
+			->will($this->returnValue($checkExpr));
+		$qb->expects($this->any())
+			->method('where')
+			->will($this->returnSelf());
+		$statement = $this->getMockBuilder('\\Doctrine\\DBAL\\Driver\\Statement')
+			->disableOriginalConstructor()
+			->getMock();
+		$qb->expects($this->any())
+			->method('execute')
+			->will($this->returnValue($statement));
+		$statement->expects($this->any())
+			->method('fetch')
+			->will($this->returnValue([]));
+		$qb->expects($this->once())
+			->method('insert')
+			->with('*PREFIX*sessions')
+			->will($this->returnSelf());
+		$qb->expects($this->once())
+			->method('values')
+			->with([
+				'hashed_id' => $qb->createNamedParameter('', \PDO::PARAM_STR),
+				'last_used' => $qb->createNamedParameter($this->timeFactory->getTime()),
+			])
+			->will($this->returnSelf());
+
+		$this->assertSame('MyRandomSessionId', $this->cryptoSessionHandler->create_sid());
+	}
+
+}

--- a/tests/lib/session/cryptosessionhandler.php
+++ b/tests/lib/session/cryptosessionhandler.php
@@ -435,7 +435,7 @@ class CryptoSessionHandler extends \Test\TestCase {
 			->method('generate')
 			->with(
 				64,
-				'abcdefghijklmnopqrstuvwxyz0123456789'
+				'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 			)
 			->will($this->returnValue('MyRandomSessionId'));
 		$qb = $this->getMockBuilder('\\OCP\\DB\\QueryBuilder\\IQueryBuilder')


### PR DESCRIPTION
This PR extends the default PHP `\SessionHandler` and adds the following changes to it:
1. When running on at least PHP 5.5.1 a custom `create_sid` function is offering some protection against a potential session collision on systems which are likely misconfigured or misrunning. This is achieved by writing each used session to the database.
2. The whole session data is encrypted using the original session id. This one is however never written to the local system since the extended handler only writes a hashed form of it.

I decided to extend the default `\SessionHandler` instead of writing a custom one since there are instances already using stuff such as the memcached extension and dealing with session locking on our own can be pretty risky.

This fixes https://github.com/owncloud/enterprise/issues/518 and also is related to https://github.com/owncloud/enterprise/issues/445. Replaces https://github.com/owncloud/core/pull/17744.
# Impact
- Sessions will always be stored encrypted. I'd advise against a configuration switch since this is something were we really need proper testing which can only be ensured if each user uses this code path.
- Since the session is encrypted custom integrations that operate on $_SESSION and are not including base.php will not work anymore. Note that this does not affect ownCloud apps and the core code.
- On each request a timestamp of the last usage will get updated within the new `sessions` table. This needs considerations how this behaves in huge environments. One should note that this is the same approach as in https://github.com/LukasReschke/session_login_tracker which was used at https://github.com/owncloud/enterprise/issues/445 and does not seem to have had a huge performance impact. @butonic may know more about DB stuff than me :speak_no_evil:
- If it was not possible to generate an unique secure session ID the server will issue a fatal error
- Adds a new table to track the used encrypted sessions. Needs upgrade testing as well as testing on each supported database.

This requires real proper testing on all supported systems and PHP versions and can in no case be backported. Since it is pretty independent from core with only one small change in base.php I'd say we should merge this within master as soon as possible to get early feedback on this. In case of a problem we can anyways remove this again.
# Test plan
## Local storage
- [x] session_destroy() cleans the session from the DB as well as from the local storage
- [x] Garbage collector is properly cleaning old sessions from the DB as well as from the local storage
- [x] Original session ID is not stored on local storage
- [x] Data within the session is properly encrypted
- [x] Setup still works
- [x] Updating the instance still works (switch from installed master to this branch)
- [x] Cookies are not sent multiple times when not required
## Memcache
- [ ] session_destroy() cleans the session from the DB as well as from the memcache
- [ ] Garbage collector is properly cleaning old sessions from the DB as well as from the memcache
- [ ] Original session ID is not stored on memcache
- [ ] Data within the session is properly encrypted
- [ ] Setup still works
- [ ] Updating the instance still works (switch from installed master to this branch)
- [ ] Cookies are not sent multiple times when not required
# PHP versions tested
- [x] PHP 7 
- [x] PHP 5.6
- [ ] PHP 5.5
- [ ] PHP 5.4
# Distributions tested
- [x] Mac OS X
- [ ] CentOS 6.6
- [ ] CentOS 7
- [ ] Ubuntu 15.04
- [ ] Ubuntu 14.10
- [ ] Debian 7
- [ ] Debian 8

<hr/>

@butonic Please review and test. Especially the memcache part requires your expertise.
@DeepDiver1975 @MorrisJobke Please review.
