### PR TITLE
federated sharing auto-complete, first step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !/apps/dav
 !/apps/files
 !/apps/files_encryption
+!/apps/federation
 !/apps/encryption
 !/apps/encryption_dummy
 !/apps/files_external

--- a/apps/federation/api/ocsauthapi.php
+++ b/apps/federation/api/ocsauthapi.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\API;
+
+use OC\BackgroundJob\JobList;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\Security\ISecureRandom;
+use OCP\Security\StringUtils;
+
+/**
+ * Class OCSAuthAPI
+ *
+ * OCS API end-points to exchange shared secret between two connected ownClouds
+ *
+ * @package OCA\Federation\API
+ */
+class OCSAuthAPI {
+
+	/** @var IRequest */
+	private $request;
+
+	/** @var ISecureRandom  */
+	private $secureRandom;
+
+	/** @var JobList */
+	private $jobList;
+
+	/** @var TrustedServers */
+	private $trustedServers;
+
+	/** @var DbHandler */
+	private $dbHandler;
+
+	/**
+	 * AuthController constructor.
+	 *
+	 * @param IRequest $request
+	 * @param ISecureRandom $secureRandom
+	 * @param JobList $jobList
+	 * @param TrustedServers $trustedServers
+	 * @param DbHandler $dbHandler
+	 */
+	public function __construct(
+		IRequest $request,
+		ISecureRandom $secureRandom,
+		JobList $jobList,
+		TrustedServers $trustedServers,
+		DbHandler $dbHandler
+	) {
+		$this->request = $request;
+		$this->secureRandom = $secureRandom;
+		$this->jobList = $jobList;
+		$this->trustedServers = $trustedServers;
+		$this->dbHandler = $dbHandler;
+	}
+
+	/**
+	 * request received to ask remote server for a shared secret
+	 *
+	 * @return \OC_OCS_Result
+	 */
+	public function requestSharedSecret() {
+
+		$url = $this->request->getParam('url');
+		$token = $this->request->getParam('token');
+
+		if ($this->trustedServers->isTrustedServer($url) === false) {
+			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
+		}
+
+		$this->jobList->add(
+			'OCA\Federation\BackgroundJob\GetSharedSecret',
+			[
+				'url' => $url,
+				'token' => $token,
+			]
+		);
+
+		return new \OC_OCS_Result(null, Http::STATUS_OK);
+
+	}
+
+	/**
+	 * create shared secret and return it
+	 *
+	 * @return \OC_OCS_Result
+	 */
+	public function getSharedSecret() {
+
+		$url = $this->request->getParam('url');
+		$token = $this->request->getParam('token');
+
+		if (
+			$this->trustedServers->isTrustedServer($url) === false
+			|| $this->isValidToken($url, $token) === false
+		) {
+			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
+		}
+
+		$sharedSecret = $this->secureRandom->getMediumStrengthGenerator()->generate(32);
+
+		$this->trustedServers->addSharedSecret($url, $sharedSecret);
+
+		return new \OC_OCS_Result(['sharedSecret' => $sharedSecret], Http::STATUS_OK);
+
+	}
+
+	protected function isValidToken($url, $token) {
+		$storedToken = $this->dbHandler->getToken($url);
+		return StringUtils::equals($storedToken, $token);
+	}
+
+}

--- a/apps/federation/api/ocsauthapi.php
+++ b/apps/federation/api/ocsauthapi.php
@@ -22,10 +22,10 @@
 
 namespace OCA\Federation\API;
 
-use OC\BackgroundJob\JobList;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
+use OCP\BackgroundJob\IJobList;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 use OCP\Security\StringUtils;
@@ -45,7 +45,7 @@ class OCSAuthAPI {
 	/** @var ISecureRandom  */
 	private $secureRandom;
 
-	/** @var JobList */
+	/** @var IJobList */
 	private $jobList;
 
 	/** @var TrustedServers */
@@ -55,18 +55,18 @@ class OCSAuthAPI {
 	private $dbHandler;
 
 	/**
-	 * AuthController constructor.
+	 * OCSAuthAPI constructor.
 	 *
 	 * @param IRequest $request
 	 * @param ISecureRandom $secureRandom
-	 * @param JobList $jobList
+	 * @param IJobList $jobList
 	 * @param TrustedServers $trustedServers
 	 * @param DbHandler $dbHandler
 	 */
 	public function __construct(
 		IRequest $request,
 		ISecureRandom $secureRandom,
-		JobList $jobList,
+		IJobList $jobList,
 		TrustedServers $trustedServers,
 		DbHandler $dbHandler
 	) {

--- a/apps/federation/appinfo/app.php
+++ b/apps/federation/appinfo/app.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Federation\AppInfo;
+
+$app = new Application();
+$app->registerSettings();

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -87,19 +87,6 @@ class Application extends \OCP\AppFramework\App {
 				$c->query('TrustedServers')
 			);
 		});
-
-
-		$container->registerService('AuthController', function (IAppContainer $c) {
-			$server = $c->getServer();
-			return new AuthController(
-				$c->getAppName(),
-				$server->getRequest(),
-				$server->getSecureRandom(),
-				$server->getJobList(),
-				$c->query('TrustedServers'),
-				$c->query('DbHandler')
-			);
-		});
 	}
 
 	private function registerMiddleware() {

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Federation\AppInfo;
+
+use OCA\Federation\Controller\SettingsController;
+use OCA\Federation\DbHandler;
+use OCA\Federation\Middleware\AddServerMiddleware;
+use OCA\Federation\TrustedServers;
+use OCP\App;
+use OCP\AppFramework\IAppContainer;
+use OCP\IAppConfig;
+
+class Application extends \OCP\AppFramework\App {
+
+	/**
+	 * @param array $urlParams
+	 */
+	public function __construct($urlParams = array()) {
+		parent::__construct('federation', $urlParams);
+		$this->registerService();
+		$this->registerMiddleware();
+
+	}
+
+	/**
+	 * register setting scripts
+	 */
+	public function registerSettings() {
+		App::registerAdmin('federation', 'settings/settings-admin');
+	}
+
+	private function registerService() {
+		$container = $this->getContainer();
+
+		$container->registerService('addServerMiddleware', function(IAppContainer $c) {
+			return new AddServerMiddleware(
+				$c->getAppName(),
+				\OC::$server->getL10N($c->getAppName()),
+				\OC::$server->getLogger()
+			);
+		});
+
+		$container->registerService('DbHandler', function(IAppContainer $c) {
+			return new DbHandler(
+				\OC::$server->getDatabaseConnection(),
+				\OC::$server->getL10N($c->getAppName())
+			);
+		});
+
+		$container->registerService('TrustedServers', function(IAppContainer $c) {
+			return new TrustedServers(
+				$c->query('DbHandler'),
+				\OC::$server->getHTTPClientService(),
+				\OC::$server->getLogger()
+			);
+		});
+
+		$container->registerService('SettingsController', function (IAppContainer $c) {
+			$server = $c->getServer();
+			return new SettingsController(
+				$c->getAppName(),
+				$server->getRequest(),
+				$server->getL10N($c->getAppName()),
+				$c->query('TrustedServers')
+			);
+		});
+	}
+
+	private function registerMiddleware() {
+		$container = $this->getContainer();
+		$container->registerMiddleware('addServerMiddleware');
+	}
+}

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -73,7 +73,8 @@ class Application extends \OCP\AppFramework\App {
 				\OC::$server->getHTTPClientService(),
 				\OC::$server->getLogger(),
 				\OC::$server->getJobList(),
-				\OC::$server->getSecureRandom()
+				\OC::$server->getSecureRandom(),
+				\OC::$server->getConfig()
 			);
 		});
 

--- a/apps/federation/appinfo/database.xml
+++ b/apps/federation/appinfo/database.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<database>
+	<name>*dbname*</name>
+	<create>true</create>
+	<overwrite>false</overwrite>
+	<charset>utf8</charset>
+	<table>
+		<name>*dbprefix*trusted_servers</name>
+		<declaration>
+			<field>
+				<name>id</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<autoincrement>1</autoincrement>
+				<length>4</length>
+			</field>
+			<field>
+				<name>url</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>512</length>
+				<comments>Url of trusted server</comments>
+			</field>
+			<field>
+				<name>url_hash</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>32</length>
+				<comments>md5 hash of the url</comments>
+			</field>
+			<index>
+				<name>url_hash</name>
+				<unique>true</unique>
+				<field>
+					<name>url_hash</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+		</declaration>
+	</table>
+</database>

--- a/apps/federation/appinfo/database.xml
+++ b/apps/federation/appinfo/database.xml
@@ -28,7 +28,27 @@
 				<default></default>
 				<notnull>true</notnull>
 				<length>32</length>
-				<comments>md5 hash of the url</comments>
+				<comments>md5 hash of the url without the protocol</comments>
+			</field>
+			<field>
+				<name>token</name>
+				<type>text</type>
+				<length>128</length>
+				<comments>toke used to exchange the shared secret</comments>
+			</field>
+			<field>
+				<name>shared_secret</name>
+				<type>text</type>
+				<length>256</length>
+				<comments>shared secret used to authenticate</comments>
+			</field>
+			<field>
+				<name>status</name>
+				<type>integer</type>
+				<length>4</length>
+				<notnull>true</notnull>
+				<default>2</default>
+				<comments>current status of the connection</comments>
 			</field>
 			<index>
 				<name>url_hash</name>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<info>
+    <id>federation</id>
+    <name>Federation</name>
+    <description>ownCloud Federation allows you to connect with other trusted ownClouds to exchange the user directory. For example this will be used to auto-complete external users for federated sharing.</description>
+    <licence>AGPL</licence>
+    <author>Bjoern Schiessle</author>
+    <version>0.0.1</version>
+    <namespace>Federation</namespace>
+    <category>other</category>
+    <dependencies>
+        <owncloud min-version="9.0" />
+    </dependencies>
+</info>

--- a/apps/federation/appinfo/routes.php
+++ b/apps/federation/appinfo/routes.php
@@ -1,0 +1,35 @@
+<?php
+/**
+* @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+*
+ * This code is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+return [
+    'routes' => [
+		[
+			'name' => 'Settings#addServer',
+			'url' => '/trusted-servers',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'Settings#removeServer',
+			'url' => '/trusted-servers/{id}',
+			'verb' => 'DELETE'
+		],
+    ]
+];

--- a/apps/federation/appinfo/routes.php
+++ b/apps/federation/appinfo/routes.php
@@ -35,6 +35,11 @@ $application->registerRoutes(
 				'url' => '/trusted-servers/{id}',
 				'verb' => 'DELETE'
 			],
+			[
+				'name' => 'Settings#autoAddServers',
+				'url' => '/auto-add-servers',
+				'verb' => 'POST'
+			],
 		]
 	]
 );

--- a/apps/federation/appinfo/routes.php
+++ b/apps/federation/appinfo/routes.php
@@ -19,17 +19,24 @@
  *
  */
 
