### PR TITLE
Also convert first part of email to idn

### DIFF
--- a/lib/private/mail/mailer.php
+++ b/lib/private/mail/mailer.php
@@ -139,6 +139,7 @@ class Mailer implements IMailer {
 
 		list($name, $domain) = explode('@', $email, 2);
 		$domain = idn_to_ascii($domain);
+		$name = idn_to_ascii($name);
 		return $name.'@'.$domain;
 	}
 

--- a/tests/lib/mail/mailer.php
+++ b/tests/lib/mail/mailer.php
@@ -108,6 +108,7 @@ class MailerTest extends TestCase {
 			['lukas@éxämplè.com', true],
 			['asdf', false],
 			['lukas@owncloud.org@owncloud.com', false],
+			['björn@españa.eu', true],
 		];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/13586

Basically do the same trick we did for the damain.

@SergioBertolinSG since you filled https://github.com/owncloud/core/issues/13586 can you test this. My e-mail hosten apparently does not allow those kind of e-mail addresses. (so also if e-mail is properly send).
