### PR TITLE
Fix image sizing for action icons in Edge

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -530,8 +530,8 @@ html.ie8 #fileList tr.selected td.filename>.selectCheckBox {
 }
 
 a.action > img {
-	max-height: 16px;
-	max-width: 16px;
+	height: 16px;
+	width: 16px;
 	vertical-align: text-bottom;
 }
 


### PR DESCRIPTION
Edge has a bug with svg sizing when using max-width/height

before:

![](https://i.imgur.com/a92DuHU.png)

after:

![](https://i.imgur.com/oj3VXfm.png)

cc @PVince81 
