### PR TITLE
Check if rewrite base is set if rewrite is active

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -45,6 +45,11 @@
   RewriteRule ^(\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 
   # Rewrite rules for `front_controller_active`
+ SetEnv front_controller_active true
+ Options -MultiViews
+ <IfModule mod_dir.c>
+   DirectorySlash off
+ </IfModule>
   RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
   RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
   RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$
@@ -56,7 +61,6 @@
   RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php
   RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php
   RewriteRule .* index.php [PT,E=PATH_INFO:$1]
-
 </IfModule>
 <IfModule mod_mime.c>
   AddType image/svg+xml svg svgz

--- a/.htaccess
+++ b/.htaccess
@@ -45,10 +45,10 @@
   RewriteRule ^(\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 
   # Rewrite rules for `front_controller_active`
- Options -MultiViews
- <IfModule mod_dir.c>
-   DirectorySlash off
- </IfModule>
+  Options -MultiViews
+  <IfModule mod_dir.c>
+    DirectorySlash off
+  </IfModule>
   RewriteRule ^core/js/oc.js$ index.php/core/js/oc.js [PT,E=PATH_INFO:$1]
   RewriteRule ^core/preview.png$ index.php/core/preview.png [PT,E=PATH_INFO:$1]
   RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$

--- a/.htaccess
+++ b/.htaccess
@@ -45,13 +45,12 @@
   RewriteRule ^(\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 
   # Rewrite rules for `front_controller_active`
- SetEnv front_controller_active true
  Options -MultiViews
  <IfModule mod_dir.c>
    DirectorySlash off
  </IfModule>
-  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
-  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/js/oc.js$ index.php/core/js/oc.js [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/preview.png$ index.php/core/preview.png [PT,E=PATH_INFO:$1]
   RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$
   RewriteCond %{REQUEST_FILENAME} !/remote.php
   RewriteCond %{REQUEST_FILENAME} !/public.php

--- a/.htaccess
+++ b/.htaccess
@@ -44,19 +44,18 @@
   RewriteRule ^(build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteRule ^(\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 
-  <IfModule mod_env.c>
-    SetEnv front_controller_active true
-    RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
-    RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
-    RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$
-    RewriteCond %{REQUEST_FILENAME} !/remote.php
-    RewriteCond %{REQUEST_FILENAME} !/public.php
-    RewriteCond %{REQUEST_FILENAME} !/cron.php
-    RewriteCond %{REQUEST_FILENAME} !/status.php
-    RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php
-    RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php
-    RewriteRule .* index.php [PT,E=PATH_INFO:$1]
-  </IfModule>
+  # Rewrite rules for `front_controller_active`
+  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]
+  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]
+  RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$
+  RewriteCond %{REQUEST_FILENAME} !/remote.php
+  RewriteCond %{REQUEST_FILENAME} !/public.php
+  RewriteCond %{REQUEST_FILENAME} !/cron.php
+  RewriteCond %{REQUEST_FILENAME} !/core/ajax/update.php
+  RewriteCond %{REQUEST_FILENAME} !/status.php
+  RewriteCond %{REQUEST_FILENAME} !/ocs/v1.php
+  RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php
+  RewriteRule .* index.php [PT,E=PATH_INFO:$1]
 
 </IfModule>
 <IfModule mod_mime.c>

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -434,8 +434,9 @@ class Setup {
 		}
 
 		// Add rewrite base
+		$webRoot = !empty(\OC::$WEBROOT) ? \OC::$WEBROOT : '/';
 		$content.="\n<IfModule mod_rewrite.c>";
-		$content.="\n  RewriteBase ".\OC::$WEBROOT;
+		$content.="\n  RewriteBase ".$webRoot;
 		$content .= "\n  <IfModule mod_env.c>";
 		$content .= "\n    SetEnv front_controller_active true";
 		$content.="\n  </IfModule>";

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -436,6 +436,9 @@ class Setup {
 		// Add rewrite base
 		$content.="\n<IfModule mod_rewrite.c>";
 		$content.="\n  RewriteBase ".\OC::$WEBROOT;
+		$content .= "\n  <IfModule mod_env.c>";
+		$content .= "\n    SetEnv front_controller_active true";
+		$content.="\n  </IfModule>";
 		$content.="\n</IfModule>";
 
 		if ($content !== '') {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 0, 4);
+$OC_Version = array(9, 0, 0, 5);
 
 // The human readable string
 $OC_VersionString = '9.0 pre alpha';


### PR DESCRIPTION
mod_rewrite as used by the front controller may require a `RewriteBase` in case the installation is done using an alias. Since we cannot enforce a writable `.htaccess` file this will move the `front_controller_active` environment variable into the main .htaccess file. If administrators decide to have this one not writable they can still enable this feature by setting the `front_controller_active` environment variable within the Apache config.

Follow-up of https://github.com/owncloud/core/pull/14081

<hr/>

@schiesbn That should make you happier :wink: 

@MorrisJobke @DeepDiver1975 THX
