### PR TITLE
use a normal rename when moving from the same storage in the encryption wrapper

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -424,6 +424,9 @@ class Encryption extends Wrapper {
 	 * @return bool
 	 */
 	public function moveFromStorage(Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = true) {
+		if ($sourceStorage === $this) {
+			return $this->rename($sourceInternalPath, $targetInternalPath);
+		}
 
 		// TODO clean this up once the underlying moveFromStorage in OC\Files\Storage\Wrapper\Common is fixed:
 		// - call $this->storage->moveFromStorage() instead of $this->copyBetweenStorage


### PR DESCRIPTION
Saves having to re-encrypt the data

Speeds up dav upload

cc @schiesbn @DeepDiver1975 @PVince81 
