### PR TITLE
[master] Do not print exception message

### DIFF
--- a/core/application.php
+++ b/core/application.php
@@ -85,7 +85,8 @@ class Application extends App {
 				$c->query('L10N'),
 				$c->query('UserManager'),
 				$c->query('UserSession'),
-				$c->query('UserFolder')
+				$c->query('UserFolder'),
+				$c->query('Logger')
 			);
 		});
 
@@ -127,6 +128,9 @@ class Application extends App {
 		});
 		$container->registerService('Mailer', function(SimpleContainer $c) {
 			return $c->query('ServerContainer')->getMailer();
+		});
+		$container->registerService('Logger', function(SimpleContainer $c) {
+			return $c->query('ServerContainer')->getLogger();
 		});
 		$container->registerService('TimeFactory', function(SimpleContainer $c) {
 			return new TimeFactory();


### PR DESCRIPTION
In case of an error the error message often contains sensitive data such as the full path which potentially leads to a full path disclosure.

Thus the error message should not directly get displayed to the user and instead be logged.

To test on stable8.1:
- Enable files_locking app
- Try to upload a HTML file as avatar
- See an error message leaking the full path

(on master the transaction based file-locking does not make it easy to reproduce this)

cc @rullzer @MorrisJobke  Please review.
cc @karlitschek We should backport this down to stable8.1. I will already create PRs. 

<hr/>
- [stable8.1]: https://github.com/owncloud/core/pull/19740
