### PR TITLE
Cast clobs to strings for comparison on Oracle

### DIFF
--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -223,7 +223,7 @@ class AllConfig implements \OCP\IConfig {
 					'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ? ';
 
 			if($preCondition !== null) {
-				$sql .= 'AND '.$this->connection->castColumn('`configvalue`', 'clob', 'string').' = ?';
+				$sql .= 'AND ' . $this->connection->castColumnValueToString('`configvalue`') . ' = ?';
 				$data[] = $preCondition;
 			}
 			$affectedRows = $this->connection->executeUpdate($sql, $data);

--- a/lib/private/allconfig.php
+++ b/lib/private/allconfig.php
@@ -223,12 +223,7 @@ class AllConfig implements \OCP\IConfig {
 					'WHERE `userid` = ? AND `appid` = ? AND `configkey` = ? ';
 
 			if($preCondition !== null) {
-				if($this->getSystemValue('dbtype', 'sqlite') === 'oci') {
-					//oracle hack: need to explicitly cast CLOB to CHAR for comparison
-					$sql .= 'AND to_char(`configvalue`) = ?';
-				} else {
-					$sql .= 'AND `configvalue` = ?';
-				}
+				$sql .= 'AND '.$this->connection->castColumn('`configvalue`', 'clob', 'string').' = ?';
 				$data[] = $preCondition;
 			}
 			$affectedRows = $this->connection->executeUpdate($sql, $data);

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -175,7 +175,10 @@ class AppConfig implements IAppConfig {
 			->set('configvalue', $sql->createParameter('configvalue'))
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->andWhere($sql->expr()->neq($sql->expr()->castColumn('configvalue', 'clob', 'string'), $sql->createParameter('configvalue')))
+			->andWhere($sql->expr()->neq(
+				$sql->expr()->castColumnValueToString('configvalue'),
+				$sql->createParameter('configvalue')
+			))
 			->setParameter('configvalue', $value)
 			->setParameter('app', $app)
 			->setParameter('configkey', $key)

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -175,7 +175,7 @@ class AppConfig implements IAppConfig {
 			->set('configvalue', $sql->createParameter('configvalue'))
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
-			->andWhere($sql->expr()->neq('configvalue', $sql->createParameter('configvalue')))
+			->andWhere($sql->expr()->neq($sql->expr()->castColumn('configvalue', 'clob', 'string'), $sql->createParameter('configvalue')))
 			->setParameter('configvalue', $value)
 			->setParameter('app', $app)
 			->setParameter('configkey', $key)

--- a/lib/private/appframework/db/db.php
+++ b/lib/private/appframework/db/db.php
@@ -147,6 +147,16 @@ class Db implements IDb {
 	}
 
 	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @return string wrapped column name
+	 */
+	public function castColumnValueToString($column) {
+		return $this->connection->castColumnValueToString($column);
+	}
+
+	/**
 	 * Start a transaction
 	 */
 	public function beginTransaction() {

--- a/lib/private/db/adapter.php
+++ b/lib/private/db/adapter.php
@@ -97,12 +97,10 @@ class Adapter {
 	 * Cast a column type if the DB requires it for comparisons
 	 *
 	 * @param string $column
-	 * @param string $columnType
-	 * @param string $castTo
 	 * @return string wrapped column name
 	 */
-	public function castColumn($column, $columnType, $castTo) {
-		// default impl does no casting
+	public function castColumnValueToString($column) {
+		// default implementation does nothing
 		return $column;
 	}
 }

--- a/lib/private/db/adapter.php
+++ b/lib/private/db/adapter.php
@@ -92,4 +92,17 @@ class Adapter {
 
 		return $this->conn->executeUpdate($query, $inserts);
 	}
+
+	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @param string $columnType
+	 * @param string $castTo
+	 * @return string wrapped column name
+	 */
+	public function castColumn($column, $columnType, $castTo) {
+		// default impl does no casting
+		return $column;
+	}
 }

--- a/lib/private/db/adapteroci8.php
+++ b/lib/private/db/adapteroci8.php
@@ -43,11 +43,14 @@ class AdapterOCI8 extends Adapter {
 		return $statement;
 	}
 
-	public function castColumn($column, $columnType, $castTo) {
-		if ($columnType === 'clob' && $castTo === 'string') {
-			// clobs need conversion in comparisons
-			return 'to_char('.$column.')';
-		}
-		return parent::castColumn($column, $columnType, $castTo);
+	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @return string wrapped column name
+	 */
+	public function castColumnValueToString($column) {
+		// clobs need conversion in comparisons
+		return 'to_char('.$column.')';
 	}
 }

--- a/lib/private/db/adapteroci8.php
+++ b/lib/private/db/adapteroci8.php
@@ -42,4 +42,12 @@ class AdapterOCI8 extends Adapter {
 		$statement = str_ireplace('UNIX_TIMESTAMP()', self::UNIX_TIMESTAMP_REPLACEMENT, $statement);
 		return $statement;
 	}
+
+	public function castColumn($column, $columnType, $castTo) {
+		if ($columnType === 'clob' && $castTo === 'string') {
+			// clobs need conversion in comparisons
+			return 'to_char('.$column.')';
+		}
+		return parent::castColumn($column, $columnType, $castTo);
+	}
 }

--- a/lib/private/db/connection.php
+++ b/lib/private/db/connection.php
@@ -246,12 +246,10 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 * Cast a column type if the DB requires it for comparisons
 	 *
 	 * @param string $column
-	 * @param string $columnType
-	 * @param string $castTo
 	 * @return string wrapped column name
 	 */
-	public function castColumn($column, $columnType, $castTo) {
-		return $this->adapter->castColumn($column, $columnType, $castTo);
+	public function castColumnValueToString($column) {
+		return $this->adapter->castColumnValueToString($column);
 	}
 
 	/**

--- a/lib/private/db/connection.php
+++ b/lib/private/db/connection.php
@@ -243,6 +243,18 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	}
 
 	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @param string $columnType
+	 * @param string $castTo
+	 * @return string wrapped column name
+	 */
+	public function castColumn($column, $columnType, $castTo) {
+		return $this->adapter->castColumn($column, $columnType, $castTo);
+	}
+
+	/**
 	 * returns the error code and message as a string for logging
 	 * works with DoctrineException
 	 * @return string

--- a/lib/private/db/querybuilder/expressionbuilder.php
+++ b/lib/private/db/querybuilder/expressionbuilder.php
@@ -318,13 +318,11 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * Cast a column type if the DB requires it for comparisons
 	 *
 	 * @param string $column
-	 * @param string $columnType
-	 * @param string $castTo
 	 * @return Literal
 	 */
-	public function castColumn($column, $columnType, $castTo) {
-		return new Literal($this->connection->castColumn(
-			$this->helper->quoteColumnName($column), $columnType, $castTo
+	public function castColumnValueToString($column) {
+		return new Literal($this->connection->castColumnValueToString(
+			$this->helper->quoteColumnName($column)
 		));
 	}
 }

--- a/lib/private/db/querybuilder/expressionbuilder.php
+++ b/lib/private/db/querybuilder/expressionbuilder.php
@@ -32,12 +32,16 @@ class ExpressionBuilder implements IExpressionBuilder {
 	/** @var QuoteHelper */
 	private $helper;
 
+	/** @var IDBConnection */
+	private $connection;
+
 	/**
 	 * Initializes a new <tt>ExpressionBuilder</tt>.
 	 *
 	 * @param \OCP\IDBConnection $connection
 	 */
 	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
 		$this->helper = new QuoteHelper();
 		$this->expressionBuilder = new DoctrineExpressionBuilder($connection);
 	}
@@ -308,5 +312,19 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 */
 	public function literal($input, $type = null) {
 		return new Literal($this->expressionBuilder->literal($input, $type));
+	}
+
+	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @param string $columnType
+	 * @param string $castTo
+	 * @return Literal
+	 */
+	public function castColumn($column, $columnType, $castTo) {
+		return new Literal($this->connection->castColumn(
+			$this->helper->quoteColumnName($column), $columnType, $castTo
+		));
 	}
 }

--- a/lib/public/db/querybuilder/iexpressionbuilder.php
+++ b/lib/public/db/querybuilder/iexpressionbuilder.php
@@ -249,4 +249,13 @@ interface IExpressionBuilder {
 	 * @since 8.2.0
 	 */
 	public function literal($input, $type = null);
+
+	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @return string wrapped column name
+	 * @since 8.2.0
+	 */
+	public function castColumnValueToString($column);
 }

--- a/lib/public/idbconnection.php
+++ b/lib/public/idbconnection.php
@@ -109,6 +109,15 @@ interface IDBConnection {
 	public function insertIfNotExist($table, $input, array $compare = null);
 
 	/**
+	 * Cast a column type if the DB requires it for comparisons
+	 *
+	 * @param string $column
+	 * @return string wrapped column name
+	 * @since 8.2.0
+	 */
+	public function castColumnValueToString($column);
+
+	/**
 	 * Start a transaction
 	 * @since 6.0.0
 	 */

--- a/tests/lib/allconfig.php
+++ b/tests/lib/allconfig.php
@@ -81,14 +81,7 @@ class TestAllConfig extends \Test\TestCase {
 	}
 
 	public function testSetUserValueWithPreCondition() {
-		// mock the check for the database to run the correct SQL statements for each database type
-		$systemConfig = $this->getMock('\OC\SystemConfig');
-		$systemConfig->expects($this->once())
-			->method('getValue')
-			->with($this->equalTo('dbtype'),
-				$this->equalTo('sqlite'))
-			->will($this->returnValue(\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite')));
-		$config = $this->getConfig($systemConfig);
+		$config = $this->getConfig();
 
 		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 
@@ -125,14 +118,7 @@ class TestAllConfig extends \Test\TestCase {
 	 * @expectedException \OCP\PreConditionNotMetException
 	 */
 	public function testSetUserValueWithPreConditionFailure() {
-		// mock the check for the database to run the correct SQL statements for each database type
-		$systemConfig = $this->getMock('\OC\SystemConfig');
-		$systemConfig->expects($this->once())
-			->method('getValue')
-			->with($this->equalTo('dbtype'),
-				$this->equalTo('sqlite'))
-			->will($this->returnValue(\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite')));
-		$config = $this->getConfig($systemConfig);
+		$config = $this->getConfig();
 
 		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
 

--- a/tests/lib/db/querybuilder/expressionbuildertest.php
+++ b/tests/lib/db/querybuilder/expressionbuildertest.php
@@ -326,13 +326,22 @@ class ExpressionBuilderTest extends \Test\TestCase {
 	 * @param string|null $type
 	 */
 	public function testLiteral($input, $type) {
-		/** @var \OC\DB\QueryBuilder\Literal $actual */
+		/** @var \OCP\DB\QueryBuilder\ILiteral $actual */
 		$actual = $this->expressionBuilder->literal($input, $type);
 
+		$this->assertInstanceOf('\OCP\DB\QueryBuilder\ILiteral', $actual);
 		$this->assertInstanceOf('\OC\DB\QueryBuilder\Literal', $actual);
 		$this->assertEquals(
 			$this->doctrineExpressionBuilder->literal($input, $type),
 			$actual->__toString()
 		);
+	}
+
+	public function testCastColumnValueToString() {
+		$column = $this->expressionBuilder->castColumnValueToString('test');
+
+		$this->assertInstanceOf('\OCP\DB\QueryBuilder\ILiteral', $column);
+		$this->assertInstanceOf('\OC\DB\QueryBuilder\Literal', $column);
+		$this->assertContains('`test`', $column->__toString());
 	}
 }


### PR DESCRIPTION
Clob values need to be casted using `to_char()` for comparisons on Oracle. This was already being used in AllConfig for the precondition stuff, I've generalized it and integrated it with the QueryBuilder so it's easier to use. Needs testing on Oracle of course.

I'll get some unit tests working for this soon.

cc @nickvergessen @butonic @DeepDiver1975 

Fixes #18949 
