### PR TITLE
Display external storage status as tooltip

### DIFF
--- a/apps/files_external/controller/storagescontroller.php
+++ b/apps/files_external/controller/storagescontroller.php
@@ -237,9 +237,21 @@ abstract class StoragesController extends Controller {
 				)
 			);
 		} catch (InsufficientDataForMeaningfulAnswerException $e) {
-			$storage->setStatus(\OC_Mount_Config::STATUS_INDETERMINATE);
+			$storage->setStatus(
+				\OC_Mount_Config::STATUS_INDETERMINATE,
+				$this->l10n->t('Insufficient data: %s', [$e->getMessage()])
+			);
 		} catch (StorageNotAvailableException $e) {
-			$storage->setStatus(\OC_Mount_Config::STATUS_ERROR);
+			$storage->setStatus(
+				\OC_Mount_Config::STATUS_ERROR,
+				$e->getMessage()
+			);
+		} catch (\Exception $e) {
+			// FIXME: convert storage exceptions to StorageNotAvailableException
+			$storage->setStatus(
+				\OC_Mount_Config::STATUS_ERROR,
+				get_class($e).': '.$e->getMessage()
+			);
 		}
 	}
 

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -643,6 +643,10 @@ MountConfigListView.prototype = _.extend({
 		});
 
 		addSelect2(this.$el.find('tr:not(#addMountPoint) .applicableUsers'), this._userListLimit);
+		this.$el.tooltip({
+			selector: '.status span',
+			container: 'body'
+		});
 
 		this._initEvents();
 
@@ -947,7 +951,7 @@ MountConfigListView.prototype = _.extend({
 				if (concurrentTimer === undefined
 					|| $tr.data('save-timer') === concurrentTimer
 				) {
-					self.updateStatus($tr, result.status);
+					self.updateStatus($tr, result.status, result.statusMessage);
 					$tr.attr('data-id', result.id);
 
 					if (_.isFunction(callback)) {
@@ -981,7 +985,7 @@ MountConfigListView.prototype = _.extend({
 		this.updateStatus($tr, StorageConfig.Status.IN_PROGRESS);
 		storage.recheck({
 			success: function(result) {
-				self.updateStatus($tr, result.status);
+				self.updateStatus($tr, result.status, result.statusMessage);
 			},
 			error: function() {
 				self.updateStatus($tr, StorageConfig.Status.ERROR);
@@ -994,8 +998,9 @@ MountConfigListView.prototype = _.extend({
 	 *
 	 * @param {jQuery} $tr
 	 * @param {int} status
+	 * @param {string} message
 	 */
-	updateStatus: function($tr, status) {
+	updateStatus: function($tr, status, message) {
 		var $statusSpan = $tr.find('.status span');
 		$statusSpan.removeClass('loading-small success indeterminate error');
 		switch (status) {
@@ -1014,6 +1019,7 @@ MountConfigListView.prototype = _.extend({
 			default:
 				$statusSpan.addClass('error');
 		}
+		$statusSpan.attr('data-original-title', (typeof message === 'string') ? message : '');
 	},
 
 	/**

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -269,6 +269,7 @@ class OC_Mount_Config {
 				}
 			} catch (Exception $exception) {
 				\OCP\Util::logException('files_external', $exception);
+				throw $e;
 			}
 		}
 		return self::STATUS_ERROR;

--- a/apps/files_external/lib/storageconfig.php
+++ b/apps/files_external/lib/storageconfig.php
@@ -73,6 +73,13 @@ class StorageConfig implements \JsonSerializable {
 	private $status;
 
 	/**
+	 * Status message
+	 *
+	 * @var string
+	 */
+	private $statusMessage;
+
+	/**
 	 * Priority
 	 *
 	 * @var int
@@ -295,7 +302,7 @@ class StorageConfig implements \JsonSerializable {
 	}
 
 	/**
-	 * Sets the storage status, whether the config worked last time
+	 * Gets the storage status, whether the config worked last time
 	 *
 	 * @return int $status status
 	 */
@@ -304,12 +311,23 @@ class StorageConfig implements \JsonSerializable {
 	}
 
 	/**
+	 * Gets the message describing the storage status
+	 *
+	 * @return string|null
+	 */
+	public function getStatusMessage() {
+		return $this->statusMessage;
+	}
+
+	/**
 	 * Sets the storage status, whether the config worked last time
 	 *
 	 * @param int $status status
+	 * @param string|null $message optional message
 	 */
-	public function setStatus($status) {
+	public function setStatus($status, $message = null) {
 		$this->status = $status;
+		$this->statusMessage = $message;
 	}
 
 	/**
@@ -340,6 +358,9 @@ class StorageConfig implements \JsonSerializable {
 		}
 		if (!is_null($this->status)) {
 			$result['status'] = $this->status;
+		}
+		if (!is_null($this->statusMessage)) {
+			$result['statusMessage'] = $this->statusMessage;
 		}
 		return $result;
 	}


### PR DESCRIPTION
Any exceptions thrown during testing an external storage will be sent to the client and displayed as a tooltip. Unfortunately these messages won't be translated, but it certainly gives better feedback than simply a red square. In the future when storages convert their exceptions properly and we have more exception classes (CredentialsInvalid, ConnectionFailed etc) we can translate the messages properly.

cc @PVince81 @icewind1991 
