### PR TITLE
adjust dropdown borders to button borders

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -53,7 +53,7 @@
 	text-align: left;
 	background: #f8f8f8;
 	border: 1px solid #ddd;
-	border: 1px solid rgba(190, 190, 190, 0.901961);
+	border: 1px solid rgba(240, 240, 240, 0.9);
 	border-radius: 5px;
 	border-top-left-radius: 0;
 	box-shadow: 0 2px 7px rgba(170,170,170,.4);


### PR DESCRIPTION
Since https://github.com/owncloud/core/pull/18545, the dropdown for adding a new folder/file has a different border color than the clicked button.

Before:
![bildschirmfoto von 2015-08-25 23 03 04](https://cloud.githubusercontent.com/assets/1374172/9479390/7f167572-4b7d-11e5-98e2-eb96be3c995c.png)
After:
![bildschirmfoto von 2015-08-25 22 55 18](https://cloud.githubusercontent.com/assets/1374172/9479389/7f14468a-4b7d-11e5-947d-7c633e1b7556.png)

@jancborchardt
