### PR TITLE
Properly detect setup check messages set in the HTML template

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -174,38 +174,46 @@ $(document).ready(function(){
 		var messages = [].concat(check1, check2, check3);
 		var $el = $('#postsetupchecks');
 		$el.find('.loading').addClass('hidden');
-		if (messages.length === 0) {
+
+		var hasMessages = false;
+		var $errorsEl = $el.find('.errors');
+		var $warningsEl = $el.find('.warnings');
+		var $infoEl = $el.find('.info');
+
+		for (var i = 0; i < messages.length; i++ ) {
+			switch(messages[i].type) {
+				case OC.SetupChecks.MESSAGE_TYPE_INFO:
+					$infoEl.append('<li>' + messages[i].msg + '</li>');
+					break;
+				case OC.SetupChecks.MESSAGE_TYPE_WARNING:
+					$warningsEl.append('<li>' + messages[i].msg + '</li>');
+					break;
+				case OC.SetupChecks.MESSAGE_TYPE_ERROR:
+				default:
+					$errorsEl.append('<li>' + messages[i].msg + '</li>');
+			}
+		}
+
+		if ($errorsEl.find('li').length > 0) {
+			$errorsEl.removeClass('hidden');
+			hasMessages = true;
+		}
+		if ($warningsEl.find('li').length > 0) {
+			$warningsEl.removeClass('hidden');
+			hasMessages = true;
+		}
+		if ($infoEl.find('li').length > 0) {
+			$infoEl.removeClass('hidden');
+			hasMessages = true;
+		}
+
+		if (hasMessages) {
+			$el.find('.hint').removeClass('hidden');
+		} else {
 			var securityWarning = $('#security-warning');
 			if (securityWarning.children('ul').children().length === 0) {
 				$('#security-warning-state').find('span').removeClass('hidden');
 			}
-		} else {
-			var $errorsEl = $el.find('.errors');
-			var $warningsEl = $el.find('.warnings');
-			var $infoEl = $el.find('.info');
-			for (var i = 0; i < messages.length; i++ ) {
-				switch(messages[i].type) {
-					case OC.SetupChecks.MESSAGE_TYPE_INFO:
-						$infoEl.append('<li>' + messages[i].msg + '</li>');
-						break;
-					case OC.SetupChecks.MESSAGE_TYPE_WARNING:
-						$warningsEl.append('<li>' + messages[i].msg + '</li>');
-						break;
-					case OC.SetupChecks.MESSAGE_TYPE_ERROR:
-					default:
-						$errorsEl.append('<li>' + messages[i].msg + '</li>');
-				}
-			}
-			if ($errorsEl.find('li').length > 0) {
-				$errorsEl.removeClass('hidden');
-			}
-			if ($warningsEl.find('li').length > 0) {
-				$warningsEl.removeClass('hidden');
-			}
-			if ($infoEl.find('li').length > 0) {
-				$infoEl.removeClass('hidden');
-			}
-			$el.find('.hint').removeClass('hidden');
 		}
 	});
 });


### PR DESCRIPTION
Some messages are set in the HTML generated by PHP, rather than by the async JS, and currently do not get correctly detected and so remain hidden. This PR moves some logic out of an if statement so it works properly.

Fixes #20376 

cc @PVince81 
