### PR TITLE
Update phpseclib to 2.0 for increased PHP7 compatibility

### DIFF
--- a/apps/files_external/controller/ajaxcontroller.php
+++ b/apps/files_external/controller/ajaxcontroller.php
@@ -25,6 +25,7 @@ namespace OCA\Files_External\Controller;
 use OCP\AppFramework\Controller;
 use OCP\IRequest;
 use OCP\AppFramework\Http\JSONResponse;
+use phpseclib\Crypt\RSA;
 
 class AjaxController extends Controller {
 	public function __construct($appName, IRequest $request) {
@@ -32,8 +33,8 @@ class AjaxController extends Controller {
 	}
 
 	private function generateSshKeys() {
-		$rsa = new \Crypt_RSA();
-		$rsa->setPublicKeyFormat(CRYPT_RSA_PUBLIC_FORMAT_OPENSSH);
+		$rsa = new RSA();
+		$rsa->setPublicKeyFormat(RSA::PUBLIC_FORMAT_OPENSSH);
 		$rsa->setPassword(\OC::$server->getConfig()->getSystemValue('secret', ''));
 
 		$key = $rsa->createKey();

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -31,6 +31,8 @@
  *
  */
 
+use phpseclib\Crypt\AES;
+
 /**
  * Class to configure mount.json globally and for users
  */
@@ -895,10 +897,7 @@ class OC_Mount_Config {
 	 * Returns the encryption cipher
 	 */
 	private static function getCipher() {
-		if (!class_exists('Crypt_AES', false)) {
-			include('Crypt/AES.php');
-		}
-		$cipher = new Crypt_AES(CRYPT_AES_MODE_CBC);
+		$cipher = new AES(AES::MODE_CBC);
 		$cipher->setKey(\OC::$server->getConfig()->getSystemValue('passwordsalt', null));
 		return $cipher;
 	}

--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -30,8 +30,12 @@
  */
 namespace OC\Files\Storage;
 
+use phpseclib\Net\RSA;
+use phpseclib\Net\SFTP;
+use phpseclib\Net\SFTP\Stream;
+
 /**
-* Uses phpseclib's Net_SFTP class and the Net_SFTP_Stream stream wrapper to
+* Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
 * provide access to SFTP servers.
 */
 class SFTP extends \OC\Files\Storage\Common {
@@ -42,7 +46,7 @@ class SFTP extends \OC\Files\Storage\Common {
 	private $port = 22;
 
 	/**
-	* @var \Net_SFTP
+	* @var SFTP
 	*/
 	protected $client;
 
@@ -51,10 +55,10 @@ class SFTP extends \OC\Files\Storage\Common {
 	 */
 	public function __construct($params) {
 		// Register sftp://
-		\Net_SFTP_Stream::register();
+		Stream::register();
 
 		$this->host = $params['host'];
-		
+
 		//deals with sftp://server example
 		$proto = strpos($this->host, '://');
 		if ($proto != false) {
@@ -87,7 +91,7 @@ class SFTP extends \OC\Files\Storage\Common {
 	/**
 	 * Returns the connection.
 	 *
-	 * @return \Net_SFTP connected client instance
+	 * @return SFTP connected client instance
 	 * @throws \Exception when the connection failed
 	 */
 	public function getConnection() {
@@ -96,7 +100,7 @@ class SFTP extends \OC\Files\Storage\Common {
 		}
 
 		$hostKeys = $this->readHostKeys();
-		$this->client = new \Net_SFTP($this->host, $this->port);
+		$this->client = new SFTP($this->host, $this->port);
 
 		// The SSH Host Key MUST be verified before login().
 		$currentHostKey = $this->client->getServerPublicHostKey();

--- a/apps/files_external/lib/sftp_key.php
+++ b/apps/files_external/lib/sftp_key.php
@@ -22,10 +22,9 @@
  */
 namespace OC\Files\Storage;
 
-/**
-* Uses phpseclib's Net_SFTP class and the Net_SFTP_Stream stream wrapper to
-* provide access to SFTP servers.
-*/
+use phpseclib\Crypt\RSA;
+use phpseclib\Net\SFTP;
+
 class SFTP_Key extends \OC\Files\Storage\SFTP {
 	private $publicKey;
 	private $privateKey;
@@ -39,7 +38,7 @@ class SFTP_Key extends \OC\Files\Storage\SFTP {
 	/**
 	 * Returns the connection.
 	 *
-	 * @return \Net_SFTP connected client instance
+	 * @return SFTP connected client instance
 	 * @throws \Exception when the connection failed
 	 */
 	public function getConnection() {
@@ -48,7 +47,7 @@ class SFTP_Key extends \OC\Files\Storage\SFTP {
 		}
 
 		$hostKeys = $this->readHostKeys();
-		$this->client = new \Net_SFTP($this->getHost());
+		$this->client = new SFTP($this->getHost());
 
 		// The SSH Host Key MUST be verified before login().
 		$currentHostKey = $this->client->getServerPublicHostKey();
@@ -74,10 +73,10 @@ class SFTP_Key extends \OC\Files\Storage\SFTP {
 	/**
 	 * Returns the private key to be used for authentication to the remote server.
 	 *
-	 * @return \Crypt_RSA instance or null in case of a failure to load the key.
+	 * @return RSA instance or null in case of a failure to load the key.
 	 */
 	private function getPrivateKey() {
-		$key = new \Crypt_RSA();
+		$key = new RSA();
 		$key->setPassword(\OC::$server->getConfig()->getSystemValue('secret', ''));
 		if (!$key->loadKey($this->privateKey)) {
 			// Should this exception rather than return null?

--- a/lib/private/security/crypto.php
+++ b/lib/private/security/crypto.php
@@ -23,8 +23,8 @@
 
 namespace OC\Security;
 
-use Crypt_AES;
-use Crypt_Hash;
+use phpseclib\Crypt\AES;
+use phpseclib\Crypt\Hash;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use OCP\Security\StringUtils;
@@ -41,7 +41,7 @@ use OCP\IConfig;
  * @package OC\Security
  */
 class Crypto implements ICrypto {
-	/** @var Crypt_AES $cipher */
+	/** @var AES $cipher */
 	private $cipher;
 	/** @var int */
 	private $ivLength = 16;
@@ -51,7 +51,7 @@ class Crypto implements ICrypto {
 	private $random;
 
 	function __construct(IConfig $config, ISecureRandom $random) {
-		$this->cipher = new Crypt_AES();
+		$this->cipher = new AES();
 		$this->config = $config;
 		$this->random = $random;
 	}
@@ -69,7 +69,7 @@ class Crypto implements ICrypto {
 		// Append an "a" behind the password and hash it to prevent reusing the same password as for encryption
 		$password = hash('sha512', $password . 'a');
 
-		$hash = new Crypt_Hash('sha512');
+		$hash = new Hash('sha512');
 		$hash->setKey($password);
 		return $hash->hash($message);
 	}


### PR DESCRIPTION
Depends on https://github.com/owncloud/3rdparty/pull/190

New Features Include:
- Minimum PHP Version 5.3.3
- PSR-4 autoloading with namespace rooted at `\phpseclib\`
  - Removal of PHP4 constructors
  - Removal of manual includes
  - One class per file
- Refactoring of function files into classes
- Some refactoring of defined constants into class constants (only true constants)
- Removal of side-effects from class files
- Removal of full license text from source code files
- Removal of the `phpseclib_resolve_include_path` function
