### PR TITLE
Streaming download from Swift in files_external

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -323,7 +323,8 @@ class Swift extends \OC\Files\Storage\Common {
 					$streamInterface->rewind();
 					$stream = $streamInterface->getStream();
 					stream_context_set_option($stream, 'swift','content', $streamInterface);
-					if(is_resource($stream)) {
+					if(!strrpos($streamInterface
+						->getMetaData('wrapper_data')[0], '404 Not Found')) {
 						return $stream;
 					}
 					return false;

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -323,7 +323,10 @@ class Swift extends \OC\Files\Storage\Common {
 					$streamInterface->rewind();
 					$stream = $streamInterface->getStream();
 					stream_context_set_option($stream, 'swift','content', $streamInterface);
-					return $stream;
+					if(is_resource($stream)) {
+						return $stream;
+					}
+					return false;
 				} catch (\Guzzle\Http\Exception\BadResponseException $e) {
 					\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 					return false;

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -314,27 +314,20 @@ class Swift extends \OC\Files\Storage\Common {
 		switch ($mode) {
 			case 'r':
 			case 'rb':
-				$tmpFile = \OCP\Files::tmpFile();
-				self::$tmpFiles[$tmpFile] = $path;
 				try {
-					$object = $this->getContainer()->getObject($path);
-				} catch (ClientErrorResponseException $e) {
-					\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
-					return false;
-				} catch (Exception\ObjectNotFoundException $e) {
+					$c = $this->getContainer();
+					$streamFactory = new \Guzzle\Stream\PhpStreamRequestFactory();
+					$streamInterface = $streamFactory->fromRequest(
+						$c->getClient()
+							->get($c->getUrl($path)));
+					$streamInterface->rewind();
+					$stream = $streamInterface->getStream();
+					stream_context_set_option($stream, 'swift','content', $streamInterface);
+					return $stream;
+				} catch (\Guzzle\Http\Exception\BadResponseException $e) {
 					\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 					return false;
 				}
-				try {
-					$objectContent = $object->getContent();
-					$objectContent->rewind();
-					$stream = $objectContent->getStream();
-					file_put_contents($tmpFile, $stream);
-				} catch (Exceptions\IOError $e) {
-					\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
-					return false;
-				}
-				return fopen($tmpFile, 'r');
 			case 'w':
 			case 'wb':
 			case 'a':


### PR DESCRIPTION
Speeds up downloads as they no longer need to buffer completely on the ownCloud server before being sent to the client.

A downside of this implementation is that the file can only be traversed once. ownCloud never actually attempts to do this, and `r+` offers this behaviour if required.
