### PR TITLE
Simplify occ and cron.php checks to allow more usecases

### DIFF
--- a/console.php
+++ b/console.php
@@ -45,22 +45,12 @@ try {
 
 	if (!OC::$CLI) {
 		echo "This script can be run from the command line only" . PHP_EOL;
-		exit(0);
+		exit(1);
 	}
 
-	if (!OC_Util::runningOnWindows())  {
-		if (!function_exists('posix_getuid')) {
-			echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
-			exit(0);
-		}
-		$user = posix_getpwuid(posix_getuid());
-		$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
-		if ($user['name'] !== $configUser['name']) {
-			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-			echo "Current user: " . $user['name'] . PHP_EOL;
-			echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
-			exit(0);
-		}
+	if (!is_writable(\OC::$configDir . 'config.php')) {
+		echo "Console has to be executed with a user that can write to config.php" . PHP_EOL;
+		exit(1);
 	}
 
 	$application = new Application(\OC::$server->getConfig());

--- a/cron.php
+++ b/cron.php
@@ -82,19 +82,9 @@ try {
 		set_time_limit(0);
 
 		// the cron job must be executed with the right user
-		if (!OC_Util::runningOnWindows())  {
-			if (!function_exists('posix_getuid')) {
-				echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
-				exit(0);
-			}
-			$user = posix_getpwuid(posix_getuid());
-			$configUser = posix_getpwuid(fileowner(OC::$SERVERROOT . '/config/config.php'));
-			if ($user['name'] !== $configUser['name']) {
-				echo "Console has to be executed with the same user as the web server is operated" . PHP_EOL;
-				echo "Current user: " . $user['name'] . PHP_EOL;
-				echo "Web server user: " . $configUser['name'] . PHP_EOL;
-				exit(0);
-			}
+		if (!is_writable(\OC::$configDir.'/config.php')) {
+			echo "Console has to be executed with a user that can write to config.php" . PHP_EOL;
+			exit(1);
 		}
 
 		$config = OC::$server->getConfig();


### PR DESCRIPTION
The current code only allows for the usecase where config.php is owned by the web server user. This is too restrictive, as ownCloud can operate perfectly normally when config.php is owned by some other user, usually root, but the web server has write permission to it (either through group or via extended ACLs). This PR changes the check to a straightforward `is_writable()`.

Analysing the potential cases:

config.php is owned by the web server with 0600 file mode (default installation), any console run as the web server is OK. If the occ is run as root, it also succeeds, but this is by design to allow certain operations to be run as root and modify the server code (which is usually all owned by root to prevent attacks). An example of such a command is maintenance:mimetypesjs, which writes to /core/js/mimetypelist.js.

config.php is owned by root (or some other non-web server user), but the web server has write permissions by group membership or by extended ACLs. Running occ as the real web server user would have failed, since the users don't match, but now succeeds as the `is_writable()` check passes.

Any other case involves config.php not being writable by users other than root and the web server user (unless the admin is running a really advanced set up), so occ and cron will refuse to run as any other user.

Fixes #18470 

cc @DeepDiver1975 @PVince81 @icewind1991 @mattcaron @MorrisJobke 
