### PR TITLE
Delete cookie instead of emptying value

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -427,7 +427,8 @@ class OC {
 		// session timeout
 		if ($session->exists('LAST_ACTIVITY') && (time() - $session->get('LAST_ACTIVITY') > $sessionLifeTime)) {
 			if (isset($_COOKIE[session_name()])) {
-				setcookie(session_name(), '', time() - 42000, $cookie_path);
+				setcookie(session_name(), null, -1, self::$WEBROOT ? : '/');
+				unset($_COOKIE[session_name()]);
 			}
 			session_unset();
 			session_destroy();

--- a/lib/private/session/internal.php
+++ b/lib/private/session/internal.php
@@ -41,7 +41,11 @@ class Internal extends Session {
 	public function __construct($name) {
 		session_name($name);
 		set_error_handler(array($this, 'trapError'));
-		session_start();
+		try {
+			session_start();
+		} catch (\Exception $e) {
+			setcookie(session_name(), null, -1, \OC::$WEBROOT ? : '/');
+		}
 		restore_error_handler();
 		if (!isset($_SESSION)) {
 			throw new \Exception('Failed to start session');


### PR DESCRIPTION
PHP will handle session cookies with an empty values as an E_WARNING error. ([php/#68063](https://bugs.php.net/bug.php?id=68063))

ownCloud sets the cookie to an empty value in case the session expires, it however after this starts a new session. Due to potential race conditions (or https://bugs.php.net/bug.php?id=69127) this can in unlikely cases lead to the fact that the session never gets restarted and the user is left with an empty cookie. PHP tries then to use the empty cookie which makes the instance not usable.

To work around any race condition we now tell PHP to explicitly delete the value which can be done by using `null` as value, PHP will then send a cookie with the value "deleted". Also the expiration has been set to -1.

Worst case scenario here with an invalid cookie (which _SHOULD_ not happen) is that the user has to reload ownCloud again. Way better than before though.

Fixes https://github.com/owncloud/enterprise/issues/869
