### PR TITLE
make sure that hooks are emitted properly on file move operation

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -642,10 +642,10 @@ class View {
 			}
 
 			$run = true;
-			if ($this->shouldEmitHooks() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
+			if ($this->shouldEmitHooks($path1) && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
 				// if it was a rename from a part file to a regular file it was a write and not a rename operation
 				$this->emit_file_hooks_pre($exists, $path2, $run);
-			} elseif ($this->shouldEmitHooks()) {
+			} elseif ($this->shouldEmitHooks($path1)) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, Filesystem::signal_rename,
 					array(
@@ -1087,6 +1087,11 @@ class View {
 			return true;
 		}
 		$fullPath = $this->getAbsolutePath($path);
+
+		if ($fullPath === $defaultRoot) {
+			return true;
+		}
+
 		return (strlen($fullPath) > strlen($defaultRoot)) && (substr($fullPath, 0, strlen($defaultRoot) + 1) === $defaultRoot . '/');
 	}
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1329,7 +1329,9 @@ class View extends \Test\TestCase {
 			['/foo/files/bar', '/foo', true],
 			['/foo', '/foo', false],
 			['/foo', '/files/foo', true],
-			['/foo', 'filesfoo', false]
+			['/foo', 'filesfoo', false],
+			['', '/foo/files', true],
+			['', '/foo/files/bar.txt', true]
 		];
 	}
 


### PR DESCRIPTION
make sure that we emit the hooks if a file gets moved from a sub-folder to the root folder with the nodes API

This was already fixed almost with https://github.com/owncloud/core/pull/16657

Once case was missing: If a file gets moved from a sub-folder to the roots folder with the files node api. You can test this for example with the files_mv app. The nodes API will emit his hooks from his class (\OC\Files) but most app will listen to the hooks emitted by the few which are bound to the class (OC_Filesystem).

see also https://github.com/owncloud/core/issues/17877

@karlitschek should probably be be backported to stable8.1 and stable8 because the already 99% of the fix (#16657) was backported

@icewind1991 please also have a look, thanks!
