### PR TITLE
don't show previous log level in upgrade message

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -104,10 +104,10 @@ if (OC::checkUpgrade(false)) {
 		$config->setSystemValue('maintenance', false);
 	});
 	$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
-		$eventSource->send('success', (string)$l->t('Set log level to debug - current level: "%s"', [ $logLevelName ]));
+		$eventSource->send('success', (string)$l->t('Set log level to debug'));
 	});
 	$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($eventSource, $l) {
-		$eventSource->send('success', (string)$l->t('Reset log level to  "%s"', [ $logLevelName ]));
+		$eventSource->send('success', (string)$l->t('Reset log level'));
 	});
 	$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use($eventSource, $l) {
 		$eventSource->send('success', (string)$l->t('Starting code integrity check'));

--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -199,10 +199,10 @@ class Upgrade extends Command {
 				$output->writeln("<error>$message</error>");
 			});
 			$updater->listen('\OC\Updater', 'setDebugLogLevel', function ($logLevel, $logLevelName) use($output) {
-				$output->writeln("<info>Set log level to debug - current level: '$logLevelName'</info>");
+				$output->writeln("<info>Set log level to debug</info>");
 			});
 			$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($output) {
-				$output->writeln("<info>Reset log level to '$logLevelName'</info>");
+				$output->writeln("<info>Reset log level</info>");
 			});
 
 			if(OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {


### PR DESCRIPTION
Displaying the previous log level doesn't add any additional information. The only important information is that we enable the debug level at the beginning of the upgrade process and reset it again after the upgrade.

Reason why I don't want to show the previous log level. This is how the upgrade looks on my system:

```
Updating ownCloud to version 8.2.2, this may take a while.

Preparing update
Set log level to debug - current level: "Error"
Turned on maintenance mode
Checking whether the database schema can be updated (this can take a long time depending on the database size)
Checked database schema update
Checking updates of apps
Checked database schema update for apps
Updating database schema
Updated database
Turned off maintenance mode
Reset log level to "Error"
```

I always get a heart attack if I spot the "Error" during the upgrade run and I'm sure I'm not the only one.

cc @DeepDiver1975 @VicDeo not sure if you need to take this into account for your new upgrade process
