### PR TITLE
fix height of 'All files' entry in sidebar

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -110,10 +110,6 @@
 	cursor: pointer;
 }
 
-#app-navigation .nav-files a {
-	display: inline-block;
-}
-
 #app-navigation .nav-files a.new.hidden {
 	display: none;
 }


### PR DESCRIPTION
Tiny whitespace bug. Please review @owncloud/designers 

Before & after (notice the excess whitespace below »All files«):
![capture du 2015-09-15 19-27-07](https://cloud.githubusercontent.com/assets/925062/9884476/2fd18268-5be0-11e5-89b3-38251f052d58.png) ![capture du 2015-09-15 19-26-36](https://cloud.githubusercontent.com/assets/925062/9884475/2fd0127a-5be0-11e5-9f40-0108fa9f8859.png)
