### PR TITLE
hide sort indicator when in multiselect mode, ref #19056

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -186,7 +186,8 @@ table th .sort-indicator {
 	filter: alpha(opacity=30);
 	opacity: .3;
 }
-.sort-indicator.hidden {
+.sort-indicator.hidden,
+.multiselect .sort-indicator {
 	visibility: hidden;
 }
 table th:hover .sort-indicator.hidden,

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -187,7 +187,9 @@ table th .sort-indicator {
 	opacity: .3;
 }
 .sort-indicator.hidden,
-.multiselect .sort-indicator {
+.multiselect .sort-indicator,
+table.multiselect th:hover .sort-indicator.hidden,
+table.multiselect th:focus .sort-indicator.hidden {
 	visibility: hidden;
 }
 .multiselect .sort, .multiselect .sort span {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -190,6 +190,9 @@ table th .sort-indicator {
 .multiselect .sort-indicator {
 	visibility: hidden;
 }
+.multiselect .sort, .multiselect .sort span {
+	cursor: default;
+}
 table th:hover .sort-indicator.hidden,
 table th:focus .sort-indicator.hidden {
 	visibility: visible;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -623,6 +623,9 @@
 		 * Event handler when clicking on a table header
 		 */
 		_onClickHeader: function(e) {
+			if (this.$table.hasClass('multiselect')) {
+				return;
+			}
 			var $target = $(e.target);
 			var sort;
 			if (!$target.is('a')) {

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2156,6 +2156,25 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileList.files.length).toEqual(5);
 			expect(fileList.$fileList.find('tr').length).toEqual(5);
 		});
+		it('does not sort when clicking on header whenever multiselect is enabled', function() {
+			var sortStub = sinon.stub(OCA.Files.FileList.prototype, 'setSort');
+
+			fileList.setFiles(testFiles);
+			fileList.findFileEl('One.txt').find('input:checkbox:first').click();
+
+			fileList.$el.find('.column-size .columntitle').click();
+
+			expect(sortStub.notCalled).toEqual(true);
+
+			// can sort again after deselecting
+			fileList.findFileEl('One.txt').find('input:checkbox:first').click();
+
+			fileList.$el.find('.column-size .columntitle').click();
+
+			expect(sortStub.calledOnce).toEqual(true);
+
+			sortStub.restore();
+		});
 	});
 	describe('create file', function() {
 		var deferredCreate;


### PR DESCRIPTION
Ref #19056, but as said there @PVince81 @MorrisJobke you need to remove the logic as well because the header is still clickable.
