### PR TITLE
Remove controls for file lists that don't need it

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -35,11 +35,13 @@
 }
 
 /* FILE TABLE */
-
 #filestable {
 	position: relative;
-	top: 44px;
 	width: 100%;
+}
+
+#filestable.has-controls {
+	top: 44px;
 }
 
 /* make sure there's enough room for the file actions */

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -226,7 +226,11 @@
 			}
 			this.breadcrumb = new OCA.Files.BreadCrumb(breadcrumbOptions);
 
-			this.$el.find('#controls').prepend(this.breadcrumb.$el);
+			var $controls = this.$el.find('#controls');
+			if ($controls.length > 0) {
+				$controls.prepend(this.breadcrumb.$el);
+				this.$table.addClass('has-controls');
+			}
 
 			this._renderNewButton();
 

--- a/apps/files/templates/simplelist.php
+++ b/apps/files/templates/simplelist.php
@@ -1,6 +1,3 @@
-<div id="controls">
-	<div id="file_action_panel"></div>
-</div>
 <div id='notification'></div>
 
 <div id="emptycontent" class="hidden">

--- a/apps/files_sharing/templates/list.php
+++ b/apps/files_sharing/templates/list.php
@@ -1,7 +1,4 @@
 <?php /** @var $l OC_L10N */ ?>
-<div id="controls">
-	<div id="file_action_panel"></div>
-</div>
 <div id='notification'></div>
 
 <div id="emptycontent" class="hidden"></div>


### PR DESCRIPTION
Remove controls from sharing overview and favorite file lists which
don't display paths.

Fixes https://github.com/owncloud/core/issues/8924 (an oldie)

@jancborchardt @MorrisJobke 
