### PR TITLE
Enable DAV app testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - realpath
 
 before_install:
+  - bash tests/travis/test_for_app.sh $APP
   - bash tests/travis/before_install.sh $DB
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: false
+language: php
+php:
+  - 5.4
+
+env:
+  global:
+    - APP=dav
+    - TC=litmus-v2
+  matrix:
+    - DB=sqlite
+
+branches:
+  only:
+    - master
+#    - /^stable\d+(\.\d+)?$/
+
+addons:
+  apt:
+    packages:
+    - realpath
+
+before_install:
+  - bash tests/travis/before_install.sh $DB
+
+install:
+  - bash tests/travis/install.sh $DB
+
+script:
+  - bash apps/$APP/tests/travis/$TC.sh
+
+matrix:
+  include:
+    - php: 5.4
+      env: DB=pgsql;TC=litmus-v1;APP=dav
+#    - php: 5.4
+#      env: DB=mysql;TC=caldavtester;APP=dav
+
+  fast_finish: true

--- a/apps/dav/tests/travis/litmus-v1.sh
+++ b/apps/dav/tests/travis/litmus-v1.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 

--- a/apps/dav/tests/travis/litmus-v1.sh
+++ b/apps/dav/tests/travis/litmus-v1.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+
+
+# start the server
+php -S 127.0.0.1:8888 -t "$SCRIPTPATH/../../../.." &
+
+
+# compile litmus
+if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
+  mkdir -p /tmp/litmus
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  cd /tmp/litmus
+  tar -xzf litmus-0.13.tar.gz
+  cd /tmp/litmus/litmus-0.13
+  ./configure
+  make
+fi
+
+# run the tests
+cd /tmp/litmus/litmus-0.13
+make URL=http://127.0.0.1:8888/remote.php/webdav CREDS="admin admin" TESTS="basic copymove props locks" check

--- a/apps/dav/tests/travis/litmus-v2.sh
+++ b/apps/dav/tests/travis/litmus-v2.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 

--- a/apps/dav/tests/travis/litmus-v2.sh
+++ b/apps/dav/tests/travis/litmus-v2.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+
+
+# start the server
+php -S 127.0.0.1:8888 -t "$SCRIPTPATH/../../../.." &
+
+
+# compile litmus
+if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
+  mkdir -p /tmp/litmus
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  cd /tmp/litmus
+  tar -xzf litmus-0.13.tar.gz
+  cd /tmp/litmus/litmus-0.13
+  ./configure
+  make
+fi
+
+# run the tests
+cd /tmp/litmus/litmus-0.13
+make URL=http://127.0.0.1:8888/remote.php/dav/files/admin CREDS="admin admin" TESTS="basic copymove props locks" check

--- a/tests/travis/before_install.sh
+++ b/tests/travis/before_install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# @author Thomas Müller
+# @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+#
+
+set -e
+
+WORKDIR=$PWD
+DB=$1
+echo "Work directory: $WORKDIR"
+echo "Database: $DB"
+
+if [ "$DB" == "mysql" ] ; then
+  echo "Setting up mysql ..."
+  mysql -e 'create database oc_autotest;'
+  mysql -u root -e "CREATE USER 'oc_autotest'@'localhost' IDENTIFIED BY 'owncloud'";
+  mysql -u root -e "grant all on oc_autotest.* to 'oc_autotest'@'localhost'";
+  mysql -e "SELECT User FROM mysql.user;"
+fi
+
+if [ "$DB" == "pgsql" ] ; then
+  createuser -U travis -s oc_autotest
+fi
+
+#if [ "$DB" == "oracle" ] ; then
+#  if [ ! -f before_install_oracle.sh ]; then
+#    wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install_oracle.sh
+#  fi
+#  bash ./before_install_oracle.sh
+#fi
+
+#
+# copy custom php.ini settings
+#
+if [ $(phpenv version-name) != 'hhvm' ]; then
+  phpenv config-add tests/travis/custom.ini
+fi

