### PR TITLE
[stable8.1] Do not register JS share plugin if core sharing API is disabled

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -25,6 +25,10 @@
 		 * @param {OCA.Files.FileList} fileList file list to be extended
 		 */
 		attach: function(fileList) {
+			// core sharing is disabled/not loaded
+			if (!OC.Share) {
+				return;
+			}
 			if (fileList.id === 'trashbin' || fileList.id === 'files.public') {
 				return;
 			}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/17343 to stable8.1

Please review @MorrisJobke @icewind1991 @schiesbn 
