### PR TITLE
Allow storage wrappers to through a forbidden exception with retry information for clients

### DIFF
--- a/apps/dav/lib/connector/sabre/directory.php
+++ b/apps/dav/lib/connector/sabre/directory.php
@@ -28,8 +28,10 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCP\Files\ForbiddenException;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Sabre\DAV\Exception\Locked;
@@ -117,6 +119,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		} catch (\OCP\Files\InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -146,6 +150,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
 		} catch (\OCP\Files\InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -247,6 +253,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 				// assume it wasn't possible to remove due to permission issue
 				throw new \Sabre\DAV\Exception\Forbidden();
 			}
+		} catch (ForbiddenException $ex) {
+			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}

--- a/apps/dav/lib/connector/sabre/exception/forbidden.php
+++ b/apps/dav/lib/connector/sabre/exception/forbidden.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Connector\Sabre\Exception;
+
+class Forbidden extends \Sabre\DAV\Exception\Forbidden {
+
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+
+	/**
+	 * @var bool
+	 */
+	private $retry;
+
+	/**
+	 * @param string $message
+	 * @param bool $retry
+	 * @param \Exception $previous
+	 */
+	public function __construct($message, $retry = false, \Exception $previous = null) {
+		parent::__construct($message, 0, $previous);
+		$this->retry = $retry;
+	}
+
+	/**
+	 * This method allows the exception to include additional information
+	 * into the WebDAV error response
+	 *
+	 * @param \Sabre\DAV\Server $server
+	 * @param \DOMElement $errorNode
+	 * @return void
+	 */
+	public function serialize(\Sabre\DAV\Server $server,\DOMElement $errorNode) {
+
+		// set ownCloud namespace
+		$errorNode->setAttribute('xmlns:o', self::NS_OWNCLOUD);
+
+		// adding the retry node
+		$error = $errorNode->ownerDocument->createElementNS('o:','o:retry', var_export($this->retry, true));
+		$errorNode->appendChild($error);
+
+		// adding the message node
+		$error = $errorNode->ownerDocument->createElementNS('o:','o:reason', $this->getMessage());
+		$errorNode->appendChild($error);
+	}
+}

--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -35,9 +35,11 @@ namespace OCA\DAV\Connector\Sabre;
 use OC\Files\Filesystem;
 use OCA\DAV\Connector\Sabre\Exception\EntityTooLarge;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
 use OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\EntityTooLargeException;
+use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidContentException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\LockNotAcquiredException;
@@ -175,6 +177,8 @@ class File extends Node implements IFile {
 						\OCP\Util::writeLog('webdav', 'renaming part file to final file failed', \OCP\Util::ERROR);
 						throw new Exception('Could not rename part file to final file');
 					}
+				} catch (ForbiddenException $ex) {
+					throw new DAVForbiddenException($ex->getMessage(), $ex->getRetry());
 				} catch (\Exception $e) {
 					$partStorage->unlink($internalPartPath);
 					$this->convertToSabreException($e);
@@ -273,6 +277,8 @@ class File extends Node implements IFile {
 			throw new ServiceUnavailable("Encryption not ready: " . $e->getMessage());
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to open file: " . $e->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new DAVForbiddenException($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -296,6 +302,8 @@ class File extends Node implements IFile {
 			}
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to unlink: " . $e->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new DAVForbiddenException($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -473,6 +481,10 @@ class File extends Node implements IFile {
 		if ($e instanceof NotPermittedException) {
 			// a more general case - due to whatever reason the content could not be written
 			throw new Forbidden($e->getMessage(), 0, $e);
+		}
+		if ($e instanceof ForbiddenException) {
+			// the path for the file was forbidden
+			throw new DAVForbiddenException($e->getMessage(), $e->getRetry(), $e);
 		}
 		if ($e instanceof EntityTooLargeException) {
 			// the file is too big to be stored

--- a/apps/dav/lib/connector/sabre/objecttree.php
+++ b/apps/dav/lib/connector/sabre/objecttree.php
@@ -25,10 +25,12 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OC\Files\FileInfo;
 use OC\Files\Mount\MoveableMount;
+use OCP\Files\ForbiddenException;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\LockedException;
@@ -235,6 +237,8 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			}
 		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -274,6 +278,8 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			$this->fileView->copy($source, $destination);
 		} catch (StorageNotAvailableException $e) {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+		} catch (ForbiddenException $ex) {
+			throw new Forbidden($ex->getMessage(), $ex->getRetry());
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}

