### PR TITLE
[stable8.1] only update database on the first run

### DIFF
--- a/apps/encryption/lib/migration.php
+++ b/apps/encryption/lib/migration.php
@@ -37,9 +37,10 @@ class Migration {
 	private $connection;
 	/** @var IConfig */
 	private $config;
-
 	/** @var  ILogger */
 	private $logger;
+	/** @var string*/
+	protected $installedVersion;
 
 	/**
 	 * @param IConfig $config
@@ -54,6 +55,7 @@ class Migration {
 		$this->moduleId = \OCA\Encryption\Crypto\Encryption::ID;
 		$this->config = $config;
 		$this->logger = $logger;
+		$this->installedVersion = $this->config->getAppValue('files_encryption', 'installed_version', '-1');
 	}
 
 	public function finalCleanUp() {
@@ -66,12 +68,16 @@ class Migration {
 	 * update file cache, copy unencrypted_size to the 'size' column
 	 */
 	private function updateFileCache() {
-		$query = $this->connection->createQueryBuilder();
-		$query->update('`*PREFIX*filecache`')
-			->set('`size`', '`unencrypted_size`')
-			->where($query->expr()->eq('`encrypted`', ':encrypted'))
-			->setParameter('encrypted', 1);
-		$query->execute();
+		// make sure that we don't update the file cache multiple times
+		// only update during the first run
+		if ($this->installedVersion !== '-1') {
+			$query = $this->connection->createQueryBuilder();
+			$query->update('`*PREFIX*filecache`')
+				->set('`size`', '`unencrypted_size`')
+				->where($query->expr()->eq('`encrypted`', ':encrypted'))
+				->setParameter('encrypted', 1);
+			$query->execute();
+		}
 	}
 
 	/**
@@ -143,6 +149,12 @@ class Migration {
 	 * update database
 	 */
 	public function updateDB() {
+
+		// make sure that we don't update the file cache multiple times
+		// only update during the first run
+		if ($this->installedVersion === '-1') {
+			return;
+		}
 
 		// delete left-over from old encryption which is no longer needed
 		$this->config->deleteAppValue('files_encryption', 'ocsid');

--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -306,6 +306,7 @@ class MigrationTest extends \Test\TestCase {
 		$this->prepareDB();
 
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
 		$this->verifyDB('`*PREFIX*appconfig`', 'files_encryption', 0);
@@ -325,6 +326,7 @@ class MigrationTest extends \Test\TestCase {
 		$config->setUserValue(self::TEST_ENCRYPTION_MIGRATION_USER1, 'encryption', 'recoverKeyEnabled', '9');
 
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		$m->updateDB();
 
 		$this->verifyDB('`*PREFIX*appconfig`', 'files_encryption', 0);
@@ -388,6 +390,7 @@ class MigrationTest extends \Test\TestCase {
 	public function testUpdateFileCache() {
 		$this->prepareFileCache();
 		$m = new Migration(\OC::$server->getConfig(), new \OC\Files\View(), \OC::$server->getDatabaseConnection(), $this->logger);
+		$this->invokePrivate($m, 'installedVersion', ['0.7']);
 		self::invokePrivate($m, 'updateFileCache');
 
 		// check results


### PR DESCRIPTION
approved backport of https://github.com/owncloud/core/pull/17989

only update database on the first run . Check the version number from the old encryption app to detect the first run. Otherwise we might end up with a wrong (unencrypted)size in the database which will break the download.

fix #17983
