### PR TITLE
Explicit upgrade version + prevent downgrades

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -230,14 +230,8 @@ class Updater extends BasicEmitter {
 	 * @return bool
 	 */
 	public function isUpgradePossible($oldVersion, $newVersion, $allowedPreviousVersion) {
-		// downgrade is never allowed
-		if (version_compare($oldVersion, $newVersion, '>')) {
-			return false;
-		}
-
-		// either we're updating from an allowed version or the current version
 		return (version_compare($allowedPreviousVersion, $oldVersion, '<=')
-			|| version_compare($newVersion, $oldVersion) === 0);
+			&& version_compare($oldVersion, $newVersion, '<='));
 	}
 
 	/**

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -235,22 +235,8 @@ class Updater extends BasicEmitter {
 			return false;
 		}
 
-		$oldVersion = explode('.', $oldVersion);
-		$newVersion = explode('.', $newVersion);
-
-		while (count($oldVersion) > 2) {
-			array_pop($oldVersion);
-		}
-
-		while (count($newVersion) > 2) {
-			array_pop($newVersion);
-		}
-
-		$oldVersion = implode('.', $oldVersion);
-		$newVersion = implode('.', $newVersion);
-
 		// either we're updating from an allowed version or the current version
-		return (version_compare($allowedPreviousVersion, $oldVersion) === 0
+		return (version_compare($allowedPreviousVersion, $oldVersion, '<=')
 			|| version_compare($newVersion, $oldVersion) === 0);
 	}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1448,8 +1448,12 @@ class OC_Util {
 		if ($config->getSystemValue('installed', false)) {
 			$installedVersion = $config->getSystemValue('version', '0.0.0');
 			$currentVersion = implode('.', OC_Util::getVersion());
-			if (version_compare($currentVersion, $installedVersion, '>')) {
+			$versionDiff = version_compare($currentVersion, $installedVersion);
+			if ($versionDiff > 0) {
 				return true;
+			} else if ($versionDiff < 0) {
+				// downgrade attempt, throw exception
+				throw new \OC\HintException('Downgrading is not supported and is likely to cause unpredictable issues (from ' . $installedVersion . ' to ' . $currentVersion . ')');
 			}
 
 			// also check for upgrades for apps (independently from the user)

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -67,14 +67,68 @@ class UpdaterTest extends \Test\TestCase {
 	 */
 	public function versionCompatibilityTestData() {
 		return [
-			['1.0.0.0', '2.2.0', true],
-			['1.1.1.1', '2.0.0', true],
-			['5.0.3', '4.0.3', false],
-			['12.0.3', '13.4.5', true],
-			['1', '2', true],
-			['2', '2', true],
-			['6.0.5', '6.0.6', true],
-			['5.0.6', '7.0.4', false],
+			['1', '2', '1', true],
+			['2', '2', '2', true],
+			['6.0.5.0', '6.0.6.0', '5.0', true],
+			['5.0.6.0', '7.0.4.0', '6.0', false],
+			// allow upgrading within the same major release
+			['8.0.0.0', '8.0.0.0', '8.0', true],
+			['8.0.0.0', '8.0.0.4', '8.0', true],
+			['8.0.0.0', '8.0.1.0', '8.0', true],
+			['8.0.0.0', '8.0.2.0', '8.0', true],
+			// does not allow downgrading within the same major release
+			['8.0.1.0', '8.0.0.0', '8.0', false],
+			['8.0.2.0', '8.0.1.0', '8.0', false],
+			['8.0.0.4', '8.0.0.0', '8.0', false],
+			// allows upgrading within the patch version
+			['8.0.0.0', '8.0.0.1', '8.0', true],
+			['8.0.0.0', '8.0.0.2', '8.0', true],
+			// does not allow downgrading within the same major release
+			['8.0.0.1', '8.0.0.0', '8.0', false],
+			['8.0.0.2', '8.0.0.0', '8.0', false],
+			// allow upgrading to the next major release
+			['8.0.0.0', '8.1.0.0', '8.0', true],
+			['8.0.0.0', '8.1.1.0', '8.0', true],
+			['8.0.0.0', '8.1.1.5', '8.0', true],
+			['8.0.0.2', '8.1.1.5', '8.0', true],
+			['8.1.0.0', '8.2.0.0', '8.1', true],
+			['8.1.0.2', '8.2.0.4', '8.1', true],
+			['8.1.0.5', '8.2.0.1', '8.1', true],
+			['8.1.0.0', '8.2.1.0', '8.1', true],
+			['8.1.0.2', '8.2.1.5', '8.1', true],
+			['8.1.0.5', '8.2.1.1', '8.1', true],
+			// does not allow downgrading to the previous major release
+			['8.1.0.0', '8.0.0.0', '7.0', false],
+			['8.1.1.0', '8.0.0.0', '7.0', false],
+			// does not allow skipping major releases
+			['8.0.0.0', '8.2.0.0', '8.1', false],
+			['8.0.0.0', '8.2.1.0', '8.1', false],
+			['8.0.0.0', '9.0.1.0', '8.2', false],
+			['8.0.0.0', '10.0.0.0', '9.3', false],
+			// allows updating to the next major release
+			['8.2.0.0', '9.0.0.0', '8.2', true],
+			['8.2.0.0', '9.0.0.0', '8.2', true],
+			['8.2.0.0', '9.0.1.0', '8.2', true],
+			['8.2.0.0', '9.0.1.1', '8.2', true],
+			['8.2.0.2', '9.0.1.1', '8.2', true],
+			['8.2.2.0', '9.0.1.0', '8.2', true],
+			['8.2.2.2', '9.0.1.1', '8.2', true],
+			['9.0.0.0', '9.1.0.0', '9.0', true],
+			['9.0.0.0', '9.1.0.2', '9.0', true],
+			['9.0.0.2', '9.1.0.1', '9.0', true],
+			['9.1.0.0', '9.2.0.0', '9.1', true],
+			['9.2.0.0', '9.3.0.0', '9.2', true],
+			['9.3.0.0', '10.0.0.0', '9.3', true],
+			// does not allow updating to the next major release (first number)
+			['9.0.0.0', '8.2.0.0', '8.1', false],
+			// other cases
+			['8.0.0.0', '8.1.5.0', '8.0', true],
+			['8.2.0.0', '9.0.0.0', '8.2', true],
+			['8.2.0.0', '9.1.0.0', '9.0', false],
+			['9.0.0.0', '8.1.0.0', '8.0', false],
+			['9.0.0.0', '8.0.0.0', '7.0', false],
+			['9.1.0.0', '8.0.0.0', '7.0', false],
+			['8.2.0.0', '8.1.0.0', '8.0', false],
 		];
 	}
 
