### PR TITLE
[stable8.2] Fix mtime PROPPATCH to be "lastmodified" instead of "getlastmodified"

### DIFF
--- a/lib/private/connector/sabre/filesplugin.php
+++ b/lib/private/connector/sabre/filesplugin.php
@@ -41,7 +41,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	const DOWNLOADURL_PROPERTYNAME = '{http://owncloud.org/ns}downloadURL';
 	const SIZE_PROPERTYNAME = '{http://owncloud.org/ns}size';
 	const GETETAG_PROPERTYNAME = '{DAV:}getetag';
-	const GETLASTMODIFIED_PROPERTYNAME = '{DAV:}getlastmodified';
+	const LASTMODIFIED_PROPERTYNAME = '{DAV:}lastmodified';
 
 	/**
 	 * Reference to main server object
@@ -101,7 +101,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		$server->protectedProperties[] = self::DOWNLOADURL_PROPERTYNAME;
 
 		// normally these cannot be changed (RFC4918), but we want them modifiable through PROPPATCH
-		$allowedProperties = ['{DAV:}getetag', '{DAV:}getlastmodified'];
+		$allowedProperties = ['{DAV:}getetag'];
 		$server->protectedProperties = array_diff($server->protectedProperties, $allowedProperties);
 
 		$this->server = $server;
@@ -208,7 +208,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return void
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
-		$propPatch->handle(self::GETLASTMODIFIED_PROPERTYNAME, function($time) use ($path) {
+		$propPatch->handle(self::LASTMODIFIED_PROPERTYNAME, function($time) use ($path) {
 			if (empty($time)) {
 				return false;
 			}

--- a/tests/lib/connector/sabre/filesplugin.php
+++ b/tests/lib/connector/sabre/filesplugin.php
@@ -13,7 +13,7 @@ class FilesPlugin extends \Test\TestCase {
 	const FILEID_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::FILEID_PROPERTYNAME;
 	const SIZE_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::SIZE_PROPERTYNAME;
 	const PERMISSIONS_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::PERMISSIONS_PROPERTYNAME;
-	const GETLASTMODIFIED_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::GETLASTMODIFIED_PROPERTYNAME;
+	const LASTMODIFIED_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::LASTMODIFIED_PROPERTYNAME;
 	const DOWNLOADURL_PROPERTYNAME = \OC\Connector\Sabre\FilesPlugin::DOWNLOADURL_PROPERTYNAME;
 
 	/**
@@ -190,7 +190,7 @@ class FilesPlugin extends \Test\TestCase {
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch(array(
 			self::GETETAG_PROPERTYNAME => 'newetag',
-			self::GETLASTMODIFIED_PROPERTYNAME => $testDate
+			self::LASTMODIFIED_PROPERTYNAME => $testDate
 		));
 
 		$this->plugin->handleUpdateProperties(
@@ -203,7 +203,7 @@ class FilesPlugin extends \Test\TestCase {
 		$this->assertEmpty($propPatch->getRemainingMutations());
 
 		$result = $propPatch->getResult();
-		$this->assertEquals(200, $result[self::GETLASTMODIFIED_PROPERTYNAME]);
+		$this->assertEquals(200, $result[self::LASTMODIFIED_PROPERTYNAME]);
 		$this->assertEquals(200, $result[self::GETETAG_PROPERTYNAME]);
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/19738 to stable8.1

Please review @MorrisJobke @nickvergessen @icewind1991 @DeepDiver1975 
