### PR TITLE
rename config test to prevent autoloader issue

### DIFF
--- a/tests/lib/configtests.php
+++ b/tests/lib/configtests.php
@@ -6,7 +6,9 @@
  * See the COPYING-README file.
  */
 
-class Test_Config extends \Test\TestCase {
+namespace Test;
+
+class ConfigTests extends TestCase {
 	const TESTCONTENT = '<?php $CONFIG=array("foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
 
 	/** @var array */
@@ -24,7 +26,7 @@ class Test_Config extends \Test\TestCase {
 		$this->randomTmpDir = \OC_Helper::tmpFolder();
 		$this->configFile = $this->randomTmpDir.'testconfig.php';
 		file_put_contents($this->configFile, self::TESTCONTENT);
-		$this->config = new OC\Config($this->randomTmpDir, 'testconfig.php');
+		$this->config = new \OC\Config($this->randomTmpDir, 'testconfig.php');
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
When the file is called `config.php` it can be autoloaded when the autoloader is trying to find `\OC\Config` which leads to a fatal error since it won't be able to autoload `\Test\TestCase` before `\OC\Config` is setup.

The autoloading issue is triggered when trying to run an individual tests (in phpstorm) from a file located directly in the `tests/lib` folder, since the current directory is part of the include path it finds `tests/lib/config.php` as a possible valid path for `\OC\Config`

cc @DeepDiver1975 @PVince81 
