### PR TITLE
No more deprecation messages in error log

### DIFF
--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -328,7 +328,11 @@ class Router implements IRouter {
 	public function generate($name, $parameters = array(), $absolute = false) {
 		$this->loadRoutes();
 		try {
-			return $this->getGenerator()->generate($name, $parameters, $absolute);
+			$referenceType = UrlGenerator::ABSOLUTE_URL;
+			if ($absolute === false) {
+				$referenceType = UrlGenerator::ABSOLUTE_PATH;
+			}
+			return $this->getGenerator()->generate($name, $parameters, $referenceType);
 		} catch (RouteNotFoundException $e) {
 			$this->logger->logException($e);
 			return '';


### PR DESCRIPTION
Fixes message below ...

```
[Tue Dec 29 17:23:35 2015] The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead. at /home/deepdiver/Development/ownCloud/master/3rdparty/symfony/routing/Generator/UrlGenerator.php#147
```
