### PR TITLE
Move trashbin specific CSS that modifies sidebar

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -85,19 +85,6 @@
 	background-image: url('../img/delete.svg');
 }
 
-/* move Deleted Files to bottom of sidebar */
-.nav-trashbin {
-	position: fixed !important;
-	bottom: 44px;
-	width: inherit !important;
-	background-color: #fff;
-	border-right: 1px solid #eee;
-}
-/* double padding to account for Deleted files entry, issue with Firefox */
-.app-files #app-navigation > ul li:nth-last-child(2) {
-	margin-bottom: 44px;
-}
-
 #app-navigation .nav-files a.nav-icon-files {
 	width: auto;
 }

--- a/apps/files_trashbin/css/trash.css
+++ b/apps/files_trashbin/css/trash.css
@@ -18,3 +18,21 @@
 #app-content-trashbin #filestable .summary .filesize {
 	display: none;
 }
+
+#app-navigation > ul {
+	padding-bottom: 44px;
+}
+
+/* move Deleted Files to bottom of sidebar */
+.nav-trashbin {
+	position: fixed !important;
+	bottom: 44px;
+	width: inherit !important;
+	background-color: #fff;
+	border-right: 1px solid #eee;
+}
+/* double padding to account for Deleted files entry, issue with Firefox */
+.app-files #app-navigation > ul li:nth-last-child(2) {
+	margin-bottom: 44px;
+}
+

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -35,7 +35,6 @@
 	height: 100%;
 	width: inherit;
 	overflow: auto;
-	padding-bottom: 44px;
 	-moz-box-sizing: border-box; box-sizing: border-box;
 }
 #app-navigation li {


### PR DESCRIPTION
Only when trashbin is enabled, its sidebar nav element must be fixed at
the bottom.

@MorrisJobke @jancborchardt 

@jancborchardt not sure why there was a bottom padding:44px on the UL in the first place. I moved it to trash.css to avoid having an early scrollbar with empty space. Please double check.
