### PR TITLE
Don't lock if we're only reading cache metadata

### DIFF
--- a/apps/files_sharing/lib/watcher.php
+++ b/apps/files_sharing/lib/watcher.php
@@ -29,41 +29,41 @@ namespace OC\Files\Cache;
  * check the storage backends for updates and change the cache accordingly
  */
 class Shared_Watcher extends Watcher {
+	/**
+	 * @var \OC\Files\Storage\Shared $storage
+	 */
+	protected $storage;
 
 	/**
-	 * check $path for updates
+	 * Update the cache for changes to $path
 	 *
 	 * @param string $path
-	 * @param array $cachedEntry
-	 * @return boolean true if path was updated
+	 * @param array $cachedData
 	 */
-	public function checkUpdate($path, $cachedEntry = null) {
-		if (parent::checkUpdate($path, $cachedEntry) === true) {
-			// since checkUpdate() has already updated the size of the subdirs,
-			// only apply the update to the owner's parent dirs
+	public function update($path, $cachedData) {
+		parent::update($path, $cachedData);
+		// since parent::update() has already updated the size of the subdirs,
+		// only apply the update to the owner's parent dirs
 
-			// find last parent before reaching the shared storage root,
-			// which is the actual shared dir from the owner
-			$sepPos = strpos($path, '/');
-			if ($sepPos > 0) {
-				$baseDir = substr($path, 0, $sepPos);
-			} else {
-				$baseDir = $path;
-			}
-
-			// find the path relative to the data dir
-			$file = $this->storage->getFile($baseDir);
-			$view = new \OC\Files\View('/' . $file['fileOwner']);
-
-			// find the owner's storage and path
-			list($storage, $internalPath) = $view->resolvePath($file['path']);
-
-			// update the parent dirs' sizes in the owner's cache
-			$storage->getCache()->correctFolderSize(dirname($internalPath));
-
-			return true;
+		// find last parent before reaching the shared storage root,
+		// which is the actual shared dir from the owner
+		$sepPos = strpos($path, '/');
+		if ($sepPos > 0) {
+			$baseDir = substr($path, 0, $sepPos);
+		} else {
+			$baseDir = $path;
 		}
-		return false;
+
+		// find the path relative to the data dir
+		$file = $this->storage->getFile($baseDir);
+		$view = new \OC\Files\View('/' . $file['fileOwner']);
+
+		// find the owner's storage and path
+		/** @var \OC\Files\Storage\Storage $storage */
+		list($storage, $internalPath) = $view->resolvePath($file['path']);
+
+		// update the parent dirs' sizes in the owner's cache
+		$storage->getCache()->correctFolderSize(dirname($internalPath));
 	}
 
 	/**

--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -119,6 +119,7 @@ class Watcher {
 	 */
 	public function needsUpdate($path, $cachedData) {
 		if ($this->watchPolicy === self::CHECK_ALWAYS or ($this->watchPolicy === self::CHECK_ONCE and array_search($path, $this->checkedPaths) === false)) {
+			$this->checkedPaths[] = $path;
 			return $this->storage->hasUpdated($path, $cachedData['storage_mtime']);
 		}
 		return false;

--- a/lib/private/files/cache/watcher.php
+++ b/lib/private/files/cache/watcher.php
@@ -74,34 +74,54 @@ class Watcher {
 	}
 
 	/**
-	 * check $path for updates
+	 * check $path for updates and update if needed
 	 *
 	 * @param string $path
 	 * @param array $cachedEntry
 	 * @return boolean true if path was updated
 	 */
 	public function checkUpdate($path, $cachedEntry = null) {
-		if ($this->watchPolicy === self::CHECK_ALWAYS or ($this->watchPolicy === self::CHECK_ONCE and array_search($path, $this->checkedPaths) === false)) {
-			if (is_null($cachedEntry)) {
-				$cachedEntry = $this->cache->get($path);
-			}
-			$this->checkedPaths[] = $path;
-			if ($this->storage->hasUpdated($path, $cachedEntry['storage_mtime'])) {
-				if ($this->storage->is_dir($path)) {
-					$this->scanner->scan($path, Scanner::SCAN_SHALLOW);
-				} else {
-					$this->scanner->scanFile($path);
-				}
-				if ($cachedEntry['mimetype'] === 'httpd/unix-directory') {
-					$this->cleanFolder($path);
-				}
-				$this->cache->correctFolderSize($path);
-				return true;
-			}
-			return false;
+		if (is_null($cachedEntry)) {
+			$cachedEntry = $this->cache->get($path);
+		}
+		if ($this->needsUpdate($path, $cachedEntry)) {
+			$this->update($path, $cachedEntry);
+			return true;
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Update the cache for changes to $path
+	 *
+	 * @param string $path
+	 * @param array $cachedData
+	 */
+	public function update($path, $cachedData) {
+		if ($this->storage->is_dir($path)) {
+			$this->scanner->scan($path, Scanner::SCAN_SHALLOW);
+		} else {
+			$this->scanner->scanFile($path);
+		}
+		if ($cachedData['mimetype'] === 'httpd/unix-directory') {
+			$this->cleanFolder($path);
+		}
+		$this->cache->correctFolderSize($path);
+	}
+
+	/**
+	 * Check if the cache for $path needs to be updated
+	 *
+	 * @param string $path
+	 * @param array $cachedData
+	 * @return bool
+	 */
+	public function needsUpdate($path, $cachedData) {
+		if ($this->watchPolicy === self::CHECK_ALWAYS or ($this->watchPolicy === self::CHECK_ONCE and array_search($path, $this->checkedPaths) === false)) {
+			return $this->storage->hasUpdated($path, $cachedData['storage_mtime']);
+		}
+		return false;
 	}
 
 	/**

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -1296,8 +1296,8 @@ class View {
 				$this->unlockFile($directory, ILockingProvider::LOCK_SHARED);
 			}
 
-				$folderId = $data['fileid'];
-				$contents = $cache->getFolderContentsById($folderId); //TODO: mimetype_filter
+			$folderId = $data['fileid'];
+			$contents = $cache->getFolderContentsById($folderId); //TODO: mimetype_filter
 
 			foreach ($contents as $content) {
 				if ($content['permissions'] === 0) {


### PR DESCRIPTION
Since the db ensures we get a proper metadata snapshot we don't need to lock if we're only reading from the database.

Made possible by splitting `checkUpdate` so we can still lock correctly if we need to re-scan

Makes PROPFIND a non-locking operation ([comparison](https://blackfire.io/profiles/compare/3472c9b3-b00a-4d6d-950d-2a2808787414/graph))

cc @DeepDiver1975 @PVince81 @LukasReschke 
