### PR TITLE
Replace shitty netcat use with dedicated PHP script

### DIFF
--- a/apps/files_external/tests/env/start-amazons3-ceph.sh
+++ b/apps/files_external/tests/env/start-amazons3-ceph.sh
@@ -50,19 +50,10 @@ echo "${docker_image} container: $container"
 echo $container >> $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.amazons3
 
 echo -n "Waiting for ceph initialization"
-starttime=$(date +%s)
-# support for GNU netcat and BSD netcat
-while ! (nc -c -w 1 ${host} ${port} </dev/null >&/dev/null \
-    || nc -w 1 ${host} ${port} </dev/null >&/dev/null); do
-    sleep 1
-    echo -n '.'
-    if (( $(date +%s) > starttime + 60 )); then
-	echo
-	echo "[ERROR] Waited 60 seconds, no response" >&2
-	exit 1
-    fi
-done
-echo
+if ! "$thisFolder"/env/wait-for-connection ${host} ${port} 60; then
+    echo "[ERROR] Waited 60 seconds, no response" >&2
+    exit 1
+fi
 sleep 1
 
 echo "Create ceph user"

--- a/apps/files_external/tests/env/start-ftp-morrisjobke.sh
+++ b/apps/files_external/tests/env/start-ftp-morrisjobke.sh
@@ -55,19 +55,10 @@ echo "ftp container: $container"
 echo $container >> $thisFolder/dockerContainerMorrisJobke.$EXECUTOR_NUMBER.ftp
 
 echo -n "Waiting for ftp initialization"
-starttime=$(date +%s)
-# support for GNU netcat and BSD netcat
-while ! (nc -c -w 1 ${host} 21 </dev/null >&/dev/null \
-    || nc -w 1 ${host} 21 </dev/null >&/dev/null); do
-    sleep 1
-    echo -n '.'
-    if (( $(date +%s) > starttime + 60 )); then
-	echo
-	echo "[ERROR] Waited 60 seconds, no response" >&2
-	exit 1
-    fi
-done
-echo
+if ! "$thisFolder"/env/wait-for-connection ${host} 21 60; then
+    echo "[ERROR] Waited 60 seconds, no response" >&2
+    exit 1
+fi
 sleep 1
 
 if [ -n "$DEBUG" ]; then

--- a/apps/files_external/tests/env/start-sftp-atmoz.sh
+++ b/apps/files_external/tests/env/start-sftp-atmoz.sh
@@ -55,19 +55,10 @@ echo "sftp container: $container"
 echo $container >> $thisFolder/dockerContainerAtmoz.$EXECUTOR_NUMBER.sftp
 
 echo -n "Waiting for sftp initialization"
-starttime=$(date +%s)
-# support for GNU netcat and BSD netcat
-while ! (nc -c -w 1 ${host} 22 </dev/null >&/dev/null \
-    || nc -w 1 ${host} 22 </dev/null >&/dev/null); do
-    sleep 1
-    echo -n '.'
-    if (( $(date +%s) > starttime + 60 )); then
-	echo
-	echo "[ERROR] Waited 60 seconds, no response" >&2
-	exit 1
-    fi
-done
-echo
+if ! "$thisFolder"/env/wait-for-connection ${host} 22 60; then
+    echo "[ERROR] Waited 60 seconds, no response" >&2
+    exit 1
+fi
 sleep 1
 
 if [ -n "$DEBUG" ]; then

--- a/apps/files_external/tests/env/start-smb-silvershell.sh
+++ b/apps/files_external/tests/env/start-smb-silvershell.sh
@@ -53,19 +53,10 @@ echo "samba container: $container"
 echo $container >> $thisFolder/dockerContainerSilvershell.$EXECUTOR_NUMBER.smb
 
 echo -n "Waiting for samba initialization"
