### PR TITLE
Get the icon in javascript for the filepicker

### DIFF
--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -753,6 +753,7 @@ var OCdialogs = {
 			var sorted = dirs.concat(others);
 
 			$.each(sorted, function(idx, entry) {
+				entry.icon = OC.MimeType.getIconUrl(entry.mimetype);
 				var $li = self.$listTmpl.octemplate({
 					type: entry.type,
 					dir: dir,


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/20573
Fixes #20525

Pretty straight forward fix. The server no longer calculates the icon. So we do it in javascript.

CC: @PVince81 @Henni @owncloud/designers 
