### PR TITLE
[stable8.1] Show strage full warning for shared storages temporary

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -116,7 +116,7 @@
 				ownerDisplayName = $('#ownerDisplayName').val();
 			if (usedSpacePercent > 98) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
+					OC.Notification.showTemporary(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
 						{ owner: ownerDisplayName }));
 					return;
 				}
@@ -125,7 +125,7 @@
 			}
 			if (usedSpacePercent > 90) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
+					OC.Notification.showTemporary(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
 						{ usedSpacePercent: usedSpacePercent,  owner: ownerDisplayName }));
 					return;
 				}
@@ -239,7 +239,6 @@
 
 			// display storage warnings
 			setTimeout(Files.displayStorageWarnings, 100);
-			OC.Notification.setDefault(Files.displayStorageWarnings);
 
 			// only possible at the moment if user is logged in or the files app is loaded
 			if (OC.currentUser && OCA.Files.App) {


### PR DESCRIPTION
- removed the setDefault call because then it will always be
  reshown
  - was added with ba475d486258c0b7ea86cd766814053df6c69170
- fixes #18208

Backport of #18231
Approval: https://github.com/owncloud/core/pull/18231#issuecomment-130663991

I tested it and it worked.

@PVince81 @jancborchardt  Review please
