### PR TITLE
catch all exception if table doesn't exists

### DIFF
--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -187,7 +187,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 	public function __destruct() {
 		try {
 			$this->cleanEmptyLocks();
-		} catch (\PDOException $e) {
+		} catch (\Exception $e) {
 			// If the table is missing, the clean up was successful
 			if ($this->connection->tableExists('file_locks')) {
 				throw $e;


### PR DESCRIPTION
catch all exception if file locking table doesn't exists

cc @nickvergessen 

cc @karlitschek should be backported to 8.2 to avoid error messages during upgrade
