### PR TITLE
Do not update mime types for folders with extension

### DIFF
--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -514,5 +514,22 @@ class RepairMimeTypes extends \Test\TestCase {
 
 		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
 	}
+
+	/**
+	 * Test that mime type renaming does not affect folders
+	 */
+	public function testDoNotChangeFolderMimeType() {
+		$currentMimeTypes = [
+			['test.conf', 'httpd/unix-directory'],
+			['test.cnf', 'httpd/unix-directory'],
+		];
+
+		$fixedMimeTypes = [
+			['test.conf', 'httpd/unix-directory'],
+			['test.cnf', 'httpd/unix-directory'],
+		];
+
+		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
+	}
 }
 


### PR DESCRIPTION
Some folders might have an extension like "test.conf".
This fix prevents to overwrite the folder's mime type with another mime
type while running the mimetype repair step.

Fixes https://github.com/owncloud/core/issues/17881
Steps here https://github.com/owncloud/core/issues/17881#issuecomment-146911353

Please review @oparoz @VicDeo @MorrisJobke @nickvergessen 
