### PR TITLE
fix filepicker loading spinner

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -1025,7 +1025,7 @@ a.bookmarklet { background-color:#ddd; border:1px solid #ccc; padding:5px;paddin
 #oc-dialog-filepicker-content .dirtree span:not(:last-child)::after { content: '>'; padding: 3px;}
 #oc-dialog-filepicker-content .filelist {
 	overflow-y:auto;
-	max-height: 300px;
+	height: 300px;
 	background-color:white;
 	width:100%;
 }

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -171,7 +171,6 @@ var OCdialogs = {
 
 			$('body').append(self.$filePicker);
 
-
 			self.$filePicker.ready(function() {
 				self.$filelist = self.$filePicker.find('.filelist');
 				self.$dirTree = self.$filePicker.find('.dirtree');
@@ -738,9 +737,10 @@ var OCdialogs = {
 		var dirs = [];
 		var others = [];
 		var self = this;
-		this.$filelist.empty().addClass('loading');
+		this.$filelist.empty().addClass('icon-loading');
 		this.$filePicker.data('path', dir);
 		$.when(this._getFileList(dir, this.$filePicker.data('mimetype'))).then(function(response) {
+
 			$.each(response.data.files, function(index, file) {
 				if (file.type === 'dir') {
 					dirs.push(file);
@@ -772,7 +772,7 @@ var OCdialogs = {
 				self.$filelist.append($li);
 			});
 
-			self.$filelist.removeClass('loading');
+			self.$filelist.removeClass('icon-loading');
 			if (!OC.Util.hasSVGSupport()) {
 				OC.Util.replaceSVG(self.$filePicker.find('.dirtree'));
 			}


### PR DESCRIPTION
This makes the loading spinner visible again.

@Xenopathic @jancborchardt @MorrisJobke have a look at this please :-)

There's another scenario where a loading spinner might be helpful for visual feedback: the time between pressing the button (e.g. mail app »Add attachment from Files«) and the template being fetched and rendered.

fixes #16105
