### PR TITLE
[8.1] fix infinite loops with propagating etags on reshares

### DIFF
--- a/apps/files_sharing/lib/propagation/recipientpropagator.php
+++ b/apps/files_sharing/lib/propagation/recipientpropagator.php
@@ -133,8 +133,8 @@ class RecipientPropagator {
 			$this->markDirty($share, microtime(true));
 
 			// propagate up the share tree
-			$user = $share['uid_owner'];
-			if($user !== $this->userId) {
+			if ($share['share_with'] === $this->userId) {
+				$user = $share['uid_owner'];
 				$view = new View('/' . $user . '/files');
 				$path = $view->getPath($share['file_source']);
 				$watcher = new ChangeWatcher($view, $this->manager->getSharePropagator($user));

--- a/apps/files_sharing/tests/etagpropagation.php
+++ b/apps/files_sharing/tests/etagpropagation.php
@@ -266,15 +266,15 @@ class EtagPropagation extends TestCase {
 			\OCP\Share::unshare(
 				'folder',
 				$folderId,
-			   	\OCP\Share::SHARE_TYPE_USER,
+				\OCP\Share::SHARE_TYPE_USER,
 				self::TEST_FILES_SHARING_API_USER2
 			)
 		);
 		$this->assertEtagsForFoldersChanged([
 			// direct recipient affected
-		   	self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER2,
 			// reshare recipient affected
-		   	self::TEST_FILES_SHARING_API_USER4,
+			self::TEST_FILES_SHARING_API_USER4,
 		]);
 
 		$this->assertAllUnchaged();
@@ -287,9 +287,9 @@ class EtagPropagation extends TestCase {
 		);
 		$this->assertEtagsForFoldersChanged([
 			// direct recipient affected
-		   	self::TEST_FILES_SHARING_API_USER2,
+			self::TEST_FILES_SHARING_API_USER2,
 			// reshare recipient affected
-		   	self::TEST_FILES_SHARING_API_USER4,
+			self::TEST_FILES_SHARING_API_USER4,
 		]);
 
 		$this->assertAllUnchaged();
@@ -395,6 +395,15 @@ class EtagPropagation extends TestCase {
 		Filesystem::unlink('/sub1/sub2/inside/file.txt');
 		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER4]);
+
+		$this->assertAllUnchaged();
+	}
+
+	public function testRecipientUploadInDirectReshare() {
+		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER2);
+		Filesystem::file_put_contents('/directReshare/test.txt', 'sad');
+		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER3]);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER4]);
 
 		$this->assertAllUnchaged();
 	}


### PR DESCRIPTION
Backport of #18037

cc @DeepDiver1975 @PVince81 
