### PR TITLE
Check if files_sharing is actually enabled before using it

### DIFF
--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -104,31 +104,33 @@ API::register(
 );
 
 // Server-to-Server Sharing
-$s2s = new \OCA\Files_Sharing\API\Server2Server();
-API::register('post',
+if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
+	$s2s = new \OCA\Files_Sharing\API\Server2Server();
+	API::register('post',
 		'/cloud/shares',
 		array($s2s, 'createShare'),
 		'files_sharing',
 		API::GUEST_AUTH
-);
+	);
 
-API::register('post',
+	API::register('post',
 		'/cloud/shares/{id}/accept',
 		array($s2s, 'acceptShare'),
 		'files_sharing',
 		API::GUEST_AUTH
-);
+	);
 
-API::register('post',
+	API::register('post',
 		'/cloud/shares/{id}/decline',
 		array($s2s, 'declineShare'),
 		'files_sharing',
 		API::GUEST_AUTH
-);
+	);
 
-API::register('post',
+	API::register('post',
 		'/cloud/shares/{id}/unshare',
 		array($s2s, 'unshare'),
 		'files_sharing',
 		API::GUEST_AUTH
-);
+	);
+}


### PR DESCRIPTION
As noted in #18626, these routes really should be in the files_sharing app. But as a temporary stopgap this works.

Fixes #18930, fixes #18626 

cc @LukasReschke @nickvergessen 
