### PR TITLE
Share2.0 sharemanager

### DIFF
--- a/apps/files_sharing/api/ocssharewrapper.php
+++ b/apps/files_sharing/api/ocssharewrapper.php
@@ -22,8 +22,11 @@ namespace OCA\Files_Sharing\API;
 
 class OCSShareWrapper {
 
+	/**
+	 * @return Share20OCS
+	 */
 	private function getShare20OCS() {
-		return new share20OCS(new \OC\Share20\Manager(
+		return new Share20OCS(new \OC\Share20\Manager(
 		                   \OC::$server->getUserSession()->getUser(),
 		                   \OC::$server->getUserManager(),
 		                   \OC::$server->getGroupManager(),
@@ -31,7 +34,10 @@ class OCSShareWrapper {
 		                   \OC::$server->getAppConfig(),
 		                   \OC::$server->getUserFolder(),
 		                    new \OC\Share20\DefaultShareProvider(
-		                       \OC::$server->getDatabaseConnection()
+		                       \OC::$server->getDatabaseConnection(),
+							   \OC::$server->getUserManager(),
+							   \OC::$server->getGroupManager(),
+							   \OC::$server->getUserFolder()
 		                   )
 		               ),
 		               \OC::$server->getGroupManager(),
@@ -57,6 +63,7 @@ class OCSShareWrapper {
 	}
 
 	public function deleteShare($params) {
-		return \OCA\Files_Sharing\API\Local::deleteShare($params);
+		$id = (int)$params['id'];
+		return $this->getShare20OCS()->deleteShare($id);
 	}
 }

--- a/apps/files_sharing/api/ocssharewrapper.php
+++ b/apps/files_sharing/api/ocssharewrapper.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\API;
+
+class OCSShareWrapper {
+
+	private function getShare20OCS() {
+		return new share20OCS(new \OC\Share20\Manager(
+		                   \OC::$server->getUserSession()->getUser(),
+		                   \OC::$server->getUserManager(),
+		                   \OC::$server->getGroupManager(),
+		                   \OC::$server->getLogger(),
+		                   \OC::$server->getAppConfig(),
+		                   \OC::$server->getUserFolder(),
+		                    new \OC\Share20\DefaultShareProvider(
+		                       \OC::$server->getDatabaseConnection()
+		                   )
+		               ),
+		               \OC::$server->getGroupManager(),
+		               \OC::$server->getUserManager(),
+		               \OC::$server->getRequest(),
+		               \OC::$server->getUserFolder());
+	}
+
+	public function getAllShares($params) {
+		return \OCA\Files_Sharing\API\Local::getAllShares($params);
+	}
+
+	public function createShare($params) {
+		return \OCA\Files_Sharing\API\Local::createShare($params);
+	}
+
+	public function getShare($params) {
+		return \OCA\Files_Sharing\API\Local::getShare($params);
+	}
+
+	public function updateShare($params) {
+		return \OCA\Files_Sharing\API\Local::updateShare($params);
+	}
+
+	public function deleteShare($params) {
+		return \OCA\Files_Sharing\API\Local::deleteShare($params);
+	}
+}

--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\API;
+
+class Share20OCS {
+
+	/** @var OC\Share20\Manager */
+	private $shareManager;
+
+	/** @var OCP\IGroupManager */
+	private $groupManager;
+
+	/** @var OCP\IUserManager */
+	private $userManager;
+
+	/** @var OCP\IRequest */
+	private $request;
+
+	/** @var OCP\Files\Folder */
+	private $userFolder;
+
+	public function __construct(\OC\Share20\Manager $shareManager,
+	                            \OCP\IGroupManager $groupManager,
+	                            \OCP\IUserManager $userManager,
+	                            \OCP\IRequest $request,
+								\OCP\Files\Folder $userFolder) {
+		$this->shareManager = $shareManager;
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->request = $request;
+		$this->userFolder = $userFolder;
+	}
+
+	/**
+	 * Delete a share
+	 *
+	 * @param int $id
+	 * @return \OC_OCS_Result
+	 */
+	public function deleteShare($id) {
+		try {
+			$share = $this->shareManager->getShareById($id);
+		} catch (\OC\Share20\Exception\ShareNotFound $e) {
+			return new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
+		}
+
+		try {
+			$this->shareManager->deleteShare($share);
+		} catch (\OC\Share20\Exception\BackendError $e) {
+			return new \OC_OCS_Result(null, 404, 'could not delete share');
+		}
+
+		return new \OC_OCS_Result();
+	}
+}

--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -62,6 +62,14 @@ class Share20OCS {
 			return new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
 		}
 
+		/*
+		 * FIXME
+		 * User the old code path for remote shares until we have our remoteshareprovider
+		 */
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_REMOTE) {
+			\OCA\Files_Sharing\API\Local::deleteShare(['id' => $id]);
+		}
+
 		try {
 			$this->shareManager->deleteShare($share);
 		} catch (\OC\Share20\Exception\BackendError $e) {

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -61,29 +61,31 @@ $this->create('sharing_external_add', '/external')
 
 //TODO: SET: mail notification, waiting for PR #4689 to be accepted
 
+$OCSShare = new \OCA\Files_Sharing\API\OCSShareWrapper();
+
 API::register('get',
 		'/apps/files_sharing/api/v1/shares',
-		array('\OCA\Files_Sharing\API\Local', 'getAllShares'),
+		[$OCSShare, 'getAllShares'],
 		'files_sharing');
 
 API::register('post',
 		'/apps/files_sharing/api/v1/shares',
-		array('\OCA\Files_Sharing\API\Local', 'createShare'),
+		[$OCSShare, 'createShare'],
 		'files_sharing');
 
 API::register('get',
 		'/apps/files_sharing/api/v1/shares/{id}',
-		array('\OCA\Files_Sharing\API\Local', 'getShare'),
+		[$OCSShare, 'getShare'],
 		'files_sharing');
 
 API::register('put',
 		'/apps/files_sharing/api/v1/shares/{id}',
-		array('\OCA\Files_Sharing\API\Local', 'updateShare'),
+		[$OCSShare, 'updateShare'],
 		'files_sharing');
 
 API::register('delete',
 		'/apps/files_sharing/api/v1/shares/{id}',
-		array('\OCA\Files_Sharing\API\Local', 'deleteShare'),
+		[$OCSShare, 'deleteShare'],
 		'files_sharing');
 
 API::register('get',
@@ -130,3 +132,4 @@ API::register('get',
 		'/apps/files_sharing/api/v1/sharees',
 		[$sharees, 'search'],
 		'files_sharing', API::USER_AUTH);
+

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Tests\API;
+
+use OCA\Files_Sharing\API\Share20OCS;
+
+class Share20OCSTest extends \Test\TestCase {
+
+	/** @var OC\Share20\Manager */
+	private $shareManager;
+
+	/** @var OCP\IGroupManager */
+	private $groupManager;
+
+	/** @var OCP\IUserManager */
+	private $userManager;
+
+	/** @var OCP\IRequest */
+	private $request;
+
+	/** @var OCP\Files\Folder */
+	private $userFolder;
+
+	/** @var OCS */
+	private $ocs;
+
+	protected function setUp() {
+		$this->shareManager = $this->getMockBuilder('OC\Share20\Manager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userFolder = $this->getMockBuilder('OCP\Files\Folder')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->ocs = new Share20OCS($this->shareManager,
+									$this->groupManager,
+									$this->userManager,
+									$this->request,
+									$this->userFolder);
+	}
+
+	public function testDeleteShareShareNotFound() {
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->will($this->throwException(new \OC\Share20\Exception\ShareNotFound()));
+
+		$expected = new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
+		$this->assertEquals($expected, $this->ocs->deleteShare(42));
+	}
+
+	public function testDeleteShareCouldNotDelete() {
+		$share = $this->getMock('OC\Share20\IShare');
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->willReturn($share);
+		$this->shareManager
+			->expects($this->once())
+			->method('deleteShare')
+			->with($share)
+			->will($this->throwException(new \OC\Share20\Exception\BackendError()));
+
+
+		$expected = new \OC_OCS_Result(null, 404, 'could not delete share');
+		$this->assertEquals($expected, $this->ocs->deleteShare(42));
+	}
+
+	public function testDeleteShare() {
+		$share = $this->getMock('OC\Share20\IShare');
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->willReturn($share);
+		$this->shareManager
+			->expects($this->once())
+			->method('deleteShare')
+			->with($share);
+
+		$expected = new \OC_OCS_Result();
+		$this->assertEquals($expected, $this->ocs->deleteShare(42));
+	}
+}

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+use OC\Share20\Exception\ShareNotFound;
+use OC\Share20\Exception\BackendError;
+use OCP\IUser;
+
+class DefaultShareProvider implements IShareProvider {
+
+	/** @var \OCP\IDBConnection */
+	private $dbConn;
+
+	/** @var \OCP\IUserManager */
+	private $userManager;
+
+	/** @var \OCP\IGroupManager */
+	private $groupManager;
+
+	/** @var \OCP\Files\Folder */
+	private $userFolder;
+
+	public function __construct(\OCP\IDBConnection $connection,
+								\OCP\IUserManager $userManager,
+								\OCP\IGroupManager $groupManager,
+								\OCP\Files\Folder $userFolder) {
+		$this->dbConn = $connection;
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->userFolder = $userFolder;
+	}
+
+	/**
+	 * Share a path
+	 * 
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function create(Share $share) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Update a share
+	 *
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function update(Share $share) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get all childre of this share
+	 *
+	 * @param IShare $share
+	 * @return IShare[]
+	 */
+	private function getChildren(IShare $share) {
+		$children = [];
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('*')
+			->from('share')
+			->where($qb->expr()->eq('parent', $qb->createParameter('parent')))
+			->setParameter(':parent', $share->getId());
+
+		$cursor = $qb->execute();
+		while($data = $cursor->fetch()) {
+			$children[] = $this->createShare($data);
+		}
+		$cursor->closeCursor();
+
+		return $children;
+	}
+
+	/**
+	 * Delete all the children of this share
+	 *
+	 * @param IShare $share
+	 */
+	protected function deleteChildren(IShare $share) {
+		foreach($this->getChildren($share) as $child) {
+			$this->delete($child);
+		}
+	}
+
+	/**
+	 * Delete a share
+	 *
+	 * @param Share $share
+	 * @throws BackendError
+	 */
+	public function delete(IShare $share) {
+		$this->deleteChildren($share);
+
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->delete('share')
+			->where($qb->expr()->eq('id', $qb->createParameter('id')))
+			->setParameter(':id', $share->getId());
+	
+		try {
+			$qb->execute();
+		} catch (\Exception $e) {
+			throw new BackendError();
+		}
+	}
+
+	/**
+	 * Get all shares by the given user
+	 *
+	 * @param IUser $user
+	 * @param int $shareType
+	 * @param int $offset
+	 * @param int $limit
+	 * @return Share[]
+	 */
+	public function getShares(IUser $user, $shareType, $offset, $limit) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get share by id
+	 *
+	 * @param int $id
+	 * @return IShare
+	 * @throws ShareNotFound
+	 */
+	public function getShareById($id) {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->select('*')
+			->from('share')
+			->where($qb->expr()->eq('id', $qb->createParameter('id')))
+			->setParameter(':id', $id);
+		
+		$cursor = $qb->execute();
+		$data = $cursor->fetch();
+		$cursor->closeCursor();
+
+		if ($data === false) {
+			throw new ShareNotFound();
+		}
+
+		$share = $this->createShare($data);
+
+		return $share;
+	}
+
+	/**
+	 * Get shares for a given path
+	 *
+	 * @param \OCP\Files\Node $path
+	 * @param Share[]
+	 */
+	public function getSharesByPath(\OCP\IUser $user, \OCP\Files\Node $path) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get shared with the given user
+	 *
+	 * @param IUser $user
+	 * @param int $shareType
+	 * @param Share
+	 */
+	public function getSharedWithMe(IUser $user, $shareType = null) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get a share by token and if present verify the password
+	 *
+	 * @param string $token
+	 * @param string $password
+	 * @param Share
+	 */
+	public function getShareByToken($token, $password = null) {
+		throw new \Exception();
+	}
+	
+	/**
+	 * Create a share object from an database row
+	 *
+	 * @param mixed[] $data
+	 * @return Share
+	 */
+	private function createShare($data) {
+		$share = new Share();
+		$share->setId((int)$data['id'])
+			->setShareType((int)$data['share_type'])
+			->setPermissions((int)$data['permissions']);
+
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+			$share->setSharedWith($this->userManager->get($data['share_with']));
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$share->setSharedWith($this->groupManager->get($data['share_with']));
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+			/*
+			 * TODO: Clean this up, this should be set as password not sharedWith
+			 */
+			$share->setSharedWith($data['share_with']);
+			$share->setToken($data['token']);
+		} else {
+			$share->setSharedWith($data['share_with']);
+		}
+
+		$share->setSharedBy($this->userManager->get($data['uid_owner']));
+
+		// TODO: getById can return an array. How to handle this properly??
+		$path = $this->userFolder->getById($data['file_source']);
+		$path = $path[0];
+		$share->setPath($path);
+
+		$owner = $path->getStorage()->getOwner('.');
+		if ($owner !== false) {
+			$share->setShareOwner($this->userManager->get($owner));
+		}
+
+		if ($data['expiration'] !== null) {
+			$expiration = \DateTime::createFromFormat('Y-m-d H:i:s', $data['expiration']);
+			$share->setExpirationDate($expiration);
+		}
+
+		return $share;
+	}
+
+
+}

--- a/lib/private/share20/exception/backenderror.php
+++ b/lib/private/share20/exception/backenderror.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20\Exception;
+
+class BackendError extends \Exception {
+
+}

--- a/lib/private/share20/exception/sharenotfound.php
+++ b/lib/private/share20/exception/sharenotfound.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20\Exception;
+
+class ShareNotFound extends \Exception {
+
+}

--- a/lib/private/share20/ishare.php
+++ b/lib/private/share20/ishare.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\IUser;
+use OCP\IGroup;
+
+interface IShare {
+
+	/**
+	 * Get the id of the share
+	 *
+	 * @return string
+	 */
+	public function getId();
+
+	/**
+	 * Set the path of this share
+	 *
+	 * @param File|Folder $path
+	 * @return Share The modified object
+	 */
+	public function setPath(Node $path);
+
+	/**
+	 * Get the path of this share for the current user
+	 * 
+	 * @return File|Folder
+	 */
+	public function getPath();
+
+	/**
+	 * Set the shareType
+	 *
+	 * @param int $shareType
+	 * @return Share The modified object
+	 */
+	public function setShareType($shareType);
+
+	/**
+	 * Get the shareType 
+	 *
+	 * @return int
+	 */
+	public function getShareType();
+
+	/**
+	 * Set the receiver of this share
+	 *
+	 * @param IUser|IGroup|string
+	 * @return Share The modified object
+	 */
+	public function setSharedWith($sharedWith);
+
+	/**
+	 * Get the receiver of this share
+	 *
+	 * @return IUser|IGroup|string
+	 */
+	public function getSharedWith();
+
+	/**
+	 * Set the permissions
+	 *
+	 * @param int $permissions
+	 * @return Share The modified object
+	 */
+	public function setPermissions($permissions);
+
+	/**
+	 * Get the share permissions
+	 *
+	 * @return int
+	 */
+	public function getPermissions();
+
+	/**
+	 * Set the expiration date
+	 *
+	 * @param \DateTime $expireDate
+	 * @return Share The modified object
+	 */
+	public function setExpirationDate(\DateTime $expireDate);
+
+	/**
+	 * Get the share expiration date
+	 *
+	 * @return \DateTime
+	 */
+	public function getExpirationDate();
+
+	/**
+	 * Get share sharer
+	 *
+	 * @return IUser|string
+	 */
+	public function getSharedBy();
+
+	/**
+	 * Get the original share owner (who owns the path)
+	 * 
+	 * @return IUser|string
+	 */
+	public function getShareOwner();
+
+	/**
+	 * Set the password
+	 *
+	 * @param string $password
+	 *
+	 * @return Share The modified object
+	 */
+	public function setPassword($password);
+
+	/**
+	 * Get the token
+	 *
+	 * @return string
+	 */
+	public function getToken();
+
+	/**
+	 * Get the parent it
+	 *
+	 * @return int
+	 */
+	public function getParent();
+}

--- a/lib/private/share20/ishare.php
+++ b/lib/private/share20/ishare.php
@@ -146,4 +146,11 @@ interface IShare {
 	 * @return int
 	 */
 	public function getParent();
+
+	/**
+	 * Get the target of this share
+	 *
+	 * @return string
+	 */
+	public function getTarget();
 }

--- a/lib/private/share20/ishareprovider.php
+++ b/lib/private/share20/ishareprovider.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+use OCP\IUser;
+
+interface IShareProvider {
+
+	/**
+	 * Share a path
+	 * 
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function create(Share $share);
+
+	/**
+	 * Update a share
+	 *
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function update(Share $share);
+
+	/**
+	 * Delete a share
+	 *
+	 * @param Share $share
+	 */
+	public function delete(Share $share);
+
+	/**
+	 * Get all shares by the given user
+	 *
+	 * @param IUser $user
+	 * @param int $shareType
+	 * @param int $offset
+	 * @param int $limit
+	 * @return Share[]
+	 */
+	public function getShares(IUser $user, $shareType, $offset, $limit);
+
+	/**
+	 * Get share by id
+	 *
+	 * @param int $id
+	 * @return Share
+	 */
+	public function getShareById($id);
+
+	/**
+	 * Get shares for a given path
+	 *
+	 * @param \OCP\Files\Node $path
+	 * @param Share[]
+	 */
+	public function getSharesByPath(\OCP\IUser $user, \OCP\Files\Node $path);
+
+	/**
+	 * Get shared with the given user
+	 *
+	 * @param IUser $user
+	 * @param int $shareType
+	 * @param Share
+	 */
+	public function getSharedWithMe(IUser $user, $shareType = null);
+
+	/**
+	 * Get a share by token and if present verify the password
+	 *
+	 * @param string $token
+	 * @param string $password
+	 * @param Share
+	 */
+	public function getShareByToken($token, $password = null);
+}

--- a/lib/private/share20/ishareprovider.php
+++ b/lib/private/share20/ishareprovider.php
@@ -20,6 +20,8 @@
  */
 namespace OC\Share20;
 
+use OC\Share20\Exception\ShareNotFound;
+use OC\Share20\Exception\BackendError;
 use OCP\IUser;
 
 interface IShareProvider {
@@ -44,8 +46,9 @@ interface IShareProvider {
 	 * Delete a share
 	 *
 	 * @param Share $share
+	 * @throws BackendError
 	 */
-	public function delete(Share $share);
+	public function delete(IShare $share);
 
 	/**
 	 * Get all shares by the given user
@@ -62,7 +65,8 @@ interface IShareProvider {
 	 * Get share by id
 	 *
 	 * @param int $id
-	 * @return Share
+	 * @return IShare
+	 * @throws ShareNotFound
 	 */
 	public function getShareById($id);
 

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+
+use OCP\IAppConfig;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\ILogger;
+use OCP\Files\Folder;
+
+use OC\Share20\Exceptions\ShareNotFoundException;
+use OC\Share20\Exception\PreconditionFailed;
+
+/**
+ * This class is the communication hub for all sharing related operations.
+ */
+class Manager {
+
+	/**
+	 * @var IShareProvider[]
+	 */
+	private $shareProviders;
+
+	/**
+	 * @var string[]
+	 */
+	private $shareTypeToProviderId;
+
+	/** @var IUser */
+	private $currentUser;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var IGroupManager */
+	private $groupManager;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var IAppConfig */
+	private $appConfig;
+
+	/** @var IFolder */
+	private $userFolder;
+
+	public function __construct(IUser $user,
+								IUserManager $userManager,
+								IGroupManager $groupManager,
+								ILogger $logger,
+								IAppConfig $appConfig,
+								Folder $userFolder,
+								IShareProvider $defaultProvider) {
+		$this->currentUser = $user;
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->logger = $logger;
+		$this->appConfig = $appConfig;
+		$this->userFolder = $userFolder;
+
+		// TEMP SOLUTION JUST TO GET STARTED
+		$this->shareProviders['ocdef'] = $defaultProvider;
+		$this->shareTypeToProviderId = [
+			\OCP\Share::SHARE_TYPE_USER  => 'ocdef',
+			\OCP\Share::SHARE_TYPE_GROUP => 'ocdef',
+			\OCP\Share::SHARE_TYPE_LINK  => 'ocdef',
+		];
+
+		// TODO: Get storage share provider from primary storage
+	}
+
+	/**
+	 * Get a ShareProvider
+	 *
+	 * @param string $id
+	 * @return IShareProvider
+	 */
+	private function getShareProvider($id) {
+		if (!isset($this->shareProviders[$id])) {
+			//Throw exception;
+		}
+
+		// Check if we have instanciated this provider yet
+		if (!($this->shareProviders[$id] instanceOf \OC\Share20\IShareProvider)) {
+			throw new \Exception();
+		}
+
+		return $this->shareProviders[$id];
+	}
+
+	/**
+	 * Get shareProvider based on shareType
+	 *
+	 * @param int $shareType
+	 * @return IShareProvider
+	 */
+	private function getShareProviderByType($shareType) {
+		if (!isset($this->shareTypeToProviderId[$shareType])) {
+			//Throw exception
+		}
+
+		return $this->getShareProvider($this->shareTypeToProviderId[$shareType]);
+	}
+
+	/**
+	 * Share a path
+	 * 
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function createShare(Share $share) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Update a share
+	 *
+	 * @param Share $share
+	 * @return Share The share object
+	 */
+	public function updateShare(Share $share) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Delete a share
+	 *
+	 * @param Share $share
+	 */
+	public function deleteShare(Share $share) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Retrieve all shares by the current user
+	 *
+	 * @param int $page
+	 * @param int $perPage
+	 * @return Share[]
+	 */
+	public function getShares($page=0, $perPage=50) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Retrieve a share by the share id
+	 *
+	 * @param string $id
+	 * @return Share
+	 *
+	 * @throws ShareNotFoundException
+	 */
+	public function getShareById($id) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get all the shares for a given path
+	 *
+	 * @param \OCP\Files\Node $path
+	 * @param int $page
+	 * @param int $perPage
+	 *
+	 * @return Share[]
+	 */
+	public function getSharesByPath(\OCP\Files\Node $path, $page=0, $perPage=50) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get all shares that are shared with the current user
+	 *
+	 * @param int $shareType
+	 * @param int $page
+	 * @param int $perPage
+	 *
+	 * @return Share[]
+	 */
+	public function getSharedWithMe($shareType = null, $page=0, $perPage=50) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get the share by token possible with password
+	 *
+	 * @param string $token
+	 * @param string $password
+	 *
+	 * @return Share
+	 *
+	 * @throws ShareNotFoundException
+	 */
+	public function getShareByToken($token, $password=null) {
+		throw new \Exception();
+	}
+
+	/**
+	 * Get access list to a path. This means
+	 * all the users and groups that can access a given path.
+	 *
+	 * Consider:
+	 * -root
+	 * |-folder1
+	 *  |-folder2
+	 *   |-fileA
+	 *
+	 * fileA is shared with user1
+	 * folder2 is shared with group2
+	 * folder1 is shared with user2
+	 *
+	 * Then the access list will to '/folder1/folder2/fileA' is:
+	 * [
+	 * 	'users' => ['user1', 'user2'],
+	 *  'groups' => ['group2']
+	 * ]
+	 *
+	 * This is required for encryption
+	 *
+	 * @param \OCP\Files\Node $path
+	 */
+	public function getAccessList(\OCP\Files\Node $path) {
+		throw new \Exception();
+	}
+}

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20;
+
+use OCP\Files\Node;
+use OCP\IUser;
+use OCP\IGroup;
+
+class Share {
+
+	/** @var string */
+	private $internalId;
+
+	/** @var string */
+	private $providerId;
+
+	/** @var Node */
+	private $path;
+
+	/** @var int */
+	private $shareType;
+
+	/** @var IUser|IGroup|string */
+	private $shareWith;
+
+	/** @var IUser|string */
+	private $sharedBy;
+
+	/** @var IUser|string */
+	private $shareOwner;
+
+	/** @var int */
+	private $permissions;
+
+	/** @var \DateTime */
+	private $expireDate;
+
+	/** @var string */
+	private $password;
+
+	/**
+	 * Set the id of the ShareProvider
+	 * Should only be used by the share manager
+	 *
+	 * @param string $providerId
+	 * @return Share The modified object
+	 */
+	public function setProviderId($providerId) {
+		$this->providerId = $providerId;
+		return $this;
+	}
+
+	/**
+	 * Get the id of the ShareProvider
+	 *
+	 * @return string
+	 */
+	public function getProviderId() {
+		return $this->providerId;
+	}
+
+	/**
+	 * Set the internal (to the provider) share id
+	 * Should only be used by the share provider
+	 *
+	 * @param string $id
+	 * @return Share The modified object
+	 */
+	public function setInternalId($id) {
+		$this->internalId = $id;
+		return $this;
+	}
+
+	/**
+	 * Get the internal (to the provider) share id
+	 * Should only be used by the share provider
+	 *
+	 * @return string
+	 */
+	public function getInternalId() {
+		return $this->internalId;
+	}
+
+	/**
+	 * Get the id of the share
+	 *
+	 * @return string
+	 */
+	public function getId() {
+		//TODO $id should be set as well as $providerId
+		return $this->providerId . ':' . $this->internalId;
+	}
+
+	/**
+	 * Set the path of this share
+	 *
+	 * @param Node $path
+	 * @return Share The modified object
+	 */
+	public function setPath(Node $path) {
+		$this->path = $path;
+		return $this;
+	}
+
+	/**
+	 * Get the path of this share for the current user
+	 * 
+	 * @return Node
+	 */
+	public function getPath() {
+		return $this->path;
+	}
+
+	/**
+	 * Set the shareType
+	 *
+	 * @param int $shareType
+	 * @return Share The modified object
+	 */
+	public function setShareType($shareType) {
+		$this->shareType = $shareType;
+		return $this;
+	}
+
+	/**
+	 * Get the shareType 
+	 *
+	 * @return int
+	 */
+	public function getShareType() {
+		return $this->shareType;
+	}
+
+	/**
+	 * Set the shareWith
+	 *
+	 * @param IUser|IGroup|string
+	 * @return Share The modified object
+	 */
+	public function setShareWith($shareWith) {
+		$this->shareWith = $shareWith;
+		return $this;
+	}
+
+	/**
+	 * Get the shareWith
+	 *
+	 * @return IUser|IGroup|string
+	 */
+	public function getShareWith() {
+		return $this->shareWith;
+	}
+
+	/**
+	 * Set the permissions
+	 *
+	 * @param int $permissions
+	 * @return Share The modified object
+	 */
+	public function setPermissions($permissions) {
+		//TODO checkes
+
+		$this->permissions = $permissions;
+		return $this;
+	}
+
+	/**
+	 * Get the share permissions
+	 *
+	 * @return int
+	 */
+	public function getPermissions() {
+		return $this->permissions;
+	}
+
+	/**
+	 * Set the expiration date
+	 *
+	 * @param \DateTime $expireDate
+	 * @return Share The modified object
+	 */
+	public function setExpirationDate(\DateTime $expireDate) {
+		//TODO checks
+
+		$this->expireDate = $expireDate;
+		return $this;
+	}
+
+	/**
+	 * Get the share expiration date
+	 *
+	 * @return \DateTime
+	 */
+	public function getExpirationDate() {
+		return $this->expireDate;
+	}
+
+	/**
+	 * Set the sharer of the path
+	 *
+	 * @param IUser|string $sharedBy
+	 * @return Share The modified object
+	 */
+	public function setSharedBy($sharedBy) {
+		//TODO checks
+		$this->sharedBy = $sharedBy;
+
+		return $this;
+	}
+
+	/**
+	 * Get share sharer
+	 *
+	 * @return IUser|string
+	 */
+	public function getSharedBy() {
+		//TODO check if set
+		return $this->sharedBy;
+	}
+
+	/**
+	 * Set the original share owner (who owns the path)
+	 *
+	 * @param IUser|string
+	 *
+	 * @return Share The modified object
+	 */
+	public function setShareOwner($shareOwner) {
+		//TODO checks
+
+		$this->shareOwner = $shareOwner;
+		return $this;
+	}
+
+	/**
+	 * Get the original share owner (who owns the path)
+	 * 
+	 * @return IUser|string
+	 */
+	public function getShareOwner() {
+		//TODO check if set
+		return $this->shareOwner;
+	}
+
+	/**
+	 * Set the password
+	 *
+	 * @param string $password
+	 *
+	 * @return Share The modified object
+	 */
+	public function setPassword($password) {
+		//TODO verify
+
+		$this->password = $password;
+		return $this;
+	}
+
+	/**
+	 * Get the password
+	 *
+	 * @return string
+	 */
+	public function getPassword($password) {
+		return $this->password;
+	}
+}

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -59,6 +59,9 @@ class Share implements IShare {
 	/** @var int */
 	private $parent;
 
+	/** @var string */
+	private $target;
+
 	/**
 	 * Set the id of the share
 	 *
@@ -291,5 +294,25 @@ class Share implements IShare {
 	 */
 	public function getParent() {
 		return $this->parent;
+	}
+
+	/**
+	 * Set the target of this share
+	 *
+	 * @param string target
+	 * @return Share The modified object
+	 */
+	public function setTarget($target) {
+		$this->target = $target;
+		return $this;
+	}
+
+	/**
+	 * Get the target of this share
+	 *
+	 * @return string
+	 */
+	public function getTarget() {
+		return $this->target;
 	}
 }

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -24,13 +24,10 @@ use OCP\Files\Node;
 use OCP\IUser;
 use OCP\IGroup;
 
-class Share {
+class Share implements IShare {
 
 	/** @var string */
-	private $internalId;
-
-	/** @var string */
-	private $providerId;
+	private $id;
 
 	/** @var Node */
 	private $path;
@@ -39,7 +36,7 @@ class Share {
 	private $shareType;
 
 	/** @var IUser|IGroup|string */
-	private $shareWith;
+	private $sharedWith;
 
 	/** @var IUser|string */
 	private $sharedBy;
@@ -56,47 +53,21 @@ class Share {
 	/** @var string */
 	private $password;
 
+	/** @var string */
+	private $token;
+
+	/** @var int */
+	private $parent;
+
 	/**
-	 * Set the id of the ShareProvider
-	 * Should only be used by the share manager
+	 * Set the id of the share
 	 *
-	 * @param string $providerId
+	 * @param int id
 	 * @return Share The modified object
 	 */
-	public function setProviderId($providerId) {
-		$this->providerId = $providerId;
+	public function setId($id) {
+		$this->id = $id;
 		return $this;
-	}
-
-	/**
-	 * Get the id of the ShareProvider
-	 *
-	 * @return string
-	 */
-	public function getProviderId() {
-		return $this->providerId;
-	}
-
-	/**
-	 * Set the internal (to the provider) share id
-	 * Should only be used by the share provider
-	 *
-	 * @param string $id
-	 * @return Share The modified object
-	 */
-	public function setInternalId($id) {
-		$this->internalId = $id;
-		return $this;
-	}
-
-	/**
-	 * Get the internal (to the provider) share id
-	 * Should only be used by the share provider
-	 *
-	 * @return string
-	 */
-	public function getInternalId() {
-		return $this->internalId;
 	}
 
 	/**
@@ -105,8 +76,7 @@ class Share {
 	 * @return string
 	 */
 	public function getId() {
-		//TODO $id should be set as well as $providerId
-		return $this->providerId . ':' . $this->internalId;
+		return $this->id;
 	}
 
 	/**
@@ -150,23 +120,23 @@ class Share {
 	}
 
 	/**
-	 * Set the shareWith
+	 * Set the receiver of this share
 	 *
 	 * @param IUser|IGroup|string
 	 * @return Share The modified object
 	 */
-	public function setShareWith($shareWith) {
-		$this->shareWith = $shareWith;
+	public function setSharedWith($sharedWith) {
+		$this->sharedWith = $sharedWith;
 		return $this;
 	}
 
 	/**
-	 * Get the shareWith
+	 * Get the receiver of this share
 	 *
 	 * @return IUser|IGroup|string
 	 */
-	public function getShareWith() {
-		return $this->shareWith;
+	public function getSharedWith() {
+		return $this->sharedWith;
 	}
 
 	/**
@@ -281,5 +251,45 @@ class Share {
 	 */
 	public function getPassword($password) {
 		return $this->password;
+	}
+
+	/**
+	 * Set the token
+	 *
+	 * @param string $token
+	 * @return Share The modified object
+	 */
+	public function setToken($token) {
+		$this->token = $token;
+		return $this;
+	}
+
+	/**
+	 * Get the token
+	 *
+	 * @return string
+	 */
+	public function getToken() {
+		return $this->token;
+	}
+
+	/**
+	 * Set the parent id of this share
+	 *
+	 * @param int $parent
+	 * @return Share The modified object
+	 */
+	public function setParent($parent) {
+		$this->parent = $parent;
+		return $this;
+	}
+
+	/**
+	 * Get the parent id of this share
+	 *
+	 * @return int
+	 */
+	public function getParent() {
+		return $this->parent;
 	}
 }

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -1,0 +1,543 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Share20;
+
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\Files\Folder;
+use OC\Share20\DefaultShareProvider;
+
+class DefaultShareProviderTest extends \Test\TestCase {
+
+	/** @var IDBConnection */
+	protected $dbConn;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IGroupManager */
+	protected $groupManager;
+
+	/** @var Folder */
+	protected $userFolder;
+
+	/** @var DefaultShareProvider */
+	protected $provider;
+
+	public function setUp() {
+		$this->dbConn = \OC::$server->getDatabaseConnection();
+		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->groupManager = $this->getMock('OCP\IGroupManager');
+		$this->userFolder = $this->getMock('OCP\Files\Folder');
+
+		//Empty share table
+		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+
+		$this->provider = new DefaultShareProvider(
+			$this->dbConn,
+			$this->userManager,
+			$this->groupManager,
+			$this->userFolder
+		);
+	}
+
+	public function tearDown() {
+		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+	}
+
+	/**
+	 * @expectedException OC\Share20\Exception\ShareNotFound
+	 */
+	public function testGetShareByIdNotExist() {
+		$this->provider->getShareById(1);
+	}
+
+	public function testGetShareByIdUserShare() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedWith = $this->getMock('OCP\IUser');
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedWith', $sharedWith],
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+
+		$this->assertEquals(1, $share->getId());
+		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
+		$this->assertEquals($sharedWith, $share->getSharedWith());
+		$this->assertEquals($sharedBy, $share->getSharedBy());
+		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals($path, $share->getPath());
+		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(null, $share->getToken());
+		$this->assertEquals(null, $share->getExpirationDate());
+	}
+
+	public function testGetShareByIdGroupShare() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_GROUP),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedWith = $this->getMock('OCP\IGroup');
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+		$this->groupManager
+			->expects($this->once())
+			->method('get')
+			->with('sharedWith')
+			->willReturn($sharedWith);
+
+		$share = $this->provider->getShareById(1);
+
+		$this->assertEquals(1, $share->getId());
+		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
+		$this->assertEquals($sharedWith, $share->getSharedWith());
+		$this->assertEquals($sharedBy, $share->getSharedBy());
+		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals($path, $share->getPath());
+		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(null, $share->getToken());
+		$this->assertEquals(null, $share->getExpirationDate());
+	}
+
+	public function testGetShareByIdLinkShare() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+				'token' => $qb->expr()->literal('token'),
+				'expiration' => $qb->expr()->literal('2000-01-02 00:00:00'),
+			]);
+		$qb->execute();
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+
+		$this->assertEquals(1, $share->getId());
+		$this->assertEquals(\OCP\Share::SHARE_TYPE_LINK, $share->getShareType());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals($sharedBy, $share->getSharedBy());
+		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals($path, $share->getPath());
+		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals('token', $share->getToken());
+		$this->assertEquals(\DateTime::createFromFormat('Y-m-d H:i:s', '2000-01-02 00:00:00'), $share->getExpirationDate());
+	}
+
+	public function testGetShareByIdRemoteShare() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_REMOTE),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+
+		$this->assertEquals(1, $share->getId());
+		$this->assertEquals(\OCP\Share::SHARE_TYPE_REMOTE, $share->getShareType());
+		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals($sharedBy, $share->getSharedBy());
+		$this->assertEquals($shareOwner, $share->getShareOwner());
+		$this->assertEquals($path, $share->getPath());
+		$this->assertEquals(13, $share->getPermissions());
+		$this->assertEquals(null, $share->getToken());
+		$this->assertEquals(null, $share->getExpirationDate());
+	}
+
+	public function testDeleteSingleShare() {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedWith = $this->getMock('OCP\IUser');
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedWith', $sharedWith],
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+		$this->provider->delete($share);
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('*')
+			->from('share');
+
+		$cursor = $qb->execute();
+		$result = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		$this->assertEmpty($result);
+	}
+
+	public function testDeleteSingleShareKeepOther() {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(2),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->once())
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->once())
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->once())
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedWith = $this->getMock('OCP\IUser');
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedWith', $sharedWith],
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+		$this->provider->delete($share);
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('*')
+			->from('share');
+
+		$cursor = $qb->execute();
+		$result = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		$this->assertCount(1, $result);
+	}
+
+	public function testDeleteNestedShares() {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(1),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith'),
+				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+			]);
+		$qb->execute();
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(2),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith2'),
+				'uid_owner' => $qb->expr()->literal('sharedBy2'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+				'parent' => $qb->expr()->literal(1),
+			]);
+		$qb->execute();
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'id' => $qb->expr()->literal(3),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+				'share_with' => $qb->expr()->literal('sharedWith2'),
+				'uid_owner' => $qb->expr()->literal('sharedBy2'),
+				'file_source' => $qb->expr()->literal(42),
+				'permissions' => $qb->expr()->literal(13),
+				'parent' => $qb->expr()->literal(2),
+			]);
+		$qb->execute();
+
+
+		$storage = $this->getMock('OC\Files\Storage\Storage');
+		$storage
+			->expects($this->exactly(3))
+			->method('getOwner')
+			->willReturn('shareOwner');
+		$path = $this->getMock('OCP\Files\Node');
+		$path
+			->expects($this->exactly(3))
+			->method('getStorage')
+			->wilLReturn($storage);
+		$this->userFolder
+			->expects($this->exactly(3))
+			->method('getById')
+			->with(42)
+			->willReturn([$path]);
+
+		$sharedWith = $this->getMock('OCP\IUser');
+		$sharedBy = $this->getMock('OCP\IUser');
+		$shareOwner = $this->getMock('OCP\IUser');
+		$this->userManager
+			->method('get')
+			->will($this->returnValueMap([
+				['sharedWith', $sharedWith],
+				['sharedBy', $sharedBy],
+				['shareOwner', $shareOwner],
+			]));
+
+		$share = $this->provider->getShareById(1);
+		$this->provider->delete($share);
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('*')
+			->from('share');
+
+		$cursor = $qb->execute();
+		$result = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		$this->assertEmpty($result);
+	}
+
+	/**
+	 * @expectedException \OC\Share20\Exception\BackendError
+	 */
+	public function testDeleteFails() {
+		$share = $this->getMock('OC\Share20\IShare');
+		$expr = $this->getMock('OCP\DB\QueryBuilder\IExpressionBuilder');
+		$qb = $this->getMock('OCP\DB\QueryBuilder\IQueryBuilder');
+		$qb->expects($this->once())
+			->method('delete')
+			->will($this->returnSelf());
+		$qb->expects($this->once())
+			->method('expr')
+			->willReturn($expr);
+		$qb->expects($this->once())
+			->method('where')
+			->will($this->returnSelf());
+		$qb->expects($this->once())
+			->method('setParameter')
+			->will($this->returnSelf());
+		$qb->expects($this->once())
+			->method('execute')
+			->will($this->throwException(new \Exception));
+
+		$db = $this->getMock('OCP\IDBConnection');
+		$db->expects($this->once())
+			->method('getQueryBuilder')
+			->with()
+			->willReturn($qb);
+
+		$provider = $this->getMockBuilder('OC\Share20\DefaultShareProvider')
+            ->setConstructorArgs([  
+                    $db,
+                    $this->userManager,
+                    $this->groupManager,
+                    $this->userFolder,
+                ]        
+            )            
+            ->setMethods(['deleteChildren'])
+            ->getMock();
+		$provider
+			->expects($this->once())
+			->method('deleteChildren')
+			->with($share);
+		
+
+		$provider->delete($share);
+	}
+
+}

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -76,22 +76,33 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type'  => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
 				'share_with'  => $qb->expr()->literal('sharedWith'),
 				'uid_owner'   => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
