### PR TITLE
Remove deprecated OC_Helper::linkTo

### DIFF
--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -16,7 +16,7 @@ if(!isset($_)) {//also provide standalone error page
 		<li class="error">
 			<?php p($l->t('File not found')); ?><br>
 			<p class="hint"><?php p($l->t('The specified document has not been found on the server.')); ?></p>
-			<p class="hint"><a href="<?php p(OC_Helper::linkTo('', 'index.php')) ?>"><?php p($l->t('You can click here to return to %s.', array($theme->getName()))); ?></a></p>
+			<p class="hint"><a href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>"><?php p($l->t('You can click here to return to %s.', array($theme->getName()))); ?></a></p>
 		</li>
 	</ul>
 <?php endif; ?>

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -93,7 +93,7 @@ class OC_Helper {
 	 */
 	public static function linkToAbsolute($app, $file, $args = array()) {
 		return OC::$server->getURLGenerator()->getAbsoluteURL(
-			self::linkTo($app, $file, $args)
+			OC::$server->getURLGenerator()->linkTo($app, $file, $args)
 		);
 	}
 
@@ -117,7 +117,7 @@ class OC_Helper {
 	 * Returns a url to the given service.
 	 */
 	public static function linkToRemoteBase($service) {
-		return self::linkTo('', 'remote.php') . '/' . $service;
+		return OC::$server->getURLGenerator()->linkTo('', 'remote.php') . '/' . $service;
 	}
 
 	/**
@@ -147,7 +147,7 @@ class OC_Helper {
 		if ($service === 'files') {
 			$url = OC::$server->getURLGenerator()->getAbsoluteURL('/s');
 		} else {
-			$url = OC::$server->getURLGenerator()->getAbsoluteURL(self::linkTo('', 'public.php').'?service='.$service);
+			$url = OC::$server->getURLGenerator()->getAbsoluteURL(OC::$server->getURLGenerator()->linkTo('', 'public.php').'?service='.$service);
 		}
 		return $url . (($add_slash && $service[strlen($service) - 1] != '/') ? '/' : '');
 	}

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -67,21 +67,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * Creates an url
-	 * @param string $app app
-	 * @param string $file file
-	 * @param array $args array with param=>value, will be appended to the returned url
-	 *    The value of $args will be urlencoded
-	 * @return string the url
-	 * @deprecated Use \OC::$server->getURLGenerator()->linkTo($app, $file, $args)
-	 *
-	 * Returns a url to the given app and file.
-	 */
-	public static function linkTo( $app, $file, $args = array() ) {
-		return OC::$server->getURLGenerator()->linkTo($app, $file, $args);
-	}
-
-	/**
 	 * Creates an absolute url
 	 * @param string $app app
 	 * @param string $file file

--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -92,7 +92,7 @@ class Router implements IRouter {
 		$this->logger = $logger;
 		$baseUrl = \OC::$WEBROOT;
 		if(!(getenv('front_controller_active') === 'true')) {
-			$baseUrl = \OC_Helper::linkTo('', 'index.php');
+			$baseUrl = \OC::$server->getURLGenerator()->linkTo('', 'index.php');
 		}
 		if (!\OC::$CLI) {
 			$method = $_SERVER['REQUEST_METHOD'];

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -146,7 +146,7 @@ function component($app, $file) {
  * For further information have a look at OC_Helper::linkTo
  */
 function link_to( $app, $file, $args = array() ) {
-	return OC_Helper::linkTo( $app, $file, $args );
+	return \OC::$server->getURLGenerator()->linkTo($app, $file, $args);
 }
 
 /**

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -275,8 +275,8 @@ class OC_TemplateLayout extends OC_Template {
 			$writer->writeAsset($cssCollection);
 		}
 
-		$this->append('jsfiles', OC_Helper::linkTo('assets', "$jsHash.js"));
-		$this->append('cssfiles', OC_Helper::linkTo('assets', "$cssHash.css"));
+		$this->append('jsfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$jsHash.js"));
+		$this->append('cssfiles', \OC::$server->getURLGenerator()->linkTo('assets', "$cssHash.css"));
 	}
 
 	/**

--- a/lib/public/util.php
+++ b/lib/public/util.php
@@ -316,7 +316,7 @@ class Util {
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 */
 	public static function linkTo( $app, $file, $args = array() ) {
-		return(\OC_Helper::linkTo( $app, $file, $args ));
+		return \OC::$server->getURLGenerator()->linkTo($app, $file, $args);
 	}
 
 	/**

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -296,52 +296,6 @@ class Test_Helper extends \Test\TestCase {
 
 	/**
 	 * @small
-	 * test linkTo URL construction
-	 * @dataProvider provideDocRootAppUrlParts
-	 */
-	public function testLinkToDocRoot($app, $file, $args, $expectedResult) {
-		\OC::$WEBROOT = '';
-		$result = \OC_Helper::linkTo($app, $file, $args);
-
-		$this->assertEquals($expectedResult, $result);
-	}
-
-	/**
-	 * @small
-	 * test linkTo URL construction in sub directory
-	 * @dataProvider provideSubDirAppUrlParts
-	 */
-	public function testLinkToSubDir($app, $file, $args, $expectedResult) {
-		\OC::$WEBROOT = '/owncloud';
-		$result = \OC_Helper::linkTo($app, $file, $args);
-
-		$this->assertEquals($expectedResult, $result);
-	}
-
-	/**
-	 * @return array
-	 */
-	public function provideDocRootAppUrlParts() {
-		return array(
-			array('files', 'ajax/list.php', array(), '/index.php/apps/files/ajax/list.php'),
-			array('files', 'ajax/list.php', array('trut' => 'trat', 'dut' => 'dat'), '/index.php/apps/files/ajax/list.php?trut=trat&dut=dat'),
-			array('', 'index.php', array('trut' => 'trat', 'dut' => 'dat'), '/index.php?trut=trat&dut=dat'),
-		);
-	}
-
-	/**
-	 * @return array
-	 */
-	public function provideSubDirAppUrlParts() {
-		return array(
-			array('files', 'ajax/list.php', array(), '/owncloud/index.php/apps/files/ajax/list.php'),
-			array('files', 'ajax/list.php', array('trut' => 'trat', 'dut' => 'dat'), '/owncloud/index.php/apps/files/ajax/list.php?trut=trat&dut=dat'),
-			array('', 'index.php', array('trut' => 'trat', 'dut' => 'dat'), '/owncloud/index.php?trut=trat&dut=dat'),
-		);
-	}
-
-	/**
-	 * @small
 	 * test linkToAbsolute URL construction
 	 * @dataProvider provideDocRootAppAbsoluteUrlParts
 	 */


### PR DESCRIPTION
More code cleanup.

All calls to the function are replaced with the suggested body of the function.

CC: @MorrisJobke @PVince81 @LukasReschke 
