### PR TITLE
Keep searchbox open if it is in action

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -329,7 +329,8 @@ input:disabled+label, input:disabled:hover+label, input:disabled:focus+label {
 	opacity: .7;
 }
 .searchbox input[type="search"]:focus,
-.searchbox input[type="search"]:active {
+.searchbox input[type="search"]:active,
+.searchbox input[type="search"]:valid {
 	color: #fff;
 	width: 155px;
 	max-width: 50%;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -103,7 +103,7 @@
 					<?php p($l->t('Search'));?>
 				</label>
 				<input id="searchbox" class="svg" type="search" name="query"
-					value=""
+					value="" required
 					autocomplete="off" tabindex="5">
 			</form>
 		</div></header>


### PR DESCRIPTION
This addition keeps the searchbox open if it contains any text.

fixes #20165 

cc @MorrisJobke @jancborchardt 
