### PR TITLE
Remove arbitrary expression in empty

### DIFF
--- a/apps/user_ldap/lib/configuration.php
+++ b/apps/user_ldap/lib/configuration.php
@@ -150,8 +150,9 @@ class Configuration {
 					$setMethod = 'setRawValue';
 					break;
 				case 'homeFolderNamingRule':
-					if(!empty(trim($val)) && strpos($val, 'attr:') === false) {
-						$val = 'attr:'.trim($val);
+					$trimmedVal = trim($val);
+					if(!empty($trimmedVal) && strpos($val, 'attr:') === false) {
+						$val = 'attr:'.$trimmedVal;
 					}
 					break;
 				case 'ldapBase':


### PR DESCRIPTION
Those are only allowed in PHP 5.5, thus making our code incompatible with PHP 5.4

Fixes https://github.com/owncloud/core/issues/19793
