### PR TITLE
Sanitize class names before registerService/query

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -99,6 +99,7 @@ class SimpleContainer extends Container implements IContainer {
 	 * @throws QueryException if the query could not be resolved
 	 */
 	public function query($name) {
+		$name = $this->sanitizeName($name);
 		if ($this->offsetExists($name)) {
 			return $this->offsetGet($name);
 		} else {
@@ -128,6 +129,7 @@ class SimpleContainer extends Container implements IContainer {
 	 * @param bool $shared
 	 */
 	public function registerService($name, Closure $closure, $shared = true) {
+		$name = $this->sanitizeName($name);
 		if (isset($this[$name]))  {
 			unset($this[$name]);
 		}
@@ -149,6 +151,14 @@ class SimpleContainer extends Container implements IContainer {
 		$this->registerService($alias, function (IContainer $container) use ($target) {
 			return $container->query($target);
 		});
+	}
+
+	/*
+	 * @param string $name
+	 * @return string
+	 */
+	protected function sanitizeName($name) {
+		return ltrim($name, '\\');
 	}
 
 }

--- a/tests/lib/appframework/utility/SimpleContainerTest.php
+++ b/tests/lib/appframework/utility/SimpleContainerTest.php
@@ -167,6 +167,25 @@ class SimpleContainerTest extends \Test\TestCase {
         $this->assertEquals('abc', $this->container->query('test1'));
     }
 
+    public function sanitizeNameProvider() {
+        return [
+            ['ABC\\Foo', 'ABC\\Foo'],
+            ['\\ABC\\Foo', '\\ABC\\Foo'],
+            ['\\ABC\\Foo', 'ABC\\Foo'],
+            ['ABC\\Foo', '\\ABC\\Foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider sanitizeNameProvider
+     */
+    public function testSanitizeName($register, $query) {
+        $this->container->registerService($register, function() {
+            return 'abc';
+        });
+        $this->assertEquals('abc', $this->container->query($query));
+    }
+
     /**
      * @expectedException \OCP\AppFramework\QueryException
      */


### PR DESCRIPTION
Leading backslashes are removed, so a `registerService('\\OC\\Foo')` can still be resolved with `query('OC\\Foo')`.

Rationale: sometimes people query services with a leading backslash, while the appframework auto-reflection system queries without the leading backslash (and sometimes, people query like that too). Since both class names are perfectly valid, they should be resolved correctly to the same object. As the appframework has used the form without the backslash all this time, I decided to sanitize all class names to that form.

cc @rullzer @MorrisJobke @DeepDiver1975 @nickvergessen @LukasReschke 
