### PR TITLE
Make sure that permissions stay in sync for share_type 2

### DIFF
--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -277,7 +277,7 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 			\OCP\Constants::PERMISSION_UPDATE,
 			\OCP\Constants::PERMISSION_CREATE,
 			\OCP\Constants::PERMISSION_SHARE,
-			\OCP\Constants::PERMISSION_DELETE
+			\OCP\Constants::PERMISSION_DELETE,
 		];
 
 		$allPermissions = $powerset($permissions);

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -237,6 +237,141 @@ class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 		);
 	}
 
+	function dataPermissionMovedGroupShare() {
+		$data = [];
+
+		$powerset = function($permissions) {
+			$results = [\OCP\Constants::PERMISSION_READ];
+
+			foreach ($permissions as $permission) {
+				foreach ($results as $combination) {
+					$results[] = $permission | $combination;
+				}
+			}
+			return $results;
+		};
+
+		//Generate file permissions
+		$permissions = [
+			\OCP\Constants::PERMISSION_UPDATE,
+			\OCP\Constants::PERMISSION_CREATE,
+			\OCP\Constants::PERMISSION_SHARE,
+		];
+
+		$allPermissions = $powerset($permissions);
+
+		foreach ($allPermissions as $before) {
+			foreach ($allPermissions as $after) {
+				if ($before === $after) { continue; }
+
+				$data[] = [
+					'file', 
+					$before,
+					$after,
+				];
+			}
+		}
+
+		//Generate folder permissions
+		$permissions = [
+			\OCP\Constants::PERMISSION_UPDATE,
+			\OCP\Constants::PERMISSION_CREATE,
+			\OCP\Constants::PERMISSION_SHARE,
+			\OCP\Constants::PERMISSION_DELETE
+		];
+
+		$allPermissions = $powerset($permissions);
+
+		foreach ($allPermissions as $before) {
+			foreach ($allPermissions as $after) {
+				if ($before === $after) { continue; }
+
+				$data[] = [
+					'folder',
+					$before,
+					$after,
+				];
+			}
+		}
+
+		return $data;
+	}
+
+
+
+	/**
+	 * moved mountpoints of a group share should keep the same permission as their parent group share.
+	 * See #15253
+	 *
+	 * @dataProvider dataPermissionMovedGroupShare
+	 */
+	function testPermissionMovedGroupShare($type, $beforePerm, $afterPerm) {
+
+		if ($type === 'file') {
+			$path = $this->filename;
+		} else if ($type === 'folder') {
+			$path = $this->folder;
+		}
+
+		\OC_Group::createGroup('testGroup');
+		\OC_Group::addToGroup(self::TEST_FILES_SHARING_API_USER1, 'testGroup');
+		\OC_Group::addToGroup(self::TEST_FILES_SHARING_API_USER2, 'testGroup');
+		\OC_Group::addToGroup(self::TEST_FILES_SHARING_API_USER3, 'testGroup');
+
+		// Share item with group
+		$fileinfo = $this->view->getFileInfo($path);
+		$this->assertTrue(
+			\OCP\Share::shareItem($type, $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP,	"testGroup", $beforePerm)
+		);
+
+		// Login as user 2 and verify the item exists
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue(\OC\Files\Filesystem::file_exists($path));
+		$result = \OCP\Share::getItemSharedWithBySource($type, $fileinfo['fileid']);
+		$this->assertNotEmpty($result);
+		$this->assertEquals($beforePerm, $result['permissions']);
+
+		// Now move the item forcing a new entry in the share table
+		\OC\Files\Filesystem::rename($path, "newPath");
+		$this->assertTrue(\OC\Files\Filesystem::file_exists('newPath'));
+		$this->assertFalse(\OC\Files\Filesystem::file_exists($path));
+
+		// Login as user 1 again and change permissions
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$this->assertTrue(
+			\OCP\Share::setPermissions($type, $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, "testGroup", $afterPerm)
+		);
+
+		// Login as user 3 and verify that the permissions are changed
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+		$result = \OCP\Share::getItemSharedWithBySource($type, $fileinfo['fileid']);
+		$this->assertNotEmpty($result);
+		$this->assertEquals($afterPerm, $result['permissions']);
+		$groupShareId = $result['id'];
+
+		// Login as user 2 and verify that the permissions are changed
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$result = \OCP\Share::getItemSharedWithBySource($type, $fileinfo['fileid']);
+		$this->assertNotEmpty($result);
+		$this->assertEquals($afterPerm, $result['permissions']);
+		$this->assertNotEquals($groupShareId, $result['id']);
+
+		// Also verify in the DB
+		$statement = "SELECT `permissions` FROM `*PREFIX*share` WHERE `id`=?";
+		$query = \OCP\DB::prepare($statement);
+		$result = $query->execute([$result['id']]);
+		$shares = $result->fetchAll();
+		$this->assertCount(1, $shares);
+		$this->assertEquals($afterPerm, $shares[0]['permissions']);
+
+		//cleanup
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		\OCP\Share::unshare($type, $fileinfo['fileid'], \OCP\Share::SHARE_TYPE_GROUP, 'testGroup');
+		\OC_Group::removeFromGroup(self::TEST_FILES_SHARING_API_USER1, 'testGroup');
+		\OC_Group::removeFromGroup(self::TEST_FILES_SHARING_API_USER2, 'testGroup');
+		\OC_Group::removeFromGroup(self::TEST_FILES_SHARING_API_USER3, 'testGroup');
+	}
+
 }
 
 class DummyTestClassSharedMount extends \OCA\Files_Sharing\SharedMount {

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1217,8 +1217,10 @@ class Share extends Constants {
 					->from('share')
 					->where($qb->expr()->eq('parent', $qb->createParameter('parent')))
 					->andWhere($qb->expr()->eq('share_type', $qb->createParameter('share_type')))
+					->andWhere($qb->expr()->neq('permissions', $qb->createParameter('shareDeleted')))
 					->setParameter(':parent', (int)$rootItem['id'])
-					->setParameter(':share_type', 2);
+					->setParameter(':share_type', 2)
+					->setParameter(':shareDeleted', 0);
 				$result = $qb->execute();
 
 				$ids = [];

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1123,9 +1123,10 @@ class Share extends Constants {
 					->from('share')
 					->where($qb->expr()->eq('id', $qb->createParameter('id')))
 					->setParameter(':id', $rootItem['parent']);
-				$result = $qb->execute();
+				$dbresult = $qb->execute();
 
-				$result = $result->fetch();
+				$result = $dbresult->fetch();
+				$dbresult->closeCursor();
 				if (~(int)$result['permissions'] & $permissions) {
 					$message = 'Setting permissions for %s failed,'
 						.' because the permissions exceed permissions granted to %s';
@@ -1189,6 +1190,7 @@ class Share extends Constants {
 							$parents[] = $item['id'];
 						}
 					}
+					$result->closeCursor();
 				}
 
 				// Remove the permissions for all reshares of this item
@@ -1209,7 +1211,7 @@ class Share extends Constants {
 
 			/*
 			 * Permissions were added
-			 * Update all USERGROUP shares. (So group shares where the user moved his mountpoint).
+			 * Update all USERGROUP shares. (So group shares where the user moved their mountpoint).
 			 */
 			if ($permissions & ~(int)$rootItem['permissions']) {
 				$qb = $connection->getQueryBuilder();
@@ -1229,6 +1231,7 @@ class Share extends Constants {
 					$items[] = $item;
 					$ids[] = $item['id'];
 				}
+				$result->closeCursor();
 
 				// Add permssions for all USERGROUP shares of this item
 				if (!empty($ids)) {


### PR DESCRIPTION
Fixes #15253

When a file/folder is shared with a group and one of the group members
moves this file/folder an extra entry is created in the share table.

When the permission of the group share is updated we used to only
sometimes update the shares for individual users.
- Added intergration tests

CC: @PVince81 @mhaggle @schiesbn 
