### PR TITLE
Use color instead of transparency for proper tooltip appearance

### DIFF
--- a/apps/files/css/detailsView.css
+++ b/apps/files/css/detailsView.css
@@ -83,6 +83,9 @@
 }
 
 #app-sidebar .file-details {
+	color: #999;
+}
+#app-sidebar .file-details img {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
 }


### PR DESCRIPTION
- fixes #21436

cc @owncloud/designers @fcturner  - Please review
