### PR TITLE
fix size of filetype icons in filepicker

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -977,6 +977,7 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 }
 #oc-dialog-filepicker-content .filelist img {
 	margin: 2px 1em 0 4px;
+	width: 32px;
 }
 #oc-dialog-filepicker-content .filelist .date {
 	float: right;


### PR DESCRIPTION
They were 16px before (original size of the files), now forced to the 32px used in the filepicker. Please review @owncloud/designers 
