### PR TITLE
Fix moment.js "a few seconds ago" with "seconds ago"

### DIFF
--- a/apps/files/tests/js/mainfileinfodetailviewSpec.js
+++ b/apps/files/tests/js/mainfileinfodetailviewSpec.js
@@ -58,7 +58,7 @@ describe('OCA.Files.MainFileInfoDetailView tests', function() {
 			expect(view.$el.find('.fileName h3').attr('title')).toEqual('One.txt');
 			expect(view.$el.find('.size').text()).toEqual('117.7 MB');
 			expect(view.$el.find('.size').attr('title')).toEqual('123456789 bytes');
-			expect(view.$el.find('.date').text()).toEqual('a few seconds ago');
+			expect(view.$el.find('.date').text()).toEqual('seconds ago');
 			expect(view.$el.find('.date').attr('title')).toEqual(dateExpected);
 			clock.restore();
 		});

--- a/apps/files_versions/tests/js/versionstabviewSpec.js
+++ b/apps/files_versions/tests/js/versionstabviewSpec.js
@@ -76,7 +76,7 @@ describe('OCA.Versions.VersionsTabView', function() {
 			expect($versions.length).toEqual(2);
 			var $item = $versions.eq(0);
 			expect($item.find('.downloadVersion').attr('href')).toEqual(version1.getDownloadUrl());
-			expect($item.find('.versiondate').text()).toEqual('a few seconds ago');
+			expect($item.find('.versiondate').text()).toEqual('seconds ago');
 			expect($item.find('.revertVersion').length).toEqual(1);
 			expect($item.find('.preview').attr('src')).toEqual(version1.getPreviewUrl());
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1533,6 +1533,10 @@ OC.Util = {
 	 * @returns {string} human readable difference from now
 	 */
 	relativeModifiedDate: function (timestamp) {
+		var diff = moment().diff(moment(timestamp));
+		if (diff >= 0 && diff < 45000 ) {
+			return t('core', 'seconds ago');
+		}
 		return moment(timestamp).fromNow();
 	},
 	/**


### PR DESCRIPTION
- fixes #18627 

The upstream patch is pending, because I first asked if this is an option for them to accept such a change: https://github.com/moment/moment/issues/2644

Moment.js prints "a few seconds ago" for everything between 0 and 45 seconds ago. The `diff()` returns milliseconds.

cc @PVince81 @raghunayyar @owncloud/designers @LukasReschke 
