### PR TITLE
Fix spinner positions in share tab

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -6,7 +6,6 @@
 
 .shareTabView .shareWithLoading {
 	padding-left: 10px;
-	position: relative;
 	right: 30px;
 	top: 2px;
 }
@@ -73,9 +72,18 @@
 }
 
 .shareTabView .icon-loading-small {
-	position: absolute;
 	display: inline-block;
 	z-index: 1;
 	background-color: white;
-	padding: 2px;
+	padding: 2px 0;
 }
+
+.shareTabView .shareWithList .icon-loading-small,
+.shareTabView .linkShareView .icon-loading-small {
+	position: absolute;
+}
+
+.shareTabView .linkPass .icon-loading-small {
+	margin-top: 9px;
+}
+

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -141,6 +141,7 @@
 					this.$el.find('.linkPassText').focus();
 				}
 			} else {
+				$loading.removeClass('hidden');
 				if (this.model.get('linkShare').isLinkShare) {
 					this.model.removeLinkShare();
 				} else {


### PR DESCRIPTION
Also fix missing spinner when removing link share.
Fix autocomplete spinner to properly be inside the field.
Better alignment of spinner over checkboxes.

Before: (notice the misplaced spinner on the top right)
![spinner-before](https://cloud.githubusercontent.com/assets/277525/10543395/5f2026ea-741e-11e5-9084-12140653e103.png)

After:
![spinner-after](https://cloud.githubusercontent.com/assets/277525/10543400/63d740c4-741e-11e5-881e-ee6042903e14.png)

@jancborchardt @Henni @rullzer @MorrisJobke 
