### PR TITLE
OC.FilePath has still a valid use case when generating paths to stati…

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -174,7 +174,6 @@ var OC={
 	 * @param {string} type the type of the file to link to (e.g. css,img,ajax.template)
 	 * @param {string} file the filename
 	 * @return {string} Absolute URL for a file in an app
-	 * @deprecated use OC.generateUrl() instead
 	 */
 	filePath:function(app,type,file){
 		var isCore=OC.coreApps.indexOf(app)!==-1,


### PR DESCRIPTION
…c files what for generateUrl cannot be used for - closes #15604
