### PR TITLE
Start to show remote shares in shared with you section

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -191,14 +191,18 @@
 				// convert share data to file data
 				.map(function(share) {
 					var file = {
-						shareOwner: share.owner + '@' + share.remote,
-						name: share.name
+						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
+						name: OC.basename(share.mountpoint),
+						mtime: share.mtime,
+						mimetype: share.mimetype,
+						type: share.type,
+						id: share.file_id,
+						path: OC.dirname(share.mountpoint)
 					};
 
 					file.shares = [{
 						id: share.id,
-						type: OC.Share.SHARE_TYPE_REMOTE,
-						target: share.mountpoint
+						type: OC.Share.SHARE_TYPE_REMOTE
 					}];
 					return file;
 				})

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -151,6 +151,9 @@
 					},
 				});
 				promises.push(remoteShares);
+			} else {
+				//Push empty promise so callback gets called the same way
+				promises.push($.Deferred().resolve());
 			}
 
 			this._reloadCall = $.when.apply($, promises);
@@ -174,7 +177,7 @@
 				// TODO: error handling
 			}
 
-			if (remoteShares[0].ocs && remoteShares[0].ocs.data) {
+			if (remoteShares && remoteShares[0].ocs && remoteShares[0].ocs.data) {
 				files = files.concat(this._makeFilesFromRemoteShares(remoteShares[0].ocs.data));
 			} else {
 				// TODO: error handling
@@ -193,11 +196,12 @@
 					var file = {
 						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
 						name: OC.basename(share.mountpoint),
-						mtime: share.mtime,
+						mtime: share.mtime * 1000,
 						mimetype: share.mimetype,
 						type: share.type,
 						id: share.file_id,
-						path: OC.dirname(share.mountpoint)
+						path: OC.dirname(share.mountpoint),
+						permissions: share.permissions
 					};
 
 					file.shares = [{

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -122,7 +122,9 @@
 			if (this._reloadCall) {
 				this._reloadCall.abort();
 			}
-			this._reloadCall = $.ajax({
+
+			var promises = [];
+			var shares = $.ajax({
 				url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares',
 				/* jshint camelcase: false */
 				data: {
@@ -132,25 +134,76 @@
 				type: 'GET',
 				beforeSend: function(xhr) {
 					xhr.setRequestHeader('OCS-APIREQUEST', 'true');
-				}
+				},
 			});
+			promises.push(shares);
+
+			if (!!this._sharedWithUser) {
+				var remoteShares = $.ajax({
+					url: OC.linkToOCS('apps/files_sharing/api/v1') + 'remote_shares',
+					/* jshint camelcase: false */
+					data: {
+						format: 'json'
+					},
+					type: 'GET',
+					beforeSend: function(xhr) {
+						xhr.setRequestHeader('OCS-APIREQUEST', 'true');
+					},
+				});
+				promises.push(remoteShares);
+			}
+
+			this._reloadCall = $.when.apply($, promises);
 			var callBack = this.reloadCallback.bind(this);
 			return this._reloadCall.then(callBack, callBack);
 		},
 
-		reloadCallback: function(result) {
+		reloadCallback: function(shares, remoteShares) {
 			delete this._reloadCall;
 			this.hideMask();
 
 			this.$el.find('#headerSharedWith').text(
 				t('files_sharing', this._sharedWithUser ? 'Shared by' : 'Shared with')
 			);
-			if (result.ocs && result.ocs.data) {
-				this.setFiles(this._makeFilesFromShares(result.ocs.data));
-			}
-			else {
+
+			var files = [];
+
+			if (shares[0].ocs && shares[0].ocs.data) {
+				files = files.concat(this._makeFilesFromShares(shares[0].ocs.data));
+			} else {
 				// TODO: error handling
 			}
+
+			if (remoteShares[0].ocs && remoteShares[0].ocs.data) {
+				files = files.concat(this._makeFilesFromRemoteShares(remoteShares[0].ocs.data));
+			} else {
+				// TODO: error handling
+			}
+
+			this.setFiles(files);
+		},
+
+		_makeFilesFromRemoteShares: function(data) {
+			var self = this;
+			var files = data;
+
+			files = _.chain(files)
+				// convert share data to file data
+				.map(function(share) {
+					var file = {
+						shareOwner: share.owner,
+						name: share.name
+					};
+
+					file.shares = [{
+						id: share.id,
+						type: OC.Share.SHARE_TYPE_REMOTE,
+						target: share.mountpoint
+					}];
+					return file;
+				})
+				.value();
+			return files;
 		},
 
 		/**

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -191,7 +191,7 @@
 				// convert share data to file data
 				.map(function(share) {
 					var file = {
-						shareOwner: share.owner,
+						shareOwner: share.owner + '@' + share.remote,
 						name: share.name
 					};
 


### PR DESCRIPTION
Fixes #9098
Depends on #19386

Start of code that lists the remote shares in the shared with you section.
Not done but here to keep track since it is related #19386 

TODO:
- [x] Get remote shares to display
- [ ] Get them to properly display
- [ ] Fix unit tests
- [ ] Add unit tests
