### PR TITLE
Load all enabled apps in test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,9 +10,8 @@ require_once __DIR__ . '/../lib/base.php';
 
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 
-// load minimum set of apps
-OC_App::loadApps(array('authentication'));
-OC_App::loadApps(array('filesystem', 'logging'));
+// load all enabled apps
+\OC_App::loadApps();
 
 if (!class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');


### PR DESCRIPTION
A possible solution to the chaos caused by #18839. We should load all apps that have been enabled, so that autoloader valid roots are properly registered (and so that all `app.php` is correctly run in case there's special initialization logic). Previously, we only loaded 'minimal' apps.

Reasoning:

In autotest.sh, we enable the apps we want to test. The same happens with autotest-external.sh. The autotest executor looks at all enabled apps and runs their tests, so if an app isn't loaded it will break at this point, as the paths are not valid.

When running tests manually for individual apps (aka outside of autotest), the dev must make sure that the app is enabled in the running instance before attempting to run tests against it, OR the app test bootstrap explicitly loads the app. I don't see any situations where it is desired that an app isn't loaded, but still has tests run against it.

Please state if this is an acceptable solution @nickvergessen @oparoz @ChristophWurst 

cc @MorrisJobke @LukasReschke 
