### PR TITLE
Update: state which step we are going to start and warn if it might b…

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -68,11 +68,23 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'maintenanceActive', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Maintenance mode is kept active'));
 	});
+	$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Updating database schema'));
+	});
 	$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Updated database'));
 	});
+	$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Checking whether the database schema can be updated (this can take a long time depending on the database size)'));
+	});
 	$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Checked database schema update'));
+	});
+	$updater->listen('\OC\Updater', 'appUpgradeCheckBefore', function () use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Checking updates of apps'));
+	});
+	$updater->listen('\OC\Updater', 'appSimulateUpdate', function ($app) use ($eventSource, $l) {
+		$eventSource->send('success', (string)$l->t('Checking whether the database schema for %s can be updated (this can take a long time depending on the database size)', [$app]));
 	});
 	$updater->listen('\OC\Updater', 'appUpgradeCheck', function () use ($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Checked database schema update for apps'));

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -155,8 +155,14 @@ class Upgrade extends Command {
 					}
 					$output->writeln($message);
 				});
+			$updater->listen('\OC\Updater', 'dbUpgradeBefore', function () use($output) {
+				$output->writeln('<info>Updating database schema</info>');
+			});
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use($output) {
 				$output->writeln('<info>Updated database</info>');
+			});
+			$updater->listen('\OC\Updater', 'dbSimulateUpgradeBefore', function () use($output) {
+				$output->writeln('<info>Checking whether the database schema can be updated (this can take a long time depending on the database size)</info>');
 			});
 			$updater->listen('\OC\Updater', 'dbSimulateUpgrade', function () use($output) {
 				$output->writeln('<info>Checked database schema update</info>');
@@ -175,6 +181,12 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'repairError', function ($app) use($output) {
 				$output->writeln('<error>Repair error: ' . $app . '</error>');
+			});
+			$updater->listen('\OC\Updater', 'appUpgradeCheckBefore', function () use ($output) {
+				$output->writeln('<info>Checking updates of apps</info>');
+			});
+			$updater->listen('\OC\Updater', 'appSimulateUpdate', function ($app) use ($output) {
+				$output->writeln("<info>Checking whether the database schema for <$app> can be updated (this can take a long time depending on the database size)</info>");
 			});
 			$updater->listen('\OC\Updater', 'appUpgradeCheck', function () use ($output) {
 				$output->writeln('<info>Checked database schema update for apps</info>');

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -337,6 +337,8 @@ class Updater extends BasicEmitter {
 	}
 
 	protected function checkCoreUpgrade() {
+		$this->emit('\OC\Updater', 'dbSimulateUpgradeBefore');
+
 		// simulate core DB upgrade
 		\OC_DB::simulateUpdateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 
@@ -344,6 +346,8 @@ class Updater extends BasicEmitter {
 	}
 
 	protected function doCoreUpgrade() {
+		$this->emit('\OC\Updater', 'dbUpgradeBefore');
+
 		// do the real upgrade
 		\OC_DB::updateDbFromStructure(\OC::$SERVERROOT . '/db_structure.xml');
 
@@ -355,6 +359,7 @@ class Updater extends BasicEmitter {
 	 */
 	protected function checkAppUpgrade($version) {
 		$apps = \OC_App::getEnabledApps();
+		$this->emit('\OC\Updater', 'appUpgradeCheckBefore');
 
 		foreach ($apps as $appId) {
 			$info = \OC_App::getAppInfo($appId);
@@ -372,6 +377,7 @@ class Updater extends BasicEmitter {
 					$this->includePreUpdate($appId);
 				}
 				if (file_exists(\OC_App::getAppPath($appId) . '/appinfo/database.xml')) {
+					$this->emit('\OC\Updater', 'appSimulateUpdate', array($appId));
 					\OC_DB::simulateUpdateDbFromStructure(\OC_App::getAppPath($appId) . '/appinfo/database.xml');
 				}
 			}


### PR DESCRIPTION
…e slow

New UI output:

```
        Preparing update
        Set log level to debug - current level: "Info"
        Turned on maintenance mode
NEW >>> Checking whether the database schema can be updated (this can take a long time depending on the database size)
        Checked database schema update
NEW >>> Checking updates of apps
NEW >>> Checking whether the database schema for activity can be updated (this can take a long time depending on the database size)
        Checked database schema update for apps
        Updating database schema
        Updated database
        Updated "activity" to 2.2.0
        Turned off maintenance mode
        Reset log level to "Info"
```

The problem previous was we only stated what we did, and not what we were about to do.
So the slow step didn't say anything until it was done.

@DeepDiver1975 @MorrisJobke @LukasReschke 

@karlitschek we should backport this to 8.2.1
