### PR TITLE
[stable8] setting to skip migration tests by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -971,6 +971,15 @@ $CONFIG = array(
 'max_filesize_animated_gifs_public_sharing' => 10,
 
 /**
+ * Skips the migration test during upgrades
+ *
+ * If this is set to true the migration test are deactivated during upgrade.
+ * This is only recommended in installations where upgrade tests are run in
+ * advance with the same data on a test system.
+ */
+'update.skip-migration-test' => false,
+
+/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -11,11 +11,18 @@ if (OC::checkUpgrade(false)) {
 
 	$l = new \OC_L10N('core');
 	$eventSource = \OC::$server->createEventSource();
+	$config = \OC::$server->getConfig();
 	$updater = new \OC\Updater(
 			\OC::$server->getHTTPHelper(),
-			\OC::$server->getConfig(),
+			$config,
 			\OC_Log::$object
 	);
+
+	if ($config->getSystemValue('update.skip-migration-test', false)) {
+		$eventSource->send('success', (string)$l->t('Migration tests are skipped - "update.skip-migration-test" is activated in config.php'));
+		$updater->setSimulateStepEnabled(false);
+	}
+
 	$incompatibleApps = [];
 	$disabledThirdPartyApps = [];
 

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -73,6 +73,12 @@ class Upgrade extends Command {
 		$updateStepEnabled = true;
 		$skip3rdPartyAppsDisable = false;
 
+		if ($this->config->getSystemValue('update.skip-migration-test', false)) {
+			$output->writeln(
+				'<info>"skip-migration-test" is activated via config.php</info>'
+			);
+			$simulateStepEnabled = false;
+		}
 		if ($input->getOption('skip-migration-test')) {
 			$simulateStepEnabled = false;
 		}
@@ -94,7 +100,7 @@ class Upgrade extends Command {
 		if(\OC::checkUpgrade(false)) {
 			$self = $this;
 			$updater = new Updater(\OC::$server->getHTTPHelper(),
-				\OC::$server->getConfig());
+				$this->config);
 
 			$updater->setSimulateStepEnabled($simulateStepEnabled);
 			$updater->setUpdateStepEnabled($updateStepEnabled);


### PR DESCRIPTION
- if you install owncloud via package it is not
  possible to skip migration tests
- this also allows to disable migration tests for
  an instance by default

Backport of #19508 - @karlitschek Please approve

@PVince81 @LukasReschke @nickvergessen Please review

I tested this with occ and webUI each with migration tests enabled and disabled.
