### PR TITLE
[stable7] take share target into account when updating recipient etags

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -145,10 +145,10 @@ class Shared_Updater {
 			$shareType = $params['shareType'];
 
 			if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
-				self::correctUsersFolder($shareWith, '/');
+				self::correctUsersFolder($shareWith, $params['fileTarget']);
 			} elseif ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
 				foreach (\OC_Group::usersInGroup($shareWith) as $user) {
-					self::correctUsersFolder($user, '/');
+					self::correctUsersFolder($user, $params['fileTarget']);
 				}
 			}
 		}

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -115,14 +115,34 @@ class Test_Files_Sharing_Updater extends Test_Files_Sharing_Base {
 		}
 	}
 
+	public function shareFolderProvider() {
+		return [
+			['/'],
+			['/my_shares'],
+		];
+	}
+
 	/**
 	 * if a file gets shared the etag for the recipients root should change
+	 *
+	 * @dataProvider shareFolderProvider
+	 *
+	 * @param string $shareFolder share folder to use
 	 */
-	function testShareFile() {
+	public function testShareFile($shareFolder) {
+		$config = \OC::$server->getConfig();
+		$oldShareFolder = $config->getSystemValue('share_folder');
+		$config->setSystemValue('share_folder', $shareFolder);
+
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$beforeShare = \OC\Files\Filesystem::getFileInfo('');
-		$etagBeforeShare = $beforeShare->getEtag();
+		$beforeShareRoot = \OC\Files\Filesystem::getFileInfo('');
+		$etagBeforeShareRoot = $beforeShareRoot->getEtag();
+
+		\OC\Files\Filesystem::mkdir($shareFolder);
+
+		$beforeShareDir = \OC\Files\Filesystem::getFileInfo($shareFolder);
+		$etagBeforeShareDir = $beforeShareDir->getEtag();
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
@@ -131,17 +151,25 @@ class Test_Files_Sharing_Updater extends Test_Files_Sharing_Base {
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$afterShare = \OC\Files\Filesystem::getFileInfo('');
-		$etagAfterShare = $afterShare->getEtag();
+		$afterShareRoot = \OC\Files\Filesystem::getFileInfo('');
+		$etagAfterShareRoot = $afterShareRoot->getEtag();
 
-		$this->assertTrue(is_string($etagBeforeShare));
-		$this->assertTrue(is_string($etagAfterShare));
-		$this->assertTrue($etagBeforeShare !== $etagAfterShare);
+		$afterShareDir = \OC\Files\Filesystem::getFileInfo($shareFolder);
+		$etagAfterShareDir = $afterShareDir->getEtag();
+
+		$this->assertTrue(is_string($etagBeforeShareRoot));
+		$this->assertTrue(is_string($etagBeforeShareDir));
+		$this->assertTrue(is_string($etagAfterShareRoot));
+		$this->assertTrue(is_string($etagAfterShareDir));
+		$this->assertTrue($etagBeforeShareRoot !== $etagAfterShareRoot);
+		$this->assertTrue($etagBeforeShareDir !== $etagAfterShareDir);
 
 		// cleanup
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
 		$result = \OCP\Share::unshare('folder', $fileinfo->getId(), \OCP\Share::SHARE_TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue($result);
+
+		$config->setSystemValue('share_folder', $oldShareFolder);
 	}
 
 	/**


### PR DESCRIPTION
Backport of #17083 
Approval https://github.com/owncloud/core/pull/17083#issuecomment-135373160

cc @icewind1991 @PVince81 @rullzer 

@cmonteroluque I got asked by @cdamken if this can make it into 7.0.9 because there are at least two open cases - see https://github.com/owncloud/core/pull/17083#issuecomment-135396482

Steps to reproduce: https://github.com/owncloud/core/pull/17083#issue-90145440
Do a webdav request (that contains the etag): `curl -X PROPFIND -u test:test   http://localhost/master/remote.php/webdav/ | xmllint --format -`
