### PR TITLE
Respect disabled sharing API settings

### DIFF
--- a/apps/files_sharing/lib/middleware/sharingcheckmiddleware.php
+++ b/apps/files_sharing/lib/middleware/sharingcheckmiddleware.php
@@ -87,6 +87,11 @@ class SharingCheckMiddleware extends Middleware {
 			return false;
 		}
 
+		// Check if the shareAPI is enabled
+		if ($this->config->getAppValue('core', 'shareapi_enabled', 'yes') !== 'yes') {
+			return false;
+		}
+
 		// Check whether public sharing is enabled
 		if($this->config->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
 			return false;

--- a/apps/files_sharing/tests/middleware/sharingcheckmiddleware.php
+++ b/apps/files_sharing/tests/middleware/sharingcheckmiddleware.php
@@ -54,7 +54,13 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 			->will($this->returnValue(true));
 
 		$this->config
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('core', 'shareapi_enabled', 'yes')
+			->will($this->returnValue('yes'));
+
+		$this->config
+			->expects($this->at(1))
 			->method('getAppValue')
 			->with('core', 'shareapi_allow_links', 'yes')
 			->will($this->returnValue('yes'));
@@ -72,7 +78,29 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
 
-	public function testIsSharingEnabledWithSharingDisabled() {
+	public function testIsSharingEnabledWithLinkSharingDisabled() {
+		$this->appManager
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->will($this->returnValue(true));
+
+		$this->config
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('core', 'shareapi_enabled', 'yes')
+			->will($this->returnValue('yes'));
+
+		$this->config
+			->expects($this->at(1))
+			->method('getAppValue')
+			->with('core', 'shareapi_allow_links', 'yes')
+			->will($this->returnValue('no'));
+
+		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
+	}
+
+	public function testIsSharingEnabledWithSharingAPIDisabled() {
 		$this->appManager
 			->expects($this->once())
 			->method('isEnabledForUser')
@@ -82,9 +110,10 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
-			->with('core', 'shareapi_allow_links', 'yes')
+			->with('core', 'shareapi_enabled', 'yes')
 			->will($this->returnValue('no'));
 
 		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
+
 }


### PR DESCRIPTION
Respect the disabling for the sharing API for link shares.

Fixes #18970

Simple fix. And easy to test.

CC: @PVince81 @davitol @MorrisJobke @Xenopathic 
