### PR TITLE
Squash collection shares

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -1914,6 +1914,7 @@ class Share extends Constants {
 				}
 			}
 			if (!empty($collectionItems)) {
+				$collectionItems = array_unique($collectionItems, SORT_REGULAR);
 				$items = array_merge($items, $collectionItems);
 			}
 


### PR DESCRIPTION
Fixes #17560

If folder1 is shared to user2 and user3. And folder1/folder2 is shared
to user4 and user5 then getting all the users with access to
folder1/folder2 should only list user2 and user 3 once.

Previously this was done twice since we request the info two times.

This fix makes sure that we only append unique results to the array. Note that we should actually fix getItems. But... yeah...

Fix is pretty simple.
- Added test

CC: @litauer @amc2002 @PVince81 @schiesbn 
