### PR TITLE
[8.1] handle NoUserException in sharing code

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -31,6 +31,7 @@
 
 namespace OC\Files\Cache;
 
+use OC\User\NoUserException;
 use OCP\Share_Backend_Collection;
 
 /**
@@ -62,7 +63,12 @@ class Shared_Cache extends Cache {
 		}
 		$source = \OC_Share_Backend_File::getSource($target, $this->storage->getShare());
 		if (isset($source['path']) && isset($source['fileOwner'])) {
-			\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+			try {
+				\OC\Files\Filesystem::initMountPoints($source['fileOwner']);
+			} catch(NoUserException $e) {
+				\OC::$server->getLogger()->logException($e, ['app' => 'files_sharing']);
+				return false;
+			}
 			$mounts = \OC\Files\Filesystem::getMountByNumericId($source['storage']);
 			if (is_array($mounts) and !empty($mounts)) {
 				$fullPath = $mounts[0]->getMountPoint() . $source['path'];


### PR DESCRIPTION
- setup LDAP users
- share from an LDAP user
- delete that LDAP user
- log in as share recipient
- before: unhandled NoUserException
- after: NoUserEception is logged and share is not shown anymore
