### PR TITLE
Make compatible with PHPUnit 5.1

### DIFF
--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -44,4 +44,7 @@ class StartSessionListener implements PHPUnit_Framework_TestListener {
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
 	}
 
+	public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time) {
+	}
+
 }


### PR DESCRIPTION
`addWarning` needs to be defined as well for it:

```
➜  master git:(master) ✗ bash autotest.sh sqlite
Using PHP executable /usr/local/opt/php56/bin/php
Parsing all files in lib/public for the presence of @since or @deprecated on each method...

Using database oc_autotest
Setup environment for sqlite testing on local storage ...
Installing ....
ownCloud is not installed - only a limited number of commands are available
Mac OS X is not supported and ownCloud will not work properly on this platform. Use it at your own risk!
 -> For the best results, please consider using a GNU/Linux server instead.
creating sqlite db
ownCloud was successfully installed
Testing with sqlite ...
No coverage
/usr/local/bin/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml
PHP Notice:  Constant PHPUNIT_RUN already defined in /Users/lukasreschke/Documents/Programming/master/apps/firstrunwizard/tests/bootstrap.php on line 6
PHP Stack trace:
PHP   1. {main}() /usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar:514
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/Command.php:106
PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/Command.php:117
PHP   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/Command.php:663
PHP   6. PHPUnit_Util_Configuration->getTestSuite() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/Util/Configuration.php:796
PHP   7. PHPUnit_Framework_TestSuite->addTestFile() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/Util/Configuration.php:926
PHP   8. PHPUnit_Util_Fileloader::checkAndLoad() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/Framework/TestSuite.php:335
PHP   9. PHPUnit_Util_Fileloader::load() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/Util/Fileloader.php:38
PHP  10. include_once() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/Util/Fileloader.php:56
PHP  11. loadDirectory() /Users/lukasreschke/Documents/Programming/master/tests/apps.php:42
PHP  12. require_once() /Users/lukasreschke/Documents/Programming/master/tests/apps.php:20
PHP  13. define() /Users/lukasreschke/Documents/Programming/master/apps/firstrunwizard/tests/bootstrap.php:6
PHP Fatal error:  Class StartSessionListener contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (PHPUnit_Framework_TestListener::addWarning) in /Users/lukasreschke/Documents/Programming/master/tests/startsessionlistener.php on line 47
PHP Stack trace:
PHP   1. {main}() /usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar:514
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/Command.php:106
PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/Command.php:155
PHP   5. PHPUnit_TextUI_TestRunner->handleConfiguration() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/TestRunner.php:153
PHP   6. require_once() phar:///usr/local/Cellar/phpunit/5.1.0/libexec/phpunit-5.1.0.phar/phpunit/TextUI/TestRunner.php:805
```

@MorrisJobke 
