### PR TITLE
Fix ShareItemModel.hasUserShares to only check shares of current item

### DIFF
--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -297,8 +297,7 @@
 		 * @returns {boolean}
 		 */
 		hasUserShares: function() {
-			var shares = this.get('shares');
-			return _.isArray(shares) && shares.length > 0;
+			return this.getSharesWithCurrentItem().length > 0;
 		},
 
 		/**
@@ -405,6 +404,20 @@
 		 */
 		getReshareType: function() {
 			return this.get('reshare').share_type;
+		},
+
+		/**
+		 * Returns all share entries that only apply to the current item
+		 * (file/folder)
+		 *
+		 * @return {Array.<OC.Share.Types.ShareInfo>}
+		 */
+		getSharesWithCurrentItem: function() {
+			var shares = this.get('shares') || [];
+			var fileId = this.fileInfoModel.get('id');
+			return _.filter(shares, function(share) {
+				return share.item_source === fileId;
+			});
 		},
 
 		/**

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -304,6 +304,63 @@ describe('OC.Share.ShareItemModel', function() {
 			expect(share.expiration).toEqual(1403900000);
 		});
 	});
+	describe('hasUserShares', function() {
+		it('returns false when no user shares exist', function() {
+			loadItemStub.yields({
+				reshare: {},
+				shares: []
+			});
+
+			model.fetch();
+
+			expect(model.hasUserShares()).toEqual(false);
+		});
+		it('returns true when user shares exist on the current item', function() {
+			loadItemStub.yields({
+				reshare: {},
+				shares: [{
+					id: 1,
+					share_type: OC.Share.SHARE_TYPE_USER,
+					share_with: 'user1',
+					item_source: '123'
+				}]
+			});
+
+			model.fetch();
+
+			expect(model.hasUserShares()).toEqual(true);
+		});
+		it('returns true when group shares exist on the current item', function() {
+			loadItemStub.yields({
+				reshare: {},
+				shares: [{
+					id: 1,
+					share_type: OC.Share.SHARE_TYPE_GROUP,
+					share_with: 'group1',
+					item_source: '123'
+				}]
+			});
+
+			model.fetch();
+
+			expect(model.hasUserShares()).toEqual(true);
+		});
+		it('returns false when share exist on parent item', function() {
+			loadItemStub.yields({
+				reshare: {},
+				shares: [{
+					id: 1,
+					share_type: OC.Share.SHARE_TYPE_GROUP,
+					share_with: 'group1',
+					item_source: '111'
+				}]
+			});
+
+			model.fetch();
+
+			expect(model.hasUserShares()).toEqual(false);
+		});
+	});
 
 	describe('Util', function() {
 		it('parseTime should properly parse strings', function() {


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/19294

The shares array is based on what the server returns and can contain
share info for parent folders.

hasUserShares is now fixed to ignore parent folders and only checks for
shares on the current item.

Please review @blizzz @nickvergessen @schiesbn @rullzer @DeepDiver1975 
