### PR TITLE
Keep original index names in target schema during update simulation

### DIFF
--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -28,6 +28,7 @@
 namespace OC\DB;
 
 use \Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use \Doctrine\DBAL\Schema\Index;
 use \Doctrine\DBAL\Schema\Table;
 use \Doctrine\DBAL\Schema\Schema;
@@ -180,7 +181,11 @@ class Migrator {
 		$indexes = $table->getIndexes();
 		$newIndexes = array();
 		foreach ($indexes as $index) {
-			$newIndexes[] = new Index($index->getName(), $index->getColumns(), $index->isUnique(), $index->isPrimary());
+			$indexName = $index->getName();
+			if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform && strpos($indexName, $table->getName()) === 0) {
+				$indexName = $newName . substr($indexName, strlen($table->getName()));
+			}
+			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}
 
 		// foreign keys are not supported so we just set it to an empty array

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -180,14 +180,7 @@ class Migrator {
 		$indexes = $table->getIndexes();
 		$newIndexes = array();
 		foreach ($indexes as $index) {
-			if ($index->isPrimary()) {
-				// do not rename primary key
-				$indexName = $index->getName();
-			} else {
-				// avoid conflicts in index names
-				$indexName = $this->config->getSystemValue('dbtableprefix', 'oc_') . $this->random->generate(13, ISecureRandom::CHAR_LOWER);
-			}
-			$newIndexes[] = new Index($indexName, $index->getColumns(), $index->isUnique(), $index->isPrimary());
+			$newIndexes[] = new Index($index->getName(), $index->getColumns(), $index->isUnique(), $index->isPrimary());
 		}
 
 		// foreign keys are not supported so we just set it to an empty array

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -261,7 +261,11 @@ class Migrator {
 		$quotedSource = $this->connection->quoteIdentifier($sourceName);
 		$quotedTarget = $this->connection->quoteIdentifier($targetName);
 
-		$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' (LIKE ' . $quotedSource . ')');
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+			$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' (LIKE ' . $quotedSource . ' INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)');
+		} else {
+			$this->connection->exec('CREATE TABLE ' . $quotedTarget . ' (LIKE ' . $quotedSource . ')');
+		}
 		$this->connection->exec('INSERT INTO ' . $quotedTarget . ' SELECT * FROM ' . $quotedSource);
 	}
 

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -215,12 +215,14 @@ class Migrator {
 		// Set the autoincrement for integer columns of the primary key
 		// This is required, because we manually set the primary key for
 		// autoincrement columns in \OC\DB\OCSqlitePlatform()
-		foreach ($targetSchema->getTables() as $table) {
-			if ($table->hasPrimaryKey()) {
-				foreach ($table->getPrimaryKeyColumns() as $column) {
-					$column = $table->getColumn($column);
-					if ($column->getType() instanceof \Doctrine\DBAL\Types\IntegerType) {
-						$column->setAutoincrement(true);
+		if ($this->connection->getDatabasePlatform() instanceof \OC\DB\OCSqlitePlatform) {
+			foreach ($targetSchema->getTables() as $table) {
+				if ($table->hasPrimaryKey()) {
+					foreach ($table->getPrimaryKeyColumns() as $column) {
+						$column = $table->getColumn($column);
+						if ($column->getType() instanceof \Doctrine\DBAL\Types\IntegerType) {
+							$column->setAutoincrement(true);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is to prevent Doctrine to detect them as renamed indices, which
happens since the upgrade to Doctrine 2.5.

Added a test that no change is detected when schemas are identical.
Added tests for renaming and adding indices.

Fixes https://github.com/owncloud/core/issues/19317

Needs careful testing on all databases.
Please note that this only affects the DB schema update **simulation**, not the actual migration.

@icewind1991 @DeepDiver1975 @nickvergessen @butonic 
