### PR TITLE
Remove whitespace from base-DNs

### DIFF
--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -145,6 +145,7 @@ class Configuration {
 			}
 
 			$setMethod = 'setValue';
+            $trim = false;
 			switch($key) {
 				case 'homeFolderNamingRule':
 					if(!empty($val) && strpos($val, 'attr:') === false) {
@@ -154,6 +155,7 @@ class Configuration {
 				case 'ldapBase':
 				case 'ldapBaseUsers':
 				case 'ldapBaseGroups':
+                    $trim = true;// Prevent login errors due to whitespace
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
 				case 'ldapUserFilterObjectclass':
@@ -164,7 +166,7 @@ class Configuration {
 					$setMethod = 'setMultiLine';
 					break;
 			}
-			$this->$setMethod($key, $val);
+			$this->$setMethod($key, $val, $trim);
 			if(is_array($applied)) {
 				$applied[] = $inputKey;
 			}
@@ -275,14 +277,18 @@ class Configuration {
 	 * @param string $varName
 	 * @param array|string $value
 	 */
-	protected function setMultiLine($varName, $value) {
+	protected function setMultiLine($varName, $value, $trim = false) {
 		if(empty($value)) {
 			$value = '';
 		} else if (!is_array($value)) {
 			$value = preg_split('/\r\n|\r|\n|;/', $value);
 			if($value === false) {
 				$value = '';
-			}
+			} else if($trim) {
+                foreach($value as $key => $val) {
+                    $value[$key] = trim($val);
+                }
+            }
 		}
 
 		$this->setValue($varName, $value);
@@ -328,11 +334,11 @@ class Configuration {
 	}
 
 	/**
-	 * @param string $varName
+	 * @param string $varName 
 	 * @param mixed $value
 	 */
-	protected function setValue($varName, $value) {
-		$this->config[$varName] = $value;
+	protected function setValue($varName, $value, $trim = false) {
+		$this->config[$varName] = $trim ? trim($value) : $value;
 	}
 
 	/**

--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -145,7 +145,7 @@ class Configuration {
 			}
 
 			$setMethod = 'setValue';
-            $trim = false;
+			$trim = false;
 			switch($key) {
 				case 'homeFolderNamingRule':
 					if(!empty($val) && strpos($val, 'attr:') === false) {
@@ -155,7 +155,7 @@ class Configuration {
 				case 'ldapBase':
 				case 'ldapBaseUsers':
 				case 'ldapBaseGroups':
-                    $trim = true;// Prevent login errors due to whitespace
+					$trim = true;// Prevent login errors due to whitespace
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
 				case 'ldapUserFilterObjectclass':
@@ -274,8 +274,11 @@ class Configuration {
 	}
 
 	/**
-	 * @param string $varName
-	 * @param array|string $value
+	 * Sets multi-line values as arrays
+	 * 
+	 * @param string $varName name of config-key
+	 * @param array|string $value to set
+	 * @param boolean $trim Trim value? (default: false)
 	 */
 	protected function setMultiLine($varName, $value, $trim = false) {
 		if(empty($value)) {
@@ -284,11 +287,17 @@ class Configuration {
 			$value = preg_split('/\r\n|\r|\n|;/', $value);
 			if($value === false) {
 				$value = '';
-			} else if($trim) {
-                foreach($value as $key => $val) {
-                    $value[$key] = trim($val);
-                }
-            }
+			}
+		}
+
+		if($trim) {
+			if(!is_array($value)) {
+				$value = trim($value);
+			} else {
+				foreach($value as $key => $val) {
+					$value[$key] = trim($val);
+				}
+			}
 		}
 
 		$this->setValue($varName, $value);
@@ -334,11 +343,17 @@ class Configuration {
 	}
 
 	/**
-	 * @param string $varName 
-	 * @param mixed $value
+	 * Sets a scalar value.
+	 * 
+	 * @param string $varName name of config key
+	 * @param mixed $value to set
+	 * @param boolean $trim Trim value? (default: false)
 	 */
 	protected function setValue($varName, $value, $trim = false) {
-		$this->config[$varName] = $trim ? trim($value) : $value;
+		if($trim && is_string($value)) {
+			$value = trim($value);
+		}
+		$this->config[$varName] = $value;
 	}
 
 	/**

--- a/apps/user_ldap/tests/configuration.php
+++ b/apps/user_ldap/tests/configuration.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @author Arthur Schiwon <blizzz@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\user_ldap\tests;
+
+class Test_Configuration extends \Test\TestCase {
+
+	public function configurationDataProvider() {
+		$inputWithDN = array(
+			'cn=someUsers,dc=example,dc=org',
+			'  ',
+			' cn=moreUsers,dc=example,dc=org '
+		);
+		$expectWithDN = array(
+			'cn=someUsers,dc=example,dc=org',
+			'cn=moreUsers,dc=example,dc=org'
+		);
+
+		$inputNames = array(
+			'  uid  ',
+			'cn ',
+			' ',
+			'',
+			' whats my name',
+		    '	'
+		);
+		$expectedNames = array('uid', 'cn', 'whats my name');
+
+		$inputString = ' alea iacta est ';
+		$expectedString = 'alea iacta est';
+
+		$inputHomeFolder = array(
+			' homeDirectory ',
+			' attr:homeDirectory ',
+			' '
+		);
+
+		$expectedHomeFolder = array(
+			'attr:homeDirectory', 'attr:homeDirectory', ''
+		);
+
+		$password = ' such a passw0rd ';
+
+		return array(
+			'set general base' => array('ldapBase', $inputWithDN, $expectWithDN),
+			'set user base'    => array('ldapBaseUsers', $inputWithDN, $expectWithDN),
+			'set group base'   => array('ldapBaseGroups', $inputWithDN, $expectWithDN),
+
+			'set search attributes users'  => array('ldapAttributesForUserSearch', $inputNames, $expectedNames),
+			'set search attributes groups' => array('ldapAttributesForGroupSearch', $inputNames, $expectedNames),
+
+			'set user filter objectclasses'  => array('ldapUserFilterObjectclass', $inputNames, $expectedNames),
+			'set user filter groups'         => array('ldapUserFilterGroups', $inputNames, $expectedNames),
+			'set group filter objectclasses' => array('ldapGroupFilterObjectclass', $inputNames, $expectedNames),
+			'set group filter groups'        => array('ldapGroupFilterGroups', $inputNames, $expectedNames),
+			'set login filter attributes'    => array('ldapLoginFilterAttributes', $inputNames, $expectedNames),
+
+			'set agent password' => array('ldapAgentPassword', $password, $password),
+
+			'set home folder, variant 1' => array('homeFolderNamingRule', $inputHomeFolder[0], $expectedHomeFolder[0]),
+			'set home folder, variant 2' => array('homeFolderNamingRule', $inputHomeFolder[1], $expectedHomeFolder[1]),
+			'set home folder, empty'     => array('homeFolderNamingRule', $inputHomeFolder[2], $expectedHomeFolder[2]),
+
+			// default behaviour, one case is enough, special needs must be tested
+			// individually
+			'set string value' => array('ldapHost', $inputString, $expectedString),
+		);
+	}
+
+	/**
+	 * @dataProvider configurationDataProvider
+	 */
+	public function testSetValue($key, $input, $expected) {
+		$configuration = new \OCA\user_ldap\lib\Configuration('t01', false);
+
+		$settingsInput = array(
+			'ldapBaseUsers' => array(
+				'cn=someUsers,dc=example,dc=org',
+				'  ',
+				' cn=moreUsers,dc=example,dc=org '
+			)
+		);
+
+		$configuration->setConfiguration([$key => $input]);
+		$this->assertSame($configuration->$key, $expected);
+	}
+
+}


### PR DESCRIPTION
Fixes #17964. 

I've tried to implement trimming in `Connection::doCriticalValidation()` as hinted in the issue. However, this does not work that way. Everything that is changed during that method call is somehow being reset to its original value afterwards. I am not sure why that is. As far as my understanding of the code goes, this should not happen.

Because of this, I've opted to implement trim when saving these specific config values in `Configuration::setConfiguration()` which works reliably for me. 

cc @blizzz: Please review. Thanks 
