### PR TITLE
Make resolve public to avoid boiler plate code

### DIFF
--- a/lib/private/appframework/utility/simplecontainer.php
+++ b/lib/private/appframework/utility/simplecontainer.php
@@ -77,7 +77,7 @@ class SimpleContainer extends Container implements IContainer {
 	 * @return stdClass
 	 * @throws QueryException if the class could not be found or instantiated
 	 */
-	private function resolve($name) {
+	public function resolve($name) {
 		$baseMsg = 'Could not resolve ' . $name . '!';
 		try {
 			$class = new ReflectionClass($name);

--- a/lib/public/icontainer.php
+++ b/lib/public/icontainer.php
@@ -44,6 +44,16 @@ use Closure;
 interface IContainer {
 
 	/**
+	 * If a parameter is not registered in the container try to instantiate it
+	 * by using reflection to find out how to build the class
+	 * @param string $name the class name to resolve
+	 * @return \stdClass
+	 * @since 8.2.0
+	 * @throws QueryException if the class could not be found or instantiated
+	 */
+	public function resolve($name);
+
+	/**
 	 * Look up a service for a given name in the container.
 	 *
 	 * @param string $name


### PR DESCRIPTION
Usecase here is the following:

``` php
$this->registerService(ItemMapper::class, function ($c) {
    if ($c->query('databaseType') === 'mysql') {
        return $c->query(MysqlItemMapper::class);
    } else {
        return new ItemMapper($c->query(OCP\IDBConnection::class));
    }
});
```

If possible you want to avoid direct instantiation of the ItemMapper class. Why? If you change the ItemMapper constructor your code will break because you forgot to change it in the container.

This PR will make the following possible:

``` php
$this->registerService(ItemMapper::class, function ($c) {
    if ($c->query('databaseType') === 'mysql') {
        return $c->query(MysqlItemMapper::class);
    } else {
        return $c->resolve(ItemMapper::class);
    }
});
```

Now after changing your constructor, your code will still work, since only the essence is wired up and not the full build details :)

PS: If you used query instead of resolve, your code would get stuck in an infinite loop

@DeepDiver1975 @MorrisJobke @LukasReschke @oparoz @PVince81 @Xenopathic 
