### PR TITLE
[stable8.2] Fixed double file upload on failed auth using WebDAV

### DIFF
--- a/lib/private/connector/sabre/auth.php
+++ b/lib/private/connector/sabre/auth.php
@@ -142,7 +142,10 @@ class Auth extends AbstractBasic {
 	 */
 	private function auth(\Sabre\DAV\Server $server, $realm) {
 		if (\OC_User::handleApacheAuth() ||
-			(\OC_User::isLoggedIn() && is_null(\OC::$server->getSession()->get(self::DAV_AUTHENTICATED)))
+			//Fix for broken webdav clients
+			(\OC_User::isLoggedIn() && is_null(\OC::$server->getSession()->get(self::DAV_AUTHENTICATED))) ||
+			//Well behaved clients that only send the cookie are allowed
+			(\OC_User::isLoggedIn() && \OC::$server->getSession()->get(self::DAV_AUTHENTICATED) === \OC_User::getUser())
 		) {
 			$user = \OC_User::getUser();
 			\OC_Util::setupFS($user);


### PR DESCRIPTION
Backport of this fix: https://github.com/owncloud/core/pull/21491
Fixes https://github.com/owncloud/core/issues/21486

/cc @rullzer @guruz @PVince81 please check whether my fix is correct. I've tested it and here is the result:

```
123.123.123.123 - - [08/Jan/2016:11:47:10 +0100] "PROPFIND /remote.php/webdav/BigFiles/ HTTP/1.1" 401 253 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - user [08/Jan/2016:11:47:10 +0100] "PROPFIND /remote.php/webdav/BigFiles/ HTTP/1.1" 207 596 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:11 +0100] "PROPFIND /remote.php/webdav/BigFiles/ HTTP/1.1" 207 2913 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:22 +0100] "PROPFIND /remote.php/webdav/BigFiles/files/big.file.tacitpart HTTP/1.1" 404 6301 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:27 +0100] "PUT /remote.php/webdav/BigFiles/files/big.file.tacitpart HTTP/1.1" 201 25 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:28 +0100] "PROPFIND /remote.php/webdav/BigFiles/files/big.file.tacitpart HTTP/1.1" 207 665 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:29 +0100] "MOVE /remote.php/webdav/BigFiles/files/big.file.tacitpart HTTP/1.1" 201 0 "-" "android-cloud-api - Android 4.4.2"
123.123.123.123 - - [08/Jan/2016:11:47:29 +0100] "PROPFIND /remote.php/webdav/BigFiles/files/big.file HTTP/1.1" 207 640 "-" "android-cloud-api - Android 4.4.2"
```
