### PR TITLE
Remove unused setActiveNavigationEntry of OC_App - it's also in OCP\App

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -361,23 +361,6 @@ class OC_App {
 	}
 
 	/**
-	 * marks a navigation entry as active
-	 *
-	 * @param string $id id of the entry
-	 * @return bool
-	 *
-	 * This function sets a navigation entry as active and removes the 'active'
-	 * property from all other entries. The templates can use this for
-	 * highlighting the current position of the user.
-	 *
-	 * @deprecated Use \OC::$server->getNavigationManager()->setActiveEntry() instead
-	 */
-	public static function setActiveNavigationEntry($id) {
-		OC::$server->getNavigationManager()->setActiveEntry($id);
-		return true;
-	}
-
-	/**
 	 * gets the active Menu entry
 	 *
 	 * @return string id or empty string

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -361,20 +361,6 @@ class OC_App {
 	}
 
 	/**
-	 * gets the active Menu entry
-	 *
-	 * @return string id or empty string
-	 *
-	 * This function returns the id of the active navigation entry (set by
-	 * setActiveNavigationEntry
-	 *
-	 * @deprecated Use \OC::$server->getNavigationManager()->getActiveEntry() instead
-	 */
-	public static function getActiveNavigationEntry() {
-		return OC::$server->getNavigationManager()->getActiveEntry();
-	}
-
-	/**
 	 * Returns the Settings Navigation
 	 *
 	 * @return string[]

--- a/lib/public/app.php
+++ b/lib/public/app.php
@@ -82,7 +82,8 @@ class App {
 	 * @since 4.0.0
 	 */
 	public static function setActiveNavigationEntry( $id ) {
-		return \OC_App::setActiveNavigationEntry( $id );
+		\OC::$server->getNavigationManager()->setActiveEntry($id);
+		return true;
 	}
 
 	/**

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -33,7 +33,7 @@
 use OC\Lock\NoopLockingProvider;
 
 OC_Util::checkAdminUser();
-OC_App::setActiveNavigationEntry("admin");
+\OC::$server->getNavigationManager()->setActiveEntry("admin");
 
 $template = new OC_Template('settings', 'admin', 'user');
 $l = \OC::$server->getL10N('settings');

--- a/settings/help.php
+++ b/settings/help.php
@@ -30,7 +30,7 @@ OC_Util::checkLoggedIn();
 
 // Load the files we need
 OC_Util::addStyle( "settings", "settings" );
-OC_App::setActiveNavigationEntry( "help" );
+\OC::$server->getNavigationManager()->setActiveEntry('help');
 
 
 if(isset($_GET['mode']) and $_GET['mode'] === 'admin') {

--- a/settings/users.php
+++ b/settings/users.php
@@ -35,7 +35,7 @@
 
 OC_Util::checkSubAdminUser();
 
-OC_App::setActiveNavigationEntry( 'core_users' );
+\OC::$server->getNavigationManager()->setActiveEntry('core_users');
 
 $userManager = \OC_User::getManager();
 $groupManager = \OC_Group::getManager();


### PR DESCRIPTION
This cleans up old private namespace.

cc @LukasReschke @DeepDiver1975 @nickvergessen @rullzer @Xenopathic Please review
