### PR TITLE
Verify the path is a file on avatar update

### DIFF
--- a/core/avatar/avatarcontroller.php
+++ b/core/avatar/avatarcontroller.php
@@ -160,6 +160,9 @@ class AvatarController extends Controller {
 		if (isset($path)) {
 			$path = stripslashes($path);
 			$node = $this->userFolder->get($path);
+			if (!($node instanceof \OCP\Files\File)) {
+				return new DataResponse(['data' => ['message' => $this->l->t('Please select a file.')]], Http::STATUS_OK, $headers);
+			}
 			if ($node->getSize() > 20*1024*1024) {
 				return new DataResponse(
 					['data' => ['message' => $this->l->t('File is too big')]],

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -17,7 +17,7 @@ input#openid, input#webdav { width:20em; }
 	margin-bottom: 10px;
 }
 #avatar .warning {
-	width: 350px;
+	width: 100%;
 }
 #uploadavatarbutton,
 #selectavatar,

--- a/tests/core/avatar/avatarcontrollertest.php
+++ b/tests/core/avatar/avatarcontrollertest.php
@@ -324,6 +324,23 @@ class AvatarControllerTest extends \Test\TestCase {
 	}
 
 	/**
+	 * Test posting avatar from existing folder
+	 */
+	public function testPostAvatarFromNoFile() {
+		$file = $this->getMock('OCP\Files\Node');
+		$this->container['UserFolder']
+			->method('get')
+			->with('folder')
+			->willReturn($file);
+
+		//Create request return
+		$response = $this->avatarController->postAvatar('folder');
+
+		//On correct upload always respond with the notsquare message
+		$this->assertEquals(['data' => ['message' => 'Please select a file.']], $response->getData());
+	}
+
+	/**
 	 * Test what happens if the upload of the avatar fails
 	 */
 	public function testPostAvatarException() {


### PR DESCRIPTION
Fixes #21533

Before we just assumed that the passed path was a file. This does not
have to be the case. Thus check if it actually is a file before doing
any more tests.

Added a unit test.

Please verify @davitol 

CC: @PVince81 @nickvergessen @MorrisJobke 
