### PR TITLE
change default sharing options to default to readonly

### DIFF
--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -226,6 +226,8 @@
 			// Default permissions are Edit (CRUD) and Share
 			// Check if these permissions are possible
 			var permissions = OC.PERMISSION_READ;
+			/* Default should be readonly shares
+			   TODO add config option for this
 			if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
 				permissions = OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_READ;
 			} else {
@@ -242,6 +244,7 @@
 					permissions = permissions | OC.PERMISSION_SHARE;
 				}
 			}
+			*/
 
 			var model = this;
 			var itemType = this.get('itemType');


### PR DESCRIPTION
change default sharing options to default to readonly.

for whatever reason this seems to be a [controversial issue](https://github.com/owncloud/core/issues/11707), so I am providing a patch that at least gives admins a way to change the behavior, if only by applying this patch.
