### PR TITLE
enable transational locking by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1053,17 +1053,15 @@ $CONFIG = array(
 
 /**
  * Enables transactional file locking.
- * This is disabled by default as it is still beta.
+ * This is enabled by default.
  *
  * Prevents concurrent processes from accessing the same files
  * at the same time. Can help prevent side effects that would
  * be caused by concurrent operations. Mainly relevant for
  * very large installations with many users working with
  * shared files.
- *
- * WARNING: BETA quality
  */
-'filelocking.enabled' => false,
+'filelocking.enabled' => true,
 
 /**
  * Memory caching backend for file locking

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -451,13 +451,13 @@ class Server extends SimpleContainer implements IServerContainer {
 			);
 		});
 		$this->registerService('LockingProvider', function (Server $c) {
-			if ($c->getConfig()->getSystemValue('filelocking.enabled', false) or (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
+			if ($c->getConfig()->getSystemValue('filelocking.enabled', true) or (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				/** @var \OC\Memcache\Factory $memcacheFactory */
 				$memcacheFactory = $c->getMemCacheFactory();
 				$memcache = $memcacheFactory->createLocking('lock');
-//				if (!($memcache instanceof \OC\Memcache\NullCache)) {
-//					return new MemcacheLockingProvider($memcache);
-//				}
+				if (!($memcache instanceof \OC\Memcache\NullCache)) {
+					return new MemcacheLockingProvider($memcache);
+				}
 				return new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger());
 			}
 			return new NoopLockingProvider();


### PR DESCRIPTION
Also fixes memcache locking backend not being used due to debug work that was commited.

cc @DeepDiver1975 @PVince81 @MorrisJobke @Xenopathic 
