### PR TITLE
Mark files_drop as shipped

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -8,6 +8,7 @@
     "external",
     "files",
     "files_antivirus",
+    "files_drop",
     "files_external",
     "files_ldap_home",
     "files_locking",


### PR DESCRIPTION
Fixes https://github.com/owncloud/enterprise/issues/895

@karlitschek We should backport this to 8.2
