### PR TITLE
Repair step to remove bogus expiration dates from non-link shares

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -44,6 +44,7 @@ use OC\Repair\RepairLegacyStorages;
 use OC\Repair\RepairMimeTypes;
 use OC\Repair\SearchLuceneTables;
 use OC\Repair\UpdateOutdatedOcsIds;
+use OC\Repair\RepairInvalidShares;
 
 class Repair extends BasicEmitter {
 	/**
@@ -113,6 +114,7 @@ class Repair extends BasicEmitter {
 			new DropOldJobs(\OC::$server->getJobList()),
 			new RemoveGetETagEntries(\OC::$server->getDatabaseConnection()),
 			new UpdateOutdatedOcsIds(\OC::$server->getConfig()),
+			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 		];
 	}
 

--- a/lib/repair/repairinvalidshares.php
+++ b/lib/repair/repairinvalidshares.php
@@ -71,7 +71,7 @@ class RepairInvalidShares extends BasicEmitter implements \OC\RepairStep {
 
 	public function run() {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
-		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0', '<')) {
+		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0.7', '<')) {
 			// this situation was only possible before 8.2
 			$this->removeExpirationDateFromNonLinkShares();
 		}

--- a/lib/repair/repairinvalidshares.php
+++ b/lib/repair/repairinvalidshares.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OC\Hooks\BasicEmitter;
+
+/**
+ * Repairs shares with invalid data
+ */
+class RepairInvalidShares extends BasicEmitter implements \OC\RepairStep {
+
+	/**
+	 * @var \OCP\IConfig
+	 */
+	protected $config;
+
+	/**
+	 * @var \OCP\IDBConnection
+	 */
+	protected $connection;
+
+	/**
+	 * @param \OCP\IConfig $config
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct($config, $connection) {
+		$this->connection = $connection;
+		$this->config = $config;
+	}
+
+	public function getName() {
+		return 'Repair invalid shares';
+	}
+
+	/**
+	 * Past bugs would make it possible to set an expiration date on user shares even
+	 * though it is not supported. This functions removes the expiration date from such entries.
+	 */
+	private function removeExpirationDateFromNonLinkShares() {
+		$builder = $this->connection->getQueryBuilder();
+		$builder
+			->update('share')
+			->set('expiration', 'null')
+			->where($builder->expr()->isNotNull('expiration'))
+			->andWhere($builder->expr()->neq('share_type', $builder->expr()->literal(\OC\Share\Constants::SHARE_TYPE_LINK)));
+
+		$updatedEntries = $builder->execute();
+		if ($updatedEntries > 0) {
+			$this->emit('\OC\Repair', 'info', array('Removed invalid expiration date from ' . $updatedEntries . ' shares'));
+		}
+	}
+
+	public function run() {
+		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
+		if (version_compare($ocVersionFromBeforeUpdate, '8.2.0', '<')) {
+			// this situation was only possible before 8.2
+			$this->removeExpirationDateFromNonLinkShares();
+		}
+	}
+}

--- a/tests/lib/repair/repairinvalidshares.php
+++ b/tests/lib/repair/repairinvalidshares.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright (c) 2015 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+namespace Test\Repair;
+
+/**
+ * Tests for repairing invalid shares
+ *
+ * @see \OC\Repair\RepairInvalidShares
+ */
+class RepairInvalidShares extends \Test\TestCase {
+
+	/** @var \OC\RepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$config = $this->getMockBuilder('OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$config->expects($this->any())
+			->method('getSystemValue')
+			->with('version')
+			->will($this->returnValue('8.0.0.0'));
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$this->repair = new \OC\Repair\RepairInvalidShares($config, $this->connection);
+	}
+
+	protected function tearDown() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('share')->execute();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test remove expiration date for non-link shares
+	 */
+	public function testRemoveExpirationDateForNonLinkShares() {
+		// user share with bogus expiration date
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'share_type' => $qb->expr()->literal(\OC\Share\Constants::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('recipientuser1'),
+				'uid_owner' => $qb->expr()->literal('user1'),
+				'item_type' => $qb->expr()->literal('folder'),
+				'item_source' => $qb->expr()->literal(123),
+				'item_target' => $qb->expr()->literal('/123'),
+				'file_source' => $qb->expr()->literal(123),
+				'file_target' => $qb->expr()->literal('/test'),
+				'permissions' => $qb->expr()->literal(1),
+				'stime' => $qb->expr()->literal(time()),
+				'expiration' => $qb->expr()->literal('2015-09-25 00:00:00')
+			])
+			->execute();
+
+		// select because lastInsertId does not work with OCI
+		$results = $this->connection->getQueryBuilder()
+			->select('id')
+			->from('share')
+			->execute()
+			->fetchAll();
+		$bogusShareId = $results[0]['id'];
+
+		// link share with expiration date
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'share_type' => $qb->expr()->literal(\OC\Share\Constants::SHARE_TYPE_LINK),
+				'uid_owner' => $qb->expr()->literal('user1'),
+				'item_type' => $qb->expr()->literal('folder'),
+				'item_source' => $qb->expr()->literal(123),
+				'item_target' => $qb->expr()->literal('/123'),
+				'file_source' => $qb->expr()->literal(123),
+				'file_target' => $qb->expr()->literal('/test'),
+				'permissions' => $qb->expr()->literal(1),
+				'stime' => $qb->expr()->literal(time()),
+				'expiration' => $qb->expr()->literal('2015-09-25 00:00:00'),
+				'token' => $qb->expr()->literal('abcdefg')
+			])->execute();
+
+		$this->repair->run();
+
+		$results = $this->connection->getQueryBuilder()
+			->select('*')
+			->from('share')
+			->orderBy('share_type', 'ASC')
+			->execute()
+			->fetchAll();
+
+		$this->assertCount(2, $results);
+
+		$userShare = $results[0];
+		$linkShare = $results[1];
+		$this->assertEquals($bogusShareId, $userShare['id'], 'sanity check');
+		$this->assertNull($userShare['expiration'], 'bogus expiration date was removed');
+		$this->assertNotNull($linkShare['expiration'], 'valid link share expiration date still there');
+	}
+}
+

