### PR TITLE
Remove deprecated OC_Helper mimetype functions

### DIFF
--- a/apps/dav/lib/connector/sabre/file.php
+++ b/apps/dav/lib/connector/sabre/file.php
@@ -329,7 +329,7 @@ class File extends Node implements IFile {
 		if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'PROPFIND') {
 			return $mimeType;
 		}
-		return \OC_Helper::getSecureMimeType($mimeType);
+		return \OC::$server->getMimeTypeDetector()->getSecureMimeType($mimeType);
 	}
 
 	/**

--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -39,7 +39,7 @@ if(!\OC\Files\Filesystem::file_exists($filename)) {
 	exit;
 }
 
-$ftype=\OC_Helper::getSecureMimeType(\OC\Files\Filesystem::getMimeType( $filename ));
+$ftype=\OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType( $filename ));
 
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');

--- a/apps/files/lib/helper.php
+++ b/apps/files/lib/helper.php
@@ -66,15 +66,15 @@ class Helper {
 	 */
 	public static function determineIcon($file) {
 		if($file['type'] === 'dir') {
-			$icon = \OC_Helper::mimetypeIcon('dir');
+			$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir');
 			// TODO: move this part to the client side, using mountType
 			if ($file->isShared()) {
-				$icon = \OC_Helper::mimetypeIcon('dir-shared');
+				$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir-shared');
 			} elseif ($file->isMounted()) {
-				$icon = \OC_Helper::mimetypeIcon('dir-external');
+				$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir-external');
 			}
 		}else{
-			$icon = \OC_Helper::mimetypeIcon($file->getMimetype());
+			$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon($file->getMimetype());
 		}
 
 		return substr($icon, 0, -3) . 'svg';

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -41,7 +41,7 @@ $thumbSize = 1024;
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
-<input type="hidden" name="mimetypeIcon" value="<?php p(OC_Helper::mimetypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
+<input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
 <input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
 <input type="hidden" name="maxSizeAnimateGif" value="<?php p($_['maxSizeAnimateGif']); ?>" id="maxSizeAnimateGif">
 

--- a/apps/files_versions/download.php
+++ b/apps/files_versions/download.php
@@ -35,7 +35,7 @@ $versionName = '/'.$uid.'/files_versions/'.$filename.'.v'.$revision;
 
 $view = new OC\Files\View('/');
 
-$ftype = \OC_Helper::getSecureMimeType($view->getMimeType('/'.$uid.'/files/'.$filename));
+$ftype = \OC::$server->getMimeTypeDetector()->getSecureMimeType($view->getMimeType('/'.$uid.'/files/'.$filename));
 
 header('Content-Type:'.$ftype);
 OCP\Response::setContentDispositionHeader(basename($filename), 'attachment');

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -347,17 +347,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * Get a secure mimetype that won't expose potential XSS.
-	 *
-	 * @param string $mimeType
-	 * @return string
-	 * @deprecated 8.2.0 Use \OC::$server->getMimeTypeDetector()->getSecureMimeType($mimeType)
-	 */
-	static function getSecureMimeType($mimeType) {
-		return \OC::$server->getMimeTypeDetector()->getSecureMimeType($mimeType);
-	}
-
-	/**
 	 * get the mimetype form a data string
 	 *
 	 * @param string $data

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -347,17 +347,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * get the mimetype form a data string
-	 *
-	 * @param string $data
-	 * @return string
-	 * @deprecated 8.2.0 Use \OC::$server->getMimeTypeDetector()->detectString($data)
-	 */
-	static function getStringMimeType($data) {
-		return \OC::$server->getMimeTypeDetector()->detectString($data);
-	}
-
-	/**
 	 * detect if a given program is found in the search PATH
 	 *
 	 * @param string $name

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -138,18 +138,6 @@ class OC_Helper {
 	}
 
 	/**
-	 * get path to icon of file type
-	 * @param string $mimetype mimetype
-	 * @return string the url
-	 *
-	 * Returns the path to the image of this file type.
-	 * @deprecated 8.2.0 Use \OC::$server->getMimeTypeDetector()->mimeTypeIcon($mimetype)
-	 */
-	public static function mimetypeIcon($mimetype) {
-		return \OC::$server->getMimeTypeDetector()->mimeTypeIcon($mimetype);
-	}
-
-	/**
 	 * get path to preview of file
 	 * @param string $path path
 	 * @return string the url
@@ -333,17 +321,6 @@ class OC_Helper {
 			self::$templateManager = new \OC\Files\Type\TemplateManager();
 		}
 		return self::$templateManager;
-	}
-
-	/**
-	 * Try to guess the mimetype based on filename
-	 *
-	 * @param string $path
-	 * @return string
-	 * @deprecated 8.2.0 Use \OC::$server->getMimeTypeDetector()->detectPath($path)
-	 */
-	static public function getFileNameMimeType($path) {
-		return \OC::$server->getMimeTypeDetector()->detectPath($path);
 	}
 
 	/**

--- a/lib/private/preview.php
+++ b/lib/private/preview.php
@@ -1168,7 +1168,7 @@ class Preview {
 	 */
 	private function getMimeIcon() {
 		$image = new \OC_Image();
-		$mimeIconWebPath = \OC_Helper::mimetypeIcon($this->mimeType);
+		$mimeIconWebPath = \OC::$server->getMimeTypeDetector()->mimeTypeIcon($this->mimeType);
 		if (empty(\OC::$WEBROOT)) {
 			$mimeIconServerPath = \OC::$SERVERROOT . $mimeIconWebPath;
 		} else {

--- a/lib/private/template/functions.php
+++ b/lib/private/template/functions.php
@@ -173,11 +173,9 @@ function image_path( $app, $image ) {
  * make OC_Helper::mimetypeIcon available as a simple function
  * @param string $mimetype mimetype
  * @return string link to the image
- *
- * For further information have a look at OC_Helper::mimetypeIcon
  */
 function mimetype_icon( $mimetype ) {
-	return OC_Helper::mimetypeIcon( $mimetype );
+	return \OC::$server->getMimeTypeDetector()->mimeTypeIcon( $mimetype );
 }
 
 /**

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -71,16 +71,6 @@ class Test_Helper extends \Test\TestCase {
 		];
 	}
 
-	function testGetStringMimeType() {
-		if (\OC_Util::runningOnWindows()) {
-			$this->markTestSkipped('[Windows] Strings have mimetype application/octet-stream on Windows');
-		}
-
-		$result = OC_Helper::getStringMimeType("/data/data.tar.gz");
-		$expected = 'text/plain; charset=us-ascii';
-		$this->assertEquals($result, $expected);
-	}
-
 	function testIsSubDirectory() {
 		$result = OC_Helper::isSubDirectory("./data/", "/anotherDirectory/");
 		$this->assertFalse($result);

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -71,18 +71,6 @@ class Test_Helper extends \Test\TestCase {
 		];
 	}
 
-	function testGetSecureMimeType() {
-		$dir=OC::$SERVERROOT.'/tests/data';
-
-		$result = OC_Helper::getSecureMimeType('image/svg+xml');
-		$expected = 'text/plain';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::getSecureMimeType('image/png');
-		$expected = 'image/png';
-		$this->assertEquals($result, $expected);
-	}
-
 	function testGetStringMimeType() {
 		if (\OC_Util::runningOnWindows()) {
 			$this->markTestSkipped('[Windows] Strings have mimetype application/octet-stream on Windows');


### PR DESCRIPTION
More cleanups!

They were deprecated simple private wrappers. Again all callers are replaced.

CC: @MorrisJobke @PVince81 @DeepDiver1975 @nickvergessen 
