### PR TITLE
Cleanup OC_DB methods

### DIFF
--- a/apps/files_trashbin/appinfo/update.php
+++ b/apps/files_trashbin/appinfo/update.php
@@ -25,12 +25,6 @@
 $config = \OC::$server->getConfig();
 $installedVersion = $config->getAppValue('files_trashbin', 'installed_version');
 
-if (version_compare($installedVersion, '0.6', '<')) {
-	//size of the trash bin could be incorrect, remove it for all users to
-	//enforce a recalculation during next usage.
-	\OC_DB::dropTable('files_trashsize');
-}
-
 if (version_compare($installedVersion, '0.6.4', '<')) {
 	$isExpirationEnabled = $config->getSystemValue('trashbin_auto_expire', true);
 	$oldObligation = $config->getSystemValue('trashbin_retention_obligation', null);

--- a/apps/files_versions/appinfo/update.php
+++ b/apps/files_versions/appinfo/update.php
@@ -20,11 +20,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-$installedVersion=OCP\Config::getAppValue('files_versions', 'installed_version');
-// move versions to new directory
-if (version_compare($installedVersion, '1.0.4', '<')) {
-	\OC_DB::dropTable("files_versions");
-}
 
 // Cron job for deleting expired trash items
 \OC::$server->getJobList()->add('OCA\Files_Versions\BackgroundJob\ExpireVersions');

--- a/core/command/db/converttype.php
+++ b/core/command/db/converttype.php
@@ -166,7 +166,7 @@ class ConvertType extends Command {
 		$this->validateInput($input, $output);
 		$this->readPassword($input, $output);
 
-		$fromDB = \OC_DB::getConnection();
+		$fromDB = \OC::$server->getDatabaseConnection();
 		$toDB = $this->getToDBConnection($input, $output);
 
 		if ($input->getOption('clear-schema')) {

--- a/core/command/db/generatechangescript.php
+++ b/core/command/db/generatechangescript.php
@@ -45,7 +45,7 @@ class GenerateChangeScript extends Command {
 
 		$file = $input->getArgument('schema-xml');
 
-		$schemaManager = new \OC\DB\MDB2SchemaManager(\OC_DB::getConnection());
+		$schemaManager = new \OC\DB\MDB2SchemaManager(\OC::$server->getDatabaseConnection());
 
 		try {
 			$result = $schemaManager->updateDbFromStructure($file, true);

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -158,21 +158,6 @@ class OC_DB {
 	}
 
 	/**
-	 * gets last value of autoincrement
-	 * @param string $table The optional table name (will replace *PREFIX*) and add sequence suffix
-	 * @return string id
-	 * @throws \OC\DatabaseException
-	 *
-	 * \Doctrine\DBAL\Connection lastInsertId
-	 *
-	 * Call this method right after the insert command or other functions may
-	 * cause trouble!
-	 */
-	public static function insertid($table=null) {
-		return \OC::$server->getDatabaseConnection()->lastInsertId($table);
-	}
-
-	/**
 	 * saves database schema to xml file
 	 * @param string $file name of file
 	 * @param int $mode

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -263,15 +263,6 @@ class OC_DB {
 	}
 
 	/**
-	 * check if a result is an error, works with Doctrine
-	 * @param mixed $result
-	 * @return bool
-	 */
-	public static function isError($result) {
-		//Doctrine returns false on error (and throws an exception)
-		return $result === false;
-	}
-	/**
 	 * check if a result is an error and throws an exception, works with \Doctrine\DBAL\DBALException
 	 * @param mixed $result
 	 * @param string $message
@@ -279,20 +270,16 @@ class OC_DB {
 	 * @throws \OC\DatabaseException
 	 */
 	public static function raiseExceptionOnError($result, $message = null) {
-		if(self::isError($result)) {
+		if($result === false) {
 			if ($message === null) {
 				$message = self::getErrorMessage();
 			} else {
 				$message .= ', Root cause:' . self::getErrorMessage();
 			}
-			throw new \OC\DatabaseException($message, self::getErrorCode());
+			throw new \OC\DatabaseException($message, \OC::$server->getDatabaseConnection()->errorCode());
 		}
 	}
 
-	public static function getErrorCode() {
-		$connection = \OC::$server->getDatabaseConnection();
-		return $connection->errorCode();
-	}
 	/**
 	 * returns the error code and message as a string for logging
 	 * works with DoctrineException

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -36,13 +36,6 @@
 class OC_DB {
 
 	/**
-	 * @return \OCP\IDBConnection
-	 */
-	static public function getConnection() {
-		return \OC::$server->getDatabaseConnection();
-	}
-
-	/**
 	 * get MDB2 schema manager
 	 *
 	 * @return \OC\DB\MDB2SchemaManager

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -173,27 +173,6 @@ class OC_DB {
 	}
 
 	/**
-	 * Start a transaction
-	 */
-	public static function beginTransaction() {
-		return \OC::$server->getDatabaseConnection()->beginTransaction();
-	}
-
-	/**
-	 * Commit the database changes done during a transaction that is in progress
-	 */
-	public static function commit() {
-		return \OC::$server->getDatabaseConnection()->commit();
-	}
-
-	/**
-	 * Rollback the database changes done during a transaction that is in progress
-	 */
-	public static function rollback() {
-		return \OC::$server->getDatabaseConnection()->rollback();
-	}
-
-	/**
 	 * saves database schema to xml file
 	 * @param string $file name of file
 	 * @param int $mode

--- a/lib/private/db.php
+++ b/lib/private/db.php
@@ -254,15 +254,6 @@ class OC_DB {
 	}
 
 	/**
-	 * drop a table - the database prefix will be prepended
-	 * @param string $tableName the table to drop
-	 */
-	public static function dropTable($tableName) {
-		$connection = \OC::$server->getDatabaseConnection();
-		$connection->dropTable($tableName);
-	}
-
-	/**
 	 * remove all tables defined in a database structure xml file
 	 * @param string $file the xml file describing the tables
 	 */

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -336,7 +336,7 @@ class Scanner extends BasicEmitter {
 		$newChildren = $this->getNewChildren($path);
 
 		if ($this->useTransactions) {
-			\OC_DB::beginTransaction();
+			\OC::$server->getDatabaseConnection()->beginTransaction();
 		}
 		$exceptionOccurred = false;
 		foreach ($newChildren as $file) {
@@ -361,7 +361,7 @@ class Scanner extends BasicEmitter {
 				$exceptionOccurred = true;
 			} catch (\OCP\Lock\LockedException $e) {
 				if ($this->useTransactions) {
-					\OC_DB::rollback();
+					\OC::$server->getDatabaseConnection()->rollback();
 				}
 				throw $e;
 			}
@@ -372,7 +372,7 @@ class Scanner extends BasicEmitter {
 			$this->removeFromCache($child);
 		}
 		if ($this->useTransactions) {
-			\OC_DB::commit();
+			\OC::$server->getDatabaseConnection()->commit();
 		}
 		if ($exceptionOccurred) {
 			// It might happen that the parallel scan process has already

--- a/lib/private/files/cache/storage.php
+++ b/lib/private/files/cache/storage.php
@@ -58,10 +58,10 @@ class Storage {
 		if ($row = self::getStorageById($this->storageId)) {
 			$this->numericId = $row['numeric_id'];
 		} else {
-			$connection = \OC_DB::getConnection();
+			$connection = \OC::$server->getDatabaseConnection();
 			$available = $isAvailable ? 1 : 0;
 			if ($connection->insertIfNotExist('*PREFIX*storages', ['id' => $this->storageId, 'available' => $available])) {
-				$this->numericId = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*storages');
+				$this->numericId = $connection->lastInsertId('*PREFIX*storages');
 			} else {
 				if ($row = self::getStorageById($this->storageId)) {
 					$this->numericId = $row['numeric_id'];

--- a/lib/private/files/cache/storage.php
+++ b/lib/private/files/cache/storage.php
@@ -61,7 +61,7 @@ class Storage {
 			$connection = \OC_DB::getConnection();
 			$available = $isAvailable ? 1 : 0;
 			if ($connection->insertIfNotExist('*PREFIX*storages', ['id' => $this->storageId, 'available' => $available])) {
-				$this->numericId = \OC_DB::insertid('*PREFIX*storages');
+				$this->numericId = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*storages');
 			} else {
 				if ($row = self::getStorageById($this->storageId)) {
 					$this->numericId = $row['numeric_id'];

--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -136,10 +136,11 @@ class Repair extends BasicEmitter {
 	 * @return array of RepairStep instances
 	 */
 	public static function getBeforeUpgradeRepairSteps() {
+		$connection = \OC::$server->getDatabaseConnection();
 		$steps = [
 			new InnoDB(),
-			new Collation(\OC::$server->getConfig(), \OC_DB::getConnection()),
-			new SqliteAutoincrement(\OC_DB::getConnection()),
+			new Collation(\OC::$server->getConfig(), $connection),
+			new SqliteAutoincrement($connection),
 			new SearchLuceneTables(),
 		];
 

--- a/lib/private/repair/innodb.php
+++ b/lib/private/repair/innodb.php
@@ -37,7 +37,7 @@ class InnoDB extends BasicEmitter implements \OC\RepairStep {
 	 * Fix mime types
 	 */
 	public function run() {
-		$connection = \OC_DB::getConnection();
+		$connection = \OC::$server->getDatabaseConnection();
 		if (!$connection->getDatabasePlatform() instanceof MySqlPlatform) {
 			$this->emit('\OC\Repair', 'info', array('Not a mysql database -> nothing to do'));
 			return;

--- a/lib/private/repair/searchlucenetables.php
+++ b/lib/private/repair/searchlucenetables.php
@@ -52,10 +52,10 @@ class SearchLuceneTables extends BasicEmitter implements \OC\RepairStep {
 	 * search_lucene will then reindex the fileids without a status when the next indexing job is executed
 	 */
 	public function run() {
-		if (\OC_DB::tableExists('lucene_status')) {
+		$connection = \OC::$server->getDatabaseConnection();
+		if ($connection->tableExists('lucene_status')) {
 			$this->emit('\OC\Repair', 'info', array('removing duplicate entries from lucene_status'));
 
-			$connection = \OC_DB::getConnection();
 			$query = $connection->prepare('
 				DELETE FROM `*PREFIX*lucene_status`
 				WHERE `fileid` IN (

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -242,8 +242,8 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('SystemConfig', function ($c) use ($config) {
 			return new \OC\SystemConfig($config);
 		});
-		$this->registerService('AppConfig', function ($c) {
-			return new \OC\AppConfig(\OC_DB::getConnection());
+		$this->registerService('AppConfig', function (Server $c) {
+			return new \OC\AppConfig($c->getDatabaseConnection());
 		});
 		$this->registerService('L10NFactory', function ($c) {
 			return new \OC\L10N\Factory();

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -491,7 +491,7 @@ class Share extends Constants {
 	public static function getShareByToken($token, $checkPasswordProtection = true) {
 		$query = \OC_DB::prepare('SELECT * FROM `*PREFIX*share` WHERE `token` = ?', 1);
 		$result = $query->execute(array($token));
-		if (\OC_DB::isError($result)) {
+		if ($result === false) {
 			\OCP\Util::writeLog('OCP\Share', \OC_DB::getErrorMessage() . ', token=' . $token, \OCP\Util::ERROR);
 		}
 		$row = $result->fetchRow();
@@ -1722,7 +1722,7 @@ class Share extends Constants {
 		$root = strlen($root);
 		$query = \OC_DB::prepare('SELECT '.$select.' FROM `*PREFIX*share` '.$where, $queryLimit);
 		$result = $query->execute($queryArgs);
-		if (\OC_DB::isError($result)) {
+		if ($result === false) {
 			\OCP\Util::writeLog('OCP\Share',
 				\OC_DB::getErrorMessage() . ', select=' . $select . ' where=',
 				\OCP\Util::ERROR);
@@ -1786,7 +1786,7 @@ class Share extends Constants {
 				if (isset($row['parent'])) {
 					$query = \OC_DB::prepare('SELECT `file_target` FROM `*PREFIX*share` WHERE `id` = ?');
 					$parentResult = $query->execute(array($row['parent']));
-					if (\OC_DB::isError($result)) {
+					if ($result === false) {
 						\OCP\Util::writeLog('OCP\Share', 'Can\'t select parent: ' .
 							\OC_DB::getErrorMessage() . ', select=' . $select . ' where=' . $where,
 							\OCP\Util::ERROR);

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -2191,7 +2191,7 @@ class Share extends Constants {
 		if ($isGroupShare) {
 			$id = self::insertShare($queriesToExecute['groupShare']);
 			// Save this id, any extra rows for this group share will need to reference it
-			$parent = \OC_DB::insertid('*PREFIX*share');
+			$parent = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*share');
 			unset($queriesToExecute['groupShare']);
 		}
 

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -436,7 +436,7 @@ class Share extends Constants {
 
 				// TODO: inject connection, hopefully one day in the future when this
 				// class isn't static anymore...
-				$conn = \OC_DB::getConnection();
+				$conn = \OC::$server->getDatabaseConnection();
 				$result = $conn->executeQuery(
 					'SELECT ' . $select . ' FROM `*PREFIX*share` ' . $where,
 					$arguments,

--- a/lib/private/tags.php
+++ b/lib/private/tags.php
@@ -215,7 +215,7 @@ class Tags implements \OCP\ITags {
 		$entries = array();
 
 		try {
-			$conn = \OC_DB::getConnection();
+			$conn = \OC::$server->getDatabaseConnection();
 			$chunks = array_chunk($objIds, 900, false);
 			foreach ($chunks as $chunk) {
 				$result = $conn->executeQuery(

--- a/lib/private/user/database.php
+++ b/lib/private/user/database.php
@@ -210,7 +210,7 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 			$query = OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
 			$result = $query->execute(array($uid));
 
-			if (OC_DB::isError($result)) {
+			if ($result === false) {
 				\OCP\Util::writeLog('core', OC_DB::getErrorMessage(), \OCP\Util::ERROR);
 				return false;
 			}
@@ -287,7 +287,7 @@ class OC_User_Database extends OC_User_Backend implements \OCP\IUserBackend {
 	public function countUsers() {
 		$query = OC_DB::prepare('SELECT COUNT(*) FROM `*PREFIX*users`');
 		$result = $query->execute();
-		if (OC_DB::isError($result)) {
+		if ($result === false) {
 			\OCP\Util::writeLog('core', OC_DB::getErrorMessage(), \OCP\Util::ERROR);
 			return false;
 		}

--- a/tests/lib/app.php
+++ b/tests/lib/app.php
@@ -461,7 +461,7 @@ class Test_App extends \Test\TestCase {
 		$appConfig = $this->getMock(
 			'\OC\AppConfig',
 			array('getValues'),
-			array(\OC_DB::getConnection()),
+			array(\OC::$server->getDatabaseConnection()),
 			'',
 			false
 		);
@@ -488,8 +488,8 @@ class Test_App extends \Test\TestCase {
 	 * Restore the original app config service.
 	 */
 	private function restoreAppConfig() {
-		\OC::$server->registerService('AppConfig', function ($c) {
-			return new \OC\AppConfig(\OC_DB::getConnection());
+		\OC::$server->registerService('AppConfig', function (\OC\Server $c) {
+			return new \OC\AppConfig($c->getDatabaseConnection());
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) {
 			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(), $c->getGroupManager(), $c->getMemCacheFactory());

--- a/tests/lib/db.php
+++ b/tests/lib/db.php
@@ -111,11 +111,11 @@ class Test_DB extends \Test\TestCase {
 	public function testLastInsertId() {
 		$query = OC_DB::prepare('INSERT INTO `*PREFIX*'.$this->table2.'` (`fullname`,`uri`) VALUES (?,?)');
 		$result1 = OC_DB::executeAudited($query, array('insertid 1','uri_1'));
-		$id1 = OC_DB::insertid('*PREFIX*'.$this->table2);
+		$id1 = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*'.$this->table2);
 		
 		// we don't know the id we should expect, so insert another row
 		$result2 = OC_DB::executeAudited($query, array('insertid 2','uri_2'));
-		$id2 = OC_DB::insertid('*PREFIX*'.$this->table2);
+		$id2 = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*'.$this->table2);
 		// now we can check if the two ids are in correct order
 		$this->assertGreaterThan($id1, $id2);
 	}

--- a/tests/lib/db/connection.php
+++ b/tests/lib/db/connection.php
@@ -40,7 +40,7 @@ class Connection extends \Test\TestCase {
 	protected static function dropTestTable()
 	{
 		if (\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') !== 'oci') {
-			\OC_DB::dropTable('table');
+			\OC::$server->getDatabaseConnection()->dropTable('table');
 		}
 	}
 

--- a/tests/lib/db/mdb2schemamanager.php
+++ b/tests/lib/db/mdb2schemamanager.php
@@ -24,7 +24,7 @@ class MDB2SchemaManager extends \Test\TestCase {
 		// do not drop the table for Oracle as it will create a bogus transaction
 		// that will break the following test suites requiring transactions
 		if (\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') !== 'oci') {
-			\OC_DB::dropTable('table');
+			\OC::$server->getDatabaseConnection()->dropTable('table');
 		}
 
 		parent::tearDown();

--- a/tests/lib/db/mdb2schemamanager.php
+++ b/tests/lib/db/mdb2schemamanager.php
@@ -32,7 +32,7 @@ class MDB2SchemaManager extends \Test\TestCase {
 
 	public function testAutoIncrement() {
 
-		$connection = \OC_DB::getConnection();
+		$connection = \OC::$server->getDatabaseConnection();
 		if ($connection->getDatabasePlatform() instanceof OraclePlatform) {
 			$this->markTestSkipped('Adding auto increment columns in Oracle is not supported.');
 		}

--- a/tests/lib/db/migrator.php
+++ b/tests/lib/db/migrator.php
@@ -45,7 +45,7 @@ class Migrator extends \Test\TestCase {
 		parent::setUp();
 
 		$this->config = \OC::$server->getConfig();
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
 			$this->markTestSkipped('DB migration tests are not supported on OCI');
 		}

--- a/tests/lib/db/mysqlmigration.php
+++ b/tests/lib/db/mysqlmigration.php
@@ -22,7 +22,7 @@ class TestMySqlMigration extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform) {
 			$this->markTestSkipped("Test only relevant on MySql");
 		}

--- a/tests/lib/db/sqlitemigration.php
+++ b/tests/lib/db/sqlitemigration.php
@@ -22,7 +22,7 @@ class TestSqliteMigration extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
 			$this->markTestSkipped("Test only relevant on Sqlite");
 		}

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -51,7 +51,7 @@ class Test_DBSchema extends \Test\TestCase {
 	 * @medium
 	 */
 	public function testSchema() {
-		$platform = \OC_DB::getConnection()->getDatabasePlatform();
+		$platform = \OC::$server->getDatabaseConnection()->getDatabasePlatform();
 		$this->doTestSchemaCreating();
 		$this->doTestSchemaChanging();
 		$this->doTestSchemaDumping();
@@ -94,7 +94,7 @@ class Test_DBSchema extends \Test\TestCase {
 	 * @param string $table
 	 */
 	public function assertTableNotExist($table) {
-		$platform = \OC_DB::getConnection()->getDatabasePlatform();
+		$platform = \OC::$server->getDatabaseConnection()->getDatabasePlatform();
 		if ($platform instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
 			// sqlite removes the tables after closing the DB
 			$this->assertTrue(true);

--- a/tests/lib/repair/repaircollation.php
+++ b/tests/lib/repair/repaircollation.php
@@ -48,7 +48,7 @@ class TestRepairCollation extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->config = \OC::$server->getConfig();
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform) {
 			$this->markTestSkipped("Test only relevant on MySql");

--- a/tests/lib/repair/repairinnodb.php
+++ b/tests/lib/repair/repairinnodb.php
@@ -28,7 +28,7 @@ class RepairInnoDB extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform) {
 			$this->markTestSkipped("Test only relevant on MySql");
 		}

--- a/tests/lib/repair/repairlegacystorage.php
+++ b/tests/lib/repair/repairlegacystorage.php
@@ -99,7 +99,7 @@ class RepairLegacyStorages extends TestCase {
 		$numRows = $this->connection->executeUpdate($sql, array($storageId));
 		$this->assertEquals(1, $numRows);
 
-		return \OC_DB::insertid('*PREFIX*storages');
+		return \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*storages');
 	}
 
 	/**

--- a/tests/lib/repair/repairsqliteautoincrement.php
+++ b/tests/lib/repair/repairsqliteautoincrement.php
@@ -38,7 +38,7 @@ class RepairSqliteAutoincrement extends \Test\TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->connection = \OC_DB::getConnection();
+		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->config = \OC::$server->getConfig();
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
 			$this->markTestSkipped("Test only relevant on Sqlite");

--- a/tests/lib/tags.php
+++ b/tests/lib/tags.php
@@ -60,7 +60,7 @@ class Test_Tags extends \Test\TestCase {
 	}
 
 	protected function tearDown() {
-		$conn = \OC_DB::getConnection();
+		$conn = \OC::$server->getDatabaseConnection();
 		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory_to_object`');
 		$conn->executeQuery('DELETE FROM `*PREFIX*vcategory`');
 
@@ -199,7 +199,7 @@ class Test_Tags extends \Test\TestCase {
 		$tagId = $tagData[0]['id'];
 		$tagType = $tagData[0]['type'];
 
-		$conn = \OC_DB::getConnection();
+		$conn = \OC::$server->getDatabaseConnection();
 		$statement = $conn->prepare(
 				'INSERT INTO `*PREFIX*vcategory_to_object` ' .
 				'(`objid`, `categoryid`, `type`) VALUES ' .


### PR DESCRIPTION
cc @LukasReschke @nickvergessen @PVince81 @rullzer @Xenopathic @DeepDiver1975 

This mostly replaces the method calls with the encapsulated code.

It's quite easy to review if it is done per commit.
