### PR TITLE
Whitelist "data:" in legacy CSP headers

### DIFF
--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -247,7 +247,7 @@ class OC_Response {
 			. 'script-src \'self\' \'unsafe-eval\'; '
 			. 'style-src \'self\' \'unsafe-inline\'; '
 			. 'frame-src *; '
-			. 'img-src *; '
+			. 'img-src * data:; '
 			. 'font-src \'self\' data:; '
 			. 'media-src *; ' 
 			. 'connect-src *';


### PR DESCRIPTION
Fixes #19425 

Policy is now `'img-src * data:;`

@LukasReschke 
