### PR TITLE
Redirect to correct URL after updating

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -84,7 +84,7 @@
 						.append(t('core', 'The update was successful. Redirecting you to ownCloud now.'))
 						.appendTo($el);
 					setTimeout(function () {
-						OC.redirect(OC.webroot);
+						OC.redirect(OC.webroot + '/');
 					}, 3000);
 				}
 			});


### PR DESCRIPTION
Now requires a trailing slash to make sure we don't land on the
forbidden page.

@LukasReschke @MorrisJobke @DeepDiver1975 

(master only, related to the change of URL that discards index.php)
