### PR TITLE
Don't trust update server

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -4,7 +4,7 @@
 <!--[if (gt IE 9)|!(IE)]><!--><html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" ><!--<![endif]-->
 	<head data-user="<?php p($_['user_uid']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>"
 		<?php if ($_['updateAvailable']): ?>
-			data-update-version="<?php print($_['updateVersion']); ?>" data-update-link="<?php print_unescaped($_['updateLink']); ?>"
+			data-update-version="<?php p($_['updateVersion']); ?>" data-update-link="<?php p($_['updateLink']); ?>"
 		<?php endif; ?>
 		>
 		<meta charset="utf-8">

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -85,7 +85,9 @@ class OC_TemplateLayout extends OC_Template {
 				if(isset($data['version']) && $data['version'] != '' and $data['version'] !== Array()) {
 					$this->assign('updateAvailable', true);
 					$this->assign('updateVersion', $data['versionstring']);
-					$this->assign('updateLink', $data['web']);
+					if(substr($data['web'], 0, 8) === 'https://') {
+						$this->assign('updateLink', $data['web']);
+					}
 					\OCP\Util::addScript('core', 'update-notification');
 				} else {
 					$this->assign('updateAvailable', false); // No update available or not an admin user


### PR DESCRIPTION
In case the update server may deliver malicious content this would allow an adversary to inject arbitrary HTML into the response. So very bad stuff.

While signing the response would be better and something we can also do in the future (considering the code signing work), this is already a good first start.
