### PR TITLE
Make a modifiable copy of the webdav properties in JS file list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1383,7 +1383,7 @@
 		 * Returns list of webdav properties to request
 		 */
 		_getWebdavProperties: function() {
-			return this.filesClient.getPropfindProperties();
+			return [].concat(this.filesClient.getPropfindProperties());
 		},
 
 		/**


### PR DESCRIPTION
Plugins can extend _getWebdavProperties to add custom properties.
These should not be added to the original properties list, so now the
FileList makes a copy of the array.

Before this fix: the more PROPFIND requests you make, the more times the properties list will be duplicated.

PROPFIND request before fix (after 3 requests, switching folders):

``` xml
<?xml version="1.0"?>
<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
  <d:prop>
    <d:getlastmodified />
    <d:getetag />
    <d:getcontenttype />
    <d:resourcetype />
    <oc:fileid />
    <oc:permissions />
    <oc:size />
    <d:getcontentlength />
    <oc:tags />
    <oc:favorite />
    <oc:owner-display-name />
    <oc:tags />
    <oc:favorite />
    <oc:owner-display-name />
    <oc:tags />
    <oc:favorite />
    <oc:owner-display-name />
    <oc:tags />
    <oc:favorite />
    <oc:owner-display-name />
  </d:prop>
</d:propfind>
```

PROPFIND request after fix:

``` xml
<?xml version="1.0"?>
<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
  <d:prop>
    <d:getlastmodified />
    <d:getetag />
    <d:getcontenttype />
    <d:resourcetype />
    <oc:fileid />
    <oc:permissions />
    <oc:size />
    <d:getcontentlength />
    <oc:tags />
    <oc:favorite />
    <oc:owner-display-name />
  </d:prop>
</d:propfind>
```

Please review @MorrisJobke @icewind1991 @DeepDiver1975 @rullzer 
