### PR TITLE
Disable remote share notifications for now

### DIFF
--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -83,6 +83,8 @@ class Server2Server {
 					Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_RECEIVED, array($user, trim($name, '/')), '', array(),
 					'', '', $shareWith, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);
 
+				/**
+				 * FIXME
 				$urlGenerator = \OC::$server->getURLGenerator();
 
 				$notificationManager = \OC::$server->getNotificationManager();
@@ -104,6 +106,7 @@ class Server2Server {
 				$notification->addAction($acceptAction);
 
 				$notificationManager->notify($notification);
+				 */
 
 				return new \OC_OCS_Result();
 			} catch (\Exception $e) {

--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -93,15 +93,15 @@ class Server2Server {
 					->setObject('remote_share', $remoteId)
 					->setSubject('remote_share', [$user, trim($name, '/')]);
 
-				$acceptAction = $notification->createAction();
-				$acceptAction->setLabel('accept')
-					->setLink($urlGenerator->getAbsoluteURL('/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/' . $remoteId), 'POST');
 				$declineAction = $notification->createAction();
 				$declineAction->setLabel('decline')
 					->setLink($urlGenerator->getAbsoluteURL('/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/' . $remoteId), 'DELETE');
+				$notification->addAction($declineAction);
 
-				$notification->addAction($acceptAction)
-					->addAction($declineAction);
+				$acceptAction = $notification->createAction();
+				$acceptAction->setLabel('accept')
+					->setLink($urlGenerator->getAbsoluteURL('/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/' . $remoteId), 'POST');
+				$notification->addAction($acceptAction);
 
 				$notificationManager->notify($notification);
 

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -113,9 +113,12 @@ if ($config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes') {
 	}
 }
 
+/**
+ * FIXME
 $manager = \OC::$server->getNotificationManager();
 $manager->registerNotifier(function() {
 	return new \OCA\Files_Sharing\Notifier(
 		\OC::$server->getL10NFactory()
 	);
 });
+ */

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -214,7 +214,7 @@ class Manager {
 			$acceptShare->execute(array(1, $mountPoint, $hash, $id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
 
-			$this->scrapNotification($share['remote_id']);
+			//FIXME $this->scrapNotification($share['remote_id']);
 			return true;
 		}
 
@@ -237,7 +237,7 @@ class Manager {
 			$removeShare->execute(array($id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
 
-			$this->scrapNotification($share['remote_id']);
+			//FIXME $this->scrapNotification($share['remote_id']);
 			return true;
 		}
 


### PR DESCRIPTION
Fix owncloud/notifications#21

@karlitschek @jancborchardt @PVince81 

as discussed:
1. Swapping the buttons to fix owncloud/notifications#21
2. Disabling remote share notifications for now
