### PR TITLE
make installer working with github-zips

### DIFF
--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -106,10 +106,10 @@ class OC_Installer{
 			throw new \Exception($l->t("Can't create app folder. Please fix permissions. %s", array($basedir)));
 		}
 
-		$extractDir .= '/' . $info['id'];
+		$extractDir=@glob($extractDir.'/'.$info['id'].'*', GLOB_ONLYDIR)[0];
 		if(!file_exists($extractDir)) {
 			OC_Helper::rmdirr($basedir);
-			throw new \Exception($l->t("Archive does not contain a directory named %s", $info['id']));
+			throw new \Exception($l->t("Archive does not contain a directory starting with %s", $info['id']));
 		}
 		OC_Helper::copyr($extractDir, $basedir);
 


### PR DESCRIPTION
Improvement for #18116

Make installer compatible with github-zips that contain a directory like "appid-version" instead of "appid" only.
appid only is working too.

If there are multiple directories that match with "appid*" the alphabetically first is used.
