### PR TITLE
[WIP] [PoC] Make the application class the main entry point for an app

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -122,31 +122,8 @@ class OC_App {
 	 * @throws \OC\NeedsUpdateException
 	 */
 	public static function loadApp($app, $checkUpgrade = true) {
-		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
-			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
-			if ($checkUpgrade and self::shouldUpgrade($app)) {
-				throw new \OC\NeedsUpdateException();
-			}
-			self::requireAppFile($app);
-			if (self::isType($app, array('authentication'))) {
-				// since authentication apps affect the "is app enabled for group" check,
-				// the enabled apps cache needs to be cleared to make sure that the
-				// next time getEnableApps() is called it will also include apps that were
-				// enabled for groups
-				self::$enabledAppsCache = array();
-			}
-			\OC::$server->getEventLogger()->end('load_app_' . $app);
-		}
-	}
-
-	/**
-	 * Load app.php from the given app
-	 *
-	 * @param string $app app name
-	 */
-	private static function requireAppFile($app) {
-		// encapsulated here to avoid variable scope conflicts
-		require_once $app . '/appinfo/app.php';
+		$appLoader = \OC::$server->getAppLoader();
+		$appLoader->loadApp($app);
 	}
 
 	/**

--- a/lib/private/app/apploader.php
+++ b/lib/private/app/apploader.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\App;
+
+use OCP\Diagnostics\IEventLogger;
+use OC\NeedsUpdateException;
+use OCP\AppFramework\App;
+
+class AppLoader {
+	/**
+	 * @var \OCP\Diagnostics\IEventLogger
+	 */
+	private $eventLogger;
+
+	/**
+	 * @var \OCP\AppFramework\App[]
+	 */
+	private $loadedApps = [];
+
+	/**
+	 * @param \OCP\Diagnostics\IEventLogger $eventLogger
+	 */
+	public function __construct(IEventLogger $eventLogger) {
+		$this->eventLogger = $eventLogger;
+	}
+
+	/**
+	 * Load the app and return the Application instance
+	 *
+	 * @param string $appId
+	 * @return \OCP\AppFramework\App
+	 * @throws \OC\NeedsUpdateException
+	 */
+	public function loadApp($appId) {
+		if (isset($this->loadedApps[$appId])) {
+			return $this->loadedApps[$appId];
+		}
+		$this->eventLogger->start('load_app_' . $appId, 'Load app: ' . $appId);
+		if (\OC_App::shouldUpgrade($appId)) {
+			throw new NeedsUpdateException();
+		}
+		$appClass = $this->getApplicationClassName($appId);
+		$this->loadedApps[$appId] = new $appClass($appId);
+		return $this->loadedApps[$appId];
+	}
+
+	private function getApplicationClassName($appId) {
+		$appPath = $this->getAppPath($appId);
+		$base = '\OCP\AppFramework\App';
+		if (!file_exists($appPath . '/appinfo/application.php')) {
+			return $base;
+		} else {
+			$class = App::buildAppNamespace($appId) . '/Application';
+			if (class_exists($class) && is_subclass_of($class, $base)) {
+				return $class;
+			} else {
+				return $base;
+			}
+		}
+	}
+
+	/**
+	 * Get the directory for the given app.
+	 * If the app is defined in multiple directories, the first one is taken. (false if not found)
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 */
+	public function getAppPath($appId) {
+		return \OC_App::getAppPath($appId);
+	}
+}

