### PR TITLE
fix layout and wording for file handling admin setting

### DIFF
--- a/apps/files/templates/admin.php
+++ b/apps/files/templates/admin.php
@@ -7,14 +7,12 @@
 		<?php if($_['displayMaxPossibleUploadSize']):?>
 			(<?php p($l->t('max. possible: ')); p($_['maxPossibleUploadSize']) ?>)
 		<?php endif;?>
-		<br/>
 		<input type="hidden" value="<?php p($_['requesttoken']); ?>" name="requesttoken" />
 		<?php if($_['uploadChangable']): ?>
-			<?php p($l->t('With PHP-FPM this value may take up to 5 minutes to take effect after saving.')); ?>
-			<br/>
 			<input type="submit" name="submitFilesAdminSettings" id="submitFilesAdminSettings"
 				   value="<?php p($l->t( 'Save' )); ?>"/>
+			<p><em><?php p($l->t('With PHP-FPM it might take 5 minutes for changes to be applied.')); ?></em></p>
 		<?php else: ?>
-			<?php p($l->t('Can not be edited from here due to insufficient permissions.')); ?>
+			<p><em><?php p($l->t('Missing permissions to edit from here.')); ?></em></p>
 		<?php endif; ?>
 	</form>


### PR DESCRIPTION
- fixed the wording
- made the info message half-grey
- put the save button behind the input field it affects

Please review @owncloud/designers @rullzer 
