### PR TITLE
fix name autocomplete not showing on mobile, fix #18551

### DIFF
--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -45,6 +45,10 @@
 	width: 80% !important;
 }
 
+/* fix name autocomplete not showing on mobile */
+.ui-autocomplete {
+	z-index: 1000 !important;
+}
 
 /* fix error display on smaller screens */
 .error-wide {


### PR DESCRIPTION
Fix #18551 with brute force CSS, not sure if it’s the best idea. Please test @owncloud/designers @MorrisJobke @PVince81 @oparoz @libasys @schiesbn

This fixes the share user dropdown not showing on mobile.
