### PR TITLE
Fix file list reload callback result

### DIFF
--- a/apps/files/js/favoritesfilelist.js
+++ b/apps/files/js/favoritesfilelist.js
@@ -71,6 +71,10 @@ $(document).ready(function() {
 				if (this._reloadCall) {
 					this._reloadCall.abort();
 				}
+
+				// there is only root
+				this._setCurrentDir('/', false);
+
 				this._reloadCall = $.ajax({
 					url: OC.generateUrl('/apps/files/api/v1/tags/{tagName}/files', {tagName: tagName}),
 					type: 'GET',
@@ -86,10 +90,9 @@ $(document).ready(function() {
 
 				if (result.files) {
 					this.setFiles(result.files.sort(this._sortComparator));
+					return true;
 				}
-				else {
-					// TODO: error handling
-				}
+				return false;
 			}
 		});
 

--- a/apps/files_external/js/mountsfilelist.js
+++ b/apps/files_external/js/mountsfilelist.js
@@ -86,6 +86,10 @@
 			if (this._reloadCall) {
 				this._reloadCall.abort();
 			}
+
+			// there is only root
+			this._setCurrentDir('/', false);
+
 			this._reloadCall = $.ajax({
 				url: OC.linkToOCS('apps/files_external/api/v1') + 'mounts',
 				data: {
@@ -106,10 +110,9 @@
 
 			if (result.ocs && result.ocs.data) {
 				this.setFiles(this._makeFiles(result.ocs.data));
+				return true;
 			}
-			else {
-				// TODO: error handling
-			}
+			return false;
 		},
 
 		/**

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -123,6 +123,9 @@
 				this._reloadCall.abort();
 			}
 
+			// there is only root
+			this._setCurrentDir('/', false);
+
 			var promises = [];
 			var shares = $.ajax({
 				url: OC.linkToOCS('apps/files_sharing/api/v1') + 'shares',
@@ -173,17 +176,14 @@
 
 			if (shares[0].ocs && shares[0].ocs.data) {
 				files = files.concat(this._makeFilesFromShares(shares[0].ocs.data));
-			} else {
-				// TODO: error handling
 			}
 
 			if (remoteShares && remoteShares[0].ocs && remoteShares[0].ocs.data) {
 				files = files.concat(this._makeFilesFromRemoteShares(remoteShares[0].ocs.data));
-			} else {
-				// TODO: error handling
 			}
 
 			this.setFiles(files);
+			return true;
 		},
 
 		_makeFilesFromRemoteShares: function(data) {


### PR DESCRIPTION
All reloadCallback must return either true for success or false in case
of failure / non-existing folder.

Some file lists only have a root folder (favorite, shares), so restrict
the path to that to avoid having a wrong path in the breadcrumbs.

Fixes https://github.com/owncloud/core/issues/10813

Please review @rullzer @icewind1991 @nickvergessen @jvillafanez 
