### PR TITLE
fix button text color

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -774,6 +774,9 @@ html.ie8 #body-login form input[type="checkbox"] {
 	color: #fff !important;
 	font-weight: 600 !important;
 }
+.error a.button {
+	color: #555 !important;
+}
 .error pre {
 	white-space: pre-wrap;
 	text-align: left;


### PR DESCRIPTION
Before & after:
![capture du 2015-11-02 17-58-57](https://cloud.githubusercontent.com/assets/925062/10888270/7352718e-818b-11e5-95e6-bbd457c1f7b8.png)![capture du 2015-11-02 17-57-59](https://cloud.githubusercontent.com/assets/925062/10888271/7352bd1a-818b-11e5-86e0-ddcb614e1569.png)

Please review @owncloud/designers @ChristophWurst @Gomez @irgendwie (can be tested with the mail app when Ctrl-clicking on a link in an email)
