### PR TITLE
Add namespace in case the file is loaded individually

### DIFF
--- a/apps/files/js/detailtabview.js
+++ b/apps/files/js/detailtabview.js
@@ -88,6 +88,8 @@
 	});
 	DetailTabView._TAB_COUNT = 0;
 
+	OCA.Files = OCA.Files || {};
+
 	OCA.Files.DetailTabView = DetailTabView;
 })();
 


### PR DESCRIPTION
Some apps might load this file in JS unit tests and need the OCA.Files
namespace to exist.

@Xenopathic @nickvergessen @MorrisJobke quick one
