### PR TITLE
Disable app icon preview in apps page for IE

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1633,6 +1633,15 @@ OC.Util = {
 	},
 
 	/**
+	 * Returns whether this is IE
+	 *
+	 * @return {bool} true if this is IE, false otherwise
+	 */
+	isIE: function() {
+		return $('html').hasClass('ie');
+	},
+
+	/**
 	 * Returns whether this is IE8
 	 *
 	 * @return {bool} true if this is IE8, false otherwise

--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -161,8 +161,8 @@ OC.Settings.Apps = OC.Settings.Apps || {
 
 		var page = $('#app-' + app.id);
 
-		// image loading kung-fu
-		if (app.preview) {
+		// image loading kung-fu (IE doesn't properly scale SVGs, so disable app icons)
+		if (app.preview && !OC.Util.isIE()) {
 			var currentImage = new Image();
 			currentImage.src = app.preview;
 


### PR DESCRIPTION
All IE versions are not able to properly upscale SVG icons unless the
said SVG files contain a "viewBox" attribute, which is not always the
case. Also we cannot guarantee that all third party apps will have this
attribute in their icons.

So for now, app icons will not be displayed in IE instead of broken
ones.

backport of https://github.com/owncloud/core/pull/19923
