### PR TITLE
Allowing access to Swift containers shared by ACL in files_external

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -31,6 +31,7 @@
 
 namespace OC\Files\Storage;
 
+use Guzzle\Http\Url;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use Icewind\Streams\IteratorDirectory;
 use OpenCloud;
@@ -119,7 +120,14 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 
 		$this->id = 'swift::' . $params['user'] . md5($params['bucket']);
-		$this->bucket = $params['bucket'];
+
+		$bucketUrl = Url::factory($params['bucket']);
+		if ($bucketUrl->isAbsolute()) {
+			$this->bucket = end(($bucketUrl->getPathSegments()));
+			$params['endpoint_url'] = $bucketUrl->addPath('..')->normalizePath();
+		} else {
+			$this->bucket = $params['bucket'];
+		}
 
 		if (empty($params['url'])) {
 			$params['url'] = 'https://identity.api.rackspacecloud.com/v2.0/';
@@ -513,7 +521,16 @@ class Swift extends \OC\Files\Storage\Common {
 			$this->anchor = new OpenStack($this->params['url'], $settings);
 		}
 
-		$this->connection = $this->anchor->objectStoreService($this->params['service_name'], $this->params['region']);
+		$connection = $this->anchor->objectStoreService($this->params['service_name'], $this->params['region']);
+
+		if (!empty($this->params['endpoint_url'])) {
+			$endpoint = $connection->getEndpoint();
+			$endpoint->setPublicUrl($this->params['endpoint_url']);
+			$endpoint->setPrivateUrl($this->params['endpoint_url']);
+			$connection->setEndpoint($endpoint);
+		}
+
+		$this->connection = $connection;
 
 		return $this->connection;
 	}


### PR DESCRIPTION
OpenStack Swift provides the ability to share read/write access to a container without requiring the accessing user to be a member of the container's tenant/project. This is useful for providing ownCloud access to containers without also providing it privileges beyond that container.

To avoid a confusing extra field, the bucket field is overloaded to optionally take a URL, which allows ownCloud to use its Swift user credentials with arbitrary containers.
