### PR TITLE
Expose federated sharing capabilities to authenticated users

### DIFF
--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -67,6 +67,13 @@ class Capabilities implements ICapability {
 
 		$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 
+
+		//Federated sharing
+		$res['federation'] = [
+			'outgoing'  => $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes',
+			'incoming' => $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes') === 'yes'
+		];
+
 		return [
 			'files_sharing' => $res,
 		];

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -202,5 +202,40 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['upload']);
 	}
 
+	public function testFederatedSharingIncomming() {
+		$map = [
+			['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('federation', $result);
+		$this->assertTrue($result['federation']['incoming']);
+	}
+
+	public function testFederatedSharingNoIncomming() {
+		$map = [
+			['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('federation', $result);
+		$this->assertFalse($result['federation']['incoming']);
+	}
+
+	public function testFederatedSharingOutgoing() {
+		$map = [
+			['files_sharing', 'outgoing_server2server_share_enabled', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('federation', $result);
+		$this->assertTrue($result['federation']['outgoing']);
+	}
+
+	public function testFederatedSharingNoOutgoing() {
+		$map = [
+			['files_sharing', 'outgoing_server2server_share_enabled', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('federation', $result);
+		$this->assertFalse($result['federation']['outgoing']);
+	}
 
 }


### PR DESCRIPTION
As promised fix for #12289

Expose federated sharing capabilities.
Only to authenticated users, so client etc can take advantage of this.

FYI: @cmonteroluque @karlitschek 

CC:  @PVince81 @MorrisJobke @LukasReschke @Xenopathic 
