### PR TITLE
allow overwriting the config directory when using the occ command

### DIFF
--- a/console.php
+++ b/console.php
@@ -38,6 +38,16 @@ if (version_compare(PHP_VERSION, '5.4.0') === -1) {
 }
 
 try {
+	// allow overwriting the config dir
+	// needs to be done outside the symphony console application since we load the config before we can use that
+	$options = getopt('', [
+		'config:'
+	]);
+
+	if (isset($options['config'])) {
+		define('CONFIG_DIR', $options['config']);
+	}
+
 	require_once 'lib/base.php';
 
 	// set to run indefinitely if needed

--- a/lib/base.php
+++ b/lib/base.php
@@ -124,7 +124,9 @@ class OC {
 			get_include_path()
 		);
 
-		if(defined('PHPUNIT_CONFIG_DIR')) {
+		if (defined('CONFIG_DIR')) {
+			self::$configDir = CONFIG_DIR . '/';
+		} elseif(defined('PHPUNIT_CONFIG_DIR')) {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';

--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -27,6 +27,7 @@ use OCP\IConfig;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Application {
@@ -42,6 +43,7 @@ class Application {
 		$defaults = new OC_Defaults;
 		$this->config = $config;
 		$this->application = new SymfonyApplication($defaults->getName(), \OC_Util::getVersionString());
+		$this->application->getDefinition()->addOption(new InputOption('config', null, InputOption::VALUE_REQUIRED, 'the config directory to use'));
 	}
 
 	/**


### PR DESCRIPTION
Mostly to make it easier for me to upgrade the various instances I run phpunit against

usage:

```
./occ --config=tests/config/encryption/ upgrade
```
