### PR TITLE
Global classes in core CSS

### DIFF
--- a/core/css/global.css
+++ b/core/css/global.css
@@ -1,0 +1,50 @@
+/* Copyright (c) 2015, Raghu Nayyar, http://raghunayyar.com
+ This file is licensed under the Affero General Public License version 3 or later.
+ See the COPYING-README file. */
+
+/* Global Components */
+
+.pull-left {
+	float: left;
+}
+
+.pull-right {
+	float: right;
+}
+
+.clear-left {
+	clear: left;
+}
+
+.clear-right {
+	clear: right;
+}
+
+.clear-both {
+	clear: both;
+}
+
+.hidden {
+	display: none;
+}
+
+.hidden-visually {
+	position: absolute;
+	left:-10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+}
+
+.bold {
+	font-weight:600;
+}
+
+.center {
+	text-align:center;
+}
+
+.inlineblock {
+	display: inline-block;
+}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -856,26 +856,6 @@ html.ie8 #body-login form input[type="checkbox"] {
 	height: 70px;
 }
 
-
-
-
-/* VARIOUS REUSABLE SELECTORS */
-.hidden {
-	display: none;
-}
-.hidden-visually {
-	position: absolute;
-	left:-10000px;
-	top: auto;
-	width: 1px;
-	height: 1px;
-	overflow: hidden;
-}
-
-.bold { font-weight:600; }
-.center { text-align:center; }
-.inlineblock { display: inline-block; }
-
 /* round profile photos */
 .avatar,
 .avatar img,

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -108,6 +108,7 @@ class OC_Template extends \OC\Template\Base {
 			OC_Util::addVendorStyle('jquery-ui/themes/base/jquery-ui',null,true);
 			OC_Util::addStyle("multiselect",null,true);
 			OC_Util::addStyle("fixes",null,true);
+			OC_Util::addStyle("global",null,true);
 			OC_Util::addStyle("apps",null,true);
 			OC_Util::addStyle("fonts",null,true);
 			OC_Util::addStyle("icons",null,true);


### PR DESCRIPTION
A small start to shorten the CSS we write while building both apps or core. I think we should have a bunch of classes that we necessarily need, declared in core that can be re-used. Though, I can introduce a separate file for that but this seems good for the starters. What do you guys think? @jancborchardt @MorrisJobke @owncloud/designers 
