### PR TITLE
passing an empty base in this diagnosis call will not result  in LDAP…

### DIFF
--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -49,7 +49,7 @@ try {
 			 * pass (like e.g. expected syntax error).
 			 */
 			try {
-				$ldapWrapper->read($connection->getConnectionResource(), 'neverwhere', 'objectClass=*', array('dn'));
+				$ldapWrapper->read($connection->getConnectionResource(), '', 'objectClass=*', array('dn'));
 			} catch (\Exception $e) {
 				if($e->getCode() === 1) {
 					OCP\JSON::error(array('message' => $l->t('The configuration is invalid: anonymous bind is not allowed.')));


### PR DESCRIPTION
… errors

Neither in "Invalid DN syntax" nor in "Object not found".

How to test:
1. Have an LDAP configuration (ideally also on a server with allowed anonymous bind)
2. In the wizard you got Advanced Tab and click "Test Connection"
3. Watch the log.
### Observed before

An entry about:

`Error PHP ldap_read(): Search: Invalid DN syntax at /var/www/owncloud/apps/user_ldap/lib/ldap.php#257`

Correct result of the test is presented in the wizard nevertheless.
### Expected

No such entry. Correct result is still presented in the wizard.

Please test and review @owncloud/ldap @CaptionF @davitol 
