### PR TITLE
Configurable temporary directory

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -80,6 +80,16 @@ $CONFIG = array(
 'datadirectory' => '/var/www/owncloud/data',
 
 /**
+ * Override where ownCloud stores temporary files. Useful in situations where
+ * the system temporary directory is on a limited space ramdisk or is otherwise
+ * restricted, or if external storages which do not support streaming are in
+ * use.
+ *
+ * The web server user must have write access to this directory.
+ */
+'tempdirectory' => '/tmp/owncloudtemp',
+
+/**
  * The current version number of your ownCloud installation. This is set up
  * during installation and update, so you shouldn't need to change it.
  */

--- a/lib/base.php
+++ b/lib/base.php
@@ -1108,27 +1108,16 @@ class OC {
 		}
 		return true;
 	}
-}
 
-if (!function_exists('get_temp_dir')) {
 	/**
 	 * Get the temporary dir to store uploaded data
 	 * @return null|string Path to the temporary directory or null
 	 */
 	function get_temp_dir() {
-		if ($temp = ini_get('upload_tmp_dir')) return $temp;
-		if ($temp = getenv('TMP')) return $temp;
-		if ($temp = getenv('TEMP')) return $temp;
-		if ($temp = getenv('TMPDIR')) return $temp;
-		$temp = tempnam(__FILE__, '');
-		if (file_exists($temp)) {
-			unlink($temp);
-			return dirname($temp);
-		}
-		if ($temp = sys_get_temp_dir()) return $temp;
-
-		return null;
+		return \OC::$server->getTempManager()->t_get_temp_dir();
 	}
+
 }
+
 
 OC::init();

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -344,7 +344,10 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 		});
 		$this->registerService('TempManager', function (Server $c) {
-			return new TempManager($c->getLogger());
+			return new TempManager(
+				$c->getLogger(),
+				$c->getConfig()
+			);
 		});
 		$this->registerService('AppManager', function(Server $c) {
 			return new \OC\App\AppManager(

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -344,7 +344,7 @@ class Server extends SimpleContainer implements IServerContainer {
 			}
 		});
 		$this->registerService('TempManager', function (Server $c) {
-			return new TempManager(get_temp_dir(), $c->getLogger());
+			return new TempManager($c->getLogger());
 		});
 		$this->registerService('AppManager', function(Server $c) {
 			return new \OC\App\AppManager(

--- a/lib/public/itempmanager.php
+++ b/lib/public/itempmanager.php
@@ -58,4 +58,12 @@ interface ITempManager {
 	 * @since 8.0.0
 	 */
 	public function cleanOld();
+
+	/**
+	 * Get the temporary base directory
+	 *
+	 * @return string
+	 * @since 8.2.0
+	 */
+	public function getTempBaseDir();
 }

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -22,12 +22,11 @@ class NullLogger extends Log {
 }
 
 class TempManager extends \Test\TestCase {
-	protected $baseDir;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->baseDir = get_temp_dir() . $this->getUniqueID('/oc_tmp_test');
+		$this->baseDir = $this->getManager()->t_get_temp_dir() . $this->getUniqueID('/oc_tmp_test');
 		if (!is_dir($this->baseDir)) {
 			mkdir($this->baseDir);
 		}
@@ -46,7 +45,7 @@ class TempManager extends \Test\TestCase {
 		if (!$logger) {
 			$logger = new NullLogger();
 		}
-		return new \OC\TempManager($this->baseDir, $logger);
+		return new \OC\TempManager($logger);
 	}
 
 	public function testGetFile() {

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -23,10 +23,12 @@ class NullLogger extends Log {
 
 class TempManager extends \Test\TestCase {
 
+	protected $baseDir = null;
+
 	protected function setUp() {
 		parent::setUp();
 
-		$this->baseDir = $this->getManager()->t_get_temp_dir() . $this->getUniqueID('/oc_tmp_test');
+		$this->baseDir = $this->getManager()->getTempBaseDir() . $this->getUniqueID('/oc_tmp_test');
 		if (!is_dir($this->baseDir)) {
 			mkdir($this->baseDir);
 		}
@@ -34,18 +36,27 @@ class TempManager extends \Test\TestCase {
 
 	protected function tearDown() {
 		\OC_Helper::rmdirr($this->baseDir);
+		$this->baseDir = null;
 		parent::tearDown();
 	}
 
 	/**
 	 * @param  \OCP\ILogger $logger
+	 * @param  \OCP\IConfig $config
 	 * @return \OC\TempManager
 	 */
-	protected function getManager($logger = null) {
+	protected function getManager($logger = null, $config = null) {
 		if (!$logger) {
 			$logger = new NullLogger();
 		}
-		return new \OC\TempManager($logger);
+		if (!$config) {
+			$config = \OC::$server->getConfig();
+		}
+		$manager = new \OC\TempManager($logger, $config);
+		if ($this->baseDir) {
+			$manager->overrideTempBaseDir($this->baseDir);
+		}
+		return $manager;
 	}
 
 	public function testGetFile() {

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -50,7 +50,10 @@ class TempManager extends \Test\TestCase {
 			$logger = new NullLogger();
 		}
 		if (!$config) {
-			$config = \OC::$server->getConfig();
+			$config = $this->getMock('\OCP\IConfig');
+			$config->method('getSystemValue')
+				->with('tempdirectory', null)
+				->willReturn('/tmp');
 		}
 		$manager = new \OC\TempManager($logger, $config);
 		if ($this->baseDir) {
@@ -194,5 +197,20 @@ class TempManager extends \Test\TestCase {
 
 		$this->assertStringEndsNotWith('./Traversal\\../FileName', $tmpManager);
 		$this->assertStringEndsWith('.Traversal..FileName', $tmpManager);
+	}
+
+	public function testGetTempBaseDirFromConfig() {
+		$dir = $this->getManager()->getTemporaryFolder();
+
+		$config = $this->getMock('\OCP\IConfig');
+		$config->expects($this->once())
+			->method('getSystemValue')
+			->with('tempdirectory', null)
+			->willReturn($dir);
+
+		$this->baseDir = null; // prevent override
+		$tmpManager = $this->getManager(null, $config);
+
+		$this->assertEquals($dir, $tmpManager->getTempBaseDir());
 	}
 }


### PR DESCRIPTION
This allows the temporary directory used by ownCloud to be configured in `config.php`.

Replaces #16636 

Fixes #14886, fixes #12910

cc @mmattel @MorrisJobke @PVince81 @DeepDiver1975 
