### PR TITLE
Replace some OC_Config calls with ILogger methods

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -43,9 +43,10 @@ if (OC::checkUpgrade(false)) {
 	\OC_User::setIncognitoMode(true);
 
 	$logger = \OC::$server->getLogger();
+	$config = \OC::$server->getConfig();
 	$updater = new \OC\Updater(
 			\OC::$server->getHTTPHelper(),
-			\OC::$server->getConfig(),
+			$config,
 			$logger
 	);
 	$incompatibleApps = [];
@@ -96,10 +97,10 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use (&$disabledThirdPartyApps) {
 		$disabledThirdPartyApps[]= $app;
 	});
-	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource) {
+	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource, $config) {
 		$eventSource->send('failure', $message);
 		$eventSource->close();
-		OC_Config::setValue('maintenance', false);
+		$config->setSystemValue('maintenance', false);
 	});
 	$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Set log level to debug - current level: "%s"', [ $logLevelName ]));

--- a/core/command/status.php
+++ b/core/command/status.php
@@ -38,7 +38,7 @@ class Status extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$values = array(
-			'installed' => (bool) \OC_Config::getValue('installed'),
+			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
 			'version' => implode('.', \OC_Util::getVersion()),
 			'versionstring' => \OC_Util::getVersionString(),
 			'edition' => \OC_Util::getEditionString(),

--- a/cron.php
+++ b/cron.php
@@ -60,9 +60,10 @@ try {
 	\OC::$server->setSession($session);
 
 	$logger = \OC::$server->getLogger();
+	$config = \OC::$server->getConfig();
 
 	// Don't do anything if ownCloud has not been installed
-	if (!OC_Config::getValue('installed', false)) {
+	if (!$config->getSystemValue('installed', false)) {
 		exit(0);
 	}
 
@@ -99,7 +100,6 @@ try {
 			}
 		}
 
-		$config = OC::$server->getConfig();
 		$instanceId = $config->getSystemValue('instanceid');
 		$lockFileName = 'owncloud-server-' . $instanceId . '-cron.lock';
 		$lockDirectory = $config->getSystemValue('cron.lockfile.location', sys_get_temp_dir());


### PR DESCRIPTION
cc @PVince81 @rullzer @LukasReschke 

I tested:
- `./occ status`
- upgrade via web UI
- `php cron.php`

All works fine. This just was in a local stash and I want to get this in ;)
