### PR TITLE
Fix duplicate bogus share field when link sharing is not allowed

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -48,7 +48,7 @@
 			'    {{/if}}' +
 			'{{else}}' +
 			// FIXME: this doesn't belong in this view
-			'<input id="shareWith-{{cid}}" class="shareWithField" type="text" placeholder="{{noSharingPlaceholder}}" disabled="disabled"/>' +
+			'{{#if noSharingPlaceholder}}<input id="shareWith-{{cid}}" class="shareWithField" type="text" placeholder="{{noSharingPlaceholder}}" disabled="disabled"/>{{/if}}' +
 			'{{/if}}'
 		;
 
@@ -238,15 +238,18 @@
 
 		render: function() {
 			var linkShareTemplate = this.template();
+			var resharingAllowed = this.model.sharePermissionPossible();
 
-			if(    !this.model.sharePermissionPossible()
+			if(!resharingAllowed
 				|| !this.showLink
 				|| !this.configModel.isShareWithLinkAllowed())
 			{
-				this.$el.html(linkShareTemplate({
-					shareAllowed: false,
-					noSharingPlaceholder: t('core', 'Resharing is not allowed')
-				}));
+				var templateData = {shareAllowed: false};
+				if (!resharingAllowed) {
+					// add message
+					templateData.noSharingPlaceholder = t('core', 'Resharing is not allowed');
+				}
+				this.$el.html(linkShareTemplate(templateData));
 				return this;
 			}
 

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -218,6 +218,7 @@ describe('OC.Share.ShareDialogView', function() {
 			dialog.render();
 
 			expect(dialog.$el.find('.linkCheckbox').length).toEqual(0);
+			expect(dialog.$el.find('.shareWithField').length).toEqual(1);
 		});
 		it('shows populated link share when a link share exists', function() {
 			// this is how the OC.Share class does it...


### PR DESCRIPTION
Whenever link share is not allowed, it was outputting a bogus sharing
field which name would conflict with the regular sharing field.

This fix makes sure that the bogus sharing field with "Resharing not
allowed" message only appears when triggered by removed share
permissions.

Fixes https://github.com/owncloud/core/issues/20642

Please review @blizzz @rullzer @tomneedham

@karlitschek we should backport this simple fix for 8.2.2 (regression introduced by share dialog in sidebar)
