### PR TITLE
Remove unneeded check if htaccess test file already exists

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1215,10 +1215,6 @@ class OC_Util {
 		// creating a test file
 		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
 
-		if (file_exists($testFile)) {// already running this test, possible recursive call
-			return false;
-		}
-
 		$fp = @fopen($testFile, 'w');
 		if (!$fp) {
 			throw new OC\HintException('Can\'t create test file to check for working .htaccess file.',


### PR DESCRIPTION
- fixes #20199 and #17652

How to reproduce:
- run `touch data/htaccesstest.txt`
- before: htaccess test in admin settings fails
- after: htaccess test in admin settings works

cc @nickvergessen @LukasReschke @Xenopathic @ralfjung @KKyang @nodomain @mislav-eu @linucksrox @Jocko-plugout @nyklspree Please test :)
