### PR TITLE
do not bold heading of update screen

### DIFF
--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -1,9 +1,9 @@
 <div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
 	<div class="updateOverview">
 		<?php if ($_['isAppsOnlyUpgrade']) { ?>
-		<h2 class="title bold"><?php p($l->t('App update required')); ?></h2>
+		<h2 class="title"><?php p($l->t('App update required')); ?></h2>
 		<?php } else { ?>
-		<h2 class="title bold"><?php p($l->t('%s will be updated to version %s',
+		<h2 class="title"><?php p($l->t('%s will be updated to version %s',
 			array($_['productName'], $_['version']))); ?></h2>
 		<?php } ?>
 		<?php if (!empty($_['appsToUpgrade'])) { ?>


### PR DESCRIPTION
Just like the Personal settings and elsewhere, h2 headings should never be bold as they are emphasized by font-size already.

Please review @owncloud/designers 
