### PR TITLE
Discard expiration date from result for non-link shares

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2441,6 +2441,11 @@ class Share extends Constants {
 		if (isset($row['stime'])) {
 			$row['stime'] = (int) $row['stime'];
 		}
+		if (isset($row['expiration']) && $row['share_type'] !== self::SHARE_TYPE_LINK) {
+			// discard expiration date for non-link shares, which might have been
+			// set by ancient bugs
+			$row['expiration'] = null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/11396.

Note that this is only a quickfix that is backportable.

A clean fix should be done separately that prevents setting expirationDate for non-link shares in the first place and also repair the database to discard the entries that have it already. But as this is a bigger change, I chose to do a small fix first to make it backportable.

Please review @schiesbn @nickvergessen @rullzer
