### PR TITLE
Store appconfig defaults if no value is present

### DIFF
--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -125,6 +125,10 @@ class AppConfig implements IAppConfig {
 			return $this->cache[$app][$key];
 		}
 
+		if ($default !== null) {
+			$this->setValue($app, $key, $default);
+		}
+
 		return $default;
 	}
 

--- a/tests/lib/appconfig.php
+++ b/tests/lib/appconfig.php
@@ -318,6 +318,36 @@ class AppConfig extends TestCase {
 		$this->assertConfigKey('testapp', 'foo', 'v2');
 	}
 
+	public function testGettingDefaultSetsValue() {
+		$appConfig = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+
+		$this->assertFalse($appConfig->hasKey('testapp', 'foo'));
+		$this->assertEquals('bar', $appConfig->getValue('testapp', 'foo', 'bar'));
+		$this->assertConfigKey('testapp', 'foo', 'bar');
+
+	}
+
+	public function testGettingValueNoDefaultDoesNotSet() {
+		$appConfig = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+
+		$this->assertFalse($appConfig->hasKey('testapp', 'foo'));
+		$this->assertEquals(null, $appConfig->getValue('testapp', 'foo', null));
+
+		// Make sure there is no entry in the database
+		$sql = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$sql->select('configvalue')
+			->from('appconfig')
+			->where($sql->expr()->eq('appid', $sql->createParameter('appid')))
+			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
+			->setParameter('appid', 'testapp')
+			->setParameter('configkey', 'foo');
+		$query = $sql->execute();
+		$actual = $query->fetch();
+		$query->closeCursor();
+
+		$this->assertEquals(null, $actual);
+	}
+
 	/**
 	 * @param string $app
 	 * @param string $key


### PR DESCRIPTION
Before:`$appConfig->getValue('app', 'var', 'default')` if 'var' for 'app' was not in the database. Just return the default. However now if we have two places where this code is used

`$appConfig->getValue('app', 'var', 'FOO')` and `$appConfig->getValue('app', 'var', 'BAR')` this can lead to very strange situations.

Now a getValue will properly set the default if it is not in the database. So there is consistency again.

@schiesbn the encryption migration test fail. Could you have a look at them. Since I don't use encryption I don't want to mess with that.
