### PR TITLE
Just query the securerandom from the container

### DIFF
--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -553,7 +553,7 @@ class Server extends ServerContainer implements IServerContainer {
 						? $_SERVER['REQUEST_METHOD']
 						: null,
 				],
-				new SecureRandom(),
+				$c->getSecureRandom(),
 				$c->getConfig()
 			);
 


### PR DESCRIPTION
We only need one instance of the secure random. So just query it from the container.

CC: @LukasReschke @PVince81 @MorrisJobke 
