### PR TITLE
Fix overriding function from 3rdparty warning

### DIFF
--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -167,7 +167,7 @@ class Encryption extends Wrapper {
 			)
 		));
 
-		return self::wrapSource($source, $mode, $context, 'ocencryption', $wrapper);
+		return self::wrapSource($source, $context, 'ocencryption', $wrapper, $mode);
 	}
 
 	/**
@@ -181,7 +181,7 @@ class Encryption extends Wrapper {
 	 * @return resource
 	 * @throws \BadMethodCallException
 	 */
-	protected static function wrapSource($source, $mode, $context, $protocol, $class) {
+	protected static function wrapSource($source, $context, $protocol, $class, $mode = 'r+') {
 		try {
 			stream_wrapper_register($protocol, $class);
 			if (@rewinddir($source) === false) {


### PR DESCRIPTION
Fixes #20648 

Signature is now the same as the interface. But we extend it with the mode parameter (which defaults to 'r+', just like the interface).

CC: @schiesbn @icewind1991 
