### PR TITLE
Run test only when idn is available

### DIFF
--- a/tests/lib/mail/message.php
+++ b/tests/lib/mail/message.php
@@ -39,7 +39,11 @@ class MessageTest extends TestCase {
 	}
 
 	/**
+	 * @requires function idn_to_ascii
 	 * @dataProvider mailAddressProvider
+	 *
+	 * @param string $unconverted
+	 * @param string $expected
 	 */
 	public function testConvertAddresses($unconverted, $expected) {
 		$this->assertSame($expected, self::invokePrivate($this->message, 'convertAddresses', array($unconverted)));


### PR DESCRIPTION
IDN is not installed on all machines making the unit test execution fail on those without. Let's make IDN thus a pre-requirement for the text execution.
