### PR TITLE
Fix files UI mtime parsing from webdav

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -253,7 +253,7 @@
 				id: props['{' + Client.NS_OWNCLOUD + '}fileid'],
 				path: OC.dirname(path) || '/',
 				name: OC.basename(path),
-				mtime: new Date(props['{' + Client.NS_DAV + '}getlastmodified'])
+				mtime: (new Date(props['{' + Client.NS_DAV + '}getlastmodified'])).getTime()
 			};
 
 			var etagProp = props['{' + Client.NS_DAV + '}getetag'];

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -252,7 +252,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.name).toEqual('One.txt');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(250);
-				expect(info.mtime.getTime()).toEqual(1436535485000);
+				expect(info.mtime).toEqual(1436535485000);
 				expect(info.mimetype).toEqual('text/plain');
 				expect(info.etag).toEqual('559fcabd79a38');
 
@@ -264,7 +264,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.name).toEqual('sub');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(100);
-				expect(info.mtime.getTime()).toEqual(1436536800000);
+				expect(info.mtime).toEqual(1436536800000);
 				expect(info.mimetype).toEqual('httpd/unix-directory');
 				expect(info.etag).toEqual('66cfcabd79abb');
 			});
@@ -295,7 +295,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.name).toEqual('文件夹');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(120);
-				expect(info.mtime.getTime()).toEqual(1436522405000);
+				expect(info.mtime).toEqual(1436522405000);
 				expect(info.mimetype).toEqual('httpd/unix-directory');
 				expect(info.etag).toEqual('56cfcabd79abb');
 
@@ -376,7 +376,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.name).toEqual('文件夹');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(120);
-				expect(info.mtime.getTime()).toEqual(1436522405000);
+				expect(info.mtime).toEqual(1436522405000);
 				expect(info.mimetype).toEqual('httpd/unix-directory');
 				expect(info.etag).toEqual('56cfcabd79abb');
 			});
@@ -425,7 +425,7 @@ describe('OC.Files.Client tests', function() {
 				expect(info.name).toEqual('in root');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(120);
-				expect(info.mtime.getTime()).toEqual(1436522405000);
+				expect(info.mtime).toEqual(1436522405000);
 				expect(info.mimetype).toEqual('httpd/unix-directory');
 				expect(info.etag).toEqual('56cfcabd79abb');
 			});


### PR DESCRIPTION
Introduced when moving the files UI to Webdav.

Every mtime was shown as "seconds ago" instead of the real mtime.

Please review @MorrisJobke @schiesbn @rullzer @MorrisJobke @nickvergessen 
