### PR TITLE
Bail out when trying to access trashed remote share

### DIFF
--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -71,7 +71,10 @@ class Helper {
 			\OCP\JSON::checkUserExists($rootLinkItem['uid_owner']);
 			\OC_Util::tearDownFS();
 			\OC_Util::setupFS($rootLinkItem['uid_owner']);
-			$path = \OC\Files\Filesystem::getPath($linkItem['file_source']);
+			$ownerView = \OC\Files\Filesystem::getView();
+			// workaround for getRelativePath issues with missing trailing slash
+			$ownerView->chroot(rtrim($ownerView->getRoot(), '/') . '/');
+			$path = $ownerView->getPath($linkItem['file_source']);
 		}
 
 		if ($path === null) {

--- a/apps/files_sharing/publicwebdav.php
+++ b/apps/files_sharing/publicwebdav.php
@@ -64,7 +64,13 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 
 	OC_Util::setupFS($owner);
 	$ownerView = \OC\Files\Filesystem::getView();
+	// workaround for getRelativePath issues with missing trailing slash
+	$ownerView->chroot(rtrim($ownerView->getRoot(), '/') . '/');
 	$path = $ownerView->getPath($fileId);
+	if ($path === null) {
+		// share is in trash or not accessible
+		throw new \Sabre\DAV\Exception\NotAuthenticated();
+	}
 
 	return new \OC\Files\View($ownerView->getAbsolutePath($path));
 });


### PR DESCRIPTION
Whenever the remote share is in the trashbin, the share entry still
exists but cannot be accessed. Instead of letting the code run loose and
show useless warnings, bail out early as if the share did not exist.

Note: this is only a workaround for https://github.com/owncloud/core/issues/18509 and the problems with getRelativePath that resolve "files_trashbin" to "_trashbin" ...

I'll have a try reviving https://github.com/owncloud/core/pull/16479, maybe it's a better fix.

@nickvergessen check this out
