### PR TITLE
Migrate simple external storage backends to new registration API [part 1]

### DIFF
--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -111,19 +111,6 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\Dropbox', [
 	'has_dependencies' => true,
 ]);
 
-OC_Mount_Config::registerBackend('\OC\Files\Storage\FTP', [
-	'backend' => 'FTP',
-	'priority' => 100,
-	'configuration' => [
-		'host' => (string)$l->t('Host'),
-		'user' => (string)$l->t('Username'),
-		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Remote subfolder'),
-		'secure' => '!'.$l->t('Secure ftps://')
-	],
-	'has_dependencies' => true,
-]);
-
 OC_Mount_Config::registerBackend('\OC\Files\Storage\Google', [
 	'backend' => 'Google Drive',
 	'priority' => 100,

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -144,19 +144,6 @@ OC_Mount_Config::registerBackend('\OC\Files\Storage\Swift', [
 
 
 if (!OC_Util::runningOnWindows()) {
-	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB', [
-		'backend' => 'SMB / CIFS',
-		'priority' => 100,
-		'configuration' => [
-			'host' => (string)$l->t('Host'),
-			'user' => (string)$l->t('Username'),
-			'password' => '*'.$l->t('Password'),
-			'share' => (string)$l->t('Share'),
-			'root' => '&'.$l->t('Remote subfolder'),
-		],
-		'has_dependencies' => true,
-	]);
-
 	OC_Mount_Config::registerBackend('\OC\Files\Storage\SMB_OC', [
 			'backend' => (string)$l->t('SMB / CIFS using OC login'),
 			'priority' => 90,

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -157,19 +157,6 @@ if (!OC_Util::runningOnWindows()) {
 	]);
 }
 
-OC_Mount_Config::registerBackend('\OC\Files\Storage\OwnCloud', [
-	'backend' => 'ownCloud',
-	'priority' => 100,
-	'configuration' => [
-		'host' => (string)$l->t('URL'),
-		'user' => (string)$l->t('Username'),
-		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Remote subfolder'),
-		'secure' => '!'.$l->t('Secure https://'),
-	],
-]);
-
-
 OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP', [
 	'backend' => 'SFTP',
 	'priority' => 100,

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -157,17 +157,6 @@ if (!OC_Util::runningOnWindows()) {
 	]);
 }
 
-OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP', [
-	'backend' => 'SFTP',
-	'priority' => 100,
-	'configuration' => [
-		'host' => (string)$l->t('Host'),
-		'user' => (string)$l->t('Username'),
-		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Remote subfolder'),
-	],
-]);
-
 OC_Mount_Config::registerBackend('\OC\Files\Storage\SFTP_Key', [
 	'backend' => (string)$l->t('SFTP with secret key login'),
 	'priority' => 100,

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -157,19 +157,6 @@ if (!OC_Util::runningOnWindows()) {
 	]);
 }
 
