### PR TITLE
add LDAP specific API call to resolve an LDAP (login) name to an ownC…

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -57,8 +57,14 @@ API::register('delete', '/cloud/groups/{groupid}', [$groups, 'deleteGroup'], 'pr
 API::register('get', '/cloud/groups/{groupid}/subadmins', [$groups, 'getSubAdminsOfGroup'], 'provisioning_api', API::ADMIN_AUTH);
 
 // Apps
+try {
+	$ldapBackend = \OC::$server->query('LDAPUserBackend');
+} catch (\Exception $e) {
+	$ldapBackend = null;
+}
 $apps = new \OCA\Provisioning_API\Apps(
-	\OC::$server->getAppManager()
+	\OC::$server->getAppManager(),
+	$ldapBackend
 );
 API::register('get', '/cloud/apps', [$apps, 'getApps'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('get', '/cloud/apps/{appid}', [$apps, 'getAppInfo'], 'provisioning_api', API::ADMIN_AUTH);

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -64,3 +64,4 @@ API::register('get', '/cloud/apps', [$apps, 'getApps'], 'provisioning_api', API:
 API::register('get', '/cloud/apps/{appid}', [$apps, 'getAppInfo'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('post', '/cloud/apps/{appid}', [$apps, 'enable'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('delete', '/cloud/apps/{appid}', [$apps, 'disable'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/apps/user_ldap/resolveloginname/{loginname}', [$apps, 'resolveLDAPLoginName'], 'provisioning_api', API::ADMIN_AUTH);

--- a/apps/provisioning_api/lib/apps.php
+++ b/apps/provisioning_api/lib/apps.php
@@ -105,4 +105,44 @@ class Apps {
 		return new OC_OCS_Result(null, 100);
 	}
 
+	/**
+	 * resolves a provided LDAP login name to an ownCloud username that can be
+	 * used with user-related API calls.
+	 *
+	 * @param array $parameters
+	 * @return OC_OCS_Result
+	 */
+	public function resolveLDAPLoginName($parameters) {
+		$loginName = $parameters['loginname'];
+
+		if(!$this->appManager->isEnabledForUser('user_ldap')) {
+			return new OC_OCS_Result(null, \OCP\API::RESPOND_SERVER_ERROR, 'LDAP backend is not enabled');
+		}
+
+		try {
+			$helper = new \OCA\user_ldap\lib\Helper();
+			$ldapBackend = $helper->instantiateUserProxy();
+			return $this->resolveLDAPLoginNameViaBackend($loginName, $ldapBackend);
+		} catch(\Exception $e) {
+			return new OC_OCS_Result(null, \OCP\API::RESPOND_SERVER_ERROR, $e->getMessage());
+		}
+	}
+
+	/**
+	 * resolves a provided LDAP login name to an ownCloud username that can be
+	 * used with user-related API calls. This method accepts the user backend
+	 * so responses can be tested at least.
+	 *
+	 * @param string $loginName
+	 * @param \OCA\user_ldap\User_Proxy $ldapBackend
+	 * @return OC_OCS_Result
+	 */
+	public function resolveLDAPLoginNameViaBackend($loginName, $ldapBackend) {
+		$userName = $ldapBackend->loginName2UserName($loginName);
+		if($userName === false) {
+			return new OC_OCS_Result(null, \OCP\API::RESPOND_NOT_FOUND, 'Could not resolve login name to user name');
+		}
+		return new OC_OCS_Result([$userName]);
+	}
+
 }

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -97,6 +97,7 @@ class AppsTest extends TestCase {
 	}
 
 	public function testResolveLDAPNameNotFound() {
+		\OC_App::loadApp('user_ldap');
 		$loginName = 'alice';
 
 		$ldapBackend = $this->getMockBuilder('\OCA\user_ldap\User_Proxy')
@@ -114,6 +115,7 @@ class AppsTest extends TestCase {
 	}
 
 	public function testResolveLDAPNameSuccessful() {
+		\OC_App::loadApp('user_ldap');
 		$loginName = 'alice';
 		$userName = 'dc35a74a-5de6-1932-93af-e3cc75610c15';
 

--- a/apps/user_ldap/appinfo/app.php
+++ b/apps/user_ldap/appinfo/app.php
@@ -50,6 +50,7 @@ if(count($configPrefixes) === 1) {
 	$userBackend  = new OCA\user_ldap\User_Proxy(
 		$configPrefixes, $ldapWrapper, $ocConfig
 	);
+
 	$groupBackend  = new OCA\user_ldap\Group_Proxy($configPrefixes, $ldapWrapper);
 }
 
@@ -58,6 +59,10 @@ if(count($configPrefixes) > 0) {
 	OC_User::useBackend($userBackend);
 	OC_Group::useBackend($groupBackend);
 }
+\OC::$server->registerService('LDAPUserBackend', function() {
+	$helper = new \OCA\user_ldap\lib\Helper();
+	return $helper->instantiateUserProxy();
+});
 
 \OCP\Util::connectHook(
 	'\OCA\Files_Sharing\API\Server2Server',

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -191,7 +191,7 @@ class Helper {
 	 */
 	public function instantiateUserProxy() {
 		$configPrefixes = $this->getServerConfigurationPrefixes(true);
-		if($configPrefixes === 0) {
+		if(count($configPrefixes) === 0) {
 			throw new \Exception('No active LDAP configuration');
 		}
 		$ldapWrapper = new LDAP();

--- a/apps/user_ldap/lib/helper.php
+++ b/apps/user_ldap/lib/helper.php
@@ -186,6 +186,25 @@ class Helper {
 	}
 
 	/**
+	 * @return User_Proxy
+	 * @throws \Exception
+	 */
+	public function instantiateUserProxy() {
+		$configPrefixes = $this->getServerConfigurationPrefixes(true);
+		if($configPrefixes === 0) {
+			throw new \Exception('No active LDAP configuration');
+		}
+		$ldapWrapper = new LDAP();
+		$ocConfig = \OC::$server->getConfig();
+
+		$userBackend  = new User_Proxy(
+			$configPrefixes, $ldapWrapper, $ocConfig
+		);
+
+		return $userBackend;
+	}
+
+	/**
 	 * listens to a hook thrown by server2server sharing and replaces the given
 	 * login name by a username, if it matches an LDAP user.
 	 *


### PR DESCRIPTION
…loud username that can be used with user related API calls

Fixes #15084 

This introduces the cloud/apps/user_ldap/resolveloginname/{loginname} route to the  Provisioning  API as suggested in https://github.com/owncloud/core/issues/15084#issuecomment-142245453.

Following output is created on those cases:

```
# unknown user
$ curl http://master:master@zara.owncloud.bzoc/master/ocs/v1.php/cloud/apps/user_ldap/resolveloginname/foobar
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>998</statuscode>
  <message>Could not resolve login name to user name</message>
 </meta>
 <data/>
</ocs>

# success
$ curl http://master:master@zara.owncloud.bzoc/master/ocs/v1.php/cloud/apps/user_ldap/resolveloginname/alice
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message/>
 </meta>
 <data>
  <element>dc35a74a-5de6-1932-93af-e3cc75610c15</element>
 </data>
</ocs>

# LDAP enabled, but no active configurations
$ curl http://master:master@zara.owncloud.bzoc/master/ocs/v1.php/cloud/apps/user_ldap/resolveloginname/alice
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>996</statuscode>
  <message>No active LDAP configuration</message>
 </meta>
 <data/>
</ocs>

# LDAP not enabled
$ curl http://master:master@zara.owncloud.bzoc/master/ocs/v1.php/cloud/apps/user_ldap/resolveloginname/alice
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>996</statuscode>
  <message>LDAP backend is not enabled</message>
 </meta>
 <data/>
</ocs>
```

Please test and review @tomneedham @rullzer @MorrisJobke