-return [
-    'routes' => [
-		[
-			'name' => 'Settings#addServer',
-			'url' => '/trusted-servers',
-			'verb' => 'POST'
-		],
-		[
-			'name' => 'Settings#removeServer',
-			'url' => '/trusted-servers/{id}',
-			'verb' => 'DELETE'
-		],
-    ]
-];
+$application = new \OCA\Federation\AppInfo\Application();
+
+$application->registerRoutes(
+	$this,
+	[
+		'routes' => [
+			[
+				'name' => 'Settings#addServer',
+				'url' => '/trusted-servers',
+				'verb' => 'POST'
+			],
+			[
+				'name' => 'Settings#removeServer',
+				'url' => '/trusted-servers/{id}',
+				'verb' => 'DELETE'
+			],
+		]
+	]
+);
+
+$application->registerOCSApi();

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -23,6 +23,7 @@
 namespace OCA\Federation\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
+use OC\BackgroundJob\JobList;
 use OC\BackgroundJob\QueuedJob;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\BackgroundJob;
+
+use OC\BackgroundJob\QueuedJob;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http;
+use OCP\BackgroundJob\IJobList;
+use OCP\Http\Client\IClient;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+
+/**
+ * Class GetSharedSecret
+ *
+ * request shared secret from remote ownCloud
+ *
+ * @package OCA\Federation\Backgroundjob
+ */
+class GetSharedSecret extends QueuedJob{
+
+	/** @var IClient */
+	private $httpClient;
+
+	/** @var IJobList */
+	private $jobList;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	/** @var TrustedServers  */
+	private $trustedServers;
+
+	/** @var ILogger */
+	private $logger;
+
+	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/shared-secret?format=json';
+
+	/**
+	 * RequestSharedSecret constructor.
+	 *
+	 * @param IClient $httpClient
+	 * @param IURLGenerator $urlGenerator
+	 * @param IJobList $jobList
+	 * @param TrustedServers $trustedServers
+	 * @param ILogger $logger
+	 */
+	public function __construct(
+		IClient $httpClient = null,
+		IURLGenerator $urlGenerator = null,
+		IJobList $jobList = null,
+		TrustedServers $trustedServers = null,
+		ILogger $logger = null
+	) {
+		$this->logger = $logger ? $logger : \OC::$server->getLogger();
+		$this->httpClient = $httpClient ? $httpClient : \OC::$server->getHTTPClientService()->newClient();
+		$this->jobList = $jobList ? $jobList : \OC::$server->getJobList();
+		$this->urlGenerator = $urlGenerator ? $urlGenerator : \OC::$server->getURLGenerator();
+		if ($trustedServers) {
+			$this->trustedServers = $trustedServers;
+		} else {
+			$this->trustedServers = new TrustedServers(
+					new DbHandler(\OC::$server->getDatabaseConnection(), \OC::$server->getL10N('federation')),
+					\OC::$server->getHTTPClientService(),
+					\OC::$server->getLogger(),
+					$this->jobList,
+					\OC::$server->getSecureRandom()
+			);
+		}
+	}
+
+	/**
+	 * run the job, then remove it from the joblist
+	 *
+	 * @param JobList $jobList
+	 * @param ILogger $logger
+	 */
+	public function execute($jobList, ILogger $logger = null) {
+		$jobList->remove($this, $this->argument);
+		$target = $this->argument['url'];
+		// only execute if target is still in the list of trusted domains
+		if ($this->trustedServers->isTrustedServer($target)) {
+			parent::execute($jobList, $logger);
+		}
+	}
+
+	protected function run($argument) {
+		$target = $argument['url'];
+		$source = $this->urlGenerator->getAbsoluteURL('/');
+		$source = rtrim($source, '/');
+		$token = $argument['token'];
+
+		$result = $this->httpClient->get(
+			$target . $this->endPoint,
+			[
+				'query' =>
+					[
+						'url' => $source,
+						'token' => $token
+					],
+				'timeout' => 3,
+				'connect_timeout' => 3,
+			]
+		);
+
+		$status = $result->getStatusCode();
+
+		// if we received a unexpected response we try again later
+		if (
+			$status !== Http::STATUS_OK
+			&& $status !== Http::STATUS_FORBIDDEN
+		) {
+			$this->jobList->add(
+				'OCA\Federation\Backgroundjob\RequestSharedSecret',
+				$argument
+			);
+		} elseif ($status === Http::STATUS_OK) {
+			$body = $result->getBody();
+			$result = json_decode($body, true);
+			if (isset($result['ocs']['data']['sharedSecret'])) {
+				$this->trustedServers->addSharedSecret(
+						$target,
+						$result['ocs']['data']['sharedSecret']
+				);
+			} else {
+				$this->logger->error(
+						'remote server "' . $target . '"" does not return a valid shared secret',
+						['app' => 'federation']
+				);
+				$this->trustedServers->setServerStatus($target, TrustedServers::STATUS_FAILURE);
+			}
+		}
+	}
+}

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -110,8 +110,18 @@ class GetSharedSecret extends QueuedJob{
 		$target = $this->argument['url'];
 		// only execute if target is still in the list of trusted domains
 		if ($this->trustedServers->isTrustedServer($target)) {
-			parent::execute($jobList, $logger);
+			$this->parentExecute($jobList, $logger);
 		}
+	}
+
+	/**
+	 * call execute() method of parent
+	 *
+	 * @param JobList $jobList
+	 * @param ILogger $logger
+	 */
+	protected function parentExecute($jobList, $logger) {
+		parent::execute($jobList, $logger);
 	}
 
 	protected function run($argument) {
@@ -146,7 +156,7 @@ class GetSharedSecret extends QueuedJob{
 			&& $status !== Http::STATUS_FORBIDDEN
 		) {
 			$this->jobList->add(
-				'OCA\Federation\Backgroundjob\GetSharedSecret',
+				'OCA\Federation\BackgroundJob\GetSharedSecret',
 				$argument
 			);
 		}  else {

--- a/apps/federation/backgroundjob/getsharedsecret.php
+++ b/apps/federation/backgroundjob/getsharedsecret.php
@@ -85,7 +85,8 @@ class GetSharedSecret extends QueuedJob{
 					\OC::$server->getHTTPClientService(),
 					\OC::$server->getLogger(),
 					$this->jobList,
-					\OC::$server->getSecureRandom()
+					\OC::$server->getSecureRandom(),
+					\OC::$server->getConfig()
 			);
 		}
 	}

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -24,6 +24,7 @@ namespace OCA\Federation\BackgroundJob;
 
 
 use GuzzleHttp\Exception\ClientException;
+use OC\BackgroundJob\JobList;
 use OC\BackgroundJob\QueuedJob;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -77,7 +77,8 @@ class RequestSharedSecret extends QueuedJob {
 				\OC::$server->getHTTPClientService(),
 				\OC::$server->getLogger(),
 				$this->jobList,
-				\OC::$server->getSecureRandom()
+				\OC::$server->getSecureRandom(),
+				\OC::$server->getConfig()
 			);
 		}
 	}

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\BackgroundJob;
+
+
+use OC\BackgroundJob\QueuedJob;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http;
+use OCP\BackgroundJob\IJobList;
+use OCP\Http\Client\IClient;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+
+/**
+ * Class RequestSharedSecret
+ *
+ * Ask remote ownCloud to request a sharedSecret from this server
+ *
+ * @package OCA\Federation\Backgroundjob
+ */
+class RequestSharedSecret extends QueuedJob {
+
+	/** @var IClient */
+	private $httpClient;
+
+	/** @var IJobList */
+	private $jobList;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json';
+
+	/**
+	 * RequestSharedSecret constructor.
+	 *
+	 * @param IClient $httpClient
+	 * @param IURLGenerator $urlGenerator
+	 * @param IJobList $jobList
+	 * @param TrustedServers $trustedServers
+	 */
+	public function __construct(
+		IClient $httpClient = null,
+		IURLGenerator $urlGenerator = null,
+		IJobList $jobList = null,
+		TrustedServers $trustedServers = null
+	) {
+		$this->httpClient = $httpClient ? $httpClient : \OC::$server->getHTTPClientService()->newClient();
+		$this->jobList = $jobList ? $jobList : \OC::$server->getJobList();
+		$this->urlGenerator = $urlGenerator ? $urlGenerator : \OC::$server->getURLGenerator();
+		if ($trustedServers) {
+			$this->trustedServers = $trustedServers;
+		} else {
+			$this->trustedServers = new TrustedServers(
+				new DbHandler(\OC::$server->getDatabaseConnection(), \OC::$server->getL10N('federation')),
+				\OC::$server->getHTTPClientService(),
+				\OC::$server->getLogger(),
+				$this->jobList,
+				\OC::$server->getSecureRandom()
+			);
+		}
+	}
+
+
+	/**
+	 * run the job, then remove it from the joblist
+	 *
+	 * @param JobList $jobList
+	 * @param ILogger $logger
+	 */
+	public function execute($jobList, ILogger $logger = null) {
+		$jobList->remove($this, $this->argument);
+		$target = $this->argument['url'];
+		// only execute if target is still in the list of trusted domains
+		if ($this->trustedServers->isTrustedServer($target)) {
+			parent::execute($jobList, $logger);
+		}
+	}
+
+	protected function run($argument) {
+
+		$target = $argument['url'];
+		$source = $this->urlGenerator->getAbsoluteURL('/');
+		$source = rtrim($source, '/');
+		$token = $argument['token'];
+
+		$result = $this->httpClient->post(
+			$target . $this->endPoint,
+			[
+				'body' => [
+					'url' => $source,
+					'token' => $token,
+				],
+				'timeout' => 3,
+				'connect_timeout' => 3,
+			]
+		);
+
+		$status = $result->getStatusCode();
+
+		// if we received a unexpected response we try again later
+		if (
+			$status !== Http::STATUS_OK
+			&& $status !== Http::STATUS_FORBIDDEN
+		) {
+			$this->jobList->add(
+				'OCA\Federation\BackgroundJob\RequestSharedSecret',
+				$argument
+			);
+		}
+
+	}
+}

