### PR TITLE
[upgrade] switch to debug logging on upgrade

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -88,6 +88,12 @@ if (OC::checkUpgrade(false)) {
 		$eventSource->close();
 		OC_Config::setValue('maintenance', false);
 	});
+	$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Set log level to debug - current level: "%s"', [ $logLevelName ]));
+	});
+	$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Reset log level to  "%s"', [ $logLevelName ]));
+	});
 
 	try {
 		$updater->upgrade();

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -177,6 +177,12 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'failure', function ($message) use($output, $self) {
 				$output->writeln("<error>$message</error>");
 			});
+			$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($output) {
+				$output->writeln("<info>Set log level to debug - current level: '$logLevelName'</info>");
+			});
+			$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($output) {
+				$output->writeln("<info>Reset log level to '$logLevelName'</info>");
+			});
 
 			if(OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				$updater->listen('\OC\Updater', 'repairInfo', function ($message) use($output) {

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -32,6 +32,7 @@
 
 namespace OC;
 
+use OC\Core\Command\Log\Manage;
 use OC\Hooks\BasicEmitter;
 use OC_App;
 use OC_Installer;
@@ -68,6 +69,14 @@ class Updater extends BasicEmitter {
 
 	/** @var bool */
 	private $skip3rdPartyAppsDisable;
+
+	private $logLevelNames = [
+		0 => 'Debug',
+		1 => 'Info',
+		2 => 'Warning',
+		3 => 'Error',
+		4 => 'Fatal',
+	];
 
 	/**
 	 * @param HTTPHelper $httpHelper
@@ -177,6 +186,10 @@ class Updater extends BasicEmitter {
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
 	public function upgrade() {
+		$logLevel = $this->config->getSystemValue('loglevel', \OCP\Util::WARN);
+		$this->emit('\OC\Updater', 'setDebugLogLevel', [ $logLevel, $this->logLevelNames[$logLevel] ]);
+		$this->config->setSystemValue('loglevel', \OCP\Util::DEBUG);
+
 		$wasMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
 
 		if(!$wasMaintenanceModeEnabled) {
@@ -207,6 +220,9 @@ class Updater extends BasicEmitter {
 		} else {
 			$this->emit('\OC\Updater', 'maintenanceActive');
 		}
+
+		$this->emit('\OC\Updater', 'resetLogLevel', [ $logLevel, $this->logLevelNames[$logLevel] ]);
+		$this->config->setSystemValue('loglevel', $logLevel);
 
 		return $success;
 	}


### PR DESCRIPTION
- resets afterwards
- adds output about the previous log level

cc @PVince81 @nickvergessen @LukasReschke @karlitschek As discussed multiple times.

I would like to backport this down to stable7.
