### PR TITLE
Clear cache button for APCu

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -230,5 +230,7 @@ if ($updaterAppPanel) {
 }
 
 $template->assign('forms', $formsAndMore);
+$settingsCache = \OC::$server->getMemCacheFactory()->create('settings');
+$template->assign('apcuEnabled', $settingsCache instanceof \OC\Memcache\APCu);
 
 $template->printPage();

--- a/settings/application.php
+++ b/settings/application.php
@@ -28,6 +28,7 @@ namespace OC\Settings;
 
 use OC\Files\View;
 use OC\Settings\Controller\AppSettingsController;
+use OC\Settings\Controller\CacheSettingsController;
 use OC\Settings\Controller\CertificateController;
 use OC\Settings\Controller\CheckSetupController;
 use OC\Settings\Controller\EncryptionController;
@@ -157,6 +158,13 @@ class Application extends App {
 				$c->query('URLGenerator'),
 				$c->query('Util'),
 				$c->query('L10N')
+			);
+		});
+		$container->registerService('CacheSettingsController', function(IContainer $c) {
+			return new CacheSettingsController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('ICacheFactory')
 			);
 		});
 

--- a/settings/controller/cachesettingscontroller.php
+++ b/settings/controller/cachesettingscontroller.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Controller;
+
+use OC\AppFramework\Http;
+use OC\Memcache\APCu;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+
+/**
+ * @package OC\Settings\Controller
+ */
+class CacheSettingsController extends Controller {
+	/** @var \OCP\ICacheFactory */
+	private $cacheFactory;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param ICacheFactory $cacheFactory
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								ICacheFactory $cacheFactory) {
+		parent::__construct($appName, $request);
+		$this->cacheFactory = $cacheFactory;
+	}
+
+	/**
+	 * Clear cache
+	 * @return array
+	 */
+	public function clearCache() {
+		$settingsMemCache = $this->cacheFactory->create('settings');
+		if (!($settingsMemCache instanceof APCu)) {
+			return new DataResponse([ 'data' => [ 'message' => 'APCu is not in use.' ], 'status' => 'error' ]);
+		}
+
+		if ($settingsMemCache->clear('listApps')) {
+			return new DataResponse([ 'data' => [ 'message' => 'Cache successfully cleared.' ], 'status' => 'success' ]);
+		} else {
+			return new DataResponse([ 'data' => [ 'message' => 'Cache clear failed.' ], 'status' => 'error' ]);
+		}
+
+	}
+
+}

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -208,4 +208,13 @@ $(document).ready(function(){
 			$el.find('.hint').removeClass('hidden');
 		}
 	});
+
+
+	$('#clearCache').click(function(event){
+		event.preventDefault();
+		OC.msg.startAction('#clearCacheMessage', t('settings', 'Clearing...'));
+		$.post(OC.generateUrl('/settings/admin/cache/clear'), '', function(data){
+			OC.msg.finishedAction('#clearCacheMessage', data);
+		});
+	});
 });

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -53,6 +53,7 @@ $application->registerRoutes($this, [
 		['name' => 'CheckSetup#check', 'url' => '/settings/ajax/checksetup', 'verb' => 'GET'],
 		['name' => 'Certificate#addPersonalRootCertificate', 'url' => '/settings/personal/certificate', 'verb' => 'POST'],
 		['name' => 'Certificate#removePersonalRootCertificate', 'url' => '/settings/personal/certificate/{certificateIdentifier}', 'verb' => 'DELETE'],
+		['name' => 'CacheSettings#clearCache', 'url' => '/settings/admin/cache/clear', 'verb' => 'POST'],
 	]
 ]);
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -529,6 +529,17 @@ if ($_['cronErrors']) {
 	</ul>
 </div>
 
+<?php if ($_['apcuEnabled']): ?>
+	<div class="section" id="Caching">
+		<h2><?php p($l->t('Caching'));?></h2>
+		<p>
+			<?php p($l->t( 'This instance uses APCu as local cache. Due to technical restrictions CLI and webserver are using different caches. If you changed something via CLI it is possible that outdated data is presented in the web UI for a short time. Click the button below to clear the caches and fetch the latest state.')); ?>
+		</p>
+		<input id="clearCache" value="<?php p($l->t('Clear cache')) ?>" type="submit">
+		<span id="clearCacheMessage" class="msg"></span>
+	</div>
+<?php endif; ?>
+
 <div class="section" id="admin-tips">
 	<h2><?php p($l->t('Tips & tricks'));?></h2>
 	<ul>

--- a/tests/settings/controller/CacheSettingsControllerTest.php
+++ b/tests/settings/controller/CacheSettingsControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Controller;
+
+use OC\Memcache\NullCache;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+use OCP\IL10N;
+use OCP\ICertificateManager;
+
+/**
+ * Class CacheSettingsControllerTest
+ *
+ * @package OC\Settings\Controller
+ */
+class CacheSettingsControllerTest extends \Test\TestCase {
+	/** @var CacheSettingsController */
+	private $cacheSettingsController;
+	/** @var IRequest */
+	private $request;
+	/** @var ICacheFactory */
+	private $cacheFactory;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMock('\OCP\IRequest');
+		$this->cacheFactory = $this->getMock('\OCP\ICacheFactory');
+
+		$this->cacheSettingsController = new CacheSettingsController('settings', $this->request, $this->cacheFactory);
+	}
+
+	public function testClearCacheNonAPCu() {
+		$this->cacheFactory
+			->expects($this->once())
+			->method('create')
+			->with('settings')
+			->will($this->returnValue(new NullCache()));
+
+		$expected = new DataResponse([ 'data' => [ 'message' => 'APCu is not in use.' ], 'status' => 'error' ]);
+		$this->assertEquals($expected, $this->cacheSettingsController->clearCache());
+	}
+
+	public function testClearCacheAPCuSuccess() {
+		$cache = $this->getMock('\OC\Memcache\APCu');
+		$cache->expects($this->once())
+			->method('clear')
+			->with('listApps')
+			->willReturn(true);
+
+		$this->cacheFactory
+			->expects($this->once())
+			->method('create')
+			->with('settings')
+			->will($this->returnValue($cache));
+
+		$expected = new DataResponse([ 'data' => [ 'message' => 'Cache successfully cleared.' ], 'status' => 'success' ]);
+		$this->assertEquals($expected, $this->cacheSettingsController->clearCache());
+	}
+
+	public function testClearCacheAPCuFailure() {
+		$cache = $this->getMock('\OC\Memcache\APCu');
+		$cache->expects($this->once())
+			->method('clear')
+			->with('listApps')
+			->willReturn(false);
+
+		$this->cacheFactory
+			->expects($this->once())
+			->method('create')
+			->with('settings')
+			->will($this->returnValue($cache));
+
+		$expected = new DataResponse([ 'data' => [ 'message' => 'Cache clear failed.' ], 'status' => 'error' ]);
+		$this->assertEquals($expected, $this->cacheSettingsController->clearCache());
+	}
+}


### PR DESCRIPTION
Fixes #15359 

This adds a section to the admin settings with a short text and a button to clear the APCu cache. It is only shown if APCu is used.

Successful clear looks like this:
![bildschirmfoto von 2015-08-21 15-00-08](https://cloud.githubusercontent.com/assets/245432/9408724/6bfcb674-4815-11e5-82aa-2a92eb77c7ed.png)

PHP part is fully unit tested.

@jvillafanez @nickvergessen @Xenopathic @LukasReschke @jancborchardt Please review
