### PR TITLE
Replaces if ($file === '.' || $file === '..') by public function call isIgnoredDir

### DIFF
--- a/apps/files_external/lib/amazons3.php
+++ b/apps/files_external/lib/amazons3.php
@@ -517,7 +517,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$dh = $this->opendir($path1);
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if ($file === '.' || $file === '..') {
+					if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 						continue;
 					}
 

--- a/apps/files_external/lib/swift.php
+++ b/apps/files_external/lib/swift.php
@@ -175,7 +175,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 		$dh = $this->opendir($path);
 		while ($file = readdir($dh)) {
-			if ($file === '.' || $file === '..') {
+			if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 				continue;
 			}
 
@@ -429,7 +429,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 			$dh = $this->opendir($path1);
 			while ($file = readdir($dh)) {
-				if ($file === '.' || $file === '..') {
+				if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 					continue;
 				}
 

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -895,7 +895,7 @@ class Trashbin {
 		$view = new \OC\Files\View('/' . $user . '/files_trashbin');
 		if ($view->is_dir('/files') && $dh = $view->opendir('/files')) {
 			while ($file = readdir($dh)) {
-				if ($file !== '.' and $file !== '..') {
+				if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 					return false;
 				}
 			}

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -260,7 +260,7 @@ abstract class Common implements Storage {
 		$dh = $this->opendir($path);
 		if (is_resource($dh)) {
 			while (($file = readdir($dh)) !== false) {
-				if ($file !== '.' and $file !== '..') {
+				if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 					if ($this->is_dir($path . '/' . $file)) {
 						mkdir($target . '/' . $file);
 						$this->addLocalFolder($path . '/' . $file, $target . '/' . $file);
@@ -283,7 +283,7 @@ abstract class Common implements Storage {
 		$dh = $this->opendir($dir);
 		if (is_resource($dh)) {
 			while (($item = readdir($dh)) !== false) {
-				if ($item == '.' || $item == '..') continue;
+				if (\OC\Files\Filesystem::isIgnoredDir($item)) continue;
 				if (strstr(strtolower($item), strtolower($query)) !== false) {
 					$files[] = $dir . '/' . $item;
 				}

--- a/lib/private/files/storage/local.php
+++ b/lib/private/files/storage/local.php
@@ -283,7 +283,7 @@ class Local extends \OC\Files\Storage\Common {
 		$files = array();
 		$physicalDir = $this->getSourcePath($dir);
 		foreach (scandir($physicalDir) as $item) {
-			if ($item == '.' || $item == '..')
+			if (\OC\Files\Filesystem::isIgnoredDir($item))
 				continue;
 			$physicalItem = $physicalDir . '/' . $item;
 

--- a/lib/private/files/storage/polyfill/copydirectory.php
+++ b/lib/private/files/storage/polyfill/copydirectory.php
@@ -72,7 +72,7 @@ trait CopyDirectory {
 		$dh = $this->opendir($source);
 		$result = true;
 		while ($file = readdir($dh)) {
-			if ($file !== '.' and $file !== '..') {
+			if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 				if ($this->is_dir($source . '/' . $file)) {
 					$this->mkdir($target . '/' . $file);
 					$result = $this->copyRecursive($source . '/' . $file, $target . '/' . $file);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1656,7 +1656,7 @@ class View {
 		if ($trimmed === '') {
 			throw new InvalidPathException($l10n->t('Empty filename is not allowed'));
 		}
-		if ($trimmed === '.' || $trimmed === '..') {
+		if (\OC\Files\Filesystem::isIgnoredDir($trimmed)) {
 			throw new InvalidPathException($l10n->t('Dot files are not allowed'));
 		}
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1433,7 +1433,7 @@ class OC_Util {
 		if ($trimmed === '') {
 			return false;
 		}
-		if ($trimmed === '.' || $trimmed === '..') {
+		if (\OC\Files\Filesystem::isIgnoredDir($trimmed)) {
 			return false;
 		}
 		foreach (str_split($trimmed) as $char) {

--- a/tests/lib/files/storage/wrapper/jail.php
+++ b/tests/lib/files/storage/wrapper/jail.php
@@ -30,7 +30,7 @@ class Jail extends \Test\Files\Storage\Storage {
 		$contents = array();
 		$dh = $this->sourceStorage->opendir('');
 		while ($file = readdir($dh)) {
-			if ($file !== '.' and $file !== '..') {
+			if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 				$contents[] = $file;
 			}
 		}

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -193,7 +193,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	static protected function tearDownAfterClassCleanStrayDataUnlinkDir($dir) {
 		if ($dh = @opendir($dir)) {
 			while (($file = readdir($dh)) !== false) {
-				if ($file === '..' || $file === '.') {
+				if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 					continue;
 				}
 				$path = $dir . '/' . $file;


### PR DESCRIPTION
This PR is for better readability and to ease finding where this operation is beeing used.
It also harmonizes comparison operators usage from `==`  to `===`

Replaces
`if ($file === '.' || $file === '..')` by `if (\OC\Files\Filesystem::isIgnoredDir($file))`

Found at:

```
apps/files_external/lib/amazons3.php:520:               if ($file === '.' || $file === '..') {
apps/files_external/lib/swift.php:178:                  if ($file === '.' || $file === '..') {
apps/files_external/lib/swift.php:432:                  if ($file === '.' || $file === '..') {
apps/files_trashbin/lib/trashbin.php:894:               if ($file !== '.' and $file !== '..') {
lib/private/files/storage/common.php:263:               if ($file !== '.' and $file !== '..') {
lib/private/files/storage/common.php:286:               if ($item == '.' || $item == '..') 
lib/private/files/storage/local.php:286:                if ($item == '.' || $item == '..')
lib/private/files/storage/polyfill/copydirectory.php:75:if ($file !== '.' and $file !== '..') {
lib/private/files/view.php:1659:                        if ($trimmed === '.' || $trimmed === '..') {
lib/private/util.php:1436:                              if ($trimmed === '.' || $trimmed === '..') {
tests/lib/files/storage/wrapper/jail.php:33:            if ($file !== '.' and $file !== '..') {
tests/lib/testcase.php:196:                             if ($file === '..' || $file === '.') {
```
