### PR TITLE
Introduce whenUserAvailable() helper to UserSession

### DIFF
--- a/apps/encryption/tests/controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/controller/SettingsControllerTest.php
@@ -88,6 +88,7 @@ class SettingsControllerTest extends TestCase {
 				'setUser',
 				'getUser',
 				'canChangePassword',
+				'whenUserAvailable',
 			])
 			->getMock();
 

--- a/apps/encryption/tests/hooks/UserHooksTest.php
+++ b/apps/encryption/tests/hooks/UserHooksTest.php
@@ -229,7 +229,8 @@ class UserHooksTest extends TestCase {
 				'logout',
 				'setUser',
 				'getUser',
-				'canChangePassword'
+				'canChangePassword',
+				'whenUserAvailable',
 			])
 			->getMock();
 

--- a/apps/encryption/tests/lib/RecoveryTest.php
+++ b/apps/encryption/tests/lib/RecoveryTest.php
@@ -201,7 +201,8 @@ class RecoveryTest extends TestCase {
 				'login',
 				'logout',
 				'setUser',
-				'getUser'
+				'getUser',
+				'whenUserAvailable',
 			])
 			->getMock();
 

--- a/apps/encryption/tests/lib/UtilTest.php
+++ b/apps/encryption/tests/lib/UtilTest.php
@@ -82,7 +82,8 @@ class UtilTest extends TestCase {
 				'login',
 				'logout',
 				'setUser',
-				'getUser'
+				'getUser',
+				'whenUserAvailable',
 			])
 			->getMock();
 

--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -212,6 +212,14 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $this->getServer()->getUserSession();
 		});
 
+		$this->registerService('OCP\\IUser', function($c) {
+			$userSession = $c->query('OCP\\IUserSession');
+			if (!$userSession->isLoggedIn()) {
+				throw new \RuntimeException('No user logged in');
+			}
+			return $userSession->getUser();
+		});
+
 		$this->registerService('ServerContainer', function ($c) {
 			return $this->getServer();
 		});

--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -79,4 +79,12 @@ interface IUserSession {
 	 * @since 8.0.0
 	 */
 	public function isLoggedIn();
+
+	/**
+	 * Set a callback for when a user is available
+	 *
+	 * @param callable $callback function(\OCP\IUser $user)
+	 * @since 8.2.0
+	 */
+	public function whenUserAvailable(callable $callback);
 }

--- a/tests/lib/user/session.php
+++ b/tests/lib/user/session.php
@@ -397,4 +397,75 @@ class Session extends \Test\TestCase {
 		$userSession->setSession($session2);
 		$this->assertEquals($users['bar'], $userSession->getUser());
 	}
+
+	public function testWhenAvailableUserSetUser() {
+		$session = $this->getMockBuilder('\OC\Session\Memory')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$manager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$userSession = new \OC\User\Session($manager, $session);
+		$this->assertEquals(null, $userSession->getUser());
+
+		$user = $this->getMock('\OCP\IUser');
+
+		$callback1 = $this->getMock('stdClass', ['callback']);
+		$callback1->expects($this->once())
+			->method('callback')
+			->with($user);
+		$callback2 = $this->getMock('stdClass', ['callback']);
+		$callback2->expects($this->once())
+			->method('callback')
+			->with($user);
+
+		$userSession->whenUserAvailable([$callback1, 'callback']);
+
+		$userSession->setUser($user);
+
+		$userSession->whenUserAvailable([$callback2, 'callback']);
+	}
+
+	public function testWhenAvailableUserSetSession() {
+		$session = $this->getMockBuilder('\OC\Session\Memory')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$session2 = $this->getMockBuilder('\OC\Session\Memory')
+			->disableOriginalConstructor()
+			->getMock();
+		$session2->method('get')
+			->with('user_id')
+			->willReturn('foo');
+
+		$user = $this->getMock('\OCP\IUser');
+
+		$manager = $this->getMockBuilder('\OC\User\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$manager->method('get')
+			->with('foo')
+			->willReturn($user);
+
+		$userSession = new \OC\User\Session($manager, $session);
+		$this->assertEquals(null, $userSession->getUser());
+
+		$callback1 = $this->getMock('stdClass', ['callback']);
+		$callback1->expects($this->once())
+			->method('callback')
+			->with($user);
+		$callback2 = $this->getMock('stdClass', ['callback']);
+		$callback2->expects($this->once())
+			->method('callback')
+			->with($user);
+
+		$userSession->whenUserAvailable([$callback1, 'callback']);
+
+		$userSession->setSession($session2);
+
+		$userSession->whenUserAvailable([$callback2, 'callback']);
+	}
+
 }


### PR DESCRIPTION
Makes it easy to run code when a user is available in the session, when a user has logged in or if the session is still active from a previous login. Avoids needing to check for an active user _and_ have a hook set on login.

In addition, \OCP\IUser has been exposed to the appframework dependency injection containers, to get the current active user (will throw an exception if there is no active user).

cc @icewind1991 @blizzz @MorrisJobke @LukasReschke 
