### PR TITLE
improved initial explanation/warning if the admin enabled encryptrion

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -353,10 +353,10 @@ if ($_['cronErrors']) {
 	<div id="EncryptionWarning" class="warning hidden">
 		<p><?php p($l->t('Please read carefully before activating server-side encryption: ')); ?></p>
 		<ul>
-			<li><?php p($l->t('Server-side encryption is a one way process. Once encryption is enabled, all files from that point forward will be encrypted on the server and it will not be possible to disable encryption at a later date')); ?></li>
-			<li><?php p($l->t('Anyone who has privileged access to your ownCloud server can decrypt your files either by intercepting requests or reading out user passwords which are stored in plain text session files. Server-side encryption does therefore not protect against malicious administrators but is useful for protecting your data on externally hosted storage.')); ?></li>
-			<li><?php p($l->t('Depending on the actual encryption module the general file size is increased (by 35%% or more when using the default module)')); ?></li>
-			<li><?php p($l->t('You should regularly backup all encryption keys to prevent permanent data loss (data/<user>/files_encryption and data/files_encryption)')); ?></li>
+			<li><?php p($l->t('Once encryption is enabled, all files uploaded to the server from that point forward will be encrypted at rest on the server. It will only be possible to disable encryption at a later date if the active encryption module supports that function, and all pre-conditions (e.g. setting a recover key) are met.')); ?></li>
+			<li><?php p($l->t('Encryption alone does not guarantee security of the system. Please see ownCloud documentation for more information about how the encryption app works, and the supported use cases.')); ?></li>
+			<li><?php p($l->t('Be aware that encryption always increases the file size.')); ?></li>
+			<li><?php p($l->t('It is always good to create regular backups of your data, in case of encryption make sure to backup the encryption keys along with your data.')); ?></li>
 		</ul>
 
 		<p><?php p($l->t('This is the final warning: Do you really want to enable encryption?')) ?> <input type="button"


### PR DESCRIPTION
The initial explanation/warning was changed in the early dev cycle of oC8.2 to following:

![1](https://cloud.githubusercontent.com/assets/1589737/10280411/5260a6fa-6b6d-11e5-8638-6187e5b50a4c.png)

I think it contains way to much details and even assumptions which are no longer true for 8.2, so I changed it to:

![2](https://cloud.githubusercontent.com/assets/1589737/10280424/68fc9d92-6b6d-11e5-9ae9-363f99c1ebed.png)

@MTRichards please also compare both versions and let me know if you agree on the second one. Thanks!
