### PR TITLE
webdav docker tests - wait at least 5 seconds after the full startup

### DIFF
--- a/apps/files_external/tests/env/start-webdav-ownCloud.sh
+++ b/apps/files_external/tests/env/start-webdav-ownCloud.sh
@@ -62,7 +62,9 @@ while ! (nc -c -w 1 ${host} 80 </dev/null >&/dev/null \
     fi
 done
 echo
-sleep 1
+
+# wait at least 5 more seconds - sometimes the webserver still needs some additional time
+sleep 5
 
 cat > $thisFolder/config.webdav.php <<DELIM
 <?php


### PR DESCRIPTION
Makes the test execution more robust.

As wanted in IRC by @DeepDiver1975 ;)

cc @Xenopathic @nickvergessen 
