### PR TITLE
LDAP Wizard: enable/disable test login name button depending on wheth…

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
+++ b/apps/user_ldap/js/wizard/wizardTabLoginFilter.js
@@ -71,7 +71,8 @@ OCA = OCA || {};
 				],
 				'ldap_login_filter_mode'
 			);
-			_.bindAll(this, 'onVerifyClick');
+			_.bindAll(this, 'onVerifyClick', 'onTestLoginnameChange');
+			this.managedItems.ldap_test_loginname.$element.keyup(this.onTestLoginnameChange);
 			this.managedItems.ldap_test_loginname.$relatedElements.click(this.onVerifyClick);
 		},
 
@@ -231,6 +232,16 @@ OCA = OCA || {};
 			} else {
 				this.configModel.requestWizard('ldap_test_loginname', {ldap_test_loginname: testLogin});
 			}
+		},
+
+		/**
+		 * enables/disables the "Verify Settings" button, depending whether
+		 * the corresponding text input has a value or not
+		 */
+		onTestLoginnameChange: function() {
+			var loginName = this.managedItems.ldap_test_loginname.$element.val();
+			var beDisabled = !_.isString(loginName) || !loginName.trim();
+			this.managedItems.ldap_test_loginname.$relatedElements.prop('disabled', beDisabled);
 		}
 
 	});

--- a/apps/user_ldap/templates/part.wizard-loginfilter.php
+++ b/apps/user_ldap/templates/part.wizard-loginfilter.php
@@ -52,7 +52,7 @@
 				   placeholder="<?php p($l->t('Test Loginname'));?>"
 				   class="ldapVerifyInput"
 				   title="Attempts to receive a DN for the given loginname and the current login filter"/>
-			<button class="ldapVerifyLoginName" name="ldapTestLoginSettings" type="button">
+			<button class="ldapVerifyLoginName" name="ldapTestLoginSettings" type="button" disabled="disabled">
 				<?php p($l->t('Verify settings'));?>
 			</button>
 		</p>


### PR DESCRIPTION
…er a login name is provided or not

Fixes #15836 

In the LDAP Wizard on the login attribute tab, this should work now:

> how about if we grey out the verify settings button until someone enters a username in the loginname field?

please test review  @davitol @tkaufm @MorrisJobke @Xenopathic 
