### PR TITLE
Revert "Specify PHP 5.4 as version for scrutinizer"

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,13 +1,3 @@
-application:
-    environment:
-        php:
-            version: 5.4
-  
-build:
-    environment:
-        php:
-            version: 5.4
-
 filter:
     excluded_paths:
         - '3rdparty/*'


### PR DESCRIPTION
Reverts owncloud/core#19797 as this makes Scrutinizer execute our unit tests which fails hard :speak_no_evil: 

@DeepDiver1975 @MorrisJobke THX
