### PR TITLE
Allow admin to use a master key for all files

### DIFF
--- a/apps/encryption/appinfo/register_command.php
+++ b/apps/encryption/appinfo/register_command.php
@@ -21,10 +21,17 @@
  */
 
 use OCA\Encryption\Command\MigrateKeys;
+use Symfony\Component\Console\Helper\QuestionHelper;
 
 $userManager = OC::$server->getUserManager();
 $view = new \OC\Files\View();
 $config = \OC::$server->getConfig();
+$userSession = \OC::$server->getUserSession();
 $connection = \OC::$server->getDatabaseConnection();
 $logger = \OC::$server->getLogger();
+$questionHelper = new QuestionHelper();
+$crypt = new \OCA\Encryption\Crypto\Crypt($logger, $userSession, $config);
+$util = new \OCA\Encryption\Util($view, $crypt, $logger, $userSession, $config, $userManager);
+
 $application->add(new MigrateKeys($userManager, $view, $connection, $config, $logger));
+$application->add(new \OCA\Encryption\Command\EnableMasterKey($util, $config, $questionHelper));

--- a/apps/encryption/command/enablemasterkey.php
+++ b/apps/encryption/command/enablemasterkey.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Encryption\Command;
+
+
+use OCA\Encryption\Util;
+use OCP\IConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class EnableMasterKey extends Command {
+
+	/** @var Util */
+	protected $util;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var  QuestionHelper */
+	protected $questionHelper;
+
+	/**
+	 * @param Util $util
+	 * @param IConfig $config
+	 * @param QuestionHelper $questionHelper
+	 */
+	public function __construct(Util $util,
+								IConfig $config,
+								QuestionHelper $questionHelper) {
+
+		$this->util = $util;
+		$this->config = $config;
+		$this->questionHelper = $questionHelper;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('encryption:enable-master-key')
+			->setDescription('Enable the master key. Only available for fresh installations with no existing encrypted data! There is also no way to disable it again.');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$isAlreadyEnabled = $this->util->isMasterKeyEnabled();
+
+		if($isAlreadyEnabled) {
+			$output->writeln('Master key already enabled');
+		} else {
+			$question = new ConfirmationQuestion(
+				'Warning: Only available for fresh installations with no existing encrypted data! '
+			. 'There is also no way to disable it again. Do you want to continue? (y/n) ', false);
+			if ($this->questionHelper->ask($input, $output, $question)) {
+				$this->config->setAppValue('encryption', 'useMasterKey', '1');
+				$output->writeln('Master key successfully enabled.');
+			} else {
+				$output->writeln('aborted.');
+			}
+		}
+
+	}
+
+}

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -55,6 +55,10 @@ class KeyManager {
 	 */
 	private $publicShareKeyId;
 	/**
+	 * @var string
+	 */
+	private $masterKeyId;
+	/**
 	 * @var string UserID
 	 */
 	private $keyId;
@@ -131,10 +135,20 @@ class KeyManager {
 			$this->config->setAppValue('encryption', 'publicShareKeyId', $this->publicShareKeyId);
 		}
 
+		$this->masterKeyId = $this->config->getAppValue('encryption',
+			'masterKeyId');
+		if (empty($this->masterKeyId)) {
+			$this->masterKeyId = 'master_' . substr(md5(time()), 0, 8);
+			$this->config->setAppValue('encryption', 'masterKeyId', $this->masterKeyId);
+		}
+
 		$this->keyId = $userSession && $userSession->isLoggedIn() ? $userSession->getUser()->getUID() : false;
 		$this->log = $log;
 	}
 