--- a/apps/federation/backgroundjob/requestsharedsecret.php
+++ b/apps/federation/backgroundjob/requestsharedsecret.php
@@ -106,8 +106,16 @@ class RequestSharedSecret extends QueuedJob {
 		$target = $this->argument['url'];
 		// only execute if target is still in the list of trusted domains
 		if ($this->trustedServers->isTrustedServer($target)) {
-			parent::execute($jobList, $logger);
+			$this->parentExecute($jobList, $logger);
 		}
+	}
+
+	/**
+	 * @param JobList $jobList
+	 * @param ILogger $logger
+	 */
+	protected function parentExecute($jobList, $logger) {
+		parent::execute($jobList, $logger);
 	}
 
 	protected function run($argument) {

--- a/apps/federation/controller/settingscontroller.php
+++ b/apps/federation/controller/settingscontroller.php
@@ -26,6 +26,7 @@ use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -84,6 +85,16 @@ class SettingsController extends Controller {
 	public function removeServer($id) {
 		$this->trustedServers->removeServer($id);
 		return new DataResponse();
+	}
+
+	/**
+	 * enable/disable to automatically add servers to the list of trusted servers
+	 * once a federated share was created and accepted successfully
+	 *
+	 * @param bool $autoAddServers
+	 */
+	public function autoAddServers($autoAddServers) {
+		$this->trustedServers->setAutoAddServers($autoAddServers);
 	}
 
 	/**

--- a/apps/federation/controller/settingscontroller.php
+++ b/apps/federation/controller/settingscontroller.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Federation\Controller;
+
+use OC\HintException;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+
+
+class SettingsController extends Controller {
+
+	/** @var IL10N */
+	private $l;
+
+	/** @var  TrustedServers */
+	private $trustedServers;
+
+	/**
+	 * @param string $AppName
+	 * @param IRequest $request
+	 * @param IL10N $l10n
+	 * @param TrustedServers $trustedServers
+	 */
+	public function __construct($AppName,
+								IRequest $request,
+								IL10N $l10n,
+								TrustedServers $trustedServers
+	) {
+		parent::__construct($AppName, $request);
+		$this->l = $l10n;
+		$this->trustedServers = $trustedServers;
+	}
+
+
+	/**
+	 * add server to the list of trusted ownClouds
+	 *
+	 * @param string $url
+	 * @return DataResponse
+	 * @throws HintException
+	 */
+	public function addServer($url) {
+		$this->checkServer($url);
+		$id = $this->trustedServers->addServer($url);
+
+		return new DataResponse(
+			[
+				'url' => $url,
+				'id' => $id,
+				'message' => (string) $this->l->t('Server added to the list of trusted ownClouds')
+			]
+		);
+	}
+
+	/**
+	 * add server to the list of trusted ownClouds
+	 *
+	 * @param int $id
+	 * @return DataResponse
+	 */
+	public function removeServer($id) {
+		$this->trustedServers->removeServer($id);
+		return new DataResponse();
+	}
+
+	/**
+	 * check if the server should be added to the list of trusted servers or not
+	 *
+	 * @param string $url
+	 * @return bool
+	 * @throws HintException
+	 */
+	protected function checkServer($url) {
+		if ($this->trustedServers->isTrustedServer($url) === true) {
+			$message = 'Server is already in the list of trusted servers.';
+			$hint = $this->l->t('Server is already in the list of trusted servers.');
+			throw new HintException($message, $hint);
+		}
+
+		if ($this->trustedServers->isOwnCloudServer($url) === false) {
+			$message = 'No ownCloud server found';
+			$hint = $this->l->t('No ownCloud server found');
+			throw new HintException($message, $hint);
+		}
+
+		return true;
+	}
+
+}

--- a/apps/federation/css/settings-admin.css
+++ b/apps/federation/css/settings-admin.css
@@ -1,0 +1,24 @@
+#ocFederationSettings p {
+	padding-top: 10px;
+}
+
+#listOfTrustedServers li {
+	padding-top: 10px;
+	padding-left: 20px;
+}
+
+.removeTrustedServer {
+	display: none;
+	vertical-align:middle;
+	padding-left: 10px;
+}
+
+#ocFederationAddServerButton {
+	cursor: pointer;
+}
+
+#listOfTrustedServers li:hover {
+	cursor: pointer;
+	background: url(../../../core/img/actions/delete.svg) no-repeat left center;
+	padding-left: 20px;
+}

--- a/apps/federation/css/settings-admin.css
+++ b/apps/federation/css/settings-admin.css
@@ -19,6 +19,8 @@
 
 #listOfTrustedServers li:hover {
 	cursor: pointer;
-	background: url(../../../core/img/actions/delete.svg) no-repeat left center;
-	padding-left: 20px;
+}
+
+#listOfTrustedServers .status {
+	margin-right: 10px;
 }

--- a/apps/federation/js/settings-admin.js
+++ b/apps/federation/js/settings-admin.js
@@ -1,0 +1,70 @@
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+$(document).ready(function () {
+
+	// show input field to add a new trusted server
+	$("#ocFederationAddServer").on('click', function() {
+		$('#ocFederationAddServerButton').addClass('hidden');
+		$("#serverUrl").removeClass('hidden');
+		$("#serverUrl").focus();
+	});
+
+	// add new trusted server
+	$("#serverUrl").keyup(function (e) {
+		if (e.keyCode === 13) { // add server on "enter"
+			var url = $('#serverUrl').val();
+			OC.msg.startSaving('#ocFederationAddServer .msg');
+			$.post(
+				OC.generateUrl('/apps/federation/trusted-servers'),
+				{
+					url: url
+				}
+			).done(function (data) {
+					$('#serverUrl').attr('value', '');
+					$('ul#listOfTrustedServers').prepend(
+						$('<li>').attr('id', data.id).text(data.url)
+					);
+					OC.msg.finishedSuccess('#ocFederationAddServer .msg', data.message);
+				})
+				.fail(function (jqXHR) {
+					OC.msg.finishedError('#ocFederationAddServer .msg', JSON.parse(jqXHR.responseText).message);
+				});
+		} else if (e.keyCode === 27) { // hide input filed again in ESC
+			$('#ocFederationAddServerButton').toggleClass('hidden');
+			$("#serverUrl").toggleClass('hidden');
+		}
+	});
+
+	// remove trusted server from list
+	$( "#listOfTrustedServers" ).on('click', 'li', function() {
+		var id = $(this).attr('id');
+		var $this = $(this);
+		$.ajax({
+			url: OC.generateUrl('/apps/federation/trusted-servers/' + id),
+			type: 'DELETE',
+			success: function(response) {
+				$this.remove();
+			}
+		});
+
+	});
+
+});

--- a/apps/federation/js/settings-admin.js
+++ b/apps/federation/js/settings-admin.js
@@ -70,4 +70,13 @@ $(document).ready(function () {
 
 	});
 
+	$("#ocFederationSettings #autoAddServers").change(function() {
+		$.post(
+				OC.generateUrl('/apps/federation/auto-add-servers'),
+				{
+					autoAddServers: $(this).is(":checked")
+				}
+		);
+	});
+
 });

