### PR TITLE
Add full interface of server container as alias

### DIFF
--- a/lib/private/appframework/dependencyinjection/dicontainer.php
+++ b/lib/private/appframework/dependencyinjection/dicontainer.php
@@ -225,6 +225,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerService('ServerContainer', function ($c) {
 			return $this->getServer();
 		});
+		$this->registerAlias('OCP\\IServerContainer', 'ServerContainer');
 
 		$this->registerService('Symfony\Component\EventDispatcher\EventDispatcherInterface', function ($c) {
 			return $this->getServer()->getEventDispatcher();


### PR DESCRIPTION
cc @nickvergessen @PVince81

This allows to use it with automatic dependency injection. 

@BernhardPosselt We also talked about the anti-pattern that this maybe could promote: Sometimes it is really needed to use the container and we agreed on providing this way. (even if it is already there - I only add the easy to use alias)
