### PR TITLE
memberOf resembles a DN as well and is actively used

### DIFF
--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -215,7 +215,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 		$resemblingAttributes = array(
 			'dn',
 			'uniquemember',
-			'member'
+			'member',
+			// memberOf is an "operational" attribute, without a definition in any RFC
+			'memberof'
 		);
 		return in_array($attr, $resemblingAttributes);
 	}


### PR DESCRIPTION
Fixes possible not-sanitized group DNs in the mappings table, which in corner cases could end up in duplicate groups. Also see https://github.com/owncloud/enterprise/issues/815#issuecomment-143743973

There's a unit test included that replicates the fixed issue.

To test manually:
1. Have an AD (works with OpenLDAP, but it's easier to test against here) 
2. Have Groups on LDAP which have upper case letters in their DN
3. Make sure Group Mappings are cleared
4. Log in as LDAP user that belongs to such a group
5. Go to personal page
6. Check oc_ldap_group_mappings table. DNs are supposed to be all lower cased. Without the fix however, cases are preserved.

After applying the fix, the entries should even be corrected. When testing, mind the LDAP cache.

Please test and review @GreenArchon @MorrisJobke @davitol 

@karlitschek  I also request to backport to stable8.1. 
