### PR TITLE
[OCS] Error handling - fix in status code mapper

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -444,11 +444,7 @@ class OC_API {
 			return $sc;
 		}
 
-		// any error codes > 100 are treated as client errors
-		if ($sc > 100 && $sc < 200) {
-			return Http::STATUS_BAD_REQUEST;
-		}
-		return Http::STATUS_OK;
+		return Http::STATUS_BAD_REQUEST;
 	}
 
 	/**

--- a/tests/ocs/response.php
+++ b/tests/ocs/response.php
@@ -35,7 +35,7 @@ class OcsResponseTest extends \Test\TestCase {
 		return [
 			[Http::STATUS_OK, 100],
 			[Http::STATUS_BAD_REQUEST, 104],
-			[Http::STATUS_OK, 1000],
+			[Http::STATUS_BAD_REQUEST, 1000],
 			[201, 201],
 		];
 	}


### PR DESCRIPTION
"`statuscode`: The OCS status code of the response, everything except 100 MUST be handled as failure."
