### PR TITLE
Remove invalid type-cast

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -360,8 +360,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 						}
 
 						if ((!isset($_GET['itemShares'])
-							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])
-							|| !in_array($uid, (string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]))
+							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_USER])
+							|| !in_array($uid, $_GET['itemShares'][OCP\Share::SHARE_TYPE_USER]))
 							&& $uid != OC_User::getUser()) {
 							$shareWith[] = array(
 								'label' => $displayName,
@@ -386,8 +386,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 					if ($count < $request_limit) {
 						if (!isset($_GET['itemShares'])
 							|| !isset($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
-							|| !is_array((string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
-							|| !in_array($group, (string)$_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
+							|| !is_array($_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])
+							|| !in_array($group, $_GET['itemShares'][OCP\Share::SHARE_TYPE_GROUP])) {
 							$shareWith[] = array(
 								'label' => $group,
 								'value' => array(


### PR DESCRIPTION
This is an `is_array` operation and not a `in_array` one. Thus this typecast is not required.

Fixes https://github.com/owncloud/core/issues/20095

@rullzer @PVince81 THX
