### PR TITLE
Revert "Dont bother with stream_resolve_include_path if the path is already absolute"

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -170,11 +170,7 @@ class Autoloader {
 			// No cache or cache miss
 			$pathsToRequire = array();
 			foreach ($this->findClass($class) as $path) {
-				if ($path[0] === '/') {
-					$fullPath = file_exists($path) ? $path : false;
-				} else {
-					$fullPath = stream_resolve_include_path($path);
-				}
+				$fullPath = stream_resolve_include_path($path);
 				if ($fullPath && $this->isValidPath($fullPath)) {
 					$pathsToRequire[] = $fullPath;
 				}


### PR DESCRIPTION
Reverts owncloud/core#20792 (for quickfix)

Fixes regression: https://github.com/owncloud/core/issues/20819

Unless there is a better solution ? @icewind1991 @DeepDiver1975 
