### PR TITLE
Check for maintenance mode first so we send the 503 instead of login …

### DIFF
--- a/apps/files/appinfo/remote.php
+++ b/apps/files/appinfo/remote.php
@@ -45,12 +45,12 @@ $server->setBaseUri($baseuri);
 
 // Load plugins
 $defaults = new OC_Defaults();
+$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
 $server->addPlugin(new \OC\Connector\Sabre\BlockLegacyClientPlugin(\OC::$server->getConfig()));
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
 // FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 $server->addPlugin(new \OC\Connector\Sabre\DummyGetResponsePlugin());
 $server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree));
-$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig()));
 $server->addPlugin(new \OC\Connector\Sabre\ExceptionLoggerPlugin('webdav', \OC::$server->getLogger()));
 
 // wait with registering these until auth is handled and the filesystem is setup


### PR DESCRIPTION
…verification

Backport of #19077
Fix #19073
## Steps to reproduce
1. Enable maintenance mode
2. curl -v http://localhost/remote.php/webdav/
## Expected

`HTTP/1.1 503 Service Unavailable`
## Actual

`HTTP/1.1 401 Unauthorized`

@danimo @DeepDiver1975 

@karlitschek since this is a backport of #19077
