### PR TITLE
[stable8] Stop processing if PHP 7 is used

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,6 +29,14 @@ if (version_compare(PHP_VERSION, '5.4.0') === -1) {
 	return;
 }
 
+// Show warning if PHP 7 is used as ownCloud is not compatible with PHP 7 until
+// version 8.2.0.
+if (version_compare(PHP_VERSION, '7.0.0') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.<br/>';
+	echo 'You are currently running ' . PHP_VERSION . '. Please use at least ownCloud 8.2.0.';
+	return;
+}
+
 try {
 	
 	require_once 'lib/base.php';


### PR DESCRIPTION
PHP 7 is only compatible with ownCloud 8.2.0

I'd _LOVE_ to have this already in the current maintenance release as PHP 7 will be released in 3 weeks and using PHP 7 in combination with older ownCloud releases can lead to quite some hard to debug bugs.

@karlitschek @cmonteroluque @DeepDiver1975 Please review.
