### PR TITLE
Properly throw exception in OC_Mount_Config::getBackendStatus

### DIFF
--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -269,7 +269,7 @@ class OC_Mount_Config {
 				}
 			} catch (Exception $exception) {
 				\OCP\Util::logException('files_external', $exception);
-				throw $e;
+				throw $exception;
 			}
 		}
 		return self::STATUS_ERROR;


### PR DESCRIPTION
This issue is only on master.

Please review @Xenopathic @icewind1991 @nickvergessen 
