### PR TITLE
Put nodes from Directory->getChildren in the ObjectTree cache

### DIFF
--- a/apps/dav/lib/connector/sabre/directory.php
+++ b/apps/dav/lib/connector/sabre/directory.php
@@ -54,6 +54,23 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 	private $quotaInfo;
 
 	/**
+	 * @var ObjectTree|null
+	 */
+	private $tree;
+
+	/**
+	 * Sets up the node, expects a full path name
+	 *
+	 * @param \OC\Files\View $view
+	 * @param \OCP\Files\FileInfo $info
+	 * @param ObjectTree|null $tree
+	 */
+	public function __construct($view, $info, $tree = null) {
+		parent::__construct($view, $info);
+		$this->tree = $tree;
+	}
+
+	/**
 	 * Creates a new file in the directory
 	 *
 	 * Data will either be supplied as a stream resource, or in certain cases
@@ -185,9 +202,12 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 		}
 
 		if ($info['mimetype'] == 'httpd/unix-directory') {
-			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info);
+			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this->tree);
 		} else {
 			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info);
+		}
+		if ($this->tree) {
+			$this->tree->cacheNode($node);
 		}
 		return $node;
 	}

--- a/apps/dav/lib/connector/sabre/objecttree.php
+++ b/apps/dav/lib/connector/sabre/objecttree.php
@@ -94,6 +94,10 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		return $path;
 	}
 
+	public function cacheNode(Node $node) {
+		$this->cache[trim($node->getPath(), '/')] = $node;
+	}
+
 	/**
 	 * Returns the INode object for the requested path
 	 *
@@ -108,16 +112,17 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		}
 
 		$path = trim($path, '/');
+
+		if (isset($this->cache[$path])) {
+			return $this->cache[$path];
+		}
+
 		if ($path) {
 			try {
 				$this->fileView->verifyPath($path, basename($path));
 			} catch (\OCP\Files\InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
-		}
-
-		if (isset($this->cache[$path])) {
-			return $this->cache[$path];
 		}
 
 		// Is it the root node?
@@ -162,7 +167,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		}
 
 		if ($info->getType() === 'dir') {
-			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info);
+			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this);
 		} else {
 			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info);
 		}

--- a/apps/dav/lib/connector/sabre/serverfactory.php
+++ b/apps/dav/lib/connector/sabre/serverfactory.php
@@ -120,7 +120,7 @@ class ServerFactory {
 
 			// Create ownCloud Dir
 			if ($rootInfo->getType() === 'dir') {
-				$root = new \OCA\DAV\Connector\Sabre\Directory($view, $rootInfo);
+				$root = new \OCA\DAV\Connector\Sabre\Directory($view, $rootInfo, $objectTree);
 			} else {
 				$root = new \OCA\DAV\Connector\Sabre\File($view, $rootInfo);
 			}


### PR DESCRIPTION
Saves us from having to generate the node again later in `getNodeForPath` for a significant performance improvement when working with large folders

Also note that creating the node in `getChildren` is cheaper than in `getNodeForPath` since in the former we already have the fileinfo

[comparison](https://blackfire.io/profiles/compare/b57dcdd7-0607-4169-b23e-d4150d580d3d/graph)

cc @DeepDiver1975 @rullzer 
