### PR TITLE
Remove all cache avatars on avatar deletion

### DIFF
--- a/lib/private/avatar.php
+++ b/lib/private/avatar.php
@@ -124,12 +124,14 @@ class Avatar implements \OCP\IAvatar {
 	 * @return void
 	*/
 	public function remove () {
-		try {
-			$this->folder->get('avatar.jpg')->delete();
-		} catch (\OCP\Files\NotFoundException $e) {}
-		try {
-			$this->folder->get('avatar.png')->delete();
-		} catch (\OCP\Files\NotFoundException $e) {}
+		$regex = '/^avatar\.([0-9]+\.)?(jpg|png)$/';
+		$avatars = $this->folder->search('avatar');
+
+		foreach ($avatars as $avatar) {
+			if (preg_match($regex, $avatar->getName())) {
+				$avatar->delete();
+			}
+		}
 	}
 
 	/**

--- a/tests/lib/avatartest.php
+++ b/tests/lib/avatartest.php
@@ -110,13 +110,29 @@ class AvatarTest extends \Test\TestCase {
 	}
 
 	public function testSetAvatar() {
-		$oldFile = $this->getMock('\OCP\Files\File');
-		$this->folder->method('get')
-			->will($this->returnValueMap([
-				['avatar.jpg', $oldFile],
-				['avatar.png', $oldFile],
-			]));
-		$oldFile->expects($this->exactly(2))->method('delete');
+		$avatarFileJPG = $this->getMock('\OCP\Files\File');
+		$avatarFileJPG->method('getName')
+			->willReturn('avatar.jpg');
+		$avatarFileJPG->expects($this->once())->method('delete');
+
+		$avatarFilePNG = $this->getMock('\OCP\Files\File');
+		$avatarFilePNG->method('getName')
+			->willReturn('avatar.png');
+		$avatarFilePNG->expects($this->once())->method('delete');
+
+		$resizedAvatarFile = $this->getMock('\OCP\Files\File');
+		$resizedAvatarFile->method('getName')
+			->willReturn('avatar.32.jpg');
+		$resizedAvatarFile->expects($this->once())->method('delete');
+
+		$nonAvatarFile = $this->getMock('\OCP\Files\File');
+		$nonAvatarFile->method('getName')
+			->willReturn('avatarX');
+		$nonAvatarFile->expects($this->never())->method('delete');
+
+		$this->folder->method('search')
+			->with('avatar')
+			->willReturn([$avatarFileJPG, $avatarFilePNG, $resizedAvatarFile, $nonAvatarFile]);
 
 		$newFile = $this->getMock('\OCP\Files\File');
 		$this->folder->expects($this->once())


### PR DESCRIPTION
Fixes #21513

Since we cache resized avatars now we have to make sure we delete all avatars on avatar deletion.
Easy to review. And easy to test using the steps from #21513 

CC: @davitol @PVince81 @MorrisJobke @nickvergessen @LukasReschke 
