### PR TITLE
Remove "Text file" entry in the "+" menu

### DIFF
--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -44,6 +44,11 @@
 			'click .menuitem': '_onClickAction'
 		},
 
+		/**
+		 * @type OCA.Files.FileList
+		 */
+		fileList: null,
+
 		initialize: function(options) {
 			var self = this;
 			var $uploadEl = $('#file_upload_start');
@@ -55,25 +60,16 @@
 				console.warn('Missing upload element "file_upload_start"');
 			}
 
-			this._fileList = options && options.fileList;
+			this.fileList = options && options.fileList;
 
 			this._menuItems = [{
-				id: 'file',
-				displayName: t('files', 'Text file'),
-				templateName: t('files', 'New text file.txt'),
-				iconClass: 'icon-filetype-text',
-				fileType: 'file',
-				actionHandler: function(name) {
-					self._fileList.createFile(name);
-				}
-		        }, {
 				id: 'folder',
 				displayName: t('files', 'Folder'),
 				templateName: t('files', 'New folder'),
 				iconClass: 'icon-folder',
 				fileType: 'folder',
 				actionHandler: function(name) {
-					self._fileList.createDirectory(name);
+					self.fileList.createDirectory(name);
 				}
 		        }];
 
@@ -149,7 +145,7 @@
 				try {
 					if (!Files.isFileNameValid(filename)) {
 						// Files.isFileNameValid(filename) throws an exception itself
-					} else if (self._fileList.inList(filename)) {
+					} else if (self.fileList.inList(filename)) {
 						throw t('files', '{newname} already exists', {newname: filename});
 					} else {
 						return true;

--- a/apps/files/tests/js/newfilemenuSpec.js
+++ b/apps/files/tests/js/newfilemenuSpec.js
@@ -46,7 +46,7 @@ describe('OCA.Files.NewFileMenu', function() {
 	describe('rendering', function() {
 		it('renders menu items', function() {
 			var $items = menu.$el.find('.menuitem');
-			expect($items.length).toEqual(3);
+			expect($items.length).toEqual(2);
 			// label points to the file_upload_start item
 			var $item = $items.eq(0);
 			expect($item.is('label')).toEqual(true);
@@ -55,39 +55,26 @@ describe('OCA.Files.NewFileMenu', function() {
 	});
 	describe('New file/folder', function() {
 		var $input;
-		var createFileStub;
 		var createDirectoryStub;
 
 		beforeEach(function() {
-			createFileStub = sinon.stub(FileList.prototype, 'createFile');
 			createDirectoryStub = sinon.stub(FileList.prototype, 'createDirectory');
 			menu.$el.find('.menuitem').eq(1).click();
 			$input = menu.$el.find('form.filenameform input');
 		});
 		afterEach(function() {
-			createFileStub.restore();
 			createDirectoryStub.restore();
 		});
 
 		it('sets default text in field', function() {
 			expect($input.length).toEqual(1);
-			expect($input.val()).toEqual('New text file.txt');
-		});
-		it('creates file when enter is pressed', function() {
-			$input.val('somefile.txt');
-			$input.trigger(new $.Event('keyup', {keyCode: 13}));
-			$input.parent('form').submit();
-
-			expect(createFileStub.calledOnce).toEqual(true);
-			expect(createFileStub.getCall(0).args[0]).toEqual('somefile.txt');
-			expect(createDirectoryStub.notCalled).toEqual(true);
+			expect($input.val()).toEqual('New folder');
 		});
 		it('prevents entering invalid file names', function() {
 			$input.val('..');
 			$input.trigger(new $.Event('keyup', {keyCode: 13}));
 			$input.closest('form').submit();
 
-			expect(createFileStub.notCalled).toEqual(true);
 			expect(createDirectoryStub.notCalled).toEqual(true);
 		});
 		it('prevents entering file names that already exist', function() {
@@ -96,16 +83,10 @@ describe('OCA.Files.NewFileMenu', function() {
 			$input.trigger(new $.Event('keyup', {keyCode: 13}));
 			$input.closest('form').submit();
 
-			expect(createFileStub.notCalled).toEqual(true);
 			expect(createDirectoryStub.notCalled).toEqual(true);
 			inListStub.restore();
 		});
-		it('switching fields removes the previous form', function() {
-			menu.$el.find('.menuitem').eq(2).click();
-			expect(menu.$el.find('form').length).toEqual(1);
-		});
 		it('creates directory when clicking on create directory field', function() {
-			menu.$el.find('.menuitem').eq(2).click();
 			$input = menu.$el.find('form.filenameform input');
 			$input.val('some folder');
 			$input.trigger(new $.Event('keyup', {keyCode: 13}));
@@ -113,7 +94,55 @@ describe('OCA.Files.NewFileMenu', function() {
 
 			expect(createDirectoryStub.calledOnce).toEqual(true);
 			expect(createDirectoryStub.getCall(0).args[0]).toEqual('some folder');
-			expect(createFileStub.notCalled).toEqual(true);
+		});
+	});
+	describe('custom entries', function() {
+		var oldPlugins;
+		var plugin;
+		var actionStub;
+
+		beforeEach(function() {
+			oldPlugins = _.extend({}, OC.Plugins._plugins);
+			actionStub = sinon.stub();
+			plugin = {
+				attach: function(menu) {
+					menu.addMenuEntry({
+						id: 'file',
+						displayName: t('files_texteditor', 'Text file'),
+						templateName: t('files_texteditor', 'New text file.txt'),
+						iconClass: 'icon-filetype-text',
+						fileType: 'file',
+						actionHandler: actionStub
+					});
+				}
+			};
+
+			OC.Plugins.register('OCA.Files.NewFileMenu', plugin);
+			menu = new OCA.Files.NewFileMenu({
+				fileList: fileList
+			});
+			menu.showAt($trigger);
+		});
+		afterEach(function() {
+			OC.Plugins._plugins = oldPlugins;
+		});
+		it('renders custom menu items', function() {
+			expect(menu.$el.find('.menuitem').length).toEqual(3);
+			expect(menu.$el.find('.menuitem[data-action=file]').length).toEqual(1);
+		});
+		it('calls action handler when clicking on custom item', function() {
+			menu.$el.find('.menuitem').eq(2).click();
+			var $input = menu.$el.find('form.filenameform input');
+			$input.val('some name');
+			$input.trigger(new $.Event('keyup', {keyCode: 13}));
+			$input.closest('form').submit();
+
+			expect(actionStub.calledOnce).toEqual(true);
+			expect(actionStub.getCall(0).args[0]).toEqual('some name');
+		});
+		it('switching fields removes the previous form', function() {
+			menu.$el.find('.menuitem').eq(2).click();
+			expect(menu.$el.find('form').length).toEqual(1);
 		});
 	});
 });


### PR DESCRIPTION
The text editor app will register this instead.

Also made "fileList" a non-private attribute to make it possible for
plugins to access the attached file list object.

This also means that when the text editor app is disabled, there will be no "Text file" menu entry any more.

Here is the PR that re-adds the entry, but from the text editor: https://github.com/owncloud/files_texteditor/pull/148
Both must be checked out (and merged) at the same time.

Note: as soon as https://github.com/owncloud/core/pull/16902 is merged there will also be a "+" menu in the public link page. Merging https://github.com/owncloud/files_texteditor/pull/148 and this one will make sure that the "Text file" entry does NOT appear in the public link page "+" menu, because there is no text editor support for public links (yet).

Please review @owncloud/designers @MorrisJobke @icewind1991 @nickvergessen @schiesbn @rullzer 
