### PR TITLE
[stable8.1] Add option to disable autocomplete in share dialog

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -379,6 +379,16 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					}
 				}
 
+				$sharingAutocompletion = \OC::$server->getConfig()
+					->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
+
+				if ($sharingAutocompletion !== 'yes') {
+					$searchTerm = strtolower($_GET['search']);
+					$shareWith = array_filter($shareWith, function($user) use ($searchTerm) {
+						return strtolower($user['label']) === $searchTerm
+							|| strtolower($user['value']['shareWith']) === $searchTerm;
+					});
+				}
 
 				$sorter = new \OC\Share\SearchResultSorter((string)$_GET['search'],
 														   'label',

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -122,6 +122,7 @@ $template->assign('allowPublicUpload', $appConfig->getValue('core', 'shareapi_al
 $template->assign('allowResharing', $appConfig->getValue('core', 'shareapi_allow_resharing', 'yes'));
 $template->assign('allowPublicMailNotification', $appConfig->getValue('core', 'shareapi_allow_public_notification', 'no'));
 $template->assign('allowMailNotification', $appConfig->getValue('core', 'shareapi_allow_mail_notification', 'no'));
+$template->assign('allowShareDialogUserEnumeration', $appConfig->getValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'));
 $template->assign('onlyShareWithGroupMembers', \OC\Share\Share::shareWithGroupMembersOnly());
 $databaseOverload = (strpos(\OCP\Config::getSystemValue('dbtype'), 'sqlite') !== false);
 $template->assign('databaseOverload', $databaseOverload);

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -245,6 +245,11 @@ if ($_['cronErrors']) {
 			<br />
 			<em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
 		</p>
+		<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+			<input type="checkbox" name="shareapi_allow_share_dialog_user_enumeration" value="1" id="shareapi_allow_share_dialog_user_enumeration"
+				<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') print_unescaped('checked="checked"'); ?> />
+			<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog. If this is disabled the full username needs to be entered.'));?></label><br />
+		</p>
 
 		<?php print_unescaped($_['fileSharingSettings']); ?>
 	</div>


### PR DESCRIPTION
The master version of this was closed, because the sharing dialog is reworked and should use the OCS API in the future. As this is too much stuff to backport, I ported the previous implementation of this to stable8.1.

@karlitschek Please approve this.
### How to test
- add user "test" with displayname "foo"
- disable the setting in the sharing settings on the admin page
- go to the sharing dialog
- try to share something to "tes" -> nothing shown
- try to share something to "test" -> "foo" shown
- try to share something to "tesT" -> "foo" shown
- try to share something to "fo" -> nothing shown
- try to share something to "food" -> nothing shown
- try to share something to "foo" -> "foo" shown
- try to share something to "Foo" -> "foo" shown

@Xenopathic Can you have a look at the wording of the Web UI config setting?

@nickvergessen @PVince81 @felixboehm Please have a look and review 

cc @cdamken It was your request
