### PR TITLE
[stable8] Prevent objectstore being set from client side

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -490,6 +490,11 @@ class OC_Mount_Config {
 			return false;
 		}
 
+		if (isset($classOptions['objectstore'])) {
+			// objectstore cannot be set by client side
+			return false;
+		}
+
 		if (!isset($backends[$class])) {
 			// invalid backend
 			return false;
@@ -842,6 +847,13 @@ class OC_Mount_Config {
 				) {
 					$mountPoint[$applicable][$mountPath]['priority']
 						= $data[$mountType][$applicable][$mountPath]['priority'];
+				}
+				// Persistent objectstore
+				if (isset($data[$mountType][$applicable][$mountPath])
+					&& isset($data[$mountType][$applicable][$mountPath]['objectstore'])
+				) {
+					$mountPoint[$applicable][$mountPath]['objectstore']
+						= $data[$mountType][$applicable][$mountPath]['objectstore'];
 				}
 				$data[$mountType][$applicable]
 					= array_merge($data[$mountType][$applicable], $mountPoint[$applicable]);


### PR DESCRIPTION
Object stores should only be configurable manually in `mount.json`.

cc @PVince81 @icewind1991 @LukasReschke 

Backport of #18558 
