### PR TITLE
Delay setting up the filesystem for a share owner untill the share is used

### DIFF
--- a/apps/files_sharing/lib/mountprovider.php
+++ b/apps/files_sharing/lib/mountprovider.php
@@ -66,12 +66,6 @@ class MountProvider implements IMountProvider {
 			return $share['permissions'] > 0;
 		});
 		$shares = array_map(function ($share) use ($user, $storageFactory) {
-			try {
-				Filesystem::initMountPoints($share['uid_owner']);
-			} catch(NoUserException $e) {
-				\OC::$server->getLogger()->warning('The user \'' . $share['uid_owner'] . '\' of share with ID \'' . $share['id'] . '\' can\'t be retrieved.', array('app' => 'files_sharing'));
-				return null;
-			}
 			// for updating etags for the share owner when we make changes to this share.
 			$ownerPropagator = $this->propagationManager->getChangePropagator($share['uid_owner']);
 

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -55,6 +55,10 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 		$this->ownerView = $arguments['ownerView'];
 	}
 
+	private function init() {
+		Filesystem::initMountPoints($this->share['uid_owner']);
+	}
+
 	/**
 	 * get id of the mount point
 	 *
@@ -80,6 +84,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @return array Returns array with the keys path, permissions, and owner or false if not found
 	 */
 	public function getFile($target) {
+		$this->init();
 		if (!isset($this->files[$target])) {
 			// Check for partial files
 			if (pathinfo($target, PATHINFO_EXTENSION) === 'part') {
@@ -319,7 +324,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	}
 
 	public function rename($path1, $path2) {
-
+		$this->init();
 		// we need the paths relative to data/user/files
 		$relPath1 = $this->getMountPoint() . '/' . $path1;
 		$relPath2 = $this->getMountPoint() . '/' . $path2;

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -37,6 +37,7 @@
 
 namespace OC\Share;
 
+use OC\Files\Filesystem;
 use OCP\IUserSession;
 use OCP\IDBConnection;
 use OCP\IConfig;
@@ -120,6 +121,7 @@ class Share extends Constants {
 	 */
 	public static function getUsersSharingFile($path, $ownerUser, $includeOwner = false, $returnUserPaths = false) {
 
+		Filesystem::initMountPoints($ownerUser);
 		$shares = $sharePaths = $fileTargets = array();
 		$publicShare = false;
 		$remoteShare = false;


### PR DESCRIPTION
Saves having to setup multiple filesystems if a user has multiple shares

cc @PVince81 @MorrisJobke @Xenopathic 
