### PR TITLE
Fix get raw path info, always return a string

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -603,7 +603,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		if (strpos($pathInfo, $name) === 0) {
 			$pathInfo = substr($pathInfo, strlen($name));
 		}
-		if($pathInfo === '/'){
+		if($pathInfo === false || $pathInfo === '/'){
 			return '';
 		} else {
 			return $pathInfo;

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -60,18 +60,18 @@ class RequestTest extends \Test\TestCase {
 		);
 
 		// Countable
-		$this->assertEquals(2, count($request));
+		$this->assertSame(2, count($request));
 		// Array access
-		$this->assertEquals('Joey', $request['nickname']);
+		$this->assertSame('Joey', $request['nickname']);
 		// "Magic" accessors
-		$this->assertEquals('Joey', $request->{'nickname'});
+		$this->assertSame('Joey', $request->{'nickname'});
 		$this->assertTrue(isset($request['nickname']));
 		$this->assertTrue(isset($request->{'nickname'}));
-		$this->assertEquals(false, isset($request->{'flickname'}));
+		$this->assertFalse(isset($request->{'flickname'}));
 		// Only testing 'get', but same approach for post, files etc.
-		$this->assertEquals('Joey', $request->get['nickname']);
+		$this->assertSame('Joey', $request->get['nickname']);
 		// Always returns null if variable not set.
-		$this->assertEquals(null, $request->{'flickname'});
+		$this->assertSame(null, $request->{'flickname'});
 
 	}
 
@@ -92,9 +92,9 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals(3, count($request));
-		$this->assertEquals('Janey', $request->{'nickname'});
-		$this->assertEquals('Johnny Weissmüller', $request->{'name'});
+		$this->assertSame(3, count($request));
+		$this->assertSame('Janey', $request->{'nickname'});
+		$this->assertSame('Johnny Weissmüller', $request->{'name'});
 	}
 
 
@@ -172,10 +172,10 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('GET', $request->method);
+		$this->assertSame('GET', $request->method);
 		$result = $request->get;
