### PR TITLE
 Check for maintenance mode first so we send the 503 instead of login…

### DIFF
--- a/lib/private/connector/sabre/serverfactory.php
+++ b/lib/private/connector/sabre/serverfactory.php
@@ -63,12 +63,12 @@ class ServerFactory {
 
 		// Load plugins
 		$defaults = new \OC_Defaults();
+		$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin($this->config));
 		$server->addPlugin(new \OC\Connector\Sabre\BlockLegacyClientPlugin($this->config));
 		$server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, $defaults->getName()));
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new \OC\Connector\Sabre\DummyGetResponsePlugin());
 		$server->addPlugin(new \OC\Connector\Sabre\FilesPlugin($objectTree));
-		$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin($this->config));
 		$server->addPlugin(new \OC\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OC\Connector\Sabre\LockPlugin($objectTree));
 


### PR DESCRIPTION
… verification

Fix #19073
## Steps to reproduce
1. Enable maintenance mode
2. curl -v http://localhost/remote.php/webdav/
## Expected

`HTTP/1.1 503 Service Unavailable`
## Actual

`HTTP/1.1 401 Unauthorized`

@danimo @DeepDiver1975 

The fix effect is currently hidden behind https://github.com/owncloud/core/issues/19076 but stable8.1 works with the same patch #19075 
