### PR TITLE
Correctly check whether an app is shipped

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -837,7 +837,7 @@ class OC_App {
 
 				$info['active'] = $active;
 
-				if (isset($info['shipped']) and ($info['shipped'] == 'true')) {
+				if (self::isShipped($app)) {
 					$info['internal'] = true;
 					$info['level'] = self::officialApp;
 					$info['removable'] = false;


### PR DESCRIPTION
1. Don't trust the app author
2. Verify against the shipped list

Fixes the status of the notifications app
