### PR TITLE
Allow `set('column', 'null')` to work like in Doctrine's QueryBuilder

### DIFF
--- a/lib/private/db/querybuilder/quotehelper.php
+++ b/lib/private/db/querybuilder/quotehelper.php
@@ -52,7 +52,7 @@ class QuoteHelper {
 			return (string) $string;
 		}
 
-		if ($string === null || $string === '*') {
+		if ($string === null || $string === 'null' || $string === '*') {
 			return $string;
 		}
 

--- a/tests/lib/db/querybuilder/quotehelpertest.php
+++ b/tests/lib/db/querybuilder/quotehelpertest.php
@@ -43,6 +43,10 @@ class QuoteHelperTest extends \Test\TestCase {
 			[new Literal('literal'), 'literal'],
 			[new Literal(1), '1'],
 			[new Parameter(':param'), ':param'],
+
+			// (string) 'null' is Doctrines way to set columns to null
+			// See https://github.com/owncloud/core/issues/19314
+			['null', 'null'],
 		];
 	}
 


### PR DESCRIPTION
Fix #19314 

@PVince81 @DeepDiver1975 
