### PR TITLE
[stable8.1] Deduplicate version expire jobs

### DIFF
--- a/apps/files_versions/command/expire.php
+++ b/apps/files_versions/command/expire.php
@@ -36,16 +36,6 @@ class Expire implements ICommand {
 	private $fileName;
 
 	/**
-	 * @var int|null
-	 */
-	private $versionsSize;
-
-	/**
-	 * @var int
-	 */
-	private $neededSpace = 0;
-
-	/**
 	 * @var string
 	 */
 	private $user;
@@ -53,14 +43,10 @@ class Expire implements ICommand {
 	/**
 	 * @param string $user
 	 * @param string $fileName
-	 * @param int|null $versionsSize
-	 * @param int $neededSpace
 	 */
-	function __construct($user, $fileName, $versionsSize = null, $neededSpace = 0) {
+	function __construct($user, $fileName) {
 		$this->user = $user;
 		$this->fileName = $fileName;
-		$this->versionsSize = $versionsSize;
-		$this->neededSpace = $neededSpace;
 	}
 
 
@@ -72,7 +58,7 @@ class Expire implements ICommand {
 		}
 
 		\OC_Util::setupFS($this->user);
-		Storage::expire($this->fileName, $this->versionsSize, $this->neededSpace);
+		Storage::expire($this->fileName);
 		\OC_Util::tearDownFS();
 	}
 }


### PR DESCRIPTION
- versionSize is calculated anyway in the expire job - > dropped
- offset/neededSpace was needed for expiry before the file is moved to the versions -> now this is included already in the currently used space because the expiry job is defered to a point in time after the version creation
- fixes #21108 
- backport of #21109 
- [x] approval by @karlitschek required 

cc @PVince81 @rullzer 
