### PR TITLE
Fix unshare link click element

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -245,12 +245,14 @@
 
 		onUnshare: function(event) {
 			var $element = $(event.target);
-			console.log($element);
+			if (!$element.is('a')) {
+				$element = $element.closest('a');
+			}
 
-			var $loading = $element.siblings('.icon-loading-small').eq(0);
+			var $loading = $element.find('.icon-loading-small').eq(0);
 			if(!$loading.hasClass('hidden')) {
 				// in process
-				return;
+				return false;
 			}
 			$loading.removeClass('hidden');
 


### PR DESCRIPTION
When clicking on the unshare link (trash icon), the correct link element
needs to be used instead of whatever child was clicked. Then, that
element might contain a visible loading icon.

This fixes the spinner detection and also prevents a full page reload in
case the spinner was visible.

Fixes https://github.com/owncloud/core/issues/21013 (very annoying, happens to me often)

@MorrisJobke @rullzer @blizzz 
