### PR TITLE
fix details on redirect and update page

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -538,6 +538,8 @@ html.ie8 #body-login form input[type="checkbox"] {
 }
 .error a.button {
 	color: #555 !important;
+	display: inline-block;
+	text-align: center;
 }
 .error pre {
 	white-space: pre-wrap;

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -240,8 +240,7 @@ body {
 }
 
 #body-login .update h2 {
-	line-height: 130%;
-	margin-bottom: 30px;
+	margin: 12px 0 20px;
 }
 
 #body-login .update a {

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -8,7 +8,7 @@
 		<?php } ?>
 		<?php if (!empty($_['appsToUpgrade'])) { ?>
 		<div class="infogroup">
-			<span class="bold"><?php p($l->t('These apps will be updated:')); ?></span>
+			<span><?php p($l->t('These apps will be updated:')); ?></span>
 			<ul class="content appList">
 				<?php foreach ($_['appsToUpgrade'] as $appInfo) { ?>
 				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
@@ -18,7 +18,7 @@
 		<?php } ?>
 		<?php if (!empty($_['incompatibleAppsList'])) { ?>
 		<div class="infogroup">
-			<span class="bold"><?php p($l->t('These incompatible apps will be disabled:')) ?></span>
+			<span><?php p($l->t('These incompatible apps will be disabled:')) ?></span>
 			<ul class="content appList">
 				<?php foreach ($_['incompatibleAppsList'] as $appInfo) { ?>
 				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
@@ -27,7 +27,7 @@
 		</div>
 		<?php } ?>
 		<?php if (!empty($_['oldTheme'])) { ?>
-		<div class="infogroup bold">
+		<div class="infogroup">
 			<?php p($l->t('The theme %s has been disabled.', array($_['oldTheme']))) ?>
 		</div>
 		<?php } ?>


### PR DESCRIPTION
Fix error page button text when label too long. Before & after:
![capture du 2015-11-25 13-06-26](https://cloud.githubusercontent.com/assets/925062/11397297/afd98a1c-9378-11e5-8485-5e97525579a7.png)![capture du 2015-11-25 13-06-00](https://cloud.githubusercontent.com/assets/925062/11397296/afbf5156-9378-11e5-9b54-a4b5ac99f75e.png)

Update page: fix heading whitespace and unbold less important sections. Before & after:
![capture du 2015-11-25 13-25-39](https://cloud.githubusercontent.com/assets/925062/11397295/afb75f82-9378-11e5-895f-dc2e49735e2e.png)![capture du 2015-11-25 13-15-07](https://cloud.githubusercontent.com/assets/925062/11397298/b0075938-9378-11e5-96ce-2f6abe3d45ef.png)

Please review @owncloud/designers 
