### PR TITLE
[PHP 7] Change type hint to also accept Errors

### DIFF
--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -222,9 +222,9 @@ class OC_Template extends \OC\Template\Base {
 
 	/**
 	 * print error page using Exception details
-	 * @param Exception $exception
+	 * @param Exception|Error $exception
 	 */
-	public static function printExceptionErrorPage(Exception $exception) {
+	public static function printExceptionErrorPage($exception) {
 		$request = \OC::$server->getRequest();
 		$content = new \OC_Template('', 'exception', 'error', false);
 		$content->assign('errorClass', get_class($exception));


### PR DESCRIPTION
PHP 7 changed the exception types and thus our error handler needs to be able to catch this. See also https://github.com/tpunt/PHP7-Reference#exceptions-in-the-engine

Without this in some cases just a white page is shown instead of an error message.

@DeepDiver1975 THX
