### PR TITLE
improve layout of personal settings page

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -705,9 +705,9 @@ code { font-family:"Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono
 
 #quota {
 	cursor: default;
-	margin: 30px;
+	margin: 30px !important;
 	position: relative;
-	padding: 0;
+	padding: 0 !important;
 }
 #quota div {
 	padding: 0;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -6,6 +6,41 @@ select#languageinput, select#timezone { width:15em; }
 input#openid, input#webdav { width:20em; }
 
 /* PERSONAL */
+
+#avatar {
+	display: inline-block;
+	float: left;
+	width: 160px;
+	padding-right: 0;
+}
+#avatar .avatardiv {
+	margin-bottom: 10px;
+}
+#avatar .warning {
+	width: 350px;
+}
+#uploadavatarbutton,
+#selectavatar,
+#removeavatar {
+	width: 33px;
+	height: 33px;
+}
+
+#displaynameform,
+#lostpassword,
+#groups {
+	display: inline-block;
+	margin-bottom: 0;
+	padding-bottom: 0;
+	padding-right: 0;
+	min-width: 60%;
+}
+#avatar,
+#passwordform {
+	margin-bottom: 0;
+	padding-bottom: 0;
+}
+
 #sslCertificate tr.expired {
 	background-color: rgba(255, 0, 0, 0.5);
 }
@@ -13,22 +48,6 @@ input#openid, input#webdav { width:20em; }
 	padding: 5px;
 }
 
-/* Sync clients */
-.clientsbox {
-	padding-top: 30px;
-	margin-top: -30px;
-}
-.clientsbox h2 {
-	font-weight: 300;
-	font-size: 20px;
-	margin: 35px 0 10px;
-}
-.clientsbox .center {
-	margin-top: 10px;
-}
-.clientsbox a {
-	font-weight: 600;
-}
 
 #displaynameerror {
 	display: none;
@@ -42,10 +61,6 @@ input#identity {
 #displayName,
 #email {
 	width: 17em;
-}
-
-#avatar .warning {
-	width: 350px;
 }
 
 .msg.success {

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -25,6 +25,15 @@ input#openid, input#webdav { width:20em; }
 	width: 33px;
 	height: 33px;
 }
+.jcrop-holder {
+	z-index: 500;
+}
+#avatar #cropper {
+	float: left;
+	background-color: #fff;
+	z-index: 500;
+	position: relative;
+}
 
 #displaynameform,
 #lostpassword,
@@ -39,6 +48,10 @@ input#openid, input#webdav { width:20em; }
 #passwordform {
 	margin-bottom: 0;
 	padding-bottom: 0;
+}
+#groups {
+	overflow-wrap: break-word;
+	max-width: 75%;
 }
 
 #sslCertificate tr.expired {
@@ -61,6 +74,10 @@ input#identity {
 #displayName,
 #email {
 	width: 17em;
+}
+
+#showWizard {
+	display: inline-block;
 }
 
 .msg.success {

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -98,7 +98,7 @@ function updateAvatar (hidedefault) {
 		$('#header .avatardiv').addClass('avatardiv-shown');
 	}
 	$displaydiv.css({'background-color': ''});
-	$displaydiv.avatar(OC.currentUser, 128, true);
+	$displaydiv.avatar(OC.currentUser, 145, true);
 
 	$('#removeavatar').show();
 }

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -408,7 +408,7 @@ $(document).ready(function () {
 
 	// Load the big avatar
 	if (oc_config.enable_avatars) {
-		$('#avatar .avatardiv').avatar(OC.currentUser, 128);
+		$('#avatar .avatardiv').avatar(OC.currentUser, 145);
 	}
 });
 

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -163,9 +163,8 @@ $tmpl->assign('groups', $groups2);
 // add hardcoded forms from the template
 $l = \OC::$server->getL10N('settings');
 $formsAndMore = [];
+$formsAndMore[]= ['anchor' => 'avatar', 'section-name' => $l->t('Personal info')];
 $formsAndMore[]= ['anchor' => 'clientsbox', 'section-name' => $l->t('Sync clients')];
-$formsAndMore[]= ['anchor' => 'passwordform', 'section-name' => $l->t('Personal info')];
-$formsAndMore[]= ['anchor' => 'groups', 'section-name' => $l->t('Groups')];
 
 $forms=OC_App::getForms('personal');
 

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -55,7 +55,7 @@
 
 	<div id="cropper" class="hidden">
 		<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
-		<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile image')); ?></div>
+		<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile picture')); ?></div>
 	</div>
 </form>
 <?php endif; ?>
