### PR TITLE
Use Authorization headers for public webdav in web UI

### DIFF
--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -89,7 +89,8 @@ describe('OCA.Sharing.PublicApp tests', function() {
 		it('Uses public webdav endpoint', function() {
 			expect(fakeServer.requests.length).toEqual(1);
 			expect(fakeServer.requests[0].method).toEqual('PROPFIND');
-			expect(fakeServer.requests[0].url).toEqual('https://sh4tok@example.com/owncloud/public.php/webdav/subdir');
+			expect(fakeServer.requests[0].url).toEqual('https://example.com/owncloud/public.php/webdav/subdir');
+			expect(fakeServer.requests[0].requestHeaders.Authorization).toEqual('Basic c2g0dG9rOm51bGw=');
 		});
 
 		describe('Download Url', function() {

--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
     "bootstrap": "~3.3.6",
     "backbone": "~1.2.3",
     "davclient.js": "https://github.com/evert/davclient.js.git",
-    "es6-promise": "https://github.com/jakearchibald/es6-promise.git#~2.3.0"
+    "es6-promise": "https://github.com/jakearchibald/es6-promise.git#~2.3.0",
+    "base64": "~0.3.0"
   }
 }

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -35,27 +35,25 @@
 		if (options.useHTTPS) {
 			url = 'https://';
 		}
-		var credentials = '';
-		if (options.userName) {
-			credentials += encodeURIComponent(options.userName);
-		}
-		if (options.password) {
-			credentials += ':' + encodeURIComponent(options.password);
-		}
-		if (credentials.length > 0) {
-			url += credentials + '@';
-		}
 
 		url += options.host + this._root;
 		this._defaultHeaders = options.defaultHeaders || {'X-Requested-With': 'XMLHttpRequest'};
 		this._baseUrl = url;
-		this._client = new dav.Client({
+
+		var clientOptions = {
 			baseUrl: this._baseUrl,
 			xmlNamespaces: {
 				'DAV:': 'd',
 				'http://owncloud.org/ns': 'oc'
 			}
-		});
+		};
+		if (options.userName) {
+			clientOptions.userName = options.userName;
+		}
+		if (options.password) {
+			clientOptions.password = options.password;
+		}
+		this._client = new dav.Client(clientOptions);
 		this._client.xhrProvider = _.bind(this._xhrProvider, this);
 	};
 

--- a/core/vendor/.gitignore
+++ b/core/vendor/.gitignore
@@ -133,3 +133,5 @@ es6-promise/**
 !es6-promise/LICENSE
 !es6-promise/dist/es6-promise.js
 
+# base64
+base64/*min.js

--- a/core/vendor/base64/.bower.json
+++ b/core/vendor/base64/.bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "base64",
+  "version": "0.3.0",
+  "description": "Base64 encoding and decoding",
+  "main": "./base64.js",
+  "license": "WTFPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/davidchambers/Base64.js.git"
+  },
+  "ignore": [
+    "**/.*",
+    "Makefile",
+    "coverage/",
+    "scripts/",
+    "test/"
+  ],
+  "homepage": "https://github.com/davidchambers/Base64.js",
+  "_release": "0.3.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "0.3.0",
+    "commit": "772df096a5ffe983f40202684ad45eed1e0e2d59"
+  },
+  "_source": "git://github.com/davidchambers/Base64.js.git",
+  "_target": "~0.3.0",
+  "_originalSource": "base64",
+  "_direct": true
+}

--- a/core/vendor/base64/LICENSE
+++ b/core/vendor/base64/LICENSE
@@ -1,0 +1,14 @@
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+ Copyright (c) 2011..2012 David Chambers <dc@hashify.me>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/core/vendor/base64/base64.js
+++ b/core/vendor/base64/base64.js
@@ -1,0 +1,61 @@
+;(function () {
+
+  var object = typeof exports != 'undefined' ? exports : this; // #8: web workers
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+  function InvalidCharacterError(message) {
+    this.message = message;
+  }
+  InvalidCharacterError.prototype = new Error;
+  InvalidCharacterError.prototype.name = 'InvalidCharacterError';
+
+  // encoder
+  // [https://gist.github.com/999166] by [https://github.com/nignag]
+  object.btoa || (
+  object.btoa = function (input) {
+    var str = String(input);
+    for (
+      // initialize result and counter
+      var block, charCode, idx = 0, map = chars, output = '';
+      // if the next str index does not exist:
+      //   change the mapping table to "="
+      //   check if d has no fractional digits
+      str.charAt(idx | 0) || (map = '=', idx % 1);
+      // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+      output += map.charAt(63 & block >> 8 - idx % 1 * 8)
+    ) {
+      charCode = str.charCodeAt(idx += 3/4);
+      if (charCode > 0xFF) {
+        throw new InvalidCharacterError("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+      }
+      block = block << 8 | charCode;
+    }
+    return output;
+  });
+
+  // decoder
+  // [https://gist.github.com/1020396] by [https://github.com/atk]
+  object.atob || (
+  object.atob = function (input) {
+    var str = String(input).replace(/=+$/, '');
+    if (str.length % 4 == 1) {
+      throw new InvalidCharacterError("'atob' failed: The string to be decoded is not correctly encoded.");
+    }
+    for (
+      // initialize result and counters
+      var bc = 0, bs, buffer, idx = 0, output = '';
+      // get next character
+      buffer = str.charAt(idx++);
+      // character found in table? initialize bit storage and add its ascii value;
+      ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer,
+        // and if not first of each 4 characters,
+        // convert the first 8 bits to one ascii character
+        bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0
+    ) {
+      // try to find character in table (0-63, not found => -1)
+      buffer = chars.indexOf(buffer);
+    }
+    return output;
+  });
+
+}());

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -162,6 +162,8 @@ class OC_Template extends \OC\Template\Base {
 			}
 
 			if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE])) {
+				// polyfill for btoa/atob for IE friends
+				OC_Util::addVendorScript('base64/base64');
 				// shim for the davclient.js library
 				\OCP\Util::addScript('files/iedavclient');
 			}


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/21196

Now using Authorization headers instead of prepending the token in the URL. This, because IE9 and co would believe it's a cross-domain call and refuse to do it...

Need to public link with password in:
- [x] IE8
- [x] IE9
- [x] IE10
- [x] IE11
- [x] Safari
- [x] Firefox
- [x] Chromium
