### PR TITLE
Allow 0 and false as password

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -765,7 +765,7 @@ class Share extends Constants {
 				}
 
 				// Generate hash of password - same method as user passwords
-				if (!empty($shareWith)) {
+				if (is_string($shareWith) && $shareWith !== '') {
 					self::verifyPassword($shareWith);
 					$shareWith = \OC::$server->getHasher()->hash($shareWith);
 				} else {


### PR DESCRIPTION
When we use the check for "empty" here passwords such as 0 will not work. A lot of static code, no idea how to unit test.

Fixes https://github.com/owncloud/password_policy/issues/8
