### PR TITLE
Remember scroll distance of every directory, solves #18805

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1318,15 +1318,13 @@
 				return;
 			}
 			var distance = this.$container.scrollTop() ? this.$container.scrollTop().toString() : '0';
-			var key = ($('#sharingToken').val() === undefined) ? currentDir : $('#sharingToken').val()+':'+currentDir;
-			sessionStorage.setItem(key, distance);
+			sessionStorage.setItem(currentDir, distance);
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {
 					self.changeDirectory(currentDir, true);
 				} else {
-					var key = ($('#sharingToken').val() === undefined) ? targetDir : $('#sharingToken').val()+':'+targetDir;
-					self.loadAndScrollTo(parseInt(sessionStorage.getItem(key)));
+					self.loadAndScrollTo(parseInt(sessionStorage.getItem(targetDir)));
 				}
 			});
 		},

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1318,13 +1318,15 @@
 				return;
 			}
 			var distance = this.$container.scrollTop() ? this.$container.scrollTop().toString() : '0';
-			sessionStorage.setItem(currentDir, distance);
+			var key = ($('#sharingToken').val() === undefined) ? currentDir : $('#sharingToken').val()+':'+currentDir;
+			sessionStorage.setItem(key, distance);
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {
 					self.changeDirectory(currentDir, true);
 				} else {
-					self.loadAndScrollTo(parseInt(sessionStorage.getItem(targetDir)));
+					var key = ($('#sharingToken').val() === undefined) ? targetDir : $('#sharingToken').val()+':'+targetDir;
+					self.loadAndScrollTo(parseInt(sessionStorage.getItem(key)));
 				}
 			});
 		},

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1317,7 +1317,8 @@
 			if (!force && currentDir === targetDir) {
 				return;
 			}
-			sessionStorage.setItem(currentDir, this.$container.scrollTop().toString());
+			var distance = this.$container.scrollTop() ? this.$container.scrollTop().toString() : '0';
+			sessionStorage.setItem(currentDir, distance);
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1317,7 +1317,7 @@
 			if (!force && currentDir === targetDir) {
 				return;
 			}
-			sessionStorage.setItem(currentDir, $('#app-content').scrollTop().toString());
+			sessionStorage.setItem(currentDir, this.$container.scrollTop().toString());
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1317,10 +1317,13 @@
 			if (!force && currentDir === targetDir) {
 				return;
 			}
+			sessionStorage.setItem(currentDir, $('#app-content').scrollTop().toString());
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {
 					self.changeDirectory(currentDir, true);
+				} else {
+					self.loadAndScrollTo(parseInt(sessionStorage.getItem(targetDir)));
 				}
 			});
 		},
@@ -2647,6 +2650,20 @@
 				self.updateStorageStatistics();
 			});
 
+		},
+
+		/**
+		 * Load enough rows and scroll to that distance
+		 * @param distance distance in pixel to scroll to
+		 */
+		loadAndScrollTo: function(distance) {
+			if ( this.$container[0].scrollHeight - this.$container.innerHeight() > distance ) {
+				this.$container.scrollTop(distance);
+			} else {
+				while(this.$container[0].scrollHeight - this.$container.innerHeight() < distance && this._nextPage(false) !== false) {
+				}
+				this.$container.scrollTop(distance);
+			}
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1371,6 +1371,17 @@ describe('OCA.Files.FileList tests', function() {
 			setDirSpy.restore();
 			getFolderContentsStub.restore();
 		});
+		it('scroll distance is passed to sessionStorage ', function() {
+			var setItemStub = sinon.stub(window.sessionStorage, 'setItem');
+			fileList.changeDirectory('/somedir');
+			fileList.changeDirectory('/anotherdir');
+			expect(setItemStub.getCall(0).args[0]).toEqual('/subdir');
+			expect(setItemStub.getCall(0).args[1]).toEqual('0');
+			expect(setItemStub.getCall(1).args[0]).toEqual('/somedir');
+			expect(setItemStub.getCall(1).args[1]).toEqual('0');
+			setItemStub.restore();
+			getFolderContentsStub.restore();
+		});
 	});
 	describe('breadcrumb events', function() {
 		var deferredList;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1371,15 +1371,26 @@ describe('OCA.Files.FileList tests', function() {
 			setDirSpy.restore();
 			getFolderContentsStub.restore();
 		});
-		it('scroll distance is passed to sessionStorage ', function() {
+		it('scroll distance is passed to sessionStorage', function() {
 			var setItemStub = sinon.stub(window.sessionStorage, 'setItem');
 			fileList.changeDirectory('/somedir');
+			deferredList.resolve(200, [testRoot].concat(testFiles));
 			fileList.changeDirectory('/anotherdir');
 			expect(setItemStub.getCall(0).args[0]).toEqual('/subdir');
 			expect(setItemStub.getCall(0).args[1]).toEqual('0');
 			expect(setItemStub.getCall(1).args[0]).toEqual('/somedir');
 			expect(setItemStub.getCall(1).args[1]).toEqual('0');
 			setItemStub.restore();
+			getFolderContentsStub.restore();
+		});
+		it('scroll distance is read from sessionStorage', function() {
+			var getItemStub = sinon.stub(window.sessionStorage, 'getItem');
+			fileList.changeDirectory('/somedir');
+			deferredList.resolve(200, [testRoot].concat(testFiles));
+			fileList.changeDirectory('/anotherdir');
+			expect(getItemStub.getCall(0).args[0]).toEqual('/somedir');
+			expect(getItemStub.getCall(1).args[0]).toEqual('/anotherdir');
+			getItemStub.restore();
 			getFolderContentsStub.restore();
 		});
 	});

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -172,6 +172,27 @@ OCA.Sharing.PublicApp = {
 				return OC.filePath('files_sharing', 'ajax', action + '.php') + '?' + OC.buildQueryString(params);
 			};
 
+			this.fileList.changeDirectory = function (targetDir, changeUrl, force) {
+				var self = this;
+				var currentDir = this.getCurrentDirectory();
+				targetDir = targetDir || '/';
+				if (!force && currentDir === targetDir) {
+					return;
+				}
+				var distance = this.$container.scrollTop() ? this.$container.scrollTop().toString() : '0';
+				var key = $('#sharingToken').val()+':'+currentDir;
+				sessionStorage.setItem(key, distance);
+				this._setCurrentDir(targetDir, changeUrl);
+				this.reload().then(function(success){
+					if (!success) {
+						self.changeDirectory(currentDir, true);
+					} else {
+						var key = $('#sharingToken').val()+':'+targetDir;
+						self.loadAndScrollTo(parseInt(sessionStorage.getItem(key)));
+					}
+				});
+			};
+
 			this.fileList.linkTo = function (dir) {
 				return OC.generateUrl('/s/' + token + '', {dir: dir});
 			};


### PR DESCRIPTION
- scroll distance $('#app-content').scrollTop() will be recorded whenever
  directory is changed
- will be restored after _setDirectory(), and load enough file rows if
  scroll distance is not enough
- recording using sessionStorage, the storage is per-window-session
  ie. every window has its own, will survive reload and restore
