### PR TITLE
Only load app routes if the app has already been loaded

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -74,6 +74,16 @@ class OC_App {
 	}
 
 	/**
+	 * Check if an app is loaded
+	 *
+	 * @param string $app
+	 * @return bool
+	 */
+	public static function isAppLoaded($app) {
+		return in_array($app, self::$loadedApps, true);
+	}
+
+	/**
 	 * loads all apps
 	 *
 	 * @param array $types

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -150,6 +150,12 @@ class Router implements IRouter {
 		\OC::$server->getEventLogger()->start('loadroutes' . $requestedApp, 'Loading Routes');
 		foreach ($routingFiles as $app => $file) {
 			if (!isset($this->loadedApps[$app])) {
+				if (!\OC_App::isAppLoaded($app)) {
+					// app MUST be loaded before app routes
+					// try again next time loadRoutes() is called
+					$this->loaded = false;
+					continue;
+				}
 				$this->loadedApps[$app] = true;
 				$this->useCollection($app);
 				$this->requireRouteFile($file, $app);


### PR DESCRIPTION
Fixes #18095 

If an app isn't loaded when the router tries to load routes, it marks itself as 'not loaded', so the next time a route is requested any non-loaded routes attempt to get loaded again.

cc @schiesbn @LukasReschke @PVince81 @DeepDiver1975 
