### PR TITLE
no need to list users if all users already had a key-pair

### DIFF
--- a/apps/encryption/lib/crypto/encryptall.php
+++ b/apps/encryption/lib/crypto/encryptall.php
@@ -280,6 +280,12 @@ class EncryptAll {
 				$newPasswords[] = [$uid, $password];
 			}
 		}
+
+		if (empty($newPasswords)) {
+			$this->output->writeln("\nAll users already had a key-pair, no further action needed.\n");
+			return;
+		}
+
 		$table->setRows($newPasswords);
 		$table->render();
 


### PR DESCRIPTION
small user experience improvement. No need to list the user which already had a key if all users already had one before encrypt-all was called.

fix https://github.com/owncloud/core/issues/19332
