### PR TITLE
more understandable 'Wrong password' feedback

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -58,7 +58,7 @@ script('core', [
 
 		<?php if (isset($_['invalidpassword']) && ($_['invalidpassword'])): ?>
 		<a id="lost-password" class="warning" href="">
-			<?php p($l->t('Forgot your password? Reset it!')); ?>
+			<?php p($l->t('Wrong password. Reset it?')); ?>
 		</a>
 		<?php endif; ?>
 		<?php if ($_['rememberLoginAllowed'] === true) : ?>
@@ -83,4 +83,3 @@ script('core', [
 	</fieldset>
 </form>
 <?php }
-


### PR DESCRIPTION
Before:
![capture du 2015-08-12 18-43-42](https://cloud.githubusercontent.com/assets/925062/9230474/b5efac90-4122-11e5-97f1-449f6c82cba4.png)
After:
![capture du 2015-08-12 18-42-51](https://cloud.githubusercontent.com/assets/925062/9230475/b60c1e8e-4122-11e5-8582-76f75f9692e6.png)

The feedback we should be giving is that the password is wrong – not directly assume that someone forgot it. :) Please review @owncloud/designers 

(Thanks to the feedback about this, Bastian/@Urne – we could need your video skills for ownCloud as well. :)
