### PR TITLE
encryption: versions should always use the keys of the original file, no need to …

### DIFF
--- a/tests/lib/files/storage/wrapper/encryption.php
+++ b/tests/lib/files/storage/wrapper/encryption.php
@@ -558,4 +558,27 @@ class Encryption extends \Test\Files\Storage\Storage {
 
 		$this->assertFalse(false);
 	}
+
+	/**
+	 * @dataProvider dataTestIsVersion
+	 * @param string $path
+	 * @param bool $expected
+	 */
+	public function testIsVersion($path, $expected) {
+		$this->assertSame($expected,
+			$this->invokePrivate($this->instance, 'isVersion', [$path])
+		);
+	}
+
+	public function dataTestIsVersion() {
+		return [
+			['files_versions/foo', true],
+			['/files_versions/foo', true],
+			['//files_versions/foo', true],
+			['files/versions/foo', false],
+			['files/files_versions/foo', false],
+			['files_versions_test/foo', false],
+		];
+	}
+
 }


### PR DESCRIPTION
versions should always use the keys of the original file, no need to create new one

Steps to test:
1. Enable encryption
2. Create two users "user1" and "user2"
3. Login as "user2"
4. Create folder "test"
5. Share "test" with "user1"
6. Login as "test1"
7. Create a file "test/versions.txt"
8. Edit the file several times to create versions
9. Delete the file

-> Check if delete operation worked

fix #18132 

Open issues: depending on who restores the file from the trash bin version might be broken. I will take care of this separately

cc @PVince81 
