### PR TITLE
Only set encrypted flag if file is encrypted

### DIFF
--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -542,12 +542,14 @@ class Encryption extends Wrapper {
 				}
 				$isEncrypted = $this->encryptionManager->isEnabled() && $this->mount->getOption('encrypt', true) ? 1 : 0;
 
-				// in case of a rename we need to manipulate the source cache because
-				// this information will be kept for the new target
-				if ($isRename) {
-					$sourceStorage->getCache()->put($sourceInternalPath, ['encrypted' => $isEncrypted]);
-				} else {
-					$this->getCache()->put($targetInternalPath, ['encrypted' => $isEncrypted]);
+				if ($isEncrypted) {
+					// in case of a rename we need to manipulate the source cache because
+					// this information will be kept for the new target
+					if ($isRename) {
+						$sourceStorage->getCache()->put($sourceInternalPath, ['encrypted' => $isEncrypted]);
+					} else {
+						$this->getCache()->put($targetInternalPath, ['encrypted' => $isEncrypted]);
+					}
 				}
 			} else {
 				// delete partially written target file


### PR DESCRIPTION
Needed for the storage api flexibility since it prevents a cache write the storage has no control over

cc @schiesbn
