### PR TITLE
Remove unnecessary group name validation in provisioning_api

### DIFF
--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -131,7 +131,7 @@ class Groups{
 		// Validate name
 		$groupId = $this->request->getParam('groupid', '');
 		if(empty($groupId)){
-			\OCP\Util::writeLog('provisioning_api', 'Attempt made to create group using invalid characters.', \OCP\Util::ERROR);
+			\OCP\Util::writeLog('provisioning_api', 'Group name not supplied', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}
 		// Check if it exists

--- a/apps/provisioning_api/lib/groups.php
+++ b/apps/provisioning_api/lib/groups.php
@@ -130,7 +130,7 @@ class Groups{
 	public function addGroup($parameters) {
 		// Validate name
 		$groupId = $this->request->getParam('groupid', '');
-		if( preg_match( '/[^a-zA-Z0-9 _\.@\-]/', $groupId ) || empty($groupId)){
+		if(empty($groupId)){
 			\OCP\Util::writeLog('provisioning_api', 'Attempt made to create group using invalid characters.', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -381,7 +381,7 @@ class GroupsTest extends \Test\TestCase {
 
 		$this->groupManager
 			->method('groupExists')
-			->with('NewGroup')
+			->with('Iñtërnâtiônàlizætiøn')
 			->willReturn(false);
 
 		$this->groupManager

--- a/apps/provisioning_api/tests/groupstest.php
+++ b/apps/provisioning_api/tests/groupstest.php
@@ -373,6 +373,27 @@ class GroupsTest extends \Test\TestCase {
 		$this->assertTrue($result->succeeded());
 	}
 
+	public function testAddGroupWithSpecialChar() {
+		$this->request
+			->method('getParam')
+			->with('groupid')
+			->willReturn('Iñtërnâtiônàlizætiøn');
+
+		$this->groupManager
+			->method('groupExists')
+			->with('NewGroup')
+			->willReturn(false);
+
+		$this->groupManager
+			->expects($this->once())
+			->method('createGroup')
+			->with('Iñtërnâtiônàlizætiøn');
+
+		$result = $this->api->addGroup([]);
+		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertTrue($result->succeeded());
+	}
+
 	public function testDeleteGroupNonExisting() {
 		$result = $this->api->deleteGroup([
 			'groupid' => 'NonExistingGroup'


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20817 by removing the unnecessary group name validation that is not present elsewhere in ownCloud - allows the full range of characters.

WIP as I need to fix my env so I can check the tests.