--- a/tests/lib/repair/repairinvalidsharestest.php
+++ b/tests/lib/repair/repairinvalidsharestest.php
@@ -5,14 +5,20 @@
  * later.
  * See the COPYING-README file.
  */
+
 namespace Test\Repair;
+
+
+use OC\Repair\RepairInvalidShares;
+use OC\Share\Constants;
+use Test\TestCase;
 
 /**
  * Tests for repairing invalid shares
  *
  * @see \OC\Repair\RepairInvalidShares
  */
-class RepairInvalidShares extends \Test\TestCase {
+class RepairInvalidSharesTest extends TestCase {
 
 	/** @var \OC\RepairStep */
 	private $repair;
@@ -32,15 +38,21 @@ class RepairInvalidShares extends \Test\TestCase {
 			->will($this->returnValue('8.0.0.0'));
 
 		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->deleteAllShares();
 
-		$this->repair = new \OC\Repair\RepairInvalidShares($config, $this->connection);
+		/** @var \OCP\IConfig $config */
+		$this->repair = new RepairInvalidShares($config, $this->connection);
 	}
 
 	protected function tearDown() {
-		$qb = $this->connection->getQueryBuilder();
-		$qb->delete('share')->execute();
+		$this->deleteAllShares();
 
 		parent::tearDown();
+	}
+
+	protected function deleteAllShares() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('share')->execute();
 	}
 
 	/**
@@ -51,7 +63,7 @@ class RepairInvalidShares extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'share_type' => $qb->expr()->literal(\OC\Share\Constants::SHARE_TYPE_USER),
+				'share_type' => $qb->expr()->literal(Constants::SHARE_TYPE_USER),
 				'share_with' => $qb->expr()->literal('recipientuser1'),
 				'uid_owner' => $qb->expr()->literal('user1'),
 				'item_type' => $qb->expr()->literal('folder'),
@@ -77,7 +89,7 @@ class RepairInvalidShares extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'share_type' => $qb->expr()->literal(\OC\Share\Constants::SHARE_TYPE_LINK),
+				'share_type' => $qb->expr()->literal(Constants::SHARE_TYPE_LINK),
 				'uid_owner' => $qb->expr()->literal('user1'),
 				'item_type' => $qb->expr()->literal('folder'),
 				'item_source' => $qb->expr()->literal(123),

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(8, 2, 0, 6);
+$OC_Version = array(8, 2, 0, 7);
 
 // The human readable string
 $OC_VersionString = '8.2 beta1';


### PR DESCRIPTION
To clean up the mess by the bug that existed pre-8.2: https://github.com/owncloud/core/issues/11396
The new share dialog doesn't set the expiration date for user shares any more, so cleaning that up should be permanent (hence the version check)

@MorrisJobke @nickvergessen @schiesbn @DeepDiver1975 

(8.2 only)
