### PR TITLE
[stable8.1] Fix removal of share permissions when share disabled for user

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1354,7 +1354,7 @@ class View {
 
 							// if sharing was disabled for the user we remove the share permissions
 							if (\OCP\Util::isSharingDisabledForUser()) {
-								$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
+								$rootEntry['permissions'] = $rootEntry['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 							}
 
 							$files[] = new FileInfo($path . '/' . $rootEntry['name'], $subStorage, '', $rootEntry, $mount);


### PR DESCRIPTION
I pressed merge too quickly on the original PR... here's a new one (the old commits were wiped from the history, it was near immediate).

Replaces #18135

Registered :+1:s : @karlitschek (https://github.com/owncloud/core/pull/18135#issuecomment-128791539) and me (https://github.com/owncloud/core/pull/18135#issuecomment-128835941)
