### PR TITLE
Log timestamps with microseconds precision

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -72,7 +72,7 @@ class OC_Log_Owncloud {
 		} catch (Exception $e) {
 			$timezone = new DateTimeZone('UTC');
 		}
-		$time = new DateTime(null, $timezone);
+		$time = DateTime::createFromFormat("U.u", microtime(true), $timezone);
 		$request = \OC::$server->getRequest();
 		$reqId = $request->getId();
 		$remoteAddr = $request->getRemoteAddress();

--- a/tests/lib/log/owncloud.php
+++ b/tests/lib/log/owncloud.php
@@ -17,15 +17,30 @@
 
 class Test_Log_Owncloud extends \PHPUnit_Framework_TestCase
 {
+	private $restore_logfile;
+	private $restore_logdateformat;
 
 	public function setUp() {
+		$restore_logfile = OC_Config::getValue("logfile");
+		$restore_logdateformat = OC_Config::getValue('logdateformat');
+		
 		OC_Config::setValue("logfile", OC_Config::getValue('datadirectory') . "/logtest");
 		OC_Log_Owncloud::init();
 	}
 	public function tearDown() {
-		OC_Config::setValue("logfile", null);
+		if (isset($this->restore_logfile)) {
+			OC_Config::setValue("logfile", $this->restore_logfile);
+		} else {
+			OC_Config::deleteKey("logfile");
+		}		
+		if (isset($this->restore_logdateformat)) {
+			OC_Config::setValue("logdateformat", $this->restore_logdateformat);
+		} else {
+			OC_Config::deleteKey("restore_logdateformat");
+		}		
 		OC_Log_Owncloud::init();
 	}
+	
 	public function testMicrosecondsLogTimestamp() {
 		# delete old logfile
 		unlink(OC_Config::getValue('logfile'));

--- a/tests/lib/log/owncloud.php
+++ b/tests/lib/log/owncloud.php
@@ -15,19 +15,20 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class Test_Log_Owncloud extends \PHPUnit_Framework_TestCase
+class Test_Log_Owncloud extends Test\TestCase
 {
 	private $restore_logfile;
 	private $restore_logdateformat;
 
-	public function setUp() {
+	protected function setUp() {
+		parent::setUp();
 		$restore_logfile = OC_Config::getValue("logfile");
 		$restore_logdateformat = OC_Config::getValue('logdateformat');
 		
 		OC_Config::setValue("logfile", OC_Config::getValue('datadirectory') . "/logtest");
 		OC_Log_Owncloud::init();
 	}
-	public function tearDown() {
+	protected function tearDown() {
 		if (isset($this->restore_logfile)) {
 			OC_Config::setValue("logfile", $this->restore_logfile);
 		} else {
@@ -39,6 +40,7 @@ class Test_Log_Owncloud extends \PHPUnit_Framework_TestCase
 			OC_Config::deleteKey("restore_logdateformat");
 		}		
 		OC_Log_Owncloud::init();
+		parent::tearDown();
 	}
 	
 	public function testMicrosecondsLogTimestamp() {

--- a/tests/lib/log/owncloud.php
+++ b/tests/lib/log/owncloud.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class Test_Log_Owncloud extends \PHPUnit_Framework_TestCase
+{
+
+	public function setUp() {
+		OC_Config::setValue("logfile", OC_Config::getValue('datadirectory') . "/logtest");
+		OC_Log_Owncloud::init();
+	}
+	public function tearDown() {
+		OC_Config::setValue("logfile", null);
+		OC_Log_Owncloud::init();
+	}
+	public function testMicrosecondsLogTimestamp() {
+		# delete old logfile
+		unlink(OC_Config::getValue('logfile'));
+
+		# set format & write log line
+		OC_Config::setValue('logdateformat', 'u');
+		OC_Log_Owncloud::write('test', 'message', \OCP\Util::ERROR);
+		
+		# read log line
+		$handle = @fopen(OC_Config::getValue('logfile'), 'r');
+		$line = fread($handle, 1000);
+		fclose($handle);
+		
+		# check timestamp has microseconds part
+		$values = (array) json_decode($line);
+		$microseconds = $values['time'];
+		$this->assertNotEquals(0, $microseconds);
+		
+	}
+
+
+}


### PR DESCRIPTION
When forwarding logs to logstash/kibana log lines get out of order since may of them have the same timestamp (which has currently only a seconds resolution).

With this patch, the precision is increased to microseconds. That way kibana can display log lines in chronological order.
