### PR TITLE
Set config direcotry over environment variable

### DIFF
--- a/core/setup/controller.php
+++ b/core/setup/controller.php
@@ -40,7 +40,7 @@ class Controller {
 	 * @param Setup $setupHelper
 	 */
 	function __construct(Setup $setupHelper) {
-		$this->autoConfigFile = \OC::$SERVERROOT.'/config/autoconfig.php';
+		$this->autoConfigFile = \OC::$configDir.'autoconfig.php';
 		$this->setupHelper = $setupHelper;
 	}
 

--- a/cron.php
+++ b/cron.php
@@ -85,7 +85,7 @@ try {
 				exit(0);
 			}
 			$user = posix_getpwuid(posix_getuid());
-			$configUser = posix_getpwuid(fileowner(OC::$SERVERROOT . '/config/config.php'));
+			$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
 			if ($user['name'] !== $configUser['name']) {
 				echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
 				echo "Current user: " . $user['name'] . PHP_EOL;

--- a/lib/base.php
+++ b/lib/base.php
@@ -128,6 +128,8 @@ class OC {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
+		} elseif(getenv('OWNCLOUD_CONFIG')) {
+			self::$configDir = getenv('OWNCLOUD_CONFIG');
 		} else {
 			self::$configDir = OC::$SERVERROOT . '/config/';
 		}
@@ -243,7 +245,7 @@ class OC {
 		$l = \OC::$server->getL10N('lib');
 
 		// Create config in case it does not already exists
-		$configFilePath = self::$configDir .'/config.php';
+		$configFilePath = self::$configDir .'config.php';
 		if(!file_exists($configFilePath)) {
 			@touch($configFilePath);
 		}


### PR DESCRIPTION
I host several ownCloud instances, and I just want a ownCloud application on the server. For that I need a way to change the configuration-directory.

For php-fpm add the following to pool config:
env[OWNCLOUD_CONFIG] = /etc/owncloud/

For apache add the following to vhost config:
SetEnv OWNCLOUD_CONFIG /etc/owncloud/

Add to variables_order E in php.ini:
for example: variables_order     = "EGPCS"
