### PR TITLE
[stable8.2] Remove Dropbox metadata from cache after upload

### DIFF
--- a/apps/files_external/lib/dropbox.php
+++ b/apps/files_external/lib/dropbox.php
@@ -288,6 +288,7 @@ class Dropbox extends \OC\Files\Storage\Common {
 			try {
 				$this->dropbox->putFile(self::$tempFiles[$tmpFile], $handle);
 				unlink($tmpFile);
+				$this->deleteMetaData(self::$tempFiles[$tmpFile]);
 			} catch (\Exception $exception) {
 				\OCP\Util::writeLog('files_external', $exception->getMessage(), \OCP\Util::ERROR);
 			}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/19831

Please review @icewind1991 @schiesbn @nickvergessen @Xenopathic @DeepDiver1975

@karlitschek please confirm this backport
