### PR TITLE
Use setifempty to please incompatible httpd versions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,9 +14,12 @@
     Header set X-Frame-Options "SAMEORIGIN"
     SetEnv modHeadersAvailable true
 
-    # Add CSP header if not set, used for static resources
-    Header append Content-Security-Policy ""
-    Header edit Content-Security-Policy "^$" "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    <IfModule mod_version.c>
+        <IfVersion >= 2.4.7>
+            # Add CSP header if not set, used for static resources
+            Header setifempty Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+        </IfVersion>
+    </IfModule>
   </IfModule>
 
   # Add cache control for CSS and JS files

--- a/.htaccess
+++ b/.htaccess
@@ -17,7 +17,7 @@
     <IfModule mod_version.c>
         <IfVersion >= 2.4.7>
             # Add CSP header if not set, used for static resources
-            Header setifempty Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+            Header always setifempty Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; script-src 'self'"
         </IfVersion>
     </IfModule>
   </IfModule>


### PR DESCRIPTION
Some httpd versions have problem with the old logic leading to resourced served with multiple headers.

@MorrisJobke Should fix your issue.
