### PR TITLE
File shares can't have create permissions

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -45,6 +45,9 @@
 				if (fileData.type === 'file') {
 					// files can't be shared with delete permissions
 					sharePermissions = sharePermissions & ~OC.PERMISSION_DELETE;
+
+					// create permissions don't mean anything for files
+					sharePermissions = sharePermissions & ~OC.PERMISSION_CREATE;
 				}
 				tr.attr('data-share-permissions', sharePermissions);
 				if (fileData.shareOwner) {

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -712,7 +712,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			$tr = fileList.$el.find('tr:first');
 
 			expect(parseInt($tr.attr('data-share-permissions'), 10))
-				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE);
+				.toEqual(OC.PERMISSION_ALL - OC.PERMISSION_SHARE - OC.PERMISSION_DELETE - OC.PERMISSION_CREATE);
 		});
 	});
 });


### PR DESCRIPTION
fixes #21187 

Since the shared with others view does not retrieve its permissions from webdav we need to explicitly make sure that files can't have create permissions.

CC: @PVince81 @MorrisJobke 
