### PR TITLE
Expire token after 12h and if user logged-in again

### DIFF
--- a/core/application.php
+++ b/core/application.php
@@ -27,6 +27,7 @@
 namespace OC\Core;
 
 use OC\AppFramework\Utility\SimpleContainer;
+use OC\AppFramework\Utility\TimeFactory;
 use \OCP\AppFramework\App;
 use OC\Core\LostPassword\Controller\LostController;
 use OC\Core\User\UserController;
@@ -63,7 +64,8 @@ class Application extends App {
 				$c->query('SecureRandom'),
 				$c->query('DefaultEmailAddress'),
 				$c->query('IsEncryptionEnabled'),
-				$c->query('Mailer')
+				$c->query('Mailer'),
+				$c->query('TimeFactory')
 			);
 		});
 		$container->registerService('UserController', function(SimpleContainer $c) {
@@ -120,14 +122,14 @@ class Application extends App {
 		$container->registerService('UserFolder', function(SimpleContainer $c) {
 			return $c->query('ServerContainer')->getUserFolder();
 		});
-
-
-
 		$container->registerService('Defaults', function() {
 			return new \OC_Defaults;
 		});
 		$container->registerService('Mailer', function(SimpleContainer $c) {
 			return $c->query('ServerContainer')->getMailer();
+		});
+		$container->registerService('TimeFactory', function(SimpleContainer $c) {
+			return new TimeFactory();
 		});
 		$container->registerService('DefaultEmailAddress', function() {
 			return Util::getDefaultEmailAddress('lostpassword-noreply');


### PR DESCRIPTION
As an hardening measure we should expire password reset tokens after 12h and if the user has logged-in again successfully after the token was requested.
