### PR TITLE
Unset `path` for shared with me

### DIFF
--- a/apps/files_sharing/api/local.php
+++ b/apps/files_sharing/api/local.php
@@ -233,6 +233,7 @@ class Local {
 					if (\OC::$server->getPreviewManager()->isMimeSupported($share['mimetype'])) {
 						$share['isPreviewAvailable'] = true;
 					}
+					unset($share['path']);
 				}
 			}
 			$result = new \OC_OCS_Result($shares);


### PR DESCRIPTION
The original path is not required for a share recipient.
