### PR TITLE
dont trigger the scroll event of every single item we filter in the file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2117,15 +2117,16 @@
 				this.hideIrrelevantUIWhenNoFilesMatch();
 			}
 			var that = this;
+			filter = filter.toLowerCase();
 			this.$fileList.find('tr').each(function(i,e) {
 				var $e = $(e);
-				if ($e.data('file').toString().toLowerCase().indexOf(filter.toLowerCase()) === -1) {
+				if ($e.data('file').toString().toLowerCase().indexOf(filter) === -1) {
 					$e.addClass('hidden');
-					that.$container.trigger('scroll');
 				} else {
 					$e.removeClass('hidden');
 				}
 			});
+			that.$container.trigger('scroll');
 		},
 		hideIrrelevantUIWhenNoFilesMatch:function() {
 			if (this._filter && this.fileSummary.summary.totalDirs + this.fileSummary.summary.totalFiles === 0) {


### PR DESCRIPTION
Fixes filtering of large folders being terribly slow.

To test:
- Navigate to a folder with 1000+ items
- Start typing in the search bar
- Watch the entire ui not freeze for multiple seconds.

cc @DeepDiver1975 @PVince81 @butonic 
