### PR TITLE
Add \OCP\IRequest::getHttpProtocol

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -553,6 +553,27 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	}
 
 	/**
+	 * Returns the used HTTP protocol.
+	 *
+	 * @return string HTTP protocol. HTTP/2, HTTP/1.1 or HTTP/1.0.
+	 */
+	public function getHttpProtocol() {
+		$claimedProtocol = strtoupper($this->server['SERVER_PROTOCOL']);
+
+		$validProtocols = [
+			'HTTP/1.0',
+			'HTTP/1.1',
+			'HTTP/2',
+		];
+
+		if(in_array($claimedProtocol, $validProtocols, true)) {
+			return $claimedProtocol;
+		}
+
+		return 'HTTP/1.1';
+	}
+
+	/**
 	 * Returns the request uri, even if the website uses one or more
 	 * reverse proxies
 	 * @return string

--- a/lib/public/irequest.php
+++ b/lib/public/irequest.php
@@ -168,6 +168,14 @@ interface IRequest {
 	public function getServerProtocol();
 
 	/**
+	 * Returns the used HTTP protocol.
+	 *
+	 * @return string HTTP protocol. HTTP/2, HTTP/1.1 or HTTP/1.0.
+	 * @since 8.2.0
+	 */
+	public function getHttpProtocol();
+
+	/**
 	* Returns the request uri, even if the website uses one or more
 	* reverse proxies
 	* @return string

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -497,6 +497,57 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('192.168.0.233', $request->getRemoteAddress());
 	}
 
+	/**
+	 * @return array
+	 */
+	public function httpProtocolProvider() {
+		return [
+			// Valid HTTP 1.0
+			['HTTP/1.0', 'HTTP/1.0'],
+			['http/1.0', 'HTTP/1.0'],
+			['HTTp/1.0', 'HTTP/1.0'],
+
+			// Valid HTTP 1.1
+			['HTTP/1.1', 'HTTP/1.1'],
+			['http/1.1', 'HTTP/1.1'],
+			['HTTp/1.1', 'HTTP/1.1'],
+
+			// Valid HTTP 2.0
+			['HTTP/2', 'HTTP/2'],
+			['http/2', 'HTTP/2'],
+			['HTTp/2', 'HTTP/2'],
+
+			// Invalid
+			['HTTp/394', 'HTTP/1.1'],
+			['InvalidProvider/1.1', 'HTTP/1.1'],
+			[null, 'HTTP/1.1'],
+			['', 'HTTP/1.1'],
+
+		];
+	}
+
+	/**
+	 * @dataProvider httpProtocolProvider
+	 *
+	 * @param mixed $input
+	 * @param string $expected
+	 */
+	public function testGetHttpProtocol($input, $expected) {
+		$request = new Request(
+			[
+				'server' => [
+					'SERVER_PROTOCOL' => $input,
+				],
+			],
+			$this->secureRandom,
+			$this->getMock('\OCP\Security\ICrypto'),
+			$this->config,
+			$this->stream
+		);
+
+		$this->assertSame($expected, $request->getHttpProtocol());
+	}
+
 	public function testGetServerProtocolWithOverride() {
 		$this->config
 			->expects($this->at(0))


### PR DESCRIPTION
Only allow valid HTTP protocols.

Ref https://github.com/owncloud/core/pull/19537#discussion_r41252333 + https://github.com/owncloud/security-tracker/issues/119

@MorrisJobke As discussed.
@karlitschek @DeepDiver1975 I'd love to have this in 8.2 as API already. It's fully unit-tested and not affecting any existing code.
