### PR TITLE
AmazonS3 automatic tests

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -592,7 +592,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			'key' => $this->params['key'],
 			'secret' => $this->params['secret'],
 			'base_url' => $base_url,
-			'region' => $this->params['region']
+			'region' => $this->params['region'],
+			S3Client::COMMAND_PARAMS => [
+				'PathStyle' => $this->params['use_path_style'],
+			],
 		));
 
 		if (!$this->connection->isValidBucketName($this->bucket)) {

--- a/apps/files_external/tests/backends/amazons3.php
+++ b/apps/files_external/tests/backends/amazons3.php
@@ -32,11 +32,11 @@ class AmazonS3 extends Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.php');
-		if ( ! is_array($this->config) or ! isset($this->config['amazons3']) or ! $this->config['amazons3']['run']) {
+		$this->config = include('files_external/tests/config.amazons3.php');
+		if ( ! is_array($this->config) or ! $this->config['run']) {
 			$this->markTestSkipped('AmazonS3 backend not configured');
 		}
-		$this->instance = new \OC\Files\Storage\AmazonS3($this->config['amazons3']);
+		$this->instance = new \OC\Files\Storage\AmazonS3($this->config);
 	}
 
 	protected function tearDown() {

--- a/apps/files_external/tests/env/start-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/start-amazons3-ceph.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# This script start a docker container to test the files_external tests
+# against. It will also change the files_external config to use the docker
+# container as testing environment. This is reverted in the stop step.W
+#
+# Set environment variable DEBUG to print config file
+#
+# @author Morris Jobke
+# @author Robin McCorkell
+# @copyright 2015 ownCloud
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "No docker executable found - skipped docker setup"
+    exit 0;
+fi
+
+echo "Docker executable found - setup docker"
+
+docker_image=xenopathic/ceph-keystone
+
+echo "Fetch recent ${docker_image} docker image"
+docker pull ${docker_image}
+
+# retrieve current folder to place the config in the parent folder
+thisFolder=`echo $0 | replace "env/start-amazons3-ceph.sh" ""`
+
+if [ -z "$thisFolder" ]; then
+    thisFolder="."
+fi;
+
+user=test
+accesskey=aaabbbccc
+secretkey=cccbbbaaa
+bucket=testbucket
+port=80
+
+container=`docker run -d \
+    -e RGW_CIVETWEB_PORT=$port \
+    ${docker_image}`
+
+host=`docker inspect $container | grep IPAddress | cut -d '"' -f 4`
+
+
+echo "${docker_image} container: $container"
+
+# put container IDs into a file to drop them after the test run (keep in mind that multiple tests run in parallel on the same host)
+echo $container >> $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3
+
+# TODO find a way to determine the successful initialization inside the docker container
+echo "Waiting 20 seconds for ceph initialization ... "
+sleep 20
+
+echo "Create ceph user"
+docker exec $container radosgw-admin user create \
+    --uid="$user" --display-name="$user" \
+    --access-key="$accesskey" --secret="$secretkey" \
+    >/dev/null
+
+cat > $thisFolder/config.amazons3.php <<DELIM
+<?php
+
+return array(
+    'run'=>true,
+    'bucket'=>'$bucket',
+    'hostname'=>'$host',
+    'port'=>'$port',
+    'key'=>'$accesskey',
+    'secret'=>'$secretkey',
+    'use_ssl'=>false,
+    'use_path_style'=>true,
+);
+
+DELIM
+
+if [ -n "$DEBUG" ]; then
+    cat $thisFolder/config.amazons3.php
+    cat $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3
+fi

--- a/apps/files_external/tests/env/stop-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/stop-amazons3-ceph.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# This script stops the docker container the files_external tests were run
+# against. It will also revert the config changes done in start step.
+#
+# @author Morris Jobke
+# @author Robin McCorkell
+# @copyright 2015 ownCloud
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "No docker executable found - skipped docker stop"
+    exit 0;
+fi
+
+echo "Docker executable found - stop and remove docker containers"
+
+# retrieve current folder to remove the config from the parent folder
+thisFolder=`echo $0 | replace "env/stop-amazons3-ceph.sh" ""`
+
+if [ -z "$thisFolder" ]; then
+    thisFolder="."
+fi;
+
+# stopping and removing docker containers
+for container in `cat $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3`; do
+    echo "Stopping and removing docker container $container"
+    # kills running container and removes it
+    docker rm -f $container
+done;
+
+# cleanup
+rm $thisFolder/config.amazons3.php
+rm $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3
+


### PR DESCRIPTION
This uses the same Docker image as in #14077, but this time with the S3 API. In getting it working however I discovered that the 'Enable path style' option was broken, being completely disconnected from any code. Trawling through some API references, I fixed that, so now that option actually works (and is used by the tests since we don't control the DNS infrastructure).

Oh, and all the tests pass too! :grinning: 

Given that this includes a bug fix, and the only other part is tests, I'm marking this as for 8.2.

cc @icewind1991 @MorrisJobke @butonic @DeepDiver1975 
