### PR TITLE
[stable7] Fix PHP 5.3 compatiblity

### DIFF
--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -251,9 +251,12 @@ class Updater extends BasicEmitter {
 		}
 	}
 
+	/**
+	 * @param Repair $repair
+	 */
 	protected function emitRepairMessages(Repair $repair) {
-		$repair->listen('\OC\Repair', 'info', function($description){
-			$this->emit('\OC\Repair', 'info', array($description));
+		$repair->listen('\OC\Repair', 'info', function($description) use ($repair){
+			$repair->emit('\OC\Repair', 'info', array($description));
 		});
 	}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/18877

@karlitschek @cmonteroluque @DeepDiver1975 I'd advise to get this shipped ASAP, maybe repackage a 7 release with 8.1.2 or so. This will break all updates on instances using PHP 5.3.