-				'permissions' => $qb->expr()->literal(13),
 				'file_target' => $qb->expr()->literal('myTarget'),
+				'permissions' => $qb->expr()->literal(13),
 			]);
 		$qb->execute();
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id = $cursor->fetch();
+		$id = $id['id'];
+		$cursor->closeCursor();
 
 		$storage = $this->getMock('OC\Files\Storage\Storage');
 		$storage
 			->expects($this->once())
 			->method('getOwner')
 			->willReturn('shareOwner');
-		$path = $this->getMock('OCP\Files\Node');
+		$path = $this->getMock('OCP\Files\File');
 		$path
 			->expects($this->once())
 			->method('getStorage')
@@ -113,9 +124,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				['shareOwner', $shareOwner],
 			]));
 
-		$share = $this->provider->getShareById(1);
+		$share = $this->provider->getShareById($id);
 
-		$this->assertEquals(1, $share->getId());
+		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_USER, $share->getShareType());
 		$this->assertEquals($sharedWith, $share->getSharedWith());
 		$this->assertEquals($sharedBy, $share->getSharedBy());
@@ -132,22 +143,33 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_GROUP),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
-				'permissions' => $qb->expr()->literal(13),
 				'file_target' => $qb->expr()->literal('myTarget'),
+				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id = $cursor->fetch();
+		$id = $id['id'];
+		$cursor->closeCursor();
 
 		$storage = $this->getMock('OC\Files\Storage\Storage');
 		$storage
 			->expects($this->once())
 			->method('getOwner')
 			->willReturn('shareOwner');
