### PR TITLE
Remove unneeded methods in OC_Helper

### DIFF
--- a/lib/private/archive/tar.php
+++ b/lib/private/archive/tar.php
@@ -86,7 +86,7 @@ class OC_Archive_TAR extends OC_Archive {
 	 * @return bool
 	 */
 	function addFolder($path) {
-		$tmpBase = OC_Helper::tmpFolder();
+		$tmpBase = \OC::$server->getTempManager()->getTemporaryFolder();
 		if (substr($path, -1, 1) != '/') {
 			$path .= '/';
 		}

--- a/lib/private/files/objectstore/objectstorestorage.php
+++ b/lib/private/files/objectstore/objectstorestorage.php
@@ -274,7 +274,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC_Helper::tmpFile($ext);
+				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
 				\OC\Files\Stream\Close::registerCallback($tmpFile, array($this, 'writeBack'));
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');

--- a/lib/private/files/storage/common.php
+++ b/lib/private/files/storage/common.php
@@ -248,7 +248,7 @@ abstract class Common implements Storage {
 	}
 
 	public function getLocalFolder($path) {
-		$baseDir = \OC_Helper::tmpFolder();
+		$baseDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->addLocalFolder($path, $baseDir);
 		return $baseDir;
 	}

--- a/lib/private/files/storage/localtempfiletrait.php
+++ b/lib/private/files/storage/localtempfiletrait.php
@@ -70,7 +70,7 @@ trait LocalTempFileTrait {
 		} else {
 			$extension = '';
 		}
-		$tmpFile = \OC_Helper::tmpFile($extension);
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
 		$target = fopen($tmpFile, 'w');
 		\OC_Helper::streamCopy($source, $target);
 		fclose($target);

--- a/lib/private/files/storage/temporary.php
+++ b/lib/private/files/storage/temporary.php
@@ -29,7 +29,7 @@ namespace OC\Files\Storage;
  */
 class Temporary extends Local{
 	public function __construct($arguments = null) {
-		parent::__construct(array('datadir' => \OC_Helper::tmpFolder()));
+		parent::__construct(array('datadir' => \OC::$server->getTempManager()->getTemporaryFolder()));
 	}
 
 	public function cleanUp() {

--- a/lib/private/files/type/detection.php
+++ b/lib/private/files/type/detection.php
@@ -238,7 +238,7 @@ class Detection implements IMimeTypeDetector {
 			$finfo = finfo_open(FILEINFO_MIME);
 			return finfo_buffer($finfo, $data);
 		} else {
-			$tmpFile = \OC_Helper::tmpFile();
+			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 			$fh = fopen($tmpFile, 'wb');
 			fwrite($fh, $data, 8024);
 			fclose($fh);

--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -912,7 +912,7 @@ class View {
 			$source = $this->fopen($path, 'r');
 			if ($source) {
 				$extension = pathinfo($path, PATHINFO_EXTENSION);
-				$tmpFile = \OC_Helper::tmpFile($extension);
+				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
 				file_put_contents($tmpFile, $source);
 				return $tmpFile;
 			} else {

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -457,19 +457,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * create a temporary file with an unique filename
-	 *
-	 * @param string $postfix
-	 * @return string
-	 * @deprecated Use the TempManager instead
-	 *
-	 * temporary files are automatically cleaned up after the script is finished
-	 */
-	public static function tmpFile($postfix = '') {
-		return \OC::$server->getTempManager()->getTemporaryFile($postfix);
-	}
-
-	/**
 	 * Adds a suffix to the name in case the file exists
 	 *
 	 * @param string $path

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -470,18 +470,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * create a temporary folder with an unique filename
-	 *
-	 * @return string
-	 * @deprecated Use the TempManager instead
-	 *
-	 * temporary files are automatically cleaned up after the script is finished
-	 */
-	public static function tmpFolder() {
-		return \OC::$server->getTempManager()->getTemporaryFolder();
-	}
-
-	/**
 	 * Adds a suffix to the name in case the file exists
 	 *
 	 * @param string $path

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -165,16 +165,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * shows whether the user has an avatar
-	 * @param string $user username
-	 * @return bool avatar set or not
-	 * @deprecated 9.0.0 Use \OC::$server->getAvatarManager()->getAvatar($user)->exists();
-	**/
-	public static function userAvatarSet($user) {
-		return \OC::$server->getAvatarManager()->getAvatar($user)->exists();
-	}
-
-	/**
 	 * Make a human file size
 	 * @param int $bytes file size in bytes
 	 * @return string a human readable file size

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -264,7 +264,7 @@ class OC_Installer{
 		//download the file if necessary
 		if($data['source']=='http') {
 			$pathInfo = pathinfo($data['href']);
-			$path=OC_Helper::tmpFile('.' . $pathInfo['extension']);
+			$path = \OC::$server->getTempManager()->getTemporaryFile('.' . $pathInfo['extension']);
 			if(!isset($data['href'])) {
 				throw new \Exception($l->t("No href specified when installing app from http"));
 			}

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -284,7 +284,7 @@ class OC_Installer{
 		}
 
 		//extract the archive in a temporary folder
-		$extractDir=OC_Helper::tmpFolder();
+		$extractDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		OC_Helper::rmdirr($extractDir);
 		mkdir($extractDir);
 		if($archive=OC_Archive::open($path)) {

--- a/lib/private/preview/movie.php
+++ b/lib/private/preview/movie.php
@@ -46,7 +46,7 @@ class Movie extends Provider {
 		if ($useFileDirectly) {
 			$absPath = $fileview->getLocalFile($path);
 		} else {
-			$absPath = \OC_Helper::tmpFile();
+			$absPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 			$handle = $fileview->fopen($path, 'rb');
 
@@ -79,7 +79,7 @@ class Movie extends Provider {
 	 * @return bool|\OCP\IImage
 	 */
 	private function generateThumbNail($maxX, $maxY, $absPath, $second) {
-		$tmpPath = \OC_Helper::tmpFile();
+		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 		if (self::$avconvBinary) {
 			$cmd = self::$avconvBinary . ' -an -y -ss ' . escapeshellarg($second) .

--- a/tests/lib/configtests.php
+++ b/tests/lib/configtests.php
@@ -23,7 +23,7 @@ class ConfigTests extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->randomTmpDir = \OC_Helper::tmpFolder();
+		$this->randomTmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->configFile = $this->randomTmpDir.'testconfig.php';
 		file_put_contents($this->configFile, self::TESTCONTENT);
 		$this->config = new \OC\Config($this->randomTmpDir, 'testconfig.php');

--- a/tests/lib/files/cache/homecache.php
+++ b/tests/lib/files/cache/homecache.php
@@ -69,7 +69,7 @@ class HomeCache extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->user = new DummyUser('foo', \OC_Helper::tmpFolder());
+		$this->user = new DummyUser('foo', \OC::$server->getTempManager()->getTemporaryFolder());
 		$this->storage = new \OC\Files\Storage\Home(array('user' => $this->user));
 		$this->cache = $this->storage->getCache();
 	}

--- a/tests/lib/files/etagtest.php
+++ b/tests/lib/files/etagtest.php
@@ -39,7 +39,7 @@ class EtagTest extends \Test\TestCase {
 
 		$config = \OC::$server->getConfig();
 		$this->datadir = $config->getSystemValue('datadirectory');
-		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$config->setSystemValue('datadirectory', $this->tmpDir);
 
 		$this->userBackend = new \Test\Util\User\Dummy();

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -302,7 +302,7 @@ class Filesystem extends \Test\TestCase {
 		\OC\Files\Filesystem::mkdir('/bar');
 //		\OC\Files\Filesystem::file_put_contents('/bar//foo', 'foo');
 
-		$tmpFile = \OC_Helper::tmpFile();
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 		file_put_contents($tmpFile, 'foo');
 		$fh = fopen($tmpFile, 'r');
 //		\OC\Files\Filesystem::file_put_contents('/bar//foo', $fh);

--- a/tests/lib/files/filesystem.php
+++ b/tests/lib/files/filesystem.php
@@ -72,7 +72,7 @@ class Filesystem extends \Test\TestCase {
 	 * @return array
 	 */
 	private function getStorageData() {
-		$dir = \OC_Helper::tmpFolder();
+		$dir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->tmpDirs[] = $dir;
 		return array('datadir' => $dir);
 	}
@@ -416,7 +416,7 @@ class Filesystem extends \Test\TestCase {
 		$config = \OC::$server->getConfig();
 		$oldCachePath = $config->getSystemValue('cache_path', '');
 		// set cache path to temp dir
-		$cachePath = \OC_Helper::tmpFolder() . '/extcache';
+		$cachePath = \OC::$server->getTempManager()->getTemporaryFolder() . '/extcache';
 		$config->setSystemValue('cache_path', $cachePath);
 
 		\OC::$server->getUserManager()->createUser($userId, $userId);

--- a/tests/lib/files/storage/commontest.php
+++ b/tests/lib/files/storage/commontest.php
@@ -37,7 +37,7 @@ class CommonTest extends Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tmpDir=\OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->instance=new \OC\Files\Storage\CommonTest(array('datadir'=>$this->tmpDir));
 	}
 

--- a/tests/lib/files/storage/home.php
+++ b/tests/lib/files/storage/home.php
@@ -70,7 +70,7 @@ class Home extends Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->userId = $this->getUniqueID('user_');
 		$this->user = new DummyUser($this->userId, $this->tmpDir);
 		$this->instance = new \OC\Files\Storage\Home(array('user' => $this->user));

--- a/tests/lib/files/storage/local.php
+++ b/tests/lib/files/storage/local.php
@@ -38,7 +38,7 @@ class Local extends Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->instance = new \OC\Files\Storage\Local(array('datadir' => $this->tmpDir));
 	}
 

--- a/tests/lib/files/storage/wrapper/quota.php
+++ b/tests/lib/files/storage/wrapper/quota.php
@@ -27,7 +27,7 @@ class Quota extends \Test\Files\Storage\Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$storage = new \OC\Files\Storage\Local(array('datadir' => $this->tmpDir));
 		$this->instance = new \OC\Files\Storage\Wrapper\Quota(array('storage' => $storage, 'quota' => 10000000));
 	}

--- a/tests/lib/files/storage/wrapper/wrapper.php
+++ b/tests/lib/files/storage/wrapper/wrapper.php
@@ -17,7 +17,7 @@ class Wrapper extends \Test\Files\Storage\Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tmpDir = \OC_Helper::tmpFolder();
+		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$storage = new \OC\Files\Storage\Local(array('datadir' => $this->tmpDir));
 		$this->instance = new \OC\Files\Storage\Wrapper\Wrapper(array('storage' => $storage));
 	}

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -757,7 +757,7 @@ class View extends \Test\TestCase {
 		 * 228 is the max path length in windows
 		 */
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
-		$tmpdirLength = strlen(\OC_Helper::tmpFolder());
+		$tmpdirLength = strlen(\OC::$server->getTempManager()->getTemporaryFolder());
 		if (\OC_Util::runningOnWindows()) {
 			$this->markTestSkipped('[Windows] ');
 			$depth = ((260 - $tmpdirLength) / 57);

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -403,7 +403,7 @@ class Test_Helper extends \Test\TestCase {
 	 * Tests recursive folder deletion with rmdirr()
 	 */
 	public function testRecursiveFolderDeletion() {
-		$baseDir = \OC_Helper::tmpFolder() . '/';
+		$baseDir = \OC::$server->getTempManager()->getTemporaryFolder() . '/';
 		mkdir($baseDir . 'a/b/c/d/e', 0777, true);
 		mkdir($baseDir . 'a/b/c1/d/e', 0777, true);
 		mkdir($baseDir . 'a/b/c2/d/e', 0777, true);

--- a/tests/lib/installer.php
+++ b/tests/lib/installer.php
@@ -32,7 +32,7 @@ class Test_Installer extends \Test\TestCase {
 		$pathOfTestApp .= '/../data/';
 		$pathOfTestApp .= 'testapp.zip';
 
-		$tmp = OC_Helper::tmpFile('.zip');
+		$tmp = \OC::$server->getTempManager()->getTemporaryFile('.zip');
 		OC_Helper::copyr($pathOfTestApp, $tmp);
 
 		$data = array(
@@ -51,7 +51,7 @@ class Test_Installer extends \Test\TestCase {
 		$pathOfOldTestApp .= '/../data/';
 		$pathOfOldTestApp .= 'testapp.zip';
 
-		$oldTmp = OC_Helper::tmpFile('.zip');
+		$oldTmp = \OC::$server->getTempManager()->getTemporaryFile('.zip');
 		OC_Helper::copyr($pathOfOldTestApp, $oldTmp);
 
 		$oldData = array(
@@ -63,7 +63,7 @@ class Test_Installer extends \Test\TestCase {
 		$pathOfNewTestApp .= '/../data/';
 		$pathOfNewTestApp .= 'testapp2.zip';
 
-		$newTmp = OC_Helper::tmpFile('.zip');
+		$newTmp = \OC::$server->getTempManager()->getTemporaryFile('.zip');
 		OC_Helper::copyr($pathOfNewTestApp, $newTmp);
 
 		$newData = array(

--- a/tests/lib/streamwrappers.php
+++ b/tests/lib/streamwrappers.php
@@ -55,7 +55,7 @@ class Test_StreamWrappers extends \Test\TestCase {
 	public function testCloseStream() {
 		//ensure all basic stream stuff works
 		$sourceFile = OC::$SERVERROOT . '/tests/data/lorem.txt';
-		$tmpFile = OC_Helper::TmpFile('.txt');
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('.txt');
 		$file = 'close://' . $tmpFile;
 		$this->assertTrue(file_exists($file));
 		file_put_contents($file, file_get_contents($sourceFile));
@@ -65,7 +65,7 @@ class Test_StreamWrappers extends \Test\TestCase {
 		$this->assertFalse(file_exists($file));
 
 		//test callback
-		$tmpFile = OC_Helper::TmpFile('.txt');
+		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('.txt');
 		$file = 'close://' . $tmpFile;
 		$actual = false;
 		$callback = function($path) use (&$actual) { $actual = $path; };

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -37,7 +37,7 @@ class Test_Util_CheckServer extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->datadir = \OC_Helper::tmpFolder();
+		$this->datadir = \OC::$server->getTempManager()->getTemporaryFolder();
 
 		file_put_contents($this->datadir . '/.ocdata', '');
 		\OC::$server->getSession()->set('checkServer_succeeded', false);


### PR DESCRIPTION
cc @DeepDiver1975 @LukasReschke @rullzer @nickvergessen 

Easiest way is to review this per commit. It only replaces the wrapper method call with the actual function.
