### PR TITLE
initialize l10n instance earlier, fixes an undefined var warning foll…

### DIFF
--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -55,10 +55,10 @@ class Controller {
 		\OC_JSON::callCheck();
 		\OC_JSON::checkLoggedIn();
 
+		$l = new \OC_L10n('settings');
 		if (isset($_POST['username'])) {
 			$username = $_POST['username'];
 		} else {
-			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array('data' => array('message' => $l->t('No user supplied')) ));
 			exit();
 		}
@@ -78,7 +78,6 @@ class Controller {
 		} elseif ($isUserAccessible) {
 			$userstatus = 'subadmin';
 		} else {
-			$l = new \OC_L10n('settings');
 			\OC_JSON::error(array('data' => array('message' => $l->t('Authentication error')) ));
 			exit();
 		}
@@ -122,7 +121,6 @@ class Controller {
 				$validRecoveryPassword = $keyManager->checkRecoveryPassword($recoveryPassword);
 				$recoveryEnabledForUser = $recovery->isRecoveryEnabledForUser($username);
 			}
-			$l = new \OC_L10n('settings');
 
 			if ($recoveryEnabledForUser && $recoveryPassword === '') {
 				\OC_JSON::error(array('data' => array(


### PR DESCRIPTION
…owed by a php error

How to test:
1. Have LDAP configured (probably any user backend that cannot change passwords is enough)
2. Go to users page
3. Attempt to change a password of the LDAP user

Expected: error notification pops up telling this is not possible

Actual behaviour: no information, 500 server error, log contains 

```
{"reqId":"1SQkp1HkxbWCja380dE+","remoteAddr":"127.0.0.1","app":"PHP","message":"Undefined variable: l at \/home\/blizzz\/owncloud\/dev\/master\/settings\/changepassword\/controller.php#154","level":0,"time":"2015-12-17T13:52:51+00:00","method":"POST","url":"\/master\/index.php\/settings\/users\/changepassword"}
{"reqId":"1SQkp1HkxbWCja380dE+","remoteAddr":"127.0.0.1","app":"PHP","message":"Call to a member function t() on null at \/home\/blizzz\/owncloud\/dev\/master\/settings\/changepassword\/controller.php#154","level":3,"time":"2015-12-17T13:52:51+00:00","method":"POST","url":"\/master\/index.php\/settings\/users\/changepassword"}
```

Please test and review @michag86 @LukasReschke @PVince81 
