### PR TITLE
check for the right user if we can change his password

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -83,6 +83,7 @@ class Application extends \OCP\AppFramework\App {
 
 			$hookManager->registerHook([
 				new UserHooks($container->query('KeyManager'),
+					$server->getUserManager(),
 					$server->getLogger(),
 					$container->query('UserSetup'),
 					$server->getUserSession(),

--- a/apps/encryption/hooks/userhooks.php
+++ b/apps/encryption/hooks/userhooks.php
@@ -24,6 +24,7 @@
 namespace OCA\Encryption\Hooks;
 
 
+use OCP\IUserManager;
 use OCP\Util as OCUtil;
 use OCA\Encryption\Hooks\Contracts\IHook;
 use OCA\Encryption\KeyManager;
@@ -41,6 +42,10 @@ class UserHooks implements IHook {
 	 * @var KeyManager
 	 */
 	private $keyManager;
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
 	/**
 	 * @var ILogger
 	 */
@@ -74,6 +79,7 @@ class UserHooks implements IHook {
 	 * UserHooks constructor.
 	 *
 	 * @param KeyManager $keyManager
+	 * @param IUserManager $userManager
 	 * @param ILogger $logger
 	 * @param Setup $userSetup
 	 * @param IUserSession $user
@@ -83,6 +89,7 @@ class UserHooks implements IHook {
 	 * @param Recovery $recovery
 	 */
 	public function __construct(KeyManager $keyManager,
+								IUserManager $userManager,
 								ILogger $logger,
 								Setup $userSetup,
 								IUserSession $user,
@@ -92,6 +99,7 @@ class UserHooks implements IHook {
 								Recovery $recovery) {
 
 		$this->keyManager = $keyManager;
+		$this->userManager = $userManager;
 		$this->logger = $logger;
 		$this->userSetup = $userSetup;
 		$this->user = $user;
@@ -196,7 +204,7 @@ class UserHooks implements IHook {
 	public function preSetPassphrase($params) {
 		if (App::isEnabled('encryption')) {
 
-			$user = $this->user->getUser();
+			$user = $this->userManager->get($params['uid']);
 
 			if ($user && !$user->canChangePassword()) {
 				$this->setPassphrase($params);


### PR DESCRIPTION
We need to check if we can change the password from the user for whom we want to change the password and not for the currently logged in user.

Steps to test:
1. use a LDAP user backend with at least two users: admin and user1
2. enable encryption
3. login as user1 and upload a file
4. create two users admin and user1
5. enable recovery key as admin and for user1
6. change user1's password on the ldap server
7. login as admin
8. go to the user management
9. change with the recovery key the password for user1 to the same password you have chosen  at step 4
10. login as user1 and check if you can access your files again

fix #18926 

cc @karlitschek we should backport this to 8.1
