### PR TITLE
clarify log level setting design, fix #20514

### DIFF
--- a/settings/templates/admin.php
+++ b/settings/templates/admin.php
@@ -491,15 +491,6 @@ if ($_['cronErrors']) {
 
 <div class="section" id="log-section">
 	<h2><?php p($l->t('Log'));?></h2>
-	<?php p($l->t('Log level'));?> <select name='loglevel' id='loglevel'>
-<?php for ($i = 0; $i < 5; $i++):
-	$selected = '';
-	if ($i == $_['loglevel']):
-		$selected = 'selected="selected"';
-	endif; ?>
-		<option value='<?php p($i)?>' <?php p($selected) ?>><?php p($levelLabels[$i])?></option>
-<?php endfor;?>
-</select>
 <?php if ($_['showLog'] && $_['doesLogFileExist']): ?>
 	<table id="log" class="grid">
 		<?php foreach ($_['entries'] as $entry): ?>
@@ -537,6 +528,16 @@ if ($_['cronErrors']) {
 	</em>
 	<?php endif; ?>
 	<?php endif; ?>
+
+	<p><?php p($l->t('What to log'));?> <select name='loglevel' id='loglevel'>
+	<?php for ($i = 0; $i < 5; $i++):
+		$selected = '';
+		if ($i == $_['loglevel']):
+			$selected = 'selected="selected"';
+		endif; ?>
+			<option value='<?php p($i)?>' <?php p($selected) ?>><?php p($levelLabels[$i])?></option>
+	<?php endfor;?>
+	</select></p>
 </div>
 
 <div class="section" id="admin-tips">


### PR DESCRIPTION
Moving the log level selection dropdown below the list and change wording to »What to log« to make it obvious it’s a setting and not a view switcher.

Fix #20514, please review @v1r0x @RealRancor @owncloud/designers 
