### PR TITLE
fix trashbin previews for text files

### DIFF
--- a/apps/files_trashbin/lib/helper.php
+++ b/apps/files_trashbin/lib/helper.php
@@ -65,11 +65,14 @@ class Helper
 				if (!\OC\Files\Filesystem::isIgnoredDir($entryName)) {
 					$id = $entryName;
 					if ($dir === '' || $dir === '/') {
+						$size = $view->filesize($id);
 						$pathparts = pathinfo($entryName);
 						$timestamp = substr($pathparts['extension'], 1);
 						$id = $pathparts['filename'];
+
 					} else if ($timestamp === null) {
 						// for subfolders we need to calculate the timestamp only once
+						$size = $view->filesize($dir . '/' . $id);
 						$parts = explode('/', ltrim($dir, '/'));
 						$timestamp = substr(pathinfo($parts[0], PATHINFO_EXTENSION), 1);
 					}
@@ -86,6 +89,7 @@ class Helper
 						'mimetype' => $view->is_dir($dir . '/' . $entryName) ? 'httpd/unix-directory' : \OC_Helper::getFileNameMimeType($id),
 						'type' => $view->is_dir($dir . '/' . $entryName) ? 'dir' : 'file',
 						'directory' => ($dir === '/') ? '' : $dir,
+						'size' => $size,
 					);
 					if ($originalPath) {
 						$i['extraData'] = $originalPath.'/'.$id;


### PR DESCRIPTION
make sure to add the correct file size to the file info, otherwise we will not show the preview for some file types

Steps to test:
- upload a non-empty text file
- delete it
- go to the trashbin
- check if you have a correct preview for the text file

fix #18516

cc @nickvergessen @georgehrke 
