### PR TITLE
[files_external] fix empty user mounts setting

### DIFF
--- a/apps/files_external/service/backendservice.php
+++ b/apps/files_external/service/backendservice.php
@@ -72,6 +72,11 @@ class BackendService {
 		$this->userMountingBackends = explode(',',
 			$this->config->getAppValue('files_external', 'user_mounting_backends', '')
 		);
+
+		// if no backend is in the list an empty string is in the array and user mounting is disabled
+		if ($this->userMountingBackends === ['']) {
+			$this->userMountingAllowed = false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
- fixes #19858
- if no backend is allowed to be mounted also the user mount setting should be disabled

cc @nickvergessen @Xenopathic @PVince81 @jancborchardt Please review

I tested it also with existing settings and now also the initial state behaves like the JS code.
