### PR TITLE
Markup fixes to Deleted Items section

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -417,19 +417,21 @@ $CONFIG = array(
  *
  * Available values:
  *
- * * ``auto``      default setting. keeps files and folders in the trash bin
- *                 for 30 days and automatically deletes anytime after that
- *                 if space is needed (note: files may not be deleted if space
- *                 is not needed).
- * * ``D, auto``   keeps files and folders in the trash bin for D+ days,
- *                 delete anytime if space needed (note: files may not be deleted
- *                 if space is not needed)
- * * ``auto, D``   delete all files in the trash bin that are older than D days
- *                 automatically, delete other files anytime if space needed
- * * ``D1, D2``    keep files and folders the in trash bin for at least D1 days
- *                 and delete when exceeds D2 days
- * * ``disabled``  trash bin auto clean disabled, files and folders will be
- *                 kept forever
+ * * ``auto``      
+ *     default setting. keeps files and folders in the trash bin for 30 days 
+ *     and automatically deletes anytime after that if space is needed (note: 
+ *     files may not be deleted if space is not needed).
+ * * ``D, auto``   
+ *     keeps files and folders in the trash bin for D+ days, delete anytime if 
+ *     space needed (note: files may not be deleted if space is not needed)
+ * * ``auto, D``   
+ *     delete all files in the trash bin that are older than D days   
+ *     automatically, delete other files anytime if space needed
+ * * ``D1, D2``    
+ *     keep files and folders the in trash bin for at least D1 days and 
+ *     delete when exceeds D2 days
+ * * ``disabled``  
+ *     trash bin auto clean disabled, files and folders will be kept forever
  */
 'trashbin_retention_obligation' => 'auto',
 
@@ -448,18 +450,23 @@ $CONFIG = array(
  * ownCloud 8.1 and before.
  *
  * Available values:
- *   ``auto``      default setting. Automatically expire versions according to
- *                 expire rules. Please refer to Files_versions online documentation 
- *                 for more info.
- *   ``D, auto``   keep versions at least for D days, apply expire rules to all
- *                 versions that are older than D days
- * * ``auto, D``   delete all versions that are older than D days automatically,
- *                 delete other versions according to expire rules
- * * ``D1, D2``    keep versions for at least D1 days and delete when exceeds D2 days
- *   ``disabled``  versions auto clean disabled, versions will be kept forever
+ *
+ * * ``auto``      
+ *     default setting. Automatically expire versions according to expire 
+ *     rules. Please refer to Files_versions online documentation for more 
+ *     info.
+ * * ``D, auto``   
+ *     keep versions at least for D days, apply expire rules to all versions 
+ *     that are older than D days
+ * * ``auto, D``   
+ *     delete all versions that are older than D days automatically, delete 
+ *     other versions according to expire rules
+ * * ``D1, D2``    
+ *     keep versions for at least D1 days and delete when exceeds D2 days
+ * * ``disabled``  
+ *     versions auto clean disabled, versions will be kept forever
  */
 'versions_retention_obligation' => 'auto',
-
 
 /**
  * ownCloud Verifications


### PR DESCRIPTION
For 8.2 only. Clean up the formatting in the Deleted Items section (see how it looks now at https://doc.owncloud.org/server/8.2/admin_manual/configuration_server/config_sample_php_parameters.html#deleted-items-trash-bin)
