### PR TITLE
[wip] Split out appinfo handling and app locating into their own classes

### DIFF
--- a/core/command/app/checkcode.php
+++ b/core/command/app/checkcode.php
@@ -117,7 +117,7 @@ class CheckCode extends Command {
 		$errors = $codeChecker->analyse($appId);
 
 		if(!$input->getOption('skip-validate-info')) {
-			$infoChecker = new InfoChecker($this->infoParser);
+			$infoChecker = new InfoChecker($this->infoParser, \OC::$server->getAppLocator());
 
 			$infoChecker->listen('InfoChecker', 'mandatoryFieldMissing', function($key) use ($output) {
 				$output->writeln("<error>Mandatory field missing: $key</error>");

--- a/lib/base.php
+++ b/lib/base.php
@@ -379,6 +379,7 @@ class OC {
 		$installedVersion = $systemConfig->getValue('version', '0.0.0');
 		$currentVersion = implode('.', \OCP\Util::getVersion());
 
+		/** @var \OC\App\AppManager $appManager */
 		$appManager = \OC::$server->getAppManager();
 
 		$tmpl = new OC_Template('', 'update.admin', 'guest');
@@ -393,8 +394,11 @@ class OC {
 
 		// get third party apps
 		$ocVersion = \OCP\Util::getVersion();
-		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
-		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
+		$appInfoToArray = function(\OC\App\AppInfo $info) {
+			return $info->toArray();
+		};
+		$tmpl->assign('appsToUpgrade', array_map($appInfoToArray, $appManager->getAppsNeedingUpgrade($ocVersion)));
+		$tmpl->assign('incompatibleAppsList', array_map($appInfoToArray, $appManager->getIncompatibleApps($ocVersion)));
 		$tmpl->assign('productName', 'ownCloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/app/appinfo.php
+++ b/lib/private/app/appinfo.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\App;
+
+use OCP\App\IAppInfo;
+
+/**
+ * App metadata
+ *
+ * @since 9.0.0
+ */
+class AppInfo implements IAppInfo {
+	/**
+	 * @var string
+	 */
+	private $file;
+
+	/**
+	 * Parsed appinfo
+	 *
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * App version
+	 *
+	 * @var int
+	 */
+	private $version;
+
+	/**
+	 * @var InfoParser
+	 */
+	private $parser;
+
+	/**
+	 * @var string
+	 */
+	private $appId;
+
+	/**
+	 * @var null|string
+	 */
+	private $versionFile;
+
+	/**
+	 * AppInfo constructor.
+	 *
+	 * @param string $appId
+	 * @param string $file
+	 * @param InfoParser $parser
+	 * @param string|null $versionFile
+	 * @param array $data
+	 */
+	public function __construct($appId, $file, InfoParser $parser, $versionFile = null, $data = []) {
+		$this->appId = $appId;
+		$this->file = $file;
+		$this->parser = $parser;
+		$this->versionFile = $versionFile;
+		$this->data = $data;
+	}
+
+	private function parse() {
+		if (!$this->data) {
+			$this->data = $this->fixAppDescription($this->parser->parse($this->file));
+
+			if (isset($this->data['ocsid'])) {
+				$storedId = \OC::$server->getConfig()->getAppValue($this->appId, 'ocsid');
+				if ($storedId !== '' && $storedId !== $this->data['ocsid']) {
+					$this->data['ocsid'] = $storedId;
+				}
+			}
+			if (!isset($this->data['version'])) {
+				$this->data['version'] = $this->getVersion();
+			} else {
+				$this->version = $this->data['version'];
+			}
+		}
+	}
+
+	private function fixAppDescription($data) {
+		// just modify the description if it is available
+		// otherwise this will create a $data element with an empty 'description'
+		if (isset($data['description'])) {
+			if (is_string($data['description'])) {
+				// sometimes the description contains line breaks and they are then also
+				// shown in this way in the app management which isn't wanted as HTML
+				// manages line breaks itself
+
+				// first of all we split on empty lines
+				$paragraphs = preg_split("!\n[[:space:]]*\n!mu", $data['description']);
+
+				$result = [];
+				foreach ($paragraphs as $value) {
+					// replace multiple whitespace (tabs, space, newlines) inside a paragraph
+					// with a single space - also trims whitespace
+					$result[] = trim(preg_replace('![[:space:]]+!mu', ' ', $value));
+				}
+
+				// join the single paragraphs with a empty line in between
+				$data['description'] = implode("\n\n", $result);
+
+			} else {
+				$data['description'] = '';
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * extract the version without doing full xml parsing
+	 */
+	private function parseVersion() {
+		if (!$this->version) {
+			if (isset($this->data['version'])) {
+				$this->version = $this->data['version'];
+			} else if ($this->versionFile && file_exists($this->versionFile)) {
+				$this->version = trim(file_get_contents($this->versionFile));
+			} else if (file_exists($this->file)) {
+				$regex = '/\<version\>([0-9.]+)<\/version\>/';
+				if (preg_match($regex, file_get_contents($this->file), $matches)) {
+					$this->version = $matches[1];
+				}
+			} else {
+				$this->version = '0';
+			}
+		}
+	}
+
+	public function getAppId() {
+		return $this->appId;
+	}
+
+	public function getVersion() {
+		$this->parseVersion();
+		return $this->version;
+	}
+
+	public function toArray() {
+		$this->parse();
+		return $this->data;
+	}
+}

--- a/lib/private/app/codechecker/infochecker.php
+++ b/lib/private/app/codechecker/infochecker.php
@@ -22,6 +22,7 @@
 namespace OC\App\CodeChecker;
 
 use OC\App\InfoParser;
+use OC\App\Locator;
 use OC\Hooks\BasicEmitter;
 
 class InfoChecker extends BasicEmitter {
@@ -59,8 +60,12 @@ class InfoChecker extends BasicEmitter {
 		'standalone',
 	];
 
-	public function __construct(InfoParser $infoParser) {
+	/** @var Locator  */
+	private $appLocator;
+
+	public function __construct(InfoParser $infoParser, Locator $appLocator) {
 		$this->infoParser = $infoParser;
+		$this->appLocator = $appLocator;
 	}
 
 	/**
@@ -68,7 +73,7 @@ class InfoChecker extends BasicEmitter {
 	 * @return array
 	 */
 	public function analyse($appId) {
-		$appPath = \OC_App::getAppPath($appId);
+		$appPath = $this->appLocator->getAppPath($appId);
 		if ($appPath === false) {
 			throw new \RuntimeException("No app with given id <$appId> known.");
 		}

--- a/lib/private/app/locator.php
+++ b/lib/private/app/locator.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\App;
+
+/**
+ * Find an app in the configured app directories
+ *
+ * @package OC\App
+ */
+class Locator {
+	/**
+	 * @var string[]
+	 */
+	private $cache = [];
+
+	private $appRoots = [];
+
+	/**
+	 * Locator constructor.
+	 *
+	 * @param array $appRoots
+	 */
+	public function __construct(array $appRoots) {
+		$this->appRoots = $appRoots;
+	}
+
+	/**
+	 * Get the absolute path of an app
+	 *
+	 * @param string $appId
+	 * @return bool|string
+	 */
+	public function getAppPath($appId) {
+		if (($dir = $this->getDirectoryForApp($appId)) != false) {
+			return $dir['path'] . '/' . $appId;
+		}
+		return false;
+	}
+
+	/**
+	 * Get the directory an app is in
+	 *
+	 * @param string $appId
+	 * @return bool|string
+	 */
+	public function getDirectoryForApp($appId) {
+		$sanitizedAppId = \OC_App::cleanAppId($appId);
+		if ($sanitizedAppId !== $appId) {
+			return false;
+		}
+
+		if (isset($this->cache[$appId])) {
+			return $this->cache[$appId];
+		}
+
+		$possibleApps = array();
+		foreach ($this->appRoots as $dir) {
+			if (file_exists($dir['path'] . '/' . $appId)) {
+				$possibleApps[] = $dir;
+			}
+		}
+
+		if (empty($possibleApps)) {
+			return false;
+		} elseif (count($possibleApps) === 1) {
+			$dir = array_shift($possibleApps);
+			$this->cache[$appId] = $dir;
+		} else {
+			$latestMtime = 0;
+			foreach ($possibleApps as $possibleApp) {
+				$mtime = filemtime($possibleApp['path']);
+				if ($mtime > $latestMtime) {
+					$this->cache[$appId] = $possibleApp;
+					$latestMtime = $mtime;
+				}
+			}
+		}
+		return $this->cache[$appId];
+	}
+}

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -38,6 +38,7 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\App\Locator;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\SimpleContainer;
@@ -382,12 +383,18 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getConfig()
 			);
 		});
+		$this->registerService('AppLocator', function () {
+			return new Locator(\OC::$APPSROOTS);
+		});
 		$this->registerService('AppManager', function(Server $c) {
+			$parser = new \OC\App\InfoParser($c->getHTTPHelper(), $c->getURLGenerator());
 			return new \OC\App\AppManager(
 				$c->getUserSession(),
 				$c->getAppConfig(),
 				$c->getGroupManager(),
-				$c->getMemCacheFactory()
+				$c->getMemCacheFactory(),
+				$parser,
+				$c->getAppLocator()
 			);
 		});
 		$this->registerService('DateTimeZone', function(Server $c) {
@@ -992,6 +999,15 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getAppManager() {
 		return $this->query('AppManager');
+	}
+
+	/**
+	 * Get the app locator
+	 *
+	 * @return \OC\App\Locator
+	 */
+	public function getAppLocator() {
+		return $this->query('AppLocator');
 	}
 
 	/**

--- a/lib/public/app/iappinfo.php
+++ b/lib/public/app/iappinfo.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Robin Appelman <icewind@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\App;
+
+interface IAppInfo {
+	/**
+	 * @return string
+	 * @since 9.0.0
+	 */
+	public function getAppId();
+
+	/**
+	 * @return string
+	 * @since 9.0.0
+	 */
+	public function getVersion();
+
+	/**
+	 * @return array
+	 * @since 9.0.0
+	 */
+	public function toArray();
+}

--- a/lib/public/app/iappmanager.php
+++ b/lib/public/app/iappmanager.php
@@ -111,4 +111,11 @@ interface IAppManager {
 	 * @since 9.0.0
 	 */
 	public function getAlwaysEnabledApps();
+
+	/**
+	 * @param string $appId
+	 * @return IAppInfo
+	 * @since 9.0.0
+	 */
+	public function getAppInfo($appId);
 }

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -480,7 +480,8 @@ class Test_App extends \Test\TestCase {
 			return $appConfig;
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) use ($appConfig) {
-			return new \OC\App\AppManager($c->getUserSession(), $appConfig, $c->getGroupManager(), $c->getMemCacheFactory());
+			$parser = new \OC\App\InfoParser($c->getHTTPHelper(), $c->getURLGenerator());
+			return new \OC\App\AppManager($c->getUserSession(), $appConfig, $c->getGroupManager(), $c->getMemCacheFactory(), $parser, $c->getAppLocator());
 		});
 	}
 
@@ -492,7 +493,8 @@ class Test_App extends \Test\TestCase {
 			return new \OC\AppConfig(\OC_DB::getConnection());
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) {
-			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(), $c->getGroupManager(), $c->getMemCacheFactory());
+			$parser = new \OC\App\InfoParser($c->getHTTPHelper(), $c->getURLGenerator());
+			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(), $c->getGroupManager(), $c->getMemCacheFactory(), $parser, $c->getAppLocator());
 		});
 
 		// Remove the cache of the mocked apps list with a forceRefresh

--- a/tests/lib/app/codechecker/infocheckertest.php
+++ b/tests/lib/app/codechecker/infocheckertest.php
@@ -22,30 +22,23 @@
 namespace OC\App\CodeChecker;
 
 use OC\App\InfoParser;
+use OC\App\Locator;
 use Test\TestCase;
 
 class InfoCheckerTest extends TestCase {
 	/** @var  InfoChecker */
 	protected $infoChecker;
 
-	public static function setUpBeforeClass() {
-		\OC::$APPSROOTS[] = [
-			'path' => \OC::$SERVERROOT . '/tests/apps',
-			'url' => '/apps-test',
-			'writable' => false,
-		];
-	}
-
-	public static function tearDownAfterClass() {
-		// remove last element
-		array_pop(\OC::$APPSROOTS);
-	}
-
 	protected function setUp() {
 		parent::setUp();
 		$infoParser = new InfoParser(\OC::$server->getHTTPHelper(), \OC::$server->getURLGenerator());
 
-		$this->infoChecker = new InfoChecker($infoParser);
+		$appLocator = new Locator([[
+			'path' => \OC::$SERVERROOT . '/tests/apps',
+			'url' => '/apps-test',
+			'writable' => false,
+		]]);
+		$this->infoChecker = new InfoChecker($infoParser, $appLocator);
 	}
 
 	public function appInfoData() {


### PR DESCRIPTION
- [ ] add tests

Also improves performance a bit by not doing full xml parsing if we only need the version ([comparison](https://blackfire.io/profiles/compare/87d23a9e-f8d5-4533-abbc-c362f18cd0c6/graph))
