### PR TITLE
[stable8.2] [files_external] fix empty user mounts setting

### DIFF
--- a/apps/files_external/service/backendservice.php
+++ b/apps/files_external/service/backendservice.php
@@ -72,6 +72,11 @@ class BackendService {
 		$this->userMountingBackends = explode(',',
 			$this->config->getAppValue('files_external', 'user_mounting_backends', '')
 		);
+
+		// if no backend is in the list an empty string is in the array and user mounting is disabled
+		if ($this->userMountingBackends === ['']) {
+			$this->userMountingAllowed = false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
- fixes #19858
- if no backend is allowed to be mounted also the user mount setting should be disabled

Backport of #20301 - approval in https://github.com/owncloud/core/pull/20301#issuecomment-153780622

cc @nickvergessen @Xenopathic @PVince81 @LukasReschke @jancborchardt Please review

I tested it and it works
