### PR TITLE
Force approval in GDrive oauth to get refresh_token

### DIFF
--- a/apps/files_external/ajax/oauth2.php
+++ b/apps/files_external/ajax/oauth2.php
@@ -41,6 +41,7 @@ if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST
 	$client->setClientSecret((string)$_POST['client_secret']);
 	$client->setRedirectUri((string)$_POST['redirect']);
 	$client->setScopes(array('https://www.googleapis.com/auth/drive'));
+	$client->setApprovalPrompt('force');
 	$client->setAccessType('offline');
 	if (isset($_POST['step'])) {
 		$step = $_POST['step'];


### PR DESCRIPTION
Forcing the approval of app permissions makes sure that the GDrive API will always return a refresh_token.

In the case of apps that were already authorized for the current user/domain, the API doesn't return the refresh_token which causes expiration issues.

See a more detailed explanation here https://github.com/owncloud/core/issues/15768#issuecomment-154385482
- [x] BLOCKED by https://github.com/owncloud/core/pull/20358

@karlitschek we should backport this to 8.2.1 to fix GDrive refresh_token: https://github.com/owncloud/core/issues/15768#issuecomment-154385482
