### PR TITLE
Correctly make use of the languageCode argument in the files activity extension

### DIFF
--- a/apps/files/lib/activity.php
+++ b/apps/files/lib/activity.php
@@ -136,25 +136,26 @@ class Activity implements IExtension {
 			return false;
 		}
 
+		$l = $this->getL10N($languageCode);
 		switch ($text) {
 			case 'created_self':
-				return (string) $this->l->t('You created %1$s', $params);
+				return (string) $l->t('You created %1$s', $params);
 			case 'created_by':
-				return (string) $this->l->t('%2$s created %1$s', $params);
+				return (string) $l->t('%2$s created %1$s', $params);
 			case 'created_public':
-				return (string) $this->l->t('%1$s was created in a public folder', $params);
+				return (string) $l->t('%1$s was created in a public folder', $params);
 			case 'changed_self':
-				return (string) $this->l->t('You changed %1$s', $params);
+				return (string) $l->t('You changed %1$s', $params);
 			case 'changed_by':
-				return (string) $this->l->t('%2$s changed %1$s', $params);
+				return (string) $l->t('%2$s changed %1$s', $params);
 			case 'deleted_self':
-				return (string) $this->l->t('You deleted %1$s', $params);
+				return (string) $l->t('You deleted %1$s', $params);
 			case 'deleted_by':
-				return (string) $this->l->t('%2$s deleted %1$s', $params);
+				return (string) $l->t('%2$s deleted %1$s', $params);
 			case 'restored_self':
-				return (string) $this->l->t('You restored %1$s', $params);
+				return (string) $l->t('You restored %1$s', $params);
 			case 'restored_by':
-				return (string) $this->l->t('%2$s restored %1$s', $params);
+				return (string) $l->t('%2$s restored %1$s', $params);
 
 			default:
 				return false;


### PR DESCRIPTION
### Steps to reproduce

1 Add a user with a different language (not english) and set up the email address
2 Add an activity for the user or use the query:

``` sql
INSERT INTO `oc_temp`.`oc_activity_mq` (`mail_id` , `amq_timestamp` , `amq_latest_send` , `amq_type` , `amq_affecteduser` , `amq_appid` , `amq_subject` , `amq_subjectparams`)
VALUES (NULL , UNIX_TIMESTAMP( now( ) ) , UNIX_TIMESTAMP( now( ) ) - 10, 'file_deleted', 'test', 'files', 'deleted_self', '["\/test.txt"]')
```

3 Reset the cron jobs run time:

``` sql
UPDATE `oc_temp`.`oc_jobs` SET `last_run` = '0' WHERE `oc_jobs`.`class` = 'OCA\Activity\BackgroundJob\EmailNotification';
```

4 Trigger the cron with a user that has language set to english
5 Check the Email that has been sent: Should not say "You deleted ..." but be translated.

@MorrisJobke @LukasReschke 

@karlitschek should backport to 8.1.2

Fix https://github.com/owncloud/activity/issues/355
