### PR TITLE
Fix scanning: emit 'scanFile' will only fire on files and not on folders

### DIFF
--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -132,16 +132,25 @@ class Scanner extends BasicEmitter {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true) {
-		if (!self::isPartialFile($file)
-			and !Filesystem::isFileBlacklisted($file)
-		) {
+
+		// only proceed if $file is not a partial file nor a blacklisted file
+		if (!self::isPartialFile($file) and !Filesystem::isFileBlacklisted($file)) {
+
+			//acquire a lock
 			if ($lock) {
 				$this->storage->acquireLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 			}
-			$this->emit('\OC\Files\Cache\Scanner', 'scanFile', array($file, $this->storageId));
-			\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
+
 			$data = $this->getData($file);
+
 			if ($data) {
+
+				// pre-emit only if it was a file. By that we avoid counting/treating folders as files
+				if ($data['mimetype'] !== 'httpd/unix-directory') {
+					$this->emit('\OC\Files\Cache\Scanner', 'scanFile', array($file, $this->storageId));
+					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', array('path' => $file, 'storage' => $this->storageId));
+				}
+
 				$parent = dirname($file);
 				if ($parent === '.' or $parent === '/') {
 					$parent = '';
@@ -189,16 +198,25 @@ class Scanner extends BasicEmitter {
 				if (!empty($newData)) {
 					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 				}
-				$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
-				\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
+
+				// post-emit only if it was a file. By that we avoid counting/treating folders as files
+				if ($data['mimetype'] !== 'httpd/unix-directory') {
+					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', array($file, $this->storageId));
+					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', array('path' => $file, 'storage' => $this->storageId));
+				}
+
 			} else {
 				$this->removeFromCache($file);
 			}
+
+			//release the acquire a lock
 			if ($lock) {
 				$this->storage->releaseLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 			}
+
 			return $data;
 		}
+
 		return null;
 	}
 


### PR DESCRIPTION
This is a fix for #19458 (Scanner sends folder through the scanFile event)
In addition, I did some optical cleanups and improvements at ScanFile for better readability.
@icewind1991 @PVince81 @DeepDiver1975 @oparoz 

Before:

```
sudo -uwww-data ./occ files:scan --all -v
Scanning file   /user0/
Scanning folder /user0/
Scanning file   /user0/files
Scanning file   /user0/thumbnails
Scanning file   /user0/cache
Scanning folder /user0/files
Scanning file   /user0/files/welcome.txt
Scanning file   /user0/files/folder2
Scanning file   /user0/files/folder1
Scanning folder /user0/files/folder2
Scanning folder /user0/files/folder1
Scanning file   /user0/files/folder1/hs_err_pid3522.log
Scanning file   /user0/files/folder1/x11vnc-0.9.14-dev.tar.gz
Scanning folder /user0/thumbnails
Scanning file   /user0/thumbnails/3
Scanning folder /user0/thumbnails/3
Scanning file   /user0/thumbnails/3/2048-2048-max.png
Scanning file   /user0/thumbnails/3/32-32.png
Scanning folder /user0/cache
Scanning file   /user1/
Scanning folder /user1/
Scanning file   /user1/files
Scanning folder /user1/files
Scanning file   /user1/files/welcome.txt
Scanning file   /user2/
Scanning folder /user2/
Scanning file   /user2/files
Scanning folder /user2/files
Scanning file   /user2/files/welcome.txt

+---------+-------+--------------+
| Folders | Files | Elapsed time |
+---------+-------+--------------+
| 11      | 18    | 00:00:00.4   |
+---------+-------+--------------+
```

After:

```
sudo -uwww-data ./occ files:scan --all -v
Scanning folder /user0/
Scanning folder /user0/files
Scanning file   /user0/files/welcome.txt
Scanning folder /user0/files/folder2
Scanning folder /user0/files/folder1
Scanning file   /user0/files/folder1/hs_err_pid3522.log
Scanning file   /user0/files/folder1/x11vnc-0.9.14-dev.tar.gz
Scanning folder /user0/thumbnails
Scanning folder /user0/thumbnails/3
Scanning file   /user0/thumbnails/3/2048-2048-max.png
Scanning file   /user0/thumbnails/3/32-32.png
Scanning folder /user0/cache
Scanning folder /user1/
Scanning folder /user1/files
Scanning file   /user1/files/welcome.txt
Scanning folder /user2/
Scanning folder /user2/files
Scanning file   /user2/files/welcome.txt

+---------+-------+--------------+
| Folders | Files | Elapsed time |
+---------+-------+--------------+
| 11      | 7     | 00:00:00.5   |
+---------+-------+--------------+
```
