### PR TITLE
Still show share link when recipient but no share permission

### DIFF
--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -179,7 +179,7 @@ describe('OCA.Sharing.Util tests', function() {
 			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
 			expect($action.find('img').length).toEqual(1);
 		});
-		it('shows static share text when file shared with user that has no share permission', function() {
+		it('shows share action when shared with user who has no share permission', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
@@ -193,14 +193,9 @@ describe('OCA.Sharing.Util tests', function() {
 				shareOwner: 'User One'
 			}]);
 			$tr = fileList.$el.find('tbody tr:first');
-			expect($tr.find('.action-share').length).toEqual(0);
-			$action = $tr.find('.action-share-notification');
-			expect($action.find('>span').text().trim()).toEqual('User One');
-			expect(OC.basename($action.find('img').attr('src'))).toEqual('share.svg');
-			expect(OC.basename(getImageUrl($tr.find('.filename .thumbnail')))).toEqual('folder-shared.svg');
-			expect($action.find('img').length).toEqual(1);
+			expect($tr.find('.action-share').length).toEqual(1);
 		});
-		it('do not show static share text when share exists but neither permission nor owner is available', function() {
+		it('do not show share action when share exists but neither permission nor owner is available', function() {
 			var $action, $tr;
 			fileList.setFiles([{
 				id: 1,
@@ -214,8 +209,6 @@ describe('OCA.Sharing.Util tests', function() {
 			}]);
 			$tr = fileList.$el.find('tbody tr:first');
 			expect($tr.find('.action-share').length).toEqual(0);
-			$action = $tr.find('.action-share-notification');
-			expect($action.length).toEqual(0);
 		});
 	});
 	describe('Share action', function() {


### PR DESCRIPTION
This makes it possible for the recipient to still trigger the sidebar
and share tab to see information about the share.

In the case where the file is not shared and no permissions exists, no
action icon will be displayed.

Fixes https://github.com/owncloud/core/issues/19412 (contains the steps to reproduce)

Please review @rullzer @blizzz @schiesbn @jancborchardt @nickvergessen 
