### PR TITLE
Fix controls bar calculation

### DIFF
--- a/core/js/apps.js
+++ b/core/js/apps.js
@@ -27,8 +27,8 @@
 	 */
 	exports.Apps.showAppSidebar = function($el) {
 		var $appSidebar = $el || $('#app-sidebar');
-		$appSidebar.removeClass('disappear')
-		$('#app-content').addClass('with-app-sidebar');
+		$appSidebar.removeClass('disappear');
+		$('#app-content').addClass('with-app-sidebar').trigger(new $.Event('appresized'));
 
 	};
 
@@ -41,7 +41,7 @@
 	exports.Apps.hideAppSidebar = function($el) {
 		var $appSidebar = $el || $('#app-sidebar');
 		$appSidebar.addClass('disappear');
-		$('#app-content').removeClass('with-app-sidebar');
+		$('#app-content').removeClass('with-app-sidebar').trigger(new $.Event('appresized'));
 	};
 
 	/**

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1393,13 +1393,19 @@ function initCore() {
 				// if there is a scrollbar …
 				if($('#app-content').get(0).scrollHeight > $('#app-content').height()) {
 					if($(window).width() > 768) {
-						controlsWidth = $('#content').width() - $('#app-navigation').width() - $('#app-sidebar').width() - getScrollBarWidth();
+						controlsWidth = $('#content').width() - $('#app-navigation').width() - getScrollBarWidth();
+						if (!$('#app-sidebar').hasClass('hidden') && !$('#app-sidebar').hasClass('disappear')) {
+							controlsWidth -= $('#app-sidebar').width();
+						}
 					} else {
 						controlsWidth = $('#content').width() - getScrollBarWidth();
 					}
 				} else { // if there is none
 					if($(window).width() > 768) {
-						controlsWidth = $('#content').width() - $('#app-navigation').width() - $('#app-sidebar').width();
+						controlsWidth = $('#content').width() - $('#app-navigation').width();
+						if (!$('#app-sidebar').hasClass('hidden') && !$('#app-sidebar').hasClass('disappear')) {
+							controlsWidth -= $('#app-sidebar').width();
+						}
 					} else {
 						controlsWidth = $('#content').width();
 					}
@@ -1411,7 +1417,7 @@ function initCore() {
 
 		$(window).resize(_.debounce(adjustControlsWidth, 250));
 
-		$('body').delegate('#app-content', 'apprendered', adjustControlsWidth);
+		$('body').delegate('#app-content', 'apprendered appresized', adjustControlsWidth);
 
 	}
 


### PR DESCRIPTION
Controls bar calculation needs to take the sidebar visibility into
account.

Recalculation is now triggered when sidebar is toggled, using a new
app-content event "appresized".

Fixes https://github.com/owncloud/core/issues/18618

@jancborchardt @MorrisJobke @tomneedham @nickvergessen 
