### PR TITLE
Add security hardenings to $.ajax()

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1215,6 +1215,20 @@ function object(o) {
  * Initializes core
  */
 function initCore() {
+	/**
+	 * Disable automatic evaluation of responses for $.ajax() functions (and its
+	 * higher-level alternatives like $.get() and $.post()).
+	 *
+	 * If a response to a $.ajax() request returns a content type of "application/javascript"
+	 * JQuery would previously execute the response body. This is a pretty unexpected
+	 * behaviour and can result in a bypass of our Content-Security-Policy as well as
+	 * multiple unexpected XSS vectors.
+	 */
+	$.ajaxSetup({
+		contents: {
+			script: false
+		}
+	});
 
 	/**
 	 * Set users locale to moment.js as soon as possible

--- a/core/js/oc-requesttoken.js
+++ b/core/js/oc-requesttoken.js
@@ -1,4 +1,6 @@
-$(document).on('ajaxSend',function(elm, xhr) {
-	xhr.setRequestHeader('requesttoken', oc_requesttoken);
-	xhr.setRequestHeader('OCS-APIREQUEST', 'true');
+$(document).on('ajaxSend',function(elm, xhr, settings) {
+	if(settings.crossDomain === false) {
+		xhr.setRequestHeader('requesttoken', oc_requesttoken);
+		xhr.setRequestHeader('OCS-APIREQUEST', 'true');
+	}
 });


### PR DESCRIPTION
Adds two security hardening to `$.ajax`:
1. Do not add sensitive request headers for cross domain requests
   - Prevents leaking the CSRF token to another third-party domain by mistake. (fixes https://github.com/owncloud/core/issues/16926)
2. Disable automatic evaluation of responses
   - If a response to a $.ajax() request returns a content type of "application/javascript"
     JQuery would previously execute the response body. This is a pretty unexpected
     behaviour and can result in a bypass of our Content-Security-Policy as well as
     multiple unexpected XSS vectors.
