### PR TITLE
Avoid weird behaviour in SMB-CIFS external storage

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -795,8 +795,10 @@ class OC_Helper {
 	 */
 	public static function findBinaryPath($program) {
 		$memcache = \OC::$server->getMemCacheFactory()->create('findBinaryPath');
-		if ($memcache->hasKey($program)) {
-			return $memcache->get($program);
+		// Avoid returning null if for some reason an empty key in memcache is there
+		$str = $memcache->get($program);
+		if ($memcache->hasKey($program) && !empty($str)) {
+			return $str;
 		}
 		$result = null;
 		if (!\OC_Util::runningOnWindows() && self::is_function_enabled('exec')) {


### PR DESCRIPTION
Hi!
I was able to use 8.1.1.3 without major problems. I mounted without fuss 3 SMB-CIF shares. All good. After 2 hours I accessed admin settings page and the shares were still there, but all the parameters fields were blank, and the Note: smbclient is not installed... appeared. I've been stuck with this behaviour for many days, seeing that sometimes the parameters were reappearing, and after a while  disappearing again. When parameters were out, I kept having this in my logs:

Error: PHP   Undefined index: \OC\Files\Storage\SMB at /usr/apache/owncloud/apps/files_external/lib/config.php#256

After some debug, I found out that the findBinaryPath function in lib/private/helper.php was returning null all the time because some 'smbclient' key was in memcache, but it had a null or empty value. I don't know the cause of this. I could probably check my APCu cache configuration.
I think that some other users might find themselves in just this maddening situation, and the little, elementary patch I suggest here fixes it.
I also chose to file in a pull request instead of a bug report because it seems to me that this fix is so straightforward, but the bug behind it so difficult to explain, and its effects so nasty.

Another thing I really don't understand is why the code keeps tracking the existence of the smbclient binary when everywhere in the docs they say that one doesn't need it anymore, and that one must have the libsmbclient.so dynamic extension. Why then not check the presence of the extension instead of the binary if it's not used anymore?
Hope it's also ok to make the pull request directly in the master branch. If it's not my apologies in advance.
Bye all,
macgherl57
