### PR TITLE
Don't perform checks for outdated TLS libs when no internet connection

### DIFF
--- a/settings/controller/checksetupcontroller.php
+++ b/settings/controller/checksetupcontroller.php
@@ -123,7 +123,7 @@ class CheckSetupController extends Controller {
 	 *
 	 * @return array
 	 */
-	public function getCurlVersion() {
+	protected function getCurlVersion() {
 		return curl_version();
 	}
 
@@ -137,6 +137,24 @@ class CheckSetupController extends Controller {
 	 * @return string
 	 */
 	private function isUsedTlsLibOutdated() {
+		// Appstore is disabled by default in EE
+		$appStoreDefault = false;
+		if (\OC_Util::getEditionString() === '') {
+			$appStoreDefault = true;
+		}
+
+		// Don't run check when:
+		// 1. Server has `has_internet_connection` set to false
+		// 2. AppStore AND S2S is disabled
+		if(!$this->config->getSystemValue('has_internet_connection', true)) {
+			return '';
+		}
+		if(!$this->config->getSystemValue('appstoreenabled', $appStoreDefault)
+			&& $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'no'
+			&& $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes') === 'no') {
+			return '';
+		}
+
 		$versionString = $this->getCurlVersion();
 		if(isset($versionString['ssl_version'])) {
 			$versionString = $versionString['ssl_version'];
@@ -145,7 +163,7 @@ class CheckSetupController extends Controller {
 		}
 
 		$features = (string)$this->l10n->t('installing and updating apps via the app store or Federated Cloud Sharing');
-		if(!$this->config->getSystemValue('appstoreenabled', true)) {
+		if(!$this->config->getSystemValue('appstoreenabled', $appStoreDefault)) {
 			$features = (string)$this->l10n->t('Federated Cloud Sharing');
 		}
 

--- a/settings/controller/checksetupcontroller.php
+++ b/settings/controller/checksetupcontroller.php
@@ -178,7 +178,7 @@ class CheckSetupController extends Controller {
 		return '';
 	}
 	
-	/*
+	/**
 	 * Whether the php version is still supported (at time of release)
 	 * according to: https://secure.php.net/supported-versions.php
 	 *
@@ -195,7 +195,7 @@ class CheckSetupController extends Controller {
 		return ['eol' => $eol, 'version' => PHP_VERSION];
 	}
 
-	/*
+	/**
 	 * Check if the reverse proxy configuration is working as expected
 	 *
 	 * @return bool


### PR DESCRIPTION
This change makes the check return a positive result when:
- The instance has been configured to not use the internet
  AND/OR
- S2S AND the appstore is disabled

Fixes https://github.com/owncloud/enterprise/issues/797
