### PR TITLE
Fix default values of sharing capabilities

### DIFF
--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -49,20 +49,20 @@ class Capabilities implements ICapability {
 		$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 		if ($public['enabled']) {
 			$public['password'] = [];
-			$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'yes') === 'yes');
+			$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
 
 			$public['expire_date'] = [];
-			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'yes') === 'yes';
+			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';
 			if ($public['expire_date']['enabled']) {
 				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
-				$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'yes') === 'yes';
+				$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
 			}
 
-			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'yes') === 'yes';
+			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
 		}
 		$res["public"] = $public;
 
-		$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'yes') === 'yes';
+		$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') === 'yes';
 
 		$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -77,7 +77,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkPassword() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'yes', 'yes'],
+			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
@@ -88,7 +88,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkNoPassword() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'yes', 'no'],
+			['core', 'shareapi_enforce_links_password', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
@@ -99,7 +99,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkNoExpireDate() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_default_expire_date', 'yes', 'no'],
+			['core', 'shareapi_default_expire_date', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
@@ -110,9 +110,9 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkExpireDate() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_default_expire_date', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date', 'no', 'yes'],
 			['core', 'shareapi_expire_after_n_days', '7', '7'],
-			['core', 'shareapi_enforce_expire_date', 'yes', 'no'],
+			['core', 'shareapi_enforce_expire_date', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
@@ -125,8 +125,8 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkExpireDateEnforced() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_default_expire_date', 'yes', 'yes'],
-			['core', 'shareapi_enforce_expire_date', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date', 'no', 'yes'],
+			['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('expire_date', $result['public']);
@@ -137,7 +137,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkSendMail() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_allow_public_notification', 'yes', 'yes'],
+			['core', 'shareapi_allow_public_notification', 'no', 'yes'],
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['public']['send_mail']);
@@ -146,7 +146,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 	public function testLinkNoSendMail() {
 		$map = [
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_allow_public_notification', 'yes', 'no'],
+			['core', 'shareapi_allow_public_notification', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['public']['send_mail']);
@@ -154,7 +154,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testUserSendMail() {
 		$map = [
-			['core', 'shareapi_allow_mail_notification', 'yes', 'yes'],
+			['core', 'shareapi_allow_mail_notification', 'no', 'yes'],
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['user']['send_mail']);
@@ -162,7 +162,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testUserNoSendMail() {
 		$map = [
-			['core', 'shareapi_allow_mail_notification', 'yes', 'no'],
+			['core', 'shareapi_allow_mail_notification', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['user']['send_mail']);


### PR DESCRIPTION
The problem is the UI used a different default than the capabilities.
So when you never touched the config, the setting in admins said "disabled"
while the capabilities said "enabled".

@guruz should fix your issue

Fix #18261 

@rullzer @DeepDiver1975 
