### PR TITLE
Issue 20218 min max owncloud version warning

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -6,7 +6,6 @@
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
 	<version>0.1.3</version>
-	<shipped>true</shipped>
 	<standalone/>
 	<default_enable/>
 	<types>

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -6,7 +6,6 @@
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
 	<version>0.1.3</version>
-	<requiremin>9.0</requiremin>
 	<shipped>true</shipped>
 	<standalone/>
 	<default_enable/>
@@ -21,4 +20,7 @@
 	<public>
 		<webdav>appinfo/v1/publicwebdav.php</webdav>
 	</public>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
 </info>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -14,7 +14,6 @@
 	<name>Default encryption module</name>
 	<license>AGPL</license>
 	<author>Bjoern Schiessle, Clark Tomlinson</author>
-	<shipped>true</shipped>
 	<documentation>
 		<user>user-encryption</user>
 		<admin>admin-encryption</admin>

--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -26,7 +26,7 @@
 	</types>
 	<dependencies>
 		<lib>openssl</lib>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 
 </info>

--- a/apps/federation/appinfo/info.xml
+++ b/apps/federation/appinfo/info.xml
@@ -8,7 +8,7 @@
     <version>0.0.1</version>
     <namespace>Federation</namespace>
     <category>other</category>
-    <dependencies>
-        <owncloud min-version="9.0" />
-    </dependencies>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
 </info>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -13,7 +13,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 	<documentation>
 		<user>user-files</user>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -5,7 +5,6 @@
 	<description>File Management</description>
 	<licence>AGPL</licence>
 	<author>Robin Appelman, Vincent Petry</author>
-	<shipped>true</shipped>
 	<standalone/>
 	<default_enable/>
 	<version>1.4.1</version>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -21,6 +21,6 @@
 	<ocsid>166048</ocsid>
 
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 </info>

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -9,7 +9,6 @@
 	</description>
 	<licence>AGPL</licence>
 	<author>Robin Appelman, Michael Gapczynski, Vincent Petry</author>
-	<shipped>true</shipped>
 	<documentation>
 		<admin>admin-external-storage</admin>
 	</documentation>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -16,7 +16,7 @@ Turning the feature off removes shared files and folders on the server for all s
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 	<public>
 		<files>public.php</files>

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -9,7 +9,6 @@ Turning the feature off removes shared files and folders on the server for all s
 	</description>
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
-	<shipped>true</shipped>
 	<default_enable/>
 	<version>0.8.1</version>
 	<types>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -9,7 +9,6 @@ To prevent a user from running out of disk space, the ownCloud Deleted files app
 	</description>
 	<licence>AGPL</licence>
 	<author>Bjoern Schiessle</author>
-	<shipped>true</shipped>
 	<default_enable/>
 	<version>0.8.0</version>
 	<types>

--- a/apps/files_trashbin/appinfo/info.xml
+++ b/apps/files_trashbin/appinfo/info.xml
@@ -16,7 +16,7 @@ To prevent a user from running out of disk space, the ownCloud Deleted files app
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 	<documentation>
 		<user>user-trashbin</user>

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -4,7 +4,6 @@
 	<name>Versions</name>
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek, Bjoern Schiessle</author>
-	<shipped>true</shipped>
 	<description>
 	This application enables ownCloud to automatically maintain older versions of files that are changed. When enabled, a hidden versions folder is provisioned in every user’s directory and is used to store old file versions. A user can revert to an older version through the web interface at any time, with the replaced file becoming a version. ownCloud then automatically manages the versions folder to ensure the user doesn’t run out of Quota because of versions.
 In addition to the expiry of versions, ownCloud’s versions app makes certain never to use more than 50% of the user’s currently available free space. If stored versions exceed this limit, ownCloud will delete the oldest versions first until it meets this limit. More information is available in the Versions documentation. 

--- a/apps/files_versions/appinfo/info.xml
+++ b/apps/files_versions/appinfo/info.xml
@@ -15,7 +15,7 @@ In addition to the expiry of versions, ownCloud’s versions app makes certain n
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 	<documentation>
 		<user>user-versions</user>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -24,6 +24,6 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 </info>

--- a/apps/provisioning_api/appinfo/info.xml
+++ b/apps/provisioning_api/appinfo/info.xml
@@ -13,7 +13,6 @@
 	</description>
 	<licence>AGPL</licence>
 	<author>Tom Needham</author>
