### PR TITLE
Remove unused custom session object

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -412,15 +412,10 @@ class OC {
 		$sessionName = OC_Util::getInstanceId();
 
 		try {
-			// Allow session apps to create a custom session object
-			$useCustomSession = false;
-			$session = self::$server->getSession();
-			OC_Hook::emit('OC', 'initSession', array('session' => &$session, 'sessionName' => &$sessionName, 'useCustomSession' => &$useCustomSession));
-			if (!$useCustomSession) {
-				// set the session name to the instance id - which is unique
-				$session = new \OC\Session\Internal($sessionName);
-			}
+			// set the session name to the instance id - which is unique
+			$session = new \OC\Session\Internal($sessionName);
 
+			// Wrap the crypto wrapper
 			$cryptoWrapper = \OC::$server->getSessionCryptoWrapper();
 			$session = $cryptoWrapper->wrapSession($session);
 			self::$server->setSession($session);


### PR DESCRIPTION
This has been added in https://github.com/owncloud/core/pull/8557 but is never used, a code search did not show anything on our repositories and this is a kinda confusing functionality.

Plus, it will very likely not work properly with our crypto session wrapper plus the stuff that @MorrisJobke was working on today (allowing to kill sessions). So I'd vote for removing it.

@MorrisJobke Another one of the things we stumbled upon today :wink: 
@DeepDiver1975 @karlitschek Thoughts?
