### PR TITLE
Settings admin warning levels

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -26,9 +26,10 @@
 			var afterCall = function(xhr) {
 				var messages = [];
 				if (xhr.status !== 207 && xhr.status !== 401) {
-					messages.push(
-						t('core', 'Your web server is not yet set up properly to allow file synchronization because the WebDAV interface seems to be broken.')
-					);
+					messages.push({
+						msg: t('core', 'Your web server is not yet set up properly to allow file synchronization because the WebDAV interface seems to be broken.'),
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					});
 				}
 				deferred.resolve(messages);
 			};
@@ -56,31 +57,40 @@
 				var messages = [];
 				if (xhr.status === 200 && data) {
 					if (!data.serverHasInternetConnection) {
-						messages.push(
-							t('core', 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.')
-						);
+						messages.push({
+							msg: t('core', 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 					if(!data.dataDirectoryProtected) {
-						messages.push(
-							t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.')
-						);
+						messages.push({
+							msg: t('core', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+						});
 					}
 					if(!data.isMemcacheConfigured) {
 						messages.push({
 							msg: t('core', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.memcacheDocs}),
-							type: OC.SetupChecks.MESSAGE_TYPE_TIP
+							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						});
 					}
 					if(!data.isUrandomAvailable) {
-						messages.push(
-							t('core', '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.securityDocs})
-						);
+						messages.push({
+							msg: t('core', '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.securityDocs}),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 					if(data.isUsedTlsLibOutdated) {
-						messages.push(data.isUsedTlsLibOutdated);
+						messages.push({
+							msg: data.isUsedTlsLibOutdated,
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 				} else {
-					messages.push(t('core', 'Error occurred while checking server setup'));
+					messages.push({
+						msg: t('core', 'Error occurred while checking server setup'),
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					});
 				}
 				deferred.resolve(messages);
 			};
@@ -136,13 +146,17 @@
 
 				for (var header in securityHeaders) {
 					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
-						messages.push(
-							t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]})
-						);
+						messages.push({
+							msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 				}
 			} else {
-				messages.push(t('core', 'Error occurred while checking server setup'));
+				messages.push({
+					msg: t('core', 'Error occurred while checking server setup'),
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				});
 			}
 
 			return messages;
@@ -172,17 +186,22 @@
 
 					var minimumSeconds = 15768000;
 					if(isNaN(transportSecurityValidity) || transportSecurityValidity <= (minimumSeconds - 1)) {
-						messages.push(
-							t('core', 'The "Strict-Transport-Security" HTTP header is not configured to least "{seconds}" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="{docUrl}">security tips</a>.', {'seconds': minimumSeconds, docUrl: '#admin-tips'})
-						);
+						messages.push({
+							msg: t('core', 'The "Strict-Transport-Security" HTTP header is not configured to least "{seconds}" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="{docUrl}">security tips</a>.', {'seconds': minimumSeconds, docUrl: '#admin-tips'}),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 				} else {
-					messages.push(
-						t('core', 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="{docUrl}">security tips</a>.', {docUrl: '#admin-tips'})
-					);
+					messages.push({
+						msg: t('core', 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="{docUrl}">security tips</a>.', {docUrl: '#admin-tips'}),
+						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+					});
 				}
 			} else {
-				messages.push(t('core', 'Error occurred while checking server setup'));
+				messages.push({
+					msg: t('core', 'Error occurred while checking server setup'),
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				});
 			}
 
 			return messages;

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -10,6 +10,12 @@
 
 (function() {
 	OC.SetupChecks = {
+
+		/* Message types */
+		MESSAGE_TYPE_INFO:0,
+		MESSAGE_TYPE_WARNING:1,
+		MESSAGE_TYPE_ERROR:2,
+
 		/**
 		 * Check whether the WebDAV connection works.
 		 *
@@ -60,9 +66,10 @@
 						);
 					}
 					if(!data.isMemcacheConfigured) {
-						messages.push(
-							t('core', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.memcacheDocs})
-						);
+						messages.push({
+							msg: t('core', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="{docLink}">documentation</a>.', {docLink: data.memcacheDocs}),
+							type: OC.SetupChecks.MESSAGE_TYPE_TIP
+						});
 					}
 					if(!data.isUrandomAvailable) {
 						messages.push(

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -29,7 +29,10 @@ describe('OC.SetupChecks tests', function() {
 			suite.server.requests[0].respond(200);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['Your web server is not yet set up properly to allow file synchronization because the WebDAV interface seems to be broken.']);
+				expect(data).toEqual([{
+					msg: 'Your web server is not yet set up properly to allow file synchronization because the WebDAV interface seems to be broken.',
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				}]);
 				done();
 			});
 		});
@@ -71,9 +74,13 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([
-					'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
-					'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
 					{
+						msg: 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
+						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+					}, {
+						msg: 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					}, {
 						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
 						type: OC.SetupChecks.MESSAGE_TYPE_INFO
 					}]);
@@ -94,11 +101,17 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([
-					'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
-					'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+					{
+						msg: 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
+						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+					},
+					{
+						msg: 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					},
 					{
 						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
-						type: OC.SetupChecks.MESSAGE_TYPE_TIP
+						type: OC.SetupChecks.MESSAGE_TYPE_INFO
 					}]);
 				done();
 			});
@@ -116,7 +129,15 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.']);
+				expect(data).toEqual([
+				{
+					msg: 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				},
+				{
+					msg: 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				}]);
 				done();
 			});
 		});
@@ -133,7 +154,10 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="https://docs.owncloud.org/myDocs.html">documentation</a>.']);
+				expect(data).toEqual([{
+					msg: '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a href="https://docs.owncloud.org/myDocs.html">documentation</a>.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}]);
 				done();
 			});
 		});
@@ -150,7 +174,10 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['Error occurred while checking server setup']);
+				expect(data).toEqual([{
+					msg: 'Error occurred while checking server setup',
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				}]);
 				done();
 			});
 		});
@@ -168,7 +195,13 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['Error occurred while checking server setup', 'Error occurred while checking server setup']);
+				expect(data).toEqual([{
+					msg: 'Error occurred while checking server setup', 
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				},{
+					msg: 'Error occurred while checking server setup',
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				}]);
 				done();
 			});
 		});
@@ -186,7 +219,21 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.', 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.', 'The "X-Robots-Tag" HTTP header is not configured to equal to "none". This is a potential security or privacy risk and we recommend adjusting this setting.', 'The "X-Frame-Options" HTTP header is not configured to equal to "SAMEORIGIN". This is a potential security or privacy risk and we recommend adjusting this setting.']);
+				expect(data).toEqual([
+				{
+					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}, {
+					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}, {
+					msg: 'The "X-Robots-Tag" HTTP header is not configured to equal to "none". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+
+				}, {
+					msg: 'The "X-Frame-Options" HTTP header is not configured to equal to "SAMEORIGIN". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}]);
 				done();
 			});
 		});
@@ -205,7 +252,13 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.', 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.']);
+				expect(data).toEqual([{
+					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.', 
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING,
+				}, {
+					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}]);
 				done();
 			});
 		});
@@ -246,7 +299,10 @@ describe('OC.SetupChecks tests', function() {
 		);
 
 		async.done(function( data, s, x ){
-			expect(data).toEqual(['You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="#admin-tips">security tips</a>.']);
+			expect(data).toEqual([{
+				msg: 'You are accessing this site via HTTP. We strongly suggest you configure your server to require using HTTPS instead as described in our <a href="#admin-tips">security tips</a>.',
+				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+			}]);
 			done();
 		});
 	});
@@ -262,7 +318,13 @@ describe('OC.SetupChecks tests', function() {
 			JSON.stringify({data: {serverHasInternetConnection: false, dataDirectoryProtected: false}})
 		);
 		async.done(function( data, s, x ){
-			expect(data).toEqual(['Error occurred while checking server setup', 'Error occurred while checking server setup']);
+			expect(data).toEqual([{
+				msg: 'Error occurred while checking server setup', 
+				type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+			}, {
+				msg: 'Error occurred while checking server setup',
+				type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+			}]);
 			done();
 		});
 	});
@@ -281,7 +343,10 @@ describe('OC.SetupChecks tests', function() {
 		);
 
 		async.done(function( data, s, x ){
-			expect(data).toEqual(['The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.']);
+			expect(data).toEqual([{
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.',
+				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+			}]);
 			done();
 		});
 	});
@@ -301,7 +366,10 @@ describe('OC.SetupChecks tests', function() {
 		);
 
 		async.done(function( data, s, x ){
-			expect(data).toEqual(['The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.']);
+			expect(data).toEqual([{
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.',
+				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+			}]);
 			done();
 		});
 	});
@@ -321,7 +389,10 @@ describe('OC.SetupChecks tests', function() {
 		);
 
 		async.done(function( data, s, x ){
-			expect(data).toEqual(['The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.']);
+			expect(data).toEqual([{
+				msg: 'The "Strict-Transport-Security" HTTP header is not configured to least "15768000" seconds. For enhanced security we recommend enabling HSTS as described in our <a href="#admin-tips">security tips</a>.',
+				type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+			}]);
 			done();
 		});
 	});

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -70,7 +70,13 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.']);
+				expect(data).toEqual([
+					'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
+					'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+					{
+						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
+						type: OC.SetupChecks.MESSAGE_TYPE_INFO
+					}]);
 				done();
 			});
 		});
@@ -87,7 +93,13 @@ describe('OC.SetupChecks tests', function() {
 			);
 
 			async.done(function( data, s, x ){
-				expect(data).toEqual(['This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.', 'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.', 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.']);
+				expect(data).toEqual([
+					'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
+					'Your data directory and your files are probably accessible from the Internet. The .htaccess file is not working. We strongly suggest that you configure your web server in a way that the data directory is no longer accessible or you move the data directory outside the web server document root.',
+					{
+						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
+						type: OC.SetupChecks.MESSAGE_TYPE_TIP
+					}]);
 				done();
 			});
 		});

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -360,7 +360,6 @@ table.grid td.date{
 #security-warning li {
 	list-style: initial;
 	margin: 10px 0;
-	color: #ce3702;
 }
 
 #shareAPI p { padding-bottom: 0.8em; }
@@ -483,6 +482,12 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 #postsetupchecks .loading {
 	height: 50px;
 	background-position: left center;
+}
+
+#postsetupchecks .errors,
+#postsetupchecks .warnings,
+#security-warning > ul {
+	color: #ce3702;
 }
 
 #admin-tips li {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -175,20 +175,16 @@ $(document).ready(function(){
 			var $warningsEl = $el.find('.warnings');
 			var $infoEl = $el.find('.info');
 			for (var i = 0; i < messages.length; i++ ) {
-				if ($.isPlainObject(messages[i])) {
-					switch(messages[i].type) {
-						case OC.SetupChecks.MESSAGE_TYPE_INFO:
-							$tipsEl.append('<li>' + messages[i].msg + '</li>');
-							break;
-						case OC.SetupChecks.MESSAGE_TYPE_WARNING:
-							$warningsEl.append('<li>' + messages[i].msg + '</li>');
-							break;
-						case OC.SetupChecks.MESSAGE_TYPE_ERROR:
-						default:
-							$errorsEl.append('<li>' + messages[i].msg + '</li>');
-					}
-				} else {
-					$errorsEl.append('<li>' + messages[i] + '</li>');
+				switch(messages[i].type) {
+					case OC.SetupChecks.MESSAGE_TYPE_INFO:
+						$infoEl.append('<li>' + messages[i].msg + '</li>');
+						break;
+					case OC.SetupChecks.MESSAGE_TYPE_WARNING:
+						$warningsEl.append('<li>' + messages[i].msg + '</li>');
+						break;
+					case OC.SetupChecks.MESSAGE_TYPE_ERROR:
+					default:
+						$errorsEl.append('<li>' + messages[i].msg + '</li>');
 				}
 			}
 			if ($errorsEl.find('li').length > 0) {

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -166,17 +166,40 @@ $(document).ready(function(){
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric()
 	).then(function(check1, check2, check3) {
-		var errors = [].concat(check1, check2, check3);
+		var messages = [].concat(check1, check2, check3);
 		var $el = $('#postsetupchecks');
-		var $errorsEl;
 		$el.find('.loading').addClass('hidden');
-		if (errors.length === 0) {
+		if (messages.length === 0) {
 		} else {
-			$errorsEl = $el.find('.errors');
-			for (var i = 0; i < errors.length; i++ ) {
-				$errorsEl.append('<li>' + errors[i] + '</li>');
+			var $errorsEl = $el.find('.errors');
+			var $warningsEl = $el.find('.warnings');
+			var $infoEl = $el.find('.info');
+			for (var i = 0; i < messages.length; i++ ) {
+				if ($.isPlainObject(messages[i])) {
+					switch(messages[i].type) {
+						case OC.SetupChecks.MESSAGE_TYPE_INFO:
+							$tipsEl.append('<li>' + messages[i].msg + '</li>');
+							break;
+						case OC.SetupChecks.MESSAGE_TYPE_WARNING:
+							$warningsEl.append('<li>' + messages[i].msg + '</li>');
+							break;
+						case OC.SetupChecks.MESSAGE_TYPE_ERROR:
+						default:
+							$errorsEl.append('<li>' + messages[i].msg + '</li>');
+					}
+				} else {
+					$errorsEl.append('<li>' + messages[i] + '</li>');
+				}
 			}
-			$errorsEl.removeClass('hidden');
+			if ($errorsEl.find('li').length > 0) {
+				$errorsEl.removeClass('hidden');
+			}
+			if ($warningsEl.find('li').length > 0) {
+				$warningsEl.removeClass('hidden');
+			}
+			if ($infoEl.find('li').length > 0) {
+				$infoEl.removeClass('hidden');
+			}
 			$el.find('.hint').removeClass('hidden');
 		}
 	});

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -171,6 +171,8 @@ if ($_['cronErrors']) {
 <div id="postsetupchecks">
 	<div class="loading"></div>
 	<ul class="errors hidden"></ul>
+	<ul class="warnings hidden"></ul>
+	<ul class="info hidden"></ul>
 	<p class="hint hidden">
 		<?php print_unescaped($l->t('Please double check the <a target="_blank" href="%s">installation guides ↗</a>, and check for any errors or warnings in the <a href="#log-section">log</a>.', link_to_docs('admin-install'))); ?>
 	</p>


### PR DESCRIPTION
Before we can merge #17919 we first should have different levels of warnings.

This adds 3 warnings levels to the setupchecks.
- INFO
- WARNING
- ERROR

I assigned the error levels to the messages. But feel free to correct me if I'm wrong.

Somebody work the CSS magic please (CC: @jancborchardt @MorrisJobke)

Eventually we should move to #17109 (also in the admin panel).
