### PR TITLE
Only load the big (128x128) avatar on the perosnal page

### DIFF
--- a/core/js/avatar.js
+++ b/core/js/avatar.js
@@ -1,7 +1,6 @@
 $(document).ready(function(){
 	if (OC.currentUser) {
-		// Personal settings
-		$('#avatar .avatardiv').avatar(OC.currentUser, 128);
+
 	}
 	// User settings
 	$.each($('td.avatar .avatardiv'), function(i, element) {

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -405,6 +405,11 @@ $(document).ready(function () {
 	if ($('#sslCertificate > tbody > tr').length === 0) {
 		$('#sslCertificate').hide();
 	}
+
+	// Load the big avatar
+	if (oc_config.enable_avatars) {
+		$('#avatar .avatardiv').avatar(OC.currentUser, 128);
+	}
 });
 
 if (!OC.Encryption) {


### PR DESCRIPTION
Before on each page the `avatars.js` was loaded. This then searched for the avatar div of the personal page and loaded the big avatar there. Now even if that div not existed it would still try to load the avatar.

This will thus save 1 request per page load (if avatars are enabled).

CC: @MorrisJobke @PVince81
