### PR TITLE
Allow classes in <h2> tags

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -197,8 +197,8 @@ if (\OC::$server->getLockingProvider() instanceof NoopLockingProvider) {
 }
 
 $formsMap = array_map(function ($form) {
-	if (preg_match('%(<h2[^>]*>.*?</h2>)%i', $form, $regs)) {
-		$sectionName = str_replace('<h2>', '', $regs[0]);
+	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form, $regs)) {
+		$sectionName = str_replace('<h2'.$regs['class'].'>', '', $regs[0]);
 		$sectionName = str_replace('</h2>', '', $sectionName);
 		$anchor = strtolower($sectionName);
 		$anchor = str_replace(' ', '-', $anchor);

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -137,8 +137,8 @@ $formsAndMore[]= ['anchor' => 'passwordform', 'section-name' => $l->t('Personal 
 $forms=OC_App::getForms('personal');
 
 $formsMap = array_map(function($form){
-	if (preg_match('%(<h2[^>]*>.*?</h2>)%i', $form, $regs)) {
-		$sectionName = str_replace('<h2>', '', $regs[0]);
+	if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form, $regs)) {
+		$sectionName = str_replace('<h2'.$regs['class'].'>', '', $regs[0]);
 		$sectionName = str_replace('</h2>', '', $sectionName);
 		$anchor = strtolower($sectionName);
 		$anchor = str_replace(' ', '-', $anchor);


### PR DESCRIPTION
Previously something like `<h2 class="inlineblock"><?php p($l->t('Some title')) ?></h2>` was shown as `<h2 class="inlineblock">Some title` within the sidebar instead as `Some Title` due to the fact that the regex was catching these classes but was not properly running the string replace function.

Fixes https://github.com/LukasReschke/relay/issues/11

@DeepDiver1975 Please review.
@karlitschek I'd like to backport this to 8.1
