### PR TITLE
Feature client certificate

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -146,6 +146,25 @@ class Auth extends AbstractBasic {
 			return true;
 		}
 
+		if (\OC::$server->getAppConfig()->getValue("core", "client_certificate_enabled", "no") === "yes"
+			&& isset($_SERVER["SSL_CLIENT_VERIFY"])
+			&& isset($_SERVER["SSL_CLIENT_CERT"])
+			&& $_SERVER["SSL_CLIENT_VERIFY"] === "SUCCESS") {
+
+			\OCP\Util::writeLog('core', 'Trying to login with certificate', \OCP\Util::DEBUG);
+
+			$result = \OC_User::loginWithCertificate($_SERVER["SSL_CLIENT_CERT"]);
+
+			if($result === true) {
+				$user = \OC_User::getUser();
+				\OC_Util::setUpFS(\OC_User::getUser());
+				$this->currentUser = $user;
+				\OC::$server->getSession()->close();
+				return true;
+			}
+		}
+
+
 		return parent::authenticate($server, $realm);
 	}
 }

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -262,6 +262,26 @@ class OC_User {
 	}
 
 	/**
+	 * Try to login with the given PEM encoded certificate. At this point
+	 * the certificate is valid (checked by Apache or Nginx).
+	 *
+	 * @param string $certificate PEM encoded client certificate
+	 * @return bool
+	 */
+	public static function loginWithCertificate($certificate) {
+		$result = self::getUserSession()->loginWithCertificate($certificate);
+
+		if($result) {
+			//we need to pass the user name, which may differ from login name
+			$user = self::getUserSession()->getUser()->getUID();
+			OC_Util::setupFS($user);
+			//trigger creation of user home and /files folder
+			\OC::$server->getUserFolder($user);
+		}
+		return $result;
+	}
+
+	/**
 	 * Try to login a user, assuming authentication
 	 * has already happened (e.g. via Single Sign On).
 	 *

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -91,6 +91,7 @@ $backends = \OC::$server->getUserManager()->getBackends();
 $externalBackends = (count($backends) > 1) ? true : false;
 $template->assign('encryptionReady', \OC::$server->getEncryptionManager()->isReady());
 $template->assign('externalBackendsEnabled', $externalBackends);
+$template->assign('clientCertificateEnabled', $appConfig->getValue('core', 'client_certificate_enabled', 'no'));
 
 $encryptionModules = \OC::$server->getEncryptionManager()->getEncryptionModules();
 $defaultEncryptionModuleId = \OC::$server->getEncryptionManager()->getDefaultEncryptionModuleId();

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -97,6 +97,16 @@ $(document).ready(function(){
 		OC.AppConfig.setValue('core', $(this).attr('name'), value);
 	});
 
+	$('#clientCertificateEnabled').change(function() {
+		var value = $(this).val();
+		if (this.checked) {
+			value = 'yes';
+		} else {
+			value = 'no';
+		}
+		OC.AppConfig.setValue('core', $(this).attr('name'), value);
+	});
+
 	$('#shareapiDefaultExpireDate').change(function() {
 		$("#setDefaultExpireDate").toggleClass('hidden', !this.checked);
 	});

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -311,6 +311,18 @@ if ($_['cronErrors']) {
 	</p>
 </div>
 
+<div class="section" id="clientCertificate">
+	<h2><?php p($l->t('Client Certificate Mapping')); ?></h2>
+
+	<p id="enable">
+		<input type="checkbox" name="client_certificate_enabled" id="clientCertificateEnabled"
+			value="1" <?php if ($_['clientCertificateEnabled'] === "yes") print_unescaped('checked="checked"'); ?> />
+		<label for="clientCertificateEnabled">
+			<?php p($l->t('Enable client certificate mapping (using the commonName attribute from the certificate)')); ?>
+		</label><br/>
+	</p>
+</div>
+
 <div class="section" id='encryptionAPI'>
 	<h2><?php p($l->t('Server-side encryption')); ?></h2>
 	<a target="_blank" class="icon-info svg"


### PR DESCRIPTION
This feature adds the possiblity of mapping client certificates to owncloud users. It works relatively simply by using the common name from the certificate as username. 

This setup requires a proper setup of the webserver:
1. Create a CA
2. Configure the webserver (apache, nginx) to request a client certificate (if the client certificate is optionally or required is up to the admin). This client certificate must be signed by the CA created in step 1
3. Configure the webserver to pass the certificate to PHP (yes, the entire certificate)
4. Create and distribute certificates (or sign the CSRs) for your users, use the common name as username
5. Profit???

There are some issues with this feature:

Once the user selects the certificate in the browser, there is no going back. He can't logout because the browser will _always_ send the certificate for this session. In a new private tab the user could select another certificate or none at all. Owning a client certificate will not make Owncloud create a new account, so the user must already exist. I am not sure if LDAP works with this. The desktop client does not work with client certificates, as far as I know.
