### PR TITLE
Add a new core capability which tells the clients which url to use

### DIFF
--- a/lib/private/ocs/corecapabilities.php
+++ b/lib/private/ocs/corecapabilities.php
@@ -49,7 +49,8 @@ class CoreCapabilities implements ICapability {
 	public function getCapabilities() {
 		return [
 			'core' => [
-				'pollinterval' => $this->config->getSystemValue('pollinterval', 60)
+				'pollinterval' => $this->config->getSystemValue('pollinterval', 60),
+				'webdav-root' => $this->config->getSystemValue('webdav-root', 'remote.php/webdav'),
 			]
 		];
 	}


### PR DESCRIPTION
@dragotin

``` sh
$ curl http://admin:admin@localhost:8888/ocs/v1.php/cloud/capabilities
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message/>
 </meta>
 <data>
  <version>
   <major>9</major>
   <minor>0</minor>
   <micro>0</micro>
   <string>9.0 pre alpha</string>
   <edition></edition>
  </version>
  <capabilities>
   <core>
    <pollinterval>60</pollinterval>
    <webdav-root>remote.php/webdav</webdav-root>
   </core>
   <files_sharing>
    <api_enabled>1</api_enabled>
    <public>
     <enabled>1</enabled>
     <password>
      <enforced></enforced>
     </password>
     <expire_date>
      <enabled>1</enabled>
      <days>2</days>
      <enforced>1</enforced>
     </expire_date>
     <send_mail></send_mail>
     <upload>1</upload>
    </public>
    <user>
     <send_mail></send_mail>
    </user>
    <resharing>1</resharing>
    <federation>
     <outgoing>1</outgoing>
     <incoming>1</incoming>
    </federation>
   </files_sharing>
   <files>
    <bigfilechunking>1</bigfilechunking>
    <versioning>1</versioning>
   </files>
  </capabilities>
 </data>
</ocs>
```
