### PR TITLE
[stable8.1] Add CORS header to status.php to allow client-based check…

### DIFF
--- a/status.php
+++ b/status.php
@@ -41,6 +41,7 @@ try {
 	if (OC::$CLI) {
 		print_r($values);
 	} else {
+		header('Access-Control-Allow-Origin: *');
 		header('Content-Type: application/json');
 		echo json_encode($values);
 	}


### PR DESCRIPTION
… in the future

Related to https://github.com/owncloud/core/pull/18486

@karlitschek I would love to have this in since in the future we should get rid of the server-based check as pointed out at https://github.com/owncloud/core/pull/18486, however we should already add the pre-requisites so once we migrate all supported versions are still compatible.
