### PR TITLE
Allow searching apps by ID

### DIFF
--- a/settings/js/apps.js
+++ b/settings/js/apps.js
@@ -422,6 +422,11 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			return app.name.toLowerCase().indexOf(query) !== -1;
 		});
 
+		// App ID
+		apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
+			return app.id.toLowerCase().indexOf(query) !== -1;
+		}));
+
 		// App Description
 		apps = apps.concat(_.filter(OC.Settings.Apps.State.apps, function (app) {
 			return app.description.toLowerCase().indexOf(query) !== -1;


### PR DESCRIPTION
Sometimes the app name is very different from the app ID and the logic behind it,
so it may be useful to add it to the search criteria as well. (e.g. `files_`)

@MorrisJobke @LukasReschke 
