### PR TITLE
Cleanup OC_User deprecated methods

### DIFF
--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -43,9 +43,9 @@ class MigrationTest extends \Test\TestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		\OC_User::createUser(self::TEST_ENCRYPTION_MIGRATION_USER1, 'foo');
-		\OC_User::createUser(self::TEST_ENCRYPTION_MIGRATION_USER2, 'foo');
-		\OC_User::createUser(self::TEST_ENCRYPTION_MIGRATION_USER3, 'foo');
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_MIGRATION_USER1, 'foo');
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_MIGRATION_USER2, 'foo');
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_MIGRATION_USER3, 'foo');
 	}
 
 	public static function tearDownAfterClass() {

--- a/apps/encryption/tests/lib/MigrationTest.php
+++ b/apps/encryption/tests/lib/MigrationTest.php
@@ -49,9 +49,12 @@ class MigrationTest extends \Test\TestCase {
 	}
 
 	public static function tearDownAfterClass() {
-		\OC_User::deleteUser(self::TEST_ENCRYPTION_MIGRATION_USER1);
-		\OC_User::deleteUser(self::TEST_ENCRYPTION_MIGRATION_USER2);
-		\OC_User::deleteUser(self::TEST_ENCRYPTION_MIGRATION_USER3);
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_MIGRATION_USER1);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_MIGRATION_USER2);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_MIGRATION_USER3);
+		if ($user !== null) { $user->delete(); }
 		parent::tearDownAfterClass();
 	}
 

--- a/apps/files/appinfo/register_command.php
+++ b/apps/files/appinfo/register_command.php
@@ -20,5 +20,5 @@
  *
  */
 
-$application->add(new OCA\Files\Command\Scan(OC_User::getManager()));
+$application->add(new OCA\Files\Command\Scan(\OC::$server->getUserManager()));
 $application->add(new OCA\Files\Command\DeleteOrphanedFiles(\OC::$server->getDatabaseConnection()));

