### PR TITLE
Clean temp files used for thumbnail generation

### DIFF
--- a/lib/private/preview/image.php
+++ b/lib/private/preview/image.php
@@ -46,12 +46,16 @@ abstract class Image extends Provider {
 
 		$image = new \OC_Image();
 
-		if ($fileInfo['encrypted'] === true) {
+		$useTempFile = $fileInfo->isEncrypted() || !$fileInfo->getStorage()->isLocal();
+		if ($useTempFile) {
 			$fileName = $fileview->toTmpFile($path);
 		} else {
 			$fileName = $fileview->getLocalFile($path);
 		}
 		$image->loadFromFile($fileName);
+		if ($useTempFile) {
+			unlink($fileName);
+		}
 		$image->fixOrientation();
 		if ($image->valid()) {
 			$image->scaleDownToFit($maxX, $maxY);


### PR DESCRIPTION
When using a temp file for thumbnail creation delete it after we loaded the image.

Fixes #19469

@mmattel can you verify that this fixes the problem

cc @PVince81 @MorrisJobke 
