### PR TITLE
Consider both hash params and query when parsing URL

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1773,9 +1773,7 @@ OC.Util.History = {
 			params = OC.parseQueryString(this._decodeQuery(query));
 		}
 		// else read from query attributes
-		if (!params) {
-			params = OC.parseQueryString(this._decodeQuery(location.search));
-		}
+		params = _.extend(params || {}, OC.parseQueryString(this._decodeQuery(location.search)));
 		return params || {};
 	},
 


### PR DESCRIPTION
Should fix https://github.com/owncloud/core/issues/14828

Also when leaving the new text editor (close the popup), and then refreshing the page, it should properly show the current folder.
- [x] TEST: IE8
- [x] TEST: test test!

@oparoz @rullzer 
