### PR TITLE
When sharing with the owner show the path

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -619,10 +619,13 @@ class Share extends Constants {
 		if (is_null($itemSourceName)) {
 			$itemSourceName = $itemSource;
 		}
+		$itemName = $itemSourceName;
 
 		// check if file can be shared
 		if ($itemType === 'file' or $itemType === 'folder') {
 			$path = \OC\Files\Filesystem::getPath($itemSource);
+			$itemName = $path;
+
 			// verify that the file exists before we try to share it
 			if (!$path) {
 				$message = 'Sharing %s failed, because the file does not exist';
@@ -678,7 +681,7 @@ class Share extends Constants {
 		if ($shareType === self::SHARE_TYPE_USER) {
 			if ($shareWith == $uidOwner) {
 				$message = 'Sharing %s failed, because the user %s is the item owner';
-				$message_t = $l->t('Sharing %s failed, because the user %s is the item owner', array($itemSourceName, $shareWith));
+				$message_t = $l->t('Sharing %s failed, because the user %s is the item owner', array($itemName, $shareWith));
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -680,9 +680,9 @@ class Share extends Constants {
 		// Verify share type and sharing conditions are met
 		if ($shareType === self::SHARE_TYPE_USER) {
 			if ($shareWith == $uidOwner) {
-				$message = 'Sharing %s failed, because the user %s is the item owner';
-				$message_t = $l->t('Sharing %s failed, because the user %s is the item owner', array($itemName, $shareWith));
-				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
+				$message = 'Sharing %s failed, because you can not share with yourself';
+				$message_t = $l->t('Sharing %s failed, because you can not share with yourself', [$itemName]);
+				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}
 			if (!\OC_User::userExists($shareWith)) {
@@ -2212,7 +2212,7 @@ class Share extends Constants {
 			// Check if attempting to share back to owner
 			if ($checkReshare['uid_owner'] == $shareWith && $shareType == self::SHARE_TYPE_USER) {
 				$message = 'Sharing %s failed, because the user %s is the original sharer';
-				$message_t = $l->t('Sharing %s failed, because the user %s is the original sharer', array($itemSourceName, $shareWith));
+				$message_t = $l->t('Sharing failed, because the user %s is the original sharer', [$shareWith]);
 
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -1735,6 +1735,30 @@ class Test_Share extends \Test\TestCase {
 		);
 		$this->assertCount(4, $res);
 	}
+
+	public function testShareWithOwnerError() {
+		OC_User::setUserId($this->user1);
+		$view = new \OC\Files\View('/' . $this->user1 . '/');
+		$view->mkdir('files/folder1');
+
+		$fileInfo = $view->getFileInfo('files/folder1');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $fileInfo);
+		$fileId = $fileInfo->getId();
+
+		$this->assertTrue(
+			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_USER, $this->user2, \OCP\Constants::PERMISSION_ALL),
+			'Failed asserting that user 1 successfully shared "test" with user 2.'
+		);
+
+		OC_User::setUserId($this->user1);
+
+		try {
+			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_ALL);
+			$this->fail();
+		} catch (\Exception $e) {
+			$this->assertEquals('Sharing /folder1 failed, because the user ' . $this->user1 . ' is the item owner', $e->getMessage());
+		}
+	}
 }
 
 class DummyShareClass extends \OC\Share\Share {

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -218,7 +218,7 @@ class Test_Share extends \Test\TestCase {
 
 	public function testShareWithUser() {
 		// Invalid shares
-		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the item owner';
+		$message = 'Sharing test.txt failed, because you can not share with yourself';
 		try {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
@@ -255,7 +255,7 @@ class Test_Share extends \Test\TestCase {
 
 		// Attempt to share back
 		OC_User::setUserId($this->user2);
-		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the original sharer';
+		$message = 'Sharing failed, because the user '.$this->user1.' is the original sharer';
 		try {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
@@ -640,7 +640,7 @@ class Test_Share extends \Test\TestCase {
 
 		// Attempt to share back to owner of group share
 		OC_User::setUserId($this->user2);
-		$message = 'Sharing test.txt failed, because the user '.$this->user1.' is the original sharer';
+		$message = 'Sharing failed, because the user '.$this->user1.' is the original sharer';
 		try {
 			OCP\Share::shareItem('test', 'test.txt', OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_READ);
 			$this->fail('Exception was expected: '.$message);
@@ -1736,6 +1736,24 @@ class Test_Share extends \Test\TestCase {
 		$this->assertCount(4, $res);
 	}
 
+	public function testShareWithSelfError() {
+		OC_User::setUserId($this->user1);
+		$view = new \OC\Files\View('/' . $this->user1 . '/');
+		$view->mkdir('files/folder1');
+
+		$fileInfo = $view->getFileInfo('files/folder1');
+		$this->assertInstanceOf('\OC\Files\FileInfo', $fileInfo);
+		$fileId = $fileInfo->getId();
+
+		try {
+			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_ALL);
+			$this->fail();
+		} catch (\Exception $e) {
+			$this->assertEquals('Sharing /folder1 failed, because you can not share with yourself', $e->getMessage());
+		}
+	}
+
+
 	public function testShareWithOwnerError() {
 		OC_User::setUserId($this->user1);
 		$view = new \OC\Files\View('/' . $this->user1 . '/');
@@ -1750,13 +1768,12 @@ class Test_Share extends \Test\TestCase {
 			'Failed asserting that user 1 successfully shared "test" with user 2.'
 		);
 
-		OC_User::setUserId($this->user1);
-
+		OC_User::setUserId($this->user2);
 		try {
 			OCP\Share::shareItem('folder', $fileId, OCP\Share::SHARE_TYPE_USER, $this->user1, \OCP\Constants::PERMISSION_ALL);
 			$this->fail();
 		} catch (\Exception $e) {
-			$this->assertEquals('Sharing /folder1 failed, because the user ' . $this->user1 . ' is the item owner', $e->getMessage());
+			$this->assertEquals('Sharing failed, because the user ' . $this->user1 . ' is the original sharer', $e->getMessage());
 		}
 	}
 }


### PR DESCRIPTION
The error message should contain the path that is being shared not the
numeric id.

First bullet in #19788 @rperezb 

Easy to review

CC: @PVince81 @MorrisJobke @schiesbn 
