### PR TITLE
Expose \OCP\IUserSession::get/setSession()

### DIFF
--- a/lib/public/iusersession.php
+++ b/lib/public/iusersession.php
@@ -79,4 +79,21 @@ interface IUserSession {
 	 * @since 8.0.0
 	 */
 	public function isLoggedIn();
+
+	/**
+	 * Get the current active session
+	 *
+	 * @return \OCP\ISession
+	 * @since 8.2.0
+	 */
+	public function getSession();
+
+	/**
+	 * Set the current active session
+	 *
+	 * @param \OCP\ISession $session
+	 * @since 8.2.0
+	 */
+	public function setSession(\OCP\ISession $session);
+
 }


### PR DESCRIPTION
We have `\OCP\ISession` in the server container, and `\OCP\IUserSession`, but no way to get from the user session to the session object. This exposes the relevant methods into the OCP interface.

Requirement for #15914 

Background: apps use the session object all the time, but currently get it via `\OC::$server->getSession()`. Now, they can have IUserSession injected, then just call `->getSession()` to get the session object. `setSession()` is provided for symmetry (we have `setUser()` too)

cc @MorrisJobke @bartv2 @Raydiation @LukasReschke 
