### PR TITLE
Return path instead of itemsource

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -633,8 +633,8 @@ class Share extends Constants {
 			// verify that the user has share permission
 			if (!\OC\Files\Filesystem::isSharable($path)) {
 				$message = 'You are not allowed to share %s';
-				$message_t = $l->t('You are not allowed to share %s', array($itemSourceName));
-				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName), \OCP\Util::DEBUG);
+				$message_t = $l->t('You are not allowed to share %s', [$path]);
+				\OCP\Util::writeLog('OCP\Share', sprintf($message, $path), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}
 		}


### PR DESCRIPTION
Fixes #19678
Errors should contain paths and not internal ids

Very simple patch.

CC: @schiesbn @PVince81 @MorrisJobke @SergioBertolinSG
