### PR TITLE
The root of a storage always exists

### DIFF
--- a/lib/private/files/storage/wrapper/availability.php
+++ b/lib/private/files/storage/wrapper/availability.php
@@ -220,6 +220,9 @@ class Availability extends Wrapper {
 
 	/** {@inheritdoc} */
 	public function file_exists($path) {
+		if ($path === '') {
+			return true;
+		}
 		$this->checkAvailability();
 		try {
 			return parent::file_exists($path);


### PR DESCRIPTION
Even when a storage is not available.

Fixes errors when trying to unmount a non-available storage such as when trying to unshare a remote share from self if the remote server is down.

Fixes #18360

cc @PVince81 @DeepDiver1975 @Xenopathic 
