### PR TITLE
Only reject ajax auth if user is really logged out

### DIFF
--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -159,7 +159,7 @@ class Auth extends AbstractBasic {
 			return [true, $this->principalPrefix . $user];
 		}
 
-		if ($request->getHeader('X-Requested-With') === 'XMLHttpRequest') {
+		if (!$this->userSession->isLoggedIn() && $request->getHeader('X-Requested-With') === 'XMLHttpRequest') {
 			// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
 			$response->addHeader('WWW-Authenticate','DummyBasic realm="' . $this->realm . '"');
 			$response->setStatus(401);

--- a/apps/dav/tests/unit/connector/sabre/auth.php
+++ b/apps/dav/tests/unit/connector/sabre/auth.php
@@ -309,11 +309,41 @@ class Auth extends TestCase {
 		$httpResponse = $this->getMockBuilder('\Sabre\HTTP\ResponseInterface')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->userSession
+			->expects($this->any())
+			->method('isLoggedIn')
+			->will($this->returnValue(false));
 		$httpRequest
 			->expects($this->once())
 			->method('getHeader')
 			->with('X-Requested-With')
 			->will($this->returnValue('XMLHttpRequest'));
+		$this->auth->check($httpRequest, $httpResponse);
+	}
+
+	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn() {
+		/** @var \Sabre\HTTP\RequestInterface $httpRequest */
+		$httpRequest = $this->getMockBuilder('\Sabre\HTTP\RequestInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		/** @var \Sabre\HTTP\ResponseInterface $httpResponse */
+		$httpResponse = $this->getMockBuilder('\Sabre\HTTP\ResponseInterface')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession
+			->expects($this->any())
+			->method('isLoggedIn')
+			->will($this->returnValue(true));
+		$this->session
+			->expects($this->once())
+			->method('get')
+			->with('AUTHENTICATED_TO_DAV_BACKEND')
+			->will($this->returnValue('MyTestUser'));
+		$httpRequest
+			->expects($this->once())
+			->method('getHeader')
+			->with('Authorization')
+			->will($this->returnValue(null));
 		$this->auth->check($httpRequest, $httpResponse);
 	}
 


### PR DESCRIPTION
Tentative fix for: https://github.com/owncloud/core/issues/20727

It seems that in some cases the Webdav auth can overrule (or underrule?) the regular session, and that makes the condition at the top be false even though `isLoggedIn()` was true.

This fix makes sure we only throw the ajax special 401 when the user is actually logged out.

Note: I could not test this as I couldn't reproduce the issue.

Please review @nickvergessen @LukasReschke @MorrisJobke 
