### PR TITLE
Fix mount type root detection in web UI

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -990,13 +990,16 @@
 			}
 
 			if (fileData.mountType) {
-				// FIXME: HACK: detect shared-root
-				if (fileData.mountType === 'shared' && this.dirInfo.mountType !== 'shared') {
-					// if parent folder isn't share, assume the displayed folder is a share root
-					fileData.mountType = 'shared-root';
-				} else if (fileData.mountType === 'external' && this.dirInfo.mountType !== 'external') {
-					// if parent folder isn't external, assume the displayed folder is the external storage root
-					fileData.mountType = 'external-root';
+				// dirInfo (parent) only exist for the "real" file list
+				if (this.dirInfo.id) {
+					// FIXME: HACK: detect shared-root
+					if (fileData.mountType === 'shared' && this.dirInfo.mountType !== 'shared' && this.dirInfo.mountType !== 'shared-root') {
+						// if parent folder isn't share, assume the displayed folder is a share root
+						fileData.mountType = 'shared-root';
+					} else if (fileData.mountType === 'external' && this.dirInfo.mountType !== 'external' && this.dirInfo.mountType !== 'external-root') {
+						// if parent folder isn't external, assume the displayed folder is the external storage root
+						fileData.mountType = 'external-root';
+					}
 				}
 				tr.attr('data-mounttype', fileData.mountType);
 			}

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2534,4 +2534,34 @@ describe('OCA.Files.FileList tests', function() {
 			expect(newFileMenuStub.notCalled).toEqual(true);
 		});
 	});
+	describe('mount type detection', function() {
+		function testMountType(dirInfoId, dirInfoMountType, inputMountType, expectedMountType) {
+			var $tr;
+			fileList.dirInfo.id = dirInfoId;
+			fileList.dirInfo.mountType = dirInfoMountType;
+			$tr = fileList.add({
+				type: 'dir',
+				mimetype: 'httpd/unix-directory',
+				name: 'test dir',
+				mountType: inputMountType
+			});
+
+			expect($tr.attr('data-mounttype')).toEqual(expectedMountType);
+		}
+
+		it('leaves mount type as is if no parent exists', function() {
+			testMountType(null, null, 'external', 'external');
+			testMountType(null, null, 'shared', 'shared');
+		});
+		it('detects share root if parent exists', function() {
+			testMountType(123, null, 'shared', 'shared-root');
+			testMountType(123, 'shared', 'shared', 'shared');
+			testMountType(123, 'shared-root', 'shared', 'shared');
+		});
+		it('detects external storage root if parent exists', function() {
+			testMountType(123, null, 'external', 'external-root');
+			testMountType(123, 'external', 'external', 'external');
+			testMountType(123, 'external-root', 'external', 'external');
+		});
+	});
 });


### PR DESCRIPTION
Since the Webdav response doesn't contain mount type information, we need to rely on the
parent folder's mount type to find out whether a child item is a
shared/external root or not.

Fixed the mount type detection logic and added unit test.

Also added a fix that ignores detection if no parent folder exists (ex:
shared file list, favorites, etc)

To verify:
1. Have an outgoing share, data-mounttype of the share and its children is null (absent)
2. Have an incoming share, data-mounttype of the share itself is "shared-root" and subfolders is "shared"
3. Have an external storage, data-mounttype of the root is "external-root" and subfolders is "external"

As a side-effect, the "Delete" action of an outgoing share should now say "Delete" instead of "Unshare" (it is based on this information) @MorrisJobke 

Please review @MorrisJobke @rullzer @icewind1991 

This is for **master only**.

(in the future we might want to expose the mount type through webdav properties to avoid such gymnastics)
