### PR TITLE
Changes matching string to seconds ago from a few seconds ago.

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1519,7 +1519,11 @@ OC.Util = {
 	 * @returns {string} human readable difference from now
 	 */
 	relativeModifiedDate: function (timestamp) {
-		return moment(timestamp).fromNow();
+		var relativedate = moment(timestamp).fromNow();
+		if (relativedate === t('core', 'a few seconds ago')) {
+			relativedate = t('core', 'seconds ago');
+		}
+		return relativedate;
 	},
 	/**
 	 * Returns whether the browser supports SVG


### PR DESCRIPTION
A possible fix for : https://github.com/owncloud/core/issues/18627
I think we will have to manually change the string. Couldn't find another way. Have a look
@owncloud/designers @jancborchardt 
