### PR TITLE
Return permissions and expiration on create share responses

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -346,6 +346,10 @@ class Local {
 					}
 				}
 			}
+
+			$data['permissions'] = $share['permissions'];
+			$data['expiration'] = $share['expiration'];
+
 			return new \OC_OCS_Result($data);
 		} else {
 			return new \OC_OCS_Result(null, 404, "couldn't share file");

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -73,40 +73,108 @@ class Test_Files_Sharing_Api extends TestCase {
 	/**
 	 * @medium
 	 */
-	function testCreateShare() {
-
-		// share to user
-
+	function testCreateShareUserFile() {
 		// simulate a post request
 		$_POST['path'] = $this->filename;
 		$_POST['shareWith'] = \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2;
 		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_USER;
 
-		$result = \OCA\Files_Sharing\API\Local::createShare(array());
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
 
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
+		$this->assertEquals(23, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
 
 		$share = $this->getShareFromId($data['id']);
-
 		$items = \OCP\Share::getItemShared('file', $share['item_source']);
-
 		$this->assertTrue(!empty($items));
 
-		// share link
+		$fileinfo = $this->view->getFileInfo($this->filename);
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+	}
 
+	function testCreateShareUserFolder() {
+		// simulate a post request
+		$_POST['path'] = $this->folder;
+		$_POST['shareWith'] = \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2;
+		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_USER;
+
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
+
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals(31, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
+
+		$share = $this->getShareFromId($data['id']);
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+	}
+
+
+	function testCreateShareGroupFile() {
+		// simulate a post request
+		$_POST['path'] = $this->filename;
+		$_POST['shareWith'] = \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_GROUP1;
+		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
+
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
+
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals(23, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
+
+		$share = $this->getShareFromId($data['id']);
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->filename);
+		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_GROUP1);
+	}
+
+	function testCreateShareGroupFolder() {
+		// simulate a post request
+		$_POST['path'] = $this->folder;
+		$_POST['shareWith'] = \Test_Files_Sharing_Api::TEST_FILES_SHARING_API_GROUP1;
+		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_GROUP;
+
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
+
+		$this->assertTrue($result->succeeded());
+		$data = $result->getData();
+		$this->assertEquals(31, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
+
+		$share = $this->getShareFromId($data['id']);
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
+
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP,
+				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_GROUP1);
+	}
+
+	public function testCreateShareLink() {
 		// simulate a post request
 		$_POST['path'] = $this->folder;
 		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
 
-		$result = \OCA\Files_Sharing\API\Local::createShare(array());
+		$result = \OCA\Files_Sharing\API\Local::createShare([]);
 
 		// check if API call was successful
 		$this->assertTrue($result->succeeded());
 
 		$data = $result->getData();
-
-		// check if we have a token
+		$this->assertEquals(1, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
 		$this->assertTrue(is_string($data['token']));
 
 		// check for correct link
@@ -115,18 +183,39 @@ class Test_Files_Sharing_Api extends TestCase {
 
 
 		$share = $this->getShareFromId($data['id']);
-
 		$items = \OCP\Share::getItemShared('file', $share['item_source']);
-
 		$this->assertTrue(!empty($items));
 
-		$fileinfo = $this->view->getFileInfo($this->filename);
+		$fileinfo = $this->view->getFileInfo($this->folder);
+		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
+	}
 
-		\OCP\Share::unshare('file', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_USER,
-				\Test_Files_Sharing_Api::TEST_FILES_SHARING_API_USER2);
+	public function testCreateShareLinkPublicUpload() {
+		// simulate a post request
+		$_POST['path'] = $this->folder;
+		$_POST['shareType'] = \OCP\Share::SHARE_TYPE_LINK;
+		$_POST['publicUpload'] = 'true';
+
+		$result = \OCA\Files_Sharing\API\Local::createShare(array());
+
+		// check if API call was successful
+		$this->assertTrue($result->succeeded());
+
+		$data = $result->getData();
+		$this->assertEquals(7, $data['permissions']);
+		$this->assertEmpty($data['expiration']);
+		$this->assertTrue(is_string($data['token']));
+
+		// check for correct link
+		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);
+		$this->assertEquals($url, $data['url']);
+
+
+		$share = $this->getShareFromId($data['id']);
+		$items = \OCP\Share::getItemShared('file', $share['item_source']);
+		$this->assertTrue(!empty($items));
 
 		$fileinfo = $this->view->getFileInfo($this->folder);
-
 		\OCP\Share::unshare('folder', $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_LINK, null);
 	}
 
@@ -287,7 +376,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
 	 */
 	function testGetAllShares() {
 
@@ -334,7 +423,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareLink
 	 */
 	function testPublicLinkUrl() {
 		// simulate a post request
@@ -379,7 +468,8 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
+	 * @depends testCreateShareLink
 	 */
 	function testGetShareFromSource() {
 
@@ -409,7 +499,8 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
+	 * @depends testCreateShareLink
 	 */
 	function testGetShareFromSourceWithReshares() {
 
@@ -463,7 +554,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
 	 */
 	function testGetShareFromId() {
 
@@ -911,7 +1002,8 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
+	 * @depends testCreateShareLink
 	 */
 	function testUpdateShare() {
 
@@ -1037,7 +1129,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
 	 */
 	public function testUpdateShareInvalidPermissions() {
 
@@ -1232,7 +1324,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 	/**
 	 * @medium
-	 * @depends testCreateShare
+	 * @depends testCreateShareUserFile
 	 */
 	function testDeleteShare() {
 
@@ -1526,6 +1618,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 		$data = $result->getData();
 		$this->assertTrue(is_string($data['token']));
+		$this->assertEquals($date, substr($data['expiration'], 0, 10));
 
 		// check for correct link
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);
@@ -1564,6 +1657,7 @@ class Test_Files_Sharing_Api extends TestCase {
 
 		$data = $result->getData();
 		$this->assertTrue(is_string($data['token']));
+		$this->assertEquals($date->format('Y-m-d') . ' 00:00:00', $data['expiration']);
 
 		// check for correct link
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);


### PR DESCRIPTION
On creation of a share return the set of permissions and the expiration date.

As requested in #18476.

Now if an expiration date is enforced the client directly gets the right date etc.

@SergioBertolinSG @PVince81 this was what you wanted right?
