### PR TITLE
Remove last occurences of OC_Helper::getMimeType()

### DIFF
--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -370,7 +370,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		$stat['size'] = filesize($tmpFile);
 		$stat['mtime'] = $mTime;
 		$stat['storage_mtime'] = $mTime;
-		$stat['mimetype'] = \OC_Helper::getMimeType($tmpFile);
+		$stat['mimetype'] = \OC::$server->getMimeTypeDetector()->detect($tmpFile);
 		$stat['etag'] = $this->getETag($path);
 
 		$fileId = $this->getCache()->put($path, $stat);

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -402,18 +402,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * get the mimetype form a local file
-	 *
-	 * @param string $path
-	 * @return string
-	 * does NOT work for ownClouds filesystem, use OC_FileSystem::getMimeType instead
-	 * @deprecated 8.2.0 Use \OC::$server->getMimeTypeDetector()->detect($path)
-	 */
-	static function getMimeType($path) {
-		return \OC::$server->getMimeTypeDetector()->detect($path);
-	}
-
-	/**
 	 * Get a secure mimetype that won't expose potential XSS.
 	 *
 	 * @param string $mimeType

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -278,7 +278,7 @@ class OC_Installer{
 		}
 
 		//detect the archive type
-		$mime=OC_Helper::getMimeType($path);
+		$mime = \OC::$server->getMimeTypeDetector()->detect($path);
 		if ($mime !=='application/zip' && $mime !== 'application/x-gzip' && $mime !== 'application/x-bzip2') {
 			throw new \Exception($l->t("Archives of type %s are not supported", array($mime)));
 		}

--- a/lib/public/files.php
+++ b/lib/public/files.php
@@ -60,7 +60,7 @@ class Files {
 	 * @since 5.0.0
 	 */
 	static function getMimeType( $path ) {
-		return(\OC_Helper::getMimeType( $path ));
+		return \OC::$server->getMimeTypeDetector()->detect($path);
 	}
 
 	/**

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -71,29 +71,6 @@ class Test_Helper extends \Test\TestCase {
 		];
 	}
 
-	function testGetMimeType() {
-		$dir=OC::$SERVERROOT.'/tests/data';
-		$result = OC_Helper::getMimeType($dir."/");
-		$expected = 'httpd/unix-directory';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::getMimeType($dir."/data.tar.gz");
-		$expected = 'application/x-gzip';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::getMimeType($dir."/data.zip");
-		$expected = 'application/zip';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::getMimeType($dir."/desktopapp.svg");
-		$expected = 'image/svg+xml';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::getMimeType($dir."/desktopapp.png");
-		$expected = 'image/png';
-		$this->assertEquals($result, $expected);
-	}
-
 	function testGetSecureMimeType() {
 		$dir=OC::$SERVERROOT.'/tests/data';
 


### PR DESCRIPTION
- ref #4774

cc @PVince81 @nickvergessen @rullzer 

This just brings up the very same code out of the method call `OC_Helper::getMimeType` https://github.com/owncloud/core/blob/8f09d5b67c3689eb90690d0c8b58bcfec68e60dd/lib/private/helper.php#L413-L413
