### PR TITLE
Hide notification on delete

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2011,6 +2011,8 @@
 							self.fileSummary.update();
 							self.updateSelectionSummary();
 							self.updateStorageStatistics();
+							// in case there was a "storage full" permanent notification
+							OC.Notification.hide();
 						} else {
 							if (result.status === 'error' && result.data.message) {
 								OC.Notification.show(result.data.message);


### PR DESCRIPTION
In case a permanent notification "storage full" was displayed, it will
be hidden after deleting a file.

Directly after that a getstoragestats.php call is made that will decide
whether to reshow the notification based on the new free space.

Fixes https://github.com/owncloud/core/issues/15452

@SergioBertolinSG @MorrisJobke @rullzer @icewind1991 
