### PR TITLE
Validate config values with the type of the default

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -95,7 +95,7 @@ class Config {
 					return [];
 				}
 				if ($requiredType !== 'array' && $type === 'array') {
-					return $default; // config is seriously broken
+					throw new \Exception('Value for config key "'.$key.'" must be a '.$requiredType);
 				}
 				if ($requiredType === 'boolean' && $type === 'string') {
 					switch ($value) {
@@ -104,11 +104,11 @@ class Config {
 					case 'false':
 						return false;
 					default:
-						return $default;
+						throw new \Exception('Value for config key "'.$key.'" must be a boolean');
 					}
 				}
 				if ($requiredType === 'string' && $type === 'boolean') {
-					return $default; // no casting
+					throw new \Exception('Value for config key "'.$key.'" must be a string');
 				}
 
 				settype($value, $requiredType);

--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -84,7 +84,36 @@ class Config {
 	 */
 	public function getValue($key, $default = null) {
 		if (isset($this->cache[$key])) {
-			return $this->cache[$key];
+			$value = $this->cache[$key];
+			if (isset($default)) {
+				// ensure type is valid
+				$requiredType = gettype($default);
+				$type = gettype($value);
+
+				// special cases first
+				if ($requiredType === 'array' && $value === '') {
+					return [];
+				}
+				if ($requiredType !== 'array' && $type === 'array') {
+					return $default; // config is seriously broken
+				}
+				if ($requiredType === 'boolean' && $type === 'string') {
+					switch ($value) {
+					case 'true':
+						return true;
+					case 'false':
+						return false;
+					default:
+						return $default;
+					}
+				}
+				if ($requiredType === 'string' && $type === 'boolean') {
+					return $default; // no casting
+				}
+
+				settype($value, $requiredType);
+			}
+			return $value;
 		}
 
 		return $default;

--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -463,9 +463,9 @@ class OC_L10N implements \OCP\IL10N {
 			}
 		}
 
-		$default_language = \OC::$server->getConfig()->getSystemValue('default_language', false);
+		$default_language = \OC::$server->getConfig()->getSystemValue('default_language');
 
-		if($default_language !== false) {
+		if (isset($default_language)) {
 			return $default_language;
 		}
 

--- a/lib/private/systemconfig.php
+++ b/lib/private/systemconfig.php
@@ -63,7 +63,7 @@ class SystemConfig {
 	 * @param mixed $default the default value to be returned if the value isn't set
 	 * @return mixed the value or $default
 	 */
-	public function getValue($key, $default = '') {
+	public function getValue($key, $default = null) {
 		return \OC_Config::getValue($key, $default);
 	}
 

--- a/tests/lib/config.php
+++ b/tests/lib/config.php
@@ -60,8 +60,23 @@ class Test_Config extends \Test\TestCase {
 		$this->assertSame(false, $this->config->getValue('zeroint', true));
 		$this->assertSame(true, $this->config->getValue('someint', false));
 
-		$this->assertSame('someNonBoolean', $this->config->getValue('alcohol_free', 'someNonBoolean'));
 		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers', array('otherValue')));
+	}
+
+	public function getValueValidateInvalidProvider() {
+		return [
+			['alcohol_free', 'someNonBoolean'],
+			['beers', 'someNonArray'],
+			['foo', false],
+		];
+	}
+
+	/**
+	 * @dataProvider getValueValidateInvalidProvider
+	 * @expectedException \Exception
+	 */
+	public function testGetValueValidateInvalid($key, $default) {
+		$this->config->getValue($key, $default);
 	}
 
 	public function testSetValue() {

--- a/tests/lib/config.php
+++ b/tests/lib/config.php
@@ -41,9 +41,27 @@ class Test_Config extends \Test\TestCase {
 		$this->assertSame('bar', $this->config->getValue('foo'));
 		$this->assertSame(null, $this->config->getValue('bar'));
 		$this->assertSame('moo', $this->config->getValue('bar', 'moo'));
-		$this->assertSame(false, $this->config->getValue('alcohol_free', 'someBogusValue'));
-		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers', 'someBogusValue'));
 		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers'));
+	}
+
+	public function testGetValueValidate() {
+		// for these tests: gettype($default) !== gettype($value)
+		$this->config->setValues([
+			'emptystring' => '',
+			'boolstring' => 'false',
+			'zeroint' => 0,
+			'someint' => 42,
+		]);
+
+		$this->assertSame(array('bar'), $this->config->getValue('foo', array('abc')));
+		$this->assertSame(array(), $this->config->getValue('emptystring', array('abc')));
+
+		$this->assertSame(false, $this->config->getValue('boolstring', true));
+		$this->assertSame(false, $this->config->getValue('zeroint', true));
+		$this->assertSame(true, $this->config->getValue('someint', false));
+
+		$this->assertSame('someNonBoolean', $this->config->getValue('alcohol_free', 'someNonBoolean'));
+		$this->assertSame(array('Appenzeller', 'Guinness', 'Kölsch'), $this->config->getValue('beers', array('otherValue')));
 	}
 
 	public function testSetValue() {


### PR DESCRIPTION
In case the type of the default value does not match that in the config, the value is attempted to be converted into the required type, according to these simple rules (default | value => result):
- array | empty string => empty array
- non-array | array => throw exception
- boolean | string => 'true' => true, 'false' => false, else throw exception
- string | boolean => throw exception

Otherwise, the type is converted with `settype()`

The reasoning behind this comes from https://github.com/owncloud/core/issues/18405#issuecomment-132357987, where a user had set `'blacklisted_files'` to the empty string, causing problems as the code expected an array. That, and other reasonable conversions, are done here. In case the value cannot be converted (e.g. an array to some non-array) an exception is thrown. The alternative is some other code failing, perhaps silently, potentially with disastrous consequences.

cc @DeepDiver1975 @LukasReschke @RealRancor @MorrisJobke 
