### PR TITLE
Tags in FileInfo map must be an array

### DIFF
--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -150,7 +150,13 @@
 			var oldElementToFile = fileList.elementToFile;
 			fileList.elementToFile = function($el) {
 				var fileInfo = oldElementToFile.apply(this, arguments);
-				fileInfo.tags = $el.attr('data-tags') || [];
+				var tags = $el.attr('data-tags');
+				if (_.isUndefined(tags)) {
+					tags = '';
+				}
+				tags = tags.split('|');
+				tags = _.without(tags, '');
+				fileInfo.tags = tags;
 				return fileInfo;
 			};
 		},

--- a/apps/files/tests/js/tagspluginspec.js
+++ b/apps/files/tests/js/tagspluginspec.js
@@ -112,4 +112,19 @@ describe('OCA.Files.TagsPlugin tests', function() {
 			expect($action.find('img').attr('src')).toEqual(OC.imagePath('core', 'actions/star'));
 		});
 	});
+	describe('elementToFile', function() {
+		it('returns tags', function() {
+			fileList.setFiles(testFiles);
+			var $tr = fileList.findFileEl('One.txt');
+			var data = fileList.elementToFile($tr);
+			expect(data.tags).toEqual(['tag1', 'tag2']);
+		});
+		it('returns empty array when no tags present', function() {
+			delete testFiles[0].tags;
+			fileList.setFiles(testFiles);
+			var $tr = fileList.findFileEl('One.txt');
+			var data = fileList.elementToFile($tr);
+			expect(data.tags).toEqual([]);
+		});
+	});
 });


### PR DESCRIPTION
Fixes FileList.elementToFile to make an array for the tags instead of
keeping the original joined string

I don't remember how to reproduce it but the problem / warnings might reappear later with the versions tab: https://github.com/owncloud/core/pull/18748
The only thing I remember is that you need to have a file set as favorite and fiddle with the sidebar.

Please review the code change @icewind1991 @blizzz @MorrisJobke @nickvergessen 
