### PR TITLE
Always detect remote changes for fed sharing

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -88,6 +88,8 @@ class Storage extends DAV implements ISharedStorage {
 			'user' => $options['token'],
 			'password' => (string)$options['password']
 		));
+
+		$this->getWatcher()->setPolicy(\OC\Files\Cache\Watcher::CHECK_ONCE);
 	}
 
 	public function getRemoteUser() {


### PR DESCRIPTION
This is even more important now that filesystem_check_changes is 0 by
default.

Fixes part of https://github.com/owncloud/core/issues/18474

Please review @icewind1991 @Xenopathic @MorrisJobke @nickvergessen 
