### PR TITLE
Do not compare the value on Oracle

### DIFF
--- a/tests/lib/appconfig.php
+++ b/tests/lib/appconfig.php
@@ -191,7 +191,10 @@ class AppConfig extends TestCase {
 		$this->assertEquals('1.2.3', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.2.3');
 
-		$this->assertFalse($config->setValue('testapp', 'installed_version', '1.2.3'));
+		$wasModified = $config->setValue('testapp', 'installed_version', '1.2.3');
+		if (!(\OC::$server->getDatabaseConnection() instanceof \OC\DB\OracleConnection)) {
+			$this->assertFalse($wasModified);
+		}
 
 		$this->assertEquals('1.2.3', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.2.3');
@@ -218,7 +221,10 @@ class AppConfig extends TestCase {
 		$this->assertEquals('somevalue', $config->getValue('someapp', 'somekey'));
 		$this->assertConfigKey('someapp', 'somekey', 'somevalue');
 
-		$this->assertFalse($config->setValue('someapp', 'somekey', 'somevalue'));
+		$wasInserted = $config->setValue('someapp', 'somekey', 'somevalue');
+		if (!(\OC::$server->getDatabaseConnection() instanceof \OC\DB\OracleConnection)) {
+			$this->assertFalse($wasInserted);
+		}
 	}
 
 	public function testDeleteKey() {


### PR DESCRIPTION
As per docs: http://docs.oracle.com/cd/E11882_01/server.112/e26088/conditions002.htm#i1033286

> Large objects (LOBs) are not supported in comparison conditions.

@MorrisJobke @LukasReschke @DeepDiver1975 

Fixes #18949
