### PR TITLE
Syncing system addressbooks across federated ownClouds

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -19,6 +19,21 @@
  *
  */
 
+use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\DAV\CardDAV\SyncService;
+use OCA\DAV\Connector\Sabre\Principal;
+
+\OC::$server->registerService('CardDAVSyncService', function() {
+	$principalBackend = new Principal(
+		$this->config,
+		$this->userManager
+	);
+
+	$backend = new CardDavBackend($this->dbConnection, $principalBackend);
+
+	return new SyncService($backend);
+});
+
 $cm = \OC::$server->getContactsManager();
 $cm->register(function() use ($cm) {
 	$userId = \OC::$server->getUserSession()->getUser()->getUID();

--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -21,18 +21,12 @@
 
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
-use OCA\DAV\Connector\Sabre\Principal;
 
 \OC::$server->registerService('CardDAVSyncService', function() {
 
-	$userManager = \OC::$server->getUserManager();
-	$dbConnection = \OC::$server->getDatabaseConnection();
-
-	$principalBackend = new Principal(
-		$userManager
-	);
-
-	$backend = new CardDavBackend($dbConnection, $principalBackend);
+	$app = new \OCA\Dav\AppInfo\Application();
+	/** @var CardDavBackend */
+	$backend = $app->getContainer()->query('CardDavBackend');
 
 	return new SyncService($backend);
 });

--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -25,12 +25,10 @@ use OCA\DAV\Connector\Sabre\Principal;
 
 \OC::$server->registerService('CardDAVSyncService', function() {
 
-	$config = \OC::$server->getConfig();
 	$userManager = \OC::$server->getUserManager();
 	$dbConnection = \OC::$server->getDatabaseConnection();
 
 	$principalBackend = new Principal(
-		$config,
 		$userManager
 	);
 

--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -24,12 +24,17 @@ use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\Connector\Sabre\Principal;
 
 \OC::$server->registerService('CardDAVSyncService', function() {
+
+	$config = \OC::$server->getConfig();
+	$userManager = \OC::$server->getUserManager();
+	$dbConnection = \OC::$server->getDatabaseConnection();
+
 	$principalBackend = new Principal(
-		$this->config,
-		$this->userManager
+		$config,
+		$userManager
 	);
 
-	$backend = new CardDavBackend($this->dbConnection, $principalBackend);
+	$backend = new CardDavBackend($dbConnection, $principalBackend);
 
 	return new SyncService($backend);
 });

--- a/apps/dav/command/createaddressbook.php
+++ b/apps/dav/command/createaddressbook.php
@@ -63,7 +63,6 @@ class CreateAddressBook extends Command {
 			throw new \InvalidArgumentException("User <$user> in unknown.");
 		}
 		$principalBackend = new Principal(
-				$this->config,
 				$this->userManager
 		);
 

--- a/apps/dav/command/syncsystemaddressbook.php
+++ b/apps/dav/command/syncsystemaddressbook.php
@@ -57,7 +57,6 @@ class SyncSystemAddressBook extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$principalBackend = new Principal(
-				$this->config,
 				$this->userManager
 		);
 

--- a/apps/dav/lib/carddav/carddavbackend.php
+++ b/apps/dav/lib/carddav/carddavbackend.php
@@ -37,9 +37,6 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	/** @var Principal */
 	private $principalBackend;
 
-	/** @var ILogger */
-	private $logger;
-
 	/** @var string */
 	private $dbCardsTable = 'cards';
 
@@ -59,12 +56,10 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 *
 	 * @param IDBConnection $db
 	 * @param Principal $principalBackend
-	 * @param ILogger $logger
 	 */
-	public function __construct(IDBConnection $db, Principal $principalBackend, ILogger $logger) {
+	public function __construct(IDBConnection $db, Principal $principalBackend) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\CardDAV;
+
+use Sabre\DAV\Client;
+use Sabre\DAV\Xml\Response\MultiStatus;
+use Sabre\DAV\Xml\Service;
+
+class SyncService {
+
+	/** @var CardDavBackend */
+	private $backend;
+
+	public function __construct(CardDavBackend $backend) {
+		$this->backend = $backend;
+	}
+
+	public function syncRemoteAddressBook($url, $userName, $sharedSecret, $syncToken, $targetBookId, $targetPrincipal, $targetProperties) {
+		// 1. create addressbook
+		$book = $this->ensureSystemAddressBookExists($targetPrincipal, $targetBookId, $targetProperties);
+		$addressBookId = $book['id'];
+
+		// 2. query changes
+		$response = $this->requestSyncReport($url, $userName, $sharedSecret, $syncToken);
+
+		// 3. apply changes
+		// TODO: use multi-get for download
+		foreach ($response['response'] as $resource => $status) {
+			$cardUri = basename($resource);
+			if (isset($status[200])) {
+				$vCard = $this->download($url, $sharedSecret, $resource);
+				$existingCard = $this->backend->getCard($addressBookId, $cardUri);
+				if ($existingCard === false) {
+					$this->backend->createCard($addressBookId, $cardUri, $vCard['body']);
+				} else {
+					$this->backend->updateCard($addressBookId, $cardUri, $vCard['body']);
+				}
+			} else {
+				$this->backend->deleteCard($addressBookId, $cardUri);
+			}
+		}
+
+		return $response['token'];
+	}
+
+	protected function ensureSystemAddressBookExists($principal, $id, $properties) {
+		$book = $this->backend->getAddressBooksByUri($id);
+		if (!is_null($book)) {
+			return $book;
+		}
+		$this->backend->createAddressBook($principal, $id, $properties);
+
+		return $this->backend->getAddressBooksByUri($id);
+	}
+
+	/**
+	 * @param string $url
+	 * @param string $userName
+	 * @param string $sharedSecret
+	 * @param string $syncToken
+	 * @return array
+	 */
+	private function requestSyncReport($url, $userName, $sharedSecret, $syncToken) {
+		$settings = [
+			'baseUri' => $url,
+			'userName' => $userName,
+			'password' => $sharedSecret,
+		];
+		$client = new Client($settings);
+		$client->setThrowExceptions(true);
+
+		$addressBookUrl = "/remote.php/dav/addressbooks/system/system/system";
+		$body = $this->buildSyncCollectionRequestBody($syncToken);
+
+		$response = $client->request('REPORT', $addressBookUrl, $body, [
+			'Content-Type' => 'application/xml'
+		]);
+
+//		if ((int)$response->getStatus() >= 400) {
+//			throw new Exception('HTTP error: ' . $response->getStatus());
+//		}
+
+		$result = $this->parseMultiStatus($response['body']);
+
+		return $result;
+	}
+
+	private function download($url, $sharedSecret, $changeSet) {
+		$settings = [
+			'baseUri' => $url,
+			'userName' => 'system',
+			'password' => $sharedSecret,
+		];
+		$client = new Client($settings);
+		$client->setThrowExceptions(true);
+
+		$response = $client->request('GET', $changeSet);
+		return $response;
+	}
+
+	function buildSyncCollectionRequestBody($synToken) {
+
+		$dom = new \DOMDocument('1.0', 'UTF-8');
+		$dom->formatOutput = true;
+		$root = $dom->createElementNS('DAV:', 'd:sync-collection');
+		$sync = $dom->createElement('d:sync-token', $synToken);
+		$prop = $dom->createElement('d:prop');
+		$cont = $dom->createElement('d:getcontenttype');
+		$etag = $dom->createElement('d:getetag');
+
+		$prop->appendChild($cont);
+		$prop->appendChild($etag);
+		$root->appendChild($sync);
+		$root->appendChild($prop);
+		$dom->appendChild($root);
+		$body = $dom->saveXML();
+
+		return $body;
+	}
+
+	private function parseMultiStatus($body) {
+		$xml = new Service();
+
+		/** @var MultiStatus $multiStatus */
+		$multiStatus = $xml->expect('{DAV:}multistatus', $body);
+
+		$result = [];
+		foreach ($multiStatus->getResponses() as $response) {
+			$result[$response->getHref()] = $response->getResponseProperties();
+		}
+
+		return ['response' => $result, 'token' => $multiStatus->getSyncToken()];
+	}
+
+
+}

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -96,7 +96,7 @@ class SyncService {
 	 * @param string $syncToken
 	 * @return array
 	 */
-	private function requestSyncReport($url, $userName, $sharedSecret, $syncToken) {
+	protected function requestSyncReport($url, $userName, $sharedSecret, $syncToken) {
 		$settings = [
 			'baseUri' => $url,
 			'userName' => $userName,

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -141,15 +141,15 @@ class SyncService {
 	}
 
 	/**
-	 * @param string|null $synToken
+	 * @param string|null $syncToken
 	 * @return string
 	 */
-	private function buildSyncCollectionRequestBody($synToken) {
+	private function buildSyncCollectionRequestBody($syncToken) {
 
 		$dom = new \DOMDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
 		$root = $dom->createElementNS('DAV:', 'd:sync-collection');
-		$sync = $dom->createElement('d:sync-token', $synToken);
+		$sync = $dom->createElement('d:sync-token', $syncToken);
 		$prop = $dom->createElement('d:prop');
 		$cont = $dom->createElement('d:getcontenttype');
 		$etag = $dom->createElement('d:getetag');

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -24,6 +24,7 @@ namespace OCA\DAV\CardDAV;
 use Sabre\DAV\Client;
 use Sabre\DAV\Xml\Response\MultiStatus;
 use Sabre\DAV\Xml\Service;
+use Sabre\HTTP\ClientException;
 
 class SyncService {
 
@@ -111,10 +112,6 @@ class SyncService {
 		$response = $client->request('REPORT', $addressBookUrl, $body, [
 			'Content-Type' => 'application/xml'
 		]);
-
-//		if ((int)$response->getStatus() >= 400) {
-//			throw new Exception('HTTP error: ' . $response->getStatus());
-//		}
 
 		$result = $this->parseMultiStatus($response['body']);
 

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -34,6 +34,16 @@ class SyncService {
 		$this->backend = $backend;
 	}
 
+	/**
+	 * @param string $url
+	 * @param string $userName
+	 * @param string $sharedSecret
+	 * @param string $syncToken
+	 * @param int $targetBookId
+	 * @param string $targetPrincipal
+	 * @param array $targetProperties
+	 * @return string
+	 */
 	public function syncRemoteAddressBook($url, $userName, $sharedSecret, $syncToken, $targetBookId, $targetPrincipal, $targetProperties) {
 		// 1. create addressbook
 		$book = $this->ensureSystemAddressBookExists($targetPrincipal, $targetBookId, $targetProperties);
@@ -62,6 +72,13 @@ class SyncService {
 		return $response['token'];
 	}
 
+	/**
+	 * @param string $principal
+	 * @param string $id
+	 * @param array $properties
+	 * @return array|null
+	 * @throws \Sabre\DAV\Exception\BadRequest
+	 */
 	protected function ensureSystemAddressBookExists($principal, $id, $properties) {
 		$book = $this->backend->getAddressBooksByUri($id);
 		if (!is_null($book)) {
@@ -104,7 +121,13 @@ class SyncService {
 		return $result;
 	}
 
-	private function download($url, $sharedSecret, $changeSet) {
+	/**
+	 * @param string $url
+	 * @param string $sharedSecret
+	 * @param string $resourcePath
+	 * @return array
+	 */
+	private function download($url, $sharedSecret, $resourcePath) {
 		$settings = [
 			'baseUri' => $url,
 			'userName' => 'system',
@@ -113,11 +136,15 @@ class SyncService {
 		$client = new Client($settings);
 		$client->setThrowExceptions(true);
 
-		$response = $client->request('GET', $changeSet);
+		$response = $client->request('GET', $resourcePath);
 		return $response;
 	}
 
-	function buildSyncCollectionRequestBody($synToken) {
+	/**
+	 * @param string|null $synToken
+	 * @return string
+	 */
+	private function buildSyncCollectionRequestBody($synToken) {
 
 		$dom = new \DOMDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
@@ -137,6 +164,11 @@ class SyncService {
 		return $body;
 	}
 
+	/**
+	 * @param string $body
+	 * @return array
+	 * @throws \Sabre\Xml\ParseException
+	 */
 	private function parseMultiStatus($body) {
 		$xml = new Service();
 

--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -99,14 +99,14 @@ class SyncService {
 	 */
 	protected function requestSyncReport($url, $userName, $sharedSecret, $syncToken) {
 		$settings = [
-			'baseUri' => $url,
+			'baseUri' => $url . '/',
 			'userName' => $userName,
 			'password' => $sharedSecret,
 		];
 		$client = new Client($settings);
 		$client->setThrowExceptions(true);
 
-		$addressBookUrl = "/remote.php/dav/addressbooks/system/system/system";
+		$addressBookUrl = "remote.php/dav/addressbooks/system/system/system";
 		$body = $this->buildSyncCollectionRequestBody($syncToken);
 
 		$response = $client->request('REPORT', $addressBookUrl, $body, [

--- a/apps/dav/lib/connector/fedauth.php
+++ b/apps/dav/lib/connector/fedauth.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Connector;
+
+use OCA\Federation\DbHandler;
+use OCP\IDBConnection;
+use Sabre\DAV\Auth\Backend\AbstractBasic;
+
+class FedAuth extends AbstractBasic {
+
+	/**
+	 * FedAuth constructor.
+	 *
+	 * @param IDBConnection $db
+	 */
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+		$this->principalPrefix = 'principals/system/';
+	}
+
+	/**
+	 * Validates a username and password
+	 *
+	 * This method should return true or false depending on if login
+	 * succeeded.
+	 *
+	 * @param string $username
+	 * @param string $password
+	 * @return bool
+	 */
+	protected function validateUserPass($username, $password) {
+		$h = new DbHandler($this->db,
+				\OC::$server->getL10N('federation')
+		);
+		return $h->auth($username, $password);
+	}
+}

--- a/apps/dav/lib/rootcollection.php
+++ b/apps/dav/lib/rootcollection.php
@@ -46,11 +46,11 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagObjectMapper()
 		);
 
-		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, \OC::$server->getLogger());
+		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend);
 		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, 'principals/users');
 		$usersAddressBookRoot->disableListing = $disableListing;
 
-		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, \OC::$server->getLogger());
+		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend);
 		$systemAddressBookRoot = new AddressBookRoot(new SystemPrincipalBackend(), $systemCardDavBackend, 'principals/system');
 		$systemAddressBookRoot->disableListing = $disableListing;
 

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -3,6 +3,7 @@
 namespace OCA\DAV;
 
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
+use OCA\DAV\Connector\FedAuth;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Files\CustomPropertiesBackend;
@@ -35,7 +36,9 @@ class Server {
 		$this->server->setBaseUri($this->baseUri);
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
-		$this->server->addPlugin(new Plugin($authBackend, 'ownCloud'));
+		$authPlugin = new Plugin($authBackend, 'ownCloud');
+		$authPlugin->addBackend(new FedAuth(\OC::$server->getDatabaseConnection()));
+		$this->server->addPlugin($authPlugin);
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());

--- a/apps/dav/lib/server.php
+++ b/apps/dav/lib/server.php
@@ -8,6 +8,7 @@ use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Files\CustomPropertiesBackend;
 use OCP\IRequest;
+use OCP\SabrePluginEvent;
 use Sabre\DAV\Auth\Plugin;
 
 class Server {
@@ -37,8 +38,12 @@ class Server {
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
 		$authPlugin = new Plugin($authBackend, 'ownCloud');
-		$authPlugin->addBackend(new FedAuth(\OC::$server->getDatabaseConnection()));
 		$this->server->addPlugin($authPlugin);
+
+		// allow setup of additional auth backends
+		$event = new SabrePluginEvent($this->server);
+		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\DummyGetResponsePlugin());
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $logger));
 		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());

--- a/apps/dav/tests/unit/carddav/carddavbackendtest.php
+++ b/apps/dav/tests/unit/carddav/carddavbackendtest.php
@@ -45,9 +45,6 @@ class CardDavBackendTest extends TestCase {
 	/** @var  Principal | \PHPUnit_Framework_MockObject_MockObject */
 	private $principal;
 
-	/** @var  ILogger | \PHPUnit_Framework_MockObject_MockObject */
-	private $logger;
-
 	/** @var  IDBConnection */
 	private $db;
 
@@ -70,11 +67,10 @@ class CardDavBackendTest extends TestCase {
 			->willReturn([
 				'uri' => 'principals/best-friend'
 			]);
-		$this->logger = $this->getMock('\OCP\ILogger');
 
 		$this->db = \OC::$server->getDatabaseConnection();
 
-		$this->backend = new CardDavBackend($this->db, $this->principal, $this->logger);
+		$this->backend = new CardDavBackend($this->db, $this->principal);
 
 		// start every test with a empty cards_properties and cards table
 		$query = $this->db->getQueryBuilder();
@@ -129,7 +125,7 @@ class CardDavBackendTest extends TestCase {
 
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
-				->setConstructorArgs([$this->db, $this->principal, $this->logger])
+				->setConstructorArgs([$this->db, $this->principal])
 				->setMethods(['updateProperties', 'purgeProperties'])->getMock();
 
 		// create a new address book
@@ -175,7 +171,7 @@ class CardDavBackendTest extends TestCase {
 	public function testMultiCard() {
 
 		$this->backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
-			->setConstructorArgs([$this->db, $this->principal, $this->logger])
+			->setConstructorArgs([$this->db, $this->principal])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -222,7 +218,7 @@ class CardDavBackendTest extends TestCase {
 	public function testSyncSupport() {
 
 		$this->backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
-			->setConstructorArgs([$this->db, $this->principal, $this->logger])
+			->setConstructorArgs([$this->db, $this->principal])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -279,7 +275,7 @@ class CardDavBackendTest extends TestCase {
 		$cardId = 2;
 
 		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDavBackend')
-			->setConstructorArgs([$this->db, $this->principal, $this->logger])
+			->setConstructorArgs([$this->db, $this->principal])
 			->setMethods(['getCardId'])->getMock();
 
 		$backend->expects($this->any())->method('getCardId')->willReturn($cardId);

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -51,7 +51,6 @@ class SyncServiceTest extends TestCase {
 
 	public function testSyncWithDeletedElement() {
 		$backend = $this->getBackendMock(0, 0, 1);
-//		$backend->method('getCard')->willReturn(true);
 
 		$ss = $this->getSyncServiceMock($backend, ['0' => [404 => '']]);
 		$return = $ss->syncRemoteAddressBook('', 'system', '1234567890', null, '1', 'principals/system/system', []);

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\CardDAV;
+
+use Test\TestCase;
+
+class SyncServiceTest extends TestCase {
+	public function testEmptySync() {
+		$backend = $this->getBackendMock(0, 0, 0);
+
+		$ss = $this->getSyncServiceMock($backend, []);
+		$return = $ss->syncRemoteAddressBook('', 'system', '1234567890', null, '1', 'principals/system/system', []);
+		$this->assertEquals('sync-token-1', $return);
+	}
+
+	public function testSyncWithNewElement() {
+		$backend = $this->getBackendMock(1, 0, 0);
+		$backend->method('getCard')->willReturn(false);
+
+		$ss = $this->getSyncServiceMock($backend, ['0' => [200 => '']]);
+		$return = $ss->syncRemoteAddressBook('', 'system', '1234567890', null, '1', 'principals/system/system', []);
+		$this->assertEquals('sync-token-1', $return);
+	}
+
+	public function testSyncWithUpdatedElement() {
+		$backend = $this->getBackendMock(0, 1, 0);
+		$backend->method('getCard')->willReturn(true);
+
+		$ss = $this->getSyncServiceMock($backend, ['0' => [200 => '']]);
+		$return = $ss->syncRemoteAddressBook('', 'system', '1234567890', null, '1', 'principals/system/system', []);
+		$this->assertEquals('sync-token-1', $return);
+	}
+
+	public function testSyncWithDeletedElement() {
+		$backend = $this->getBackendMock(0, 0, 1);
+//		$backend->method('getCard')->willReturn(true);
+
+		$ss = $this->getSyncServiceMock($backend, ['0' => [404 => '']]);
+		$return = $ss->syncRemoteAddressBook('', 'system', '1234567890', null, '1', 'principals/system/system', []);
+		$this->assertEquals('sync-token-1', $return);
+	}
+
+	/**
+	 * @param int $createCount
+	 * @param int $updateCount
+	 * @param int $deleteCount
+	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getBackendMock($createCount, $updateCount, $deleteCount) {
+		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDAVBackend')->disableOriginalConstructor()->getMock();
+		$backend->expects($this->exactly($createCount))->method('createCard');
+		$backend->expects($this->exactly($updateCount))->method('updateCard');
+		$backend->expects($this->exactly($deleteCount))->method('deleteCard');
+		return $backend;
+	}
+
+	/**
+	 * @param $backend
+	 * @param $response
+	 * @return SyncService|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getSyncServiceMock($backend, $response) {
+		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $ss */
+		$ss = $this->getMock('OCA\DAV\CardDAV\SyncService', ['ensureSystemAddressBookExists', 'requestSyncReport', 'download'], [$backend]);
+		$ss->method('requestSyncReport')->withAnyParameters()->willReturn(['response' => $response, 'token' => 'sync-token-1']);
+		$ss->method('ensureSystemAddressBookExists')->willReturn(['id' => 1]);
+		$ss->method('download')->willReturn([
+			'body' => '',
+			'statusCode' => 200,
+			'headers' => []
+		]);
+		return $ss;
+	}
+
+}

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -153,8 +153,10 @@ class Application extends \OCP\AppFramework\App {
 			if ($event instanceof SabrePluginEvent) {
 				$authPlugin = $event->getServer()->getPlugin('auth');
 				if ($authPlugin instanceof Plugin) {
-					$db = $container->getServer()->getDatabaseConnection();
-					$authPlugin->addBackend(new FedAuth($db));
+					$h = new DbHandler($container->getServer()->getDatabaseConnection(),
+							$container->getServer()->getL10N('federation')
+					);
+					$authPlugin->addBackend(new FedAuth($h));
 				}
 			}
 		});

--- a/apps/federation/appinfo/application.php
+++ b/apps/federation/appinfo/application.php
@@ -23,6 +23,7 @@ namespace OCA\Federation\AppInfo;
 
 use OCA\Federation\API\OCSAuthAPI;
 use OCA\Federation\Controller\SettingsController;
+use OCA\Federation\DAV\FedAuth;
 use OCA\Federation\DbHandler;
 use OCA\Federation\Hooks;
 use OCA\Federation\Middleware\AddServerMiddleware;
@@ -30,7 +31,9 @@ use OCA\Federation\TrustedServers;
 use OCP\API;
 use OCP\App;
 use OCP\AppFramework\IAppContainer;
+use OCP\SabrePluginEvent;
 use OCP\Util;
+use Sabre\DAV\Auth\Plugin;
 
 class Application extends \OCP\AppFramework\App {
 
@@ -144,6 +147,17 @@ class Application extends \OCP\AppFramework\App {
 				$hooksManager,
 				'addServerHook'
 		);
+
+		$dispatcher = $this->getContainer()->getServer()->getEventDispatcher();
+		$dispatcher->addListener('OCA\DAV\Connector\Sabre::authInit', function($event) use($container) {
+			if ($event instanceof SabrePluginEvent) {
+				$authPlugin = $event->getServer()->getPlugin('auth');
+				if ($authPlugin instanceof Plugin) {
+					$db = $container->getServer()->getDatabaseConnection();
+					$authPlugin->addBackend(new FedAuth($db));
+				}
+			}
+		});
 	}
 
 }

--- a/apps/federation/appinfo/database.xml
+++ b/apps/federation/appinfo/database.xml
@@ -52,9 +52,8 @@
 			</field>
 			<field>
 				<name>sync_token</name>
-				<type>integer</type>
-				<notnull>true</notnull>
-				<default>0</default>
+				<type>text</type>
+				<length>512</length>
 				<comments>cardDav sync token</comments>
 			</field>
 			<index>

--- a/apps/federation/appinfo/database.xml
+++ b/apps/federation/appinfo/database.xml
@@ -34,7 +34,7 @@
 				<name>token</name>
 				<type>text</type>
 				<length>128</length>
-				<comments>toke used to exchange the shared secret</comments>
+				<comments>token used to exchange the shared secret</comments>
 			</field>
 			<field>
 				<name>shared_secret</name>
@@ -49,6 +49,13 @@
 				<notnull>true</notnull>
 				<default>2</default>
 				<comments>current status of the connection</comments>
+			</field>
+			<field>
+				<name>sync_token</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<default>0</default>
+				<comments>cardDav sync token</comments>
 			</field>
 			<index>
 				<name>url_hash</name>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -5,7 +5,7 @@
     <description>ownCloud Federation allows you to connect with other trusted ownClouds to exchange the user directory. For example this will be used to auto-complete external users for federated sharing.</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <namespace>Federation</namespace>
     <category>other</category>
 	<dependencies>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -11,4 +11,7 @@
 	<dependencies>
 		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
+    <types>
+        <authentication/>
+    </types>
 </info>

--- a/apps/federation/appinfo/register_command.php
+++ b/apps/federation/appinfo/register_command.php
@@ -1,0 +1,9 @@
+<?php
+
+$config = \OC::$server->getConfig();
+$dbConnection = \OC::$server->getDatabaseConnection();
+$userManager = OC::$server->getUserManager();
+$config = \OC::$server->getConfig();
+
+/** @var Symfony\Component\Console\Application $application */
+$application->add(new \OCA\Federation\Command\SyncFederationAddressBooks($userManager, $dbConnection, $config));

--- a/apps/federation/appinfo/register_command.php
+++ b/apps/federation/appinfo/register_command.php
@@ -1,9 +1,6 @@
 <?php
 
-$config = \OC::$server->getConfig();
 $dbConnection = \OC::$server->getDatabaseConnection();
-$userManager = OC::$server->getUserManager();
-$config = \OC::$server->getConfig();
 
 /** @var Symfony\Component\Console\Application $application */
-$application->add(new \OCA\Federation\Command\SyncFederationAddressBooks($userManager, $dbConnection, $config));
+$application->add(new \OCA\Federation\Command\SyncFederationAddressBooks($dbConnection));

--- a/apps/federation/appinfo/register_command.php
+++ b/apps/federation/appinfo/register_command.php
@@ -1,6 +1,8 @@
 <?php
 
 $dbConnection = \OC::$server->getDatabaseConnection();
+$l10n = \OC::$server->getL10N('federation');
+$dbHandler = new \OCA\Federation\DbHandler($dbConnection, $l10n);
 
 /** @var Symfony\Component\Console\Application $application */
-$application->add(new \OCA\Federation\Command\SyncFederationAddressBooks($dbConnection));
+$application->add(new \OCA\Federation\Command\SyncFederationAddressBooks($dbHandler));

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace OCA\Federation\Command;
+
+use OCA\DAV\CardDAV\SyncService;
+use OCA\Federation\DbHandler;
+use OCA\Federation\TrustedServers;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncFederationAddressBooks extends Command {
+
+	/** @var \OCP\IDBConnection */
+	protected $dbConnection;
+
+	/** @var SyncService */
+	private $syncService;
+
+	/**
+	 * @param IUserManager $userManager
+	 * @param IDBConnection $dbConnection
+	 * @param IConfig $config
+	 */
+	function __construct(IDBConnection $dbConnection) {
+		parent::__construct();
+
+		$this->syncService = \OC::$server->query('CardDAVSyncService');
+		$this->dbConnection = $dbConnection;
+	}
+
+	protected function configure() {
+		$this
+			->setName('federation:sync-addressbooks')
+			->setDescription('Synchronizes addressbooks of all federated clouds');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+
+		$progress = new ProgressBar($output);
+		$progress->start();
+		$db = new DbHandler($this->dbConnection, null);
+		$trustedServers = $db->getAllServer();
+		foreach ($trustedServers as $trustedServer) {
+			$progress->advance();
+			$url = $trustedServer['url'];
+			$sharedSecret = $trustedServer['shared_secret'];
+			$syncToken = $trustedServer['sync_token'];
+
+			if (is_null($sharedSecret)) {
+				continue;
+			}
+			$targetBookId = md5($url);
+			$targetPrincipal = "principals/system/system";
+			$targetBookProperties = [
+					'{DAV:}displayname' => $url
+			];
+			$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetPrincipal, $targetBookId, $targetBookProperties);
+			if ($newToken !== $syncToken) {
+				$db->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
+			}
+		}
+		$progress->finish();
+		$output->writeln('');
+	}
+}

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -16,22 +16,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SyncFederationAddressBooks extends Command {
 
-	/** @var \OCP\IDBConnection */
-	protected $dbConnection;
+	/** @var DbHandler */
+	protected $dbHandler;
 
 	/** @var SyncService */
 	private $syncService;
 
 	/**
 	 * @param IUserManager $userManager
-	 * @param IDBConnection $dbConnection
+	 * @param IDBConnection $dbHandler
 	 * @param IConfig $config
 	 */
-	function __construct(IDBConnection $dbConnection) {
+	function __construct(DbHandler $dbHandler) {
 		parent::__construct();
 
 		$this->syncService = \OC::$server->query('CardDAVSyncService');
-		$this->dbConnection = $dbConnection;
+		$this->dbHandler = $dbHandler;
 	}
 
 	protected function configure() {
@@ -48,8 +48,7 @@ class SyncFederationAddressBooks extends Command {
 
 		$progress = new ProgressBar($output);
 		$progress->start();
-		$db = new DbHandler($this->dbConnection, null);
-		$trustedServers = $db->getAllServer();
+		$trustedServers = $this->dbHandler->getAllServer();
 		foreach ($trustedServers as $trustedServer) {
 			$progress->advance();
 			$url = $trustedServer['url'];
@@ -66,7 +65,7 @@ class SyncFederationAddressBooks extends Command {
 			];
 			$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetPrincipal, $targetBookId, $targetBookProperties);
 			if ($newToken !== $syncToken) {
-				$db->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
+				$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
 			}
 		}
 		$progress->finish();

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -5,12 +5,8 @@ namespace OCA\Federation\Command;
 use OCA\DAV\CardDAV\SyncService;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
-use OCP\IConfig;
-use OCP\IDBConnection;
-use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -23,9 +19,7 @@ class SyncFederationAddressBooks extends Command {
 	private $syncService;
 
 	/**
-	 * @param IUserManager $userManager
-	 * @param IDBConnection $dbHandler
-	 * @param IConfig $config
+	 * @param DbHandler $dbHandler
 	 */
 	function __construct(DbHandler $dbHandler) {
 		parent::__construct();

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -59,7 +59,7 @@ class SyncFederationAddressBooks extends Command {
 			if (is_null($sharedSecret)) {
 				continue;
 			}
-			$targetBookId = md5($url);
+			$targetBookId = sha1($url);
 			$targetPrincipal = "principals/system/system";
 			$targetBookProperties = [
 					'{DAV:}displayname' => $url

--- a/apps/federation/command/syncfederationaddressbooks.php
+++ b/apps/federation/command/syncfederationaddressbooks.php
@@ -63,9 +63,13 @@ class SyncFederationAddressBooks extends Command {
 			$targetBookProperties = [
 					'{DAV:}displayname' => $url
 			];
-			$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetPrincipal, $targetBookId, $targetBookProperties);
-			if ($newToken !== $syncToken) {
-				$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
+			try {
+				$newToken = $this->syncService->syncRemoteAddressBook($url, 'system', $sharedSecret, $syncToken, $targetPrincipal, $targetBookId, $targetBookProperties);
+				if ($newToken !== $syncToken) {
+					$this->dbHandler->setServerStatus($url, TrustedServers::STATUS_OK, $newToken);
+				}
+			} catch (\Exception $ex) {
+				$output->writeln("Error while syncing $url : " . $ex->getMessage());
 			}
 		}
 		$progress->finish();

--- a/apps/federation/dav/fedauth.php
+++ b/apps/federation/dav/fedauth.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OCA\DAV\Connector;
+namespace OCA\Federation\DAV;
 
 use OCA\Federation\DbHandler;
 use OCP\IDBConnection;

--- a/apps/federation/dav/fedauth.php
+++ b/apps/federation/dav/fedauth.php
@@ -25,6 +25,9 @@ use Sabre\DAV\Auth\Backend\AbstractBasic;
 
 class FedAuth extends AbstractBasic {
 
+	/** @var DbHandler */
+	private $db;
+
 	/**
 	 * FedAuth constructor.
 	 *

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -207,14 +207,15 @@ class DbHandler {
 	 * @param string $url
 	 * @param int $status
 	 */
-	public function setServerStatus($url, $status) {
+	public function setServerStatus($url, $status, $token = null) {
 		$hash = $this->hash($url);
 		$query = $this->connection->getQueryBuilder();
 		$query->update($this->dbTable)
-				->set('status', $query->createParameter('status'))
-				->where($query->expr()->eq('url_hash', $query->createParameter('url_hash')))
-				->setParameter('url_hash', $hash)
-				->setParameter('status', $status);
+				->set('status', $query->createNamedParameter($status))
+				->where($query->expr()->eq('url_hash', $query->createNamedParameter($hash)));
+		if (!is_null($token)) {
+			$query->set('sync_token', $query->createNamedParameter($token));
+		}
 		$query->execute();
 	}
 

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -111,7 +111,7 @@ class DbHandler {
 	 */
 	public function getAllServer() {
 		$query = $this->connection->getQueryBuilder();
-		$query->select(['url', 'id', 'status'])->from($this->dbTable);
+		$query->select(['url', 'id', 'status', 'shared_secret', 'sync_token'])->from($this->dbTable);
 		$result = $query->execute()->fetchAll();
 		return $result;
 	}
@@ -265,6 +265,23 @@ class DbHandler {
 		$normalized = trim($normalized, '/');
 
 		return $normalized;
+	}
+
+	/**
+	 * @param $username
+	 * @param $password
+	 * @return bool
+	 */
+	public function auth($username, $password) {
+		if ($username !== 'system') {
+			return false;
+		}
+		$query = $this->connection->getQueryBuilder();
+		$query->select('url')->from($this->dbTable)
+				->where($query->expr()->eq('shared_secret', $query->createNamedParameter($password)));
+
+		$result = $query->execute()->fetch();
+		return !empty($result);
 	}
 
 }

--- a/apps/federation/lib/dbhandler.php
+++ b/apps/federation/lib/dbhandler.php
@@ -206,6 +206,7 @@ class DbHandler {
 	 *
 	 * @param string $url
 	 * @param int $status
+	 * @param string|null $token
 	 */
 	public function setServerStatus($url, $status, $token = null) {
 		$hash = $this->hash($url);

--- a/apps/federation/tests/dav/fedauthtest.php
+++ b/apps/federation/tests/dav/fedauthtest.php
@@ -18,34 +18,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OCA\Federation\DAV;
 
+
+namespace OCA\Federation\Tests\DAV;
+
+use OCA\Federation\DAV\FedAuth;
 use OCA\Federation\DbHandler;
-use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Test\TestCase;
 
-class FedAuth extends AbstractBasic {
+class FedAuthTest extends TestCase {
 
 	/**
-	 * FedAuth constructor.
+	 * @dataProvider providesUser
 	 *
-	 * @param DbHandler $db
+	 * @param array $expected
+	 * @param string $user
+	 * @param string $password
 	 */
-	public function __construct(DbHandler $db) {
-		$this->db = $db;
-		$this->principalPrefix = 'principals/system/';
+	public function testFedAuth($expected, $user, $password) {
+		/** @var DbHandler | \PHPUnit_Framework_MockObject_MockObject $db */
+		$db = $this->getMockBuilder('OCA\Federation\DbHandler')->disableOriginalConstructor()->getMock();
+		$db->method('auth')->willReturn(true);
+		$auth = new FedAuth($db);
+		$result = $this->invokePrivate($auth, 'validateUserPass', [$user, $password]);
+		$this->assertEquals($expected, $result);
 	}
 
-	/**
-	 * Validates a username and password
-	 *
-	 * This method should return true or false depending on if login
-	 * succeeded.
-	 *
-	 * @param string $username
-	 * @param string $password
-	 * @return bool
-	 */
-	protected function validateUserPass($username, $password) {
-		return $this->db->auth($username, $password);
+	public function providesUser() {
+		return [
+			[true, 'system', '123456']
+		];
 	}
 }

--- a/apps/federation/tests/lib/dbhandlertest.php
+++ b/apps/federation/tests/lib/dbhandlertest.php
@@ -26,6 +26,7 @@ namespace OCA\Federation\Tests\lib;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\IDBConnection;
+use OCP\IL10N;
 use Test\TestCase;
 
 /**
@@ -36,7 +37,7 @@ class DbHandlerTest extends TestCase {
 	/** @var  DbHandler */
 	private $dbHandler;
 
-	/** @var  \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N | \PHPUnit_Framework_MockObject_MockObject */
 	private $il10n;
 
 	/** @var  IDBConnection */
@@ -209,6 +210,11 @@ class DbHandlerTest extends TestCase {
 		$this->assertSame(TrustedServers::STATUS_OK,
 			$this->dbHandler->getServerStatus('https://server1')
 		);
+
+		// test sync token
+		$this->dbHandler->setServerStatus('http://server1', TrustedServers::STATUS_OK, 'token1234567890');
+		$servers = $this->dbHandler->getAllServer();
+		$this->assertSame('token1234567890', $servers[0]['sync_token']);
 	}
 
 	/**
@@ -256,4 +262,22 @@ class DbHandlerTest extends TestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider providesAuth
+	 */
+	public function testAuth($expectedResult, $user, $password) {
+		if ($expectedResult) {
+			$this->dbHandler->addServer('url1');
+			$this->dbHandler->addSharedSecret('url1', $password);
+		}
+		$result = $this->dbHandler->auth($user, $password);
+		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function providesAuth() {
+		return [
+			[false, 'foo', ''],
+			[true, 'system', '123456789'],
+		];
+	}
 }

--- a/lib/public/sabrepluginevent.php
+++ b/lib/public/sabrepluginevent.php
@@ -23,6 +23,7 @@ namespace OCP;
 
 
 use OCP\AppFramework\Http;
+use Sabre\DAV\Server;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -36,12 +37,16 @@ class SabrePluginEvent extends Event {
 	/** @var string */
 	protected $message;
 
+	/** @var Server */
+	protected $server;
+
 	/**
 	 * @since 8.2.0
 	 */
-	public function __construct() {
+	public function __construct($server = null) {
 		$this->message = '';
 		$this->statusCode = Http::STATUS_OK;
+		$this->server = $server;
 	}
 
 	/**
@@ -78,5 +83,13 @@ class SabrePluginEvent extends Event {
 	 */
 	public function getMessage() {
 		return $this->message;
+	}
+
+	/**
+	 * @return null|Server
+	 * @since 9.0.0
+	 */
+	public function getServer() {
+		return $this->server;
 	}
 }


### PR DESCRIPTION
# Test scenario:
1. start two servers with this code base
2. add server A to server B under federation section in admin
3. add server B to server ! under federation section in admin
4. execute cron job on both sides until both servers have exchanged the shared_secret
5. run ./occ dav:sync-system-addressbook on both servers to populate the system addressbook with the users of this instance
6. run on one of these two servers (or both) ./occ federation:sync-addressbooks - a new addressbook will be generated holding the users of the other server
