### PR TITLE
Bring back file delete action text to be based on context

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -617,7 +617,16 @@
 
 			this.registerAction({
 				name: 'Delete',
-				displayName: t('files', 'Delete'),
+				displayName: function(context) {
+					var mountType = context.$file.attr('data-mounttype');
+					var deleteTitle = t('files', 'Delete');
+					if (mountType === 'external-root') {
+						deleteTitle = t('files', 'Disconnect storage');
+					} else if (mountType === 'shared-root') {
+						deleteTitle = t('files', 'Unshare');
+					}
+					return deleteTitle;
+				},
 				mime: 'all',
 				order: 1000,
 				// permission is READ because we show a hint instead if there is no permission
@@ -668,8 +677,9 @@
 	 * @typedef {Object} OCA.Files.FileAction
 	 *
 	 * @property {String} name identifier of the action
-	 * @property {String} displayName display name of the action, defaults
-	 * to the name given in name property
+	 * @property {(String|OCA.Files.FileActions~displayNameFunction)} displayName
+	 * display name string for the action, or function that returns the display name.
+	 * Defaults to the name given in name property
 	 * @property {String} mime mime type
 	 * @property {int} permissions permissions
 	 * @property {(Function|String)} icon icon path to the icon or function
@@ -700,6 +710,16 @@
 	 * @param {boolean} isDefault true if the action is the default one,
 	 * false otherwise
 	 * @return {Object} jQuery link object
+	 */
+
+	/**
+	 * Display name function for actions.
+	 * The function returns the display name of the action using
+	 * the given context information..
+	 *
+	 * @callback OCA.Files.FileActions~displayNameFunction
+	 * @param {OCA.Files.FileActionContext} context action context
+	 * @return {String} display name
 	 */
 
 	/**

--- a/apps/files/js/fileactionsmenu.js
+++ b/apps/files/js/fileactionsmenu.js
@@ -81,6 +81,7 @@
 		 * Renders the menu with the currently set items
 		 */
 		render: function() {
+			var self = this;
 			var fileActions = this._context.fileActions;
 			var actions = fileActions.getActions(
 				fileActions.getCurrentMimeType(),
@@ -99,6 +100,13 @@
 					actionSpec.type === OCA.Files.FileActions.TYPE_DROPDOWN &&
 					(!defaultAction || actionSpec.name !== defaultAction.name)
 				);
+			});
+			items = _.map(items, function(item) {
+				if (_.isFunction(item.displayName)) {
+					item = _.extend({}, item);
+					item.displayName = item.displayName(self._context);
+				}
+				return item;
 			});
 			items = items.sort(function(actionA, actionB) {
 				var orderA = actionA.order || 0;

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -20,7 +20,7 @@
 */
 
 describe('OCA.Files.FileActionsMenu tests', function() {
-	var fileList, fileActions, menu, actionStub, $tr;
+	var fileList, fileActions, menu, actionStub, menuContext, $tr;
 
 	beforeEach(function() {
 		// init horrible parameters
@@ -80,7 +80,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 		};
 		$tr = fileList.add(fileData);
 
-		var menuContext = {
+		menuContext = {
 			$file: $tr,
 			fileList: fileList,
 			fileActions: fileActions,
@@ -188,6 +188,22 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 			var wactionIndex = menu.$el.find('a[data-action=Waction]').closest('li').index();
 			var yactionIndex = menu.$el.find('a[data-action=Yaction]').closest('li').index();
 			expect(wactionIndex).toBeLessThan(yactionIndex);
+		});
+		it('calls displayName function', function() {
+			var displayNameStub = sinon.stub().returns('Test');
+
+			fileActions.registerAction({
+				name: 'Something',
+				displayName: displayNameStub,
+				mime: 'text/plain',
+				permissions: OC.PERMISSION_ALL
+			});
+
+			menu.render();
+
+			expect(displayNameStub.calledOnce).toEqual(true);
+			expect(displayNameStub.calledWith(menuContext)).toEqual(true);
+			expect(menu.$el.find('a[data-action=Something]').text()).toEqual('Test');
 		});
 	});
 


### PR DESCRIPTION
For received shares, the delete action becomes "Unshare" and for
personal mounts it becomes "Disconnect storage".

This also makes it possible from now on to pass a function to a file
action's "displayName" attribute.

Fixes https://github.com/owncloud/core/issues/20172

Note: it used to work before using hacks but the hack got scrapped when moving to the file actions menu approach.

Please review @schiesbn @jancborchardt @MorrisJobke @nickvergessen @icewind1991 @blizzz @rullzer 

Backport was requested in the ticket already by @karlitschek, see https://github.com/owncloud/core/issues/20172#issuecomment-154883548
