### PR TITLE
use inline confirm button style for password-protected links, ref #15176

### DIFF
--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -1,5 +1,4 @@
 #password {
-	width: 190px !important;
 	padding: 10px;
 	margin:	6px;
 }

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -19,7 +19,8 @@
 				autocomplete="off" autocapitalize="off" autocorrect="off"
 				autofocus />
 			<img class="svg" id="password-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt=""/>
-			<input type="submit" value="" class="svg icon-confirm" />
+			<input type="submit" value=""
+				class="svg icon-confirm input-button-inline" />
 		</p>
 	</fieldset>
 </form>

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -278,6 +278,14 @@ input[type="submit"].enabled {
 	border: 1px solid #5e5;
 }
 
+.input-button-inline {
+	position: absolute !important;
+	right: 0;
+	background-color: transparent !important;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
+	opacity: .3;
+}
+
 
 
 /* CONTENT ------------------------------------------------------------------ */


### PR DESCRIPTION
Before:
![capture du 2015-07-29 16-29-42](https://cloud.githubusercontent.com/assets/925062/8960301/897dbcc4-360f-11e5-9779-8e8d4d83d361.png)
After:
![capture du 2015-07-29 16-29-52](https://cloud.githubusercontent.com/assets/925062/8960302/8980dc4c-360f-11e5-963d-a96c512d8647.png)

Ref #15176, please review @owncloud/designers 

Kind of similar to the inline button style in the Bookmarks app: https://github.com/owncloud/bookmarks/pull/170
