### PR TITLE
[IE9] Prevent LDAP password field to become plain text

### DIFF
--- a/apps/user_ldap/js/wizard/wizardTabElementary.js
+++ b/apps/user_ldap/js/wizard/wizardTabElementary.js
@@ -137,6 +137,10 @@ OCA = OCA || {};
 			this.setElementValue(
 				this.managedItems.ldap_agent_password.$element, agentPwd
 			);
+			if (agentPwd && $('html').hasClass('lte9')) {
+				// make it a password field again (IE fix, placeholders bug)
+				this.managedItems.ldap_agent_password.$element.attr('type', 'password');
+			}
 		},
 		/**
 		 * updates the base DN text area


### PR DESCRIPTION
The placeholders library converts the password field to a text field to
achieve placeholders functionality. However this is buggy and doesn't
properly mask the password when it was set through $el.val().

This workaround sets the type back to password directly after setting a
value.

Fixes https://github.com/owncloud/core/issues/19330

Please review @blizzz @davitol @MorrisJobke @LukasReschke 
