### PR TITLE
Add internal fileid to webdav response

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -37,6 +37,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	// namespace
 	const NS_OWNCLOUD = 'http://owncloud.org/ns';
 	const FILEID_PROPERTYNAME = '{http://owncloud.org/ns}id';
+	const INTERNAL_FILEID_PROPERTYNAME = '{http://owncloud.org/ns}fileid';
 	const PERMISSIONS_PROPERTYNAME = '{http://owncloud.org/ns}permissions';
 	const DOWNLOADURL_PROPERTYNAME = '{http://owncloud.org/ns}downloadURL';
 	const SIZE_PROPERTYNAME = '{http://owncloud.org/ns}size';
@@ -98,6 +99,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 
 		$server->xmlNamespaces[self::NS_OWNCLOUD] = 'oc';
 		$server->protectedProperties[] = self::FILEID_PROPERTYNAME;
+		$server->protectedProperties[] = self::INTERNAL_FILEID_PROPERTYNAME;
 		$server->protectedProperties[] = self::PERMISSIONS_PROPERTYNAME;
 		$server->protectedProperties[] = self::SIZE_PROPERTYNAME;
 		$server->protectedProperties[] = self::DOWNLOADURL_PROPERTYNAME;
@@ -173,6 +175,10 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 
 			$propFind->handle(self::FILEID_PROPERTYNAME, function() use ($node) {
 				return $node->getFileId();
+			});
+
+			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, function() use ($node) {
+				return $node->getInternalFileId();
 			});
 
 			$propFind->handle(self::PERMISSIONS_PROPERTYNAME, function() use ($node) {

--- a/apps/dav/lib/connector/sabre/node.php
+++ b/apps/dav/lib/connector/sabre/node.php
@@ -207,6 +207,13 @@ abstract class Node implements \Sabre\DAV\INode {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getInternalFileId() {
+		return $this->info->getId();
+	}
+
+	/**
 	 * @return string|null
 	 */
 	public function getDavPermissions() {

--- a/apps/dav/tests/unit/connector/sabre/filesplugin.php
+++ b/apps/dav/tests/unit/connector/sabre/filesplugin.php
@@ -11,6 +11,7 @@ namespace OCA\DAV\Tests\Unit\Connector\Sabre;
 class FilesPlugin extends \Test\TestCase {
 	const GETETAG_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::GETETAG_PROPERTYNAME;
 	const FILEID_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::FILEID_PROPERTYNAME;
+	const INTERNAL_FILEID_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::INTERNAL_FILEID_PROPERTYNAME;
 	const SIZE_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::SIZE_PROPERTYNAME;
 	const PERMISSIONS_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::PERMISSIONS_PROPERTYNAME;
 	const LASTMODIFIED_PROPERTYNAME = \OCA\DAV\Connector\Sabre\FilesPlugin::LASTMODIFIED_PROPERTYNAME;
@@ -69,7 +70,10 @@ class FilesPlugin extends \Test\TestCase {
 
 		$node->expects($this->any())
 			->method('getFileId')
-			->will($this->returnValue(123));
+			->will($this->returnValue('00000123instanceid'));
+		$node->expects($this->any())
+			->method('getInternalFileId')
+			->will($this->returnValue('123'));
 		$node->expects($this->any())
 			->method('getEtag')
 			->will($this->returnValue('"abc"'));
@@ -90,6 +94,7 @@ class FilesPlugin extends \Test\TestCase {
 			array(
 				self::GETETAG_PROPERTYNAME,
 				self::FILEID_PROPERTYNAME,
+				self::INTERNAL_FILEID_PROPERTYNAME,
 				self::SIZE_PROPERTYNAME,
 				self::PERMISSIONS_PROPERTYNAME,
 				self::DOWNLOADURL_PROPERTYNAME,
@@ -125,7 +130,8 @@ class FilesPlugin extends \Test\TestCase {
 		);
 
 		$this->assertEquals('"abc"', $propFind->get(self::GETETAG_PROPERTYNAME));
-		$this->assertEquals(123, $propFind->get(self::FILEID_PROPERTYNAME));
+		$this->assertEquals('00000123instanceid', $propFind->get(self::FILEID_PROPERTYNAME));
+		$this->assertEquals('123', $propFind->get(self::INTERNAL_FILEID_PROPERTYNAME));
 		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
 		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals('http://example.com/', $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
@@ -186,7 +192,7 @@ class FilesPlugin extends \Test\TestCase {
 		);
 
 		$this->assertEquals('"abc"', $propFind->get(self::GETETAG_PROPERTYNAME));
-		$this->assertEquals(123, $propFind->get(self::FILEID_PROPERTYNAME));
+		$this->assertEquals('00000123instanceid', $propFind->get(self::FILEID_PROPERTYNAME));
 		$this->assertEquals(1025, $propFind->get(self::SIZE_PROPERTYNAME));
 		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals(null, $propFind->get(self::DOWNLOADURL_PROPERTYNAME));


### PR DESCRIPTION
Introduce a new property "oc:fileid" to return the internal file id.

This is because the original "oc:id" property is a compound and it is
not possible to extract the real id without knowing the instance id. The
instance id is not available to external clients.

Note: this is required for the new web UI impl that uses Webdav: https://github.com/owncloud/core/pull/16902
#### To test:
1. Create a folder "test"
2. Save the following into "propfind.txt"

``` xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
        <a:prop><oc:id/></a:prop>
        <a:prop><oc:fileid/></a:prop>
</a:propfind>
```
1. `curl -X PROPFIND -H "Content-Type: text/xml" --data-binary "@propfind.txt" http://root:admin@localhost/owncloud/remote.php/webdav/test | xmllint --format -`

This PR will output two additional properties, when requested as above:

``` xml
<d:response>
    <d:href>/owncloud/remote.php/webdav/test/</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>00000003ockbfur1449k</oc:id>
        <oc:fileid>3</oc:fileid>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
```

Please review @DeepDiver1975 @nickvergessen @icewind1991 @rullzer 

I'm also open to better suggestions. Another alternative is to expose the "instanceid" through some API to make it possible to extract the file id from "oc:id".
