### PR TITLE
Add an option to occ ldap:showremnants to output a json encoded array…

### DIFF
--- a/apps/user_ldap/command/showremnants.php
+++ b/apps/user_ldap/command/showremnants.php
@@ -24,6 +24,7 @@ namespace OCA\user_ldap\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use OCA\user_ldap\lib\user\DeletedUsersIndex;
@@ -50,7 +51,7 @@ class ShowRemnants extends Command {
 		$this
 			->setName('ldap:show-remnants')
 			->setDescription('shows which users are not available on LDAP anymore, but have remnants in ownCloud.')
-		;
+			->addOption('json', null, InputOption::VALUE_NONE, 'return JSON array instead of pretty table.');
 	}
 
 	/**
@@ -70,18 +71,21 @@ class ShowRemnants extends Command {
 			$hAS = $user->getHasActiveShares() ? 'Y' : 'N';
 			$lastLogin = ($user->getLastLogin() > 0) ?
 				$this->dateFormatter->formatDate($user->getLastLogin()) : '-';
-			$rows[] = array(
-				$user->getOCName(),
-				$user->getDisplayName(),
-				$user->getUid(),
-				$user->getDN(),
-				$lastLogin,
-				$user->getHomePath(),
-				$hAS
+			$rows[] = array('ocName'      => $user->getOCName(),
+							'displayName' => $user->getDisplayName(),
+							'uid'         => $user->getUid(),
+							'dn'          => $user->getDN(),
+							'lastLogin'   => $lastLogin,
+							'homePath'    => $user->getHomePath(),
+							'sharer'      => $hAS
 			);
 		}
 
-		$table->setRows($rows);
-		$table->render($output);
+		if ($input->getOption('json')) {
+			$output->writeln(json_encode($rows));			
+		} else {
+			$table->setRows($rows);
+			$table->render($output);
+		}
 	}
 }


### PR DESCRIPTION
… for use in scripts and other tools. Keying the $rows array with strings has no impact on the existing table output but makes for more flexible use of json output.
