### PR TITLE
Add check for .well-known URL in the root of the webservers URL

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -166,6 +166,7 @@ $array = array(
 			'baseUrl' => $defaults->getBaseUrl(),
 			'syncClientUrl' => $defaults->getSyncClientUrl(),
 			'docBaseUrl' => $defaults->getDocBaseUrl(),
+			'docPlaceholderUrl' => $defaults->buildDocLinkToKey('PLACEHOLDER'),
 			'slogan' => $defaults->getSlogan(),
 			'logoClaim' => $defaults->getLogoClaim(),
 			'shortFooter' => $defaults->getShortFooter(),

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -47,6 +47,35 @@
 		},
 
 		/**
+		 * Check whether the .well-known URLs works.
+		 *
+		 * @param url the URL to test
+		 * @param placeholderUrl the placeholder URL - can be found at oc_defaults.docPlaceholderUrl
+		 * @return $.Deferred object resolved with an array of error messages
+		 */
+		checkWellKnownUrl: function(url, placeholderUrl) {
+			var deferred = $.Deferred();
+			var afterCall = function(xhr) {
+				var messages = [];
+				if (xhr.status !== 207) {
+					var docUrl = placeholderUrl.replace('PLACEHOLDER', 'admin-setup-well-known-URL');
+					messages.push({
+						msg: t('core', 'Your web server is not set up properly to resolve "{url}". Further information can be found in our <a target="_blank" href="{docLink}">documentation</a>.', { docLink: docUrl, url: url }),
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					});
+				}
+				deferred.resolve(messages);
+			};
+
+			$.ajax({
+				type: 'PROPFIND',
+				url: url,
+				complete: afterCall
+			});
+			return deferred.promise();
+		},
+
+		/**
 		 * Runs setup checks on the server side
 		 *
 		 * @return $.Deferred object resolved with an array of error messages

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -60,6 +60,33 @@ describe('OC.SetupChecks tests', function() {
 		});
 	});
 
+	describe('checkWellKnownUrl', function() {
+		it('should fail with another response status code than 207', function(done) {
+			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER');
+
+			suite.server.requests[0].respond(200);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([{
+					msg: 'Your web server is not set up properly to resolve "/.well-known/caldav/". Further information can be found in our <a target="_blank" href="http://example.org/admin-setup-well-known-URL">documentation</a>.',
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+				}]);
+				done();
+			});
+		});
+
+		it('should return no error with a response status code of 207', function(done) {
+			var async = OC.SetupChecks.checkWebDAV('/.well-known/caldav/', 'http://example.org/PLACEHOLDER');
+
+			suite.server.requests[0].respond(207);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([]);
+				done();
+			});
+		});
+	});
+
 	describe('checkSetup', function() {
 		it('should return an error if server has no internet connection', function(done) {
 			var async = OC.SetupChecks.checkSetup();

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -168,6 +168,8 @@ $(document).ready(function(){
 	// run setup checks then gather error messages
 	$.when(
 		OC.SetupChecks.checkWebDAV(),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl),
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric()
 	).then(function(check1, check2, check3) {


### PR DESCRIPTION
- fixes #20012 

<img width="532" alt="bildschirmfoto 2016-01-08 um 22 33 25" src="https://cloud.githubusercontent.com/assets/245432/12210092/e60d5c9c-b657-11e5-9c26-43fe902d579e.png">

Should we add a link to https://doc.owncloud.org/server/9.0/admin_manual/issues/general_troubleshooting.html#service-discovery ? I think it would be useful.

@RealRancor @DeepDiver1975 @evert @LukasReschke 

Easy to test with an installation of owncloud in a subdirectory ;)
