### PR TITLE
Fix search operations for the Node API

### DIFF
--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -222,7 +222,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 		$results = call_user_func_array(array($cache, $method), $args);
 		foreach ($results as $result) {
-			if ($internalRootLength === 0 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
+			if ($internalRootLength === 1 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
 				$result['internalPath'] = $result['path'];
 				$result['path'] = substr($result['path'], $internalRootLength);
 				$result['storage'] = $storage;

--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -215,14 +215,17 @@ class Folder extends Node implements \OCP\Files\Folder {
 		 * @var \OC\Files\Storage\Storage $storage
 		 */
 		list($storage, $internalPath) = $this->view->resolvePath($this->path);
-		$internalPath = rtrim($internalPath, '/') . '/';
+		$internalPath = rtrim($internalPath, '/');
+		if ($internalPath !== '') {
+			$internalPath = $internalPath . '/';
+		}
 		$internalRootLength = strlen($internalPath);
 
 		$cache = $storage->getCache('');
 
 		$results = call_user_func_array(array($cache, $method), $args);
 		foreach ($results as $result) {
-			if ($internalRootLength === 1 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
+			if ($internalRootLength === 0 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
 				$result['internalPath'] = $result['path'];
 				$result['path'] = substr($result['path'], $internalRootLength);
 				$result['storage'] = $storage;

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -421,6 +421,45 @@ class Folder extends \Test\TestCase {
 		$this->assertEquals('/foo', $result[0]->getPath());
 	}
 
+	public function testSearchInStorageRoot() {
+		$manager = $this->getMock('\OC\Files\Mount\Manager');
+		/**
+		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
+		 */
+		$view = $this->getMock('\OC\Files\View');
+		$root = $this->getMock('\OC\Files\Node\Root', array(), array($manager, $view, $this->user));
+		$root->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($this->user));
+		$storage = $this->getMock('\OC\Files\Storage\Storage');
+		$cache = $this->getMock('\OC\Files\Cache\Cache', array(), array(''));
+
+		$storage->expects($this->once())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$cache->expects($this->once())
+			->method('search')
+			->with('%qw%')
+			->will($this->returnValue(array(
+				array('fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain')
+			)));
+
+		$root->expects($this->once())
+			->method('getMountsIn')
+			->with('/bar')
+			->will($this->returnValue(array()));
+
+		$view->expects($this->once())
+			->method('resolvePath')
+			->will($this->returnValue(array($storage, '')));
+
+		$node = new \OC\Files\Node\Folder($root, $view, '/bar');
+		$result = $node->search('qw');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
+	}
+
 	public function testSearchByTag() {
 		$manager = $this->getMock('\OC\Files\Mount\Manager');
 		/**


### PR DESCRIPTION
Fix for _Node API: search operations don't work on the top folder of external shares_
Fixes https://github.com/owncloud/core/issues/19544
- [x] Add test to cover this case

@icewind1991 @PVince81 @Xenopathic @nickvergessen if you could let me know if you have any objection.
