### PR TITLE
Send password reset link when creating new users with e-mail

### DIFF
--- a/settings/Application.php
+++ b/settings/Application.php
@@ -153,7 +153,8 @@ class Application extends App {
 				$c->query('DefaultMailAddress'),
 				$c->query('URLGenerator'),
 				$c->query('OCP\\App\\IAppManager'),
-				$c->query('OCP\\IAvatarManager')
+				$c->query('OCP\\IAvatarManager'),
+				$c->query('OCP\\Security\\ISecureRandom')
 			);
 		});
 		$container->registerService('LogSettingsController', function(IContainer $c) {
@@ -187,7 +188,7 @@ class Application extends App {
 			);
 		});
 		// Execute middlewares
-		$container->registerMiddleware('SubadminMiddleware');
+		$container->registerMiddleWare('SubadminMiddleware');
 
 		/**
 		 * Core class wrappers

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -46,6 +46,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use OCP\IAvatarManager;
+use OCP\Security\ISecureRandom;
 
 /**
  * @package OC\Settings\Controller
@@ -79,6 +80,8 @@ class UsersController extends Controller {
 	private $isRestoreEnabled = false;
 	/** @var IAvatarManager */
 	private $avatarManager;
+	/** @var ISecureRandom */
+	private $secureRandom;
 
 	/**
 	 * @param string $appName
@@ -110,7 +113,8 @@ class UsersController extends Controller {
 								$fromMailAddress,
 								IURLGenerator $urlGenerator,
 								IAppManager $appManager,
-								IAvatarManager $avatarManager) {
+								IAvatarManager $avatarManager,
+								ISecureRandom $secureRandom) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
@@ -124,6 +128,7 @@ class UsersController extends Controller {
 		$this->fromMailAddress = $fromMailAddress;
 		$this->urlGenerator = $urlGenerator;
 		$this->avatarManager = $avatarManager;
+		$this->secureRandom = $secureRandom;
 
 		// check for encryption state - TODO see formatUserForIndex
 		$this->isEncryptionAppEnabled = $appManager->isEnabledForUser('encryption');
@@ -385,10 +390,18 @@ class UsersController extends Controller {
 			if($email !== '') {
 				$user->setEMailAddress($email);
 
+				$token = $this->secureRandom->generate(21,
+					ISecureRandom::CHAR_DIGITS.
+					ISecureRandom::CHAR_LOWER.
+					ISecureRandom::CHAR_UPPER);
+				$this->config->setUserValue($username, 'owncloud', 'lostpassword', $token);
+
+				$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', array('userId' => $username, 'token' => $token));
+
 				// data for the mail template
 				$mailData = [
 					'username' => $username,
-					'url' => $this->urlGenerator->getAbsoluteURL('/')
+					'url' => $link,
 				];
 
 				$mail = new TemplateResponse('settings', 'email.new_user', $mailData, 'blank');

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -79,6 +79,8 @@ class UsersControllerTest extends \Test\TestCase {
 			->with('enable_avatars', true)
 			->willReturn(true);
 
+		$this->container['OCP\\Security\\ISecureRandom'] = $this->getMockBuilder('\OCP\Security\ISecureRandom')
+			->disableOriginalConstructor()->getMock();
 	}
 
 	public function testIndexAdmin() {


### PR DESCRIPTION
This implements #17398.

Instead of the Login-URL the user is sent to the reset password form where he can set his initial password. 

**Important note about unit test**
I've done my best to update the unit test but I am unable to get the unit tests working on my system at all so this is blind.

Running `./autotest.sh sqlite` as described [in the developer manual](https://doc.owncloud.org/server/8.0/developer_manual/core/unit-testing.html) just produces this output on my system:

```
Using PHP executable /usr/local/bin/php
Parsing all files in lib/public for the presence of @since or @deprecated on each method...

Using database oc_autotest
Setup environment for sqlite testing ...
Installing ....
ownCloud is not installed - only a limited number of commands are available
Mac OS X is not supported and ownCloud will not work properly on this platform. Use it at your own risk! 
 -> For the best results, please consider using a GNU/Linux server instead.
```

PHPUnit is installed, running OS X 10.10.5 which seems to be unsupported?. Any pointers are welcome. 
