### PR TITLE
[stable8.1] Clear the shares after the test like storages and files

### DIFF
--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -100,6 +100,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 
 		self::tearDownAfterClassCleanFileMapper($dataDir);
+		self::tearDownAfterClassCleanShares();
 		self::tearDownAfterClassCleanStorages();
 		self::tearDownAfterClassCleanFileCache();
 		self::tearDownAfterClassCleanStrayDataFiles($dataDir);
@@ -119,6 +120,17 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			$mapper = new \OC\Files\Mapper($dataDir);
 			$mapper->removePath($dataDir, true, true);
 		}
+	}
+
+	/**
+	 * Remove all entries from the share table
+	 *
+	 * @throws \OC\DatabaseException
+	 */
+	static protected function tearDownAfterClassCleanShares() {
+		$sql = 'DELETE FROM `*PREFIX*share`';
+		$query = \OC_DB::prepare($sql);
+		$query->execute();
 	}
 
 	/**


### PR DESCRIPTION
- adjusted to stable8.1 backport of #19574 

In stable8.1 the query builder is not available. Therefore I only backported the actual fix.

cc @DeepDiver1975 @nickvergessen @LukasReschke 
