### PR TITLE
add data: to allowed image domains

### DIFF
--- a/lib/public/appframework/http/contentsecuritypolicy.php
+++ b/lib/public/appframework/http/contentsecuritypolicy.php
@@ -63,6 +63,7 @@ class ContentSecurityPolicy {
 	/** @var array Domains from which images can get loaded */
 	private $allowedImageDomains = [
 		'\'self\'',
+		'data:',
 	];
 	/** @var array Domains to which connections can be done */
 	private $allowedConnectDomains = [

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -177,7 +177,7 @@ class ControllerTest extends \Test\TestCase {
 			'test' => 'something',
 			'Cache-Control' => 'no-cache, must-revalidate',
 			'Content-Type' => 'application/json; charset=utf-8',
-			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'",
+			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'",
 		];
 
 		$response = $this->controller->customDataResponse(array('hi'));

--- a/tests/lib/appframework/http/ContentSecurityPolicyTest.php
+++ b/tests/lib/appframework/http/ContentSecurityPolicyTest.php
@@ -28,19 +28,19 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDefault() {
-		$defaultPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$defaultPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 		$this->assertSame($defaultPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com www.owncloud.org 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com www.owncloud.org 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
@@ -48,7 +48,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
@@ -56,7 +56,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
@@ -64,7 +64,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
@@ -72,14 +72,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInline() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' www.owncloud.com 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineScript(true);
@@ -87,7 +87,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptDisallowInlineAndEval() {
-		$expectedPolicy = "default-src 'none';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->allowInlineScript(false);
 		$this->contentSecurityPolicy->allowEvalScript(false);
@@ -95,14 +95,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
@@ -110,7 +110,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
@@ -118,7 +118,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
@@ -126,7 +126,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
@@ -134,35 +134,35 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInline() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDisallowInline() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(false);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' www.owncloud.com;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: www.owncloud.com;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' www.owncloud.com www.owncloud.org;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: www.owncloud.com www.owncloud.org;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
@@ -170,7 +170,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
@@ -178,7 +178,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' www.owncloud.com;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: www.owncloud.com;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
@@ -186,7 +186,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
@@ -194,14 +194,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self' www.owncloud.com;connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self' www.owncloud.com;connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self' www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self' www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
@@ -209,7 +209,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
@@ -217,7 +217,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self' www.owncloud.com;connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self' www.owncloud.com;connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
@@ -225,7 +225,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
@@ -233,14 +233,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self' www.owncloud.com;media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self' www.owncloud.com;media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
@@ -248,7 +248,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
@@ -256,7 +256,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self' www.owncloud.com;media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self' www.owncloud.com;media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
@@ -264,7 +264,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
@@ -272,14 +272,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
@@ -287,7 +287,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
@@ -295,7 +295,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
@@ -303,7 +303,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
@@ -311,14 +311,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
@@ -326,7 +326,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
@@ -334,7 +334,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
@@ -342,7 +342,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
@@ -350,14 +350,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
@@ -365,7 +365,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
@@ -373,7 +373,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
@@ -381,7 +381,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
@@ -389,14 +389,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
@@ -404,7 +404,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
@@ -412,7 +412,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self';child-src www.owncloud.com";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self';child-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
@@ -420,7 +420,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
@@ -428,7 +428,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testConfigureStacked() {
-		$expectedPolicy = "default-src 'none';script-src 'self' script.owncloud.org;style-src 'self' style.owncloud.org;img-src 'self' img.owncloud.org;font-src 'self' font.owncloud.org;connect-src 'self' connect.owncloud.org;media-src 'self' media.owncloud.org;object-src objects.owncloud.org;frame-src frame.owncloud.org;child-src child.owncloud.org";
+		$expectedPolicy = "default-src 'none';script-src 'self' script.owncloud.org;style-src 'self' style.owncloud.org;img-src 'self' data: img.owncloud.org;font-src 'self' font.owncloud.org;connect-src 'self' connect.owncloud.org;media-src 'self' media.owncloud.org;object-src objects.owncloud.org;frame-src frame.owncloud.org;child-src child.owncloud.org";
 
 		$this->contentSecurityPolicy->allowInlineStyle(false)
 			->allowEvalScript(false)

--- a/tests/lib/appframework/http/DataResponseTest.php
+++ b/tests/lib/appframework/http/DataResponseTest.php
@@ -68,7 +68,7 @@ class DataResponseTest extends \Test\TestCase {
 
 		$expectedHeaders = [
 			'Cache-Control' => 'no-cache, must-revalidate',
-			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'",
+			'Content-Security-Policy' => "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'",
 		];
 		$expectedHeaders = array_merge($expectedHeaders, $headers);
 

--- a/tests/lib/appframework/http/ResponseTest.php
+++ b/tests/lib/appframework/http/ResponseTest.php
@@ -58,7 +58,7 @@ class ResponseTest extends \Test\TestCase {
 
 		$this->childResponse->setHeaders($expected);
 		$headers = $this->childResponse->getHeaders();
-		$expected['Content-Security-Policy'] = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self';font-src 'self';connect-src 'self';media-src 'self'";
+		$expected['Content-Security-Policy'] = "default-src 'none';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->assertEquals($expected, $headers);
 	}


### PR DESCRIPTION
The default csp of the appframework is very restrictive and therefore avatars in my [chat application](https://apps.owncloud.com/content/show.php/JavaScript+XMPP+Chat?content=162257) are no longer displayed jsxc/jsxc#201 on pages which uses the appframework.

I have to use data urls, because I receive base64 encoded images from the xmpp server and I do not see any security drawback for data urls.
