### PR TITLE
 Clear the shares after the test like storages and files

### DIFF
--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -78,6 +78,17 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * Remove all entries from the storages table
+	 *
+	 * @throws \OC\DatabaseException
+	 */
+	static protected function tearDownAfterClassCleanShares() {
+		$sql = 'DELETE FROM `*PREFIX*share`';
+		$query = \OC_DB::prepare($sql);
+		$query->execute();
+	}
+
+	/**
+	 * Remove all entries from the storages table
 	 * @throws \OC\DatabaseException
 	 */
 	static protected function tearDownAfterClassCleanStorages() {


### PR DESCRIPTION
- adjusted to stable8.1 backport of #19574 / #19604

Fixes failing tests on stable8

@DeepDiver1975 @MorrisJobke 
