### PR TITLE
Add avatar dav endpoint

### DIFF
--- a/apps/dav/lib/avatars/avatar.php
+++ b/apps/dav/lib/avatars/avatar.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace OCA\DAV\Avatars;
+
+use OCP\Files\File;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\IFile;
+
+class Avatar implements IFile {
+	/** @var File */
+	private $avatar;
+
+	/**
+	 * Avatar constructor.
+	 *
+	 * @param File $avatar
+	 */
+	public function __construct(File $avatar) {
+		$this->avatar = $avatar;
+	}
+
+	/**
+	 * Deleting avatars is not possible at this point
+	 *
+	 * @throws Forbidden
+	 */
+	public function delete() {
+		throw new Forbidden('Permission denied to delete');
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return $this->avatar->getName();
+	}
+
+	/**
+	 * Renaming avatars is not allowed
+	 *
+	 * @param string $name
+	 * @throws Forbidden
+	 */
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename');
+	}
+
+	/**
+	 * Get the modification (creation) date of the avatar (of this size)
+	 *
+	 * @return int
+	 */
+	public function getLastModified() {
+		return $this->avatar->getMTime();
+	}
+
+	/**
+	 * It is not allowed to update the avatar currently
+	 *
+	 * @param resource $data
+	 * @throws Forbidden
+	 */
+	public function put($data) {
+		throw new Forbidden('Permission denied to update');
+	}
+
+	/**
+	 * Get the actual avatar data
+	 *
+	 * @return string
+	 */
+	public function get() {
+		return $this->avatar->getContent();
+	}
+
+	/**
+	 * Get the etag of the avatar
+	 *
+	 * @return string
+	 */
+	public function getETag() {
+		return $this->avatar->getEtag();
+	}
+
+	/**
+	 * Get the content type of the avatar
+	 *
+	 * @return string
+	 */
+	public function getContentType() {
+		return $this->avatar->getMimeType();
+	}
+
+	/**
+	 * Get the file size of the avatar
+	 *
+	 * @return int
+	 */
+	public function getSize() {
+		return $this->avatar->getSize();
+	}
+
+}

