### PR TITLE
Do not overwrite the language when it's just missing for one app

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -116,13 +116,17 @@ class OC_L10N implements \OCP\IL10N {
 				$preferred_language = str_replace('-', '_', $preferred_language);
 				foreach ($available as $available_language) {
 					if ($preferred_language === strtolower($available_language)) {
-						self::$language = $available_language;
+						if (!self::$language) {
+							self::$language = $available_language;
+						}
 						return $available_language;
 					}
 				}
 				foreach ($available as $available_language) {
 					if (substr($preferred_language, 0, 2) === $available_language) {
-						self::$language = $available_language;
+						if (!self::$language) {
+							self::$language = $available_language;
+						}
 						return $available_language;
 					}
 				}
@@ -407,7 +411,7 @@ class OC_L10N implements \OCP\IL10N {
 	 * If nothing works it returns 'en'
 	 */
 	public static function findLanguage($app = null) {
-		if(self::$language != '') {
+		if (self::$language != '' && self::languageExists($app, self::$language)) {
 			return self::$language;
 		}
 


### PR DESCRIPTION
Fix #20666
### Steps
1. Make sure your browsers "accept language header" does not contain Russian
2. Make sure you have no default language in the config.php
3. Select Russian as language on the personal page
4. Visit the activity page
### Expected

The page should be in Russian
### Actual

It's in the first language of your accept header

@karlitschek should backport to 8.2

@MorrisJobke @PVince81 please review
