### PR TITLE
Use OCP classes as much as possible in files_external v2

### DIFF
--- a/apps/files_external/ajax/applicable.php
+++ b/apps/files_external/ajax/applicable.php
@@ -37,8 +37,15 @@ if (isset($_GET['offset'])) {
 	$offset = (int)$_GET['offset'];
 }
 
-$groups = \OC_Group::getGroups($pattern, $limit, $offset);
-$users = \OCP\User::getDisplayNames($pattern, $limit, $offset);
+$groups = [];
+foreach (\OC::$server->getGroupManager()->search($pattern, $limit, $offset) as $group) {
+	$groups[$group->getGID()] = $group->getGID();
+}
+
+$users = [];
+foreach (\OC::$server->getUserManager()->searchDisplayName($pattern, $limit, $offset) as $user) {
+	$users[$user->getUID()] = $user->getDisplayName();
+}
 
 $results = array('groups' => $groups, 'users' => $users);
 

--- a/apps/files_external/appinfo/routes.php
+++ b/apps/files_external/appinfo/routes.php
@@ -26,7 +26,7 @@
 namespace OCA\Files_External\AppInfo;
 
 /**
- * @var $this \OC\Route\Router
+ * @var $this \OCP\Route\IRouter
  **/
 \OC_Mount_Config::$app->registerRoutes(
 	$this,

--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -372,7 +372,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				self::$tmpFiles[$tmpFile] = $path;
 
 				try {
@@ -404,7 +404,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');
@@ -464,7 +464,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				]);
 				$this->testTimeout();
 			} else {
-				$mimeType = \OC_Helper::getMimetypeDetector()->detectPath($path);
+				$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($path);
 				$this->getConnection()->putObject([
 					'Bucket' => $this->bucket,
 					'Key' => $this->cleanKey($path),
@@ -629,7 +629,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				'Bucket' => $this->bucket,
 				'Key' => $this->cleanKey(self::$tmpFiles[$tmpFile]),
 				'SourceFile' => $tmpFile,
-				'ContentType' => \OC_Helper::getMimeType($tmpFile),
+				'ContentType' => \OC::$server->getMimeTypeDetector()->detect($tmpFile),
 				'ContentLength' => filesize($tmpFile)
 			));
 			$this->testTimeout();

--- a/apps/files_external/lib/api.php
+++ b/apps/files_external/lib/api.php
@@ -71,7 +71,7 @@ class Api {
 	 */
 	public static function getUserMounts($params) {
 		$entries = array();
-		$user = \OC_User::getUser();
+		$user = \OC::$server->getUserSession()->getUser()->getUID();
 
 		$mounts = \OC_Mount_Config::getAbsoluteMountPoints($user);
 		foreach($mounts as $mountPoint => $mount) {

--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -244,7 +244,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				try {
 					$data = $this->dropbox->getFile($path);
 					file_put_contents($tmpFile, $data);
@@ -270,7 +270,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');

--- a/apps/files_external/lib/google.php
+++ b/apps/files_external/lib/google.php
@@ -429,7 +429,7 @@ class Google extends \OC\Files\Storage\Common {
 						$request = new \Google_Http_Request($downloadUrl, 'GET', null, null);
 						$httpRequest = $this->client->getAuth()->authenticatedRequest($request);
 						if ($httpRequest->getResponseHttpCode() == 200) {
-							$tmpFile = \OC_Helper::tmpFile($ext);
+							$tmpFile = \OCP\Files::tmpFile($ext);
 							$data = $httpRequest->getResponseBody();
 							file_put_contents($tmpFile, $data);
 							return fopen($tmpFile, $mode);
@@ -449,7 +449,7 @@ class Google extends \OC\Files\Storage\Common {
 			case 'x+':
 			case 'c':
 			case 'c+':
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'rb');
@@ -466,7 +466,7 @@ class Google extends \OC\Files\Storage\Common {
 			$parentFolder = $this->getDriveFile(dirname($path));
 			if ($parentFolder) {
 				// TODO Research resumable upload
-				$mimetype = \OC_Helper::getMimeType($tmpFile);
+				$mimetype = \OC::$server->getMimeTypeDetector()->detect($tmpFile);
 				$data = file_get_contents($tmpFile);
 				$params = array(
 					'data' => $data,

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -310,7 +310,7 @@ class Swift extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OC_Helper::tmpFile();
+				$tmpFile = \OCP\Files::tmpFile();
 				self::$tmpFiles[$tmpFile] = $path;
 				try {
 					$object = $this->getContainer()->getObject($path);
@@ -348,7 +348,7 @@ class Swift extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');
@@ -387,7 +387,7 @@ class Swift extends \OC\Files\Storage\Common {
 			$object->saveMetadata($metadata);
 			return true;
 		} else {
-			$mimeType = \OC_Helper::getMimetypeDetector()->detectPath($path);
+			$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($path);
 			$customHeaders = array('content-type' => $mimeType);
 			$metadataHeaders = DataObject::stockHeaders($metadata);
 			$allHeaders = $customHeaders + $metadataHeaders;

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -418,7 +418,7 @@ abstract class StoragesService {
 	 */
 	protected function triggerApplicableHooks($signal, $mountPoint, $mountType, $applicableArray) {
 		foreach ($applicableArray as $applicable) {
-			\OC_Hook::emit(
+			\OCP\Util::emitHook(
 				Filesystem::CLASSNAME,
 				$signal,
 				[

--- a/apps/files_external/settings.php
+++ b/apps/files_external/settings.php
@@ -28,7 +28,7 @@
 
 use \OCA\Files_External\Service\BackendService;
 
-OC_Util::checkAdminUser();
+\OCP\User::checkAdminUser();
 
 // we must use the same container
 $appContainer = \OC_Mount_Config::$app->getContainer();

--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -1,4 +1,4 @@
-<?php /** @var $l OC_L10N */ ?>
+<?php /** @var $l \OCP\IL10N */ ?>
 <div id="controls">
 	<div id="file_action_panel"></div>
 </div>

--- a/apps/files_external/tests/service/userstoragesservicetest.php
+++ b/apps/files_external/tests/service/userstoragesservicetest.php
@@ -31,9 +31,14 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 	public function setUp() {
 		parent::setUp();
 
-		$this->userId = $this->getUniqueID('user_');
+		$userManager = \OC::$server->getUserManager();
 
-		$this->user = new \OC\User\User($this->userId, null);
+		$this->userId = $this->getUniqueID('user_');
+		$this->user = $userManager->createUser(
+			$this->userId,
+			$this->userId
+		);
+
 		$userSession = $this->getMock('\OCP\IUserSession');
 		$userSession
 			->expects($this->any())
@@ -48,6 +53,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 
 	public function tearDown() {
 		@unlink($this->dataDir . '/' . $this->userId . '/mount.json');
+		$this->user->delete();
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
Revival of #15363, with some further replacements and tests fixed.

@DeepDiver1975 The problem was with registration of users - one test didn't do so, relying on the (dangerous!) behaviour of `OC_User::getHome()`. Now it just registers the user, and all is well.

Please review @rullzer @karlitschek @PVince81 
