### PR TITLE
Files can't have create permissions

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -303,10 +303,6 @@
 							}
 							break;
 						case 'W':
-							if (isFile) {
-								// also add create permissions
-								data.permissions |= OC.PERMISSION_CREATE;
-							}
 							data.permissions |= OC.PERMISSION_UPDATE;
 							break;
 						case 'D':


### PR DESCRIPTION
Fixes #20839 

@PVince81 we discussed this already a bit. I can't find any reason why those lines were there. It is even weird to add them there since the filecache also shows that files can't have CREATE permissions. So I'm pretty confident this is save to remove.

And it fixes the issue.

CC: @PVince81 @icewind1991
