### PR TITLE
[app management] fix dependency check on install

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1139,7 +1139,7 @@ class OC_App {
 
 			// check for required dependencies
 			$dependencyAnalyzer = new DependencyAnalyzer(new Platform($config), $l);
-			$missing = $dependencyAnalyzer->analyze($app);
+			$missing = $dependencyAnalyzer->analyze($info);
 			if (!empty($missing)) {
 				$missingMsg = join(PHP_EOL, $missing);
 				throw new \Exception(


### PR DESCRIPTION
Fixes #18434 and also checks correctly for all the depencencies. Previously this simply was ignored and the app could be installed anyway.

cc @DeepDiver1975 @nickvergessen @Xenopathic Please review this carefully! I'm not that familiar with this, but from my debugging this looks like the way to go

Was introduced with #12625. @DeepDiver1975 Should this be backported to stable8 and stable8.1? This hopefully makes app install more robust like it was intended. :see_no_evil: 
