### PR TITLE
Use mount providers for setting up home and cache storages

### DIFF
--- a/lib/private/files/mount/cachemountprovider.php
+++ b/lib/private/files/mount/cachemountprovider.php
@@ -26,6 +26,9 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IUser;
 
+/**
+ * Mount provider for custom cache mount
+ */
 class CacheMountProvider implements IMountProvider {
 	/**
 	 * @var IConfig
@@ -42,7 +45,7 @@ class CacheMountProvider implements IMountProvider {
 	}
 
 	/**
-	 * Get the home mount for a user
+	 * Get the cache mount for a user
 	 *
 	 * @param IUser $user
 	 * @param IStorageFactory $loader

--- a/lib/private/files/mount/cachemountprovider.php
+++ b/lib/private/files/mount/cachemountprovider.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+
+class CacheMountProvider implements IMountProvider {
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * ObjectStoreHomeMountProvider constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Get the home mount for a user
+	 *
+	 * @param IUser $user
+	 * @param IStorageFactory $loader
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 */
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+		$cacheBaseDir = $this->config->getSystemValue('cache_path', '');
+		if ($cacheBaseDir !== '') {
+			$cacheDir = rtrim($cacheBaseDir, '/') . '/' . $user->getUID();
+			if (!file_exists($cacheDir)) {
+				mkdir($cacheDir, 0770, true);
+			}
+
+			return [
+				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir, $loader])
+			];
+		} else {
+			return [];
+		}
+	}
+}

--- a/lib/private/files/mount/homemountprovider.php
+++ b/lib/private/files/mount/homemountprovider.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+
+class HomeMountProvider implements IMountProvider {
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * ObjectStoreHomeMountProvider constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Get the home mount for a user
+	 *
+	 * @param IUser $user
+	 * @param IStorageFactory $loader
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 */
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+		$objectStore = $this->config->getSystemValue('objectstore');
+
+		if (is_array($objectStore)) {
+			return []; // ObjectStoreHomeMountProvider will provide the object store home storage
+		} else {
+			return [
+				new MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), ['user' => $user], $loader)
+			];
+		}
+	}
+}

--- a/lib/private/files/mount/homemountprovider.php
+++ b/lib/private/files/mount/homemountprovider.php
@@ -54,8 +54,12 @@ class HomeMountProvider implements IMountProvider {
 		if (is_array($objectStore)) {
 			return []; // ObjectStoreHomeMountProvider will provide the object store home storage
 		} else {
+			$legacy = \OC\Files\Cache\Storage::exists('local::' . $user->getHome() . '/');
 			return [
-				new MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), ['user' => $user], $loader)
+				new MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), [
+					'user' => $user,
+					'legacy' => $legacy
+				], $loader)
 			];
 		}
 	}

--- a/lib/private/files/mount/objectstorehomemountprovider.php
+++ b/lib/private/files/mount/objectstorehomemountprovider.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IUser;
+
+class ObjectStoreHomeMountProvider implements IMountProvider {
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * ObjectStoreHomeMountProvider constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	/**
+	 * Get the home mount for a user
+	 *
+	 * @param IUser $user
+	 * @param IStorageFactory $loader
+	 * @return \OCP\Files\Mount\IMountPoint[]
+	 * @throws \Exception
+	 */
+	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+		$homeStorage = $this->config->getSystemValue('objectstore');
+		if (!is_array($homeStorage)) {
+			return []; // HomeMountProvider will provide the regular home storage
+		}
+		// sanity checks
+		if (empty($homeStorage['class'])) {
+			throw new \Exception('No class given for objectstore');
+		}
+		if (!isset($homeStorage['arguments'])) {
+			$homeStorage['arguments'] = [];
+		}
+
+		$objectStore = new $homeStorage['class']($homeStorage['arguments']);
+
+		return [
+			new MountPoint('\OC\Files\ObjectStore\HomeObjectStoreStorage', '/' . $user->getUID(), [
+				'objectstore' => $objectStore,
+				'user' => $user
+			], $loader)
+		];
+	}
+}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -47,6 +47,9 @@ use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\NullEventLogger;
 use OC\Diagnostics\NullQueryLogger;
 use OC\Diagnostics\QueryLogger;
+use OC\Files\Mount\CacheMountProvider;
+use OC\Files\Mount\HomeMountProvider;
+use OC\Files\Mount\ObjectStoreHomeMountProvider;
 use OC\Files\Node\HookConnector;
 use OC\Files\Node\Root;
 use OC\Files\View;
@@ -388,9 +391,18 @@ class Server extends SimpleContainer implements IServerContainer {
 				$c->getL10N('lib', $language)
 			);
 		});
-		$this->registerService('MountConfigManager', function () {
+		$this->registerService('MountConfigManager', function (Server $c) {
 			$loader = \OC\Files\Filesystem::getLoader();
-			return new \OC\Files\Config\MountProviderCollection($loader);
+			$manager =  new \OC\Files\Config\MountProviderCollection($loader);
+
+			// register builtin providers
+
+			$config = $c->getConfig();
+			$manager->registerProvider(new HomeMountProvider($config));
+			$manager->registerProvider(new ObjectStoreHomeMountProvider($config));
+			$manager->registerProvider(new CacheMountProvider($config));
+
+			return $manager;
 		});
 		$this->registerService('IniWrapper', function ($c) {
 			return new IniGetWrapper();

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -8,6 +8,9 @@
 namespace Test\Files;
 
 use OC\Files\Cache\Watcher;
+use OC\Files\Mount\CacheMountProvider;
+use OC\Files\Mount\HomeMountProvider;
+use OC\Files\Mount\ObjectStoreHomeMountProvider;
 use OC\Files\Storage\Common;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
@@ -107,6 +110,10 @@ class View extends \Test\TestCase {
 
 		$mountProviderCollection = \OC::$server->getMountProviderCollection();
 		\Test\TestCase::invokePrivate($mountProviderCollection, 'providers', [[]]);
+		$config = \OC::$server->getConfig();
+		$mountProviderCollection->registerProvider(new HomeMountProvider($config));
+		$mountProviderCollection->registerProvider(new ObjectStoreHomeMountProvider($config));
+		$mountProviderCollection->registerProvider(new CacheMountProvider($config));
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
Mounting all user storages trough the same code path makes it easier to keep track of it and add things like a user-storage mapping table

cc @PVince81
