### PR TITLE
[stable8.1] Prevent objectstore being set from client side

### DIFF
--- a/apps/files_external/controller/storagescontroller.php
+++ b/apps/files_external/controller/storagescontroller.php
@@ -90,6 +90,15 @@ abstract class StoragesController extends Controller {
 		}
 
 		// TODO: validate that other attrs are set
+		if ($storage->getBackendOption('objectstore')) {
+			// objectstore must not be sent from client side
+			return new DataResponse(
+				array(
+					'message' => (string)$this->l10n->t('Objectstore forbidden')
+				),
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
 
 		$backends = \OC_Mount_Config::getBackends();
 		if (!isset($backends[$storage->getBackendClass()])) {

--- a/apps/files_external/lib/storageconfig.php
+++ b/apps/files_external/lib/storageconfig.php
@@ -174,6 +174,25 @@ class StorageConfig implements \JsonSerializable {
 	}
 
 	/**
+	 * @param string $option
+	 * @return mixed
+	 */
+	public function getBackendOption($key) {
+		if (isset($this->backendOptions[$key])) {
+			return $this->backendOptions[$key];
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $option
+	 * @param mixed $value
+	 */
+	public function setBackendOption($key, $value) {
+		$this->backendOptions[$key] = $value;
+	}
+
+	/**
 	 * Returns the mount priority
 	 *
 	 * @return int priority

--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -352,10 +352,14 @@ abstract class StoragesService {
 		if (!isset($allStorages[$id])) {
 			throw new NotFoundException('Storage with id "' . $id . '" not found');
 		}
-
 		$oldStorage = $allStorages[$id];
-		$allStorages[$id] = $updatedStorage;
 
+		// ensure objectstore is persistent
+		if ($objectstore = $oldStorage->getBackendOption('objectstore')) {
+			$updatedStorage->setBackendOption('objectstore', $objectstore);
+		}
+
+		$allStorages[$id] = $updatedStorage;
 		$this->writeConfig($allStorages);
 
 		$this->triggerChangeHooks($oldStorage, $updatedStorage);


### PR DESCRIPTION
Object stores should only be configurable manually in `mount.json`.

cc @PVince81 @icewind1991 @LukasReschke 

Backport of #18558 
