### PR TITLE
Make checkDependencies a real method

### DIFF
--- a/apps/files_external/lib/backend/amazons3.php
+++ b/apps/files_external/lib/backend/amazons3.php
@@ -26,9 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
+
 use \OCA\Files_External\Lib\Auth\AmazonS3\AccessKey;
 
 class AmazonS3 extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, AccessKey $legacyAuth) {
 		$this
@@ -49,7 +53,6 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
-			->setDependencyCheck('\OC\Files\Storage\AmazonS3::checkDependencies')
 			->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/lib/backend/dav.php
+++ b/apps/files_external/lib/backend/dav.php
@@ -26,10 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 use \OCA\Files_External\Lib\Auth\Password\Password;
 
 class DAV extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, Password $legacyAuth) {
 		$this
@@ -44,7 +47,6 @@ class DAV extends Backend {
 				(new DefinitionParameter('secure', $l->t('Secure https://')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
-			->setDependencyCheck('\OC\Files\Storage\DAV::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/lib/backend/dropbox.php
+++ b/apps/files_external/lib/backend/dropbox.php
@@ -26,9 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
+
 use \OCA\Files_External\Lib\Auth\OAuth1\OAuth1;
 
 class Dropbox extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, OAuth1 $legacyAuth) {
 		$this
@@ -39,7 +43,6 @@ class Dropbox extends Backend {
 			->addParameters([
 				// all parameters handled in OAuth1 mechanism
 			])
-			->setDependencyCheck('\OC\Files\Storage\Dropbox::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH1)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/lib/backend/ftp.php
+++ b/apps/files_external/lib/backend/ftp.php
@@ -26,10 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 use \OCA\Files_External\Lib\Auth\Password\Password;
 
 class FTP extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, Password $legacyAuth) {
 		$this
@@ -44,7 +47,6 @@ class FTP extends Backend {
 				(new DefinitionParameter('secure', $l->t('Secure ftps://')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
-			->setDependencyCheck('\OC\Files\Storage\FTP::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/lib/backend/google.php
+++ b/apps/files_external/lib/backend/google.php
@@ -26,9 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
+
 use \OCA\Files_External\Lib\Auth\OAuth2\OAuth2;
 
 class Google extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, OAuth2 $legacyAuth) {
 		$this
@@ -39,7 +43,6 @@ class Google extends Backend {
 			->addParameters([
 				// all parameters handled in OAuth2 mechanism
 			])
-			->setDependencyCheck('\OC\Files\Storage\Google::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/lib/backend/legacybackend.php
+++ b/apps/files_external/lib/backend/legacybackend.php
@@ -24,11 +24,20 @@ namespace OCA\Files_External\Lib\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\Auth\Builtin;
+use \OCA\Files_External\Lib\MissingDependency;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 /**
  * Legacy compatibility for OC_Mount_Config::registerBackend()
  */
 class LegacyBackend extends Backend {
+
+	use LegacyDependencyCheckPolyfill {
+		LegacyDependencyCheckPolyfill::checkDependencies as doCheckDependencies;
+	}
+
+	/** @var bool */
+	protected $hasDependencies = false;
 
 	/**
 	 * @param string $class
@@ -78,8 +87,18 @@ class LegacyBackend extends Backend {
 			$this->setCustomJs($definition['custom']);
 		}
 		if (isset($definition['has_dependencies']) && $definition['has_dependencies']) {
-			$this->setDependencyCheck($class . '::checkDependencies');
+			$this->hasDependencies = true;
 		}
+	}
+
+	/**
+	 * @return MissingDependency[]
+	 */
+	public function checkDependencies() {
+		if ($this->hasDependencies) {
+			return $this->doCheckDependencies();
+		}
+		return [];
 	}
 
 }

--- a/apps/files_external/lib/backend/smb.php
+++ b/apps/files_external/lib/backend/smb.php
@@ -26,10 +26,13 @@ use \OCA\Files_External\Lib\Backend\Backend;
 use \OCA\Files_External\Lib\DefinitionParameter;
 use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 use \OCA\Files_External\Lib\Auth\Password\Password;
 
 class SMB extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, Password $legacyAuth) {
 		$this
@@ -43,7 +46,6 @@ class SMB extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
-			->setDependencyCheck('\OC\Files\Storage\SMB::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)
 		;

--- a/apps/files_external/tests/backend/legacybackendtest.php
+++ b/apps/files_external/tests/backend/legacybackendtest.php
@@ -23,15 +23,25 @@ namespace OCA\Files_External\Tests\Backend;
 
 use \OCA\Files_External\Lib\Backend\LegacyBackend;
 use \OCA\Files_External\Lib\DefinitionParameter;
+use \OCA\Files_External\Lib\MissingDependency;
 
 class LegacyBackendTest extends \Test\TestCase {
+
+	/**
+	 * @return MissingDependency[]
+	 */
+	public static function checkDependencies() {
+		return [
+			(new MissingDependency('abc'))->setMessage('foobar')
+		];
+	}
 
 	public function testConstructor() {
 		$auth = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\Builtin')
 			->disableOriginalConstructor()
 			->getMock();
 
-		$class = '\OC\Files\Storage\SMB';
+		$class = '\OCA\Files_External\Tests\Backend\LegacyBackendTest';
 		$definition = [
 			'configuration' => [
 				'textfield' => 'Text field',
@@ -49,13 +59,17 @@ class LegacyBackendTest extends \Test\TestCase {
 
 		$backend = new LegacyBackend($class, $definition, $auth);
 
-		$this->assertEquals('\OC\Files\Storage\SMB', $backend->getStorageClass());
+		$this->assertEquals('\OCA\Files_External\Tests\Backend\LegacyBackendTest', $backend->getStorageClass());
 		$this->assertEquals('Backend text', $backend->getText());
 		$this->assertEquals(123, $backend->getPriority());
 		$this->assertEquals('foo/bar.js', $backend->getCustomJs());
-		$this->assertEquals(true, $backend->hasDependencies());
 		$this->assertArrayHasKey('builtin', $backend->getAuthSchemes());
 		$this->assertEquals($auth, $backend->getLegacyAuthMechanism());
+
+		$dependencies = $backend->checkDependencies();
+		$this->assertCount(1, $dependencies);
+		$this->assertEquals('abc', $dependencies[0]->getDependency());
+		$this->assertEquals('foobar', $dependencies[0]->getMessage());
 
 		$parameters = $backend->getParameters();
 		$this->assertEquals('Text field', $parameters['textfield']->getText());

--- a/apps/files_external/tests/backend/legacybackendtest.php
+++ b/apps/files_external/tests/backend/legacybackendtest.php
@@ -92,4 +92,22 @@ class LegacyBackendTest extends \Test\TestCase {
 		$this->assertEquals(DefinitionParameter::FLAG_OPTIONAL, $parameters['optionalpassword']->getFlags());
 	}
 
+	public function testNoDependencies() {
+		$auth = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\Builtin')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$class = '\OCA\Files_External\Tests\Backend\LegacyBackendTest';
+		$definition = [
+			'configuration' => [
+			],
+			'backend' => 'Backend text',
+		];
+
+		$backend = new LegacyBackend($class, $definition, $auth);
+
+		$dependencies = $backend->checkDependencies();
+		$this->assertCount(0, $dependencies);
+	}
+
 }

--- a/apps/files_external/tests/legacydependencycheckpolyfilltest.php
+++ b/apps/files_external/tests/legacydependencycheckpolyfilltest.php
@@ -23,16 +23,23 @@ namespace OCA\Files_External\Tests;
 
 use \OCA\Files_External\Lib\MissingDependency;
 
-class DependencyTraitTest extends \Test\TestCase {
+class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
+
+	/**
+	 * @return MissingDependency[]
+	 */
+	public static function checkDependencies() {
+		return [
+			(new MissingDependency('dependency'))->setMessage('missing dependency'),
+			(new MissingDependency('program'))->setMessage('cannot find program'),
+		];
+	}
 
 	public function testCheckDependencies() {
-		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\DependencyTrait');
-		$trait->setDependencyCheck(function() {
-			return [
-				(new MissingDependency('dependency'))->setMessage('missing dependency'),
-				(new MissingDependency('program'))->setMessage('cannot find program'),
-			];
-		});
+		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\LegacyDependencyCheckPolyfill');
+		$trait->expects($this->once())
+			->method('getStorageClass')
+			->willReturn('\OCA\Files_External\Tests\LegacyDependencyCheckPolyfillTest');
 
 		$dependencies = $trait->checkDependencies();
 		$this->assertCount(2, $dependencies);


### PR DESCRIPTION
Replace `->setDependencyCheck(callable)` with a real method `checkDependencies()`. Easy support for legacy dependency checks is provided by LegacyDependencyCheckPolyfill.

So, any backend that was using `->setDependencyCheck('\Storage\Class::checkDependencies')` now just needs the following instead:

```
use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;

class MyBackend {
    use LegacyDependencyCheckPolyfill;
    ...
}
```

cc @jmaciasportela 

Please review @icewind1991 @PVince81 @MorrisJobke 
