### PR TITLE
Repeated calls to loginWithApache() should not not try to set user in…

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -277,11 +277,13 @@ class OC_User {
 		OC_Hook::emit("OC_User", "pre_login", array("run" => &$run, "uid" => $uid));
 
 		if ($uid) {
-			self::setUserId($uid);
-			self::setDisplayName($uid);
-			self::getUserSession()->setLoginName($uid);
+			if (self::getUser() !== $uid) {
+				self::setUserId($uid);
+				self::setDisplayName($uid);
+				self::getUserSession()->setLoginName($uid);
 
-			OC_Hook::emit("OC_User", "post_login", array("uid" => $uid, 'password' => ''));
+				OC_Hook::emit("OC_User", "post_login", array("uid" => $uid, 'password' => ''));
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
…formation in the session again

@karlitschek for backport

@LukasReschke I guess this fix is necessary due to the changes in https://github.com/owncloud/core/commit/dfbc405a45f42acd1202d5f0649619388adbfb83 - just a wild guess ...
