### PR TITLE
Cache result of check upgrade

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -237,7 +237,7 @@ class OC {
 		// Check if config is writable
 		$configFileWritable = is_writable($configFilePath);
 		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
-			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
+			|| !$configFileWritable && self::checkUpgrade(false)) {
 			if (self::$CLI) {
 				echo $l->t('Cannot write into "config" directory!')."\n";
 				echo $l->t('This can usually be fixed by giving the webserver write access to the config directory')."\n";
@@ -320,7 +320,7 @@ class OC {
 	 * @deprecated use \OCP\Util::needUpgrade() instead
 	 */
 	public static function needUpgrade() {
-		return \OCP\Util::needUpgrade();
+		return self::checkUpgrade(false);
 	}
 
 	protected static $needUpgrade = null;
@@ -341,7 +341,6 @@ class OC {
 				exit();
 			}
 		}
-
 		return self::$needUpgrade;
 	}
 
@@ -745,7 +744,7 @@ class OC {
 	 */
 	public static function registerCacheHooks() {
 		//don't try to do this before we are properly setup
-		if (\OC::$server->getSystemConfig()->getValue('installed', false) && !\OCP\Util::needUpgrade()) {
+		if (\OC::$server->getSystemConfig()->getValue('installed', false) && !self::checkUpgrade(false)) {
 
 			// NOTE: This will be replaced to use OCP
 			$userSession = self::$server->getUserSession();
@@ -781,7 +780,7 @@ class OC {
 	 */
 	public static function registerLogRotate() {
 		$systemConfig = \OC::$server->getSystemConfig();
-		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !\OCP\Util::needUpgrade()) {
+		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !self::checkUpgrade(false)) {
 			//don't try to do this before we are properly setup
 			//use custom logfile path if defined, otherwise use default of owncloud.log in data directory
 			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/owncloud.log'));
@@ -873,8 +872,7 @@ class OC {
 
 		// Load minimum set of apps
 		if (!self::checkUpgrade(false)
-			&& !$systemConfig->getValue('maintenance', false)
-			&& !\OCP\Util::needUpgrade()) {
+			&& !$systemConfig->getValue('maintenance', false)) {
 			// For logged-in users: Load everything
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();
@@ -887,7 +885,7 @@ class OC {
 
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
-				if (!$systemConfig->getValue('maintenance', false) && !\OCP\Util::needUpgrade()) {
+				if (!$systemConfig->getValue('maintenance', false) && !self::checkUpgrade(false)) {
 					OC_App::loadApps(array('filesystem', 'logging'));
 					OC_App::loadApps();
 				}

--- a/lib/base.php
+++ b/lib/base.php
@@ -323,22 +323,26 @@ class OC {
 		return \OCP\Util::needUpgrade();
 	}
 
+	protected static $needUpgrade = null;
+
 	/**
 	 * Checks if the version requires an update and shows
 	 * @param bool $showTemplate Whether an update screen should get shown
 	 * @return bool|void
 	 */
 	public static function checkUpgrade($showTemplate = true) {
-		if (\OCP\Util::needUpgrade()) {
+		if (!isset(self::$needUpgrade)) {
+			self::$needUpgrade=\OCP\Util::needUpgrade();
+		}
+		if (self::$needUpgrade) {
 			$systemConfig = \OC::$server->getSystemConfig();
 			if ($showTemplate && !$systemConfig->getValue('maintenance', false)) {
 				self::printUpgradePage();
 				exit();
-			} else {
-				return true;
 			}
 		}
-		return false;
+
+		return self::$needUpgrade;
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -320,10 +320,8 @@ class OC {
 	 * @deprecated use \OCP\Util::needUpgrade() instead
 	 */
 	public static function needUpgrade() {
-		return self::checkUpgrade(false);
+		return \OCP\Util::needUpgrade();
 	}
-
-	protected static $needUpgrade = null;
 
 	/**
 	 * Checks if the version requires an update and shows
@@ -331,17 +329,16 @@ class OC {
 	 * @return bool|void
 	 */
 	public static function checkUpgrade($showTemplate = true) {
-		if (!isset(self::$needUpgrade)) {
-			self::$needUpgrade=\OCP\Util::needUpgrade();
-		}
-		if (self::$needUpgrade) {
+		if (\OCP\Util::needUpgrade()) {
 			$systemConfig = \OC::$server->getSystemConfig();
 			if ($showTemplate && !$systemConfig->getValue('maintenance', false)) {
 				self::printUpgradePage();
 				exit();
+			} else {
+				return true;
 			}
 		}
-		return self::$needUpgrade;
+		return false;
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -661,6 +661,7 @@ class Util {
 		return \OC_Util::isDefaultExpireDateEnforced();
 	}
 
+	protected static $needUpgrade = null;
 
 	/**
 	 * Checks whether the current version needs upgrade.
@@ -669,6 +670,9 @@ class Util {
 	 * @since 7.0.0
 	 */
 	public static function needUpgrade() {
-		return \OC_Util::needUpgrade(\OC::$server->getConfig());
+		if (!isset(self::$needUpgrade)) {
+			self::$needUpgrade=\OC_Util::needUpgrade(\OC::$server->getConfig());
+		}		
+		return self::$needUpgrade;
 	}
 }


### PR DESCRIPTION
instead of calling `\OCP\Util::needUpgrade()` again and again, save the result in `self::$needUpgrade` and return that value when asked

I have done some performance tests. Running 4 user sessions, every uploading 10 folders with 10 small files (4byte) in it. After the upload the test runs PROFIND and downloads all the files again.
Here is the code of the test: https://github.com/individual-it/owncloud-performance-test
It depends on https://github.com/owncloud/pyocclient/

I have compared (means of 4 runs):
- 8.1
- the master branch of the state before I've branched out 73b43db
- this skip_unnecessary_cache_updates patch #18753 
- and this patch

![owncloud_perf](https://cloud.githubusercontent.com/assets/2425577/9811317/2c8babe4-5896-11e5-8780-1a16635a2836.png)
