### PR TITLE
remove mention of 'filesystem_check_changes' => 2 from the config sample

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -27,7 +27,6 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<select id="mountOptionsFilesystemCheck" name="filesystem_check_changes" data-type="int">' +
 	'			<option value="0">{{t "files_external" "Never"}}</option>' +
 	'			<option value="1" selected="selected">{{t "files_external" "Once every direct access"}}</option>' +
-	'			<option value="2">{{t "files_external" "Every time the filesystem is used"}}</option>' +
 	'		</select>' +
 	'	</div>' +
 	'</div>';
@@ -39,7 +38,6 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	t("files_external", "Check for changes")
 	t("files_external", "Never")
 	t("files_external", "Once every direct access")
-	t("files_external", "Every time the filesystem is used")
 	 */
 
 /**

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -254,13 +254,13 @@ describe('OCA.External.Settings tests', function() {
 				// defaults to true
 				var $field = $td.find('.dropdown [name=previews]');
 				expect($field.prop('checked')).toEqual(true);
-				$td.find('.dropdown [name=filesystem_check_changes]').val(2);
+				$td.find('.dropdown [name=filesystem_check_changes]').val(0);
 				$('body').mouseup();
 
 				expect(JSON.parse($tr.find('input.mountOptions').val())).toEqual({
 					encrypt: true,
 					previews: true,
-					filesystem_check_changes: 2
+					filesystem_check_changes: 0
 				});
 			});
 		});

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1063,9 +1063,6 @@ $CONFIG = array(
  *
  * 1 -> Check each file or folder at most once per request, recommended for
  * general use if outside changes might happen.
- *
- * 2 -> Check every time the filesystem is used, causes a performance hit when
- * using external storages, not recommended for regular use.
  */
 'filesystem_check_changes' => 0,
 


### PR DESCRIPTION
There is literally no reason for anyone to ever use that setting and people should really trying it.

Having it shown as an optional will make people think it will solve their problems with external changes not being detected (spoiler: it wont)

cc @PVince81 
