### PR TITLE
Disable filesystem_check_changes by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -975,7 +975,7 @@ $CONFIG = array(
  * 2 -> Check every time the filesystem is used, causes a performance hit when
  * using external storages, not recommended for regular use.
  */
-'filesystem_check_changes' => 1,
+'filesystem_check_changes' => 0,
 
 /**
  * All css and js files will be served by the web server statically in one js

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -338,7 +338,7 @@ abstract class Common implements Storage {
 		}
 		if (!isset($this->watcher)) {
 			$this->watcher = new Watcher($storage);
-			$globalPolicy = \OC::$server->getConfig()->getSystemValue('filesystem_check_changes', Watcher::CHECK_ONCE);
+			$globalPolicy = \OC::$server->getConfig()->getSystemValue('filesystem_check_changes', Watcher::CHECK_NEVER);
 			$this->watcher->setPolicy((int)$this->getMountOption('filesystem_check_changes', $globalPolicy));
 		}
 		return $this->watcher;

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -39,6 +39,7 @@ class Watcher extends \Test\TestCase {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
 		$updater = $storage->getWatcher();
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_ONCE);
 
 		//set the mtime to the past so it can detect an mtime change
 		$cache->put('', array('storage_mtime' => 10));
@@ -79,6 +80,7 @@ class Watcher extends \Test\TestCase {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
 		$updater = $storage->getWatcher();
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_ONCE);
 
 		//set the mtime to the past so it can detect an mtime change
 		$cache->put('', array('storage_mtime' => 10));
@@ -95,6 +97,7 @@ class Watcher extends \Test\TestCase {
 		$storage = $this->getTestStorage();
 		$cache = $storage->getCache();
 		$updater = $storage->getWatcher();
+		$updater->setPolicy(\OC\Files\Cache\Watcher::CHECK_ONCE);
 
 		//set the mtime to the past so it can detect an mtime change
 		$cache->put('foo.txt', array('storage_mtime' => 10));


### PR DESCRIPTION
This will prevent detecting remote changes done in the data folder /
root storage by default. In the rare cases where the data folder is
shared with other apps/users outside ownCloud and change detection is
needed, the admin will have to set the option explicitly from now on.

Note that this doesn't affect external storages which have their own
setting in the mount options.

Fixes https://github.com/owncloud/core/issues/16897, see discussion there.

Please review @nickvergessen @schiesbn @DeepDiver1975 @Xenopathic @icewind1991 @karlitschek (CC @MTRichards)

This should go in 8.2. Not sure if we want this in the 8.1 as well because we'd be changing a default value. If we do, we'll need a mention in the release notes.
