### PR TITLE
Improve settings/apps page

### DIFF
--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -96,11 +96,13 @@ class AppSettingsController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
+	 * @param int $category
 	 * @return TemplateResponse
 	 */
-	public function viewApps() {
+	public function viewApps($category = 0) {
 		$params = [];
 		$params['experimentalEnabled'] = $this->config->getSystemValue('appstore.experimental.enabled', false);
+		$params['category'] = $category;
 		$this->navigationManager->setActiveEntry('core_apps');
 
 		$templateResponse = new TemplateResponse($this->appName, 'apps', $params, 'user');

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -40,8 +40,8 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 
 		var categories = [
-			{displayName: t('settings', 'Enabled'), id: '0'},
-			{displayName: t('settings', 'Not enabled'), id: '1'}
+			{displayName: t('settings', 'Enabled'), ident: 'enabled', id: '0'},
+			{displayName: t('settings', 'Not enabled'), ident: 'disabled', id: '1'}
 		];
 
 		var source   = $("#categories-template").html();
@@ -49,7 +49,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		var html = template(categories);
 		$('#apps-categories').html(html);
 
-		OC.Settings.Apps.loadCategory(parseInt($('#app-navigation').attr('data-category'), 10));
+		OC.Settings.Apps.loadCategory($('#app-navigation').attr('data-category'));
 
 		this._loadCategoriesCall = $.ajax(OC.generateUrl('settings/apps/categories'), {
 			data:{},

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -116,7 +116,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					});
 				} else {
 					$('#apps-list').addClass('hidden');
-					$('#apps-list-empty').removeClass('hidden');
+					$('#apps-list-empty').removeClass('hidden').find('h2').text(t('settings', 'No apps found for your version'));
 				}
 
 				$('.app-level .official').tipsy({fallback: t('settings', 'Official apps are developed by and within the ownCloud community. They offer functionality central to ownCloud and are ready for production use.')});
@@ -416,12 +416,14 @@ OC.Settings.Apps = OC.Settings.Apps || {
 	filter: function(query) {
 		var $appList = $('#apps-list'),
 			$emptyList = $('#apps-list-empty');
+		$appList.removeClass('hidden');
+		$appList.find('.section').removeClass('hidden');
+		$emptyList.addClass('hidden');
+
 		if (query === '') {
-			$appList.find('.section').removeClass('hidden');
-			$appList.removeClass('hidden');
-			$emptyList.addClass('hidden');
 			return;
 		}
+
 		query = query.toLowerCase();
 		$appList.find('.section').addClass('hidden');
 
@@ -462,6 +464,9 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		if (apps.length === 0) {
 			$appList.addClass('hidden');
 			$emptyList.removeClass('hidden');
+			$emptyList.removeClass('hidden').find('h2').text(t('settings', 'No apps found for "{query}"', {
+				query: query
+			}));
 		} else {
 			_.each(apps, function (app) {
 				$('#app-' + app.id).removeClass('hidden');

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -40,7 +40,8 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 
 		var categories = [
-			{displayName: 'Enabled', id: '0'}
+			{displayName: t('settings', 'Enabled'), id: '0'},
+			{displayName: t('settings', 'Not enabled'), id: '1'}
 		];
 
 		var source   = $("#categories-template").html();
@@ -48,7 +49,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		var html = template(categories);
 		$('#apps-categories').html(html);
 
-		OC.Settings.Apps.loadCategory(0);
+		OC.Settings.Apps.loadCategory(parseInt($('#app-navigation').attr('data-category'), 10));
 
 		this._loadCategoriesCall = $.ajax(OC.generateUrl('settings/apps/categories'), {
 			data:{},
@@ -398,14 +399,14 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			.text('');
 	},
 
-	showReloadMessage: function(appId) {
+	showReloadMessage: function() {
 		OC.dialogs.info(
 			t(
 				'settings',
 				'The app has been enabled but needs to be updated. You will be redirected to the update page in 5 seconds.'
 			),
 			t('settings','App update'),
-			function (result) {
+			function () {
 				window.location.reload();
 			},
 			true
@@ -443,6 +444,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		$(document).on('click', 'ul#apps-categories li', function () {
 			var categoryId = $(this).data('categoryId');
 			OC.Settings.Apps.loadCategory(categoryId);
+			OC.Util.History.pushState('category=' + categoryId);
 		});
 
 		$(document).on('click', '.app-description-toggle-show', function () {
@@ -508,7 +510,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		});
 
 		$(document).on('click', '#enable-experimental-apps', function () {
-			var state = $(this).prop('checked')
+			var state = $(this).prop('checked');
 			$.ajax(OC.generateUrl('settings/apps/experimental'), {
 				data: {state: state},
 				type: 'POST',

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -474,6 +474,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			var categoryId = $(this).data('categoryId');
 			OC.Settings.Apps.loadCategory(categoryId);
 			OC.Util.History.pushState('category=' + categoryId);
+			$('#searchbox').val('');
 		});
 
 		$(document).on('click', '.app-description-toggle-show', function () {

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -414,9 +414,12 @@ OC.Settings.Apps = OC.Settings.Apps || {
 	},
 
 	filter: function(query) {
-		var $appList = $('#apps-list');
+		var $appList = $('#apps-list'),
+			$emptyList = $('#apps-list-empty');
 		if (query === '') {
 			$appList.find('.section').removeClass('hidden');
+			$appList.removeClass('hidden');
+			$emptyList.addClass('hidden');
 			return;
 		}
 		query = query.toLowerCase();
@@ -456,11 +459,16 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 		apps = _.uniq(apps, function(app){return app.id;});
 
-		_.each(apps, function (app) {
-			$('#app-' + app.id).removeClass('hidden');
-		});
+		if (apps.length === 0) {
+			$appList.addClass('hidden');
+			$emptyList.removeClass('hidden');
+		} else {
+			_.each(apps, function (app) {
+				$('#app-' + app.id).removeClass('hidden');
+			});
 
-		$('#searchresults').hide();
+			$('#searchresults').hide();
+		}
 	},
 
 	/**

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -414,16 +414,45 @@ OC.Settings.Apps = OC.Settings.Apps || {
 	},
 
 	filter: function(query) {
+		var $appList = $('#apps-list');
+		if (query === '') {
+			$appList.find('.section').removeClass('hidden');
+			return;
+		}
 		query = query.toLowerCase();
-		$('#apps-list').find('.section').addClass('hidden');
+		$appList.find('.section').addClass('hidden');
 
+		// App Name
 		var apps = _.filter(OC.Settings.Apps.State.apps, function (app) {
 			return app.name.toLowerCase().indexOf(query) !== -1;
 		});
 
+		// App Description
 		apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
 			return app.description.toLowerCase().indexOf(query) !== -1;
 		}));
+
+		// Author Name
+		apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
+			return app.author.toLowerCase().indexOf(query) !== -1;
+		}));
+
+		// App status
+		if (t('settings', 'Official').toLowerCase().indexOf(query) !== -1) {
+			apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
+				return app.level === 200;
+			}));
+		}
+		if (t('settings', 'Approved').toLowerCase().indexOf(query) !== -1) {
+			apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
+				return app.level === 100;
+			}));
+		}
+		if (t('settings', 'Experimental').toLowerCase().indexOf(query) !== -1) {
+			apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
+				return app.level !== 100 && app.level !== 200;
+			}));
+		}
 
 		apps = _.uniq(apps, function(app){return app.id;});
 

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -476,17 +476,28 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 	},
 
+	_onPopState: function(params) {
+		params = _.extend({
+			category: 'enabled'
+		}, params);
+
+		OC.Settings.Apps.loadCategory(params.category);
+	},
+
 	/**
 	 * Initializes the apps list
 	 */
 	initialize: function($el) {
 		OC.Plugins.register('OCA.Search', OC.Settings.Apps.Search);
 		OC.Settings.Apps.loadCategories();
+		OC.Util.History.addOnPopStateHandler(_.bind(this._onPopState, this));
 
 		$(document).on('click', 'ul#apps-categories li', function () {
 			var categoryId = $(this).data('categoryId');
 			OC.Settings.Apps.loadCategory(categoryId);
-			OC.Util.History.pushState('category=' + categoryId);
+			OC.Util.History.pushState({
+				category: categoryId
+			});
 			$('#searchbox').val('');
 		});
 

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -127,7 +127,7 @@ script(
 	</div>
 </script>
 
-<div id="app-navigation" class="icon-loading">
+<div id="app-navigation" class="icon-loading" data-category="<?php p($_['category']);?>">
 	<ul id="apps-categories">
 
 	</ul>

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -24,7 +24,7 @@ script(
 ?>
 <script id="categories-template" type="text/x-handlebars-template">
 {{#each this}}
-	<li id="app-category-{{id}}" data-category-id="{{id}}" tabindex="0">
+	<li id="app-category-{{ident}}" data-category-id="{{ident}}" tabindex="0">
 		<a>{{displayName}}</a>
 	</li>
 {{/each}}

--- a/settings/tests/js/appsSpec.js
+++ b/settings/tests/js/appsSpec.js
@@ -59,10 +59,10 @@ describe('OC.Settings.Apps tests', function() {
 
 		beforeEach(function() {
 			loadApps([
-				{id: 'appone', name: 'App One', description: 'The first app'},
-				{id: 'apptwo', name: 'App Two', description: 'The second app'},
-				{id: 'appthree', name: 'App Three', description: 'Third app'},
-				{id: 'somestuff', name: 'Some Stuff', description: 'whatever'}
+				{id: 'appone', name: 'App One', description: 'The first app', author: 'author1', level: 200},
+				{id: 'apptwo', name: 'App Two', description: 'The second app', author: 'author2', level: 100},
+				{id: 'appthree', name: 'App Three', description: 'Third app', author: 'author3', level: 0},
+				{id: 'somestuff', name: 'Some Stuff', description: 'whatever', author: 'author4', level: 0}
 			]);
 		});
 
@@ -96,6 +96,45 @@ describe('OC.Settings.Apps tests', function() {
 			results = getResultsFromDom();
 			expect(results.length).toEqual(1);
 			expect(results[0]).toEqual('somestuff');
+		});
+		it('returns relevant results when query matches author name', function() {
+			var results;
+			Apps.filter('author');
+			results = getResultsFromDom();
+			expect(results.length).toEqual(4);
+			expect(results[0]).toEqual('appone');
+			expect(results[1]).toEqual('apptwo');
+			expect(results[2]).toEqual('appthree');
+			expect(results[3]).toEqual('somestuff');
+		});
+		it('returns relevant result when query matches author name', function() {
+			var results;
+			Apps.filter('thor3');
+			results = getResultsFromDom();
+			expect(results.length).toEqual(1);
+			expect(results[0]).toEqual('appthree');
+		});
+		it('returns relevant result when query matches level name', function() {
+			var results;
+			Apps.filter('Offic');
+			results = getResultsFromDom();
+			expect(results.length).toEqual(1);
+			expect(results[0]).toEqual('appone');
+		});
+		it('returns relevant result when query matches level name', function() {
+			var results;
+			Apps.filter('Appro');
+			results = getResultsFromDom();
+			expect(results.length).toEqual(1);
+			expect(results[0]).toEqual('apptwo');
+		});
+		it('returns relevant result when query matches level name', function() {
+			var results;
+			Apps.filter('Exper');
+			results = getResultsFromDom();
+			expect(results.length).toEqual(2);
+			expect(results[0]).toEqual('appthree');
+			expect(results[1]).toEqual('somestuff');
 		});
 	});
 

--- a/settings/tests/js/appsSpec.js
+++ b/settings/tests/js/appsSpec.js
@@ -24,6 +24,7 @@ describe('OC.Settings.Apps tests', function() {
 
 	beforeEach(function() {
 		var $el = $('<div id="apps-list"></div>' +
+			'<div id="apps-list-empty" class="hidden"></div>' +
 			'<div id="app-template">' +
 			// dummy template for testing
 			'<div id="app-{{id}}" data-id="{{id}}" class="section">{{name}}</div>' +
@@ -66,15 +67,26 @@ describe('OC.Settings.Apps tests', function() {
 			]);
 		});
 
-		it('does not filter when no query passed', function() {
-			Apps.filter('');
-			expect(getResultsFromDom().length).toEqual(4);
-		});
 		it('returns no results when query does not match anything', function() {
+			expect(getResultsFromDom().length).toEqual(4);
+			expect($('#apps-list:not(.hidden)').length).toEqual(1);
+			expect($('#apps-list-empty:not(.hidden)').length).toEqual(0);
+
 			Apps.filter('absurdity');
 			expect(getResultsFromDom().length).toEqual(0);
+			expect($('#apps-list:not(.hidden)').length).toEqual(0);
+			expect($('#apps-list-empty:not(.hidden)').length).toEqual(1);
+
+			Apps.filter('');
+			expect(getResultsFromDom().length).toEqual(4);
+			expect($('#apps-list:not(.hidden)').length).toEqual(1);
+			expect($('#apps-list-empty:not(.hidden)').length).toEqual(0);
+			expect(getResultsFromDom().length).toEqual(4);
 		});
 		it('returns relevant results when query matches name', function() {
+			expect($('#apps-list:not(.hidden)').length).toEqual(1);
+			expect($('#apps-list-empty:not(.hidden)').length).toEqual(0);
+
 			var results;
 			Apps.filter('app');
 			results = getResultsFromDom();
@@ -82,6 +94,9 @@ describe('OC.Settings.Apps tests', function() {
 			expect(results[0]).toEqual('appone');
 			expect(results[1]).toEqual('apptwo');
 			expect(results[2]).toEqual('appthree');
+
+			expect($('#apps-list:not(.hidden)').length).toEqual(1);
+			expect($('#apps-list-empty:not(.hidden)').length).toEqual(0);
 		});
 		it('returns relevant result when query matches name', function() {
 			var results;

--- a/tests/settings/controller/AppSettingsControllerTest.php
+++ b/tests/settings/controller/AppSettingsControllerTest.php
@@ -132,10 +132,12 @@ class AppSettingsControllerTest extends TestCase {
 		$expected = [
 			[
 				'id' => 0,
+				'ident' => 'enabled',
 				'displayName' => 'Enabled',
 			],
 			[
 				'id' => 1,
+				'ident' => 'disabled',
 				'displayName' => 'Not enabled',
 			],
 		];
@@ -157,27 +159,33 @@ class AppSettingsControllerTest extends TestCase {
 		$expected = [
 			[
 				'id' => 0,
+				'ident' => 'enabled',
 				'displayName' => 'Enabled',
 			],
 			[
 				'id' => 1,
+				'ident' => 'disabled',
 				'displayName' => 'Not enabled',
 			],
 			[
 				'id' => 0,
+				'ident' => 'tools',
 				'displayName' => 'Tools',
 			],
 			[
 				'id' => 1,
-				'displayName' => 'Awesome Games',
+				'ident' => 'games',
+				'displayName' => 'Games',
 			],
 			[
 				'id' => 2,
-				'displayName' => 'PIM',
+				'ident' => 'productivity',
+				'displayName' => 'Productivity',
 			],
 			[
 				'id' => 3,
-				'displayName' => 'Papershop',
+				'ident' => 'multimedia',
+				'displayName' => 'Multimedia',
 			],
 		];
 
@@ -201,9 +209,9 @@ class AppSettingsControllerTest extends TestCase {
 			->will($this->returnValue(
 				[
 					'ownCloud Tools',
-					'Awesome Games',
-					'ownCloud PIM',
-					'Papershop',
+					'Games',
+					'ownCloud Productivity',
+					'Multimedia',
 				]
 			));
 
@@ -223,7 +231,7 @@ class AppSettingsControllerTest extends TestCase {
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedImageDomain('https://apps.owncloud.com');
 
-		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 0], 'user');
+		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 'enabled'], 'user');
 		$expected->setContentSecurityPolicy($policy);
 
 		$this->assertEquals($expected, $this->appSettingsController->viewApps());
@@ -242,9 +250,9 @@ class AppSettingsControllerTest extends TestCase {
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedImageDomain('https://apps.owncloud.com');
 
-		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 1], 'user');
+		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 'disabled'], 'user');
 		$expected->setContentSecurityPolicy($policy);
 
-		$this->assertEquals($expected, $this->appSettingsController->viewApps(1));
+		$this->assertEquals($expected, $this->appSettingsController->viewApps('disabled'));
 	}
 }

--- a/tests/settings/controller/AppSettingsControllerTest.php
+++ b/tests/settings/controller/AppSettingsControllerTest.php
@@ -223,9 +223,28 @@ class AppSettingsControllerTest extends TestCase {
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedImageDomain('https://apps.owncloud.com');
 
-		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false], 'user');
+		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 0], 'user');
 		$expected->setContentSecurityPolicy($policy);
 
 		$this->assertEquals($expected, $this->appSettingsController->viewApps());
+	}
+
+	public function testViewAppsNotEnabled() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('appstore.experimental.enabled', false);
+		$this->navigationManager
+			->expects($this->once())
+			->method('setActiveEntry')
+			->with('core_apps');
+
+		$policy = new ContentSecurityPolicy();
+		$policy->addAllowedImageDomain('https://apps.owncloud.com');
+
+		$expected = new TemplateResponse('settings', 'apps', ['experimentalEnabled' => false, 'category' => 1], 'user');
+		$expected->setContentSecurityPolicy($policy);
+
+		$this->assertEquals($expected, $this->appSettingsController->viewApps(1));
 	}
 }


### PR DESCRIPTION
- Search by author name
- Search by app level (Experimental, official, ...)
- Load same category again when refreshing page https://github.com/owncloud/core/issues/15650
- Clear search field when changing category, until we search cross categories https://github.com/owncloud/core/issues/15651
- Display #empty-content when search result is empty https://github.com/owncloud/core/issues/16836

@PVince81 @MorrisJobke @LukasReschke 

Fix #15650
Fix #15651
Fix #16836
