### PR TITLE
Make it possible to set locks that last longer than the request

### DIFF
--- a/lib/private/lock/abstractlockingprovider.php
+++ b/lib/private/lock/abstractlockingprovider.php
@@ -34,6 +34,18 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 	];
 
 	/**
+	 * Forget about all marked locks
+	 *
+	 * Caution: prevent automatic lock cleanup
+	 */
+	public function clearMarkedLocks() {
+		$this->acquiredLocks = [
+			'shared' => [],
+			'exclusive' => []
+		];
+	}
+
+	/**
 	 * Mark a locally acquired lock
 	 *
 	 * @param string $path

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -80,10 +80,8 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	 */
 	public function releaseLock($path, $type) {
 		if ($type === self::LOCK_SHARED) {
-			if (isset($this->acquiredLocks['shared'][$path]) and $this->acquiredLocks['shared'][$path] > 0) {
-				$this->memcache->dec($path);
-				$this->memcache->cad($path, 0);
-			}
+			$this->memcache->dec($path);
+			$this->memcache->cad($path, 0);
 		} else if ($type === self::LOCK_EXCLUSIVE) {
 			$this->memcache->cad($path, 'exclusive');
 		}


### PR DESCRIPTION
Make it possible to prevent oc from auto-cleaning locks by calling `$lockingProvider->clearMarkedLocks()` manually from an app.

Mainly intended to help with testing locks, such as acquiring a lock over and api, testing that you can't modify the locked file, release the lock over an api.

Example implementation of such a lock api: https://github.com/icewind1991/locktools
