### PR TITLE
[stable8.1] Deduplicate queued trashbin expire jobs

### DIFF
--- a/apps/files_trashbin/command/expire.php
+++ b/apps/files_trashbin/command/expire.php
@@ -38,17 +38,10 @@ class Expire implements ICommand {
 	private $user;
 
 	/**
-	 * @var int
-	 */
-	private $trashBinSize;
-
-	/**
 	 * @param string $user
-	 * @param int $trashBinSize
 	 */
-	function __construct($user, $trashBinSize) {
+	function __construct($user) {
 		$this->user = $user;
-		$this->trashBinSize = $trashBinSize;
 	}
 
 	public function handle() {
@@ -60,7 +53,7 @@ class Expire implements ICommand {
 
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($this->user);
-		Trashbin::expire($this->trashBinSize, $this->user);
+		Trashbin::expire($this->user);
 		\OC_Util::tearDownFS();
 	}
 }

--- a/apps/files_trashbin/tests/command/expiretest.php
+++ b/apps/files_trashbin/tests/command/expiretest.php
@@ -26,7 +26,7 @@ use Test\TestCase;
 
 class ExpireTest extends TestCase {
 	public function testExpireNonExistingUser() {
-		$command = new Expire('test', 0);
+		$command = new Expire('test');
 		$command->handle();
 
 		$this->assertTrue(true);


### PR DESCRIPTION
- fixes #20425
- this removes the argument trashbin size from the expire job - it is now
  calculated in the expire job
- the queue now detects properly that the job is already queue and doesn't
  add it again
- backport of #20790
