### PR TITLE
Add integrity protection using Encrypt-Then-MAC to default encryption module

### DIFF
--- a/apps/encryption/appinfo/application.php
+++ b/apps/encryption/appinfo/application.php
@@ -131,7 +131,8 @@ class Application extends \OCP\AppFramework\App {
 				$server = $c->getServer();
 				return new Crypt($server->getLogger(),
 					$server->getUserSession(),
-					$server->getConfig());
+					$server->getConfig(),
+					$server->getL10N($c->getAppName()));
 			});
 
 		$container->registerService('Session',

--- a/apps/encryption/appinfo/register_command.php
+++ b/apps/encryption/appinfo/register_command.php
@@ -25,11 +25,12 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 $userManager = OC::$server->getUserManager();
 $view = new \OC\Files\View();
 $config = \OC::$server->getConfig();
+$l = \OC::$server->getL10N('encryption');
 $userSession = \OC::$server->getUserSession();
 $connection = \OC::$server->getDatabaseConnection();
 $logger = \OC::$server->getLogger();
 $questionHelper = new QuestionHelper();
-$crypt = new \OCA\Encryption\Crypto\Crypt($logger, $userSession, $config);
+$crypt = new \OCA\Encryption\Crypto\Crypt($logger, $userSession, $config, $l);
 $util = new \OCA\Encryption\Util($view, $crypt, $logger, $userSession, $config, $userManager);
 
 $application->add(new MigrateKeys($userManager, $view, $connection, $config, $logger));

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -462,7 +462,7 @@ class Crypt {
 	 */
 	private function checkSignature($data, $passPhrase, $expectedSignature) {
 		$signature = $this->createSignature($data, $passPhrase);
-		if (hash_equals($expectedSignature, $signature)) {
+		if (!hash_equals($expectedSignature, $signature)) {
 			throw new HintException('Bad Signature', $this->l->t('Bad Signature'));
 		}
 	}
@@ -517,7 +517,7 @@ class Crypt {
 			$meta = substr($catFile, -22);
 			$iv = substr($meta, -16);
 			$sig = false;
-			$encrypted = substr($catFile, 0, -93);
+			$encrypted = substr($catFile, 0, -22);
 		}
 
 		return [

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -475,6 +475,7 @@ class Crypt {
 	 * @return string
 	 */
 	private function createSignature($data, $passPhrase) {
+		$passPhrase = hash('sha512', $passPhrase . 'a', true);
 		$signature = hash_hmac('sha256', $data, $passPhrase);
 		return $signature;
 	}
@@ -607,14 +608,14 @@ class Crypt {
 	}
 
 	/**
-	 * Generate a cryptographically secure pseudo-random base64 encoded 256-bit
-	 * ASCII key, used as file key
+	 * Generate a cryptographically secure pseudo-random 256-bit ASCII key, used
+	 * as file key
 	 *
 	 * @return string
 	 * @throws \Exception
 	 */
 	public function generateFileKey() {
-		return base64_encode(random_bytes(32));
+		return random_bytes(32);
 	}
 
 	/**

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -48,6 +48,8 @@ use OCP\IUserSession;
  * - AES-256-CFB
  * - AES-128-CFB
  *
+ * For integrity protection Encrypt-Then-MAC using HMAC-SHA256 is used.
+ *
  * @package OCA\Encryption\Crypto
  */
 class Crypt {

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -614,14 +614,7 @@ class Crypt {
 	 * @throws \Exception
 	 */
 	public function generateFileKey() {
-		// Generate key
-		$key = base64_encode(openssl_random_pseudo_bytes(32, $strong));
-		if (!$key || !$strong) {
-				// If OpenSSL indicates randomness is insecure, log error
-				throw new \Exception('Encryption library, Insecure symmetric key was generated using openssl_random_pseudo_bytes()');
-		}
-
-		return $key;
+		return base64_encode(random_bytes(32));
 	}
 
 	/**

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -536,7 +536,7 @@ class Crypt {
 	 * @throws HintException
 	 */
 	private function hasSignature($catFile, $cipher) {
-		$meta = substr($catFile, 93);
+		$meta = substr($catFile, -93);
 		$signaturePosition = strpos($meta, '00sig00');
 
 		// enforce signature for the new 'CTR' ciphers

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -170,10 +170,11 @@ class Crypt {
 	 * @param string $plainContent
 	 * @param string $passPhrase
 	 * @param int $version
+	 * @param int $position
 	 * @return false|string
 	 * @throws EncryptionFailedException
 	 */
-	public function symmetricEncryptFileContent($plainContent, $passPhrase, $version) {
+	public function symmetricEncryptFileContent($plainContent, $passPhrase, $version, $position) {
 
 		if (!$plainContent) {
 			$this->logger->error('Encryption Library, symmetrical encryption failed no content given',
@@ -189,7 +190,7 @@ class Crypt {
 			$this->getCipher());
 
 		// Create a signature based on the key as well as the current version
-		$sig = $this->createSignature($encryptedContent, $passPhrase.$version);
+		$sig = $this->createSignature($encryptedContent, $passPhrase.$version.$position);
 
 		// combine content to encrypt the IV identifier and actual IV
 		$catFile = $this->concatIV($encryptedContent, $iv);
@@ -368,6 +369,7 @@ class Crypt {
 		$encryptedKey = $this->symmetricEncryptFileContent(
 			$privateKey,
 			$hash,
+			0,
 			0
 		);
 
@@ -444,14 +446,15 @@ class Crypt {
 	 * @param string $passPhrase
 	 * @param string $cipher
 	 * @param int $version
+	 * @param int $position
 	 * @return string
 	 * @throws DecryptionFailedException
 	 */
-	public function symmetricDecryptFileContent($keyFileContents, $passPhrase, $cipher = self::DEFAULT_CIPHER, $version = 0) {
+	public function symmetricDecryptFileContent($keyFileContents, $passPhrase, $cipher = self::DEFAULT_CIPHER, $version = 0, $position = 0) {
 		$catFile = $this->splitMetaData($keyFileContents, $cipher);
 
 		if ($catFile['signature'] !== false) {
-			$this->checkSignature($catFile['encrypted'], $passPhrase.$version, $catFile['signature']);
+			$this->checkSignature($catFile['encrypted'], $passPhrase.$version.$position, $catFile['signature']);
 		}
 
 		return $this->decrypt($catFile['encrypted'],

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -288,6 +288,10 @@ class Crypt {
 	}
 
 	/**
+	 * Note: This is _NOT_ a padding used for encryption purposes. It is solely
+	 * used to achieve the PHP stream size. It has _NOTHING_ to do with the
+	 * encrypted content and is not used in any crypto primitive.
+	 *
 	 * @param string $data
 	 * @return string
 	 */

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -442,7 +442,7 @@ class Crypt {
 
 		$catFile = $this->splitMetaData($keyFileContents, $cipher);
 
-		if ($catFile['signature']) {
+		if ($catFile['signature'] !== false) {
 			$this->checkSignature($catFile['encrypted'], $passPhrase, $catFile['signature']);
 		}
 

--- a/apps/encryption/lib/crypto/crypt.php
+++ b/apps/encryption/lib/crypto/crypt.php
@@ -156,7 +156,7 @@ class Crypt {
 	 * @param string $plainContent
 	 * @param string $passPhrase
 	 * @return false|string
-	 * @throws GenericEncryptionException
+	 * @throws EncryptionFailedException
 	 */
 	public function symmetricEncryptFileContent($plainContent, $passPhrase) {
 
@@ -512,22 +512,7 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function generateIv() {
-		$random = openssl_random_pseudo_bytes(12, $strong);
-		if ($random) {
-			if (!$strong) {
-				// If OpenSSL indicates randomness is insecure log error
-				$this->logger->error('Encryption Library: Insecure symmetric key was generated using openssl_random_psudo_bytes()',
-					['app' => 'encryption']);
-			}
-
-			/*
-			 * We encode the iv purely for string manipulation
-			 * purposes -it gets decoded before use
-			 */
-			return base64_encode($random);
-		}
-		// If we ever get here we've failed anyway no need for an else
-		throw new GenericEncryptionException('Generating IV Failed');
+		return random_bytes(16);
 	}
 
 	/**

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -94,8 +94,12 @@ class Encryption implements IEncryptionModule {
 	/** @var DecryptAll  */
 	private $decryptAll;
 
+	/** @var int unencrypted block size if block contains signature */
+	private $unencryptedBlockSizeSigned = 6072;
+
 	/** @var int unencrypted block size */
-	private $unencryptedBlockSize = 6072;
+	private $unencryptedBlockSize = 6126;
+
 
 	/**
 	 *
@@ -198,7 +202,7 @@ class Encryption implements IEncryptionModule {
 			$this->cipher = $this->crypt->getLegacyCipher();
 		}
 
-		return array('cipher' => $this->cipher);
+		return array('cipher' => $this->cipher, 'signed' => 'true');
 	}
 
 	/**
@@ -278,7 +282,7 @@ class Encryption implements IEncryptionModule {
 
 			// If data remaining to be written is less than the
 			// size of 1 6126 byte block
-			if ($remainingLength < $this->unencryptedBlockSize) {
+			if ($remainingLength < $this->unencryptedBlockSizeSigned) {
 
 				// Set writeCache to contents of $data
 				// The writeCache will be carried over to the
@@ -296,14 +300,14 @@ class Encryption implements IEncryptionModule {
 			} else {
 
 				// Read the chunk from the start of $data
-				$chunk = substr($data, 0, $this->unencryptedBlockSize);
+				$chunk = substr($data, 0, $this->unencryptedBlockSizeSigned);
 
 				$encrypted .= $this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey);
 
 				// Remove the chunk we just processed from
 				// $data, leaving only unprocessed data in $data
 				// var, for handling on the next round
-				$data = substr($data, $this->unencryptedBlockSize);
+				$data = substr($data, $this->unencryptedBlockSizeSigned);
 
 			}
 
@@ -410,10 +414,15 @@ class Encryption implements IEncryptionModule {
 	 * get size of the unencrypted payload per block.
 	 * ownCloud read/write files with a block size of 8192 byte
 	 *
-	 * @return integer
+	 * @param bool $signed
+	 * @return int
 	 */
-	public function getUnencryptedBlockSize() {
-		return $this->unencryptedBlockSize;
+	public function getUnencryptedBlockSize($signed = false) {
+		if ($signed === false) {
+			return $this->unencryptedBlockSize;
+		}
+
+		return $this->unencryptedBlockSizeSigned;
 	}
 
 	/**

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -29,6 +29,7 @@ namespace OCA\Encryption\Crypto;
 
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
+use OC\Files\View;
 use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use OCA\Encryption\Session;
 use OCA\Encryption\Util;
@@ -186,7 +187,7 @@ class Encryption implements IEncryptionModule {
 			$this->fileKey = $this->keyManager->getFileKey($this->path, $this->user);
 		}
 
-		$this->version = (int)$this->keyManager->getVersion($this->realPath);
+		$this->version = (int)$this->keyManager->getVersion($this->realPath, new View());
 
 		if (
 			$mode === 'w'
@@ -235,7 +236,7 @@ class Encryption implements IEncryptionModule {
 			} else {
 				$version = $this->version + 1;
 			}
-			$this->keyManager->setVersion($this->path, $this->version+1);
+			$this->keyManager->setVersion($this->path, $this->version+1, new View());
 			if (!empty($this->writeCache)) {
 				$result = $this->crypt->symmetricEncryptFileContent($this->writeCache, $this->fileKey, $version, $position);
 				$this->writeCache = '';
@@ -371,7 +372,7 @@ class Encryption implements IEncryptionModule {
 		if(empty($this->realPath)) {
 			$this->realPath = $path;
 		}
-		$version = $this->keyManager->getVersion($this->realPath);
+		$version = $this->keyManager->getVersion($this->realPath, new View());
 
 		if (!empty($fileKey)) {
 
@@ -392,7 +393,7 @@ class Encryption implements IEncryptionModule {
 
 			$this->keyManager->setAllFileKeys($path, $encryptedFileKey);
 
-			$this->keyManager->setVersion($path, $version);
+			$this->keyManager->setVersion($path, $version, new View());
 
 		} else {
 			$this->logger->debug('no file key found, we assume that the file "{file}" is not encrypted',

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -94,6 +94,9 @@ class Encryption implements IEncryptionModule {
 	/** @var DecryptAll  */
 	private $decryptAll;
 
+	/** @var int unencrypted block size */
+	private $unencryptedBlockSize = 6072;
+
 	/**
 	 *
 	 * @param Crypt $crypt
@@ -253,7 +256,7 @@ class Encryption implements IEncryptionModule {
 	public function encrypt($data) {
 
 		// If extra data is left over from the last round, make sure it
-		// is integrated into the next 6126 / 8192 block
+		// is integrated into the next block
 		if ($this->writeCache) {
 
 			// Concat writeCache to start of $data
@@ -275,7 +278,7 @@ class Encryption implements IEncryptionModule {
 
 			// If data remaining to be written is less than the
 			// size of 1 6126 byte block
-			if ($remainingLength < 6126) {
+			if ($remainingLength < $this->unencryptedBlockSize) {
 
 				// Set writeCache to contents of $data
 				// The writeCache will be carried over to the
@@ -293,14 +296,14 @@ class Encryption implements IEncryptionModule {
 			} else {
 
 				// Read the chunk from the start of $data
-				$chunk = substr($data, 0, 6126);
+				$chunk = substr($data, 0, $this->unencryptedBlockSize);
 
 				$encrypted .= $this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey);
 
 				// Remove the chunk we just processed from
 				// $data, leaving only unprocessed data in $data
 				// var, for handling on the next round
-				$data = substr($data, 6126);
+				$data = substr($data, $this->unencryptedBlockSize);
 
 			}
 
@@ -410,7 +413,7 @@ class Encryption implements IEncryptionModule {
 	 * @return integer
 	 */
 	public function getUnencryptedBlockSize() {
-		return 6126;
+		return $this->unencryptedBlockSize;
 	}
 
 	/**

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -231,11 +231,13 @@ class Encryption implements IEncryptionModule {
 		if ($this->isWriteOperation) {
 			// Partial files do not increase the version
 			if(\OC\Files\Cache\Scanner::isPartialFile($path)) {
-				$this->version = $this->version-1;
+				$version = $this->version;
+			} else {
+				$version = $this->version + 1;
 			}
 			$this->keyManager->setVersion($this->path, $this->version+1);
 			if (!empty($this->writeCache)) {
-				$result = $this->crypt->symmetricEncryptFileContent($this->writeCache, $this->fileKey, $this->version+1, $position);
+				$result = $this->crypt->symmetricEncryptFileContent($this->writeCache, $this->fileKey, $version, $position);
 				$this->writeCache = '';
 			}
 			$publicKeys = array();
@@ -318,9 +320,11 @@ class Encryption implements IEncryptionModule {
 
 				// Partial files do not increase the version
 				if(\OC\Files\Cache\Scanner::isPartialFile($this->path)) {
-					$this->version = $this->version - 1;
+					$version = $this->version;
+				} else {
+					$version = $this->version + 1;
 				}
-				$encrypted .= $this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey, $this->version+1, $position);
+				$encrypted .= $this->crypt->symmetricEncryptFileContent($chunk, $this->fileKey, $version, $position);
 
 				// Remove the chunk we just processed from
 				// $data, leaving only unprocessed data in $data

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -192,10 +192,10 @@ class Encryption implements IEncryptionModule {
 			}
 		}
 
-		if (isset($header['cipher'])) {
-			$this->cipher = $header['cipher'];
-		} elseif ($this->isWriteOperation) {
+		if ($this->isWriteOperation) {
 			$this->cipher = $this->crypt->getCipher();
+		} elseif (isset($header['cipher'])) {
+			$this->cipher = $header['cipher'];
 		} else {
 			// if we read a file without a header we fall-back to the legacy cipher
 			// which was used in <=oC6

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -170,7 +170,7 @@ class Encryption implements IEncryptionModule {
 	 */
 	public function begin($path, $user, $mode, array $header, array $accessList) {
 		$this->path = $this->getPathToRealFile($path);
-		$this->realPath = $this->path;
+		$this->realPath = $path;
 		$this->accessList = $accessList;
 		$this->user = $user;
 		$this->isWriteOperation = false;

--- a/apps/encryption/lib/crypto/encryption.php
+++ b/apps/encryption/lib/crypto/encryption.php
@@ -56,6 +56,9 @@ class Encryption implements IEncryptionModule {
 	private $path;
 
 	/** @var string */
+	private $realPath;
+
+	/** @var string */
 	private $user;
 
 	/** @var string */
@@ -167,6 +170,7 @@ class Encryption implements IEncryptionModule {
 	 */
 	public function begin($path, $user, $mode, array $header, array $accessList) {
 		$this->path = $this->getPathToRealFile($path);
+		$this->realPath = $this->path;
 		$this->accessList = $accessList;
 		$this->user = $user;
 		$this->isWriteOperation = false;
@@ -182,7 +186,7 @@ class Encryption implements IEncryptionModule {
 			$this->fileKey = $this->keyManager->getFileKey($this->path, $this->user);
 		}
 
-		$this->version = (int)$this->keyManager->getVersion($this->path);
+		$this->version = (int)$this->keyManager->getVersion($this->realPath);
 
 		if (
 			$mode === 'w'
@@ -360,7 +364,10 @@ class Encryption implements IEncryptionModule {
 	 */
 	public function update($path, $uid, array $accessList) {
 		$fileKey = $this->keyManager->getFileKey($path, $uid);
-		$version = $this->keyManager->getVersion($path);
+		if(empty($this->realPath)) {
+			$this->realPath = $path;
+		}
+		$version = $this->keyManager->getVersion($this->realPath);
 
 		if (!empty($fileKey)) {
 

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -413,6 +413,24 @@ class KeyManager {
 	}
 
 	/**
+	 * Get the current version of a file
+	 *
+	 * @param string $path
+	 * @return mixed
+	 */
+	public function getVersion($path) {
+		return $this->keyStorage->getFileKey($path, 'version', Encryption::ID);
+	}
+
+	/**
+	 * @param string $path
+	 * @param string $version
+	 */
+	public function setVersion($path, $version) {
+		$this->keyStorage->setFileKey($path, 'version', $version, Encryption::ID);
+	}
+
+	/**
 	 * get the encrypted file key
 	 *
 	 * @param string $path
@@ -546,6 +564,7 @@ class KeyManager {
 
 	/**
 	 * @param string $path
+	 * @return bool
 	 */
 	public function deleteAllFileKeys($path) {
 		return $this->keyStorage->deleteAllFileKeys($path);

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -441,7 +441,7 @@ class KeyManager {
 
 		if($fileInfo !== false) {
 			$cache = $fileInfo->getStorage()->getCache();
-			$cache->put($path, ['fileid' => $fileInfo->getId(), 'encrypted' => $version, 'encryptedVersion' => $version]);
+			$cache->update($fileInfo->getId(), ['encrypted' => $version, 'encryptedVersion' => $version]);
 		}
 	}
 

--- a/apps/encryption/lib/keymanager.php
+++ b/apps/encryption/lib/keymanager.php
@@ -418,10 +418,10 @@ class KeyManager {
 	 * Get the current version of a file
 	 *
 	 * @param string $path
+	 * @param View $view
 	 * @return int
 	 */
-	public function getVersion($path) {
-		$view = new \OC\Files\View();
+	public function getVersion($path, View $view) {
 		$fileInfo = $view->getFileInfo($path);
 		if($fileInfo === false) {
 			return 0;
@@ -433,19 +433,15 @@ class KeyManager {
 	 * Set the current version of a file
 	 *
 	 * @param string $path
-	 * @param string $version
+	 * @param int $version
+	 * @param View $view
 	 */
-	public function setVersion($path, $version) {
-		$view = new \OC\Files\View();
+	public function setVersion($path, $version, View $view) {
 		$fileInfo= $view->getFileInfo($path);
 
 		if($fileInfo !== false) {
-			$fileId = $fileInfo->getId();
-			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-			$qb->update('filecache')
-				->set('encrypted', $qb->createNamedParameter($version))
-				->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)))
-				->execute();
+			$cache = $fileInfo->getStorage()->getCache();
+			$cache->put($path, ['fileid' => $fileInfo->getId(), 'encrypted' => $version, 'encryptedVersion' => $version]);
 		}
 	}
 

--- a/apps/encryption/settings/settings-admin.php
+++ b/apps/encryption/settings/settings-admin.php
@@ -29,7 +29,8 @@ $tmpl = new OCP\Template('encryption', 'settings-admin');
 $crypt = new \OCA\Encryption\Crypto\Crypt(
 	\OC::$server->getLogger(),
 	\OC::$server->getUserSession(),
-	\OC::$server->getConfig());
+	\OC::$server->getConfig(),
+	\OC::$server->getL10N('encryption'));
 
 $util = new \OCA\Encryption\Util(
 	new \OC\Files\View(),

--- a/apps/encryption/settings/settings-personal.php
+++ b/apps/encryption/settings/settings-personal.php
@@ -28,7 +28,8 @@ $template = new OCP\Template('encryption', 'settings-personal');
 $crypt = new \OCA\Encryption\Crypto\Crypt(
 	\OC::$server->getLogger(),
 	$userSession,
-	\OC::$server->getConfig());
+	\OC::$server->getConfig(),
+	\OC::$server->getL10N('encryption'));
 
 $util = new \OCA\Encryption\Util(
 	new \OC\Files\View(),

--- a/apps/encryption/tests/lib/KeyManagerTest.php
+++ b/apps/encryption/tests/lib/KeyManagerTest.php
@@ -606,4 +606,44 @@ class KeyManagerTest extends TestCase {
 		$this->assertSame(1337, $this->instance->getVersion('/admin/files/myfile.txt', $view));
 	}
 
+	public function testSetVersionWithFileInfo() {
+		$view = $this->getMockBuilder('\\OC\\Files\\View')
+			->disableOriginalConstructor()->getMock();
+		$cache = $this->getMockBuilder('\\OCP\\Files\\Cache\\ICache')
+			->disableOriginalConstructor()->getMock();
+		$cache->expects($this->once())
+			->method('update')
+			->with(123, ['encrypted' => 5, 'encryptedVersion' => 5]);
+		$storage = $this->getMockBuilder('\\OCP\\Files\\Storage')
+			->disableOriginalConstructor()->getMock();
+		$storage->expects($this->once())
+			->method('getCache')
+			->willReturn($cache);
+		$fileInfo = $this->getMockBuilder('\\OC\\Files\\FileInfo')
+			->disableOriginalConstructor()->getMock();
+		$fileInfo->expects($this->once())
+			->method('getStorage')
+			->willReturn($storage);
+		$fileInfo->expects($this->once())
+			->method('getId')
+			->willReturn(123);
+		$view->expects($this->once())
+			->method('getFileInfo')
+			->with('/admin/files/myfile.txt')
+			->willReturn($fileInfo);
+
+		$this->instance->setVersion('/admin/files/myfile.txt', 5, $view);
+	}
+
+	public function testSetVersionWithoutFileInfo() {
+		$view = $this->getMockBuilder('\\OC\\Files\\View')
+			->disableOriginalConstructor()->getMock();
+		$view->expects($this->once())
+			->method('getFileInfo')
+			->with('/admin/files/myfile.txt')
+			->willReturn(false);
+
+		$this->instance->setVersion('/admin/files/myfile.txt', 5, $view);
+	}
+
 }

--- a/apps/encryption/tests/lib/KeyManagerTest.php
+++ b/apps/encryption/tests/lib/KeyManagerTest.php
@@ -579,4 +579,31 @@ class KeyManagerTest extends TestCase {
 		];
 	}
 
+	public function testGetVersionWithoutFileInfo() {
+		$view = $this->getMockBuilder('\\OC\\Files\\View')
+			->disableOriginalConstructor()->getMock();
+		$view->expects($this->once())
+			->method('getFileInfo')
+			->with('/admin/files/myfile.txt')
+			->willReturn(false);
+
+		$this->assertSame(0, $this->instance->getVersion('/admin/files/myfile.txt', $view));
+	}
+
+	public function testGetVersionWithFileInfo() {
+		$view = $this->getMockBuilder('\\OC\\Files\\View')
+			->disableOriginalConstructor()->getMock();
+		$fileInfo = $this->getMockBuilder('\\OC\\Files\\FileInfo')
+			->disableOriginalConstructor()->getMock();
+		$fileInfo->expects($this->once())
+			->method('getEncryptedVersion')
+			->willReturn(1337);
+		$view->expects($this->once())
+			->method('getFileInfo')
+			->with('/admin/files/myfile.txt')
+			->willReturn($fileInfo);
+
+		$this->assertSame(1337, $this->instance->getVersion('/admin/files/myfile.txt', $view));
+	}
+
 }

--- a/apps/encryption/tests/lib/crypto/cryptTest.php
+++ b/apps/encryption/tests/lib/crypto/cryptTest.php
@@ -39,6 +39,10 @@ class cryptTest extends TestCase {
 	/** @var \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	private $l;
+
 	/** @var  Crypt */
 	private $crypt;
 
@@ -57,8 +61,9 @@ class cryptTest extends TestCase {
 		$this->config = $this->getMockBuilder('OCP\IConfig')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->l = $this->getMock('OCP\IL10N');
 
-		$this->crypt = new Crypt($this->logger, $this->userSession, $this->config);
+		$this->crypt = new Crypt($this->logger, $this->userSession, $this->config, $this->l);
 	}
 
 	/**

--- a/apps/encryption/tests/lib/crypto/encryptionTest.php
+++ b/apps/encryption/tests/lib/crypto/encryptionTest.php
@@ -229,7 +229,7 @@ class EncryptionTest extends TestCase {
 
 	public function dataTestBegin() {
 		return array(
-			array('w', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'fileKey', 'myCipher'),
+			array('w', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'fileKey', 'defaultCipher'),
 			array('r', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'fileKey', 'myCipher'),
 			array('w', [], 'legacyCipher', 'defaultCipher', '', 'defaultCipher'),
 			array('r', [], 'legacyCipher', 'defaultCipher', 'file_key', 'legacyCipher'),

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -165,7 +165,15 @@ class Storage {
 			$mtime = $users_view->filemtime('files/' . $filename);
 			$users_view->copy('files/' . $filename, 'files_versions/' . $filename . '.v' . $mtime);
 			// call getFileInfo to enforce a file cache entry for the new version
-			$users_view->getFileInfo('files_versions/' . $filename . '.v' . $mtime);
+			$newFileInfo = $users_view->getFileInfo('files_versions/' . $filename . '.v' . $mtime);
+
+			// Keep the "encrypted" value of the original file
+			$oldVersion = $files_view->getFileInfo($filename)->getEncryptedVersion();
+			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$qb->update('filecache')
+				->set('encrypted', $qb->createNamedParameter($oldVersion))
+				->where($qb->expr()->eq('fileid', $qb->createNamedParameter($newFileInfo->getId())))
+				->execute();
 		}
 	}
 

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -145,6 +145,7 @@ class Cache implements ICache {
 			$data['size'] = 0 + $data['size'];
 			$data['mtime'] = (int)$data['mtime'];
 			$data['storage_mtime'] = (int)$data['storage_mtime'];
+			$data['encryptedVersion'] = (int)$data['encrypted'];
 			$data['encrypted'] = (bool)$data['encrypted'];
 			$data['storage'] = $this->storageId;
 			$data['mimetype'] = $this->mimetypeLoader->getMimetypeById($data['mimetype']);
@@ -345,8 +346,12 @@ class Cache implements ICache {
 						$queryParts[] = '`mtime`';
 					}
 				} elseif ($name === 'encrypted') {
-					// Boolean to integer conversion
-					$value = $value ? 1 : 0;
+					if(isset($data['encryptedVersion'])) {
+						$value = $data['encryptedVersion'];
+					} else {
+						// Boolean to integer conversion
+						$value = $value ? 1 : 0;
+					}
 				}
 				$params[] = $value;
 				$queryParts[] = '`' . $name . '`';

--- a/lib/private/files/fileinfo.php
+++ b/lib/private/files/fileinfo.php
@@ -194,6 +194,15 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
+	 * Return the currently version used for the HMAC in the encryption app
+	 *
+	 * @return int
+	 */
+	public function getEncryptedVersion() {
+		return isset($this->data['encryptedVersion']) ? (int) $this->data['encryptedVersion'] : 1;
+	}
+
+	/**
 	 * @return int
 	 */
 	public function getPermissions() {

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -39,6 +39,7 @@ use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\ILogger;
+use OCP\Files\Cache\ICacheEntry;
 
 class Encryption extends Wrapper {
 
@@ -129,11 +130,13 @@ class Encryption extends Wrapper {
 		if (isset($this->unencryptedSize[$fullPath])) {
 			$size = $this->unencryptedSize[$fullPath];
 			// update file cache
-			if ($info) {
+			if ($info instanceof ICacheEntry) {
 				$info = $info->getData();
 				$info['encrypted'] = $info['encryptedVersion'];
 			} else {
-				$info = [];
+				if (!is_array($info)) {
+					$info = [];
+				}
 				$info['encrypted'] = true;
 			}
 

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -343,6 +343,7 @@ class Encryption extends Wrapper {
 		$shouldEncrypt = false;
 		$encryptionModule = null;
 		$header = $this->getHeader($path);
+		$signed = (isset($header['signed']) && $header['signed'] === 'true') ? true : false;
 		$fullPath = $this->getFullPath($path);
 		$encryptionModuleId = $this->util->getEncryptionModuleId($header);
 
@@ -377,7 +378,7 @@ class Encryption extends Wrapper {
 					|| $mode === 'wb'
 					|| $mode === 'wb+'
 				) {
-					// don't overwrite encrypted files if encyption is not enabled
+					// don't overwrite encrypted files if encryption is not enabled
 					if ($targetIsEncrypted && $encryptionEnabled === false) {
 						throw new GenericEncryptionException('Tried to access encrypted file but encryption is not enabled');
 					}
@@ -385,6 +386,7 @@ class Encryption extends Wrapper {
 						// if $encryptionModuleId is empty, the default module will be used
 						$encryptionModule = $this->encryptionManager->getEncryptionModule($encryptionModuleId);
 						$shouldEncrypt = $encryptionModule->shouldEncrypt($fullPath);
+						$signed = true;
 					}
 				} else {
 					$info = $this->getCache()->get($path);
@@ -422,7 +424,7 @@ class Encryption extends Wrapper {
 				}
 				$handle = \OC\Files\Stream\Encryption::wrap($source, $path, $fullPath, $header,
 					$this->uid, $encryptionModule, $this->storage, $this, $this->util, $this->fileHelper, $mode,
-					$size, $unencryptedSize, $headerSize);
+					$size, $unencryptedSize, $headerSize, $signed);
 				return $handle;
 			}
 

--- a/lib/private/files/storage/wrapper/encryption.php
+++ b/lib/private/files/storage/wrapper/encryption.php
@@ -131,11 +131,12 @@ class Encryption extends Wrapper {
 			// update file cache
 			if ($info) {
 				$info = $info->getData();
+				$info['encrypted'] = $info['encryptedVersion'];
 			} else {
 				$info = [];
+				$info['encrypted'] = true;
 			}
 
-			$info['encrypted'] = true;
 			$info['size'] = $size;
 			$this->getCache()->put($path, $info);
 

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -72,6 +72,9 @@ class Encryption extends Wrapper {
 	/** @var string */
 	protected $fullPath;
 
+	/** @var  bool */
+	protected $signed;
+
 	/**
 	 * header data returned by the encryption module, will be written to the file
 	 * in case of a write operation

--- a/lib/private/files/stream/encryption.php
+++ b/lib/private/files/stream/encryption.php
@@ -110,7 +110,8 @@ class Encryption extends Wrapper {
 			'size',
 			'unencryptedSize',
 			'encryptionStorage',
-			'headerSize'
+			'headerSize',
+			'signed'
 		);
 	}
 
@@ -132,6 +133,7 @@ class Encryption extends Wrapper {
 	 * @param int $size
 	 * @param int $unencryptedSize
 	 * @param int $headerSize
+	 * @param bool $signed
 	 * @param string $wrapper stream wrapper class
 	 * @return resource
 	 *
@@ -148,6 +150,7 @@ class Encryption extends Wrapper {
 								$size,
 								$unencryptedSize,
 								$headerSize,
+								$signed,
 								$wrapper =  'OC\Files\Stream\Encryption') {
 
 		$context = stream_context_create(array(
@@ -164,7 +167,8 @@ class Encryption extends Wrapper {
 				'size' => $size,
 				'unencryptedSize' => $unencryptedSize,
 				'encryptionStorage' => $encStorage,
-				'headerSize' => $headerSize
+				'headerSize' => $headerSize,
+				'signed' => $signed
 			)
 		));
 
@@ -225,7 +229,7 @@ class Encryption extends Wrapper {
 		$this->position = 0;
 		$this->cache = '';
 		$this->writeFlag = false;
-		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize();
+		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize($this->signed);
 
 		if (
 			$mode === 'w'

--- a/lib/public/encryption/iencryptionmodule.php
+++ b/lib/public/encryption/iencryptionmodule.php
@@ -119,10 +119,11 @@ interface IEncryptionModule {
 	 * get size of the unencrypted payload per block.
 	 * ownCloud read/write files with a block size of 8192 byte
 	 *
-	 * @return integer
-	 * @since 8.1.0
+	 * @param bool $signed
+	 * @return int
+	 * @since 8.1.0 optional parameter $signed was added in 9.0.0
 	 */
-	public function getUnencryptedBlockSize();
+	public function getUnencryptedBlockSize($signed = false);
 
 	/**
 	 * check if the encryption module is able to read the file,

--- a/settings/changepassword/controller.php
+++ b/settings/changepassword/controller.php
@@ -89,7 +89,8 @@ class Controller {
 			$crypt = new \OCA\Encryption\Crypto\Crypt(
 				\OC::$server->getLogger(),
 				\OC::$server->getUserSession(),
-				\OC::$server->getConfig());
+				\OC::$server->getConfig(),
+				\OC::$server->getL10N('encryption'));
 			$keyStorage = \OC::$server->getEncryptionKeyStorage();
 			$util = new \OCA\Encryption\Util(
 				new \OC\Files\View(),

--- a/tests/lib/files/stream/encryption.php
+++ b/tests/lib/files/stream/encryption.php
@@ -117,6 +117,7 @@ class Encryption extends \Test\TestCase {
 		$header->setAccessible(true);
 		$header->setValue($streamWrapper, array());
 		$header->setAccessible(false);
+		$this->invokePrivate($streamWrapper, 'signed', [true]);
 
 		// call stream_open, that's the method we want to test
 		$dummyVar = 'foo';


### PR DESCRIPTION
This adds an integrity protection using Encrypt-Then-MAC to the default encryption module. Authenticated encryption prevents that a storage administrator can tamper with the files such as performing bitflipping attacks on them.

To achieve this the following changes have been done by @schiesbn and me:
1. Switched to AES-CTR-256 as default cipher for new or modified files
2. All new files have the HMAC data in the metadata as well.
3. When decrypting files the signature gets verified. All files encrypted using CTR need this field to be there mandatory, the old CFB mode can have this field but it is not enforced.

This approach gives us the possibility to have complete backwards compatibility with the existing encrypted files (as in: you should be able to read all files as before as well) as well as an easy way to differentiate whether a file needs to have a mandatory HMAC.

To test this also try to modify the encrypted ciphertext in the encrypted document on new or modified files and see whether you can still open the document. With this change applied you should not, it will simply fail to decrypt the file.

There will be no automatic migration as we all know the pain of such. Thus this will only affect new or modified files.

Partially addresses https://github.com/owncloud/security-tracker/issues/191. Some documentation changes are still pending.
