### PR TITLE
Check libsmbclient-php as well as smbclient binary

### DIFF
--- a/apps/files_external/lib/smb.php
+++ b/apps/files_external/lib/smb.php
@@ -302,7 +302,9 @@ class SMB extends Common {
 	 * check if smbclient is installed
 	 */
 	public static function checkDependencies() {
-		$smbClientExists = (bool)\OC_Helper::findBinaryPath('smbclient');
-		return $smbClientExists ? true : array('smbclient');
+		return (
+			(bool)\OC_Helper::findBinaryPath('smbclient')
+			|| Server::NativeAvailable()
+		) ? true : ['smbclient'];
 	}
 }


### PR DESCRIPTION
The SMB backend is available if `smbclient` is available or if `libsmbclient-php` is installed.

Fixes #19479

cc @icewind1991 
