### PR TITLE
Increment timeout on Oracle startup comment

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -203,7 +203,7 @@ function execute_tests {
 
 		echo "Waiting for Oracle initialization ... "
 
-		# grep exits on the first match and then the script continues - times out after 2 minutes
+		# grep exits on the first match and then the script continues - times out after 4 minutes
 		timeout 240 docker logs -f "$DOCKER_CONTAINER_ID" 2>&1 | grep -q "Grant succeeded."
 
 		DATABASEUSER=autotest


### PR DESCRIPTION
Noticed that commit https://github.com/owncloud/core/commit/e7448574181fd21c1c552d1dfe601707ffe305ed changed the timeout without also changing the comment.
