### PR TITLE
Storage availability fixes for files_sharing and FailedStorage

### DIFF
--- a/apps/files_external/lib/failedstorage.php
+++ b/apps/files_external/lib/failedstorage.php
@@ -197,4 +197,12 @@ class FailedStorage extends Common {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
+	public function getAvailability() {
+		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
+	}
+
+	public function setAvailability($isAvailable) {
+		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
+	}
+
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -662,4 +662,22 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		list($targetStorage, $targetInternalPath) = $this->resolvePath($path);
 		$targetStorage->changeLock($targetInternalPath, $type, $provider);
 	}
+
+	/**
+	 * @return array [ available, last_checked ]
+	 */
+	public function getAvailability() {
+		// shares do not participate in availability logic
+		return [
+			'available' => true,
+			'last_checked' => 0
+		];
+	}
+
+	/**
+	 * @param bool $available
+	 */
+	public function setAvailability($available) {
+		// shares do not participate in availability logic
+	}
 }


### PR DESCRIPTION
The first commit prevents local shares from creating oc_storages entries due to updating storage availability (which is irrelevant for shares anyway). The second commit prevents the same happening for FailedStorage from files_external, as that is by definition a failed storage so we don't need to store it in the DB.

Fixes #18455 

Please review and test @PVince81 @MorrisJobke @DeepDiver1975 @icewind1991 
