### PR TITLE
Assume apps from the appstore are compatible with the current version

### DIFF
--- a/lib/private/app.php
+++ b/lib/private/app.php
@@ -912,6 +912,11 @@ class OC_App {
 				$apps[$i]['internalclass'] = 'recommendedapp';
 			}
 
+			// Apps from the appstore are always assumed to be compatible with the
+			// the current release as the initial filtering is done on the appstore
+			$apps[$i]['dependencies']['owncloud']['@attributes']['min-version'] = implode('.', \OCP\Util::getVersion());
+			$apps[$i]['dependencies']['owncloud']['@attributes']['max-version'] = implode('.', \OCP\Util::getVersion());
+
 			$i++;
 		}
 


### PR DESCRIPTION
Filtering is done server-side already so only compatible apps are delivered. Otherwise this leads to a ton of error messages as the info.xml cannot be read at that state.

Fixes https://github.com/owncloud/core/issues/21556
