### PR TITLE
Remove the need for the transaction in the database locking backend

### DIFF
--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -76,11 +76,10 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function acquireLock($path, $type) {
-		if ($this->connection->inTransaction()){
+		if ($this->connection->inTransaction()) {
 			$this->logger->warning("Trying to acquire a lock for '$path' while inside a transition");
 		}
 
-		$this->connection->beginTransaction();
 		$this->initLockField($path);
 		if ($type === self::LOCK_SHARED) {
 			$result = $this->connection->executeUpdate(
@@ -93,7 +92,6 @@ class DBLockingProvider extends AbstractLockingProvider {
 				[$path]
 			);
 		}
-		$this->connection->commit();
 		if ($result !== 1) {
 			throw new LockedException($path);
 		}
@@ -145,18 +143,5 @@ class DBLockingProvider extends AbstractLockingProvider {
 			throw new LockedException($path);
 		}
 		$this->markChange($path, $targetType);
-	}
-
-	/**
-	 * cleanup empty locks
-	 */
-	public function cleanEmptyLocks() {
-		$this->connection->executeUpdate(
-			'DELETE FROM `*PREFIX*file_locks` WHERE `lock` = 0'
-		);
-	}
-
-	public function __destruct() {
-		$this->cleanEmptyLocks();
 	}
 }

--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -45,7 +45,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 	 */
 	private $timeFactory;
 
-	const TTL = 3600; // how long until we clear stray locks
+	const TTL = 3600; // how long until we clear stray locks in seconds
 
 	/**
 	 * @param \OCP\IDBConnection $connection

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -460,7 +460,7 @@ class Server extends SimpleContainer implements IServerContainer {
 				if (!($memcache instanceof \OC\Memcache\NullCache)) {
 					return new MemcacheLockingProvider($memcache);
 				}
-				return new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger());
+				return new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger(), new TimeFactory());
 			}
 			return new NoopLockingProvider();
 		});


### PR DESCRIPTION
transactions lead to errors during concurrent access.

The only reason we required the transaction was to prevent the lock field from being removed between init and update.

Fixes smashbox test_uploadFiles and test_basicSync for me

cc @DeepDiver1975 @PVince81 @nickvergessen 
