### PR TITLE
Fix uploading avatar and root certs in IE8

### DIFF
--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -141,7 +141,7 @@ class AvatarController extends Controller {
 		$files = $this->request->getUploadedFile('files');
 
 		$headers = [];
-		if (\OCP\Util::isIE8()) {
+		if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
 			// due to upload iframe workaround, need to set content-type to text/plain
 			$headers['Content-Type'] = 'text/plain';
 		}

--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -141,7 +141,7 @@ class AvatarController extends Controller {
 		$files = $this->request->getUploadedFile('files');
 
 		$headers = [];
-		if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
+		if ($this->request->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
 			// due to upload iframe workaround, need to set content-type to text/plain
 			$headers['Content-Type'] = 'text/plain';
 		}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -85,6 +85,7 @@ var OC={
 	appConfig: window.oc_appconfig || {},
 	theme: window.oc_defaults || {},
 	coreApps:['', 'admin','log','core/search','settings','core','3rdparty'],
+	requestToken: oc_requesttoken,
 	menuSpeed: 50,
 
 	/**

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -43,6 +43,7 @@ use OCP\Security\ISecureRandom;
 class Request implements \ArrayAccess, \Countable, IRequest {
 
 	const USER_AGENT_IE = '/MSIE/';
+	const USER_AGENT_IE_8 = '/MSIE 8.0/';
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
 	const USER_AGENT_FREEBOX = '#^Mozilla/5\.0$#';

--- a/lib/public/appframework/controller.php
+++ b/lib/public/appframework/controller.php
@@ -83,7 +83,13 @@ abstract class Controller {
 						$data->getData(),
 						$data->getStatus()
 					);
-					$response->setHeaders(array_merge($data->getHeaders(), $response->getHeaders()));
+					$dataHeaders = $data->getHeaders();
+					$headers = $response->getHeaders();
+					// do not overwrite Content-Type if it already exists
+					if (isset($dataHeaders['Content-Type'])) {
+						unset($headers['Content-Type']);
+					}
+					$response->setHeaders(array_merge($dataHeaders, $headers));
 					return $response;
 				} else {
 					return new JSONResponse($data);

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -670,18 +670,4 @@ class Util {
 		}		
 		return self::$needUpgradeCache;
 	}
-
-	/**
-	 * Returns whether the current request is coming from a
-	 * famous awfully old browser.
-	 *
-	 * @return boolean true if it's IE8, false otherwise
-	 */
-	public static function isIE8() {
-		preg_match('/MSIE (.*?);/', $_SERVER['HTTP_USER_AGENT'], $matches);
-		if (count($matches) > 0 && $matches[1] <= 9) {
-			return true;
-		}
-		return false;
-	}
 }

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -670,4 +670,18 @@ class Util {
 		}		
 		return self::$needUpgradeCache;
 	}
+
+	/**
+	 * Returns whether the current request is coming from a
+	 * famous awfully old browser.
+	 *
+	 * @return boolean true if it's IE8, false otherwise
+	 */
+	public static function isIE8() {
+		preg_match('/MSIE (.*?);/', $_SERVER['HTTP_USER_AGENT'], $matches);
+		if (count($matches) > 0 && $matches[1] <= 9) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/settings/controller/certificatecontroller.php
+++ b/settings/controller/certificatecontroller.php
@@ -69,7 +69,7 @@ class CertificateController extends Controller {
 	 */
 	public function addPersonalRootCertificate() {
 		$headers = [];
-		if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
+		if ($this->request->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
 			// due to upload iframe workaround, need to set content-type to text/plain
 			$headers['Content-Type'] = 'text/plain';
 		}

--- a/settings/controller/certificatecontroller.php
+++ b/settings/controller/certificatecontroller.php
@@ -68,19 +68,25 @@ class CertificateController extends Controller {
 	 * @return array
 	 */
 	public function addPersonalRootCertificate() {
+		$headers = [];
+		if (\OCP\Util::isIE8()) {
+			// due to upload iframe workaround, need to set content-type to text/plain
+			$headers['Content-Type'] = 'text/plain';
+		}
 
 		if ($this->isCertificateImportAllowed() === false) {
-			return new DataResponse('Individual certificate management disabled', Http::STATUS_FORBIDDEN);
+			return new DataResponse(['message' => 'Individual certificate management disabled'], Http::STATUS_FORBIDDEN, $headers);
 		}
 
 		$file = $this->request->getUploadedFile('rootcert_import');
 		if(empty($file)) {
-			return new DataResponse(['message' => 'No file uploaded'], Http::STATUS_UNPROCESSABLE_ENTITY);
+			return new DataResponse(['message' => 'No file uploaded'], Http::STATUS_UNPROCESSABLE_ENTITY, $headers);
 		}
 
 		try {
 			$certificate = $this->certificateManager->addCertificate(file_get_contents($file['tmp_name']), $file['name']);
-			return new DataResponse([
+			return new DataResponse(
+				[
 				'name' => $certificate->getName(),
 				'commonName' => $certificate->getCommonName(),
 				'organization' => $certificate->getOrganization(),
@@ -90,9 +96,12 @@ class CertificateController extends Controller {
 				'validTillString' => $this->l10n->l('date', $certificate->getExpireDate()),
 				'issuer' => $certificate->getIssuerName(),
 				'issuerOrganization' => $certificate->getIssuerOrganization(),
-			]);
+				],
+				Http::STATUS_OK,
+				$headers
+			);
 		} catch (\Exception $e) {
-			return new DataResponse('An error occurred.', Http::STATUS_UNPROCESSABLE_ENTITY);
+			return new DataResponse('An error occurred.', Http::STATUS_UNPROCESSABLE_ENTITY, $headers);
 		}
 	}
 

--- a/settings/controller/certificatecontroller.php
+++ b/settings/controller/certificatecontroller.php
@@ -69,7 +69,7 @@ class CertificateController extends Controller {
 	 */
 	public function addPersonalRootCertificate() {
 		$headers = [];
-		if (\OCP\Util::isIE8()) {
+		if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE_8])) {
 			// due to upload iframe workaround, need to set content-type to text/plain
 			$headers['Content-Type'] = 'text/plain';
 		}

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -5,8 +5,6 @@
  * See the COPYING-README file.
  */
 
-/* global OC, t */
-
 /**
  * The callback will be fired as soon as enter is pressed by the
  * user or 1 second after the last data entry
@@ -156,6 +154,9 @@ function cleanCropper () {
 }
 
 function avatarResponseHandler (data) {
+	if (typeof data === 'string') {
+		data = $.parseJSON(data);
+	}
 	var $warning = $('#avatar .warning');
 	$warning.hide();
 	if (data.status === "success") {
@@ -233,7 +234,21 @@ $(document).ready(function () {
 
 	var uploadparms = {
 		done: function (e, data) {
-			avatarResponseHandler(data.result);
+			var response = data;
+			if (typeof data.result === 'string') {
+				response = $.parseJSON(data.result);
+			} else if (data.result && data.result.length) {
+				// fetch response from iframe
+				response = $.parseJSON(data.result[0].body.innerText);
+			} else {
+				response = data.result;
+			}
+			avatarResponseHandler(response);
+		},
+		submit: function(e, data) {
+			data.formData = _.extend(data.formData || {}, {
+				requesttoken: OC.requestToken
+			});
 		},
 		fail: function (e, data){
 			var msg = data.jqXHR.statusText + ' (' + data.jqXHR.status + ')';
@@ -250,10 +265,6 @@ $(document).ready(function () {
 			});
 		}
 	};
-
-	$('#uploadavatarbutton').click(function () {
-		$('#uploadavatar').click();
-	});
 
 	$('#uploadavatar').fileupload(uploadparms);
 
@@ -344,7 +355,24 @@ $(document).ready(function () {
 	$('#sslCertificate tr > td').tipsy({gravity: 'n', live: true});
 
 	$('#rootcert_import').fileupload({
+		submit: function(e, data) {
+			data.formData = _.extend(data.formData || {}, {
+				requesttoken: OC.requestToken
+			});
+		},
 		success: function (data) {
+			if (typeof data === 'string') {
+				data = $.parseJSON(data);
+			} else if (data && data.length) {
+				// fetch response from iframe
+				data = $.parseJSON(data[0].body.innerText);
+			}
+			if (!data || typeof(data) === 'string') {
+				// IE8 iframe workaround comes here instead of fail()
+				OC.Notification.showTemporary(
+					t('settings', 'An error occurred. Please upload an ASCII-encoded PEM certificate.'));
+				return;
+			}
 			var issueDate = new Date(data.validFrom * 1000);
 			var expireDate = new Date(data.validTill * 1000);
 			var now = new Date();
@@ -372,10 +400,6 @@ $(document).ready(function () {
 			OC.Notification.showTemporary(
 				t('settings', 'An error occurred. Please upload an ASCII-encoded PEM certificate.'));
 		}
-	});
-
-	$('#rootcert_import_button').click(function () {
-		$('#rootcert_import').click();
 	});
 
 	if ($('#sslCertificate > tbody > tr').length === 0) {

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -46,6 +46,7 @@ OC_Util::addScript( 'settings', 'personal' );
 OC_Util::addStyle( 'settings', 'settings' );
 \OC_Util::addVendorScript('strengthify/jquery.strengthify');
 \OC_Util::addVendorStyle('strengthify/strengthify');
+\OC_Util::addScript('files', 'jquery.iframe-transport');
 \OC_Util::addScript('files', 'jquery.fileupload');
 if ($config->getSystemValue('enable_avatars', true) === true) {
 	\OC_Util::addVendorScript('jcrop/js/jquery.Jcrop');

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -155,10 +155,11 @@ if($_['passwordChangeSupported']) {
 		<div class="avatardiv"></div><br>
 		<div class="warning hidden"></div>
 		<?php if ($_['avatarChangeSupported']): ?>
-		<div class="inlineblock button" id="uploadavatarbutton"><?php p($l->t('Upload new')); ?></div>
-		<input type="file" class="hidden" name="files[]" id="uploadavatar">
+		<label for="uploadavatar" class="inlineblock button" id="uploadavatarbutton"><?php p($l->t('Upload new')); ?></label>
 		<div class="inlineblock button" id="selectavatar"><?php p($l->t('Select new from Files')); ?></div>
-		<div class="inlineblock button" id="removeavatar"><?php p($l->t('Remove image')); ?></div><br>
+		<div class="inlineblock button" id="removeavatar"><?php p($l->t('Remove image')); ?></div>
+		<input type="file" name="files[]" id="uploadavatar" class="hiddenuploadfield">
+		<br>
 		<?php p($l->t('Either png or jpg. Ideally square but you will be able to crop it. The file is not allowed to exceed the maximum size of 20 MB.')); ?>
 		<?php else: ?>
 		<?php p($l->t('Your avatar is provided by your original account.')); ?>
@@ -239,8 +240,8 @@ if($_['passwordChangeSupported']) {
 		</tbody>
 	</table>
 	<form class="uploadButton" method="post" action="<?php p($_['urlGenerator']->linkToRoute('settings.Certificate.addPersonalRootCertificate')); ?>" target="certUploadFrame">
-		<input type="file" id="rootcert_import" name="rootcert_import" class="hidden">
-		<input type="button" id="rootcert_import_button" value="<?php p($l->t('Import root certificate')); ?>"/>
+		<label for="rootcert_import" class="inlineblock button" id="rootcert_import_button"><?php p($l->t('Import root certificate')); ?></label>
+		<input type="file" id="rootcert_import" name="rootcert_import" class="hiddenuploadfield">
 	</form>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/18007

Avatar tests:
- [x] TEST: upload avatar with IE8, with cropping
- [x] TEST: select avatar from files in IE8, with cropping
- [x] TEST: upload avatar with Chromium, with cropping
- [x] TEST: select avatar from files with Chromium, with cropping

Root cert tests:
- [x] TEST: upload invalid cert file in IE8
- [x] TEST: upload invalid cert file in Chromium
- [x] TEST: upload valid cert file in IE8
- [x] TEST: upload valid cert file in Chromium

To be able to upload root certs you need to enable the "External storage" app and select at least one backend in "Allow users to mount the following external storage"
- [x] REQUIRE: https://github.com/owncloud/core/issues/18585 due to a bug on master uploading certs is broken and cannot be tested.

CC @SergioBertolinSG @DeepDiver1975 
