### PR TITLE
[WIP] Detect app loading issues and disable the app on the next request

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -99,6 +99,14 @@ class OC_App {
 		if (OC_Config::getValue('maintenance', false)) {
 			return false;
 		}
+
+		$failedApp = \OC::$server->getConfig()->getAppValue('core', 'last-loaded-app-failed', null);
+		if (!is_null($failedApp)) {
+			self::disable($failedApp);
+			\OC::$server->getConfig()->deleteAppValue('core', 'last-loaded-app-failed');
+			\OC::$server->getLogger()->error("App $failedApp failed to load - we are disabling it for now", ['app' => 'core']);
+		}
+
 		// Load the enabled apps here
 		$apps = self::getEnabledApps();
 
@@ -137,7 +145,9 @@ class OC_App {
 			if ($checkUpgrade and self::shouldUpgrade($app)) {
 				throw new \OC\NeedsUpdateException();
 			}
+			\OC::$server->getConfig()->setAppValue('core', 'last-loaded-app-failed', $app);
 			self::requireAppFile($app);
+			\OC::$server->getConfig()->deleteAppValue('core', 'last-loaded-app-failed');
 			if (self::isType($app, array('authentication'))) {
 				// since authentication apps affect the "is app enabled for group" check,
 				// the enabled apps cache needs to be cleared to make sure that the


### PR DESCRIPTION
POC implementation based on the discussion last night with @karlitschek and @jancborchardt 

Basically we save the app which failed to load in the db and upon next request we disable the app.

To test:
1. enable an working app
2. introduce a syntax error in the apps app.php
3. reload the browser
4. WSOD
5. reload
6. owncloud wroks again
7. in the log you will see a message: "App mail failed to load - we are disabling it for now"

TODO:
- [ ] how does this scale?
- [ ] this is not race conditions save
- [ ] how to grab errors out side of app.php - e.g. in remote.php or any of the controllers

@PVince81 @schiesbn @nickvergessen @icewind1991 input and ideas welcome
