### PR TITLE
Restrict autoloaded paths to loaded apps (and other enhancements)

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -58,7 +58,7 @@ class Autoloader {
 	 * @param string $root
 	 */
 	public function addValidRoot($root) {
-		$this->validRoots[] = $root;
+		$this->validRoots[] = stream_resolve_include_path($root);
 	}
 
 	/**

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -27,6 +27,8 @@
 
 namespace OC;
 
+use \OCP\AutoloadNotAllowedException;
+
 class Autoloader {
 	private $useGlobalClassPath = true;
 
@@ -129,7 +131,7 @@ class Autoloader {
 				return true;
 			}
 		}
-		throw new \Exception('Path not allowed: '. $fullPath);
+		throw new AutoloadNotAllowedException($fullPath);
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -552,10 +552,6 @@ class OC {
 			exit();
 		}
 
-		foreach(OC::$APPSROOTS as $appRoot) {
-			self::$loader->addValidRoot($appRoot['path']);
-		}
-
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT);
 		\OC::$server->getEventLogger()->log('autoloader', 'Autoloader', $loaderStart, $loaderEnd);

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -105,7 +105,6 @@ class OC_App {
 		ob_start();
 		foreach ($apps as $app) {
 			if ((is_null($types) or self::isType($app, $types)) && !in_array($app, self::$loadedApps)) {
-				self::$loadedApps[] = $app;
 				self::loadApp($app);
 			}
 		}
@@ -122,6 +121,8 @@ class OC_App {
 	 * @throws \OC\NeedsUpdateException
 	 */
 	public static function loadApp($app, $checkUpgrade = true) {
+		self::$loadedApps[] = $app;
+		\OC::$loader->addValidRoot(self::getAppPath($app));
 		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			if ($checkUpgrade and self::shouldUpgrade($app)) {

--- a/lib/private/backgroundjob/joblist.php
+++ b/lib/private/backgroundjob/joblist.php
@@ -26,6 +26,7 @@
 namespace OC\BackgroundJob;
 
 use OCP\BackgroundJob\IJobList;
+use OCP\AutoloadNotAllowedException;
 
 class JobList implements IJobList {
 	/**
@@ -185,15 +186,20 @@ class JobList implements IJobList {
 		/**
 		 * @var Job $job
 		 */
-		if (!class_exists($class)) {
-			// job from disabled app or old version of an app, no need to do anything
-			return null;
+		try {
+			if (!class_exists($class)) {
+				// job from disabled app or old version of an app, no need to do anything
+				return null;
+			}
+			$job = new $class();
+			$job->setId($row['id']);
+			$job->setLastRun($row['last_run']);
+			$job->setArgument(json_decode($row['argument'], true));
+			return $job;
+		} catch (AutoloadNotAllowedException $e) {
+			// job is from a disabled app, ignore
 		}
-		$job = new $class();
-		$job->setId($row['id']);
-		$job->setLastRun($row['last_run']);
-		$job->setArgument(json_decode($row['argument'], true));
-		return $job;
+		return null;
 	}
 
 	/**

--- a/lib/public/autoloadnotallowedexception.php
+++ b/lib/public/autoloadnotallowedexception.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Robin McCorkell <rmccorkell@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace OCP;
+
+/**
+ * Exception for when a not allowed path is attempted to be autoloaded
+ * @since 8.2.0
+ */
+class AutoloadNotAllowedException extends \DomainException {
+	/**
+	 * @param string $path
+	 * @since 8.2.0
+	 */
+	public function __construct($path) {
+		parent::__construct('Autoload path not allowed: '.$path);
+	}
+}
+


### PR DESCRIPTION
Unloaded apps (aka not enabled apps) will not get any files autoloaded anymore, which can prevent an unloaded app becoming an attack vector if it is not regularly updated.

In addition, the autoloader will properly resolve symlinked app directories, to allow for a semi-common usecase where apps are stored elsewhere but are symlinked into the ownCloud directory. Fixes issues as noted in https://github.com/owncloud/core/pull/18396#issuecomment-137419945

@fossxplorer want to test this out with your symlinked apps?

cc @icewind1991 @MorrisJobke @PVince81 @LukasReschke 