--- a/lib/private/app/apploader.php
+++ b/lib/private/app/apploader.php
@@ -44,6 +44,19 @@ class AppLoader {
 	}
 
 	/**
+	 * Retrieve an app Application instance
+	 *
+	 * @param string $appId
+	 * @return \OCP\AppFramework\App|null
+	 */
+	public function getApp($appId) {
+		if (isset($this->loadedApps[$appId])) {
+			return $this->loadedApps[$appId];
+		}
+		return null;
+	}
+
+	/**
 	 * Load the app and return the Application instance
 	 *
 	 * @param string $appId

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -501,7 +501,8 @@ class OC_Installer{
 			if($dir = opendir( $app_dir['path'] )) {
 				while( false !== ( $filename = readdir( $dir ))) {
 					if( substr( $filename, 0, 1 ) != '.' and is_dir($app_dir['path']."/$filename") ) {
-						if( file_exists( $app_dir['path']."/$filename/appinfo/app.php" )) {
+						if( file_exists( $app_dir['path']."/$filename/appinfo/app.php") ||
+							file_exists($app_dir['path'] . "/$filename/appinfo/application.php")) {
 							if(!OC_Installer::isInstalled($filename)) {
 								$info=OC_App::getAppInfo($filename);
 								$enabled = isset($info['default_enable']);

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -367,6 +367,11 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getMemCacheFactory()
 			);
 		});
+		$this->registerService('AppLoader', function (Server $c) {
+			return new \OC\App\AppLoader(
+				$c->getEventLogger()
+			);
+		});
 		$this->registerService('DateTimeZone', function(Server $c) {
 			return new DateTimeZone(
 				$c->getConfig(),
@@ -911,6 +916,15 @@ class Server extends SimpleContainer implements IServerContainer {
 	 */
 	public function getAppManager() {
 		return $this->query('AppManager');
+	}
+
+	/**
+	 * Get the app loader
+	 *
+	 * @return \OCP\App\IAppLoader
+	 */
+	public function getAppLoader() {
+		return $this->query('AppLoader');
 	}
 
 	/**

--- a/lib/public/app/iapploader.php
+++ b/lib/public/app/iapploader.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\App;
+
+interface IAppLoader {
+	/**
+	 * Load the app and return the Application instance
+	 *
+	 * @param string $appId
+	 * @return \OCP\AppFramework\App
+	 */
+	public function loadApp($appId);
+}

--- a/lib/public/app/iapploader.php
+++ b/lib/public/app/iapploader.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Robin Appelman <icewind@owncloud.com>
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
  * @license AGPL-3.0
@@ -21,12 +22,28 @@
 
 namespace OCP\App;
 
+/**
+ * Application loader
+ *
+ * @since 8.2.0
+ */
 interface IAppLoader {
+
+	/**
+	 * Retrieve an app Application instance
+	 *
+	 * @param string $appId
+	 * @return \OCP\AppFramework\App|null
+	 * @since 8.2.0
+	 */
+	public function getApp($appId);
+
 	/**
 	 * Load the app and return the Application instance
 	 *
 	 * @param string $appId
 	 * @return \OCP\AppFramework\App
+	 * @since 8.2.0
 	 */
 	public function loadApp($appId);
 }

