### PR TITLE
Expose share owner id and display name via files webdav

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -42,6 +42,8 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	const SIZE_PROPERTYNAME = '{http://owncloud.org/ns}size';
 	const GETETAG_PROPERTYNAME = '{DAV:}getetag';
 	const LASTMODIFIED_PROPERTYNAME = '{DAV:}lastmodified';
+	const OWNER_ID_PROPERTYNAME = '{http://owncloud.org/ns}owner-id';
+	const OWNER_DISPLAY_NAME_PROPERTYNAME = '{http://owncloud.org/ns}owner-display-name';
 
 	/**
 	 * Reference to main server object
@@ -99,6 +101,8 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 		$server->protectedProperties[] = self::PERMISSIONS_PROPERTYNAME;
 		$server->protectedProperties[] = self::SIZE_PROPERTYNAME;
 		$server->protectedProperties[] = self::DOWNLOADURL_PROPERTYNAME;
+		$server->protectedProperties[] = self::OWNER_ID_PROPERTYNAME;
+		$server->protectedProperties[] = self::OWNER_DISPLAY_NAME_PROPERTYNAME;
 
 		// normally these cannot be changed (RFC4918), but we want them modifiable through PROPPATCH
 		$allowedProperties = ['{DAV:}getetag'];
@@ -201,6 +205,16 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 				return $node->getSize();
 			});
 		}
+
+		$propFind->handle(self::OWNER_ID_PROPERTYNAME, function() use ($node) {
+			$owner = $node->getOwner();
+			return $owner->getUID();
+		});
+		$propFind->handle(self::OWNER_DISPLAY_NAME_PROPERTYNAME, function() use ($node) {
+			$owner = $node->getOwner();
+			$displayName = $owner->getDisplayName();
+			return $displayName;
+		});
 	}
 
 	/**

--- a/apps/dav/lib/connector/sabre/node.php
+++ b/apps/dav/lib/connector/sabre/node.php
@@ -238,6 +238,10 @@ abstract class Node implements \Sabre\DAV\INode {
 		return $p;
 	}
 
+	public function getOwner() {
+		return $this->info->getOwner();
+	}
+
 	protected function verifyPath() {
 		try {
 			$fileName = basename($this->info->getPath());

--- a/lib/public/files/node.php
+++ b/lib/public/files/node.php
@@ -225,4 +225,12 @@ interface Node extends FileInfo {
 	 * @since 6.0.0
 	 */
 	public function getName();
+
+	/**
+	 * Get the file owner
+	 *
+	 * @since 9.0.0
+	 * @return string
+	 */
+	public function getOwner();
 }

--- a/lib/public/files/storage.php
+++ b/lib/public/files/storage.php
@@ -462,4 +462,10 @@ interface Storage {
 	 * @param bool $isAvailable
 	 */
 	public function setAvailability($isAvailable);
+
+	/**
+	 * @param $path path for which to retrieve the owner
+	 * @since 9.0.0
+	 */
+	public function getOwner($path);
 }


### PR DESCRIPTION
- Required by the Webdav files UI: we need the share owner to be able to display it in the UI. It was formerly available in the "ajax/list.php" response.
- This PR brings this value to the files' Webdav response, when requested explicitly.
- Whether a folder is an incoming share is already available in the "S" permission (oc:permissions)
- This does not cause a performance penalty because the share info has already been resolved at the time the mount point was created. So we're basically reading information that is already available.
#### To test:
1. Create two users "root" and "user1"
2. Login as "user1"
3. Share a folder "test" with "root"
4. Save the following into "propfind.txt"

``` xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
        <a:prop><oc:permissions/></a:prop>
        <a:prop><oc:owner-id/></a:prop>
        <a:prop><oc:owner-display-name/></a:prop>
</a:propfind>
```
1. `curl -X PROPFIND -H "Content-Type: text/xml" --data-binary "@propfind.txt" http://root:admin@localhost/owncloud/remote.php/webdav/test | xmllint --format -`

This PR will output two additional properties, when requested as above:

``` xml
<d:response>
    <d:href>/owncloud/remote.php/webdav/test/</d:href>
    <d:propstat>
      <d:prop>
        <oc:owner-id>user1</oc:share-owner-id>
        <oc:owner-display-name>User One</oc:share-owner-display-name>
        <oc:permissions>SRDNVCK</oc:permissions>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
```

Edit: now renamed to "owner-id" and "owner-display-name"
#### Open questions:
- [x] Should we rename "share owner" to simply "owner" ? If yes:
  - In ownCloud's terms, the owner of a file is always either the current user or the sharer.
  - Note that is we rename it to "owner" we'll need to return the current user.
  - It is still possible to detect if this is a shared mount by checking the "S" permission.
  - We'd then remove SharesPlugin and move the attribute to FilesPlugin, as it is more generic
- [x] @icewind1991 do you think we should cache the `getOwner()` for better performance ? The code path looks like it goes up to the SharedStorage which has the share cached
- [x] TODO: add unit tests once everything is clarified

Let's discuss @DeepDiver1975 @icewind1991 @schiesbn @rullzer @nickvergessen 
