### PR TITLE
p() supports string as argument

### DIFF
--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -30,7 +30,7 @@
 
 /**
  * Prints a sanitized string
- * @param string|array $string the string which will be escaped and printed
+ * @param string $string the string which will be escaped and printed
  */
 function p($string) {
 	print(OC_Util::sanitizeHTML($string));


### PR DESCRIPTION
Replaces #18921 

The code never supported anything else. This then only fixes the documentation.

cc @PVince81 @nickvergessen @zyrill
