### PR TITLE
Explicitly cast number to integer

### DIFF
--- a/lib/private/files/cache/storage.php
+++ b/lib/private/files/cache/storage.php
@@ -142,7 +142,7 @@ class Storage {
 	public function getAvailability() {
 		if ($row = self::getStorageById($this->storageId)) {
 			return [
-				'available' => ($row['available'] === 1),
+				'available' => ((int)$row['available'] === 1),
 				'last_checked' => $row['last_checked']
 			];
 		} else {


### PR DESCRIPTION
The database layer likes to return strings for numbers, because that makes perfect sense. So we should explicitly cast the string to an integer before comparing it.

Fixes #19084, fixes #19060 

cc @PVince81 @icewind1991 
