### PR TITLE
When creating addressbooks, make sure the displayname is set

### DIFF
--- a/apps/dav/lib/carddav/carddavbackend.php
+++ b/apps/dav/lib/carddav/carddavbackend.php
@@ -134,7 +134,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param string $principalUri
 	 * @param string $url Just the 'basename' of the url.
 	 * @param array $properties
-	 * @return void
+	 * @throws BadRequest
 	 */
 	function createAddressBook($principalUri, $url, array $properties) {
 		$values = [
@@ -158,6 +158,12 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 					throw new BadRequest('Unknown property: ' . $property);
 			}
 
+		}
+
+		// Fallback to make sure the displayname is set. Some clients may refuse
+		// to work with addressbooks not having a displayname.
+		if(is_null($values['displayname'])) {
+			$values['displayname'] = $url;
 		}
 
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/tests/unit/carddav/carddavbackendtest.php
+++ b/apps/dav/tests/unit/carddav/carddavbackendtest.php
@@ -60,6 +60,7 @@ class CardDavBackendTest extends TestCase {
 
 		$books = $this->backend->getAddressBooksForUser(self::UNIT_TEST_USER);
 		$this->assertEquals(1, count($books));
+		$this->assertEquals('Example', $books[0]['{DAV:}displayname']);
 
 		// update it's display name
 		$patch = new PropPatch([


### PR DESCRIPTION
Some CardDAV clients won't work with addressbooks that do not have a display name et (https://github.com/owncloud/core/pull/20415#issuecomment-155380204).

@DeepDiver1975 @LukasReschke 
