### PR TITLE
Add a basic unit test which notifies us about incompatible extending

### DIFF
--- a/apps/files_sharing/tests/external/scannertest.php
+++ b/apps/files_sharing/tests/external/scannertest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Tests\External;
+
+use OCA\Files_Sharing\External\Scanner;
+use Test\TestCase;
+
+class ScannerTest extends TestCase {
+	/** @var \OCA\Files_Sharing\External\Scanner */
+	protected $scanner;
+	/** @var \OCA\Files_Sharing\External\Storage|\PHPUnit_Framework_MockObject_MockObject */
+	protected $storage;
+	/** @var \OC\Files\Cache\Cache|\PHPUnit_Framework_MockObject_MockObject */
+	protected $cache;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->storage = $this->getMockBuilder('\OCA\Files_Sharing\External\Storage')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->storage->expects($this->any())
+			->method('getCache')
+			->willReturn($this->cache);
+
+		$this->scanner = new Scanner($this->storage);
+	}
+
+	public function testScanAll() {
+		$this->storage->expects($this->any())
+			->method('getShareInfo')
+			->willReturn(['status' => 'success', 'data' => []]);
+
+		// FIXME add real tests, we are currently only checking for
+		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
+		// compatible with OC\Files\Cache\Scanner::*()
+		$this->scanner->scanAll();
+		$this->assertTrue(true);
+	}
+
+	public function testScan() {
+		$this->storage->expects($this->any())
+			->method('getShareInfo')
+			->willReturn(['status' => 'success', 'data' => []]);
+
+		// FIXME add real tests, we are currently only checking for
+		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
+		// compatible with OC\Files\Cache\Scanner::*()
+		$this->scanner->scan('test', Scanner::SCAN_RECURSIVE);
+		$this->assertTrue(true);
+	}
+
+	public function testScanFile() {
+		// FIXME add real tests, we are currently only checking for
+		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
+		// compatible with OC\Files\Cache\Scanner::*()
+		$this->scanner->scanFile('test', Scanner::SCAN_RECURSIVE);
+		$this->assertTrue(true);
+	}
+}


### PR DESCRIPTION
A test for https://github.com/owncloud/core/pull/17295

```
1) OCA\Files_Sharing\Tests\External\ScannerTest::testScanFile
Declaration of OCA\Files_Sharing\External\Scanner::scanFile()
should be compatible with
OC\Files\Cache\Scanner::scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = NULL, $lock = true)

/home/nickv/ownCloud/master/core/apps/files_sharing/lib/external/scanner.php:32
/home/nickv/ownCloud/master/core/lib/autoloader.php:133
/home/nickv/ownCloud/master/core/apps/files_sharing/tests/external/scannertest.php:37
```

@MorrisJobke @PVince81 @DeepDiver1975 
