### PR TITLE
handle non existing job classes in $jobList->getNext

### DIFF
--- a/tests/lib/backgroundjob/joblist.php
+++ b/tests/lib/backgroundjob/joblist.php
@@ -202,4 +202,30 @@ class JobList extends \Test\TestCase {
 
 		$this->instance->remove($job);
 	}
+
+	public function testGetNextNonExisting() {
+		$job = new TestJob();
+		$this->instance->add($job, 1);
+		$this->instance->add('\OC\Non\Existing\Class');
+		$this->instance->add($job, 2);
+
+		$jobs = $this->instance->getAll();
+
+		$savedJob1 = $jobs[count($jobs) - 2];
+		$savedJob2 = $jobs[count($jobs) - 1];
+
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->with('backgroundjob', 'lastjob', 0)
+			->will($this->returnValue($savedJob1->getId()));
+
+		$this->instance->getNext();
+
+		$nextJob = $this->instance->getNext();
+
+		$this->assertEquals($savedJob2, $nextJob);
+
+		$this->instance->remove($job, 1);
+		$this->instance->remove($job, 2);
+	}
 }


### PR DESCRIPTION
Fixes issues after disabling an app that has registered a job when not using system cron.

Fixes #18295

@MarioSchymura can you check if this fixes the problem

cc @PVince81 @DeepDiver1975
