### PR TITLE
[jenkins] Cache result of check upgrade

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -237,7 +237,7 @@ class OC {
 		// Check if config is writable
 		$configFileWritable = is_writable($configFilePath);
 		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
-			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
+			|| !$configFileWritable && self::checkUpgrade(false)) {
 			if (self::$CLI) {
 				echo $l->t('Cannot write into "config" directory!')."\n";
 				echo $l->t('This can usually be fixed by giving the webserver write access to the config directory')."\n";
@@ -678,7 +678,7 @@ class OC {
 	 */
 	public static function registerCacheHooks() {
 		//don't try to do this before we are properly setup
-		if (\OC::$server->getSystemConfig()->getValue('installed', false) && !\OCP\Util::needUpgrade()) {
+		if (\OC::$server->getSystemConfig()->getValue('installed', false) && !self::checkUpgrade(false)) {
 
 			// NOTE: This will be replaced to use OCP
 			$userSession = self::$server->getUserSession();
@@ -714,7 +714,7 @@ class OC {
 	 */
 	public static function registerLogRotate() {
 		$systemConfig = \OC::$server->getSystemConfig();
-		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !\OCP\Util::needUpgrade()) {
+		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !self::checkUpgrade(false)) {
 			//don't try to do this before we are properly setup
 			//use custom logfile path if defined, otherwise use default of owncloud.log in data directory
 			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/owncloud.log'));
@@ -807,8 +807,7 @@ class OC {
 
 		// Load minimum set of apps
 		if (!self::checkUpgrade(false)
-			&& !$systemConfig->getValue('maintenance', false)
-			&& !\OCP\Util::needUpgrade()) {
+			&& !$systemConfig->getValue('maintenance', false)) {
 			// For logged-in users: Load everything
 			if(OC_User::isLoggedIn()) {
 				OC_App::loadApps();
@@ -821,7 +820,7 @@ class OC {
 
 		if (!self::$CLI and (!isset($_GET["logout"]) or ($_GET["logout"] !== 'true'))) {
 			try {
-				if (!$systemConfig->getValue('maintenance', false) && !\OCP\Util::needUpgrade()) {
+				if (!$systemConfig->getValue('maintenance', false) && !self::checkUpgrade(false)) {
 					OC_App::loadApps(array('filesystem', 'logging'));
 					OC_App::loadApps();
 				}

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -654,6 +654,7 @@ class Util {
 		return \OC_Util::isDefaultExpireDateEnforced();
 	}
 
+	protected static $needUpgradeCache = null;
 
 	/**
 	 * Checks whether the current version needs upgrade.
@@ -662,6 +663,9 @@ class Util {
 	 * @since 7.0.0
 	 */
 	public static function needUpgrade() {
-		return \OC_Util::needUpgrade(\OC::$server->getConfig());
+		if (!isset(self::$needUpgradeCache)) {
+			self::$needUpgradeCache=\OC_Util::needUpgrade(\OC::$server->getConfig());
+		}		
+		return self::$needUpgradeCache;
 	}
 }

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -406,11 +406,13 @@ class Test_Util extends \Test\TestCase {
 
 		OC_Config::setValue('version', '7.0.0.0');
 		\OC::$server->getSession()->set('OC_Version', array(7, 0, 0, 1));
+		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', array(null));
 
 		$this->assertTrue(\OCP\Util::needUpgrade());
 
 		OC_Config::setValue('version', $oldConfigVersion);
 		$oldSessionVersion = \OC::$server->getSession()->set('OC_Version', $oldSessionVersion);
+		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', array(null));
 
 		$this->assertFalse(\OCP\Util::needUpgrade());
 	}


### PR DESCRIPTION
new PR for CI
original:  #18945

instead of calling `\OCP\Util::needUpgrade()` again and again, save the result in self::$needUpgrade and return that value when asked
