### PR TITLE
Hook to load extra scripts in the files app page

### DIFF
--- a/apps/files/index.php
+++ b/apps/files/index.php
@@ -143,6 +143,9 @@ OCP\Util::addscript('files', 'fileactionsmenu');
 OCP\Util::addscript('files', 'files');
 OCP\Util::addscript('files', 'navigation');
 OCP\Util::addscript('files', 'keyboardshortcuts');
+
+\OC_Hook::emit('OCA\Files', 'loadAdditionalScripts', []);
+
 $tmpl = new OCP\Template('files', 'index', 'user');
 $tmpl->assign('usedSpacePercent', (int)$storageInfo['relative']);
 $tmpl->assign('owner', $storageInfo['owner']);


### PR DESCRIPTION
Apps can connect to this hook to load additional Javascript and CSS
required to extend the files app. For example: extending FileActions,
FileList or other classes.

This removes the need for such scripts to be always loaded in
appinfo/app.php but instead be loaded on-demand through the hook.

@nickvergessen @DeepDiver1975 as discussed