--- a/apps/dav/lib/avatars/avatarcollection.php
+++ b/apps/dav/lib/avatars/avatarcollection.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace OCA\DAV\Avatars;
+
+use OCP\Files\NotFoundException;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use OCP\IAvatarManager;
+
+class AvatarCollection implements ICollection {
+
+	/** @var IAvatarManager */
+	private $manager;
+
+	/** @var array */
+	private $principalInfo;
+
+	/**
+	 * FilesHome constructor.
+	 *
+	 * @param array $principalInfo
+	 * @param IAvatarManager $manager
+	 */
+	public function __construct($principalInfo, $manager) {
+		$this->principalInfo = $principalInfo;
+		$this->manager = $manager;
+	}
+
+	/**
+	 * Creating new files is not allowed here
+	 *
+	 * @param string $name
+	 * @param resource|string $data
+	 * @throws Forbidden
+	 */
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Permission denied to create files');
+	}
+
+	/**
+	 * Creating new directories is not allowed here
+	 *
+	 * @param string $name
+	 * @throws Forbidden
+	 */
+	public function createDirectory($name) {
+		throw new Forbidden('Permission denied to create folders');
+	}
+
+	/**
+	 * Get an avatar of a given size
+	 *
+	 * @param string $name
+	 * @return Avatar
+	 * @throws NotFound
+	 */
+	public function getChild($name) {
+		$user = $this->getName();
+
+		if (!$this->childExists($name)) {
+			throw new NotFound();
+		}
+
+		try {
+			$avatar = $this->manager->getAvatar($user)->getFile((int)$name);
+		} catch (NotFoundException $e) {
+			throw new NotFound();
+		}
+
+		return new Avatar($avatar);
+	}
+
+	/**
+	 * Do not list avatars
+	 *
+	 * @throws Forbidden
+	 */
+	public function getChildren() {
+		throw new Forbidden('Listing of avatars not allowed. Use /SIZE to get an avatar of size');
+	}
+
+	/**
+	 * A child exists if it is an integer larger than 0
+	 *
+	 * @param string $name
+	 * @return bool
+	 */
+	public function childExists($name) {
+		if (ctype_digit($name)) {
+			if ((int)$name === 0) {
+				return false;
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Not allowed to delete avatars via this endpoint
+	 *
+	 * @throws Forbidden
+	 */
+	public function delete() {
+		throw new Forbidden('Permission denied to delete');
+	}
+
+	/**
+	 * The name if just the name of the principal
+	 *
+	 * @return mixed
+	 */
+	public function getName() {
+		list(,$name) = \Sabre\Uri\split($this->principalInfo['uri']);
+		return $name;
+	}
+
+	/**
+	 * Now allowed to update name
+	 *
+	 * @param string $name
+	 * @throws Forbidden
+	 */
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	/**
+	 * Returns the last modification time, as a unix timestamp
+	 *
+	 * @return int
+	 */
+	public function getLastModified() {
+	}
+
+}

--- a/apps/dav/lib/avatars/rootcollection.php
+++ b/apps/dav/lib/avatars/rootcollection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace OCA\DAV\Avatars;
+
+use OCP\IAvatarManager;
+use Sabre\DAVACL\AbstractPrincipalCollection;
+use Sabre\DAVACL\IPrincipal;
+
+class RootCollection extends AbstractPrincipalCollection {
+
+	/* @var IAvatarManager */
+	private $manager;
+
+	/**
+	 * RootCollection constructor.
+	 *
+	 * @param \Sabre\DAVACL\PrincipalBackend\BackendInterface $principalBackend
+	 * @param string $principalPrefix
+	 * @param IAvatarManager $avatarManager
+	 */
+	public function __construct($principalBackend, $principalPrefix, $avatarManager) {
+			$this->manager = $avatarManager;
+			parent::__construct($principalBackend, $principalPrefix);
+		}
+
+	/**
+	 * This method returns a node for a principal.
+	 *
+	 * The passed array contains principal information, and is guaranteed to
+	 * at least contain a uri item. Other properties may or may not be
+	 * supplied by the authentication backend.
+	 *
+	 * @param array $principalInfo
+	 * @return IPrincipal
+	 */
+	public function getChildForPrincipal(array $principalInfo) {
+		return new AvatarCollection($principalInfo, $this->manager);
+	}
+
+	/**
+	 * Returns the name of this collection.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'avatars';
+	}
+}

--- a/apps/dav/lib/rootcollection.php
+++ b/apps/dav/lib/rootcollection.php
@@ -40,6 +40,8 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper()
 		);
+		$avatarCollection = new \OCA\DAV\Avatars\RootCollection($principalBackend, 'principals/users', \OC::$server->getAvatarManager());
+		$avatarCollection->disableListing = $disableListing;
 
 		$usersCardDavBackend = new CardDavBackend($db, $principalBackend, \OC::$server->getLogger());
 		$usersAddressBookRoot = new AddressBookRoot($principalBackend, $usersCardDavBackend, 'principals/users');
@@ -60,6 +62,7 @@ class RootCollection extends SimpleCollection {
 						$systemAddressBookRoot]),
 				$systemTagCollection,
 				$systemTagRelationsCollection,
+				$avatarCollection,
 		];
 
 		parent::__construct('root', $children);

--- a/apps/dav/tests/unit/avatars/avatarcollectiontest.php
+++ b/apps/dav/tests/unit/avatars/avatarcollectiontest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace OCA\DAV\Tests\Unit\Avatars;
+
+use OCP\Files\NotFoundException;
+use OCP\IAvatarManager;
+use OCA\DAV\Avatars\AvatarCollection;
+
+class AvatarCollectionTest extends  \Test\TestCase {
+
+	/** @var IAvatarManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $manager;
+
+	/** @var AvatarCollection */
+	private $collection;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->manager = $this->getMock('\OCP\IAvatarManager');
+		$this->collection = new AvatarCollection(['uri' => 'principals/users/user'], $this->manager);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testCreateFile() {
+		$this->collection->createFile('foo');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testCreateDirectory() {
+		$this->collection->createDirectory('foo');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testGetChildInvalid() {
+		$this->collection->getChild('foo');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testGetChildNoAvatar() {
+		$avatar = $this->getMock('\OCP\IAvatar');
+
+		$this->manager
+			->method('getAvatar')
+			->with('user')
+			->willReturn($avatar);
+
+		$avatar->method('getFile')
+			->with(123)
+			->will($this->throwException(new NotFoundException()));
+
+		$this->collection->getChild('123');
+	}
+
+	public function testGetChildAvatar() {
+		$avatar = $this->getMock('\OCP\IAvatar');
+		$file = $this->getMock('\OCP\Files\File');
+
+		$this->manager
+			->method('getAvatar')
+			->with('user')
+			->willReturn($avatar);
+
+		$avatar->method('getFile')
+			->with(123)
+			->willReturn($file);
+
+		$this->collection->getChild('123');
+	}
+
+	public function dataGetChild() {
+		return [
+			['foo', true],
+			['123', true],
+			['456', false],
+		];
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testGetChildren() {
+		$this->collection->getChildren();
+	}
+
+	/**
+	 * @dataProvider dataChildExists
+	 * @param string $size
+	 * @param bool $expected
+	 */
+	public function testChildExists($size, $expected) {
+		$this->assertEquals($expected, $this->collection->childExists($size));
+	}
+
+	public function dataChildExists() {
+		return [
+			['foo', false],
+			['123', true],
+			['0x123', false],
+			['0', false],
+			['-1', false],
+			['one', false],
+		];
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDelete() {
+		$this->collection->delete();
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testSetName() {
+		$this->collection->setName('bar');
+	}
+
+}

--- a/apps/dav/tests/unit/avatars/avatarcollectiontest.php
+++ b/apps/dav/tests/unit/avatars/avatarcollectiontest.php
@@ -36,10 +36,10 @@ class AvatarCollectionTest extends  \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testGetChildInvalid() {
-		$this->collection->getChild('foo');
+		$this->collection->getChild('foo.svg');
 	}
 
 	/**
@@ -57,10 +57,10 @@ class AvatarCollectionTest extends  \Test\TestCase {
 			->with(123)
 			->will($this->throwException(new NotFoundException()));
 
-		$this->collection->getChild('123');
+		$this->collection->getChild('123.png');
 	}
 
-	public function testGetChildAvatar() {
+	public function testGetChildAvatarFormatNotAllowed() {
 		$avatar = $this->getMock('\OCP\IAvatar');
 		$file = $this->getMock('\OCP\Files\File');
 
@@ -73,15 +73,25 @@ class AvatarCollectionTest extends  \Test\TestCase {
 			->with(123)
 			->willReturn($file);
 
-		$this->collection->getChild('123');
+		$this->collection->getChild('123.png');
 	}
 
-	public function dataGetChild() {
-		return [
-			['foo', true],
-			['123', true],
-			['456', false],
-		];
+	public function testGetChildAvatar() {
+		$avatar = $this->getMock('\OCP\IAvatar');
+		$file = $this->getMock('\OCP\Files\File');
+		$file->method('getMimeType')
+			->willReturn('image/jpeg');
+
+		$this->manager
+			->method('getAvatar')
+			->with('user')
+			->willReturn($avatar);
+
+		$avatar->method('getFile')
+			->with(123)
+			->willReturn($file);
+
+		$this->collection->getChild('123.jpg');
 	}
 
 	/**
@@ -89,26 +99,6 @@ class AvatarCollectionTest extends  \Test\TestCase {
 	 */
 	public function testGetChildren() {
 		$this->collection->getChildren();
-	}
-
-	/**
-	 * @dataProvider dataChildExists
-	 * @param string $size
-	 * @param bool $expected
-	 */
-	public function testChildExists($size, $expected) {
-		$this->assertEquals($expected, $this->collection->childExists($size));
-	}
-
-	public function dataChildExists() {
-		return [
-			['foo', false],
-			['123', true],
-			['0x123', false],
-			['0', false],
-			['-1', false],
-			['one', false],
-		];
 	}
 
 	/**

--- a/apps/dav/tests/unit/avatars/avatartest.php
+++ b/apps/dav/tests/unit/avatars/avatartest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace OCA\DAV\Tests\Unit\Avatars;
+
+use OCA\DAV\Avatars\Avatar;
+use OCP\Files\File;
+
+class AvatarTest extends \Test\TestCase {
+
+	/** @var File | \PHPUnit_Framework_MockObject_MockObject */
+	private $file;
+
+	/** @var Avatar */
+	private $avatar;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->file = $this->getMock('\OCP\Files\File');
+
+		$this->avatar = new Avatar($this->file);
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDelete() {
+		$this->avatar->delete();
+	}
+
+	public function testGetName() {
+		$this->file->expects($this->once())
+			->method('getName')
+			->willReturn('name');
+
+		$this->assertEquals('name', $this->avatar->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testSetName() {
+		$this->avatar->setName('foo');
+	}
+
+	public function testGetLastModified() {
+		$this->file->expects($this->once())
+			->method('getMTime')
+			->willReturn(42);
+
+		$this->assertEquals(42, $this->avatar->getLastModified());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testPut() {
+		$this->avatar->put('new data');
+	}
+
+	public function testGet() {
+		$this->file->expects($this->once())
+			->method('getContent')
+			->willReturn('my avatar');
+
+		$this->assertEquals('my avatar', $this->avatar->get());
+	}
+
+	public function testGetETag() {
+		$this->file->expects($this->once())
+			->method('getEtag')
+			->willReturn('1337');
+
+		$this->assertEquals('1337', $this->avatar->getETag());
+	}
+
+	public function testGetContentType() {
+		$this->file->expects($this->once())
+			->method('getMimeType')
+			->willReturn('mime mime mime');
+
+		$this->assertEquals('mime mime mime', $this->avatar->getContentType());
+	}
+
+	public function testGetSize() {
+		$this->file->expects($this->once())
+			->method('getSize')
+			->willReturn(123456);
+
+		$this->assertEquals(123456, $this->avatar->getSize());
+	}
+
+}


### PR DESCRIPTION
This add an avatar collection to the new dav endpoint. Right now it is still authenticated but once we figure it out properly we can have anonymous actions here (for getting!) avatars. But for now it will allow authenticated clients to retrieve avatars for local users.

Pretty straight forward actually.

CC: @DeepDiver1975 @PVince81 @nickvergessen
