### PR TITLE
Make sure the share we found is for the same item

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2070,7 +2070,7 @@ class Share extends Constants {
 
 			$userShareType = ($isGroupShare) ? self::$shareTypeGroupUserUnique : $shareType;
 
-			if ($sourceExists) {
+			if ($sourceExists && $sourceExists['item_source'] === $itemSource) {
 				$fileTarget = $sourceExists['file_target'];
 				$itemTarget = $sourceExists['item_target'];
 

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1989,6 +1989,8 @@ class Share extends Constants {
 
 		$queriesToExecute = array();
 		$suggestedItemTarget = null;
+		$groupFileTarget = $fileTarget = $suggestedFileTarget = $filePath = '';
+		$groupItemTarget = $itemTarget = $fileSource = $parent = 0;
 
 		$result = self::checkReshare($itemType, $itemSource, $shareType, $shareWith, $uidOwner, $permissions, $itemSourceName, $expirationDate);
 		if(!empty($result)) {


### PR DESCRIPTION
Fix #13213

We need to check if the item was shared directly. If we only get a parent share, than we need to ignore it.

@rullzer @PVince81 @schiesbn 

PS: this should have a test, but I'm not into the huge sharing test file
