### PR TITLE
[Avatars] Calculate 'sane' hue precissions

### DIFF
--- a/core/js/placeholder.js
+++ b/core/js/placeholder.js
@@ -51,8 +51,8 @@
 		// set optional argument "text" to value of "seed" if undefined
 		text = text || seed;
 
-		var hash = md5(seed),
-			maxRange = parseInt('ffffffffffffffffffffffffffffffff', 16),
+		var hash = md5(seed).substring(0, 4),
+			maxRange = parseInt('ffff', 16),
 			hue = parseInt(hash, 16) / maxRange * 256,
 			height = this.height() || size || 32;
 		this.css('background-color', 'hsl(' + hue + ', 90%, 65%)');


### PR DESCRIPTION
We used to get the numeric value of the entrire md5 string which is a
128bit integer. We would then devide this by the maxval of a 128bit int.

There is no need for such huge computations. As we just require a value
between 0 and 255. Thus using two 16 bit values is more than enough to
get the precision we need. By just taking the MSB we get nearly
identical results.

To test, simply get share with a user without an avatar or with a group. You should see the placeholder. Now switch to this branch and the placeholder should stay the same.

CC: @PVince81 @LukasReschke @MorrisJobke 