-starttime=$(date +%s)
-# support for GNU netcat and BSD netcat
-while ! (nc -c -w 1 ${host} 445 </dev/null >&/dev/null \
-    || nc -w 1 ${host} 445 </dev/null >&/dev/null); do
-    sleep 1
-    echo -n '.'
-    if (( $(date +%s) > starttime + 60 )); then
-	echo
-	echo "[ERROR] Waited 60 seconds, no response" >&2
-	exit 1
-    fi
-done
-echo
+if ! "$thisFolder"/env/wait-for-connection ${host} 445 60; then
+    echo "[ERROR] Waited 60 seconds, no response" >&2
+    exit 1
+fi
 sleep 1
 
 if [ -n "$DEBUG" ]; then

--- a/apps/files_external/tests/env/start-smb-windows.sh
+++ b/apps/files_external/tests/env/start-smb-windows.sh
@@ -19,8 +19,7 @@ user=smb-test
 password=!owncloud123
 host=WIN-9GTFAS08C15
 
-if ! (nc -c -w 1 ${host} 445 </dev/null >&/dev/null \
-    || nc -w 1 ${host} 445 </dev/null >&/dev/null); then
+if ! "$thisFolder"/env/wait-for-connection ${host} 445 0; then
     echo "[ERROR] Server not reachable" >&2
     exit 1
 fi

--- a/apps/files_external/tests/env/start-swift-ceph.sh
+++ b/apps/files_external/tests/env/start-swift-ceph.sh
@@ -57,19 +57,10 @@ echo "${docker_image} container: $container"
 echo $container >> $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.swift
 
 echo -n "Waiting for ceph initialization"
-starttime=$(date +%s)
-# support for GNU netcat and BSD netcat
-while ! (nc -c -w 1 ${host} 80 </dev/null >&/dev/null \
-    || nc -w 1 ${host} 80 </dev/null >&/dev/null); do
-    sleep 1
-    echo -n '.'
-    if (( $(date +%s) > starttime + 60 )); then
-	echo
-	echo "[ERROR] Waited 60 seconds, no response" >&2
-	exit 1
-    fi
-done
-echo
+if ! "$thisFolder"/env/wait-for-connection ${host} 80 60; then
+    echo "[ERROR] Waited 60 seconds, no response" >&2
+    exit 1
+fi
 sleep 1
 
 cat > $thisFolder/config.swift.php <<DELIM

--- a/apps/files_external/tests/env/wait-for-connection
+++ b/apps/files_external/tests/env/wait-for-connection
@@ -1,0 +1,45 @@
+#!/usr/bin/php
+<?php
+
+$timeout = 60;
+
+switch ($argc) {
+case 4:
+	$timeout = (float)$argv[3];
+case 3:
+	$host = $argv[1];
+	$port = (int)$argv[2];
+	break;
+default:
+	fwrite(STDERR, 'Usage: '.$argv[0].' host port [timeout]'."\n");
+	exit(2);
+}
+
+if ($timeout < 0) {
+	fwrite(STDERR, 'Timeout must be greater than zero'."\n");
+	exit(2);
+}
+if ($port < 1) {
+	fwrite(STDERR, 'Port must be an integer greater than zero'."\n");
+	exit(2);
+}
+
+$socketTimeout = (float)ini_get('default_socket_timeout');
+if ($socketTimeout > $timeout) {
+	$socketTimeout = $timeout;
+}
+
+$stopTime = time() + $timeout;
+do {
+	$sock = @fsockopen($host, $port, $errno, $errstr, $socketTimeout);
+	if ($sock !== false) {
+		fclose($sock);
+		fwrite(STDOUT, "\n");
+		exit(0);
+	}
+	sleep(1);
+	fwrite(STDOUT, '.');
+} while (time() < $stopTime);
+
+fwrite(STDOUT, "\n");
+exit(1);


### PR DESCRIPTION
Netcat is like Linux distros, there's hundreds of variants, each with a different way of doing things. The original scripts supported OpenBSD and GNU netcat, but Debian ships traditional netcat by default, FreeBSD has something else etc. Each with _different fcking command line options_.

So I've replaced it with a simple PHP script that does the same thing.

There was also a small update in getting the IP address of the webdav-ownCloud container, updated to the new syntax (the old syntax was actually broken in a strange way)

cc @DeepDiver1975 @MorrisJobke @butonic @PVince81 
