### PR TITLE
Serve files with an attachment disposition for new DAV endpoint

### DIFF
--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -110,10 +110,15 @@ class Server {
 
 		// Serve all files with an Content-Disposition of type "attachment"
 		$this->server->on('beforeMethod', function (RequestInterface $requestInterface, ResponseInterface $responseInterface) {
-				$node = $this->server->tree->getNodeForPath($requestInterface->getPath());
-				if (($node instanceof IFile)) {
-					$responseInterface->addHeader('Content-Disposition', 'attachment');
+			if ($requestInterface->getMethod() === 'GET') {
+				$path = $requestInterface->getPath();
+				if ($this->server->tree->nodeExists($path)) {
+					$node = $this->server->tree->getNodeForPath($path);
+					if (($node instanceof IFile)) {
+						$responseInterface->addHeader('Content-Disposition', 'attachment');
+					}
 				}
+			}
 		});
 
 		// wait with registering these until auth is handled and the filesystem is setup

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -30,6 +30,10 @@ use OCA\DAV\Files\CustomPropertiesBackend;
 use OCP\IRequest;
 use OCP\SabrePluginEvent;
 use Sabre\DAV\Auth\Plugin;
+use Sabre\DAV\IFile;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\Util;
 
 class Server {
 
@@ -103,6 +107,14 @@ class Server {
 		])) {
 			$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\FakeLockerPlugin());
 		}
+
+		// Serve all files with an Content-Disposition of type "attachment"
+		$this->server->on('beforeMethod', function (RequestInterface $requestInterface, ResponseInterface $responseInterface) {
+				$node = $this->server->tree->getNodeForPath($requestInterface->getPath());
+				if (($node instanceof IFile)) {
+					$responseInterface->addHeader('Content-Disposition', 'attachment');
+				}
+		});
 
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod', function () {


### PR DESCRIPTION
This adds a `Content-Disposition: attachment` header to all files served via the DAV endpoint.

That said. I'm personally not too happy with this approach as we may aim to serve different content than files through this endpoint and thus this would more belong sort into file specific code instead of global error handling.

Thoughts @DeepDiver1975?

cc @evert If you have a spare minute left and any better idea how to achieve this, this would be utmost welcome.
