### PR TITLE
Register DAVACL plugin to provide current-user-principal

### DIFF
--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -33,6 +33,8 @@ class Server {
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
 		$this->server->addPlugin(new Plugin($authBackend, 'ownCloud'));
 
+		$this->server->addPlugin(new \Sabre\DAVACL\Plugin());
+
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod', function () {
 			// custom properties plugin must be the last one


### PR DESCRIPTION
@dmfs this will bring back the current-user-principal

``` sh
$ curl -k -X PROPFIND -H "content-type: application/xml" -u admin:admin --data-binary '<?xml version="1.0" encoding="UTF-8"?><A:propfind xmlns:A="DAV:"><A:prop><A:current-user-principal/><A:resourcetype/></A:prop></A:propfind>' -H "Depth: 0" http://localhost:8080/remote.php/dav/ | xmllint --format -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   545    0   406  100   139   1553    531 --:--:-- --:--:-- --:--:--  1549
<?xml version="1.0" encoding="utf-8"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <d:response>
    <d:href>/remote.php/dav/</d:href>
    <d:propstat>
      <d:prop>
        <d:current-user-principal>
          <d:href>/remote.php/dav/principals/admin/</d:href>
        </d:current-user-principal>
        <d:resourcetype>
          <d:collection/>
        </d:resourcetype>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```
