### PR TITLE
Respect disabled incoming federated shares

### DIFF
--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -57,7 +57,9 @@ $eventDispatcher->addListener(
 	function() {
 		\OCP\Util::addScript('files_sharing', 'share');
 		\OCP\Util::addScript('files_sharing', 'sharetabview');
-		\OCP\Util::addScript('files_sharing', 'external');
+		if (\OC::$server->getConfig()->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes') === 'yes') {
+			\OCP\Util::addScript('files_sharing', 'external');
+		}
 		\OCP\Util::addStyle('files_sharing', 'sharetabview');
 	}
 );


### PR DESCRIPTION
Only fetch the incoming federated shares if incoming shares are actually
enabled.

Fixes #20713 

CC: @PoPoutdoor @PVince81 @schiesbn 
