### PR TITLE
[trashbin] fix broken versions on restore

### DIFF
--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -142,6 +142,13 @@ class Storage extends Wrapper {
 		) {
 			return call_user_func_array([$this->storage, $method], [$path]);
 		}
+
+		// check permissions before we continue, this is especially important for
+		// shared files
+		if (!$this->isDeletable($path)) {
+			return false;
+		}
+
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$result = true;
 		if (!isset($this->deletedFiles[$normalized])) {


### PR DESCRIPTION
first copy to file to the trash bin for the owner and then move it to the current user's trash bin because the encryption wrapper always expect to work on the owner storage

This fix broken versions for shared files on restore if encryption is enabled

Steps to test:
1. Enable encryption
2. Create two users "user1" and "user2"
3. Login as "user2"
4. Create folder "test"
5. Share "test" with "user1"
6. Login as "test1"
7. Create a file "test/versions.txt"
8. Edit the file several times to create versions
9. Delete the file
10. restore file again (once as user1 and once as user2)

-> check if in both cases user1 and user2 can read the file and all it's versions

cc @PVince81 follow-up on https://github.com/owncloud/core/pull/19463 to fix https://github.com/owncloud/core/issues/18132 completely.
