### PR TITLE
Only enable apps that are not intentionally disabled

### DIFF
--- a/lib/private/installer.php
+++ b/lib/private/installer.php
@@ -506,9 +506,10 @@ class OC_Installer{
 							if(!OC_Installer::isInstalled($filename)) {
 								$info=OC_App::getAppInfo($filename);
 								$enabled = isset($info['default_enable']);
-								if( $enabled ) {
+								if (($enabled || in_array($filename, \OC::$server->getAppManager()->getAlwaysEnabledApps()))
+									  && \OC::$server->getConfig()->getAppValue($filename, 'enabled') !== 'no') {
 									OC_Installer::installShippedApp($filename);
-									\OC::$server->getAppConfig()->setValue($filename, 'enabled', 'yes');
+									\OC::$server->getConfig()->setAppValue($filename, 'enabled', 'yes');
 								}
 							}
 						}


### PR DESCRIPTION
In order to enable the dav app, we added code that enables apps that are "enabled by default" with the update. However this also happens when you intentionally disabled the app, which I think is quite nasty.
### Steps
1. Install ownCloud
2. Disabled "Deleted files"
3. Trigger update of the "Files" app by lowering the version in the database
4. Execute the update
### Expected

"Deleted files" should still be disabled
### Actual

"Deleted files" is enabled

I added a simple check for !== no, to make sure the app is kept off, when it was installed and has been disabled

@MorrisJobke @DeepDiver1975 
