### PR TITLE
[stable8.1] make sure that hooks are emitted properly on file move operation

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -642,10 +642,10 @@ class View {
 			}
 
 			$run = true;
-			if ($this->shouldEmitHooks() && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
+			if ($this->shouldEmitHooks($path1) && (Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2))) {
 				// if it was a rename from a part file to a regular file it was a write and not a rename operation
 				$this->emit_file_hooks_pre($exists, $path2, $run);
-			} elseif ($this->shouldEmitHooks()) {
+			} elseif ($this->shouldEmitHooks($path1)) {
 				\OC_Hook::emit(
 					Filesystem::CLASSNAME, Filesystem::signal_rename,
 					array(
@@ -1087,6 +1087,11 @@ class View {
 			return true;
 		}
 		$fullPath = $this->getAbsolutePath($path);
+
+		if ($fullPath === $defaultRoot) {
+			return true;
+		}
+
 		return (strlen($fullPath) > strlen($defaultRoot)) && (substr($fullPath, 0, strlen($defaultRoot) + 1) === $defaultRoot . '/');
 	}
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1329,7 +1329,9 @@ class View extends \Test\TestCase {
 			['/foo/files/bar', '/foo', true],
 			['/foo', '/foo', false],
 			['/foo', '/files/foo', true],
-			['/foo', 'filesfoo', false]
+			['/foo', 'filesfoo', false],
+			['', '/foo/files', true],
+			['', '/foo/files/bar.txt', true]
 		];
 	}
 


### PR DESCRIPTION
Approved backport of https://github.com/owncloud/core/pull/17932

This bug was detected in combination of the files_mv app and encyption. The hooks are not triggered correctly if the rename operation is done with the files node api. This doesn't effect encryption in 8.1 because since 8.1 we don't use the hooks but move the keys directly in the storage wrapper. Still we should make sure that hooks are triggered correctly. This could affect many other parts of the system as well.

@DeepDiver1975 @cmonteroluque please decide if this should go in 8.1.1 or 8.1.2 (not super urgent since encryption isn't affected on 8.1, as described above, but still...)
