### PR TITLE
files_external event dispatcher

### DIFF
--- a/apps/files_external/appinfo/application.php
+++ b/apps/files_external/appinfo/application.php
@@ -50,6 +50,11 @@ class Application extends App {
 
 		$this->loadBackends();
 		$this->loadAuthMechanisms();
+
+		// app developers: do NOT depend on this! it will disappear with oC 9.0!
+		\OC::$server->getEventDispatcher()->dispatch(
+			'OCA\\Files_External::loadAdditionalBackends'
+		);
 	}
 
 	/**

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -1035,4 +1035,36 @@ class Server extends SimpleContainer implements IServerContainer {
 	public function getSessionCryptoWrapper() {
 		return $this->query('CryptoWrapper');
 	}
+
+	/**
+	 * Not a public API as of 8.2, wait for 9.0
+	 * @return \OCA\Files_External\Service\BackendService
+	 */
+	public function getStoragesBackendService() {
+		return \OC_Mount_Config::$app->getContainer()->query('OCA\\Files_External\\Service\\BackendService');
+	}
+
+	/**
+	 * Not a public API as of 8.2, wait for 9.0
+	 * @return \OCA\Files_External\Service\GlobalStoragesService
+	 */
+	public function getGlobalStoragesService() {
+		return \OC_Mount_Config::$app->getContainer()->query('OCA\\Files_External\\Service\\GlobalStoragesService');
+	}
+
+	/**
+	 * Not a public API as of 8.2, wait for 9.0
+	 * @return \OCA\Files_External\Service\UserGlobalStoragesService
+	 */
+	public function getUserGlobalStoragesService() {
+		return \OC_Mount_Config::$app->getContainer()->query('OCA\\Files_External\\Service\\UserGlobalStoragesService');
+	}
+
+	/**
+	 * Not a public API as of 8.2, wait for 9.0
+	 * @return \OCA\Files_External\Service\UserStoragesService
+	 */
+	public function getUserStoragesService() {
+		return \OC_Mount_Config::$app->getContainer()->query('OCA\\Files_External\\Service\\UserStoragesService');
+	}
 }


### PR DESCRIPTION
~~3 commits here - one exposes the EventDispatcher to the AppFramework (via \OCP\IEventDispatcher, since we like OCP interfaces), another dispatches an event from files_external when backends are ready to be registered, and the final one exposes some pseudo-public static methods on OC_Mount_Config to easily get the various services.~~

EventDispatcher is used to fire an event when files_external has been initialized: `OCA\\Files_External::loadAdditionalBackends`. The services can be retrieved via the new Server functions, that are currently not OCP (waiting for 9.0)

Please review @PVince81 @icewind1991 @MorrisJobke @DeepDiver1975 
