### PR TITLE
More consistent permissions for mount points

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -173,9 +173,13 @@ class FileTest extends \Test\TestCase {
 			->method('getRelativePath')
 			->will($this->returnArgument(0));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -233,9 +237,13 @@ class FileTest extends \Test\TestCase {
 
 		$_SERVER['HTTP_OC_CHUNKED'] = true;
 
-		$info = new \OC\Files\FileInfo('/test.txt-chunking-12345-2-0', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		], null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt-chunking-12345-2-0',
+			$this->getMockStorage(),
+			'/test.txt-chunking-12345-2-0',
+			['permissions' => \OCP\Constants::PERMISSION_ALL ],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
 		// put first chunk
@@ -243,9 +251,13 @@ class FileTest extends \Test\TestCase {
 		$this->assertNull($file->put('test data one'));
 		$file->releaseLock(ILockingProvider::LOCK_SHARED);
 
-		$info = new \OC\Files\FileInfo('/test.txt-chunking-12345-2-1', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		], null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt-chunking-12345-2-1',
+			$this->getMockStorage(),
+			'/test.txt-chunking-12345-2-1',
+			['permissions' => \OCP\Constants::PERMISSION_ALL ],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
 		// action
@@ -286,7 +298,7 @@ class FileTest extends \Test\TestCase {
 		$info = new \OC\Files\FileInfo(
 			$viewRoot . '/' . ltrim($path, '/'),
 			$this->getMockStorage(),
-			null,
+			$viewRoot . '/' . ltrim($path, '/'),
 			['permissions' => \OCP\Constants::PERMISSION_ALL],
 			null
 		);
@@ -543,9 +555,13 @@ class FileTest extends \Test\TestCase {
 		$_SERVER['CONTENT_LENGTH'] = 123456;
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -576,9 +592,13 @@ class FileTest extends \Test\TestCase {
 		// simulate situation where the target file is locked
 		$view->lockFile('/test.txt', ILockingProvider::LOCK_EXCLUSIVE);
 
-		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/' . $this->user . '/files/test.txt',
+			$this->getMockStorage(),
+			'/' . $this->user . '/files/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -611,17 +631,25 @@ class FileTest extends \Test\TestCase {
 
 		$_SERVER['HTTP_OC_CHUNKED'] = true;
 
-		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt-chunking-12345-2-0', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		], null);
+		$info = new \OC\Files\FileInfo(
+			'/' . $this->user . '/files/test.txt-chunking-12345-2-0',
+			$this->getMockStorage(),
+			'/' . $this->user . '/files/test.txt-chunking-12345-2-0',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 		$file->acquireLock(ILockingProvider::LOCK_SHARED);
 		$this->assertNull($file->put('test data one'));
 		$file->releaseLock(ILockingProvider::LOCK_SHARED);
 
-		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt-chunking-12345-2-1', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		], null);
+		$info = new \OC\Files\FileInfo(
+			'/' . $this->user . '/files/test.txt-chunking-12345-2-1',
+			$this->getMockStorage(),
+			'/' . $this->user . '/files/test.txt-chunking-12345-2-1',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
 		// action
@@ -648,9 +676,13 @@ class FileTest extends \Test\TestCase {
 			->method('getRelativePath')
 			->will($this->returnArgument(0));
 
-		$info = new \OC\Files\FileInfo('/*', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/*',
+			$this->getMockStorage(),
+			'/*',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
 		// action
@@ -684,9 +716,13 @@ class FileTest extends \Test\TestCase {
 			->method('getRelativePath')
 			->will($this->returnArgument(0));
 
-		$info = new \OC\Files\FileInfo('/*', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/*',
+			$this->getMockStorage(),
+			'/*',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 		$file->setName('/super*star.txt');
 	}
@@ -711,9 +747,13 @@ class FileTest extends \Test\TestCase {
 		$_SERVER['CONTENT_LENGTH'] = 12345;
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -747,9 +787,13 @@ class FileTest extends \Test\TestCase {
 			->method('unlink')
 			->will($this->returnValue(true));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -765,9 +809,13 @@ class FileTest extends \Test\TestCase {
 		$view = $this->getMock('\OC\Files\View',
 			array());
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => 0
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => 0],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -788,9 +836,13 @@ class FileTest extends \Test\TestCase {
 			->method('unlink')
 			->will($this->returnValue(false));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -811,9 +863,13 @@ class FileTest extends \Test\TestCase {
 			->method('unlink')
 			->willThrowException(new ForbiddenException('', true));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -847,7 +903,7 @@ class FileTest extends \Test\TestCase {
 		$info = new \OC\Files\FileInfo(
 			'/' . $this->user . '/files/' . $path,
 			$this->getMockStorage(),
-			null,
+			'/' . $this->user . '/files/' . $path,
 			['permissions' => \OCP\Constants::PERMISSION_ALL],
 			null
 		);
@@ -958,9 +1014,13 @@ class FileTest extends \Test\TestCase {
 			->method('fopen')
 			->will($this->returnValue(false));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 
@@ -976,9 +1036,13 @@ class FileTest extends \Test\TestCase {
 			->method('fopen')
 			->willThrowException(new ForbiddenException('', true));
 
-		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, array(
-			'permissions' => \OCP\Constants::PERMISSION_ALL
-		), null);
+		$info = new \OC\Files\FileInfo(
+			'/test.txt',
+			$this->getMockStorage(),
+			'/test.txt',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			null
+		);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
 

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -202,14 +202,20 @@ class SharedStorageTest extends TestCase {
 
 		// for the share root we expect:
 		// the shared permissions (1)
+		// the update permission (4), to allow rename/move
 		// the delete permission (8), to enable unshare
 		$rootInfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$this->assertSame(9, $rootInfo->getPermissions());
+		$this->assertSame(
+			\OCP\Constants::PERMISSION_READ |
+			\OCP\Constants::PERMISSION_UPDATE |
+			\OCP\Constants::PERMISSION_DELETE,
+			$rootInfo->getPermissions()
+		);
 
 		// for the file within the shared folder we expect:
 		// the shared permissions (1)
 		$subfileInfo = \OC\Files\Filesystem::getFileInfo($this->folder . $this->filename);
-		$this->assertSame(1, $subfileInfo->getPermissions());
+		$this->assertSame(\OCP\Constants::PERMISSION_READ, $subfileInfo->getPermissions());
 
 
 		//cleanup

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -202,6 +202,22 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^as "([^"]*)" gets list of folder "([^"]*)" with$/
+	 * @param string $user
+	 * @param string $path
+	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
+	 */
+	public function asGetsListOfFolderWith($user, $path, $propertiesTable) {
+		$properties = null;
+		if ($propertiesTable instanceof \Behat\Gherkin\Node\TableNode) {
+			foreach ($propertiesTable->getRows() as $row) {
+				$properties[] = $row[0];
+			}
+		}
+		$this->response = $this->listFolder($user, $path, 1, $properties);
+	}
+
+	/**
 	 * @Then the single response should contain a property :key with value :value
 	 * @param string $key
 	 * @param string $expectedValue
@@ -214,6 +230,41 @@ trait WebDav {
 		}
 
 		$value = $keys[$key];
+		if ($value !== $expectedValue) {
+			throw new \Exception("Property \"$key\" found with value \"$value\", expected \"$expectedValue\"");
+		}
+	}
+
+	/**
+	 * @Then the response for ":path" should contain a property :key with value :value
+	 * @param string $key
+	 * @param string $expectedValue
+	 * @throws \Exception
+	 */
+	public function theResponseForPathShouldContainAPropertyWithValue($path, $key, $expectedValue) {
+		$davPath = ltrim($this->davPath, '/');
+		$foundEntry = null;
+		$path = trim($path, '/');
+		foreach ($this->response as $href => $entry) {
+			$href = ltrim($href, '/');
+			if (strpos($href, $this->davPath) === 0) {
+				$href = substr($href, strlen($davPath) + 1);
+			}
+			$href = trim($href, '/');
+			if ($href === $path) {
+				$foundEntry = $entry;
+				break;
+			}
+		}
+		if (!$foundEntry) {
+			throw new \Exception("Path \"$path\" was not found in response");
+		}
+
+		if (!array_key_exists($key, $foundEntry)) {
+			throw new \Exception("Cannot find property \"$key\" with \"$expectedValue\" for path \"$path\"");
+		}
+
+		$value = $foundEntry[$key];
 		if ($value !== $expectedValue) {
 			throw new \Exception("Property \"$key\" found with value \"$value\", expected \"$expectedValue\"");
 		}

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -251,6 +251,7 @@ Feature: webdav-related
 			| 1 |
 			| 3 |
 
+
 	Scenario: Upload chunked file asc with new chunking
 		Given using dav path "remote.php/dav"
 		And user "user0" exists
@@ -293,4 +294,34 @@ Feature: webdav-related
 		And assure user "userToBeDisabled" is disabled
 		When Downloading file "/welcome.txt" as "userToBeDisabled"
 		Then the HTTP status code should be "503"
+
+	Scenario: Retrieving permissions for parent entry and entry itself
+		Given using dav path "remote.php/webdav"
+		And user "user0" exists
+		And As an "user0"
+		And user "user0" created a folder "/testperms"
+		When as "user0" gets properties of folder "/testperms" with
+			|{http://owncloud.org/ns}permissions|
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
+		When as "user0" gets list of folder "/" with
+			|{http://owncloud.org/ns}permissions|
+		Then the response for "/testperms" should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
+
+	Scenario: Retrieving permissions for parent entry and entry itself for share recipient
+		Given using dav path "remote.php/webdav"
+		And user "user0" exists
+		And user "user1" exists
+		And As an "user1"
+		And user "user1" created a folder "/testperms"
+		And as "user1" creating a share with
+		  | path | testperms |
+		  | shareType | 0 |
+		  | permissions | 31 |
+		  | shareWith | user0 |
+		When as "user0" gets properties of folder "/testperms" with
+			|{http://owncloud.org/ns}permissions|
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		When as "user0" gets list of folder "/" with
+			|{http://owncloud.org/ns}permissions|
+		Then the response for "/testperms" should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -31,6 +31,7 @@ namespace OC\Files;
 
 use OCP\Files\Cache\ICacheEntry;
 use OCP\IUser;
+use OC\Files\Mount\MoveableMount;
 
 class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	/**
@@ -207,6 +208,14 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 */
 	public function getPermissions() {
 		$perms = $this->data['permissions'];
+		// if this is the mount point itself
+		if ($this->internalPath === '') {
+			if ($this->mount instanceof MoveableMount) {
+				$perms = $perms | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+			} else {
+				$perms = $perms & (\OCP\Constants::PERMISSION_ALL - (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE));
+			}
+		}
 		if (\OCP\Util::isSharingDisabledForUser() || ($this->isShared() && !\OC\Share\Share::isResharingAllowed())) {
 			$perms = $perms & ~\OCP\Constants::PERMISSION_SHARE;
 		}

--- a/tests/lib/Files/FileInfoTest.php
+++ b/tests/lib/Files/FileInfoTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\Files;
+
+/**
+ * Class FileInfo
+ *
+ * @package Test\Files
+ */
+class FileInfoTest extends \Test\TestCase {
+
+	protected function getMockStorage() {
+		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('home::someuser'));
+		return $storage;
+	}
+
+	protected function getMockSharedStorage() {
+		$storage = $this->getMock('\OCP\Files\Storage');
+		$storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('shared::abcdefg'));
+		return $storage;
+	}
+
+	protected function getMockMount() {
+		$mount = $this->getMock('\OCP\Files\Mount');
+		return $mount;
+	}
+
+	protected function getMockMoveableMount() {
+		$mount = $this->getMock('\OC\Files\Mount\MoveableMount');
+		return $mount;
+	}
+
+	public function testGetPermissions() {
+		$fileInfo = new \OC\Files\FileInfo(
+			'/bar/foo',
+			$this->getMockStorage(),
+			'/bar/foo',
+			['permissions' => \OCP\Constants::PERMISSION_ALL],
+			$this->getMockMount()
+		);
+
+		$this->assertEquals(
+			\OCP\Constants::PERMISSION_ALL,
+			$fileInfo->getPermissions()
+		);
+	}
+
+	/**
+	 * @dataProvider moveablePermissionsProvider
+	 */
+	public function testGetPermissionsOnMount($mount, $mountPerms, $expectedPerms) {
+		$fileInfo = new \OC\Files\FileInfo(
+			'',
+			$this->getMockStorage(),
+			'',
+			['permissions' => $mountPerms],
+			$mount
+		);
+
+		$this->assertEquals(
+			$expectedPerms,
+			$fileInfo->getPermissions()
+		);
+	}
+
+	public function moveablePermissionsProvider() {
+		return [
+			// regular mount with all permissions
+			[
+				$this->getMockMount(),
+				\OCP\Constants::PERMISSION_ALL,
+				\OCP\Constants::PERMISSION_ALL - (\OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE),
+			],
+			// regular mount with less permissions
+			[
+				$this->getMockMount(),
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE,
+				\OCP\Constants::PERMISSION_READ,
+			],
+			// regular mount with less permissions
+			[
+				$this->getMockMount(),
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE,
+				\OCP\Constants::PERMISSION_READ,
+			],
+			// moveable mount with all permissions
+			[
+				$this->getMockMoveableMount(),
+				\OCP\Constants::PERMISSION_ALL,
+				\OCP\Constants::PERMISSION_ALL,
+			],
+			// moveable mount with less permissions
+			[
+				$this->getMockMoveableMount(),
+				\OCP\Constants::PERMISSION_READ,
+				// adds update and delete permissions even when they were not set
+				\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE,
+			],
+		];
+	}
+}

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -30,7 +30,7 @@ class FileTest extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', $this->getMockStorage(), '', $data, null);
+		return new FileInfo($data['path'], $this->getMockStorage(), $data['path'], $data, null);
 	}
 
 	public function testDelete() {
@@ -52,7 +52,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL
+			])));
 
 		$view->expects($this->once())
 			->method('unlink')
@@ -104,7 +107,12 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1, 'mimetype' => 'text/plain'))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'fileid' => 1,
+				'mimetype' => 'text/plain'
+			])));
 
 		$view->expects($this->once())
 			->method('unlink')
@@ -139,7 +147,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->delete();
@@ -171,7 +182,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+		])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$this->assertEquals('bar', $node->getContent());
@@ -195,7 +209,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => 0))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => 0,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->getContent();
@@ -216,7 +233,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$view->expects($this->once())
 			->method('file_put_contents')
