### PR TITLE
add port to host only, if an URL is used instead of a plain hostname

### DIFF
--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -1290,9 +1290,13 @@ class Wizard extends LDAPUtility {
 		if(!is_null($this->cr)) {
 			return $this->cr;
 		}
-		$cr = $this->ldap->connect(
-			$this->configuration->ldapHost.':'.$this->configuration->ldapPort,
-			$this->configuration->ldapPort);
+
+		$host = $this->configuration->ldapHost;
+		if(strpos($host, '://') !== false) {
+			//ldap_connect ignores port parameter when URLs are passed
+			$host .= ':' . $this->configuration->ldapPort;
+		}
+		$cr = $this->ldap->connect($host, $this->configuration->ldapPort);
 
 		$this->ldap->setOption($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
 		$this->ldap->setOption($cr, LDAP_OPT_REFERRALS, 0);


### PR DESCRIPTION
Fixes #20020, on >= PHP 5.6.11

Problem was: LDAP wizard could not open a connection to LDAP if a plain hostname was provided, because it would add the port, internally. This is only supported with proper URLs since PHP 5.6.11. 

@Xenopathic please test :D
