### PR TITLE
allow an attribute to return more than one value

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -247,7 +247,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 		if(empty($result)) {
 			return false;
 		}
-		$dn = $result[0];
+		$dn = $result[0]['dn'][0];
 
 		//and now the group name
 		//NOTE once we have separate ownCloud group IDs and group names we can

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -653,7 +653,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 					str_replace('%uid', $member, $this->access->connection->ldapLoginFilter),
 					$this->access->getFilterPartForUserSearch($search)
 				));
-				$ldap_users = $this->access->fetchListOfUsers($filter, 'dn');
+				$ldap_users = $this->access->fetchListOfUsers($filter, 'dn', 1);
 				if(count($ldap_users) < 1) {
 					continue;
 				}

--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -491,7 +491,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 			array($this->access->connection->ldapGroupDisplayName, 'dn'));
 		if (is_array($groups)) {
 			foreach ($groups as $groupobj) {
-				$groupDN = $groupobj['dn'];
+				$groupDN = $groupobj['dn'][0];
 				$allGroups[$groupDN] = $groupobj;
 				$nestedGroups = $this->access->connection->ldapNestedGroups;
 				if (!empty($nestedGroups)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -710,6 +710,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 			if($manyAttributes) {
 				return $list;
 			} else {
+				$list = array_reduce($list, function($carry, $item) {
+					$carry[] = $item[0];
+				}, array());
 				return array_unique($list, SORT_LOCALE_STRING);
 			}
 		}
@@ -982,44 +985,26 @@ class Access extends LDAPUtility implements user\IUserTools {
 
 		if(!is_null($attr)) {
 			$selection = array();
-			$multiArray = false;
-			if(count($attr) > 1) {
-				$multiArray = true;
-				$i = 0;
-			}
+			$i = 0;
 			foreach($findings as $item) {
 				if(!is_array($item)) {
 					continue;
 				}
 				$item = \OCP\Util::mb_array_change_key_case($item, MB_CASE_LOWER, 'UTF-8');
-
-				if($multiArray) {
-					foreach($attr as $key) {
-						$key = mb_strtolower($key, 'UTF-8');
-						if(isset($item[$key])) {
-							if($key !== 'dn') {
-								$selection[$i][$key] = $this->resemblesDN($key) ?
-									$this->sanitizeDN($item[$key][0])
-									: $item[$key][0];
-							} else {
-								$selection[$i][$key] = $this->sanitizeDN($item[$key]);
-							}
-						}
-
-					}
-					$i++;
-				} else {
-					//tribute to case insensitivity
-					$key = mb_strtolower($attr[0], 'UTF-8');
-
+				foreach($attr as $key) {
+					$key = mb_strtolower($key, 'UTF-8');
 					if(isset($item[$key])) {
-						if($this->resemblesDN($key)) {
-							$selection[] = $this->sanitizeDN($item[$key]);
+						if($key !== 'dn') {
+							$selection[$i][$key] = $this->resemblesDN($key) ?
+								$this->sanitizeDN($item[$key])
+								: $item[$key];
 						} else {
-							$selection[] = $item[$key];
+							$selection[$i][$key] = $this->sanitizeDN($item[$key]);
 						}
 					}
+
 				}
+				$i++;
 			}
 			$findings = $selection;
 		}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -721,7 +721,9 @@ class Access extends LDAPUtility implements user\IUserTools {
 				return $list;
 			} else {
 				$list = array_reduce($list, function($carry, $item) {
-					$carry[] = $item[0];
+					$attribute = array_keys($item)[0];
+					$carry[] = $item[$attribute][0];
+					return $carry;
 				}, array());
 				return array_unique($list, SORT_LOCALE_STRING);
 			}

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -532,7 +532,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 				$nameByLDAP = $ldapObject[$nameAttribute][0];
 			}
 
-			$ocName = $this->dn2ocname($ldapObject['dn'], $nameByLDAP, $isUsers);
+			$ocName = $this->dn2ocname($ldapObject['dn'][0], $nameByLDAP, $isUsers);
 			if($ocName) {
 				$ownCloudNames[] = $ocName;
 				if($isUsers) {
@@ -692,7 +692,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 */
 	public function batchApplyUserAttributes(array $ldapRecords){
 		foreach($ldapRecords as $userRecord) {
-			$ocName  = $this->dn2ocname($userRecord['dn'], $userRecord[$this->connection->ldapUserDisplayName]);
+			$ocName  = $this->dn2ocname($userRecord['dn'][0], $userRecord[$this->connection->ldapUserDisplayName]);
 			$this->cacheUserExists($ocName);
 			$user = $this->userManager->get($ocName);
 			$user->processAttributes($userRecord);
@@ -1012,7 +1012,7 @@ class Access extends LDAPUtility implements user\IUserTools {
 								$this->sanitizeDN($item[$key])
 								: $item[$key];
 						} else {
-							$selection[$i][$key] = $this->sanitizeDN($item[$key]);
+							$selection[$i][$key] = [$this->sanitizeDN($item[$key])];
 						}
 					}
 

--- a/apps/user_ldap/lib/user/user.php
+++ b/apps/user_ldap/lib/user/user.php
@@ -147,21 +147,21 @@ class User {
 		//Quota
 		$attr = strtolower($this->connection->ldapQuotaAttribute);
 		if(isset($ldapEntry[$attr])) {
-			$this->updateQuota($ldapEntry[$attr]);
+			$this->updateQuota($ldapEntry[$attr][0]);
 		}
 		unset($attr);
 
 		//Email
 		$attr = strtolower($this->connection->ldapEmailAttribute);
 		if(isset($ldapEntry[$attr])) {
-			$this->updateEmail($ldapEntry[$attr]);
+			$this->updateEmail($ldapEntry[$attr][0]);
 		}
 		unset($attr);
 
 		//displayName
 		$attr = strtolower($this->connection->ldapUserDisplayName);
 		if(isset($ldapEntry[$attr])) {
-			$displayName = $ldapEntry[$attr];
+			$displayName = $ldapEntry[$attr][0];
 			if(!empty($displayName)) {
 				$this->storeDisplayName($displayName);
 				$this->access->cacheUserDisplayName($this->getUsername(), $displayName);
@@ -171,18 +171,20 @@ class User {
 
 		// LDAP Username, needed for s2s sharing
 		if(isset($ldapEntry['uid'])) {
-			$this->storeLDAPUserName($ldapEntry['uid']);
+			$this->storeLDAPUserName($ldapEntry['uid'][0]);
 		} else if(isset($ldapEntry['samaccountname'])) {
-			$this->storeLDAPUserName($ldapEntry['samaccountname']);
+			$this->storeLDAPUserName($ldapEntry['samaccountname'][0]);
 		}
+
 		//homePath
 		if(strpos($this->connection->homeFolderNamingRule, 'attr:') === 0) {
 			$attr = strtolower(substr($this->connection->homeFolderNamingRule, strlen('attr:')));
 			if(isset($ldapEntry[$attr])) {
 				$this->access->cacheUserHome(
-					$this->getUsername(), $this->getHomePath($ldapEntry[$attr]));
+					$this->getUsername(), $this->getHomePath($ldapEntry[$attr][0]));
 			}
 		}
+
 		//memberOf groups
 		$cacheKey = 'getMemberOf'.$this->getUsername();
 		$groups = false;
@@ -190,11 +192,12 @@ class User {
 			$groups = $ldapEntry['memberof'];
 		}
 		$this->connection->writeToCache($cacheKey, $groups);
+
 		//Avatar
 		$attrs = array('jpegphoto', 'thumbnailphoto');
 		foreach ($attrs as $attr)  {
 			if(isset($ldapEntry[$attr])) {
-				$this->avatarImage = $ldapEntry[$attr];
+				$this->avatarImage = $ldapEntry[$attr][0];
 				$this->updateAvatar();
 				break;
 			}

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -435,7 +435,7 @@ class Wizard extends LDAPUtility {
 			// detection will fail later
 			$result = $this->access->searchGroups($filter, array('cn', 'dn'), $limit, $offset);
 			foreach($result as $item) {
-				$groupNames[] = $item['cn'];
+				$groupNames[] = $item['cn'][0];
 				$groupEntries[] = $item;
 			}
 			$offset += $limit;

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -435,6 +435,10 @@ class Wizard extends LDAPUtility {
 			// detection will fail later
 			$result = $this->access->searchGroups($filter, array('cn', 'dn'), $limit, $offset);
 			foreach($result as $item) {
+				if(!isset($item['cn']) && !is_array($item['cn']) && !isset($item['cn'][0])) {
+					// just in case - no issue known
+					continue;
+				}
 				$groupNames[] = $item['cn'][0];
 				$groupEntries[] = $item;
 			}

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -145,7 +145,7 @@ class Test_Group_Ldap extends \Test\TestCase {
 
 		$access->expects($this->once())
 			->method('searchGroups')
-			->will($this->returnValue(array('cn=foo,dc=barfoo,dc=bar')));
+			->will($this->returnValue([['dn' => ['cn=foo,dc=barfoo,dc=bar']]]));
 
 		$access->expects($this->once())
 			->method('dn2groupname')
@@ -221,7 +221,7 @@ class Test_Group_Ldap extends \Test\TestCase {
 
 		$access->expects($this->once())
 			->method('searchGroups')
-			->will($this->returnValue(array('cn=foo,dc=barfoo,dc=bar')));
+			->will($this->returnValue([['dn' => ['cn=foo,dc=barfoo,dc=bar']]]));
 
 		$access->expects($this->once())
 			->method('dn2groupname')

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -124,7 +124,7 @@ class Test_User_Ldap_Direct extends \Test\TestCase {
 			   ->method('fetchListOfUsers')
 			   ->will($this->returnCallback(function($filter) {
 					if($filter === 'roland') {
-						return array(array('dn' => 'dnOfRoland,dc=test'));
+						return array(array('dn' => ['dnOfRoland,dc=test']));
 					}
 					return array();
 			   }));
@@ -133,7 +133,7 @@ class Test_User_Ldap_Direct extends \Test\TestCase {
 			->method('fetchUsersByLoginName')
 			->will($this->returnCallback(function($uid) {
 				if($uid === 'roland') {
-					return array(array('dn' => 'dnOfRoland,dc=test'));
+					return array(array('dn' => ['dnOfRoland,dc=test']));
 				}
 				return array();
 			}));

--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -78,7 +78,7 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	public function loginName2UserName($loginName) {
 		try {
 			$ldapRecord = $this->getLDAPUserByLoginName($loginName);
-			$user = $this->access->userManager->get($ldapRecord['dn']);
+			$user = $this->access->userManager->get($ldapRecord['dn'][0]);
 			if($user instanceof OfflineUser) {
 				return false;
 			}
@@ -119,7 +119,7 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		} catch(\Exception $e) {
 			return false;
 		}
-		$dn = $ldapRecord['dn'];
+		$dn = $ldapRecord['dn'][0];
 		$user = $this->access->userManager->get($dn);
 
 		if(!$user instanceof User) {


### PR DESCRIPTION
With https://github.com/owncloud/core/pull/18469 I have overseen that our result processing does always only accept on value per attribute. The relevant piece of code is from 2012. Ancient! Anyway, usually it is not a problem. There is just one DN, just one displayname to use and it is also ok to just one email address for instance. However with that PR we also cache the groups a user belongs to, if 'memberof' is present. And just one groups sucks :( This means that a user has maximum of one (maybe 2 with primary) group(s) shown.

Now I am fixing this, but it is not fully done yet. Open ToDos:
- [x] SYMPTOM: username fallback instead of display name attribute value is used as display name (e.g. on users page).
- [x] SYMPTOM: array_xx values in the user management group box (next to totally correct ones from LDAP)
- [x] TODO: LDAP returns the dn not in an array, but in a string. I am not aware of any other attribute that works like this. However, we don't have a handling yet that compares attribute names when accessing the values. Attributes that are provided by users can very well be a DN, although it hardly makes sense in most cases. When this happens, PHP will happily just take the first letter of the DN. Since checking in any possible situation where we check for an attributes value if the attribute is 'dn' is just stupid and error prone, I will modify the resutl array from search() so that 'dn' is dealt with as with any other.
- [x] BUG: AD Primary Group is not read.
- [x] TODO: adjust tests

FYI @DeepDiver1975 @cmonteroluque 

For the record, "changelog" about affected and relevant methods:

```
search 
    - uses to return different array structure dependend on there was one or more attributes given
    - if more: [ 0 => [ 'attr1' => $values[0] ], … ]
    - if one : [ 0 => $values, … ]
    - now, structure is always: [ 0 => [ 'attr1' => $values[, 'attr2' => $values[] ], … ]

searchUsers 
    · returns result from search without modification

searchGroups
    · returns result from search without modification

fetchList 
    · returns result from search without modification, if many attributes where requested
    · returns flattened array otherwise: [ 0 => [ 'attr' => $values ] ]   →  $values
    · maintaines behaviour as before, when just one attribute was provided

fetchListOfUsers
    · passes  result from search to batchApplyUserAttributes without modification
    · returns result from fetchList without modification

fetchListOfGroups
    · returns result from fetchList without modification

fetchUsersByLoginName
    · returns result from fetchList without modification    

wizard::fetchGroups
    · returns result from searchGroups

ownCloudUserNames($result)
    · passes $result to ldap2ownCloudNames

getGroupsByMember
    · returns result from fetchList

ldap2ownCloudNames($result)
    · used to expect $result to be [ 'attr1' = $value, … ], i.e. always more requested attributes
    · now adjusted to return format from fetchList

getLDAPUserByLoginName
    · return first result from fetchList (via fetchUsersByLoginName) without modification

processAttributes($record)
    · $record is one item of the whole result set
    · adjusted

fetchListOfUsers used by:
    - OK countUsersInGroup, one attribute
    - OK getUsersInPrimaryGroup 
    - OK inGroup, one attribute, 2x
    - OK usersInGroup, one attribute
    - OK getUsers
    - OK fetchUsersByLoginName

searchGroups used by:
    - OK primaryGroupID2Name, one attribute
    - OK wizard::fetchGroups

fetchListOfGroups used by:
    - OK getGroupsByMember
    - OK getGroupsChunk

wizard::fetchGroups used by:
    · OK determineGroups, return value not used

getGroupsByMember used by:
    - OK getUserGroups

fetchUsersByLoginName used by:
    - OK getLDAPUserByLoginName
    - OK wizard::testLoginName

getLDAPUserByLoginName used by:
    - OK checkPassword
    - OK loginName2UserName
```
