### PR TITLE
[stable8.2] Use IRequest's `getScriptName` functionality instead of $_SERVER

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -133,7 +133,18 @@ class OC {
 		OC_Config::$object = new \OC\Config(self::$configDir);
 
 		OC::$SUBURI = str_replace("\\", "/", substr(realpath($_SERVER["SCRIPT_FILENAME"]), strlen(OC::$SERVERROOT)));
-		$scriptName = $_SERVER['SCRIPT_NAME'];
+		/**
+		 * FIXME: The following lines are required because we can't yet instantiiate
+		 *        \OC::$server->getRequest() since \OC::$server does not yet exist.
+		 */
+		$params = [
+			'server' => [
+				'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+				'SCRIPT_FILENAME' => $_SERVER['SCRIPT_FILENAME'],
+			],
+		];
+		$fakeRequest = new \OC\AppFramework\Http\Request($params, null, new \OC\AllConfig(new \OC\SystemConfig()));
+		$scriptName = $fakeRequest->getScriptName();
 		if (substr($scriptName, -1) == '/') {
 			$scriptName .= 'index.php';
 			//make sure suburi follows the same rules as scriptName
@@ -144,6 +155,7 @@ class OC {
 				OC::$SUBURI = OC::$SUBURI . 'index.php';
 			}
 		}
+
 
 		if (OC::$CLI) {
 			OC::$WEBROOT = OC_Config::getValue('overwritewebroot', '');

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -438,7 +438,6 @@ class Server extends SimpleContainer implements IServerContainer {
 					'requesttoken' => $requestToken,
 				],
 				$this->getSecureRandom(),
-				$this->getCrypto(),
 				$this->getConfig(),
 				$stream
 			);
@@ -512,7 +511,6 @@ class Server extends SimpleContainer implements IServerContainer {
 						: null,
 				],
 				new SecureRandom(),
-				$c->getCrypto(),
 				$c->getConfig()
 			);
 

