### PR TITLE
Use `/` if installed in main folder

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -79,7 +79,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 
 		$this->registerService('OCP\\AppFramework\\Http\\IOutput', function($c){
-			return new Output();
+			return new Output($this->getServer()->getWebRoot());
 		});
 
 		$this->registerService('OCP\\IAvatarManager', function($c) {

--- a/lib/private/appframework/http/output.php
+++ b/lib/private/appframework/http/output.php
@@ -27,6 +27,15 @@ use OCP\AppFramework\Http\IOutput;
  * Very thin wrapper class to make output testable
  */
 class Output implements IOutput {
+	/** @var string */
+	private $webRoot;
+
+	/**
+	 * @param $webRoot
+	 */
+	public function __construct($webRoot) {
+		$this->webRoot = $webRoot;
+	}
 
 	/**
 	 * @param string $out
@@ -72,10 +81,11 @@ class Output implements IOutput {
 	 * @param string $path
 	 * @param string $domain
 	 * @param bool $secure
-	 * @param bool $httponly
+	 * @param bool $httpOnly
 	 */
-	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httponly) {
-		setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly) {
+		$path = $this->webRoot ? : '/';
+		setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
 	}
 
 }

--- a/lib/public/appframework/http/ioutput.php
+++ b/lib/public/appframework/http/ioutput.php
@@ -68,9 +68,9 @@ interface IOutput {
 	 * @param string $path
 	 * @param string $domain
 	 * @param bool $secure
-	 * @param bool $httponly
+	 * @param bool $httpOnly
 	 * @since 8.1.0
 	 */
-	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httponly);
+	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
 
 }


### PR DESCRIPTION
Otherwise an empty string is used indicating the cookie is only valid for those resources. This can lead to unexpected behaviour.

Fixes https://github.com/owncloud/core/issues/19196

@oparoz @DeepDiver1975 THX
