### PR TITLE
also don't count group members when more than 1 ldap configs are active

### DIFF
--- a/settings/users.php
+++ b/settings/users.php
@@ -42,7 +42,9 @@ $groupManager = \OC_Group::getManager();
 $sortGroupsBy = \OC\Group\MetaData::SORT_USERCOUNT;
 
 if (class_exists('\OCA\user_ldap\GROUP_LDAP')) {
-	$isLDAPUsed = $groupManager->isBackendUsed('\OCA\user_ldap\GROUP_LDAP');
+	$isLDAPUsed =
+		   $groupManager->isBackendUsed('\OCA\user_ldap\GROUP_LDAP')
+		|| $groupManager->isBackendUsed('\OCA\user_ldap\Group_Proxy');
 	if ($isLDAPUsed) {
 		// LDAP user count can be slow, so we sort by group name here
 		$sortGroupsBy = \OC\Group\MetaData::SORT_GROUPNAME;


### PR DESCRIPTION
For perfomance reasons we hide user count in groups and in general when LDAP is enabled. However, the check passes if there is more than one LDAP configuration active.

Reproduction steps:
1. Configure 2 LDAP servers (you can configure one and clone it, works just as well)
2. Go to Users page

Without the fix: user number next to groups, everyone count will show at some point to

With the fix: list is sorted by group name, no user numbers next to them.

Please test and review @MorrisJobke @nickvergessen @Xenopathic @GreenArchon or others
