### PR TITLE
Normalize file names for comparison with array

### DIFF
--- a/lib/private/files/storage/wrapper/normalizedirwrapper.php
+++ b/lib/private/files/storage/wrapper/normalizedirwrapper.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage\Wrapper;
+
+use Icewind\Streams\Directory;
+
+class NormalizeDirWrapper implements Directory {
+	/**
+	 * @var resource
+	 */
+	public $context;
+
+	/**
+	 * @var resource
+	 */
+	protected $source;
+
+	/**
+	 * Load the source from the stream context and return the context options
+	 *
+	 * @param string $name
+	 * @return array
+	 * @throws \Exception
+	 */
+	protected function loadContext($name) {
+		$context = stream_context_get_options($this->context);
+		if (isset($context[$name])) {
+			$context = $context[$name];
+		} else {
+			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
+		}
+		if (isset($context['source']) and is_resource($context['source'])) {
+			$this->source = $context['source'];
+		} else {
+			throw new \BadMethodCallException('Invalid context, source not set');
+		}
+		return $context;
+	}
+
+	/**
+	 * @param string $path
+	 * @param array $options
+	 * @return bool
+	 */
+	public function dir_opendir($path, $options) {
+		$this->loadContext('dir');
+		return true;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function dir_readdir() {
+		$file = readdir($this->source);
+		if ($file === '.' || $file === '..') {
+			return $this->dir_readdir();
+		}
+		if ($file !== false) {
+			$file = normalizer_normalize($file);
+		}
+		return $file;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function dir_closedir() {
+		closedir($this->source);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function dir_rewinddir() {
+		rewinddir($this->source);
+	}
+
+	/**
+	 * Creates a directory handle from the provided array or iterator
+	 *
+	 * @param resource $source
+	 * @return resource
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public static function wrap($source) {
+		$context = stream_context_create(array(
+			'dir' => array(
+				'source' => $source)
+		));
+		stream_wrapper_register('normalize', '\OC\Files\Storage\Wrapper\NormalizeDirWrapper');
+		$wrapped = opendir('normalize://', $context);
+		stream_wrapper_unregister('normalize');
+		return $wrapped;
+	}
+}

--- a/lib/private/files/storage/wrapper/normalizedirwrapper.php
+++ b/lib/private/files/storage/wrapper/normalizedirwrapper.php
@@ -71,9 +71,6 @@ class NormalizeDirWrapper implements Directory {
 	 */
 	public function dir_readdir() {
 		$file = readdir($this->source);
-		if ($file === '.' || $file === '..') {
-			return $this->dir_readdir();
-		}
 		if ($file !== false) {
 			$file = normalizer_normalize($file);
 		}

--- a/lib/private/files/storage/wrapper/normalizewrapper.php
+++ b/lib/private/files/storage/wrapper/normalizewrapper.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage\Wrapper;
+
+class NormalizeWrapper extends Wrapper {
+	public function opendir($path) {
+		return NormalizeDirWrapper::wrap(parent::opendir($path));
+	}
+}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -146,6 +146,14 @@ class OC_Util {
 			return $storage;
 		});
 
+		\OC\Files\Filesystem::addStorageWrapper('normalizer', function ($mountPoint, \OCP\Files\Storage $storage, \OCP\Files\Mount\IMountPoint $mount) {
+			if(!$storage->instanceOfStorage('\OC\Files\Storage\Wrapper\NormalizeWrapper')) {
+				return new \OC\Files\Storage\Wrapper\NormalizeWrapper(['storage' => $storage]);
+			} else {
+				return $storage;
+			}
+		});
+
 		// install storage availability wrapper, before most other wrappers
 		\OC\Files\Filesystem::addStorageWrapper('oc_availability', function ($mountPoint, $storage) {
 			if (!$storage->isLocal()) {

--- a/tests/lib/files/storage/wrapper/normalizedirwrapper.php
+++ b/tests/lib/files/storage/wrapper/normalizedirwrapper.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage\Wrapper;
+
+use Icewind\Streams\IteratorDirectory;
+use Test\TestCase;
+
+class NormalizeDirWrapper extends TestCase {
+	public function specialNameProvider() {
+		return [
+			['a', 'a'],
+			['Å', 'Å'], //U+0041 U+030A(NFD), U+00C5(NFC)
+		];
+	}
+
+	/**
+	 * @param string $file
+	 * @param string $expected
+	 * @dataProvider specialNameProvider
+	 */
+	public function testReadSingle($file, $expected) {
+		$source = IteratorDirectory::wrap([$file]);
+		$wrapped = \OC\Files\Storage\Wrapper\NormalizeDirWrapper::wrap($source);
+		$result = readdir($wrapped);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function folderProvider() {
+		return [
+			[['foo', 'bar', 'asd']],
+			[[]]
+		];
+	}
+
+	/**
+	 * @param string[] $files
+	 * @dataProvider folderProvider
+	 */
+	public function testFolderBasics($files) {
+		$source = IteratorDirectory::wrap($files);
+		$wrapped = \OC\Files\Storage\Wrapper\NormalizeDirWrapper::wrap($source);
+
+		$firstResult = readdir($wrapped);
+		rewinddir($wrapped);
+		$this->assertEquals($firstResult, readdir($wrapped));
+
+		rewinddir($wrapped);
+		$result = [];
+		while (($file = readdir($wrapped)) !== false) {
+			$result[] = $file;
+		}
+		$this->assertEquals($files, $result);
+	}
+
+	public function folderFilterProvider() {
+		return [
+			[['.', '..', 'foo', 'bar', 'asd'], ['foo', 'bar', 'asd']],
+			[[], []],
+			[['asd'], ['asd']]
+		];
+	}
+
+	/**
+	 * @param string[] $files
+	 * @param string[] $expected
+	 * @dataProvider folderFilterProvider
+	 */
+	public function testFilterParentAndSelf($files, $expected) {
+		$source = IteratorDirectory::wrap($files);
+		$wrapped = \OC\Files\Storage\Wrapper\NormalizeDirWrapper::wrap($source);
+
+		$result = [];
+		while (($file = readdir($wrapped)) !== false) {
+			$result[] = $file;
+		}
+		$this->assertEquals($expected, $result);
+	}
+}

--- a/tests/lib/files/storage/wrapper/normalizedirwrapper.php
+++ b/tests/lib/files/storage/wrapper/normalizedirwrapper.php
@@ -70,28 +70,4 @@ class NormalizeDirWrapper extends TestCase {
 		}
 		$this->assertEquals($files, $result);
 	}
-
-	public function folderFilterProvider() {
-		return [
-			[['.', '..', 'foo', 'bar', 'asd'], ['foo', 'bar', 'asd']],
-			[[], []],
-			[['asd'], ['asd']]
-		];
-	}
-
-	/**
-	 * @param string[] $files
-	 * @param string[] $expected
-	 * @dataProvider folderFilterProvider
-	 */
-	public function testFilterParentAndSelf($files, $expected) {
-		$source = IteratorDirectory::wrap($files);
-		$wrapped = \OC\Files\Storage\Wrapper\NormalizeDirWrapper::wrap($source);
-
-		$result = [];
-		while (($file = readdir($wrapped)) !== false) {
-			$result[] = $file;
-		}
-		$this->assertEquals($expected, $result);
-	}
 }


### PR DESCRIPTION
Mac OS X uses the NFD normalization form to encode UTF-8, this leads to the problem that the values compared in the array are differently encoded making these tests on OS X fail.

Personally I'd more prefer if we would have a wrapper around readdir adressing encoding issues as there are a lot of encoding issues on different filesystems. Evert has done an interesting write-up: http://evertpot.com/filesystem-encoding-and-php/

Fixes the following failing tests:

```
/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

2) Test\Files\Storage\CopyDirectory::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

3) Test\Files\Storage\Home::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

4) Test\Files\Storage\Local::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

5) Test\Files\Storage\Wrapper\Encryption::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

6) Test\Files\Storage\Wrapper\Jail::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

7) Test\Files\Storage\Wrapper\PermissionsMask::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

8) Test\Files\Storage\Wrapper\Quota::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )

/Users/lukasreschke/Documents/Programming/master/tests/lib/files/storage/storage.php:88

9) Test\Files\Storage\Wrapper\Wrapper::testDirectories with data set #4 ('spéciäl földer')
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'spéciäl földer'
+    0 => 'spéciäl földer'
 )
```

@MorrisJobke @icewind1991 THX.
