### PR TITLE
make encryption configurable for home storage

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -201,7 +201,8 @@ class Application extends \OCP\AppFramework\App {
 				$c->query('KeyManager'),
 				$c->query('Crypt'),
 				$c->query('Session'),
-				$server->getSession()
+				$server->getSession(),
+				$c->query('Util')
 			);
 		});
 

--- a/apps/encryption/appinfo/routes.php
+++ b/apps/encryption/appinfo/routes.php
@@ -36,6 +36,11 @@ namespace OCA\Encryption\AppInfo;
 		'verb' => 'POST'
 	],
 	[
+		'name' => 'Settings#setEncryptHomeStorage',
+		'url' => '/ajax/setEncryptHomeStorage',
+		'verb' => 'POST'
+	],
+	[
 		'name' => 'Recovery#changeRecoveryPassword',
 		'url' => '/ajax/changeRecoveryPassword',
 		'verb' => 'POST'

--- a/apps/encryption/controller/settingscontroller.php
+++ b/apps/encryption/controller/settingscontroller.php
@@ -25,6 +25,7 @@ namespace OCA\Encryption\Controller;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
+use OCA\Encryption\Util;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -57,6 +58,9 @@ class SettingsController extends Controller {
 	/** @var ISession  */
 	private $ocSession;
 
+	/** @var  Util */
+	private $util;
+
 	/**
 	 * @param string $AppName
 	 * @param IRequest $request
@@ -67,6 +71,7 @@ class SettingsController extends Controller {
 	 * @param Crypt $crypt
 	 * @param Session $session
 	 * @param ISession $ocSession
+	 * @param Util $util
 	 */
 	public function __construct($AppName,
 								IRequest $request,
@@ -76,7 +81,9 @@ class SettingsController extends Controller {
 								KeyManager $keyManager,
 								Crypt $crypt,
 								Session $session,
-								ISession $ocSession) {
+								ISession $ocSession,
+								Util $util
+) {
 		parent::__construct($AppName, $request);
 		$this->l = $l10n;
 		$this->userSession = $userSession;
@@ -85,6 +92,7 @@ class SettingsController extends Controller {
 		$this->crypt = $crypt;
 		$this->session = $session;
 		$this->ocSession = $ocSession;
+		$this->util = $util;
 	}
 
 
@@ -142,5 +150,16 @@ class SettingsController extends Controller {
 			);
 		}
 
+	}
+
+	/**
+	 * @UseSession
+	 *
+	 * @param bool $encryptHomeStorage
+	 * @return DataResponse
+	 */
+	public function setEncryptHomeStorage($encryptHomeStorage) {
+		$this->util->setEncryptHomeStorage($encryptHomeStorage);
+		return new DataResponse();
 	}
 }

--- a/apps/encryption/js/settings-admin.js
+++ b/apps/encryption/js/settings-admin.js
@@ -76,4 +76,13 @@ $(document).ready(function () {
 			});
 	});
 
