### PR TITLE
Define allowed app roots earlier

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -104,7 +104,10 @@ class OC_App {
 
 		// Add each apps' folder as allowed class path
 		foreach($apps as $app) {
-			\OC::$loader->addValidRoot(self::getAppPath($app));
+			$path = self::getAppPath($app);
+			if($path !== false) {
+				\OC::$loader->addValidRoot($path);
+			}
 		}
 
 		// prevent app.php from printing output

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -101,6 +101,12 @@ class OC_App {
 		}
 		// Load the enabled apps here
 		$apps = self::getEnabledApps();
+
+		// Add each apps' folder as allowed class path
+		foreach($apps as $app) {
+			\OC::$loader->addValidRoot(self::getAppPath($app));
+		}
+
 		// prevent app.php from printing output
 		ob_start();
 		foreach ($apps as $app) {
@@ -122,7 +128,6 @@ class OC_App {
 	 */
 	public static function loadApp($app, $checkUpgrade = true) {
 		self::$loadedApps[] = $app;
-		\OC::$loader->addValidRoot(self::getAppPath($app));
 		if (is_file(self::getAppPath($app) . '/appinfo/app.php')) {
 			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			if ($checkUpgrade and self::shouldUpgrade($app)) {


### PR DESCRIPTION
The autoloader needs to be run before including the app.php, otherwise it depends on what app gets executed first and apps that rely on the dependency of other apps in app.php may break.
