### PR TITLE
Dont bother with stream_resolve_include_path if the path is already absolute

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -170,7 +170,11 @@ class Autoloader {
 			// No cache or cache miss
 			$pathsToRequire = array();
 			foreach ($this->findClass($class) as $path) {
-				$fullPath = stream_resolve_include_path($path);
+				if ($path[0] === '/') {
+					$fullPath = file_exists($path) ? $path : false;
+				} else {
+					$fullPath = stream_resolve_include_path($path);
+				}
 				if ($fullPath && $this->isValidPath($fullPath)) {
 					$pathsToRequire[] = $fullPath;
 				}


### PR DESCRIPTION
Significantly improves the speed of our autoloder

[comparison](https://blackfire.io/profiles/compare/b7497e04-f194-4f61-ace2-b9a24c017dfe/graph)

This fix is brought to you by observations from looking at an strace log for a completely unrelated bug :smile: 

cc @DeepDiver1975 @PVince81 
