### PR TITLE
Skip unnecessary cache updates

### DIFF
--- a/lib/private/connector/sabre/file.php
+++ b/lib/private/connector/sabre/file.php
@@ -200,11 +200,11 @@ class File extends Node implements IFile {
 				// touch() has done already a updateMtime(), now we only need to run a updateFolderSize()
 				$this->fileView->getUpdater ()->updateFolderSize ( $this->path );
 			} else { // no touch was done so we need to do a full update
-			         // since we skipped the view we need to scan and emit the hooks ourselves
+
+				// since we skipped the view we need to scan and emit the hooks ourselves
 				$this->fileView->getUpdater ()->update ( $this->path );
 			}
 			$this->refreshInfo();
-			$this->fileView->unlockFile($this->path, ILockingProvider::LOCK_SHARED);
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
 		}
@@ -417,19 +417,18 @@ class File extends Node implements IFile {
 				// allow sync clients to send the mtime along in a header
 				$request = \OC::$server->getRequest();
 				if (isset($request->server['HTTP_X_OC_MTIME'])) {
-					if ($targetStorage->touch($targetInternalPath, $request->server['HTTP_X_OC_MTIME'],true)) {
+					if ($targetStorage->touch($targetInternalPath, $request->server['HTTP_X_OC_MTIME'])) {
 						header('X-OC-MTime: accepted');
 					}
-					$this->changeLock(ILockingProvider::LOCK_SHARED);
-					//touch() has done already a updateMtime(), now we only need to run a updateFolderSize()
-					$this->fileView->getUpdater()->updateFolderSize($this->path);
-				} else { //no touch was done so we need to do a full update
-					// since we skipped the view we need to scan and emit the hooks ourselves
-					$this->changeLock(ILockingProvider::LOCK_SHARED);
-					$this->fileView->getUpdater()->update($this->path);
 				}
+
+				$this->changeLock(ILockingProvider::LOCK_SHARED);
+
+				// since we skipped the view we need to scan and emit the hooks ourselves
+				$this->fileView->getUpdater()->update($targetPath);
+
 				$this->emitPostHooks($exists, $targetPath);
-				
+
 				$info = $this->fileView->getFileInfo($targetPath);
 				return $info->getEtag();
 			} catch (\Exception $e) {

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -98,7 +98,7 @@ class Updater {
 	 * @param string $path
 	 * @param int $time
 	 */
-	public function update($path, $time = null) {
+	public function update($path, $time = null, $updateType=array('ParentStorageMtime','FolderSize')) {
 		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
@@ -109,11 +109,15 @@ class Updater {
 		list($storage, $internalPath) = $this->view->resolvePath($path);
 		if ($storage) {
 			$this->propagator->addChange($path);
-			$cache = $storage->getCache($internalPath);
-			$scanner = $storage->getScanner($internalPath);
-			$data = $scanner->scan($internalPath, Scanner::SCAN_SHALLOW, -1, false);
-			$this->correctParentStorageMtime($storage, $internalPath);
-			$cache->correctFolderSize($internalPath, $data);
+			if (in_array('ParentStorageMtime', $updateType)) {
+				$this->correctParentStorageMtime($storage, $internalPath);
+			}
+			if (in_array('FolderSize', $updateType)) {
+				$scanner = $storage->getScanner($internalPath);
+				$data = $scanner->scan($internalPath, Scanner::SCAN_SHALLOW, -1, false);				
+				$cache = $storage->getCache($internalPath);
+				$cache->correctFolderSize($internalPath, $data);
+			}			
 			$this->propagator->propagateChanges($time);
 		}
 	}

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -127,9 +127,15 @@ class Updater {
 		if ($storage) {
 			$this->correctParentStorageMtime($storage, $internalPath);
 			if (!$skipPropagatingChanges) {
+				$data=[];
+				$scanner = $storage->getScanner ( $internalPath );
+				$data = $scanner->scan ( $internalPath, Scanner::SCAN_SHALLOW, - 1, false );
+				$cache = $storage->getCache ( $internalPath );
+				$entry = $cache->get($internalPath);
+				$cache->update($entry['fileid'],$data);
 				$this->propagator->addChange($path);
 				$this->propagator->propagateChanges($time);
-			}			
+			}
 		}
 	}	
 	

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -107,7 +107,7 @@ class Updater {
 		$this->updateFolderSize($path,$time);
 		
 	}
-	
+
 	/**
 	 * Update the cache for $path update the mtime of the parent folders
 	 *
@@ -137,9 +137,8 @@ class Updater {
 				$this->propagator->propagateChanges($time);
 			}
 		}
-	}	
-	
-	
+	}
+
 	/**
 	 * Update the cache for $path update the size and etag of the parent folders
 	 *
@@ -165,9 +164,9 @@ class Updater {
 			if (!$skipPropagatingChanges) {
 				$this->propagator->addChange($path);
 				$this->propagator->propagateChanges($time);
-			}			
+			}
 		}
-	}	
+	}
 
 	/**
 	 * Remove $path from the cache and update the size, etag and mtime of the parent folders

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1037,7 +1037,7 @@ class View {
 					$this->updater->update($path);
 				}
 				if (in_array('touch', $hooks)) {
-					$this->updater->update($path, $extraParam);
+					$this->updater->update($path, $extraParam,array('ParentStorageMtime'));
 				}
 
 				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -451,7 +451,7 @@ class View {
 	 * @param int|string $mtime
 	 * @return bool
 	 */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null, $skipPropagatingChanges=false) {
 		if (!is_null($mtime) and !is_numeric($mtime)) {
 			$mtime = strtotime($mtime);
 		}
@@ -462,7 +462,7 @@ class View {
 			$hooks[] = 'create';
 			$hooks[] = 'write';
 		}
-		$result = $this->basicOperation('touch', $path, $hooks, $mtime);
+		$result = $this->basicOperation('touch', $path, $hooks, $mtime, $skipPropagatingChanges);
 		if (!$result) {
 			// If create file fails because of permissions on external storage like SMB folders,
 			// check file exists and return false if not.
@@ -993,7 +993,7 @@ class View {
 	 * files), processes hooks and proxies, sanitises paths, and finally passes them on to
 	 * \OC\Files\Storage\Storage for delegation to a storage backend for execution
 	 */
-	private function basicOperation($operation, $path, $hooks = array(), $extraParam = null) {
+	private function basicOperation($operation, $path, $hooks = array(), $extraParam = null, $skipPropagatingChanges=false) {
 		$postFix = (substr($path, -1, 1) === '/') ? '/' : '';
 		$absolutePath = Filesystem::normalizePath($this->getAbsolutePath($path));
 		if (Filesystem::isValidPath($path)
@@ -1037,7 +1037,7 @@ class View {
 					$this->updater->update($path);
 				}
 				if (in_array('touch', $hooks)) {
-					$this->updater->update($path, $extraParam,array('ParentStorageMtime'));
+					$this->updater->updateMtime($path, $extraParam, $skipPropagatingChanges);
 				}
 
 				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {


### PR DESCRIPTION
This is the rebased copy of the PR #18753

`OC\Files\Cache\Updater::update` does a couple of updates. Not all are needed in every case the method is called.
In this example if `touch()` only is changing the mtime we should skip the update of the folder size as that would not change.
