### PR TITLE
Fix owncloud logging with ms precision

### DIFF
--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -73,7 +73,7 @@ class OC_Log_Owncloud {
 		} catch (Exception $e) {
 			$timezone = new DateTimeZone('UTC');
 		}
-		$time = DateTime::createFromFormat("U.u", microtime(true), $timezone);
+		$time = DateTime::createFromFormat("U.u", number_format(microtime(true), 4, ".", ""), $timezone);
 		if ($time === false) {
 			$time = new DateTime(null, $timezone);
 		}


### PR DESCRIPTION
When microtime(true) returns a whole number, then the parsing fails.
This patch makes sure, that the value can always be parsed correctly.
