### PR TITLE
Remove storing storage_id in mount.json

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -81,9 +81,7 @@ class OC_Mount_Config {
 	 * @param array $data
 	 */
 	public static function initMountPointsHook($data) {
-		self::addStorageIdToConfig(null);
 		if ($data['user']) {
-			self::addStorageIdToConfig($data['user']);
 			$user = \OC::$server->getUserManager()->get($data['user']);
 			if (!$user) {
 				\OC::$server->getLogger()->warning(
@@ -210,7 +208,6 @@ class OC_Mount_Config {
 			'users' => $storage->getApplicableUsers(),
 		];
 		$mountEntry['id'] = $storage->getId();
-		// $mountEntry['storage_id'] = null; // we don't store this!
 
 		return $mountEntry;
 	}
@@ -308,14 +305,6 @@ class OC_Mount_Config {
 			$config = \OC::$server->getConfig();
 			$datadir = $config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data/');
 			$file = $config->getSystemValue('mount_file', $datadir . '/mount.json');
-		}
-
-		foreach ($data as &$applicables) {
-			foreach ($applicables as &$mountPoints) {
-				foreach ($mountPoints as &$options) {
-					self::addStorageId($options);
-				}
-			}
 		}
 
 		$content = json_encode($data, JSON_PRETTY_PRINT);
@@ -491,61 +480,5 @@ class OC_Mount_Config {
 			)
 		);
 		return hash('md5', $data);
-	}
-
-	/**
-	 * Add storage id to the storage configurations that did not have any.
-	 *
-	 * @param string $user user for which to process storage configs
-	 */
-	private static function addStorageIdToConfig($user) {
-		$config = self::readData($user);
-
-		$needUpdate = false;
-		foreach ($config as &$applicables) {
-			foreach ($applicables as &$mountPoints) {
-				foreach ($mountPoints as &$options) {
-					$needUpdate |= !isset($options['storage_id']);
-				}
-			}
-		}
-
-		if ($needUpdate) {
-			self::writeData($user, $config);
-		}
-	}
-
-	/**
-	 * Get storage id from the numeric storage id and set
-	 * it into the given options argument. Only do this
-	 * if there was no storage id set yet.
-	 *
-	 * This might also fail if a storage wasn't fully configured yet
-	 * and couldn't be mounted, in which case this will simply return false.
-	 *
-	 * @param array $options storage options
-	 *
-	 * @return bool true if the storage id was added, false otherwise
-	 */
-	private static function addStorageId(&$options) {
-		if (isset($options['storage_id'])) {
-			return false;
-		}
-
-		$service = self::$app->getContainer()->query('OCA\Files_External\Service\BackendService');
-		$class = $service->getBackend($options['backend'])->getStorageClass();
-		try {
-			/** @var \OC\Files\Storage\Storage $storage */
-			$storage = new $class($options['options']);
-			// TODO: introduce StorageConfigException
-		} catch (\Exception $e) {
-			// storage might not be fully configured yet (ex: Dropbox)
-			// note that storage instances aren't supposed to open any connections
-			// in the constructor, so this exception is likely to be a config exception
-			return false;
-		}
-
-		$options['storage_id'] = $storage->getCache()->getNumericStorageId();
-		return true;
 	}
 }


### PR DESCRIPTION
One mount configuration does not necessarily map to a single storage, due to `$user` substitution or special auth mechanisms. Since the behaviour of this item is completely inconsistent, the best thing is just to remove it. As far as I'm aware nothing actually makes use of it, so that's good, and that's the reason for the 8.2 milestone.

Other benefits: we don't need to instantiate storage classes every time we write or initialize mount points, so ++$performance.

Please review @icewind1991 @MorrisJobke @LukasReschke @DeepDiver1975 
