### PR TITLE
Allow public webdav auth to recognize sesssion

### DIFF
--- a/apps/files_sharing/lib/connector/publicauth.php
+++ b/apps/files_sharing/lib/connector/publicauth.php
@@ -82,10 +82,13 @@ class PublicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 
 					}
 					return true;
+				} else if (\OC::$server->getSession()->exists('public_link_authenticated')
+					&& \OC::$server->getSession()->get('public_link_authenticated') === $linkItem['id']) {
+					return true;
 				} else {
 					return false;
 				}
-			} elseif ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_REMOTE) {
+			} else if ($linkItem['share_type'] == \OCP\Share::SHARE_TYPE_REMOTE) {
 				return true;
 			} else {
 				return false;


### PR DESCRIPTION
When a public link password has been input, its auth is stored in the
session.
This fix makes it possible to recognize the session when using public
webdav from the files UI.

This also expects the passed token to match the one from the session.

Fixes https://github.com/owncloud/core/issues/18731
Also a prerequisite to be able to use public Webdav later for the move of files app endpoints to Webdav: https://github.com/owncloud/core/pull/16902

Please review @LukasReschke @oparoz @icewind1991 @schiesbn 
