### PR TITLE
Fix ext storage mount options dropdown

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -460,7 +460,6 @@ MountOptionsDropdown.prototype = {
 
 		var $el = $(template());
 		this.$el = $el;
-		$el.addClass('hidden');
 
 		this.setOptions(mountOptions, enabledOptions);
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20566

Not sure why it had the "hidden" class in the first place...

To test: select an external storage type in the UI then click directly on the cog icon.
Before: mount options did not appear
After: mount options dropdown visible

Please review @MorrisJobke @icewind1991 @Xenopathic @nickvergessen 
