### PR TITLE
Avoid double slashes in URL when trying to add an remote share

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -274,8 +274,12 @@ OCA.Sharing.PublicApp = {
 
 	_saveToOwnCloud: function (remote, token, owner, name, isProtected) {
 		var location = window.location.protocol + '//' + window.location.host + OC.webroot;
+		
+		if(remote.substr(-1) !== '/') {
+			remote += '/'
+		};
 
-		var url = remote + '/index.php/apps/files#' + 'remote=' + encodeURIComponent(location) // our location is the remote for the other server
+		var url = remote + 'index.php/apps/files#' + 'remote=' + encodeURIComponent(location) // our location is the remote for the other server
 			+ "&token=" + encodeURIComponent(token) + "&owner=" + encodeURIComponent(owner) + "&name=" + encodeURIComponent(name) + "&protected=" + isProtected;
 
 


### PR DESCRIPTION
When being on a link share and clicking "Add to your ownCloud" a double slash might be inserted in the URL if the entered ownCloud host ended with a slash. Results in a server error.

@LukasReschke @schiesbn @PVince81 
