### PR TITLE
Fix title attribute of tipsy shim

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1886,9 +1886,7 @@ jQuery.fn.tipsy = function(argument) {
 		if(argument.html) {
 			options.html = true;
 		}
-		if(argument.title) {
-			options.title = argument.title;
-		} else if(argument.fallback) {
+		if(argument.fallback) {
 			options.title = argument.fallback;
 		}
 		// destroy old tooltip in case the title has changed


### PR DESCRIPTION
As described by @Xenopathic at https://github.com/owncloud/core/pull/17871#issuecomment-124899372 the title option of the shim doesn't represent the correct logic.

I propose to remove the title option from the shim, because there is no corresponding attribute for the bootstrap tooltip and it isn't used in core or any of the major apps.
