### PR TITLE
Fix column width of mtime column

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -224,8 +224,8 @@ table th.column-last, table td.column-last {
 	box-sizing: border-box;
 	position: relative;
 	/* this can not be just width, both need to be set … table styling */
-	min-width: 130px;
-	max-width: 130px;
+	min-width: 165px;
+	max-width: 165px;
 }
 
 /* Multiselect bar */


### PR DESCRIPTION
- in some translations (e.g. german) the header of this column otherwise
  got truncated
  "Zeitpunkt der Freigabe" vs "Zeitpunkt der Freig"

Before:
![bildschirmfoto 2015-11-30 um 16 28 45](https://cloud.githubusercontent.com/assets/245432/11475834/c349d5f6-977f-11e5-807e-347afcf3399e.png)

After:
![bildschirmfoto 2015-11-30 um 16 28 14](https://cloud.githubusercontent.com/assets/245432/11475837/c8e5d226-977f-11e5-9e69-a85963af04d0.png)

Steps:
- switch to german
- share a file
- go to "shared by you"

00004281

@owncloud/designers @PVince81 @raghunayyar @Henni Please review

@karlitschek Also occurs in stable8.2 and I would like to backport this.
