### PR TITLE
Use a universal shebang

### DIFF
--- a/apps/files_external/tests/env/start-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/start-amazons3-ceph.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/start-ftp-morrisjobke.sh
+++ b/apps/files_external/tests/env/start-ftp-morrisjobke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/start-sftp-atmoz.sh
+++ b/apps/files_external/tests/env/start-sftp-atmoz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/start-smb-silvershell.sh
+++ b/apps/files_external/tests/env/start-smb-silvershell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/start-smb-windows.sh
+++ b/apps/files_external/tests/env/start-smb-windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/start-webdav-ownCloud.sh
+++ b/apps/files_external/tests/env/start-webdav-ownCloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/stop-amazons3-ceph.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-ftp-morrisjobke.sh
+++ b/apps/files_external/tests/env/stop-ftp-morrisjobke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-sftp-atmoz.sh
+++ b/apps/files_external/tests/env/stop-sftp-atmoz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-smb-silvershell.sh
+++ b/apps/files_external/tests/env/stop-smb-silvershell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-smb-windows.sh
+++ b/apps/files_external/tests/env/stop-smb-windows.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/apps/files_external/tests/env/stop-webdav-ownCloud.sh
+++ b/apps/files_external/tests/env/stop-webdav-ownCloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/autotest-js.sh
+++ b/autotest-js.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/autotest.sh
+++ b/autotest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/buildjsdocs.sh
+++ b/buildjsdocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ownCloud
 #

--- a/core/img/image-optimization.sh
+++ b/core/img/image-optimization.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function recursive_optimize_images() {
 cd $1;

--- a/l10n/rm-old.sh
+++ b/l10n/rm-old.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 lang=(ach ady af_ZA ak am_ET ar ast az bal be bg_BG bn_BD bn_IN bs ca cs_CZ cy_GB da de de_AT de_DE el en_GB en@pirate eo es es_AR es_CL es_MX et_EE eu fa fi_FI fil fr fy_NL gl gu he hi hr hu_HU hy ia id io is it ja jv ka_GE km kn ko ku_IQ la lb lo lt_LT lv mg mk ml ml_IN mn mr ms_MY mt_MT my_MM nb_NO nds ne nl nn_NO nqo oc or_IN pa pl pt_BR pt_PT ro ru si_LK sk_SK sl sq sr sr@latin su sv sw_KE ta_IN ta_LK te tg_TJ th_TH tl_PH tr tzl tzm ug uk ur_PK uz vi yo zh_CN zh_HK zh_TW)
 


### PR DESCRIPTION
Fixes #15037

> You can't use /bin/bash as the shebang as it will surely fail on some systems.
> A safer call is /usr/bin/env bash

@DeepDiver1975 @Xenopathic @nickvergessen @BernhardPosselt 
