### PR TITLE
Allow autoloading from all installed apps in tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,13 @@ require_once __DIR__ . '/../lib/base.php';
 
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 
+$appDirs = array_map(function($appRoot) {
+	return $appRoot['path'];
+}, OC::$APPSROOTS);
+foreach($appDirs as $appDir) {
+	\OC::$loader->addValidRoot($appDir);
+}
+
 // load all enabled apps
 \OC_App::loadApps();
 


### PR DESCRIPTION
Not all tests are as strict about only using enabled apps as they should

or more specifically, core encryption tests tries to load classes from the encryption app

Fixes failing tests if encryption app is disabled

cc @DeepDiver1975 
