### PR TITLE
[stable7] forward repair events to updater

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -209,6 +209,7 @@ class Updater extends BasicEmitter {
 
 		// pre-upgrade repairs
 		$repair = new \OC\Repair(\OC\Repair::getBeforeUpgradeRepairSteps());
+		$this->emitRepairMessages($repair);
 		$repair->run();
 
 		// simulate DB upgrade
@@ -239,6 +240,7 @@ class Updater extends BasicEmitter {
 
 			// post-upgrade repairs
 			$repair = new \OC\Repair(\OC\Repair::getRepairSteps());
+			$this->emitRepairMessages($repair);
 			$repair->run();
 
 			//Invalidate update feed
@@ -247,6 +249,12 @@ class Updater extends BasicEmitter {
 			// only set the final version if everything went well
 			\OC_Config::setValue('version', implode('.', \OC_Util::getVersion()));
 		}
+	}
+
+	protected function emitRepairMessages(Repair $repair) {
+		$repair->listen('\OC\Repair', 'info', function($description){
+			$this->emit('\OC\Repair', 'info', array($description));
+		});
 	}
 
 	protected function checkCoreUpgrade() {


### PR DESCRIPTION
- fixes #17313
- already in stable8+: 22bc37cb82368fba912a9e5a5ef0e87017d04b1e - #13513

cc @jvillafanez @nickvergessen @karlitschek Please review.

This only applies for stable7, because there the forwarding wasn't present.
