### PR TITLE
Fix users list dropdown position after scroll

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -171,6 +171,11 @@ td.password>img,td.displayName>img, td.remove>a, td.quota>img { visibility:hidde
 td.password, td.quota, td.displayName { width:12em; cursor:pointer; }
 td.password>span, td.quota>span, rd.displayName>span { margin-right: 1.2em; color: #C7C7C7; }
 span.usersLastLoginTooltip { white-space: nowrap; }
+
+/* dropdowns will be relative to this element */
+#userlist {
+	position: relative;
+}
 #userlist .mailAddress,
 #userlist .storageLocation,
 #userlist .userBackend,


### PR DESCRIPTION
When scrolling, the position calculation of the multiselect dropdown was
wrong. Adding "position: relative" to the list container makes the
button calculation relative to it instead of the whole page. In this
case the dropdown is properly aligned with the field regardless of
scrolling.

Fixes https://github.com/owncloud/core/issues/20503

I only tested with Chromium and IE8, IE9.

Please review @MorrisJobke @icewind1991 @rullzer @jgrete @blizzz 

@karlitschek backport to OC down to 8.0 ?
