### PR TITLE
adjust filesystem tests to objectstore

### DIFF
--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -325,8 +325,14 @@ class Filesystem extends \Test\TestCase {
 
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
 
-		$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\Storage\Home'));
-		$this->assertEquals('home::' . $userId, $homeMount->getId());
+		$this->assertTrue($homeMount->instanceOfStorage('\OCP\Files\IHomeStorage'));
+		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+			$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\ObjectStore\HomeObjectStoreStorage'));
+			$this->assertEquals('object::user:' . $userId, $homeMount->getId());
+		} else {
+			$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\Storage\Home'));
+			$this->assertEquals('home::' . $userId, $homeMount->getId());
+		}
 
 		\OC_User::deleteUser($userId);
 	}
@@ -336,6 +342,9 @@ class Filesystem extends \Test\TestCase {
 	 * for the user's mount point
 	 */
 	public function testLegacyHomeMount() {
+		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+			$this->markTestSkipped('legacy storage unrelated to objectstore environments');
+		}
 		$datadir = \OC_Config::getValue("datadirectory", \OC::$SERVERROOT . "/data");
 		$userId = $this->getUniqueID('user_');
 
@@ -380,7 +389,7 @@ class Filesystem extends \Test\TestCase {
 			\OC\Files\Filesystem::getMountPoint('/' . $userId . '/cache')
 		);
 		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath('/' . $userId . '/cache');
-		$this->assertTrue($storage->instanceOfStorage('\OC\Files\Storage\Home'));
+		$this->assertTrue($storage->instanceOfStorage('\OCP\Files\IHomeStorage'));
 		$this->assertEquals('cache', $internalPath);
 		\OC_User::deleteUser($userId);
 


### PR DESCRIPTION
skips legacy storage test and changes home mount test to be compatible with objectstores.

cc @icewind1991 for filesystem test review

@DeepDiver1975 please enable objectstore tests for this one
