### PR TITLE
Don't use `empty()` with a return value, PHP 5.4

### DIFF
--- a/apps/files_external/service/backendservice.php
+++ b/apps/files_external/service/backendservice.php
@@ -140,7 +140,7 @@ class BackendService {
 	 */
 	public function getAvailableBackends() {
 		return array_filter($this->getBackends(), function($backend) {
-			return empty($backend->checkDependencies());
+			return !($backend->checkDependencies());
 		});
 	}
 
@@ -256,7 +256,7 @@ class BackendService {
 	 */
 	protected function isAllowedUserBackend(Backend $backend) {
 		if ($this->userMountingAllowed &&
-			!empty(array_intersect($backend->getIdentifierAliases(), $this->userMountingBackends))
+			array_intersect($backend->getIdentifierAliases(), $this->userMountingBackends)
 		) {
 			return true;
 		}


### PR DESCRIPTION
Fixes #18435

files_external unit tests still pass (locally, at least, on PHP 5.6)

cc @DeepDiver1975 @MorrisJobke @PVince81 
