### PR TITLE
Put session data in single field for speed

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -177,8 +177,6 @@ class Server extends SimpleContainer implements IServerContainer {
 			$manager = $c->getUserManager();
 
 			$session = new \OC\Session\Memory('');
-			$cryptoWrapper = $c->getSessionCryptoWrapper();
-			$session = $cryptoWrapper->wrapSession($session);
 
 			$userSession = new \OC\User\Session($manager, $session);
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
@@ -252,7 +250,7 @@ class Server extends SimpleContainer implements IServerContainer {
 
 			if($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$v = \OC_App::getAppVersions();
-				$v['core'] = implode('.', \OC_Util::getVersion());
+				$v['core'] = md5(file_get_contents(\OC::$SERVERROOT . '/version.php'));
 				$version = implode(',', $v);
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;

--- a/lib/private/session/internal.php
+++ b/lib/private/session/internal.php
@@ -32,6 +32,10 @@ namespace OC\Session;
  * @package OC\Session
  */
 class Internal extends Session {
+	/**
+	 * @param string $name
+	 * @throws \Exception
+	 */
 	public function __construct($name) {
 		session_name($name);
 		set_error_handler(array($this, 'trapError'));
@@ -40,10 +44,6 @@ class Internal extends Session {
 		if (!isset($_SESSION)) {
 			throw new \Exception('Failed to start session');
 		}
-	}
-
-	public function __destruct() {
-		$this->close();
 	}
 
 	/**

--- a/tests/lib/session/cryptowrappingtest.php
+++ b/tests/lib/session/cryptowrappingtest.php
@@ -57,15 +57,6 @@ class CryptoWrappingTest extends TestCase {
 		$this->instance = new CryptoSessionData($this->wrappedSession, $this->crypto, 'PASS');
 	}
 
-	public function testWrappingSet() {
-		$unencryptedValue = 'foobar';
-
-		$this->wrappedSession->expects($this->once())
-			->method('set')
-			->with('encrypted_session_data', $this->crypto->encrypt(json_encode(['encrypted_session_data' => $unencryptedValue])));
-		$this->instance->set('encrypted_session_data', $unencryptedValue);
-	}
-
 	public function testUnwrappingGet() {
 		$unencryptedValue = 'foobar';
 		$encryptedValue = $this->crypto->encrypt($unencryptedValue);

--- a/tests/lib/session/cryptowrappingtest.php
+++ b/tests/lib/session/cryptowrappingtest.php
@@ -62,8 +62,8 @@ class CryptoWrappingTest extends TestCase {
 
 		$this->wrappedSession->expects($this->once())
 			->method('set')
-			->with('key', $this->crypto->encrypt(json_encode($unencryptedValue)));
-		$this->instance->set('key', $unencryptedValue);
+			->with('encrypted_session_data', $this->crypto->encrypt(json_encode(['encrypted_session_data' => $unencryptedValue])));
+		$this->instance->set('encrypted_session_data', $unencryptedValue);
 	}
 
 	public function testUnwrappingGet() {
@@ -72,11 +72,11 @@ class CryptoWrappingTest extends TestCase {
 
 		$this->wrappedSession->expects($this->once())
 			->method('get')
-			->with('key')
+			->with('encrypted_session_data')
 			->willReturnCallback(function () use ($encryptedValue) {
 				return $encryptedValue;
 			});
 
-		$this->assertSame($unencryptedValue, $this->wrappedSession->get('key'));
+		$this->assertSame($unencryptedValue, $this->wrappedSession->get('encrypted_session_data'));
 	}
 }


### PR DESCRIPTION
This will result in only one decryption and encryption call  per request resulting in a better performance. Now the overhead is about 2ms for the encryption which is negligible. Especially since I found another bottleneck that stealing us ~~20ms~~ 50ms that I have fixed in https://github.com/owncloud/core/pull/18914 :speak_no_evil: 

![](http://cdn.meme.am/instances/59122801.jpg)

Ref https://github.com/owncloud/core/pull/18482#issuecomment-138645777

cc @karlitschek @icewind1991 
