### PR TITLE
remove unneeded 'goto' prefix from settings anchors

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -177,7 +177,7 @@ OCA.External.StatusManager = {
 				} else {
 					OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in personal settings page?', t('files_external', 'External mount error'), function(e){
 						if(e === true) {
-							window.location.href = OC.generateUrl('/settings/personal#' + t('files_external', 'goto-external-storage'));
+							window.location.href = OC.generateUrl('/settings/personal#external-storage');
 						}
 					});
 				}

--- a/settings/admin.php
+++ b/settings/admin.php
@@ -210,7 +210,7 @@ $formsMap = array_map(function ($form) {
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(
-			'anchor' => 'goto-' . $anchor,
+			'anchor' => $anchor,
 			'section-name' => $sectionName,
 			'form' => $form
 		);

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -177,7 +177,7 @@ $formsMap = array_map(function($form){
 		$anchor = str_replace(' ', '-', $anchor);
 
 		return array(
-			'anchor' => 'goto-' . $anchor,
+			'anchor' => $anchor,
 			'section-name' => $sectionName,
 			'form' => $form
 		);


### PR DESCRIPTION
They are not really needed. On top of that, translating them (in external storage) makes no sense.

Please review @PVince81 @MorrisJobke
