### PR TITLE
treat LDAP users not available by user filter as deleted PR#2

### DIFF
--- a/apps/user_ldap/user_ldap.php
+++ b/apps/user_ldap/user_ldap.php
@@ -203,8 +203,12 @@ class USER_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		}
 
 		$dn = $user->getDN();
+		$userFilter = 'objectclass=*';
+		if ($this->access->connection->ldapUserFilter !== '') {
+			$userFilter = $this->access->connection->ldapUserFilter;
+		}
 		//check if user really still exists by reading its entry
-		if(!is_array($this->access->readAttribute($dn, ''))) {
+		if(!is_array($this->access->readAttribute($dn, 'cn', $userFilter))) {
 			$lcr = $this->access->connection->getConnectionResource();
 			if(is_null($lcr)) {
 				throw new \Exception('No LDAP Connection to server ' . $this->access->connection->ldapHost);


### PR DESCRIPTION
A different approach for the bug #15656. Passing the 'cn' attribute to readAttribute() function and don't modify the readAttribute() function itself.
