### PR TITLE
Check if app is enabled instead of if class exists

### DIFF
--- a/settings/users.php
+++ b/settings/users.php
@@ -41,7 +41,7 @@ $groupManager = \OC_Group::getManager();
 // Set the sort option: SORT_USERCOUNT or SORT_GROUPNAME
 $sortGroupsBy = \OC\Group\MetaData::SORT_USERCOUNT;
 
-if (class_exists('\OCA\user_ldap\GROUP_LDAP')) {
+if (\OC_App::isEnabled('user_ldap')) {
 	$isLDAPUsed =
 		   $groupManager->isBackendUsed('\OCA\user_ldap\GROUP_LDAP')
 		|| $groupManager->isBackendUsed('\OCA\user_ldap\Group_Proxy');


### PR DESCRIPTION
Further down in the same file, we already use `isEnabled()` to check if an app is enabled. This approach is better not only for consistency, but also because it avoids autoloading the class.

In addition, the existing check was bogus, since the class would get autoloaded regardless of if LDAP is enabled or not (hooray insecure autoloading!). Since the merge of #18839, that was prevented, so user management broke. This fixes #18871 

@nickvergessen Hopefully you see how the other PR actually found this completely broken code, and that's a _good thing_?

cc @icewind1991 @DeepDiver1975 @MorrisJobke @PVince81 
