### PR TITLE
Move common test logic to re-usable traits

### DIFF
--- a/tests/lib/connector/sabre/requesttest/requesttest.php
+++ b/tests/lib/connector/sabre/requesttest/requesttest.php
@@ -16,12 +16,10 @@ use OC\Files\View;
 use OCP\IUser;
 use Sabre\HTTP\Request;
 use Test\TestCase;
+use Test\Traits\UserTrait;
 
 abstract class RequestTest extends TestCase {
-	/**
-	 * @var \OC_User_Dummy
-	 */
-	protected $userBackend;
+	use UserTrait;
 
 	/**
 	 * @var \OCP\Files\Config\IMountProvider[]
@@ -65,8 +63,6 @@ abstract class RequestTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->userBackend = new \OC_User_Dummy();
-		\OC::$server->getUserManager()->registerBackend($this->userBackend);
 
 		$this->serverFactory = new ServerFactory(
 			\OC::$server->getConfig(),
@@ -78,15 +74,10 @@ abstract class RequestTest extends TestCase {
 		);
 	}
 
-	protected function tearDown() {
-		parent::tearDown();
-		\OC::$server->getUserManager()->removeBackend($this->userBackend);
-	}
-
 	protected function setupUser($name, $password) {
-		$this->userBackend->createUser($name, $password);
+		$this->createUser($name, $password);
 		\OC::$server->getMountProviderCollection()->registerProvider($this->getMountProvider($name, [
-			'/' . $name => new Temporary()
+			'/' . $name => '\OC\Files\Storage\Temporary'
 		]));
 		$this->loginAsUser($name);
 		return new View('/' . $name . '/files');

--- a/tests/lib/traits/mountprovidertrait.php
+++ b/tests/lib/traits/mountprovidertrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Traits;
+
+use OC\Files\Mount\MountPoint;
+use OC\Files\Storage\StorageFactory;
+use OCP\IUser;
+
+/**
+ * Allow setting mounts for users
+ */
+trait MountProviderTrait {
+	/**
+	 * @var \OCP\Files\Config\IMountProvider
+	 */
+	protected $mountProvider;
+
+	/**
+	 * @var \OC\Files\Storage\StorageFactory
+	 */
+	protected $storageFactory;
+
+	protected $mounts = [];
+
+	protected function registerMount($userId, $storage, $mountPoint, $arguments = null) {
+		if (!isset($this->mounts[$userId])) {
+			$this->mounts[$userId] = [];
+		}
+		$this->mounts[$userId][] = new MountPoint($storage, $mountPoint, $arguments, $this->storageFactory);
+	}
+
+	protected function registerStorageWrapper($name, $wrapper) {
+		$this->storageFactory->addStorageWrapper($name, $wrapper);
+	}
+
+	protected function setUpMountProviderTrait() {
+		$this->storageFactory = new StorageFactory();
+		$this->mountProvider = $this->getMock('\OCP\Files\Config\IMountProvider');
+		$this->mountProvider->expects($this->any())
+			->method('getMountsForUser')
+			->will($this->returnCallback(function (IUser $user) {
+				if (isset($this->mounts[$user->getUID()])) {
+					return $this->mounts[$user->getUID()];
+				} else {
+					return [];
+				}
+			}));
+		\OC::$server->getMountProviderCollection()->registerProvider($this->mountProvider);
+	}
+}

--- a/tests/lib/traits/usertrait.php
+++ b/tests/lib/traits/usertrait.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Traits;
+
+/**
+ * Allow creating users in a temporary backend
+ */
+trait UserTrait {
+	/**
+	 * @var \OC_User_Dummy|\OCP\UserInterface
+	 */
+	protected $userBackend;
+
+	protected function createUser($name, $password) {
+		$this->userBackend->createUser($name, $password);
+	}
+
+	protected function setUpUserTrait() {
+		$this->userBackend = new \OC_User_Dummy();
+		\OC::$server->getUserManager()->registerBackend($this->userBackend);
+	}
+
+	protected function tearDownUserTrait() {
+		\OC::$server->getUserManager()->removeBackend($this->userBackend);
+	}
+}


### PR DESCRIPTION
Prevents having to keep writing the same test code or moving to much code into `\Test\TestCase`

Currently comes with 2 test traits which were factored out of the webdav request tests
- `UserTrait` allows creating users in a temporary user backend to prevent having to add real users to the db
- `MountProviderTrait` allows registering temporary mountpoints for a user in a dummy mount provider.

cc @DeepDiver1975 @PVince81 
