### PR TITLE
List remote shares in shared with you

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -191,14 +191,18 @@
 				// convert share data to file data
 				.map(function(share) {
 					var file = {
-						shareOwner: share.owner + '@' + share.remote,
-						name: share.name
+						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
+						name: OC.basename(share.mountpoint),
+						mtime: share.mtime,
+						mimetype: share.mimetype,
+						type: share.type,
+						id: share.file_id,
+						path: OC.dirname(share.mountpoint)
 					};
 
 					file.shares = [{
 						id: share.id,
-						type: OC.Share.SHARE_TYPE_REMOTE,
-						target: share.mountpoint
+						type: OC.Share.SHARE_TYPE_REMOTE
 					}];
 					return file;
 				})

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -151,6 +151,9 @@
 					},
 				});
 				promises.push(remoteShares);
+			} else {
+				//Push empty promise so callback gets called the same way
+				promises.push($.Deferred().resolve());
 			}
 
 			this._reloadCall = $.when.apply($, promises);
@@ -174,7 +177,7 @@
 				// TODO: error handling
 			}
 
-			if (remoteShares[0].ocs && remoteShares[0].ocs.data) {
+			if (remoteShares && remoteShares[0].ocs && remoteShares[0].ocs.data) {
 				files = files.concat(this._makeFilesFromRemoteShares(remoteShares[0].ocs.data));
 			} else {
 				// TODO: error handling
@@ -193,11 +196,12 @@
 					var file = {
 						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
 						name: OC.basename(share.mountpoint),
-						mtime: share.mtime,
+						mtime: share.mtime * 1000,
 						mimetype: share.mimetype,
 						type: share.type,
 						id: share.file_id,
-						path: OC.dirname(share.mountpoint)
+						path: OC.dirname(share.mountpoint),
+						permissions: share.permissions
 					};
 
 					file.shares = [{


### PR DESCRIPTION
Fixes #9098
- [x] Depends on #19386

Start of code that lists the remote shares in the shared with you section.
Not done but here to keep track since it is related #19386 

TODO:
- [x] Get remote shares to display
- [x] Get them to properly display
- [x] Fix unit tests
- [x] Add unit tests
