### PR TITLE
[Sharing 2.0] Add a new db column for the file owner

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -684,11 +684,25 @@
 			</field>
 
 			<!-- Foreign Key users::uid -->
+            <!-- This is the initiator of the share -->
 			<field>
 				<name>uid_owner</name>
 				<type>text</type>
 				<default></default>
 				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<!-- Foreign Key users::uid -->
+            <!-- This is the owner of the file, this can be
+                 different from the initiator of the share.
+                 The naming is subobtimal but prevents huge
+                 migration steps -->
+			<field>
+				<name>uid_fileowner</name>
+				<type>text</type>
+				<default></default>
+				<notnull>false</notnull>
 				<length>64</length>
 			</field>
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 0, 2);
+$OC_Version = array(9, 0, 0, 3);
 
 // The human readable string
 $OC_VersionString = '9.0 pre alpha';


### PR DESCRIPTION
This column is required since we make flat reshares. For the owner of the file we want to know all the files that are shared. Even if they are shared by someone we gave reshare permissions on a file.

Without this field we have to construct the path for each fileid in the share table and figure out the owner. This does not scale at all!

The field is currently not in use. But hopefully soon ;)

CC: @DeepDiver1975 @schiesbn @nickvergessen @PVince81 

For https://github.com/owncloud/core/issues/19331
