### PR TITLE
[Avatar] No need to setup FS for avatar tests

### DIFF
--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -28,6 +28,10 @@ use OCP\AppFramework\Http;
 use OCP\Image;
 use OCP\Files\Folder;
 use OCP\Files\File;
+use OCP\IUser;
+use OCP\IAvatar;
+
+use Test\Traits\UserTrait;
 
 /**
  * Overwrite is_uploaded_file in this namespace to allow proper unit testing of 
@@ -43,79 +47,53 @@ function is_uploaded_file($filename) {
  * @package OC\Core\Avatar
  */
 class AvatarControllerTest extends \Test\TestCase {
+	use UserTrait;
 
 	/** @var IAppContainer */
 	private $container;
-	/** @var string */
-	private $user;
-	/** @var string */
-	private $oldUser; 
 	/** @var AvatarController */
 	private $avatarController;
-	
+	/** @var IAvatar */
 	private $avatarMock;
-
+	/** @var IUser */
 	private $userMock;
-
+	
 	protected function setUp() {
+		parent::setUp();
+		$this->createUser('userid', 'pass');
+		$this->loginAsUser('userid');
+		
 		$app = new Application;
 		$this->container = $app->getContainer();
 		$this->container['AppName'] = 'core';
-		$this->container['AvatarManager'] = $this->getMockBuilder('OCP\IAvatarManager')
-			->disableOriginalConstructor()->getMock();
+		$this->container['AvatarManager'] = $this->getMock('OCP\IAvatarManager');
 		$this->container['Cache'] = $this->getMockBuilder('OC\Cache\File')
 			->disableOriginalConstructor()->getMock();
-		$this->container['L10N'] = $this->getMockBuilder('OCP\IL10N')
-			->disableOriginalConstructor()->getMock();
+		$this->container['L10N'] = $this->getMock('OCP\IL10N');
 		$this->container['L10N']->method('t')->will($this->returnArgument(0));
-		$this->container['UserManager'] = $this->getMockBuilder('OCP\IUserManager')
-			->disableOriginalConstructor()->getMock();
-		$this->container['UserSession'] = $this->getMockBuilder('OCP\IUserSession')
-			->disableOriginalConstructor()->getMock();
-		$this->container['Request'] = $this->getMockBuilder('OCP\IRequest')
-			->disableOriginalConstructor()->getMock();
-		$this->container['UserFolder'] = $this->getMockBuilder('OCP\Files\Folder')
-			->disableOriginalConstructor()->getMock();
-		$this->container['Logger'] = $this->getMockBuilder('OCP\ILogger')
-			->disableOriginalConstructor()->getMock();
+		$this->container['UserManager'] = $this->getMock('OCP\IUserManager');
+		$this->container['UserSession'] = $this->getMock('OCP\IUserSession');
+		$this->container['Request'] = $this->getMock('OCP\IRequest');
+		$this->container['UserFolder'] = $this->getMock('OCP\Files\Folder');
+		$this->container['Logger'] = $this->getMock('OCP\ILogger');
 
-		$this->avatarMock = $this->getMockBuilder('OCP\IAvatar')
-			->disableOriginalConstructor()->getMock();
-		$this->userMock = $this->getMockBuilder('OCP\IUser')
-			->disableOriginalConstructor()->getMock();
+		$this->avatarMock = $this->getMock('OCP\IAvatar');
+		$this->userMock = $this->getMock('OCP\IUser');
 
 		$this->avatarController = $this->container['AvatarController'];
 
-		// Store current User
-		$this->oldUser = \OC_User::getUser();
-
-		// Create a dummy user
-		$this->user = $this->getUniqueID('user');
-
-		OC::$server->getUserManager()->createUser($this->user, $this->user);
-		$this->loginAsUser($this->user);
-
 		// Configure userMock
-		$this->userMock->method('getDisplayName')->willReturn($this->user);
-		$this->userMock->method('getUID')->willReturn($this->user);
+		$this->userMock->method('getDisplayName')->willReturn('displayName');
+		$this->userMock->method('getUID')->willReturn('userId');
 		$this->container['UserManager']->method('get')
-			->willReturnMap([[$this->user, $this->userMock]]);
+			->willReturnMap([['userId', $this->userMock]]);
 		$this->container['UserSession']->method('getUser')->willReturn($this->userMock);
 
 	}
 
 	public function tearDown() {
-		\OC_Util::tearDownFS();
-		\OC_User::setUserId('');
-		Filesystem::tearDown();
-		OC::$server->getUserManager()->get($this->user)->delete();
-		\OC_User::setIncognitoMode(false);
-		
-		\OC::$server->getSession()->set('public_link_authenticated', '');
-
-		// Set old user
-		\OC_User::setUserId($this->oldUser);
-		\OC_Util::setupFS($this->oldUser);
+		$this->logout();
+		parent::tearDown();
 	}
 
 	/**
@@ -123,29 +101,32 @@ class AvatarControllerTest extends \Test\TestCase {
 	 */
 	public function testGetAvatarNoAvatar() {
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
-		$response = $this->avatarController->getAvatar($this->user, 32);
+		$response = $this->avatarController->getAvatar('userId', 32);
 
 		//Comment out until JS is fixed
 		//$this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
-		$this->assertEquals($this->user, $response->getData()['data']['displayname']);
+		$this->assertEquals('displayName', $response->getData()['data']['displayname']);
 	}
 
 	/**
 	 * Fetch the user's avatar
 	 */
 	public function testGetAvatar() {
-		$image = new Image(OC::$SERVERROOT.'/tests/data/testimage.jpg');
+		$image = $this->getMock('OCP\IImage');
+		$image->method('data')->willReturn('image data');
+		$image->method('mimeType')->willReturn('image type');
+
 		$this->avatarMock->method('get')->willReturn($image);
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
 
-		$response = $this->avatarController->getAvatar($this->user, 32);
+		$response = $this->avatarController->getAvatar('userId', 32);
 
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertArrayHasKey('Content-Type', $response->getHeaders());
+		$this->assertEquals('image type', $response->getHeaders()['Content-Type']);
 
-		$image2 = new Image($response->getData());
-		$this->assertEquals($image->mimeType(), $image2->mimeType());
-		$this->assertEquals(crc32($response->getData()), $response->getEtag());
+		$this->assertEquals(crc32('image data'), $response->getEtag());
 	}
 
 	/**
@@ -155,7 +136,7 @@ class AvatarControllerTest extends \Test\TestCase {
 		$this->avatarMock->method('get')->willReturn(null);
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
 
-		$response = $this->avatarController->getAvatar($this->user . 'doesnotexist', 32);
+		$response = $this->avatarController->getAvatar('userDoesnotexist', 32);
 
 		//Comment out until JS is fixed
 		//$this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -173,7 +154,7 @@ class AvatarControllerTest extends \Test\TestCase {
 
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
 
-		$this->avatarController->getAvatar($this->user, 32);
+		$this->avatarController->getAvatar('userId', 32);
 	}
 
 	/**
@@ -186,7 +167,7 @@ class AvatarControllerTest extends \Test\TestCase {
 
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
 
-		$this->avatarController->getAvatar($this->user, 0);
+		$this->avatarController->getAvatar('userId', 0);
 	}
 
 	/**
@@ -199,7 +180,7 @@ class AvatarControllerTest extends \Test\TestCase {
 
 		$this->container['AvatarManager']->method('getAvatar')->willReturn($this->avatarMock);
 
-		$this->avatarController->getAvatar($this->user, 2049);
+		$this->avatarController->getAvatar('userId', 2049);
 	}
 
 	/**


### PR DESCRIPTION
PR uses the new fancy UserTrait to not setup user for each test. This reduces unit test time from 3 seconds => 0.6 seconds. And it removes the database dependency (https://github.com/owncloud/core/pull/20248)!

Unit tests still pass locally. Lets see what CI says.

@DeepDiver1975 as discussed last week!

@icewind1991 @LukasReschke @PVince81 @MorrisJobke 
