### PR TITLE
Rename data provider to avoid risky test warning

### DIFF
--- a/tests/lib/appframework/http/JSONResponseTest.php
+++ b/tests/lib/appframework/http/JSONResponseTest.php
@@ -69,7 +69,7 @@ class JSONResponseTest extends \Test\TestCase {
 	/**
 	 * @return array
 	 */
-	public function testRenderProvider() {
+	public function renderDataProvider() {
 		return [
 			[
 				['test' => 'hi'], '{"test":"hi"}',
@@ -81,7 +81,7 @@ class JSONResponseTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider testRenderProvider
+	 * @dataProvider renderDataProvider
 	 * @param array $input
 	 * @param string $expected
 	 */


### PR DESCRIPTION
```
06:49:56 There was 1 risky test:
06:49:56
06:49:56 1) OC\AppFramework\Http\JSONResponseTest::testRenderProvider
06:49:56 This test did not perform any assertions
```