--- a/apps/federation/js/settings-admin.js
+++ b/apps/federation/js/settings-admin.js
@@ -40,7 +40,10 @@ $(document).ready(function () {
 			).done(function (data) {
 					$('#serverUrl').attr('value', '');
 					$('ul#listOfTrustedServers').prepend(
-						$('<li>').attr('id', data.id).text(data.url)
+						$('<li>')
+								.attr('id', data.id)
+								.attr('class', 'icon-delete')
+								.html('<span class="status indeterminate"></span>' + data.url)
 					);
 					OC.msg.finishedSuccess('#ocFederationAddServer .msg', data.message);
 				})

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -82,7 +82,7 @@ class DbHandler {
 		$result = $query->execute();
 
 		if ($result) {
-			return $this->connection->lastInsertId('*PREFIX*'.$this->dbTable);
+			return (int)$this->connection->lastInsertId('*PREFIX*'.$this->dbTable);
 		} else {
 			$message = 'Internal failure, Could not add ownCloud as trusted server: ' . $url;
 			$message_t = $this->l->t('Could not add server');
@@ -231,7 +231,7 @@ class DbHandler {
 				->setParameter('url_hash', $hash);
 
 		$result = $query->execute()->fetch();
-		return $result['status'];
+		return (int)$result['status'];
 	}
 
 	/**

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -110,7 +110,7 @@ class DbHandler {
 	 */
 	public function getAllServer() {
 		$query = $this->connection->getQueryBuilder();
-		$query->select('url', 'id')->from($this->dbTable);
+		$query->select('url', 'id', 'status')->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		return $result;
 	}

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation;
+
+
+use OC\HintException;
+use OCP\IDBConnection;
+use OCP\IL10N;
+
+class DbHandler {
+
+	/** @var  IDBConnection */
+	private $connection;
+
+	/** @var  IL10N */
+	private $l;
+
+	/** @var string  */
+	private $dbTable = 'trusted_servers';
+
+	/**
+	 * @param IDBConnection $connection
+	 * @param IL10N $il10n
+	 */
+	public function __construct(
+		IDBConnection $connection,
+		IL10N $il10n
+	) {
+		$this->connection = $connection;
+		$this->IL10N = $il10n;
+	}
+
+	/**
+	 * add server to the list of trusted ownCloud servers
+	 *
+	 * @param $url
+	 * @return int
+	 * @throws HintException
+	 */
+	public function add($url) {
+		$hash = md5($url);
+		$query = $this->connection->getQueryBuilder();
+		$query->insert($this->dbTable)
+			->values(
+				[
+					'url' =>  $query->createParameter('url'),
+					'url_hash' => $query->createParameter('url_hash'),
+				]
+			)
+			->setParameter('url', $url)
+			->setParameter('url_hash', $hash);
+
+		$result = $query->execute();
+
+		if ($result) {
+			$id = $this->connection->lastInsertId();
+			// Fallback, if lastInterId() doesn't work we need to perform a select
+			// to get the ID (seems to happen sometimes on Oracle)
+			if (!$id) {
+				$server = $this->get($url);
+				$id = $server['id'];
+			}
+			return $id;
+		} else {
+			$message = 'Internal failure, Could not add ownCloud as trusted server: ' . $url;
+			$message_t = $this->l->t('Could not add server');
+			throw new HintException($message, $message_t);
+		}
+	}
+
+	/**
+	 * remove server from the list of trusted ownCloud servers
+	 *
+	 * @param int $id
+	 */
+	public function remove($id) {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete($this->dbTable)
+			->where($query->expr()->eq('id', $query->createParameter('id')))
+			->setParameter('id', $id);
+		$query->execute();
+	}
+
+	/**
+	 * get trusted server from database
+	 *
+	 * @param $url
+	 * @return mixed
+	 */
+	public function get($url) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('url', 'id')->from($this->dbTable)
+			->where($query->expr()->eq('url_hash', $query->createParameter('url_hash')))
+			->setParameter('url_hash', md5($url));
+
+		return $query->execute()->fetch();
+	}
+
+	/**
+	 * get all trusted servers
+	 *
+	 * @return array
+	 */
+	public function getAll() {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('url', 'id')->from($this->dbTable);
+		$result = $query->execute()->fetchAll();
+		return $result;
+	}
+
+	/**
+	 * check if server already exists in the database table
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	public function exists($url) {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('url')->from($this->dbTable)
+			->where($query->expr()->eq('url_hash', $query->createParameter('url_hash')))
+			->setParameter('url_hash', md5($url));
+		$result = $query->execute()->fetchAll();
+
+		return !empty($result);
+	}
+
+}

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -82,7 +82,7 @@ class DbHandler {
 		$result = $query->execute();
 
 		if ($result) {
-			return $this->connection->lastInsertId($this->dbTable);
+			return $this->connection->lastInsertId('*PREFIX*'.$this->dbTable);
 		} else {
 			$message = 'Internal failure, Could not add ownCloud as trusted server: ' . $url;
 			$message_t = $this->l->t('Could not add server');
@@ -110,7 +110,7 @@ class DbHandler {
 	 */
 	public function getAllServer() {
 		$query = $this->connection->getQueryBuilder();
-		$query->select('url', 'id', 'status')->from($this->dbTable);
+		$query->select(['url', 'id', 'status'])->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		return $result;
 	}

--- a/apps/federation/lib/trustedservers.php
+++ b/apps/federation/lib/trustedservers.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation;
+
+
+use OC\Files\Filesystem;
+use OCP\AppFramework\Http;
+use OCP\Http\Client\IClientService;
+use OCP\IDBConnection;
+use OCP\ILogger;
+
+class TrustedServers {
+
+	/** @var  dbHandler */
+	private $dbHandler;
+
+	/** @var  IClientService */
+	private $httpClientService;
+
+	/** @var ILogger */
+	private $logger;
+
+	private $dbTable = 'trusted_servers';
+
+	/**
+	 * @param DbHandler $dbHandler
+	 * @param IClientService $httpClientService
+	 * @param ILogger $logger
+	 */
+	public function __construct(
+		DbHandler $dbHandler,
+		IClientService $httpClientService,
+		ILogger $logger
+	) {
+		$this->dbHandler = $dbHandler;
+		$this->httpClientService = $httpClientService;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * add server to the list of trusted ownCloud servers
+	 *
+	 * @param $url
+	 * @return int server id
+	 */
+	public function addServer($url) {
+		return $this->dbHandler->add($this->normalizeUrl($url));
+	}
+
+	/**
+	 * remove server from the list of trusted ownCloud servers
+	 *
+	 * @param int $id
+	 */
+	public function removeServer($id) {
+		$this->dbHandler->remove($id);
+	}
+
+	/**
+	 * get all trusted servers
+	 *
+	 * @return array
+	 */
+	public function getServers() {
+		return $this->dbHandler->getAll();
+	}
+
+	/**
+	 * check if given server is a trusted ownCloud server
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	public function isTrustedServer($url) {
+		return $this->dbHandler->exists($this->normalizeUrl($url));
+	}
+
+	/**
+	 * check if URL point to a ownCloud server
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	public function isOwnCloudServer($url) {
+		$isValidOwnCloud = false;
+		$client = $this->httpClientService->newClient();
+		try {
+			$result = $client->get(
+				$url . '/status.php',
+				[
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			);
+			if ($result->getStatusCode() === Http::STATUS_OK) {
+				$isValidOwnCloud = $this->checkOwnCloudVersion($result->getBody());
+			}
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['app' => 'federation']);
+			return false;
+		}
+		return $isValidOwnCloud;
+	}
+
+	/**
+	 * check if ownCloud version is >= 9.0
+	 *
+	 * @param $statusphp
+	 * @return bool
+	 */
+	protected function checkOwnCloudVersion($statusphp) {
+		$decoded = json_decode($statusphp, true);
+		if (!empty($decoded) && isset($decoded['version'])) {
+			return version_compare($decoded['version'], '9.0.0', '>=');
+		}
+		return false;
+	}
+
+	/**
+	 * normalize URL
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	protected function normalizeUrl($url) {
+
+		$normalized = $url;
+
+		if (strpos($url, 'https://') === 0) {
+			$normalized = substr($url, strlen('https://'));
+		} else if (strpos($url, 'http://') === 0) {
+			$normalized = substr($url, strlen('http://'));
+		}
+
+		$normalized = Filesystem::normalizePath($normalized);
+		$normalized = trim($normalized, '/');
+
+		return $normalized;
+	}
+}

--- a/apps/federation/lib/trustedservers.php
+++ b/apps/federation/lib/trustedservers.php
@@ -25,6 +25,7 @@ namespace OCA\Federation;
 use OCP\AppFramework\Http;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Security\ISecureRandom;
 
@@ -52,25 +53,31 @@ class TrustedServers {
 	/** @var ISecureRandom */
 	private $secureRandom;
 
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * @param DbHandler $dbHandler
 	 * @param IClientService $httpClientService
 	 * @param ILogger $logger
 	 * @param IJobList $jobList
 	 * @param ISecureRandom $secureRandom
+	 * @param IConfig $config
 	 */
 	public function __construct(
 		DbHandler $dbHandler,
 		IClientService $httpClientService,
 		ILogger $logger,
 		IJobList $jobList,
-		ISecureRandom $secureRandom
+		ISecureRandom $secureRandom,
+		IConfig $config
 	) {
 		$this->dbHandler = $dbHandler;
 		$this->httpClientService = $httpClientService;
 		$this->logger = $logger;
 		$this->jobList = $jobList;
 		$this->secureRandom = $secureRandom;
+		$this->config = $config;
 	}
 
 	/**
@@ -95,6 +102,28 @@ class TrustedServers {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * enable/disable to automatically add servers to the list of trusted servers
+	 * once a federated share was created and accepted successfully
+	 *
+	 * @param bool $status
+	 */
+	public function setAutoAddServers($status) {
+		$value = $status ? '1' : '0';
+		$this->config->setAppValue('federation', 'autoAddServers', $value);
+	}
+
+	/**
+	 * return if we automatically add servers to the list of trusted servers
+	 * once a federated share was created and accepted successfully
+	 *
+	 * @return bool
+	 */
+	public function getAutoAddServers() {
+		$value = $this->config->getAppValue('federation', 'autoAddServers', '1');
+		return $value === '1';
 	}
 
 	/**

--- a/apps/federation/middleware/addservermiddleware.php
+++ b/apps/federation/middleware/addservermiddleware.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Federation\Middleware ;
+
+use OC\HintException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Middleware;
+use OCP\IL10N;
+use OCP\ILogger;
+
+class AddServerMiddleware extends Middleware {
+
+	/** @var  string */
+	protected $appName;
+
+	/** @var  IL10N */
+	protected $l;
+
+	/** @var  ILogger */
+	protected $logger;
+
+	public function __construct($appName, IL10N $l, ILogger $logger) {
+		$this->appName = $appName;
+		$this->l = $l;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Log error message and return a response which can be displayed to the user
+	 *
+	 * @param \OCP\AppFramework\Controller $controller
+	 * @param string $methodName
+	 * @param \Exception $exception
+	 * @return JSONResponse
+	 */
+	public function afterException($controller, $methodName, \Exception $exception) {
+		$this->logger->error($exception->getMessage(), ['app' => $this->appName]);
+		if ($exception instanceof HintException) {
+			$message = $exception->getHint();
+		} else {
+			$message = $this->l->t('Unknown error');
+		}
+
+		return new JSONResponse(
+			['message' => $message],
+			Http::STATUS_BAD_REQUEST
+		);
+
+	}
+
+}

--- a/apps/federation/settings/settings-admin.php
+++ b/apps/federation/settings/settings-admin.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+\OC_Util::checkAdminUser();
+
+$template = new OCP\Template('federation', 'settings-admin');
+
+$dbHandler = new \OCA\Federation\DbHandler(
+	\OC::$server->getDatabaseConnection(),
+	\OC::$server->getL10N('federation')
+);
+
+$trustedServers = new \OCA\Federation\TrustedServers(
+	$dbHandler,
+	\OC::$server->getHTTPClientService(),
+	\OC::$server->getLogger()
+);
+
+$template->assign('trustedServers', $trustedServers->getServers());
+
+return $template->fetchPage();

--- a/apps/federation/settings/settings-admin.php
+++ b/apps/federation/settings/settings-admin.php
@@ -31,7 +31,9 @@ $dbHandler = new \OCA\Federation\DbHandler(
 $trustedServers = new \OCA\Federation\TrustedServers(
 	$dbHandler,
 	\OC::$server->getHTTPClientService(),
-	\OC::$server->getLogger()
+	\OC::$server->getLogger(),
+	\OC::$server->getJobList(),
+	\OC::$server->getSecureRandom()
 );
 
 $template->assign('trustedServers', $trustedServers->getServers());

--- a/apps/federation/settings/settings-admin.php
+++ b/apps/federation/settings/settings-admin.php
@@ -33,9 +33,11 @@ $trustedServers = new \OCA\Federation\TrustedServers(
 	\OC::$server->getHTTPClientService(),
 	\OC::$server->getLogger(),
 	\OC::$server->getJobList(),
-	\OC::$server->getSecureRandom()
+	\OC::$server->getSecureRandom(),
+	\OC::$server->getConfig()
 );
 
 $template->assign('trustedServers', $trustedServers->getServers());
+$template->assign('autoAddServers', $trustedServers->getAutoAddServers());
 
 return $template->fetchPage();

--- a/apps/federation/templates/settings-admin.php
+++ b/apps/federation/templates/settings-admin.php
@@ -10,9 +10,9 @@ style('federation', 'settings-admin')
 	<h2><?php p($l->t('Federation')); ?></h2>
 	<em><?php p($l->t('ownCloud Federation allows you to connect with other trusted ownClouds to exchange the user directory. For example this will be used to auto-complete external users for federated sharing.')); ?></em>
 
-	<p id="ocFederationShareUsers">
-		<input type="checkbox" class="checkbox" id="shareUsers" />
-		<label for="shareUsers">Share internal user list with other ownClouds</label>
+	<p>
+		<input id="autoAddServers" type="checkbox" class="checkbox" <?php if($_['autoAddServers']) p('checked'); ?> />
+		<label for="autoAddServers">Add server automatically once a federated share was created successfully</label>
 	</p>
 
 	<h3>Trusted ownCloud Servers</h3>

--- a/apps/federation/templates/settings-admin.php
+++ b/apps/federation/templates/settings-admin.php
@@ -1,5 +1,7 @@
 <?php
 /** @var array $_ */
+use OCA\Federation\TrustedServers;
+
 /** @var OC_L10N $l */
 script('federation', 'settings-admin');
 style('federation', 'settings-admin')
@@ -21,7 +23,14 @@ style('federation', 'settings-admin')
 	</p>
 	<ul id="listOfTrustedServers">
 		<?php foreach($_['trustedServers'] as $trustedServer) { ?>
-			<li id="<?php p($trustedServer['id']); ?>">
+			<li id="<?php p($trustedServer['id']); ?>" class="icon-delete">
+				<?php if((int)$trustedServer['status'] === TrustedServers::STATUS_OK) { ?>
+					<span class="status success"></span>
+				<?php } elseif((int)$trustedServer['status'] === TrustedServers::STATUS_PENDING) { ?>
+					<span class="status indeterminate"></span>
+				<?php } else {?>
+					<span class="status error"></span>
+				<?php } ?>
 				<?php p($trustedServer['url']); ?>
 			</li>
 		<?php } ?>

--- a/apps/federation/templates/settings-admin.php
+++ b/apps/federation/templates/settings-admin.php
@@ -1,0 +1,31 @@
+<?php
+/** @var array $_ */
+/** @var OC_L10N $l */
+script('federation', 'settings-admin');
+style('federation', 'settings-admin')
+?>
+<div id="ocFederationSettings" class="section">
+	<h2><?php p($l->t('Federation')); ?></h2>
+	<em><?php p($l->t('ownCloud Federation allows you to connect with other trusted ownClouds to exchange the user directory. For example this will be used to auto-complete external users for federated sharing.')); ?></em>
+
+	<p id="ocFederationShareUsers">
+		<input type="checkbox" class="checkbox" id="shareUsers" />
+		<label for="shareUsers">Share internal user list with other ownClouds</label>
+	</p>
+
+	<h3>Trusted ownCloud Servers</h3>
+	<p id="ocFederationAddServer">
+		<button id="ocFederationAddServerButton" class="">+ Add ownCloud server</button>
+		<input id="serverUrl" class="hidden" type="text" value="" placeholder="ownCloud Server" name="server_url"/>
+		<span class="msg"></span>
+	</p>
+	<ul id="listOfTrustedServers">
+		<?php foreach($_['trustedServers'] as $trustedServer) { ?>
+			<li id="<?php p($trustedServer['id']); ?>">
+				<?php p($trustedServer['url']); ?>
+			</li>
+		<?php } ?>
+	</ul>
+
+</div>
+

--- a/apps/federation/tests/api/ocsauthapitest.php
+++ b/apps/federation/tests/api/ocsauthapitest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\API;
+
+
+use OC\BackgroundJob\JobList;
+use OCA\Federation\API\OCSAuthAPI;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\Security\ISecureRandom;
+use Test\TestCase;
+
+class OCSAuthAPITest extends TestCase {
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IRequest */
+	private $request;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | ISecureRandom  */
+	private $secureRandom;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | JobList */
+	private $jobList;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	private $trustedServers;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	private $dbHandler;
+
+	/** @var  OCSAuthApi */
+	private $ocsAuthApi;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMock('OCP\IRequest');
+		$this->secureRandom = $this->getMock('OCP\Security\ISecureRandom');
+		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->disableOriginalConstructor()->getMock();
+		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+			->disableOriginalConstructor()->getMock();
+		$this->jobList = $this->getMockBuilder('OC\BackgroundJob\JobList')
+			->disableOriginalConstructor()->getMock();
+
+		$this->ocsAuthApi = new OCSAuthAPI(
+			$this->request,
+			$this->secureRandom,
+			$this->jobList,
+			$this->trustedServers,
+			$this->dbHandler
+		);
+
+	}
+
+	/**
+	 * @dataProvider dataTestRequestSharedSecret
+	 *
+	 * @param string $token
+	 * @param string $localToken
+	 * @param bool $isTrustedServer
+	 * @param int $expected
+	 */
+	public function testRequestSharedSecret($token, $localToken, $isTrustedServer, $expected) {
+
+		$url = 'url';
+
+		$this->request->expects($this->at(0))->method('getParam')->with('url')->willReturn($url);
+		$this->request->expects($this->at(1))->method('getParam')->with('token')->willReturn($token);
+		$this->trustedServers
+			->expects($this->once())
+			->method('isTrustedServer')->with($url)->willReturn($isTrustedServer);
+		$this->dbHandler->expects($this->any())
+			->method('getToken')->with($url)->willReturn($localToken);
+
+		if ($expected === Http::STATUS_OK) {
+			$this->jobList->expects($this->once())->method('add')
+				->with('OCA\Federation\BackgroundJob\GetSharedSecret', ['url' => $url, 'token' => $token]);
+		} else {
+			$this->jobList->expects($this->never())->method('add');
+		}
+
+		$result = $this->ocsAuthApi->requestSharedSecret();
+		$this->assertSame($expected, $result->getStatusCode());
+	}
+
+	public function dataTestRequestSharedSecret() {
+		return [
+			['token2', 'token1', true, Http::STATUS_OK],
+			['token1', 'token2', false, Http::STATUS_FORBIDDEN],
+			['token1', 'token2', true, Http::STATUS_FORBIDDEN],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestGetSharedSecret
+	 *
+	 * @param bool $isTrustedServer
+	 * @param bool $isValidToken
+	 * @param int $expected
+	 */
+	public function testGetSharedSecret($isTrustedServer, $isValidToken, $expected) {
+
+		$url = 'url';
+		$token = 'token';
+
+		$this->request->expects($this->at(0))->method('getParam')->with('url')->willReturn($url);
+		$this->request->expects($this->at(1))->method('getParam')->with('token')->willReturn($token);
+
+		/** @var OCSAuthAPI | \PHPUnit_Framework_MockObject_MockObject $ocsAuthApi */
+		$ocsAuthApi = $this->getMockBuilder('OCA\Federation\API\OCSAuthAPI')
+			->setConstructorArgs(
+				[
+					$this->request,
+					$this->secureRandom,
+					$this->jobList,
+					$this->trustedServers,
+					$this->dbHandler
+				]
+			)->setMethods(['isValidToken'])->getMock();
+
+		$this->trustedServers
+			->expects($this->any())
+			->method('isTrustedServer')->with($url)->willReturn($isTrustedServer);
+		$ocsAuthApi->expects($this->any())
+			->method('isValidToken')->with($url, $token)->willReturn($isValidToken);
+
+		if($expected === Http::STATUS_OK) {
+			$this->secureRandom->expects($this->once())->method('getMediumStrengthGenerator')
+				->willReturn($this->secureRandom);
+			$this->secureRandom->expects($this->once())->method('generate')->with(32)
+				->willReturn('secret');
+			$this->trustedServers->expects($this->once())
+				->method('addSharedSecret')->willReturn($url, 'secret');
+			$this->dbHandler->expects($this->once())
+				->method('addToken')->with($url, '');
+		} else {
+			$this->secureRandom->expects($this->never())->method('getMediumStrengthGenerator');
+			$this->secureRandom->expects($this->never())->method('generate');
+			$this->trustedServers->expects($this->never())->method('addSharedSecret');
+			$this->dbHandler->expects($this->never())->method('addToken');
+		}
+
+		$result = $ocsAuthApi->getSharedSecret();
+
+		$this->assertSame($expected, $result->getStatusCode());
+
+		if ($expected === Http::STATUS_OK) {
+			$data =  $result->getData();
+			$this->assertSame('secret', $data['sharedSecret']);
+		}
+	}
+
+	public function dataTestGetSharedSecret() {
+		return [
+			[true, true, Http::STATUS_OK],
+			[false, true, Http::STATUS_FORBIDDEN],
+			[true, false, Http::STATUS_FORBIDDEN],
+			[false, false, Http::STATUS_FORBIDDEN],
+		];
+	}
+
+}

--- a/apps/federation/tests/backgroundjob/getsharedsecrettest.php
+++ b/apps/federation/tests/backgroundjob/getsharedsecrettest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\BackgroundJob;
+
+
+use OCA\Federation\BackgroundJob\GetSharedSecret;
+use OCA\Files_Sharing\Tests\TestCase;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\Http;
+use OCP\BackgroundJob\IJobList;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IResponse;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+
+class GetSharedSecretTest extends TestCase {
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IClient */
+	private $httpClient;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	private $jobList;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IURLGenerator */
+	private $urlGenerator;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers  */
+	private $trustedServers;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	private $dbHandler;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	private $logger;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	private $response;
+
+	/** @var GetSharedSecret */
+	private $getSharedSecret;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
+		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
+		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
+		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->disableOriginalConstructor()->getMock();
+		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+			->disableOriginalConstructor()->getMock();
+		$this->logger = $this->getMock('OCP\ILogger');
+		$this->response = $this->getMock('OCP\Http\Client\IResponse');
+
+		$this->getSharedSecret = new GetSharedSecret(
+			$this->httpClient,
+			$this->urlGenerator,
+			$this->jobList,
+			$this->trustedServers,
+			$this->logger,
+			$this->dbHandler
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestExecute
+	 *
+	 * @param bool $isTrustedServer
+	 */
+	public function testExecute($isTrustedServer) {
+		/** @var GetSharedSecret |\PHPUnit_Framework_MockObject_MockObject $getSharedSecret */
+		$getSharedSecret = $this->getMockBuilder('OCA\Federation\BackgroundJob\GetSharedSecret')
+			->setConstructorArgs(
+				[
+					$this->httpClient,
+					$this->urlGenerator,
+					$this->jobList,
+					$this->trustedServers,
+					$this->logger,
+					$this->dbHandler
+				]
+			)->setMethods(['parentExecute'])->getMock();
+		$this->invokePrivate($getSharedSecret, 'argument', [['url' => 'url']]);
+
+		$this->jobList->expects($this->once())->method('remove');
+		$this->trustedServers->expects($this->once())->method('isTrustedServer')
+			->with('url')->willReturn($isTrustedServer);
+		if ($isTrustedServer) {
+			$getSharedSecret->expects($this->once())->method('parentExecute');
+		} else {
+			$getSharedSecret->expects($this->never())->method('parentExecute');
+		}
+
+		$getSharedSecret->execute($this->jobList);
+
+	}
+
+	public function dataTestExecute() {
+		return [
+			[true],
+			[false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestRun
+	 *
+	 * @param int $statusCode
+	 */
+	public function testRun($statusCode) {
+
+		$target = 'targetURL';
+		$source = 'sourceURL';
+		$token = 'token';
+
+		$argument = ['url' => $target, 'token' => $token];
+
+		$this->urlGenerator->expects($this->once())->method('getAbsoluteURL')->with('/')
+			->willReturn($source);
+		$this->httpClient->expects($this->once())->method('get')
+			->with(
+				$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret?format=json',
+				[
+					'query' =>
+						[
+							'url' => $source,
+							'token' => $token
+						],
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			)->willReturn($this->response);
+
+		$this->response->expects($this->once())->method('getStatusCode')
+			->willReturn($statusCode);
+
+		if (
+			$statusCode !== Http::STATUS_OK
+			&& $statusCode !== Http::STATUS_FORBIDDEN
+		) {
+			$this->jobList->expects($this->once())->method('add')
+				->with('OCA\Federation\BackgroundJob\GetSharedSecret', $argument);
+			$this->dbHandler->expects($this->never())->method('addToken');
+		}  else {
+			$this->dbHandler->expects($this->once())->method('addToken')->with($target, '');
+			$this->jobList->expects($this->never())->method('add');
+		}
+
+		if ($statusCode === Http::STATUS_OK) {
+			$this->response->expects($this->once())->method('getBody')
+				->willReturn('{"ocs":{"data":{"sharedSecret":"secret"}}}');
+			$this->trustedServers->expects($this->once())->method('addSharedSecret')
+				->with($target, 'secret');
+		} else {
+			$this->trustedServers->expects($this->never())->method('addSharedSecret');
+		}
+
+		$this->invokePrivate($this->getSharedSecret, 'run', [$argument]);
+	}
+
+	public function dataTestRun() {
+		return [
+			[Http::STATUS_OK],
+			[Http::STATUS_FORBIDDEN],
+			[Http::STATUS_CONFLICT],
+		];
+	}
+
+}

--- a/apps/federation/tests/backgroundjob/requestsharedsecrettest.php
+++ b/apps/federation/tests/backgroundjob/requestsharedsecrettest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\BackgroundJob;
+
+
+use OCA\Federation\BackgroundJob\RequestSharedSecret;
+use OCP\AppFramework\Http;
+use Test\TestCase;
+
+class RequestSharedSecretTest extends TestCase {
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IClient */
+	private $httpClient;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	private $jobList;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IURLGenerator */
+	private $urlGenerator;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	private $dbHandler;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	private $trustedServers;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	private $response;
+
+	/** @var  RequestSharedSecret */
+	private $requestSharedSecret;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
+		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
+		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
+		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->disableOriginalConstructor()->getMock();
+		$this->dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+			->disableOriginalConstructor()->getMock();
+		$this->response = $this->getMock('OCP\Http\Client\IResponse');
+
+		$this->requestSharedSecret = new RequestSharedSecret(
+			$this->httpClient,
+			$this->urlGenerator,
+			$this->jobList,
+			$this->trustedServers,
+			$this->dbHandler
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestExecute
+	 *
+	 * @param bool $isTrustedServer
+	 */
+	public function testExecute($isTrustedServer) {
+		/** @var RequestSharedSecret |\PHPUnit_Framework_MockObject_MockObject $requestSharedSecret */
+		$requestSharedSecret = $this->getMockBuilder('OCA\Federation\BackgroundJob\RequestSharedSecret')
+			->setConstructorArgs(
+				[
+					$this->httpClient,
+					$this->urlGenerator,
+					$this->jobList,
+					$this->trustedServers,
+					$this->dbHandler
+				]
+			)->setMethods(['parentExecute'])->getMock();
+		$this->invokePrivate($requestSharedSecret, 'argument', [['url' => 'url']]);
+
+		$this->jobList->expects($this->once())->method('remove');
+		$this->trustedServers->expects($this->once())->method('isTrustedServer')
+			->with('url')->willReturn($isTrustedServer);
+		if ($isTrustedServer) {
+			$requestSharedSecret->expects($this->once())->method('parentExecute');
+		} else {
+			$requestSharedSecret->expects($this->never())->method('parentExecute');
+		}
+
+		$requestSharedSecret->execute($this->jobList);
+
+	}
+
+	public function dataTestExecute() {
+		return [
+			[true],
+			[false]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestRun
+	 *
+	 * @param int $statusCode
+	 */
+	public function testRun($statusCode) {
+
+		$target = 'targetURL';
+		$source = 'sourceURL';
+		$token = 'token';
+
+		$argument = ['url' => $target, 'token' => $token];
+
+		$this->urlGenerator->expects($this->once())->method('getAbsoluteURL')->with('/')
+			->willReturn($source);
+		$this->httpClient->expects($this->once())->method('post')
+			->with(
+				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json',
+				[
+					'body' =>
+						[
+							'url' => $source,
+							'token' => $token
+						],
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			)->willReturn($this->response);
+
+		$this->response->expects($this->once())->method('getStatusCode')
+			->willReturn($statusCode);
+
+		if (
+			$statusCode !== Http::STATUS_OK
+			&& $statusCode !== Http::STATUS_FORBIDDEN
+		) {
+			$this->jobList->expects($this->once())->method('add')
+				->with('OCA\Federation\BackgroundJob\RequestSharedSecret', $argument);
+			$this->dbHandler->expects($this->never())->method('addToken');
+		}
+
+		if ($statusCode === Http::STATUS_FORBIDDEN) {
+			$this->jobList->expects($this->never())->method('add');
+			$this->dbHandler->expects($this->once())->method('addToken')->with($target, '');
+		}
+
+		$this->invokePrivate($this->requestSharedSecret, 'run', [$argument]);
+	}
+
+	public function dataTestRun() {
+		return [
+			[Http::STATUS_OK],
+			[Http::STATUS_FORBIDDEN],
+			[Http::STATUS_CONFLICT],
+		];
+	}
+}

--- a/apps/federation/tests/controller/settingscontrollertest.php
+++ b/apps/federation/tests/controller/settingscontrollertest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\Controller;
+
+
+use OCA\Federation\Controller\SettingsController;
+use OCP\AppFramework\Http\DataResponse;
+use Test\TestCase;
+
+class SettingsControllerTest extends TestCase {
+
+	/** @var SettingsController  */
+	private $controller;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IRequest */
+	private $request;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IL10N */
+	private $l10n;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCA\Federation\TrustedServers */
+	private $trustedServers;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMock('OCP\IRequest');
+		$this->l10n = $this->getMock('OCP\IL10N');
+		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->disableOriginalConstructor()->getMock();
+
+		$this->controller = new SettingsController(
+			'SettingsControllerTest',
+			$this->request,
+			$this->l10n,
+			$this->trustedServers
+		);
+	}
+
+	public function testAddServer() {
+		$this->trustedServers
+			->expects($this->once())
+			->method('isTrustedServer')
+			->with('url')
+			->willReturn(false);
+		$this->trustedServers
+			->expects($this->once())
+			->method('isOwnCloudServer')
+			->with('url')
+			->willReturn(true);
+
+		$result = $this->controller->addServer('url');
+		$this->assertTrue($result instanceof DataResponse);
+
+		$data = $result->getData();
+		$this->assertSame(200, $result->getStatus());
+		$this->assertSame('url', $data['url']);
+		$this->assertArrayHasKey('id', $data);
+	}
+
+	/**
+	 * @dataProvider checkServerFails
+	 * @expectedException \OC\HintException
+	 *
+	 * @param bool $isTrustedServer
+	 * @param bool $isOwnCloud
+	 */
+	public function testAddServerFail($isTrustedServer, $isOwnCloud) {
+		$this->trustedServers
+			->expects($this->any())
+			->method('isTrustedServer')
+			->with('url')
+			->willReturn($isTrustedServer);
+		$this->trustedServers
+			->expects($this->any())
+			->method('isOwnCloudServer')
+			->with('url')
+			->willReturn($isOwnCloud);
+
+		$this->controller->addServer('url');
+	}
+
+	public function testRemoveServer() {
+		$this->trustedServers->expects($this->once())->method('removeServer')
+		->with('url');
+		$result = $this->controller->removeServer('url');
+		$this->assertTrue($result instanceof DataResponse);
+		$this->assertSame(200, $result->getStatus());
+	}
+
+	public function testCheckServer() {
+		$this->trustedServers
+			->expects($this->once())
+			->method('isTrustedServer')
+			->with('url')
+			->willReturn(false);
+		$this->trustedServers
+			->expects($this->once())
+			->method('isOwnCloudServer')
+			->with('url')
+			->willReturn(true);
+
+		$this->assertTrue(
+			$this->invokePrivate($this->controller, 'checkServer', ['url'])
+		);
+
+	}
+
+	/**
+	 * @dataProvider checkServerFails
+	 * @expectedException \OC\HintException
+	 *
+	 * @param bool $isTrustedServer
+	 * @param bool $isOwnCloud
+	 */
+	public function testCheckServerFail($isTrustedServer, $isOwnCloud) {
+		$this->trustedServers
+			->expects($this->any())
+			->method('isTrustedServer')
+			->with('url')
+			->willReturn($isTrustedServer);
+		$this->trustedServers
+			->expects($this->any())
+			->method('isOwnCloudServer')
+			->with('url')
+			->willReturn($isOwnCloud);
+
+		$this->assertTrue(
+			$this->invokePrivate($this->controller, 'checkServer', ['url'])
+		);
+
+	}
+
+	/**
+	 * data to simulate checkServer fails
+	 *
+	 * @return array
+	 */
+	public function checkServerFails() {
+		return [
+			[true, true],
+			[false, false]
+		];
+	}
+
+}

--- a/apps/federation/tests/lib/dbhandlertest.php
+++ b/apps/federation/tests/lib/dbhandlertest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\lib;
+
+
+use OCA\Federation\DbHandler;
+use OCP\IDBConnection;
+use Test\TestCase;
+
+class DbHandlerTest extends TestCase {
+
+	/** @var  DbHandler */
+	private $dbHandler;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject */
+	private $il10n;
+
+	/** @var  IDBConnection */
+	private $connection;
+
+	/** @var string  */
+	private $dbTable = 'trusted_servers';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->il10n = $this->getMock('OCP\IL10N');
+
+		$this->dbHandler = new DbHandler(
+			$this->connection,
+			$this->il10n
+		);
+
+		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
+		$result = $query->execute()->fetchAll();
+		$this->assertEmpty($result, 'we need to start with a empty trusted_servers table');
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$query = $this->connection->getQueryBuilder()->delete($this->dbTable);
+		$query->execute();
+	}
+
+	public function testAdd() {
+		$id = $this->dbHandler->add('server1');
+
+		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
+		$result = $query->execute()->fetchAll();
+		$this->assertSame(1, count($result));
+		$this->assertSame('server1', $result[0]['url']);
+		$this->assertSame($id, $result[0]['id']);
+	}
+
+	public function testRemove() {
+		$id1 = $this->dbHandler->add('server1');
+		$id2 = $this->dbHandler->add('server2');
+
+		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
+		$result = $query->execute()->fetchAll();
+		$this->assertSame(2, count($result));
+		$this->assertSame('server1', $result[0]['url']);
+		$this->assertSame('server2', $result[1]['url']);
+		$this->assertSame($id1, $result[0]['id']);
+		$this->assertSame($id2, $result[1]['id']);
+
+		$this->dbHandler->remove($id2);
+		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
+		$result = $query->execute()->fetchAll();
+		$this->assertSame(1, count($result));
+		$this->assertSame('server1', $result[0]['url']);
+		$this->assertSame($id1, $result[0]['id']);
+	}
+
+	public function testGetAll() {
+		$id1 = $this->dbHandler->add('server1');
+		$id2 = $this->dbHandler->add('server2');
+
+		$result = $this->dbHandler->getAll();
+		$this->assertSame(2, count($result));
+		$this->assertSame('server1', $result[0]['url']);
+		$this->assertSame('server2', $result[1]['url']);
+		$this->assertSame($id1, $result[0]['id']);
+		$this->assertSame($id2, $result[1]['id']);
+	}
+
+	/**
+	 * @dataProvider dataTestExists
+	 *
+	 * @param string $serverInTable
+	 * @param string $checkForServer
+	 * @param bool $expected
+	 */
+	public function testExists($serverInTable, $checkForServer, $expected) {
+		$this->dbHandler->add($serverInTable);
+		$this->assertSame($expected,
+			$this->dbHandler->exists($checkForServer)
+		);
+	}
+
+	public function dataTestExists() {
+		return [
+			['server1', 'server1', true],
+			['server1', 'server1', true],
+			['server1', 'server2', false]
+		];
+	}
+
+}

--- a/apps/federation/tests/lib/trustedserverstest.php
+++ b/apps/federation/tests/lib/trustedserverstest.php
@@ -25,11 +25,13 @@ namespace OCA\Federation\Tests\lib;
 
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
+use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
-use OCP\IDBConnection;
+use OCP\IConfig;
 use OCP\ILogger;
+use OCP\Security\ISecureRandom;
 use Test\TestCase;
 
 class TrustedServersTest extends TestCase {
@@ -52,6 +54,15 @@ class TrustedServersTest extends TestCase {
 	/** @var  \PHPUnit_Framework_MockObject_MockObject | ILogger */
 	private $logger;
 
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | IJobList */
+	private $jobList;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | ISecureRandom */
+	private $secureRandom;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | IConfig */
+	private $config;
+
 	public function setUp() {
 		parent::setUp();
 
@@ -61,45 +72,79 @@ class TrustedServersTest extends TestCase {
 		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
 		$this->response = $this->getMock('OCP\Http\Client\IResponse');
 		$this->logger = $this->getMock('OCP\ILogger');
+		$this->jobList = $this->getMock('OCP\BackgroundJob\IJobList');
+		$this->secureRandom = $this->getMock('OCP\Security\ISecureRandom');
+		$this->config = $this->getMock('OCP\IConfig');
 
 		$this->trustedServers = new TrustedServers(
 			$this->dbHandler,
 			$this->httpClientService,
-			$this->logger
+			$this->logger,
+			$this->jobList,
+			$this->secureRandom,
+			$this->config
 		);
 
 	}
 
-	public function testAddServer() {
+	/**
+	 * @dataProvider dataTestAddServer
+	 *
+	 * @param bool $success
+	 */
+	public function testAddServer($success) {
 		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServer */
 		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
 			->setConstructorArgs(
 				[
 					$this->dbHandler,
 					$this->httpClientService,
-					$this->logger
+					$this->logger,
+					$this->jobList,
+					$this->secureRandom,
+					$this->config
 				]
 			)
-			->setMethods(['normalizeUrl'])
+			->setMethods(['normalizeUrl', 'updateProtocol'])
 			->getMock();
-		$trustedServers->expects($this->once())->method('normalizeUrl')
-			->with('url')->willReturn('normalized');
-		$this->dbHandler->expects($this->once())->method('add')->with('normalized')
-		->willReturn(true);
+		$trustedServers->expects($this->once())->method('updateProtocol')
+				->with('url')->willReturn('https://url');
+		$this->dbHandler->expects($this->once())->method('addServer')->with('https://url')
+			->willReturn($success);
 
-		$this->assertTrue(
+		if ($success) {
+			$this->secureRandom->expects($this->once())->method('getMediumStrengthGenerator')
+				->willReturn($this->secureRandom);
+			$this->secureRandom->expects($this->once())->method('generate')
+				->willReturn('token');
+			$this->dbHandler->expects($this->once())->method('addToken')->with('https://url', 'token');
+			$this->jobList->expects($this->once())->method('add')
+				->with('OCA\Federation\BackgroundJob\RequestSharedSecret',
+						['url' => 'https://url', 'token' => 'token']);
+		} else {
+			$this->jobList->expects($this->never())->method('add');
+		}
+
+		$this->assertSame($success,
 			$trustedServers->addServer('url')
 		);
 	}
 
+	public function dataTestAddServer() {
+		return [
+			[true],
+			[false]
+		];
+	}
+
 	public function testRemoveServer() {
 		$id = 42;
-		$this->dbHandler->expects($this->once())->method('remove')->with($id);
+		$this->dbHandler->expects($this->once())->method('removeServer')->with($id);
 		$this->trustedServers->removeServer($id);
 	}
 
 	public function testGetServers() {
-		$this->dbHandler->expects($this->once())->method('getAll')->willReturn(true);
+		$this->dbHandler->expects($this->once())->method('getAllServer')->willReturn(true);
 
 		$this->assertTrue(
 			$this->trustedServers->getServers()
@@ -108,24 +153,11 @@ class TrustedServersTest extends TestCase {
 
 
 	public function testIsTrustedServer() {
-		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServer */
-		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
-			->setConstructorArgs(
-				[
-					$this->dbHandler,
-					$this->httpClientService,
-					$this->logger
-				]
-			)
-			->setMethods(['normalizeUrl'])
-			->getMock();
-		$trustedServers->expects($this->once())->method('normalizeUrl')
-			->with('url')->willReturn('normalized');
-		$this->dbHandler->expects($this->once())->method('exists')->with('normalized')
-		->willReturn(true);
+		$this->dbHandler->expects($this->once())->method('serverExists')->with('url')
+			->willReturn(true);
 
 		$this->assertTrue(
-			$trustedServers->isTrustedServer('url')
+			$this->trustedServers->isTrustedServer('url')
 		);
 	}
 
@@ -146,7 +178,10 @@ class TrustedServersTest extends TestCase {
 				[
 					$this->dbHandler,
 					$this->httpClientService,
-					$this->logger
+					$this->logger,
+					$this->jobList,
+					$this->secureRandom,
+					$this->config
 				]
 			)
 			->setMethods(['checkOwnCloudVersion'])
@@ -192,7 +227,7 @@ class TrustedServersTest extends TestCase {
 			->with('simulated exception', ['app' => 'federation']);
 
 		$this->httpClient->expects($this->once())->method('get')->with($server . '/status.php')
-			->willReturnCallback(function() {
+			->willReturnCallback(function () {
 				throw new \Exception('simulated exception');
 			});
 
@@ -221,24 +256,22 @@ class TrustedServersTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestNormalizeUrl
-	 *
+	 * @dataProvider dataTestUpdateProtocol
 	 * @param string $url
 	 * @param string $expected
 	 */
-	public function testNormalizeUrl($url, $expected) {
+	public function testUpdateProtocol($url, $expected) {
 		$this->assertSame($expected,
-			$this->invokePrivate($this->trustedServers, 'normalizeUrl', [$url])
+			$this->invokePrivate($this->trustedServers, 'updateProtocol', [$url])
 		);
 	}
 
-	public function dataTestNormalizeUrl() {
+	public function dataTestUpdateProtocol() {
 		return [
-			['owncloud.org', 'owncloud.org'],
-			['http://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org//mycloud', 'owncloud.org/mycloud'],
-			['https://owncloud.org/mycloud/', 'owncloud.org/mycloud'],
+			['http://owncloud.org', 'http://owncloud.org'],
+			['https://owncloud.org', 'https://owncloud.org'],
+			['owncloud.org', 'https://owncloud.org'],
+			['httpserver', 'https://httpserver'],
 		];
 	}
 }

--- a/apps/federation/tests/lib/trustedserverstest.php
+++ b/apps/federation/tests/lib/trustedserverstest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\lib;
+
+
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use Test\TestCase;
+
+class TrustedServersTest extends TestCase {
+
+	/** @var  TrustedServers */
+	private $trustedServers;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | DbHandler */
+	private $dbHandler;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | IClientService */
+	private $httpClientService;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | IClient */
+	private $httpClient;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | IResponse */
+	private $response;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	private $logger;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->dbHandler = $this->getMockBuilder('\OCA\Federation\DbHandler')
+			->disableOriginalConstructor()->getMock();
+		$this->httpClientService = $this->getMock('OCP\Http\Client\IClientService');
+		$this->httpClient = $this->getMock('OCP\Http\Client\IClient');
+		$this->response = $this->getMock('OCP\Http\Client\IResponse');
+		$this->logger = $this->getMock('OCP\ILogger');
+
+		$this->trustedServers = new TrustedServers(
+			$this->dbHandler,
+			$this->httpClientService,
+			$this->logger
+		);
+
+	}
+
+	public function testAddServer() {
+		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServer */
+		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->setConstructorArgs(
+				[
+					$this->dbHandler,
+					$this->httpClientService,
+					$this->logger
+				]
+			)
+			->setMethods(['normalizeUrl'])
+			->getMock();
+		$trustedServers->expects($this->once())->method('normalizeUrl')
+			->with('url')->willReturn('normalized');
+		$this->dbHandler->expects($this->once())->method('add')->with('normalized')
+		->willReturn(true);
+
+		$this->assertTrue(
+			$trustedServers->addServer('url')
+		);
+	}
+
+	public function testRemoveServer() {
+		$id = 42;
+		$this->dbHandler->expects($this->once())->method('remove')->with($id);
+		$this->trustedServers->removeServer($id);
+	}
+
+	public function testGetServers() {
+		$this->dbHandler->expects($this->once())->method('getAll')->willReturn(true);
+
+		$this->assertTrue(
+			$this->trustedServers->getServers()
+		);
+	}
+
+
+	public function testIsTrustedServer() {
+		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServer */
+		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->setConstructorArgs(
+				[
+					$this->dbHandler,
+					$this->httpClientService,
+					$this->logger
+				]
+			)
+			->setMethods(['normalizeUrl'])
+			->getMock();
+		$trustedServers->expects($this->once())->method('normalizeUrl')
+			->with('url')->willReturn('normalized');
+		$this->dbHandler->expects($this->once())->method('exists')->with('normalized')
+		->willReturn(true);
+
+		$this->assertTrue(
+			$trustedServers->isTrustedServer('url')
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestIsOwnCloudServer
+	 *
+	 * @param int $statusCode
+	 * @param bool $isValidOwnCloudVersion
+	 * @param bool $expected
+	 */
+	public function testIsOwnCloudServer($statusCode, $isValidOwnCloudVersion, $expected) {
+
+		$server = 'server1';
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers $trustedServer */
+		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->setConstructorArgs(
+				[
+					$this->dbHandler,
+					$this->httpClientService,
+					$this->logger
+				]
+			)
+			->setMethods(['checkOwnCloudVersion'])
+			->getMock();
+
+		$this->httpClientService->expects($this->once())->method('newClient')
+			->willReturn($this->httpClient);
+
+		$this->httpClient->expects($this->once())->method('get')->with($server . '/status.php')
+			->willReturn($this->response);
+
+		$this->response->expects($this->once())->method('getStatusCode')
+			->willReturn($statusCode);
+
+		if ($statusCode === 200) {
+			$trustedServers->expects($this->once())->method('checkOwnCloudVersion')
+				->willReturn($isValidOwnCloudVersion);
+		} else {
+			$trustedServers->expects($this->never())->method('checkOwnCloudVersion');
+		}
+
+		$this->assertSame($expected,
+			$trustedServers->isOwnCloudServer($server)
+		);
+
+	}
+
+	public function dataTestIsOwnCloudServer() {
+		return [
+			[200, true, true],
+			[200, false, false],
+			[404, true, false],
+		];
+	}
+
+	public function testIsOwnCloudServerFail() {
+		$server = 'server1';
+
+		$this->httpClientService->expects($this->once())->method('newClient')
+			->willReturn($this->httpClient);
+
+		$this->logger->expects($this->once())->method('error')
+			->with('simulated exception', ['app' => 'federation']);
+
+		$this->httpClient->expects($this->once())->method('get')->with($server . '/status.php')
+			->willReturnCallback(function() {
+				throw new \Exception('simulated exception');
+			});
+
+		$this->assertFalse($this->trustedServers->isOwnCloudServer($server));
+
+	}
+
+	/**
+	 * @dataProvider dataTestCheckOwnCloudVersion
+	 *
+	 * @param $statusphp
+	 * @param $expected
+	 */
+	public function testCheckOwnCloudVersion($statusphp, $expected) {
+		$this->assertSame($expected,
+			$this->invokePrivate($this->trustedServers, 'checkOwnCloudVersion', [$statusphp])
+		);
+	}
+
+	public function dataTestCheckOwnCloudVersion() {
+		return [
+			['{"version":"8.4.0"}', false],
+			['{"version":"9.0.0"}', true],
+			['{"version":"9.1.0"}', true]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestNormalizeUrl
+	 *
+	 * @param string $url
+	 * @param string $expected
+	 */
+	public function testNormalizeUrl($url, $expected) {
+		$this->assertSame($expected,
+			$this->invokePrivate($this->trustedServers, 'normalizeUrl', [$url])
+		);
+	}
+
+	public function dataTestNormalizeUrl() {
+		return [
+			['owncloud.org', 'owncloud.org'],
+			['http://owncloud.org', 'owncloud.org'],
+			['https://owncloud.org', 'owncloud.org'],
+			['https://owncloud.org//mycloud', 'owncloud.org/mycloud'],
+			['https://owncloud.org/mycloud/', 'owncloud.org/mycloud'],
+		];
+	}
+}

--- a/apps/federation/tests/lib/trustedserverstest.php
+++ b/apps/federation/tests/lib/trustedserverstest.php
@@ -88,7 +88,7 @@ class TrustedServersTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestAddServer
+	 * @dataProvider dataTrueFalse
 	 *
 	 * @param bool $success
 	 */
@@ -130,11 +130,64 @@ class TrustedServersTest extends TestCase {
 		);
 	}
 
-	public function dataTestAddServer() {
+	public function dataTrueFalse() {
 		return [
 			[true],
 			[false]
 		];
+	}
+
+	/**
+	 * @dataProvider dataTrueFalse
+	 *
+	 * @param bool $status
+	 */
+	public function testSetAutoAddServers($status) {
+		if ($status) {
+			$this->config->expects($this->once())->method('setAppValue')
+				->with('federation', 'autoAddServers', '1');
+		} else {
+			$this->config->expects($this->once())->method('setAppValue')
+				->with('federation', 'autoAddServers', '0');
+		}
+
+		$this->trustedServers->setAutoAddServers($status);
+	}
+
+	/**
+	 * @dataProvider dataTestGetAutoAddServers
+	 *
+	 * @param string $status
+	 * @param bool $expected
+	 */
+	public function testGetAutoAddServers($status, $expected) {
+		$this->config->expects($this->once())->method('getAppValue')
+			->with('federation', 'autoAddServers', '1')->willReturn($status);
+
+		$this->assertSame($expected,
+			$this->trustedServers->getAutoAddServers($status)
+		);
+	}
+
+	public function dataTestGetAutoAddServers() {
+		return [
+			['1', true],
+			['0', false]
+		];
+	}
+
+	public function testAddSharedSecret() {
+		$this->dbHandler->expects($this->once())->method('addSharedSecret')
+			->with('url', 'secret');
+		$this->trustedServers->addSharedSecret('url', 'secret');
+	}
+
+	public function testGetSharedSecret() {
+		$this->dbHandler->expects($this->once())->method('getSharedSecret')
+			->with('url')->willReturn(true);
+		$this->assertTrue(
+			$this->trustedServers->getSharedSecret('url')
+		);
 	}
 
 	public function testRemoveServer() {
@@ -158,6 +211,20 @@ class TrustedServersTest extends TestCase {
 
 		$this->assertTrue(
 			$this->trustedServers->isTrustedServer('url')
+		);
+	}
+
+	public function testSetServerStatus() {
+		$this->dbHandler->expects($this->once())->method('setServerStatus')
+			->with('url', 'status');
+		$this->trustedServers->setServerStatus('url', 'status');
+	}
+
+	public function testGetServerStatus() {
+		$this->dbHandler->expects($this->once())->method('getServerStatus')
+			->with('url')->willReturn(true);
+		$this->assertTrue(
+			$this->trustedServers->getServerStatus('url')
 		);
 	}
 

--- a/apps/federation/tests/middleware/addservermiddlewaretest.php
+++ b/apps/federation/tests/middleware/addservermiddlewaretest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\Middleware;
+
+
+use OC\HintException;
+use OCA\Federation\Middleware\AddServerMiddleware;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use Test\TestCase;
+
+class AddServerMiddlewareTest extends TestCase {
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | ILogger */
+	private $logger;
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | \OCP\IL10N */
+	private $l10n;
+
+	/** @var  AddServerMiddleware */
+	private $middleware;
+
+	/** @var  \PHPUnit_Framework_MockObject_MockObject | Controller */
+	private $controller;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->logger = $this->getMock('OCP\ILogger');
+		$this->l10n = $this->getMock('OCP\IL10N');
+		$this->controller = $this->getMockBuilder('OCP\AppFramework\Controller')
+			->disableOriginalConstructor()->getMock();
+
+		$this->middleware = new AddServerMiddleware(
+			'AddServerMiddlewareTest',
+			$this->l10n,
+			$this->logger
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestAfterException
+	 *
+	 * @param \Exception $exception
+	 * @param string $message
+	 * @param string $hint
+	 */
+	public function testAfterException($exception, $message, $hint) {
+
+		$this->logger->expects($this->once())->method('error')
+			->with($message, ['app' => 'AddServerMiddlewareTest']);
+
+		$this->l10n->expects($this->any())->method('t')
+			->willReturnCallback(
+				function($message) {
+					return $message;
+				}
+			);
+
+		$result = $this->middleware->afterException($this->controller, 'method', $exception);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST,
+			$result->getStatus()
+		);
+
+		$data = $result->getData();
+
+		$this->assertSame($hint,
+			$data['message']
+		);
+	}
+
+	public function dataTestAfterException() {
+		return [
+			[new HintException('message', 'hint'), 'message', 'hint'],
+			[new \Exception('message'), 'message', 'Unknown error'],
+		];
+	}
+
+}

--- a/core/shipped.json
+++ b/core/shipped.json
@@ -32,7 +32,8 @@
     "user_ldap",
     "user_shibboleth",
     "windows_network_drive",
-    "password_policy"
+    "password_policy",
+    "federation"
   ],
   "alwaysEnabled": [
     "files",

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -412,13 +412,13 @@ table.grid td.date{
 .cronlog {
 	margin-left: 10px;
 }
-.cronstatus {
+.status {
 	display: inline-block;
 	height: 16px;
 	width: 16px;
 	vertical-align: text-bottom;
 }
-.cronstatus.success {
+.status.success {
 	border-radius: 50%;
 }
 

--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -290,18 +290,18 @@ if ($_['cronErrors']) {
 			$relative_time = relative_modified_date($_['lastcron']);
 			$absolute_time = OC_Util::formatDate($_['lastcron']);
 			if (time() - $_['lastcron'] <= 3600): ?>
-				<span class="cronstatus success"></span>
+				<span class="status success"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
 					<?php p($l->t("Last cron job execution: %s.", [$relative_time]));?>
 				</span>
 			<?php else: ?>
-				<span class="cronstatus error"></span>
+				<span class="status error"></span>
 				<span class="crondate" original-title="<?php p($absolute_time);?>">
 					<?php p($l->t("Last cron job execution: %s. Something seems wrong.", [$relative_time]));?>
 				</span>
 			<?php endif;
 		else: ?>
-			<span class="cronstatus error"></span>
+			<span class="status error"></span>
 			<?php p($l->t("Cron was not executed yet!"));
 		endif; ?>
 	</p>

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -22,4 +22,4 @@ enableApp('encryption');
 enableApp('user_ldap');
 enableApp('files_versions');
 enableApp('provisioning_api');
-
+enableApp('federation');


### PR DESCRIPTION
This is the first part of the federated sharing auto-complete feature for ownCloud 9.0 (https://github.com/owncloud/core/issues/19566)

It provides a user interface for the admin to add and remove trusted ownClouds.

Steps to test:
- Enable the app "federation"
- Go to the admin settings
- You should be able to add/remove ownCloud servers from the list of trusted servers

In the next step we will exchange the user list between trusted ownClouds and use it in the share dialog for auto-complete
