### PR TITLE
Change small thumbnails to 32 px

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1408,10 +1408,10 @@
 		generatePreviewUrl: function(urlSpec) {
 			urlSpec = urlSpec || {};
 			if (!urlSpec.x) {
-				urlSpec.x = this.$table.data('preview-x') || 36;
+				urlSpec.x = this.$table.data('preview-x') || 32;
 			}
 			if (!urlSpec.y) {
-				urlSpec.y = this.$table.data('preview-y') || 36;
+				urlSpec.y = this.$table.data('preview-y') || 32;
 			}
 			urlSpec.x *= window.devicePixelRatio;
 			urlSpec.y *= window.devicePixelRatio;

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -51,7 +51,7 @@
 	<p></p>
 </div>
 
-<table id="filestable" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="36" data-preview-y="36">
+<table id="filestable" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="32" data-preview-y="32">
 	<thead>
 		<tr>
 			<th id='headerName' class="hidden column-name">

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -28,8 +28,8 @@ OCP\JSON::checkAppEnabled('files_sharing');
 \OC_User::setIncognitoMode(true);
 
 $file = array_key_exists('file', $_GET) ? (string) $_GET['file'] : '';
-$maxX = array_key_exists('x', $_GET) ? (int) $_GET['x'] : '36';
-$maxY = array_key_exists('y', $_GET) ? (int) $_GET['y'] : '36';
+$maxX = array_key_exists('x', $_GET) ? (int) $_GET['x'] : '32';
+$maxY = array_key_exists('y', $_GET) ? (int) $_GET['y'] : '32';
 $scalingUp = array_key_exists('scalingup', $_GET) ? (bool) $_GET['scalingup'] : true;
 $token = array_key_exists('t', $_GET) ? (string) $_GET['t'] : '';
 $keepAspect = array_key_exists('a', $_GET) ? true : false;

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -161,10 +161,10 @@ OCA.Sharing.PublicApp = {
 			this.fileList.generatePreviewUrl = function (urlSpec) {
 				urlSpec = urlSpec || {};
 				if (!urlSpec.x) {
-					urlSpec.x = 36;
+					urlSpec.x = 32;
 				}
 				if (!urlSpec.y) {
-					urlSpec.y = 36;
+					urlSpec.y = 32;
 				}
 				urlSpec.x *= window.devicePixelRatio;
 				urlSpec.y *= window.devicePixelRatio;

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -908,6 +908,6 @@ class Trashbin {
 	 * @return string
 	 */
 	public static function preview_icon($path) {
-		return \OCP\Util::linkToRoute('core_ajax_trashbin_preview', array('x' => 36, 'y' => 36, 'file' => $path));
+		return \OCP\Util::linkToRoute('core_ajax_trashbin_preview', array('x' => 32, 'y' => 32, 'file' => $path));
 	}
 }

--- a/core/ajax/preview.php
+++ b/core/ajax/preview.php
@@ -26,8 +26,8 @@
 \OC::$server->getSession()->close();
 
 $file = array_key_exists('file', $_GET) ? (string)$_GET['file'] : '';
-$maxX = array_key_exists('x', $_GET) ? (int)$_GET['x'] : '36';
-$maxY = array_key_exists('y', $_GET) ? (int)$_GET['y'] : '36';
+$maxX = array_key_exists('x', $_GET) ? (int)$_GET['x'] : '32';
+$maxY = array_key_exists('y', $_GET) ? (int)$_GET['y'] : '32';
 $scalingUp = array_key_exists('scalingup', $_GET) ? (bool)$_GET['scalingup'] : true;
 $keepAspect = array_key_exists('a', $_GET) ? true : false;
 $always = array_key_exists('forceIcon', $_GET) ? (bool)$_GET['forceIcon'] : true;

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -193,11 +193,11 @@ class OC_Helper {
 	 * Returns the path to the preview of the file.
 	 */
 	public static function previewIcon($path) {
-		return self::linkToRoute( 'core_ajax_preview', array('x' => 36, 'y' => 36, 'file' => $path ));
+		return self::linkToRoute( 'core_ajax_preview', array('x' => 32, 'y' => 32, 'file' => $path ));
 	}
 
 	public static function publicPreviewIcon( $path, $token ) {
-		return self::linkToRoute( 'core_ajax_public_preview', array('x' => 36, 'y' => 36, 'file' => $path, 't' => $token));
+		return self::linkToRoute( 'core_ajax_public_preview', array('x' => 32, 'y' => 32, 'file' => $path, 't' => $token));
 	}
 
 	/**

--- a/lib/private/preview/txt.php
+++ b/lib/private/preview/txt.php
@@ -53,7 +53,7 @@ class TXT extends Provider {
 
 		$lines = preg_split("/\r\n|\n|\r/", $content);
 
-		$fontSize = ($maxX) ? (int) ((5 / 36) * $maxX) : 5; //5px
+		$fontSize = ($maxX) ? (int) ((5 / 32) * $maxX) : 5; //5px
 		$lineSize = ceil($fontSize * 1.25);
 
 		$image = imagecreate($maxX, $maxY);

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -534,10 +534,10 @@ class Preview extends TestCase {
 		// Small thumbnails are always cropped
 		$this->keepAspect = false;
 		// Smaller previews should be based on the previous, larger preview, with the correct aspect ratio
-		$this->createThumbnailFromBiggerCachedPreview($fileId, 36, 36);
+		$this->createThumbnailFromBiggerCachedPreview($fileId, 32, 32);
 
 		// 2nd cache query should indicate that we have a cached copy of the exact dimension
-		$this->getCachedSmallThumbnail($fileId, 36, 36);
+		$this->getCachedSmallThumbnail($fileId, 32, 32);
 
 		// We create a preview in order to be able to delete the cache
 		$preview = $this->createPreview(rand(), rand());


### PR DESCRIPTION
- fixes #16913
- fixes issues in IE8 where the thumbnail is too big

All current previews are resized by CSS (`background-size: 32px`) which cause the issues with IE8.

cc @oparoz @PVince81 @georgehrke 
