### PR TITLE
Make AppManager->checkAppForUser more robust

### DIFF
--- a/lib/private/app/appmanager.php
+++ b/lib/private/app/appmanager.php
@@ -148,6 +148,13 @@ class AppManager implements IAppManager {
 			return false;
 		} else {
 			$groupIds = json_decode($enabled);
+
+			if (!is_array($groupIds)) {
+				$jsonError = json_last_error();
+				\OC::$server->getLogger()->warning('AppManger::checkAppForUser - can\'t decode group IDs: ' . print_r($enabled, true) . ' - json error code: ' . $jsonError, ['app' => 'lib']);
+				return false;
+			}
+
 			$userGroups = $this->groupManager->getUserGroupIds($user);
 			foreach ($userGroups as $groupId) {
 				if (array_search($groupId, $groupIds) !== false) {


### PR DESCRIPTION
- if the JSON that is stored in the DB is corrupt an error was thrown
- with this change it is properly handled and the app is disabled

cc @DeepDiver1975 @LukasReschke 

I will also try to investigate how this invalid JSON went into the DB, but this check makes it more robust and still usable instead of erroring.
