### PR TITLE
Remove unnecessary border from login button

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -381,6 +381,8 @@ body {
 .groupbottom input {
 	margin-top: 0;
 	border-top: 0;
+}
+#body-login .groupbottom #password {
 	border-top-right-radius: 0;
 	border-top-left-radius: 0;
 	box-shadow: 0 1px 0 rgba(0,0,0,.1) inset !important;


### PR DESCRIPTION
replaces #21334

I selected the password field as `#body-login .groupbottom #password` since there seem to be other inputs with the same id (e.g. lost password).

@MorrisJobke  @PVince81 have another look please.
