### PR TITLE
Session closed exception wording

### DIFF
--- a/lib/private/session/cryptowrapper.php
+++ b/lib/private/session/cryptowrapper.php
@@ -39,7 +39,7 @@ use OCP\Security\ISecureRandom;
  * it as an additional small security obfuscation layer to comply with compliance
  * guidelines.
  *
- * TODO: Remove this in a future relase with an approach such as
+ * TODO: Remove this in a future release with an approach such as
  * https://github.com/owncloud/core/pull/17866
  *
  * @package OC\Session

--- a/lib/private/session/internal.php
+++ b/lib/private/session/internal.php
@@ -106,7 +106,7 @@ class Internal extends Session {
 
 	private function validateSession() {
 		if ($this->sessionClosed) {
-			throw new \Exception('Session has been closed - no further changes to the session as allowed');
+			throw new \Exception('Session has been closed - no further changes to the session are allowed');
 		}
 	}
 }

--- a/lib/private/session/memory.php
+++ b/lib/private/session/memory.php
@@ -93,7 +93,7 @@ class Memory extends Session {
 	 */
 	private function validateSession() {
 		if ($this->sessionClosed) {
-			throw new \Exception('Session has been closed - no further changes to the session as allowed');
+			throw new \Exception('Session has been closed - no further changes to the session are allowed');
 		}
 	}
 }


### PR DESCRIPTION
and a small comment typo.
I was actually searching for where the message:

```
Password holds invalid special characters. Only #! as allowed
```

is stored.
That appears in a screen shot in https://github.com/owncloud/core/issues/19422
But my search of the code did not find that.
Maybe that password validation code is in some other repo?

Might as well fix the text here anyway.
