### PR TITLE
changed ZipStreamer to use composer for updates, update to 0.7

### DIFF
--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -41,7 +41,7 @@
  */
 
 // TODO: get rid of this using proper composer packages
-require_once 'mcnetic/phpzipstreamer/ZipStreamer.php';
+require_once 'mcnetic/phpzipstreamer/src/ZipStreamer.php';
 
 use OC\Lock\NoopLockingProvider;
 use OCP\Lock\ILockingProvider;
@@ -121,7 +121,7 @@ class OC_Files {
 		if ($get_type === self::FILE) {
 			$zip = false;
 		} else {
-			$zip = new ZipStreamer(false);
+			$zip = new ZipStreamer\ZipStreamer();
 		}
 		OC_Util::obEnd();
 

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -40,9 +40,6 @@
  *
  */
 
-// TODO: get rid of this using proper composer packages
-require_once 'mcnetic/phpzipstreamer/src/ZipStreamer.php';
-
 use OC\Lock\NoopLockingProvider;
 use OCP\Lock\ILockingProvider;
 


### PR DESCRIPTION
This is the necessary (really very small) change necessary to bump ZipStreamer to v0.7 (as discussed in #10001). Additionally, Zipstreamer is not referenced via composer properly. Also requires corresponding pull request owncloud/3rdparty#196.
