### PR TITLE
Add reset method to mimetype loader

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -377,7 +377,7 @@ class Scanner extends BasicEmitter {
 			// inserted mimetypes but those weren't available yet inside the transaction
 			// To make sure to have the updated mime types in such cases,
 			// we reload them here
-			$this->cache->loadMimetypes();
+			\OC::$server->getMimeTypeLoader()->reset();
 		}
 
 		foreach ($childQueue as $child => $childData) {

--- a/lib/private/files/type/loader.php
+++ b/lib/private/files/type/loader.php
@@ -97,6 +97,14 @@ class Loader implements IMimeTypeLoader {
 	}
 
 	/**
+	 * Clear all loaded mimetypes, allow for re-loading
+	 */
+	public function reset() {
+		$this->mimetypes = [];
+		$this->mimetypeIds = [];
+	}
+
+	/**
 	 * Store a mimetype in the DB
 	 *
 	 * @param string $mimetype

--- a/lib/public/files/imimetypeloader.php
+++ b/lib/public/files/imimetypeloader.php
@@ -56,4 +56,11 @@ interface IMimeTypeLoader {
 	 * @since 8.2.0
 	 */
 	public function exists($mimetype);
+
+	/**
+	 * Clear all loaded mimetypes, allow for re-loading
+	 *
+	 * @since 8.2.0
+	 */
+	public function reset();
 }

--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -24,13 +24,7 @@ class RepairMimeTypes extends \Test\TestCase {
 		parent::setUp();
 
 		$this->savedMimetypeLoader = \OC::$server->getMimeTypeLoader();
-		$this->mimetypeLoader = $this->getMockBuilder('\OC\Files\Type\Loader')
-			->setConstructorArgs([\OC::$server->getDatabaseConnection()])
-			->setMethods(null)
-			->getMock();
-		\OC::$server->registerService('MimeTypeLoader', function ($c) {
-			return $this->mimetypeLoader;
-		});
+		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 
 		$this->storage = new \OC\Files\Storage\Temporary([]);
 		$this->repair = new \OC\Repair\RepairMimeTypes();
@@ -42,16 +36,13 @@ class RepairMimeTypes extends \Test\TestCase {
 		\OC_DB::executeAudited($sql, [$this->storage->getId()]);
 		$this->clearMimeTypes();
 
-		\OC::$server->registerService('MimeTypeLoader', function($c) {
-			return $this->savedMimetypeLoader;
-		});
-
 		parent::tearDown();
 	}
 
 	private function clearMimeTypes() {
 		$sql = 'DELETE FROM `*PREFIX*mimetypes`';
 		\OC_DB::executeAudited($sql);
+		$this->mimetypeLoader->reset();
 	}
 
 	private function addEntries($entries) {
@@ -97,7 +88,7 @@ class RepairMimeTypes extends \Test\TestCase {
 		$this->repair->run();
 
 		// force mimetype reload
-		self::invokePrivate($this->mimetypeLoader, 'loadMimetypes');
+		$this->mimetypeLoader->reset();
 
 		$this->checkEntries($fixedMimeTypes);
 	}


### PR DESCRIPTION
Used to solve concurrency issues in the scanner. Also simplifies some repair unit tests, which is cool.

Fixes #18975 

cc @rullzer @MorrisJobke @nickvergessen 
