### PR TITLE
[IE8] Remove non-working ellipsis support

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -330,10 +330,6 @@ table td.filename .nametext {
 	max-width: 800px;
 	height: 100%;
 }
-/* IE8 text-overflow: ellipsis support */
-.ie8 table td.filename .nametext {
-	min-width: 50%;
-}
 .has-favorites #fileList td.filename a.name {
 	left: 50px;
 	margin-right: 50px;
@@ -345,13 +341,6 @@ table td.filename .nametext .innernametext {
 	position: relative;
 	display: inline-block;
 	vertical-align: top;
-}
-/* IE8 text-overflow: ellipsis support */
-.ie8 table td.filename .nametext .innernametext {
-	white-space: nowrap;
-	word-wrap: normal;
-	-ms-text-overflow: ellipsis;
-	max-width: 47%;
 }
 
 @media only screen and (min-width: 1500px) {

--- a/core/css/fixes.css
+++ b/core/css/fixes.css
@@ -24,6 +24,10 @@ select {
 	background-image: url('../img/actions/checkmark.png');
 }
 
+.ie8 .icon-close {
+	background-image: url('../img/actions/close.png');
+}
+
 .lte9 .icon-triangle-e {
 	background-image: url('../img/actions/triangle-e.png');
 }


### PR DESCRIPTION
This prevents the name element to be too wide, which would cause users
to mistakenly click on it instead of the empty space when wanting to
focus on a file for the sidebar.

Also fixed the close button on the sidebar (make it appear)
(I know the button looks shitty, but it's better than no button at all...)

Fixes https://github.com/owncloud/core/issues/18619#issuecomment-144096505

Please review @davitol @MorrisJobke @blizzz @rullzer @Henni 
