### PR TITLE
Fix dependency check for Swift and SMB_OC

### DIFF
--- a/apps/files_external/lib/backend/smb_oc.php
+++ b/apps/files_external/lib/backend/smb_oc.php
@@ -28,11 +28,14 @@ use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
 use \OCA\Files_External\Lib\Auth\Password\SessionCredentials;
 use \OCA\Files_External\Lib\StorageConfig;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 /**
  * Deprecated SMB_OC class - use SMB with the password::sessioncredentials auth mechanism
  */
 class SMB_OC extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, SessionCredentials $legacyAuth) {
 		$this
@@ -48,7 +51,6 @@ class SMB_OC extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
-			->setDependencyCheck('\OC\Files\Storage\SMB::checkDependencies')
 			->removeAllowedPermission(BackendService::USER_PERSONAL, BackendService::PERMISSION_CREATE)
 			->removeAllowedPermission(BackendService::USER_ADMIN, BackendService::PERMISSION_CREATE)
 			->setPriority(BackendService::PRIORITY_DEFAULT - 10)

--- a/apps/files_external/lib/backend/swift.php
+++ b/apps/files_external/lib/backend/swift.php
@@ -28,8 +28,11 @@ use \OCA\Files_External\Lib\Auth\AuthMechanism;
 use \OCA\Files_External\Service\BackendService;
 use \OCA\Files_External\Lib\Auth\OpenStack\OpenStack;
 use \OCA\Files_External\Lib\Auth\OpenStack\Rackspace;
+use \OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
 class Swift extends Backend {
+
+	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l, OpenStack $openstackAuth, Rackspace $rackspaceAuth) {
 		$this
@@ -46,7 +49,6 @@ class Swift extends Backend {
 				(new DefinitionParameter('timeout', $l->t('Request timeout (seconds)')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
-			->setDependencyCheck('\OC\Files\Storage\Swift::checkDependencies')
 			->addAuthScheme(AuthMechanism::SCHEME_OPENSTACK)
 			->setLegacyAuthMechanismCallback(function(array $params) use ($openstackAuth, $rackspaceAuth) {
 				if (isset($params['options']['key']) && $params['options']['key']) {


### PR DESCRIPTION
Mistake caused during merging, where the API had changed. The code of #18441 was written before #18733, but they were merged in reverse order causing this issue.

cc @icewind1991 @DeepDiver1975 @PVince81 @MorrisJobke 
