### PR TITLE
Stricter autoloader

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -488,8 +488,10 @@ class OC {
 			OC::$SERVERROOT . '/settings',
 			OC::$SERVERROOT . '/ocs',
 			OC::$SERVERROOT . '/ocs-provider',
-			OC::$SERVERROOT . '/tests',
 		]);
+		if (defined('PHPUNIT_RUN')) {
+			self::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+		}
 		spl_autoload_register(array(self::$loader, 'load'));
 		$loaderEnd = microtime(true);
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -488,7 +488,6 @@ class OC {
 			OC::$SERVERROOT . '/settings',
 			OC::$SERVERROOT . '/ocs',
 			OC::$SERVERROOT . '/ocs-provider',
-			OC::$SERVERROOT . '/3rdparty',
 			OC::$SERVERROOT . '/tests',
 		]);
 		spl_autoload_register(array(self::$loader, 'load'));


### PR DESCRIPTION
Restrict out autoloader a bit more where it can load from.
- `3rdparty` is handled by the composer autoloader from the 3rdparty repo
- `tests` only has to be loaded during phpunit runs

CC: @nickvergessen @Xenopathic @LukasReschke @MorrisJobke 
