### PR TITLE
Variables don't have a class, so we can't use toString() on it

### DIFF
--- a/lib/private/app/codechecker/nodevisitor.php
+++ b/lib/private/app/codechecker/nodevisitor.php
@@ -167,9 +167,9 @@ class NodeVisitor extends NodeVisitorAbstract {
 					 *       $c = "OC_API";
 					 *       $n = $i::ADMIN_AUTH;
 					 */
+				} else {
+					$this->checkBlackListConstant($node->class->toString(), $node->name, $node);
 				}
-
-				$this->checkBlackListConstant($node->class->toString(), $node->name, $node);
 			}
 		}
 		if ($node instanceof Node\Expr\New_) {


### PR DESCRIPTION
@oparoz @MorrisJobke 

@karlitschek please approve backport to 8.2.1
It fixes a problem with the app check-code, so not urgent for 8.2.0
