### PR TITLE
Add ttl for redis based locking

### DIFF
--- a/lib/private/lock/abstractlockingprovider.php
+++ b/lib/private/lock/abstractlockingprovider.php
@@ -28,6 +28,8 @@ use OCP\Lock\ILockingProvider;
  * to release any left over locks at the end of the request
  */
 abstract class AbstractLockingProvider implements ILockingProvider {
+	const TTL = 3600; // how long until we clear stray locks in seconds
+
 	protected $acquiredLocks = [
 		'shared' => [],
 		'exclusive' => []

--- a/lib/private/lock/dblockingprovider.php
+++ b/lib/private/lock/dblockingprovider.php
@@ -51,8 +51,6 @@ class DBLockingProvider extends AbstractLockingProvider {
 
 	private $sharedLocks = [];
 
-	const TTL = 3600; // how long until we clear stray locks in seconds
-
 	/**
 	 * Check if we have an open shared lock for a path
 	 *

--- a/lib/private/lock/memcachelockingprovider.php
+++ b/lib/private/lock/memcachelockingprovider.php
@@ -21,6 +21,7 @@
 
 namespace OC\Lock;
 
+use OCP\IMemcacheTTL;
 use OCP\Lock\LockedException;
 use OCP\IMemcache;
 
@@ -35,6 +36,12 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	 */
 	public function __construct(IMemcache $memcache) {
 		$this->memcache = $memcache;
+	}
+
+	private function setTTL($path) {
+		if ($this->memcache instanceof IMemcacheTTL) {
+			$this->memcache->setTTL($path, self::TTL);
+		}
 	}
 
 	/**
@@ -69,6 +76,7 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 				throw new LockedException($path);
 			}
 		}
+		$this->setTTL($path);
 		$this->markAcquire($path, $type);
 	}
 
@@ -106,6 +114,7 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 				throw new LockedException($path);
 			}
 		}
+		$this->setTTL($path);
 		$this->markChange($path, $targetType);
 	}
 }

--- a/lib/private/memcache/redis.php
+++ b/lib/private/memcache/redis.php
@@ -25,9 +25,9 @@
 
 namespace OC\Memcache;
 
-use OCP\IMemcache;
+use OCP\IMemcacheTTL;
 
-class Redis extends Cache implements IMemcache {
+class Redis extends Cache implements IMemcacheTTL {
 	/**
 	 * @var \Redis $cache
 	 */
@@ -193,6 +193,10 @@ class Redis extends Cache implements IMemcache {
 		}
 		self::$cache->unwatch();
 		return false;
+	}
+
+	public function setTTL($key, $ttl) {
+		self::$cache->expire($this->getNamespace() . $key, $ttl);
 	}
 
 	static public function isAvailable() {

--- a/lib/public/imemcachettl.php
+++ b/lib/public/imemcachettl.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Interface for memcache backends that support setting ttl after the value is set
+ *
+ * @since 9.0.0
+ */
+interface IMemcacheTTL extends IMemcache {
+	/**
+	 * Set the ttl for an existing value
+	 *
+	 * @param string $key
+	 * @param int $ttl time to live in seconds
+	 */
+	public function setTTL($key, $ttl);
+}

--- a/lib/public/imemcachettl.php
+++ b/lib/public/imemcachettl.php
@@ -32,6 +32,7 @@ interface IMemcacheTTL extends IMemcache {
 	 *
 	 * @param string $key
 	 * @param int $ttl time to live in seconds
+	 * @since 9.0.0
 	 */
 	public function setTTL($key, $ttl);
 }


### PR DESCRIPTION
Adds ttl to memcache locking if the locking backend support setting ttl on existing keys (redis)

We can't simply set the ttl when adding the key to the memcache since then the ttl wont be updated properly if multiple requests are increasing and decreasing locks.

The other part of the fix for https://github.com/owncloud/core/issues/20380 (db ttl is [here](https://github.com/owncloud/core/pull/21072))

cc @PVince81 
