### PR TITLE
remove border around button of password protected link confirmation

### DIFF
--- a/apps/files_sharing/css/authenticate.css
+++ b/apps/files_sharing/css/authenticate.css
@@ -11,7 +11,8 @@ input[type='submit'] {
 
 #body-login input[type='submit'] {
 	position: absolute;
-	top: 0px;
+	top: 0;
+	border: none;
 }
 
 fieldset > p {


### PR DESCRIPTION
On the password input page for password-protected links, there was an ever so slight light grey border around the confirm (arrow) icon. This fixes that.

Please review @owncloud/designers @oparoz @schiesbn
