### PR TITLE
[stable8.1] let the encryption storage wrapper always update the file cache

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -127,12 +127,11 @@ class Encryption extends Wrapper {
 		$info = $this->getCache()->get($path);
 		if (isset($this->unencryptedSize[$fullPath])) {
 			$size = $this->unencryptedSize[$fullPath];
+			// update file cache
+			$info['encrypted'] = true;
+			$info['size'] = $size;
+			$this->getCache()->put($path, $info);
 
-			if (isset($info['fileid'])) {
-				$info['encrypted'] = true;
-				$info['size'] = $size;
-				$this->getCache()->put($path, $info);
-			}
 			return $size;
 		}
 

--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -261,10 +261,12 @@ class Encryption extends \Test\Files\Storage\Storage {
 				->expects($this->once())
 				->method('copyKeys')
 				->willReturn($copyKeysReturn);
-			$this->cache->expects($this->once())
+			$this->cache->expects($this->atLeastOnce())
 				->method('put')
-				->with($this->anything(), ['encrypted' => true])
-				->willReturn(true);
+				->willReturnCallback(function($path, $data) {
+					$this->assertArrayHasKey('encrypted', $data);
+					$this->assertTrue($data['encrypted']);
+				});
 		} else {
 			$this->cache->expects($this->never())->method('put');
 			$this->keyStore->expects($this->never())->method('copyKeys');


### PR DESCRIPTION
approved backport of https://github.com/owncloud/core/pull/18009
