### PR TITLE
Allow checking whether there are notifiers registered

### DIFF
--- a/lib/private/notification/imanager.php
+++ b/lib/private/notification/imanager.php
@@ -53,4 +53,10 @@ interface IManager extends IApp, INotifier {
 	 * @since 8.2.0
 	 */
 	public function createNotification();
+
+	/**
+	 * @return bool
+	 * @since 8.2.0
+	 */
+	public function hasNotifiers();
 }

--- a/lib/private/notification/manager.php
+++ b/lib/private/notification/manager.php
@@ -113,6 +113,14 @@ class Manager implements IManager {
 	}
 
 	/**
+	 * @return bool
+	 * @since 8.2.0
+	 */
+	public function hasNotifiers() {
+		return !empty($this->notifiersClosures);
+	}
+
+	/**
 	 * @param INotification $notification
 	 * @return null
 	 * @throws \InvalidArgumentException When the notification is not valid


### PR DESCRIPTION
When there are none, the notification app can stop asking for notifications.
