### PR TITLE
[provisioning api] Return empty list if group does not have subadmins

### DIFF
--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -176,14 +176,8 @@ class Groups{
 		foreach ($subadmins as $user) {
 			$uids[] = $user->getUID();
 		}
-		$subadmins = $uids;
 
-		// Go
-		if(!$subadmins) {
-			return new OC_OCS_Result(null, 102, 'Unknown error occured');
-		} else {
-			return new OC_OCS_Result($subadmins);
-		}
+		return new OC_OCS_Result($uids);
 	}
 
 }

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -308,9 +308,8 @@ class GroupsTest extends \Test\TestCase {
 		]);
 
 		$this->assertInstanceOf('OC_OCS_Result', $result);
-		$this->assertFalse($result->succeeded());
-		$this->assertEquals(102, $result->getStatusCode());
-		$this->assertEquals('Unknown error occured', $result->getMeta()['message']);
+		$this->assertTrue($result->succeeded());
+		$this->assertEquals([], $result->getData());
 	}
 
 	public function testAddGroupEmptyGroup() {


### PR DESCRIPTION
Fixes #19789
Instead of throwing an error just return an empty list. Since that is actually what it is. 

CC: @SergioBertolinSG @tomneedham @PVince81 @MorrisJobke @nickvergessen 
