### PR TITLE
log in screen style

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -26,14 +26,7 @@ body {
 
 #body-login {
 	text-align: center;
-	background: #1d2d44; /* Old browsers */
-	background: -moz-linear-gradient(top, #35537a 0%, #1d2d44 100%); /* FF3.6+ */
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#35537a), color-stop(100%,#1d2d44)); /* Chrome,Safari4+ */
-	background: -webkit-linear-gradient(top, #35537a 0%,#1d2d44 100%); /* Chrome10+,Safari5.1+ */
-	background: -o-linear-gradient(top, #35537a 0%,#1d2d44 100%); /* Opera11.10+ */
-	background: -ms-linear-gradient(top, #35537a 0%,#1d2d44 100%); /* IE10+ */
-	background: linear-gradient(top, #35537a 0%,#1d2d44 100%); /* W3C */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#35537a', endColorstr='#1d2d44',GradientType=0 ); /* IE6-9 */
+	background: #35537a;
 }
 
 .float-spinner {
@@ -539,10 +532,8 @@ input[name='password-clone'] {
 /* General new input field look */
 #body-login input[type="text"],
 #body-login input[type="password"],
-#body-login input[type="email"],
-#body-login input[type="submit"] {
+#body-login input[type="email"] {
 	border: none;
-	border-radius: 5px;
 }
 
 /* Nicely grouping input field sets */

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -449,11 +449,30 @@ input[type="submit"].enabled {
 	padding: 13px;
 	margin: -13px;
 }
-/* quick fix for log in button not being aligned with input fields, should be properly fixed by input field width later */
+
+/* position log in button as confirm icon in right of password field */
 #body-login #submit.login {
-	margin-right: 7px;
+	position: absolute;
+	right: 0;
+	top: 49px;
+	border: none;
+	background-color: transparent;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
+	opacity: .3;
 }
+#body-login #submit.login:hover,
+#body-login #submit.login:focus {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)";
+	opacity: .7;
+}
+#body-login input[type="password"] {
+	padding-right: 40px;
+	box-sizing: border-box;
+	min-width: 269px;
+}
+
 #body-login form {
+	position: relative;
 	width: 22em;
 	margin: 2em auto 2em;
 	padding: 0;
@@ -773,6 +792,9 @@ label.infield {
 #remember_login {
 	margin: 24px 5px 0 16px !important;
 	vertical-align: text-bottom;
+}
+#body-login .remember-login-container {
+	text-align: center;
 }
 
 /* Sticky footer */

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -62,13 +62,15 @@ script('core', [
 		</a>
 		<?php endif; ?>
 		<?php if ($_['rememberLoginAllowed'] === true) : ?>
-		<input type="checkbox" name="remember_login" value="1" id="remember_login">
-		<label for="remember_login"><?php p($l->t('remember')); ?></label>
+		<div class="remember-login-container">
+			<input type="checkbox" name="remember_login" value="1" id="remember_login">
+			<label for="remember_login"><?php p($l->t('remember')); ?></label>
+		</div>
 		<?php endif; ?>
 		<input type="hidden" name="timezone-offset" id="timezone-offset"/>
 		<input type="hidden" name="timezone" id="timezone"/>
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
-		<input type="submit" id="submit" class="login primary" value="<?php p($l->t('Log in')); ?>" disabled="disabled"/>
+		<input type="submit" id="submit" class="login primary icon-confirm" value="" disabled="disabled"/>
 	</fieldset>
 </form>
 <?php if (!empty($_['alt_login'])) { ?>


### PR DESCRIPTION
- remove gradient, switch to lighter and friendlier color (this is the color which was at the top of the gradient)
- move log in button into fields and use icon instead of text – this reduces the amount of different elements on the screen a lot and makes it even easier.

Please review @owncloud/designers @karlitschek. Ideal would be to have the confirm arrow transform into a spinner (using `icon-loading-small`) when it’s clicked, is that possible @PVince81?

Before:
![capture du 2015-08-26 19-10-43](https://cloud.githubusercontent.com/assets/925062/9500517/340db19a-4c26-11e5-8682-2e91395be3b4.png)
After:
![capture du 2015-08-26 19-10-09](https://cloud.githubusercontent.com/assets/925062/9500518/34115e44-4c26-11e5-9449-b1d6fc0a3a33.png)

@karlitschek @jospoortvliet the interesting question is whether this is intelligent from a branding perspective. The dark ownCloud blue color however is too dark to use as a plain color on that page. And maybe we can use this blue for the header and as the general color as well. What do you think?
