### PR TITLE
Replace tipsy with tooltip

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -409,6 +409,7 @@
 					);
 				}
 			);
+			$actionEl.tooltip({placement:'top'});
 			return $actionEl;
 		},
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -243,6 +243,8 @@
 			this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
 			this.$el.find('.delete-selected').click(_.bind(this._onClickDeleteSelected, this));
 
+			this.$el.find('.selectedActions a').tooltip({placement:'top'});
+
 			this.setupUploadEvents();
 
 			this.$container.on('scroll', _.bind(this._onScroll, this));
@@ -854,6 +856,7 @@
 					fileData.extraData = fileData.extraData.substr(1);
 				}
 				nameSpan.addClass('extra-data').attr('title', fileData.extraData);
+				nameSpan.tooltip({placement: 'right'});
 			}
 			// dirs can show the number of uploaded files
 			if (type === 'dir') {
@@ -1532,7 +1535,7 @@
 			};
 
 			function restore() {
-				input.tipsy('hide');
+				input.tooltip('hide');
 				tr.data('renaming',false);
 				form.remove();
 				td.children('a.name').show();
@@ -1547,7 +1550,7 @@
 
 				try {
 					var newName = input.val();
-					input.tipsy('hide');
+					input.tooltip('hide');
 					form.remove();
 
 					if (newName !== oldname) {
@@ -1599,8 +1602,8 @@
 					}
 				} catch (error) {
 					input.attr('title', error);
-					input.tipsy({gravity: 'w', trigger: 'manual'});
-					input.tipsy('show');
+					input.tooltip({placement: 'left', trigger: 'manual'});
+					input.tooltip('show');
 					input.addClass('error');
 				}
 				return false;
@@ -1609,12 +1612,12 @@
 				// verify filename on typing
 				try {
 					checkInput();
-					input.tipsy('hide');
+					input.tooltip('hide');
 					input.removeClass('error');
 				} catch (error) {
 					input.attr('title', error);
-					input.tipsy({gravity: 'w', trigger: 'manual'});
-					input.tipsy('show');
+					input.tooltip({placement: 'left', trigger: 'manual'});
+					input.tooltip('show');
 					input.addClass('error');
 				}
 				if (event.keyCode === 27) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -265,6 +265,8 @@
 				$('#webdavurl').select();
 			});
 
+			$('#upload').tooltip({placement:'right'});
+
 			//FIXME scroll to and highlight preselected file
 			/*
 			if (getURLParameter('scrollto')) {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1278,17 +1278,6 @@ function initCore() {
 		$('#settings #expanddiv').slideUp(OC.menuSpeed);
 	});
 
-	// all the tipsy stuff needs to be here (in reverse order) to work
-	$('.displayName .action').tipsy({gravity:'se', live:true});
-	$('.password .action').tipsy({gravity:'se', live:true});
-	$('#upload').tipsy({gravity:'w'});
-	$('.selectedActions a').tipsy({gravity:'s', live:true});
-	$('a.action.delete').tipsy({gravity:'e', live:true});
-	$('a.action').tipsy({gravity:'s', live:true});
-	$('td.lastLogin').tipsy({gravity:'s', html:true});
-	$('input').tipsy({gravity:'w'});
-	$('.extra-data').tipsy({gravity:'w', live:true});
-
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function(event) {
 		var $el = $(event.target);

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -77,6 +77,9 @@ var UserList = {
 		$tr.find('.name').text(user.name);
 		$tr.find('td.displayName > span').text(user.displayname);
 		$tr.find('td.mailAddress > span').text(user.email);
+		$tr.find('td.displayName > .action').tooltip({placement: 'top'});
+		$tr.find('td.mailAddress > .action').tooltip({placement: 'top'});
+		$tr.find('td.password > .action').tooltip({placement: 'top'});
 
 		/**
 		 * groups and subadmins
@@ -158,12 +161,9 @@ var UserList = {
 		}
 		var $tdLastLogin = $tr.find('td.lastLogin');
 		$tdLastLogin.text(lastLoginRel);
-		//tooltip makes it complicated … to not insert new HTML, we adjust the
-		//original title. We use a temporary div to get back the html that we
-		//can pass later. It is also required to initialise tipsy.
-		var tooltip = $('<div>').html($($tdLastLogin.attr('original-title')).text(lastLoginAbs)).html();
-		$tdLastLogin.tipsy({gravity:'s', html:true});
-		$tdLastLogin.attr('title', tooltip);
+		$tdLastLogin.attr('title', lastLoginAbs);
+		// setup tooltip with #app-content as container to prevent the td to resize on hover
+		$tdLastLogin.tooltip({placement: 'top', container: '#app-content'});
 
 		/**
 		 * append generated row to user list


### PR DESCRIPTION
fixes #18069

TODO (for now):
**core/js/js.js**
- [x] `$('.displayName .action').tipsy({gravity:'se', live:true});`
- [x] `$('.password .action').tipsy({gravity:'se', live:true});`
- [x] `$('#upload').tipsy({gravity:'w'});`
- [x] `$('.selectedActions a').tipsy({gravity:'s', live:true});`
- [x] `$('a.action.delete').tipsy({gravity:'e', live:true});`
- [x] `$('a.action').tipsy({gravity:'s', live:true});`
- [x] `$('td.lastLogin').tipsy({gravity:'s', html:true});`
- [x] `$('input').tipsy({gravity:'w'});`
- [x] `$('.extra-data').tipsy({gravity:'w', live:true});`

more can be found [here](https://github.com/owncloud/core/search?l=javascript&q=tipsy%28&utf8=%E2%9C%93)
