### PR TITLE
Fix the string counting a selected files/dirs

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1945,12 +1945,11 @@
 				var directoryInfo = n('files', '%n folder', '%n folders', summary.totalDirs);
 				var fileInfo = n('files', '%n file', '%n files', summary.totalFiles);
 
-				var selectionVars = {
-					dirs: directoryInfo,
-					files: fileInfo
-				};
-
 				if (summary.totalDirs > 0 && summary.totalFiles > 0) {
+					var selectionVars = {
+						dirs: directoryInfo,
+						files: fileInfo
+					};
 					var selection = t('files', '{dirs} and {files}', selectionVars);
 				} else if (summary.totalDirs > 0) {
 					var selection = directoryInfo;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1930,6 +1930,8 @@
 		updateSelectionSummary: function() {
 			var summary = this._selectionSummary.summary;
 			var canDelete;
+			var selection;
+
 			if (summary.totalFiles === 0 && summary.totalDirs === 0) {
 				this.$el.find('#headerName a.name>span:first').text(t('files','Name'));
 				this.$el.find('#headerSize a>span:first').text(t('files','Size'));
@@ -1950,11 +1952,11 @@
 						dirs: directoryInfo,
 						files: fileInfo
 					};
-					var selection = t('files', '{dirs} and {files}', selectionVars);
+					selection = t('files', '{dirs} and {files}', selectionVars);
 				} else if (summary.totalDirs > 0) {
-					var selection = directoryInfo;
+					selection = directoryInfo;
 				} else {
-					var selection = fileInfo;
+					selection = fileInfo;
 				}
 
 				this.$el.find('#headerName a.name>span:first').text(selection);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1941,16 +1941,23 @@
 				canDelete = (this.getDirectoryPermissions() & OC.PERMISSION_DELETE) && this.isSelectedDeletable();
 				this.$el.find('.selectedActions').removeClass('hidden');
 				this.$el.find('#headerSize a>span:first').text(OC.Util.humanFileSize(summary.totalSize));
-				var selection = '';
-				if (summary.totalDirs > 0) {
-					selection += n('files', '%n folder', '%n folders', summary.totalDirs);
-					if (summary.totalFiles > 0) {
-						selection += ' & ';
-					}
+
+				var directoryInfo = n('files', '%n folder', '%n folders', summary.totalDirs);
+				var fileInfo = n('files', '%n file', '%n files', summary.totalFiles);
+
+				var selectionVars = {
+					dirs: directoryInfo,
+					files: fileInfo
+				};
+
+				if (summary.totalDirs > 0 && summary.totalFiles > 0) {
+					var selection = t('files', '{dirs} and {files}', selectionVars);
+				} else if (summary.totalDirs > 0) {
+					var selection = directoryInfo;
+				} else {
+					var selection = fileInfo;
 				}
-				if (summary.totalFiles > 0) {
-					selection += n('files', '%n file', '%n files', summary.totalFiles);
-				}
+
 				this.$el.find('#headerName a.name>span:first').text(selection);
 				this.$el.find('#modified a>span:first').text('');
 				this.$el.find('table').addClass('multiselect');

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1606,7 +1606,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.findFileEl('One.txt').find('input:checkbox').click();
 			fileList.findFileEl('Three.pdf').find('input:checkbox').click();
 			fileList.findFileEl('somedir').find('input:checkbox').click();
-			expect($summary.text()).toEqual('1 folder & 2 files');
+			expect($summary.text()).toEqual('1 folder and 2 files');
 		});
 		it('Unselecting files hides selection summary', function() {
 			var $summary = $('#headerName a.name>span:first');


### PR DESCRIPTION
The old one contains untranslatable ' & ' if both files and dirs are
selected. The new code is especially designed to reuse strings from file
listing summary view (apps/files/js/filesummary.js), so no translation
is broken.
