### PR TITLE
[stable8.2] Revert "setting to skip migration tests by default"

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1153,15 +1153,6 @@ $CONFIG = array(
 'debug' => false,
 
 /**
- * Skips the migration test during upgrades
- *
- * If this is set to true the migration test are deactivated during upgrade.
- * This is only recommended in installations where upgrade tests are run in
- * advance with the same data on a test system.
- */
-'update.skip-migration-test' => false,
-
-/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -41,21 +41,12 @@ if (OC::checkUpgrade(false)) {
 	// avoid side effects
 	\OC_User::setIncognitoMode(true);
 
-
-
 	$logger = \OC::$server->getLogger();
-	$config = \OC::$server->getConfig();
 	$updater = new \OC\Updater(
 			\OC::$server->getHTTPHelper(),
-			$config,
+			\OC::$server->getConfig(),
 			$logger
 	);
-
-	if ($config->getSystemValue('update.skip-migration-test', false)) {
-		$eventSource->send('success', (string)$l->t('Migration tests are skipped - "update.skip-migration-test" is activated in config.php'));
-		$updater->setSimulateStepEnabled(false);
-	}
-
 	$incompatibleApps = [];
 	$disabledThirdPartyApps = [];
 

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -96,12 +96,6 @@ class Upgrade extends Command {
 		$updateStepEnabled = true;
 		$skip3rdPartyAppsDisable = false;
 
-		if ($this->config->getSystemValue('update.skip-migration-test', false)) {
-			$output->writeln(
-				'<info>"skip-migration-test" is activated via config.php</info>'
-			);
-			$simulateStepEnabled = false;
-		}
 		if ($input->getOption('skip-migration-test')) {
 			$simulateStepEnabled = false;
 		}


### PR DESCRIPTION
This reverts commit 7cbdd9b90bcea3566b7d0198f23da3d427e6ef45.

Backport of #20097
Reverts #19508

Reason: https://github.com/owncloud/core/pull/19661#issuecomment-151631544

@nickvergessen @PVince81 @LukasReschke @DeepDiver1975 Please review
