### PR TITLE
Push updates for federated shares

### DIFF
--- a/apps/files_sharing/api/server2server.php
+++ b/apps/files_sharing/api/server2server.php
@@ -271,6 +271,7 @@ class Server2Server {
 		$share = $query->fetchRow();
 
 		if ($token && $id && !empty($share)) {
+			$share['token'] = $token;
 			$this->externalUpdater->handleUpdate($share['user'], $share, $path, $etag);
 		}
 

--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -25,6 +25,7 @@
 
 namespace OCA\Files_Sharing\AppInfo;
 
+use OC\Files\Filesystem;
 use OCA\Files_Sharing\MountProvider;
 use OCP\AppFramework\App;
 use OC\AppFramework\Utility\SimpleContainer;
@@ -122,9 +123,19 @@ class Application extends App {
 			$server = $c->query('ServerContainer');
 			return new \OCA\Files_Sharing\External\MountProvider(
 				$server->getDatabaseConnection(),
-				function() use ($c) {
+				function () use ($c) {
 					return $c->query('ExternalManager');
 				}
+			);
+		});
+
+		$container->registerService('ExternalUpdater', function (IContainer $c) {
+			/** @var \OCP\IServerContainer $server */
+			$server = $c->query('ServerContainer');
+			return new \OCA\Files_Sharing\External\ExternalUpdater(
+				$c->query('ExternalMountProvider'),
+				Filesystem::getLoader(),
+				$server->getUserManager()
 			);
 		});
 

--- a/apps/files_sharing/command/notifyexternalshare.php
+++ b/apps/files_sharing/command/notifyexternalshare.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Command;
+
+use OC\Command\FileAccess;
+use OCA\Files_Sharing\AppInfo\Application;
+use OCA\Files_Sharing\External\Manager;
+use OCP\Command\ICommand;
+use OCP\Files\Node;
+
+class Expire implements ICommand {
+	use FileAccess;
+
+	/**
+	 * @var string
+	 */
+	private $user;
+
+	/**
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * @param string $user
+	 * @param string $path root path of the external share
+	 */
+	function __construct($user, $path) {
+		$this->user = $user;
+		$this->path = $path;
+	}
+
+	public function handle() {
+		$userManager = \OC::$server->getUserManager();
+		$application = new Application();
+		if (!$userManager->userExists($this->user)) {
+			return;
+		}
+		$user = $userManager->get($this->user);
+
+		$userFolder = $this->getUserFolder($user);
+		$node = $userFolder->get($this->path);
+		/** @var Manager $externalManager */
+		$externalManager = $application->getContainer()->query('ExternalManager');
+		$info = $externalManager->getOutgoingShare($node->getId());
+		if (!$info) {
+			return;
+		}
+
+		$remote = $this->getRemote($info['share_with']);
+		$externalManager->notifyUpdate($remote, $info['token'], $info['id'], '', $node->getEtag());
+	}
+
+	private function getRemote($shareWith) {
+		list(, $remote) = explode('@', $shareWith);
+		return $remote;
+	}
+
+}

--- a/apps/files_sharing/command/notifyexternalshare.php
+++ b/apps/files_sharing/command/notifyexternalshare.php
@@ -65,13 +65,15 @@ class NotifyExternalShare implements ICommand {
 		$node = $nodes[0];
 		/** @var Manager $externalManager */
 		$externalManager = $application->getContainer()->query('ExternalManager');
-		$info = $externalManager->getOutgoingShare($this->fileId, $this->user);
-		if (!$info) {
+		$sharesInfo = $externalManager->getOutgoingShares($this->fileId, $this->user);
+		if (count($sharesInfo) === 0) {
 			return;
 		}
 
-		$remote = $this->getRemote($info['share_with']);
-		$externalManager->notifyUpdate($remote, $info['token'], $info['id'], '', $node->getEtag());
+		foreach ($sharesInfo as $info) {
+			$remote = $this->getRemote($info['share_with']);
+			$externalManager->notifyUpdate($remote, $info['token'], $info['id'], '', $node->getEtag());
+		}
 	}
 
 	private function getRemote($shareWith) {

--- a/apps/files_sharing/lib/external/externalupdater.php
+++ b/apps/files_sharing/lib/external/externalupdater.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\External;
+
+use OC\User\NoUserException;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IUserManager;
+
+/**
+ * Handle updates from owner
+ */
+class ExternalUpdater {
+	/**
+	 * @var MountProvider
+	 */
+	private $externalShareMountProvider;
+
+	/**
+	 * @var IStorageFactory
+	 */
+	private $storageFactory;
+
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+
+	/**
+	 * ExternalUpdater constructor.
+	 *
+	 * @param MountProvider $externalShareMountProvider
+	 * @param IStorageFactory $storageFactory
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(MountProvider $externalShareMountProvider, IStorageFactory $storageFactory, IUserManager $userManager) {
+		$this->externalShareMountProvider = $externalShareMountProvider;
+		$this->storageFactory = $storageFactory;
+		$this->userManager = $userManager;
+	}
+
+	public function handleUpdate($userId, $data, $path, $newEtag) {
+		$user = $this->userManager->get($userId);
+		if (is_null($user)) {
+			throw new NoUserException('user ' . $userId . 'not found');
+		}
+
+		$mount = $this->externalShareMountProvider->getMount($user, $data, $this->storageFactory);
+		$storage = $mount->getStorage();
+		$cache = $storage->getCache();
+		$scanner = $storage->getScanner();
+
+		$oldInfo = $cache->get($path);
+		if ($oldInfo['etag'] !== $newEtag) {
+			$scanner->scan($path);
+		}
+	}
+}

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -426,13 +426,13 @@ class Manager {
 	 * @param string $userId
 	 * @return mixed share of false
 	 */
-	public function getOutgoingShare($fileId, $userId) {
+	public function getOutgoingShares($fileId, $userId) {
 		$getShare = $this->connection->prepare('
 			SELECT `id`, `share_with`, `token`
 			FROM  `*PREFIX*share`
 			WHERE `file_source` = ? AND `uid_owner` = ? AND `share_type` = 6');
 		$result = $getShare->execute([$fileId, $userId]);
 
-		return $result ? $getShare->fetch() : false;
+		return $result ? $getShare->fetchAll() : [];
 	}
 }

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -423,14 +423,15 @@ class Manager {
 
 	/**
 	 * @param int $fileId file id of the root of the outgoing share
+	 * @param string $userId
 	 * @return mixed share of false
 	 */
-	public function getOutgoingShare($fileId) {
+	public function getOutgoingShare($fileId, $userId) {
 		$getShare = $this->connection->prepare('
 			SELECT `id`, `share_with`, `token`
 			FROM  `*PREFIX*share`
 			WHERE `file_source` = ? AND `uid_owner` = ? AND `share_type` = 6');
-		$result = $getShare->execute([$fileId, $this->uid]);
+		$result = $getShare->execute([$fileId, $userId]);
 
 		return $result ? $getShare->fetch() : false;
 	}

--- a/apps/files_sharing/lib/external/manager.php
+++ b/apps/files_sharing/lib/external/manager.php
@@ -255,6 +255,21 @@ class Manager {
 		return ($result['success'] && $status['ocs']['meta']['statuscode'] === 100);
 	}
 
+	public function notifyUpdate($remote, $token, $remoteId, $path, $newEtag) {
+		$url = rtrim($remote, '/') . \OCP\Share::BASE_PATH_TO_SHARE_API . '/' . $remoteId . '/update?format=' . \OCP\Share::RESPONSE_FORMAT;
+
+		$fields = [
+			'token' => $token,
+			'path' => $path,
+			'etag' => $newEtag
+		];
+
+		$result = $this->httpHelper->post($url, $fields);
+		$status = json_decode($result['result'], true);
+
+		return ($result['success'] && $status['ocs']['meta']['statuscode'] === 100);
+	}
+
 	/**
 	 * remove '/user/files' from the path and trailing slashes
 	 *
@@ -404,5 +419,19 @@ class Manager {
 		$result = $shares->execute($parameters);
 
 		return $result ? $shares->fetchAll() : [];
+	}
+
+	/**
+	 * @param int $fileId file id of the root of the outgoing share
+	 * @return mixed share of false
+	 */
+	public function getOutgoingShare($fileId) {
+		$getShare = $this->connection->prepare('
+			SELECT `id`, `share_with`, `token`
+			FROM  `*PREFIX*share`
+			WHERE `file_source` = ? AND `uid_owner` = ? AND `share_type` = 6');
+		$result = $getShare->execute([$fileId, $this->uid]);
+
+		return $result ? $getShare->fetch() : false;
 	}
 }

--- a/apps/files_sharing/lib/helper.php
+++ b/apps/files_sharing/lib/helper.php
@@ -43,6 +43,8 @@ class Helper {
 		\OCP\Util::connectHook('OCP\Share', 'post_unshareFromSelf', '\OC\Files\Cache\Shared_Updater', 'postUnshareFromSelfHook');
 
 		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
+
+		\OCP\Util::connectHook('\OC\Files\Cache\Propagator', 'propagate', '\OCA\Files_Sharing\Hooks', 'postWriteHook');
 	}
 
 	/**

--- a/apps/files_sharing/lib/hooks.php
+++ b/apps/files_sharing/lib/hooks.php
@@ -60,11 +60,13 @@ class Hooks {
 		$entry = $params['entry'];
 		$shares = \OCP\Share::getItemShared('folder', $entry['fileid']);
 		if ($shares) {
-			$share = current($shares);
-			if ($share['share_type'] === \OCP\Share::SHARE_TYPE_REMOTE) {
-				$user = \OC::$server->getUserSession()->getUser();
-				$bus = \OC::$server->getCommandBus();
-				$bus->push(new NotifyExternalShare($user->getUID(), $entry['fileid']));
+			foreach ($shares as $share) {
+				if ($share['share_type'] === \OCP\Share::SHARE_TYPE_REMOTE) {
+					$user = \OC::$server->getUserSession()->getUser();
+					$bus = \OC::$server->getCommandBus();
+					$bus->push(new NotifyExternalShare($user->getUID(), $entry['fileid']));
+					return;
+				}
 			}
 		}
 	}

--- a/apps/files_sharing/tests/external/externalupdatertests.php
+++ b/apps/files_sharing/tests/external/externalupdatertests.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Tests\External;
+
+use OC\Files\Storage\StorageFactory;
+use OC\User\Manager;
+use OCA\Files_Sharing\External\ExternalUpdater;
+use OCA\Files_Sharing\External\MountProvider;
+use OCP\IUserManager;
+use Test\TestCase;
+use Test\Util\User\Dummy;
+
+class ExternalUpdaterTests extends TestCase {
+	/**
+	 * @var ExternalUpdater
+	 */
+	private $updater;
+
+	/**
+	 * @var MountProvider|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mountProvider;
+
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+
+	protected function setUp() {
+		$userBackend = new Dummy();
+		$userBackend->createUser('user1', 'user1');
+		$this->userManager = new Manager();
+		$this->userManager->registerBackend($userBackend);
+
+		$this->mountProvider = $this->getMockBuilder('\OCA\Files_Sharing\External\MountProvider')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->updater = new ExternalUpdater($this->mountProvider, new StorageFactory(), $this->userManager);
+	}
+
+	/**
+	 * @param array $files
+	 * @return \OC\Files\Storage\Storage|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected function getMockStorage($files) {
+		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
+			->getMock();
+		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$cache->expects($this->any())
+			->method('get')
+			->will($this->returnCallback(function ($path) use ($files) {
+				return $files[$path];
+			}));
+
+		$storage->expects($this->any())
+			->method('getCache')
+			->will($this->returnValue($cache));
+
+		$scanner = $this->getMockBuilder('\OC\Files\Cache\Scanner')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$storage->expects($this->any())
+			->method('getScanner')
+			->will($this->returnValue($scanner));
+
+		return $storage;
+	}
+
+	protected function getMount($storage) {
+		$mount = $this->getMockBuilder('\OCP\Files\Mount\IMountPoint')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mount->expects($this->any())
+			->method('getStorage')
+			->will($this->returnValue($storage));
+
+		return $mount;
+	}
+
+	public function testHandleUpdateSameEtag() {
+		$storage = $this->getMockStorage([
+			'foo' => [
+				'etag' => 'etag1'
+			]
+		]);
+		/** @var \PHPUnit_Framework_MockObject_MockObject $scanner */
+		$scanner = $storage->getScanner();
+
+		$mount = $this->getMount($storage);
+
+		$this->mountProvider->expects($this->any())
+			->method('getMount')
+			->will($this->returnValue($mount));
+
+		$scanner->expects($this->never())
+			->method('scan');
+
+		$this->updater->handleUpdate('user1', [], 'foo', 'etag1');
+	}
+}

--- a/lib/private/files/cache/propagator.php
+++ b/lib/private/files/cache/propagator.php
@@ -59,6 +59,11 @@ class Propagator {
 			$cache->update($parentId, ['mtime' => $mtime, 'etag' => $this->storage->getETag($entry['path'])]);
 
 			$parentId = $entry['parent'];
+
+			\OC_Hook::emit('\OC\Files\Cache\Propagator', 'propagate', [
+				'storage' => $this->storage,
+				'entry' => $entry
+			]);
 		}
 
 		return $propagatedEntries;

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -99,7 +99,9 @@ API::register(
 
 // Server-to-Server Sharing
 if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
-	$s2s = new \OCA\Files_Sharing\API\Server2Server();
+	$application = new \OCA\Files_Sharing\AppInfo\Application();
+	$externalUpdater = $application->getContainer()->query('ExternalUpdater');
+	$s2s = new \OCA\Files_Sharing\API\Server2Server($externalUpdater);
 	API::register('post',
 		'/cloud/shares',
 		array($s2s, 'createShare'),

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -129,4 +129,11 @@ if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 		'files_sharing',
 		API::GUEST_AUTH
 	);
+
+	API::register('post',
+		'/cloud/shares/{id}/update',
+		array($s2s, 'updateShare'),
+		'files_sharing',
+		API::GUEST_AUTH
+	);
 }


### PR DESCRIPTION
Have the owner server of a federated share send push updates to recipients to notify them of changes made.

To test:
- setup 2 servers and create a federated share
- write to the share as the owner
- use the sync client or webdav to verify that the etag has changed _without_ opening the fed. share in the web interface

cc @PVince81
