### PR TITLE
Only use zip64 when we have 64 bit php

### DIFF
--- a/lib/private/streamer.php
+++ b/lib/private/streamer.php
@@ -39,7 +39,7 @@ class Streamer {
 		if ($request->isUserAgent($this->preferTarFor)) {
 			$this->streamerInstance = new TarStreamer();
 		} else {
-			$this->streamerInstance = new ZipStreamer();
+			$this->streamerInstance = new ZipStreamer(['zip64' => PHP_INT_SIZE !== 4]);
 		}
 	}
 	


### PR DESCRIPTION
Can be tested with https://github.com/owncloud/smashbox/pull/129 in a bit.
# Manually testing
- Install OC on 32bit
- Link-share a folder that has files in it
- Download the folder from link as zip (needs linux/windows)
- Try to unzip

@DeepDiver1975 @PVince81 

@cmonteroluque should get this into the next package
