### PR TITLE
Do not authenticate over ajax Webdav

### DIFF
--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -164,6 +164,13 @@ class Auth extends AbstractBasic {
 			return true;
 		}
 
+		if ($server->httpRequest->getHeader('X-Requested-With') === 'XMLHttpRequest') {
+			// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
+			$server->httpResponse->addHeader('WWW-Authenticate','DummyBasic realm="' . $realm . '"');
+			$server->httpResponse->setStatus(401);
+			throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
+		}
+
 		return parent::authenticate($server, $realm);
 	}
 }

--- a/apps/dav/tests/unit/connector/sabre/auth.php
+++ b/apps/dav/tests/unit/connector/sabre/auth.php
@@ -295,6 +295,28 @@ class Auth extends TestCase {
 		$this->auth->authenticate($server, 'TestRealm');
 	}
 
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotAuthenticated
+	 * @expectedExceptionMessage Cannot authenticate over ajax calls
+	 */
+	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjax() {
+		$server = $this->getMockBuilder('\Sabre\DAV\Server')
+			->disableOriginalConstructor()
+			->getMock();
+		$server->httpRequest = $this->getMockBuilder('\Sabre\HTTP\RequestInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		$server->httpResponse = $this->getMockBuilder('\Sabre\HTTP\ResponseInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		$server->httpRequest
+			->expects($this->once())
+			->method('getHeader')
+			->with('X-Requested-With')
+			->will($this->returnValue('XMLHttpRequest'));
+		$this->auth->authenticate($server, 'TestRealm');
+	}
+
 	public function testAuthenticateValidCredentials() {
 		$server = $this->getMockBuilder('\Sabre\DAV\Server')
 			->disableOriginalConstructor()
@@ -303,7 +325,12 @@ class Auth extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('getHeader')
+			->with('X-Requested-With')
+			->will($this->returnValue(null));
+		$server->httpRequest
+			->expects($this->at(1))
 			->method('getHeader')
 			->with('Authorization')
 			->will($this->returnValue('basic dXNlcm5hbWU6cGFzc3dvcmQ='));
@@ -340,7 +367,12 @@ class Auth extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('getHeader')
+			->with('X-Requested-With')
+			->will($this->returnValue(null));
+		$server->httpRequest
+			->expects($this->at(1))
 			->method('getHeader')
 			->with('Authorization')
 			->will($this->returnValue('basic dXNlcm5hbWU6cGFzc3dvcmQ='));


### PR DESCRIPTION
This makes sure that whenever a Webdav call is done through Ajax, if the
session has expired, it will not send back a challenge but a simple 401
response. Without this fix, the default code would send back a challenge
and trigger the browser's basic auth dialog.

This will be needed when we use Webdav more often in the web UI, as in https://github.com/owncloud/core/pull/16902

To test, check out the branch from https://github.com/owncloud/core/pull/16902, kill the session and then attempt to navigate into a folder (it will use PROPFIND).
Before this fix: basic auth dialog shows from the browser.
After this fix: no browser dialog, redirects to login page.

@LukasReschke @DeepDiver1975 @nickvergessen @rullzer please review
