### PR TITLE
[stable8.1] setUserVars() should only attempt substitution with strings

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -121,7 +121,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.amazonaws.com' : $params['hostname'];
 		if (!isset($params['port']) || $params['port'] === '') {
-			$params['port'] = ($params['use_ssl'] === false) ? 80 : 443;
+			$params['port'] = ($params['use_ssl'] === false || $params['use_ssl'] === 'false') ? 80 : 443;
 		}
 		$this->params = $params;
 	}
@@ -586,7 +586,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			return $this->connection;
 		}
 
-		$scheme = ($this->params['use_ssl'] === false) ? 'http' : 'https';
+		$scheme = ($this->params['use_ssl'] === false || $this->params['use_ssl'] === 'false') ? 'http' : 'https';
 		$base_url = $scheme . '://' . $this->params['hostname'] . ':' . $this->params['port'] . '/';
 
 		$this->connection = S3Client::factory(array(

--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -121,7 +121,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.amazonaws.com' : $params['hostname'];
 		if (!isset($params['port']) || $params['port'] === '') {
-			$params['port'] = ($params['use_ssl'] === 'false') ? 80 : 443;
+			$params['port'] = ($params['use_ssl'] === false) ? 80 : 443;
 		}
 		$this->params = $params;
 	}
@@ -586,7 +586,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			return $this->connection;
 		}
 
-		$scheme = ($this->params['use_ssl'] === 'false') ? 'http' : 'https';
+		$scheme = ($this->params['use_ssl'] === false) ? 'http' : 'https';
 		$base_url = $scheme . '://' . $this->params['hostname'] . ':' . $this->params['port'] . '/';
 
 		$this->connection = S3Client::factory(array(

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -297,7 +297,9 @@ class OC_Mount_Config {
 				}
 			}
 		} else {
-			$input = str_replace('$user', $user, $input);
+			if (is_string($input)) {
+				$input = str_replace('$user', $user, $input);
+			}
 		}
 		return $input;
 	}

--- a/apps/files_external/lib/smb_oc.php
+++ b/apps/files_external/lib/smb_oc.php
@@ -39,7 +39,7 @@ class SMB_OC extends SMB {
 	public function __construct($params) {
 		if (isset($params['host'])) {
 			$host = $params['host'];
-			$this->username_as_share = ($params['username_as_share'] === 'true');
+			$this->username_as_share = ($params['username_as_share'] === true);
 
 			// dummy credentials, unused, to satisfy constructor
 			$user = 'foo';

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -60,7 +60,7 @@
 								<?php elseif (strpos($placeholder, '!') === 0): ?>
 									<label><input type="checkbox"
 												  data-parameter="<?php p($parameter); ?>"
-												  <?php if ($value === true): ?> checked="checked"<?php endif; ?>
+												  <?php if ($value === true || $value === 'true'): ?> checked="checked"<?php endif; ?>
 												  /><?php p(substr($placeholder, 1)); ?></label>
 								<?php elseif (strpos($placeholder, '#') === 0): ?>
 									<input type="hidden"

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -60,7 +60,7 @@
 								<?php elseif (strpos($placeholder, '!') === 0): ?>
 									<label><input type="checkbox"
 												  data-parameter="<?php p($parameter); ?>"
-												  <?php if ($value == 'true'): ?> checked="checked"<?php endif; ?>
+												  <?php if ($value === true): ?> checked="checked"<?php endif; ?>
 												  /><?php p(substr($placeholder, 1)); ?></label>
 								<?php elseif (strpos($placeholder, '#') === 0): ?>
 									<input type="hidden"


### PR DESCRIPTION
Otherwise funky things happen like `true (bool)` => `'1' (string)`

Backport of #18445
Fixes #18386 

@PVince81 @DeepDiver1975 @MorrisJobke @icewind1991

Please confirm backport @karlitschek 
