### PR TITLE
[stable8.1] Double slash for SMB storage id for compatibility

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -78,7 +78,10 @@ class SMB extends Common {
 	 * @return string
 	 */
 	public function getId() {
-		return 'smb::' . $this->server->getUser() . '@' . $this->server->getHost() . '/' . $this->share->getName() . '/' . $this->root;
+		// FIXME: double slash to keep compatible with the old storage ids,
+		// failure to do so will lead to creation of a new storage id and
+		// loss of shares from the storage
+		return 'smb::' . $this->server->getUser() . '@' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
 	}
 
 	/**

--- a/apps/files_external/tests/backends/smb.php
+++ b/apps/files_external/tests/backends/smb.php
@@ -61,4 +61,16 @@ class SMB extends Storage {
 		$this->assertTrue($result);
 		$this->assertTrue($this->instance->is_dir('foo bar'));
 	}
+
+	public function testStorageId() {
+		$this->instance = new \OC\Files\Storage\SMB([
+			'host' => 'testhost',
+			'user' => 'testuser',
+			'password' => 'somepass',
+			'share' => 'someshare',
+			'root' => 'someroot',
+		]);
+		$this->assertEquals('smb::testuser@testhost//someshare//someroot/', $this->instance->getId());
+		$this->instance = null;
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/17922 to stable8.1.

@DeepDiver1975 feel free to reschedule if needed.
