### PR TITLE
Use -t instead of -bs

### DIFF
--- a/lib/private/mail/mailer.php
+++ b/lib/private/mail/mailer.php
@@ -205,7 +205,7 @@ class Mailer implements IMailer {
 				break;
 		}
 
-		return \Swift_SendmailTransport::newInstance($binaryPath . ' -bs');
+		return \Swift_SendmailTransport::newInstance($binaryPath . ' -t');
 	}
 
 	/**

--- a/tests/lib/mail/mailer.php
+++ b/tests/lib/mail/mailer.php
@@ -45,7 +45,7 @@ class MailerTest extends TestCase {
 			->with('mail_smtpmode', 'sendmail')
 			->will($this->returnValue('sendmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(\Swift_SendmailTransport::newInstance('/usr/sbin/sendmail -t'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetSendMailInstanceSendMailQmail() {
@@ -55,7 +55,7 @@ class MailerTest extends TestCase {
 			->with('mail_smtpmode', 'sendmail')
 			->will($this->returnValue('qmail'));
 
-		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -bs'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
+		$this->assertEquals(\Swift_SendmailTransport::newInstance('/var/qmail/bin/sendmail -t'), self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
 	public function testGetInstanceDefault() {


### PR DESCRIPTION
`-bs` has some portability problems depending on the configuration of the server resulting in failing sending mails when sendmail is used. (SMTP and others still work on such environments)

As alternative we can use `-t`, which is also used by most of the other implementations by default, and is generally more compatible.

From the [SendMail man pages](http://www.postfix.org/sendmail.1.html):

> ```
>    -bs    Stand-alone  SMTP  server mode. Read SMTP commands from standard
>            input, and write responses to standard output.   In  stand-alone
>            SMTP  server  mode,  mail relaying and other access controls are
>            disabled by default. To enable them,  run  the  process  as  the
>            mail_owner user.
> 
>            This  mode  of  operation is implemented by running the smtpd(8)
>            daemon.
> 
>   -t     Extract recipients from message headers. These are added to  any
>          recipients specified on the command line.
> 
>          With Postfix versions prior to 2.1, this option requires that no
>          recipient addresses are specified on the command line.
> ```

This works reliably when sending mails to single recipients as well as multiple users.

@msrex FYI
@karlitschek Backport to 8.1? - Fixes the mail issues on S3
