### PR TITLE
Add command to get and set config for external mounts

### DIFF
--- a/apps/files_external/appinfo/register_command.php
+++ b/apps/files_external/appinfo/register_command.php
@@ -21,6 +21,7 @@
 
 
 use OCA\Files_External\Command\ListCommand;
+use OCA\Files_External\Command\Config;
 
 $userManager = OC::$server->getUserManager();
 $userSession = OC::$server->getUserSession();
@@ -32,3 +33,4 @@ $userStorageService = $app->getContainer()->query('\OCA\Files_external\Service\U
 
 /** @var Symfony\Component\Console\Application $application */
 $application->add(new ListCommand($globalStorageService, $userStorageService, $userSession, $userManager));
+$application->add(new Config($globalStorageService, $userStorageService, $userSession, $userManager));

--- a/apps/files_external/appinfo/register_command.php
+++ b/apps/files_external/appinfo/register_command.php
@@ -22,6 +22,7 @@
 
 use OCA\Files_External\Command\ListCommand;
 use OCA\Files_External\Command\Config;
+use OCA\Files_External\Command\Option;
 
 $userManager = OC::$server->getUserManager();
 $userSession = OC::$server->getUserSession();
@@ -33,4 +34,5 @@ $userStorageService = $app->getContainer()->query('\OCA\Files_external\Service\U
 
 /** @var Symfony\Component\Console\Application $application */
 $application->add(new ListCommand($globalStorageService, $userStorageService, $userSession, $userManager));
-$application->add(new Config($globalStorageService, $userStorageService, $userSession, $userManager));
+$application->add(new Config($globalStorageService));
+$application->add(new Option($globalStorageService));

--- a/apps/files_external/command/config.php
+++ b/apps/files_external/command/config.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Command;
+
+use OC\Core\Command\Base;
+use OCA\Files_external\Lib\StorageConfig;
+use OCA\Files_external\Service\GlobalStoragesService;
+use OCA\Files_external\Service\UserStoragesService;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Config extends Base {
+	/**
+	 * @var GlobalStoragesService
+	 */
+	private $globalService;
+
+	function __construct(GlobalStoragesService $globalService) {
+		parent::__construct();
+		$this->globalService = $globalService;
+	}
+
+	protected function configure() {
+		$this
+			->setName('files_external:config')
+			->setDescription('Manage backend configuration for a mount')
+			->addArgument(
+				'mount_id',
+				InputArgument::REQUIRED,
+				'The id of the mount to edit'
+			)->addArgument(
+				'key',
+				InputArgument::REQUIRED,
+				'key of the config option to set/get'
+			)->addArgument(
+				'value',
+				InputArgument::OPTIONAL,
+				'value to set the config option to, when no value is provided the existing value will be printed'
+			);
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$mountId = $input->getArgument('mount_id');
+		$key = $input->getArgument('key');
+		$mount = $this->globalService->getStorage($mountId);
+
+		if (!$mount instanceof StorageConfig) {
+			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
+			return;
+		}
+
+		$value = $input->getArgument('value');
+		if ($value) {
+			$this->setOption($mount, $key, $value, $output);
+		} else {
+			$this->getOption($mount, $key, $output);
+		}
+	}
+
+	/**
+	 * @param StorageConfig $mount
+	 * @param string $key
+	 * @param OutputInterface $output
+	 */
+	private function getOption(StorageConfig $mount, $key, OutputInterface $output) {
+		$value = $mount->getBackendOption($key);
+		if (!is_string($value)) { // show bools and objects correctly
+			$value = json_encode($value);
+		}
+		$output->writeln($value);
+	}
+
+	/**
+	 * @param StorageConfig $mount
+	 * @param string $key
+	 * @param string $value
+	 * @param OutputInterface $output
+	 */
+	private function setOption(StorageConfig $mount, $key, $value, OutputInterface $output) {
+		$decoded = json_decode($value, true);
+		if (!is_null($decoded)) {
+			$value = $decoded;
+		}
+		$mount->setBackendOption($key, $value);
+		$this->globalService->updateStorage($mount);
+	}
+}

--- a/apps/files_external/command/config.php
+++ b/apps/files_external/command/config.php
@@ -71,7 +71,7 @@ class Config extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return;
+			return 404;
 		}
 
 		$value = $input->getArgument('value');

--- a/apps/files_external/lib/storageconfig.php
+++ b/apps/files_external/lib/storageconfig.php
@@ -302,6 +302,25 @@ class StorageConfig implements \JsonSerializable {
 	}
 
 	/**
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function getMountOption($key) {
+		if (isset($this->mountOptions[$key])) {
+			return $this->mountOptions[$key];
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function setMountOption($key, $value) {
+		$this->mountOptions[$key] = $value;
+	}
+
+	/**
 	 * Gets the storage status, whether the config worked last time
 	 *
 	 * @return int $status status


### PR DESCRIPTION
Usage:

![usage](https://i.imgur.com/B8NAqFv.png)

Currently this only works for admin configured storage due to limitations in the way we store mounts, with https://github.com/owncloud/core/pull/20370 it can be extended to properly handle user configured mounts

cc @PVince81 @Xenopathic 
