### PR TITLE
Fix file action download spinner

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -589,7 +589,7 @@
 							context.fileList.showFileBusyState(filename, false);
 						};
 
-						context.fileList.showFileBusyState(downloadFileaction, true);
+						context.fileList.showFileBusyState(filename, true);
 						OCA.Files.Files.handleDownload(url, disableLoadingState);
 					}
 				}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -295,7 +295,12 @@
 					}
 				};
 
-			OC.redirect(url + '&downloadStartSecret=' + randomToken);
+			if (url.indexOf('?') >= 0) {
+				url += '&';
+			} else {
+				url += '?';
+			}
+			OC.redirect(url + 'downloadStartSecret=' + randomToken);
 			OC.Util.waitFor(checkForDownloadCookie, 500);
 		}
 	};

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -227,7 +227,7 @@ describe('OCA.Files.FileActions tests', function() {
 				name: 'Test',
 				type: OCA.Files.FileActions.TYPE_INLINE,
 				mime: 'all',
-				icon: OC.imagePath('core', 'actions/test'), 
+				icon: OC.imagePath('core', 'actions/test'),
 				permissions: OC.PERMISSION_READ,
 				actionHandler: actionStub
 			});
@@ -554,6 +554,47 @@ describe('OCA.Files.FileActions tests', function() {
 				actionHandler: actionStub
 			});
 			expect(handler.notCalled).toEqual(true);
+		});
+	});
+	describe('default actions', function() {
+		describe('download', function() {
+			it('redirects to URL and sets busy state to list', function() {
+				var handleDownloadStub = sinon.stub(OCA.Files.Files, 'handleDownload');
+				var busyStub = sinon.stub(fileList, 'showFileBusyState');
+				var fileData = {
+					id: 18,
+					type: 'file',
+					name: 'testName.txt',
+					mimetype: 'text/plain',
+					size: '1234',
+					etag: 'a01234c',
+					mtime: '123456',
+					permissions: OC.PERMISSION_READ | OC.PERMISSION_UPDATE
+				};
+
+				// note: FileActions.display() is called implicitly
+				fileList.add(fileData);
+
+				var model = fileList.getModelForFile('testName.txt');
+
+				fileActions.registerDefaultActions();
+				fileActions.triggerAction('Download', model, fileList);
+
+				expect(busyStub.calledOnce).toEqual(true);
+				expect(busyStub.calledWith('testName.txt', true)).toEqual(true);
+				expect(handleDownloadStub.calledOnce).toEqual(true);
+				expect(handleDownloadStub.getCall(0).args[0]).toEqual(
+					OC.webroot + '/index.php/apps/files/ajax/download.php?dir=%2Fsubdir&files=testName.txt'
+				);
+				busyStub.reset();
+				handleDownloadStub.yield();
+
+				expect(busyStub.calledOnce).toEqual(true);
+				expect(busyStub.calledWith('testName.txt', false)).toEqual(true);
+
+				busyStub.restore();
+				handleDownloadStub.restore();
+			});
 		});
 	});
 });


### PR DESCRIPTION
To test: add `sleep(10);` in "apps/files/ajax/download.php" then download a single file using the actions menu. A spinner should now appear (busy state) and disappear after 10 seconds when the download starts.
- fixes issue where the spinner did not appear due to passing the wrong argument to the busy state function.
- fixes appending URL parameter for download token (fix needed by https://github.com/owncloud/core/pull/16902 where the future webdav URL contains no extra params)
- added unit tests

@MorrisJobke check these out :smile: 

Please review @nickvergessen @schiesbn @MorrisJobke @rullzer @icewind1991 
