### PR TITLE
[OCI setup] remove static logger/config calls

### DIFF
--- a/lib/private/setup/oci.php
+++ b/lib/private/setup/oci.php
@@ -40,7 +40,7 @@ class OCI extends AbstractDatabase {
 		// allow empty hostname for oracle
 		$this->dbHost = $config['dbhost'];
 
-		\OC_Config::setValues([
+		$this->config->setSystemValues([
 			'dbhost'		=> $this->dbHost,
 			'dbtablespace'	=> $this->dbtablespace,
 		]);
@@ -66,7 +66,7 @@ class OCI extends AbstractDatabase {
 		} else {
 			$easy_connect_string = '//'.$e_host.'/'.$e_dbname;
 		}
-		\OCP\Util::writeLog('setup oracle', 'connect string: ' . $easy_connect_string, \OCP\Util::DEBUG);
+		$this->logger->debug('connect string: ' . $easy_connect_string, ['app' => 'setup.oci']);
 		$connection = @oci_connect($this->dbUser, $this->dbPassword, $easy_connect_string);
 		if(!$connection) {
 			$errorMessage = $this->getLastError();
@@ -93,7 +93,7 @@ class OCI extends AbstractDatabase {
 		if (!$stmt) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
 		}
 		$result = oci_execute($stmt);
 		if($result) {
@@ -116,7 +116,7 @@ class OCI extends AbstractDatabase {
 			}
 		}
 
-		\OC_Config::setValues([
+		$this->config->setSystemValues([
 			'dbuser'		=> $this->dbUser,
 			'dbname'		=> $this->dbName,
 			'dbpassword'	=> $this->dbPassword,
@@ -131,9 +131,9 @@ class OCI extends AbstractDatabase {
 		oci_close($connection);
 
 		// connect to the oracle database (schema=$this->dbuser) an check if the schema needs to be filled
-		$this->dbUser = \OC_Config::getValue('dbuser');
+		$this->dbUser = $this->config->getSystemValue('dbuser');
 		//$this->dbname = \OC_Config::getValue('dbname');
-		$this->dbPassword = \OC_Config::getValue('dbpassword');
+		$this->dbPassword = $this->config->getSystemValue('dbpassword');
 
 		$e_host = addslashes($this->dbHost);
 		$e_dbname = addslashes($this->dbName);
@@ -155,7 +155,7 @@ class OCI extends AbstractDatabase {
 		if (!$stmt) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning( $entry, ['app' => 'setup.oci']);
 		}
 		$result = oci_execute($stmt);
 
@@ -178,14 +178,14 @@ class OCI extends AbstractDatabase {
 		if (!$stmt) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
 		}
 		oci_bind_by_name($stmt, ':un', $name);
 		$result = oci_execute($stmt);
 		if(!$result) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
 		}
 
 		if(! oci_fetch_row($stmt)) {
@@ -196,7 +196,8 @@ class OCI extends AbstractDatabase {
 			if (!$stmt) {
 				$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 				$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-				\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+				$this->logger->warning($entry, ['app' => 'setup.oci']);
+
 			}
 			//oci_bind_by_name($stmt, ':un', $name);
 			$result = oci_execute($stmt);
@@ -204,7 +205,8 @@ class OCI extends AbstractDatabase {
 				$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 				$entry .= $this->trans->t('Offending command was: "%s", name: %s, password: %s',
 					array($query, $name, $password)) . '<br />';
-				\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+				$this->logger->warning($entry, ['app' => 'setup.oci']);
+
 			}
 		} else { // change password of the existing role
 			$query = "ALTER USER :un IDENTIFIED BY :pw";
@@ -212,7 +214,7 @@ class OCI extends AbstractDatabase {
 			if (!$stmt) {
 				$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 				$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-				\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+				$this->logger->warning($entry, ['app' => 'setup.oci']);
 			}
 			oci_bind_by_name($stmt, ':un', $name);
 			oci_bind_by_name($stmt, ':pw', $password);
@@ -220,7 +222,7 @@ class OCI extends AbstractDatabase {
 			if(!$result) {
 				$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 				$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-				\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+				$this->logger->warning($entry, ['app' => 'setup.oci']);
 			}
 		}
 		// grant necessary roles
@@ -229,14 +231,14 @@ class OCI extends AbstractDatabase {
 		if (!$stmt) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s"', array($query)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
 		}
 		$result = oci_execute($stmt);
 		if(!$result) {
 			$entry = $this->trans->t('DB Error: "%s"', array($this->getLastError($connection))) . '<br />';
 			$entry .= $this->trans->t('Offending command was: "%s", name: %s, password: %s',
 				array($query, $name, $password)) . '<br />';
-			\OCP\Util::writeLog('setup.oci', $entry, \OCP\Util::WARN);
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
 		}
 	}
 


### PR DESCRIPTION
- logger/config object are already injected - this only uses it

I noticed this while debugging.

cc @nickvergessen @LukasReschke @DeepDiver1975 @butonic 