--- a/apps/files/tests/service/tagservice.php
+++ b/apps/files/tests/service/tagservice.php
@@ -82,7 +82,8 @@ class TagServiceTest extends \Test\TestCase {
 
 	protected function tearDown() {
 		\OC_User::setUserId('');
-		\OC_User::deleteUser($this->user);
+		$user = \OC::$server->getUserManager()->get($this->user);
+		if ($user !== null) { $user->delete(); }
 	}
 
 	public function testUpdateFileTags() {

--- a/apps/files/tests/service/tagservice.php
+++ b/apps/files/tests/service/tagservice.php
@@ -54,7 +54,7 @@ class TagServiceTest extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 		$this->user = $this->getUniqueId('user');
-		\OC_User::createUser($this->user, 'test');
+		\OC::$server->getUserManager()->createUser($this->user, 'test');
 		\OC_User::setUserId($this->user);
 		\OC_Util::setupFS($this->user);
 		/**

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -78,7 +78,7 @@ class ShareControllerTest extends \Test\TestCase {
 		// Create a dummy user
 		$this->user = \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(12, ISecureRandom::CHAR_LOWER);
 
-		\OC_User::createUser($this->user, $this->user);
+		\OC::$server->getUserManager()->createUser($this->user, $this->user);
 		\OC_Util::tearDownFS();
 		$this->loginAsUser($this->user);
 

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -98,7 +98,8 @@ class ShareControllerTest extends \Test\TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		Filesystem::tearDown();
-		\OC_User::deleteUser($this->user);
+		$user = \OC::$server->getUserManager()->get($this->user);
+		if ($user !== null) { $user->delete(); }
 		\OC_User::setIncognitoMode(false);
 
 		\OC::$server->getSession()->set('public_link_authenticated', '');

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -149,7 +149,7 @@ abstract class TestCase extends \Test\TestCase {
 		}
 
 		if ($create) {
-			\OC_User::createUser($user, $password);
+			\OC::$server->getUserManager()->createUser($user, $password);
 			\OC_Group::createGroup('group');
 			\OC_Group::addToGroup($user, 'group');
 		}

--- a/apps/files_sharing/tests/testcase.php
+++ b/apps/files_sharing/tests/testcase.php
@@ -117,9 +117,12 @@ abstract class TestCase extends \Test\TestCase {
 
 	public static function tearDownAfterClass() {
 		// cleanup users
-		\OC_User::deleteUser(self::TEST_FILES_SHARING_API_USER1);
-		\OC_User::deleteUser(self::TEST_FILES_SHARING_API_USER2);
-		\OC_User::deleteUser(self::TEST_FILES_SHARING_API_USER3);
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER1);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER2);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER3);
+		if ($user !== null) { $user->delete(); }
 
 		// delete group
 		\OC_Group::deleteGroup(self::TEST_FILES_SHARING_API_GROUP1);

--- a/apps/files_trashbin/tests/storage.php
+++ b/apps/files_trashbin/tests/storage.php
@@ -75,7 +75,8 @@ class Storage extends \Test\TestCase {
 	protected function tearDown() {
 		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 		$this->logout();
-		\OC_User::deleteUser($this->user);
+		$user = \OC::$server->getUserManager()->get($this->user);
+		if ($user !== null) { $user->delete(); }
 		\OC_Hook::clear();
 		parent::tearDown();
 	}

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -636,7 +636,7 @@ class Test_Trashbin extends \Test\TestCase {
 	public static function loginHelper($user, $create = false) {
 		if ($create) {
 			try {
-				\OC_User::createUser($user, $user);
+				\OC::$server->getUserManager()->createUser($user, $user);
 			} catch(\Exception $e) { // catch username is already being used from previous aborted runs
 
 			}

--- a/apps/files_trashbin/tests/trashbin.php
+++ b/apps/files_trashbin/tests/trashbin.php
@@ -88,7 +88,8 @@ class Test_Trashbin extends \Test\TestCase {
 
 	public static function tearDownAfterClass() {
 		// cleanup test user
-		\OC_User::deleteUser(self::TEST_TRASHBIN_USER1);
+		$user = \OC::$server->getUserManager()->get(self::TEST_TRASHBIN_USER1);
+		if ($user !== null) { $user->delete(); }
 
 		\OC::$server->getConfig()->setSystemValue('trashbin_retention_obligation', self::$rememberRetentionObligation);
 

--- a/apps/files_versions/tests/versions.php
+++ b/apps/files_versions/tests/versions.php
@@ -61,8 +61,10 @@ class Test_Files_Versioning extends \Test\TestCase {
 
 	public static function tearDownAfterClass() {
 		// cleanup test user
-		\OC_User::deleteUser(self::TEST_VERSIONS_USER);
-		\OC_User::deleteUser(self::TEST_VERSIONS_USER2);
+		$user = \OC::$server->getUserManager()->get(self::TEST_VERSIONS_USER);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_VERSIONS_USER2);
+		if ($user !== null) { $user->delete(); }
 
 		parent::tearDownAfterClass();
 	}

--- a/core/templates/internalmail.php
+++ b/core/templates/internalmail.php
@@ -4,7 +4,7 @@
 <tr>
 <td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
 <td bgcolor="<?php p($theme->getMailHeaderColor());?>">
-<img src="<?php p(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
 </td>
 </tr>
 <tr><td colspan="2">&nbsp;</td></tr>

--- a/core/templates/mail.php
+++ b/core/templates/mail.php
@@ -4,7 +4,7 @@
 <tr>
 <td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
 <td bgcolor="<?php p($theme->getMailHeaderColor());?>">
-<img src="<?php p(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
 </td>
 </tr>
 <tr><td colspan="2">&nbsp;</td></tr>

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -10,7 +10,7 @@
 			<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
 			<br><br>
 			<p style="text-align:center;">
-				<a href="<?php print_unescaped(OC_Helper::makeURLAbsolute(\OCP\Util::linkToRoute('settings_admin'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
+				<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings_admin'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
 					<?php p($l->t('Add "%s" as trusted domain', array($_['domain']))); ?>
 				</a>
 			</p>

--- a/lib/base.php
+++ b/lib/base.php
@@ -875,7 +875,7 @@ class OC {
 
 		// Handle redirect URL for logged in users
 		if (isset($_REQUEST['redirect_url']) && OC_User::isLoggedIn()) {
-			$location = OC_Helper::makeURLAbsolute(urldecode($_REQUEST['redirect_url']));
+			$location = \OC::$server->getURLGenerator()->getAbsoluteURL(urldecode($_REQUEST['redirect_url']));
 
 			// Deny the redirect if the URL contains a @
 			// This prevents unvalidated redirects like ?redirect_url=:user@domain.com

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -76,44 +76,6 @@ class OC_User {
 	private static $incognitoMode = false;
 
 	/**
-	 * registers backend
-	 *
-	 * @param string $backend name of the backend
-	 * @deprecated Add classes by calling OC_User::useBackend() with a class instance instead
-	 * @return bool
-	 *
-	 * Makes a list of backends that can be used by other modules
-	 */
-	public static function registerBackend($backend) {
-		self::$_backends[] = $backend;
-		return true;
-	}
-
-	/**
-	 * gets available backends
-	 *
-	 * @deprecated
-	 * @return array an array of backends
-	 *
-	 * Returns the names of all backends.
-	 */
-	public static function getBackends() {
-		return self::$_backends;
-	}
-
-	/**
-	 * gets used backends
-	 *
-	 * @deprecated
-	 * @return array an array of backends
-	 *
-	 * Returns the names of all used backends.
-	 */
-	public static function getUsedBackends() {
-		return array_keys(self::$_usedBackends);
-	}
-
-	/**
 	 * Adds the backend to the list of used backends
 	 *
 	 * @param string|OC_User_Interface $backend default: database The backend to use for user management

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -66,14 +66,6 @@ class OC_User {
 		return OC::$server->getUserSession();
 	}
 
-	/**
-	 * @return \OC\User\Manager
-	 * @deprecated Use \OC::$server->getUserManager()
-	 */
-	public static function getManager() {
-		return OC::$server->getUserManager();
-	}
-
 	private static $_backends = array();
 
 	private static $_usedBackends = array();
@@ -132,7 +124,7 @@ class OC_User {
 	public static function useBackend($backend = 'database') {
 		if ($backend instanceof OC_User_Interface) {
 			self::$_usedBackends[get_class($backend)] = $backend;
-			self::getManager()->registerBackend($backend);
+			\OC::$server->getUserManager()->registerBackend($backend);
 		} else {
 			// You'll never know what happens
 			if (null === $backend OR !is_string($backend)) {
@@ -146,17 +138,17 @@ class OC_User {
 				case 'sqlite':
 					\OCP\Util::writeLog('core', 'Adding user backend ' . $backend . '.', \OCP\Util::DEBUG);
 					self::$_usedBackends[$backend] = new OC_User_Database();
-					self::getManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				case 'dummy':
 					self::$_usedBackends[$backend] = new \Test\Util\User\Dummy();
-					self::getManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				default:
 					\OCP\Util::writeLog('core', 'Adding default user backend ' . $backend . '.', \OCP\Util::DEBUG);
 					$className = 'OC_USER_' . strToUpper($backend);
 					self::$_usedBackends[$backend] = new $className();
-					self::getManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
 			}
 		}
@@ -168,7 +160,7 @@ class OC_User {
 	 */
 	public static function clearBackends() {
 		self::$_usedBackends = array();
-		self::getManager()->clearBackends();
+		\OC::$server->getUserManager()->clearBackends();
 	}
 
 	/**
@@ -213,7 +205,7 @@ class OC_User {
 	 * @deprecated Use \OC::$server->getUserManager()->createUser($uid, $password)
 	 */
 	public static function createUser($uid, $password) {
-		return self::getManager()->createUser($uid, $password);
+		return \OC::$server->getUserManager()->createUser($uid, $password);
 	}
 
 	/**
@@ -226,7 +218,7 @@ class OC_User {
 	 * @deprecated Use \OC::$server->getUserManager()->get() and then run delete() on the return
 	 */
 	public static function deleteUser($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->delete();
 		} else {
@@ -343,7 +335,7 @@ class OC_User {
 		if (is_null($displayName)) {
 			$displayName = $uid;
 		}
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->setDisplayName($displayName);
 		} else {
@@ -452,7 +444,7 @@ class OC_User {
 	 */
 	public static function getDisplayName($uid = null) {
 		if ($uid) {
-			$user = self::getManager()->get($uid);
+			$user = \OC::$server->getUserManager()->get($uid);
 			if ($user) {
 				return $user->getDisplayName();
 			} else {
@@ -490,7 +482,7 @@ class OC_User {
 	 * Change the password of a user
 	 */
 	public static function setPassword($uid, $password, $recoveryPassword = null) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->setPassword($password, $recoveryPassword);
 		} else {
@@ -507,7 +499,7 @@ class OC_User {
 	 * Check whether a specified user can change his avatar
 	 */
 	public static function canUserChangeAvatar($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->canChangeAvatar();
 		} else {
@@ -524,7 +516,7 @@ class OC_User {
 	 * Check whether a specified user can change his password
 	 */
 	public static function canUserChangePassword($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->canChangePassword();
 		} else {
@@ -541,7 +533,7 @@ class OC_User {
 	 * Check whether a specified user can change his display name
 	 */
 	public static function canUserChangeDisplayName($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->canChangeDisplayName();
 		} else {
@@ -560,7 +552,7 @@ class OC_User {
 	 * returns the user id or false
 	 */
 	public static function checkPassword($uid, $password) {
-		$manager = self::getManager();
+		$manager = \OC::$server->getUserManager();
 		$username = $manager->checkPassword($uid, $password);
 		if ($username !== false) {
 			return $username->getUID();
@@ -576,7 +568,7 @@ class OC_User {
 	 * @deprecated Use \OC::$server->getUserManager->getHome()
 	 */
 	public static function getHome($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->getHome();
 		} else {
@@ -595,7 +587,7 @@ class OC_User {
 	 * @param integer $offset
 	 */
 	public static function getUsers($search = '', $limit = null, $offset = null) {
-		$users = self::getManager()->search($search, $limit, $offset);
+		$users = \OC::$server->getUserManager()->search($search, $limit, $offset);
 		$uids = array();
 		foreach ($users as $user) {
 			$uids[] = $user->getUID();
@@ -616,7 +608,7 @@ class OC_User {
 	 */
 	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = array();
-		$users = self::getManager()->searchDisplayName($search, $limit, $offset);
+		$users = \OC::$server->getUserManager()->searchDisplayName($search, $limit, $offset);
 		foreach ($users as $user) {
 			$displayNames[$user->getUID()] = $user->getDisplayName();
 		}
@@ -630,7 +622,7 @@ class OC_User {
 	 * @return boolean
 	 */
 	public static function userExists($uid) {
-		return self::getManager()->userExists($uid);
+		return \OC::$server->getUserManager()->userExists($uid);
 	}
 
 	/**
@@ -639,7 +631,7 @@ class OC_User {
 	 * @param string $uid the user to disable
 	 */
 	public static function disableUser($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			$user->setEnabled(false);
 		}
@@ -651,7 +643,7 @@ class OC_User {
 	 * @param string $uid
 	 */
 	public static function enableUser($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			$user->setEnabled(true);
 		}
@@ -664,7 +656,7 @@ class OC_User {
 	 * @return bool
 	 */
 	public static function isEnabled($uid) {
-		$user = self::getManager()->get($uid);
+		$user = \OC::$server->getUserManager()->get($uid);
 		if ($user) {
 			return $user->isEnabled();
 		} else {

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -191,24 +191,6 @@ class OC_User {
 	}
 
 	/**
-	 * Create a new user
-	 *
-	 * @param string $uid The username of the user to create
-	 * @param string $password The password of the new user
-	 * @throws Exception
-	 * @return bool true/false
-	 *
-	 * Creates a new user. Basic checking of username is done in OC_User
-	 * itself, not in its subclasses.
-	 *
-	 * Allowed characters in the username are: "a-z", "A-Z", "0-9" and "_.@-"
-	 * @deprecated Use \OC::$server->getUserManager()->createUser($uid, $password)
-	 */
-	public static function createUser($uid, $password) {
-		return \OC::$server->getUserManager()->createUser($uid, $password);
-	}
-
-	/**
 	 * delete a user
 	 *
 	 * @param string $uid The username of the user to delete

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -153,24 +153,6 @@ class OC_User {
 	}
 
 	/**
-	 * delete a user
-	 *
-	 * @param string $uid The username of the user to delete
-	 * @return bool
-	 *
-	 * Deletes a user
-	 * @deprecated Use \OC::$server->getUserManager()->get() and then run delete() on the return
-	 */
-	public static function deleteUser($uid) {
-		$user = \OC::$server->getUserManager()->get($uid);
-		if ($user) {
-			return $user->delete();
-		} else {
-			return false;
-		}
-	}
-
-	/**
 	 * Try to login a user
 	 *
 	 * @param string $loginname The login name of the user to log in

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1250,7 +1250,7 @@ class OC_Util {
 		fclose($fp);
 
 		// accessing the file via http
-		$url = OC_Helper::makeURLAbsolute(OC::$WEBROOT . '/data' . $fileName);
+		$url = \OC::$server->getURLGenerator()->getAbsoluteURL(OC::$WEBROOT . '/data' . $fileName);
 		try {
 			$content = \OC::$server->getHTTPClientService()->newClient()->get($url)->getBody();
 		} catch (\Exception $e) {

--- a/settings/templates/email.new_user.php
+++ b/settings/templates/email.new_user.php
@@ -4,7 +4,7 @@
 				<tr>
 					<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
 					<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
-						<img src="<?php p(OC_Helper::makeURLAbsolute(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+						<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
 					</td>
 				</tr>
 				<tr><td colspan="2">&nbsp;</td></tr>

--- a/settings/users.php
+++ b/settings/users.php
@@ -37,7 +37,7 @@ OC_Util::checkSubAdminUser();
 
 \OC::$server->getNavigationManager()->setActiveEntry('core_users');
 
-$userManager = \OC_User::getManager();
+$userManager = \OC::$server->getUserManager();
 $groupManager = \OC_Group::getManager();
 
 // Set the sort option: SORT_USERCOUNT or SORT_GROUPNAME

--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -71,7 +71,7 @@ class FileCache extends \Test_Cache {
 		\OC_User::useBackend(new \Test\Util\User\Dummy());
 
 		//login
-		\OC_User::createUser('test', 'test');
+		\OC::$server->getUserManager()->createUser('test', 'test');
 
 		$this->user = \OC_User::getUser();
 		\OC_User::setUserId('test');

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -317,7 +317,7 @@ class Cache extends \Test\TestCase {
 
 	function testSearchByTag() {
 		$userId = $this->getUniqueId('user');
-		\OC_User::createUser($userId, $userId);
+		\OC::$server->getUserManager()->createUser($userId, $userId);
 		$this->loginAsUser($userId);
 		$user = new \OC\User\User($userId, null);
 

--- a/tests/lib/files/cache/cache.php
+++ b/tests/lib/files/cache/cache.php
@@ -373,7 +373,8 @@ class Cache extends \Test\TestCase {
 		$tagManager->delete('tag2');
 
 		$this->logout();
-		\OC_User::deleteUser($userId);
+		$user = \OC::$server->getUserManager()->get($userId);
+		if ($user !== null) { $user->delete(); }
 	}
 
 	function testMove() {

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -57,7 +57,7 @@ class UpdaterLegacy extends \Test\TestCase {
 			self::$user = $this->getUniqueID();
 		}
 
-		\OC_User::createUser(self::$user, 'password');
+		\OC::$server->getUserManager()->createUser(self::$user, 'password');
 		$this->loginAsUser(self::$user);
 
 		Filesystem::init(self::$user, '/' . self::$user . '/files');

--- a/tests/lib/files/cache/updaterlegacy.php
+++ b/tests/lib/files/cache/updaterlegacy.php
@@ -72,7 +72,10 @@ class UpdaterLegacy extends \Test\TestCase {
 		if ($this->cache) {
 			$this->cache->clear();
 		}
-		$result = \OC_User::deleteUser(self::$user);
+
+		$result = false;
+		$user = \OC::$server->getUserManager()->get(self::$user);
+		if ($user !== null) { $result = $user->delete(); }
 		$this->assertTrue($result);
 
 		$this->logout();

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -325,7 +325,7 @@ class Filesystem extends \Test\TestCase {
 	public function testHomeMount() {
 		$userId = $this->getUniqueID('user_');
 
-		\OC_User::createUser($userId, $userId);
+		\OC::$server->getUserManager()->createUser($userId, $userId);
 
 		\OC\Files\Filesystem::initMountPoints($userId);
 
@@ -360,7 +360,7 @@ class Filesystem extends \Test\TestCase {
 		// this will trigger the insert
 		$cache = $localStorage->getCache();
 
-		\OC_User::createUser($userId, $userId);
+		\OC::$server->getUserManager()->createUser($userId, $userId);
 		\OC\Files\Filesystem::initMountPoints($userId);
 
 		$homeMount = \OC\Files\Filesystem::getStorage('/' . $userId . '/');
@@ -388,7 +388,7 @@ class Filesystem extends \Test\TestCase {
 		// no cache path configured
 		$config->setSystemValue('cache_path', '');
 
-		\OC_User::createUser($userId, $userId);
+		\OC::$server->getUserManager()->createUser($userId, $userId);
 		\OC\Files\Filesystem::initMountPoints($userId);
 
 		$this->assertEquals(
@@ -416,7 +416,7 @@ class Filesystem extends \Test\TestCase {
 		$cachePath = \OC_Helper::tmpFolder() . '/extcache';
 		$config->setSystemValue('cache_path', $cachePath);
 
-		\OC_User::createUser($userId, $userId);
+		\OC::$server->getUserManager()->createUser($userId, $userId);
 		\OC\Files\Filesystem::initMountPoints($userId);
 
 		$this->assertEquals(

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -340,7 +340,8 @@ class Filesystem extends \Test\TestCase {
 			$this->assertEquals('home::' . $userId, $homeMount->getId());
 		}
 
-		\OC_User::deleteUser($userId);
+		$user = \OC::$server->getUserManager()->get($userId);
+		if ($user !== null) { $user->delete(); }
 	}
 
 	/**
@@ -368,7 +369,8 @@ class Filesystem extends \Test\TestCase {
 		$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\Storage\Home'));
 		$this->assertEquals('local::' . $datadir . '/' . $userId . '/', $homeMount->getId());
 
-		\OC_User::deleteUser($userId);
+		$user = \OC::$server->getUserManager()->get($userId);
+		if ($user !== null) { $user->delete(); }
 		// delete storage entry
 		$cache->clear();
 	}
@@ -398,7 +400,8 @@ class Filesystem extends \Test\TestCase {
 		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath('/' . $userId . '/cache');
 		$this->assertTrue($storage->instanceOfStorage('\OCP\Files\IHomeStorage'));
 		$this->assertEquals('cache', $internalPath);
-		\OC_User::deleteUser($userId);
+		$user = \OC::$server->getUserManager()->get($userId);
+		if ($user !== null) { $user->delete(); }
 
 		$config->setSystemValue('cache_path', $oldCachePath);
 	}
@@ -426,7 +429,8 @@ class Filesystem extends \Test\TestCase {
 		list($storage, $internalPath) = \OC\Files\Filesystem::resolvePath('/' . $userId . '/cache');
 		$this->assertTrue($storage->instanceOfStorage('\OC\Files\Storage\Local'));
 		$this->assertEquals('', $internalPath);
-		\OC_User::deleteUser($userId);
+		$user = \OC::$server->getUserManager()->get($userId);
+		if ($user !== null) { $user->delete(); }
 
 		$config->setSystemValue('cache_path', $oldCachePath);
 	}

--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -51,7 +51,8 @@ class Swift extends \Test\Files\Storage\Storage {
 		// create users
 		$users = array('test');
 		foreach($users as $userName) {
-			\OC_User::deleteUser($userName);
+			$user = \OC::$server->getUserManager()->get($userName);
+			if ($user !== null) { $user->delete(); }
 			\OC::$server->getUserManager()->createUser($userName, $userName);
 		}
 
@@ -76,7 +77,8 @@ class Swift extends \Test\Files\Storage\Storage {
 
 		$users = array('test');
 		foreach($users as $userName) {
-			\OC_User::deleteUser($userName);
+			$user = \OC::$server->getUserManager()->get($userName);
+			if ($user !== null) { $user->delete(); }
 		}
 		parent::tearDown();
 	}

--- a/tests/lib/files/objectstore/swift.php
+++ b/tests/lib/files/objectstore/swift.php
@@ -52,7 +52,7 @@ class Swift extends \Test\Files\Storage\Storage {
 		$users = array('test');
 		foreach($users as $userName) {
 			\OC_User::deleteUser($userName);
-			\OC_User::createUser($userName, $userName);
+			\OC::$server->getUserManager()->createUser($userName, $userName);
 		}
 
 		// main test user

--- a/tests/lib/files/storage/homestoragequota.php
+++ b/tests/lib/files/storage/homestoragequota.php
@@ -44,7 +44,8 @@ class HomeStorageQuota extends \Test\TestCase {
 
 		// clean up
 		\OC_User::setUserId('');
-		\OC_User::deleteUser($user1);
+		$user = \OC::$server->getUserManager()->get($user1);
+		if ($user !== null) { $user->delete(); }
 		\OC::$server->getConfig()->deleteAllUserValues($user1);
 		\OC_Util::tearDownFS();
 	}
@@ -71,7 +72,8 @@ class HomeStorageQuota extends \Test\TestCase {
 
 		// clean up
 		\OC_User::setUserId('');
-		\OC_User::deleteUser($user1);
+		$user = \OC::$server->getUserManager()->get($user1);
+		if ($user !== null) { $user->delete(); }
 		\OC::$server->getConfig()->deleteAllUserValues($user1);
 		\OC_Util::tearDownFS();
 	}

--- a/tests/lib/files/storage/homestoragequota.php
+++ b/tests/lib/files/storage/homestoragequota.php
@@ -32,7 +32,7 @@ class HomeStorageQuota extends \Test\TestCase {
 	 */
 	function testHomeStorageWrapperWithoutQuota() {
 		$user1 = $this->getUniqueID();
-		\OC_User::createUser($user1, 'test');
+		\OC::$server->getUserManager()->createUser($user1, 'test');
 		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', 'none');
 		\OC_User::setUserId($user1);
 
@@ -54,7 +54,7 @@ class HomeStorageQuota extends \Test\TestCase {
 	 */
 	function testHomeStorageWrapperWithQuota() {
 		$user1 = $this->getUniqueID();
-		\OC_User::createUser($user1, 'test');
+		\OC::$server->getUserManager()->createUser($user1, 'test');
 		\OC::$server->getConfig()->setUserValue($user1, 'files', 'quota', '1024');
 		\OC_User::setUserId($user1);
 

--- a/tests/lib/group.php
+++ b/tests/lib/group.php
@@ -31,7 +31,7 @@ class Test_Group extends \Test\TestCase {
 
 	public function testSingleBackend() {
 		$userBackend = new \Test\Util\User\Dummy();
-		\OC_User::getManager()->registerBackend($userBackend);
+		\OC::$server->getUserManager()->registerBackend($userBackend);
 		OC_Group::useBackend(new OC_Group_Dummy());
 
 		$group1 = $this->getUniqueID();
@@ -113,7 +113,7 @@ class Test_Group extends \Test\TestCase {
 	public function testUsersInGroup() {
 		OC_Group::useBackend(new OC_Group_Dummy());
 		$userBackend = new \Test\Util\User\Dummy();
-		\OC_User::getManager()->registerBackend($userBackend);
+		\OC::$server->getUserManager()->registerBackend($userBackend);
 
 		$group1 = $this->getUniqueID();
 		$group2 = $this->getUniqueID();
@@ -142,7 +142,7 @@ class Test_Group extends \Test\TestCase {
 
 	public function testMultiBackend() {
 		$userBackend = new \Test\Util\User\Dummy();
-		\OC_User::getManager()->registerBackend($userBackend);
+		\OC::$server->getUserManager()->registerBackend($userBackend);
 		$backend1 = new OC_Group_Dummy();
 		$backend2 = new OC_Group_Dummy();
 		OC_Group::useBackend($backend1);

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -23,7 +23,7 @@ class Test_Helper_Storage extends \Test\TestCase {
 		parent::setUp();
 
 		$this->user = $this->getUniqueID('user_');
-		\OC_User::createUser($this->user, $this->user);
+		\OC::$server->getUserManager()->createUser($this->user, $this->user);
 
 		$this->storage = \OC\Files\Filesystem::getStorage('/');
 		\OC\Files\Filesystem::tearDown();

--- a/tests/lib/helperstorage.php
+++ b/tests/lib/helperstorage.php
@@ -45,7 +45,8 @@ class Test_Helper_Storage extends \Test\TestCase {
 		\OC\Files\Filesystem::mount($this->storage, array(), '/');
 
 		\OC_User::setUserId('');
-		\OC_User::deleteUser($this->user);
+		$user = \OC::$server->getUserManager()->get($this->user);
+		if ($user !== null) { $user->delete(); }
 		\OC::$server->getConfig()->deleteAllUserValues($this->user);
 
 		parent::tearDown();

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -24,7 +24,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->username = $this->getUniqueID('', 20);
-		OC_User::createUser($this->username, $this->getUniqueID('', 20));
+		\OC::$server->getUserManager()->createUser($this->username, $this->getUniqueID('', 20));
 
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');

--- a/tests/lib/security/certificatemanager.php
+++ b/tests/lib/security/certificatemanager.php
@@ -39,7 +39,8 @@ class CertificateManagerTest extends \Test\TestCase {
 	}
 
 	protected function tearDown() {
-		\OC_User::deleteUser($this->username);
+		$user = \OC::$server->getUserManager()->get($this->username);
+		if ($user !== null) { $user->delete(); }
 		parent::tearDown();
 	}
 

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -54,13 +54,13 @@ class Test_Share extends \Test\TestCase {
 		$this->user5 = $this->getUniqueID('user5_');
 		$this->user6 = $this->getUniqueID('user6_');
 		$this->groupAndUser = $this->getUniqueID('groupAndUser_');
-		OC_User::createUser($this->user1, 'pass');
-		OC_User::createUser($this->user2, 'pass');
-		OC_User::createUser($this->user3, 'pass');
-		OC_User::createUser($this->user4, 'pass');
-		OC_User::createUser($this->user5, 'pass');
-		OC_User::createUser($this->user6, 'pass'); // no group
-		OC_User::createUser($this->groupAndUser, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user1, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user2, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user3, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user4, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user5, 'pass');
+		\OC::$server->getUserManager()->createUser($this->user6, 'pass'); // no group
+		\OC::$server->getUserManager()->createUser($this->groupAndUser, 'pass');
 		OC_User::setUserId($this->user1);
 		OC_Group::clearBackends();
 		OC_Group::useBackend(new OC_Group_Dummy);

--- a/tests/lib/share/share.php
+++ b/tests/lib/share/share.php
@@ -94,13 +94,20 @@ class Test_Share extends \Test\TestCase {
 		$query->execute(array('test'));
 		\OC::$server->getAppConfig()->setValue('core', 'shareapi_allow_resharing', $this->resharing);
 
-		OC_User::deleteUser($this->user1);
-		OC_User::deleteUser($this->user2);
-		OC_User::deleteUser($this->user3);
-		OC_User::deleteUser($this->user4);
-		OC_User::deleteUser($this->user5);
-		OC_User::deleteUser($this->user6);
-		OC_User::deleteUser($this->groupAndUser);
+		$user = \OC::$server->getUserManager()->get($this->user1);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->user2);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->user3);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->user4);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->user5);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->user6);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get($this->groupAndUser);
+		if ($user !== null) { $user->delete(); }
 
 		OC_Group::deleteGroup($this->group1);
 		OC_Group::deleteGroup($this->group2);
@@ -375,7 +382,8 @@ class Test_Share extends \Test\TestCase {
 
 		// Remove user
 		OC_User::setUserId($this->user1);
-		OC_User::deleteUser($this->user1);
+		$user = \OC::$server->getUserManager()->get($this->user1);
+		if ($user !== null) { $user->delete(); }
 		OC_User::setUserId($this->user2);
 		$this->assertEquals(array('test1.txt'), OCP\Share::getItemsSharedWith('test', Test_Share_Backend::FORMAT_TARGET));
 	}

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -44,7 +44,7 @@ class Test_Tags extends \Test\TestCase {
 		OC_User::clearBackends();
 		OC_User::useBackend('dummy');
 		$userId = $this->getUniqueID('user_');
-		OC_User::createUser($userId, 'pass');
+		\OC::$server->getUserManager()->createUser($userId, 'pass');
 		OC_User::setUserId($userId);
 		$this->user = new OC\User\User($userId, null);
 		$this->userSession = $this->getMock('\OCP\IUserSession');
@@ -290,7 +290,7 @@ class Test_Tags extends \Test\TestCase {
 		$tagger->tagAs(1, $testTag);
 
 		$otherUserId = $this->getUniqueID('user2_');
-		OC_User::createUser($otherUserId, 'pass');
+		\OC::$server->getUserManager()->createUser($otherUserId, 'pass');
 		OC_User::setUserId($otherUserId);
 		$otherUserSession = $this->getMock('\OCP\IUserSession');
 		$otherUserSession

--- a/tests/lib/user.php
+++ b/tests/lib/user.php
@@ -51,15 +51,5 @@ class User extends TestCase {
 		$uid = \OC_User::checkPassword('foo', 'bar');
 		$this->assertEquals($uid, 'foo');
 	}
-	
-	public function testDeleteUser() {
-		$fail = \OC_User::deleteUser('victim');
-		$this->assertFalse($fail);
-		
-		$success = \OC::$server->getUserManager()->createUser('victim', 'password');
-		
-		$success = \OC_User::deleteUser('victim');
-		$this->assertTrue($success);
-	}
 
 }

--- a/tests/lib/user.php
+++ b/tests/lib/user.php
@@ -56,25 +56,10 @@ class User extends TestCase {
 		$fail = \OC_User::deleteUser('victim');
 		$this->assertFalse($fail);
 		
-		$success = \OC_User::createUser('victim', 'password');
+		$success = \OC::$server->getUserManager()->createUser('victim', 'password');
 		
 		$success = \OC_User::deleteUser('victim');
 		$this->assertTrue($success);
-	}
-	
-	public function testCreateUser(){
-		$this->backend->expects($this->any())
-			->method('implementsActions')
-			->will($this->returnCallback(function ($actions) {
-				if ($actions === \OC_USER_BACKEND_CREATE_USER) {
-					return true;
-				} else {
-					return false;
-				}
-			}));
-			
-		$user = \OC_User::createUser('newuser', 'newpassword');
-		$this->assertEquals('newuser', $user->getUid());
 	}
 
 }

--- a/tests/lib/user.php
+++ b/tests/lib/user.php
@@ -26,7 +26,7 @@ class User extends TestCase {
 		parent::setUp();
 
 		$this->backend = $this->getMock('\Test\Util\User\Dummy');
-		$manager = \OC_User::getManager();
+		$manager = \OC::$server->getUserManager();
 		$manager->registerBackend($this->backend);
 	}
 	


### PR DESCRIPTION
To continue my cleaning thursday!

We were still using deprecated OC_User methods all over the place. Which is of course not a good idea. Most methods are handled in this PR and deleted now that they are no longer used.

Probabaly easiest to look at each commit individually.

Replacements are straight forward and basically do what the deprecated methods already did.

CC: @MorrisJobke @PVince81 @LukasReschke @icewind1991 
