### PR TITLE
Remove unnecessary border from login button

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -270,6 +270,7 @@ body {
 	background-color: transparent;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
 	opacity: .3;
+	box-shadow: none !important;
 }
 #body-login #submit.login:hover,
 #body-login #submit.login:focus {


### PR DESCRIPTION
This small patch removes an unnecessary border that made the dividing line between login name and password a tad darker on hover or focus:

Before:
![bildschirmfoto von 2015-12-22 16-50-11](https://cloud.githubusercontent.com/assets/1374172/11959416/752ba9bc-a8cd-11e5-9577-2177b94ef091.png)
After:
![bildschirmfoto von 2015-12-22 16-50-40](https://cloud.githubusercontent.com/assets/1374172/11959303/d500a5a0-a8cc-11e5-8ef0-1b31217da0be.png)

Tested on Firefox and Chromium on Linux.
@owncloud/designers review please ;-)
