### PR TITLE
Make compatible with Symfony 3 router

### DIFF
--- a/lib/private/route/router.php
+++ b/lib/private/route/router.php
@@ -328,6 +328,11 @@ class Router implements IRouter {
 	public function generate($name, $parameters = array(), $absolute = false) {
 		$this->loadRoutes();
 		try {
+			if($absolute) {
+				$absolute = \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL;
+			} else {
+				$absolute = \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_PATH;
+			}
 			return $this->getGenerator()->generate($name, $parameters, $absolute);
 		} catch (RouteNotFoundException $e) {
 			$this->logger->logException($e);


### PR DESCRIPTION
`$absolute` cannot be a boolean anymore and is deprecated. Using it like that would throw an error and fail in the future. This has been introduced into master with https://github.com/owncloud/3rdparty/pull/234

Fixes https://github.com/owncloud/maps/issues/94

@rullzer @jancborchardt Please test
