### PR TITLE
Allow framing 'self'

### DIFF
--- a/apps/files/controller/viewcontroller.php
+++ b/apps/files/controller/viewcontroller.php
@@ -23,6 +23,7 @@ namespace OCA\Files\Controller;
 
 use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IL10N;
@@ -215,10 +216,15 @@ class ViewController extends Controller {
 		$params['appContents'] = $contentItems;
 		$this->navigationManager->setActiveEntry('files_index');
 
-		return new TemplateResponse(
+		$response = new TemplateResponse(
 			$this->appName,
 			'index',
 			$params
 		);
+		$policy = new ContentSecurityPolicy();
+		$policy->addAllowedFrameDomain('\'self\'');
+		$response->setContentSecurityPolicy($policy);
+
+		return $response;
 	}
 }

--- a/apps/files/tests/controller/ViewControllerTest.php
+++ b/apps/files/tests/controller/ViewControllerTest.php
@@ -245,6 +245,9 @@ class ViewControllerTest extends TestCase {
 				],
 			]
 		);
+		$policy = new Http\ContentSecurityPolicy();
+		$policy->addAllowedFrameDomain('\'self\'');
+		$expected->setContentSecurityPolicy($policy);
 		$this->assertEquals($expected, $this->viewController->index('MyDir', 'MyView'));
 	}
 }


### PR DESCRIPTION
This is required by the pdf viewer, since the files app on master uses the AppFramework it had applied the more strict defaults which made it not work on master.

@MorrisJobke The issue we talked about.
@PVince81 Please review. Just test whether the PDF viewer works on master with and without this PR in a CSP compliant browser :smile: 
