### PR TITLE
Fix the width of the share with input

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -28,7 +28,7 @@
 	width: 94%;
 	margin-left: 0;
 }
-.shareTabView #shareWith {
+.shareTabView input[type="text"].shareWithField {
 	width: 80%;
 }
 


### PR DESCRIPTION
- the ID of this has changed to #shareWith-viewNUMBER and shouldn't
  be used in CSS
- now uses the proper classes
- fixes #20061 - replaces #20096

Please review @owncloud/designers @PVince81 @Henni @schiesbn @raghunayyar 

@karlitschek I would like to backport this to stable8.2 because there the little "i" beside the input also jumps around and is hard to discover.
