### PR TITLE
Sidebare preview fixes

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -34,10 +34,14 @@
 	display:block;
 	height: 250px;
 	background-repeat: no-repeat;
-	background-position: 50% top;
+	background-position: center;
 	background-size: 100%;
 	float: none;
 	margin: 0;
+}
+
+#app-sidebar .image.portrait .thumbnail {
+	background-position: 50% top;
 }
 
 #app-sidebar .image.portrait .thumbnail {

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -25,6 +25,10 @@
 	margin-top: -15px;
 }
 
+#app-sidebar .thumbnailContainer.image.portrait {
+	margin: 0; /* if we dont fit the image anyway we give it back the margin */
+}
+
 #app-sidebar .image .thumbnail {
 	width:100%;
 	display:block;

--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -72,10 +72,13 @@
 #app-sidebar .fileName h3 {
 	max-width: 300px;
 	float:left;
+	padding: 5px 0;
+	margin: -5px 0;
 }
 
 #app-sidebar .file-details {
 	margin-top: 3px;
+	margin-bottom: 15px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
 	float:left;

--- a/apps/files/js/fileinfomodel.js
+++ b/apps/files/js/fileinfomodel.js
@@ -57,7 +57,13 @@
 		 * @return {boolean} true if this is an image, false otherwise
 		 */
 		isImage: function() {
-			return this.has('mimetype') ? this.get('mimetype').substr(0, 6) === 'image/' : false;
+			if (!this.has('mimetype')) {
+				return false;
+			}
+			return this.get('mimetype').substr(0, 6) === 'image/'
+				|| this.get('mimetype') === 'application/postscript'
+				|| this.get('mimetype') === 'application/illustrator'
+				|| this.get('mimetype') === 'application/x-photoshop';
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -327,7 +327,7 @@
 			// and contain existing models that can be used.
 			// This method would in the future simply retrieve the matching model from the collection.
 			var model = new OCA.Files.FileInfoModel(this.elementToFile($tr));
-			if (!model.has('path')) {
+			if (!model.get('path')) {
 				model.set('path', this.getCurrentDirectory(), {silent: true});
 			}
 

--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -124,9 +124,9 @@
 
 				// TODO: we really need OC.Previews
 				var $iconDiv = this.$el.find('.thumbnail');
-				$iconDiv.addClass('icon-loading icon-32');
 				var $container = this.$el.find('.thumbnailContainer');
 				if (!this.model.isDirectory()) {
+					$iconDiv.addClass('icon-loading icon-32');
 					this.loadPreview(this.model.getFullPath(), this.model.get('mimetype'), this.model.get('etag'), $iconDiv, $container, this.model.isImage());
 				} else {
 					// TODO: special icons / shared / external
@@ -173,7 +173,7 @@
 					if (!img) {
 						return;
 					}
-					$iconDiv.removeClass('icon-loading  icon-32');
+					$iconDiv.removeClass('icon-loading icon-32');
 					var targetHeight = getTargetHeight(img);
 					if (this.model.isImage() && targetHeight > smallPreviewSize) {
 						if (!isLandscape(img)) {
@@ -190,7 +190,7 @@
 					});
 				}.bind(this),
 				error: function () {
-					$iconDiv.removeClass('icon-loading');
+					$iconDiv.removeClass('icon-loading icon-32');
 					this.$el.find('.thumbnailContainer').removeClass('image'); //fall back to regular view
 					$iconDiv.css({
 						'background-image': 'url("' + $iconDiv.previewImg + '")'


### PR DESCRIPTION
- square images as no longer handled as landscape
- height for landscape image previews now based on the sidebar width instead of constant (16/9 atm, not sure if that's optimal)
- Fix invalid url for previews for images in subfolders
- portrait previews have their regular margin since we dont fit them anyways
- landscape previews are cropped to the center instead of the top

cc @jancborchardt @oparoz 
