### PR TITLE
auto-add ownClouds to the list of trusted servers

### DIFF
--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -22,7 +22,6 @@
 namespace OCA\Federation\AppInfo;
 
 use OCA\Federation\API\OCSAuthAPI;
-use OCA\Federation\Controller\AuthController;
 use OCA\Federation\Controller\SettingsController;
 use OCA\Federation\DbHandler;
 use OCA\Federation\Hooks;

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -25,11 +25,13 @@ use OCA\Federation\API\OCSAuthAPI;
 use OCA\Federation\Controller\AuthController;
 use OCA\Federation\Controller\SettingsController;
 use OCA\Federation\DbHandler;
+use OCA\Federation\Hooks;
 use OCA\Federation\Middleware\AddServerMiddleware;
 use OCA\Federation\TrustedServers;
 use OCP\API;
 use OCP\App;
 use OCP\AppFramework\IAppContainer;
+use OCP\Util;
 
 class Application extends \OCP\AppFramework\App {
 
@@ -125,6 +127,23 @@ class Application extends \OCP\AppFramework\App {
 			API::GUEST_AUTH
 		);
 
+	}
+
+	/**
+	 * listen to federated_share_added hooks to auto-add new servers to the
+	 * list of trusted servers.
+	 */
+	public function registerHooks() {
+
+		$container = $this->getContainer();
+		$hooksManager = new Hooks($container->query('TrustedServers'));
+
+		Util::connectHook(
+				'OCP\Share',
+				'federated_share_added',
+				$hooksManager,
+				'addServerHook'
+		);
 	}
 
 }

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -68,6 +68,7 @@ class DbHandler {
 	 */
 	public function addServer($url) {
 		$hash = $this->hash($url);
+		$url = rtrim($url, '/');
 		$query = $this->connection->getQueryBuilder();
 		$query->insert($this->dbTable)
 			->values(

--- a/apps/federation/lib/hooks.php
+++ b/apps/federation/lib/hooks.php
@@ -19,8 +19,32 @@
  *
  */
 
-namespace OCA\Federation\AppInfo;
 
-$app = new Application();
-$app->registerSettings();
-$app->registerHooks();
+namespace OCA\Federation;
+
+
+
+class Hooks {
+
+	/** @var TrustedServers */
+	private $trustedServers;
+
+	public function __construct(TrustedServers $trustedServers) {
+		$this->trustedServers = $trustedServers;
+	}
+
+	/**
+	 * add servers to the list of trusted servers once a federated share was established
+	 *
+	 * @param array $params
+	 */
+	public function addServerHook($params) {
+		if (
+			$this->trustedServers->getAutoAddServers() === true &&
+			$this->trustedServers->isTrustedServer($params['server']) === false
+		) {
+			$this->trustedServers->addServer($params['server']);
+		}
+	}
+
+}

--- a/apps/federation/tests/lib/dbhandlertest.php
+++ b/apps/federation/tests/lib/dbhandlertest.php
@@ -67,15 +67,31 @@ class DbHandlerTest extends TestCase {
 		$query->execute();
 	}
 
-	public function testAddServer() {
-		$id = $this->dbHandler->addServer('server1');
+	/**
+	 * @dataProvider dataTestAddServer
+	 *
+	 * @param string $url passed to the method
+	 * @param string $expectedUrl the url we expect to be written to the db
+	 * @param string $expectedHash the hash value we expect to be written to the db
+	 */
+	public function testAddServer($url, $expectedUrl, $expectedHash) {
+		$id = $this->dbHandler->addServer($url);
 
 		$query = $this->connection->getQueryBuilder()->select('*')->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		$this->assertSame(1, count($result));
-		$this->assertSame('server1', $result[0]['url']);
+		$this->assertSame($expectedUrl, $result[0]['url']);
 		$this->assertSame($id, (int)$result[0]['id']);
+		$this->assertSame($expectedHash, $result[0]['url_hash']);
 		$this->assertSame(TrustedServers::STATUS_PENDING, (int)$result[0]['status']);
+	}
+
+	public function dataTestAddServer() {
+		return [
+				['http://owncloud.org', 'http://owncloud.org', md5('owncloud.org')],
+				['https://owncloud.org', 'https://owncloud.org', md5('owncloud.org')],
+				['http://owncloud.org/', 'http://owncloud.org', md5('owncloud.org')],
+		];
 	}
 
 	public function testRemove() {

--- a/apps/federation/tests/lib/hookstest.php
+++ b/apps/federation/tests/lib/hookstest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Björn Schießle <schiessle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\Federation\Tests\lib;
+
+
+use OCA\Federation\Hooks;
+use OCA\Federation\TrustedServers;
+use Test\TestCase;
+
+class HooksTest extends TestCase {
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject | TrustedServers */
+	private $trustedServers;
+
+	/** @var  Hooks */
+	private $hooks;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+			->disableOriginalConstructor()->getMock();
+
+		$this->hooks = new Hooks($this->trustedServers);
+	}
+
+	/**
+	 * @dataProvider dataTestAddServerHook
+	 *
+	 * @param bool $autoAddEnabled is auto-add enabled
+	 * @param bool $isTrustedServer is the server already in the list of trusted servers
+	 * @param bool $addServer should the server be added
+	 */
+	public function testAddServerHook($autoAddEnabled, $isTrustedServer, $addServer) {
+		$this->trustedServers->expects($this->any())->method('getAutoAddServers')
+			->willReturn($autoAddEnabled);
+		$this->trustedServers->expects($this->any())->method('isTrustedServer')
+				->with('url')->willReturn($isTrustedServer);
+
+		if ($addServer) {
+			$this->trustedServers->expects($this->once())->method('addServer')
+				->with('url');
+		} else {
+			$this->trustedServers->expects($this->never())->method('addServer');
+		}
+
+		$this->hooks->addServerHook(['server' => 'url']);
+
+	}
+
+	public function dataTestAddServerHook() {
+		return [
+			[true, true, false],
+			[false, true, false],
+			[true, false, true],
+			[false, false, false],
+		];
+	}
+}

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -192,6 +192,8 @@ class Manager {
 			$acceptShare->execute(array(1, $mountPoint, $hash, $id, $this->uid));
 			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
 
+			\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $share['remote']]);
+
 			//FIXME $this->scrapNotification($share['remote_id']);
 			return true;
 		}

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2566,7 +2566,10 @@ class Share extends Constants {
 			$result = self::tryHttpPost($url, $fields);
 			$status = json_decode($result['result'], true);
 
-			return ($result['success'] && $status['ocs']['meta']['statuscode'] === 100);
+			if ($result['success'] && $status['ocs']['meta']['statuscode'] === 100) {
+				\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $remote]);
+				return true;
+			}
 
 		}
 


### PR DESCRIPTION
use hooks to auto add server to the list of trusted servers once a federated share was created

Steps to test:
- Enable the federation app
- Create a server-2-server share
- check the Admin section "Federation" if both server added the other server as trusted server

part of https://github.com/owncloud/core/issues/19566
