### PR TITLE
Add warning for broken l10n json files

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -144,6 +144,8 @@ class OC_L10N implements \OCP\IL10N {
 
 		$json = json_decode(file_get_contents($transFile), true);
 		if (!is_array($json)) {
+			$jsonError = json_last_error();
+			\OC::$server->getLogger()->warning("Failed to load $transFile - json error code: $jsonError", ['app' => 'l10n']);
 			return false;
 		}
 


### PR DESCRIPTION
- makes it easier to spot broken l10n files

I recently needed to debug some l10n failure. This made it easy to spot the broken file including the error message.

cc @nickvergessen @LukasReschke 
