### PR TITLE
-- Fixed error where $enabled is parsed but empty

### DIFF
--- a/lib/private/app/appmanager.php
+++ b/lib/private/app/appmanager.php
@@ -147,6 +147,10 @@ class AppManager implements IAppManager {
 		} elseif (is_null($user)) {
 			return false;
 		} else {
+                        if(empty($enabled)){
+                            return false;
+                        }
+                        
 			$groupIds = json_decode($enabled);
 
 			if (!is_array($groupIds)) {


### PR DESCRIPTION
The missing check if $enabled is empty caused spam in the ownCloud.log. This is fixed with this PR. The log entries looked like:

{"reqId":"RV\/n4CoB7Gx5GP1KtDHc","remoteAddr":"127.0.0.1","app":"lib","message":"AppManger::checkAppForUser - can't decode group IDs: 0 - json error code: 0","level":2,"time":"2016-01-07T18:16:08+00:00"}
