### PR TITLE
Settings user only load avatar if available

### DIFF
--- a/settings/application.php
+++ b/settings/application.php
@@ -136,7 +136,8 @@ class Application extends App {
 				$c->query('Mailer'),
 				$c->query('DefaultMailAddress'),
 				$c->query('URLGenerator'),
-				$c->query('OCP\\App\\IAppManager')
+				$c->query('OCP\\App\\IAppManager'),
+				$c->query('OCP\\IAvatarManager')
 			);
 		});
 		$container->registerService('LogSettingsController', function(IContainer $c) {

--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -43,6 +43,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
+use OCP\IAvatarManager;
 
 /**
  * @package OC\Settings\Controller
@@ -74,6 +75,8 @@ class UsersController extends Controller {
 	private $isEncryptionAppEnabled;
 	/** @var bool contains the state of the admin recovery setting */
 	private $isRestoreEnabled = false;
+	/** @var IAvatarManager */
+	private $avatarManager;
 
 	/**
 	 * @param string $appName
@@ -104,7 +107,8 @@ class UsersController extends Controller {
 								IMailer $mailer,
 								$fromMailAddress,
 								IURLGenerator $urlGenerator,
-								IAppManager $appManager) {
+								IAppManager $appManager,
+								IAvatarManager $avatarManager) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
@@ -117,6 +121,7 @@ class UsersController extends Controller {
 		$this->mailer = $mailer;
 		$this->fromMailAddress = $fromMailAddress;
 		$this->urlGenerator = $urlGenerator;
+		$this->avatarManager = $avatarManager;
 
 		// check for encryption state - TODO see formatUserForIndex
 		$this->isEncryptionAppEnabled = $appManager->isEnabledForUser('encryption');
@@ -168,6 +173,12 @@ class UsersController extends Controller {
 		if (is_null($displayName)) {
 			$displayName = '';
 		}
+
+		$avatarAvailable = false;
+		if ($this->config->getSystemValue('enable_avatars', true) === true) {
+			$avatarAvailable = $this->avatarManager->getAvatar($user->getUID())->exists();
+		}
+
 		return [
 			'name' => $user->getUID(),
 			'displayname' => $user->getDisplayName(),
@@ -179,6 +190,7 @@ class UsersController extends Controller {
 			'backend' => $user->getBackendClassName(),
 			'email' => $displayName,
 			'isRestoreDisabled' => !$restorePossible,
+			'isAvatarAvailable' => $avatarAvailable,
 		];
 	}
 

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -64,8 +64,12 @@ var UserList = {
 		/**
 		 * Avatar or placeholder
 		 */
-		if ($tr.find('div.avatardiv').length){
-			$('div.avatardiv', $tr).avatar(user.name, 32, undefined, undefined, undefined, user.displayname);
+		if ($tr.find('div.avatardiv').length) {
+			if (user.isAvatarAvailable === true) {
+				$('div.avatardiv', $tr).avatar(user.name, 32, undefined, undefined, undefined, user.displayname);
+			} else {
+				$('div.avatardiv', $tr).imageplaceholder(user.displayname);
+			}
 		}
 
 		/**

--- a/tests/settings/controller/userscontrollertest.php
+++ b/tests/settings/controller/userscontrollertest.php
@@ -54,6 +54,30 @@ class UsersControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->container['OCP\\App\\IAppManager'] = $this->getMockBuilder('OCP\\App\\IAppManager')
 			->disableOriginalConstructor()->getMock();
+
+
+		/*
+		 * Set default avtar behaviour for whole testsuite
+		 */
+		$this->container['OCP\\IAvatarManager'] = $this->getMock('OCP\IAvatarManager');
+
+		$avatarExists = $this->getMock('OCP\IAvatar');
+		$avatarExists->method('exists')->willReturn(true);
+		$avatarNotExists = $this->getMock('OCP\IAvatar');
+		$avatarNotExists->method('exists')->willReturn(false);
+		$this->container['OCP\\IAvatarManager']
+			->method('getAvatar')
+			->will($this->returnValueMap([
+				['foo', $avatarExists],
+				['bar', $avatarExists],
+				['admin', $avatarNotExists],
+			]));
+
+		$this->container['Config']
+			->method('getSystemValue')
+			->with('enable_avatars', true)
+			->willReturn(true);
+
 	}
 
 	public function testIndexAdmin() {
@@ -62,7 +86,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -86,7 +110,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -112,7 +136,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -188,7 +212,6 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('getSubAdmin')
 			->will($this->returnValue($subadmin));
 
-
 		$expectedResponse = new DataResponse(
 			array(
 				0 => array(
@@ -202,6 +225,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => 'OC_User_Database',
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				),
 				1 => array(
 					'name' => 'admin',
@@ -214,6 +238,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => false,
 				),
 				2 => array(
 					'name' => 'bar',
@@ -226,6 +251,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				),
 			)
 		);
@@ -246,7 +272,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -270,7 +296,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -296,7 +322,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -401,6 +427,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				],
 				1=> [
 					'name' => 'foo',
@@ -413,6 +440,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => 'OC_User_Database',
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				],
 				2 => [
 					'name' => 'admin',
@@ -425,6 +453,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => false,
 				],
 			]
 		);
@@ -443,7 +472,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -467,7 +496,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -493,7 +522,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -553,6 +582,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => 'OC_User_Database',
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				),
 				1 => array(
 					'name' => 'admin',
@@ -565,6 +595,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => false,
 				),
 				2 => array(
 					'name' => 'bar',
@@ -577,6 +608,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => '\Test\Util\User\Dummy',
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				),
 			)
 		);
@@ -590,7 +622,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$user = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$user
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$user
@@ -648,6 +680,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'backend' => 'OC_User_Database',
 					'email' => null,
 					'isRestoreDisabled' => false,
+					'isAvatarAvailable' => true,
 				)
 			)
 		);
@@ -719,6 +752,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'subadmin' => array(),
 				'email' => null,
 				'isRestoreDisabled' => false,
+				'isAvatarAvailable' => true,
 			),
 			Http::STATUS_CREATED
 		);
@@ -807,6 +841,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'subadmin' => [],
 				'email' => null,
 				'isRestoreDisabled' => false,
+				'isAvatarAvailable' => true,
 			),
 			Http::STATUS_CREATED
 		);
@@ -889,6 +924,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'subadmin' => array(),
 				'email' => null,
 				'isRestoreDisabled' => false,
+				'isAvatarAvailable' => true,
 			),
 			Http::STATUS_CREATED
 		);
@@ -984,6 +1020,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'subadmin' => [],
 				'email' => null,
 				'isRestoreDisabled' => false,
+				'isAvatarAvailable' => true,
 			),
 			Http::STATUS_CREATED
 		);
@@ -1480,6 +1517,7 @@ class UsersControllerTest extends \Test\TestCase {
 			'backend' => $backend,
 			'email' => null,
 			'isRestoreDisabled' => false,
+			'isAvatarAvailable' => true,
 		];
 
 		return [$user, $result];


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20644

While generating the list of users check directly if the avatar is available. If it is not then the user does not even have to try to load it.

The assumption here is that if an installation has a large number of users it is likely that a lot of them do not have avatars. This then reduces significantly the number of requests to the server (which should also limit the load on the server).

So basically we trade of time vs time. Generating the user list will take slightly longer but this will result most likely in significant less requests.

CC: @MorrisJobke @PVince81 @blizzz 