@@ -241,7 +261,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->putContent('bar');
@@ -258,7 +281,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('mimetype' => 'text/plain'))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'mimetype' => 'text/plain',
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$this->assertEquals('text/plain', $node->getMimeType());
@@ -294,7 +320,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$fh = $node->fopen('r');
@@ -331,7 +360,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$fh = $node->fopen('w');
@@ -363,7 +395,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => 0))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => 0,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->fopen('r');
@@ -390,7 +425,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_UPDATE))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_UPDATE,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->fopen('w');
@@ -417,7 +455,10 @@ class FileTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$node->fopen('w');
@@ -440,7 +481,11 @@ class FileTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 3))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'fileid' => 3,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -484,7 +529,11 @@ class FileTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ, 'fileid' => 3))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+				'fileid' => 3,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -571,7 +620,11 @@ class FileTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'fileid' => 1,
+			])));
 
 		$node = new \OC\Files\Node\File($root, $view, '/bar/foo');
 		$parentNode = new \OC\Files\Node\Folder($root, $view, '/bar');
@@ -602,7 +655,10 @@ class FileTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$view->expects($this->never())
 			->method('rename');

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -40,7 +40,7 @@ class FolderTest extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', $this->getMockStorage(), '', $data, null);
+		return new FileInfo($data['path'], $this->getMockStorage(), $data['path'], $data, null);
 	}
 
 	public function testDelete() {
@@ -59,7 +59,10 @@ class FolderTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$view->expects($this->once())
 			->method('rmdir')
@@ -108,7 +111,10 @@ class FolderTest extends \Test\TestCase {
 
 		$view->expects($this->any())
 			->method('getFileInfo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1,
+			])));
 
 		$view->expects($this->once())
 			->method('rmdir')
