### PR TITLE
Bugfix: "remember" checkbox at login now working

### DIFF
--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -22,4 +22,5 @@
 	<dependencies>
 		<owncloud min-version="8" />
 	</dependencies>
+	<rememberlogin>true</rememberlogin>
 </info>


### PR DESCRIPTION
Look at this forum for more on the issue: https://forum.owncloud.org/viewtopic.php?f=31&t=26330

This way, the fix will survive an app update.

The files_external app is overriding the "remember" checkbox at login. This fixes it.
