### PR TITLE
Add Snap plugin to OC namespace

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1338,7 +1338,7 @@ function initCore() {
 	if($('#app-navigation').length && !$('html').hasClass('lte9')) {
 
 		// App sidebar on mobile
-		var snapper = new Snap({
+		var snapper = OC.Snap = new Snap({
 			element: document.getElementById('app-content'),
 			disable: 'right',
 			maxPosition: 250,


### PR DESCRIPTION
For developers this is very useful, to have control about the snap plugin! It is often needed to get the state of snap!
As an example, if i use a phone and i would like to drag a contact to a group on the left sidebar! But at the moment this is not possible cause snap interacts with the dragging element and so moving a contact not works! 

An example how i could prevend this issue with dragging!

```
$(" .dragClass" ).draggable({
    appendTo: "body",
start: function(event, ui) {
    if($(window).width() < 768){
    if(OC.Snap.state().state !== 'left'){
           OC.Snap.disable();       
            OC.Snap.open('left');
    }
   }
}
});
```

So for me as a dev it would be really great to get this into OC namespace!
