### PR TITLE
On rename, also refresh storage_mtime of the target file

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -313,6 +313,14 @@ class Cache {
 		$fields = array(
 			'path', 'parent', 'name', 'mimetype', 'size', 'mtime', 'storage_mtime', 'encrypted',
 			'etag', 'permissions');
+
+		$doNotCopyStorageMTime = false;
+		if (array_key_exists('mtime', $data) && $data['mtime'] === null) {
+			// this horrific magic tells it to not copy storage_mtime to mtime
+			unset($data['mtime']);
+			$doNotCopyStorageMTime = true;
+		}
+
 		$params = array();
 		$queryParts = array();
 		foreach ($data as $name => $value) {
@@ -325,7 +333,7 @@ class Cache {
 					$queryParts[] = '`mimepart`';
 					$value = $this->mimetypeLoader->getId($value);
 				} elseif ($name === 'storage_mtime') {
-					if (!isset($data['mtime'])) {
+					if (!$doNotCopyStorageMTime && !isset($data['mtime'])) {
 						$params[] = $value;
 						$queryParts[] = '`mtime`';
 					}

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -193,9 +193,23 @@ class Updater {
 			$targetCache->correctFolderSize($targetInternalPath);
 			$this->correctParentStorageMtime($sourceStorage, $sourceInternalPath);
 			$this->correctParentStorageMtime($targetStorage, $targetInternalPath);
+			$this->updateStorageMTimeOnly($targetStorage, $targetInternalPath);
 			$this->propagator->addChange($source);
 			$this->propagator->addChange($target);
 			$this->propagator->propagateChanges();
+		}
+	}
+
+	private function updateStorageMTimeOnly($storage, $internalPath) {
+		$cache = $storage->getCache();
+		$fileId = $cache->getId($internalPath);
+		if ($fileId !== -1) {
+			$cache->update(
+				$fileId, [
+					'mtime' => null, // this magic tells it to not overwrite mtime
+					'storage_mtime' => $storage->filemtime($internalPath)
+				]
+			);
 		}
 	}
 

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -1976,8 +1976,12 @@ class View extends \Test\TestCase {
 		$view = new \OC\Files\View('/' . $this->user . '/files/');
 
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
-			->setMethods([$operation])
+			->setMethods([$operation, 'filemtime'])
 			->getMock();
+
+		$storage->expects($this->any())
+			->method('filemtime')
+			->will($this->returnValue(123456789));
 
 		$sourcePath = 'original.txt';
 		$targetPath = 'target.txt';
@@ -2117,8 +2121,12 @@ class View extends \Test\TestCase {
 			->setMethods([$storageOperation])
 			->getMock();
 		$storage2 = $this->getMockBuilder('\OC\Files\Storage\Temporary')
-			->setMethods([$storageOperation])
+			->setMethods([$storageOperation, 'filemtime'])
 			->getMock();
+
+		$storage2->expects($this->any())
+			->method('filemtime')
+			->will($this->returnValue(123456789));
 
 		$sourcePath = 'original.txt';
 		$targetPath = 'substorage/target.txt';


### PR DESCRIPTION
This is to make it work with Dropbox which changes the mtime value of the remote file on rename.

@icewind1991 please advise, I'm not sure this is the right approach. Also this adds an additional DB update and would affect every other storage out there.
