### PR TITLE
Fix file actions menu in public page

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -616,7 +616,7 @@
 				name: 'Delete',
 				mime: 'all',
 				// permission is READ because we show a hint instead if there is no permission
-				permissions: OC.PERMISSION_READ,
+				permissions: OC.PERMISSION_DELETE,
 				icon: function() {
 					return OC.imagePath('core', 'actions/delete');
 				},

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -16,6 +16,7 @@ OCP\Util::addStyle('files', 'files');
 OCP\Util::addStyle('files', 'upload');
 OCP\Util::addScript('files', 'filesummary');
 OCP\Util::addScript('files', 'breadcrumb');
+OCP\Util::addScript('files', 'fileinfomodel');
 OCP\Util::addScript('files', 'files');
 OCP\Util::addScript('files', 'filelist');
 OCP\Util::addscript('files', 'keyboardshortcuts');


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/18371

Also removes the bogus "Delete" action from the menu when no delete permission is given.

Please review @nickvergessen @MorrisJobke @jancborchardt @rullzer 