--- a/lib/public/appframework/app.php
+++ b/lib/public/appframework/app.php
@@ -64,6 +64,19 @@ class App {
 	 */
 	public function __construct($appName, $urlParams = array()) {
 		$this->container = new \OC\AppFramework\DependencyInjection\DIContainer($appName, $urlParams);
+		$this->loadAppPhp($appName);
+	}
+
+	/**
+	 * Load app.php if exists for backwards compatibility
+	 *
+	 * @param string $appId
+	 */
+	private function loadAppPhp($appId) {
+		$appDir = \OC_App::getAppPath($appId);
+		if (file_exists($appDir . '/appinfo/app.php')) {
+			require_once $appDir . '/appinfo/app.php';
+		}
 	}
 
 	private $container;

--- a/lib/public/appframework/app.php
+++ b/lib/public/appframework/app.php
@@ -29,6 +29,8 @@
  */
 
 namespace OCP\AppFramework;
+
+use OCP\Route\IRouter;
 use OC\AppFramework\routing\RouteConfig;
 
 
@@ -36,12 +38,52 @@ use OC\AppFramework\routing\RouteConfig;
  * Class App
  * @package OCP\AppFramework
  *
- * Any application must inherit this call - all controller instances to be used are
+ * All applications must inherit this class - all controller instances to be used are
  * to be registered using IContainer::registerService
  * @since 6.0.0
  */
 class App {
 
+	/** @var string */
+	protected $appName;
+
+	/**
+	 * Initialize application
+	 * Override me to do custom initialization
+	 *
+	 * @param string $appName
+	 * @param array $urlParams an array with variables extracted from the routes
+	 * @since 6.0.0
+	 */
+	public function __construct($appName, $urlParams = array()) {
+		$this->appName = $appName;
+		$this->container = new \OC\AppFramework\DependencyInjection\DIContainer($appName, $urlParams);
+		$this->loadAppPhp();
+	}
+
+	/**
+	 * Load application routes
+	 * Override me to add your routes
+	 *
+	 * @param IRouter $router
+	 * @since 8.2.0
+	 */
+	public function loadRoutes(IRouter $router) {
+		$path = \OC_App::getAppPath($this->appName) . '/appinfo/routes.php';
+		if (file_exists($path)) {
+			$router->loadLegacyAppRoutes($path, $this);
+		}
+	}
+
+	/**
+	 * Load app.php if exists for backwards compatibility
+	 */
+	private function loadAppPhp() {
+		$path = \OC_App::getAppPath($this->appName) . '/appinfo/app.php';
+		if (file_exists($path)) {
+			require_once $path;
+		}
+	}
 
 	/**
 	 * Turns an app id into a namespace by convetion. The id is split at the
@@ -55,28 +97,6 @@ class App {
 	 */
 	public static function buildAppNamespace($appId, $topNamespace='OCA\\') {
 		return \OC\AppFramework\App::buildAppNamespace($appId, $topNamespace);
-	}
-
-
-	/**
-	 * @param array $urlParams an array with variables extracted from the routes
-	 * @since 6.0.0
-	 */
-	public function __construct($appName, $urlParams = array()) {
-		$this->container = new \OC\AppFramework\DependencyInjection\DIContainer($appName, $urlParams);
-		$this->loadAppPhp($appName);
-	}
-
-	/**
-	 * Load app.php if exists for backwards compatibility
-	 *
-	 * @param string $appId
-	 */
-	private function loadAppPhp($appId) {
-		$appDir = \OC_App::getAppPath($appId);
-		if (file_exists($appDir . '/appinfo/app.php')) {
-			require_once $appDir . '/appinfo/app.php';
-		}
 	}
 
 	private $container;
@@ -103,11 +123,11 @@ class App {
 	 * $a = new TasksApp();
 	 * $a->registerRoutes($this, $routes);
 	 *
-	 * @param \OCP\Route\IRouter $router
+	 * @param IRouter $router
 	 * @param array $routes
 	 * @since 6.0.0
 	 */
-	public function registerRoutes($router, $routes) {
+	public function registerRoutes(IRouter $router, $routes) {
 		$routeConfig = new RouteConfig($this->container, $router, $routes);
 		$routeConfig->register();
 	}

--- a/lib/public/iservercontainer.php
+++ b/lib/public/iservercontainer.php
@@ -384,6 +384,14 @@ interface IServerContainer {
 	public function getAppManager();
 
 	/**
+	 * Get the app loader
+	 *
+	 * @return \OCP\App\IAppLoader
+	 * @since 8.2.0
+	 */
+	public function getAppLoader();
+
+	/**
 	 * Get the webroot
 	 *
 	 * @return string

--- a/lib/public/route/irouter.php
+++ b/lib/public/route/irouter.php
@@ -37,6 +37,7 @@ interface IRouter {
 	 *
 	 * @return string[]
 	 * @since 7.0.0
+	 * @deprecated 8.2.0 routes are loaded in Application
 	 */
 	public function getRoutingFiles();
 


### PR DESCRIPTION
First step of the "kill app.php" plan.

Instead of loading `app.php` when loading an app we create an instance of the `Application` class for the app, which in turn loads app.php if it exists

The next steps would be to move all the code that's currently in app.php to various methods in the Application class(`getRoutes`, `getAppNavigation`, `setupFileSystem`, etc) so we can finally stop doing to much while loading apps which has been the cause of a large amount of breakage over the past.

cc @Xenopathic @DeepDiver1975 @PVince81 @MorrisJobke @Raydiation
