### PR TITLE
Deduplicate version expire jobs

### DIFF
--- a/apps/files_versions/command/expire.php
+++ b/apps/files_versions/command/expire.php
@@ -35,16 +35,6 @@ class Expire implements ICommand {
 	private $fileName;
 
 	/**
-	 * @var int|null
-	 */
-	private $versionsSize;
-
-	/**
-	 * @var int
-	 */
-	private $neededSpace = 0;
-
-	/**
 	 * @var string
 	 */
 	private $user;
@@ -52,14 +42,10 @@ class Expire implements ICommand {
 	/**
 	 * @param string $user
 	 * @param string $fileName
-	 * @param int|null $versionsSize
-	 * @param int $neededSpace
 	 */
-	function __construct($user, $fileName, $versionsSize = null, $neededSpace = 0) {
+	function __construct($user, $fileName) {
 		$this->user = $user;
 		$this->fileName = $fileName;
-		$this->versionsSize = $versionsSize;
-		$this->neededSpace = $neededSpace;
 	}
 
 
@@ -71,7 +57,7 @@ class Expire implements ICommand {
 		}
 
 		\OC_Util::setupFS($this->user);
-		Storage::expire($this->fileName, $this->versionsSize, $this->neededSpace);
+		Storage::expire($this->fileName);
 		\OC_Util::tearDownFS();
 	}
 }

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -168,14 +168,7 @@ class Storage {
 			// create all parent folders
 			self::createMissingDirectories($filename, $users_view);
 
-			$versionsSize = self::getVersionsSize($uid);
-
-			// assumption: we need filesize($filename) for the new version +
-			// some more free space for the modified file which might be
-			// 1.5 times as large as the current version -> 2.5
-			$neededSpace = $files_view->filesize($filename) * 2.5;
-
-			self::scheduleExpire($uid, $filename, $versionsSize, $neededSpace);
+			self::scheduleExpire($uid, $filename);
 
 			// store a new version of a file
 			$mtime = $users_view->filemtime('files/' . $filename);
@@ -634,14 +627,12 @@ class Storage {
 	 *
 	 * @param string $uid owner of the file
 	 * @param string $fileName file/folder for which to schedule expiration
-	 * @param int|null $versionsSize current versions size
-	 * @param int $neededSpace requested versions size
 	 */
-	private static function scheduleExpire($uid, $fileName, $versionsSize = null, $neededSpace = 0) {
+	private static function scheduleExpire($uid, $fileName) {
 		// let the admin disable auto expire
 		$expiration = self::getExpiration();
 		if ($expiration->isEnabled()) {
-			$command = new Expire($uid, $fileName, $versionsSize, $neededSpace);
+			$command = new Expire($uid, $fileName);
 			\OC::$server->getCommandBus()->push($command);
 		}
 	}
@@ -650,11 +641,9 @@ class Storage {
 	 * Expire versions which exceed the quota
 	 *
 	 * @param string $filename
-	 * @param int|null $versionsSize
-	 * @param int $offset
 	 * @return bool|int|null
 	 */
-	public static function expire($filename, $versionsSize = null, $offset = 0) {
+	public static function expire($filename) {
 		$config = \OC::$server->getConfig();
 		$expiration = self::getExpiration();
 		
@@ -680,9 +669,7 @@ class Storage {
 			}
 
 			// make sure that we have the current size of the version history
-			if ( $versionsSize === null ) {
-				$versionsSize = self::getVersionsSize($uid);
-			}
+			$versionsSize = self::getVersionsSize($uid);
 
 			// calculate available space for version history
 			// subtract size of files and current versions size from quota
@@ -692,12 +679,12 @@ class Storage {
 					$rootInfo = $files_view->getFileInfo('/', false);
 					$free = $quota - $rootInfo['size']; // remaining free space for user
 					if ($free > 0) {
-						$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - ($versionsSize + $offset); // how much space can be used for versions
+						$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
 					} else {
-						$availableSpace = $free - $versionsSize - $offset;
+						$availableSpace = $free - $versionsSize;
 					}
 				} else {
-					$availableSpace = $quota - $offset;
+					$availableSpace = $quota;
 				}
 			} else {
 				$availableSpace = PHP_INT_MAX;


### PR DESCRIPTION
- versionSize is calculated anyway in the expire job - > dropped
- offset/neededSpace was needed for expiry before the file is moved to the versions -> now this is included already in the currently used space because the expiry job is defered to a point in time after the version creation
- fixes #21108 

cc @schiesbn @nickvergessen @PVince81 @rullzer 

@karlitschek I would like to backport this down to stable8.1 because in this version the expiry job was added.