-OC_Mount_Config::registerBackend('\OC\Files\Storage\DAV', [
-	'backend' => 'WebDAV',
-	'priority' => 100,
-	'configuration' => [
-		'host' => (string)$l->t('URL'),
-		'user' => (string)$l->t('Username'),
-		'password' => '*'.$l->t('Password'),
-		'root' => '&'.$l->t('Remote subfolder'),
-		'secure' => '!'.$l->t('Secure https://'),
-	],
-	'has_dependencies' => true,
-]);
-
 OC_Mount_Config::registerBackend('\OC\Files\Storage\OwnCloud', [
 	'backend' => 'ownCloud',
 	'priority' => 100,

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -70,18 +70,6 @@ if (OCP\Config::getAppValue('files_external', 'allow_user_mounting', 'yes') == '
 OCP\Util::connectHook('OC_Filesystem', 'post_initMountPoints', '\OC_Mount_Config', 'initMountPointsHook');
 OCP\Util::connectHook('OC_User', 'post_login', 'OC\Files\Storage\SMB_OC', 'login');
 
-OC_Mount_Config::registerBackend('\OC\Files\Storage\Local', [
-	'backend' => (string)$l->t('Local'),
-	'priority' => 150,
-	'configuration' => [
-		'datadir' => (string)$l->t('Location')
-	],
-]);
-// Local must only be visible to the admin
-$appContainer->query('OCA\Files_External\Service\BackendService')
-	->getBackend('\OC\Files\Storage\Local')
-	->setAllowedVisibility(\OCA\Files_External\Service\BackendService::VISIBILITY_ADMIN);
-
 OC_Mount_Config::registerBackend('\OC\Files\Storage\AmazonS3', [
 	'backend' => (string)$l->t('Amazon S3'),
 	'priority' => 100,

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -28,8 +28,6 @@ use \OCA\Files_External\Controller\AjaxController;
 use \OCP\AppFramework\App;
 use \OCP\IContainer;
 use \OCA\Files_External\Service\BackendService;
-use \OCA\Files_External\Lib\BackendConfig;
-use \OCA\Files_External\Lib\BackendParameter;
 
 /**
  * @package OCA\Files_External\Appinfo
@@ -60,6 +58,10 @@ class Application extends App {
 	protected function loadBackends() {
 		$container = $this->getContainer();
 		$service = $container->query('OCA\\Files_External\\Service\\BackendService');
+
+		$service->registerBackends([
+			$container->query('OCA\Files_External\Lib\Backend\Local'),
+		]);
 	}
 
 	/**

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -64,6 +64,7 @@ class Application extends App {
 			$container->query('OCA\Files_External\Lib\Backend\FTP'),
 			$container->query('OCA\Files_External\Lib\Backend\DAV'),
 			$container->query('OCA\Files_External\Lib\Backend\OwnCloud'),
+			$container->query('OCA\Files_External\Lib\Backend\SFTP'),
 		]);
 
 		if (!\OC_Util::runningOnWindows()) {

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -62,6 +62,7 @@ class Application extends App {
 		$service->registerBackends([
 			$container->query('OCA\Files_External\Lib\Backend\Local'),
 			$container->query('OCA\Files_External\Lib\Backend\FTP'),
+			$container->query('OCA\Files_External\Lib\Backend\DAV'),
 		]);
 
 		if (!\OC_Util::runningOnWindows()) {

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -61,6 +61,7 @@ class Application extends App {
 
 		$service->registerBackends([
 			$container->query('OCA\Files_External\Lib\Backend\Local'),
+			$container->query('OCA\Files_External\Lib\Backend\FTP'),
 		]);
 	}
 

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -63,6 +63,12 @@ class Application extends App {
 			$container->query('OCA\Files_External\Lib\Backend\Local'),
 			$container->query('OCA\Files_External\Lib\Backend\FTP'),
 		]);
+
+		if (!\OC_Util::runningOnWindows()) {
+			$service->registerBackends([
+				$container->query('OCA\Files_External\Lib\Backend\SMB'),
+			]);
+		}
 	}
 
 	/**

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -75,6 +75,10 @@ class Application extends App {
 
 			// AuthMechanism::SCHEME_BUILTIN mechanism
 			$container->query('OCA\Files_External\Lib\Auth\Builtin'),
+
+			// AuthMechanism::SCHEME_PASSWORD mechanisms
+			$container->query('OCA\Files_External\Lib\Auth\Password\Password'),
+			$container->query('OCA\Files_External\Lib\Auth\Password\SessionCredentials'),
 		]);
 	}
 

--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -63,6 +63,7 @@ class Application extends App {
 			$container->query('OCA\Files_External\Lib\Backend\Local'),
 			$container->query('OCA\Files_External\Lib\Backend\FTP'),
 			$container->query('OCA\Files_External\Lib\Backend\DAV'),
+			$container->query('OCA\Files_External\Lib\Backend\OwnCloud'),
 		]);
 
 		if (!\OC_Util::runningOnWindows()) {

--- a/apps/files_external/lib/auth/password/password.php
+++ b/apps/files_external/lib/auth/password/password.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Auth\Password;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+
+/**
+ * Basic password authentication mechanism
+ */
+class Password extends AuthMechanism {
+
+	public function __construct(IL10N $l) {
+		$this
+			->setIdentifier('password::password')
+			->setScheme(self::SCHEME_PASSWORD)
+			->setText($l->t('Username and password'))
+			->addParameters([
+				(new DefinitionParameter('user', $l->t('Username'))),
+				(new DefinitionParameter('password', $l->t('Password')))
+					->setType(DefinitionParameter::VALUE_PASSWORD),
+			]);
+	}
+
+}

--- a/apps/files_external/lib/auth/password/sessioncredentials.php
+++ b/apps/files_external/lib/auth/password/sessioncredentials.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Auth\Password;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Lib\StorageConfig;
+use \OCP\ISession;
+use \OCP\Security\ICrypto;
+use \OCP\Files\Storage;
+use \OCA\Files_External\Lib\SessionStorageWrapper;
+use \OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
+
+/**
+ * Username and password from login credentials, saved in session
+ */
+class SessionCredentials extends AuthMechanism {
+
+	/** @var ISession */
+	protected $session;
+
+	/** @var ICrypto */
+	protected $crypto;
+
+	public function __construct(IL10N $l, ISession $session, ICrypto $crypto) {
+		$this->session = $session;
+		$this->crypto = $crypto;
+
+		$this
+			->setIdentifier('password::sessioncredentials')
+			->setScheme(self::SCHEME_PASSWORD)
+			->setText($l->t('Session credentials'))
+			->addParameters([
+			])
+		;
+
+		\OCP\Util::connectHook('OC_User', 'post_login', $this, 'authenticate');
+	}
+
+	/**
+	 * Hook listener on post login
+	 *
+	 * @param array $params
+	 */
+	public function authenticate(array $params) {
+		$this->session->set('password::sessioncredentials/credentials', $this->crypto->encrypt(json_encode($params)));
+	}
+
+	public function manipulateStorageConfig(StorageConfig &$storage) {
+		$encrypted = $this->session->get('password::sessioncredentials/credentials');
+		if (!isset($encrypted)) {
+			throw new InsufficientDataForMeaningfulAnswerException('No session credentials saved');
+		}
+
+		$credentials = json_decode($this->crypto->decrypt($encrypted), true);
+		$storage->setBackendOption('user', $this->session->get('loginname'));
+		$storage->setBackendOption('password', $credentials['password']);
+	}
+
+	public function wrapStorage(Storage $storage) {
+		return new SessionStorageWrapper(['storage' => $storage]);
+	}
+
+}

--- a/apps/files_external/lib/backend/dav.php
+++ b/apps/files_external/lib/backend/dav.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+
+use \OCA\Files_External\Lib\Auth\Password\Password;
+
+class DAV extends Backend {
+
+	public function __construct(IL10N $l, Password $legacyAuth) {
+		$this
+			->setIdentifier('dav')
+			->addIdentifierAlias('\OC\Files\Storage\DAV') // legacy compat
+			->setStorageClass('\OC\Files\Storage\DAV')
+			->setText($l->t('WebDAV'))
+			->addParameters([
+				(new DefinitionParameter('host', $l->t('URL'))),
+				(new DefinitionParameter('root', $l->t('Remote subfolder')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('secure', $l->t('Secure https://')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN),
+			])
+			->setDependencyCheck('\OC\Files\Storage\DAV::checkDependencies')
+			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/backend/ftp.php
+++ b/apps/files_external/lib/backend/ftp.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+
+use \OCA\Files_External\Lib\Auth\Password\Password;
+
+class FTP extends Backend {
+
+	public function __construct(IL10N $l, Password $legacyAuth) {
+		$this
+			->setIdentifier('ftp')
+			->addIdentifierAlias('\OC\Files\Storage\FTP') // legacy compat
+			->setStorageClass('\OC\Files\Storage\FTP')
+			->setText($l->t('FTP'))
+			->addParameters([
+				(new DefinitionParameter('host', $l->t('Host'))),
+				(new DefinitionParameter('root', $l->t('Remote subfolder')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('secure', $l->t('Secure ftps://')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN),
+			])
+			->setDependencyCheck('\OC\Files\Storage\FTP::checkDependencies')
+			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/backend/local.php
+++ b/apps/files_external/lib/backend/local.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\Auth\NullMechanism;
+
+class Local extends Backend {
+
+	public function __construct(IL10N $l, NullMechanism $legacyAuth) {
+		$this
+			->setIdentifier('local')
+			->addIdentifierAlias('\OC\Files\Storage\Local') // legacy compat
+			->setStorageClass('\OC\Files\Storage\Local')
+			->setText($l->t('Local'))
+			->addParameters([
+				(new DefinitionParameter('datadir', $l->t('Location'))),
+			])
+			->setAllowedVisibility(BackendService::VISIBILITY_ADMIN)
+			->setPriority(BackendService::PRIORITY_DEFAULT + 50)
+			->addAuthScheme(AuthMechanism::SCHEME_NULL)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/backend/owncloud.php
+++ b/apps/files_external/lib/backend/owncloud.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+
+use \OCA\Files_External\Lib\Auth\Password\Password;
+
+class OwnCloud extends Backend {
+
+	public function __construct(IL10N $l, Password $legacyAuth) {
+		$this
+			->setIdentifier('owncloud')
+			->addIdentifierAlias('\OC\Files\Storage\OwnCloud') // legacy compat
+			->setStorageClass('\OC\Files\Storage\OwnCloud')
+			->setText($l->t('ownCloud'))
+			->addParameters([
+				(new DefinitionParameter('host', $l->t('URL'))),
+				(new DefinitionParameter('root', $l->t('Remote subfolder')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('secure', $l->t('Secure https://')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN),
+			])
+			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/backend/sftp.php
+++ b/apps/files_external/lib/backend/sftp.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+
+use \OCA\Files_External\Lib\Auth\Password\Password;
+
+class SFTP extends Backend {
+
+	public function __construct(IL10N $l, Password $legacyAuth) {
+		$this
+			->setIdentifier('sftp')
+			->addIdentifierAlias('\OC\Files\Storage\SFTP') // legacy compat
+			->setStorageClass('\OC\Files\Storage\SFTP')
+			->setText($l->t('SFTP'))
+			->addParameters([
+				(new DefinitionParameter('host', $l->t('Host'))),
+				(new DefinitionParameter('root', $l->t('Root')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+			])
+			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/backend/smb.php
+++ b/apps/files_external/lib/backend/smb.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Backend;
+
+use \OCP\IL10N;
+use \OCA\Files_External\Lib\Backend\Backend;
+use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\Auth\AuthMechanism;
+use \OCA\Files_External\Service\BackendService;
+
+use \OCA\Files_External\Lib\Auth\Password\Password;
+
+class SMB extends Backend {
+
+	public function __construct(IL10N $l, Password $legacyAuth) {
+		$this
+			->setIdentifier('smb')
+			->addIdentifierAlias('\OC\Files\Storage\SMB') // legacy compat
+			->setStorageClass('\OC\Files\Storage\SMB')
+			->setText($l->t('SMB / CIFS'))
+			->addParameters([
+				(new DefinitionParameter('host', $l->t('Host'))),
+				(new DefinitionParameter('share', $l->t('Share'))),
+				(new DefinitionParameter('root', $l->t('Remote subfolder')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+			])
+			->setDependencyCheck('\OC\Files\Storage\SMB::checkDependencies')
+			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			->setLegacyAuthMechanism($legacyAuth)
+		;
+	}
+
+}

--- a/apps/files_external/lib/sessionstoragewrapper.php
+++ b/apps/files_external/lib/sessionstoragewrapper.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib;
+
+use \OCP\Files\Storage;
+use \OC\Files\Storage\Wrapper\PermissionsMask;
+use \OCP\Constants;
+
+/**
+ * Wrap Storage in PermissionsMask for session ephemeral use
+ */
+class SessionStorageWrapper extends PermissionsMask {
+
+	/**
+	 * @param array $arguments ['storage' => $storage]
+	 */
+	public function __construct(array $arguments) {
+		// disable sharing permission
+		$arguments['mask'] = Constants::PERMISSION_ALL & ~Constants::PERMISSION_SHARE;
+		parent::__construct($arguments);
+	}
+
+}
+

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -87,7 +87,7 @@ abstract class StoragesService {
 		}
 		$storageConfig->setBackend($backend);
 
-		if (isset($storageOptions['authMechanism'])) {
+		if (isset($storageOptions['authMechanism']) && $storageOptions['authMechanism'] !== 'builtin::builtin') {
 			$authMechanism = $this->backendService->getAuthMechanism($storageOptions['authMechanism']);
 		} else {
 			$authMechanism = $backend->getLegacyAuthMechanism($storageOptions);

--- a/lib/private/files/mount/mountpoint.php
+++ b/lib/private/files/mount/mountpoint.php
@@ -29,7 +29,6 @@ namespace OC\Files\Mount;
 use \OC\Files\Filesystem;
 use OC\Files\Storage\StorageFactory;
 use OC\Files\Storage\Storage;
-use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Files\Mount\IMountPoint;
 
 class MountPoint implements IMountPoint {
@@ -93,11 +92,7 @@ class MountPoint implements IMountPoint {
 		$this->mountPoint = $mountpoint;
 		if ($storage instanceof Storage) {
 			$this->class = get_class($storage);
-			$this->storage = $storage;
-			// only wrap if not already wrapped
-			if (!($this->storage instanceof Wrapper)) {
-				$this->storage = $this->loader->wrap($this, $this->storage);
-			}
+			$this->storage = $this->loader->wrap($this, $storage);
 		} else {
 			// Update old classes to new namespace
 			if (strpos($storage, 'OC_Filestorage_') !== false) {

--- a/lib/private/files/storage/wrapper/permissionsmask.php
+++ b/lib/private/files/storage/wrapper/permissionsmask.php
@@ -65,6 +65,10 @@ class PermissionsMask extends Wrapper {
 		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::isDeletable($path);
 	}
 
+	public function isSharable($path) {
+		return $this->checkMask(Constants::PERMISSION_SHARE) and parent::isSharable($parm);
+	}
+
 	public function getPermissions($path) {
 		return $this->storage->getPermissions($path) & $this->mask;
 	}

--- a/tests/lib/files/mount/mountpoint.php
+++ b/tests/lib/files/mount/mountpoint.php
@@ -70,25 +70,4 @@ class MountPoint extends \Test\TestCase {
 		// storage wrapper never called
 		$this->assertFalse($called);
 	}
-
-	public function testWrappedStorage() {
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Wrapper')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$loader = $this->getMock('\OCP\Files\Storage\IStorageFactory');
-		$loader->expects($this->never())
-			->method('getInstance');
-		$loader->expects($this->never())
-			->method('wrap');
-
-		$mountPoint = new \OC\Files\Mount\MountPoint(
-			$storage,
-			'/mountpoint',
-			null,
-			$loader
-		);
-
-		$this->assertEquals($storage, $mountPoint->getStorage());
-	}
 }


### PR DESCRIPTION
This PR introduces the 'password' authentication scheme, implemented by the basic username/password input and session-based credentials (like SMB_OC worked). As a result, I reverted a (broken) fix for multi-wrapping storages. The fix was only necessary to prevent function nesting overloads in some broken unit tests, if the issue comes up again, I'll fix the unit tests this time.

The following storages have been migrated:
- Local
- FTP
- SMB
- SFTP
- DAV
- ownCloud

Please review @PVince81 @DeepDiver1975 @MorrisJobke @icewind1991 

cc @jmaciasportela for an example of how registration works. These are quite simple, more advanced ones to come.

Replaces #18245 
