### PR TITLE
Fix scrutinizer issues in provisioning API

### DIFF
--- a/apps/provisioning_api/tests/testcase.php
+++ b/apps/provisioning_api/tests/testcase.php
@@ -46,7 +46,7 @@ abstract class TestCase extends \Test\TestCase {
 	/**
 	 * Generates a temp user
 	 * @param int $num number of users to generate
-	 * @return array
+	 * @return IUser[]|Iuser
 	 */
 	protected function generateUsers($num = 1) {
 		$users = array();

--- a/apps/provisioning_api/tests/userstest.php
+++ b/apps/provisioning_api/tests/userstest.php
@@ -234,7 +234,7 @@ class UsersTest extends TestCase {
 		$user = $this->generateUsers();
 		$user->setDisplayName('foobar');
 		$this->userSession->setUser($user);
-		$params['userid'] = $user->getUID();
+		$params = ['userid' => $user->getUID()];
 		$result = $this->api->getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
@@ -261,7 +261,7 @@ class UsersTest extends TestCase {
 
 	public function testGetUserOnOtherUser() {
 		$users = $this->generateUsers(2);
-		$params['userid'] = $users[0];
+		$params = ['userid' => $users[0]->getUID()];
 		$this->userSession->setUser($users[1]);
 		$result = $this->api->getUser($params);
 		$this->assertInstanceOf('OC_OCS_Result', $result);


### PR DESCRIPTION
- PHPDoc
- Proper array initialization

Easy one.

CC: @MorrisJobke @PVince81 @nickvergessen @LukasReschke 