-		$path = $this->getMock('OCP\Files\Node');
+		$path = $this->getMock('OCP\Files\Folder');
 		$path
 			->expects($this->once())
 			->method('getStorage')
@@ -173,9 +195,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->with('sharedWith')
 			->willReturn($sharedWith);
 
-		$share = $this->provider->getShareById(1);
+		$share = $this->provider->getShareById($id);
 
-		$this->assertEquals(1, $share->getId());
+		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_GROUP, $share->getShareType());
 		$this->assertEquals($sharedWith, $share->getSharedWith());
 		$this->assertEquals($sharedBy, $share->getSharedBy());
@@ -192,17 +214,28 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 				'token' => $qb->expr()->literal('token'),
 				'expiration' => $qb->expr()->literal('2000-01-02 00:00:00'),
-				'file_target' => $qb->expr()->literal('myTarget'),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id = $cursor->fetch();
+		$id = $id['id'];
+		$cursor->closeCursor();
 
 		$storage = $this->getMock('OC\Files\Storage\Storage');
 		$storage
@@ -229,9 +262,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				['shareOwner', $shareOwner],
 			]));
 
-		$share = $this->provider->getShareById(1);
+		$share = $this->provider->getShareById($id);
 
-		$this->assertEquals(1, $share->getId());
+		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_LINK, $share->getShareType());
 		$this->assertEquals('sharedWith', $share->getSharedWith());
 		$this->assertEquals($sharedBy, $share->getSharedBy());
