### PR TITLE
Remove code related to session regeneration after some time

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -431,20 +431,10 @@ class OC {
 			//show the user a detailed error page
 			OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 			OC_Template::printExceptionErrorPage($e);
+			die();
 		}
 
 		$sessionLifeTime = self::getSessionLifeTime();
-		// regenerate session id periodically to avoid session fixation
-		/**
-		 * @var \OCP\ISession $session
-		 */
-		$session = self::$server->getSession();
-		if (!$session->exists('SID_CREATED')) {
-			$session->set('SID_CREATED', time());
-		} else if (time() - $session->get('SID_CREATED') > $sessionLifeTime / 2) {
-			$session->regenerateId();
-			$session->set('SID_CREATED', time());
-		}
 
 		// session timeout
 		if ($session->exists('LAST_ACTIVITY') && (time() - $session->get('LAST_ACTIVITY') > $sessionLifeTime)) {


### PR DESCRIPTION
I do not really consider this necessary or a real security addition. Let's get rid of it thus, cleans up the code and makes the logic easier.

@MorrisJobke As discussed