@@ -106,9 +160,9 @@ class UpdaterTest extends \Test\TestCase {
 	 * @param string $newVersion
 	 * @param bool $result
 	 */
-	public function testIsUpgradePossible($oldVersion, $newVersion, $result) {
+	public function testIsUpgradePossible($oldVersion, $newVersion, $allowedVersion, $result) {
 		$updater = new Updater($this->httpHelper, $this->config);
-		$this->assertSame($result, $updater->isUpgradePossible($oldVersion, $newVersion));
+		$this->assertSame($result, $updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersion));
 	}
 
 	public function testCheckInCache() {

--- a/version.php
+++ b/version.php
@@ -2,6 +2,7 @@
 /**
  * @author Frank Karlitschek <frank@owncloud.org>
  * @author Lukas Reschke <lukas@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -22,14 +23,16 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version=array(8, 2, 0, 4);
+$OC_Version = [8, 2, 0, 4];
 
 // The human readable string
-$OC_VersionString='8.2 pre alpha';
+$OC_VersionString = '8.2 pre alpha';
+
+$OC_VersionCanBeUpgradedFrom = [8, 1];
 
 // The ownCloud channel
-$OC_Channel='git';
+$OC_Channel = 'git';
 
 // The build number
-$OC_Build='';
+$OC_Build = '';
 


### PR DESCRIPTION
- version.php now contains the previous version from which an upgrade is allowed. It **MUST** be updated every time a new major release is made
- when a downgrade is attempted, throws an exception. It appears inside an error page

Please review @MorrisJobke @DeepDiver1975 @nickvergessen @karlitschek @cmonteroluque @LukasReschke 
