### PR TITLE
Fix share link focus on click

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -151,8 +151,9 @@
 		},
 
 		onLinkTextClick: function() {
-			this.focus();
-			this.select();
+			var $el = this.$el.find('.linkText');
+			$el.focus();
+			$el.select();
 		},
 
 		onShowPasswordClick: function() {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -237,6 +237,29 @@ describe('OC.Share.ShareDialogView', function() {
 			expect(dialog.$el.find('.linkCheckbox').prop('checked')).toEqual(true);
 			expect(dialog.$el.find('.linkText').val()).toEqual(link);
 		});
+		it('autofocus link text when clicked', function() {
+			$('#allowShareWithLink').val('yes');
+
+			dialog.render();
+
+			// Toggle linkshare
+			dialog.$el.find('.linkCheckbox').click();
+			fakeServer.requests[0].respond(
+				200,
+				{ 'Content-Type': 'application/json' },
+				JSON.stringify({data: {token: 'xyz'}, status: 'success'})
+			);
+
+			var focusStub = sinon.stub($.fn, 'focus');
+			var selectStub = sinon.stub($.fn, 'select');
+			dialog.$el.find('.linkText').click();
+
+			expect(focusStub.calledOnce).toEqual(true);
+			expect(selectStub.calledOnce).toEqual(true);
+
+			focusStub.restore();
+			selectStub.restore();
+		});
 		describe('password', function() {
 			var slideToggleStub;
 


### PR DESCRIPTION
Clicking on the link share must focus and select it

Fixes https://github.com/owncloud/core/issues/19979

Please review @rullzer @schiesbn @DeepDiver1975 @tomneedham @MorrisJobke 

Note: this is 9.0 only because I recently moved the event registration to the top of the class, so `this` isn't the current jquery element any more but the actual view class.
