### PR TITLE
Fix spinner when deleting all files in a folder

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1748,7 +1748,7 @@
 				// no files passed, delete all in current dir
 				params.allfiles = true;
 				// show spinner for all files
-				this.$fileList.find('tr').addClass('busy');
+				this.showFileBusyState(this.$fileList.find('tr'), true);
 			}
 
 			$.post(OC.filePath('files', 'ajax', 'delete.php'),
@@ -1791,7 +1791,7 @@
 							}
 							else {
 								$.each(files,function(index,file) {
-									self.$fileList.find('tr').removeClass('busy');
+									self.showFileBusyState(file, false);
 								});
 							}
 						}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/18377

Simply select all files in a folder then delete them. They should all show a spinner and have no action icons shown during the operation.

Please review @jancborchardt @MorrisJobke @rullzer @blizzz 
