### PR TITLE
fix horizontal scrollbar in personal settings caused by federated cloud ID section

### DIFF
--- a/apps/files_sharing/css/settings-personal.css
+++ b/apps/files_sharing/css/settings-personal.css
@@ -4,6 +4,7 @@
 
 #fileSharingSettings xmp {
 	margin-top: 0;
+	white-space: pre-wrap;
 }
 
 [class^="social-"], [class*=" social-"] {


### PR DESCRIPTION
Please review @schiesbn @owncloud/designers – this just breaks the HTML instead of causing a horizontal scrollbar.
