### PR TITLE
listen() requires a callable and not an array

### DIFF
--- a/apps/files/ajax/scan.php
+++ b/apps/files/ajax/scan.php
@@ -47,7 +47,9 @@ $listener = new ScanListener($eventSource);
 foreach ($users as $user) {
 	$eventSource->send('user', $user);
 	$scanner = new \OC\Files\Utils\Scanner($user, \OC::$server->getDatabaseConnection());
-	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', array($listener, 'folder'));
+	$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($listener) {
+		$listener->file();
+	});
 	if ($force) {
 		$scanner->scan($dir);
 	} else {


### PR DESCRIPTION
- fixes #21350 
- fixes regression introduced with #20764

@icewind1991 @rullzer @localguru @christianlx Please review

Stable8.1 version of #21457 

Backport approved in https://github.com/owncloud/core/pull/21457#issuecomment-168996107
