### PR TITLE
[stable8.2] Show the language code in personal settings for unknown languages

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -93,6 +93,14 @@ foreach($languageCodes as $lang) {
 	}
 }
 
+// if user language is not available but set somehow: show the actual code as name
+if (!is_array($userLang)) {
+	$userLang = [
+		'code' => $userLang,
+		'name' => $userLang,
+	];
+}
+
 ksort($commonlanguages);
 
 // sort now by displayed language not the iso-code


### PR DESCRIPTION
Steps to reproduce:
- having an unknown language set in oc_preferences
- browse the personal settings
- only get listed the first letter of this language in the language chooser

Backport #20346 

Approval: https://github.com/owncloud/core/pull/20346#issuecomment-154398687

cc @LukasReschke @PVince81 @nickvergessen 
