### PR TITLE
[stable8.2] Fix the width of the share with input

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -28,7 +28,7 @@
 	width: 94%;
 	margin-left: 0;
 }
-.shareTabView #shareWith {
+.shareTabView input[type="text"].shareWithField {
 	width: 80%;
 }
 


### PR DESCRIPTION
- the ID of this has changed to #shareWith-viewNUMBER and shouldn't
  be used in CSS
- now uses the proper classes
- approved in https://github.com/owncloud/core/pull/20843#issuecomment-160668189

Please review @owncloud/designers @PVince81 @Henni @schiesbn @raghunayyar
