### PR TITLE
Hide sidebar tab headers conditionally

### DIFF
--- a/apps/files/js/detailtabview.js
+++ b/apps/files/js/detailtabview.js
@@ -95,6 +95,17 @@
 		 */
 		nextPage: function() {
 			// load the next page, if applicable
+		},
+
+		/**
+		 * Returns whether the current tab is able to display
+		 * the given file info, for example based on mime type.
+		 *
+		 * @param {OCA.Files.FileInfoModel} fileInfo file info model
+		 * @return {bool} whether to display this tab
+		 */
+		canDisplay: function(fileInfo) {
+			return true;
 		}
 	});
 	DetailTabView._TAB_COUNT = 0;

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -189,6 +189,18 @@
 			this.$el.find('.has-tooltip').tooltip();
 			this.$versionsContainer = this.$el.find('ul.versions');
 			this.delegateEvents();
+		},
+
+		/**
+		 * Returns true for files, false for folders.
+		 *
+		 * @return {bool} true for files, false for folders
+		 */
+		canDisplay: function(fileInfo) {
+			if (!fileInfo) {
+				return false;
+			}
+			return !fileInfo.isDirectory();
 		}
 	});
 


### PR DESCRIPTION
Added canDisplay() in DetailsTabView that should return false if the tab
header of this tab must be hidden.

Fixes https://github.com/owncloud/core/issues/18899

Please review @jancborchardt @MorrisJobke @rullzer @nickvergessen @schiesbn @blizzz 
