### PR TITLE
[IE9] Don't send link share password placeholder

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -13,6 +13,9 @@
 		OC.Share = {};
 	}
 
+	var PASSWORD_PLACEHOLDER = '**********';
+	var PASSWORD_PLACEHOLDER_MESSAGE = t('core', 'Choose a password for the public link');
+
 	var TEMPLATE =
 			'{{#if shareAllowed}}' +
 			'<span class="icon-loading-small hidden"></span>' +
@@ -133,11 +136,6 @@
 					this.model.saveLinkShare();
 				} else {
 					this.$el.find('.linkPass').slideToggle(OC.menuSpeed);
-					// TODO drop with IE8 drop
-					if($('html').hasClass('ie8')) {
-						this.$el.find('.linkPassText').attr('placeholder', null);
-						this.$el.find('.linkPassText').val('');
-					}
 					this.$el.find('.linkPassText').focus();
 				}
 			} else {
@@ -182,7 +180,8 @@
 			var $input = this.$el.find('.linkPassText');
 			$input.removeClass('error');
 			var password = $input.val();
-			if(password === '') {
+			// in IE9 the password might be the placeholder due to bugs in the placeholders polyfill
+			if(password === '' || password === PASSWORD_PLACEHOLDER || password === PASSWORD_PLACEHOLDER_MESSAGE) {
 				return;
 			}
 
@@ -276,7 +275,7 @@
 				urlLabel: t('core', 'Link'),
 				enablePasswordLabel: t('core', 'Password protect'),
 				passwordLabel: t('core', 'Password'),
-				passwordPlaceholder: isPasswordSet ? '**********' : t('core', 'Choose a password for the public link'),
+				passwordPlaceholder: isPasswordSet ? PASSWORD_PLACEHOLDER : PASSWORD_PLACEHOLDER_MESSAGE,
 				isPasswordSet: isPasswordSet,
 				showPasswordCheckBox: showPasswordCheckBox,
 				publicUpload: publicUpload && isLinkShare,
@@ -312,6 +311,12 @@
 						.append('<a>' + escapeHTML(item.displayname) + "<br>" + escapeHTML(item.email) + '</a>' )
 						.appendTo( ul );
 				};
+			}
+
+			// TODO drop with IE8 drop
+			if($('html').hasClass('ie8')) {
+				this.$el.find('#linkPassText').removeAttr('placeholder');
+				this.$el.find('#linkPassText').val('');
 			}
 
 			this.delegateEvents();


### PR DESCRIPTION
When exiting the password field in the share dialog, IE9 would
mistakenly think that the password has changed and would send the
placeholder.

This fix prevents changing the password whenever the placeholder is set
as value.

Fixes https://github.com/owncloud/core/issues/16511#issuecomment-148668819

@davitol @MorrisJobke @rullzer @nickvergessen 