-	<shipped>true</shipped>
 	<default_enable/>
 	<documentation>
 		<admin>admin-provisioning-api</admin>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -9,7 +9,6 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	</description>
 	<licence>AGPL</licence>
 	<author>Dominik Schmidt and Arthur Schiwon</author>
-	<shipped>true</shipped>
 	<version>0.8.0</version>
 	<types>
 		<authentication/>

--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -19,6 +19,6 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	</documentation>
 	<dependencies>
 		<lib>ldap</lib>
-		<owncloud min-version="9.0" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 </info>

--- a/core/command/app/checkcode.php
+++ b/core/command/app/checkcode.php
@@ -131,6 +131,10 @@ class CheckCode extends Command {
 				}
 			});
 
+			$infoChecker->listen('InfoChecker', 'missingRequirement', function($minMax) use ($output) {
+				$output->writeln("<comment>ownCloud $minMax version requirement missing (will be an error in ownCloud 11 and later)</comment>");
+			});
+
 			$infoChecker->listen('InfoChecker', 'duplicateRequirement', function($minMax) use ($output) {
 				$output->writeln("<error>Duplicate $minMax ownCloud version requirement found</error>");
 			});

--- a/lib/private/app/codechecker/infochecker.php
+++ b/lib/private/app/codechecker/infochecker.php
@@ -83,13 +83,18 @@ class InfoChecker extends BasicEmitter {
 				'type' => 'duplicateRequirement',
 				'field' => 'min',
 			];
+		} else if (!isset($info['dependencies']['owncloud']['@attributes']['min-version'])) {
+			$this->emit('InfoChecker', 'missingRequirement', ['min']);
 		}
+
 		if (isset($info['dependencies']['owncloud']['@attributes']['max-version']) && $info['requiremax']) {
 			$this->emit('InfoChecker', 'duplicateRequirement', ['max']);
 			$errors[] = [
 				'type' => 'duplicateRequirement',
 				'field' => 'max',
 			];
+		} else if (!isset($info['dependencies']['owncloud']['@attributes']['max-version'])) {
+			$this->emit('InfoChecker', 'missingRequirement', ['max']);
 		}
 
 		foreach ($info as $key => $value) {

--- a/settings/controller/appsettingscontroller.php
+++ b/settings/controller/appsettingscontroller.php
@@ -296,6 +296,9 @@ class AppSettingsController extends Controller {
 			$app['canInstall'] = empty($missing);
 			$app['missingDependencies'] = $missing;
 
+			$app['missingMinOwnCloudVersion'] = !isset($app['dependencies']['owncloud']['@attributes']['min-version']);
+			$app['missingMaxOwnCloudVersion'] = !isset($app['dependencies']['owncloud']['@attributes']['max-version']);
+
 			return $app;
 		}, $apps);
 

--- a/settings/templates/apps.php
+++ b/settings/templates/apps.php
@@ -97,6 +97,18 @@ script(
 	<div class="app-description-toggle-show"><?php p($l->t("Show description …"));?></div>
 	<div class="app-description-toggle-hide hidden"><?php p($l->t("Hide description …"));?></div>
 
+	{{#if missingMinOwnCloudVersion}}
+		<div class="app-dependencies">
+			<p><?php p($l->t('This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later.')); ?></p>
+		</div>
+	{{else}}
+		{{#if missingMaxOwnCloudVersion}}
+			<div class="app-dependencies">
+				<p><?php p($l->t('This app has no maximum ownCloud version assigned. This will be an error in ownCloud 11 and later.')); ?></p>
+			</div>
+		{{/if}}
+	{{/if}}
+
 	{{#unless canInstall}}
 	<div class="app-dependencies">
 	<p><?php p($l->t('This app cannot be installed because the following dependencies are not fulfilled:')); ?></p>


### PR DESCRIPTION
Fix #20218
1. Added warning in the UI
2. Added warning in the console check
3. Fixed the warning for shipped apps (in this repo)
4. Removed the deprecated shipped field from shipped apps.

For now it's a warning, app still passes the code-check and can be installed.
That is to be changed in ownCloud 11 as per the comments.
### occ app:check-code:

![app-check-code](https://cloud.githubusercontent.com/assets/213943/12172609/463db0e6-b552-11e5-8251-c4325bb8472d.png)
(minMax is replaced with either one, just took an old screenshot)
### app list

![app-list](https://cloud.githubusercontent.com/assets/213943/12172610/4b64b0a6-b552-11e5-97e9-c348b8cfb179.png)

@LukasReschke @DeepDiver1975 @karlitschek 
