### PR TITLE
Correctly render uploadtext indicator only on folders

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1068,7 +1068,7 @@
 				nameSpan.tooltip({placement: 'right'});
 			}
 			// dirs can show the number of uploaded files
-			if (mime !== 'httpd/unix-directory') {
+			if (mime === 'httpd/unix-directory') {
 				linkElem.append($('<span></span>').attr({
 					'class': 'uploadtext',
 					'currentUploads': 0

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2072,7 +2072,7 @@
 		 */
 		showFileBusyState: function(files, state) {
 			var self = this;
-			if (!_.isArray(files)) {
+			if (!_.isArray(files) && !files.is) {
 				files = [files];
 			}
 
@@ -2080,10 +2080,13 @@
 				state = true;
 			}
 
-			_.each(files, function($tr) {
+			_.each(files, function(fileName) {
 				// jquery element already ?
-				if (!$tr.is) {
-					$tr = self.findFileEl($tr);
+				var $tr;
+				if (_.isString(fileName)) {
+					$tr = self.findFileEl(fileName);
+				} else {
+					$tr = $(fileName);
 				}
 
 				var $thumbEl = $tr.find('.thumbnail');
@@ -2468,6 +2471,7 @@
 				}
 			});
 			fileUploadStart.on('fileuploadadd', function(e, data) {
+				console.log('XXXXXXX');
 				OC.Upload.log('filelist handle fileuploadadd', e, data);
 
 				//finish delete if we are uploading a deleted file
@@ -2487,8 +2491,7 @@
 
 					var translatedText = n('files', 'Uploading %n file', 'Uploading %n files', currentUploads);
 					if (currentUploads === 1) {
-						var img = OC.imagePath('core', 'loading.gif');
-						data.context.find('.thumbnail').css('background-image', 'url(' + img + ')');
+						self.showFileBusyState(uploadText.closest('tr'), true);
 						uploadText.text(translatedText);
 						uploadText.show();
 					} else {
@@ -2526,8 +2529,7 @@
 						uploadText.attr('currentUploads', currentUploads);
 						var translatedText = n('files', 'Uploading %n file', 'Uploading %n files', currentUploads);
 						if (currentUploads === 0) {
-							var img = OC.imagePath('core', 'filetypes/folder');
-							data.context.find('.thumbnail').css('background-image', 'url(' + img + ')');
+							self.showFileBusyState(uploadText.closest('tr'), false);
 							uploadText.text(translatedText);
 							uploadText.hide();
 						} else {
@@ -2604,18 +2606,15 @@
 					}
 				}
 			});
-			fileUploadStart.on('fileuploadstop', function(e, data) {
-				OC.Upload.log('filelist handle fileuploadstop', e, data);
+			fileUploadStart.on('fileuploadstop', function() {
+				OC.Upload.log('filelist handle fileuploadstop');
 
-				//if user pressed cancel hide upload chrome
-				if (data.errorThrown === 'abort') {
-					//cleanup uploading to a dir
-					var uploadText = $('tr .uploadtext');
-					var img = OC.imagePath('core', 'filetypes/folder');
-					uploadText.parents('td.filename').find('.thumbnail').css('background-image', 'url(' + img + ')');
-					uploadText.fadeOut();
-					uploadText.attr('currentUploads', 0);
-				}
+				//cleanup uploading to a dir
+				var uploadText = self.$fileList.find('tr .uploadtext');
+				self.showFileBusyState(uploadText.closest('tr'), false);
+				uploadText.fadeOut();
+				uploadText.attr('currentUploads', 0);
+
 				self.updateStorageStatistics();
 			});
 			fileUploadStart.on('fileuploadfail', function(e, data) {
@@ -2624,9 +2623,8 @@
 				//if user pressed cancel hide upload chrome
 				if (data.errorThrown === 'abort') {
 					//cleanup uploading to a dir
-					var uploadText = $('tr .uploadtext');
-					var img = OC.imagePath('core', 'filetypes/folder');
-					uploadText.parents('td.filename').find('.thumbnail').css('background-image', 'url(' + img + ')');
+					var uploadText = self.$fileList.find('tr .uploadtext');
+					self.showFileBusyState(uploadText.closest('tr'), false);
 					uploadText.fadeOut();
 					uploadText.attr('currentUploads', 0);
 				}

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2402,6 +2402,21 @@ describe('OCA.Files.FileList tests', function() {
 				expect(ev.result).not.toEqual(false);
 				expect(uploadData.targetDir).toEqual('/a/b');
 			});
+			it('renders upload indicator element for folders only', function() {
+				fileList.add({
+					name: 'afolder',
+					type: 'dir',
+					mime: 'httpd/unix-directory'
+				});
+				fileList.add({
+					name: 'afile.txt',
+					type: 'file',
+					mime: 'text/plain'
+				});
+
+				expect(fileList.findFileEl('afolder').find('.uploadtext').length).toEqual(1);
+				expect(fileList.findFileEl('afile.txt').find('.uploadtext').length).toEqual(0);
+			});
 		});
 	});
 	describe('Handling errors', function () {


### PR DESCRIPTION
Fixes these issues:
- have a folder with many files, upload many files and cancel upload: regular files must NOT have their icon converted to folder icons
- drag and drop upload into a folder, properly show spinner
- drag and drop upload into a shared folder, icon must be properly restored to the non-default folder icon

Please review @MorrisJobke @icewind1991 @nickvergessen @schiesbn @DeepDiver1975 
