### PR TITLE
only check if the user exists if a user was added as parameter

### DIFF
--- a/lib/private/encryption/decryptall.php
+++ b/lib/private/encryption/decryptall.php
@@ -80,7 +80,7 @@ class DecryptAll {
 		$this->input = $input;
 		$this->output = $output;
 
-		if ($user !== '' && $this->userManager->userExists($user) === false) {
+		if (!empty($user) && $this->userManager->userExists($user) === false) {
 			$this->output->writeln('User "' . $user . '" does not exist. Please check the username and try again');
 			return false;
 		}

--- a/tests/lib/encryption/decryptalltest.php
+++ b/tests/lib/encryption/decryptalltest.php
@@ -82,11 +82,13 @@ class DecryptAllTest extends TestCase {
 	 * @dataProvider dataTrueFalse
 	 * @param bool $prepareResult
 	 */
-	public function testDecryptAll($prepareResult) {
+	public function testDecryptAll($prepareResult, $user) {
 
-		$user = 'user1';
-
-		$this->userManager->expects($this->once())->method('userExists')->willReturn(true);
+		if (!empty($user)) {
+			$this->userManager->expects($this->once())->method('userExists')->willReturn(true);
+		} else {
+			$this->userManager->expects($this->never())->method('userExists');
+		}
 		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
 		$instance = $this->getMockBuilder('OC\Encryption\DecryptAll')
 			->setConstructorArgs(
@@ -117,8 +119,10 @@ class DecryptAllTest extends TestCase {
 
 	public function dataTrueFalse() {
 		return [
-			[true],
-			[false]
+			[true, 'user1'],
+			[false, 'user1'],
+			[true, ''],
+			[true, null]
 		];
 	}
 


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/19327

was introduced here https://github.com/owncloud/core/pull/19221 because I didn't noticed that $user is null if no parameter was given.

cc @SergioBertolinSG @DeepDiver1975 
