### PR TITLE
disable "ssl root certificate" settings if user can't mount external storages

### DIFF
--- a/settings/application.php
+++ b/settings/application.php
@@ -107,7 +107,8 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('CertificateManager'),
-				$c->query('L10N')
+				$c->query('L10N'),
+				$c->query('IAppManager')
 			);
 		});
 		$container->registerService('GroupsController', function(IContainer $c) {

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -104,6 +104,17 @@ $clients = array(
 	'ios'     => $config->getSystemValue('customclient_ios', $defaults->getiOSClientUrl())
 );
 
+// only show root certificate import if external storages are enabled
+$enableCertImport = false;
+$externalStorageEnabled = \OC::$server->getAppManager()->isEnabledForUser('files_external');
+if ($externalStorageEnabled) {
+	$backends = OC_Mount_Config::getPersonalBackends();
+	if (!empty($backends)) {
+		$enableCertImport = true;
+	}
+}
+
+
 // Return template
 $tmpl = new OC_Template( 'settings', 'personal', 'user');
 $tmpl->assign('usage', OC_Helper::humanFileSize($storageInfo['used']));
@@ -120,6 +131,7 @@ $tmpl->assign('displayName', OC_User::getDisplayName());
 $tmpl->assign('enableAvatars', $config->getSystemValue('enable_avatars', true));
 $tmpl->assign('avatarChangeSupported', OC_User::canUserChangeAvatar(OC_User::getUser()));
 $tmpl->assign('certs', $certificateManager->listCertificates());
+$tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
 
 // Get array of group ids for this user
@@ -157,7 +169,11 @@ $formsMap = array_map(function($form){
 $formsAndMore = array_merge($formsAndMore, $formsMap);
 
 // add bottom hardcoded forms from the template
-$formsAndMore[]= array( 'anchor' => 'ssl-root-certificates', 'section-name' => $l->t('SSL root certificates') );
+if($enableCertImport) {
+	$formsAndMore[]= array( 'anchor' => 'ssl-root-certificates', 'section-name' => $l->t('SSL root certificates') );
+}
+
+
 
 $tmpl->assign('forms', $formsAndMore);
 $tmpl->printPage();

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -205,6 +205,7 @@ if($_['passwordChangeSupported']) {
 	<?php }
 };?>
 
+<?php if($_['showCertificates']) : ?>
 <div id="ssl-root-certificates" class="section">
 	<h2><?php p($l->t('SSL root certificates')); ?></h2>
 	<table id="sslCertificate" class="grid">
@@ -242,6 +243,7 @@ if($_['passwordChangeSupported']) {
 		<input type="button" id="rootcert_import_button" value="<?php p($l->t('Import root certificate')); ?>"/>
 	</form>
 </div>
+<?php endif; ?>
 
 <div class="section">
 	<h2><?php p($l->t('Version'));?></h2>

--- a/tests/settings/controller/CertificateControllerTest.php
+++ b/tests/settings/controller/CertificateControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace OC\Settings\Controller;
 
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
@@ -41,6 +42,8 @@ class CertificateControllerTest extends \Test\TestCase {
 	private $certificateManager;
 	/** @var IL10N */
 	private $l10n;
+	/** @var IAppManager */
+	private $appManager;
 
 	public function setUp() {
 		parent::setUp();
@@ -48,13 +51,21 @@ class CertificateControllerTest extends \Test\TestCase {
 		$this->request = $this->getMock('\OCP\IRequest');
 		$this->certificateManager = $this->getMock('\OCP\ICertificateManager');
 		$this->l10n = $this->getMock('\OCP\IL10N');
+		$this->appManager = $this->getMock('OCP\App\IAppManager');
 
-		$this->certificateController = new CertificateController(
-			'settings',
-			$this->request,
-			$this->certificateManager,
-			$this->l10n
-		);
+		$this->certificateController = $this->getMockBuilder('OC\Settings\Controller\CertificateController')
+			->setConstructorArgs(
+				[
+					'settings',
+					$this->request,
+					$this->certificateManager,
+					$this->l10n,
+					$this->appManager
+				]
+			)->setMethods(['isCertificateImportAllowed'])->getMock();
+
+		$this->certificateController->expects($this->any())
+			->method('isCertificateImportAllowed')->willReturn(true);
 	}
 
 	public function testAddPersonalRootCertificateWithEmptyFile() {


### PR DESCRIPTION
only add the possibility to import ssl root certificates at the personal setting if the user can mount external storages

cc @MTRichards @LukasReschke @CaptionF 
