### PR TITLE
Remove Log info when no group filter is set, fixes #17921

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -341,8 +341,6 @@ class Connection extends LDAPUtility {
 			}
 		}
 
-		$groupFilter = $this->configuration->ldapGroupFilter;
-
 		foreach(array('ldapExpertUUIDUserAttr'  => 'ldapUuidUserAttribute',
 					  'ldapExpertUUIDGroupAttr' => 'ldapUuidGroupAttribute')
 				as $expertSetting => $effectiveSetting) {

--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -342,12 +342,6 @@ class Connection extends LDAPUtility {
 		}
 
 		$groupFilter = $this->configuration->ldapGroupFilter;
-		if(empty($groupFilter)) {
-			\OCP\Util::writeLog('user_ldap',
-								'No group filter is specified, LDAP group '.
-								'feature will not be used.',
-								\OCP\Util::INFO);
-		}
 
 		foreach(array('ldapExpertUUIDUserAttr'  => 'ldapUuidUserAttribute',
 					  'ldapExpertUUIDGroupAttr' => 'ldapUuidGroupAttribute')


### PR DESCRIPTION
The log message is superfluous and too noisy. If an admin decides not to use groups, he does not need to be reminded about it on almost every request.

There's actually not much you can test, only that a log message does not appear anymore :)

Please review @SergioBertolinSG @DeepDiver1975  @ryno83 @Crote
