### PR TITLE
Throw an error when the page count or perPage setting is invalid

### DIFF
--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -20,6 +20,7 @@
  */
 namespace OCA\Files_Sharing\API;
 
+use OCP\AppFramework\Http;
 use OCP\Contacts\IManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -295,10 +296,10 @@ class Sharees {
 		$perPage = isset($_GET['perPage']) ? (int) $_GET['perPage'] : 200;
 
 		if ($perPage <= 0) {
-			return new \OC_OCS_Result(null, 401, 'Invalid perPage argument');
+			return new \OC_OCS_Result(null, Http::STATUS_BAD_REQUEST, 'Invalid perPage argument');
 		}
 		if ($page <= 0) {
-			return new \OC_OCS_Result(null, 402, 'Invalid page');
+			return new \OC_OCS_Result(null, Http::STATUS_BAD_REQUEST, 'Invalid page');
 		}
 
 		$shareTypes = [
@@ -355,7 +356,7 @@ class Sharees {
 	protected function searchSharees($search, $itemType, array $shareTypes, $page, $perPage) {
 		// Verify arguments
 		if ($itemType === null) {
-			return new \OC_OCS_Result(null, 400, 'Missing itemType');
+			return new \OC_OCS_Result(null, Http::STATUS_BAD_REQUEST, 'Missing itemType');
 		}
 
 		// Get users

--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -291,8 +291,15 @@ class Sharees {
 	public function search() {
 		$search = isset($_GET['search']) ? (string) $_GET['search'] : '';
 		$itemType = isset($_GET['itemType']) ? (string) $_GET['itemType'] : null;
-		$page = !empty($_GET['page']) ? max(1, (int) $_GET['page']) : 1;
-		$perPage = !empty($_GET['perPage']) ? max(1, (int) $_GET['perPage']) : 200;
+		$page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
+		$perPage = isset($_GET['perPage']) ? (int) $_GET['perPage'] : 200;
+
+		if ($perPage <= 0) {
+			return new \OC_OCS_Result(null, 401, 'Invalid perPage argument');
+		}
+		if ($page <= 0) {
+			return new \OC_OCS_Result(null, 402, 'Invalid page');
+		}
 
 		$shareTypes = [
 			Share::SHARE_TYPE_USER,
@@ -348,7 +355,7 @@ class Sharees {
 	protected function searchSharees($search, $itemType, array $shareTypes, $page, $perPage) {
 		// Verify arguments
 		if ($itemType === null) {
-			return new \OC_OCS_Result(null, 400, 'missing itemType');
+			return new \OC_OCS_Result(null, 400, 'Missing itemType');
 		}
 
 		// Get users

--- a/apps/files_sharing/tests/api/shareestest.php
+++ b/apps/files_sharing/tests/api/shareestest.php
@@ -21,10 +21,9 @@
 
 namespace OCA\Files_Sharing\Tests\API;
 
-use Doctrine\DBAL\Connection;
-use OC\Share\Constants;
 use OCA\Files_Sharing\API\Sharees;
 use OCA\Files_sharing\Tests\TestCase;
+use OCP\AppFramework\Http;
 use OCP\Share;
 
 class ShareesTest extends TestCase {
@@ -745,24 +744,24 @@ class ShareesTest extends TestCase {
 			// Test invalid pagination
 			[[
 				'page' => 0,
-			], 402, 'Invalid page'],
+			], 'Invalid page'],
 			[[
 				'page' => '0',
-			], 402, 'Invalid page'],
+			], 'Invalid page'],
 			[[
 				'page' => -1,
-			], 402, 'Invalid page'],
+			], 'Invalid page'],
 
 			// Test invalid perPage
 			[[
 				'perPage' => 0,
-			], 401, 'Invalid perPage argument'],
+			], 'Invalid perPage argument'],
 			[[
 				'perPage' => '0',
-			], 401, 'Invalid perPage argument'],
+			], 'Invalid perPage argument'],
 			[[
 				'perPage' => -1,
-			], 401, 'Invalid perPage argument'],
+			], 'Invalid perPage argument'],
 		];
 	}
 
@@ -770,10 +769,9 @@ class ShareesTest extends TestCase {
 	 * @dataProvider dataSearchInvalid
 	 *
 	 * @param array $getData
-	 * @param int $code
 	 * @param string $message
 	 */
-	public function testSearchInvalid($getData, $code, $message) {
+	public function testSearchInvalid($getData, $message) {
 		$oldGet = $_GET;
 		$_GET = $getData;
 
@@ -805,7 +803,7 @@ class ShareesTest extends TestCase {
 		$ocs = $sharees->search();
 		$this->assertInstanceOf('\OC_OCS_Result', $ocs);
 
-		$this->assertOCSError($ocs, $code, $message);
+		$this->assertOCSError($ocs, $message);
 
 		$_GET = $oldGet;
 	}
@@ -992,7 +990,7 @@ class ShareesTest extends TestCase {
 		$ocs = $this->invokePrivate($this->sharees, 'searchSharees', ['', null, [], [], 0, 0, false]);
 		$this->assertInstanceOf('\OC_OCS_Result', $ocs);
 
-		$this->assertOCSError($ocs, 400, 'Missing itemType');
+		$this->assertOCSError($ocs, 'Missing itemType');
 	}
 
 	public function dataGetPaginationLink() {
@@ -1041,11 +1039,10 @@ class ShareesTest extends TestCase {
 
 	/**
 	 * @param \OC_OCS_Result $ocs
-	 * @param int $code
 	 * @param string $message
 	 */
-	protected function assertOCSError(\OC_OCS_Result $ocs, $code, $message) {
-		$this->assertSame($code, $ocs->getStatusCode(), 'Expected status code ' . $code);
+	protected function assertOCSError(\OC_OCS_Result $ocs, $message) {
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $ocs->getStatusCode(), 'Expected status code 400');
 		$this->assertSame([], $ocs->getData(), 'Expected that no data is send');
 
 		$meta = $ocs->getMeta();


### PR DESCRIPTION
Instead of duplicating pages tell the user that he was wrong

Fix #18924 

@DeepDiver1975 @rullzer @SergioBertolinSG 
