### PR TITLE
Bubble up hint exceptions in hooks, so the user can see the hint

### DIFF
--- a/lib/private/hook.php
+++ b/lib/private/hook.php
@@ -112,6 +112,9 @@ class OC_Hook{
 				if (empty($message)) {
 					$message = get_class($e);
 				}
+				if($e instanceof \OC\HintException) {
+					throw $e;
+				}
 				\OCP\Util::writeLog('hook',
 					'error while running hook (' . $class . '::' . $i["name"] . '): ' . $message,
 					\OCP\Util::ERROR);

--- a/lib/private/hook.php
+++ b/lib/private/hook.php
@@ -56,7 +56,7 @@ class OC_Hook{
 			self::$registered[$signalClass][$signalName] = array();
 		}
 
-		// dont connect hooks twice
+		// don't connect hooks twice
 		foreach (self::$registered[$signalClass][$signalName] as $hook) {
 			if ($hook['class'] === $slotClass and $hook['name'] === $slotName) {
 				return false;
@@ -79,8 +79,8 @@ class OC_Hook{
 	 * @param string $signalName name of signal
 	 * @param mixed $params default: array() array with additional data
 	 * @return bool true if slots exists or false if not
-	 * @throws \OC\ServerNotAvailableException
-	 * Emits a signal. To get data from the slot use references!
+	 * @throws \OC\HintException
+	 * @throws \OC\ServerNotAvailableException Emits a signal. To get data from the slot use references!
 	 *
 	 * TODO: write example
 	 */
@@ -104,41 +104,30 @@ class OC_Hook{
 				call_user_func( array( $i["class"], $i["name"] ), $params );
 			} catch (Exception $e){
 				self::$thrownExceptions[] = $e;
-				$class = $i["class"];
-				if (is_object($i["class"])) {
-					$class = get_class($i["class"]);
-				}
-				$message = $e->getMessage();
-				if (empty($message)) {
-					$message = get_class($e);
-				}
+				\OC::$server->getLogger()->logException($e);
 				if($e instanceof \OC\HintException) {
 					throw $e;
 				}
-				\OCP\Util::writeLog('hook',
-					'error while running hook (' . $class . '::' . $i["name"] . '): ' . $message,
-					\OCP\Util::ERROR);
 				if($e instanceof \OC\ServerNotAvailableException) {
 					throw $e;
 				}
 			}
 		}
 
-		// return true
 		return true;
 	}
 
 	/**
 	 * clear hooks
-	 * @param string $signalclass
-	 * @param string $signalname
+	 * @param string $signalClass
+	 * @param string $signalName
 	 */
-	static public function clear($signalclass='', $signalname='') {
-		if($signalclass) {
-			if($signalname) {
-				self::$registered[$signalclass][$signalname]=array();
+	static public function clear($signalClass='', $signalName='') {
+		if ($signalClass) {
+			if ($signalName) {
+				self::$registered[$signalClass][$signalName]=array();
 			}else{
-				self::$registered[$signalclass]=array();
+				self::$registered[$signalClass]=array();
 			}
 		}else{
 			self::$registered=array();

--- a/lib/private/log.php
+++ b/lib/private/log.php
@@ -32,6 +32,7 @@ use InterfaSys\LogNormalizer\Normalizer;
 
 use \OCP\ILogger;
 use OCP\Security\StringUtils;
+use OCP\Util;
 
 /**
  * logging utilities
@@ -47,11 +48,13 @@ class Log implements ILogger {
 
 	/** @var string */
 	private $logger;
+
 	/** @var SystemConfig */
 	private $config;
 
 	/** @var boolean|null cache the result of the log condition check for the request */
 	private $logConditionSatisfied = null;
+
 	/** @var Normalizer */
 	private $normalizer;
 
@@ -83,15 +86,15 @@ class Log implements ILogger {
 
 	}
 
-
 	/**
 	 * System is unusable.
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function emergency($message, array $context = array()) {
-		$this->log(\OCP\Util::FATAL, $message, $context);
+		$this->log(Util::FATAL, $message, $context);
 	}
 
 	/**
@@ -102,9 +105,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function alert($message, array $context = array()) {
-		$this->log(\OCP\Util::ERROR, $message, $context);
+		$this->log(Util::ERROR, $message, $context);
 	}
 
 	/**
@@ -114,9 +118,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function critical($message, array $context = array()) {
-		$this->log(\OCP\Util::ERROR, $message, $context);
+		$this->log(Util::ERROR, $message, $context);
 	}
 
 	/**
@@ -125,9 +130,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function error($message, array $context = array()) {
-		$this->log(\OCP\Util::ERROR, $message, $context);
+		$this->log(Util::ERROR, $message, $context);
 	}
 
 	/**
@@ -138,9 +144,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function warning($message, array $context = array()) {
-		$this->log(\OCP\Util::WARN, $message, $context);
+		$this->log(Util::WARN, $message, $context);
 	}
 
 	/**
@@ -148,9 +155,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function notice($message, array $context = array()) {
-		$this->log(\OCP\Util::INFO, $message, $context);
+		$this->log(Util::INFO, $message, $context);
 	}
 
 	/**
@@ -160,9 +168,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function info($message, array $context = array()) {
-		$this->log(\OCP\Util::INFO, $message, $context);
+		$this->log(Util::INFO, $message, $context);
 	}
 
 	/**
@@ -170,9 +179,10 @@ class Log implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function debug($message, array $context = array()) {
-		$this->log(\OCP\Util::DEBUG, $message, $context);
+		$this->log(Util::DEBUG, $message, $context);
 	}
 
 
@@ -182,9 +192,10 @@ class Log implements ILogger {
 	 * @param mixed $level
 	 * @param string $message
 	 * @param array $context
+	 * @return void
 	 */
 	public function log($level, $message, array $context = array()) {
-		$minLevel = min($this->config->getValue('loglevel', \OCP\Util::WARN), \OCP\Util::ERROR);
+		$minLevel = min($this->config->getValue('loglevel', Util::WARN), Util::ERROR);
 		$logCondition = $this->config->getValue('log.condition', []);
 
 		array_walk($context, [$this->normalizer, 'format']);
@@ -199,7 +210,7 @@ class Log implements ILogger {
 			if(!empty($logCondition)
 				&& isset($logCondition['apps'])
 				&& in_array($app, $logCondition['apps'], true)) {
-				$minLevel = \OCP\Util::DEBUG;
+				$minLevel = Util::DEBUG;
 			}
 
 		} else {
@@ -247,7 +258,7 @@ class Log implements ILogger {
 
 		// if log condition is satisfied change the required log level to DEBUG
 		if($this->logConditionSatisfied) {
-			$minLevel = \OCP\Util::DEBUG;
+			$minLevel = Util::DEBUG;
 		}
 
 		if ($level >= $minLevel) {


### PR DESCRIPTION
Otherwise the exception gets swallowed in the hook catch all and the user just does not even see an error.

@MorrisJobke @DeepDiver1975 thougts?
