### PR TITLE
Add `fallback` to shim

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1888,6 +1888,8 @@ jQuery.fn.tipsy = function(argument) {
 		}
 		if(argument.title) {
 			options.title = argument.title;
+		} else if(argument.fallback) {
+			options.title = argument.fallback;
 		}
 		// destroy old tooltip in case the title has changed
 		jQuery.fn.tooltip.call(this, 'destroy');


### PR DESCRIPTION
Tipsy also supported the `fallback` element which will now not work anymore. To enhance compatibility we shall also implement it in the shim.

To test go to the apps interface and hover over one of the levels.

Fixes https://github.com/owncloud/core/issues/17870

<hr/>

@Henni Please review.
