### PR TITLE
add back gradient for log in page in Firefox, fix accidental removal

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -26,6 +26,7 @@ body {
 #body-login {
 	text-align: center;
 	background: #1d2d44; /* Old browsers */
+	background: -moz-linear-gradient(top, #35537a 0%, #1d2d44 100%); /* FF3.6+ */
 	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#35537a), color-stop(100%,#1d2d44)); /* Chrome,Safari4+ */
 	background: -webkit-linear-gradient(top, #35537a 0%,#1d2d44 100%); /* Chrome10+,Safari5.1+ */
 	background: linear-gradient(top, #35537a 0%,#1d2d44 100%); /* W3C */


### PR DESCRIPTION
https://github.com/owncloud/core/pull/20480 seems to have led to the gradient on the log in screen being removed for Firefox. Using version 43 (newest), so it still seems the prefix is necessary.

@Henni @owncloud/designers can you review this fix?
