### PR TITLE
Dont lock /$user/files

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1941,7 +1941,7 @@ class View {
 		$pathSegments = explode('/', $path);
 		if (isset($pathSegments[2])) {
 			// E.g.: /username/files/path-to-file
-			return $pathSegments[2] === 'files';
+			return ($pathSegments[2] === 'files') && (count($pathSegments) > 3);
 		}
 
 		return true;


### PR DESCRIPTION
No use locking a users home folder since we don't need to worry about a request trying to rename/delete that.

[comparison](https://blackfire.io/profiles/compare/00cae63d-620a-4166-bbf5-e4dbd00207a6/graph) (propfind of a subfolder)

cc @DeepDiver1975 @PVince81 @LukasReschke 
