### PR TITLE
Replace deprecated OC_Helper::linkToRoute calls

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -380,7 +380,7 @@ class OC_App {
 				array(
 					"id" => "help",
 					"order" => 1000,
-					"href" => OC_Helper::linkToRoute("settings_help"),
+					"href" => \OC::$server->getURLGenerator()->linkToRoute('settings_help'),
 					"name" => $l->t("Help"),
 					"icon" => OC_Helper::imagePath("settings", "help.svg")
 				)
@@ -393,7 +393,7 @@ class OC_App {
 			$settings[] = array(
 				"id" => "personal",
 				"order" => 1,
-				"href" => OC_Helper::linkToRoute("settings_personal"),
+				"href" => \OC::$server->getURLGenerator()->linkToRoute('settings_personal'),
 				"name" => $l->t("Personal"),
 				"icon" => OC_Helper::imagePath("settings", "personal.svg")
 			);
@@ -409,7 +409,7 @@ class OC_App {
 				$settings[] = array(
 					"id" => "core_users",
 					"order" => 2,
-					"href" => OC_Helper::linkToRoute("settings_users"),
+					"href" => \OC::$server->getURLGenerator()->linkToRoute('settings_users'),
 					"name" => $l->t("Users"),
 					"icon" => OC_Helper::imagePath("settings", "users.svg")
 				);
@@ -421,7 +421,7 @@ class OC_App {
 				$settings[] = array(
 					"id" => "admin",
 					"order" => 1000,
-					"href" => OC_Helper::linkToRoute("settings_admin"),
+					"href" => \OC::$server->getURLGenerator()->linkToRoute('settings_admin'),
 					"name" => $l->t("Admin"),
 					"icon" => OC_Helper::imagePath("settings", "admin.svg")
 				);

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -170,11 +170,11 @@ class OC_Helper {
 	 * Returns the path to the preview of the file.
 	 */
 	public static function previewIcon($path) {
-		return self::linkToRoute( 'core_ajax_preview', array('x' => 32, 'y' => 32, 'file' => $path ));
+		return \OC::$server->getURLGenerator()->linkToRoute('core_ajax_preview', ['x' => 32, 'y' => 32, 'file' => $path]);
 	}
 
 	public static function publicPreviewIcon( $path, $token ) {
-		return self::linkToRoute( 'core_ajax_public_preview', array('x' => 32, 'y' => 32, 'file' => $path, 't' => $token));
+		return \OC::$server->getURLGenerator()->linkToRoute('core_ajax_public_preview', ['x' => 32, 'y' => 32, 'file' => $path, 't' => $token]);
 	}
 
 	/**

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -54,19 +54,6 @@ class OC_Helper {
 	private static $templateManager;
 
 	/**
-	 * Creates an url using a defined route
-	 * @param string $route
-	 * @param array $parameters with param=>value, will be appended to the returned url
-	 * @return string the url
-	 * @deprecated Use \OC::$server->getURLGenerator()->linkToRoute($route, $parameters)
-	 *
-	 * Returns a url to the given app and file.
-	 */
-	public static function linkToRoute($route, $parameters = array()) {
-		return OC::$server->getURLGenerator()->linkToRoute($route, $parameters);
-	}
-
-	/**
 	 * Creates an absolute url
 	 * @param string $app app
 	 * @param string $file file

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -165,14 +165,14 @@ class OC_TemplateLayout extends OC_Template {
 
 		$useAssetPipeline = self::isAssetPipelineEnabled();
 		if ($useAssetPipeline) {
-			$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config', array('v' => self::$versionHash)));
+			$this->append( 'jsfiles', \OC::$server->getURLGenerator()->linkToRoute('js_config', ['v' => self::$versionHash]));
 			$this->generateAssets();
 		} else {
 			// Add the js files
 			$jsFiles = self::findJavascriptFiles(OC_Util::$scripts);
 			$this->assign('jsfiles', array());
 			if ($this->config->getSystemValue('installed', false) && $renderAs != 'error') {
-				$this->append( 'jsfiles', OC_Helper::linkToRoute('js_config', array('v' => self::$versionHash)));
+				$this->append( 'jsfiles', \OC::$server->getURLGenerator()->linkToRoute('js_config', ['v' => self::$versionHash]));
 			}
 			foreach($jsFiles as $info) {
 				$web = $info[1];

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -302,7 +302,7 @@ class Util {
 	 * @since 5.0.0
 	 */
 	public static function linkToRoute( $route, $parameters = array() ) {
-		return \OC_Helper::linkToRoute($route, $parameters);
+		return \OC::$server->getURLGenerator()->linkToRoute($route, $parameters);
 	}
 
 	/**

--- a/settings/help.php
+++ b/settings/help.php
@@ -43,8 +43,8 @@ if(isset($_GET['mode']) and $_GET['mode'] === 'admin') {
 	$style2='';
 }
 
-$url1=OC_Helper::linkToRoute( "settings_help" ).'?mode=user';
-$url2=OC_Helper::linkToRoute( "settings_help" ).'?mode=admin';
+$url1=\OC::$server->getURLGenerator()->linkToRoute('settings_help').'?mode=user';
+$url2=\OC::$server->getURLGenerator()->linkToRoute('settings_help').'?mode=admin';
 
 $tmpl = new OC_Template( "settings", "help", "user" );
 $tmpl->assign( "admin", OC_User::isAdminUser(OC_User::getUser()));

--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -149,7 +149,7 @@ if($_['passwordChangeSupported']) {
 </div>
 
 <?php if ($_['enableAvatars']): ?>
-<form id="avatar" class="section" method="post" action="<?php p(\OC_Helper::linkToRoute('core.avatar.postAvatar')); ?>">
+<form id="avatar" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
 	<h2><?php p($l->t('Profile picture')); ?></h2>
 	<div id="displayavatar">
 		<div class="avatardiv"></div><br>


### PR DESCRIPTION
Just replace it with the body (and suggested replacement) of the call.

Easy one ;)

CC: @MorrisJobke @PVince81 @LukasReschke @nickvergessen 
