### PR TITLE
Catch "missing table" exception when cleaning up locks

### DIFF
--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -185,6 +185,13 @@ class DBLockingProvider extends AbstractLockingProvider {
 	}
 
 	public function __destruct() {
-		$this->cleanEmptyLocks();
+		try {
+			$this->cleanEmptyLocks();
+		} catch (\PDOException $e) {
+			// If the table is missing, the clean up was successful
+			if ($this->connection->tableExists('file_locks')) {
+				throw $e;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fix #19617 

@DeepDiver1975 @icewind1991 @jvillafanez
