### PR TITLE
[stable7] Fallback to complete Memcached flush if getAllKeys fails

### DIFF
--- a/lib/private/memcache/memcached.php
+++ b/lib/private/memcache/memcached.php
@@ -67,6 +67,11 @@ class Memcached extends Cache {
 	public function clear($prefix = '') {
 		$prefix = $this->getNamespace() . $prefix;
 		$allKeys = self::$cache->getAllKeys();
+		if ($allKeys === false) {
+			// newer Memcached doesn't like getAllKeys(), flush everything
+			self::$cache->flush();
+			return true;
+		}
 		$keys = array();
 		$prefixLength = strlen($prefix);
 		foreach ($allKeys as $key) {

--- a/tests/lib/memcache/memcached.php
+++ b/tests/lib/memcache/memcached.php
@@ -23,4 +23,27 @@ class Memcached extends Cache {
 	public function setUp() {
 		$this->instance = new \OC\Memcache\Memcached(uniqid());
 	}
+
+	public function testClear() {
+		// Memcached is sometimes broken with clear(), so we don't test it thoroughly
+		$value='ipsum lorum';
+		$this->instance->set('1_value1', $value);
+		$this->instance->set('1_value2', $value);
+		$this->instance->set('2_value1', $value);
+		$this->instance->set('3_value1', $value);
+
+		$this->assertTrue($this->instance->clear('1_'));
+
+		$this->assertFalse($this->instance->hasKey('1_value1'));
+		$this->assertFalse($this->instance->hasKey('1_value2'));
+		//$this->assertTrue($this->instance->hasKey('2_value1'));
+		//$this->assertTrue($this->instance->hasKey('3_value1'));
+
+		$this->assertTrue($this->instance->clear());
+
+		$this->assertFalse($this->instance->hasKey('1_value1'));
+		$this->assertFalse($this->instance->hasKey('1_value2'));
+		$this->assertFalse($this->instance->hasKey('2_value1'));
+		$this->assertFalse($this->instance->hasKey('3_value1'));
+	}
 }


### PR DESCRIPTION
Newer Memcached's do not support the underlying protocol commands that getAllKeys() is implemented with. We should fallback to clearing everything in that case, as causing (temporary) performance problems for other applications on the server is better than having stale cached data.

Backport of #18851

cc @LukasReschke @karlitschek @DeepDiver1975 @icewind1991 @MorrisJobke

Backport requested at https://github.com/owncloud/core/pull/18855#issuecomment-138109390
