### PR TITLE
Properly show update exception in web UI

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -28,15 +28,19 @@
 set_time_limit(0);
 require_once '../../lib/base.php';
 
-\OCP\JSON::callCheck();
+$l = \OC::$server->getL10N('core');
+
+$eventSource = \OC::$server->createEventSource();
+// need to send an initial message to force-init the event source,
+// which will then trigger its own CSRF check and produces its own CSRF error
+// message
+$eventSource->send('success', (string)$l->t('Preparing update'));
 
 if (OC::checkUpgrade(false)) {
 	// if a user is currently logged in, their session must be ignored to
 	// avoid side effects
 	\OC_User::setIncognitoMode(true);
 
-	$l = new \OC_L10N('core');
-	$eventSource = \OC::$server->createEventSource();
 	$logger = \OC::$server->getLogger();
 	$updater = new \OC\Updater(
 			\OC::$server->getHTTPHelper(),
@@ -96,6 +100,10 @@ if (OC::checkUpgrade(false)) {
 			(string)$l->t('Following apps have been disabled: %s', implode(', ', $disabledThirdPartyApps)));
 	}
 
-	$eventSource->send('done', '');
-	$eventSource->close();
+} else {
+	$eventSource->send('notice', (string)$l->t('Already up to date'));
 }
+
+$eventSource->send('done', '');
+$eventSource->close();
+

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -89,7 +89,13 @@ if (OC::checkUpgrade(false)) {
 		OC_Config::setValue('maintenance', false);
 	});
 
-	$updater->upgrade();
+	try {
+		$updater->upgrade();
+	} catch (\Exception $e) {
+		$eventSource->send('failure', get_class($e) . ': ' . $e->getMessage());
+		$eventSource->close();
+		exit();
+	}
 
 	if (!empty($incompatibleApps)) {
 		$eventSource->send('notice',


### PR DESCRIPTION
Properly displays CSRF errors and exceptions that happened during the update.

The problem was that the exceptions need to be piped through the event source to make it possible to display it.

To test:
- trigger CSRF issue (or upgrade from stable8.1 to this branch to trigger https://github.com/owncloud/core/issues/18557)
- add `throw new \Exception('test exception')` in lib/private/updater.php in the `upgrade()` function then run the upgrade
- run a regular upgrade

@MorrisJobke @LukasReschke @icewind1991 @nickvergessen 
