### PR TITLE
Properly propagate changes between related storages

### DIFF
--- a/apps/files_external/lib/config/configadapter.php
+++ b/apps/files_external/lib/config/configadapter.php
@@ -118,6 +118,7 @@ class ConfigAdapter implements IMountProvider {
 			try {
 				$this->prepareStorageConfig($storage, $user);
 				$impl = $this->constructStorage($storage);
+				$impl->getStorageCache()->addConfigId('ext:global:'.$storage->getId());
 			} catch (\Exception $e) {
 				// propagate exception into filesystem
 				$impl = new FailedStorage(['exception' => $e]);
@@ -137,6 +138,7 @@ class ConfigAdapter implements IMountProvider {
 			try {
 				$this->prepareStorageConfig($storage, $user);
 				$impl = $this->constructStorage($storage);
+				$impl->getStorageCache()->addConfigId('ext:personal:'.$user->getUID().':'.$storage->getId());
 			} catch (\Exception $e) {
 				// propagate exception into filesystem
 				$impl = new FailedStorage(['exception' => $e]);

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -114,6 +114,14 @@
 				<type>integer</type>
 			</field>
 
+			<field>
+				<name>config_id</name>
+				<type>text</type>
+				<default></default>
+				<notnull>false</notnull>
+				<length>64</length>
+			</field>
+
 			<index>
 				<name>storages_id_index</name>
 				<unique>true</unique>
@@ -123,9 +131,55 @@
 				</field>
 			</index>
 
+			<index>
+				<name>storages_config_id_index</name>
+				<unique>false</unique>
+				<field>
+					<name>config_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
 		</declaration>
 
 	</table>
+
+	<table>
+
+		<!--
+		List of dirty paths that need rescanning
+		-->
+		<name>*dbprefix*storages_recheck</name>
+
+		<declaration>
+
+			<field>
+				<name>storage</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
+				<name>path</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>4000</length>
+			</field>
+
+			<index>
+				<name>storages_recheck_storage_index</name>
+				<unique>false</unique>
+				<field>
+					<name>storage</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+		</declaration>
+
+	</table>
+
+
 
 	<table>
 

--- a/lib/private/files/cache/changepropagator.php
+++ b/lib/private/files/cache/changepropagator.php
@@ -62,6 +62,7 @@ class ChangePropagator extends BasicEmitter {
 	 */
 	public function propagateChanges($time = null) {
 		$parents = $this->getAllParents();
+		$changes = $this->getChanges();
 		$this->changedFiles = array();
 		if (!$time) {
 			$time = time();
@@ -78,6 +79,13 @@ class ChangePropagator extends BasicEmitter {
 				$entry = $cache->get($internalPath);
 				$cache->update($entry['fileid'], array('mtime' => max($time, $entry['mtime']), 'etag' => $storage->getETag($internalPath)));
 				$this->emit('\OC\Files', 'propagate', [$parent, $entry]);
+			}
+		}
+
+		foreach ($changes as $change) {
+			list($storage, $internalPath) = $this->view->resolvePath($change);
+			if ($storage) {
+				$storage->getScanner()->markRelatedStorageUnclean($internalPath);
 			}
 		}
 	}

--- a/lib/private/files/mount/manager.php
+++ b/lib/private/files/mount/manager.php
@@ -39,6 +39,10 @@ class Manager implements IMountManager {
 	 */
 	public function addMount(IMountPoint $mount) {
 		$this->mounts[$mount->getMountPoint()] = $mount;
+
+		// rescan unclean paths
+		// done here to avoid unless absolutely necessary
+		$mount->getStorage()->getScanner()->rescanUncleanPaths();
 	}
 
 	/**

--- a/tests/lib/files/node/root.php
+++ b/tests/lib/files/node/root.php
@@ -25,7 +25,7 @@ class Root extends \Test\TestCase {
 	}
 
 	public function testGet() {
-		$manager = new Manager();
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**
 		 * @var \OC\Files\Storage\Storage $storage
 		 */
@@ -61,7 +61,7 @@ class Root extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotFoundException
 	 */
 	public function testGetNotFound() {
-		$manager = new Manager();
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**
 		 * @var \OC\Files\Storage\Storage $storage
 		 */
@@ -85,7 +85,7 @@ class Root extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testGetInvalidPath() {
-		$manager = new Manager();
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
@@ -99,7 +99,7 @@ class Root extends \Test\TestCase {
 	 * @expectedException \OCP\Files\NotFoundException
 	 */
 	public function testGetNoStorages() {
-		$manager = new Manager();
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1925,7 +1925,7 @@ class View extends \Test\TestCase {
 		$this->loginAsUser('test');
 
 		$subStorage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
-			->setMethods([])
+			->setMethods(null)
 			->getMock();
 
 		$mount = $this->getMock(

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(8, 2, 0, 6);
+$OC_Version = array(8, 2, 0, 7);
 
 // The human readable string
 $OC_VersionString = '8.2 beta1';


### PR DESCRIPTION
An attempt at fixing owncloud/enterprise#804.

The ETag propagator looks for related storage, which are detected using a new oc_storages field 'config_id', set by files_external to a unique value that groups together storage configs. When a cache entry is being updated in such a storage, the path gets written to a new table oc_storages_recheck along with the related storage IDs. When the other user(s) log in, this table is consulted and any paths listed get rescanned, and the entries deleted. Thus, changes get properly propagated across related storages that do not share a storage ID.

I encountered one problem: apps/files/ajax/scan.php will try to scan the storage, but for some reason marks everything as changed. Thus on login in the web interface oc_storages_recheck will be populated with every file the scanner finds, which isn't great, since the vast majority of them (if not all) are not changes at all. @icewind1991 can you shed some light on this? This results in vastly decreased performance, since it effectively triggers a DELETE query for every file in the storage (when oc_storages_recheck gets read and cleared). Not good.

cc @cmonteroluque @DeepDiver1975 @PVince81 @jvillafanez 
