### PR TITLE
Set proper mimetype for directories

### DIFF
--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -83,7 +83,7 @@ class Helper
 					$i = array(
 						'name' => $id,
 						'mtime' => $timestamp,
-						'mimetype' => \OC_Helper::getFileNameMimeType($id),
+						'mimetype' => $view->is_dir($dir . '/' . $entryName) ? 'httpd/unix-directory' : \OC_Helper::getFileNameMimeType($id),
 						'type' => $view->is_dir($dir . '/' . $entryName) ? 'dir' : 'file',
 						'directory' => ($dir === '/') ? '' : $dir,
 					);


### PR DESCRIPTION
Since we no longer use the icon provided by the ajax endpoints we now should really return the proper mimetype.

Before we tried to get the mimetype from the file name. But this fails for a directory.

Quick and easy fix.

@davitol please test.

Please review: @PVince81 @MorrisJobke @Xenopathic 