@@ -248,15 +281,27 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_REMOTE),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
-				'permissions' => $qb->expr()->literal(13),
 				'file_target' => $qb->expr()->literal('myTarget'),
+				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id = $cursor->fetch();
+		$id = $id['id'];
+		$cursor->closeCursor();
+
 
 		$storage = $this->getMock('OC\Files\Storage\Storage');
 		$storage
@@ -283,9 +328,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				['shareOwner', $shareOwner],
 			]));
 
-		$share = $this->provider->getShareById(1);
+		$share = $this->provider->getShareById($id);
 
-		$this->assertEquals(1, $share->getId());
+		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_REMOTE, $share->getShareType());
 		$this->assertEquals('sharedWith', $share->getSharedWith());
 		$this->assertEquals($sharedBy, $share->getSharedBy());
@@ -301,14 +346,27 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id = $cursor->fetch();
+		$id = $id['id'];
+		$cursor->closeCursor();
+
 
 		$path = $this->getMock('OCP\Files\File');
 		$path
@@ -330,7 +388,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share = $this->getMock('OC\Share20\IShare');
 		$share
 			->method('getId')
-			->willReturn(1);
+			->willReturn($id);
 		$share
 			->expects($this->once())
 			->method('getShareType')
@@ -375,7 +433,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListner, 'listen');
 
 		$hookListnerExpects = [
-			'id' => 1,
+			'id' => $id,
 			'itemType' => 'file',
 			'itemSource' => 42,
 			'shareType' => \OCP\Share::SHARE_TYPE_USER,
@@ -409,41 +467,67 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(1),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id1 = $cursor->fetch();
+		$id1 = $id1['id'];
+		$cursor->closeCursor();
+
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(2),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
-				'parent' => $qb->expr()->literal(1),
+				'parent' => $qb->expr()->literal($id1),
 			]);
