### PR TITLE
[stable8.2] Make AppManager->checkAppForUser more robust

### DIFF
--- a/lib/private/app/appmanager.php
+++ b/lib/private/app/appmanager.php
@@ -140,6 +140,13 @@ class AppManager implements IAppManager {
 			return false;
 		} else {
 			$groupIds = json_decode($enabled);
+
+			if (!is_array($groupIds)) {
+				$jsonError = json_last_error();
+				\OC::$server->getLogger()->warning('AppManger::checkAppForUser - can\'t decode group IDs: ' . print_r($enabled, true) . ' - json error code: ' . $jsonError, ['app' => 'lib']);
+				return false;
+			}
+
 			$userGroups = $this->groupManager->getUserGroupIds($user);
 			foreach ($userGroups as $groupId) {
 				if (array_search($groupId, $groupIds) !== false) {


### PR DESCRIPTION
- if the JSON that is stored in the DB is corrupt an error was thrown
- with this change it is properly handled and the app is disabled

backport of #21119 

Approved in https://github.com/owncloud/core/pull/21119#issuecomment-163666525

cc @icewind1991 @LukasReschke @nickvergessen 
