### PR TITLE
[stable8.2] properly preserve home folder naming enforcement setting

### DIFF
--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -10,7 +10,7 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	<licence>AGPL</licence>
 	<author>Dominik Schmidt and Arthur Schiwon</author>
 	<shipped>true</shipped>
-	<version>0.7.0</version>
+	<version>0.7.1</version>
 	<types>
 		<authentication/>
 	</types>

--- a/apps/user_ldap/appinfo/update.php
+++ b/apps/user_ldap/appinfo/update.php
@@ -23,7 +23,12 @@
 
 $installedVersion = \OC::$server->getConfig()->getAppValue('user_ldap', 'installed_version');
 
-if (version_compare($installedVersion, '0.6.1', '<')) {
+
+if (
+	version_compare($installedVersion, '0.5.2', '<') || // stable8
+	(version_compare($installedVersion, '0.5.99', '>') && version_compare($installedVersion, '0.6.1.1', '<')) || // stable8.1
+	(version_compare($installedVersion, '0.6.99', '>') && version_compare($installedVersion, '0.7.1', '<')) // stable8.2
+) {
 	\OC::$server->getConfig()->setAppValue('user_ldap', 'enforce_home_folder_naming_rule', false);
 }
 


### PR DESCRIPTION
Same as #21210 but for stable8.2

@LukasReschke @blizzz Please review

@karlitschek @cmonteroluque Would be good to get this in 8.2.2 because it properly preserves the setting for enforce of the homeFolderNamingRule in the LDAP settings.
