### PR TITLE
Use phpunit groups to run database code in isolation

### DIFF
--- a/apps/dav/tests/unit/bootstrap.php
+++ b/apps/dav/tests/unit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
-define('PHPUNIT_RUN', 1);
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
 
 require_once __DIR__.'/../../../../lib/base.php';
 

--- a/apps/dav/tests/unit/connector/sabre/custompropertiesbackend.php
+++ b/apps/dav/tests/unit/connector/sabre/custompropertiesbackend.php
@@ -8,6 +8,14 @@ namespace OCA\DAV\Tests\Unit\Connector\Sabre;
  * later.
  * See the COPYING-README file.
  */
+
+/**
+ * Class CustomPropertiesBackend
+ *
+ * @group DB
+ *
+ * @package Tests\Connector\Sabre
+ */
 class CustomPropertiesBackend extends \Test\TestCase {
 
 	/**

--- a/apps/dav/tests/unit/connector/sabre/file.php
+++ b/apps/dav/tests/unit/connector/sabre/file.php
@@ -14,6 +14,13 @@ use Test\HookHelper;
 use OC\Files\Filesystem;
 use OCP\Lock\ILockingProvider;
 
+/**
+ * Class File
+ *
+ * @group DB
+ *
+ * @package Test\Connector\Sabre
+ */
 class File extends \Test\TestCase {
 
 	/**

--- a/apps/dav/tests/unit/connector/sabre/objecttree.php
+++ b/apps/dav/tests/unit/connector/sabre/objecttree.php
@@ -41,6 +41,13 @@ class TestDoubleFileView extends \OC\Files\View {
 	}
 }
 
+/**
+ * Class ObjectTree
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\Unit\Connector\Sabre
+ */
 class ObjectTree extends \Test\TestCase {
 
 	/**

--- a/apps/dav/tests/unit/connector/sabre/requesttest/downloadtest.php
+++ b/apps/dav/tests/unit/connector/sabre/requesttest/downloadtest.php
@@ -11,6 +11,13 @@ namespace OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest;
 use OCP\AppFramework\Http;
 use OCP\Lock\ILockingProvider;
 
+/**
+ * Class DownloadTest
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
+ */
 class DownloadTest extends RequestTest {
 	public function testDownload() {
 		$user = $this->getUniqueID();

--- a/apps/dav/tests/unit/connector/sabre/requesttest/encryptionuploadtest.php
+++ b/apps/dav/tests/unit/connector/sabre/requesttest/encryptionuploadtest.php
@@ -11,6 +11,13 @@ namespace OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest;
 use OC\Files\View;
 use Test\Traits\EncryptionTrait;
 
+/**
+ * Class EncryptionUploadTest
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
+ */
 class EncryptionUploadTest extends UploadTest {
 	use EncryptionTrait;
 

--- a/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
+++ b/apps/dav/tests/unit/connector/sabre/requesttest/uploadtest.php
@@ -12,6 +12,13 @@ use OC\Connector\Sabre\Exception\FileLocked;
 use OCP\AppFramework\Http;
 use OCP\Lock\ILockingProvider;
 
+/**
+ * Class UploadTest
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\Unit\Connector\Sabre\RequestTest
+ */
 class UploadTest extends RequestTest {
 	public function testBasicUpload() {
 		$user = $this->getUniqueID();

--- a/apps/federation/tests/backgroundjob/getsharedsecrettest.php
+++ b/apps/federation/tests/backgroundjob/getsharedsecrettest.php
@@ -34,6 +34,13 @@ use OCP\Http\Client\IResponse;
 use OCP\ILogger;
 use OCP\IURLGenerator;
 
+/**
+ * Class GetSharedSecretTest
+ *
+ * @group DB
+ *
+ * @package OCA\Federation\Tests\BackgroundJob
+ */
 class GetSharedSecretTest extends TestCase {
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject | IClient */

--- a/apps/files/tests/command/deleteorphanedfilestest.php
+++ b/apps/files/tests/command/deleteorphanedfilestest.php
@@ -25,6 +25,13 @@ namespace OCA\Files\Tests\Command;
 use OCA\Files\Command\DeleteOrphanedFiles;
 use OCP\Files\StorageNotAvailableException;
 
+/**
+ * Class DeleteOrphanedFilesTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files\Tests\Command
+ */
 class DeleteOrphanedFilesTest extends \Test\TestCase {
 
 	/**

--- a/apps/files/tests/service/tagservice.php
+++ b/apps/files/tests/service/tagservice.php
@@ -22,6 +22,13 @@ namespace OCA\Files;
 
 use \OCA\Files\Service\TagService;
 
+/**
+ * Class TagServiceTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files
+ */
 class TagServiceTest extends \Test\TestCase {
 
 	/**

--- a/apps/files_external/tests/amazons3migration.php
+++ b/apps/files_external/tests/amazons3migration.php
@@ -25,6 +25,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class AmazonS3Migration
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class AmazonS3Migration extends \Test\TestCase {
 
 	/**

--- a/apps/files_external/tests/backends/amazons3.php
+++ b/apps/files_external/tests/backends/amazons3.php
@@ -25,6 +25,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class AmazonS3
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class AmazonS3 extends Storage {
 
 	private $config;

--- a/apps/files_external/tests/backends/dropbox.php
+++ b/apps/files_external/tests/backends/dropbox.php
@@ -25,6 +25,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class Dropbox
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class Dropbox extends Storage {
 	private $config;
 

--- a/apps/files_external/tests/backends/ftp.php
+++ b/apps/files_external/tests/backends/ftp.php
@@ -26,6 +26,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class FTP
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class FTP extends Storage {
 	private $config;
 

--- a/apps/files_external/tests/backends/google.php
+++ b/apps/files_external/tests/backends/google.php
@@ -28,6 +28,13 @@ namespace Test\Files\Storage;
 
 require_once 'files_external/lib/google.php';
 
+/**
+ * Class Google
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class Google extends Storage {
 
 	private $config;

--- a/apps/files_external/tests/backends/owncloud.php
+++ b/apps/files_external/tests/backends/owncloud.php
@@ -23,6 +23,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class OwnCloud
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class OwnCloud extends Storage {
 
 	private $config;

--- a/apps/files_external/tests/backends/sftp.php
+++ b/apps/files_external/tests/backends/sftp.php
@@ -25,6 +25,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class SFTP
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class SFTP extends Storage {
 	/**
 	 * @var \OC\Files\Storage\SFTP instance

--- a/apps/files_external/tests/backends/sftp_key.php
+++ b/apps/files_external/tests/backends/sftp_key.php
@@ -23,6 +23,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class SFTP_Key
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class SFTP_Key extends Storage {
 	private $config;
 

--- a/apps/files_external/tests/backends/smb.php
+++ b/apps/files_external/tests/backends/smb.php
@@ -24,6 +24,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class SMB
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class SMB extends Storage {
 
 	protected function setUp() {

--- a/apps/files_external/tests/backends/swift.php
+++ b/apps/files_external/tests/backends/swift.php
@@ -25,6 +25,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class Swift
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class Swift extends Storage {
 
 	private $config;

--- a/apps/files_external/tests/backends/webdav.php
+++ b/apps/files_external/tests/backends/webdav.php
@@ -24,6 +24,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class DAV
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class DAV extends Storage {
 
 	protected function setUp() {

--- a/apps/files_external/tests/etagpropagator.php
+++ b/apps/files_external/tests/etagpropagator.php
@@ -26,6 +26,13 @@ namespace Tests\Files_External;
 use OC\Files\Filesystem;
 use OC\User\User;
 
+/**
+ * Class EtagPropagator
+ *
+ * @group DB
+ *
+ * @package Tests\Files_External
+ */
 class EtagPropagator extends \Test\TestCase {
 	protected function getUser() {
 		return new User($this->getUniqueID(), null);

--- a/apps/files_external/tests/owncloudfunctions.php
+++ b/apps/files_external/tests/owncloudfunctions.php
@@ -24,6 +24,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class OwnCloudFunctions
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class OwnCloudFunctions extends \Test\TestCase {
 
 	function configUrlProvider() {

--- a/apps/files_sharing/tests/activity.php
+++ b/apps/files_sharing/tests/activity.php
@@ -22,10 +22,15 @@
  */
 
 namespace OCA\Files_sharing\Tests;
-use OCA\Files_sharing\Tests\TestCase;
 
-
-class Activity extends \OCA\Files_Sharing\Tests\TestCase{
+/**
+ * Class Activity
+ *
+ * @group DB
+ *
+ * @package OCA\Files_sharing\Tests
+ */
+class Activity extends \OCA\Files_Sharing\Tests\TestCase {
 
 	/**
 	 * @var \OCA\Files_Sharing\Activity

--- a/apps/files_sharing/tests/api.php
+++ b/apps/files_sharing/tests/api.php
@@ -31,6 +31,8 @@ use OCA\Files_sharing\Tests\TestCase;
 
 /**
  * Class Test_Files_Sharing_Api
+ *
+ * @group DB
  */
 class Test_Files_Sharing_Api extends TestCase {
 

--- a/apps/files_sharing/tests/api/shareestest.php
+++ b/apps/files_sharing/tests/api/shareestest.php
@@ -27,6 +27,13 @@ use OCA\Files_sharing\Tests\TestCase;
 use OCP\AppFramework\Http;
 use OCP\Share;
 
+/**
+ * Class ShareesTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests\API
+ */
 class ShareesTest extends TestCase {
 	/** @var Sharees */
 	protected $sharees;

--- a/apps/files_sharing/tests/backend.php
+++ b/apps/files_sharing/tests/backend.php
@@ -27,6 +27,8 @@ use OCA\Files_sharing\Tests\TestCase;
 
 /**
  * Class Test_Files_Sharing
+ *
+ * @group DB
  */
 class Test_Files_Sharing_Backend extends TestCase {
 

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -47,6 +47,12 @@ use OCA\Files_sharing\Tests\TestCase;
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+/**
+ * Class Test_Files_Sharing_Cache
+ *
+ * @group DB
+ */
 class Test_Files_Sharing_Cache extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/capabilities.php
+++ b/apps/files_sharing/tests/capabilities.php
@@ -26,6 +26,8 @@ use OCA\Files_Sharing\Tests\TestCase;
 
 /**
  * Class FilesSharingCapabilitiesTest
+ *
+ * @group DB
  */
 class FilesSharingCapabilitiesTest extends \Test\TestCase {
 

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -38,6 +38,8 @@ use OCP\Share;
 use OC\URLGenerator;
 
 /**
+ * @group DB
+ *
  * @package OCA\Files_Sharing\Controllers
  */
 class ShareControllerTest extends \Test\TestCase {

--- a/apps/files_sharing/tests/deleteorphanedsharesjobtest.php
+++ b/apps/files_sharing/tests/deleteorphanedsharesjobtest.php
@@ -23,6 +23,13 @@ namespace Test\BackgroundJob;
 
 use OCA\Files_sharing\Lib\DeleteOrphanedSharesJob;
 
+/**
+ * Class DeleteOrphanedSharesJobTest
+ *
+ * @group DB
+ *
+ * @package Test\BackgroundJob
+ */
 class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 	/**

--- a/apps/files_sharing/tests/etagpropagation.php
+++ b/apps/files_sharing/tests/etagpropagation.php
@@ -27,6 +27,13 @@ namespace OCA\Files_sharing\Tests;
 use OC\Files\Filesystem;
 use OC\Files\View;
 
+/**
+ * Class EtagPropagation
+ *
+ * @group DB
+ *
+ * @package OCA\Files_sharing\Tests
+ */
 class EtagPropagation extends TestCase {
 	/**
 	 * @var \OC\Files\View

--- a/apps/files_sharing/tests/expiresharesjobtest.php
+++ b/apps/files_sharing/tests/expiresharesjobtest.php
@@ -23,6 +23,13 @@ namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\ExpireSharesJob;
 
+/**
+ * Class ExpireSharesJobTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests
+ */
 class ExpireSharesJobTest extends \Test\TestCase {
 
 	/**

--- a/apps/files_sharing/tests/external/cache.php
+++ b/apps/files_sharing/tests/external/cache.php
@@ -23,24 +23,11 @@ namespace OCA\Files_sharing\Tests\External;
 use OCA\Files_sharing\Tests\TestCase;
 
 /**
- * ownCloud
+ * Class Cache
  *
- * @author Vincent Petry
- * @copyright 2015 Vincent Petry <pvince81@owncloud.com>
+ * @group DB
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * @package OCA\Files_sharing\Tests\External
  */
 class Cache extends TestCase {
 

--- a/apps/files_sharing/tests/external/managertest.php
+++ b/apps/files_sharing/tests/external/managertest.php
@@ -28,6 +28,13 @@ use OCA\Files_Sharing\External\MountProvider;
 use OCA\Files_Sharing\Tests\TestCase;
 use Test\Traits\UserTrait;
 
+/**
+ * Class ManagerTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests\External
+ */
 class ManagerTest extends TestCase {
 	use UserTrait;
 

--- a/apps/files_sharing/tests/externalstorage.php
+++ b/apps/files_sharing/tests/externalstorage.php
@@ -24,6 +24,8 @@
 
 /**
  * Tests for the external Storage class for remote shares.
+ *
+ * @group DB
  */
 class Test_Files_Sharing_External_Storage extends \Test\TestCase {
 

--- a/apps/files_sharing/tests/helper.php
+++ b/apps/files_sharing/tests/helper.php
@@ -24,26 +24,10 @@
 use OCA\Files_sharing\Tests\TestCase;
 
 /**
- * ownCloud
+ * Class Test_Files_Sharing_Helper
  *
- * @author Bjoern Schiessle
- * @copyright 2014 Bjoern Schiessle <schiessle@owncloud.com>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * @group DB
  */
-
 class Test_Files_Sharing_Helper extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/locking.php
+++ b/apps/files_sharing/tests/locking.php
@@ -27,6 +27,13 @@ use OC\Files\View;
 use OC\Lock\MemcacheLockingProvider;
 use OCP\Lock\ILockingProvider;
 
+/**
+ * Class Locking
+ *
+ * @group DB
+ *
+ * @package OCA\Files_sharing\Tests
+ */
 class Locking extends TestCase {
 	/**
 	 * @var \Test\Util\User\Dummy

--- a/apps/files_sharing/tests/migrationtest.php
+++ b/apps/files_sharing/tests/migrationtest.php
@@ -24,6 +24,11 @@
 use OCA\Files_Sharing\Tests\TestCase;
 use OCA\Files_Sharing\Migration;
 
+/**
+ * Class MigrationTest
+ *
+ * @group DB
+ */
 class MigrationTest extends TestCase {
 
 	/**

--- a/apps/files_sharing/tests/permissions.php
+++ b/apps/files_sharing/tests/permissions.php
@@ -26,7 +26,11 @@ use OC\Files\Cache\Cache;
 use OC\Files\Storage\Storage;
 use OC\Files\View;
 
-
+/**
+ * Class Test_Files_Sharing_Permissions
+ *
+ * @group DB
+ */
 class Test_Files_Sharing_Permissions extends OCA\Files_sharing\Tests\TestCase {
 
 	/**

--- a/apps/files_sharing/tests/server2server.php
+++ b/apps/files_sharing/tests/server2server.php
@@ -26,6 +26,8 @@ use OCA\Files_Sharing\Tests\TestCase;
 
 /**
  * Class Test_Files_Sharing_Api
+ *
+ * @group DB
  */
 class Test_Files_Sharing_S2S_OCS_API extends TestCase {
 

--- a/apps/files_sharing/tests/share.php
+++ b/apps/files_sharing/tests/share.php
@@ -27,6 +27,8 @@ use OCA\Files\Share;
 
 /**
  * Class Test_Files_Sharing
+ *
+ * @group DB
  */
 class Test_Files_Sharing extends OCA\Files_sharing\Tests\TestCase {
 

--- a/apps/files_sharing/tests/sharedmount.php
+++ b/apps/files_sharing/tests/sharedmount.php
@@ -27,6 +27,8 @@
 
 /**
  * Class Test_Files_Sharing_Api
+ *
+ * @group DB
  */
 class Test_Files_Sharing_Mount extends OCA\Files_sharing\Tests\TestCase {
 

--- a/apps/files_sharing/tests/sharedstorage.php
+++ b/apps/files_sharing/tests/sharedstorage.php
@@ -28,6 +28,8 @@ use OCA\Files\Share;
 
 /**
  * Class Test_Files_Sharing_Api
+ *
+ * @group DB
  */
 class Test_Files_Sharing_Storage extends OCA\Files_sharing\Tests\TestCase {
 

--- a/apps/files_sharing/tests/sizepropagation.php
+++ b/apps/files_sharing/tests/sizepropagation.php
@@ -24,6 +24,13 @@ namespace OCA\Files_sharing\Tests;
 
 use OC\Files\View;
 
+/**
+ * Class SizePropagation
+ *
+ * @group DB
+ *
+ * @package OCA\Files_sharing\Tests
+ */
 class SizePropagation extends TestCase {
 
 	public function testSizePropagationWhenOwnerChangesFile() {

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -36,6 +36,8 @@ use OCA\Files_Sharing\Appinfo\Application;
 /**
  * Class Test_Files_Sharing_Base
  *
+ * @group DB
+ *
  * Base class for sharing tests.
  */
 abstract class TestCase extends \Test\TestCase {

--- a/apps/files_sharing/tests/unsharechildren.php
+++ b/apps/files_sharing/tests/unsharechildren.php
@@ -26,6 +26,13 @@ namespace OCA\Files_sharing\Tests;
 
 use OCA\Files\Share;
 
+/**
+ * Class UnshareChildren
+ *
+ * @group DB
+ *
+ * @package OCA\Files_sharing\Tests
+ */
 class UnshareChildren extends TestCase {
 
 	protected $subsubfolder;

--- a/apps/files_sharing/tests/updater.php
+++ b/apps/files_sharing/tests/updater.php
@@ -25,6 +25,8 @@
 
 /**
  * Class Test_Files_Sharing_Updater
+ *
+ * @group DB
  */
 class Test_Files_Sharing_Updater extends OCA\Files_Sharing\Tests\TestCase {
 

--- a/apps/files_sharing/tests/watcher.php
+++ b/apps/files_sharing/tests/watcher.php
@@ -25,6 +25,11 @@
  *
  */
 
+/**
+ * Class Test_Files_Sharing_Watcher
+ *
+ * @group DB
+ */
 class Test_Files_Sharing_Watcher extends OCA\Files_sharing\Tests\TestCase {
 
 	/**

--- a/apps/files_trashbin/tests/command/cleanuptest.php
+++ b/apps/files_trashbin/tests/command/cleanuptest.php
@@ -29,6 +29,13 @@ use Test\TestCase;
 use OC\User\Manager;
 use OCP\Files\IRootFolder;
 
+/**
+ * Class CleanUpTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Trashbin\Tests\Command
+ */
 class CleanUpTest extends TestCase {
 
 	/** @var  CleanUp */

--- a/apps/files_trashbin/tests/command/expiretest.php
+++ b/apps/files_trashbin/tests/command/expiretest.php
@@ -24,6 +24,13 @@ namespace OCA\Files_Trashbin\Tests\Command;
 use OCA\Files_Trashbin\Command\Expire;
 use Test\TestCase;
 
+/**
+ * Class ExpireTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Trashbin\Tests\Command
+ */
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser() {
 		$command = new Expire('test');

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -27,6 +27,13 @@ namespace OCA\Files_trashbin\Tests\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\Filesystem;
 
+/**
+ * Class Storage
+ *
+ * @group DB
+ *
+ * @package OCA\Files_trashbin\Tests\Storage
+ */
 class Storage extends \Test\TestCase {
 	/**
 	 * @var string

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -29,6 +29,8 @@ use OCA\Files_Trashbin;
 
 /**
  * Class Test_Encryption
+ *
+ * @group DB
  */
 class Test_Trashbin extends \Test\TestCase {
 

--- a/apps/files_versions/tests/command/cleanuptest.php
+++ b/apps/files_versions/tests/command/cleanuptest.php
@@ -28,6 +28,13 @@ use Test\TestCase;
 use OC\User\Manager;
 use OCP\Files\IRootFolder;
 
+/**
+ * Class CleanupTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Versions\Tests\Command
+ */
 class CleanupTest extends TestCase {
 
 	/** @var  CleanUp */

--- a/apps/files_versions/tests/command/expiretest.php
+++ b/apps/files_versions/tests/command/expiretest.php
@@ -25,6 +25,13 @@ namespace OCA\Files_Versions\Tests\Command;
 use OCA\Files_Versions\Command\Expire;
 use Test\TestCase;
 
+/**
+ * Class ExpireTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Versions\Tests\Command
+ */
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser() {
 		$command = new Expire($this->getUniqueID('test'), '');

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -34,6 +34,8 @@ use OC\Files\Storage\Temporary;
 /**
  * Class Test_Files_versions
  * this class provide basic files versions test
+ *
+ * @group DB
  */
 class Test_Files_Versioning extends \Test\TestCase {
 

--- a/apps/provisioning_api/tests/appstest.php
+++ b/apps/provisioning_api/tests/appstest.php
@@ -23,15 +23,35 @@
  */
 
 namespace OCA\Provisioning_API\Tests;
+use OCA\Provisioning_API\Apps;
+use OCP\API;
+use OCP\App\IAppManager;
+use OCP\IUserSession;
 
+/**
+ * Class AppsTest
+ *
+ * @group DB
+ *
+ * @package OCA\Provisioning_API\Tests
+ */
 class AppsTest extends TestCase {
-	
+
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var Apps */
+	private $api;
+
+	/** @var IUserSession */
+	private $userSession;
+
 	public function setup() {
 		parent::setup();
 		$this->appManager = \OC::$server->getAppManager();
 		$this->groupManager = \OC::$server->getGroupManager();
 		$this->userSession = \OC::$server->getUserSession();
-		$this->api = new \OCA\Provisioning_API\Apps($this->appManager);
+		$this->api = new Apps($this->appManager);
 	}
 
 	public function testGetAppInfo() {
@@ -46,7 +66,7 @@ class AppsTest extends TestCase {
 		$result = $this->api->getAppInfo(['appid' => 'not_provisioning_api']);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertFalse($result->succeeded());
-		$this->assertEquals(\OCP\API::RESPOND_NOT_FOUND, $result->getStatusCode());
+		$this->assertEquals(API::RESPOND_NOT_FOUND, $result->getStatusCode());
 
 	}
 

--- a/apps/provisioning_api/tests/testcase.php
+++ b/apps/provisioning_api/tests/testcase.php
@@ -23,10 +23,13 @@
 
 namespace OCA\Provisioning_API\Tests;
 
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IGroupManager;
 
 abstract class TestCase extends \Test\TestCase {
+
+	/** @var IUser[] */
 	protected $users = array();
 
 	/** @var IUserManager */
@@ -46,7 +49,7 @@ abstract class TestCase extends \Test\TestCase {
 	/**
 	 * Generates a temp user
 	 * @param int $num number of users to generate
-	 * @return IUser[]|Iuser
+	 * @return IUser[]|IUser
 	 */
 	protected function generateUsers($num = 1) {
 		$users = array();

--- a/apps/user_ldap/tests/access.php
+++ b/apps/user_ldap/tests/access.php
@@ -28,6 +28,13 @@ use \OCA\user_ldap\lib\Access;
 use \OCA\user_ldap\lib\Connection;
 use \OCA\user_ldap\lib\ILDAPWrapper;
 
+/**
+ * Class Test_Access
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_Access extends \Test\TestCase {
 	private function getConnectorAndLdapMock() {
 		static $conMethods;

--- a/apps/user_ldap/tests/connection.php
+++ b/apps/user_ldap/tests/connection.php
@@ -23,6 +23,13 @@
 
 namespace OCA\user_ldap\tests;
 
+/**
+ * Class Test_Connection
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_Connection extends \Test\TestCase {
 
 	public function testOriginalAgentUnchangedOnClone() {

--- a/apps/user_ldap/tests/group_ldap.php
+++ b/apps/user_ldap/tests/group_ldap.php
@@ -30,6 +30,13 @@ use \OCA\user_ldap\lib\Access;
 use \OCA\user_ldap\lib\Connection;
 use \OCA\user_ldap\lib\ILDAPWrapper;
 
+/**
+ * Class Test_Group_Ldap
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_Group_Ldap extends \Test\TestCase {
 	private function getAccessMock() {
 		static $conMethods;

--- a/apps/user_ldap/tests/mapping/groupmapping.php
+++ b/apps/user_ldap/tests/mapping/groupmapping.php
@@ -24,6 +24,13 @@ namespace OCA\user_ldap\tests\mapping;
 
 use OCA\User_LDAP\Mapping\GroupMapping;
 
+/**
+ * Class Test_GroupMapping
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests\mapping
+ */
 class Test_GroupMapping extends AbstractMappingTest {
 	public function getMapper(\OCP\IDBConnection $dbMock) {
 		return new GroupMapping($dbMock);

--- a/apps/user_ldap/tests/mapping/usermapping.php
+++ b/apps/user_ldap/tests/mapping/usermapping.php
@@ -24,6 +24,13 @@ namespace OCA\user_ldap\tests\mapping;
 
 use OCA\User_LDAP\Mapping\UserMapping;
 
+/**
+ * Class Test_UserMapping
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests\mapping
+ */
 class Test_UserMapping extends AbstractMappingTest {
 	public function getMapper(\OCP\IDBConnection $dbMock) {
 		return new UserMapping($dbMock);

--- a/apps/user_ldap/tests/user/manager.php
+++ b/apps/user_ldap/tests/user/manager.php
@@ -26,6 +26,13 @@ namespace OCA\user_ldap\tests;
 
 use OCA\user_ldap\lib\user\Manager;
 
+/**
+ * Class Test_User_Manager
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_User_Manager extends \Test\TestCase {
 
 	private function getTestInstances() {

--- a/apps/user_ldap/tests/user/user.php
+++ b/apps/user_ldap/tests/user/user.php
@@ -25,6 +25,13 @@ namespace OCA\user_ldap\tests;
 
 use OCA\user_ldap\lib\user\User;
 
+/**
+ * Class Test_User_User
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_User_User extends \Test\TestCase {
 
 	private function getTestInstances() {

--- a/apps/user_ldap/tests/user_ldap.php
+++ b/apps/user_ldap/tests/user_ldap.php
@@ -31,6 +31,13 @@ use \OCA\user_ldap\lib\Access;
 use \OCA\user_ldap\lib\Connection;
 use \OCA\user_ldap\lib\ILDAPWrapper;
 
+/**
+ * Class Test_User_Ldap_Direct
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_User_Ldap_Direct extends \Test\TestCase {
 	protected $backend;
 	protected $access;

--- a/apps/user_ldap/tests/wizard.php
+++ b/apps/user_ldap/tests/wizard.php
@@ -31,6 +31,13 @@ use \OCA\user_ldap\lib\Wizard;
 // use \OCA\user_ldap\lib\Configuration;
 // use \OCA\user_ldap\lib\ILDAPWrapper;
 
+/**
+ * Class Test_Wizard
+ *
+ * @group DB
+ *
+ * @package OCA\user_ldap\tests
+ */
 class Test_Wizard extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();

--- a/autotest.sh
+++ b/autotest.sh
@@ -260,14 +260,27 @@ function execute_tests {
 	if [[ "$_XDEBUG_CONFIG" ]]; then
 		export XDEBUG_CONFIG=$_XDEBUG_CONFIG
 	fi
+	if [ -z "$TEST_SELECTION" ]; then
+		TEST_SELECTION='all'
+	fi
+	GROUP=''
+	if [ "$TEST_SELECTION" == "DB" ]; then
+		GROUP='--group DB'
+	fi
+	if [ "$TEST_SELECTION" == "NODB" ]; then
+		GROUP='--exclude-group DB'
+	fi
+
+	COVER=''
 	if [ -z "$NOCOVERAGE" ]; then
-		"${PHPUNIT[@]}" --configuration phpunit-autotest.xml --log-junit "autotest-results-$DB.xml" --coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB" "$2" "$3"
-		RESULT=$?
+		COVER='--coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB"'
+		"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP --log-junit "autotest-results-$DB.xml" --coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB" "$2" "$3"
 	else
 		echo "No coverage"
-		"${PHPUNIT[@]}" --configuration phpunit-autotest.xml --log-junit "autotest-results-$DB.xml" "$2" "$3"
-		RESULT=$?
 	fi
+	echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+		RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then
 		cd ..

--- a/autotest.sh
+++ b/autotest.sh
@@ -271,7 +271,6 @@ function execute_tests {
 	COVER=''
 	if [ -z "$NOCOVERAGE" ]; then
 		COVER='--coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB"'
-		"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP --log-junit "autotest-results-$DB.xml" --coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB" "$2" "$3"
 	else
 		echo "No coverage"
 	fi

--- a/autotest.sh
+++ b/autotest.sh
@@ -260,9 +260,6 @@ function execute_tests {
 	if [[ "$_XDEBUG_CONFIG" ]]; then
 		export XDEBUG_CONFIG=$_XDEBUG_CONFIG
 	fi
-	if [ -z "$TEST_SELECTION" ]; then
-		TEST_SELECTION='all'
-	fi
 	GROUP=''
 	if [ "$TEST_SELECTION" == "DB" ]; then
 		GROUP='--group DB'

--- a/lib/private/files/storage/dav.php
+++ b/lib/private/files/storage/dav.php
@@ -105,6 +105,7 @@ class DAV extends Common {
 				$this->secure = false;
 			}
 			if ($this->secure === true) {
+				// inject mock for testing
 				$certPath = \OC_User::getHome(\OC_User::getUser()) . '/files_external/rootcerts.crt';
 				if (file_exists($certPath)) {
 					$this->certPath = $certPath;

--- a/lib/private/urlgenerator.php
+++ b/lib/private/urlgenerator.php
@@ -62,6 +62,7 @@ class URLGenerator implements IURLGenerator {
 	 * Returns a url to the given route.
 	 */
 	public function linkToRoute($route, $parameters = array()) {
+		// TODO: mock router
 		$urlLinkTo = \OC::$server->getRouter()->generate($route, $parameters);
 		return $urlLinkTo;
 	}

--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -44,6 +44,8 @@ function is_uploaded_file($filename) {
 /**
  * Class AvatarControllerTest
  *
+ * @group DB
+ *
  * @package OC\Core\Avatar
  */
 class AvatarControllerTest extends \Test\TestCase {

--- a/tests/lib/allconfig.php
+++ b/tests/lib/allconfig.php
@@ -8,6 +8,13 @@
 
 namespace Test;
 
+/**
+ * Class TestAllConfig
+ *
+ * @group DB
+ *
+ * @package Test
+ */
 class TestAllConfig extends \Test\TestCase {
 
 	/** @var  \OCP\IDBConnection */

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -1,11 +1,16 @@
 <?php
-
 /**
  * Copyright (c) 2012 Bernhard Posselt <dev@bernhard-posselt.com>
  * Copyright (c) 2014 Vincent Petry <pvince81@owncloud.com>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
+ */
+
+/**
+ * Class Test_App
+ *
+ * @group DB
  */
 class Test_App extends \Test\TestCase {
 

--- a/tests/lib/appconfig.php
+++ b/tests/lib/appconfig.php
@@ -11,6 +11,13 @@ namespace Test\Lib;
 
 use Test\TestCase;
 
+/**
+ * Class AppConfig
+ *
+ * @group DB
+ *
+ * @package Test\Lib
+ */
 class AppConfig extends TestCase {
 	/** @var \OCP\IAppConfig */
 	protected $appConfig;

--- a/tests/lib/appframework/AppTest.php
+++ b/tests/lib/appframework/AppTest.php
@@ -128,6 +128,7 @@ class AppTest extends \Test\TestCase {
 
 	protected function tearDown() {
 		rrmdir($this->appPath);
+		parent::tearDown();
 	}
 
 

--- a/tests/lib/appframework/dependencyinjection/DIContainerTest.php
+++ b/tests/lib/appframework/dependencyinjection/DIContainerTest.php
@@ -36,7 +36,9 @@ class DIContainerTest extends \Test\TestCase {
 
 	protected function setUp(){
 		parent::setUp();
-		$this->container = new DIContainer('name');
+		$this->container = $this->getMock('OC\AppFramework\DependencyInjection\DIContainer',
+				['isAdminUser'], ['name']
+		);
 		$this->api = $this->getMock('OC\AppFramework\Core\API', array(), array('hi'));
 	}
 

--- a/tests/lib/avatar.php
+++ b/tests/lib/avatar.php
@@ -9,6 +9,11 @@
 
 use OC\Avatar;
 
+/**
+ * Class Test_Avatar
+ *
+ * @group DB
+ */
 class Test_Avatar extends \Test\TestCase {
 	private static $trashBinStatus;
 

--- a/tests/lib/backgroundjob/joblist.php
+++ b/tests/lib/backgroundjob/joblist.php
@@ -9,8 +9,16 @@
 namespace Test\BackgroundJob;
 
 use OCP\BackgroundJob\IJob;
+use Test\TestCase;
 
-class JobList extends \Test\TestCase {
+/**
+ * Class JobList
+ *
+ * @group DB
+ *
+ * @package Test\BackgroundJob
+ */
+class JobList extends TestCase {
 	/**
 	 * @var \OC\BackgroundJob\JobList
 	 */

--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -22,6 +22,13 @@
 
 namespace Test\Cache;
 
+/**
+ * Class FileCache
+ *
+ * @group DB
+ *
+ * @package Test\Cache
+ */
 class FileCache extends \Test_Cache {
 	/**
 	 * @var string

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -6,6 +6,11 @@
  * See the COPYING-README file.
  */
 
+/**
+ * Class Test_DB
+ *
+ * @group DB
+ */
 class Test_DB extends \Test\TestCase {
 	protected $backupGlobals = FALSE;
 

--- a/tests/lib/db/connection.php
+++ b/tests/lib/db/connection.php
@@ -12,6 +12,13 @@ namespace Test\DB;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OC\DB\MDB2SchemaManager;
 
+/**
+ * Class Connection
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
 class Connection extends \Test\TestCase {
 	/**
 	 * @var \OCP\IDBConnection

--- a/tests/lib/db/mdb2schemamanager.php
+++ b/tests/lib/db/mdb2schemamanager.php
@@ -11,6 +11,13 @@ namespace Test\DB;
 
 use Doctrine\DBAL\Platforms\OraclePlatform;
 
+/**
+ * Class MDB2SchemaManager
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
 class MDB2SchemaManager extends \Test\TestCase {
 
 	protected function tearDown() {

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -15,6 +15,13 @@ use \Doctrine\DBAL\Schema\Schema;
 use \Doctrine\DBAL\Schema\SchemaConfig;
 use OCP\IConfig;
 
+/**
+ * Class Migrator
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
 class Migrator extends \Test\TestCase {
 	/**
 	 * @var \Doctrine\DBAL\Connection $connection

--- a/tests/lib/db/mysqlmigration.php
+++ b/tests/lib/db/mysqlmigration.php
@@ -6,6 +6,11 @@
  * See the COPYING-README file.
  */
 
+/**
+ * Class TestMySqlMigration
+ *
+ * @group DB
+ */
 class TestMySqlMigration extends \Test\TestCase {
 
 	/** @var \Doctrine\DBAL\Connection */

--- a/tests/lib/db/querybuilder/expressionbuildertest.php
+++ b/tests/lib/db/querybuilder/expressionbuildertest.php
@@ -24,6 +24,13 @@ namespace Test\DB\QueryBuilder;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder as DoctrineExpressionBuilder;
 use OC\DB\QueryBuilder\ExpressionBuilder;
 
+/**
+ * Class ExpressionBuilderTest
+ *
+ * @group DB
+ *
+ * @package Test\DB\QueryBuilder
+ */
 class ExpressionBuilderTest extends \Test\TestCase {
 	/** @var ExpressionBuilder */
 	protected $expressionBuilder;

--- a/tests/lib/db/querybuilder/querybuildertest.php
+++ b/tests/lib/db/querybuilder/querybuildertest.php
@@ -27,6 +27,13 @@ use OC\DB\QueryBuilder\Parameter;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * Class QueryBuilderTest
+ *
+ * @group DB
+ *
+ * @package Test\DB\QueryBuilder
+ */
 class QueryBuilderTest extends \Test\TestCase {
 	/** @var QueryBuilder */
 	protected $queryBuilder;

--- a/tests/lib/db/sqlitemigration.php
+++ b/tests/lib/db/sqlitemigration.php
@@ -6,6 +6,11 @@
  * See the COPYING-README file.
  */
 
+/**
+ * Class TestSqliteMigration
+ *
+ * @group DB
+ */
 class TestSqliteMigration extends \Test\TestCase {
 
 	/** @var \Doctrine\DBAL\Connection */

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -9,6 +9,11 @@
 
 use OCP\Security\ISecureRandom;
 
+/**
+ * Class Test_DBSchema
+ *
+ * @group DB
+ */
 class Test_DBSchema extends \Test\TestCase {
 	protected $schema_file = 'static://test_db_scheme';
 	protected $schema_file2 = 'static://test_db_scheme2';

--- a/tests/lib/encryption/decryptalltest.php
+++ b/tests/lib/encryption/decryptalltest.php
@@ -30,6 +30,13 @@ use OC\Files\View;
 use OCP\IUserManager;
 use Test\TestCase;
 
+/**
+ * Class DecryptAllTest
+ *
+ * @group DB
+ *
+ * @package Test\Encryption
+ */
 class DecryptAllTest extends TestCase {
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject | IUserManager */

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -16,6 +16,13 @@ class LongId extends \OC\Files\Storage\Temporary {
 	}
 }
 
+/**
+ * Class Cache
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class Cache extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Temporary $storage ;

--- a/tests/lib/files/cache/changepropagator.php
+++ b/tests/lib/files/cache/changepropagator.php
@@ -12,6 +12,13 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 
+/**
+ * Class ChangePropagator
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class ChangePropagator extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Cache\ChangePropagator

--- a/tests/lib/files/cache/homecache.php
+++ b/tests/lib/files/cache/homecache.php
@@ -43,6 +43,13 @@ class DummyUser extends \OC\User\User {
 	}
 }
 
+/**
+ * Class HomeCache
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class HomeCache extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Home $storage

--- a/tests/lib/files/cache/scanner.php
+++ b/tests/lib/files/cache/scanner.php
@@ -8,6 +8,13 @@
 
 namespace Test\Files\Cache;
 
+/**
+ * Class Scanner
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class Scanner extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Storage $storage

--- a/tests/lib/files/cache/updater.php
+++ b/tests/lib/files/cache/updater.php
@@ -12,6 +12,13 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 
+/**
+ * Class Updater
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class Updater extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Storage

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -12,6 +12,13 @@ use \OC\Files\Filesystem as Filesystem;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 
+/**
+ * Class UpdaterLegacy
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class UpdaterLegacy extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Storage $storage

--- a/tests/lib/files/cache/watcher.php
+++ b/tests/lib/files/cache/watcher.php
@@ -8,6 +8,13 @@
 
 namespace Test\Files\Cache;
 
+/**
+ * Class Watcher
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache
+ */
 class Watcher extends \Test\TestCase {
 
 	/**

--- a/tests/lib/files/cache/wrapper/cachejail.php
+++ b/tests/lib/files/cache/wrapper/cachejail.php
@@ -10,6 +10,13 @@ namespace Test\Files\Cache\Wrapper;
 
 use Test\Files\Cache\Cache;
 
+/**
+ * Class CacheJail
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache\Wrapper
+ */
 class CacheJail extends Cache {
 	/**
 	 * @var \OC\Files\Cache\Cache $sourceCache

--- a/tests/lib/files/cache/wrapper/cachepermissionsmask.php
+++ b/tests/lib/files/cache/wrapper/cachepermissionsmask.php
@@ -11,6 +11,13 @@ namespace Test\Files\Cache\Wrapper;
 use OCP\Constants;
 use Test\Files\Cache\Cache;
 
+/**
+ * Class CachePermissionsMask
+ *
+ * @group DB
+ *
+ * @package Test\Files\Cache\Wrapper
+ */
 class CachePermissionsMask extends Cache {
 	/**
 	 * @var \OC\Files\Cache\Cache $sourceCache

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -11,6 +11,13 @@ namespace Test\Files;
 use OC\Files\Filesystem;
 use OCP\Share;
 
+/**
+ * Class EtagTest
+ *
+ * @group DB
+ *
+ * @package Test\Files
+ */
 class EtagTest extends \Test\TestCase {
 	private $datadir;
 

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -51,6 +51,13 @@ class DummyMountProvider implements IMountProvider {
 	}
 }
 
+/**
+ * Class Filesystem
+ *
+ * @group DB
+ *
+ * @package Test\Files
+ */
 class Filesystem extends \Test\TestCase {
 
 	const TEST_FILESYSTEM_USER1 = "test-filesystem-user1";

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -16,6 +16,13 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OC\Files\View;
 
+/**
+ * Class Folder
+ *
+ * @group DB
+ *
+ * @package Test\Files\Node
+ */
 class Folder extends \Test\TestCase {
 	private $user;
 

--- a/tests/lib/files/node/hookconnector.php
+++ b/tests/lib/files/node/hookconnector.php
@@ -17,6 +17,13 @@ use Test\TestCase;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
+/**
+ * Class HookConnector
+ *
+ * @group DB
+ * 
+ * @package Test\Files\Node
+ */
 class HookConnector extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;

--- a/tests/lib/files/node/integration.php
+++ b/tests/lib/files/node/integration.php
@@ -13,6 +13,13 @@ use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\User\User;
 
+/**
+ * Class IntegrationTests
+ *
+ * @group DB
+ *
+ * @package Test\Files\Node
+ */
 class IntegrationTests extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Node\Root $root

--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -23,6 +23,13 @@ namespace OCA\ObjectStore\Tests\Unit;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\ObjectStore\Swift as ObjectStoreToTest;
 
+/**
+ * Class Swift
+ *
+ * @group DB
+ *
+ * @package OCA\ObjectStore\Tests\Unit
+ */
 class Swift extends \Test\Files\Storage\Storage {
 
 	/**

--- a/tests/lib/files/pathverificationtest.php
+++ b/tests/lib/files/pathverificationtest.php
@@ -10,6 +10,13 @@ namespace Test\Files;
 use OC\Files\Storage\Local;
 use OC\Files\View;
 
+/**
+ * Class PathVerification
+ *
+ * @group DB
+ *
+ * @package Test\Files
+ */
 class PathVerification extends \Test\TestCase {
 
 	/**

--- a/tests/lib/files/storage/commontest.php
+++ b/tests/lib/files/storage/commontest.php
@@ -22,6 +22,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class CommonTest
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class CommonTest extends Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/files/storage/copydirectory.php
+++ b/tests/lib/files/storage/copydirectory.php
@@ -36,6 +36,13 @@ class CopyDirectoryStorage extends StorageNoRecursiveCopy {
 	use \OC\Files\Storage\PolyFill\CopyDirectory;
 }
 
+/**
+ * Class CopyDirectory
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class CopyDirectory extends Storage {
 
 	protected function setUp() {

--- a/tests/lib/files/storage/home.php
+++ b/tests/lib/files/storage/home.php
@@ -47,6 +47,13 @@ class DummyUser extends User {
 	}
 }
 
+/**
+ * Class Home
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class Home extends Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/files/storage/homestoragequota.php
+++ b/tests/lib/files/storage/homestoragequota.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage;
+
+/**
+ * Class HomeStorageQuota
+ *
+ * @group DB
+ */
+class HomeStorageQuota extends \Test\TestCase {
+	/**
+	 * Tests that the home storage is not wrapped when no quota exists.
+	 */
+	function testHomeStorageWrapperWithoutQuota() {
+		$user1 = $this->getUniqueID();
+		\OC_User::createUser($user1, 'test');
+		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', 'none');
+		\OC_User::setUserId($user1);
+
+		\OC_Util::setupFS($user1);
+
+		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
+		$this->assertNotNull($userMount);
+		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $userMount->getStorage());
+
+		// clean up
+		\OC_User::setUserId('');
+		\OC_User::deleteUser($user1);
+		\OC::$server->getConfig()->deleteAllUserValues($user1);
+		\OC_Util::tearDownFS();
+	}
+
+	/**
+	 * Tests that the home storage is not wrapped when no quota exists.
+	 */
+	function testHomeStorageWrapperWithQuota() {
+		$user1 = $this->getUniqueID();
+		\OC_User::createUser($user1, 'test');
+		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', '1024');
+		\OC_User::setUserId($user1);
+
+		\OC_Util::setupFS($user1);
+
+		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
+		$this->assertNotNull($userMount);
+		$this->assertTrue($userMount->getStorage()->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota'));
+
+		// ensure that root wasn't wrapped
+		$rootMount = \OC\Files\Filesystem::getMountManager()->find('/');
+		$this->assertNotNull($rootMount);
+		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $rootMount->getStorage());
+
+		// clean up
+		\OC_User::setUserId('');
+		\OC_User::deleteUser($user1);
+		\OC::$server->getConfig()->deleteAllUserValues($user1);
+		\OC_Util::tearDownFS();
+	}
+
+}

--- a/tests/lib/files/storage/local.php
+++ b/tests/lib/files/storage/local.php
@@ -22,6 +22,13 @@
 
 namespace Test\Files\Storage;
 
+/**
+ * Class Local
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage
+ */
 class Local extends Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -11,6 +11,13 @@ namespace Test\Files\Storage\Wrapper;
 //ensure the constants are loaded
 \OC::$loader->load('\OC\Files\Filesystem');
 
+/**
+ * Class Quota
+ *
+ * @group DB
+ *
+ * @package Test\Files\Storage\Wrapper
+ */
 class Quota extends \Test\Files\Storage\Storage {
 	/**
 	 * @var string tmpDir

--- a/tests/lib/files/utils/scanner.php
+++ b/tests/lib/files/utils/scanner.php
@@ -40,6 +40,13 @@ class TestScanner extends \OC\Files\Utils\Scanner {
 	}
 }
 
+/**
+ * Class Scanner
+ *
+ * @group DB
+ *
+ * @package Test\Files\Utils
+ */
 class Scanner extends \Test\TestCase {
 	/**
 	 * @var \Test\Util\User\Dummy

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -40,6 +40,13 @@ class TemporaryNoLocal extends \OC\Files\Storage\Temporary {
 	}
 }
 
+/**
+ * Class View
+ *
+ * @group DB
+ *
+ * @package Test\Files
+ */
 class View extends \Test\TestCase {
 	/**
 	 * @var \OC\Files\Storage\Storage[] $storages

--- a/tests/lib/group/backend.php
+++ b/tests/lib/group/backend.php
@@ -20,6 +20,11 @@
 *
 */
 
+/**
+ * Class Test_Group_Backend
+ *
+ * @group DB
+ */
 abstract class Test_Group_Backend extends \Test\TestCase {
 	/**
 	 * @var OC_Group_Backend $backend

--- a/tests/lib/group/database.php
+++ b/tests/lib/group/database.php
@@ -20,6 +20,11 @@
 *
 */
 
+/**
+ * Class Test_Group_Database
+ *
+ * @group DB
+ */
 class Test_Group_Database extends Test_Group_Backend {
 	private $groups=array();
 

--- a/tests/lib/group/dummy.php
+++ b/tests/lib/group/dummy.php
@@ -20,6 +20,11 @@
 *
 */
 
+/**
+ * Class Test_Group_Dummy
+ *
+ * @group DB
+ */
 class Test_Group_Dummy extends Test_Group_Backend {
 	protected function setUp() {
 		parent::setUp();

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -8,8 +8,9 @@
 
 /**
  * Test the storage functions of OC_Helper
+ *
+ * @group DB
  */
-
 class Test_Helper_Storage extends \Test\TestCase {
 	/** @var string */
 	private $user;

--- a/tests/lib/lock/dblockingprovider.php
+++ b/tests/lib/lock/dblockingprovider.php
@@ -23,6 +23,13 @@ namespace Test\Lock;
 
 use OCP\Lock\ILockingProvider;
 
+/**
+ * Class DBLockingProvider
+ *
+ * @group DB
+ *
+ * @package Test\Lock
+ */
 class DBLockingProvider extends LockingProvider {
 	/**
 	 * @var \OC\Lock\DBLockingProvider

--- a/tests/lib/log/owncloud.php
+++ b/tests/lib/log/owncloud.php
@@ -15,6 +15,11 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Class Test_Log_Owncloud
+ *
+ * @group DB
+ */
 class Test_Log_Owncloud extends Test\TestCase
 {
 	private $restore_logfile;
@@ -22,8 +27,8 @@ class Test_Log_Owncloud extends Test\TestCase
 
 	protected function setUp() {
 		parent::setUp();
-		$restore_logfile = OC_Config::getValue("logfile");
-		$restore_logdateformat = OC_Config::getValue('logdateformat');
+		$this->restore_logfile = OC_Config::getValue("logfile");
+		$this->restore_logdateformat = OC_Config::getValue('logdateformat');
 		
 		OC_Config::setValue("logfile", OC_Config::getValue('datadirectory') . "/logtest");
 		OC_Log_Owncloud::init();

--- a/tests/lib/ocs/privatedata.php
+++ b/tests/lib/ocs/privatedata.php
@@ -20,6 +20,11 @@
  *
  */
 
+/**
+ * Class Test_OC_OCS_Privatedata
+ *
+ * @group DB
+ */
 class Test_OC_OCS_Privatedata extends \Test\TestCase {
 	private $appKey;
 

--- a/tests/lib/preview.php
+++ b/tests/lib/preview.php
@@ -28,6 +28,13 @@ use OC\Files\View;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
+/**
+ * Class Preview
+ *
+ * @group DB
+ *
+ * @package Test
+ */
 class Preview extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;

--- a/tests/lib/preview/bitmap.php
+++ b/tests/lib/preview/bitmap.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class Bitmap
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class Bitmap extends Provider {
 
 	public function setUp() {

--- a/tests/lib/preview/image.php
+++ b/tests/lib/preview/image.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class Image
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class Image extends Provider {
 
 	public function setUp() {

--- a/tests/lib/preview/mp3.php
+++ b/tests/lib/preview/mp3.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class MP3
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class MP3 extends Provider {
 
 	public function setUp() {

--- a/tests/lib/preview/svg.php
+++ b/tests/lib/preview/svg.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class SVG
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class SVG extends Provider {
 
 	public function setUp() {

--- a/tests/lib/preview/txt.php
+++ b/tests/lib/preview/txt.php
@@ -21,6 +21,13 @@
 
 namespace Test\Preview;
 
+/**
+ * Class TXT
+ *
+ * @group DB
+ *
+ * @package Test\Preview
+ */
 class TXT extends Provider {
 
 	public function setUp() {

--- a/tests/lib/repair/cleantags.php
+++ b/tests/lib/repair/cleantags.php
@@ -11,6 +11,8 @@ namespace Test\Repair;
 /**
  * Tests for the cleaning the tags tables
  *
+ * @group DB
+ *
  * @see \OC\Repair\CleanTags
  */
 class CleanTags extends \Test\TestCase {

--- a/tests/lib/repair/dropoldjobs.php
+++ b/tests/lib/repair/dropoldjobs.php
@@ -13,6 +13,8 @@ use OCP\BackgroundJob\IJobList;
 /**
  * Tests for the dropping old tables
  *
+ * @group DB
+ *
  * @see \OC\Repair\DropOldTables
  */
 class DropOldJobs extends \Test\TestCase {

--- a/tests/lib/repair/dropoldtables.php
+++ b/tests/lib/repair/dropoldtables.php
@@ -11,6 +11,8 @@ namespace Test\Repair;
 /**
  * Tests for the dropping old tables
  *
+ * @group DB
+ *
  * @see \OC\Repair\DropOldTables
  */
 class DropOldTables extends \Test\TestCase {

--- a/tests/lib/repair/oldgroupmembershipsharestest.php
+++ b/tests/lib/repair/oldgroupmembershipsharestest.php
@@ -11,6 +11,13 @@ namespace Test\Repair;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Share\Constants;
 
+/**
+ * Class OldGroupMembershipSharesTest
+ *
+ * @group DB
+ *
+ * @package Test\Repair
+ */
 class OldGroupMembershipSharesTest extends \Test\TestCase {
 
 	/** @var OldGroupMembershipShares */

--- a/tests/lib/repair/removegetetagentriestest.php
+++ b/tests/lib/repair/removegetetagentriestest.php
@@ -24,6 +24,13 @@ namespace Test\Repair;
 use OC\Repair\RemoveGetETagEntries;
 use Test\TestCase;
 
+/**
+ * Class RemoveGetETagEntriesTest
+ *
+ * @group DB
+ *
+ * @package Test\Repair
+ */
 class RemoveGetETagEntriesTest extends TestCase {
 	/** @var \OCP\IDBConnection */
 	protected $connection;

--- a/tests/lib/repair/repaircollation.php
+++ b/tests/lib/repair/repaircollation.php
@@ -19,6 +19,8 @@ class TestCollationRepair extends \OC\Repair\Collation {
 /**
  * Tests for the converting of MySQL tables to InnoDB engine
  *
+ * @group DB
+ *
  * @see \OC\Repair\RepairMimeTypes
  */
 class TestRepairCollation extends \Test\TestCase {

--- a/tests/lib/repair/repairinnodb.php
+++ b/tests/lib/repair/repairinnodb.php
@@ -10,6 +10,8 @@ namespace Test\Repair;
 /**
  * Tests for the converting of MySQL tables to InnoDB engine
  *
+ * @group DB
+ *
  * @see \OC\Repair\RepairMimeTypes
  */
 class RepairInnoDB extends \Test\TestCase {

--- a/tests/lib/repair/repairinvalidsharestest.php
+++ b/tests/lib/repair/repairinvalidsharestest.php
@@ -16,6 +16,8 @@ use Test\TestCase;
 /**
  * Tests for repairing invalid shares
  *
+ * @group DB
+ *
  * @see \OC\Repair\RepairInvalidShares
  */
 class RepairInvalidSharesTest extends TestCase {

--- a/tests/lib/repair/repairlegacystorage.php
+++ b/tests/lib/repair/repairlegacystorage.php
@@ -15,6 +15,8 @@ use Test\TestCase;
 /**
  * Tests for the converting of legacy storages to home storages.
  *
+ * @group DB
+ *
  * @see \OC\Repair\RepairLegacyStorages
  */
 class RepairLegacyStorages extends TestCase {

--- a/tests/lib/repair/repairmimetypes.php
+++ b/tests/lib/repair/repairmimetypes.php
@@ -11,6 +11,8 @@ namespace Test\Repair;
 /**
  * Tests for the converting of legacy storages to home storages.
  *
+ * @group DB
+ *
  * @see \OC\Repair\RepairMimeTypes
  */
 class RepairMimeTypes extends \Test\TestCase {

--- a/tests/lib/repair/repairsqliteautoincrement.php
+++ b/tests/lib/repair/repairsqliteautoincrement.php
@@ -10,6 +10,8 @@ namespace Test\Repair;
 
 /**
  * Tests for fixing the SQLite id recycling
+ *
+ * @group DB
  */
 class RepairSqliteAutoincrement extends \Test\TestCase {
 

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -8,6 +8,11 @@
 
 use \OC\Security\CertificateManager;
 
+/**
+ * Class CertificateManagerTest
+ *
+ * @group DB
+ */
 class CertificateManagerTest extends \Test\TestCase {
 
 	/** @var CertificateManager */

--- a/tests/lib/server.php
+++ b/tests/lib/server.php
@@ -24,6 +24,13 @@
 
 namespace Test;
 
+/**
+ * Class Server
+ *
+ * @group DB
+ *
+ * @package Test
+ */
 class Server extends \Test\TestCase {
 	/** @var \OC\Server */
 	protected $server;

--- a/tests/lib/share/hooktests.php
+++ b/tests/lib/share/hooktests.php
@@ -25,6 +25,13 @@ namespace OC\Tests\Share;
 
 use Test\TestCase;
 
+/**
+ * Class HookTests
+ *
+ * @group DB
+ *
+ * @package OC\Tests\Share
+ */
 class HookTests extends TestCase {
 
 	protected function setUp() {

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -19,6 +19,11 @@
 * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/**
+ * Class Test_Share
+ *
+ * @group DB
+ */
 class Test_Share extends \Test\TestCase {
 
 	protected $itemType;

--- a/tests/lib/streamwrappers.php
+++ b/tests/lib/streamwrappers.php
@@ -20,6 +20,11 @@
  *
  */
 
+/**
+ * Class Test_StreamWrappers
+ *
+ * @group DB
+ */
 class Test_StreamWrappers extends \Test\TestCase {
 
 	private static $trashBinStatus;

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -20,12 +20,17 @@
 *
 */
 
+/**
+ * Class Test_Tags
+ *
+ * @group DB
+ */
 class Test_Tags extends \Test\TestCase {
 
 	protected $objectType;
-	/** @var \OC\IUser */
+	/** @var \OCP\IUser */
 	protected $user;
-	/** @var \OC\IUserSession */
+	/** @var \OCP\IUserSession */
 	protected $userSession;
 	protected $backupGlobals = FALSE;
 	/** @var \OC\Tagging\TagMapper */

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -338,6 +338,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function IsDatabaseAccessAllowed() {
+		// on travis-ci.org we allow database access in any case - otherwise
+		// this will break all apps right away
+		if (true == getenv('TRAVIS')) {
+			return true;
+		}
 		$annotations = $this->getAnnotations();
 		if (isset($annotations['class']['group']) && in_array('DB', $annotations['class']['group'])) {
 			return true;

--- a/tests/lib/urlGenerator.php
+++ b/tests/lib/urlGenerator.php
@@ -6,7 +6,12 @@
  * See the COPYING-README file.
  */
 
-class Test_Urlgenerator extends \Test\TestCase {
+/**
+ * Class Test_UrlGenerator
+ *
+ * @group DB
+ */
+class Test_UrlGenerator extends \Test\TestCase {
 
 	/**
 	 * @small

--- a/tests/lib/user.php
+++ b/tests/lib/user.php
@@ -9,6 +9,13 @@
 
 namespace Test;
 
+/**
+ * Class User
+ *
+ * @group DB
+ *
+ * @package Test
+ */
 class User extends TestCase {
 	/**
 	 * @var \OC_User_Backend | \PHPUnit_Framework_MockObject_MockObject $backend

--- a/tests/lib/user/database.php
+++ b/tests/lib/user/database.php
@@ -20,6 +20,11 @@
 *
 */
 
+/**
+ * Class Test_User_Database
+ *
+ * @group DB
+ */
 class Test_User_Database extends Test_User_Backend {
 	/** @var array */
 	private $users;

--- a/tests/lib/user/manager.php
+++ b/tests/lib/user/manager.php
@@ -9,6 +9,13 @@
 
 namespace Test\User;
 
+/**
+ * Class Manager
+ *
+ * @group DB
+ *
+ * @package Test\User
+ */
 class Manager extends \Test\TestCase {
 	public function testGetBackends() {
 		$userDummyBackend = $this->getMock('\Test\Util\User\Dummy');
@@ -441,11 +448,25 @@ class Manager extends \Test\TestCase {
 	}
 
 	public function testDeleteUser() {
-		$manager = new \OC\User\Manager();
+		$config = $this->getMockBuilder('OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$config
+				->expects($this->at(0))
+				->method('getUserValue')
+				->with('foo', 'core', 'enabled')
+				->will($this->returnValue(true));
+		$config
+				->expects($this->at(1))
+				->method('getUserValue')
+				->with('foo', 'login', 'lastLogin')
+				->will($this->returnValue(0));
+
+		$manager = new \OC\User\Manager($config);
 		$backend = new \Test\Util\User\Dummy();
 
-		$backend->createUser('foo', 'bar');
 		$manager->registerBackend($backend);
+		$backend->createUser('foo', 'bar');
 		$this->assertTrue($manager->userExists('foo'));
 		$manager->get('foo')->delete();
 		$this->assertFalse($manager->userExists('foo'));

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -167,55 +167,6 @@ class Test_Util extends \Test\TestCase {
 	}
 
 	/**
-	 * Tests that the home storage is not wrapped when no quota exists.
-	 */
-	function testHomeStorageWrapperWithoutQuota() {
-		$user1 = $this->getUniqueID();
-		\OC_User::createUser($user1, 'test');
-		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', 'none');
-		\OC_User::setUserId($user1);
-
-		\OC_Util::setupFS($user1);
-
-		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
-		$this->assertNotNull($userMount);
-		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $userMount->getStorage());
-
-		// clean up
-		\OC_User::setUserId('');
-		\OC_User::deleteUser($user1);
-		\OC::$server->getConfig()->deleteAllUserValues($user1);
-		\OC_Util::tearDownFS();
-	}
-
-	/**
-	 * Tests that the home storage is not wrapped when no quota exists.
-	 */
-	function testHomeStorageWrapperWithQuota() {
-		$user1 = $this->getUniqueID();
-		\OC_User::createUser($user1, 'test');
-		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', '1024');
-		\OC_User::setUserId($user1);
-
-		\OC_Util::setupFS($user1);
-
-		$userMount = \OC\Files\Filesystem::getMountManager()->find('/' . $user1 . '/');
-		$this->assertNotNull($userMount);
-		$this->assertTrue($userMount->getStorage()->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota'));
-
-		// ensure that root wasn't wrapped
-		$rootMount = \OC\Files\Filesystem::getMountManager()->find('/');
-		$this->assertNotNull($rootMount);
-		$this->assertNotInstanceOf('\OC\Files\Storage\Wrapper\Quota', $rootMount->getStorage());
-
-		// clean up
-		\OC_User::setUserId('');
-		\OC_User::deleteUser($user1);
-		\OC::$server->getConfig()->deleteAllUserValues($user1);
-		\OC_Util::tearDownFS();
-	}
-
-	/**
 	 * @dataProvider baseNameProvider
 	 */
 	public function testBaseName($expected, $file) {

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -8,6 +8,8 @@
 
 /**
  * Tests for server check functions
+ *
+ * @group DB
  */
 class Test_Util_CheckServer extends \Test\TestCase {
 


### PR DESCRIPTION
There have already been some code pieces to look into:
- [ ] Why do unit tests for preview generation require database access? (Yes - filesystem foo - but could be structured differently)
- [ ] Pure tests on the server container - why? 
- [ ] DIContainerTest
- [ ] avatar tests
- [x] avatar controller tests #20510
- [ ] stream wrapper tests
- [ ] OCA\Provisioning_API\Tests\AppsTest needs mocks
- [ ] ShareControllerTest needs to mock file system
- [ ] All LDAP unit tests require DB access - even those who already mock IConfig etc :fish: -y
- [ ] Test_UrlGenerator - basically the UrlGenerator needs to inject the router object
- [ ] https://github.com/owncloud/core/issues/20771
- [ ] Test_Util_CheckServer on postgresql

TODO:
- review all unit test in group DB - is real database access really required here?
- review all still failing unit tests - is real database access required?
- think about more separation of existing classes to get more isolated testing (e.g. preview generation)