+	$('#encryptHomeStorage').change(function() {
+		$.post(
+			OC.generateUrl('/apps/encryption/ajax/setEncryptHomeStorage'),
+			{
+				encryptHomeStorage: this.checked
+			}
+		);
+	});
+
 });

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -378,6 +378,12 @@ class Encryption implements IEncryptionModule {
 	 * @return boolean
 	 */
 	public function shouldEncrypt($path) {
+		if ($this->util->shouldEncryptHomeStorage() === false) {
+			$storage = $this->util->getStorage($path);
+			if ($storage->instanceOfStorage('\OCP\Files\IHomeStorage')) {
+				return false;
+			}
+		}
 		$parts = explode('/', $path);
 		if (count($parts) < 4) {
 			return false;

--- a/apps/encryption/lib/util.php
+++ b/apps/encryption/lib/util.php
@@ -94,9 +94,38 @@ class Util {
 		$recoveryMode = $this->config->getUserValue($uid,
 			'encryption',
 			'recoveryEnabled',
-			0);
+			'0');
 
 		return ($recoveryMode === '1');
+	}
+
+	/**
+	 * check if the home storage should be encrypted
+	 *
+	 * @return bool
+	 */
+	public function shouldEncryptHomeStorage() {
+		$encryptHomeStorage = $this->config->getAppValue(
+			'encryption',
+			'encryptHomeStorage',
+			'1'
+		);
+
+		return ($encryptHomeStorage === '1');
+	}
+
+	/**
+	 * check if the home storage should be encrypted
+	 *
+	 * @param bool $encryptHomeStorage
+	 */
+	public function setEncryptHomeStorage($encryptHomeStorage) {
+		$value = $encryptHomeStorage ? '1' : '0';
+		$this->config->setAppValue(
+			'encryption',
+			'encryptHomeStorage',
+			$value
+		);
 	}
 
 	/**
@@ -155,6 +184,17 @@ class Util {
 		}
 
 		return $owner;
+	}
+
+	/**
+	 * get storage of path
+	 *
+	 * @param string $path
+	 * @return \OC\Files\Storage\Storage
+	 */
+	public function getStorage($path) {
+		$storage = $this->files->getMount($path)->getStorage();
+		return $storage;
 	}
 
 }

--- a/apps/encryption/settings/settings-admin.php
+++ b/apps/encryption/settings/settings-admin.php
@@ -25,12 +25,27 @@
 
 $tmpl = new OCP\Template('encryption', 'settings-admin');
 
+$crypt = new \OCA\Encryption\Crypto\Crypt(
+	\OC::$server->getLogger(),
+	\OC::$server->getUserSession(),
+	\OC::$server->getConfig());
+
+$util = new \OCA\Encryption\Util(
+	new \OC\Files\View(),
+	$crypt,
+	\OC::$server->getLogger(),
+	\OC::$server->getUserSession(),
+	\OC::$server->getConfig(),
+	\OC::$server->getUserManager());
+
 // Check if an adminRecovery account is enabled for recovering files after lost pwd
 $recoveryAdminEnabled = \OC::$server->getConfig()->getAppValue('encryption', 'recoveryAdminEnabled', '0');
 $session = new \OCA\Encryption\Session(\OC::$server->getSession());
 
+$encryptHomeStorage = $util->shouldEncryptHomeStorage($user);
 
 $tmpl->assign('recoveryEnabled', $recoveryAdminEnabled);
 $tmpl->assign('initStatus', $session->getStatus());
+$tmpl->assign('encryptHomeStorage', $encryptHomeStorage);
 
 return $tmpl->fetchPage();

--- a/apps/encryption/templates/settings-admin.php
+++ b/apps/encryption/templates/settings-admin.php
@@ -9,56 +9,63 @@ style('encryption', 'settings-admin');
 	<?php if(!$_["initStatus"]): ?>
 		<?php p($l->t("Encryption App is enabled but your keys are not initialized, please log-out and log-in again")); ?>
 	<?php else: ?>
-	<p id="encryptionSetRecoveryKey">
-		<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>
-		<span class="msg"></span>
-		<br/>
-		<em>
-		<?php p($l->t("The recovery key is an extra encryption key that is used to encrypt files. It allows recovery of a user's files if the user forgets his or her password.")) ?>
-		</em>
-		<br/>
-		<input type="password"
-			   name="encryptionRecoveryPassword"
-			   id="encryptionRecoveryPassword"
-			   placeholder="<?php p($l->t("Recovery key password")); ?>"/>
-		<input type="password"
-			   name="encryptionRecoveryPassword"
-			   id="repeatEncryptionRecoveryPassword"
-			   placeholder="<?php p($l->t("Repeat recovery key password")); ?>"/>
-		<input type="button"
-			   name="enableRecoveryKey"
-			   id="enableRecoveryKey"
-			   status="<?php p($_["recoveryEnabled"]) ?>"
-			   value="<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>"/>
-	</p>
-	<br/><br/>
-
-	<p name="changeRecoveryPasswordBlock" id="encryptionChangeRecoveryKey" <?php if($_['recoveryEnabled'] === '0') print_unescaped('class="hidden"');?>>
-		<?php p($l->t("Change recovery key password:")); ?>
-		<span class="msg"></span>
-		<br/>
-		<input
-			type="password"
-			name="changeRecoveryPassword"
-			id="oldEncryptionRecoveryPassword"
-			placeholder="<?php p($l->t("Old recovery key password")); ?>"/>
+		<p id="encryptHomeStorageSetting">
+			<input type="checkbox" class="checkbox" name="encrypt_home_storage" id="encryptHomeStorage"
+				   value="1" <?php if ($_['encryptHomeStorage']) print_unescaped('checked="checked"'); ?> />
+			<label for="encryptHomeStorage"><?php p($l->t('Encrypt the home storage'));?></label></br>
+			<em><?php p( $l->t( "Enabling this option encrypts all files stored on the main storage, otherwise only files on external storage will be encrypted" ) ); ?></em>
+		</p>
 		<br />
-		<input
-			type="password"
-			name="changeRecoveryPassword"
-			id="newEncryptionRecoveryPassword"
-			placeholder="<?php p($l->t("New recovery key password")); ?>"/>
-		<input
-			type="password"
-			name="changeRecoveryPassword"
-			id="repeatedNewEncryptionRecoveryPassword"
-			placeholder="<?php p($l->t("Repeat new recovery key password")); ?>"/>
+		<p id="encryptionSetRecoveryKey">
+			<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>
+			<span class="msg"></span>
+			<br/>
+			<em>
+				<?php p($l->t("The recovery key is an extra encryption key that is used to encrypt files. It allows recovery of a user's files if the user forgets his or her password.")) ?>
+			</em>
+			<br/>
+			<input type="password"
+				   name="encryptionRecoveryPassword"
+				   id="encryptionRecoveryPassword"
+				   placeholder="<?php p($l->t("Recovery key password")); ?>"/>
+			<input type="password"
+				   name="encryptionRecoveryPassword"
+				   id="repeatEncryptionRecoveryPassword"
+				   placeholder="<?php p($l->t("Repeat recovery key password")); ?>"/>
+			<input type="button"
+				   name="enableRecoveryKey"
+				   id="enableRecoveryKey"
+				   status="<?php p($_["recoveryEnabled"]) ?>"
+				   value="<?php $_["recoveryEnabled"] === '0' ?  p($l->t("Enable recovery key")) : p($l->t("Disable recovery key")); ?>"/>
+		</p>
+		<br/><br/>
 
-		<button
-			type="button"
-			name="submitChangeRecoveryKey">
+		<p name="changeRecoveryPasswordBlock" id="encryptionChangeRecoveryKey" <?php if($_['recoveryEnabled'] === '0') print_unescaped('class="hidden"');?>>
+			<?php p($l->t("Change recovery key password:")); ?>
+			<span class="msg"></span>
+			<br/>
+			<input
+				type="password"
+				name="changeRecoveryPassword"
+				id="oldEncryptionRecoveryPassword"
+				placeholder="<?php p($l->t("Old recovery key password")); ?>"/>
+			<br />
+			<input
+				type="password"
+				name="changeRecoveryPassword"
+				id="newEncryptionRecoveryPassword"
+				placeholder="<?php p($l->t("New recovery key password")); ?>"/>
+			<input
+				type="password"
+				name="changeRecoveryPassword"
+				id="repeatedNewEncryptionRecoveryPassword"
+				placeholder="<?php p($l->t("Repeat new recovery key password")); ?>"/>
+
+			<button
+				type="button"
+				name="submitChangeRecoveryKey">
 				<?php p($l->t("Change Password")); ?>
-		</button>
-	</p>
+			</button>
+		</p>
 	<?php endif; ?>
 </form>

--- a/apps/encryption/tests/controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/controller/SettingsControllerTest.php
@@ -56,6 +56,9 @@ class SettingsControllerTest extends TestCase {
 	/** @var  \PHPUnit_Framework_MockObject_MockObject */
 	private $ocSessionMock;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	private $utilMock;
+
 	protected function setUp() {
 
 		parent::setUp();
@@ -106,6 +109,10 @@ class SettingsControllerTest extends TestCase {
 		$this->sessionMock = $this->getMockBuilder('OCA\Encryption\Session')
 			->disableOriginalConstructor()->getMock();
 
+		$this->utilMock = $this->getMockBuilder('OCA\Encryption\Util')
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->controller = new SettingsController(
 			'encryption',
 			$this->requestMock,
@@ -115,7 +122,8 @@ class SettingsControllerTest extends TestCase {
 			$this->keyManagerMock,
 			$this->cryptMock,
 			$this->sessionMock,
-			$this->ocSessionMock
+			$this->ocSessionMock,
+			$this->utilMock
 		);
 	}
 
@@ -232,6 +240,12 @@ class SettingsControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_OK, $result->getStatus());
 		$this->assertSame('Private key password successfully updated.',
 			$data['message']);
+	}
+
+	function testSetEncryptHomeStorage() {
+		$value = true;
+		$this->utilMock->expects($this->once())->method('setEncryptHomeStorage')->with($value);
+		$this->controller->setEncryptHomeStorage($value);
 	}
 
 }

--- a/apps/encryption/tests/lib/UtilTest.php
+++ b/apps/encryption/tests/lib/UtilTest.php
@@ -39,6 +39,9 @@ class UtilTest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	private $userManagerMock;
 
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	private $mountMock;
+
 	/** @var Util */
 	private $instance;
 
@@ -65,6 +68,7 @@ class UtilTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
+		$this->mountMock = $this->getMock('\OCP\Files\Mount\IMountPoint');
 		$this->filesMock = $this->getMock('OC\Files\View');
 		$this->userManagerMock = $this->getMock('\OCP\IUserManager');
 
@@ -149,6 +153,54 @@ class UtilTest extends TestCase {
 			['0', false],
 			['1', true]
 		];
+	}
+
+	/**
+	 * @dataProvider dataTestShouldEncryptHomeStorage
+	 * @param $returnValue return value from getAppValue()
+	 * @param $expected
+	 */
+	public function testShouldEncryptHomeStorage($returnValue, $expected) {
+		$this->configMock->expects($this->once())->method('getAppValue')
+			->with('encryption', 'encryptHomeStorage', '1')
+			->willReturn($returnValue);
+
+		$this->assertSame($expected,
+			$this->instance->shouldEncryptHomeStorage());
+	}
+
+	public function dataTestShouldEncryptHomeStorage() {
+		return [
+			['1', true],
+			['0', false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestSetEncryptHomeStorage
+	 * @param $value
+	 * @param $expected
+	 */
+	public function testSetEncryptHomeStorage($value, $expected) {
+		$this->configMock->expects($this->once())->method('setAppValue')
+			->with('encryption', 'encryptHomeStorage', $expected);
+		$this->instance->setEncryptHomeStorage($value);
+	}
+
+	public function dataTestSetEncryptHomeStorage() {
+		return [
+			[true, '1'],
+			[false, '0']
+		];
+	}
+
+	public function testGetStorage() {
+		$path = '/foo/bar.txt';
+		$this->filesMock->expects($this->once())->method('getMount')->with($path)
+			->willReturn($this->mountMock);
+		$this->mountMock->expects($this->once())->method('getStorage')->willReturn(true);
+
+		$this->assertTrue($this->instance->getStorage($path));
 	}
 
 }


### PR DESCRIPTION
Let the admin decide if the home storage should be encrypted or not. This way encryption can be use explicitly for mounted external storages.

If you want to try it out, this are the steps:
1. enable server side encryption and the ownCloud default encryption module
2. relogin
3. go to admin settings
4. now you see a checkbox to enable/disable encryption of the home storage

-> if it is checked files in the home storage should be encrypted, if it is not checked encryption should skip all files stored in the home storage

fix https://github.com/owncloud/core/issues/19061
