### PR TITLE
add theme-color for better Android browser integration

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -9,6 +9,7 @@
 		</title>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
+		<meta name="theme-color" content="<?php p($theme->getMailHeaderColor()); ?>">
 		<link rel="shortcut icon" type="image/png" href="<?php print_unescaped(image_path('', 'favicon.png')); ?>">
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path('', 'favicon-touch.png')); ?>">
 		<?php foreach ($_['cssfiles'] as $cssfile): ?>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -10,6 +10,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">
+		<meta name="theme-color" content="<?php p($theme->getMailHeaderColor()); ?>">
 		<link rel="shortcut icon" type="image/png" href="<?php print_unescaped(image_path('', 'favicon.png')); ?>">
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path('', 'favicon-touch.png')); ?>">
 		<?php foreach($_['cssfiles'] as $cssfile): ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -21,6 +21,7 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
 		<meta name="apple-mobile-web-app-title" content="<?php p((!empty($_['application']) && $_['appid']!='files')? $_['application']:'ownCloud'); ?>">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="theme-color" content="<?php p($theme->getMailHeaderColor()); ?>">
 		<link rel="shortcut icon" type="image/png" href="<?php print_unescaped(image_path($_['appid'], 'favicon.png')); ?>">
 		<link rel="apple-touch-icon-precomposed" href="<?php print_unescaped(image_path($_['appid'], 'favicon-touch.png')); ?>">
 		<?php foreach($_['cssfiles'] as $cssfile): ?>


### PR DESCRIPTION
This sets the color of the tab bar to the ownCloud color (or theme color respectively) for Android L and later. It’s also proposed to become a standard.

See the blog post at https://medium.com/google-design/redesigning-chrome-android-11eab15dc7ee (search for »theme-color«).

Please review @owncloud/designers 
