### PR TITLE
Drop oc_gallery_sharing which was removed in 8.0.0

### DIFF
--- a/lib/repair/dropoldtables.php
+++ b/lib/repair/dropoldtables.php
@@ -77,6 +77,7 @@ class DropOldTables extends BasicEmitter implements RepairStep {
 			'file_map',
 			'foldersize',
 			'fscache',
+			'gallery_sharing',
 			'locks',
 			'log',
 			'media_albums',


### PR DESCRIPTION
See https://github.com/owncloud/gallery-old/commit/c080dfe87d5eb1de8aa27b1836629b57b0316004

cc @icewind1991 @oparoz @LukasReschke @nickvergessen 

I noticed this while debugging an instance.
