### PR TITLE
[stable8.1] Do not update mime types for folders with extension

### DIFF
--- a/lib/repair/repairmimetypes.php
+++ b/lib/repair/repairmimetypes.php
@@ -29,6 +29,10 @@ namespace OC\Repair;
 use OC\Hooks\BasicEmitter;
 
 class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
+	/**
+	 * @var int
+	 */
+	protected $folderMimeTypeId;
 
 	public function getName() {
 		return 'Repair mime types';
@@ -79,7 +83,7 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 		return \OC_DB::prepare('
 			UPDATE `*PREFIX*filecache`
 			SET `mimetype` = ?
-			WHERE `mimetype` <> ? AND `name` ILIKE ?
+			WHERE `mimetype` <> ? AND `mimetype` <> ? AND `name` ILIKE ?
 		');
 	}
 
@@ -112,6 +116,10 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 	}
 
 	private function updateMimetypes($updatedMimetypes) {
+		if (empty($this->folderMimeTypeId)) {
+			$result = \OC_DB::executeAudited(self::getIdStmt(), array('httpd/unix-directory'));
+			$this->folderMimeTypeId = (int)$result->fetchOne();
+		}
 
 		foreach ($updatedMimetypes as $extension => $mimetype) {
 			$result = \OC_DB::executeAudited(self::existsStmt(), array($mimetype));
@@ -127,7 +135,7 @@ class RepairMimeTypes extends BasicEmitter implements \OC\RepairStep {
 			$mimetypeId = $result->fetchOne();
 
 			// change mimetype for files with x extension
-			\OC_DB::executeAudited(self::updateByNameStmt(), array($mimetypeId, $mimetypeId, '%.' . $extension));
+			\OC_DB::executeAudited(self::updateByNameStmt(), array($mimetypeId, $this->folderMimeTypeId, $mimetypeId, '%.' . $extension));
 		}
 	}
 

--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -432,6 +432,23 @@ class RepairMimeTypes extends \Test\TestCase {
 
 		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
 	}
+
+	/**
+	 * Test that mime type renaming does not affect folders
+	 */
+	public function testDoNotChangeFolderMimeType() {
+		$currentMimeTypes = [
+			['test.conf', 'httpd/unix-directory'],
+			['test.cnf', 'httpd/unix-directory'],
+		];
+
+		$fixedMimeTypes = [
+			['test.conf', 'httpd/unix-directory'],
+			['test.cnf', 'httpd/unix-directory'],
+		];
+
+		$this->renameMimeTypes($currentMimeTypes, $fixedMimeTypes);
+	}
 }
 
 /**


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/19683 to stable8.1

Did a quick test with and without the fix, it works.

Please review @oparoz @VicDeo @MorrisJobke @nickvergessen @DeepDiver1975 
