### PR TITLE
Track user sessions

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1723,4 +1723,73 @@
 
 	</table>
 
+
+	<table>
+
+		<!--
+		List of all user sessions
+		-->
+		<name>*dbprefix*sessions</name>
+
+		<declaration>
+
+			<field>
+				<name>user_id</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<field>
+				<name>session_id</name>
+				<type>text</type>
+				<default></default>
+				<length>128</length>
+			</field>
+
+			<field>
+				<name>created_at</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+
+			<field>
+				<name>last_activity_at</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+
+			<field>
+				<name>info</name>
+				<type>clob</type>
+				<notnull>false</notnull>
+			</field>
+
+			<index>
+				<name>sessions_session_id</name>
+				<primary>true</primary>
+				<field>
+					<name>session_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<name>sessions_user_id</name>
+				<field>
+					<name>user_id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+		</declaration>
+
+	</table>
+
+
 </database>

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 1, 0, 0);
+$OC_Version = array(9, 1, 0, 1);
 
 // The human readable string
 $OC_VersionString = '9.1.0 pre alpha';


### PR DESCRIPTION
- logs the session IDs to the database
- checks if the session is still in the DB if the session is resumed (checked at most every 5 seconds)
- updates the last used time of a session (for invalidation purposes - also updated at most every 5 seconds)
- removes the session on logout/timeout
- logs the IP and user agent of the session during session creation (for easier identification of a session and fraud detection)
- this will allow stuff like #18410, #19529, owncloud/client#3912 (force a logout of a given client)

missing items:
- [ ] occ command to list sessions of a user and kill user sessions
- [ ] acceptance test that verifies the logout mechanism works
- [ ] background job to clean up timed out sessions

cc @DeepDiver1975 @PVince81 @LukasReschke 
