### PR TITLE
Fix public link getDownloadUrl to return Webdav public link

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -148,11 +148,14 @@ OCA.Sharing.PublicApp = {
 
 		if (this.fileList) {
 			// TODO: move this to a separate PublicFileList class that extends OCA.Files.FileList (+ unit tests)
-			this.fileList.getDownloadUrl = function (filename, dir) {
-				if ($.isArray(filename)) {
+			this.fileList.getDownloadUrl = function (filename, dir, isDir) {
+				var path = dir || this.getCurrentDirectory();
+				if (filename && !_.isArray(filename) && !isDir) {
+					return OC.getRootPath() + '/public.php/webdav' + OC.joinPaths(path, filename);
+				}
+				if (_.isArray(filename)) {
 					filename = JSON.stringify(filename);
 				}
-				var path = dir || FileList.getCurrentDirectory();
 				var params = {
 					path: path,
 					files: filename

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -101,12 +101,12 @@ describe('OCA.Sharing.PublicApp tests', function() {
 
 			it('returns correct download URL for single files', function() {
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=some%20file.txt');
-				expect(fileList.getDownloadUrl('some file.txt', '/anotherpath/abc'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fanotherpath%2Fabc&files=some%20file.txt');
+					.toEqual('/owncloud/public.php/webdav/subdir/some file.txt');
+				expect(fileList.getDownloadUrl('some file.txt', '/another path/abc'))
+					.toEqual('/owncloud/public.php/webdav/another path/abc/some file.txt');
 				fileList.changeDirectory('/');
 				expect(fileList.getDownloadUrl('some file.txt'))
-					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2F&files=some%20file.txt');
+					.toEqual('/owncloud/public.php/webdav/some file.txt');
 			});
 			it('returns correct download URL for multiple files', function() {
 				expect(fileList.getDownloadUrl(['a b c.txt', 'd e f.txt']))


### PR DESCRIPTION
This is for apps that use getDownloadUrl() to access the Webdav endpoint
for example for streaming.
Also happens when clicking on the download action of a file.

Note that the regular visible download URL is still the same.

This means that apps only need to call `FileList.getDownloadUrl(fileName)` which will return the correct Webdav URL for either public or non public page.

@MorrisJobke @rullzer @LukasReschke @nickvergessen  @VicDeo 
