### PR TITLE
Add occ commands to manager trusted certificates

### DIFF
--- a/core/command/security/importcertificate.php
+++ b/core/command/security/importcertificate.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OCP\ICertificateManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImportCertificate extends Base {
+
+	/** @var ICertificateManager */
+	protected $certificateManager;
+
+	public function __construct(ICertificateManager $certificateManager) {
+		$this->certificateManager = $certificateManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('security:certificates:import')
+			->setDescription('import trusted certificate')
+			->addArgument(
+				'path',
+				InputArgument::REQUIRED,
+				'path to the certificate to import'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$path = $input->getArgument('path');
+
+		if (!file_exists($path)) {
+			$output->writeln('<error>certificate not found</error>');
+			return;
+		}
+
+		$certData = file_get_contents($path);
+		$name = basename($path);
+
+		$this->certificateManager->addCertificate($certData, $name);
+	}
+}

--- a/core/command/security/listcertificates.php
+++ b/core/command/security/listcertificates.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OCP\ICertificate;
+use OCP\ICertificateManager;
+use OCP\IL10N;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCertificates extends Base {
+
+	/** @var ICertificateManager */
+	protected $certificateManager;
+	/** @var IL10N */
+	protected $l;
+
+	public function __construct(ICertificateManager $certificateManager, IL10N $l) {
+		$this->certificateManager = $certificateManager;
+		$this->l = $l;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('security:certificates')
+			->setDescription('list trusted certificates');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$outputType = $input->getOption('output');
+		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
+			$certificates = array_map(function (ICertificate $certificate) {
+				return [
+					'name' => $certificate->getName(),
+					'common_name' => $certificate->getCommonName(),
+					'organization' => $certificate->getOrganization(),
+					'expire' => $certificate->getExpireDate()->format(\DateTime::ATOM),
+					'issuer' => $certificate->getIssuerName(),
+					'issuer_organization' => $certificate->getIssuerOrganization(),
+					'issue_date' => $certificate->getIssueDate()->format(\DateTime::ATOM)
+				];
+			}, $this->certificateManager->listCertificates());
+			if ($outputType === self::OUTPUT_FORMAT_JSON) {
+				$output->writeln(json_encode(array_values($certificates)));
+			} else {
+				$output->writeln(json_encode(array_values($certificates), JSON_PRETTY_PRINT));
+			}
+		} else {
+			$table = new Table($output);
+			$table->setHeaders([
+				'File Name',
+				'Common Name',
+				'Organization',
+				'Valid Until',
+				'Issued By'
+			]);
+
+			$rows = array_map(function (ICertificate $certificate) {
+				return [
+					$certificate->getName(),
+					$certificate->getCommonName(),
+					$certificate->getOrganization(),
+					$this->l->l('date', $certificate->getExpireDate()),
+					$certificate->getIssuerName()
+				];
+			}, $this->certificateManager->listCertificates());
+			$table->setRows($rows);
+			$table->render();
+		}
+	}
+}

--- a/core/command/security/removecertificate.php
+++ b/core/command/security/removecertificate.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OCP\ICertificateManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RemoveCertificate extends Base {
+
+	/** @var ICertificateManager */
+	protected $certificateManager;
+
+	public function __construct(ICertificateManager $certificateManager) {
+		$this->certificateManager = $certificateManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('security:certificates:remove')
+			->setDescription('import trusted certificate')
+			->addArgument(
+				'name',
+				InputArgument::REQUIRED,
+				'the file name of the certificate to remove'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$name = $input->getArgument('name');
+
+		$this->certificateManager->removeCertificate($name);
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -112,6 +112,10 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
+
+	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(null), \OC::$server->getL10N('core')));
+	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));
+	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager(null)));
 } else {
 	$application->add(new OC\Core\Command\Maintenance\Install(\OC::$server->getConfig()));
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/owncloud/core/pull/21336 for system wide cert stuff
- `oc security:certificates` list trusted certificates
- `oc security:certificates:import` add a trusted certificate
- `oc security:certificates:remove` remove a trusted certificate

![manage certificates](https://i.imgur.com/uRRSGYN.png)

Proper diff is https://github.com/owncloud/core/commit/29206df1266776d60d7a33a508d6e378012d53f1 rest is part of #21336

cc @LukasReschke @PVince81 
