### PR TITLE
Delay adding OCS prefix to route collection until all is loaded

### DIFF
--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -169,8 +169,9 @@ class Router implements IRouter {
 			$this->useCollection('root');
 			require_once 'settings/routes.php';
 			require_once 'core/routes.php';
-
-			// include ocs routes
+		}
+		if ($this->loaded) {
+			// include ocs routes, must be loaded last for /ocs prefix
 			require_once 'ocs/routes.php';
 			$collection = $this->getCollection('ocs');
 			$collection->addPrefix('/ocs');


### PR DESCRIPTION
`->addPrefix()` iterates over all registered routes, so must be run after all apps have had a chance to load their OCS routes.

To test (other than making sure everything isn't broken):
1. Install the Gallery app
2. Use netcat to send the file at the bottom of the issue to the web server (`netcat localhost 80 < file`)
3. Before this PR, notice the failure
4. After the PR, notice the success

cc @oparoz @PVince81 @LukasReschke @icewind1991 @MorrisJobke @nickvergessen 

Fixes #18428 

Raw HTTP to netcat (tries to create a user via the provisioning API). Replace the Host header as necessary, and get the base64 of your admin username/password (`username:password`):

```
POST /owncloud/ocs/v1.php/cloud/users HTTP/1.1
Host: localhost
Content-Type: application/x-www-form-urlencoded
Content-Length: 41
Connection: close
Authorization: Basic base64-encoded-username-password

userid=BlueDragon&password=testBlueDragon
```