-		$this->assertEquals('John Q. Public', $result['name']);
-		$this->assertEquals('Joey', $result['nickname']);
+		$this->assertSame('John Q. Public', $result['name']);
+		$this->assertSame('Joey', $result['nickname']);
 	}
 
 	public function testJsonPost() {
@@ -194,12 +194,12 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('POST', $request->method);
+		$this->assertSame('POST', $request->method);
 		$result = $request->post;
-		$this->assertEquals('John Q. Public', $result['name']);
-		$this->assertEquals('Joey', $result['nickname']);
-		$this->assertEquals('Joey', $request->params['nickname']);
-		$this->assertEquals('Joey', $request['nickname']);
+		$this->assertSame('John Q. Public', $result['name']);
+		$this->assertSame('Joey', $result['nickname']);
+		$this->assertSame('Joey', $request->params['nickname']);
+		$this->assertSame('Joey', $request['nickname']);
 	}
 
 	public function testPatch() {
@@ -219,11 +219,11 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('PATCH', $request->method);
+		$this->assertSame('PATCH', $request->method);
 		$result = $request->patch;
 
-		$this->assertEquals('John Q. Public', $result['name']);
-		$this->assertEquals('Joey', $result['nickname']);
+		$this->assertSame('John Q. Public', $result['name']);
+		$this->assertSame('Joey', $result['nickname']);
 	}
 
 	public function testJsonPatchAndPut() {
@@ -244,11 +244,11 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('PUT', $request->method);
+		$this->assertSame('PUT', $request->method);
 		$result = $request->put;
 
-		$this->assertEquals('John Q. Public', $result['name']);
-		$this->assertEquals('Joey', $result['nickname']);
+		$this->assertSame('John Q. Public', $result['name']);
+		$this->assertSame('Joey', $result['nickname']);
 
 		// PATCH content
 		$data = '{"name": "John Q. Public", "nickname": null}';
@@ -265,11 +265,11 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('PATCH', $request->method);
+		$this->assertSame('PATCH', $request->method);
 		$result = $request->patch;
 
-		$this->assertEquals('John Q. Public', $result['name']);
-		$this->assertEquals(null, $result['nickname']);
+		$this->assertSame('John Q. Public', $result['name']);
+		$this->assertSame(null, $result['nickname']);
 	}
 
 	public function testPutStream() {
@@ -290,10 +290,10 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('PUT', $request->method);
+		$this->assertSame('PUT', $request->method);
 		$resource = $request->put;
 		$contents = stream_get_contents($resource);
-		$this->assertEquals($data, $contents);
+		$this->assertSame($data, $contents);
 
 		try {
 			$resource = $request->put;
@@ -322,7 +322,7 @@ class RequestTest extends \Test\TestCase {
 
 		$newParams = array('id' => '3', 'test' => 'test2');
 		$request->setUrlParameters($newParams);
-		$this->assertEquals('test2', $request->getParam('test'));
+		$this->assertSame('test2', $request->getParam('test'));
 		$this->assertEquals('3', $request->getParam('id'));
 		$this->assertEquals('3', $request->getParams()['id']);
 	}
@@ -660,7 +660,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals($matches, $request->isUserAgent($userAgent));
+		$this->assertSame($matches, $request->isUserAgent($userAgent));
 	}
 
 	/**
@@ -749,7 +749,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('from.server.name:8080',  $request->getInsecureServerHost());
+		$this->assertSame('from.server.name:8080',  $request->getInsecureServerHost());
 	}
 
 	public function testInsecureServerHostHttpHostHeader() {
@@ -766,7 +766,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('from.host.header:8080',  $request->getInsecureServerHost());
+		$this->assertSame('from.host.header:8080',  $request->getInsecureServerHost());
 	}
 
 	public function testInsecureServerHostHttpFromForwardedHeaderSingle() {
@@ -784,7 +784,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('from.forwarded.host:8080',  $request->getInsecureServerHost());
+		$this->assertSame('from.forwarded.host:8080',  $request->getInsecureServerHost());
 	}
 
 	public function testInsecureServerHostHttpFromForwardedHeaderStacked() {
@@ -802,7 +802,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('from.forwarded.host2:8080',  $request->getInsecureServerHost());
+		$this->assertSame('from.forwarded.host2:8080',  $request->getInsecureServerHost());
 	}
 
 	public function testGetServerHostWithOverwriteHost() {
@@ -830,7 +830,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('my.overwritten.host',  $request->getServerHost());
+		$this->assertSame('my.overwritten.host',  $request->getServerHost());
 	}
 
 	public function testGetServerHostWithTrustedDomain() {
@@ -852,7 +852,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('my.trusted.host',  $request->getServerHost());
+		$this->assertSame('my.trusted.host',  $request->getServerHost());
 	}
 
 	public function testGetServerHostWithUntrustedDomain() {
@@ -879,7 +879,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('my.trusted.host',  $request->getServerHost());
+		$this->assertSame('my.trusted.host',  $request->getServerHost());
 	}
 
 	public function testGetServerHostWithNoTrustedDomain() {
@@ -906,7 +906,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('',  $request->getServerHost());
+		$this->assertSame('',  $request->getServerHost());
 	}
 
 	public function testGetOverwriteHostDefaultNull() {
@@ -967,7 +967,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals('apps/files/',  $request->getPathInfo());
+		$this->assertSame('apps/files/',  $request->getPathInfo());
 	}
 
 	/**
@@ -1032,7 +1032,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals($expected, $request->getPathInfo());
+		$this->assertSame($expected, $request->getPathInfo());
 	}
 
 	/**
@@ -1055,7 +1055,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals($expected, $request->getRawPathInfo());
+		$this->assertSame($expected, $request->getRawPathInfo());
 	}
 
 	/**
@@ -1078,7 +1078,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals($expected, $request->getRawPathInfo());
+		$this->assertSame($expected, $request->getRawPathInfo());
 	}
 
 	/**
@@ -1101,7 +1101,7 @@ class RequestTest extends \Test\TestCase {
 			$this->stream
 		);
 
-		$this->assertEquals($expected, $request->getPathInfo());
+		$this->assertSame($expected, $request->getPathInfo());
 	}
 
 	/**
@@ -1109,6 +1109,7 @@ class RequestTest extends \Test\TestCase {
 	 */
 	public function genericPathInfoProvider() {
 		return [
+			['/core/index.php?XDEBUG_SESSION_START=14600', '/core/index.php', ''],
 			['/index.php/apps/files/', 'index.php', '/apps/files/'],
 			['/index.php/apps/files/../&amp;/&?someQueryParameter=QueryParam', 'index.php', '/apps/files/../&amp;/&'],
 			['/remote.php/漢字編碼方法 / 汉字编码方法', 'remote.php', '/漢字編碼方法 / 汉字编码方法'],


### PR DESCRIPTION
substr may return `false`.
1. commit uses assertSame and adds a failing case to show the problem
2. commit fixes the return value.
