### PR TITLE
Resize thumbnails with keep aspect

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -31,6 +31,12 @@ $application->registerRoutes(
 	array(
 		'routes' => array(
 			array(
+				'name' => 'API#getThumbnailWithApect',
+				'url' => '/api/v1/thumbnail/keepaspect/{x}/{y}/{file}',
+				'verb' => 'GET',
+				'requirements' => array('file' => '.+')
+			),
+			array(
 				'name' => 'API#getThumbnail',
 				'url' => '/api/v1/thumbnail/{x}/{y}/{file}',
 				'verb' => 'GET',

--- a/apps/files/controller/apicontroller.php
+++ b/apps/files/controller/apicontroller.php
@@ -88,6 +88,31 @@ class ApiController extends Controller {
 	}
 
 	/**
+	 * Gets a thumbnail of the specified file with keeping aspect
+	 *
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param int $x
+	 * @param int $y
+	 * @param string $file URL-encoded filename
+	 * @return DataResponse|DataDisplayResponse
+	 */
+	public function getThumbnailWithApect($x, $y, $file) {
+		if($x < 1 || $y < 1) {
+			return new DataResponse(['message' => 'Requested size must be numeric and a positive value.'], Http::STATUS_BAD_REQUEST);
+		}
+
+		$preview = $this->previewManager->createPreview('files/'.urldecode($file), $x, $y, false, true);
+		if ($preview->valid()) {
+			return new DataDisplayResponse($preview->data(), Http::STATUS_OK, ['Content-Type' => 'image/png']);
+		} else {
+			return new DataResponse(['message' => 'File not found.'], Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
 	 * Updates the info of the specified file path
 	 * The passed tags are absolute, which means they will
 	 * replace the actual tag selection.

--- a/lib/private/previewmanager.php
+++ b/lib/private/previewmanager.php
@@ -112,10 +112,12 @@ class PreviewManager implements IPreview {
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param boolean $scaleUp Scale smaller images up to the thumbnail size or not. Might look ugly
+         * @param boolean $aspect Keep aspect
 	 * @return \OCP\IImage
 	 */
-	public function createPreview($file, $maxX = 100, $maxY = 75, $scaleUp = false) {
+	public function createPreview($file, $maxX = 100, $maxY = 75, $scaleUp = false, $aspect=false) {
 		$preview = new \OC\Preview('', '/', $file, $maxX, $maxY, $scaleUp);
+                $preview->setKeepAspect($aspect);
 		return $preview->getPreview();
 	}
 


### PR DESCRIPTION
Now you can get thumbnail for any image and keep its aspect ratio. WIth this approach http://cloud.localhost/index.php/apps/files/api/v1/thumbnail/200/300/slika.png image will be croped to exactly requested dimensions (200x300). I added new approach which can keep aspect ratio of image and resize image within requested borders. REST call is the same just you need to add keepaspect after thumbnail and before resolution, it looks like this http://cloud.localhost/index.php/apps/files/api/v1/thumbnail/keepaspect/200/300/slika.png
