### PR TITLE
Update parent when moving share into recieved share

### DIFF
--- a/apps/files_sharing/lib/updater.php
+++ b/apps/files_sharing/lib/updater.php
@@ -58,6 +58,47 @@ class Shared_Updater {
 	 */
 	static public function renameHook($params) {
 		self::renameChildren($params['oldpath'], $params['newpath']);
+		self::moveShareToShare($params['newpath']);
+	}
+
+	/**
+	 * Fix for https://github.com/owncloud/core/issues/20769
+	 *
+	 * The owner is allowed to move their files (if they are shared) into a receiving folder
+	 * In this case we need to update the parent of the moved share. Since they are
+	 * effectively handing over ownership of the file the rest of the code needs to know
+	 * they need to build up the reshare tree.
+	 *
+	 * @param string $path
+	 */
+	static private function moveShareToShare($path) {
+		$userFolder = \OC::$server->getUserFolder();
+		$src = $userFolder->get($path);
+
+		$type = $src instanceof \OCP\Files\File ? 'file' : 'folder';
+		$shares = \OCP\Share::getItemShared($type, $src->getId());
+
+		// If the path we move is not a share we don't care
+		if (empty($shares)) {
+			return;
+		}
+
+		// Check if the destination is inside a share
+		$mountManager = \OC::$server->getMountManager();
+		$dstMount = $mountManager->find($src->getPath());
+		if (!($dstMount instanceof \OCA\Files_Sharing\SharedMount)) {
+			return;
+		}
+
+		$parenShare = $dstMount->getShare();
+
+		foreach ($shares as $share) {
+			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$qb->update('share')
+					->set('parent', $qb->createNamedParameter($parenShare['id']))
+					->where($qb->expr()->eq('id', $qb->createNamedParameter($share['id'])))
+					->execute();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #20769

When I receive a share and move a share of myself into that share (which
is allowed currently) I effectively hand over ownership of the files I
move. So we need to update the share I move to have as a parent the
share I move it into. Else our mounting system gets confused.

No unit tests here since well. It is hell to write them for this code :( But we have an integration tests PR ready for exactly this case: https://github.com/owncloud/core/pull/20893

Lets see if we don't break anything else.
