### PR TITLE
Use the view logic for getFolderContent for the node api

### DIFF
--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -25,7 +25,7 @@
 
 namespace OC\Files\Node;
 
-use OC\Files\Cache\Cache;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 
@@ -77,76 +77,15 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return Node[]
 	 */
 	public function getDirectoryListing() {
-		$result = array();
+		$folderContent = $this->view->getDirectoryContent($this->path);
 
-		/**
-		 * @var \OC\Files\Storage\Storage $storage
-		 */
-		list($storage, $internalPath) = $this->view->resolvePath($this->path);
-		if ($storage) {
-			$cache = $storage->getCache($internalPath);
-
-			//trigger cache update check
-			$this->view->getFileInfo($this->path);
-
-			$files = $cache->getFolderContents($internalPath);
-		} else {
-			$files = array();
-		}
-
-		//add a folder for any mountpoint in this directory and add the sizes of other mountpoints to the folders
-		$mounts = $this->root->getMountsIn($this->path);
-		$dirLength = strlen($this->path);
-		foreach ($mounts as $mount) {
-			$subStorage = $mount->getStorage();
-			if ($subStorage) {
-				$subCache = $subStorage->getCache('');
-
-				if ($subCache->getStatus('') === Cache::NOT_FOUND) {
-					$subScanner = $subStorage->getScanner('');
-					$subScanner->scanFile('');
-				}
-
-				$rootEntry = $subCache->get('');
-				if ($rootEntry) {
-					$relativePath = trim(substr($mount->getMountPoint(), $dirLength), '/');
-					if ($pos = strpos($relativePath, '/')) {
-						//mountpoint inside subfolder add size to the correct folder
-						$entryName = substr($relativePath, 0, $pos);
-						foreach ($files as &$entry) {
-							if ($entry['name'] === $entryName) {
-								if ($rootEntry['size'] >= 0) {
-									$entry['size'] += $rootEntry['size'];
-								} else {
-									$entry['size'] = -1;
-								}
-							}
-						}
-					} else { //mountpoint in this folder, add an entry for it
-						$rootEntry['name'] = $relativePath;
-						$rootEntry['storageObject'] = $subStorage;
-
-						//remove any existing entry with the same name
-						foreach ($files as $i => $file) {
-							if ($file['name'] === $rootEntry['name']) {
-								$files[$i] = null;
-								break;
-							}
-						}
-						$files[] = $rootEntry;
-					}
-				}
+		return array_map(function(FileInfo $info) {
+			if ($info->getMimetype() === 'httpd/unix-directory') {
+				return new Folder($this->root, $this->view, $info->getPath(), $info);
+			} else {
+				return new File($this->root, $this->view, $info->getPath(), $info);
 			}
-		}
-
-		foreach ($files as $file) {
-			if ($file) {
-				$node = $this->createNode($this->path . '/' . $file['name'], $file);
-				$result[] = $node;
-			}
-		}
-
-		return $result;
+		}, $folderContent);
 	}
 
 	/**

--- a/lib/private/files/node/node.php
+++ b/lib/private/files/node/node.php
@@ -56,11 +56,13 @@ class Node implements \OCP\Files\Node {
 	 * @param \OC\Files\View $view
 	 * @param \OC\Files\Node\Root $root
 	 * @param string $path
+	 * @param FileInfo $fileInfo
 	 */
-	public function __construct($root, $view, $path) {
+	public function __construct($root, $view, $path, $fileInfo = null) {
 		$this->view = $view;
 		$this->root = $root;
 		$this->path = $path;
+		$this->fileInfo = $fileInfo;
 	}
 
 	/**

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -143,38 +143,13 @@ class Folder extends \Test\TestCase {
 			->method('getUser')
 			->will($this->returnValue($this->user));
 
-		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit_Framework_MockObject_MockObject $storage
-		 */
-		$storage = $this->getMock('\OC\Files\Storage\Storage');
-
-		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
-		$cache->expects($this->any())
-			->method('getStatus')
-			->with('foo')
-			->will($this->returnValue(Cache::COMPLETE));
-
-		$cache->expects($this->once())
-			->method('getFolderContents')
-			->with('foo')
-			->will($this->returnValue(array(
-				array('fileid' => 2, 'path' => '/bar/foo/asd', 'name' => 'asd', 'size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain'),
-				array('fileid' => 3, 'path' => '/bar/foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'httpd/unix-directory')
-			)));
-
-		$root->expects($this->once())
-			->method('getMountsIn')
-			->with('/bar/foo')
-			->will($this->returnValue(array()));
-
-		$storage->expects($this->any())
-			->method('getCache')
-			->will($this->returnValue($cache));
-
 		$view->expects($this->any())
-			->method('resolvePath')
+			->method('getDirectoryContent')
 			->with('/bar/foo')
-			->will($this->returnValue(array($storage, 'foo')));
+			->will($this->returnValue(array(
+				new FileInfo('/bar/foo/asd', null, 'foo/asd', ['fileid' => 2, 'path' => '/bar/foo/asd', 'name' => 'asd', 'size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain'], null),
+				new FileInfo('/bar/foo/qwerty', null, 'foo/qwerty', ['fileid' => 3, 'path' => '/bar/foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'httpd/unix-directory'], null)
+			)));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$children = $node->getDirectoryListing();
@@ -183,6 +158,8 @@ class Folder extends \Test\TestCase {
 		$this->assertInstanceOf('\OC\Files\Node\Folder', $children[1]);
 		$this->assertEquals('asd', $children[0]->getName());
 		$this->assertEquals('qwerty', $children[1]->getName());
+		$this->assertEquals(2, $children[0]->getId());
+		$this->assertEquals(3, $children[1]->getId());
 	}
 
 	public function testGet() {


### PR DESCRIPTION
Less duplicated logic, simply reuse the result and transform it in the form we expect.

Also provides massive speedups when using the node api if meta-data is queried for each node.

Example comparison for opening a folder with ~1100 pictures and folders in the gallery app: [blackfire.io](https://blackfire.io/profiles/compare/59ba10df-e1ee-4507-9b19-85f68f2efec0/graph)
