### PR TITLE
Fix extracting basename from path in sharing

### DIFF
--- a/apps/files_sharing/lib/share/folder.php
+++ b/apps/files_sharing/lib/share/folder.php
@@ -39,7 +39,7 @@ class OC_Share_Backend_Folder extends OC_Share_Backend_File implements OCP\Share
 			$shares = \OCP\Share::getItemSharedWithUser('folder', $parent, $shareWith, $owner);
 			if ($shares) {
 				foreach ($shares as $share) {
-					$name = substr($share['path'], strrpos($share['path'], '/') + 1);
+					$name = basename($share['path']);
 					$share['collection']['path'] = $name;
 					$share['collection']['item_type'] = 'folder';
 					$share['file_path'] = $name;


### PR DESCRIPTION
Fixes #17770 

cc @davitol @PVince81 @DeepDiver1975 @schiesbn 

I thought about adding unit tests, but I'm not familiar with the files_sharing code. Feel free someone to push directly here

@karlitschek Backport? This affects 8.1 and 8.0 only
