### PR TITLE
Add tests for downloading files over dav

### DIFF
--- a/tests/lib/connector/sabre/requesttest/downloadtest.php
+++ b/tests/lib/connector/sabre/requesttest/downloadtest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2015 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Connector\Sabre\RequestTest;
+
+use OCP\AppFramework\Http;
+use OCP\Lock\ILockingProvider;
+
+class DownloadTest extends RequestTest {
+	public function testDownload() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'bar');
+
+		$response = $this->request($view, $user, 'pass', 'GET', '/foo.txt');
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertEquals(stream_get_contents($response->getBody()), 'bar');
+	}
+
+	/**
+	 * @expectedException \OC\Connector\Sabre\Exception\FileLocked
+	 */
+	public function testDownloadWriteLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'bar');
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_EXCLUSIVE);
+
+		$this->request($view, $user, 'pass', 'GET', '/foo.txt', 'asd');
+	}
+
+	public function testDownloadReadLocked() {
+		$user = $this->getUniqueID();
+		$view = $this->setupUser($user, 'pass');
+
+		$view->file_put_contents('foo.txt', 'bar');
+
+		$view->lockFile('/foo.txt', ILockingProvider::LOCK_SHARED);
+
+		$response = $this->request($view, $user, 'pass', 'GET', '/foo.txt', 'asd');
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertEquals(stream_get_contents($response->getBody()), 'bar');
+	}
+}

--- a/tests/lib/connector/sabre/requesttest/sapi.php
+++ b/tests/lib/connector/sabre/requesttest/sapi.php
@@ -45,7 +45,7 @@ class Sapi {
 		$copyStream = fopen('php://temp', 'r+');
 		if (is_string($response->getBody())) {
 			fwrite($copyStream, $response->getBody());
-		} else {
+		} else if (is_resource($response->getBody())) {
 			stream_copy_to_stream($response->getBody(), $copyStream);
 		}
 		rewind($copyStream);

--- a/tests/lib/connector/sabre/requesttest/sapi.php
+++ b/tests/lib/connector/sabre/requesttest/sapi.php
@@ -41,7 +41,15 @@ class Sapi {
 	 * @return void
 	 */
 	public function sendResponse(Response $response) {
-		$this->response = $response;
+		// we need to copy the body since we close the source stream
+		$copyStream = fopen('php://temp', 'r+');
+		if (is_string($response->getBody())) {
+			fwrite($copyStream, $response->getBody());
+		} else {
+			stream_copy_to_stream($response->getBody(), $copyStream);
+		}
+		rewind($copyStream);
+		$this->response = new Response($response->getStatus(), $response->getHeaders(), $copyStream);
 	}
 
 	/**


### PR DESCRIPTION
The download counterpart for the dav upload tests from #18127

Once #18901 is merged this can be easily extended with tests where encryption is enabled

cc @PVince81 @DeepDiver1975 @MorrisJobke 