--- a/apps/dav/tests/unit/connector/sabre/directory.php
+++ b/apps/dav/tests/unit/connector/sabre/directory.php
@@ -9,6 +9,8 @@
 
 namespace OCA\DAV\Tests\Unit\Connector\Sabre;
 
+use OCP\Files\ForbiddenException;
+
 class Directory extends \Test\TestCase {
 
 	/** @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject */
@@ -45,6 +47,25 @@ class Directory extends \Test\TestCase {
 		$this->view->expects($this->never())
 			->method('rmdir');
 		$dir = $this->getDir();
+		$dir->delete();
+	}
+
+	/**
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\Forbidden
+	 */
+	public function testDeleteForbidden() {
+		// deletion allowed
+		$this->info->expects($this->once())
+			->method('isDeletable')
+			->will($this->returnValue(true));
+
+		// but fails
+		$this->view->expects($this->once())
+			->method('rmdir')
+			->with('sub')
+			->willThrowException(new ForbiddenException('', true));
+
+		$dir = $this->getDir('sub');
 		$dir->delete();
 	}
 

--- a/apps/dav/tests/unit/connector/sabre/exception/forbiddentest.php
+++ b/apps/dav/tests/unit/connector/sabre/exception/forbiddentest.php
@@ -8,9 +8,9 @@
 
 namespace OCA\DAV\Tests\Unit\Connector\Sabre\Exception;
 
-use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 
-class InvalidPathTest extends \Test\TestCase {
+class ForbiddenTest extends \Test\TestCase {
 
 	public function testSerialization() {
 
@@ -33,7 +33,7 @@ class InvalidPathTest extends \Test\TestCase {
 
 EOD;
 
-		$ex = new InvalidPath($message, $retry);
+		$ex = new Forbidden($message, $retry);
 		$server = $this->getMock('Sabre\DAV\Server');
 		$ex->serialize($server, $error);
 

--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -185,6 +185,8 @@ class File implements ICache {
 					} catch (\OCP\Lock\LockedException $e) {
 						// ignore locked chunks
 						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', array('app' => 'core'));
+					} catch (\OCP\Files\ForbiddenException $e) {
+						\OC::$server->getLogger()->debug('Could not cleanup forbidden chunk "' . $file . '"', array('app' => 'core'));
 					} catch (\OCP\Files\LockNotAcquiredException $e) {
 						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', array('app' => 'core'));
 					}

--- a/lib/private/files.php
+++ b/lib/private/files.php
@@ -142,6 +142,11 @@ class OC_Files {
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
 			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint);
+		} catch (\OCP\Files\ForbiddenException $ex) {
+			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
+			OC::$server->getLogger()->logException($ex);
+			$l = \OC::$server->getL10N('core');
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -432,6 +432,8 @@ class Scanner extends BasicEmitter {
 				// skip unavailable storages
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
 				// skip unavailable storages
+			} catch (\OCP\Files\ForbiddenException $e) {
+				// skip forbidden storages
 			} catch (\OCP\Lock\LockedException $e) {
 				// skip unavailable storages
 			}

--- a/lib/public/files/forbiddenexception.php
+++ b/lib/public/files/forbiddenexception.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\Files;
+
+/**
+ * Class ForbiddenException
+ *
+ * @package OCP\Files
+ * @since 9.0.0
+ */
+class ForbiddenException extends \Exception {
+
+	/** @var bool */
+	private $retry;
+
+	/**
+	 * @param string $message
+	 * @param bool $retry
+	 * @param \Exception $previous previous exception for cascading
+	 * @since 9.0.0
+	 */
+	public function __construct($message, $retry, \Exception $previous = null) {
+		parent::__construct($message, 0, $previous);
+		$this->retry = $retry;
+	}
+
+	/**
+	 * @return bool
+	 * @since 9.0.0
+	 */
+	public function getRetry() {
+		return (bool) $this->retry;
+	}
+}


### PR DESCRIPTION
Current response on webdav requests:

``` xml
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:o="http://owncloud.org/ns">
  <s:exception>OCA\DAV\Connector\Sabre\Exception\Forbidden</s:exception>
  <s:message>Access to this resource has been forbidden by law.</s:message>
  <o:retry xmlns:o="o:">true</o:retry>
  <o:reason xmlns:o="o:">Access to this resource has been forbidden by law.</o:reason>
</d:error>
```

@DeepDiver1975 @icewind1991 
Required for FW storage wrapper.

Currently reason === exception message, not sure if we want to keep it like that, but for now that should be fine so we can continue the actual work.
