### PR TITLE
Use appConfig to get app versions

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -1022,21 +1022,12 @@ class OC_App {
 	 */
 	public static function getAppVersions() {
 		static $versions;
-		if (isset($versions)) { // simple cache, needs to be fixed
-			return $versions; // when function is used besides in checkUpgrade
+
+		if(!$versions) {
+			$appConfig = \OC::$server->getAppConfig();
+			$versions = $appConfig->getValues(false, 'installed_version');
 		}
-		$versions = array();
-		try {
-			$query = OC_DB::prepare('SELECT `appid`, `configvalue` FROM `*PREFIX*appconfig`'
-				. ' WHERE `configkey` = \'installed_version\'');
-			$result = $query->execute();
-			while ($row = $result->fetchRow()) {
-				$versions[$row['appid']] = $row['configvalue'];
-			}
-			return $versions;
-		} catch (\Exception $e) {
-			return array();
-		}
+		return $versions;
 	}
 
 

--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -251,14 +251,13 @@ class AppConfig implements IAppConfig {
 		if ($key === false) {
 			return $this->getAppValues($app);
 		} else {
-			$configs = [];
-			foreach ($this->getApps() as $appId) {
-				if ($this->hasKey($appId, $key)) {
-					$configs[$appId] = $this->getValue($appId, $key);
-				}
-			}
+			$appIds = $this->getApps();
+			$values = array_map(function($appId) use ($key) {
+				return isset($this->cache[$appId][$key]) ? $this->cache[$appId][$key] : null;
+			}, $appIds);
+			$result = array_combine($appIds, $values);
 
-			return $configs;
+			return array_filter($result);
 		}
 	}
 


### PR DESCRIPTION
Saves a query by re-using the appconfig cache.

Also improved the performance of `AppConfig->getValues`
