### PR TITLE
Register valid root for all installed apps in console

### DIFF
--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -55,7 +55,9 @@ class Application {
 			if (!\OCP\Util::needUpgrade()) {
 				OC_App::loadApps();
 				foreach (\OC::$server->getAppManager()->getInstalledApps() as $app) {
-					$file = OC_App::getAppPath($app) . '/appinfo/register_command.php';
+					$appPath = \OC_App::getAppPath($app);
+					\OC::$loader->addValidRoot($appPath);
+					$file = $appPath . '/appinfo/register_command.php';
 					if (file_exists($file)) {
 						require $file;
 					}


### PR DESCRIPTION
Might be unnecessary, but I think there are some cases where we want to be able to run app commands after the app is disabled, to perform last-chance maintenance tasks. Negligible security impact, since this only gets triggered from the CLI.

cc @nickvergessen @DeepDiver1975 @MorrisJobke 

Fixes #19019 
