### PR TITLE
Check that the owner of a link share still has share permissions on access

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -46,7 +46,9 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
-$server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, function () use ($authBackend) {
+$linkCheckPlugin = new \OCA\DAV\Files\Sharing\PublicLinkCheckPlugin();
+
+$server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, function (\Sabre\DAV\Server $server) use ($authBackend, $linkCheckPlugin) {
 	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest');
 	if (OCA\Files_Sharing\Helper::isOutgoingServer2serverShareEnabled() === false && !$isAjax) {
 		// this is what is thrown when trying to access a non-existing share
@@ -68,9 +70,13 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 	OC_Util::setupFS($owner);
 	$ownerView = \OC\Files\Filesystem::getView();
 	$path = $ownerView->getPath($fileId);
+	$fileInfo = $ownerView->getFileInfo($path);
+	$linkCheckPlugin->setFileInfo($fileInfo);
 
 	return new \OC\Files\View($ownerView->getAbsolutePath($path));
 });
+
+$server->addPlugin($linkCheckPlugin);
 
 // And off we go!
 $server->exec();

--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -118,7 +118,7 @@ class ServerFactory {
 			$userFolder = \OC::$server->getUserFolder();
 			
 			/** @var \OC\Files\View $view */
-			$view = $viewCallBack();
+			$view = $viewCallBack($server);
 			$rootInfo = $view->getFileInfo('');
 
 			// Create ownCloud Dir

--- a/apps/dav/lib/files/sharing/publiclinkcheckplugin.php
+++ b/apps/dav/lib/files/sharing/publiclinkcheckplugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Files\Sharing;
+
+use OCP\Files\FileInfo;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * Verify that the public link share is valid
+ */
+class PublicLinkCheckPlugin extends ServerPlugin {
+	/**
+	 * @var FileInfo
+	 */
+	private $fileInfo;
+
+	/**
+	 * @param FileInfo $fileInfo
+	 */
+	public function setFileInfo($fileInfo) {
+		$this->fileInfo = $fileInfo;
+	}
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * @param \Sabre\DAV\Server $server Sabre server
+	 *
+	 * @return void
+	 */
+	public function initialize(\Sabre\DAV\Server $server) {
+		$server->on('beforeMethod', [$this, 'beforeMethod']);
+	}
+
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response){
+		// verify that the owner didn't have his share permissions revoked
+		if ($this->fileInfo && !$this->fileInfo->isShareable()) {
+			throw new NotFound();
+		}
+	}
+}

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -228,6 +228,16 @@ class ShareController extends Controller {
 	}
 
 	/**
+	 * Validate the permissions of the share
+	 *
+	 * @param Share\IShare $share
+	 * @return bool
+	 */
+	private function validateShare(\OCP\Share\IShare $share) {
+		return $share->getNode()->isReadable() && $share->getNode()->isShareable();
+	}
+
+	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 *
@@ -253,6 +263,9 @@ class ShareController extends Controller {
 				array('token' => $token)));
 		}
 
+		if (!$this->validateShare($share)) {
+			throw new NotFoundException();
+		}
 		// We can't get the path of a file share
 		try {
 			if ($share->getNode() instanceof \OCP\Files\File && $path !== '') {
@@ -370,6 +383,10 @@ class ShareController extends Controller {
 
 		$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
 		$originalSharePath = $userFolder->getRelativePath($share->getNode()->getPath());
+
+		if (!$this->validateShare($share)) {
+			throw new NotFoundException();
+		}
 
 		// Single file share
 		if ($share->getNode() instanceof \OCP\Files\File) {

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -304,6 +304,8 @@ class ShareControllerTest extends \Test\TestCase {
 		$file->method('getName')->willReturn('file1.txt');
 		$file->method('getMimetype')->willReturn('text/plain');
 		$file->method('getSize')->willReturn(33);
+		$file->method('isReadable')->willReturn(true);
+		$file->method('isShareable')->willReturn(true);
 
 		$share = \OC::$server->getShareManager()->newShare();
 		$share->setId(42);


### PR DESCRIPTION
Part of https://github.com/owncloud/core/issues/19157#issuecomment-161624238

Easiest way to check atm is to manually edit the permissions in the database for a publicly shared file

cc @PVince81 @DeepDiver1975 
