### PR TITLE
Switch from Math.floor() to Math.ceil() when sending the dimension to Preview

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1393,8 +1393,8 @@
 			}
 			urlSpec.x *= window.devicePixelRatio;
 			urlSpec.y *= window.devicePixelRatio;
-			urlSpec.x = Math.floor(urlSpec.x);
-			urlSpec.y = Math.floor(urlSpec.y);
+			urlSpec.x = Math.ceil(urlSpec.x);
+			urlSpec.y = Math.ceil(urlSpec.y);
 			urlSpec.forceIcon = 0;
 			return OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
 		},

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -90,8 +90,8 @@ OCA.Sharing.PublicApp = {
 		// dynamically load image previews
 		var token = $('#sharingToken').val();
 		var bottomMargin = 350;
-		var previewWidth = Math.floor($(window).width() * window.devicePixelRatio);
-		var previewHeight = Math.floor(($(window).height() - bottomMargin) * window.devicePixelRatio);
+		var previewWidth = Math.ceil($(window).width() * window.devicePixelRatio);
+		var previewHeight = Math.ceil(($(window).height() - bottomMargin) * window.devicePixelRatio);
 		previewHeight = Math.max(200, previewHeight);
 		var params = {
 			x: previewWidth,
@@ -168,8 +168,8 @@ OCA.Sharing.PublicApp = {
 				}
 				urlSpec.x *= window.devicePixelRatio;
 				urlSpec.y *= window.devicePixelRatio;
-				urlSpec.x = Math.floor(urlSpec.x);
-				urlSpec.y = Math.floor(urlSpec.y);
+				urlSpec.x = Math.ceil(urlSpec.x);
+				urlSpec.y = Math.ceil(urlSpec.y);
 				urlSpec.t = $('#dirToken').val();
 				return OC.generateUrl('/apps/files_sharing/ajax/publicpreview.php?') + $.param(urlSpec);
 			};


### PR DESCRIPTION
Fixes #18203

> We're using Math.floor() when we want to round one of the dimensions of an image after applying window.devicePixelRatio, but I think what we really want is Math.ceil(), as otherwise pictures can still end up being a bit blurry since they will be smaller than the expected size.

@PVince81 @DeepDiver1975 @rullzer 
