### PR TITLE
Remember scroll distance using history API

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -161,7 +161,7 @@
 					view: e.itemId,
 					dir: '/'
 				};
-				this._changeUrl(params.view, params.dir);
+				this._changeUrl(params.view, params.dir, params.dir);
 				OC.Apps.hideAppSidebar($('.detailsView'));
 				this.navigation.getActiveContainer().trigger(new $.Event('urlChanged', params));
 			}
@@ -172,7 +172,7 @@
 		 */
 		_onDirectoryChanged: function(e) {
 			if (e.dir) {
-				this._changeUrl(this.navigation.getActiveItem(), e.dir);
+				this._changeUrl(this.navigation.getActiveItem(), e.dir, e.previousDir);
 			}
 		},
 
@@ -211,14 +211,24 @@
 		/**
 		 * Change the URL to point to the given dir and view
 		 */
-		_changeUrl: function(view, dir) {
+		_changeUrl: function(view, dir, previousDir) {
 			var params = {dir: dir};
 			if (view !== 'files') {
 				params.view = view;
 			}
 			if ( window.history.replaceState ) {
-				var oldHistoryEntryStateParams = _.extend(window.history.state, { scrollDistance: $('#app-content').scrollTop() });
-				window.history.replaceState(oldHistoryEntryStateParams, '');
+				var oldHistoryEntryStateParams = {};
+				if ( window.history.state ) {
+					oldHistoryEntryStateParams = _.extend(window.history.state, { scrollDistance: $('#app-content').scrollTop() });
+					window.history.replaceState(oldHistoryEntryStateParams, '');
+				} else {
+					// if this is the first page user visits, there won't be window.history.state, we need to construct it manually
+					oldHistoryEntryStateParams = {
+						dir: previousDir,
+						scrollDistance: $('#app-content').scrollTop()
+					};
+					window.history.replaceState(oldHistoryEntryStateParams, '', location.pathname);
+				}
 			}
 			OC.Util.History.pushState(params);
 		}

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -216,6 +216,10 @@
 			if (view !== 'files') {
 				params.view = view;
 			}
+			if ( window.history.replaceState ) {
+				var oldHistoryEntryStateParams = _.extend(window.history.state, { scrollDistance: $('#app-content').scrollTop() });
+				window.history.replaceState(oldHistoryEntryStateParams, '');
+			}
 			OC.Util.History.pushState(params);
 		}
 	};

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -456,7 +456,7 @@
 		 */
 		_onUrlChanged: function(e) {
 			if (e && e.dir) {
-				this.changeDirectory(e.dir, false, true);
+				this.changeDirectory(e.dir, false, true, e.scrollDistance);
 			}
 		},
 
@@ -1240,8 +1240,9 @@
 		 * @param targetDir target directory (non URL encoded)
 		 * @param changeUrl false if the URL must not be changed (defaults to true)
 		 * @param {boolean} force set to true to force changing directory
+		 * @param distance distance in pixel to scroll in filelist
 		 */
-		changeDirectory: function(targetDir, changeUrl, force) {
+		changeDirectory: function(targetDir, changeUrl, force, distance) {
 			var self = this;
 			var currentDir = this.getCurrentDirectory();
 			targetDir = targetDir || '/';
@@ -1251,7 +1252,9 @@
 			this._setCurrentDir(targetDir, changeUrl);
 			this.reload().then(function(success){
 				if (!success) {
-					self.changeDirectory(currentDir, true);
+					self.changeDirectory(currentDir, true, force, distance);
+				} else if (typeof distance === 'number') {
+					self.loadAndScrollTo(distance);
 				}
 			});
 		},
@@ -2524,6 +2527,20 @@
 				self.updateStorageStatistics();
 			});
 
+		},
+
+		/**
+		 * Load enough rows and scroll to that distance
+		 * @param distance distance in pixel to scroll to
+		 */
+		loadAndScrollTo: function(distance) {
+			if ( this.$container[0].scrollHeight - this.$container.innerHeight() > distance ) {
+				this.$container.scrollTop(distance);
+			} else {
+				while(this.$container[0].scrollHeight - this.$container.innerHeight() < distance && this._nextPage(false) !== false) {
+				}
+				this.$container.scrollTop(distance);
+			}
 		},
 
 		/**


### PR DESCRIPTION
- scroll distance $('#app-content').scrollTop() will be recorded whenever
  directory is changed
- will be restored after _setDirectory(), and load enough file rows if
  scroll distance is not enough
- recording using window.history API, will only restore if you use the
  browser back button

Alternate implementation of #20132 , @PVince81 please take a look.
