### PR TITLE
improve calculation of share recipients

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -122,11 +122,12 @@ class Share extends Constants {
 	 * @param string $ownerUser owner of the file
 	 * @param boolean $includeOwner include owner to the list of users with access to the file
 	 * @param boolean $returnUserPaths Return an array with the user => path map
+	 * @param boolean $recursive take all parent folders into account (default true)
 	 * @return array
 	 * @note $path needs to be relative to user data dir, e.g. 'file.txt'
 	 *       not '/admin/data/file.txt'
 	 */
-	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false) {
+	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false, $recursive = true) {
 
 		Filesystem::initMountPoints($ownerUser);
 		$shares = $sharePaths = $fileTargets = array();
@@ -252,7 +253,7 @@ class Share extends Constants {
 
 			// let's get the parent for the next round
 			$meta = $cache->get((int)$source);
-			if($meta !== false) {
+			if ($recursive === true && $meta !== false) {
 				$source = (int)$meta['parent'];
 			} else {
 				$source = -1;

--- a/lib/public/share.php
+++ b/lib/public/share.php
@@ -80,13 +80,14 @@ class Share extends \OC\Share\Constants {
 	 * @param string $ownerUser owner of the file
 	 * @param bool $includeOwner include owner to the list of users with access to the file
 	 * @param bool $returnUserPaths Return an array with the user => path map
+	 * @param bool $recursive take parent folders into account
 	 * @return array
 	 * @note $path needs to be relative to user data dir, e.g. 'file.txt'
-	 *       not '/admin/data/file.txt'
-	 * @since 5.0.0
+	 *       not '/admin/files/file.txt'
+	 * @since 5.0.0 - $recursive was added in 8.2.0
 	 */
-	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false) {
-		return \OC\Share\Share::getUsersSharingFile($path, $ownerUser, $includeOwner, $returnUserPaths);
+	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false, $recursive = true) {
+		return \OC\Share\Share::getUsersSharingFile($path, $ownerUser, $includeOwner, $returnUserPaths, $recursive);
 	}
 
 	/**


### PR DESCRIPTION
improve calculation of share recipients by caching the result for the parent folders.

This is already a small improvement for https://github.com/owncloud/core/issues/18359. The profile in #18359 was created with this patch, now I also created a profile for master. This patch saves us 100+ queries and is about 1.5 seconds faster (folder with 6 files shared with 4 users). So it is already quite nice and will sum-up for larger folders and more users but I think the real big improvement need to come from the file cache.

cc @nickvergessen 
