### PR TITLE
Use / instead of an empty string as cookie path

### DIFF
--- a/lib/private/session/cryptowrapper.php
+++ b/lib/private/session/cryptowrapper.php
@@ -77,7 +77,11 @@ class CryptoWrapper {
 			$secureCookie = $request->getServerProtocol() === 'https';
 			// FIXME: Required for CI
 			if (!defined('PHPUNIT_RUN')) {
-				setcookie(self::COOKIE_NAME, $this->passphrase, 0, \OC::$WEBROOT, '', $secureCookie, true);
+				$webRoot = \OC::$WEBROOT;
+				if($webRoot === '') {
+					$webRoot = '/';
+				}
+				setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
 			}
 		}
 	}


### PR DESCRIPTION
When an empty string is used as cookie path PHP will assign the current directory as cookie path.

This means when an user had installed an ownCloud under "/", which is mapped to an empty string in \OC::$WEBROOT, and accessed it the cookie was set to values such as "/index.php/apps/files" since the web browser assumed this to be a directory. This means that multiple encryption cookies were set for the same domain resulting in potential havoc.

With this patch the path will be set to "/" in case an empty web root is installed which makes the cookie accessible to the whole domain.

To test this setup multiple ownCloud instances on the same domain under different ports and have both installed under "/", then try to login in both of it and previously this can in some cases lead to a lockout of the user.

Note that this affects the cookies that the browsers do sent and thus to test this you need to clear all cookies from your browser previously. I consider this an acceptable behaviour for now since this code is only in master.

Fixes https://github.com/owncloud/core/issues/18919
