### PR TITLE
append /view to shared link to view (not download) content

### DIFF
--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -215,6 +215,7 @@ class ShareController extends Controller {
 		}
 
 		$shareTmpl['downloadURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadShare', array('token' => $token));
+		$shareTmpl['viewURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.viewShare', array('token' => $token));
 		$shareTmpl['maxSizeAnimateGif'] = $this->config->getSystemValue('max_filesize_animated_gifs_public_sharing', 10);
 		$shareTmpl['previewEnabled'] = $this->config->getSystemValue('enable_previews', true);
 
@@ -236,7 +237,22 @@ class ShareController extends Controller {
 	 * @param string $downloadStartSecret
 	 * @return void|RedirectResponse
 	 */
-	public function downloadShare($token, $files = null, $path = '', $downloadStartSecret = '') {
+	public function viewShare($token, $files = null, $path = '', $downloadStartSecret = '') {
+		self::downloadShare($token, $files, $path, $downloadStartSecret, false);
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @param string $token
+	 * @param string $files
+	 * @param string $path
+	 * @param string $downloadStartSecret
+	 * @param boolean $isAttachment ; enforce download of file
+	 * @return void|RedirectResponse
+	 */
+	public function downloadShare($token, $files = null, $path = '', $downloadStartSecret = '', $isAttachment = true) {
 		\OC_User::setIncognitoMode(true);
 
 		$linkItem = OCP\Share::getShareByToken($token, false);
@@ -306,12 +322,12 @@ class ShareController extends Controller {
 		if (!is_null($files)) {
 			// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
 			// after dispatching the request which results in a "Cannot modify header information" notice.
-			OC_Files::get($originalSharePath, $files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD');
+			OC_Files::get($originalSharePath, $files_list, $_SERVER['REQUEST_METHOD'] == 'HEAD', $isAttachment);
 			exit();
 		} else {
 			// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
 			// after dispatching the request which results in a "Cannot modify header information" notice.
-			OC_Files::get(dirname($originalSharePath), basename($originalSharePath), $_SERVER['REQUEST_METHOD'] == 'HEAD');
+			OC_Files::get(dirname($originalSharePath), basename($originalSharePath), $_SERVER['REQUEST_METHOD'] == 'HEAD', $isAttachment);
 			exit();
 		}
 	}

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -24,7 +24,13 @@
 
 $urlGenerator = \OC::$server->getURLGenerator();
 $token = isset($_GET['t']) ? $_GET['t'] : '';
-$route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadShare' : 'files_sharing.sharecontroller.showShare';
+if (isset($_GET['download'])) {
+	$route = 'files_sharing.sharecontroller.downloadShare';
+} else if (isset($_GET['view'])) {
+	$route = 'files_sharing.sharecontroller.viewShare';
+} else {
+	$route = 'files_sharing.sharecontroller.showShare';
+}
 
 if($token !== '') {
 	OC_Response::redirect($urlGenerator->linkToRoute($route, array('token' => $token)));

--- a/core/routes.php
+++ b/core/routes.php
@@ -123,6 +123,10 @@ $this->create('files_sharing.sharecontroller.downloadShare', '/s/{token}/downloa
 	$app = new \OCA\Files_Sharing\AppInfo\Application($urlParams);
 	$app->dispatch('ShareController', 'downloadShare');
 });
+$this->create('files_sharing.sharecontroller.viewShare', '/s/{token}/view')->get()->action(function($urlParams) {
+	$app = new \OCA\Files_Sharing\AppInfo\Application($urlParams);
+	$app->dispatch('ShareController', 'viewShare');
+});
 
 // used for heartbeat
 $this->create('heartbeat', '/heartbeat')->action(function(){


### PR DESCRIPTION
When sharing files (images) the preview is quite small and has a long url.
Add /view to view the contents of the file inside the browser.

This commit makes no UI changes.

Example 1: http://172.17.0.7/index.php/s/2VW6HAYYxzoo3w9
Example 2: http://172.17.0.7/index.php/s/2VW6HAYYxzoo3w9/view
