### PR TITLE
Properly check X-Requested-With header in case of multiple values

### DIFF
--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -160,7 +160,7 @@ class Auth extends AbstractBasic {
 			return [true, $this->principalPrefix . $user];
 		}
 
-		if (!$this->userSession->isLoggedIn() && $request->getHeader('X-Requested-With') === 'XMLHttpRequest') {
+		if (!$this->userSession->isLoggedIn() && in_array('XMLHttpRequest', explode(',', $request->getHeader('X-Requested-With')))) {
 			// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
 			$response->addHeader('WWW-Authenticate','DummyBasic realm="' . $this->realm . '"');
 			$response->setStatus(401);


### PR DESCRIPTION
Saw this happening in IE8...

```
        $request->headers['x-requested-with'][1][0] = (string[30]) 'XMLHttpRequest, XMLHttpRequest';
```

This PR fixes that.

@MorrisJobke @icewind1991 @nickvergessen @LukasReschke 
