### PR TITLE
Remove dependency to appinfo/version

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -624,14 +624,9 @@ class OC_App {
 	 * @return string
 	 */
 	public static function getAppVersionByPath($path) {
-		$versionFile = $path . '/appinfo/version';
 		$infoFile = $path . '/appinfo/info.xml';
-		if (is_file($versionFile)) {
-			return trim(file_get_contents($versionFile));
-		} else {
-			$appData = self::getAppInfo($infoFile, true);
-			return isset($appData['version']) ? $appData['version'] : '';
-		}
+		$appData = self::getAppInfo($infoFile, true);
+		return isset($appData['version']) ? $appData['version'] : '';
 	}
 
 

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -352,17 +352,12 @@ class OC_Installer{
 			throw new \Exception($l->t("App can't be installed because it contains the <shipped>true</shipped> tag which is not allowed for non shipped apps"));
 		}
 
-		// check if the ocs version is the same as the version in info.xml/version
-		$versionFile= $extractDir.'/appinfo/version';
-		if(is_file($versionFile)) {
-			$version = trim(file_get_contents($versionFile));
-		}else{
-			$version = trim($info['version']);
-		}
+		// check if the ocs version is the same as the version in info.xml
+		$version = trim($info['version']);
 
 		if(isset($data['appdata']['version']) && $version<>trim($data['appdata']['version'])) {
 			OC_Helper::rmdirr($extractDir);
-			throw new \Exception($l->t("App can't be installed because the version in info.xml/version is not the same as the version reported from the app store"));
+			throw new \Exception($l->t("App can't be installed because the version in info.xml is not the same as the version reported from the app store"));
 		}
 
 		return $info;


### PR DESCRIPTION
- fixes #17598
- caused trouble if the version number in appinfo/version was not updated

cc @karlitschek @DeepDiver1975 @PVince81 @LukasReschke @icewind1991 

I tested this by installing a shipped app, a git cloned app and an app downloaded from the appstore via app management. Everything worked fine.
