### PR TITLE
LDAP Wizard: do not be picky about credentials when only looking for …

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -661,12 +661,13 @@ class Wizard extends LDAPUtility {
 			//connectAndBind may throw Exception, it needs to be catched by the
 			//callee of this method
 
-			// unallowed anonymous bind throws 48. But if it throws 48, we
-			// detected port and TLS, i.e. it is successful.
 			try {
 				$settingsFound = $this->connectAndBind($p, $t);
 			} catch (\Exception $e) {
-				if($e->getCode() === 48) {
+				// any reply other than -1 (= cannot connect) is already okay,
+				// because then we found the server
+				// unavailable startTLS returns -11
+				if($e->getCode() > 0) {
 					$settingsFound = true;
 				} else {
 					throw $e;
@@ -1084,7 +1085,7 @@ class Wizard extends LDAPUtility {
 		} else if ($errNo === 2) {
 			return $this->connectAndBind($port, $tls, true);
 		}
-		throw new \Exception($error);
+		throw new \Exception($error, $errNo);
 	}
 
 	/**


### PR DESCRIPTION
…the port

Fixes https://github.com/owncloud/core/issues/16154

Basically an LDAP repy is sufficient, because that indicates that the we found the server.

How to test?
1. Have a usual LDAP configuration that would work
2. Empty the port field (if non-standard port, append the port to the host field like ldap.example.org:3890)
3. Empty the password field, but leave the User DN
4. Click on "Detect Port"

Without the patch a misleading error is thrown. Now, with the fix, the port is detected properly.

Please test and review @jvillafanez @MorrisJobke @PVince81 
