### PR TITLE
Add possibility for alternative logins to force redirection of login page

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -901,14 +901,7 @@ class OC_Util {
 
 		$parameters['alt_login'] = OC_App::getAlternativeLogIns();
 		$parameters['rememberLoginAllowed'] = self::rememberLoginAllowed();
-		foreach($parameters['alt_login'] as $params)
-		{
-			if(isset($params['forceredirect']) && ($params['forceredirect'] === true))
-			{
-				\OCP\Response::redirect($params['href']);
-				exit();
-			}
-		}
+		\OC_Hook::emit('OC_Util', 'pre_displayLoginPage', array('parameters' => $parameters));
 		OC_Template::printGuestPage("", "login", $parameters);
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -901,6 +901,14 @@ class OC_Util {
 
 		$parameters['alt_login'] = OC_App::getAlternativeLogIns();
 		$parameters['rememberLoginAllowed'] = self::rememberLoginAllowed();
+		foreach($parameters['alt_login'] as $params)
+		{
+			if(isset($params['forceredirect']) && ($params['forceredirect'] === true))
+			{
+				\OCP\Response::redirect($params['href']);
+				exit();
+			}
+		}
 		OC_Template::printGuestPage("", "login", $parameters);
 	}
 


### PR DESCRIPTION
Most SSO plugins add a button to the login page to redirect to the SSO login page - either via JavaScript or by calling OC_APP::registerLogin(). 

This PR adds an option to the latter method to force redirection to the configured URL instead of displaying the login page. The SSO solution appears IMHO much better integrated and saves the user one click if it is the only login method (as is in my case). Users are either directly logged in when coming to ownCloud or presented the SSO login page.
