### PR TITLE
Fix path used in sabre's tree cache

### DIFF
--- a/apps/dav/lib/connector/sabre/objecttree.php
+++ b/apps/dav/lib/connector/sabre/objecttree.php
@@ -113,8 +113,8 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			}
 		}
 
-		if (isset($this->cache[$path])) {
-			return $this->cache[$path];
+		if (isset($this->cache['/' . $path])) {
+			return $this->cache['/' . $path];
 		}
 
 		// Is it the root node?
@@ -165,7 +165,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info);
 		}
 
-		$this->cache[$path] = $node;
+		$this->cache['/' . $path] = $node;
 		return $node;
 
 	}


### PR DESCRIPTION
Sabre's `getChildren()` cached path with a leading slash, now we properly used entries cached by `getChildren()` which prevents us from having to re-query the fileinfo.

Greatly improves performance when doing a Depth=1 PROPFIND ([comparison](https://blackfire.io/profiles/compare/e42556de-fc7a-4e16-8588-0b7284c91541/graph))

cc @DeepDiver1975 @PVince81 @LukasReschke 
