### PR TITLE
Keep scroll position in users page when sorting

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -259,6 +259,10 @@ var UserList = {
 		}
 	},
 	doSort: function() {
+		// some browsers like Chrome lose the scrolling information
+		// when messing with the list elements
+		var lastScrollTop = this.scrollArea.scrollTop();
+		var lastScrollLeft = this.scrollArea.scrollLeft();
 		var rows = $userListBody.find('tr').get();
 
 		rows.sort(function(a, b) {
@@ -284,6 +288,8 @@ var UserList = {
 		if(items.length > 0) {
 			$userListBody.append(items);
 		}
+		this.scrollArea.scrollTop(lastScrollTop);
+		this.scrollArea.scrollLeft(lastScrollLeft);
 	},
 	checkUsersToLoad: function() {
 		//30 shall be loaded initially, from then on always 10 upon scrolling
@@ -605,10 +611,11 @@ $(document).ready(function () {
 	// Implements User Search
 	OCA.Search.users= new UserManagementFilter(UserList, GroupList);
 
+	UserList.scrollArea = $('#app-content');
+
 	UserList.doSort();
 	UserList.availableGroups = $userList.data('groups');
 
-	UserList.scrollArea = $('#app-content');
 	UserList.scrollArea.scroll(function(e) {UserList._onScroll(e);});
 
 	$userList.after($('<div class="loading" style="height: 200px; visibility: hidden;"></div>'));


### PR DESCRIPTION
When sorting, some browsers like Chrome will lose the scroll position,
possibly because the sorting code is touching the DOM elements.

This fix saves the scroll position before sorting and sets it back
afterwards.

Fixes issues sometimes where the users page jumps back to the top after loading the second page or creating new users, in Chrome.

Please review @MorrisJobke @blizzz @icewind1991 @jancborchardt 
