### PR TITLE
File shares can't have create permissions

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -43,8 +43,8 @@
 					sharePermissions = sharePermissions | (OC.PERMISSION_ALL & ~OC.PERMISSION_SHARE);
 				}
 				if (fileData.type === 'file') {
-					// files can't be shared with delete permissions
-					sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;
+					// files can't be shared with delete or create permissions
+					sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE & ~OC.PERMISSION_CREATE;
 				}
 				tr.attr('data-share-permissions', sharePermissions);
 				if (fileData.shareOwner) {

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -712,7 +712,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			$tr = fileList.$el.find('tr:first');
 
 			expect(parseInt($tr.attr('data-share-permissions'), 10))
-				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE);
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE - OC.PERMISSION_CREATE);
 		});
 	});
 });


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20839

Since the new sidebar actually is cleaner in how it handles permissions etc we should make sure the permissions are correct.
