### PR TITLE
[stable7] Always add to $loadedApps

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -71,7 +71,6 @@ class OC_App {
 		ob_start();
 		foreach ($apps as $app) {
 			if ((is_null($types) or self::isType($app, $types)) && !in_array($app, self::$loadedApps)) {
-				self::$loadedApps[] = $app;
 				self::loadApp($app);
 			}
 		}
@@ -88,6 +87,7 @@ class OC_App {
 	 * @throws \OC\NeedsUpdateException
 	 */
 	public static function loadApp($app, $checkUpgrade = true) {
+		self::$loadedApps[] = $app;
 		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
 			if ($checkUpgrade and self::shouldUpgrade($app)) {
 				throw new \OC\NeedsUpdateException();


### PR DESCRIPTION
Fixes the RouteNotFoundException on app upgrade issue.

Partial backport of #18839 

cc @karlitschek @LukasReschke @MorrisJobke @DeepDiver1975 

I don't know if we want to backport this all the way to stable7, but it's such a small change I thought why not.
