### PR TITLE
Checkbox Fallback

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1973,3 +1973,23 @@ jQuery.fn.tipsy = function(argument) {
 		jQuery.fn.tooltip.call(this, argument);
 	}
 }
+
+/**
+ * fallback for checkboxes
+ * checkboxes require a label as direct sibling since 8.2
+ */
+$( document ).ready(function() {
+	$('input:checkbox').each(function () {
+		var $checkbox = $(this);
+		if ($checkbox.next().is('label')) {
+			return; // label already exists
+		}
+		var checkboxId = $checkbox.attr('id');
+		if (checkboxId === undefined) {
+			checkboxId = _.uniqueId('checkbox-');
+			$checkbox.attr('id', checkboxId);
+		}
+		$checkbox.after($('<label></label>').attr('for', checkboxId));
+		console.warn('checkboxes require a label as direct sibling since 8.2');
+	});
+});


### PR DESCRIPTION
Insert checkbox label if missing.
This is a fallback for some of the issues with the new checkboxes introduced in #18735.
It only works on static content which exists on page load. Dynamically created checkboxes aren't detected by this fallback.

@PVince81 @oparoz @jancborchardt 
