### PR TITLE
Add public upload to capability

### DIFF
--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -59,6 +59,7 @@ class Capabilities implements ICapability {
 			}
 
 			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
+			$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
 		}
 		$res["public"] = $public;
 

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -183,4 +183,24 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$result = $this->getResults($map);
 		$this->assertFalse($result['resharing']);
 	}
+
+	public function testLinkPublicUpload() {
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_public_upload', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['public']['upload']);
+	}
+
+	public function testLinkNoPublicUpload() {
+		$map = [
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_public_upload', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['public']['upload']);
+	}
+
+
 }


### PR DESCRIPTION
To allow clients to enable (or disable) public upload on shares we also need this info in the capabilities. (e.g. https://github.com/owncloud/client/issues/3551).

Pretty trivial.

CC: @PVince81 @MorrisJobke @LukasReschke @nickvergessen @DeepDiver1975 
