### PR TITLE
Allow easy XDEBUG debugging with autotest

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -17,6 +17,9 @@ BASEDIR=$PWD
 DBCONFIGS="sqlite mysql pgsql oci"
 PHPUNIT=$(which phpunit)
 
+_XDEBUG_CONFIG=$XDEBUG_CONFIG
+unset XDEBUG_CONFIG
+
 function print_syntax {
 	echo -e "Syntax: ./autotest-external.sh [dbconfigname] [startfile]\n" >&2
 	echo -e "\t\"dbconfigname\" can be one of: $DBCONFIGS" >&2
@@ -159,6 +162,9 @@ EOF
 	mkdir "coverage-external-html-$1"
 	# just enable files_external
 	php ../occ app:enable files_external
+	if [[ "$_XDEBUG_CONFIG" ]]; then
+		export XDEBUG_CONFIG=$_XDEBUG_CONFIG
+	fi
 	if [ -z "$NOCOVERAGE" ]; then
 		"$PHPUNIT" --configuration phpunit-autotest-external.xml --log-junit "autotest-external-results-$1.xml" --coverage-clover "autotest-external-clover-$1.xml" --coverage-html "coverage-external-html-$1"
 		RESULT=$?

--- a/autotest.sh
+++ b/autotest.sh
@@ -32,6 +32,9 @@ fi
 PHP=$(which "$PHP_EXE")
 PHPUNIT=$(which phpunit)
 
+_XDEBUG_CONFIG=$XDEBUG_CONFIG
+unset XDEBUG_CONFIG
+
 function print_syntax {
 	echo -e "Syntax: ./autotest.sh [dbconfigname] [testfile]\n" >&2
 	echo -e "\t\"dbconfigname\" can be one of: $DBCONFIGS" >&2
@@ -217,6 +220,9 @@ function execute_tests {
 	rm -rf "coverage-html-$DB"
 	mkdir "coverage-html-$DB"
 	"$PHP" -f enable_all.php | grep -i -C9999 error && echo "Error during setup" && exit 101
+	if [[ "$_XDEBUG_CONFIG" ]]; then
+		export XDEBUG_CONFIG=$_XDEBUG_CONFIG
+	fi
 	if [ -z "$NOCOVERAGE" ]; then
 		"${PHPUNIT[@]}" --configuration phpunit-autotest.xml --log-junit "autotest-results-$DB.xml" --coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB" "$2" "$3"
 		RESULT=$?


### PR DESCRIPTION
Debugging scripts needs the environment variable XDEBUG_CONFIG to be
set, which initiates a connection to a listening debugger. But if that
env is set and one of the PHP setup steps occurs (e.g. occ install), the
debugging session is 'completed' and the debugger no longer listens
during the actual tests. This saves the XDEBUG_CONFIG env so it only
applies during the PHPUnit execution, so only the real tests trigger the
debugging.

@PVince81 @MorrisJobke cc anyone else who does PHP debugging
