### PR TITLE
Revert the change from WHERE to AND

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1547,10 +1547,10 @@ class Share extends Constants {
 				$root = '';
 			}
 			$where = 'INNER JOIN `*PREFIX*filecache` ON `file_source` = `*PREFIX*filecache`.`fileid` ';
-			if (!isset($item)) {
-				$where .= ' AND `file_target` IS NOT NULL ';
-			}
 			$where .= 'INNER JOIN `*PREFIX*storages` ON `numeric_id` = `*PREFIX*filecache`.`storage` ';
+			if (!isset($item)) {
+				$where .= ' WHERE `file_target` IS NOT NULL ';
+			}
 			$fileDependent = true;
 			$queryArgs = array();
 		} else {


### PR DESCRIPTION
Assuming the change was unintended in 80f83ab5e079489a46ed56adee1898afb8b26ff0 from #15155
We only want shares with file_target IS NOT NULL, but the change introduced
makes the join to the filecache conditional, so we don't load the file info
for those shares anymore, instead of not returning them at all.
