### PR TITLE
Make maintenance/update text white

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -680,7 +680,6 @@ label.infield {
 #body-login .update {
 	width: inherit;
 	text-align: center;
-	color: #ccc;
 }
 
 #body-login .update .appList {


### PR DESCRIPTION
Removing the color makes it default to white as defined in the parent
style.

This is to accomodate to the font change that made it darker.

Before this PR:
![update-maintenance-color0](https://cloud.githubusercontent.com/assets/277525/9489630/a5b4eb9a-4be2-11e5-9199-787868b2b41d.png)

After this PR:
![update-maintenance-color1](https://cloud.githubusercontent.com/assets/277525/9489619/936990da-4be2-11e5-9a9b-45028e29cd11.png)

This also affects the update page.

@jancborchardt @MorrisJobke 
