### PR TITLE
Clear SMB statcache after fopen

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -33,6 +33,7 @@ use Icewind\SMB\Exception\Exception;
 use Icewind\SMB\Exception\NotFoundException;
 use Icewind\SMB\NativeServer;
 use Icewind\SMB\Server;
+use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Files\Filesystem;
 
@@ -189,7 +190,10 @@ class SMB extends Common {
 					return $this->share->read($fullPath);
 				case 'w':
 				case 'wb':
-					return $this->share->write($fullPath);
+					$source = $this->share->write($fullPath);
+					return CallBackWrapper::wrap($source, null, null, function () use ($fullPath) {
+						unset($this->statCache[$fullPath]);
+					});
 				case 'a':
 				case 'ab':
 				case 'r+':
@@ -219,7 +223,8 @@ class SMB extends Common {
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;
-					return CallBackWrapper::wrap($source, null, null, function () use ($tmpFile, $fullPath, $share) {
+					return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $fullPath, $share) {
+						unset($this->statCache[$fullPath]);
 						$share->put($tmpFile, $fullPath);
 						unlink($tmpFile);
 					});

--- a/tests/lib/files/storage/storage.php
+++ b/tests/lib/files/storage/storage.php
@@ -598,4 +598,17 @@ abstract class Storage extends \Test\TestCase {
 		$this->instance->mkdir('source');
 		$this->assertTrue($this->instance->isSharable('source'));
 	}
+
+	public function testStatAfterWrite() {
+		$this->instance->file_put_contents('foo.txt', 'bar');
+		$stat = $this->instance->stat('foo.txt');
+		$this->assertEquals(3, $stat['size']);
+
+		$fh = $this->instance->fopen('foo.txt', 'w');
+		fwrite($fh, 'qwerty');
+		fclose($fh);
+
+		$stat = $this->instance->stat('foo.txt');
+		$this->assertEquals(6, $stat['size']);
+	}
 }


### PR DESCRIPTION
Fixes #21205

Also adds a unit test to make sure this works correctly on _all_ storage backends

cc @PVince81 
