### PR TITLE
restore behavior where favorite stars only show up on hover, to not clutter the interface so much

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -616,13 +616,13 @@ a.action > img {
 }
 
 /* show share action of shared items darker to distinguish from non-shared */
-#fileList a.action.permanent.shared-style {
+#fileList a.action.permanent.shared-style,
+#fileList a.action.action-favorite.permanent {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)" !important;
 	filter: alpha(opacity=70) !important;
 	opacity: .7 !important;
 }
 /* always show actions on mobile, not only on hover */
-#fileList a.action,
 #fileList a.action.action-menu.permanent {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)" !important;
 	filter: alpha(opacity=30) !important;

--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -43,6 +43,14 @@ table td.filename .nametext {
 #fileList a.action-share span {
 	display: none;
 }
+#fileList a.action.action-favorite {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)" !important;
+	opacity: .7 !important;
+}
+#fileList a.action.action-favorite {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)" !important;
+	opacity: .3 !important;
+}
 
 /* ellipsis on file names */
 table td.filename .nametext .innernametext {


### PR DESCRIPTION
This was caused by c11ea056d06be7859071eb3176462a9d4d56964e and not intended. On desktop, the favorite stars should only show up on hover and not display all the time.

So this just restores intended behavior. Please review @owncloud/designers 
