### PR TITLE
make profile photos round

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -807,6 +807,18 @@ label.infield {
 .center { text-align:center; }
 .inlineblock { display: inline-block; }
 
+/* round profile photos */
+.avatar,
+.avatar img,
+.avatardiv,
+.avatardiv img {
+	border-radius: 50%;
+}
+td.avatar {
+	border-radius: 0;
+}
+
+
 #notification-container {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Experiment with making the profile photos round everywhere. Please review @owncloud/designers @karlitschek @MorrisJobke @PVince81 what do you think?
![capture du 2015-08-24 09-49-28](https://cloud.githubusercontent.com/assets/925062/9435280/a992f75e-4a46-11e5-8583-ce22e75e1582.png)
This applies it in the top right photo, in personal settings, in the sharing dropdown, in user management and in the activity app – cc @schiesbn @nickvergessen. Anything I missed?

Where I couldn’t get it to work was in Contacts because the image is inserted via background-image. Something we should fix, and hopefully Contacts+ does it via proper img element? cc @libasys @DeepDiver1975 
