### PR TITLE
Add doc to config.sample for enforce LDAP home folder naming rule

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -806,6 +806,21 @@ $CONFIG = array(
  */
 'ldapUserCleanupInterval' => 51,
 
+/**
+ * Enforce the existence of the home folder naming rule for all users
+ *
+ * Following scenario:
+ *  * a home folder naming rule is set in LDAP advanced settings
+ *  * a user doesn't have the home folder naming rule attribute set
+ *
+ * If this is set to **true** (default) it will NOT fallback to the core's
+ * default naming rule of using the internal user ID as home folder name.
+ *
+ * If this is set to **false** it will fallback for the users without the
+ * attribute set to naming the home folder like the internal user ID.
+ *
+ */
+'enforce_home_folder_naming_rule' => true,
 
 /**
  * Maintenance


### PR DESCRIPTION
- forgotten to be added in #16891

cc @Xenopathic @carlaschroder for wording fixes

cc @blizzz for content
