### PR TITLE
Do not blindy copy expiration date on reshare

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1998,7 +1998,6 @@ class Share extends Constants {
 			$suggestedItemTarget = $result['suggestedItemTarget'];
 			$suggestedFileTarget = $result['suggestedFileTarget'];
 			$filePath = $result['filePath'];
-			$expirationDate = $result['expirationDate'];
 		}
 
 		$isGroupShare = false;


### PR DESCRIPTION
If a file/folder is reshared we should not blindly copy the expiration date of the parent share. Because in general that won't be set since user/group shares currently do not have expiration dates.

Fixes #19119

Added a test case mirroring the behaviour of #19119 

CC: @PVince81 @blizzz @MorrisJobke @schiesbn 
