### PR TITLE
Properly implement external mount priorities

### DIFF
--- a/apps/files_external/lib/config/configadapter.php
+++ b/apps/files_external/lib/config/configadapter.php
@@ -114,7 +114,7 @@ class ConfigAdapter implements IMountProvider {
 		$this->userStoragesService->setUser($user);
 		$this->userGlobalStoragesService->setUser($user);
 
-		foreach ($this->userGlobalStoragesService->getAllStorages() as $storage) {
+		foreach ($this->userGlobalStoragesService->getUniqueStorages() as $storage) {
 			try {
 				$this->prepareStorageConfig($storage, $user);
 				$impl = $this->constructStorage($storage);


### PR DESCRIPTION
Subset of changes from #18999, only including the bug fix part.

When mounting multiple storages with the same mount point, for different groups/users, sometimes one user will have multiple storages applicable to them. For example, if the admin defines a storage for all users, but then wants to override that for a single user with a different storage. Prior to this the chosen storage was arbitrary and unpredictable, now it follows the rules as set out in the tests.

The `priority` field allows the admin to specify mounts for groups as having higher priority than for other groups, e.g. if a user is a member of multiple groups that have mounts defined.

Note, these features were introduced in 8.0 or even earlier, then broken with 8.1. Perhaps we want to backport @karlitschek ?

cc @PVince81 @DeepDiver1975 @icewind1991 
