### PR TITLE
Strip directory from scriptName

### DIFF
--- a/lib/private/api.php
+++ b/lib/private/api.php
@@ -386,7 +386,7 @@ class OC_API {
 
 		$meta = $result->getMeta();
 		$data = $result->getData();
-		if (self::isV2()) {
+		if (self::isV2(\OC::$server->getRequest())) {
 			$statusCode = self::mapStatusCodes($result->getStatusCode());
 			if (!is_null($statusCode)) {
 				$meta['statuscode'] = $statusCode;
@@ -449,13 +449,13 @@ class OC_API {
 	}
 
 	/**
-	 * @return boolean
+	 * @param \OCP\IRequest $request
+	 * @return bool
 	 */
-	private static function isV2() {
-		$request = \OC::$server->getRequest();
+	protected static function isV2(\OCP\IRequest $request) {
 		$script = $request->getScriptName();
 
-		return $script === '/ocs/v2.php';
+		return substr($script, -11) === '/ocs/v2.php';
 	}
 
 	/**

--- a/tests/lib/api.php
+++ b/tests/lib/api.php
@@ -34,6 +34,50 @@ class Test_API extends \Test\TestCase {
 		$this->assertEquals($success, $result->succeeded());
 	}
 
+	/**
+	 * @return array
+	 */
+	public function versionDataScriptNameProvider() {
+		return [
+			// Valid script name
+			[
+				'/master/ocs/v2.php',
+				true,
+			],
+
+			// Invalid script names
+			[
+				'/master/ocs/v2.php/someInvalidPathName',
+				false,
+			],
+			[
+				'/master/ocs/v1.php',
+				false,
+			],
+			[
+				'',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider versionDataScriptNameProvider
+	 * @param string $scriptName
+	 * @param bool $expected
+	 */
+	public function testIsV2($scriptName, $expected) {
+		$request = $this->getMockBuilder('\OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+		$request
+			->expects($this->once())
+			->method('getScriptName')
+			->will($this->returnValue($scriptName));
+
+		$this->assertEquals($expected, $this->invokePrivate(new \OC_API, 'isV2', [$request]));
+	}
+
 	function dataProviderTestOneResult() {
 		return array(
 			array(100, true),


### PR DESCRIPTION
`\OCP\IRequest::getScriptName` will also return the directory, so if ownCloud is installed in a subfolder such as `owncloud/` it will resolve to `/owncloud/ocs/v2.php`. This made this check fail and also made it return invalid status codes.

@DeepDiver1975 @karlitschek The mentioned bug.