@@ -142,7 +148,10 @@ class FolderTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->delete();
@@ -253,7 +262,10 @@ class FolderTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$view->expects($this->once())
 			->method('mkdir')
@@ -283,7 +295,10 @@ class FolderTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->newFolder('asd');
@@ -303,7 +318,10 @@ class FolderTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$view->expects($this->once())
 			->method('touch')
@@ -333,7 +351,10 @@ class FolderTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\Folder($root, $view, '/bar/foo');
 		$node->newFile('asd');

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -27,7 +27,7 @@ class NodeTest extends \Test\TestCase {
 	}
 
 	protected function getFileInfo($data) {
-		return new FileInfo('', $this->getMockStorage(), '', $data, null);
+		return new FileInfo($data['path'], $this->getMockStorage(), $data['path'], $data, null);
 	}
 
 	public function testStat() {
@@ -73,7 +73,8 @@ class NodeTest extends \Test\TestCase {
 			'fileid' => 1,
 			'size' => 100,
 			'etag' => 'qwerty',
-			'mtime' => 50
+			'path' => '/bar/foo',
+			'mtime' => 50,
 		));
 
 		$view->expects($this->once())
@@ -101,7 +102,8 @@ class NodeTest extends \Test\TestCase {
 			'fileid' => 1,
 			'size' => 100,
 			'etag' => 'qwerty',
-			'mtime' => 50
+			'path' => '/bar/foo',
+			'mtime' => 50,
 		));
 
 		$view->expects($this->once())
