### PR TITLE
Skip tests relying on readonly files if chmod failed

### DIFF
--- a/tests/lib/files.php
+++ b/tests/lib/files.php
@@ -106,6 +106,13 @@ class Files extends \Test\TestCase {
 		chmod($files['.htaccess'], ($htaccessWritable ? 0644 : 0444));
 		chmod($files['.user.ini'], ($userIniWritable ? 0644 : 0444));
 
+		if (!$userIniWritable && is_writable($files['.user.ini'])) {
+			$this->markTestSkipped('Failed to remove write permissions from user ini.');
+		}
+		if (!$htaccessWritable && is_writable($files['.htaccess'])) {
+			$this->markTestSkipped('Failed to remove write permissions from htaccess.');
+		}
+
 		$htaccessSize = filesize($files['.htaccess']);
 		$userIniSize = filesize($files['.user.ini']);
 		$htaccessSizeMod = 2*(strlen($htaccessStr) - strlen(self::UPLOAD_LIMIT_DEFAULT_STR));

--- a/tests/lib/tempmanager.php
+++ b/tests/lib/tempmanager.php
@@ -145,6 +145,9 @@ class TempManager extends \Test\TestCase {
 		$logger = $this->getMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
+		if (is_writable($this->baseDir)) {
+			$this->markTestSkipped('Failed to remove write permissions from temp folder.');
+		}
 		$logger->expects($this->once())
 			->method('warning')
 			->with($this->stringContains('Can not create a temporary file in directory'));
@@ -159,6 +162,9 @@ class TempManager extends \Test\TestCase {
 		$logger = $this->getMock('\Test\NullLogger');
 		$manager = $this->getManager($logger);
 		chmod($this->baseDir, 0500);
+		if (is_writable($this->baseDir)) {
+			$this->markTestSkipped('Failed to remove write permissions from temp folder.');
+		}
 		$logger->expects($this->once())
 			->method('warning')
 			->with($this->stringContains('Can not create a temporary folder in directory'));

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -148,6 +148,11 @@ class Test_Util_CheckServer extends \Test\TestCase {
 		}
 
 		chmod($this->datadir, 0300);
+
+		if (is_writable($this->datadir)) {
+			$this->markTestSkipped('Failed to remove write permissions from datadir.');
+		}
+
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => true,
 			'version' => implode('.', OC_Util::getVersion())


### PR DESCRIPTION
Fix a few failing tests in some setups

cc @DeepDiver1975 
