### PR TITLE
Make autotest.sh able to output proper coverage again

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -270,7 +270,7 @@ function execute_tests {
 
 	COVER=''
 	if [ -z "$NOCOVERAGE" ]; then
-		COVER='--coverage-clover "autotest-clover-$DB.xml" --coverage-html "coverage-html-$DB"'
+		COVER="--coverage-clover autotest-clover-$DB.xml --coverage-html coverage-html-$DB"
 	else
 		echo "No coverage"
 	fi


### PR DESCRIPTION
The usage of single quotes make sure that a string is used verbatim in
bash. And no variables are subsituted.

Introduced in https://github.com/owncloud/core/commit/678fe1b8f4c2e0557955e4552621074574970a62
