### PR TITLE
CSS Bug Fix on DatePicker

### DIFF
--- a/core/css/jquery-ui-fixes.css
+++ b/core/css/jquery-ui-fixes.css
@@ -23,6 +23,12 @@
 .ui-widget-header a {
 	color: #ffffff;
 }
+.ui-datepicker select.ui-datepicker-year option, .ui-datepicker select.ui-datepicker-month option {
+  	color: #000;
+}
+.ui-datepicker select.ui-date-picker-year:checked, .ui-datepicker select.ui-datepicker-month:checked {
+  	color: #fff;
+}
 
 /* Interaction states
 ----------------------------------*/

--- a/core/vendor/jquery-ui/themes/base/jquery-ui.css
+++ b/core/vendor/jquery-ui/themes/base/jquery-ui.css
@@ -283,12 +283,6 @@ button.ui-button::-moz-focus-inner {
 .ui-datepicker select.ui-datepicker-year {
 	width: 49%;
 }
-.ui-datepicker select.ui-datepicker-year option, .ui-datepicker select.ui-datepicker-month option {
-  	color: #000;
-}
-.ui-datepicker select.ui-date-picker-year:checked, .ui-datepicker select.ui-datepicker-month:checked {
-  	color: #fff;
-}
 .ui-datepicker table {
 	width: 100%;
 	font-size: .9em;

--- a/core/vendor/jquery-ui/themes/base/jquery-ui.css
+++ b/core/vendor/jquery-ui/themes/base/jquery-ui.css
@@ -283,6 +283,12 @@ button.ui-button::-moz-focus-inner {
 .ui-datepicker select.ui-datepicker-year {
 	width: 49%;
 }
+.ui-datepicker select.ui-datepicker-year option, .ui-datepicker select.ui-datepicker-month option {
+  	color: #000;
+}
+.ui-datepicker select.ui-date-picker-year:checked, .ui-datepicker select.ui-datepicker-month:checked {
+  	color: #fff;
+}
 .ui-datepicker table {
 	width: 100%;
 	font-size: .9em;


### PR DESCRIPTION
When adding a birthday to a contact, the month and year dropdowns are set as white font which is invisible against the white background. This fix adds a few rules to ensure that the dropdown options are in black text and the selected value is in white font as per main design.
