### PR TITLE
Set default mount options for external storages

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -756,6 +756,13 @@ MountConfigListView.prototype = _.extend({
 		$tr.append(priorityEl);
 		$td.children().not('[type=hidden]').first().focus();
 
+		// FIXME default backend mount options
+		$tr.find('input.mountOptions').val(JSON.stringify({
+			'encrypt': true,
+			'previews': true,
+			'filesystem_check_changes': 1
+		}));
+
 		$tr.find('td').last().attr('class', 'remove');
 		$tr.find('td.mountOptionsToggle').removeClass('hidden');
 		$tr.find('td').last().removeAttr('style');


### PR DESCRIPTION
A very basic change, just insert the default options (which were stored in the Handlebar template :laughing: ) into the relevant input when the row is generated. Not pretty, but it's not the time to introduce the proper solution.

Fixes #18347 

cc @PVince81 @MorrisJobke @icewind1991 
