### PR TITLE
[IE8] Fix dangling Delete action when multiselect is enabled

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -563,6 +563,10 @@ a.action > img {
 	margin-bottom: -1px;
 }
 
+html.ie8 .column-mtime .selectedActions {
+	top: -95px;
+}
+
 #fileList a.action {
 	display: inline;
 	padding: 17px 8px;


### PR DESCRIPTION
For some reason we need to cancel out the table's top: 95px, but just
for the delete action and not the other ones... whatever, IE8...

Fixes https://github.com/owncloud/core/issues/18619#issuecomment-144464342 (see screenshot there)

Please review @MorrisJobke @Henni @rullzer @blizzz @DeepDiver1975 @davitol 
