### PR TITLE
Properly translate file actions

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -594,6 +594,7 @@
 
 			this.registerAction({
 				name: 'Rename',
+				displayName: t('files', 'Rename'),
 				mime: 'all',
 				permissions: OC.PERMISSION_UPDATE,
 				icon: function() {
@@ -614,6 +615,7 @@
 
 			this.registerAction({
 				name: 'Delete',
+				displayName: t('files', 'Delete'),
 				mime: 'all',
 				// permission is READ because we show a hint instead if there is no permission
 				permissions: OC.PERMISSION_DELETE,

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -300,6 +300,7 @@
 			if (this._detailsView) {
 				this.fileActions.registerAction({
 					name: 'Details',
+					displayName: t('files', 'Details'),
 					mime: 'all',
 					icon: OC.imagePath('core', 'actions/details'),
 					permissions: OC.PERMISSION_READ,

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -78,7 +78,7 @@
 			// register "star" action
 			fileActions.registerAction({
 				name: 'Favorite',
-				displayName: 'Favorite',
+				displayName: t('files', 'Favorite'),
 				mime: 'all',
 				permissions: OC.PERMISSION_READ,
 				type: OCA.Files.FileActions.TYPE_INLINE,

--- a/apps/files_trashbin/js/app.js
+++ b/apps/files_trashbin/js/app.js
@@ -59,6 +59,7 @@ OCA.Trashbin.App = {
 
 		fileActions.registerAction({
 			name: 'Delete',
+			displayName: t('files', 'Delete'),
 			mime: 'all',
 			permissions: OC.PERMISSION_READ,
 			icon: function() {


### PR DESCRIPTION
Note: it partially worked before because it would call `t('files', actionName)`, but such syntax will prevent the translation bot to find the strings in the first place. It would work only if the strings are defined somewhere else too.

Anyway, this PR makes sure it can always work.

@nickvergessen @jancborchardt 
