### PR TITLE
Keep opacity in current item in newFileMenu

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -746,6 +746,10 @@ table.dragshadow td.size {
 	margin: 0;
 }
 
+.newFileMenu.popovermenu a.menuitem.active {
+	opacity: 1;
+}
+
 .newFileMenu.bubble:after {
 	left: 75px;
 	right: auto;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -748,6 +748,8 @@ table.dragshadow td.size {
 
 .newFileMenu.popovermenu a.menuitem.active {
 	opacity: 1;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	filter: alpha(opacity=100);
 }
 
 .newFileMenu.bubble:after {

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -84,6 +84,8 @@
 				OC.hideMenus();
 			} else {
 				event.preventDefault();
+				this.$el.find('.menuitem.active').removeClass('active');
+				$target.addClass('active');
 				this._promptFileName($target);
 			}
 		},


### PR DESCRIPTION
Whenever the input field appears, the menu item should keep its opacity
instead of reacting on hover.

Before:
![newfilemenuhighlight-before](https://cloud.githubusercontent.com/assets/277525/10188567/81edc530-6760-11e5-9187-366dd76823ab.png)

See how it looks disabled, you'd need to hover on it with the mouse to keep it enabled.

After:
![newfilemenuhighlight-after](https://cloud.githubusercontent.com/assets/277525/10188572/8804475a-6760-11e5-87cc-19a1fc599c4a.png)

Please review @jancborchardt @DeepDiver1975 @karlitschek @rullzer @blizzz @schiesbn 
