### PR TITLE
prevent selecting on log in page to solve ugliness on accidental selection

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -254,6 +254,10 @@ body {
 	width: 22em;
 	margin: 0 auto;
 	padding-top: 20px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 #body-login p.info a {
 	font-weight: 600;
@@ -291,6 +295,10 @@ body {
 #body-login form fieldset {
 	margin-bottom: 20px;
 	text-align: left;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 #body-login form #sqliteInformation {
 	margin-top: -20px;
@@ -348,6 +356,10 @@ body {
 .groupmiddle,
 .groupbottom {
 	position: relative;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 #body-login .grouptop input,
 .grouptop input {
@@ -385,6 +397,10 @@ label.infield {
 	padding: 14px;
 	padding-left: 28px;
 	vertical-align: middle;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
 html.ie8 #body-login form input[type="checkbox"]+label {
 	margin-left: -28px;


### PR DESCRIPTION
Being able to select the text inside the input fields is still possible without problems. Please review @owncloud/designers 

Before & after on selecting all on the log in page:
![capture du 2015-12-07 14-33-31](https://cloud.githubusercontent.com/assets/925062/11628126/d49e302a-9cef-11e5-8f5b-eae1a6f7027f.png)![capture du 2015-12-07 14-32-30](https://cloud.githubusercontent.com/assets/925062/11628125/d498fb5a-9cef-11e5-866d-58533153043f.png)
