### PR TITLE
Add debug log statement for IJobList steps in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -132,7 +132,9 @@ try {
 		$jobList = \OC::$server->getJobList();
 		$jobs = $jobList->getAll();
 		foreach ($jobs as $job) {
+			$logger->debug('Run job with ID ' . $job->getId(), ['app' => 'cron']);
 			$job->execute($jobList, $logger);
+			$logger->debug('Finished job with ID ' . $job->getId(), ['app' => 'cron']);
 		}
 
 		// unlock the file


### PR DESCRIPTION
- makes debugging easier

Combined with conditional logging (http://morrisjobke.de/2015/07/22/Conditional-Logging-in-ownCloud/) you can easily locate long running cron jobs.

@PVince81 @nickvergessen @DeepDiver1975 Does this make sense?
