### PR TITLE
Only return the exact match, when it's allowed

### DIFF
--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -120,6 +120,7 @@ class Sharees {
 	protected function getUsers($search) {
 		$this->result['users'] = $this->result['exact']['users'] = $users = [];
 
+		$userGroups = [];
 		if ($this->shareWithGroupOnly) {
 			// Search in all the groups this user is part of
 			$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
@@ -171,13 +172,23 @@ class Sharees {
 			// user id and if so, we add that to the exact match list
 			$user = $this->userManager->get($search);
 			if ($user instanceof IUser) {
-				array_push($this->result['exact']['users'], [
-					'label' => $user->getDisplayName(),
-					'value' => [
-						'shareType' => Share::SHARE_TYPE_USER,
-						'shareWith' => $user->getUID(),
-					],
-				]);
+				$addUser = true;
+
+				if ($this->shareWithGroupOnly) {
+					// Only add, if we have a common group
+					$commonGroups = array_intersect($userGroups, $this->groupManager->getUserGroupIds($user));
+					$addUser = !empty($commonGroups);
+				}
+
+				if ($addUser) {
+					array_push($this->result['exact']['users'], [
+						'label' => $user->getDisplayName(),
+						'value' => [
+							'shareType' => Share::SHARE_TYPE_USER,
+							'shareWith' => $user->getUID(),
+						],
+					]);
+				}
 			}
 		}
 

--- a/apps/files_sharing/tests/api/shareestest.php
+++ b/apps/files_sharing/tests/api/shareestest.php
@@ -136,12 +136,20 @@ class ShareesTest extends TestCase {
 			],
 			[
 				'test', true, true, [], [],
+				[], [], true, $this->getUserMock('test', 'Test')
+			],
+			[
+				'test', true, false, [], [],
+				[], [], true, $this->getUserMock('test', 'Test')
+			],
+			[
+				'test', true, true, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
 			],
 			[
-				'test', true, false, [], [],
+				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => Share::SHARE_TYPE_USER, 'shareWith' => 'test']],
 				], [], true, $this->getUserMock('test', 'Test')
@@ -390,10 +398,20 @@ class ShareesTest extends TestCase {
 				->with($searchTerm, $this->invokePrivate($this->sharees, 'limit'), $this->invokePrivate($this->sharees, 'offset'))
 				->willReturn($userResponse);
 		} else {
-			$this->groupManager->expects($this->once())
-				->method('getUserGroupIds')
-				->with($user)
-				->willReturn($groupResponse);
+			if ($singleUser !== false) {
+				$this->groupManager->expects($this->exactly(2))
+					->method('getUserGroupIds')
+					->withConsecutive(
+						$user,
+						$singleUser
+					)
+					->willReturn($groupResponse);
+			} else {
+				$this->groupManager->expects($this->once())
+					->method('getUserGroupIds')
+					->with($user)
+					->willReturn($groupResponse);
+			}
 
 			$this->groupManager->expects($this->exactly(sizeof($groupResponse)))
 				->method('displayNamesInGroup')


### PR DESCRIPTION
Fix owncloud/client#4226

@rullzer @blizzz @schiesbn review

@karlitschek we could backport this to 8.2 I think, it helps the client to not provide autocomplete for users which the user can not share with anyway
