### PR TITLE
Fix bogus entry that appears when switching with arrow keys

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -176,6 +176,9 @@
 				$shareField.autocomplete({
 					minLength: 2,
 					delay: 750,
+					focus: function(event) {
+						event.preventDefault();
+					},
 					source: this.autocompleteHandler,
 					select: this._onSelectRecipient
 				}).data('ui-autocomplete')._renderItem = this.autocompleteRenderItem;


### PR DESCRIPTION
This piece was missing from the old code.

Fixes https://github.com/owncloud/core/issues/19260

@schiesbn @blizzz @rullzer 
