### PR TITLE
[stable8.2] Fix column width of mtime column

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -222,8 +222,8 @@ table th.column-last, table td.column-last {
 	box-sizing: border-box;
 	position: relative;
 	/* this can not be just width, both need to be set … table styling */
-	min-width: 130px;
-	max-width: 130px;
+	min-width: 165px;
+	max-width: 165px;
 }
 
 /* Multiselect bar */


### PR DESCRIPTION
- in some translations (e.g. german) the header of this column otherwise
  got truncated
  "Zeitpunkt der Freigabe" vs "Zeitpunkt der Freig"
- backport of #20842 

@owncloud/designers @PVince81 @raghunayyar @Henni @DeepDiver1975 Please review
