### PR TITLE
use the same pattern for the command name like every other command

### DIFF
--- a/core/command/encryption/encryptall.php
+++ b/core/command/encryption/encryptall.php
@@ -83,7 +83,7 @@ class EncryptAll extends Command {
 	protected function configure() {
 		parent::configure();
 
-		$this->setName('encryption:encrypt_all');
+		$this->setName('encryption:encrypt-all');
 		$this->setDescription(
 			'This will encrypt all files for all users. '
 			. 'Please make sure that no user access his files during this process!'


### PR DESCRIPTION
use the same pattern for the command name like every other command, '-' instead of '_'.

Trivial changes... cc @MorrisJobke @LukasReschke @nickvergessen 
