### PR TITLE
[backport][stable8.1] passing an empty base in this diagnosis call will not result  in LDAP…

### DIFF
--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -49,7 +49,7 @@ try {
 			 * pass (like e.g. expected syntax error).
 			 */
 			try {
-				$ldapWrapper->read($connection->getConnectionResource(), 'neverwhere', 'objectClass=*', array('dn'));
+				$ldapWrapper->read($connection->getConnectionResource(), '', 'objectClass=*', array('dn'));
 			} catch (\Exception $e) {
 				if($e->getCode() === 1) {
 					OCP\JSON::error(array('message' => $l->t('The configuration is invalid: anonymous bind is not allowed.')));


### PR DESCRIPTION
… errors

Backport of #21037 to stable8.1

Please test and review @owncloud/ldap @CaptionF @davitol
