### PR TITLE
[stable8.2] make sure that we update the unencrypted size for the versions

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -472,6 +472,7 @@ class Encryption extends Wrapper {
 	 * @param bool $preserveMtime
 	 * @param bool $isRename
 	 * @return bool
+	 * @throws \Exception
 	 */
 	private function copyBetweenStorage(Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, $isRename) {
 
@@ -479,7 +480,18 @@ class Encryption extends Wrapper {
 		// key from the original file. Just create a 1:1 copy and done
 		if ($this->isVersion($targetInternalPath) ||
 			$this->isVersion($sourceInternalPath)) {
-			return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			$result = $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			if ($result) {
+				$info = $this->getCache('', $sourceStorage)->get($sourceInternalPath);
+				// make sure that we update the unencrypted size for the version
+				if (isset($info['encrypted']) && $info['encrypted'] === true) {
+					$this->updateUnencryptedSize(
+						$this->getFullPath($targetInternalPath),
+						$info['size']
+					);
+				}
+			}
+			return $result;
 		}
 
 		// first copy the keys that we reuse the existing file key on the target location


### PR DESCRIPTION
approved backport of https://github.com/owncloud/core/pull/20288

Steps to test:
- Enable encryption
- Upload a larger file (pdf, odt, jpg,...)
- Upload another copy of the same file
- check if you can download/revert the versions
