### PR TITLE
[encryption] fix password reset for ldap users

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -198,7 +198,8 @@ class Application extends \OCP\AppFramework\App {
 				$server->getUserSession(),
 				$c->query('KeyManager'),
 				$c->query('Crypt'),
-				$c->query('Session')
+				$c->query('Session'),
+				$server->getSession()
 			);
 		});
 

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -398,7 +398,7 @@ class Crypt {
 			}
 		}
 
-		return true;
+		return false;
 	}
 
 	/**

--- a/apps/encryption/tests/controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/controller/SettingsControllerTest.php
@@ -54,6 +54,9 @@ class SettingsControllerTest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	private $sessionMock;
 
+	/** @var  \PHPUnit_Framework_MockObject_MockObject */
+	private $ocSessionMock;
+
 	protected function setUp() {
 
 		parent::setUp();
@@ -91,9 +94,11 @@ class SettingsControllerTest extends TestCase {
 			])
 			->getMock();
 
+		$this->ocSessionMock = $this->getMockBuilder('\OCP\ISession')->disableOriginalConstructor()->getMock();
+
 		$this->userSessionMock->expects($this->any())
 			->method('getUID')
-			->willReturn('testUser');
+			->willReturn('testUserUid');
 
 		$this->userSessionMock->expects($this->any())
 			->method($this->anything())
@@ -110,7 +115,8 @@ class SettingsControllerTest extends TestCase {
 			$this->userSessionMock,
 			$this->keyManagerMock,
 			$this->cryptMock,
-			$this->sessionMock
+			$this->sessionMock,
+			$this->ocSessionMock
 		);
 	}
 
@@ -122,8 +128,10 @@ class SettingsControllerTest extends TestCase {
 		$oldPassword = 'old';
 		$newPassword = 'new';
 
+		$this->userSessionMock->expects($this->once())->method('getUID')->willReturn('uid');
+
 		$this->userManagerMock
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('checkPassword')
 			->willReturn(false);
 
@@ -171,15 +179,21 @@ class SettingsControllerTest extends TestCase {
 		$oldPassword = 'old';
 		$newPassword = 'new';
 
-		$this->userSessionMock
-			->expects($this->once())
-			->method('getUID')
-			->willReturn('testUser');
+		$this->ocSessionMock->expects($this->once())
+			->method('get')->with('loginname')->willReturn('testUser');
 
 		$this->userManagerMock
-			->expects($this->once())
+			->expects($this->at(0))
 			->method('checkPassword')
+			->with('testUserUid', 'new')
+			->willReturn(false);
+		$this->userManagerMock
+			->expects($this->at(1))
+			->method('checkPassword')
+			->with('testUser', 'new')
 			->willReturn(true);
+
+
 
 		$this->cryptMock
 			->expects($this->once())
@@ -200,7 +214,7 @@ class SettingsControllerTest extends TestCase {
 		$this->keyManagerMock
 			->expects($this->once())
 			->method('setPrivateKey')
-			->with($this->equalTo('testUser'), $this->equalTo('header.encryptedKey'));
+			->with($this->equalTo('testUserUid'), $this->equalTo('header.encryptedKey'));
 
 		$this->sessionMock
 			->expects($this->once())

--- a/apps/encryption/tests/lib/crypto/cryptTest.php
+++ b/apps/encryption/tests/lib/crypto/cryptTest.php
@@ -363,4 +363,19 @@ class cryptTest extends TestCase {
 		];
 	}
 
+	public function testIsValidPrivateKey() {
+		$res = openssl_pkey_new();
+		openssl_pkey_export($res, $privateKey);
+
+		// valid private key
+		$this->assertTrue(
+			$this->invokePrivate($this->crypt, 'isValidPrivateKey', [$privateKey])
+		);
+
+		// invalid private key
+		$this->assertFalse(
+			$this->invokePrivate($this->crypt, 'isValidPrivateKey', ['foo'])
+		);
+	}
+
 }


### PR DESCRIPTION
fix password reset for ldap users.

Steps to test:
1. Setup ownCloud and configure a LDAP server
2. Enable encryption
3. Login with a LDAP user
4. logout
5. change password of the LDAP user.
6. Login with the new password
7. Go to the personal settings and reset the password of your encryption keys

Expected: 
reset was successful and you can access the files again

01572ce should be backported to 8.1  cc @karlitschek 
