### PR TITLE
Allow forcing upgrades with occ, enabled by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -791,6 +791,13 @@ $CONFIG = array(
  */
 'singleuser' => false,
 
+/**
+ * Force use of occ for upgrades. Highly recommended for larger installations,
+ * as the web upgrader suffers from PHP timeouts. Disabling is useful for
+ * shared hosters where occ upgrades are not possible.
+ */
+'upgrade.forceocc' => true,
+
 
 /**
  * SSL

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -37,6 +37,13 @@ $eventSource = \OC::$server->createEventSource();
 $eventSource->send('success', (string)$l->t('Preparing update'));
 
 if (OC::checkUpgrade(false)) {
+	$config = \OC::$server->getSystemConfig();
+	if ($config->getValue('upgrade.forceocc', true)) {
+		$eventSource->send('failure', (string)$l->t('Upgrading must be done with the command line tool'));
+		$eventSource->close();
+		exit();
+	}
+
 	// if a user is currently logged in, their session must be ignored to
 	// avoid side effects
 	\OC_User::setIncognitoMode(true);

--- a/core/templates/update.occ.php
+++ b/core/templates/update.occ.php
@@ -1,0 +1,10 @@
+<div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
+	<div class="updateOverview">
+		<h2 class="title bold"><?php p($l->t('%s requires an update to version %s',
+			array($_['productName'], $_['version']))); ?></h2>
+		<div class="infogroup">
+			<?php p($l->t('Upgrading must be done with the command line tool:')) ?>
+			<pre>./occ upgrade</pre>
+		</div>
+	</div>
+</div>

--- a/core/templates/update.occ.php
+++ b/core/templates/update.occ.php
@@ -3,8 +3,12 @@
 		<h2 class="title bold"><?php p($l->t('%s requires an update to version %s',
 			array($_['productName'], $_['version']))); ?></h2>
 		<div class="infogroup">
-			<?php p($l->t('Upgrading must be done with the command line tool:')) ?>
+			<?php p($l->t('A configuration option has disabled the web upgrader, you must use the command line tool to upgrade:')) ?>
 			<pre>./occ upgrade</pre>
+		</div>
+		<div class="infogroup">
+			<?php p($l->t('Alternatively, where this is not possible, set the following parameter in config.php:')) ?>
+			<pre><?php p('"upgrade.forceocc" => false') // easy handling of special characters ?></pre>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Enabled by default, the web upgrader is disabled by the `upgrader.forceocc` config.php parameter. A message is displayed directing the admin to occ.

![screenshot_2015-09-02_18-27-06](https://cloud.githubusercontent.com/assets/2016878/9638766/3c1a7c04-51a0-11e5-838b-65279c481ae2.png)

(text wrapping is a bit rubbish)

Fixes #something (can't find, need food now)

cc @PVince81 @MorrisJobke @icewind1991 @DeepDiver1975
