### PR TITLE
breathing space for image in sidebar, fix #18796

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -19,12 +19,6 @@
 	float: left;
 }
 
-#app-sidebar .thumbnailContainer.image {
-	margin-left: -15px;
-	margin-right: -35px; /* 15 + 20 for the close button */
-	margin-top: -15px;
-}
-
 #app-sidebar .image .thumbnail {
 	width:100%;
 	display:block;


### PR DESCRIPTION
This just removes the overwrite of the padding and hence adds some nice whitespace around the image so it doesn’t stick to the sides nor the header.

Please review @karlitschek @owncloud/designers 

@icewind1991 in some cases the image container is too tall, taller than the image. Especially for landscape images. Can you look into that?
