### PR TITLE
Remove assumption about name of users home folder.

### DIFF
--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -49,7 +49,10 @@ class Avatar implements \OCP\IAvatar {
 		if(!Filesystem::isValidPath($user)) {
 			throw new \Exception('Username may not contain slashes');
 		}
-		$this->view = new \OC\Files\View('/'.$user);
+		$data_dir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
+		$fake_root = str_replace($data_dir, '', \OC::$server->getUserManager()->get($user)->getHome());
+		
+		$this->view = new \OC\Files\View($fake_root);
 	}
 
 	/**

--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -50,8 +50,14 @@ class Avatar implements \OCP\IAvatar {
 			throw new \Exception('Username may not contain slashes');
 		}
 		$data_dir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
-		$fake_root = str_replace($data_dir, '', \OC::$server->getUserManager()->get($user)->getHome());
+		$user_manager = \OC::$server->getUserManager();	
 		
+		if ($user_manager->userExists($user)) {
+			$fake_root = str_replace($data_dir, '', $user_manager->get($user)->getHome());
+		} else {
+			$fake_root = '/' . $user;
+		}
+	
 		$this->view = new \OC\Files\View($fake_root);
 	}
 


### PR DESCRIPTION
Backends such as user_ldap allow values other than a user's internal username to be the name of their home directory. Therefore '/'.$uid is not guaranteed to refer to a valid home. Ask the system for the users full home then remove the data directory from the beginning.
