### PR TITLE
[Share2.0] OCS Share API getShare uses new code

### DIFF
--- a/apps/files_sharing/api/ocssharewrapper.php
+++ b/apps/files_sharing/api/ocssharewrapper.php
@@ -35,15 +35,16 @@ class OCSShareWrapper {
 		                   \OC::$server->getUserFolder(),
 		                    new \OC\Share20\DefaultShareProvider(
 		                       \OC::$server->getDatabaseConnection(),
-							   \OC::$server->getUserManager(),
-							   \OC::$server->getGroupManager(),
-							   \OC::$server->getUserFolder()
+		                       \OC::$server->getUserManager(),
+		                       \OC::$server->getGroupManager(),
+		                       \OC::$server->getUserFolder()
 		                   )
 		               ),
 		               \OC::$server->getGroupManager(),
 		               \OC::$server->getUserManager(),
 		               \OC::$server->getRequest(),
-		               \OC::$server->getUserFolder());
+		               \OC::$server->getUserFolder(),
+		               \OC::$server->getURLGenerator());
 	}
 
 	public function getAllShares($params) {
@@ -55,7 +56,8 @@ class OCSShareWrapper {
 	}
 
 	public function getShare($params) {
-		return \OCA\Files_Sharing\API\Local::getShare($params);
+		$id = $params['id'];
+		return $this->getShare20OCS()->getShare($id);
 	}
 
 	public function updateShare($params) {
@@ -63,7 +65,7 @@ class OCSShareWrapper {
 	}
 
 	public function deleteShare($params) {
-		$id = (int)$params['id'];
+		$id = $params['id'];
 		return $this->getShare20OCS()->deleteShare($id);
 	}
 }

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -39,6 +39,9 @@ class Share20OCSTest extends \Test\TestCase {
 	/** @var OCP\Files\Folder */
 	private $userFolder;
 
+	/** @var OCP\IURLGenerator */
+	private $urlGenerator;
+
 	/** @var OCS */
 	private $ocs;
 
@@ -46,24 +49,18 @@ class Share20OCSTest extends \Test\TestCase {
 		$this->shareManager = $this->getMockBuilder('OC\Share20\Manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->request = $this->getMockBuilder('OCP\IRequest')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->userFolder = $this->getMockBuilder('OCP\Files\Folder')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->groupManager = $this->getMock('OCP\IGroupManager');
+		$this->userManager = $this->getMock('OCP\IUserManager');
+		$this->request = $this->getMock('OCP\IRequest');
+		$this->userFolder = $this->getMock('OCP\Files\Folder');
+		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
 
 		$this->ocs = new Share20OCS($this->shareManager,
 									$this->groupManager,
 									$this->userManager,
 									$this->request,
-									$this->userFolder);
+									$this->userFolder,
+									$this->urlGenerator);
 	}
 
 	public function testDeleteShareShareNotFound() {
@@ -110,4 +107,240 @@ class Share20OCSTest extends \Test\TestCase {
 		$expected = new \OC_OCS_Result();
 		$this->assertEquals($expected, $this->ocs->deleteShare(42));
 	}
+
+	public function testGetGetShareNotExists() {
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with(42)
+			->will($this->throwException(new \OC\Share20\Exception\ShareNotFound()));
+
+		$expected = new \OC_OCS_Result(null, 404, 'wrong share ID, share doesn\'t exist.');
+		$this->assertEquals($expected, $this->ocs->getShare(42));
+	}
+
+	public function createShare($id, $shareType, $sharedWith, $sharedBy, $path, $permissions,
+								$shareTime, $expiration, $parent, $target, $mail_send, $token=null,
+								$password=null) {
+		$share = $this->getMock('OC\Share20\IShare');
+		$share->method('getId')->willReturn($id);
+		$share->method('getShareType')->willReturn($shareType);
+		$share->method('getSharedWith')->willReturn($sharedWith);
+		$share->method('getSharedBy')->willReturn($sharedBy);
+		$share->method('getPath')->willReturn($path);
+		$share->method('getPermissions')->willReturn($permissions);
+		$share->method('getShareTime')->willReturn($shareTime);
+		$share->method('getExpirationDate')->willReturn($expiration);
+		$share->method('getParent')->willReturn($parent);
+		$share->method('getTarget')->willReturn($target);
+		$share->method('getMailSend')->willReturn($mail_send);
+		$share->method('getToken')->willReturn($token);
+		$share->method('getPassword')->willReturn($password);
+
+		return $share;
+	}
+
+	public function dataGetShare() {
+		$data = [];
+
+		$owner = $this->getMock('OCP\IUser');
+		$owner->method('getUID')->willReturn('ownerId');
+		$owner->method('getDisplayName')->willReturn('ownerDisplay');
+
+		$user = $this->getMock('OCP\IUser');
+		$user->method('getUID')->willReturn('userId');
+		$user->method('getDisplayName')->willReturn('userDisplay');
+
+		$group = $this->getMock('OCP\IGroup');
+		$group->method('getGID')->willReturn('groupId');
+
+		$storage = $this->getMock('OCP\Files\Storage');
+		$storage->method('getId')->willReturn('STORAGE');
+
+		$parentFolder = $this->getMock('OCP\Files\Folder');
+		$parentFolder->method('getId')->willReturn(3);
+
+		$file = $this->getMock('OCP\Files\File');
+		$file->method('getId')->willReturn(1);
+		$file->method('getPath')->willReturn('file');
+		$file->method('getStorage')->willReturn($storage);
+		$file->method('getParent')->willReturn($parentFolder);
+
+		$folder = $this->getMock('OCP\Files\Folder');
+		$folder->method('getId')->willReturn(2);
+		$folder->method('getPath')->willReturn('folder');
+		$folder->method('getStorage')->willReturn($storage);
+		$folder->method('getParent')->willReturn($parentFolder);
+
+		// File shared with user
+		$share = $this->createShare(100, 
+									\OCP\Share::SHARE_TYPE_USER,
+									$user,
+									$owner,
+									$file,
+									4,
+									5,
+									null,
+									6,
+									'target',
+									0);
+		$expected = [
+			'id' => 100,
+			'share_type' => \OCP\Share::SHARE_TYPE_USER,
+			'share_with' => 'userId',
+			'share_with_displayname' => 'userDisplay',
+			'uid_owner' => 'ownerId',
+			'displayname_owner' => 'ownerDisplay',
+			'item_type' => 'file',
+			'item_source' => 1,
+			'file_source' => 1,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => null,
+			'expiration' => null,
+			'permissions' => 4,
+			'stime' => 5,
+			'parent' => 6,
+			'storage_id' => 'STORAGE',
+			'path' => 'file',
+			'storage' => null, // HACK around static function
+			'mail_send' => 0,
+		];
+		$data[] = [$share, $expected];
+
+		// Folder shared with group
+		$share = $this->createShare(101, 
+									\OCP\Share::SHARE_TYPE_GROUP,
+									$group,
+									$owner,
+									$folder,
+									4,
+									5,
+									null,
+									6,
+									'target',
+									0);
+		$expected = [
+			'id' => 101,
+			'share_type' => \OCP\Share::SHARE_TYPE_GROUP,
+			'share_with' => 'groupId',
+			'share_with_displayname' => 'groupId',
+			'uid_owner' => 'ownerId',
+			'displayname_owner' => 'ownerDisplay',
+			'item_type' => 'folder',
+			'item_source' => 2,
+			'file_source' => 2,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => null,
+			'expiration' => null,
+			'permissions' => 4,
+			'stime' => 5,
+			'parent' => 6,
+			'storage_id' => 'STORAGE',
+			'path' => 'folder',
+			'storage' => null, // HACK around static function
+			'mail_send' => 0,
+		];
+		$data[] = [$share, $expected];
+
+		// Folder shared with remote
+		$share = $this->createShare(101, 
+									\OCP\Share::SHARE_TYPE_REMOTE,
+									'user@remote.com',
+									$owner,
+									$folder,
+									4,
+									5,
+									null,
+									6,
+									'target',
+									0);
+		$expected = [
+			'id' => 101,
+			'share_type' => \OCP\Share::SHARE_TYPE_REMOTE,
+			'share_with' => 'user@remote.com',
+			'share_with_displayname' => 'user@remote.com',
+			'uid_owner' => 'ownerId',
+			'displayname_owner' => 'ownerDisplay',
+			'item_type' => 'folder',
+			'item_source' => 2,
+			'file_source' => 2,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => null,
+			'expiration' => null,
+			'permissions' => 4,
+			'stime' => 5,
+			'parent' => 6,
+			'storage_id' => 'STORAGE',
+			'path' => 'folder',
+			'storage' => null, // HACK around static function
+			'mail_send' => 0,
+		];
+		$data[] = [$share, $expected];
+
+		// File shared by link with Expire
+		$expire = \DateTime::createFromFormat('Y-m-d h:i:s', '2000-01-02 01:02:03');
+		$share = $this->createShare(101, 
+									\OCP\Share::SHARE_TYPE_LINK,
+									null,
+									$owner,
+									$folder,
+									4,
+									5,
+									$expire,
+									6,
+									'target',
+									0,
+									'token',
+									'password');
+		$expected = [
+			'id' => 101,
+			'share_type' => \OCP\Share::SHARE_TYPE_LINK,
+			'share_with' => 'password',
+			'share_with_displayname' => 'password',
+			'uid_owner' => 'ownerId',
+			'displayname_owner' => 'ownerDisplay',
+			'item_type' => 'folder',
+			'item_source' => 2,
+			'file_source' => 2,
+			'file_target' => 'target',
+			'file_parent' => 3,
+			'token' => 'token',
+			'expiration' => '2000-01-02 00:00:00',
+			'permissions' => 4,
+			'stime' => 5,
+			'parent' => 6,
+			'storage_id' => 'STORAGE',
+			'path' => 'folder',
+			'storage' => null, // HACK around static function
+			'mail_send' => 0,
+			'url' => 'url',
+		];
+		$data[] = [$share, $expected];
+
+		return $data;
+	}
+
+	/**
+	 * @dataProvider dataGetShare
+	 */
+	public function testGetShare(\OC\Share20\IShare $share, array $result) {
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareById')
+			->with($share->getId())
+			->willReturn($share);
+
+		$this->userFolder
+			->method('getRelativePath')
+			->will($this->returnArgument(0));
+
+		$this->urlGenerator
+			->method('linkToRouteAbsolute')
+			->willReturn('url');
+
+		$expected = new \OC_OCS_Result($result);
+		$this->assertEquals($expected->getData(), $this->ocs->getShare($share->getId())->getData());	}
 }

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -235,17 +235,16 @@ class DefaultShareProvider implements IShareProvider {
 		$share->setId((int)$data['id'])
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
-			->setTarget($data['file_target']);
+			->setTarget($data['file_target'])
+			->setShareTime((int)$data['stime'])
+			->setMailSend((bool)$data['mail_send']);
 
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
 			$share->setSharedWith($this->userManager->get($data['share_with']));
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
 			$share->setSharedWith($this->groupManager->get($data['share_with']));
 		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-			/*
-			 * TODO: Clean this up, this should be set as password not sharedWith
-			 */
-			$share->setSharedWith($data['share_with']);
+			$share->setPassword($data['share_with']);
 			$share->setToken($data['token']);
 		} else {
 			$share->setSharedWith($data['share_with']);

--- a/lib/private/share20/ishare.php
+++ b/lib/private/share20/ishare.php
@@ -134,6 +134,13 @@ interface IShare {
 	public function setPassword($password);
 
 	/**
+	 * Is a password set for this share
+	 *
+	 * @return string
+	 */
+	public function getPassword();
+
+	/**
 	 * Get the token
 	 *
 	 * @return string
@@ -153,4 +160,18 @@ interface IShare {
 	 * @return string
 	 */
 	public function getTarget();
+
+	/**
+	 * Get the timestamp this share was created
+	 *
+	 * @return int
+	 */
+	public function getSharetime();
+
+	/**
+	 * Get mailSend
+	 *
+	 * @return bool
+	 */
+	public function getMailSend();
 }

--- a/lib/private/share20/share.php
+++ b/lib/private/share20/share.php
@@ -28,39 +28,32 @@ class Share implements IShare {
 
 	/** @var string */
 	private $id;
-
 	/** @var Node */
 	private $path;
-
 	/** @var int */
 	private $shareType;
-
 	/** @var IUser|IGroup|string */
 	private $sharedWith;
-
 	/** @var IUser|string */
 	private $sharedBy;
-
 	/** @var IUser|string */
 	private $shareOwner;
-
 	/** @var int */
 	private $permissions;
-
 	/** @var \DateTime */
 	private $expireDate;
-
 	/** @var string */
 	private $password;
-
 	/** @var string */
 	private $token;
-
 	/** @var int */
 	private $parent;
-
 	/** @var string */
 	private $target;
+	/** @var int */
+	private $shareTime;
+	/** @var bool */
+	private $mailSend;
 
 	/**
 	 * Set the id of the share
@@ -252,7 +245,7 @@ class Share implements IShare {
 	 *
 	 * @return string
 	 */
-	public function getPassword($password) {
+	public function getPassword() {
 		return $this->password;
 	}
 
@@ -314,5 +307,45 @@ class Share implements IShare {
 	 */
 	public function getTarget() {
 		return $this->target;
+	}
+
+	/**
+	 * Set the time this share was created
+	 *
+	 * @param int $shareTime
+	 * @return Share The modified object
+	 */
+	public function setShareTime($shareTime) {
+		$this->shareTime = $shareTime;
+		return $this;
+	}
+
+	/**
+	 * Get the timestamp this share was created
+	 *
+	 * @return int
+	 */
+	public function getSharetime() {
+		return $this->shareTime;
+	}
+
+	/**
+	 * Set mailSend
+	 *
+	 * @param bool $mailSend
+	 * @return Share The modified object
+	 */
+	public function setMailSend($mailSend) {
+		$this->mailSend = $mailSend;
+		return $this;
+	}
+
+	/**
+	 * Get mailSend
+	 *
+	 * @return bool
+	 */
+	public function getMailSend() {
+		return $this->mailSend;
 	}
 }

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -266,7 +266,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$this->assertEquals($id, $share->getId());
 		$this->assertEquals(\OCP\Share::SHARE_TYPE_LINK, $share->getShareType());
-		$this->assertEquals('sharedWith', $share->getSharedWith());
+		$this->assertEquals('sharedWith', $share->getPassword());
 		$this->assertEquals($sharedBy, $share->getSharedBy());
 		$this->assertEquals($shareOwner, $share->getShareOwner());
 		$this->assertEquals($path, $share->getPath());


### PR DESCRIPTION
This moves the getShares call over to the new code. So paths `v1/shares/<ID>` is now handled in the new code.

Output is consistent with current OCS Share API output.

Lets see what our CI has to say.
