### PR TITLE
OCS endpoint to list remote shares

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -88,23 +88,23 @@ API::register('delete',
 		'files_sharing');
 
 API::register('get',
-		'/apps/files_sharing/api/v1/pending_shares',
+		'/apps/files_sharing/api/v1/remote_shares',
+		array('\OCA\Files_Sharing\API\Remote', 'getShares'),
+		'files_sharing');
+
+API::register('get',
+		'/apps/files_sharing/api/v1/remote_shares/pending',
 		array('\OCA\Files_Sharing\API\Remote', 'getOpenShares'),
 		'files_sharing');
 
 API::register('post',
-		'/apps/files_sharing/api/v1/pending_shares/{id}',
+		'/apps/files_sharing/api/v1/remote_shares/pending/{id}',
 		array('\OCA\Files_Sharing\API\Remote', 'acceptShare'),
 		'files_sharing');
 
 API::register('delete',
-		'/apps/files_sharing/api/v1/pending_shares/{id}',
+		'/apps/files_sharing/api/v1/remote_shares/pending/{id}',
 		array('\OCA\Files_Sharing\API\Remote', 'declineShare'),
-		'files_sharing');
-
-API::register('get',
-		'/apps/files_sharing/api/v1/remote_shares',
-		array('\OCA\Files_Sharing\API\Remote', 'getShares'),
 		'files_sharing');
 
 API::register('get',

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -88,17 +88,17 @@ API::register('delete',
 		'files_sharing');
 
 API::register('get',
-		'/apps/files_sharing/api/v1/remote_shares',
+		'/apps/files_sharing/api/v1/pending_shares',
 		array('\OCA\Files_Sharing\API\Remote', 'getOpenShares'),
 		'files_sharing');
 
 API::register('post',
-		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		'/apps/files_sharing/api/v1/pending_shares/{id}',
 		array('\OCA\Files_Sharing\API\Remote', 'acceptShare'),
 		'files_sharing');
 
 API::register('delete',
-		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		'/apps/files_sharing/api/v1/pending_shares/{id}',
 		array('\OCA\Files_Sharing\API\Remote', 'declineShare'),
 		'files_sharing');
 

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -102,6 +102,22 @@ API::register('delete',
 		array('\OCA\Files_Sharing\API\Remote', 'declineShare'),
 		'files_sharing');
 
+API::register('get',
+		'/apps/files_sharing/api/v1/remote_shares',
+		array('\OCA\Files_Sharing\API\Remote', 'getShares'),
+		'files_sharing');
+
+API::register('get',
+		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		array('\OCA\Files_Sharing\API\Remote', 'getShare'),
+		'files_sharing');
+
+API::register('delete',
+		'/apps/files_sharing/api/v1/remote_shares/{id}',
+		array('\OCA\Files_Sharing\API\Remote', 'unshare'),
+		'files_sharing');
+
+
 $sharees = new \OCA\Files_Sharing\API\Sharees(\OC::$server->getGroupManager(),
                                               \OC::$server->getUserManager(),
                                               \OC::$server->getContactsManager(),

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -182,7 +182,7 @@ class Manager {
 	 */
 	public function getShare($id) {
 		$getShare = $this->connection->prepare('
-			SELECT *
+			SELECT `id`, `remote`, `remote_id`, `share_token`, `name`, `owner`, `user`, `mountpoint`, `accepted`
 			FROM  `*PREFIX*share_external`
 			WHERE `id` = ? AND `user` = ?');
 		$result = $getShare->execute(array($id, $this->uid));
@@ -424,7 +424,9 @@ class Manager {
 	 * @return array list of open server-to-server shares
 	 */
 	private function getShares($accepted) {
-		$query = 'SELECT * FROM `*PREFIX*share_external` WHERE `user` = ?';
+		$query = 'SELECT `id`, `remote`, `remote_id`, `share_token`, `name`, `owner`, `user`, `mountpoint`, `accepted`
+		          FROM `*PREFIX*share_external` 
+				  WHERE `user` = ?';
 		$parameters = [$this->uid];
 		if (!is_null($accepted)) {
 			$query .= ' AND `accepted` = ?';

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -180,9 +180,9 @@ class Manager {
 	 * @param int $id share id
 	 * @return mixed share of false
 	 */
-	private function getShare($id) {
+	public function getShare($id) {
 		$getShare = $this->connection->prepare('
-			SELECT `remote`, `remote_id`, `share_token`, `name`
+			SELECT *
 			FROM  `*PREFIX*share_external`
 			WHERE `id` = ? AND `user` = ?');
 		$result = $getShare->execute(array($id, $this->uid));
@@ -404,6 +404,15 @@ class Manager {
 	 */
 	public function getOpenShares() {
 		return $this->getShares(false);
+	}
+
+	/**
+	 * return a list of shares wich are accepted by the user
+	 *
+	 * @return array list of accepted server-to-server shares
+	 */
+	public function getAcceptedShares() {
+		return $this->getShares(true);
 	}
 
 	/**


### PR DESCRIPTION
Required for #9098
- Move OCS endpoint `../remote_shares` -> `../pending_shares`
- Introduce new endpoint `../remote_shares` that allows listing of incoming remote shares.

@nickvergessen since you wrote the original `../remote_shares` stuff are you fine with this?

I'm not really happy with this. But as stated in https://github.com/owncloud/core/issues/9098#issuecomment-143311672 this is the cleanest hack I can think of. Comments?

CC: @cmonteroluque @DeepDiver1975
