### PR TITLE
Also allow empty value for no-HTTPS

### DIFF
--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -541,7 +541,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 		if (isset($this->server['HTTPS'])
 			&& $this->server['HTTPS'] !== null
-			&& $this->server['HTTPS'] !== 'off') {
+			&& $this->server['HTTPS'] !== 'off'
+			&& $this->server['HTTPS'] !== '') {
 			return 'https';
 		}
 

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -648,6 +648,26 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('http', $request->getServerProtocol());
 	}
 
+	public function testGetServerProtocolWithHttpsServerValueEmpty() {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('overwriteprotocol')
+			->will($this->returnValue(''));
+
+		$request = new Request(
+			[
+				'server' => [
+					'HTTPS' => ''
+				],
+			],
+			$this->secureRandom,
+			$this->config,
+			$this->stream
+		);
+		$this->assertSame('http', $request->getServerProtocol());
+	}
+
 	public function testGetServerProtocolDefault() {
 		$this->config
 			->expects($this->once())


### PR DESCRIPTION
This makes it work better with old version of Nginx.

Before 1.1.11 and `if_not_empty` option it was common to always set `HTTPS`, but to an empty value. This is still configured like that by default in stable Debian and Ubuntu.
