### PR TITLE
Consistent interface declaration OCP\Files\Node

### DIFF
--- a/lib/public/files/node.php
+++ b/lib/public/files/node.php
@@ -225,12 +225,4 @@ interface Node extends FileInfo {
 	 * @since 6.0.0
 	 */
 	public function getName();
-
-	/**
-	 * Get the file owner
-	 *
-	 * @since 9.0.0
-	 * @return string
-	 */
-	public function getOwner();
 }


### PR DESCRIPTION
\OCP\Files\Node already extends \OCP\Files\FileInfo. So there is no need to add the same function to both interfaces. Especially if they have different return values declared. https://github.com/owncloud/core/blob/master/lib/public/files/fileinfo.php#L233-L239

CC: @icewind1991 @PVince81 @LukasReschke @MorrisJobke 
