### PR TITLE
Fix getOwner for external shares

### DIFF
--- a/apps/files_sharing/lib/external/storage.php
+++ b/apps/files_sharing/lib/external/storage.php
@@ -250,7 +250,7 @@ class Storage extends DAV implements ISharedStorage {
 			$response = $client->post($url, ['body' => ['password' => $password]]);
 		} catch (\GuzzleHttp\Exception\RequestException $e) {
 			if ($e->getCode() === 401 || $e->getCode() === 403) {
-					throw new ForbiddenException();
+				throw new ForbiddenException();
 			}
 			// throw this to be on the safe side: the share will still be visible
 			// in the UI in case the failure is intermittent, and the user will
@@ -259,5 +259,10 @@ class Storage extends DAV implements ISharedStorage {
 		}
 
 		return json_decode($response->getBody(), true);
+	}
+
+	public function getOwner($path) {
+		list(, $remote) = explode('://', $this->remote, 2);
+		return $this->remoteUser . '@' . $remote;
 	}
 }


### PR DESCRIPTION
Fixes #20580
- Implements `getOwner` for external shared storage
- Handle non-existing users when getting the owner object in the view (since the external owner doesn't exist locally)

cc @PVince81 @
