### PR TITLE
storage wrapper base class: always forward the same operation

### DIFF
--- a/lib/private/files/storage/wrapper/wrapper.php
+++ b/lib/private/files/storage/wrapper/wrapper.php
@@ -547,10 +547,6 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	 * @return bool
 	 */
 	public function copyFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		if ($sourceStorage === $this) {
-			return $this->copy($sourceInternalPath, $targetInternalPath);
-		}
-
 		return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
@@ -561,10 +557,6 @@ class Wrapper implements \OC\Files\Storage\Storage {
 	 * @return bool
 	 */
 	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-		if ($sourceStorage === $this) {
-			return $this->rename($sourceInternalPath, $targetInternalPath);
-		}
-
 		return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 


### PR DESCRIPTION
always forward the same operation so that each storage wrapper has to change to react on it. Otherwise it can happen that we by-pass important storage wrappers. See this discussion for more details: https://github.com/owncloud/core/issues/17594#issuecomment-126681110

fix https://github.com/owncloud/core/issues/17594

cc @icewind1991 please also have a look
