### PR TITLE
read all relevant user attributes on login and user search, in one qu…

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -31,6 +31,7 @@ namespace OCA\user_ldap;
 
 use OCA\user_ldap\lib\Access;
 use OCA\user_ldap\lib\BackendUtility;
+use OCA\user_ldap\lib\user\User;
 
 class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 	protected $enabled = false;
@@ -195,7 +196,11 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			return array();
 		}
 		$seen[$DN] = 1;
-		$groups = $this->access->readAttribute($DN, 'memberOf');
+		$user = $this->access->userManager->get($DN);
+		if(!$user instanceof User) {
+			return array();
+		}
+		$groups = $user->getMemberOfGroups();
 		if (!is_array($groups)) {
 			return array();
 		}

--- a/apps/user_ldap/lib/user/manager.php
+++ b/apps/user_ldap/lib/user/manager.php
@@ -127,6 +127,43 @@ class Manager {
 	}
 
 	/**
+	 * returns a list of attributes that will be processed further, e.g. quota,
+	 * email, displayname, or others.
+	 * @param bool $minimal - optional, set to true to skip attributes with big
+	 * payload
+	 * @return string[]
+	 */
+	public function getAttributes($minimal = false) {
+		$attributes = array('dn', 'uid', 'samaccountname', 'memberof');
+		$possible = array(
+			$this->access->getConnection()->ldapQuotaAttribute,
+			$this->access->getConnection()->ldapEmailAttribute,
+			$this->access->getConnection()->ldapUserDisplayName,
+		);
+		foreach($possible as $attr) {
+			if(!is_null($attr)) {
+				$attributes[] = $attr;
+			}
+		}
+
+		$homeRule = $this->access->getConnection()->homeFolderNamingRule;
+		if(strpos($homeRule, 'attr:') === 0) {
+			$attributes[] = substr($homeRule, strlen('attr:'));
+		}
+
+		if(!$minimal) {
+			// attributes that are not really important but may come with big
+			// payload.
+			$attributes = array_merge($attributes, array(
+				'jpegphoto',
+				'thumbnailphoto'
+			));
+		}
+
+		return $attributes;
+	}
+
+	/**
 	 * Checks whether the specified user is marked as deleted
 	 * @param string $id the ownCloud user name
 	 * @return bool

--- a/apps/user_ldap/lib/user/user.php
+++ b/apps/user_ldap/lib/user/user.php
@@ -225,6 +225,7 @@ class User {
 	 */
 	public function getHomePath($valueFromLDAP = null) {
 		$path = $valueFromLDAP;
+		$attr = null;
 
 		if(   is_null($path)
 		   && strpos($this->access->connection->homeFolderNamingRule, 'attr:') === 0
@@ -256,7 +257,9 @@ class User {
 			return $path;
 		}
 
-		if($this->config->getAppValue('user_ldap', 'enforce_home_folder_naming_rule', true)) {
+		if(    !is_null($attr)
+			&& $this->config->getAppValue('user_ldap', 'enforce_home_folder_naming_rule', true)
+		) {
 			// a naming rule attribute is defined, but it doesn't exist for that LDAP user
 			throw new \Exception('Home dir attribute can\'t be read from LDAP for uid: ' . $this->getUsername());
 		}

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -53,6 +53,10 @@ class Test_Group_Ldap extends \Test\TestCase {
 								 $accMethods,
 								 array($connector, $lw, $um));
 
+		$access->expects($this->any())
+			->method('getConnection')
+			->will($this->returnValue($connector));
+
 		return $access;
 	}
 
@@ -391,7 +395,7 @@ class Test_Group_Ldap extends \Test\TestCase {
 
 		$access->connection->hasPrimaryGroups = false;
 
-		$access->expects($this->once())
+		$access->expects($this->any())
 			->method('username2dn')
 			->will($this->returnValue($dn));
 

--- a/apps/user_ldap/tests/user/user.php
+++ b/apps/user_ldap/tests/user/user.php
@@ -221,7 +221,7 @@ class Test_User_User extends \Test\TestCase {
 		$connection->expects($this->at(0))
 			->method('__get')
 			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue('23 GB'));
+			->will($this->returnValue('25 GB'));
 
 		$connection->expects($this->at(1))
 			->method('__get')
@@ -242,7 +242,7 @@ class Test_User_User extends \Test\TestCase {
 			->with($this->equalTo('alice'),
 				$this->equalTo('files'),
 				$this->equalTo('quota'),
-				$this->equalTo('23 GB'))
+				$this->equalTo('25 GB'))
 			->will($this->returnValue(true));
 
 		$uid = 'alice';
@@ -278,14 +278,14 @@ class Test_User_User extends \Test\TestCase {
 			->method('readAttribute')
 			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
 				$this->equalTo('myquota'))
-			->will($this->returnValue(array('23 GB')));
+			->will($this->returnValue(array('27 GB')));
 
 		$config->expects($this->once())
 			->method('setUserValue')
 			->with($this->equalTo('alice'),
 				$this->equalTo('files'),
 				$this->equalTo('quota'),
-				$this->equalTo('23 GB'))
+				$this->equalTo('27 GB'))
 			->will($this->returnValue(true));
 
 		$uid = 'alice';
@@ -678,5 +678,62 @@ class Test_User_User extends \Test\TestCase {
 		//make sure readAttribute is not called again but the already fetched
 		//photo is returned
 		$photo = $user->getAvatarImage();
+	}
+
+	public function testProcessAttributes() {
+		list(, $config, $filesys, $image, $log, $avaMgr, $dbc) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$uid = 'alice';
+		$dn = 'uid=alice';
+
+		$requiredMethods = array(
+			'markRefreshTime',
+			'updateQuota',
+			'updateEmail',
+			'storeDisplayName',
+			'storeLDAPUserName',
+			'getHomePath',
+			'updateAvatar'
+		);
+
+		$userMock = $this->getMockBuilder('OCA\user_ldap\lib\user\User')
+			->setConstructorArgs(array($uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr))
+			->setMethods($requiredMethods)
+			->getMock();
+
+		$connection->setConfiguration(array(
+			'homeFolderNamingRule' => 'homeDirectory'
+		));
+
+		$connection->expects($this->any())
+			->method('__get')
+			//->will($this->returnArgument(0));
+			->will($this->returnCallback(function($name) {
+				if($name === 'homeFolderNamingRule') {
+					return 'attr:homeDirectory';
+				}
+				return $name;
+			}));
+
+		$record = array(
+			strtolower($connection->ldapQuotaAttribute) => array('4096'),
+			strtolower($connection->ldapEmailAttribute) => array('alice@wonderland.org'),
+			strtolower($connection->ldapUserDisplayName) => array('Aaaaalice'),
+			'uid' => array($uid),
+			'homedirectory' => array('Alice\'s Folder'),
+			'memberof' => array('cn=groupOne', 'cn=groupTwo'),
+			'jpegphoto' => array('here be an image')
+		);
+
+		foreach($requiredMethods as $method) {
+			$userMock->expects($this->once())
+				->method($method);
+		}
+
+		$userMock->processAttributes($record);
 	}
 }

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -34,6 +34,7 @@ use \OCA\user_ldap\lib\ILDAPWrapper;
 class Test_User_Ldap_Direct extends \Test\TestCase {
 	protected $backend;
 	protected $access;
+	protected $configMock;
 
 	protected function setUp() {
 		parent::setUp();
@@ -61,8 +62,9 @@ class Test_User_Ldap_Direct extends \Test\TestCase {
 									$conMethods,
 									array($lw, null, null));
 
+		$this->configMock = $this->getMock('\OCP\IConfig');
 		$um = new \OCA\user_ldap\lib\user\Manager(
-				$this->getMock('\OCP\IConfig'),
+				$this->configMock,
 				$this->getMock('\OCA\user_ldap\lib\FilesystemHelper'),
 				$this->getMock('\OCA\user_ldap\lib\LogWrapper'),
 				$this->getMock('\OCP\IAvatarManager'),
@@ -586,6 +588,13 @@ class Test_User_Ldap_Direct extends \Test\TestCase {
 		$backend = new UserLDAP($access, $config);
 		$this->prepareMockForUserExists($access);
 
+		$dataDir = \OC::$server->getConfig()->getSystemValue(
+			'datadirectory', \OC::$SERVERROOT.'/data');
+
+		$this->configMock->expects($this->once())
+			->method('getSystemValue')
+			->will($this->returnValue($dataDir));
+
 		$access->connection->expects($this->any())
 			->method('__get')
 			->will($this->returnCallback(function($name) {
@@ -609,14 +618,9 @@ class Test_User_Ldap_Direct extends \Test\TestCase {
 						return false;
 				}
 			}));
-		//datadir-relativ path
-		$datadir = '/my/data/dir';
-		$config->expects($this->once())
-			->method('getSystemValue')
-			->will($this->returnValue($datadir));
 
 		$result = $backend->getHome('ladyofshadows');
-		$this->assertEquals($datadir.'/susannah/', $result);
+		$this->assertEquals($dataDir.'/susannah/', $result);
 	}
 
 	/**


### PR DESCRIPTION
…ery. saves us some.

obsolotes #12943

fixes #17362 

Basically it does what #12943 did, but also reads the user attributes when users are being fetched, for instance in share dialog (except: avatar image).
- [ ] TODO: check performance impact (expectation: all in all better: saves LDAP requests, might cause more DB traffic)

Please review @MorrisJobke @Xenopathic @esakol @tkaufm or others
