### PR TITLE
Reload the page when an app needs an update after being enabled

### DIFF
--- a/settings/ajax/enableapp.php
+++ b/settings/ajax/enableapp.php
@@ -28,8 +28,9 @@ OCP\JSON::callCheck();
 $groups = isset($_POST['groups']) ? (array)$_POST['groups'] : null;
 
 try {
-	OC_App::enable(OC_App::cleanAppId((string)$_POST['appid']), $groups);
-	OC_JSON::success();
+	$app = OC_App::cleanAppId((string)$_POST['appid']);
+	OC_App::enable($app, $groups);
+	OC_JSON::success(['data' => ['update_required' => \OC_App::shouldUpgrade($app)]]);
 } catch (Exception $e) {
 	\OCP\Util::writeLog('core', $e->getMessage(), \OCP\Util::ERROR);
 	OC_JSON::error(array("data" => array("message" => $e->getMessage()) ));

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -245,6 +245,14 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					element.val(t('settings','Enable'));
 					appItem.addClass('appwarning');
 				} else {
+					if (result.data.update_required) {
+						OC.Notification.show(t('settings', 'The app needs to be updated, please reload the page'));
+
+						setTimeout(function() {
+							location.reload();
+						}, 5000);
+					}
+
 					OC.Settings.Apps.rebuildNavigation();
 					appItem.data('active',true);
 					element.data('active',true);

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -246,7 +246,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					appItem.addClass('appwarning');
 				} else {
 					if (result.data.update_required) {
-						OC.Notification.show(t('settings', 'The app needs to be updated, please reload the page'));
+						OC.Settings.Apps.showReloadMessage();
 
 						setTimeout(function() {
 							location.reload();
@@ -396,6 +396,20 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		$('div#app-'+appId+' .warning')
 			.hide()
 			.text('');
+	},
+
+	showReloadMessage: function(appId) {
+		OC.dialogs.info(
+			t(
+				'settings',
+				'The app needs to be updated. This page will be reloaded in 5 seconds.'
+			),
+			t('settings','App update'),
+			function (result) {
+				window.location.reload();
+			},
+			true
+		);
 	},
 
 	filter: function(query) {

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -402,7 +402,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		OC.dialogs.info(
 			t(
 				'settings',
-				'The app needs to be updated. This page will be reloaded in 5 seconds.'
+				'The app has been enabled but needs to be updated. You will be redirected to the update page in 5 seconds.'
 			),
 			t('settings','App update'),
 			function (result) {


### PR DESCRIPTION
Fix #16251

@PVince81 @oparoz 

Now displayes a notification and then reloads the page for you:

![apps_-_owncloud_-_2015-10-02_12 02 32](https://cloud.githubusercontent.com/assets/213943/10244416/638b6a5c-68ff-11e5-801e-6d9e5420f30b.png)
