### PR TITLE
[stable8.2] Make get current user behave similar to auth

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -99,6 +99,11 @@ class Auth extends AbstractBasic {
 		if($user && $this->isDavAuthenticated($user)) {
 			return $user;
 		}
+
+		if($user && is_null(\OC::$server->getSession()->get(self::DAV_AUTHENTICATED))) {
+			return $user;
+		}
+
 		return null;
 	}
 
@@ -114,6 +119,7 @@ class Auth extends AbstractBasic {
 	 * @param string $realm
 	 * @return bool
 	 * @throws ServiceUnavailable
+	 * @throws NotAuthenticated
 	 */
 	public function authenticate(\Sabre\DAV\Server $server, $realm) {
 


### PR DESCRIPTION
If DAV_AUTHENTICATED is a null value this is a valid web session and we should return the user name as we also do in `auth`. Otherwise backends which rely on `getCurrentUser`, as the contacts app for example, will receive `null` as username.

Fixes https://github.com/owncloud/core/issues/19969

<hr/>

@karlitschek This is against 8.2 - ACK?
@Henni @DeepDiver1975 Please test.

<hr/>

For master the patch will include proper unit tests which is not possible with the static code in 8.2.
