### PR TITLE
Save the settings in the user management page

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -813,44 +813,73 @@ $(document).ready(function () {
 			});
 	});
 
+	if ($('#CheckboxStorageLocation').is(':checked')) {
+		$("#userlist .storageLocation").show();
+	}
 	// Option to display/hide the "Storage location" column
 	$('#CheckboxStorageLocation').click(function() {
 		if ($('#CheckboxStorageLocation').is(':checked')) {
 			$("#userlist .storageLocation").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_storage_location', 'true');
 		} else {
 			$("#userlist .storageLocation").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_storage_location', 'false');
 		}
 	});
+
+	if ($('#CheckboxLastLogin').is(':checked')) {
+		$("#userlist .lastLogin").show();
+	}
 	// Option to display/hide the "Last Login" column
 	$('#CheckboxLastLogin').click(function() {
 		if ($('#CheckboxLastLogin').is(':checked')) {
 			$("#userlist .lastLogin").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_last_login', 'true');
 		} else {
 			$("#userlist .lastLogin").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_last_login', 'false');
 		}
 	});
+
+	if ($('#CheckboxEmailAddress').is(':checked')) {
+		$("#userlist .mailAddress").show();
+	}
 	// Option to display/hide the "Mail Address" column
 	$('#CheckboxEmailAddress').click(function() {
 		if ($('#CheckboxEmailAddress').is(':checked')) {
 			$("#userlist .mailAddress").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_email', 'true');
 		} else {
 			$("#userlist .mailAddress").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_email', 'false');
 		}
 	});
+
+	if ($('#CheckboxUserBackend').is(':checked')) {
+		$("#userlist .userBackend").show();
+	}
 	// Option to display/hide the "User Backend" column
 	$('#CheckboxUserBackend').click(function() {
 		if ($('#CheckboxUserBackend').is(':checked')) {
 			$("#userlist .userBackend").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_backend', 'true');
 		} else {
 			$("#userlist .userBackend").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_backend', 'false');
 		}
 	});
+
+	if ($('#CheckboxMailOnUserCreate').is(':checked')) {
+		$("#newemail").show();
+	}
 	// Option to display/hide the "E-Mail" input field
 	$('#CheckboxMailOnUserCreate').click(function() {
 		if ($('#CheckboxMailOnUserCreate').is(':checked')) {
 			$("#newemail").show();
+			OC.AppConfig.setValue('core', 'umgmt_send_email', 'true');
 		} else {
 			$("#newemail").hide();
+			OC.AppConfig.setValue('core', 'umgmt_send_email', 'false');
 		}
 	});
 

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -45,31 +45,36 @@ translation('settings');
 
 			<div id="userlistoptions">
 				<p>
-					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation">
+					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation" 
+						<?php if ($_['show_storage_location'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxStorageLocation">
 						<?php p($l->t('Show storage location')) ?>
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin">
+					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin"
+						<?php if ($_['show_last_login'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxLastLogin">
 						<?php p($l->t('Show last log in')) ?>
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="UserBackend" value="UserBackend" id="CheckboxUserBackend">
+					<input type="checkbox" name="UserBackend" value="UserBackend" id="CheckboxUserBackend"
+						<?php if ($_['show_backend'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxUserBackend">
 						<?php p($l->t('Show user backend')) ?>
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="MailOnUserCreate" value="MailOnUserCreate" id="CheckboxMailOnUserCreate">
+					<input type="checkbox" name="MailOnUserCreate" value="MailOnUserCreate" id="CheckboxMailOnUserCreate"
+						<?php if ($_['send_email'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxMailOnUserCreate">
 						<?php p($l->t('Send email to new user')) ?>
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="EmailAddress" value="EmailAddress" id="CheckboxEmailAddress">
+					<input type="checkbox" name="EmailAddress" value="EmailAddress" id="CheckboxEmailAddress"
+						<?php if ($_['show_email'] === 'true') print_unescaped('checked="checked"'); ?> />
 					<label for="CheckboxEmailAddress">
 						<?php p($l->t('Show email address')) ?>
 					</label>

--- a/settings/users.php
+++ b/settings/users.php
@@ -99,4 +99,11 @@ $tmpl->assign('default_quota', $defaultQuota);
 $tmpl->assign('defaultQuotaIsUserDefined', $defaultQuotaIsUserDefined);
 $tmpl->assign('recoveryAdminEnabled', $recoveryAdminEnabled);
 $tmpl->assign('enableAvatars', \OC::$server->getConfig()->getSystemValue('enable_avatars', true));
+
+$tmpl->assign('show_storage_location', $config->getAppValue('core', 'umgmt_show_storage_location', 'false'));
+$tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_login', 'false'));
+$tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
+$tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));
+$tmpl->assign('send_email', $config->getAppValue('core', 'umgmt_send_email', 'false'));
+
 $tmpl->printPage();


### PR DESCRIPTION
Fixes #12727

Quick fix to save the state of the settings checkboxes. This makes sure that once they are set ownCloud remebers the settings.

Note that it currently is global. So all admins see the same. But like I said quick fix.

CC: @jancborchardt @PVince81 @MorrisJobke @LukasReschke 
