### PR TITLE
cache found l10n per app and not globally

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -503,8 +503,9 @@ class OC_L10N implements \OCP\IL10N {
 	 * @return array an array of available languages
 	 */
 	public static function findAvailableLanguages($app=null) {
-		if(!empty(self::$availableLanguages)) {
-			return self::$availableLanguages;
+		// also works with null as key
+		if(isset(self::$availableLanguages[$app]) && !empty(self::$availableLanguages[$app])) {
+			return self::$availableLanguages[$app];
 		}
 		$available=array('en');//english is always available
 		$dir = self::findI18nDir($app);
@@ -518,7 +519,7 @@ class OC_L10N implements \OCP\IL10N {
 			}
 		}
 
-		self::$availableLanguages = $available;
+		self::$availableLanguages[$app] = $available;
 		return $available;
 	}
 


### PR DESCRIPTION
- fixes: if the first call to this is with an app that has no translations
  all future call will get a list with only english in there - even
  if their l10n holds more translations

cc @nickvergessen @LukasReschke 
