### PR TITLE
Fix #19181: Support .bz2 app archives

### DIFF
--- a/lib/private/archive/tar.php
+++ b/lib/private/archive/tar.php
@@ -48,7 +48,7 @@ class OC_Archive_TAR extends OC_Archive {
 	 * @param string $source
 	 */
 	function __construct($source) {
-		$types = array(null, 'gz', 'bz');
+		$types = array(null, 'gz', 'bz2');
 		$this->path = $source;
 		$this->tar = new Archive_Tar($source, $types[self::getTarType($source)]);
 	}

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -279,7 +279,7 @@ class OC_Installer{
 
 		//detect the archive type
 		$mime=OC_Helper::getMimeType($path);
-		if ($mime !=='application/zip' && $mime !== 'application/x-gzip') {
+		if ($mime !=='application/zip' && $mime !== 'application/x-gzip' && $mime !== 'application/x-bzip2') {
 			throw new \Exception($l->t("Archives of type %s are not supported", array($mime)));
 		}
 


### PR DESCRIPTION
At first a bz2 handling in needs to be fixed; PEAR's Archive_Tar
otherwise gives the following error:

> Unsupported compression type "bz"
> Supported types are "gz", "bz2" and "lzma2"

After that we can whitelist the application/bz2 MIME type in the installer.

Fix #19181
