### PR TITLE
[backport 8.1] get header size before we open the file to avoid locking exception

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -419,10 +419,11 @@ class Encryption extends Wrapper {
 			}
 
 			if ($shouldEncrypt === true && $encryptionModule !== null) {
+				$headerSize = $this->getHeaderSize($path);
 				$source = $this->storage->fopen($path, $mode);
 				$handle = \OC\Files\Stream\Encryption::wrap($source, $path, $fullPath, $header,
 					$this->uid, $encryptionModule, $this->storage, $this, $this->util, $this->fileHelper, $mode,
-					$size, $unencryptedSize, $this->getHeaderSize($path));
+					$size, $unencryptedSize, $headerSize);
 				return $handle;
 			}
 


### PR DESCRIPTION
get header size before we open the file to avoid locking exception

approved backport of https://github.com/owncloud/core/pull/17902
