### PR TITLE
Introduce mimetype DB update occ command

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -47,6 +47,7 @@ class Shared_Cache extends Cache {
 	 * @param \OC\Files\Storage\Shared $storage
 	 */
 	public function __construct($storage) {
+		parent::__construct($storage);
 		$this->storage = $storage;
 	}
 
@@ -94,6 +95,7 @@ class Shared_Cache extends Cache {
 	 * @return array|false
 	 */
 	public function get($file) {
+		$mimetypeLoader = \OC::$server->getMimeTypeLoader();
 		if (is_string($file)) {
 			$cache = $this->getSourceCache($file);
 			if ($cache) {
@@ -130,8 +132,8 @@ class Shared_Cache extends Cache {
 			$data['mtime'] = (int)$data['mtime'];
 			$data['storage_mtime'] = (int)$data['storage_mtime'];
 			$data['encrypted'] = (bool)$data['encrypted'];
-			$data['mimetype'] = $this->getMimetype($data['mimetype']);
-			$data['mimepart'] = $this->getMimetype($data['mimepart']);
+			$data['mimetype'] = $mimetypeLoader->getMimetypeById($data['mimetype']);
+			$data['mimepart'] = $mimetypeLoader->getMimetypeById($data['mimepart']);
 			if ($data['storage_mtime'] === 0) {
 				$data['storage_mtime'] = $data['mtime'];
 			}

--- a/core/command/maintenance/mimetype/updatedb.php
+++ b/core/command/maintenance/mimetype/updatedb.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace OC\Core\Command\Maintenance\Mimetype;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+use OCP\Files\IMimeTypeDetector;
+use OCP\Files\IMimeTypeLoader;
+
+class UpdateDB extends Command {
+
+	const DEFAULT_MIMETYPE = 'application/octet-stream';
+
+	/** @var IMimeTypeDetector */
+	protected $mimetypeDetector;
+
+	/** @var IMimeTypeLoader */
+	protected $mimetypeLoader;
+
+	public function __construct(
+		IMimeTypeDetector $mimetypeDetector,
+		IMimeTypeLoader $mimetypeLoader
+	) {
+		parent::__construct();
+		$this->mimetypeDetector = $mimetypeDetector;
+		$this->mimetypeLoader = $mimetypeLoader;
+	}
+
+	protected function configure() {
+		$this
+			->setName('maintenance:mimetype:update-db')
+			->setDescription('Update database mimetypes and update filecache')
+			->addOption(
+				'repair-filecache',
+				null,
+				InputOption::VALUE_NONE,
+				'Repair filecache for all mimetypes, not just new ones'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$mappings = $this->mimetypeDetector->getAllMappings();
+
+		$totalFilecacheUpdates = 0;
+		$totalNewMimetypes = 0;
+
+		foreach ($mappings as $ext => $mimetypes) {
+			if ($ext[0] === '_') {
+				// comment
+				continue;
+			}
+			$mimetype = $mimetypes[0];
+			$existing = $this->mimetypeLoader->exists($mimetype);
+			// this will add the mimetype if it didn't exist
+			$mimetypeId = $this->mimetypeLoader->getId($mimetype);
+
+			if (!$existing) {
+				$output->writeln('Added mimetype "'.$mimetype.'" to database');
+				$totalNewMimetypes++;
+			}
+
+			if (!$existing || $input->getOption('repair-filecache')) {
+				$touchedFilecacheRows = $this->mimetypeLoader->updateFilecache($ext, $mimetypeId);
+				if ($touchedFilecacheRows > 0) {
+					$output->writeln('Updated '.$touchedFilecacheRows.' filecache rows for mimetype "'.$mimetype.'"');
+				}
+				$totalFilecacheUpdates += $touchedFilecacheRows;
+			}
+		}
+
+		$output->writeln('Added '.$totalNewMimetypes.' new mimetypes');
+		$output->writeln('Updated '.$totalFilecacheUpdates.' filecache rows');
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -79,10 +79,11 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
 
+	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
+	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\Repair(new \OC\Repair(\OC\Repair::getRepairSteps()), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig()));
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -79,10 +79,10 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
 
-	$application->add(new OC\Core\Command\Maintenance\MimeTypesJS());
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\Repair(new \OC\Repair(\OC\Repair::getRepairSteps()), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig()));
 

--- a/lib/private/files/type/detection.php
+++ b/lib/private/files/type/detection.php
@@ -6,6 +6,7 @@
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Tanghus <thomas@tanghus.net>
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -101,13 +102,20 @@ class Detection implements IMimeTypeDetector {
 			return;
 		}
 
-		$file = file_get_contents($this->configDir . '/mimetypealiases.dist.json');
-		$this->mimeTypeAlias = get_object_vars(json_decode($file));
+		$this->mimeTypeAlias = json_decode(file_get_contents($this->configDir . '/mimetypealiases.dist.json'), true);
 
 		if (file_exists($this->configDir . '/mimetypealiases.json')) {
-			$custom = get_object_vars(json_decode(file_get_contents($this->configDir . '/mimetypealiases.json')));
+			$custom = json_decode(file_get_contents($this->configDir . '/mimetypealiases.json'), true);
 			$this->mimeTypeAlias = array_merge($this->mimeTypeAlias, $custom);
 		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAllAliases() {
+		$this->loadAliases();
+		return $this->mimeTypeAlias;
 	}
 
 	/**
@@ -118,17 +126,23 @@ class Detection implements IMimeTypeDetector {
 			return;
 		}
 
-		$dist = file_get_contents($this->configDir . '/mimetypemapping.dist.json');
-		$mimetypemapping = get_object_vars(json_decode($dist));
+		$mimetypemapping = json_decode(file_get_contents($this->configDir . '/mimetypemapping.dist.json'), true);
 
 		//Check if need to load custom mappings
 		if (file_exists($this->configDir . '/mimetypemapping.json')) {
-			$custom = file_get_contents($this->configDir . '/mimetypemapping.json');
-			$custom_mapping = get_object_vars(json_decode($custom));
-			$mimetypemapping = array_merge($mimetypemapping, $custom_mapping);
+			$custom = json_decode(file_get_contents($this->configDir . '/mimetypemapping.json'), true);
+			$mimetypemapping = array_merge($mimetypemapping, $custom);
 		}
 
 		$this->registerTypeArray($mimetypemapping);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAllMappings() {
+		$this->loadMappings();
+		return $this->mimetypes;
 	}
 
 	/**

--- a/lib/private/files/type/loader.php
+++ b/lib/private/files/type/loader.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Type;
+
+use OCP\Files\IMimeTypeLoader;
+use OCP\IDBConnection;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+
+/**
+ * Mimetype database loader
+ *
+ * @package OC\Files\Type
+ */
+class Loader implements IMimeTypeLoader {
+
+	/** @var IDBConnection */
+	private $dbConnection;
+
+	/** @var array [id => mimetype] */
+	protected $mimetypes;
+
+	/** @var array [mimetype => id] */
+	protected $mimetypeIds;
+
+	/**
+	 * @param IDBConnection $dbConnection
+	 */
+	public function __construct(IDBConnection $dbConnection) {
+		$this->dbConnection = $dbConnection;
+		$this->mimetypes = [];
+		$this->mimetypeIds = [];
+	}
+
+	/**
+	 * Get a mimetype from its ID
+	 *
+	 * @param int $id
+	 * @return string|null
+	 */
+	public function getMimetypeById($id) {
+		if (!$this->mimetypes) {
+			$this->loadMimetypes();
+		}
+		if (isset($this->mimetypes[$id])) {
+			return $this->mimetypes[$id];
+		}
+		return null;
+	}
+
+	/**
+	 * Get a mimetype ID, adding the mimetype to the DB if it does not exist
+	 *
+	 * @param string $mimetype
+	 * @return int
+	 */
+	public function getId($mimetype) {
+		if (!$this->mimetypeIds) {
+			$this->loadMimetypes();
+		}
+		if (isset($this->mimetypeIds[$mimetype])) {
+			return $this->mimetypeIds[$mimetype];
+		}
+		return $this->store($mimetype);
+	}
+
+	/**
+	 * Test if a mimetype exists in the database
+	 *
+	 * @param string $mimetype
+	 * @return bool
+	 */
+	public function exists($mimetype) {
+		if (!$this->mimetypeIds) {
+			$this->loadMimetypes();
+		}
+		return isset($this->mimetypeIds[$mimetype]);
+	}
+
+	/**
+	 * Store a mimetype in the DB
+	 *
+	 * @param string $mimetype
+	 * @param int inserted ID
+	 */
+	protected function store($mimetype) {
+		try {
+			$qb = $this->dbConnection->getQueryBuilder();
+			$qb->insert('mimetypes')
+				->values([
+					'mimetype' => $qb->createNamedParameter($mimetype)
+				]);
+			$qb->execute();
+		} catch (UniqueConstraintViolationException $e) {
+			// something inserted it before us
+		}
+
+		$fetch = $this->dbConnection->getQueryBuilder();
+		$fetch->select('id')
+			->from('mimetypes')
+			->where(
+				$fetch->expr()->eq('mimetype', $fetch->createNamedParameter($mimetype)
+			));
+		$row = $fetch->execute()->fetch();
+
+		$this->mimetypes[$row['id']] = $mimetype;
+		$this->mimetypeIds[$mimetype] = $row['id'];
+		return $row['id'];
+	}
+
+	/**
+	 * Load all mimetypes from DB
+	 */
+	private function loadMimetypes() {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->select('id', 'mimetype')
+			->from('mimetypes');
+		$results = $qb->execute()->fetchAll();
+
+		foreach ($results as $row) {
+			$this->mimetypes[$row['id']] = $row['mimetype'];
+			$this->mimetypeIds[$row['mimetype']] = $row['id'];
+		}
+	}
+
+	/**
+	 * Update filecache mimetype based on file extension
+	 *
+	 * @param string $ext file extension
+	 * @param int $mimetypeId
+	 * @return int number of changed rows
+	 */
+	public function updateFilecache($ext, $mimetypeId) {
+		$update = $this->dbConnection->getQueryBuilder();
+		$update->update('filecache')
+			->set('mimetype', $update->createNamedParameter($mimetypeId))
+			->where($update->expr()->neq(
+				'mimetype', $update->createNamedParameter($mimetypeId)
+			))
+			->andWhere($update->expr()->like(
+				$update->createFunction('LOWER(`name`)'), $update->createNamedParameter($ext)
+			));
+		return $update->execute();
+	}
+
+}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -470,6 +470,11 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getURLGenerator(),
 				\OC::$configDir);
 		});
+		$this->registerService('MimeTypeLoader', function(Server $c) {
+			return new \OC\Files\Type\Loader(
+				$c->getDatabaseConnection()
+			);
+		});
 		$this->registerService('CapabilitiesManager', function (Server $c) {
 			$manager = new \OC\CapabilitiesManager();
 			$manager->registerCapability(function() use ($c) {
@@ -1008,6 +1013,15 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getMimeTypeDetector() {
 		return $this->query('MimeTypeDetector');
+	}
+
+	/**
+	 * Get the MimeTypeLoader
+	 *
+	 * @return \OCP\Files\IMimeTypeLoader
+	 */
+	public function getMimeTypeLoader() {
+		return $this->query('MimeTypeLoader');
 	}
 
 	/**

--- a/lib/public/files/imimetypeloader.php
+++ b/lib/public/files/imimetypeloader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files;
+
+/**
+ * Interface IMimeTypeLoader
+ * @package OCP\Files
+ * @since 8.2.0
+ *
+ * Interface to load mimetypes
+ **/
+interface IMimeTypeLoader {
+
+	/**
+	 * Get a mimetype from its ID
+	 *
+	 * @param int $id
+	 * @return string|null
+	 * @since 8.2.0
+	 */
+	public function getMimetypeById($id);
+
+	/**
+	 * Get a mimetype ID, adding the mimetype to the DB if it does not exist
+	 *
+	 * @param string $mimetype
+	 * @return int
+	 * @since 8.2.0
+	 */
+	public function getId($mimetype);
+
+	/**
+	 * Test if a mimetype exists in the database
+	 *
+	 * @param string $mimetype
+	 * @return bool
+	 * @since 8.2.0
+	 */
+	public function exists($mimetype);
+}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -440,6 +440,14 @@ interface IServerContainer {
 	 */
 	public function getMimeTypeDetector();
 
+	/**
+	 * Get the MimeTypeLoader
+	 *
+	 * @return \OCP\Files\IMimeTypeLoader
+	 * @since 8.2.0
+	 */
+	public function getMimeTypeLoader();
+
 
 	/**
 	 * Get the EventDispatcher

--- a/tests/core/command/maintenance/mimetype/updatedbtest.php
+++ b/tests/core/command/maintenance/mimetype/updatedbtest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Maintenance\Mimetype;
+
+use OC\Core\Command\Maintenance\Mimetype\UpdateDB;
+use Test\TestCase;
+use OCP\Files\IMimeTypeDetector;
+use OCP\Files\IMimeTypeLoader;
+
+class UpdateDBTest extends TestCase {
+	/** @var IMimeTypeDetector */
+	protected $detector;
+	/** @var IMimeTypeLoader */
+	protected $loader;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleInput;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleOutput;
+
+	/** @var \Symfony\Component\Console\Command\Command */
+	protected $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->detector = $this->getMockBuilder('OC\Files\Type\Detection')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->loader = $this->getMockBuilder('OC\Files\Type\Loader')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->consoleInput = $this->getMock('Symfony\Component\Console\Input\InputInterface');
+		$this->consoleOutput = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+
+		$this->command = new UpdateDB($this->detector, $this->loader);
+	}
+
+	public function testNoop() {
+		$this->consoleInput->method('getOption')
+			->with('repair-filecache')
+			->willReturn(false);
+
+		$this->detector->expects($this->once())
+			->method('getAllMappings')
+			->willReturn([
+				'ext' => ['testing/existingmimetype']
+			]);
+		$this->loader->expects($this->once())
+			->method('exists')
+			->with('testing/existingmimetype')
+			->willReturn(true);
+
+		$this->loader->expects($this->never())
+			->method('updateFilecache');
+
+		$this->consoleOutput->expects($this->at(0))
+			->method('writeln')
+			->with('Added 0 new mimetypes');
+		$this->consoleOutput->expects($this->at(1))
+			->method('writeln')
+			->with('Updated 0 filecache rows');
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testAddMimetype() {
+		$this->consoleInput->method('getOption')
+			->with('repair-filecache')
+			->willReturn(false);
+
+		$this->detector->expects($this->once())
+			->method('getAllMappings')
+			->willReturn([
+				'ext' => ['testing/existingmimetype'],
+				'new' => ['testing/newmimetype']
+			]);
+		$this->loader->expects($this->exactly(2))
+			->method('exists')
+			->will($this->returnValueMap([
+				['testing/existingmimetype', true],
+				['testing/newmimetype', false],
+			]));
+		$this->loader->expects($this->exactly(2))
+			->method('getId')
+			->will($this->returnValueMap([
+				['testing/existingmimetype', 1],
+				['testing/newmimetype', 2],
+			]));
+
+		$this->loader->expects($this->once())
+			->method('updateFilecache')
+			->with('new', 2)
+			->willReturn(3);
+
+		$this->consoleOutput->expects($this->at(0))
+			->method('writeln')
+			->with('Added mimetype "testing/newmimetype" to database');
+		$this->consoleOutput->expects($this->at(1))
+			->method('writeln')
+			->with('Updated 3 filecache rows for mimetype "testing/newmimetype"');
+
+		$this->consoleOutput->expects($this->at(2))
+			->method('writeln')
+			->with('Added 1 new mimetypes');
+		$this->consoleOutput->expects($this->at(3))
+			->method('writeln')
+			->with('Updated 3 filecache rows');
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testSkipComments() {
+		$this->detector->expects($this->once())
+			->method('getAllMappings')
+			->willReturn([
+				'_comment' => 'some comment in the JSON'
+			]);
+		$this->loader->expects($this->never())
+			->method('exists');
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testRepairFilecache() {
+		$this->consoleInput->method('getOption')
+			->with('repair-filecache')
+			->willReturn(true);
+
+		$this->detector->expects($this->once())
+			->method('getAllMappings')
+			->willReturn([
+				'ext' => ['testing/existingmimetype'],
+			]);
+		$this->loader->expects($this->exactly(1))
+			->method('exists')
+			->will($this->returnValueMap([
+				['testing/existingmimetype', true],
+			]));
+		$this->loader->expects($this->exactly(1))
+			->method('getId')
+			->will($this->returnValueMap([
+				['testing/existingmimetype', 1],
+			]));
+
+		$this->loader->expects($this->once())
+			->method('updateFilecache')
+			->with('ext', 1)
+			->willReturn(3);
+
+		$this->consoleOutput->expects($this->at(0))
+			->method('writeln')
+			->with('Updated 3 filecache rows for mimetype "testing/existingmimetype"');
+
+		$this->consoleOutput->expects($this->at(1))
+			->method('writeln')
+			->with('Added 0 new mimetypes');
+		$this->consoleOutput->expects($this->at(2))
+			->method('writeln')
+			->with('Updated 3 filecache rows');
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+}

--- a/tests/lib/files/type/loadertest.php
+++ b/tests/lib/files/type/loadertest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Type;
+
+use \OC\Files\Type\Loader;
+use \OCP\IDBConnection;
+
+class LoaderTest extends \Test\TestCase {
+	/** @var IDBConnection */
+	protected $db;
+	/** @var Loader */
+	protected $loader;
+
+	protected function setUp() {
+		$this->db = \OC::$server->getDatabaseConnection();
+		$this->loader = new Loader($this->db);
+	}
+
+	protected function tearDown() {
+		$deleteMimetypes = $this->db->getQueryBuilder();
+		$deleteMimetypes->delete('mimetypes')
+			->where($deleteMimetypes->expr()->like(
+				'mimetype', $deleteMimetypes->createPositionalParameter('testing/%')
+			));
+		$deleteMimetypes->execute();
+	}
+
+
+	public function testGetMimetype() {
+		$qb = $this->db->getQueryBuilder();
+		$qb->insert('mimetypes')
+			->values([
+				'mimetype' => $qb->createPositionalParameter('testing/mymimetype')
+			]);
+		$qb->execute();
+
+		$this->assertTrue($this->loader->exists('testing/mymimetype'));
+		$mimetypeId = $this->loader->getId('testing/mymimetype');
+		$this->assertNotNull($mimetypeId);
+
+		$mimetype = $this->loader->getMimetypeById($mimetypeId);
+		$this->assertEquals('testing/mymimetype', $mimetype);
+	}
+
+	public function testGetNonexistentMimetype() {
+		$this->assertFalse($this->loader->exists('testing/nonexistent'));
+		// hopefully this ID doesn't exist
+		$this->assertNull($this->loader->getMimetypeById(12345));
+	}
+
+	public function testStore() {
+		$this->assertFalse($this->loader->exists('testing/mymimetype'));
+		$mimetypeId = $this->loader->getId('testing/mymimetype');
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('mimetype')
+			->from('mimetypes')
+			->where($qb->expr()->eq('id', $qb->createPositionalParameter($mimetypeId)));
+
+		$mimetype = $qb->execute()->fetch();
+		$this->assertEquals('testing/mymimetype', $mimetype['mimetype']);
+
+		$this->assertEquals('testing/mymimetype', $this->loader->getMimetypeById($mimetypeId));
+		$this->assertEquals($mimetypeId, $this->loader->getId('testing/mymimetype'));
+	}
+
+	public function testStoreExists() {
+		$mimetypeId = $this->loader->getId('testing/mymimetype');
+		$mimetypeId2 = $this->loader->getId('testing/mymimetype');
+
+		$this->assertEquals($mimetypeId, $mimetypeId2);
+	}
+
+}


### PR DESCRIPTION
This occ command allows mimetypes in the database to be updated from changed mimetypes in config/mimetypemapping.json. By default, it adds any new mimetypes it finds and updates the filecache based on those, but with an option it can scan all existing mimetypes to update mimetypes on files.

For example, you add a new mapping of '.foo' to 'application/foobar', but your existing '.foo' files still have the 'application/octet-stream' mimetype since they were uploaded before. Run `./occ maintenance:mimetype:update-db` to update this. Or, if the 'application/foobar' mimetype already existed, `./occ maintenance:mimetype:update-db --repair-filecache` (will be a lot slower for big filecaches!).

Please review @rullzer @icewind1991 @MorrisJobke @PVince81 @icewind1991 @DeepDiver1975 

cc @carlaschroder for documentation around the new occ command, and rename of the maintenance:mimetypesjs command to maintenance:mimetype:update-js

Fixes #17625