@@ -210,7 +210,6 @@ if($_['passwordChangeSupported']) {
 	<?php endif; ?>
 
 	<?php if(OC_APP::isEnabled('firstrunwizard')) {?>
-	<br>
 	<a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a>
 	<?php }?>
 </div>

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -22,36 +22,6 @@
 
 <div id="app-content">
 
-<div id="clientsbox" class="clientsbox center">
-	<h2><?php p($l->t('Get the apps to sync your files'));?></h2>
-	<a href="<?php p($_['clients']['desktop']); ?>" target="_blank">
-		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'desktopapp.png')); ?>"
-			alt="<?php p($l->t('Desktop client'));?>" />
-	</a>
-	<a href="<?php p($_['clients']['android']); ?>" target="_blank">
-		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'googleplay.png')); ?>"
-			alt="<?php p($l->t('Android app'));?>" />
-	</a>
-	<a href="<?php p($_['clients']['ios']); ?>" target="_blank">
-		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'appstore.png')); ?>"
-			alt="<?php p($l->t('iOS app'));?>" />
-	</a>
-
-	<?php if (OC_Util::getEditionString() === ''): ?>
-	<p class="center">
-		<?php print_unescaped($l->t('If you want to support the project
-		<a href="https://owncloud.org/contribute"
-			target="_blank" rel="noreferrer">join development</a>
-		or
-		<a href="https://owncloud.org/promote"
-			target="_blank" rel="noreferrer">spread the word</a>!'));?>
-	</p>
-	<?php endif; ?>
-
-	<?php if(OC_APP::isEnabled('firstrunwizard')) {?>
-	<p class="center"><a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a></p>
-	<?php }?>
-</div>
 
 
 <div id="quota" class="section">
@@ -63,6 +33,95 @@
 		</p>
 	</div>
 </div>
+
+
+
+<?php if ($_['enableAvatars']): ?>
+<form id="avatar" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
+	<h2><?php p($l->t('Profile picture')); ?></h2>
+	<div id="displayavatar">
+		<div class="avatardiv"></div>
+		<div class="warning hidden"></div>
+		<?php if ($_['avatarChangeSupported']): ?>
+		<label for="uploadavatar" class="inlineblock button icon-upload svg" id="uploadavatarbutton" title="<?php p($l->t('Upload new')); ?>"></label>
+		<div class="inlineblock button icon-folder svg" id="selectavatar" title="<?php p($l->t('Select from Files')); ?>"></div>
+		<div class="inlineblock button icon-delete svg" id="removeavatar" title="<?php p($l->t('Remove image')); ?>"></div>
+		<input type="file" name="files[]" id="uploadavatar" class="hiddenuploadfield">
+		<p><em><?php p($l->t('png or jpg, max. 20 MB')); ?></em></p>
+		<?php else: ?>
+		<?php p($l->t('Picture provided by original account')); ?>
+		<?php endif; ?>
+	</div>
+
+	<div id="cropper" class="hidden">
+		<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
+		<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile image')); ?></div>
+	</div>
+</form>
+<?php endif; ?>
+
+
+
+<?php
+if($_['displayNameChangeSupported']) {
+?>
+<form id="displaynameform" class="section">
+	<h2>
+		<label for="displayName"><?php echo $l->t('Full name');?></label>
+	</h2>
+	<input type="text" id="displayName" name="displayName"
+		value="<?php p($_['displayName'])?>"
+		autocomplete="on" autocapitalize="off" autocorrect="off" />
+    <span class="msg"></span>
+	<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
+</form>
+<?php
+} else {
+?>
+<div class="section">
+	<h2><?php echo $l->t('Full name');?></h2>
+	<span><?php if(isset($_['displayName'][0])) { p($_['displayName']); } else { p($l->t('No display name set')); } ?></span>
+</div>
+<?php
+}
+?>
+
+
+
+<?php
+if($_['passwordChangeSupported']) {
+?>
+<form id="lostpassword" class="section">
+	<h2>
+		<label for="email"><?php p($l->t('Email'));?></label>
+	</h2>
+	<input type="email" name="email" id="email" value="<?php p($_['email']); ?>"
+		placeholder="<?php p($l->t('Your email address'));?>"
+		autocomplete="on" autocapitalize="off" autocorrect="off" />
+	<span class="msg"></span><br />
+	<em><?php p($l->t('For password recovery and notifications'));?></em>
+</form>
+<?php
+} else {
+?>
+<div class="section">
+	<h2><?php echo $l->t('Email'); ?></h2>
+	<span><?php if(isset($_['email'][0])) { p($_['email']); } else { p($l->t('No email address set')); }?></span>
+</div>
+<?php
+}
+?>
+
+
+
+<div id="groups" class="section">
+	<h2><?php p($l->t('Groups')); ?></h2>
+	<p><?php p($l->t('You are member of the following groups:')); ?></p>
+	<p>
+	<?php p(implode(', ', $_['groups'])); ?>
+	</p>
+</div>
+
 
 
 <?php
@@ -92,85 +151,7 @@ if($_['passwordChangeSupported']) {
 }
 ?>
 
-<?php
-if($_['displayNameChangeSupported']) {
-?>
-<form id="displaynameform" class="section">
-	<h2>
-		<label for="displayName"><?php echo $l->t('Full name');?></label>
-	</h2>
-	<input type="text" id="displayName" name="displayName"
-		value="<?php p($_['displayName'])?>"
-		autocomplete="on" autocapitalize="off" autocorrect="off" />
-    <span class="msg"></span>
-	<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
-</form>
-<?php
-} else {
-?>
-<div class="section">
-	<h2><?php echo $l->t('Full name');?></h2>
-	<span><?php if(isset($_['displayName'][0])) { p($_['displayName']); } else { p($l->t('No display name set')); } ?></span>
-</div>
-<?php
-}
-?>
 
-<?php
-if($_['passwordChangeSupported']) {
-?>
-<form id="lostpassword" class="section">
-	<h2>
-		<label for="email"><?php p($l->t('Email'));?></label>
-	</h2>
-	<input type="email" name="email" id="email" value="<?php p($_['email']); ?>"
-		placeholder="<?php p($l->t('Your email address'));?>"
-		autocomplete="on" autocapitalize="off" autocorrect="off" />
-	<span class="msg"></span><br />
-	<em><?php p($l->t('Fill in an email address to enable password recovery and receive notifications'));?></em>
-</form>
-<?php
-} else {
-?>
-<div class="section">
-	<h2><?php echo $l->t('Email'); ?></h2>
-	<span><?php if(isset($_['email'][0])) { p($_['email']); } else { p($l->t('No email address set')); }?></span>
-</div>
-<?php
-}
-?>
-
-<div id="groups" class="section">
-	<h2><?php p($l->t('Groups')); ?></h2>
-	<p><?php p($l->t('You are member of the following groups:')); ?></p>
-	<p>
-	<?php p(implode(', ', $_['groups'])); ?>
-	</p>
-</div>
-
-<?php if ($_['enableAvatars']): ?>
-<form id="avatar" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
-	<h2><?php p($l->t('Profile picture')); ?></h2>
-	<div id="displayavatar">
-		<div class="avatardiv"></div><br>
-		<div class="warning hidden"></div>
-		<?php if ($_['avatarChangeSupported']): ?>
-		<label for="uploadavatar" class="inlineblock button" id="uploadavatarbutton"><?php p($l->t('Upload new')); ?></label>
-		<div class="inlineblock button" id="selectavatar"><?php p($l->t('Select new from Files')); ?></div>
-		<div class="inlineblock button" id="removeavatar"><?php p($l->t('Remove image')); ?></div>
-		<input type="file" name="files[]" id="uploadavatar" class="hiddenuploadfield">
-		<br>
-		<?php p($l->t('Either png or jpg. Ideally square but you will be able to crop it. The file is not allowed to exceed the maximum size of 20 MB.')); ?>
-		<?php else: ?>
-		<?php p($l->t('Your avatar is provided by your original account.')); ?>
-		<?php endif; ?>
-	</div>
-	<div id="cropper" class="hidden">
-		<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
-		<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile image')); ?></div>
-	</div>
-</form>
-<?php endif; ?>
 
 <form class="section">
 	<h2>
@@ -199,6 +180,42 @@ if($_['passwordChangeSupported']) {
 	</a>
 	<?php endif; ?>
 </form>
+
+
+
+<div id="clientsbox" class="section clientsbox">
+	<h2><?php p($l->t('Get the apps to sync your files'));?></h2>
+	<a href="<?php p($_['clients']['desktop']); ?>" target="_blank">
+		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'desktopapp.png')); ?>"
+			alt="<?php p($l->t('Desktop client'));?>" />
+	</a>
+	<a href="<?php p($_['clients']['android']); ?>" target="_blank">
+		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'googleplay.png')); ?>"
+			alt="<?php p($l->t('Android app'));?>" />
+	</a>
+	<a href="<?php p($_['clients']['ios']); ?>" target="_blank">
+		<img src="<?php print_unescaped(OCP\Util::imagePath('core', 'appstore.png')); ?>"
+			alt="<?php p($l->t('iOS app'));?>" />
+	</a>
+
+	<?php if (OC_Util::getEditionString() === ''): ?>
+	<p>
+		<?php print_unescaped($l->t('If you want to support the project
+		<a href="https://owncloud.org/contribute"
+			target="_blank" rel="noreferrer">join development</a>
+		or
+		<a href="https://owncloud.org/promote"
+			target="_blank" rel="noreferrer">spread the word</a>!'));?>
+	</p>
+	<?php endif; ?>
+
+	<?php if(OC_APP::isEnabled('firstrunwizard')) {?>
+	<br>
+	<a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a>
+	<?php }?>
+</div>
+
+
 
 <?php foreach($_['forms'] as $form) {
 	if (isset($form['form'])) {?>


### PR DESCRIPTION
Work in progress. Check it out @owncloud/designers 
- [x] The responsiveness of the design needs to be optimized in that we should decide what should happen with the avatar chooser cause it’s so narrow compared to the other ones. Maybe it makes sense for visual balance to put the buttons on the right next to the image then, also because there’s no way to get alt text on mobile.
- [ ] Password change should not show up by default with all the boxes. Instead a simple button »Change password« which will bring up all those boxes then. Something for a different PR probably though.

![capture du 2015-12-07 14-49-24](https://cloud.githubusercontent.com/assets/925062/11628432/efffe4b0-9cf1-11e5-998c-31a79aa1133a.png)
- fixes #20610
