### PR TITLE
Add a default size to the avatar placeholders

### DIFF
--- a/core/js/avatar.js
+++ b/core/js/avatar.js
@@ -2,8 +2,4 @@ $(document).ready(function(){
 	if (OC.currentUser) {
 
 	}
-	// User settings
-	$.each($('td.avatar .avatardiv'), function(i, element) {
-		$(element).avatar($(element).parent().parent().data('uid'), 32);
-	});
 });

--- a/core/js/avatar.js
+++ b/core/js/avatar.js
@@ -1,5 +1,0 @@
-$(document).ready(function(){
-	if (OC.currentUser) {
-
-	}
-});

--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -47,15 +47,19 @@
  */
 
 (function ($) {
-	$.fn.imageplaceholder = function(seed, text) {
+	$.fn.imageplaceholder = function(seed, text, size) {
 		// set optional argument "text" to value of "seed" if undefined
 		text = text || seed;
 
 		var hash = md5(seed),
 			maxRange = parseInt('ffffffffffffffffffffffffffffffff', 16),
 			hue = parseInt(hash, 16) / maxRange * 256,
-			height = this.height();
+			height = this.height() || size || 32;
 		this.css('background-color', 'hsl(' + hue + ', 90%, 65%)');
+
+		// Placeholders are square
+		this.height(height);
+		this.width(height);
 
 		// CSS rules
 		this.css('color', '#fff');

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -119,7 +119,6 @@ class OC_Template extends \OC\Template\Base {
 
 			// avatars
 			if (\OC::$server->getSystemConfig()->getValue('enable_avatars', true) === true) {
-				\OC_Util::addScript('avatar', null, true);
 				\OC_Util::addScript('jquery.avatar', null, true);
 				\OC_Util::addScript('placeholder', null, true);
 			}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -68,7 +68,7 @@ var UserList = {
 			if (user.isAvatarAvailable === true) {
 				$('div.avatardiv', $tr).avatar(user.name, 32, undefined, undefined, undefined, user.displayname);
 			} else {
-				$('div.avatardiv', $tr).imageplaceholder(user.displayname);
+				$('div.avatardiv', $tr).imageplaceholder(user.displayname, undefined, 32);
 			}
 		}
 


### PR DESCRIPTION
What we did was when the document was ready load the avatar of the empty row on the user page. This of course failed since there was user there.

Now we make sure that if we only load the placeholder we can specify a default size. Which allowes us to remove the additional call.

CC: @PVince81 @MorrisJobke @nickvergessen 
