### PR TITLE
handle NoUserException in sharing code

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -32,6 +32,7 @@
 
 namespace OC\Files\Cache;
 
+use OC\User\NoUserException;
 use OCP\Share_Backend_Collection;
 
 /**
@@ -64,7 +65,12 @@ class Shared_Cache extends Cache {
 		}
 		$source = \OC_Share_Backend_File::getSource($target, $this->storage->getShare());
 		if (isset($source['path']) && isset($source['fileOwner'])) {
-			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+			try {
+				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+			} catch(NoUserException $e) {
+				\OC::$server->getLogger()->logException($e, ['app' => 'files_sharing']);
+				return false;
+			}
 			$mounts = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
 			if (is_array($mounts) and !empty($mounts)) {
 				$fullPath = $mounts[0]->getMountPoint() . $source['path'];


### PR DESCRIPTION
- setup LDAP users
- share from an LDAP user
- delete that LDAP user
- log in as share recipient
- before: unhandled NoUserException
- after: NoUserEception is logged and share is not shown anymore

Note:
The weird thing is, that once the user is marked as deleted, fetching the user is totally valid and nothing bad happens. Also the share is shown. Only once the user is not in the LDAP anymore and is not marked as deleted it throws an exception. This feels just totally wrong. @blizzz I think we need to rethink this behavior.

cc @PVince81 @schiesbn @icewind1991 Is this the way we want to handle this?
