### PR TITLE
[stable7] setting to skip migration tests by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -897,4 +897,13 @@ $CONFIG = array(
  */
 'secret' => 'ICertainlyShouldHaveChangedTheDefaultSecret',
 
+/**
+ * Skips the migration test during upgrades
+ *
+ * If this is set to true the migration test are deactivated during upgrade.
+ * This is only recommended in installations where upgrade tests are run in
+ * advance with the same data on a test system.
+ */
+'update.skip-migration-test' => false,
+
 );

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -10,6 +10,12 @@ if (OC::checkUpgrade(false)) {
 	$l = new \OC_L10N('core');
 	$eventSource = new OC_EventSource();
 	$updater = new \OC\Updater(\OC_Log::$object);
+
+	if (\OC::$server->getConfig()->getSystemValue('update.skip-migration-test', false)) {
+		$eventSource->send('success', (string)$l->t('Migration tests are skipped - "update.skip-migration-test" is activated in config.php'));
+		$updater->setSimulateStepEnabled(false);
+	}
+
 	$updater->listen('\OC\Updater', 'maintenanceStart', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Turned on maintenance mode'));
 	});

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -60,6 +60,12 @@ class Upgrade extends Command {
 		$simulateStepEnabled = true;
 		$updateStepEnabled = true;
 
+		if (\OC::$server->getConfig()->getSystemValue('update.skip-migration-test', false)) {
+			$output->writeln(
+				'<info>"skip-migration-test" is activated via config.php</info>'
+			);
+			$simulateStepEnabled = false;
+		}
 		if ($input->getOption('skip-migration-test')) {
 			$simulateStepEnabled = false;
 		}


### PR DESCRIPTION
- if you install owncloud via package it is not
  possible to skip migration tests
- this also allows to disable migration tests for
  an instance by default

Backport of #19508 - @karlitschek Please approve

@PVince81 @LukasReschke @nickvergessen Please review

I tested this with occ and webUI each with migration tests enabled and disabled.
