### PR TITLE
Use OCP\Util::getVersion instead of the internal private implementation

### DIFF
--- a/core/command/status.php
+++ b/core/command/status.php
@@ -39,7 +39,7 @@ class Status extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$values = array(
 			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
-			'version' => implode('.', \OC_Util::getVersion()),
+			'version' => implode('.', \OCP\Util::getVersion()),
 			'versionstring' => \OC_Util::getVersionString(),
 			'edition' => \OC_Util::getEditionString(),
 		);

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -138,7 +138,7 @@ $array = array(
 		array(
 			'session_lifetime'	=> min(\OCP\Config::getSystemValue('session_lifetime', OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')), OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')),
 			'session_keepalive'	=> \OCP\Config::getSystemValue('session_keepalive', true),
-			'version'			=> implode('.', OC_Util::getVersion()),
+			'version'			=> implode('.', \OCP\Util::getVersion()),
 			'versionstring'		=> OC_Util::getVersionString(),
 			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true),
 			'lost_password_link'=> \OC::$server->getConfig()->getSystemValue('lost_password_link', null),

--- a/lib/base.php
+++ b/lib/base.php
@@ -377,7 +377,7 @@ class OC {
 
 		// check whether this is a core update or apps update
 		$installedVersion = $systemConfig->getValue('version', '0.0.0');
-		$currentVersion = implode('.', OC_Util::getVersion());
+		$currentVersion = implode('.', \OCP\Util::getVersion());
 
 		$appManager = \OC::$server->getAppManager();
 
@@ -392,7 +392,7 @@ class OC {
 		}
 
 		// get third party apps
-		$ocVersion = OC_Util::getVersion();
+		$ocVersion = \OCP\Util::getVersion();
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
 		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
 		$tmpl->assign('productName', 'ownCloud'); // for now

--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -318,8 +318,8 @@ class OC_App {
 			\OC::$server->getConfig(),
 			\OC::$server->getLogger()
 		);
-		$appData = $ocsClient->getApplication($app, \OC_Util::getVersion());
-		$download= $ocsClient->getApplicationDownload($app, \OC_Util::getVersion());
+		$appData = $ocsClient->getApplication($app, \OCP\Util::getVersion());
+		$download= $ocsClient->getApplicationDownload($app, \OCP\Util::getVersion());
 		if(isset($download['downloadlink']) and $download['downloadlink']!='') {
 			// Replace spaces in download link without encoding entire URL
 			$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
@@ -880,7 +880,7 @@ class OC_App {
 
 
 		if (is_null($category)) {
-			$categoryNames = $ocsClient->getCategories(\OC_Util::getVersion());
+			$categoryNames = $ocsClient->getCategories(\OCP\Util::getVersion());
 			if (is_array($categoryNames)) {
 				// Check that categories of apps were retrieved correctly
 				if (!$categories = array_keys($categoryNames)) {
@@ -892,7 +892,7 @@ class OC_App {
 		}
 
 		$page = 0;
-		$remoteApps = $ocsClient->getApplications($categories, $page, $filter, \OC_Util::getVersion());
+		$remoteApps = $ocsClient->getApplications($categories, $page, $filter, \OCP\Util::getVersion());
 		$apps = [];
 		$i = 0;
 		$l = \OC::$server->getL10N('core');
@@ -1050,7 +1050,7 @@ class OC_App {
 			$config,
 			\OC::$server->getLogger()
 		);
-		$appData = $ocsClient->getApplication($app, \OC_Util::getVersion());
+		$appData = $ocsClient->getApplication($app, \OCP\Util::getVersion());
 
 		// check if app is a shipped app or not. OCS apps have an integer as id, shipped apps use a string
 		if (!is_numeric($app)) {
@@ -1080,7 +1080,7 @@ class OC_App {
 		if ($app !== false) {
 			// check if the app is compatible with this version of ownCloud
 			$info = self::getAppInfo($app);
-			$version = OC_Util::getVersion();
+			$version = \OCP\Util::getVersion();
 			if (!self::isAppCompatible($version, $info)) {
 				throw new \Exception(
 					$l->t('App "%s" cannot be installed because it is not compatible with this version of ownCloud.',

--- a/lib/private/app/platform.php
+++ b/lib/private/app/platform.php
@@ -52,7 +52,7 @@ class Platform {
 	 * @return string
 	 */
 	public function getOcVersion() {
-		$v = OC_Util::getVersion();
+		$v = \OCP\Util::getVersion();
 		return join('.', $v);
 	}
 

--- a/lib/private/defaults.php
+++ b/lib/private/defaults.php
@@ -49,7 +49,7 @@ class OC_Defaults {
 
 	function __construct() {
 		$this->l = \OC::$server->getL10N('lib');
-		$version = OC_Util::getVersion();
+		$version = \OCP\Util::getVersion();
 
 		$this->defaultEntity = 'ownCloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'ownCloud'; /* short name, used when referring to the software */

--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -232,8 +232,8 @@ class OC_Installer{
 			\OC::$server->getConfig(),
 			\OC::$server->getLogger()
 		);
-		$appData = $ocsClient->getApplication($ocsId, \OC_Util::getVersion());
-		$download = $ocsClient->getApplicationDownload($ocsId, \OC_Util::getVersion());
+		$appData = $ocsClient->getApplication($ocsId, \OCP\Util::getVersion());
+		$download = $ocsClient->getApplicationDownload($ocsId, \OCP\Util::getVersion());
 
 		if (isset($download['downloadlink']) && trim($download['downloadlink']) !== '') {
 			$download['downloadlink'] = str_replace(' ', '%20', $download['downloadlink']);
@@ -342,7 +342,7 @@ class OC_Installer{
 		}
 
 		// check if the app is compatible with this version of ownCloud
-		if(!OC_App::isAppCompatible(OC_Util::getVersion(), $info)) {
+		if(!OC_App::isAppCompatible(\OCP\Util::getVersion(), $info)) {
 			OC_Helper::rmdirr($extractDir);
 			throw new \Exception($l->t("App can't be installed because it is not compatible with this version of ownCloud"));
 		}
@@ -400,7 +400,7 @@ class OC_Installer{
 				\OC::$server->getConfig(),
 				\OC::$server->getLogger()
 			);
-			$ocsdata = $ocsClient->getApplication($ocsid, \OC_Util::getVersion());
+			$ocsdata = $ocsClient->getApplication($ocsid, \OCP\Util::getVersion());
 			$ocsversion= (string) $ocsdata['version'];
 			$currentversion=OC_App::getAppVersion($app);
 			if (version_compare($ocsversion, $currentversion, '>')) {

--- a/lib/private/ocs/cloud.php
+++ b/lib/private/ocs/cloud.php
@@ -26,7 +26,7 @@ class OC_OCS_Cloud {
 
 	public static function getCapabilities() {
 		$result = array();
-		list($major, $minor, $micro) = OC_Util::getVersion();
+		list($major, $minor, $micro) = \OCP\Util::getVersion();
 		$result['version'] = array(
 			'major' => $major,
 			'minor' => $minor,

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -322,7 +322,7 @@ class Setup {
 			'datadirectory'		=> $dataDir,
 			'overwrite.cli.url'	=> $request->getServerProtocol() . '://' . $request->getInsecureServerHost() . \OC::$WEBROOT,
 			'dbtype'			=> $dbType,
-			'version'			=> implode('.', \OC_Util::getVersion()),
+			'version'			=> implode('.', \OCP\Util::getVersion()),
 		]);
 
 		try {

--- a/lib/private/templatelayout.php
+++ b/lib/private/templatelayout.php
@@ -159,7 +159,7 @@ class OC_TemplateLayout extends OC_Template {
 
 		if(empty(self::$versionHash)) {
 			$v = OC_App::getAppVersions();
-			$v['core'] = implode('.', \OC_Util::getVersion());
+			$v['core'] = implode('.', \OCP\Util::getVersion());
 			self::$versionHash = md5(implode(',', $v));
 		}
 

--- a/lib/private/updater.php
+++ b/lib/private/updater.php
@@ -155,7 +155,7 @@ class Updater extends BasicEmitter {
 			$this->config->setAppValue('core', 'installedat', microtime(true));
 		}
 
-		$version = \OC_Util::getVersion();
+		$version = \OCP\Util::getVersion();
 		$version['installed'] = $this->config->getAppValue('core', 'installedat');
 		$version['updated'] = $this->config->getAppValue('core', 'lastupdatedat');
 		$version['updatechannel'] = \OC_Util::getChannel();
@@ -208,7 +208,7 @@ class Updater extends BasicEmitter {
 		}
 
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
-		$currentVersion = implode('.', \OC_Util::getVersion());
+		$currentVersion = implode('.', \OCP\Util::getVersion());
 		$this->log->debug('starting upgrade from ' . $installedVersion . ' to ' . $currentVersion, array('app' => 'core'));
 
 		$success = true;
@@ -353,7 +353,7 @@ class Updater extends BasicEmitter {
 			}
 
 			// only set the final version if everything went well
-			$this->config->setSystemValue('version', implode('.', \OC_Util::getVersion()));
+			$this->config->setSystemValue('version', implode('.', \OCP\Util::getVersion()));
 		}
 	}
 
@@ -472,7 +472,7 @@ class Updater extends BasicEmitter {
 	private function checkAppsRequirements() {
 		$isCoreUpgrade = $this->isCodeUpgrade();
 		$apps = OC_App::getEnabledApps();
-		$version = OC_Util::getVersion();
+		$version = \OCP\Util::getVersion();
 		$disabledApps = [];
 		foreach ($apps as $app) {
 			// check if the app is compatible with this version of ownCloud
@@ -509,7 +509,7 @@ class Updater extends BasicEmitter {
 	 */
 	private function isCodeUpgrade() {
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
-		$currentVersion = implode('.', OC_Util::getVersion());
+		$currentVersion = implode('.', \OCP\Util::getVersion());
 		if (version_compare($currentVersion, $installedVersion, '>')) {
 			return true;
 		}

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1509,7 +1509,7 @@ class OC_Util {
 	public static function needUpgrade(\OCP\IConfig $config) {
 		if ($config->getSystemValue('installed', false)) {
 			$installedVersion = $config->getSystemValue('version', '0.0.0');
-			$currentVersion = implode('.', OC_Util::getVersion());
+			$currentVersion = implode('.', \OCP\Util::getVersion());
 			$versionDiff = version_compare($currentVersion, $installedVersion);
 			if ($versionDiff > 0) {
 				return true;

--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -159,7 +159,7 @@ class AppSettingsController extends Controller {
 
 		if($this->ocsClient->isAppStoreEnabled()) {
 			// apps from external repo via OCS
-			$ocs = $this->ocsClient->getCategories(\OC_Util::getVersion());
+			$ocs = $this->ocsClient->getCategories(\OCP\Util::getVersion());
 			if ($ocs) {
 				foreach($ocs as $k => $v) {
 					$name = str_replace('ownCloud ', '', $v);
@@ -205,9 +205,10 @@ class AppSettingsController extends Controller {
 						}
 						return ($a < $b) ? -1 : 1;
 					});
+					$version = \OCP\Util::getVersion();
 					foreach($apps as $key => $app) {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
-							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
+							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], $version);
 
 							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];
@@ -221,9 +222,10 @@ class AppSettingsController extends Controller {
 					$apps = array_filter($apps, function ($app) {
 						return !$app['active'];
 					});
+					$version = \OCP\Util::getVersion();
 					foreach($apps as $key => $app) {
 						if(!array_key_exists('level', $app) && array_key_exists('ocsid', $app)) {
-							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], \OC_Util::getVersion());
+							$remoteAppEntry = $this->ocsClient->getApplication($app['ocsid'], $version);
 
 							if(is_array($remoteAppEntry) && array_key_exists('level', $remoteAppEntry)) {
 								$apps[$key]['level'] = $remoteAppEntry['level'];

--- a/status.php
+++ b/status.php
@@ -36,7 +36,7 @@ try {
 	$values=array(
 		'installed'=>$installed,
 		'maintenance' => $maintenance,
-		'version'=>implode('.', OC_Util::getVersion()),
+		'version'=>implode('.', \OCP\Util::getVersion()),
 		'versionstring'=>OC_Util::getVersionString(),
 		'edition'=>OC_Util::getEditionString());
 	if (OC::$CLI) {

--- a/tests/lib/updater.php
+++ b/tests/lib/updater.php
@@ -66,7 +66,7 @@ class UpdaterTest extends \Test\TestCase {
 	 * @return string
 	 */
 	private function buildUpdateUrl($baseUrl) {
-		return $baseUrl . '?version='.implode('x', \OC_Util::getVersion()).'xinstalledatxlastupdatedatx'.\OC_Util::getChannel().'x'.\OC_Util::getEditionString().'x';
+		return $baseUrl . '?version='.implode('x', \OCP\Util::getVersion()).'xinstalledatxlastupdatedatx'.\OC_Util::getChannel().'x'.\OC_Util::getEditionString().'x';
 	}
 
 	/**

--- a/tests/lib/util.php
+++ b/tests/lib/util.php
@@ -8,7 +8,7 @@
  */
 class Test_Util extends \Test\TestCase {
 	public function testGetVersion() {
-		$version = \OC_Util::getVersion();
+		$version = \OCP\Util::getVersion();
 		$this->assertTrue(is_array($version));
 		foreach ($version as $num) {
 			$this->assertTrue(is_int($num));

--- a/tests/lib/utilcheckserver.php
+++ b/tests/lib/utilcheckserver.php
@@ -123,7 +123,7 @@ class Test_Util_CheckServer extends \Test\TestCase {
 
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => true,
-			'version' => implode('.', OC_Util::getVersion())
+			'version' => implode('.', \OCP\Util::getVersion())
 		)));
 		$this->assertCount(1, $result);
 	}
@@ -134,7 +134,7 @@ class Test_Util_CheckServer extends \Test\TestCase {
 	public function testDataDirWritable() {
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => true,
-			'version' => implode('.', OC_Util::getVersion())
+			'version' => implode('.', \OCP\Util::getVersion())
 		)));
 		$this->assertEmpty($result);
 	}
@@ -150,7 +150,7 @@ class Test_Util_CheckServer extends \Test\TestCase {
 		chmod($this->datadir, 0300);
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => true,
-			'version' => implode('.', OC_Util::getVersion())
+			'version' => implode('.', \OCP\Util::getVersion())
 		)));
 		$this->assertCount(1, $result);
 	}
@@ -162,7 +162,7 @@ class Test_Util_CheckServer extends \Test\TestCase {
 		chmod($this->datadir, 0300);
 		$result = \OC_Util::checkServer($this->getConfig(array(
 			'installed' => false,
-			'version' => implode('.', OC_Util::getVersion())
+			'version' => implode('.', \OCP\Util::getVersion())
 		)));
 		chmod($this->datadir, 0700); //needed for cleanup
 		$this->assertEmpty($result);


### PR DESCRIPTION
This only cleans up some OC_Util calls to OCP to make the life in core easier.

cc @rullzer @Xenopathic @nickvergessen @LukasReschke @DeepDiver1975 
