### PR TITLE
debug enhancements in subadminmiddleware.php

### DIFF
--- a/settings/middleware/subadminmiddleware.php
+++ b/settings/middleware/subadminmiddleware.php
@@ -71,7 +71,11 @@ class SubadminMiddleware extends Middleware {
 	 * @return TemplateResponse
 	 */
 	public function afterException($controller, $methodName, \Exception $exception) {
-		$response = new TemplateResponse('core', '403', array(), 'guest');
+		$message = '';
+		if (\OC::$server->getConfig()->getSystemValue('debug', false)) {
+			$message = $exception->getMessage();
+		}
+		$response = new TemplateResponse('core', '403', array('file' => $message), 'guest');
 		$response->setStatus(Http::STATUS_FORBIDDEN);
 		return $response;
 	}


### PR DESCRIPTION
Displays the exception message on the 403 error page. Very usefull (not only for newbies) to debug, becaus a 403 page without any message or log file entry is very hard to interprete. In addition a logfile entry would be a nice option.
