### PR TITLE
Use context function call instead of static

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -81,7 +81,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		);
 
 		if ($newMountPoint !== $share['file_target']) {
-			self::updateFileTarget($newMountPoint, $share);
+			$this->updateFileTarget($newMountPoint, $share);
 			$share['file_target'] = $newMountPoint;
 			$share['unique_name'] = true;
 		}


### PR DESCRIPTION
@MorrisJobke @schiesbn 

Should have been part of #17381 - 763b601e4aa109bcade4af687c4c6a9b8e66b5df
