### PR TITLE
Remove unused internal methods

### DIFF
--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -645,37 +645,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * replaces a copy of string delimited by the start and (optionally) length parameters with the string given in replacement.
-	 *
-	 * @param string $string
-	 * @param string $replacement The replacement string.
-	 * @param int $start If start is positive, the replacing will begin at the start'th offset into string. If start is negative, the replacing will begin at the start'th character from the end of string.
-	 * @param int $length Length of the part to be replaced
-	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
-	 * @return string
-	 * @deprecated 8.2.0 Use substr_replace() instead.
-	 */
-	public static function mb_substr_replace($string, $replacement, $start, $length = 0, $encoding = 'UTF-8') {
-		return substr_replace($string, $replacement, $start, $length);
-	}
-
-	/**
-	 * Replace all occurrences of the search string with the replacement string
-	 *
-	 * @param string $search The value being searched for, otherwise known as the needle.
-	 * @param string $replace The replacement
-	 * @param string $subject The string or array being searched and replaced on, otherwise known as the haystack.
-	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
-	 * @param int $count If passed, this will be set to the number of replacements performed.
-	 * @return string
-	 * @deprecated 8.2.0 Use str_replace() instead.
-	 *
-	 */
-	public static function mb_str_replace($search, $replace, $subject, $encoding = 'UTF-8', &$count = null) {
-		return str_replace($search, $replace, $subject, $count);
-	}
-
-	/**
 	 * performs a search in a nested array
 	 * @param array $haystack the array to be searched
 	 * @param string $needle the search string

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -544,7 +544,7 @@ class Util {
 	 * @deprecated 8.2.0 Use substr_replace() instead.
 	 */
 	public static function mb_substr_replace($string, $replacement, $start, $length = null, $encoding = 'UTF-8') {
-		return(\OC_Helper::mb_substr_replace($string, $replacement, $start, $length, $encoding));
+		return substr_replace($string, $replacement, $start, $length);
 	}
 
 	/**
@@ -560,7 +560,7 @@ class Util {
 	 * @deprecated 8.2.0 Use str_replace() instead.
 	 */
 	public static function mb_str_replace($search, $replace, $subject, $encoding = 'UTF-8', &$count = null) {
-		return(\OC_Helper::mb_str_replace($search, $replace, $subject, $encoding, $count));
+		return str_replace($search, $replace, $subject, $count);
 	}
 
 	/**

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -164,18 +164,6 @@ class Test_Helper extends \Test\TestCase {
 		$this->assertEquals($result, $expected);
 	}
 
-	function testMb_substr_replace() {
-		$result = OC_Helper::mb_substr_replace("This  is a teststring", "string", 5);
-		$expected = "This string is a teststring";
-		$this->assertEquals($result, $expected);
-	}
-
-	function testMb_str_replace() {
-		$result = OC_Helper::mb_str_replace("teststring", "string", "This is a teststring");
-		$expected = "This is a string";
-		$this->assertEquals($result, $expected);
-	}
-
 	function testRecursiveArraySearch() {
 		$haystack = array(
 			"Foo" => "own",


### PR DESCRIPTION
- removes OC_Helper::mb_substr_replace and OC_Helper::mb_str_replace
- keeps public interface wrapper working as expected

cc @PVince81 @nickvergessen @LukasReschke @DeepDiver1975 
