### PR TITLE
Display warning in security & setup warnings if php version is EOL

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -72,6 +72,11 @@
 					if(data.isUsedTlsLibOutdated) {
 						messages.push(data.isUsedTlsLibOutdated);
 					}
+					if(data.phpSupported && data.phpSupported.eol) {
+						messages.push(
+							t('core', 'Your PHP version ({version}) is no longer <a href="{phpLink}">supported by PHP</a>. We encourage you to upgrade your PHP version to take advantage of performance and security updates provided by PHP.', {version: data.phpSupported.version, phpLink: 'https://secure.php.net/supported-versions.php'})
+						);
+					}
 				} else {
 					messages.push(t('core', 'Error occurred while checking server setup'));
 				}

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -142,6 +142,23 @@ describe('OC.SetupChecks tests', function() {
 				done();
 			});
 		});
+
+		it('should return an error if the php version is no longer supported', function(done) {
+			var async = OC.SetupChecks.checkSetup();
+
+			suite.server.requests[0].respond(
+				200,
+				{
+					'Content-Type': 'application/json',
+				},
+				JSON.stringify({isUrandomAvailable: true, securityDocs: 'https://docs.owncloud.org/myDocs.html', serverHasInternetConnection: true, dataDirectoryProtected: true, isMemcacheConfigured: true, phpSupported: {eol: true, version: '5.4.0'}})
+			);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual(['Your PHP version (5.4.0) is no longer <a href="https://secure.php.net/supported-versions.php">supported by PHP</a>. We encourage you to upgrade your PHP version to take advantage of performance and security updates provided by PHP.']);
+				done();
+			});
+		});
 	});
 
 	describe('checkGeneric', function() {

--- a/settings/controller/checksetupcontroller.php
+++ b/settings/controller/checksetupcontroller.php
@@ -175,6 +175,23 @@ class CheckSetupController extends Controller {
 
 		return '';
 	}
+	
+	/*
+	 * Whether the php version is still supported (at time of release)
+	 * according to: https://secure.php.net/supported-versions.php
+	 *
+	 * @return array
+	 */
+	private function isPhpSupported() {
+		$eol = false;
+
+		//PHP 5.4 is EOL on 14 Sep 2015
+		if (version_compare(PHP_VERSION, '5.5.0') === -1) {
+			$eol = true;
+		}
+
+		return ['eol' => $eol, 'version' => PHP_VERSION];
+	}
 
 	/**
 	 * @return DataResponse
@@ -189,6 +206,7 @@ class CheckSetupController extends Controller {
 				'isUrandomAvailable' => $this->isUrandomAvailable(),
 				'securityDocs' => $this->urlGenerator->linkToDocs('admin-security'),
 				'isUsedTlsLibOutdated' => $this->isUsedTlsLibOutdated(),
+				'phpSupported' => $this->isPhpSupported(),
 			]
 		);
 	}


### PR DESCRIPTION
As I suggested in https://github.com/owncloud/core/issues/16428#issuecomment-103373316

When 8.2 comes out php 5.4 will be End of Life and no longer supported (https://secure.php.net/supported-versions.php). This PR makes sure that we warn admins about this, so they can either upgrade or start complaining to their distro to provider newer packages for PHP. Then at least we did what we could if all of a sudden a huge security exploit in 5.4 is discovered.

CC: @oparoz @DeepDiver1975 @karlitschek @LukasReschke 
