### PR TITLE
Improving fopen behaviour for Swift in files_external

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -350,9 +350,18 @@ class Swift extends \OC\Files\Storage\Common {
 				}
 				$tmpFile = \OCP\Files::tmpFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
-				if ($this->file_exists($path)) {
+				// Fetch existing file if required
+				if ($mode[0] !== 'w' && $this->file_exists($path)) {
+					if ($mode[0] === 'x') {
+						// File cannot already exist
+						return false;
+					}
 					$source = $this->fopen($path, 'r');
 					file_put_contents($tmpFile, $source);
+					// Seek to end if required
+					if ($mode[0] === 'a') {
+						fseek($tmpFile, 0, SEEK_END);
+					}
 				}
 				self::$tmpFiles[$tmpFile] = $path;
 


### PR DESCRIPTION
Provides proper behaviour for `fopen` flags `x` and `a`:
- `x` - `fopen` fails if the file exists
- `a` - `fopen` sets the file pointer to the end of the file
