### PR TITLE
Add support for Redis password auth

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -879,11 +879,16 @@ $CONFIG = array(
 
 /**
  * Connection details for redis to use for memory caching.
+ *
+ * For enhanced security it is recommended to configure Redis
+ * to require a password. See http://redis.io/topics/security
+ * for more information.
  */
 'redis' => array(
 	'host' => 'localhost', // can also be a unix domain socket: '/tmp/redis.sock'
 	'port' => 6379,
 	'timeout' => 0.0,
+	'password' => '', // Optional, if not defined no password will be used.
 	'dbindex' => 0, // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index.
 ),
 

--- a/lib/private/memcache/redis.php
+++ b/lib/private/memcache/redis.php
@@ -56,6 +56,9 @@ class Redis extends Cache implements IMemcache {
 			}
 
 			self::$cache->connect($host, $port, $timeout);
+			if(isset($config['password']) && $config['password'] !== '') {
+				self::$cache->auth($config['password']);
+			}
 
 			if (isset($config['dbindex'])) {
 				self::$cache->select($config['dbindex']);


### PR DESCRIPTION
For enhanced security it is recommended to configure Redis to only accept connections with a password. (http://redis.io/topics/security)

This is especially critical since Redis supports the LUA scripting language and thus a simple SSRF vulnerability (as proven in http://benmmurphy.github.io/blog/2015/06/04/redis-eval-lua-sandbox-escape/ for example) may lead to a remote code execution.

Ref https://github.com/owncloud/core/issues/18997 for Redis

@icewind1991 @MorrisJobke Mind testing?
