### PR TITLE
Replace more of OC_Config in tests with IConfig calls

### DIFF
--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -63,8 +63,9 @@ class FileCache extends \Test_Cache {
 		$storage = new \OC\Files\Storage\Temporary(array());
 		\OC\Files\Filesystem::mount($storage,array(),'/');
 		$datadir = str_replace('local::', '', $storage->getId());
-		$this->datadir = \OC_Config::getValue('cachedirectory', \OC::$SERVERROOT.'/data/cache');
-		\OC_Config::setValue('cachedirectory', $datadir);
+		$config = \OC::$server->getConfig();
+		$this->datadir = $config->getSystemValue('cachedirectory', \OC::$SERVERROOT.'/data/cache');
+		$config->setSystemValue('cachedirectory', $datadir);
 
 		\OC_User::clearBackends();
 		\OC_User::useBackend(new \Test\Util\User\Dummy());
@@ -89,7 +90,7 @@ class FileCache extends \Test_Cache {
 		$this->instance->remove('hack', 'hack');
 
 		\OC_User::setUserId($this->user);
-		\OC_Config::setValue('cachedirectory', $this->datadir);
+		\OC::$server->getConfig()->setSystemValue('cachedirectory', $this->datadir);
 
 		// Restore the original mount point
 		\OC\Files\Filesystem::clearMounts();

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -37,16 +37,17 @@ class EtagTest extends \Test\TestCase {
 		\OCP\Share::registerBackend('file', 'OC_Share_Backend_File');
 		\OCP\Share::registerBackend('folder', 'OC_Share_Backend_Folder', 'file');
 
-		$this->datadir = \OC_Config::getValue('datadirectory');
+		$config = \OC::$server->getConfig();
+		$this->datadir = $config->getSystemValue('datadirectory');
 		$this->tmpDir = \OC_Helper::tmpFolder();
-		\OC_Config::setValue('datadirectory', $this->tmpDir);
+		$config->setSystemValue('datadirectory', $this->tmpDir);
 
 		$this->userBackend = new \Test\Util\User\Dummy();
 		\OC_User::useBackend($this->userBackend);
 	}
 
 	protected function tearDown() {
-		\OC_Config::setValue('datadirectory', $this->datadir);
+		\OC::$server->getConfig()->setSystemValue('datadirectory', $this->datadir);
 
 		$this->logout();
 		parent::tearDown();


### PR DESCRIPTION
This is part of the reverted stuff of yesterday. Some of this failed for object store on Jenkins and this PR should tests which part is the root of the failure.
