### PR TITLE
[stable8.1] Use context function call instead of static

### DIFF
--- a/apps/files_sharing/lib/sharedmount.php
+++ b/apps/files_sharing/lib/sharedmount.php
@@ -75,7 +75,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		);
 
 		if ($newMountPoint !== $share['file_target']) {
-			self::updateFileTarget($newMountPoint, $share);
+			$this->updateFileTarget($newMountPoint, $share);
 			$share['file_target'] = $newMountPoint;
 			$share['unique_name'] = true;
 		}


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/18876

needs to be merged after this backport was merged: https://github.com/owncloud/core/pull/18903

cc @nickvergessen @MorrisJobke 
