### PR TITLE
Revert move of CSS rules from mobile.css

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -353,11 +353,3 @@
 		-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 		opacity: 1;
 	}
-
-/* do not show display name when profile picture is present */
-#header .avatardiv.avatardiv-shown + #expandDisplayName {
-	display: none;
-}
-#header #expand {
-	display: block;
-}

--- a/core/css/mobile.css
+++ b/core/css/mobile.css
@@ -26,6 +26,14 @@
 	display: none;
 }
 
+/* do not show display name when profile picture is present */
+#header .avatardiv.avatardiv-shown + #expandDisplayName {
+	display: none;
+}
+#header #expand {
+	display: block;
+}
+
 /* do not show update notification on mobile */
 #update-notification {
 	display: none !important;


### PR DESCRIPTION
- fixes #20455 for display name changes without a avatar
- ref #20176 

@karlitschek needs a backport to stable8.2 because this was also backported
