### PR TITLE
[8.2] Dont set the string storage id to the numeric storage id for personal mounts

### DIFF
--- a/apps/files_external/lib/personalmount.php
+++ b/apps/files_external/lib/personalmount.php
@@ -35,7 +35,7 @@ class PersonalMount extends MountPoint implements MoveableMount {
 	protected $storagesService;
 
 	/** @var int */
-	protected $storageId;
+	protected $numericStorageId;
 
 	/**
 	 * @param UserStoragesService $storagesService
@@ -57,7 +57,7 @@ class PersonalMount extends MountPoint implements MoveableMount {
 	) {
 		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions);
 		$this->storagesService = $storagesService;
-		$this->storageId = $storageId;
+		$this->numericStorageId = $storageId;
 	}
 
 	/**
@@ -67,7 +67,7 @@ class PersonalMount extends MountPoint implements MoveableMount {
 	 * @return bool
 	 */
 	public function moveMount($target) {
-		$storage = $this->storagesService->getStorage($this->storageId);
+		$storage = $this->storagesService->getStorage($this->numericStorageId);
 		// remove "/$user/files" prefix
 		$targetParts = explode('/', trim($target, '/'), 3);
 		$storage->setMountPoint($targetParts[2]);
@@ -82,7 +82,7 @@ class PersonalMount extends MountPoint implements MoveableMount {
 	 * @return bool
 	 */
 	public function removeMount() {
-		$this->storagesService->removeStorage($this->storageId);
+		$this->storagesService->removeStorage($this->numericStorageId);
 		return true;
 	}
 }

--- a/apps/files_external/tests/personalmounttest.php
+++ b/apps/files_external/tests/personalmounttest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_external\Tests;
+
+use OC\Files\Mount\Manager;
+use OCA\Files_External\Lib\PersonalMount;
+use Test\TestCase;
+
+class PersonalMountTest extends TestCase {
+	public function testFindByStorageId() {
+		/** @var \OCA\Files_External\Service\UserStoragesService $storageService */
+		$storageService = $this->getMockBuilder('\OCA\Files_External\Service\UserStoragesService')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('dummy'));
+
+		$mount = new PersonalMount($storageService, 10, $storage, '/foo');
+
+		$mountManager = new Manager();
+		$mountManager->addMount($mount);
+
+		$this->assertEquals([$mount], $mountManager->findByStorageId('dummy'));
+	}
+}


### PR DESCRIPTION
Backport of #21003 to 8.2
