### PR TITLE
Adding tests for 4 byte unicode characters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,13 +16,23 @@ timestampedNode('SLAVE') {
 
     stage 'PHPUnit 7.1/sqlite'
         executeAndReport('tests/autotest-results-sqlite.xml') {
-            sh '''
-            export NOCOVERAGE=1
-            unset USEDOCKER
-            phpenv local 7.1
-            make test-php TEST_DATABASE=sqlite
-            '''
-        }
+	        sh '''
+        	export NOCOVERAGE=1
+        	unset USEDOCKER
+        	phpenv local 7.1
+		make test-php TEST_DATABASE=sqlite
+        	'''
+	}
+
+    stage 'phpunit/7.0/mysqlmb4'
+        executeAndReport('tests/autotest-results-sqlite.xml') {
+	        sh '''
+        	export NOCOVERAGE=1
+        	unset USEDOCKER
+        	phpenv local 7.0
+		make test-php TEST_DATABASE=mysqlmb4
+        	'''
+	}
 
     stage 'PHPUnit 7.0/sqlite'
         executeAndReport('tests/autotest-results-sqlite.xml') {

--- a/build/autotest.sh
+++ b/build/autotest.sh
@@ -21,7 +21,7 @@ ADMINLOGIN=admin$EXECUTOR_NUMBER
 BASEDIR=$PWD
 
 PRIMARY_STORAGE_CONFIGS="local swift"
-DBCONFIGS="sqlite mysql mariadb pgsql oci"
+DBCONFIGS="sqlite mysql mariadb pgsql oci mysqlmb4"
 
 # $PHP_EXE is run through 'which' and as such e.g. 'php' or 'hhvm' is usually
 # sufficient. Due to the behaviour of 'which', $PHP_EXE may also be a path
@@ -146,6 +146,8 @@ function cleanup_config {
 	if [ -f config/autotest-storage-swift.config.php ]; then
 		rm config/autotest-storage-swift.config.php
 	fi
+	# Remove mysqlmb4.config.php
+	rm -f config/mysqlmb4.config.php
 }
 
 # restore config on exit
@@ -210,6 +212,31 @@ function execute_tests {
 			fi
 			mysql -u "$DATABASEUSER" -powncloud -e "DROP DATABASE IF EXISTS $DATABASENAME" -h $DATABASEHOST || true
 		fi
+	fi
+	if [ "$DB" == "mysqlmb4" ] ; then
+		echo "Fire up the mysql docker"
+		DOCKER_CONTAINER_ID=$(docker run \
+			-v $BASEDIR/tests/docker/mysqlmb4:/etc/mysql/conf.d \
+			-e MYSQL_ROOT_PASSWORD=owncloud \
+			-e MYSQL_USER="$DATABASEUSER" \
+			-e MYSQL_PASSWORD=owncloud \
+			-e MYSQL_DATABASE="$DATABASENAME" \
+			-d mysql:5.7)
+
+		DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
+
+		echo "Waiting for MySQL(utf8mb4) initialisation ..."
+
+		if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 3306 60; then
+			echo "[ERROR] Waited 60 seconds, no response" >&2
+			exit 1
+		fi
+		sleep 1
+
+		echo "MySQL(utf8mb4)  is up."
+		_DB="mysql"
+
+		cp tests/docker/mysqlmb4.config.php config
 	fi
 	if [ "$DB" == "mariadb" ] ; then
 		if [ ! -z "$USEDOCKER" ] ; then

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -123,6 +123,7 @@ $CONFIG = array(
  */
 'dbtableprefix' => '',
 
+
 /**
  * Indicates whether the ownCloud instance was installed successfully; ``true``
  * indicates a successful installation, and ``false`` indicates an unsuccessful
@@ -1068,6 +1069,34 @@ $CONFIG = array(
  * can be 'WAL' or 'DELETE' see for more details https://www.sqlite.org/wal.html
  */
 'sqlite.journal_mode' => 'DELETE',
+
+/**
+ * If this setting is set to true MySQL can handle 4 byte characters instead of
+ * 3 byte characters
+ *
+ * MySQL requires a special setup for longer indexes (> 767 bytes) which are
+ * needed:
+ *
+ * [mysqld]
+ * innodb_large_prefix=true
+ * innodb_file_format=barracuda
+ * innodb_file_per_table=true
+ *
+ * Tables will be created with
+ *  * character set: utf8mb4
+ *  * collation:     utf8mb4_bin
+ *  * row_format:    compressed
+ *
+ * See:
+ * https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html
+ * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
+ * https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_large_prefix
+ * http://www.tocker.ca/2013/10/31/benchmarking-innodb-page-compression-performance.html
+ * http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
+ *
+ * WARNING: EXPERIMENTAL
+ */
+'mysql.utf8mb4' => false,
 
 /**
  * Database types that are supported for installation.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1078,9 +1078,9 @@ $CONFIG = array(
  * needed:
  *
  * [mysqld]
- * innodb_large_prefix=true
- * innodb_file_format=barracuda
- * innodb_file_per_table=true
+ * innodb_large_prefix=ON
+ * innodb_file_format=Barracuda
+ * innodb_file_per_table=ON
  *
  * Tables will be created with
  *  * character set: utf8mb4
@@ -1093,8 +1093,6 @@ $CONFIG = array(
  * https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_large_prefix
  * http://www.tocker.ca/2013/10/31/benchmarking-innodb-page-compression-performance.html
  * http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
- *
- * WARNING: EXPERIMENTAL
  */
 'mysql.utf8mb4' => false,
 

--- a/core/Command/Db/ConvertMysqlToMB4.php
+++ b/core/Command/Db/ConvertMysqlToMB4.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Db;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\DB\MySqlTools;
+use OC\Migration\ConsoleOutput;
+use OC\Repair\Collation;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IURLGenerator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConvertMysqlToMB4 extends Command {
+	/** @var IConfig */
+	private $config;
+
+	/** @var IDBConnection */
+	private $connection;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/**
+	 * @param IConfig $config
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IConfig $config, IDBConnection $connection, IURLGenerator $urlGenerator) {
+		$this->config = $config;
+		$this->connection = $connection;
+		$this->urlGenerator = $urlGenerator;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('db:convert-mysql-charset')
+			->setDescription('Convert charset of MySQL/MariaDB to use utf8mb4');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$output->writeln("This command is only valid for MySQL/MariaDB databases.");
+			return 1;
+		}
+
+		$tools = new MySqlTools();
+		if (!$tools->supports4ByteCharset($this->connection)) {
+			$url = $this->urlGenerator->linkToDocs('admin-db-conversion');
+			$output->writeln("The database is not properly setup to use the charset utf8mb4.");
+			$output->writeln("For more information please read the documentation at $url");
+			return 1;
+		}
+
+		// enable charset
+		$this->config->setSystemValue('mysql.utf8mb4', true);
+
+		// run conversion
+		$coll = new Collation($this->config, $this->connection);
+		$coll->run(new ConsoleOutput($output));
+
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -82,6 +82,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 
 	$application->add(new OC\Core\Command\Db\GenerateChangeScript());
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
+	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -81,7 +81,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
 
 	$application->add(new OC\Core\Command\Db\GenerateChangeScript());
-	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory()));
+	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));

--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -246,4 +246,11 @@ class Db implements IDb {
 	public function getTransactionIsolation() {
 		return $this->connection->getTransactionIsolation();
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function allows4ByteCharacters() {
+		return $this->connection->allows4ByteCharacters();
+	}
 }

--- a/lib/private/DB/AdapterMySQL.php
+++ b/lib/private/DB/AdapterMySQL.php
@@ -38,7 +38,8 @@ class AdapterMySQL extends Adapter {
 	}
 
 	public function fixupStatement($statement) {
-		$statement = str_replace(' ILIKE ', ' COLLATE utf8_general_ci LIKE ', $statement);
+		$characterSet = \OC::$server->getConfig()->getSystemValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
+		$statement = str_replace(' ILIKE ', ' COLLATE ' . $characterSet . '_general_ci LIKE ', $statement);
 		return $statement;
 	}
 }

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -33,6 +33,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Exception\ConstraintViolationException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -427,4 +428,19 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 		$migrator->migrate($toSchema);
 	}
 
+	/**
+	 * Are 4-byte characters allowed or only 3-byte
+	 *
+	 * @return bool
+	 * @since 10.0
+	 */
+	public function allows4ByteCharacters() {
+		if (!$this->getDatabasePlatform() instanceof MySqlPlatform) {
+			return true;
+		}
+		if ($this->getParams()['charset'] === 'utf8mb4') {
+			return true;
+		}
+		return false;
+	}
 }

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -27,6 +27,7 @@ namespace OC\DB;
 use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
 use Doctrine\DBAL\Event\Listeners\SQLSessionInit;
 use Doctrine\DBAL\Event\Listeners\MysqlSessionInit;
+use OC\SystemConfig;
 
 /**
 * Takes care of creating and configuring Doctrine connections.
@@ -62,6 +63,12 @@ class ConnectionFactory {
 			'wrapperClass' => 'OC\DB\Connection',
 		],
 	];
+
+	public function __construct(SystemConfig $systemConfig) {
+		if($systemConfig->getValue('mysql.utf8mb4', false)) {
+			$defaultConnectionParams['mysql']['charset'] = 'utf8mb4';
+		}
+	}
 
 	/**
 	* @brief Get default connection parameters for a given DBMS.

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -130,6 +130,7 @@ class ConnectionFactory {
 				$eventManager->addEventSubscriber(new SQLiteSessionInit(true, $journalMode));
 				break;
 		}
+		/** @var Connection $connection */
 		$connection = DriverManager::getConnection(
 			array_merge($this->getDefaultConnectionParams($type), $additionalConnectionParams),
 			new Configuration(),

--- a/lib/private/DB/MDB2SchemaManager.php
+++ b/lib/private/DB/MDB2SchemaManager.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\Schema;
 use OCP\IDBConnection;
 
 class MDB2SchemaManager {
@@ -65,7 +66,8 @@ class MDB2SchemaManager {
 	 */
 	public function createDbFromStructure($file) {
 		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
-		$toSchema = $schemaReader->loadSchemaFromFile($file);
+		$toSchema = new Schema([], [], $this->conn->getSchemaManager()->createSchemaConfig());
+		$toSchema = $schemaReader->loadSchemaFromFile($file, $toSchema);
 		return $this->executeSchemaChange($toSchema);
 	}
 
@@ -99,7 +101,8 @@ class MDB2SchemaManager {
 	private function readSchemaFromFile($file) {
 		$platform = $this->conn->getDatabasePlatform();
 		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $platform);
-		return $schemaReader->loadSchemaFromFile($file);
+		$toSchema = new Schema([], [], $this->conn->getSchemaManager()->createSchemaConfig());
+		return $schemaReader->loadSchemaFromFile($file, $toSchema);
 	}
 
 	/**
@@ -136,7 +139,8 @@ class MDB2SchemaManager {
 	 */
 	public function removeDBStructure($file) {
 		$schemaReader = new MDB2SchemaReader(\OC::$server->getConfig(), $this->conn->getDatabasePlatform());
-		$fromSchema = $schemaReader->loadSchemaFromFile($file);
+		$toSchema = new Schema([], [], $this->conn->getSchemaManager()->createSchemaConfig());
+		$fromSchema = $schemaReader->loadSchemaFromFile($file, $toSchema);
 		$toSchema = clone $fromSchema;
 		/** @var $table \Doctrine\DBAL\Schema\Table */
 		foreach ($toSchema->getTables() as $table) {

--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -32,6 +32,7 @@ namespace OC\DB;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use OCP\IConfig;
 
 class MDB2SchemaReader {
@@ -53,12 +54,16 @@ class MDB2SchemaReader {
 	/** @var \Doctrine\DBAL\Schema\SchemaConfig $schemaConfig */
 	protected $schemaConfig;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param \OCP\IConfig $config
 	 * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
 	 */
 	public function __construct(IConfig $config, AbstractPlatform $platform) {
 		$this->platform = $platform;
+		$this->config = $config;
 		$this->DBNAME = $config->getSystemValue('dbname', 'owncloud');
 		$this->DBTABLEPREFIX = $config->getSystemValue('dbtableprefix', 'oc_');
 
@@ -119,8 +124,15 @@ class MDB2SchemaReader {
 					$name = str_replace('*dbprefix*', $this->DBTABLEPREFIX, $name);
 					$name = $this->platform->quoteIdentifier($name);
 					$table = $schema->createTable($name);
-					$table->addOption('collate', 'utf8_bin');
 					$table->setSchemaConfig($this->schemaConfig);
+
+					if($this->platform instanceof MySqlPlatform && $this->config->getSystemValue('mysql.utf8mb4', false)) {
+						$table->addOption('charset', 'utf8mb4');
+						$table->addOption('collate', 'utf8mb4_bin');
+						$table->addOption('row_format', 'compressed');
+					} else {
+						$table->addOption('collate', 'utf8_bin');
+					}
 					break;
 				case 'create':
 				case 'overwrite':

--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -31,31 +31,16 @@
 namespace OC\DB;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\SchemaConfig;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
 use OCP\IConfig;
 
 class MDB2SchemaReader {
-	/**
-	 * @var string $DBNAME
-	 */
-	protected $DBNAME;
 
-	/**
-	 * @var string $DBTABLEPREFIX
-	 */
+	/** @var string $DBTABLEPREFIX */
 	protected $DBTABLEPREFIX;
 
-	/**
-	 * @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-	 */
+	/** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
 	protected $platform;
-
-	/** @var \Doctrine\DBAL\Schema\SchemaConfig $schemaConfig */
-	protected $schemaConfig;
-
-	/** @var IConfig */
-	protected $config;
 
 	/**
 	 * @param \OCP\IConfig $config
@@ -63,26 +48,15 @@ class MDB2SchemaReader {
 	 */
 	public function __construct(IConfig $config, AbstractPlatform $platform) {
 		$this->platform = $platform;
-		$this->config = $config;
-		$this->DBNAME = $config->getSystemValue('dbname', 'owncloud');
 		$this->DBTABLEPREFIX = $config->getSystemValue('dbtableprefix', 'oc_');
-
-		// Oracle does not support longer index names then 30 characters.
-		// We use this limit for all DBs to make sure it does not cause a
-		// problem.
-		$this->schemaConfig = new SchemaConfig();
-		$this->schemaConfig->setMaxIdentifierLength(30);
 	}
 
 	/**
 	 * @param string $file
-	 * @return \Doctrine\DBAL\Schema\Schema
-	 * @throws \DomainException
+	 * @param Schema $schema
+	 * @return Schema
 	 */
-	public function loadSchemaFromFile($file, $schema = null) {
-		if (is_null($schema)) {
-			$schema = new \Doctrine\DBAL\Schema\Schema();
-		}
+	public function loadSchemaFromFile($file, Schema $schema) {
 		$loadEntities = libxml_disable_entity_loader(false);
 		$xml = simplexml_load_file($file);
 		libxml_disable_entity_loader($loadEntities);
@@ -124,15 +98,6 @@ class MDB2SchemaReader {
 					$name = str_replace('*dbprefix*', $this->DBTABLEPREFIX, $name);
 					$name = $this->platform->quoteIdentifier($name);
 					$table = $schema->createTable($name);
-					$table->setSchemaConfig($this->schemaConfig);
-
-					if($this->platform instanceof MySqlPlatform && $this->config->getSystemValue('mysql.utf8mb4', false)) {
-						$table->addOption('charset', 'utf8mb4');
-						$table->addOption('collate', 'utf8mb4_bin');
-						$table->addOption('row_format', 'compressed');
-					} else {
-						$table->addOption('collate', 'utf8_bin');
-					}
 					break;
 				case 'create':
 				case 'overwrite':
@@ -285,6 +250,7 @@ class MDB2SchemaReader {
 			) {
 				$options['primary'] = true;
 			}
+
 			$table->addColumn($name, $type, $options);
 			if (!empty($options['primary']) && $options['primary']) {
 				$table->setPrimaryKey([$name]);

--- a/lib/private/DB/MDB2SchemaWriter.php
+++ b/lib/private/DB/MDB2SchemaWriter.php
@@ -42,7 +42,11 @@ class MDB2SchemaWriter {
 		$xml->addChild('name', $config->getSystemValue('dbname', 'owncloud'));
 		$xml->addChild('create', 'true');
 		$xml->addChild('overwrite', 'false');
-		$xml->addChild('charset', 'utf8');
+		if($config->getSystemValue('dbtype', 'sqlite') === 'mysql' && $config->getSystemValue('mysql.utf8mb4', false)) {
+			$xml->addChild('charset', 'utf8mb4');
+		} else {
+			$xml->addChild('charset', 'utf8');
+		}
 
 		// FIX ME: bloody work around
 		if ($config->getSystemValue('dbtype', 'sqlite') === 'oci') {

--- a/lib/private/DB/MySqlTools.php
+++ b/lib/private/DB/MySqlTools.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\DB;
+
+use OCP\IDBConnection;
+
+/**
+* Various MySQL specific helper functions.
+*/
+class MySqlTools {
+
+	/**
+	 * @param Connection $connection
+	 * @return bool
+	 */
+	public function supports4ByteCharset(IDBConnection $connection) {
+		foreach (['innodb_file_format' => 'Barracuda', 'innodb_large_prefix' => 'ON', 'innodb_file_per_table' => 'ON'] as $var => $val) {
+			$result = $connection->executeQuery("SHOW VARIABLES LIKE '$var'");
+			$rows = $result->fetch();
+			$result->closeCursor();
+			if ($rows === false) {
+				return false;
+			}
+			if (strcasecmp($rows['Value'], $val) !== 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -34,7 +34,9 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 	public function iLike($x, $y, $type = null) {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->comparison($x, ' COLLATE utf8_general_ci LIKE', $y);
+
+		$characterSet = \OC::$server->getConfig()->getSystemValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
+		return $this->expressionBuilder->comparison($x, " COLLATE {$characterSet}_general_ci LIKE", $y);
 	}
 
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1793,13 +1793,15 @@ class View {
 			throw new InvalidPathException($l10n->t('Dot files are not allowed'));
 		}
 
-		// verify database - e.g. mysql only 3-byte chars
-		if (preg_match('%(?:
+		if (!\OC::$server->getDatabaseConnection()->allows4ByteCharacters()) {
+			// verify database - e.g. mysql only 3-byte chars
+			if (preg_match('%(?:
       \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
     | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
     | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
 )%xs', $fileName)) {
-			throw new InvalidPathException($l10n->t('4-byte characters are not supported in file names'));
+				throw new InvalidPathException($l10n->t('4-byte characters are not supported in file names'));
+			}
 		}
 
 		try {

--- a/lib/private/Migration/ConsoleOutput.php
+++ b/lib/private/Migration/ConsoleOutput.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\Migration;
+
+
+use OCP\Migration\IOutput;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class SimpleOutput
+ *
+ * Just a simple IOutput implementation with writes messages to the log file.
+ * Alternative implementations will write to the console or to the web ui (web update case)
+ *
+ * @package OC\Migration
+ */
+class ConsoleOutput implements IOutput {
+
+	/** @var OutputInterface */
+	private $output;
+
+	/** @var ProgressBar */
+	private $progressBar;
+
+	public function __construct(OutputInterface $output) {
+		$this->output = $output;
+	}
+
+	/**
+	 * @param string $message
+	 */
+	public function info($message) {
+		$this->output->writeln("<info>$message</info>");
+	}
+
+	/**
+	 * @param string $message
+	 */
+	public function warning($message) {
+		$this->output->writeln("<comment>$message</comment>");
+	}
+
+	/**
+	 * @param int $max
+	 */
+	public function startProgress($max = 0) {
+		if (!is_null($this->progressBar)) {
+			$this->progressBar->finish();
+		}
+		$this->progressBar = new ProgressBar($this->output);
+		$this->progressBar->start($max);
+	}
+
+	/**
+	 * @param int $step
+	 * @param string $description
+	 */
+	public function advance($step = 1, $description = '') {
+		if (!is_null($this->progressBar)) {
+			$this->progressBar = new ProgressBar($this->output);
+			$this->progressBar->start();
+		}
+		$this->progressBar->advance($step);
+	}
+
+	public function finishProgress() {
+		if (is_null($this->progressBar)) {
+			return;
+		}
+		$this->progressBar->finish();
+	}
+}

--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -60,10 +60,12 @@ class Collation implements IRepairStep {
 			return;
 		}
 
+		$characterSet = $this->config->getSystemValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
+
 		$tables = $this->getAllNonUTF8BinTables($this->connection);
 		foreach ($tables as $table) {
 			$output->info("Change collation for $table ...");
-			$query = $this->connection->prepare('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;');
+			$query = $this->connection->prepare('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET ' . $characterSet . ' COLLATE ' . $characterSet . '_bin;');
 			$query->execute();
 		}
 	}
@@ -74,11 +76,12 @@ class Collation implements IRepairStep {
 	 */
 	protected function getAllNonUTF8BinTables($connection) {
 		$dbName = $this->config->getSystemValue("dbname");
+		$characterSet = $this->config->getSystemValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
 		$rows = $connection->fetchAll(
 			"SELECT DISTINCT(TABLE_NAME) AS `table`" .
 			"	FROM INFORMATION_SCHEMA . COLUMNS" .
 			"	WHERE TABLE_SCHEMA = ?" .
-			"	AND (COLLATION_NAME <> 'utf8_bin' OR CHARACTER_SET_NAME <> 'utf8')" .
+			"	AND (COLLATION_NAME <> '" . $characterSet . "_bin' OR CHARACTER_SET_NAME <> '" . $characterSet . "')" .
 			"	AND TABLE_NAME LIKE \"*PREFIX*%\"",
 			[$dbName]
 		);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -441,8 +441,8 @@ class Server extends ServerContainer implements IServerContainer {
 			return new CredentialsManager($c->getCrypto(), $c->getDatabaseConnection());
 		});
 		$this->registerService('DatabaseConnection', function (Server $c) {
-			$factory = new \OC\DB\ConnectionFactory();
 			$systemConfig = $c->getSystemConfig();
+			$factory = new \OC\DB\ConnectionFactory($systemConfig);
 			$type = $systemConfig->getValue('dbtype', 'sqlite');
 			if (!$factory->isValidType($type)) {
 				throw new \OC\DatabaseException('Invalid database type');

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -447,7 +447,7 @@ class Server extends ServerContainer implements IServerContainer {
 			if (!$factory->isValidType($type)) {
 				throw new \OC\DatabaseException('Invalid database type');
 			}
-			$connectionParams = $factory->createConnectionParams($systemConfig);
+			$connectionParams = $factory->createConnectionParams();
 			$connection = $factory->getConnection($type, $connectionParams);
 			$connection->getConfiguration()->setSQLLogger($c->getQueryLogger());
 			return $connection;

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -80,11 +80,11 @@ class Setup {
 	}
 
 	static $dbSetupClasses = [
-		'mysql' => '\OC\Setup\MySQL',
-		'pgsql' => '\OC\Setup\PostgreSQL',
-		'oci'   => '\OC\Setup\OCI',
-		'sqlite' => '\OC\Setup\Sqlite',
-		'sqlite3' => '\OC\Setup\Sqlite',
+		'mysql' => \OC\Setup\MySQL::class,
+		'pgsql' => \OC\Setup\PostgreSQL::class,
+		'oci'   => \OC\Setup\OCI::class,
+		'sqlite' => \OC\Setup\Sqlite::class,
+		'sqlite3' => \OC\Setup\Sqlite::class,
 	];
 
 	/**

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -57,8 +57,9 @@ class MySQL extends AbstractDatabase {
 		try{
 			$name = $this->dbName;
 			$user = $this->dbUser;
-			//we can't use OC_BD functions here because we need to connect as the administrative user.
-			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET utf8 COLLATE utf8_bin;";
+			//we can't use OC_DB functions here because we need to connect as the administrative user.
+			$characterSet = \OC::$server->getSystemConfig()->getValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
+			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE ${characterSet}_bin;";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
 			$this->logger->error('Database creation failed: {error}', [

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -121,7 +121,8 @@ class MySQL extends AbstractDatabase {
 			$connectionParams['host'] = $host;
 		}
 
-		$cf = new ConnectionFactory();
+		$systemConfig = \OC::$server->getSystemConfig();
+		$cf = new ConnectionFactory($systemConfig);
 		return $cf->getConnection('mysql', $connectionParams);
 	}
 

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -28,6 +28,7 @@ namespace OC\Setup;
 
 use OC\DB\Connection;
 use OC\DB\ConnectionFactory;
+use OC\DB\MySqlTools;
 use OCP\IDBConnection;
 
 class MySQL extends AbstractDatabase {
@@ -38,9 +39,12 @@ class MySQL extends AbstractDatabase {
 		$connection = $this->connect();
 
 		// detect mb4
-		if (is_null($this->config->getSystemValue('mysql.utf8mb4', null)) && $this->supports4ByteCharset($connection)) {
-			$this->config->setSystemValue('mysql.utf8mb4', true);
-			$connection = $this->connect();
+		if (is_null($this->config->getSystemValue('mysql.utf8mb4', null))) {
+			$tools = new MySqlTools();
+			if ($tools->supports4ByteCharset($connection)) {
+				$this->config->setSystemValue('mysql.utf8mb4', true);
+				$connection = $this->connect();
+			}
 		}
 
 		$this->createSpecificUser($username, $connection);
@@ -190,24 +194,5 @@ class MySQL extends AbstractDatabase {
 			'dbuser' => $this->dbUser,
 			'dbpassword' => $this->dbPassword,
 		]);
-	}
-
-	/**
-	 * @param Connection $connection
-	 * @return bool
-	 */
-	private function supports4ByteCharset(Connection $connection) {
-		foreach (['innodb_file_format' => 'Barracuda', 'innodb_large_prefix' => 'ON', 'innodb_file_per_table' => 'ON'] as $var => $val) {
-			$result = $connection->executeQuery("SHOW VARIABLES LIKE '$var'");
-			$rows = $result->fetch();
-			$result->closeCursor();
-			if ($rows === false) {
-				return false;
-			}
-			if (strcasecmp($rows['Value'], $val) === 0) {
-				return false;
-			}
-		}
-		return true;
 	}
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -276,4 +276,11 @@ interface IDBConnection {
 	 */
 	public function getTransactionIsolation();
 
+	/**
+	 * Are 4-byte characters allowed or only 3-byte
+	 *
+	 * @return bool
+	 * @since 10.0
+	 */
+	public function allows4ByteCharacters();
 }

--- a/tests/data/db_structure.xml
+++ b/tests/data/db_structure.xml
@@ -293,4 +293,19 @@
 
 	</table>
 
+  <table>
+
+		<name>*dbprefix*text_table</name>
+		<declaration>
+
+         <field>
+          <name>textfield</name>
+          <type>text</type>
+          <notnull>false</notnull>
+          <length>255</length>
+         </field>
+
+		</declaration>
+  </table>
+
 </database>

--- a/tests/docker/mysqlmb4.config.php
+++ b/tests/docker/mysqlmb4.config.php
@@ -1,0 +1,5 @@
+<?php
+
+$CONFIG = array(
+	'mysql.utf8mb4' => true,
+);

--- a/tests/docker/mysqlmb4/mb4.cnf
+++ b/tests/docker/mysqlmb4/mb4.cnf
@@ -1,0 +1,5 @@
+
+[mysqld]
+innodb_large_prefix=true
+innodb_file_format=barracuda
+innodb_file_per_table=true

--- a/tests/docker/mysqlmb4/mb4.cnf
+++ b/tests/docker/mysqlmb4/mb4.cnf
@@ -3,3 +3,6 @@
 innodb_large_prefix=true
 innodb_file_format=barracuda
 innodb_file_per_table=true
+
+innodb_buffer_pool_size = 512M
+innodb_flush_log_at_trx_commit = 2

--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -400,7 +400,7 @@ class LegacyDBTest extends \Test\TestCase {
 	/**
 	 * @dataProvider insertAndSelectDataProvider
 	 */
-	public function testInsertAndSelectData($expected) {
+	public function testInsertAndSelectData($expected, $skipOnMysql) {
 		$table = "*PREFIX*{$this->text_table}";
 
 		$query = OC_DB::prepare("INSERT INTO `$table` (`textfield`) VALUES (?)");
@@ -408,17 +408,21 @@ class LegacyDBTest extends \Test\TestCase {
 		$this->assertEquals(1, $result);
 
 		$actual = OC_DB::prepare("SELECT `textfield` FROM `$table`")->execute()->fetchOne();
+		$config = \OC::$server->getConfig();
+		if($skipOnMysql && $config->getSystemValue('dbtype', 'sqlite') === 'mysql' && $config->getSystemValue('mysql.utf8mb4', false) === false) {
+			return;
+		}
 		$this->assertSame($expected, $actual);
 	}
 
 	public function insertAndSelectDataProvider() {
 		return [
-			['abcdefghijklmnopqrstuvwxyzABCDEFGHIKLMNOPQRSTUVWXYZ'],
-			['0123456789'],
-			['äöüÄÖÜß!"§$%&/()=?#\'+*~°^`´'],
-			['²³¼½¬{[]}\\'],
-			['♡⚗'],
-			['💩'], # :hankey: on github
+			['abcdefghijklmnopqrstuvwxyzABCDEFGHIKLMNOPQRSTUVWXYZ', false],
+			['0123456789', false],
+			['äöüÄÖÜß!"§$%&/()=?#\'+*~°^`´', false],
+			['²³¼½¬{[]}\\', false],
+			['♡⚗', false],
+			['💩', true], # :hankey: on github
 		];
 	}
 }

--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -46,6 +46,11 @@ class LegacyDBTest extends \Test\TestCase {
 	 */
 	private $table5;
 
+	/**
+	 * @var string
+	 */
+	private $text_table;
+
 	protected function setUp() {
 		parent::setUp();
 
@@ -63,6 +68,7 @@ class LegacyDBTest extends \Test\TestCase {
 		$this->table3 = $this->test_prefix.'vcategory';
 		$this->table4 = $this->test_prefix.'decimal';
 		$this->table5 = $this->test_prefix.'uniconst';
+		$this->text_table = $this->test_prefix.'text_table';
 	}
 
 	protected function tearDown() {
@@ -389,5 +395,30 @@ class LegacyDBTest extends \Test\TestCase {
 		$query = OC_DB::prepare("SELECT * FROM `$table` WHERE `fullname` ILIKE ?");
 		$result = $query->execute(['%ba%']);
 		$this->assertCount(1, $result->fetchAll());
+	}
+
+	/**
+	 * @dataProvider insertAndSelectDataProvider
+	 */
+	public function testInsertAndSelectData($expected) {
+		$table = "*PREFIX*{$this->text_table}";
+
+		$query = OC_DB::prepare("INSERT INTO `$table` (`textfield`) VALUES (?)");
+		$result = $query->execute(array($expected));
+		$this->assertEquals(1, $result);
+
+		$actual = OC_DB::prepare("SELECT `textfield` FROM `$table`")->execute()->fetchOne();
+		$this->assertSame($expected, $actual);
+	}
+
+	public function insertAndSelectDataProvider() {
+		return [
+			['abcdefghijklmnopqrstuvwxyzABCDEFGHIKLMNOPQRSTUVWXYZ'],
+			['0123456789'],
+			['äöüÄÖÜß!"§$%&/()=?#\'+*~°^`´'],
+			['²³¼½¬{[]}\\'],
+			['♡⚗'],
+			['💩'], # :hankey: on github
+		];
 	}
 }

--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -400,7 +400,13 @@ class LegacyDBTest extends \Test\TestCase {
 	/**
 	 * @dataProvider insertAndSelectDataProvider
 	 */
-	public function testInsertAndSelectData($expected, $skipOnMysql) {
+	public function testInsertAndSelectData($expected, $requires4ByteSupport) {
+
+		$connection = \OC::$server->getDatabaseConnection();
+		if($requires4ByteSupport && !$connection->allows4ByteCharacters()) {
+			$this->markTestSkipped('Test requires 4-byte support which is not present');
+		}
+
 		$table = "*PREFIX*{$this->text_table}";
 
 		$query = OC_DB::prepare("INSERT INTO `$table` (`textfield`) VALUES (?)");
@@ -408,10 +414,6 @@ class LegacyDBTest extends \Test\TestCase {
 		$this->assertEquals(1, $result);
 
 		$actual = OC_DB::prepare("SELECT `textfield` FROM `$table`")->execute()->fetchOne();
-		$config = \OC::$server->getConfig();
-		if($skipOnMysql && $config->getSystemValue('dbtype', 'sqlite') === 'mysql' && $config->getSystemValue('mysql.utf8mb4', false) === false) {
-			return;
-		}
 		$this->assertSame($expected, $actual);
 	}
 

--- a/tests/lib/DB/MDB2SchemaReaderTest.php
+++ b/tests/lib/DB/MDB2SchemaReaderTest.php
@@ -10,18 +10,30 @@
 namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use OC\DB\MDB2SchemaReader;
+use OCP\IConfig;
+use Test\TestCase;
 
-class MDB2SchemaReaderTest extends \Test\TestCase {
+/**
+ * Class MDB2SchemaReaderTest
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
+class MDB2SchemaReaderTest extends TestCase {
 	/**
-	 * @var \OC\DB\MDB2SchemaReader $reader
+	 * @var MDB2SchemaReader $reader
 	 */
 	protected $reader;
 
 	/**
-	 * @return \OC\Config
+	 * @return IConfig
 	 */
 	protected function getConfig() {
-		$config = $this->getMockBuilder('\OCP\IConfig')
+		/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject $config */
+		$config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$config->expects($this->any())
@@ -34,8 +46,8 @@ class MDB2SchemaReaderTest extends \Test\TestCase {
 	}
 
 	public function testRead() {
-		$reader = new \OC\DB\MDB2SchemaReader($this->getConfig(), new MySqlPlatform());
-		$schema = $reader->loadSchemaFromFile(__DIR__ . '/testschema.xml');
+		$reader = new MDB2SchemaReader($this->getConfig(), new MySqlPlatform());
+		$schema = $reader->loadSchemaFromFile(__DIR__ . '/testschema.xml', new Schema());
 		$this->assertCount(1, $schema->getTables());
 
 		$table = $schema->getTable('test_table');

--- a/tests/lib/DB/SchemaDiffTest.php
+++ b/tests/lib/DB/SchemaDiffTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\DB;
 
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use OC\DB\MDB2SchemaManager;
 use OC\DB\MDB2SchemaReader;
@@ -75,7 +76,8 @@ class SchemaDiffTest extends TestCase {
 		$this->manager->createDbFromStructure($schemaFile);
 
 		$schemaReader = new MDB2SchemaReader($this->config, $this->connection->getDatabasePlatform());
-		$endSchema = $schemaReader->loadSchemaFromFile($schemaFile);
+		$toSchema = new Schema([], [], $this->connection->getSchemaManager()->createSchemaConfig());
+		$endSchema = $schemaReader->loadSchemaFromFile($schemaFile, $toSchema);
 
 		// get the diff
 		/** @var SchemaDiff $diff */

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -9,6 +9,7 @@ namespace Test\Files;
 
 use OC\Files\Storage\Local;
 use OC\Files\View;
+use OCP\Files\InvalidPathException;
 
 /**
  * Class PathVerificationTest
@@ -79,10 +80,12 @@ class PathVerificationTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider providesAstralPlane
-	 * @expectedException \OCP\Files\InvalidPathException
-	 * @expectedExceptionMessage 4-byte characters are not supported in file names
 	 */
 	public function testPathVerificationAstralPlane($fileName) {
+		if (!\OC::$server->getDatabaseConnection()->allows4ByteCharacters()) {
+			$this->expectException(InvalidPathException::class);
+			$this->expectExceptionMessage('4-byte characters are not supported in file names');
+		}
 		$this->view->verifyPath('', $fileName);
 	}
 


### PR DESCRIPTION
- success on SQLite and Postgres
- failure on MySQL due to the limited charset that only supports up to 3 bytes

Use case:

![2015-07-30_10-55-52](https://cloud.githubusercontent.com/assets/245432/8979443/f4c96b28-36a9-11e5-9b07-cf1e9939d2a4.png)

People will name their folders/files with emojis. This then will cause errors like this on mysql:

```
An exception occurred while executing 'UPDATE `oc_filecache` SET `storage` = ?, `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?' with params ["1", "files\/\ud83d\udca9.txt", "743923d586454a40e08523f558ae2955", "\ud83d\udca9.txt", "2", 3]: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect string value: '\xF0\x9F\x92\xA9.t...' for column 'path' at row 1
```

cc @Raydiation @PVince81 @DeepDiver1975 

ref #4513
