### PR TITLE
Do not calculate non essential info

### DIFF
--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -137,10 +137,8 @@ class Helper {
 
 		$entry['id'] = $i['fileid'];
 		$entry['parentId'] = $i['parent'];
-		$entry['date'] = \OCP\Util::formatDate($i['mtime']);
 		$entry['mtime'] = $i['mtime'] * 1000;
 		// only pick out the needed attributes
-		$entry['icon'] = \OCA\Files\Helper::determineIcon($i);
 		if (\OC::$server->getPreviewManager()->isAvailable($i)) {
 			$entry['isPreviewAvailable'] = true;
 		}

--- a/apps/files/tests/ajax_rename.php
+++ b/apps/files/tests/ajax_rename.php
@@ -117,9 +117,6 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals('abcdef', $result['data']['etag']);
 		$this->assertFalse(isset($result['data']['tags']));
 		$this->assertEquals('/', $result['data']['path']);
-		$icon = \OC_Helper::mimetypeIcon('dir-external');
-		$icon = substr($icon, 0, -3) . 'svg';
-		$this->assertEquals($icon, $result['data']['icon']);
 	}
 
 	/**
@@ -182,9 +179,6 @@ class Test_OC_Files_App_Rename extends \Test\TestCase {
 		$this->assertEquals('abcdef', $result['data']['etag']);
 		$this->assertEquals(array('tag1', 'tag2'), $result['data']['tags']);
 		$this->assertEquals('/', $result['data']['path']);
-		$icon = \OC_Helper::mimetypeIcon('text');
-		$icon = substr($icon, 0, -3) . 'svg';
-		$this->assertEquals($icon, $result['data']['icon']);
 
 		\OC::$server->registerService('TagManager', function ($c) use ($oldTagManager) {
 			return $oldTagManager;

--- a/apps/files/tests/controller/apicontrollertest.php
+++ b/apps/files/tests/controller/apicontrollertest.php
@@ -110,9 +110,7 @@ class ApiControllerTest extends TestCase {
 				[
 					'id' => null,
 					'parentId' => null,
-					'date' => \OCP\Util::formatDate(55),
 					'mtime' => 55000,
-					'icon' => \OCA\Files\Helper::determineIcon($fileInfo),
 					'name' => 'root.txt',
 					'permissions' => null,
 					'mimetype' => 'application/pdf',
@@ -175,9 +173,7 @@ class ApiControllerTest extends TestCase {
 				[
 					'id' => null,
 					'parentId' => null,
-					'date' => \OCP\Util::formatDate(55),
 					'mtime' => 55000,
-					'icon' => \OCA\Files\Helper::determineIcon($fileInfo1),
 					'name' => 'root.txt',
 					'permissions' => null,
 					'mimetype' => 'application/pdf',
@@ -194,9 +190,7 @@ class ApiControllerTest extends TestCase {
 				[
 					'id' => null,
 					'parentId' => null,
-					'date' => \OCP\Util::formatDate(999),
 					'mtime' => 999000,
-					'icon' => \OCA\Files\Helper::determineIcon($fileInfo2),
 					'name' => 'root.txt',
 					'permissions' => null,
 					'mimetype' => 'application/binary',


### PR DESCRIPTION
Related to #https://github.com/owncloud/core/issues/14118

When working with federated shares we fetch `shareinfo.php` a lot. `shareinfo.php` returns the whole tree and we do processing on all those entries.

Including:
- generating a human readable date from the mtime
- generating the icon url

Generating a human readable date is a waste of time since clients can do this as well and then they have the exact format they want (which is what is happening already as far as I know). And string formating is very costly!

The icon can be deduced also on the client side via javascript.

Now as stated in https://github.com/owncloud/core/issues/15904 we might want to switch to actual propfinds. But this seems like an easy way to save some time for now.
## Test results

Test setup: 20 directories each with 10 files.
Test has been done 10 times.

|  | Before | After |
| --- | --- | --- |
| Blackfire | [graph](https://blackfire.io/profiles/47080a08-7b2d-4c62-b16c-acef2ca0806f/graph) | [graph](https://blackfire.io/profiles/465bf021-f8c8-4f8f-b9cd-6158363f0b41/graph) |
| Time | 1.65s | 1.49s |

This is mainly a drop is cpu time. And as you can see the path completely drops of the graph.
## TODO:
- [ ] Verify this does not break stuff in the various places (thrasbin, sharing etc)

CC: @PVince81 @icewind1991 @LukasReschke 