@@ -128,7 +130,8 @@ class NodeTest extends \Test\TestCase {
 			'fileid' => 1,
 			'size' => 100,
 			'etag' => 'qwerty',
-			'mtime' => 50
+			'path' => '/bar/foo',
+			'mtime' => 50,
 		));
 
 		$view->expects($this->once())
@@ -155,7 +158,8 @@ class NodeTest extends \Test\TestCase {
 			'fileid' => 1,
 			'size' => 100,
 			'etag' => 'qwerty',
-			'mtime' => 50
+			'path' => '/bar/foo',
+			'mtime' => 50,
 		));
 
 		$view->expects($this->once())
@@ -266,7 +270,10 @@ class NodeTest extends \Test\TestCase {
 		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);
@@ -319,7 +326,10 @@ class NodeTest extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_ALL,
+			])));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);
@@ -343,7 +353,10 @@ class NodeTest extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_READ))));
+			->will($this->returnValue($this->getFileInfo([
+				'path' => '/bar/foo',
+				'permissions' => \OCP\Constants::PERMISSION_READ,
+			])));
 
 		$node = new \OC\Files\Node\Node($root, $view, '/bar/foo');
 		$node->touch(100);


### PR DESCRIPTION
Whenever a mount point is retrieved through getFileInfo or a listing of
a directory, the permissions returned must be the same.

@icewind1991 is that what you meant in https://github.com/owncloud/core/issues/20426#issuecomment-157689999 ?

Note: this only makes the permissions consistent.

CC @rullzer @MorrisJobke 

TODO:
- [x] unit tests
