### PR TITLE
Fixes last causes for WSOD

### DIFF
--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -69,7 +69,7 @@ class OC_Template extends \OC\Template\Base {
 	
 	public function __construct( $app, $name, $renderAs = "", $registerCall = true ) {
 		// Read the selected theme from the config file
-		self::initTemplateEngine();
+		self::initTemplateEngine($renderAs);
 		
 		$theme = OC_Util::getTheme();
 
@@ -89,13 +89,13 @@ class OC_Template extends \OC\Template\Base {
 		parent::__construct($template, $requesttoken, $l10n, $themeDefaults);
 	}
 
-	public static function initTemplateEngine() {
+	public static function initTemplateEngine($renderAs) {
 		if (self::$initTemplateEngineFirstRun){
 			
 			//apps that started before the template initialization can load their own scripts/styles
 			//so to make sure this scripts/styles here are loaded first we use OC_Util::addScript() with $prepend=true
 			//meaning the last script/style in this list will be loaded first
-			if (\OC::$server->getSystemConfig ()->getValue ( 'installed', false ) && ! \OCP\Util::needUpgrade ()) {
+			if (\OC::$server->getSystemConfig()->getValue ('installed', false) && $renderAs !== 'error' && !\OCP\Util::needUpgrade()) {
 				if (\OC::$server->getConfig ()->getAppValue ( 'core', 'backgroundjobs_mode', 'ajax' ) == 'ajax') {
 					OC_Util::addScript ( 'backgroundjobs', null, true );
 				}

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -310,7 +310,7 @@ class OC_Template extends \OC\Template\Base {
 			$logger->error("$error_msg $hint", ['app' => 'core']);
 			$logger->logException($e, ['app' => 'core']);
 
-			header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error');
+			header(self::getHttpProtocol() . ' 500 Internal Server Error');
 			header('Content-Type: text/plain; charset=utf-8');
 			print("$error_msg $hint");
 		}
@@ -340,7 +340,7 @@ class OC_Template extends \OC\Template\Base {
 			$logger->logException($exception, ['app' => 'core']);
 			$logger->logException($e, ['app' => 'core']);
 
-			header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error');
+			header(self::getHttpProtocol() . ' 500 Internal Server Error');
 			header('Content-Type: text/plain; charset=utf-8');
 			print("Internal Server Error\n\n");
 			print("The server encountered an internal error and was unable to complete your request.\n");
@@ -348,6 +348,28 @@ class OC_Template extends \OC\Template\Base {
 			print("More details can be found in the server log.\n");
 		}
 		die();
+	}
+
+	/**
+	 * This is only here to reduce the dependencies in case of an exception to
+	 * still be able to print a plain error message.
+	 *
+	 * Returns the used HTTP protocol.
+	 *
+	 * @return string HTTP protocol. HTTP/2, HTTP/1.1 or HTTP/1.0.
+	 * @internal Don't use this - use AppFramework\Http\Request->getHttpProtocol instead
+	 */
+	protected static function getHttpProtocol() {
+		$claimedProtocol = strtoupper($_SERVER['SERVER_PROTOCOL']);
+		$validProtocols = [
+			'HTTP/1.0',
+			'HTTP/1.1',
+			'HTTP/2',
+		];
+		if(in_array($claimedProtocol, $validProtocols, true)) {
+			return $claimedProtocol;
+		}
+		return 'HTTP/1.1';
 	}
 
 	/**


### PR DESCRIPTION
- print plain text if rendering of exception/error page is not possible

Steps to test:
- change version.php to a lower version number ;)

This will make if easier to spot the problems without digging into owncloud.log. It also now properly logs the exception instead of just dumping the PHP "uncaught exception" text.
