### PR TITLE
Clear cron errors on change of background job mode

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -46,6 +46,8 @@ $(document).ready(function(){
 			var mode = $(this).val();
 			if (mode === 'ajax' || mode === 'webcron' || mode === 'cron') {
 				OC.AppConfig.setValue('core', 'backgroundjobs_mode', mode);
+				// clear cron errors on background job mode change
+				OC.AppConfig.deleteKey('core', 'cronErrors');
 			}
 		}
 	});


### PR DESCRIPTION
- fixes #18454 

cc @steppy 

The error is only written on the CLI cron run:

https://github.com/owncloud/core/blob/e8c3eb74730171a0f997708d36cbcf9994cab217/lib/base.php#L640

And cleared on the next successful CLI cron run. If you have an error during a cron run and change back to ajax cron the error message stays there forever.

cc @PVince81 @Xenopathic @rullzer 
