### PR TITLE
Use proper variable

### DIFF
--- a/apps/files_sharing/api/remote.php
+++ b/apps/files_sharing/api/remote.php
@@ -98,7 +98,7 @@ class Remote {
 	 */
 	private static function extendShareInfo($share) {
 		$view = new \OC\Files\View('/' . \OC_User::getUser() . '/files/');
-		$info = $view->getFileInfo($shares['mountpoint']);
+		$info = $view->getFileInfo($share['mountpoint']);
 
 		$share['mimetype'] = $info->getMimetype();
 		$share['mtime'] = $info->getMtime();


### PR DESCRIPTION
`$shares` is not defined. Introduced with https://github.com/owncloud/core/commit/c3e7d324c5e61eb087fb2ea5102d332f9f08db3d and thus also in stable8.2

cc @rullzer Please test and review. Your code. Also write "I shall use an IDE" 10 times :speak_no_evil: Also unit tests may help :speak_no_evil: 
cc @karlitschek Backport once @rullzer confirmed?
