### PR TITLE
Also allow 'only cookie' auth to webdav

### DIFF
--- a/apps/dav/lib/connector/sabre/auth.php
+++ b/apps/dav/lib/connector/sabre/auth.php
@@ -151,7 +151,10 @@ class Auth extends AbstractBasic {
 	 */
 	private function auth(RequestInterface $request, ResponseInterface $response) {
 		if (\OC_User::handleApacheAuth() ||
-			($this->userSession->isLoggedIn() && is_null($this->session->get(self::DAV_AUTHENTICATED)))
+			//Fix for broken webdav clients
+			($this->userSession->isLoggedIn() && is_null($this->session->get(self::DAV_AUTHENTICATED))) ||
+			//Well behaved clients that only send the cookie are allowed
+			($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && $request->getHeader('Authorization') === null)
 		) {
 			$user = $this->userSession->getUser()->getUID();
 			\OC_Util::setupFS($user);


### PR DESCRIPTION
Should fix https://github.com/owncloud/core/issues/21486 and https://github.com/owncloud/client/issues/4326#issuecomment-169282743

Patch allows to authenticate to webdav using only a cookie. So no Auth headers can be set.

Please test :)
CC: @guruz @LukasReschke @owncloud/security @DeepDiver1975 @PVince81 
