### PR TITLE
Avatar speedup

### DIFF
--- a/lib/public/iavatar.php
+++ b/lib/public/iavatar.php
@@ -24,6 +24,8 @@
  */
 
 namespace OCP;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
 
 /**
  * This class provides avatar functionality
@@ -64,4 +66,13 @@ interface IAvatar {
 	 * @since 6.0.0
 	 */
 	public function remove();
+
+	/**
+	 * Get the file of the avatar
+	 * @param int $size
+	 * @return File
+	 * @throws NotFoundException
+	 * @since 9.0.0
+	 */
+	public function getFile($size);
 }

--- a/tests/lib/avatartest.php
+++ b/tests/lib/avatartest.php
@@ -60,12 +60,25 @@ class AvatarTest extends \Test\TestCase {
 
 		$file = $this->getMock('\OCP\Files\File');
 		$file->method('getContent')->willReturn($expected->data());
-		$this->folder->method('get')->with('avatar.png')->willReturn($file);
+
+		$this->folder->method('get')
+			->will($this->returnCallback(
+				function($path) use ($file) {
+					if ($path === 'avatar.png') {
+						return $file;
+					} else {
+						throw new \OCP\Files\NotFoundException;
+					}
+				}
+			));
 
 		$newFile = $this->getMock('\OCP\Files\File');
 		$newFile->expects($this->once())
 			->method('putContent')
 			->with($expected2->data());
+		$newFile->expects($this->once())
+			->method('getContent')
+			->willReturn($expected2->data());
 		$this->folder->expects($this->once())
 			->method('newFile')
 			->with('avatar.32.png')


### PR DESCRIPTION
Getting an avatar first wraps it in an OC_Image. This is of no use since we do not do any image operations on it we just pass it on to the request.

Results in roughly a 10% speedup on my local machine (108 ms => 98 ms).