+	/**
+	 * check if key pair for public link shares exists, if not we create one
+	 */
 	public function validateShareKey() {
 		$shareKey = $this->getPublicShareKey();
 		if (empty($shareKey)) {
@@ -149,6 +163,26 @@ class KeyManager {
 			$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], '');
 			$header = $this->crypt->generateHeader();
 			$this->setSystemPrivateKey($this->publicShareKeyId, $header . $encryptedKey);
+		}
+	}
+
+	/**
+	 * check if a key pair for the master key exists, if not we create one
+	 */
+	public function validateMasterKey() {
+		$masterKey = $this->getPublicMasterKey();
+		if (empty($masterKey)) {
+			$keyPair = $this->crypt->createKeyPair();
+
+			// Save public key
+			$this->keyStorage->setSystemUserKey(
+				$this->masterKeyId . '.publicKey', $keyPair['publicKey'],
+				Encryption::ID);
+
+			// Encrypt private key with system password
+			$encryptedKey = $this->crypt->encryptPrivateKey($keyPair['privateKey'], $this->getMasterKeyPassword(), $this->masterKeyId);
+			$header = $this->crypt->generateHeader();
+			$this->setSystemPrivateKey($this->masterKeyId, $header . $encryptedKey);
 		}
 	}
 
@@ -304,8 +338,15 @@ class KeyManager {
 
 		$this->session->setStatus(Session::INIT_EXECUTED);
 
+
 		try {
-			$privateKey = $this->getPrivateKey($uid);
+			if($this->util->isMasterKeyEnabled()) {
+				$uid = $this->getMasterKeyId();
+				$passPhrase = $this->getMasterKeyPassword();
+				$privateKey = $this->getSystemPrivateKey($uid);
+			} else {
+				$privateKey = $this->getPrivateKey($uid);
+			}
 			$privateKey = $this->crypt->decryptPrivateKey($privateKey, $passPhrase, $uid);
 		} catch (PrivateKeyMissingException $e) {
 			return false;
@@ -344,6 +385,10 @@ class KeyManager {
 	 */
 	public function getFileKey($path, $uid) {
 		$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
+
+		if ($this->util->isMasterKeyEnabled()) {
+			$uid = $this->getMasterKeyId();
+		}
 
 		if (is_null($uid)) {
 			$uid = $this->getPublicShareKeyId();
@@ -565,5 +610,38 @@ class KeyManager {
 		}
 
 		return $publicKeys;
+	}
+
+	/**
+	 * get master key password
+	 *
+	 * @return string
+	 * @throws \Exception
+	 */
+	protected function getMasterKeyPassword() {
+		$password = $this->config->getSystemValue('secret');
+		if (empty($password)){
+			throw new \Exception('Can not get secret from ownCloud instance');
+		}
+
+		return $password;
+	}
+
+	/**
+	 * return master key id
+	 *
+	 * @return string
+	 */
+	public function getMasterKeyId() {
+		return $this->masterKeyId;
+	}
+
+	/**
+	 * get public master key
+	 *
+	 * @return string
+	 */
+	public function getPublicMasterKey() {
+		return $this->keyStorage->getSystemUserKey($this->masterKeyId . '.publicKey', Encryption::ID);
 	}
 }

--- a/apps/encryption/lib/users/setup.php
+++ b/apps/encryption/lib/users/setup.php
@@ -84,6 +84,7 @@ class Setup {
 	 */
 	public function setupServerSide($uid, $password) {
 		$this->keyManager->validateShareKey();
+		$this->keyManager->validateMasterKey();
 		// Check if user already has keys
 		if (!$this->keyManager->userHasKeys($uid)) {
 			return $this->keyManager->storeKeyPair($uid, $password,

--- a/apps/encryption/lib/util.php
+++ b/apps/encryption/lib/util.php
@@ -102,6 +102,16 @@ class Util {
 	}
 
 	/**
+	 * check if master key is enabled
+	 *
+	 * @return bool
+	 */
+	public function isMasterKeyEnabled() {
+		$userMasterKey = $this->config->getAppValue('encryption', 'useMasterKey', '0');
+		return ($userMasterKey === '1');
+	}
+
+	/**
 	 * @param $enabled
 	 * @return bool
 	 */

--- a/apps/encryption/tests/command/testenablemasterkey.php
+++ b/apps/encryption/tests/command/testenablemasterkey.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Encryption\Tests\Command;
+
+
+use OCA\Encryption\Command\EnableMasterKey;
+use Test\TestCase;
+
+class TestEnableMasterKey extends TestCase {
+
+	/** @var  EnableMasterKey */
+	protected $enableMasterKey;
+
+	/** @var  Util | \PHPUnit_Framework_MockObject_MockObject */
+	protected $util;
+
+	/** @var \OCP\IConfig | \PHPUnit_Framework_MockObject_MockObject  */
+	protected $config;
+
+	/** @var \Symfony\Component\Console\Helper\QuestionHelper | \PHPUnit_Framework_MockObject_MockObject */
+	protected $questionHelper;
+
+	/** @var  \Symfony\Component\Console\Output\OutputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	protected $output;
+
+	/** @var  \Symfony\Component\Console\Input\InputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	protected $input;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->util = $this->getMockBuilder('OCA\Encryption\Util')
+			->disableOriginalConstructor()->getMock();
+		$this->config = $this->getMockBuilder('OCP\IConfig')
+			->disableOriginalConstructor()->getMock();
+		$this->questionHelper = $this->getMockBuilder('Symfony\Component\Console\Helper\QuestionHelper')
+			->disableOriginalConstructor()->getMock();
+		$this->output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+			->disableOriginalConstructor()->getMock();
+		$this->input = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+			->disableOriginalConstructor()->getMock();
+
+		$this->enableMasterKey = new EnableMasterKey($this->util, $this->config, $this->questionHelper);
+	}
+
+	/**
+	 * @dataProvider dataTestExecute
+	 *
+	 * @param bool $isAlreadyEnabled
+	 * @param string $answer
+	 */
+	public function testExecute($isAlreadyEnabled, $answer) {
+
+		$this->util->expects($this->once())->method('isMasterKeyEnabled')
+			->willReturn($isAlreadyEnabled);
+
+		if ($isAlreadyEnabled) {
+			$this->output->expects($this->once())->method('writeln')
+				->with('Master key already enabled');
+		} else {
+			if ($answer === 'y') {
+				$this->questionHelper->expects($this->once())->method('ask')->willReturn(true);
+				$this->config->expects($this->once())->method('setAppValue')
+					->with('encryption', 'useMasterKey', '1');
+			} else {
+				$this->questionHelper->expects($this->once())->method('ask')->willReturn(false);
+				$this->config->expects($this->never())->method('setAppValue');
+
+			}
+		}
+
+		$this->invokePrivate($this->enableMasterKey, 'execute', [$this->input, $this->output]);
+	}
+
+	public function dataTestExecute() {
+		return [
+			[true, ''],
+			[false, 'y'],
+			[false, 'n'],
+			[false, '']
+		];
+	}
+}

--- a/apps/encryption/tests/lib/UtilTest.php
+++ b/apps/encryption/tests/lib/UtilTest.php
@@ -132,4 +132,25 @@ class UtilTest extends TestCase {
 		return $default ?: null;
 	}
 
+	/**
+	 * @dataProvider dataTestIsMasterKeyEnabled
+	 *
+	 * @param string $value
+	 * @param bool $expect
+	 */
+	public function testIsMasterKeyEnabled($value, $expect) {
+		$this->configMock->expects($this->once())->method('getAppValue')
+			->with('encryption', 'useMasterKey', '0')->willReturn($value);
+		$this->assertSame($expect,
+			$this->instance->isMasterKeyEnabled()
+		);
+	}
+
+	public function dataTestIsMasterKeyEnabled() {
+		return [
+			['0', false],
+			['1', true]
+		];
+	}
+
 }

--- a/apps/encryption/tests/lib/users/SetupTest.php
+++ b/apps/encryption/tests/lib/users/SetupTest.php
@@ -43,6 +43,8 @@ class SetupTest extends TestCase {
 	private $instance;
 
 	public function testSetupServerSide() {
+		$this->keyManagerMock->expects($this->exactly(2))->method('validateShareKey');
+		$this->keyManagerMock->expects($this->exactly(2))->method('validateMasterKey');
 		$this->keyManagerMock->expects($this->exactly(2))
 			->method('userHasKeys')
 			->with('admin')


### PR DESCRIPTION
This PR allows the admin to enable a master key which will be used to encrypt all files.

Enable:

```
./occ encryption:enable-master-key
```

Right now this only works for fresh installations. There is no migration to the master key and away from it.

cc @LukasReschke basically I implemented it the way we discussed it last week. Please have a look. Thanks!

fix https://github.com/owncloud/core/issues/16341
