### PR TITLE
[stable8.1] Disable app store for EE by default

### DIFF
--- a/lib/private/ocsclient.php
+++ b/lib/private/ocsclient.php
@@ -68,7 +68,13 @@ class OCSClient {
 	 * @return bool
 	 */
 	public function isAppStoreEnabled() {
-		return $this->config->getSystemValue('appstoreenabled', true) === true;
+		// For a regular edition default to true, all others default to false
+		$default = false;
+		if (\OC_Util::getEditionString() === '') {
+			$default = true;
+		}
+
+		return $this->config->getSystemValue('appstoreenabled', $default) === true;
 	}
 
 	/**


### PR DESCRIPTION
This disables the app store for EE versions by default to address some problems caused by the wrong assumption that "Official" means supported by ownCloud Inc.

Administrators can still enable the app store by setting `appstoreenabled` to true in the config file.

<hr/>

Backport of https://github.com/owncloud/core/pull/19650
