### PR TITLE
Add 'my groups' anchor to the personal page sidebar

### DIFF
--- a/settings/personal.php
+++ b/settings/personal.php
@@ -165,6 +165,7 @@ $l = \OC::$server->getL10N('settings');
 $formsAndMore = [];
 $formsAndMore[]= ['anchor' => 'clientsbox', 'section-name' => $l->t('Sync clients')];
 $formsAndMore[]= ['anchor' => 'passwordform', 'section-name' => $l->t('Personal info')];
+$formsAndMore[]= ['anchor' => 'groups', 'section-name' => $l->t('Groups')];
 
 $forms=OC_App::getForms('personal');
 


### PR DESCRIPTION
Cherry-picked from https://github.com/owncloud/core/pull/20318

Would then look like:

![bildschirmfoto 2015-12-07 um 09 59 58](https://cloud.githubusercontent.com/assets/245432/11622909/6284418a-9cc9-11e5-872f-32cf169ad760.png)

Personally I would not bring this in, because it is part of there "Personal info" section. @owncloud/designers @rullzer @nickvergessen Opinions on this?
