### PR TITLE
[stable8.1] Discard expiration date from result for non-link shares

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2394,6 +2394,11 @@ class Share extends Constants {
 		if (isset($row['stime'])) {
 			$row['stime'] = (int) $row['stime'];
 		}
+		if (isset($row['expiration']) && $row['share_type'] !== self::SHARE_TYPE_LINK) {
+			// discard expiration date for non-link shares, which might have been
+			// set by ancient bugs
+			$row['expiration'] = null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/19122 to stable8.1

Fixes https://github.com/owncloud/core/issues/11396

Please review @butonic @nickvergessen @schiesbn @rullzer 