--- a/tests/lib/appframework/controller/ApiControllerTest.php
+++ b/tests/lib/appframework/controller/ApiControllerTest.php
@@ -38,7 +38,6 @@ class ApiControllerTest extends \Test\TestCase {
         $request = new Request(
             ['server' => ['HTTP_ORIGIN' => 'test']],
             $this->getMock('\OCP\Security\ISecureRandom'),
-            $this->getMock('\OCP\Security\ICrypto'),
             $this->getMock('\OCP\IConfig')
         );
         $this->controller = new ChildApiController('app', $request, 'verbs',

--- a/tests/lib/appframework/controller/ControllerTest.php
+++ b/tests/lib/appframework/controller/ControllerTest.php
@@ -76,7 +76,6 @@ class ControllerTest extends \Test\TestCase {
 				'method' => 'hi',
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 

--- a/tests/lib/appframework/controller/OCSControllerTest.php
+++ b/tests/lib/appframework/controller/OCSControllerTest.php
@@ -43,7 +43,6 @@ class OCSControllerTest extends \Test\TestCase {
 				],
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$controller = new ChildOCSController('app', $request, 'verbs',
@@ -65,7 +64,6 @@ class OCSControllerTest extends \Test\TestCase {
 		$controller = new ChildOCSController('app', new Request(
 			[],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		));
 		$expected = "<?xml version=\"1.0\"?>\n" .
@@ -98,7 +96,6 @@ class OCSControllerTest extends \Test\TestCase {
 		$controller = new ChildOCSController('app', new Request(
 			[],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		));
 		$expected = "<?xml version=\"1.0\"?>\n" .
@@ -131,7 +128,6 @@ class OCSControllerTest extends \Test\TestCase {
 		$controller = new ChildOCSController('app', new Request(
 			[],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		));
 		$expected = '{"ocs":{"meta":{"status":"failure","statuscode":400,"message":"OK",' .

--- a/tests/lib/appframework/dependencyinjection/DIContainerTest.php
+++ b/tests/lib/appframework/dependencyinjection/DIContainerTest.php
@@ -74,7 +74,6 @@ class DIContainerTest extends \Test\TestCase {
 		$this->container['Request'] = new Request(
 			['method' => 'GET'],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$security = $this->container['SecurityMiddleware'];

--- a/tests/lib/appframework/http/DispatcherTest.php
+++ b/tests/lib/appframework/http/DispatcherTest.php
@@ -295,7 +295,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'POST'
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(
@@ -323,7 +322,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'POST',
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(
@@ -354,7 +352,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'GET'
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(
@@ -384,7 +381,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'GET'
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(
@@ -415,7 +411,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'PUT'
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(
@@ -448,7 +443,6 @@ class DispatcherTest extends \Test\TestCase {
 				'method' => 'POST'
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->dispatcher = new Dispatcher(

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -54,7 +54,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -87,7 +86,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -110,7 +108,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -130,7 +127,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -150,7 +146,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -167,7 +162,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -189,7 +183,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -213,7 +206,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -235,7 +227,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -260,7 +251,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -281,7 +271,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -306,7 +295,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -336,7 +324,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -358,7 +345,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			$vars,
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -382,7 +368,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -394,7 +379,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			\OC::$server->getSecureRandom(),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -419,7 +403,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -448,7 +431,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -477,7 +459,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -510,7 +491,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -561,7 +541,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -589,7 +568,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -611,7 +589,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -622,7 +599,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -646,7 +622,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -667,7 +642,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -684,7 +658,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -705,7 +678,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -727,7 +699,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -816,7 +787,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -833,7 +803,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -851,7 +820,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -869,7 +837,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -897,7 +864,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -919,7 +885,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -946,7 +911,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -973,7 +937,6 @@ class RequestTest extends \Test\TestCase {
 				],
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -990,7 +953,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1018,7 +980,6 @@ class RequestTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1034,7 +995,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1055,7 +1015,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1076,7 +1035,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1099,7 +1057,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1122,7 +1079,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1145,7 +1101,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1168,7 +1123,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1223,7 +1177,6 @@ class RequestTest extends \Test\TestCase {
 				]
 			],
 			$this->secureRandom,
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->config,
 			$this->stream
 		);
@@ -1263,7 +1216,6 @@ class RequestTest extends \Test\TestCase {
 					]
 				],
 				$this->secureRandom,
-				$this->getMock('\OCP\Security\ICrypto'),
 				$this->config,
 				$this->stream
 			])
@@ -1277,25 +1229,17 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	public function testPassesCSRFCheckWithGet() {
-		$crypto = $this->getMock('\OCP\Security\ICrypto');
-		$crypto
-			->expects($this->once())
-			->method('decrypt')
-			->with('1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4', 'secret')
-			->will($this->returnValue('MyStoredRequestToken'));
-
 		/** @var Request $request */
 		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
 			->setMethods(['getScriptName'])
 			->setConstructorArgs([
 				[
 					'get' => [
-						'requesttoken' => '1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4:secret',
+						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
 					'requesttoken' => 'MyStoredRequestToken',
 				],
 				$this->secureRandom,
-				$crypto,
 				$this->config,
 				$this->stream
 			])
@@ -1305,25 +1249,17 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	public function testPassesCSRFCheckWithPost() {
-		$crypto = $this->getMock('\OCP\Security\ICrypto');
-		$crypto
-			->expects($this->once())
-			->method('decrypt')
-			->with('1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4', 'secret')
-			->will($this->returnValue('MyStoredRequestToken'));
-
 		/** @var Request $request */
 		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
 			->setMethods(['getScriptName'])
 			->setConstructorArgs([
 				[
 					'post' => [
-						'requesttoken' => '1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4:secret',
+						'requesttoken' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
 					'requesttoken' => 'MyStoredRequestToken',
 				],
 				$this->secureRandom,
-				$crypto,
 				$this->config,
 				$this->stream
 			])
@@ -1333,24 +1269,17 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	public function testPassesCSRFCheckWithHeader() {
-		$crypto = $this->getMock('\OCP\Security\ICrypto');
-		$crypto
-			->expects($this->once())
-			->method('decrypt')
-			->with('1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4', 'secret')
-			->will($this->returnValue('MyStoredRequestToken'));
 		/** @var Request $request */
 		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
 			->setMethods(['getScriptName'])
 			->setConstructorArgs([
 				[
 					'server' => [
-						'HTTP_REQUESTTOKEN' => '1c637c4147e40a8a8f09428ec2059cebea3480c27b402b4e793c69710a731513|wlXxNUaFqHuQnZr5|e6ab49c9e0e20c8d3607e02f1d8e6ec17ad6020ae10b7d64ab4b0a6318c0875940943a6aa303dc090fea0b4cd5b9fb8bcbecac4308a2bd15d9f369cdc22121a4:secret',
+						'HTTP_REQUESTTOKEN' => 'AAAHGxsTCTc3BgMQESAcNR0OAR0=:MyTotalSecretShareds',
 					],
 					'requesttoken' => 'MyStoredRequestToken',
 				],
 				$this->secureRandom,
-				$crypto,
 				$this->config,
 				$this->stream
 			])
@@ -1359,6 +1288,9 @@ class RequestTest extends \Test\TestCase {
 		$this->assertTrue($request->passesCSRFCheck());
 	}
 
+	/**
+	 * @return array
+	 */
 	public function invalidTokenDataProvider() {
 		return [
 			['InvalidSentToken'],
@@ -1373,8 +1305,6 @@ class RequestTest extends \Test\TestCase {
 	 * @param string $invalidToken
 	 */
 	public function testPassesCSRFCheckWithInvalidToken($invalidToken) {
-		$crypto = new Crypto($this->config, $this->secureRandom);
-
 		/** @var Request $request */
 		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
 			->setMethods(['getScriptName'])
@@ -1386,7 +1316,6 @@ class RequestTest extends \Test\TestCase {
 					'requesttoken' => 'MyStoredRequestToken',
 				],
 				$this->secureRandom,
-				$crypto,
 				$this->config,
 				$this->stream
 			])
@@ -1402,7 +1331,6 @@ class RequestTest extends \Test\TestCase {
 			->setConstructorArgs([
 				[],
 				$this->secureRandom,
-				$this->getMock('\OCP\Security\ICrypto'),
 				$this->config,
 				$this->stream
 			])

--- a/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareDispatcherTest.php
@@ -133,7 +133,6 @@ class MiddlewareDispatcherTest extends \Test\TestCase {
 				new Request(
 					['method' => 'GET'],
 					$this->getMock('\OCP\Security\ISecureRandom'),
-					$this->getMock('\OCP\Security\ICrypto'),
 					$this->getMock('\OCP\IConfig')
 				)
 			]

--- a/tests/lib/appframework/middleware/MiddlewareTest.php
+++ b/tests/lib/appframework/middleware/MiddlewareTest.php
@@ -61,7 +61,6 @@ class MiddlewareTest extends \Test\TestCase {
 				new Request(
 					[],
 					$this->getMock('\OCP\Security\ISecureRandom'),
-					$this->getMock('\OCP\Security\ICrypto'),
 					$this->getMock('\OCP\IConfig')
 				)
 			]

--- a/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/CORSMiddlewareTest.php
@@ -42,7 +42,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				]
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -62,7 +61,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				]
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$middleware = new CORSMiddleware($request, $this->reflector, $this->session);
@@ -80,7 +78,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -104,7 +101,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				]
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -123,7 +119,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		$request = new Request(
 			[],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
@@ -149,7 +144,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_PW' => 'pass'
 			]],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->session->expects($this->once())
@@ -175,7 +169,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_PW' => 'pass'
 			]],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->session->expects($this->once())
@@ -197,7 +190,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_PW' => 'pass'
 			]],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$middleware = new CORSMiddleware($request, $this->reflector, $this->session);
@@ -214,7 +206,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_PW' => 'pass'
 			]],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$middleware = new CORSMiddleware($request, $this->reflector, $this->session);
@@ -235,7 +226,6 @@ class CORSMiddlewareTest extends \Test\TestCase {
 				'PHP_AUTH_PW' => 'pass'
 			]],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$middleware = new CORSMiddleware($request, $this->reflector, $this->session);

--- a/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
+++ b/tests/lib/appframework/middleware/security/SecurityMiddlewareTest.php
@@ -322,7 +322,6 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 				]
 			],
 			$this->getMock('\OCP\Security\ISecureRandom'),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->middleware = $this->getMiddleware(true, true);

--- a/tests/lib/appframework/middleware/sessionmiddlewaretest.php
+++ b/tests/lib/appframework/middleware/sessionmiddlewaretest.php
@@ -36,7 +36,6 @@ class SessionMiddlewareTest extends \Test\TestCase {
 		$this->request = new Request(
 			[],
 			$this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock(),
-			$this->getMock('\OCP\Security\ICrypto'),
 			$this->getMock('\OCP\IConfig')
 		);
 		$this->reflector = new ControllerMethodReflector();

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -91,7 +91,7 @@ class Test_Util extends \Test\TestCase {
 
 	function testCallRegister() {
 		$result = strlen(OC_Util::callRegister());
-		$this->assertEquals(221, $result);
+		$this->assertEquals(71, $result);
 	}
 
 	function testSanitizeHTML() {


### PR DESCRIPTION
Proposed backport of https://github.com/owncloud/core/pull/19954

@karlitschek ACK?
