### PR TITLE
Cache session in getUser

### DIFF
--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -58,12 +58,28 @@
  *   logout()
  */
 class OC_User {
+	static private $session;
+
+	static private $userSession;
 
 	/**
 	 * @return \OC\User\Session
 	 */
 	public static function getUserSession() {
-		return OC::$server->getUserSession();
+		if (!self::$userSession) {
+			self::$userSession = OC::$server->getUserSession();
+		}
+		return self::$userSession;
+	}
+
+	/**
+	 * @return \OCP\ISession
+	 */
+	private static function getSession() {
+		if (!self::$session) {
+			self::$session = OC::$server->getSession();
+		}
+		return self::$session;
 	}
 
 	private static $_backends = array();
@@ -353,7 +369,7 @@ class OC_User {
 	 * @return string|bool uid or false
 	 */
 	public static function getUser() {
-		$uid = \OC::$server->getSession() ? \OC::$server->getSession()->get('user_id') : null;
+		$uid = self::getSession() ? self::getSession()->get('user_id') : null;
 		if (!is_null($uid) && self::$incognitoMode === false) {
 			return $uid;
 		} else {


### PR DESCRIPTION
Querying the server container every time is expensive.

Gives a nice performance increase when working with large folders

[comparison](https://blackfire.io/profiles/compare/65a4966e-f043-4fc9-8cd0-353e122281f0/graph)

cc @DeepDiver1975 @rullzer 
