### PR TITLE
Use DD-MM-YYYY consistently in share sidebar

### DIFF
--- a/core/js/sharedialogexpirationview.js
+++ b/core/js/sharedialogexpirationview.js
@@ -132,6 +132,11 @@
 
 			var isExpirationSet = !!this.model.get('linkShare').expiration || isExpirationEnforced;
 
+			var expiration;
+			if (isExpirationSet) {
+				expiration = moment(this.model.get('linkShare').expiration, 'YYYY-MM-DD').format('DD-MM-YYYY')
+			}
+
 			var expirationTemplate = this.template();
 			this.$el.html(expirationTemplate({
 				setExpirationLabel: t('core', 'Set expiration date'),
@@ -142,7 +147,7 @@
 				isExpirationSet: isExpirationSet,
 				isExpirationEnforced: isExpirationEnforced,
 				disableCheckbox: isExpirationEnforced && isExpirationSet,
-				expirationValue: this.model.get('linkShare').expiration
+				expirationValue: expiration
 			}));
 
 			// what if there is another date picker on that page?

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -274,10 +274,10 @@ describe('OC.Share.ShareDialogView', function() {
 				expect(dialog.$el.find('#expirationDate').val()).toEqual('');
 			});
 			it('checks expiration date checkbox and populates field when expiration date was set', function() {
-				shareModel.get('linkShare').expiration = 1234;
+				shareModel.get('linkShare').expiration = '2014-02-01 00:00:00';
 				dialog.render();
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('checked')).toEqual(true);
-				expect(dialog.$el.find('#expirationDate').val()).toEqual('1234');
+				expect(dialog.$el.find('#expirationDate').val()).toEqual('01-02-2014');
 			});
 			it('sets default date when default date setting is enabled', function() {
 				configModel.set('isDefaultExpireDateEnabled', true);
@@ -289,8 +289,7 @@ describe('OC.Share.ShareDialogView', function() {
 
 				// enabled by default
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('checked')).toEqual(true);
-				// TODO: those zeros must go...
-				expect(dialog.$el.find('#expirationDate').val()).toEqual('2014-1-27 00:00:00');
+				expect(dialog.$el.find('#expirationDate').val()).toEqual('27-01-2014');
 
 				// disabling is allowed
 				dialog.$el.find('[name=expirationCheckbox]').click();
@@ -308,8 +307,7 @@ describe('OC.Share.ShareDialogView', function() {
 				dialog.render();
 
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('checked')).toEqual(true);
-				// TODO: those zeros must go...
-				expect(dialog.$el.find('#expirationDate').val()).toEqual('2014-1-27 00:00:00');
+				expect(dialog.$el.find('#expirationDate').val()).toEqual('27-01-2014');
 
 				// disabling is not allowed
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('disabled')).toEqual(true);
@@ -338,8 +336,7 @@ describe('OC.Share.ShareDialogView', function() {
 				);
 
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('checked')).toEqual(true);
-				// TODO: those zeros must go...
-				expect(dialog.$el.find('#expirationDate').val()).toEqual('2014-1-27 00:00:00');
+				expect(dialog.$el.find('#expirationDate').val()).toEqual('27-01-2014');
 
 				// disabling is not allowed
 				expect(dialog.$el.find('[name=expirationCheckbox]').prop('disabled')).toEqual(true);


### PR DESCRIPTION
Fixes #19549

We used to display the response from the server. Which is in non ISO8601
format. Now this is weird since the datepickers shows us 'DD-MM-YYYY'
once a date is chosen.

Now use momentJS to properly format the date.
- Unit tests updated

CC: @oparoz @PVince81 @MorrisJobke @nickvergessen @jancborchardt 
