### PR TITLE
Fix quota check for single shared files

### DIFF
--- a/apps/files/ajax/upload.php
+++ b/apps/files/ajax/upload.php
@@ -136,8 +136,12 @@ $maxUploadFileSize = $storageStats['uploadMaxFilesize'];
 $maxHumanFileSize = OCP\Util::humanFileSize($maxUploadFileSize);
 
 $totalSize = 0;
-foreach ($files['size'] as $size) {
-	$totalSize += $size;
+$isReceivedShare = \OC::$server->getRequest()->getParam('isReceivedShare', false) === 'true';
+// defer quota check for received shares
+if (!$isReceivedShare) {
+	foreach ($files['size'] as $size) {
+		$totalSize += $size;
+	}
 }
 if ($maxUploadFileSize >= 0 and $totalSize > $maxUploadFileSize) {
 	OCP\JSON::error(array('data' => array('message' => $l->t('Not enough storage available'),

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -251,7 +251,26 @@ OC.Upload = {
 		$('#file_upload_start').trigger(new $.Event('resized'));
 	},
 
+	/**
+	 * Returns whether the given file is known to be a received shared file
+	 *
+	 * @param {Object} file file
+	 * @return {bool} true if the file is a shared file
+	 */
+	_isReceivedSharedFile: function(file) {
+		if (!window.FileList) {
+			return false;
+		}
+		var $tr = window.FileList.findFileEl(file.name);
+		if (!$tr.length) {
+			return false;
+		}
+
+		return ($tr.attr('data-mounttype') === 'shared-root' && $tr.attr('data-mime') !== 'httpd/unix-directory');
+	},
+
 	init: function() {
+		var self = this;
 		if ( $('#file_upload_start').exists() ) {
 			var file_upload_param = {
 				dropZone: $('#content'), // restrict dropZone to content div
@@ -341,10 +360,15 @@ OC.Upload = {
 						}
 					}
 
-					// add size
-					selection.totalBytes += file.size;
-					// update size of biggest file
-					selection.biggestFileBytes = Math.max(selection.biggestFileBytes, file.size);
+					// only count if we're not overwriting an existing shared file
+					if (self._isReceivedSharedFile(file)) {
+						file.isReceivedShare = true;
+					} else {
+						// add size
+						selection.totalBytes += file.size;
+						// update size of biggest file
+						selection.biggestFileBytes = Math.max(selection.biggestFileBytes, file.size);
+					}
 
 					// check PHP upload limit against biggest file
 					if (selection.biggestFileBytes > $('#upload_limit').val()) {
@@ -430,11 +454,16 @@ OC.Upload = {
 						fileDirectory = data.files[0].relativePath;
 					}
 
-					addFormData(data.formData, {
+					var params = {
 						requesttoken: oc_requesttoken,
 						dir: data.targetDir || FileList.getCurrentDirectory(),
-						file_directory: fileDirectory
-					});
+						file_directory: fileDirectory,
+					};
+					if (data.files[0].isReceivedShare) {
+						params.isReceivedShare = true;
+					}
+
+					addFormData(data.formData, params);
 				},
 				fail: function(e, data) {
 					OC.Upload.log('fail', e, data);

--- a/lib/private/files/storage/wrapper/quota.php
+++ b/lib/private/files/storage/wrapper/quota.php
@@ -141,14 +141,31 @@ class Quota extends Wrapper {
 	 */
 	public function fopen($path, $mode) {
 		$source = $this->storage->fopen($path, $mode);
-		$free = $this->free_space('');
-		if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
-			// only apply quota for files, not metadata, trash or others
-			if (strpos(ltrim($path, '/'), 'files/') === 0) {
-				return \OC\Files\Stream\Quota::wrap($source, $free);
+
+		// don't apply quota for part files
+		if (!$this->isPartFile($path)) {
+			$free = $this->free_space('');
+			if ($source && $free >= 0 && $mode !== 'r' && $mode !== 'rb') {
+				// only apply quota for files, not metadata, trash or others
+				if (strpos(ltrim($path, '/'), 'files/') === 0) {
+					return \OC\Files\Stream\Quota::wrap($source, $free);
+				}
 			}
 		}
 		return $source;
+	}
+
+	/**
+	 * Checks whether the given path is a part file
+	 *
+	 * @param string $path Path that may identify a .part file
+	 * @return string File path without .part extension
+	 * @note this is needed for reusing keys
+	 */
+	private function isPartFile($path) {
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+
+		return ($extension === 'part');
 	}
 
 	/**


### PR DESCRIPTION
- [x] TODO: web UI
- [x] TODO: fix quota plugin for Webdav
- [x] TODO: ~~make part file quota check on the correct (shared) storage instead of local one~~ disable quota check on part files
#### Single file local share
- [x] TEST: upload small file to owner storage with no space left on uploader's storage => 507
- [x] TEST: upload big file to owner storage with no space left on uploader's storage => 507
- [x] TEST: upload small file to overwrite received share file with no space left on uploader's storage => works
- [x] TEST: upload big file to overwrite received share file with no space left on uploader's storage => works
- [x] TEST: web UI overwrite file with no space left on uploader's storage
#### Single file federated share
- [x] TEST: upload small file to owner storage with no space left on uploader's storage => 507
- [x] TEST: upload big file to owner storage with no space left on uploader's storage => 507
- [x] TEST: upload small file to overwrite received share file with no space left on uploader's storage => works
- [x] TEST: upload big file to overwrite received share file with no space left on uploader's storage => works
- [x] TEST: web UI overwrite file with no space left on uploader's storage
#### Other
- [x] TEST: regression test quota in general
- [x] TEST: regression test quota with folder shares
- [x] TEST: regression test quota with fed folder shares

@icewind1991 
