### PR TITLE
propagate folder size in the same query for write updates

### DIFF
--- a/apps/files_sharing/lib/sharedpropagator.php
+++ b/apps/files_sharing/lib/sharedpropagator.php
@@ -32,12 +32,13 @@ class SharedPropagator extends Propagator {
 	/**
 	 * @param string $internalPath
 	 * @param int $time
-	 * @return array[] all propagated entries
+	 * @param int $sizeDifference
+	 * @return \array[] all propagated entries
 	 */
-	public function propagateChange($internalPath, $time) {
+	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
 		$source = $this->storage->getSourcePath($internalPath);
 		/** @var \OC\Files\Storage\Storage $storage */
 		list($storage, $sourceInternalPath) = \OC\Files\Filesystem::resolvePath($source);
-		return $storage->getPropagator()->propagateChange($sourceInternalPath, $time);
+		return $storage->getPropagator()->propagateChange($sourceInternalPath, $time, $sizeDifference);
 	}
 }

--- a/apps/files_sharing/lib/sharedstorage.php
+++ b/apps/files_sharing/lib/sharedstorage.php
@@ -609,7 +609,7 @@ class Shared extends \OC\Files\Storage\Common implements ISharedStorage {
 	 * @param string $path
 	 * @return array
 	 */
-	private function resolvePath($path) {
+	public function resolvePath($path) {
 		$source = $this->getSourcePath($path);
 		return \OC\Files\Filesystem::resolvePath($source);
 	}

--- a/lib/private/files/cache/propagator.php
+++ b/lib/private/files/cache/propagator.php
@@ -43,9 +43,10 @@ class Propagator implements IPropagator {
 	/**
 	 * @param string $internalPath
 	 * @param int $time
-	 * @return array[] all propagated cache entries
+	 * @param int $sizeDifference number of bytes the file has grown
+	 * @return array[] all propagated entries
 	 */
-	public function propagateChange($internalPath, $time) {
+	public function propagateChange($internalPath, $time, $sizeDifference = 0) {
 		$cache = $this->storage->getCache($internalPath);
 
 		$parentId = $cache->getParentId($internalPath);
@@ -58,7 +59,12 @@ class Propagator implements IPropagator {
 			}
 			$mtime = max($time, $entry['mtime']);
 
-			$cache->update($parentId, ['mtime' => $mtime, 'etag' => $this->storage->getETag($entry['path'])]);
+			if ($entry['size'] === -1) {
+				$newSize = -1;
+			} else {
+				$newSize = $entry['size'] + $sizeDifference;
+			}
+			$cache->update($parentId, ['mtime' => $mtime, 'etag' => $this->storage->getETag($entry['path']), 'size' => $newSize]);
 
 			$parentId = $entry['parent'];
 		}

--- a/lib/private/files/cache/scanner.php
+++ b/lib/private/files/cache/scanner.php
@@ -198,6 +198,7 @@ class Scanner extends BasicEmitter implements IScanner {
 				if (!empty($newData)) {
 					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 				}
+				$data['oldSize'] = $cacheData['size'];
 
 				// post-emit only if it was a file. By that we avoid counting/treating folders as files
 				if ($data['mimetype'] !== 'httpd/unix-directory') {

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -118,9 +118,15 @@ class Updater implements IUpdater {
 		}
 
 		$data = $this->scanner->scan($path, Scanner::SCAN_SHALLOW, -1, false);
+		if (isset($data['oldSize']) && isset($data['size'])) {
+			$sizeDifference = $data['size'] - $data['oldSize'];
+		} else {
+			// scanner didn't provide size info, fallback to full size calculation
+			$sizeDifference = 0;
+			$this->cache->correctFolderSize($path, $data);
+		}
 		$this->correctParentStorageMtime($path);
-		$this->cache->correctFolderSize($path, $data);
-		$this->propagator->propagateChange($path, $time);
+		$this->propagator->propagateChange($path, $time, $sizeDifference);
 	}
 
 	/**

--- a/tests/lib/cache/file.php
+++ b/tests/lib/cache/file.php
@@ -87,7 +87,9 @@ class FileCache extends \Test_Cache {
 	}
 
 	protected function tearDown() {
-		$this->instance->remove('hack', 'hack');
+		if ($this->instance) {
+			$this->instance->remove('hack', 'hack');
+		}
 
 		\OC_User::setUserId($this->user);
 		\OC::$server->getConfig()->setSystemValue('cachedirectory', $this->datadir);


### PR DESCRIPTION
By getting the difference in file size on a write we can let the propagator take care of updating folder sizes which saves a significant amount of queries and time on writes ([comparison](https://blackfire.io/profiles/compare/3c48577b-dde3-46e1-a177-ec088e741618/graph))

For now only write updates have this optimization, I'll look into deletes and moves later

cc @PVince81 @DeepDiver1975 
