### PR TITLE
Add support for read only config dir

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -642,13 +642,15 @@ class OC_Util {
 		}
 
 		// Check if config folder is writable.
-		if (!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
-			$errors[] = array(
-				'error' => $l->t('Cannot write into "config" directory'),
-				'hint' => $l->t('This can usually be fixed by '
-					. '%sgiving the webserver write access to the config directory%s.',
-					array('<a href="' . $urlGenerator->linkToDocs('admin-dir_permissions') . '" target="_blank">', '</a>'))
-			);
+		if(!OC_Helper::isReadOnlyConfigEnabled()) {
+			if (!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
+				$errors[] = array(
+					'error' => $l->t('Cannot write into "config" directory'),
+					'hint' => $l->t('This can usually be fixed by '
+						. '%sgiving the webserver write access to the config directory%s.',
+						array('<a href="' . $urlGenerator->linkToDocs('admin-dir_permissions') . '" target="_blank">', '</a>'))
+				);
+			}
 		}
 
 		// Check if there is a writable install folder.


### PR DESCRIPTION
We already support the `config_is_read_only` for the config file itself. However not for the whole directory (which is a bug).

This unifies the check in the checkServer routine with the one in base.php. Now one can enable a read only config folder so that ownCloud is not allowed to overwrite it's own source code.

To test this set the whole config folder to read only, clear your session, refresh, see it fails, add the new code, refresh, see it works. Also verify that setup still works fine. (obviously setup does not work with a read only config Also verify that setup still works fine. (obviously setup does not work with a read only config))

Easy one: https://github.com/owncloud/core/pull/21060/files?w=1

Fixes https://github.com/owncloud/core/issues/14455
