### PR TITLE
Show the language code in personal settings for unknown languages

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -93,6 +93,14 @@ foreach($languageCodes as $lang) {
 	}
 }
 
+// if user language is not available but set somehow: show the actual code as name
+if (!is_array($userLang)) {
+	$userLang = [
+		'code' => $userLang,
+		'name' => $userLang,
+	];
+}
+
 ksort($commonlanguages);
 
 // sort now by displayed language not the iso-code


### PR DESCRIPTION
Steps to reproduce:
- having an unknown language set in oc_preferences
- browse the personal settings
- only get listed the first letter of this language in the language chooser

cc @michaelstingl 

@nickvergessen This looks just like a dirty hack, but I have no idea how to properly fix this. A user can set any language code in is browser and when we then choose this during the language detection it will get set and then is in the DB. We could assign another language but this is even more bad. Therefore I would simply go for "show the raw data".
