### PR TITLE
Do not check storage availability for getOwner

### DIFF
--- a/lib/private/files/storage/wrapper/availability.php
+++ b/lib/private/files/storage/wrapper/availability.php
@@ -399,7 +399,6 @@ class Availability extends Wrapper {
 
 	/** {@inheritdoc} */
 	public function getOwner($path) {
-		$this->checkAvailability();
 		try {
 			return parent::getOwner($path);
 		} catch (\OCP\Files\StorageNotAvailableException $e) {


### PR DESCRIPTION
Because the owner is always known thanks to the file cache and other
places, we don't need the remote storage to be actually available.

Partial fix for https://github.com/owncloud/core/issues/21033#issuecomment-163202948 that only affects master.
### Steps to reproduce:
1. Setup OC A and OC B
2. From OC A share a file remotely with OC B
3. Accept the share in OC B
4. Edit OC A's index.php and add garbage
5. In OC B, set "availability" to 0 in oc_storages for the remote storage (or trigger it, not sure how, it happens eventually)
6. Curl against OC B: `curl -X PROPFIND http://root:admin@localhost/owncloud/remote.php/files/`
### Expected result (after fix)

File list is returned, including the entry for the file that is not available.
### Actual result

503 storage not available

This is because since 9.0 we inject the owner into `FileInfo` inside `getDirectoryContents()`, so we need to make sure the owner is still available.

@icewind1991 @MorrisJobke @LukasReschke 
