### PR TITLE
Fix trashbin wrapper when no user is loggedin

### DIFF
--- a/apps/files_trashbin/lib/storage.php
+++ b/apps/files_trashbin/lib/storage.php
@@ -26,6 +26,7 @@ namespace OCA\Files_Trashbin;
 
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Wrapper;
+use OC\Files\View;
 use OCP\IUserManager;
 
 class Storage extends Wrapper {
@@ -151,8 +152,8 @@ class Storage extends Wrapper {
 
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$result = true;
-		if (!isset($this->deletedFiles[$normalized])) {
-			$view = Filesystem::getView();
+		$view = Filesystem::getView();
+		if (!isset($this->deletedFiles[$normalized]) && $view instanceof View) {
 			$this->deletedFiles[$normalized] = $normalized;
 			if ($filesPath = $view->getRelativePath($normalized)) {
 				$filesPath = trim($filesPath, '/');

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -531,4 +531,14 @@ class Storage extends \Test\TestCase {
 			['/schiesbn/', '/test.txt', false, false],
 		];
 	}
+
+	/**
+	 * Test that deleting a file doesn't error when nobody is logged in
+	 */
+	public function testSingleStorageDeleteFileLoggedOut() {
+		$this->logout();
+
+		$this->assertTrue($this->userView->file_exists('test.txt'));
+		$this->userView->unlink('test.txt');
+	}
 }

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -538,7 +538,10 @@ class Storage extends \Test\TestCase {
 	public function testSingleStorageDeleteFileLoggedOut() {
 		$this->logout();
 
-		$this->assertTrue($this->userView->file_exists('test.txt'));
-		$this->userView->unlink('test.txt');
+		if (!$this->userView->file_exists('test.txt')) {
+			$this->markTestSkipped('Skipping since the current home storage backend requires the user to logged in');
+		} else {
+			$this->userView->unlink('test.txt');
+		}
 	}
 }


### PR DESCRIPTION
Since #15367 the trashbin wrapper is also applied when no user is logged in.

cc @MorrisJobke @butonic @PVince81 
