### PR TITLE
[user mgnt] fix delete user feedback on failure

### DIFF
--- a/settings/js/users/deleteHandler.js
+++ b/settings/js/users/deleteHandler.js
@@ -194,16 +194,16 @@ DeleteHandler.prototype.deleteEntry = function(keepNotification) {
 		// FIXME: do not use synchronous ajax calls as they block the browser !
 		async: false,
 		success: function (result) {
-			if (result.status === 'success') {
-				// Remove undo option, & remove user from table
+			// Remove undo option, & remove user from table
 
-				//TODO: following line
-				dh.removeCallback(dh.oidToDelete);
-				dh.canceled = true;
-			} else {
-				OC.dialogs.alert(result.data.message, t('settings', 'Unable to delete {objName}', {objName: dh.oidToDelete}));
-				dh.undoCallback(dh.oidToDelete);
-			}
+			//TODO: following line
+			dh.removeCallback(dh.oidToDelete);
+			dh.canceled = true;
+		},
+		error: function (jqXHR) {
+			OC.dialogs.alert(jqXHR.responseJSON.data.message, t('settings', 'Unable to delete {objName}', {objName: dh.oidToDelete}));
+			dh.undoCallback(dh.oidToDelete);
+
 		}
 	});
 };

--- a/settings/tests/js/users/deleteHandlerSpec.js
+++ b/settings/tests/js/users/deleteHandlerSpec.js
@@ -63,6 +63,17 @@ describe('DeleteHandler tests', function() {
 		expect(fakeServer.requests.length).toEqual(0);
 	});
 	it('deletes first entry and reshows notification on second delete', function() {
+		fakeServer.respondWith(/\/index\.php\/dummyendpoint.php\/some_uid/, [
+			204,
+			{ 'Content-Type': 'application/json' },
+			JSON.stringify({status: 'success'})
+		]);
+		fakeServer.respondWith(/\/index\.php\/dummyendpoint.php\/some_other_uid/, [
+			204,
+			{ 'Content-Type': 'application/json' },
+			JSON.stringify({status: 'success'})
+		]);
+
 		var handler = init(markCallback, removeCallback, undoCallback);
 		handler.mark('some_uid');
 
@@ -79,7 +90,8 @@ describe('DeleteHandler tests', function() {
 		expect(markCallback.calledTwice).toEqual(true);
 		expect(markCallback.getCall(0).args[0]).toEqual('some_uid');
 		expect(markCallback.getCall(1).args[0]).toEqual('some_other_uid');
-		expect(removeCallback.notCalled).toEqual(true);
+		// called only once, because it is called once the second user is deleted
+		expect(removeCallback.calledOnce).toEqual(true);
 		expect(undoCallback.notCalled).toEqual(true);
 
 		// previous one was delete
@@ -88,6 +100,12 @@ describe('DeleteHandler tests', function() {
 		expect(request.url).toEqual(OC.webroot + '/index.php/dummyendpoint.php/some_uid');
 	});
 	it('automatically deletes after timeout', function() {
+		fakeServer.respondWith(/\/index\.php\/dummyendpoint.php\/some_uid/, [
+			204,
+			{ 'Content-Type': 'application/json' },
+			JSON.stringify({status: 'success'})
+		]);
+
 		var handler = init(markCallback, removeCallback, undoCallback);
 		handler.mark('some_uid');
 
@@ -101,6 +119,11 @@ describe('DeleteHandler tests', function() {
 		expect(request.url).toEqual(OC.webroot + '/index.php/dummyendpoint.php/some_uid');
 	});
 	it('deletes when deleteEntry is called', function() {
+		fakeServer.respondWith(/\/index\.php\/dummyendpoint.php\/some_uid/, [
+			200,
+			{ 'Content-Type': 'application/json' },
+			JSON.stringify({status: 'success'})
+		]);
 		var handler = init(markCallback, removeCallback, undoCallback);
 		handler.mark('some_uid');
 
@@ -157,7 +180,7 @@ describe('DeleteHandler tests', function() {
 		// stub t to avoid extra calls
 		var tStub = sinon.stub(window, 't').returns('text');
 		fakeServer.respondWith(/\/index\.php\/dummyendpoint.php\/some_uid/, [
-			200,
+			403,
 			{ 'Content-Type': 'application/json' },
 			JSON.stringify({status: 'error', data: {message: 'test error'}})
 		]);


### PR DESCRIPTION
- fixes #18099 

To reproduce the failure case change the condition of the if in https://github.com/owncloud/core/blob/637edfde24eefd9e9723ce3d438a7d627059681c/settings/controller/userscontroller.php#L393-393 to `true`.

Before:
- no error message shown - looks like delete was successful

After:
- error message
- user is added to the user list again
