### PR TITLE
Fix postScanFile event and make it available to utils scanner

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -186,9 +186,9 @@ class Scanner extends BasicEmitter {
 				}
 				if (!empty($newData)) {
 					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
-					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
-					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
 				}
+				$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
+				\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
 			} else {
 				$this->removeFromCache($file);
 			}

--- a/lib/private/files/utils/scanner.php
+++ b/lib/private/files/utils/scanner.php
@@ -99,7 +99,12 @@ class Scanner extends PublicEmitter {
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($mount, $emitter) {
 			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFolder', array($mount->getMountPoint() . $path));
 		});
-
+		$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFile', function ($path) use ($mount, $emitter) {
+			$emitter->emit('\OC\Files\Utils\Scanner', 'postScanFile', array($mount->getMountPoint() . $path));
+		});
+		$scanner->listen('\OC\Files\Cache\Scanner', 'postScanFolder', function ($path) use ($mount, $emitter) {
+			$emitter->emit('\OC\Files\Utils\Scanner', 'postScanFolder', array($mount->getMountPoint() . $path));
+		});
 		// propagate etag and mtimes when files are changed or removed
 		$propagator = $this->propagator;
 		$propagatorListener = function ($path) use ($mount, $propagator) {


### PR DESCRIPTION
The `postScanFile` event is important when scanning external storage as it indicates when the file is ready to be used and it currently only fires when updated metadata is available.

The 2nd commit makes the 2 events `postScanFile` and `postScanFolder` events available in OC\Files\Utils\Scanner. This one can be postponed as this would be considered an enhancement.

@icewind1991 @PVince81 @Xenopathic 
