### PR TITLE
[stable8.1] Backport of #19553: show MM-DD-YYYY as expiration date consistently

### DIFF
--- a/core/js/share.js
+++ b/core/js/share.js
@@ -502,7 +502,8 @@ OC.Share={
 						}
 					}
 					if (share.expiration != null) {
-						OC.Share.showExpirationDate(share.expiration, share.stime);
+						var expireDate = moment(share.expiration, 'YYYY-MM-DD').format('DD-MM-YYYY');
+						OC.Share.showExpirationDate(expireDate, share.stime);
 					}
 				});
 			}

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -626,11 +626,11 @@ describe('OC.Share tests', function() {
 					expect($('#dropdown #expirationDate').val()).toEqual('');
 				});
 				it('checks expiration date checkbox and populates field when expiration date was set', function() {
-					shareItem.expiration = 1234;
+					shareItem.expiration = '2014-02-01 00:00:00';
 					shareData.shares.push(shareItem);
 					showDropDown();
 					expect($('#dropdown [name=expirationCheckbox]').prop('checked')).toEqual(true);
-					expect($('#dropdown #expirationDate').val()).toEqual('1234');
+					expect($('#dropdown #expirationDate').val()).toEqual('01-02-2014');
 				});
 				it('sets default date when default date setting is enabled', function() {
 					/* jshint camelcase:false */


### PR DESCRIPTION
Backport of #19553 

Basically parse the date properly from the OCS Share API and not blindy show it. Which leads to weird behaviour.

@oparoz this needs to be changed :)

CC: @karlitschek  @MorrisJobke 
