### PR TITLE
Prevent objectstore being set from client side

### DIFF
--- a/apps/files_external/controller/storagescontroller.php
+++ b/apps/files_external/controller/storagescontroller.php
@@ -138,6 +138,16 @@ abstract class StoragesController extends Controller {
 			);
 		}
 
+		if ($storage->getBackendOption('objectstore')) {
+			// objectstore must not be sent from client side
+			return new DataResponse(
+				array(
+					'message' => (string)$this->l10n->t('Objectstore forbidden')
+				),
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
+
 		/** @var Backend */
 		$backend = $storage->getBackend();
 		/** @var AuthMechanism */

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -472,10 +472,14 @@ abstract class StoragesService {
 		if (!isset($allStorages[$id])) {
 			throw new NotFoundException('Storage with id "' . $id . '" not found');
 		}
-
 		$oldStorage = $allStorages[$id];
-		$allStorages[$id] = $updatedStorage;
 
+		// ensure objectstore is persistent
+		if ($objectstore = $oldStorage->getBackendOption('objectstore')) {
+			$updatedStorage->setBackendOption('objectstore', $objectstore);
+		}
+
+		$allStorages[$id] = $updatedStorage;
 		$this->writeConfig($allStorages);
 
 		$this->triggerChangeHooks($oldStorage, $updatedStorage);


### PR DESCRIPTION
Object stores should only be configurable manually in `mount.json`.

cc @PVince81 @icewind1991 @LukasReschke 

@karlitschek Request backport to stable8.1, stable8, stable7?
