### PR TITLE
Do not increase filecount in web on file update

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1758,7 +1758,9 @@
 		updateRow: function($tr, fileInfo, options) {
 			this.files.splice($tr.index(), 1);
 			$tr.remove();
-			$tr = this.add(fileInfo, _.extend({updateSummary: false, silent: true}, options));
+			options = _.extend({silent: true}, options);
+			options = _.extend(options, {updateSummary: false});
+			$tr = this.add(fileInfo, options);
 			this.$fileList.trigger($.Event('fileActionsReady', {fileList: this, $files: $tr}));
 			return $tr;
 		},

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -812,6 +812,22 @@ describe('OCA.Files.FileList tests', function() {
 				.toEqual(OC.imagePath('core', 'filetypes/text.svg'));
 		});
 	});
+	describe('Update file', function() {
+		it('does not change summary', function() {
+			var $summary = $('#filestable .summary');
+			var fileData = new FileInfo({
+				type: 'file',
+				name: 'test file',
+			});
+			var $tr = fileList.add(fileData);
+
+			expect($summary.find('.info').text()).toEqual('0 folders and 1 file');
+
+			var model = fileList.getModelForFile('test file');
+			model.set({size: '100'});
+			expect($summary.find('.info').text()).toEqual('0 folders and 1 file');
+		});
+	})
 	describe('List rendering', function() {
 		it('renders a list of files using add()', function() {
 			expect(fileList.files.length).toEqual(0);


### PR DESCRIPTION
Fixes #21534 and #21535 

When a file is updated (for example by closing the text editor, or marking a file as favorite) the summary of the total folders and files should not change.

We must make sure that 'updateSummary' is set to false.

CC: @PVince81 @davitol @owncloud/javascript 
