### PR TITLE
Don't mock the ISecure

### DIFF
--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -54,8 +54,6 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->container['OCP\\App\\IAppManager'] = $this->getMockBuilder('OCP\\App\\IAppManager')
 			->disableOriginalConstructor()->getMock();
-		$this->container['OCP\\Security\\ISecureRandom'] = $this->getMockBuilder('\OCP\Security\ISecureRandom')
-			->disableOriginalConstructor()->getMock();
 	}
 
 	public function testIndexAdmin() {


### PR DESCRIPTION
Should get https://github.com/owncloud/core/pull/18485 tests passing

Mocked ISecure leads to a fatal error when user controller calls 

```
$this->secureRandom->getMediumStrengthGenerator()->generate( ... )
```

I didn't see any reason this needed to be mocked so I nuked the mock
