### PR TITLE
Show cached previews directly

### DIFF
--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -772,6 +772,12 @@ class Preview {
 			throw new NotFoundException('File not found.');
 		}
 
+		if ($cachedPath = $this->isCached($this->info->getId())) {
+			header('Content-Type: ' . $this->info->getMimetype());
+			$this->userView->readfile($cachedPath);
+			return;
+		}
+
 		if (is_null($this->preview)) {
 			$this->getPreview();
 		}


### PR DESCRIPTION
Going trough `getPreview()`, `preview->show()`, etc involves decoding the cached image files before re-encoding it again in the exact same format before we send it off the the browser.

Instead we just output the file directly to the browser

Not as big of an performance improvement as I would have hoped but it's an easy way to shave off a few ms which should help server load for folders with a lot of images to preview ([comparison](https://blackfire.io/profiles/compare/399b6ccc-45f6-4c8b-94d6-a1019f26cfb4/graph))

cc @DeepDiver1975 @LukasReschke 
