### PR TITLE
Fix namespace XML output of files and tags dav

### DIFF
--- a/apps/dav/lib/connector/sabre/filesplugin.php
+++ b/apps/dav/lib/connector/sabre/filesplugin.php
@@ -97,7 +97,7 @@ class FilesPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 
-		$server->xmlNamespaces[self::NS_OWNCLOUD] = 'oc';
+		$server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 		$server->protectedProperties[] = self::FILEID_PROPERTYNAME;
 		$server->protectedProperties[] = self::INTERNAL_FILEID_PROPERTYNAME;
 		$server->protectedProperties[] = self::PERMISSIONS_PROPERTYNAME;

--- a/apps/dav/lib/connector/sabre/tagsplugin.php
+++ b/apps/dav/lib/connector/sabre/tagsplugin.php
@@ -107,7 +107,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 
-		$server->xmlNamespaces[self::NS_OWNCLOUD] = 'oc';
+		$server->xml->namespacesMap[self::NS_OWNCLOUD] = 'oc';
 		$server->propertyMap[self::TAGS_PROPERTYNAME] = 'OCA\\DAV\\Connector\\Sabre\\TagList';
 
 		$this->server = $server;


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20930

To test, open the web UI and inspect the "webdav/" call and see if the response contains "oc:xxx" elements instead of "x:xxx" elements.

@DeepDiver1975 @icewind1991 @MorrisJobke @nickvergessen 
