### PR TITLE
Handle (some) exceptions in the scanner

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -35,8 +35,12 @@
 namespace OC\Files\Cache;
 
 use OC\Files\Filesystem;
+use OC\ForbiddenException;
 use OC\Hooks\BasicEmitter;
 use OCP\Config;
+use OCP\Files\NotFoundException;
+use OCP\Files\StorageInvalidException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
 use OCP\Files\Storage\ILockingStorage;
@@ -143,6 +147,12 @@ class Scanner extends BasicEmitter implements IScanner {
 
 			try {
 				$data = $this->getData($file);
+			} catch (StorageNotAvailableException $e) {
+				return null;
+			} catch (StorageInvalidException $e) {
+				return null;
+			} catch (NotFoundException $e) {
+				return null;
 			} catch (ForbiddenException $e) {
 				return null;
 			}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -38,6 +38,7 @@ use GuzzleHttp\Message\ResponseInterface;
 use OC\Files\Filesystem;
 use OC\Files\Stream\Close;
 use Icewind\Streams\IteratorDirectory;
+use OC\ForbiddenException;
 use OC\MemCache\ArrayCache;
 use OCP\AppFramework\Http;
 use OCP\Constants;
@@ -837,7 +838,8 @@ class DAV extends Common {
 			} else if ($e->getHttpStatus() === Http::STATUS_METHOD_NOT_ALLOWED) {
 				// ignore exception for MethodNotAllowed, false will be returned
 				return;
-			}
+			} else if ($e->getHttpStatus() === Http::STATUS_FORBIDDEN) {
+				throw new ForbiddenException($e->getMessage(), $e->getCode(), $e);
 			throw new StorageNotAvailableException(get_class($e) . ': ' . $e->getMessage());
 		} else if ($e instanceof ClientException) {
 			// connection timeout or refused, server could be temporarily down


### PR DESCRIPTION
Catch some exceptions in the scanner and continue scanning.

Also improves the exception throwing in the dav backend a bit.

cc @DeepDiver1975 @PVince81 @Xenopathic 
