### PR TITLE
make mkdir recursive, add phpdoc to api

### DIFF
--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -62,6 +62,7 @@ interface Storage {
 
 	/**
 	 * see http://php.net/manual/en/function.mkdir.php
+	 * implementations need to implement a recursive mkdir
 	 *
 	 * @param string $path
 	 * @return bool


### PR DESCRIPTION
Makes mkdir implementation of objectstore recursive. Fixes a few failing tests.

@DeepDiver1975 can you enable the objectstorage testsuite for PRs now that https://github.com/owncloud/core/pull/19414 has been merged?
