### PR TITLE
Properly return 304 in AppFramework

### DIFF
--- a/lib/private/appframework/http.php
+++ b/lib/private/appframework/http.php
@@ -121,7 +121,7 @@ class Http extends BaseHttp {
 
 		// if etag or lastmodified have not changed, return a not modified
 		if ((isset($this->server['HTTP_IF_NONE_MATCH'])
-			&& trim($this->server['HTTP_IF_NONE_MATCH']) === $ETag) 
+			&& trim(trim($this->server['HTTP_IF_NONE_MATCH']), '"') === (string)$ETag)
 
 			||
 

--- a/tests/lib/appframework/http/HttpTest.php
+++ b/tests/lib/appframework/http/HttpTest.php
@@ -65,6 +65,14 @@ class HttpTest extends \Test\TestCase {
 	}
 
 
+	public function testQuotedEtagMatchReturnsNotModified() {
+		$http = new Http(array('HTTP_IF_NONE_MATCH' => '"hi"'));
+
+		$header = $http->getStatusHeader(Http::STATUS_OK, null, 'hi');
+		$this->assertEquals('HTTP/1.1 304 Not Modified', $header);
+	}
+
+
 	public function testLastModifiedMatchReturnsNotModified() {
 		$dateTime = new \DateTime(null, new \DateTimeZone('GMT'));
 		$dateTime->setTimestamp('12');


### PR DESCRIPTION
Fix for #18719 

Parse the IF_NONE_MATCH header properly so we actually return 304 responses.

To test:
1. Get your avatar with headers 
    `curl -D - http://localhost/index.php/avatar/<USER>/32`
2. Get the Etag ( for example `ETag: "abc"`)
3. Request the avatar again with: 
    `curl -D - http://localhost/index.php/avatar/<USER>/32 --header 'If-None-Match: "abc"'`

Before you would get a status 200 and the avatar returned again.

After you get a 304 Not Modified

CC: @Raydiation @LukasReschke @MorrisJobke @PVince81 @Xenopathic 
