### PR TITLE
[stable8] backport of #17464: fix uncaught exception on not permitted file types when setting avata…

### DIFF
--- a/apps/user_ldap/lib/user/user.php
+++ b/apps/user_ldap/lib/user/user.php
@@ -343,7 +343,13 @@ class User {
 		}
 
 		$avatar = $this->avatarManager->getAvatar($this->uid);
-		$avatar->set($this->image);
+		try {
+			$avatar->set($this->image);
+		} catch (\Exception $e) {
+			\OC::$server->getLogger()->notice(
+				'Could not set avatar for ' . $this->dn	. ', because: ' . $e->getMessage(),
+				['app' => 'user_ldap']);
+		}
 	}
 
 }


### PR DESCRIPTION
…r, fixes #17232

Includes the plain fix, not the integration tests (not backportable).

@MorrisJobke @SergioBertolinSG @hostingnuggets here is the backport to OC 8 if you like to test and review.
