### PR TITLE
Correct regular expressions

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1656,11 +1656,11 @@ class View {
 		}
 
 		// verify database - e.g. mysql only 3-byte chars
-		if (preg_match('%^(?:
+		if (preg_match('%(?:
       \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
     | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
     | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
-)*$%xs', $fileName)) {
+)%xs', $fileName)) {
 			throw new InvalidPathException($l10n->t('4-byte characters are not supported in file names'));
 		}
 

--- a/tests/lib/files/pathverificationtest.php
+++ b/tests/lib/files/pathverificationtest.php
@@ -83,6 +83,8 @@ class PathVerification extends \Test\TestCase {
 		return [
 			// this is the monkey emoji - http://en.wikipedia.org/w/index.php?title=%F0%9F%90%B5&redirect=no
 			['🐵'],
+			['🐵.txt'],
+			['txt.💩'],
 		];
 	}
 

--- a/tests/lib/files/pathverificationtest.php
+++ b/tests/lib/files/pathverificationtest.php
@@ -85,6 +85,8 @@ class PathVerification extends \Test\TestCase {
 			['🐵'],
 			['🐵.txt'],
 			['txt.💩'],
+			['💩🐵.txt'],
+			['💩🐵'],
 		];
 	}
 


### PR DESCRIPTION
Previously the regex was only matching on single characters. Meaning that file names such as ":+1:.txt" where possible while ":+1:" alone never was. This check apparently never worked as expected.

@DeepDiver1975 
