### PR TITLE
Allow /tests folder in autoloader by default

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -528,7 +528,8 @@ class OC {
 			OC::$SERVERROOT . '/settings',
 			OC::$SERVERROOT . '/ocs',
 			OC::$SERVERROOT . '/ocs-provider',
-			OC::$SERVERROOT . '/3rdparty'
+			OC::$SERVERROOT . '/3rdparty',
+			OC::$SERVERROOT . '/tests',
 		]);
 		spl_autoload_register(array(self::$loader, 'load'));
 		$loaderEnd = microtime(true);


### PR DESCRIPTION
Given the fact that "/tests" is not shipped by default and this has broken some applications and frustrated quite some people we should add "/tests" to the default allowed autoloading set.

I do consider the security impact marginally since the /tests folder is not shipped within the release as well as usually has a hard requirement on being called by phpunit.

@DeepDiver1975 @Xenopathic 
