### PR TITLE
[stable8.2] Force approval in GDrive oauth to get refresh_token

### DIFF
--- a/apps/files_external/ajax/oauth2.php
+++ b/apps/files_external/ajax/oauth2.php
@@ -41,6 +41,7 @@ if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST
 	$client->setClientSecret((string)$_POST['client_secret']);
 	$client->setRedirectUri((string)$_POST['redirect']);
 	$client->setScopes(array('https://www.googleapis.com/auth/drive'));
+	$client->setApprovalPrompt('force');
 	$client->setAccessType('offline');
 	if (isset($_POST['step'])) {
 		$step = $_POST['step'];


### PR DESCRIPTION
Forcing the approval of app permissions makes sure that the GDrive API
will always return a refresh_token.

In the case of apps that were already authorized for the current user/domain,
the API doesn't return the refresh_token which causes expiration issues.

See steps to reproduce and explanation here https://github.com/owncloud/core/issues/15768#issuecomment-154385482
- [x] backport approval pending: https://github.com/owncloud/core/pull/20360

(note: the master PR is blocked due to another issue preventing testing)
