### PR TITLE
only update database on the first run

### DIFF
--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -306,6 +306,7 @@ class MigrationTest extends \Test\TestCase {
 		$this->prepareDB();
 
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
 		$this->verifyDB('*PREFIX*appconfig', 'files_encryption', 0);
@@ -325,6 +326,7 @@ class MigrationTest extends \Test\TestCase {
 		$config->setUserValue(self::TEST_ENCRYPTION_MIGRATION_USER1, 'encryption', 'recoverKeyEnabled', '9');
 
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
 		$this->verifyDB('*PREFIX*appconfig', 'files_encryption', 0);
@@ -388,6 +390,7 @@ class MigrationTest extends \Test\TestCase {
 	public function testUpdateFileCache() {
 		$this->prepareFileCache();
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		self::invokePrivate($m, 'updateFileCache');
 
 		// check results


### PR DESCRIPTION
only update database on the first run . Check the version number from the old encryption app to detect the first run. Otherwise we might end up with a wrong (unencrypted)size in the database which will break the download.

fix https://github.com/owncloud/core/issues/17983

cc @karlitschek needs to be backported to 8.1.1
