### PR TITLE
Detect old NSS and OpenSSL versions

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -69,6 +69,9 @@
 							t('core', '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.securityDocs})
 						);
 					}
+					if(data.isUsedTlsLibOutdated) {
+						messages.push(data.isUsedTlsLibOutdated);
+					}
 				} else {
 					messages.push(t('core', 'Error occurred while checking server setup'));
 				}

--- a/settings/application.php
+++ b/settings/application.php
@@ -154,7 +154,8 @@ class Application extends App {
 				$c->query('Config'),
 				$c->query('ClientService'),
 				$c->query('URLGenerator'),
-				$c->query('Util')
+				$c->query('Util'),
+				$c->query('L10N')
 			);
 		});
 


### PR DESCRIPTION
This will detect old NSS and OpenSSL versions and show appropriate errors in the admin interface.

Fixes https://github.com/owncloud/core/issues/17901

@karlitschek @DeepDiver1975 Please review.
