### PR TITLE
Do not delete background jobs, in case an exception occured

### DIFF
--- a/lib/private/backgroundjob/job.php
+++ b/lib/private/backgroundjob/job.php
@@ -54,7 +54,6 @@ abstract class Job implements IJob {
 			if ($logger) {
 				$logger->error('Error while running background job: ' . $e->getMessage());
 			}
-			$jobList->remove($this, $this->argument);
 		}
 	}
 

--- a/tests/lib/backgroundjob/job.php
+++ b/tests/lib/backgroundjob/job.php
@@ -23,10 +23,17 @@ class Job extends \Test\TestCase {
 		});
 		$jobList->add($job);
 
+		$logger = $this->getMockBuilder('OCP\ILogger')
+			->disableOriginalConstructor()
+			->getMock();
+		$logger->expects($this->once())
+			->method('error')
+			->with('Error while running background job: ');
+
 		$this->assertCount(1, $jobList->getAll());
-		$job->execute($jobList);
+		$job->execute($jobList, $logger);
 		$this->assertTrue($this->run);
-		$this->assertCount(0, $jobList->getAll());
+		$this->assertCount(1, $jobList->getAll());
 	}
 
 	public function markRun() {


### PR DESCRIPTION
This approach is not valid anymore. It initially was added for jobs
of non existing apps. But jobs of non-existing apps can not be created
so they will never be executed and so this call just catches other
cases which were not intended. (Periodic jobs, etc)

This reverts commit 4f4ad72460f8ef299cd1235b5774c5f121cca430.

Fix #20399

cc @butonic @MorrisJobke 

@karlitschek should backport to 8.2.3 since we changed our jobs in 8.2
