### PR TITLE
[stable8.2] listen() requires a callable and not an array

### DIFF
--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -48,7 +48,9 @@ $listener = new ScanListener($eventSource);
 foreach ($users as $user) {
 	$eventSource->send('user', $user);
 	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection(), \OC::$server->getLogger());
-	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', array($listener, 'file'));
+	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($listener) {
+		$listener->file();
+	});
 	try {
 		if ($force) {
 			$scanner->scan($dir);


### PR DESCRIPTION
- fixes #21350

@karlitschek This file is gone in master, but it causes a bug in stable8.2 and stable8.1. I would like to backport this fix to the two versions.

@icewind1991 @rullzer @localguru @christianlx  Please review