-		$qb->execute();
+		$this->assertEquals(1, $qb->execute());
+
+		// Get the id
+		$qb = $this->dbConn->getQueryBuilder();
+		$cursor = $qb->select('id')
+			->from('share')
+			->setMaxResults(1)
+			->orderBy('id', 'DESC')
+			->execute();
+		$id2 = $cursor->fetch();
+		$id2 = $id2['id'];
+		$cursor->closeCursor();
+
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
 			->values([
-				'id' => $qb->expr()->literal(3),
 				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
 				'share_with' => $qb->expr()->literal('sharedWith'),
 				'uid_owner' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
-				'parent' => $qb->expr()->literal(2),
+				'parent' => $qb->expr()->literal($id2),
 			]);
-		$qb->execute();
-
+		$this->assertEquals(1, $qb->execute());
 
 		$storage = $this->getMock('OC\Files\Storage\Storage');
 		$storage
@@ -475,7 +559,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				['shareOwner', $shareOwner],
 			]));
 
-		$share = $this->provider->getShareById(1);
+		$share = $this->provider->getShareById($id1);
 		$this->provider->delete($share);
 
 		$qb = $this->dbConn->getQueryBuilder();

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Share20;
+
+use OC\Share20\Manager;
+use OC\Share20\Exception;
+
+
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\ILogger;
+use OCP\IAppConfig;
+use OCP\Files\Folder;
+use OCP\Share20\IShareProvider;
+
+class ManagerTest extends \Test\TestCase {
+
+	/** @var Manager */
+	protected $manager;
+
+	/** @var IUser */
+	protected $user;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IGroupManager */
+	protected $groupManager;
+
+	/** @var ILogger */
+	protected $logger;
+
+	/** @var IAppConfig */
+	protected $appConfig;
+
+	/** @var Folder */
+	protected $userFolder;
+
+	/** @var IShareProvider */
+	protected $defaultProvider;
+
+	public function setUp() {
+		
+		$this->user = $this->getMock('\OCP\IUser');
+		$this->userManager = $this->getMock('\OCP\IUserManager');
+		$this->groupManager = $this->getMock('\OCP\IGroupManager');
+		$this->logger = $this->getMock('\OCP\ILogger');
+		$this->appConfig = $this->getMock('\OCP\IAppConfig');
+		$this->userFolder = $this->getMock('\OCP\Files\Folder');
+		$this->defaultProvider = $this->getMock('\OC\Share20\IShareProvider');
+
+		$this->manager = new Manager(
+			$this->user,
+			$this->userManager,
+			$this->groupManager,
+			$this->logger,
+			$this->appConfig,
+			$this->userFolder,
+			$this->defaultProvider
+		);
+	}
+
+	/**
+	 * @expectedException OC\Share20\Exception\ShareNotFound
+	 */
+	public function testDeleteNoShareId() {
+		$share = $this->getMock('\OC\Share20\IShare');
+
+		$share
+			->expects($this->once())
+			->method('getId')
+			->with()
+			->willReturn(null);
+
+		$this->manager->deleteShare($share);
+	}
+
+	public function testDelete() {
+		$share = $this->getMock('\OC\Share20\IShare');
+
+		$share
+			->expects($this->once())
+			->method('getId')
+			->with()
+			->willReturn(42);
+		$this->defaultProvider
+			->expects($this->once())
+			->method('delete')
+			->with($share);
+
+		$this->manager->deleteShare($share);
+	}
+
+	/**
+	 * @expectedException OC\Share20\Exception\ShareNotFound
+	 */
+	public function testGetShareByIdNotFoundInBackend() {
+		$this->defaultProvider
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->will($this->throwException(new \OC\Share20\Exception\ShareNotFound()));
+
+		$this->manager->getShareById(42);
+	}
+
+	/**
+	 * @expectedException OC\Share20\Exception\ShareNotFound
+	 */
+	public function testGetShareByIdNotAuthorized() {
+		$otherUser1 = $this->getMock('\OCP\IUser');
+		$otherUser2 = $this->getMock('\OCP\IUser');
+		$otherUser3 = $this->getMock('\OCP\IUser');
+
+		$share = $this->getMock('\OC\Share20\IShare');
+		$share
+			->expects($this->once())
+			->method('getSharedWith')
+			->with()
+			->willReturn($otherUser1);
+		$share
+			->expects($this->once())
+			->method('getSharedBy')
+			->with()
+			->willReturn($otherUser2);
+		$share
+			->expects($this->once())
+			->method('getShareOwner')
+			->with()
+			->willReturn($otherUser3);
+
+		$this->defaultProvider
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->willReturn($share);
+
+		$this->manager->getShareById(42);
+	}
+
+	public function dataGetShareById() {
+		return [
+			['getSharedWith'],
+			['getSharedBy'],
+			['getShareOwner'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetShareById
+	 */
+	public function testGetShareById($currentUserIs) {
+		$otherUser1 = $this->getMock('\OCP\IUser');
+		$otherUser2 = $this->getMock('\OCP\IUser');
+		$otherUser3 = $this->getMock('\OCP\IUser');
+
+		$share = $this->getMock('\OC\Share20\IShare');
+		$share
+			->method('getSharedWith')
+			->with()
+			->willReturn($currentUserIs === 'getSharedWith' ? $this->user : $otherUser1);
+		$share
+			->method('getSharedBy')
+			->with()
+			->willReturn($currentUserIs === 'getSharedBy' ? $this->user : $otherUser2);
+		$share
+			->method('getShareOwner')
+			->with()
+			->willReturn($currentUserIs === 'getShareOwner' ? $this->user : $otherUser3);
+
+		$this->defaultProvider
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->willReturn($share);
+
+		$this->assertEquals($share, $this->manager->getShareById(42));
+	}
+}


### PR DESCRIPTION
@schiesbn @DeepDiver1975 first draft is here.

for now we have a sharemanager object and a ishareprovider and that is it. So no share object. Basically everything goes trough the share manager.

The manager itself acts like some kind of middleware between the shareprovider and the OCS Share API. Making sure that arguments are in the right format (date for example). And making sure that the user we want to share with exists etc.

IShareProviders register themself at the sharemanager with a callback function. And then all the magic happens.

Many things in the code do not work as expected yet or are even plain wrong now. But if we agree this is the way to go I can start cleaning up and already write some simple unit tests for this part. And do some squashing of commits :P

So feedback please :)
