### PR TITLE
Remove oc_storages entries after removing ext storages

### DIFF
--- a/apps/files_external/service/storagesservice.php
+++ b/apps/files_external/service/storagesservice.php
@@ -550,6 +550,21 @@ abstract class StoragesService {
 		$this->writeConfig($allStorages);
 
 		$this->triggerHooks($deletedStorage, Filesystem::signal_delete_mount);
+
+		// delete oc_storages entries and oc_filecache
+		try {
+			$rustyStorageId = $this->getRustyStorageIdFromConfig($deletedStorage);
+			\OC\Files\Cache\Storage::remove($rustyStorageId);
+		} catch (\Exception $e) {
+			// can happen either for invalid configs where the storage could not
+			// be instantiated or whenever $user vars where used, in which case
+			// the storage id could not be computed
+			\OCP\Util::writeLog(
+				'files_external',
+				'Exception: "' . $e->getMessage() . '"',
+				\OCP\Util::ERROR
+			);
+		}
 	}
 
 	/**
@@ -568,6 +583,32 @@ abstract class StoragesService {
 		// will disappear once we move to DB tables to
 		// store the config
 		return (max(array_keys($allStorages)) + 1);
+	}
+
+	/**
+	 * Returns the rusty storage id from oc_storages from the given storage config.
+	 *
+	 * @param StorageConfig $storageConfig
+	 * @return string rusty storage id
+	 */
+	private function getRustyStorageIdFromConfig(StorageConfig $storageConfig) {
+		// if any of the storage options contains $user, it is not possible
+		// to compute the possible storage id as we don't know which users
+		// mounted it already (and we certainly don't want to iterate over ALL users)
+		foreach ($storageConfig->getBackendOptions() as $value) {
+			if (strpos($value, '$user') !== false) {
+				throw new \Exception('Cannot compute storage id for deletion due to $user vars in the configuration');
+			}
+		}
+
+		// note: similar to ConfigAdapter->prepateStorageConfig()
+		$storageConfig->getAuthMechanism()->manipulateStorageConfig($storageConfig);
+		$storageConfig->getBackend()->manipulateStorageConfig($storageConfig);
+
+		$class = $storageConfig->getBackend()->getStorageClass();
+		$storageImpl = new $class($storageConfig->getBackendOptions());
+
+		return $storageImpl->getId();
 	}
 
 }

--- a/apps/files_external/tests/service/userstoragesservicetest.php
+++ b/apps/files_external/tests/service/userstoragesservicetest.php
@@ -138,8 +138,11 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 		$this->assertEmpty(self::$hookCalls);
 	}
 
-	public function testDeleteStorage() {
-		parent::testDeleteStorage();
+	/**
+	 * @dataProvider deleteStorageDataProvider
+	 */
+	public function testDeleteStorage($backendOptions, $rustyStorageId, $expectedCountAfterDeletion) {
+		parent::testDeleteStorage($backendOptions, $rustyStorageId, $expectedCountAfterDeletion);
 
 		// hook called once for user (first one was during test creation)
 		$this->assertHookCall(


### PR DESCRIPTION
When removing external storages, either system-wide or user-wide,
automatically remove the matching oc_storages and oc_filecache entries.

This can only work if the backend configuration doesn't contain any
substitution variable $user in which case the storage id cannot be
computed, so this case is ignored for now.

Fixes https://github.com/owncloud/core/issues/10820

@icewind1991 @Xenopathic @DeepDiver1975 @schiesbn @MorrisJobke 
