### PR TITLE
Adjust the method name to reflect it's behaviour

### DIFF
--- a/lib/public/systemtag/isystemtagobjectmapper.php
+++ b/lib/public/systemtag/isystemtagobjectmapper.php
@@ -110,6 +110,6 @@ interface ISystemTagObjectMapper {
 	 *
 	 * @since 9.0.0
 	 */
-	public function hasTags($objIds, $objectType, $tagId, $all = true);
+	public function haveTag($objIds, $objectType, $tagId, $all = true);
 
 }


### PR DESCRIPTION
Should it be "haveTag" or "hasTag"?
I mean a lot of people autocomplete with has, get or set. But since we can pass multiple objects have would be more correct.
At least the s at the end is wrong.

@PVince81 up to you
