### PR TITLE
[stable8] Add custom CSP for Win 10 compatibility

### DIFF
--- a/lib/private/eventsource.php
+++ b/lib/private/eventsource.php
@@ -41,6 +41,17 @@ class OC_EventSource implements \OCP\IEventSource {
 		$this->fallback = isset($_GET['fallback']) and $_GET['fallback'] == 'true';
 		if ($this->fallback) {
 			$this->fallBackId = (int)$_GET['fallback_id'];
+			/**
+			 * FIXME: The default content-security-policy of ownCloud forbids inline
+			 * JavaScript for security reasons. IE starting on Windows 10 will
+			 * however also obey the CSP which will break the event source fallback.
+			 *
+			 * As a workaround thus we set a custom policy which allows the execution
+			 * of inline JavaScript.
+			 *
+			 * @link https://github.com/owncloud/core/issues/14286
+			 */
+			header("Content-Security-Policy: default-src 'none'; script-src 'unsafe-inline'");
 			header("Content-Type: text/html");
 			echo str_repeat('<span></span>' . PHP_EOL, 10); //dummy data to keep IE happy
 		} else {


### PR DESCRIPTION
The default content-security-policy of ownCloud forbids inline
JavaScript for security reasons. IE starting on Windows 10 will
however also obey the CSP which will break the event source fallback.
As a workaround thus we set a custom policy which allows the execution
of inline JavaScript.

This fixes https://github.com/owncloud/core/issues/14286

Backport of https://github.com/owncloud/core/pull/17791

cc @karlitschek 
