### PR TITLE
Remove last occurence of `forcessl`

### DIFF
--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -297,8 +297,8 @@ class Session implements IUserSession, Emitter {
 	 * Remove cookie for "remember username"
 	 */
 	public function unsetMagicInCookie() {
-		//TODO: DI for cookies and OC_Config
-		$secureCookie = \OC_Config::getValue('forcessl', false);
+		//TODO: DI for cookies and IRequest
+		$secureCookie = \OC::$server->getRequest()->getServerProtocol() === 'https';
 
 		unset($_COOKIE["oc_username"]); //TODO: DI
 		unset($_COOKIE["oc_token"]);


### PR DESCRIPTION
This should have been adjusted as well, now it's consistent with `setMagicInCookie`. While it does not have a security impact directly some automated scanners reported this all the time.
