### PR TITLE
Add metadata to post delete hooks

### DIFF
--- a/lib/private/files/node/file.php
+++ b/lib/private/files/node/file.php
@@ -99,8 +99,9 @@ class File extends Node implements \OCP\Files\File {
 	public function delete() {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
 			$this->sendHooks(array('preDelete'));
+			$fileInfo = $this->getFileInfo();
 			$this->view->unlink($this->path);
-			$nonExisting = new NonExistingFile($this->root, $this->view, $this->path);
+			$nonExisting = new NonExistingFile($this->root, $this->view, $this->path, $fileInfo);
 			$this->root->emit('\OC\Files', 'postDelete', array($nonExisting));
 			$this->exists = false;
 			$this->fileInfo = null;

--- a/lib/private/files/node/folder.php
+++ b/lib/private/files/node/folder.php
@@ -295,8 +295,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 	public function delete() {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
 			$this->sendHooks(array('preDelete'));
+			$fileInfo = $this->getFileInfo();
 			$this->view->rmdir($this->path);
-			$nonExisting = new NonExistingFolder($this->root, $this->view, $this->path);
+			$nonExisting = new NonExistingFolder($this->root, $this->view, $this->path, $fileInfo);
 			$this->root->emit('\OC\Files', 'postDelete', array($nonExisting));
 			$this->exists = false;
 		} else {

--- a/lib/private/files/node/nonexistingfile.php
+++ b/lib/private/files/node/nonexistingfile.php
@@ -46,7 +46,11 @@ class NonExistingFile extends File {
 	}
 
 	public function getId() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getId();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function stat() {
@@ -54,35 +58,67 @@ class NonExistingFile extends File {
 	}
 
 	public function getMTime() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getMTime();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getSize() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getSize();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getEtag() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getEtag();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getPermissions() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getPermissions();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isReadable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isReadable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isUpdateable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isUpdateable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isDeletable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isDeletable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isShareable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isShareable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getContent() {
@@ -94,7 +130,11 @@ class NonExistingFile extends File {
 	}
 
 	public function getMimeType() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getMimeType();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function fopen($mode) {

--- a/lib/private/files/node/nonexistingfolder.php
+++ b/lib/private/files/node/nonexistingfolder.php
@@ -47,7 +47,11 @@ class NonExistingFolder extends Folder {
 	}
 
 	public function getId() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getId();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function stat() {
@@ -55,35 +59,67 @@ class NonExistingFolder extends Folder {
 	}
 
 	public function getMTime() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getMTime();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getSize() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getSize();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getEtag() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getEtag();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function getPermissions() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::getPermissions();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isReadable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isReadable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isUpdateable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isUpdateable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isDeletable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isDeletable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function isShareable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isShareable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 
 	public function get($path) {
@@ -127,6 +163,10 @@ class NonExistingFolder extends Folder {
 	}
 
 	public function isCreatable() {
-		throw new NotFoundException();
+		if ($this->fileInfo) {
+			return parent::isCreatable();
+		} else {
+			throw new NotFoundException();
+		}
 	}
 }

--- a/tests/lib/files/node/file.php
+++ b/tests/lib/files/node/file.php
@@ -76,6 +76,8 @@ class File extends \Test\TestCase {
 			$test->assertInstanceOf('\OC\Files\Node\NonExistingFile', $node);
 			$test->assertEquals('foo', $node->getInternalPath());
 			$test->assertEquals('/bar/foo', $node->getPath());
+			$test->assertEquals(1, $node->getId());
+			$test->assertEquals('text/plain', $node->getMimeType());
 			$hooksRun++;
 		};
 
@@ -94,7 +96,7 @@ class File extends \Test\TestCase {
 		$view->expects($this->any())
 			->method('getFileInfo')
 			->with('/bar/foo')
-			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1))));
+			->will($this->returnValue($this->getFileInfo(array('permissions' => \OCP\Constants::PERMISSION_ALL, 'fileid' => 1, 'mimetype' => 'text/plain'))));
 
 		$view->expects($this->once())
 			->method('unlink')

--- a/tests/lib/files/node/folder.php
+++ b/tests/lib/files/node/folder.php
@@ -82,6 +82,7 @@ class Folder extends \Test\TestCase {
 			$test->assertInstanceOf('\OC\Files\Node\NonExistingFolder', $node);
 			$test->assertEquals('foo', $node->getInternalPath());
 			$test->assertEquals('/bar/foo', $node->getPath());
+			$test->assertEquals(1, $node->getId());
 			$hooksRun++;
 		};
 


### PR DESCRIPTION
Allows reading metadata (fileid, mimetype, etc) from postDelete hooks

cc @PVince81 @blizzz 
