### PR TITLE
Also allow apps directory for unit testing

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,7 @@ if ($configDir) {
 require_once __DIR__ . '/../lib/base.php';
 
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+\OC::$loader->addValidRoot(OC::$SERVERROOT . '/apps');
 
 // load all enabled apps
 \OC_App::loadApps();


### PR DESCRIPTION
Simple way to fix app unit tests since all enabled apps are loaded by default anyways

@LukasReschke @Xenopathic @oparoz @PVince81 @MorrisJobke @DeepDiver1975 
