### PR TITLE
Handle files which require Swift large object storage in files_external

### DIFF
--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -86,6 +86,8 @@ class Swift extends \OC\Files\Storage\Common {
 
 	const SUBCONTAINER_FILE = '.subcontainers';
 
+	const LARGE_OBJECT_THRESHOLD = 4294967296;
+
 	/**
 	 * translate directory path to container name
 	 *
@@ -108,6 +110,24 @@ class Swift extends \OC\Files\Storage\Common {
 			\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 			return false;
 		}
+	}
+
+	/**
+	* Get large object file segments paths. If a the specified resource
+	* isn't a Dynamic Large Object, then array will be empty.
+	**/
+	private function getFileSegments($path) {
+		// A later version of PHP OpenCloud with manifest support could do this
+		// better, but this works for now.
+		$defaultSegmentPath = sprintf('%s/%s/', $path, 'segment');
+		$objects = $this->getContainer()->objectList(array(
+			'path' => $defaultSegmentPath
+		));
+		$objectPaths = [];
+		foreach ($objects as $object) {
+			$objectPaths[] = $object->getName();
+		}
+		return $objectPaths;
 	}
 
 	public function __construct($params) {
@@ -295,7 +315,12 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 
 		try {
-			$this->getContainer()->dataObject()->setName($path)->delete();
+			$containerName = $this->getContainer()->getName();
+			$pathsToDelete = array(sprintf('/%s/%s', $containerName, $path));
+			foreach ($this->getFileSegments($path) as $segmentPath) {
+				$pathsToDelete[] = sprintf('/%s/%s', $containerName, $segmentPath);
+			}
+			$this->getConnection()->bulkDelete($pathsToDelete);
 		} catch (ClientErrorResponseException $e) {
 			\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 			return false;
@@ -407,8 +432,16 @@ class Swift extends \OC\Files\Storage\Common {
 			$this->unlink($path2);
 
 			try {
-				$source = $this->getContainer()->getPartialObject($path1);
-				$source->copy($this->bucket . '/' . $path2);
+				$fileSegments = $this->getFileSegments($path1);
+				if (count($fileSegments) == 0) {
+					// Normal file
+					$source = $this->getContainer()->getPartialObject($path1);
+					$source->copy($this->bucket . '/' . $path2);
+				} else {
+					// Large object file
+					// TODO: Implement after PHP OpenCloud is upgraded
+					return false;
+				}
 			} catch (ClientErrorResponseException $e) {
 				\OCP\Util::writeLog('files_external', $e->getMessage(), \OCP\Util::ERROR);
 				return false;
@@ -545,8 +578,16 @@ class Swift extends \OC\Files\Storage\Common {
 		if (!isset(self::$tmpFiles[$tmpFile])) {
 			return false;
 		}
-		$fileData = fopen($tmpFile, 'r');
-		$this->getContainer()->uploadObject(self::$tmpFiles[$tmpFile], $fileData);
+		if (filesize($tmpFile) < self::LARGE_OBJECT_THRESHOLD) {
+			$fileData = fopen($tmpFile, 'r');
+			$this->getContainer()->uploadObject(self::$tmpFiles[$tmpFile], $fileData);
+		} else {
+			$transfer = $this->getContainer()->setupObjectTransfer(array(
+				'name' => self::$tmpFiles[$tmpFile],
+				'path' => $tmpFile
+			));
+			$transfer->upload();
+		}
 		unlink($tmpFile);
 	}
 


### PR DESCRIPTION
At a particular threshold, php-opencloud DLO support is used to upload the object in segments.

Large object files are detected when copying, renaming and deleting. Deletions remove any segments that follow the naming convention used by php-opencloud.

For now, copy/rename simply fails for large files. The best solution for implementing it later involves upgrading php-opencloud, which will provide better manifest support.
