### PR TITLE
Add DirectorySlash to dynamic .htaccess write

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -50,9 +50,6 @@
 
   # Rewrite rules for `front_controller_active`
   Options -MultiViews
-  <IfModule mod_dir.c>
-    DirectorySlash off
-  </IfModule>
   RewriteRule ^core/js/oc.js$ index.php/core/js/oc.js [PT,E=PATH_INFO:$1]
   RewriteRule ^core/preview.png$ index.php/core/preview.png [PT,E=PATH_INFO:$1]
   RewriteCond %{REQUEST_FILENAME} !\.(css|js|svg|gif|png|html|ttf|woff)$

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -439,6 +439,9 @@ class Setup {
 		$content.="\n  RewriteBase ".$webRoot;
 		$content .= "\n  <IfModule mod_env.c>";
 		$content .= "\n    SetEnv front_controller_active true";
+		$content .= "\n    <IfModule mod_dir.c>";
+		$content .= "\n      DirectorySlash off";
+		$content .= "\n    </IfModule>";
 		$content.="\n  </IfModule>";
 		$content.="\n</IfModule>";
 


### PR DESCRIPTION
When `DirectorySlash off` is set then Apache will not lookup folders anymore. This is required for example when we use the rewrite directives on an existing path such as  `/core/search`. By default Apache would load `/core/search/` instead `/core/search` so the redirect would fail here.

This leads however to the problem that URLs such as `localhost/owncloud` would not load anymore while `localhost/owncloud/` would. This has caused problems such as https://github.com/owncloud/core/pull/21015

With this change we add the `DirectorySlash off` directive only when the `.htaccess` is writable to the dynamic part of it. This would also make `localhost/owncloud` work again as it would trigger the 404 directive which triggers the redirect in base.php.

@PVince81 :wink: 
