### PR TITLE
use SVG for toggle image on installation instead of PNG

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -667,7 +667,7 @@ label.infield {
 	position: absolute !important;
 	height: 20px;
 	width: 24px;
-	background-image: url("../img/actions/toggle.png");
+	background-image: url('../img/actions/toggle.svg');
 	background-repeat: no-repeat;
 	background-position: center;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -53,7 +53,7 @@ script('core', [
 			<label for="adminpass" class="infield"><?php p($l->t( 'Password' )); ?></label>
 			<img class="svg" id="adminpass-icon" src="<?php print_unescaped(image_path('', 'actions/password.svg')); ?>" alt="">
 			<input type="checkbox" id="show" name="show">
-			<label for="show"></label>
+			<label for="show" class="svg"></label>
 			<div class="strengthify-wrapper"></div>
 		</p>
 	</fieldset>
@@ -149,7 +149,7 @@ script('core', [
 		</fieldset>
 		<?php endif; ?>
 	<?php endif; ?>
-	
+
 	<div class="icon-loading-dark float-spinner">&nbsp;</div>
 
 	<?php if(!$_['dbIsSet'] OR count($_['errors']) > 0): ?>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -83,7 +83,7 @@ if($_['passwordChangeSupported']) {
 		placeholder="<?php echo $l->t('New password');?>"
 		data-typetoggle="#personal-show"
 		autocomplete="off" autocapitalize="off" autocorrect="off" />
-	<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
+	<input type="checkbox" id="personal-show" name="show" /><label for="personal-show" class="svg"></label>
 	<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password');?>" />
 	<br/>
 	<div class="strengthify-wrapper"></div>


### PR DESCRIPTION
Currently, the icon would be pixelated when zoomed in or on retina. Switching it to SVG as all other icons, this one was probably just missed.

To test, check installation and look at the show-password toggle eye icon. Or also in the personal settings for the change password field.

Please review @owncloud/designers 