--- a/tests/travis/custom.ini
+++ b/tests/travis/custom.ini
@@ -1,0 +1,4 @@
+always_populate_raw_post_data = -1
+mbstring.func_overload = 0
+default_charset = 'UTF-8'
+output_buffering = off

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# @author Thomas Müller
+# @copyright 2014 Thomas Müller thomas.mueller@tmit.eu
+#
+
+set -e
+
+DATABASENAME=oc_autotest
+DATABASEUSER=oc_autotest
+ADMINLOGIN=admin
+BASEDIR=$PWD
+
+DBCONFIGS="sqlite mysql pgsql oracle"
+PHPUNIT=$(which phpunit)
+
+# set oracle home if it is not set
+TRAVIS_ORACLE_HOME="/usr/lib/oracle/xe/app/oracle/product/10.2.0/server"
+[ -z "$ORACLE_HOME" ] && ORACLE_HOME=$TRAVIS_ORACLE_HOME
+
+if [ $1 ]; then
+	FOUND=0
+	for DBCONFIG in $DBCONFIGS; do
+		if [ $1 = $DBCONFIG ]; then
+			FOUND=1
+			break
+		fi
+	done
+	if [ $FOUND = 0 ]; then
+		echo -e "Unknown database config name \"$1\"\n" >&2
+		print_syntax
+		exit 2
+	fi
+fi
+
+# use tmpfs for datadir - should speedup unit test execution
+DATADIR=$BASEDIR/data-autotest
+
+echo "Using database $DATABASENAME"
+
+# create autoconfig for sqlite, mysql and postgresql
+cat > ./tests/autoconfig-sqlite.php <<DELIM
+<?php
+\$AUTOCONFIG = array (
+  'installed' => false,
+  'dbtype' => 'sqlite',
+  'dbtableprefix' => 'oc_',
+  'adminlogin' => '$ADMINLOGIN',
+  'adminpass' => 'admin',
+  'directory' => '$DATADIR',
+);
+DELIM
+
+cat > ./tests/autoconfig-mysql.php <<DELIM
+<?php
+\$AUTOCONFIG = array (
+  'installed' => false,
+  'dbtype' => 'mysql',
+  'dbtableprefix' => 'oc_',
+  'adminlogin' => '$ADMINLOGIN',
+  'adminpass' => 'admin',
+  'directory' => '$DATADIR',
+  'dbuser' => '$DATABASEUSER',
+  'dbname' => '$DATABASENAME',
+  'dbhost' => 'localhost',
+  'dbpass' => 'owncloud',
+);
+DELIM
+
+cat > ./tests/autoconfig-pgsql.php <<DELIM
+<?php
+\$AUTOCONFIG = array (
+  'installed' => false,
+  'dbtype' => 'pgsql',
+  'dbtableprefix' => 'oc_',
+  'adminlogin' => '$ADMINLOGIN',
+  'adminpass' => 'admin',
+  'directory' => '$DATADIR',
+  'dbuser' => '$DATABASEUSER',
+  'dbname' => '$DATABASENAME',
+  'dbhost' => 'localhost',
+  'dbpass' => '',
+);
+DELIM
+
+cat > ./tests/autoconfig-oracle.php <<DELIM
+<?php
+\$AUTOCONFIG = array (
+  'installed' => false,
+  'dbtype' => 'oci',
+  'dbtableprefix' => 'oc_',
+  'adminlogin' => '$ADMINLOGIN',
+  'adminpass' => 'admin',
+  'directory' => '$DATADIR',
+  'dbuser' => '$DATABASENAME',
+  'dbname' => 'XE',
+  'dbhost' => 'localhost',
+  'dbpass' => 'owncloud',
+  'loglevel' => 0,
+);
+DELIM
+
+function execute_tests {
+	echo "Setup environment for $1 testing ..."
+	# back to root folder
+	cd $BASEDIR
+
+	# revert changes to tests/data
+	git checkout tests/data/*
+
+	# reset data directory
+	rm -rf $DATADIR
+	mkdir $DATADIR
+
+	cp tests/preseed-config.php config/config.php
+
+	if [ "$1" == "oracle" ] ; then
+		echo "Load Oracle environment variables so that we can run 'sqlplus'."
+		. $ORACLE_HOME/bin/oracle_env.sh
+
+		echo "create the database"
+		sqlplus -s -l / as sysdba <<EOF
+			create user $DATABASENAME identified by owncloud;
+			alter user $DATABASENAME default tablespace users
+			temporary tablespace temp
+			quota unlimited on users;
+			grant create session
+			, create table
+			, create procedure
+			, create sequence
+			, create trigger
+			, create view
+			, create synonym
+			, alter session
+			to $DATABASENAME;
+			exit;
+EOF
+	fi
+
+	# copy autoconfig
+	cp $BASEDIR/tests/autoconfig-$1.php $BASEDIR/config/autoconfig.php
+
+	# trigger installation
+	echo "INDEX"
+	php -f index.php
+	echo "END INDEX"
+
+	#test execution
+	cd tests
+	#php -f enable_all.php
+}
+
+#
+# start test execution
+#
+if [ -z "$1" ]
+  then
+	# run all known database configs
+	for DBCONFIG in $DBCONFIGS; do
+		execute_tests $DBCONFIG
+	done
+else
+	execute_tests $1 $2 $3
+fi
+
+# show environment
+echo "owncloud configuration:"
+cat $BASEDIR/config/config.php
+
+
+echo "data directory:"
+ls -ll $DATADIR
+
+echo "owncloud.log:"
+[ -f "$DATADIR/owncloud.log" ] && cat $DATADIR/owncloud.log
+[ -f "$BASEDIR/data/owncloud.log" ] && cat $BASEDIR/data/owncloud.log
+
+cd $BASEDIR

--- a/tests/travis/test_for_app.sh
+++ b/tests/travis/test_for_app.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# @author Thomas Müller
+# @copyright 2015 Thomas Müller thomas.mueller@tmit.eu
+#
+
+set -e
+APP=$1
+
+if git diff ${TRAVIS_COMMIT_RANGE} | grep -- "^+++ b/apps/$APP/"; then
+	echo "Executing this test config ...."
+else
+	echo "Test config is not relevant for this change. terminating"
+	exit 1
+fi


### PR DESCRIPTION
So ..... what is this about?

All integration tests in the area of the new dav implementation will be executed on travis.

Why? - Maintenance of these test on travis is much easier
Why not all tests? - Our phpuit tests run toooo long and we have to wait for ever ... we did this already in the past

@karlitschek @icewind1991 @nickvergessen @PVince81 @schiesbn @blizzz @rullzer @MorrisJobke 

Please have a look and let me know what you think - THX
