### PR TITLE
Remove all locks after ttl from the db

### DIFF
--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -235,10 +235,10 @@ class DBLockingProvider extends AbstractLockingProvider {
 	/**
 	 * cleanup empty locks
 	 */
-	public function cleanEmptyLocks() {
+	public function cleanExpiredLocks() {
 		$expire = $this->timeFactory->getTime();
 		$this->connection->executeUpdate(
-			'DELETE FROM `*PREFIX*file_locks` WHERE `lock` = 0 AND `ttl` < ?',
+			'DELETE FROM `*PREFIX*file_locks` WHERE `ttl` < ?',
 			[$expire]
 		);
 	}
@@ -262,7 +262,7 @@ class DBLockingProvider extends AbstractLockingProvider {
 
 	public function __destruct() {
 		try {
-			$this->cleanEmptyLocks();
+			$this->cleanExpiredLocks();
 		} catch (\Exception $e) {
 			// If the table is missing, the clean up was successful
 			if ($this->connection->tableExists('file_locks')) {

--- a/tests/lib/lock/dblockingprovider.php
+++ b/tests/lib/lock/dblockingprovider.php
@@ -85,13 +85,7 @@ class DBLockingProvider extends LockingProvider {
 
 		$this->assertEquals(3, $this->getLockEntryCount());
 
-		$this->instance->cleanEmptyLocks();
-
-		$this->assertEquals(3, $this->getLockEntryCount());
-
-		$this->instance->releaseAll();
-
-		$this->instance->cleanEmptyLocks();
+		$this->instance->cleanExpiredLocks();
 
 		$this->assertEquals(2, $this->getLockEntryCount());
 	}


### PR DESCRIPTION
not just empty lock entries.

> 1 hour ought to be enough for every operation

Partial fix for https://github.com/owncloud/core/issues/20380, will add ttl for memcache based locking separately (https://github.com/owncloud/core/issues/21073)

cc @PVince81 
