### PR TITLE
[update] show default error message if empty message

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -45,6 +45,7 @@
 				hasWarnings = true;
 			});
 			updateEventSource.listen('error', function(message) {
+				message = message || t('core', 'An error occurred.');
 				$('<span>').addClass('error').append(message).append('<br />').appendTo($el);
 				message = t('core', 'Please reload the page.');
 				$('<span>').addClass('error').append(message).append('<br />').appendTo($el);


### PR DESCRIPTION
Before:

![bildschirmfoto von 2015-10-14 08-19-04](https://cloud.githubusercontent.com/assets/245432/10476256/4e00bf56-724c-11e5-8a39-87120f202f7a.png)

After:

![bildschirmfoto von 2015-10-14 08-18-42](https://cloud.githubusercontent.com/assets/245432/10476258/52ed71e4-724c-11e5-830f-fccb1ecb2bf7.png)

This happens, when the event source stream crashes (because the PHP has crashed too).

Steps to reproduce:
- install stable8.1 core and stable8.1 activity
- only upgrade core to master but not activity
- run upgrade

cc @PVince81 @LukasReschke 
