### PR TITLE
fix wording of other search results to 'elsewhere'

### DIFF
--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -217,10 +217,10 @@
 					$status.addClass('emptycontent').removeClass('status');
 					$status.html('');
 					$status.append('<div class="icon-search"></div>');
-					$status.append('<h2>' + t('core', 'No search results in other places') + '</h2>');
+					$status.append('<h2>' + t('core', 'No search results in other folders') + '</h2>');
 				} else {
 					$status.removeClass('emptycontent').addClass('status');
-					$status.text(n('core', '{count} search result in other places', '{count} search results in other places', count, {count:count}));
+					$status.text(n('core', '{count} search result in another folder', '{count} search results in other folders', count, {count:count}));
 				}
 			}
 			function renderCurrent() {


### PR DESCRIPTION
Previously:

> 3 search results in other places

Now:

> 3 search results elsewhere

Shorter, makes more sense, and is easier to translate. (The German translation for example was »3 Suchergebnisse in den anderen Orten« …)

Please review @owncloud/designers @butonic 
