### PR TITLE
Adding occ upgrade text note

### DIFF
--- a/lib/private/console/application.php
+++ b/lib/private/console/application.php
@@ -65,6 +65,7 @@ class Application {
 				}
 			} else {
 				$output->writeln("ownCloud or one of the apps require upgrade - only a limited number of commands are available");
+				$output->writeln("You may use your browser or the occ upgrade command to do the upgrade");
 			}
 		} else {
 			$output->writeln("ownCloud is not installed - only a limited number of commands are available");


### PR DESCRIPTION
This PR adds an additional printed line to the console when an upgrade is necessary / recommended.

Before:

```
ownCloud or one of the apps require upgrade - only a limited number of commands are available
```

After:

```
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
```
