### PR TITLE
Reflect enabled shareAPI in capabilities

### DIFF
--- a/apps/files_sharing/lib/capabilities.php
+++ b/apps/files_sharing/lib/capabilities.php
@@ -45,28 +45,36 @@ class Capabilities implements ICapability {
 	public function getCapabilities() {
 		$res = [];
 
-		$public = [];
-		$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
-		if ($public['enabled']) {
-			$public['password'] = [];
-			$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
+		if ($this->config->getAppValue('core', 'shareapi_enabled', 'yes') !== 'yes') {
+			$res['api_enabled'] = false;
+			$res['public'] = ['enabled' => false];
+			$res['user'] = ['send_mail' => false];
+			$res['resharing'] = false;
+		} else {
+			$res['api_enabled'] = true;
 
-			$public['expire_date'] = [];
-			$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';
-			if ($public['expire_date']['enabled']) {
-				$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
-				$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
+			$public = [];
+			$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
+			if ($public['enabled']) {
+				$public['password'] = [];
+				$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
+
+				$public['expire_date'] = [];
+				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';
+				if ($public['expire_date']['enabled']) {
+					$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
+					$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
+				}
+
+				$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
+				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
 			}
+			$res["public"] = $public;
 
-			$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
-			$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
+			$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') === 'yes';
+
+			$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 		}
-		$res["public"] = $public;
-
-		$res['user']['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') === 'yes';
-
-		$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
-
 
 		//Federated sharing
 		$res['federation'] = [

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -56,8 +56,31 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 		return $result;
 	}
 
+	public function testEnabledSharingAPI() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['api_enabled']);
+		$this->assertContains('public', $result);
+		$this->assertContains('user', $result);
+		$this->assertContains('resharing', $result);
+	}
+
+	public function testDisabledSharingAPI() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['api_enabled']);
+		$this->assertNotContains('public', $result);
+		$this->assertNotContains('user', $result);
+		$this->assertNotContains('resharing', $result);
+	}
+
 	public function testNoLinkSharing() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'no'],
 		];
 		$result = $this->getResults($map);
@@ -67,6 +90,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testOnlyLinkSharing() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 		];
 		$result = $this->getResults($map);
@@ -76,6 +100,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkPassword() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
 		];
@@ -87,6 +112,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkNoPassword() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_enforce_links_password', 'no', 'no'],
 		];
@@ -98,6 +124,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkNoExpireDate() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_default_expire_date', 'no', 'no'],
 		];
@@ -109,6 +136,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkExpireDate() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_default_expire_date', 'no', 'yes'],
 			['core', 'shareapi_expire_after_n_days', '7', '7'],
@@ -124,6 +152,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkExpireDateEnforced() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_default_expire_date', 'no', 'yes'],
 			['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
@@ -136,6 +165,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkSendMail() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_allow_public_notification', 'no', 'yes'],
 		];
@@ -145,6 +175,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkNoSendMail() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_allow_public_notification', 'no', 'no'],
 		];
@@ -154,6 +185,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testUserSendMail() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_mail_notification', 'no', 'yes'],
 		];
 		$result = $this->getResults($map);
@@ -162,6 +194,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testUserNoSendMail() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_mail_notification', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
@@ -170,6 +203,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testResharing() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_resharing', 'yes', 'yes'],
 		];
 		$result = $this->getResults($map);
@@ -178,6 +212,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testNoResharing() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_resharing', 'yes', 'no'],
 		];
 		$result = $this->getResults($map);
@@ -186,6 +221,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkPublicUpload() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_allow_public_upload', 'yes', 'yes'],
 		];
@@ -195,6 +231,7 @@ class FilesSharingCapabilitiesTest extends \Test\TestCase {
 
 	public function testLinkNoPublicUpload() {
 		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
 			['core', 'shareapi_allow_public_upload', 'yes', 'no'],
 		];


### PR DESCRIPTION
Found while looking into https://github.com/owncloud/client/issues/3879

If the shareAPI is disabled from the admin panel we should reflect this properly in the capabilities of the server.

This will help clients to see that sharing is disabled.
- Added unit tests.

CC: @nickvergessen @MorrisJobke @PVince81 @DeepDiver1975 
