### PR TITLE
use password hash to encrypt private key

### DIFF
--- a/apps/encryption/controller/settingscontroller.php
+++ b/apps/encryption/controller/settingscontroller.php
@@ -103,7 +103,7 @@ class SettingsController extends Controller {
 			$decryptedKey = $this->crypt->decryptPrivateKey($encryptedKey, $oldPassword);
 
 			if ($decryptedKey) {
-				$encryptedKey = $this->crypt->symmetricEncryptFileContent($decryptedKey, $newPassword);
+				$encryptedKey = $this->crypt->encryptPrivateKey($decryptedKey, $newPassword);
 				$header = $this->crypt->generateHeader();
 				if ($encryptedKey) {
 					$this->keyManager->setPrivateKey($uid, $header . $encryptedKey);

--- a/apps/encryption/controller/settingscontroller.php
+++ b/apps/encryption/controller/settingscontroller.php
@@ -100,10 +100,10 @@ class SettingsController extends Controller {
 
 		if ($passwordCorrect !== false) {
 			$encryptedKey = $this->keyManager->getPrivateKey($uid);
-			$decryptedKey = $this->crypt->decryptPrivateKey($encryptedKey, $oldPassword);
+			$decryptedKey = $this->crypt->decryptPrivateKey($encryptedKey, $oldPassword, $uid);
 
 			if ($decryptedKey) {
-				$encryptedKey = $this->crypt->encryptPrivateKey($decryptedKey, $newPassword);
+				$encryptedKey = $this->crypt->encryptPrivateKey($decryptedKey, $newPassword, $uid);
 				$header = $this->crypt->generateHeader();
 				if ($encryptedKey) {
 					$this->keyManager->setPrivateKey($uid, $header . $encryptedKey);

--- a/apps/encryption/hooks/userhooks.php
+++ b/apps/encryption/hooks/userhooks.php
@@ -220,8 +220,7 @@ class UserHooks implements IHook {
 		if ($user && $params['uid'] === $user->getUID() && $privateKey) {
 
 			// Encrypt private key with new user pwd as passphrase
-			$encryptedPrivateKey = $this->crypt->symmetricEncryptFileContent($privateKey,
-				$params['password']);
+			$encryptedPrivateKey = $this->crypt->encryptPrivateKey($privateKey, $params['password']);
 
 			// Save private key
 			if ($encryptedPrivateKey) {
@@ -259,8 +258,7 @@ class UserHooks implements IHook {
 				$this->keyManager->setPublicKey($user, $keyPair['publicKey']);
 
 				// Encrypt private key with new password
-				$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'],
-					$newUserPassword);
+				$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $newUserPassword);
 
 				if ($encryptedKey) {
 					$this->keyManager->setPrivateKey($user, $this->crypt->generateHeader() . $encryptedKey);

--- a/apps/encryption/hooks/userhooks.php
+++ b/apps/encryption/hooks/userhooks.php
@@ -220,7 +220,7 @@ class UserHooks implements IHook {
 		if ($user && $params['uid'] === $user->getUID() && $privateKey) {
 
 			// Encrypt private key with new user pwd as passphrase
-			$encryptedPrivateKey = $this->crypt->encryptPrivateKey($privateKey, $params['password']);
+			$encryptedPrivateKey = $this->crypt->encryptPrivateKey($privateKey, $params['password'], $params['uid']);
 
 			// Save private key
 			if ($encryptedPrivateKey) {
@@ -258,7 +258,7 @@ class UserHooks implements IHook {
 				$this->keyManager->setPublicKey($user, $keyPair['publicKey']);
 
 				// Encrypt private key with new password
-				$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $newUserPassword);
+				$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $newUserPassword, $user);
 
 				if ($encryptedKey) {
 					$this->keyManager->setPrivateKey($user, $this->crypt->generateHeader() . $encryptedKey);

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -30,6 +30,7 @@ use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Encryption\Exceptions\EncryptionFailedException;
 use OCA\Encryption\Exceptions\MultiKeyDecryptException;
 use OCA\Encryption\Exceptions\MultiKeyEncryptException;
+use OCA\Encryption\Vendor\PBKDF2Fallback;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -41,6 +42,10 @@ class Crypt {
 	const DEFAULT_CIPHER = 'AES-256-CFB';
 	// default cipher from old ownCloud versions
 	const LEGACY_CIPHER = 'AES-128-CFB';
+
+	// default key format, old ownCloud version encrypted the private key directly
+	// with the user password
+	const LEGACY_KEY_FORMAT = 'password';
 
 	const HEADER_START = 'HBEGIN';
 	const HEADER_END = 'HEND';
@@ -58,6 +63,11 @@ class Crypt {
 	private $config;
 
 	/**
+	 * @var array
+	 */
+	private $supportedKeyFormats;
+
+	/**
 	 * @param ILogger $logger
 	 * @param IUserSession $userSession
 	 * @param IConfig $config
@@ -66,6 +76,7 @@ class Crypt {
 		$this->logger = $logger;
 		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser() : false;
 		$this->config = $config;
+		$this->supportedKeyFormats = ['hash', 'password'];
 	}
 
 	/**
@@ -161,10 +172,23 @@ class Crypt {
 
 	/**
 	 * generate header for encrypted file
+	 *
+	 * @param string $keyFormat (can be 'hash' or 'password')
+	 * @return string
+	 * @throws \InvalidArgumentException
 	 */
-	public function generateHeader() {
+	public function generateHeader($keyFormat = 'hash') {
+
+		if (in_array($keyFormat, $this->supportedKeyFormats, true) === false) {
+			throw new \InvalidArgumentException('key format "' . $keyFormat . '" is not supported');
+		}
+
 		$cipher = $this->getCipher();
-		$header = self::HEADER_START . ':cipher:' . $cipher . ':' . self::HEADER_END;
+
+		$header = self::HEADER_START
+			. ':cipher:' . $cipher
+			. ':keyFormat:' . $keyFormat
+			. ':' . self::HEADER_END;
 
 		return $header;
 	}
@@ -212,6 +236,25 @@ class Crypt {
 	}
 
 	/**
+	 * get key size depending on the cipher
+	 *
+	 * @param string $cipher supported ('AES-256-CFB' and 'AES-128-CFB')
+	 * @return int
+	 * @throws \InvalidArgumentException
+	 */
+	protected function getKeySize($cipher) {
+		if ($cipher === 'AES-256-CFB') {
+			return 32;
+		} else if ($cipher === 'AES-128-CFB') {
+			return 16;
+		}
+
+		throw new \InvalidArgumentException(
+			'Wrong cipher defined only AES-128-CFB and AES-256-CFB are supported.'
+		);
+	}
+
+	/**
 	 * get legacy cipher
 	 *
 	 * @return string
@@ -238,6 +281,63 @@ class Crypt {
 	}
 
 	/**
+	 * generate password hash used to encrypt the users private key
+	 *
+	 * @param string $password
+	 * @param string $cipher
+	 * @return string
+	 */
+	protected function generatePasswordHash($password, $cipher) {
+		$instanceId = $this->config->getSystemValue('instanceid');
+		$instanceSecret = $this->config->getSystemValue('secret');
+		$salt = hash('sha256', $instanceId . $instanceSecret, true);
+		$keySize = $this->getKeySize($cipher);
+
+		if (function_exists('hash_pbkdf2')) {
+			$hash = hash_pbkdf2(
+				'sha256',
+				$password,
+				$salt,
+				100000,
+				$keySize,
+				true
+			);
+		} else {
+			// fallback to 3rdparty lib for PHP <= 5.4.
+			// FIXME: Can be removed as soon as support for PHP 5.4 was dropped
+			$fallback = new PBKDF2Fallback();
+			$hash = $fallback->pbkdf2(
+				'sha256',
+				$password,
+				$salt,
+				100000,
+				$keySize,
+				true
+			);
+		}
+
+		return $hash;
+	}
+
+	/**
+	 * encrypt private key
+	 *
+	 * @param string $privateKey
+	 * @param string $password
+	 * @return bool|string
+	 */
+	public function encryptPrivateKey($privateKey, $password) {
+		$cipher = $this->getCipher();
+		$hash = $this->generatePasswordHash($password, $cipher);
+		$encryptedKey = $this->symmetricEncryptFileContent(
+			$privateKey,
+			$hash
+		);
+
+		return $encryptedKey;
+	}
+
+	/**
 	 * @param string $privateKey
 	 * @param string $password
 	 * @return bool|string
@@ -252,6 +352,16 @@ class Crypt {
 			$cipher = self::LEGACY_CIPHER;
 		}
 
+		if (isset($header['keyFormat'])) {
+			$keyFormat = $header['keyFormat'];
+		} else {
+			$keyFormat = self::LEGACY_KEY_FORMAT;
+		}
+
+		if ($keyFormat === 'hash') {
+			$password = $this->generatePasswordHash($password, $cipher);
+		}
+
 		// If we found a header we need to remove it from the key we want to decrypt
 		if (!empty($header)) {
 			$privateKey = substr($privateKey,
@@ -263,18 +373,29 @@ class Crypt {
 			$password,
 			$cipher);
 
-		// Check if this is a valid private key
-		$res = openssl_get_privatekey($plainKey);
-		if (is_resource($res)) {
-			$sslInfo = openssl_pkey_get_details($res);
-			if (!isset($sslInfo['key'])) {
-				return false;
-			}
-		} else {
+		if ($this->isValidPrivateKey($plainKey) === false) {
 			return false;
 		}
 
 		return $plainKey;
+	}
+
+	/**
+	 * check if it is a valid private key
+	 *
+	 * @param $plainKey
+	 * @return bool
+	 */
+	protected function isValidPrivateKey($plainKey) {
+		$res = openssl_get_privatekey($plainKey);
+		if (is_resource($res)) {
+			$sslInfo = openssl_pkey_get_details($res);
+			if (isset($sslInfo['key'])) {
+				return true;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -358,7 +479,7 @@ class Crypt {
 	 * @param $data
 	 * @return array
 	 */
-	private function parseHeader($data) {
+	protected function parseHeader($data) {
 		$result = [];
 
 		if (substr($data, 0, strlen(self::HEADER_START)) === self::HEADER_START) {

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -285,12 +285,13 @@ class Crypt {
 	 *
 	 * @param string $password
 	 * @param string $cipher
+	 * @param string $uid only used for user keys
 	 * @return string
 	 */
-	protected function generatePasswordHash($password, $cipher) {
+	protected function generatePasswordHash($password, $cipher, $uid = '') {
 		$instanceId = $this->config->getSystemValue('instanceid');
 		$instanceSecret = $this->config->getSystemValue('secret');
-		$salt = hash('sha256', $instanceId . $instanceSecret, true);
+		$salt = hash('sha256', $uid . $instanceId . $instanceSecret, true);
 		$keySize = $this->getKeySize($cipher);
 
 		if (function_exists('hash_pbkdf2')) {
@@ -324,11 +325,12 @@ class Crypt {
 	 *
 	 * @param string $privateKey
 	 * @param string $password
+	 * @param string $uid for regular users, empty for system keys
 	 * @return bool|string
 	 */
-	public function encryptPrivateKey($privateKey, $password) {
+	public function encryptPrivateKey($privateKey, $password, $uid = '') {
 		$cipher = $this->getCipher();
-		$hash = $this->generatePasswordHash($password, $cipher);
+		$hash = $this->generatePasswordHash($password, $cipher, $uid);
 		$encryptedKey = $this->symmetricEncryptFileContent(
 			$privateKey,
 			$hash
@@ -340,9 +342,10 @@ class Crypt {
 	/**
 	 * @param string $privateKey
 	 * @param string $password
+	 * @param string $uid for regular users, empty for system keys
 	 * @return bool|string
 	 */
-	public function decryptPrivateKey($privateKey, $password = '') {
+	public function decryptPrivateKey($privateKey, $password = '', $uid = '') {
 
 		$header = $this->parseHeader($privateKey);
 
@@ -359,7 +362,7 @@ class Crypt {
 		}
 
 		if ($keyFormat === 'hash') {
-			$password = $this->generatePasswordHash($password, $cipher);
+			$password = $this->generatePasswordHash($password, $cipher, $uid);
 		}
 
 		// If we found a header we need to remove it from the key we want to decrypt

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -184,8 +184,7 @@ class KeyManager {
 	 */
 	public function checkRecoveryPassword($password) {
 		$recoveryKey = $this->keyStorage->getSystemUserKey($this->recoveryKeyId . '.privateKey', Encryption::ID);
-		$decryptedRecoveryKey = $this->crypt->decryptPrivateKey($recoveryKey,
-			$password);
+		$decryptedRecoveryKey = $this->crypt->decryptPrivateKey($recoveryKey, $password);
 
 		if ($decryptedRecoveryKey) {
 			return true;
@@ -203,7 +202,7 @@ class KeyManager {
 		// Save Public Key
 		$this->setPublicKey($uid, $keyPair['publicKey']);
 
-		$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $password);
+		$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $password, $uid);
 
 		$header = $this->crypt->generateHeader();
 
@@ -307,8 +306,7 @@ class KeyManager {
 
 		try {
 			$privateKey = $this->getPrivateKey($uid);
-			$privateKey = $this->crypt->decryptPrivateKey($privateKey,
-				$passPhrase);
+			$privateKey = $this->crypt->decryptPrivateKey($privateKey, $passPhrase, $uid);
 		} catch (PrivateKeyMissingException $e) {
 			return false;
 		} catch (DecryptionFailedException $e) {

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -146,7 +146,7 @@ class KeyManager {
 				Encryption::ID);
 
 			// Encrypt private key empty passphrase
-			$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'], '');
+			$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], '');
 			$header = $this->crypt->generateHeader();
 			$this->setSystemPrivateKey($this->publicShareKeyId, $header . $encryptedKey);
 		}
@@ -203,8 +203,8 @@ class KeyManager {
 		// Save Public Key
 		$this->setPublicKey($uid, $keyPair['publicKey']);
 
-		$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'],
-			$password);
+		$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $password);
+
 		$header = $this->crypt->generateHeader();
 
 		if ($encryptedKey) {
@@ -226,8 +226,7 @@ class KeyManager {
 			$keyPair['publicKey'],
 			Encryption::ID);
 
-		$encryptedKey = $this->crypt->symmetricEncryptFileContent($keyPair['privateKey'],
-			$password);
+		$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $password);
 		$header = $this->crypt->generateHeader();
 
 		if ($encryptedKey) {

--- a/apps/encryption/lib/recovery.php
+++ b/apps/encryption/lib/recovery.php
@@ -136,7 +136,7 @@ class Recovery {
 	public function changeRecoveryKeyPassword($newPassword, $oldPassword) {
 		$recoveryKey = $this->keyManager->getSystemPrivateKey($this->keyManager->getRecoveryKeyId());
 		$decryptedRecoveryKey = $this->crypt->decryptPrivateKey($recoveryKey, $oldPassword);
-		$encryptedRecoveryKey = $this->crypt->symmetricEncryptFileContent($decryptedRecoveryKey, $newPassword);
+		$encryptedRecoveryKey = $this->crypt->encryptPrivateKey($decryptedRecoveryKey, $newPassword);
 		$header = $this->crypt->generateHeader();
 		if ($encryptedRecoveryKey) {
 			$this->keyManager->setSystemPrivateKey($this->keyManager->getRecoveryKeyId(), $header . $encryptedRecoveryKey);

--- a/apps/encryption/lib/recovery.php
+++ b/apps/encryption/lib/recovery.php
@@ -263,8 +263,7 @@ class Recovery {
 	public function recoverUsersFiles($recoveryPassword, $user) {
 		$encryptedKey = $this->keyManager->getSystemPrivateKey($this->keyManager->getRecoveryKeyId());
 
-		$privateKey = $this->crypt->decryptPrivateKey($encryptedKey,
-			$recoveryPassword);
+		$privateKey = $this->crypt->decryptPrivateKey($encryptedKey, $recoveryPassword);
 
 		$this->recoverAllFiles('/' . $user . '/files/', $privateKey, $user);
 	}

--- a/apps/encryption/tests/controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/controller/SettingsControllerTest.php
@@ -188,7 +188,7 @@ class SettingsControllerTest extends TestCase {
 
 		$this->cryptMock
 			->expects($this->once())
-			->method('symmetricEncryptFileContent')
+			->method('encryptPrivateKey')
 			->willReturn('encryptedKey');
 
 		$this->cryptMock

--- a/apps/encryption/tests/hooks/UserHooksTest.php
+++ b/apps/encryption/tests/hooks/UserHooksTest.php
@@ -114,7 +114,7 @@ class UserHooksTest extends TestCase {
 			->willReturnOnConsecutiveCalls(true, false);
 
 		$this->cryptMock->expects($this->exactly(4))
-			->method('symmetricEncryptFileContent')
+			->method('encryptPrivateKey')
 			->willReturn(true);
 
 		$this->cryptMock->expects($this->any())

--- a/apps/encryption/tests/lib/KeyManagerTest.php
+++ b/apps/encryption/tests/lib/KeyManagerTest.php
@@ -260,7 +260,7 @@ class KeyManagerTest extends TestCase {
 			->method('setSystemUserKey')
 			->willReturn(true);
 		$this->cryptMock->expects($this->any())
-			->method('symmetricEncryptFileContent')
+			->method('encryptPrivateKey')
 			->with($this->equalTo('privateKey'), $this->equalTo('pass'))
 			->willReturn('decryptedPrivateKey');
 

--- a/apps/encryption/tests/lib/RecoveryTest.php
+++ b/apps/encryption/tests/lib/RecoveryTest.php
@@ -96,7 +96,7 @@ class RecoveryTest extends TestCase {
 			->method('decryptPrivateKey');
 
 		$this->cryptMock->expects($this->once())
-			->method('symmetricEncryptFileContent')
+			->method('encryptPrivateKey')
 			->willReturn(true);
 
 		$this->assertTrue($this->instance->changeRecoveryKeyPassword('password',

--- a/apps/encryption/vendor/pbkdf2fallback.php
+++ b/apps/encryption/vendor/pbkdf2fallback.php
@@ -1,0 +1,87 @@
+<?php
+/* Note; This class can be removed as soon as we drop PHP 5.4 support.
+ *
+ *
+ * Password Hashing With PBKDF2 (http://crackstation.net/hashing-security.htm).
+ * Copyright (c) 2013, Taylor Hornby
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OCA\Encryption\Vendor;
+
+class PBKDF2Fallback {
+
+	/*
+	 * PBKDF2 key derivation function as defined by RSA's PKCS #5: https://www.ietf.org/rfc/rfc2898.txt
+	 * $algorithm - The hash algorithm to use. Recommended: SHA256
+	 * $password - The password.
+	 * $salt - A salt that is unique to the password.
+	 * $count - Iteration count. Higher is better, but slower. Recommended: At least 1000.
+	 * $key_length - The length of the derived key in bytes.
+	 * $raw_output - If true, the key is returned in raw binary format. Hex encoded otherwise.
+	 * Returns: A $key_length-byte key derived from the password and salt.
+	 *
+	 * Test vectors can be found here: https://www.ietf.org/rfc/rfc6070.txt
+	 *
+	 * This implementation of PBKDF2 was originally created by https://defuse.ca
+	 * With improvements by http://www.variations-of-shadow.com
+	 */
+	public function pbkdf2($algorithm, $password, $salt, $count, $key_length, $raw_output = false) {
+		$algorithm = strtolower($algorithm);
+		if (!in_array($algorithm, hash_algos(), true))
+			trigger_error('PBKDF2 ERROR: Invalid hash algorithm.', E_USER_ERROR);
+		if ($count <= 0 || $key_length <= 0)
+			trigger_error('PBKDF2 ERROR: Invalid parameters.', E_USER_ERROR);
+
+		if (function_exists("hash_pbkdf2")) {
+			// The output length is in NIBBLES (4-bits) if $raw_output is false!
+			if (!$raw_output) {
+				$key_length = $key_length * 2;
+			}
+			return hash_pbkdf2($algorithm, $password, $salt, $count, $key_length, $raw_output);
+		}
+
+		$hash_length = strlen(hash($algorithm, "", true));
+		$block_count = ceil($key_length / $hash_length);
+
+		$output = "";
+		for ($i = 1; $i <= $block_count; $i++) {
+			// $i encoded as 4 bytes, big endian.
+			$last = $salt . pack("N", $i);
+			// first iteration
+			$last = $xorsum = hash_hmac($algorithm, $last, $password, true);
+			// perform the other $count - 1 iterations
+			for ($j = 1; $j < $count; $j++) {
+				$xorsum ^= ($last = hash_hmac($algorithm, $last, $password, true));
+			}
+			$output .= $xorsum;
+		}
+
+		if ($raw_output)
+			return substr($output, 0, $key_length);
+		else
+			return bin2hex(substr($output, 0, $key_length));
+	}
+}


### PR DESCRIPTION
use password hash instead of the plain password to encrypt the private key as discussed with @LukasReschke .

What should be tested:
- setup ownCloud with master
- enable encryption
- create recovery key (private recovery key shouldn't have "keyFormat" in the header)
- re-login (user should have a private key which doesn't contain "keyFormat" in the header)
- upload a encrypted file
- switch to this branch
- create a new user (new user should have a private key which has "keyFormat:hash" in the header)
- check if both the new user and the old one can create new files and read existing ons
- change recovery key password (new key should have  "keyFormat:hash" in the header)
- the old user changes his password in his personal settings (updated private key should have  "keyFormat:hash" in the header) and he should still be able to read/write his files after re-login
