### PR TITLE
[autotest.sh] list warnings, errors and fatals in ownCloud.log

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -275,6 +275,18 @@ function execute_tests {
 		tests/objectstore/stop-swift-ceph.sh
 	fi
 
+	echo "Warnings in owncloud.log:"
+	grep '"level":2' "$DATADIR/owncloud.log" || echo "Nothing found"
+	echo "Errors in owncloud.log:"
+	grep '"level":3' "$DATADIR/owncloud.log" || echo "Nothing found"
+	echo "Fatals in owncloud.log:"
+	grep '"level":4' "$DATADIR/owncloud.log" || echo "Nothing found"
+
+	warnings=$(grep '"level":2' "$DATADIR/owncloud.log" | wc -l)
+	errors=$(grep '"level":3' "$DATADIR/owncloud.log" | wc -l)
+	fatals=$(grep '"level":4' "$DATADIR/owncloud.log" | wc -l)
+	echo "$warnings warnings, $errors errors, $fatals fatals"
+
 	if [ ! -z "$DOCKER_CONTAINER_ID" ] ; then
 		echo "Kill the docker $DOCKER_CONTAINER_ID"
 		docker rm -f $DOCKER_CONTAINER_ID


### PR DESCRIPTION
@DeepDiver1975 @nickvergessen Should we maybe have a look at those messages? I think especially for fatal logs we should look. The others maybe indicate a broken behaviour but it looks like they are also caused by negative tests that check if ownCloud properly blocks access by unauthenticated users or wrong data.

On the otherside this maybe also reveals some broken behaviour.

Opinions?

cc @PVince81 @LukasReschke @rullzer 
