### PR TITLE
remove uselessly used parameter, read all user attributes also when l…

### DIFF
--- a/apps/user_ldap/group_ldap.php
+++ b/apps/user_ldap/group_ldap.php
@@ -553,6 +553,7 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 
 		$groupUsers = array();
 		$isMemberUid = (strtolower($this->access->connection->ldapGroupMemberAssocAttr) === 'memberuid');
+		$attrs = $this->access->userManager->getAttributes(true);
 		foreach($members as $member) {
 			if($isMemberUid) {
 				//we got uids, need to get their DNs to 'translate' them to user names
@@ -560,11 +561,11 @@ class GROUP_LDAP extends BackendUtility implements \OCP\GroupInterface {
 					str_replace('%uid', $member, $this->access->connection->ldapLoginFilter),
 					$this->access->getFilterPartForUserSearch($search)
 				));
-				$ldap_users = $this->access->fetchListOfUsers($filter, 'dn');
+				$ldap_users = $this->access->fetchListOfUsers($filter, $attrs, 1);
 				if(count($ldap_users) < 1) {
 					continue;
 				}
-				$groupUsers[] = $this->access->dn2username($ldap_users[0]);
+				$groupUsers[] = $this->access->dn2username($ldap_users[0]['dn'][0]);
 			} else {
 				//we got DNs, check if we need to filter by search or we can give back all of them
 				if(!empty($search)) {

--- a/apps/user_ldap/lib/access.php
+++ b/apps/user_ldap/lib/access.php
@@ -706,9 +706,8 @@ class Access extends LDAPUtility implements user\IUserTools {
 	 * @param array $ldapRecords
 	 */
 	public function batchApplyUserAttributes(array $ldapRecords){
-		$displayNameAttribute = strtolower($this->connection->ldapUserDisplayName);
 		foreach($ldapRecords as $userRecord) {
-			$ocName  = $this->dn2ocname($userRecord['dn'][0], $userRecord[$displayNameAttribute]);
+			$ocName  = $this->dn2ocname($userRecord['dn'][0]);
 			$this->cacheUserExists($ocName);
 			$user = $this->userManager->get($ocName);
 			if($user instanceof OfflineUser) {


### PR DESCRIPTION
…ooking up users in groups

Two improvements based on @eidota 's findings in https://github.com/owncloud/core/pull/20093, see https://github.com/owncloud/core/pull/20093#discussion_r43270323 and https://github.com/owncloud/core/pull/20093#issuecomment-151889286 for further explanation.

Basically, with the background job or when looking at an LDAP group with users on the Users page, there should not be any undefined index warnings anymore, but email address and co should be fetched this way just as well.

Since it was found after #20093 was merged this is kind of an P.S. to it, and needs to be backported alongside with that. fyi @karlitschek 

Please test and review @davitol @eidota @MorrisJobke
