### PR TITLE
Fix already defined warning from dav test bootstrap

### DIFF
--- a/apps/dav/tests/unit/bootstrap.php
+++ b/apps/dav/tests/unit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
-define('PHPUNIT_RUN', 1);
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
 
 require_once __DIR__.'/../../../../lib/base.php';
 


### PR DESCRIPTION
Prevents

> PHP Notice:  Constant PHPUNIT_RUN already defined in /ssd/jenkins/workspace/core-ci-linux-swift-primary-storage/database/mysql/label/SLAVE/apps/dav/tests/unit/bootstrap.php on line 3

cc @DeepDiver1975 
