### PR TITLE
app-loading icon not replaced onbeforeupload dialog choice

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -592,6 +592,9 @@ OC.Upload = {
 
 		// warn user not to leave the page while upload is in progress
 		$(window).on('beforeunload', function(e) {
+			setTimeout(function() {
+				$('#apps ul li a').removeClass('app-loading');
+			}, 500);
 			if (OC.Upload.isProcessing()) {
 				return t('files', 'File upload is in progress. Leaving the page now will cancel the upload.');
 			}

--- a/core/css/jquery-ui-fixes.css
+++ b/core/css/jquery-ui-fixes.css
@@ -23,6 +23,12 @@
 .ui-widget-header a {
 	color: #ffffff;
 }
+.ui-datepicker select.ui-datepicker-year option, .ui-datepicker select.ui-datepicker-month option {
+  	color: #000;
+}
+.ui-datepicker select.ui-date-picker-year:checked, .ui-datepicker select.ui-datepicker-month:checked {
+  	color: #fff;
+}
 
 /* Interaction states
 ----------------------------------*/


### PR DESCRIPTION
Relates to issue #20766. 

**Issue**

When a user is uploading a file and attempts to navigate to a different app before it has finished, they are presented with an onbeforeupload dialog box. If the user chooses to stay on the current page and complete the upload, the app icon remains the spinning GIF rather than it's own image.

**How to replicate**

Upload a file and before it is complete, try to navigate to the Activity tab from the Files. The Activity icon will be replaced with a spinning GIF. When the dialog box pops up, choose to stay on the same page. The spinning GIF will remain in place rather than reverting back to the icon.

**Potential Solution**

Someone might know of a way to tell which button the user clicks on the onbeforeupload dialog box but I couldn't find a way to do it. This solution simply sets a timeout of 500ms to revert the icon back to how it was.

If the user chooses to leave the page, the navigation will be reloaded properly anyway. If the user chooses to stay, then the spinning GIF will revert back to how it was and they can wait for the file to complete uploading.
