### PR TITLE
Fix tooltip placement on rename error

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1783,7 +1783,7 @@
 					}
 				} catch (error) {
 					input.attr('title', error);
-					input.tooltip({placement: 'left', trigger: 'manual'});
+					input.tooltip({placement: 'right', trigger: 'manual'});
 					input.tooltip('show');
 					input.addClass('error');
 				}
@@ -1797,7 +1797,7 @@
 					input.removeClass('error');
 				} catch (error) {
 					input.attr('title', error);
-					input.tooltip({placement: 'left', trigger: 'manual'});
+					input.tooltip({placement: 'right', trigger: 'manual'});
 					input.tooltip('show');
 					input.addClass('error');
 				}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/19579

Probably a regression from when switching to the new tooltip library, where the meaning of placement became confusing.

Please review this quick one @Henni @MorrisJobke @LukasReschke @icewind1991 @rullzer 
