### PR TITLE
Add warning log entry when user accesses untrusted domain

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -673,6 +673,15 @@ class OC {
 			header('HTTP/1.1 400 Bad Request');
 			header('Status: 400 Bad Request');
 
+			\OC::$server->getLogger()->warning(
+					'Trusted domain error. "{remoteAddress}" tried to access using "{host}" as host.',
+					[
+						'app' => 'core',
+						'remoteAddress' => $request->getRemoteAddress(),
+						'host' => $host,
+					]
+			);
+
 			$tmpl = new OCP\Template('core', 'untrustedDomain', 'guest');
 			$tmpl->assign('domain', $request->server['SERVER_NAME']);
 			$tmpl->printPage();


### PR DESCRIPTION
@blizzz @DeepDiver1975 As discussed.

``` json
{"reqId":"VkHDL8CosWQAAAWNf14AAAAH","remoteAddr":"::1","app":"core","message":"Trusted domain error. \"::1\" tried to access using \"localhost\" as host.","level":2,"time":"2015-11-10T10:13:03+00:00"}
```
