### PR TITLE
Fix get_temp_dir compat shim

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1115,16 +1115,17 @@ class OC {
 		}
 		return true;
 	}
+}
 
+if (!function_exists('get_temp_dir')) {
 	/**
 	 * Get the temporary dir to store uploaded data
 	 * @return null|string Path to the temporary directory or null
+	 * @deprecated 8.2.0 use \OC::$server->getTempManager()->getTempBaseDir();
 	 */
 	function get_temp_dir() {
-		return \OC::$server->getTempManager()->t_get_temp_dir();
+		return \OC::$server->getTempManager()->getTempBaseDir();
 	}
-
 }
-
 
 OC::init();


### PR DESCRIPTION
With #18658 we moved the code to TempManager, but inadvertently moved the function `get_temp_dir()` from the global namespace to the OC class. This moves it back, and fixes an incorrect function call.

cc @DeepDiver1975 @MorrisJobke @mmattel 

Fixes #19021 
