### PR TITLE
if the mountpoint is accessible for all user the array should contain 'all'

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -207,6 +207,11 @@ class OC_Mount_Config {
 			'groups' => $storage->getApplicableGroups(),
 			'users' => $storage->getApplicableUsers(),
 		];
+		// if mountpoint is applicable to all users the old API expects ['all']
+		if (empty($mountEntry['applicable']['groups']) && empty($mountEntry['applicable']['users'])) {
+			$mountEntry['applicable']['users'] = ['all'];
+		}
+
 		$mountEntry['id'] = $storage->getId();
 
 		return $mountEntry;


### PR DESCRIPTION
fix https://github.com/owncloud/core/issues/19532

This code was introduced by  @PVince81 https://github.com/owncloud/core/commit/72632ad402bd905107db836ed0f9bfae825d6c52#diff-0f47b36d20317b1e2c180d98ff981cbdR53, please have a look to make sure that it doesn't break anything else.

I see the potential danger that the user "all" could collide with a real user "all". Probably this was one of the reason it was removed. Still we have quite some references to "all" alone in files_external, see https://github.com/owncloud/core/issues/19532#issuecomment-145007224, therefore I feel more comfortable to bring back the "all". At least for 8.2

Opinions...  @PVince81 @icewind1991 @Xenopathic @DeepDiver1975 
