### PR TITLE
Show conflict dialog before upload when possible

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -719,8 +719,23 @@
 			return true;
 		},
 		/**
-		 * Returns the tr element for a given file name
-		 * @param fileName file name
+		 * Returns the file info for the given file name from the internal collection.
+		 *
+		 * @param {string} fileName file name
+		 * @return {OCA.Files.FileInfo} file info or null if it was not found
+		 *
+		 * @since 8.2
+		 */
+		findFile: function(fileName) {
+			return _.find(this.files, function(aFile) {
+				return (aFile.name === fileName);
+			}) || null;
+		},
+		/**
+		 * Returns the tr element for a given file name, but only if it was already rendered.
+		 *
+		 * @param {string} fileName file name
+		 * @return {Object} jQuery object of the matching row
 		 */
 		findFileEl: function(fileName){
 			// use filterAttr to avoid escaping issues
@@ -1877,7 +1892,7 @@
 		 * @return {bool} true if the file exists in the list, false otherwise
 		 */
 		inList:function(file) {
-			return this.findFileEl(file).length;
+			return this.findFile(file);
 		},
 
 		/**


### PR DESCRIPTION
When uploading files, first check if the files exist in the current file list. For the ones that do, show a conflict dialog. For the rest, upload directly.

If the upload operation detects a conflict on the server side, it will also continue populating the conflict dialog.

From now on, server side conflict can only occur if someone concurrently uploaded a file into the same folder but the current user hasn't refreshed the list yet.

Fixes https://github.com/owncloud/core/issues/8664

Please review @butonic (you are the one who has the most understanding of this) @nickvergessen @icewind1991 

To test:
- regular upload multiple files into current
- upload into folder that has visibly duplicates: check network console, it should not upload anything before conflict resolution (new behavior)
- upload into folder where duplicates are not visible (add the duplicates from another tab): check network console, it will upload the file first before showing conflict (previous behavior)
- test all these in IE8 and other browsers

I tested with Chromium and IE8 so far
