### PR TITLE
fix wrong class name in phpdoc

### DIFF
--- a/apps/dav/tests/unit/systemtag/systemtagplugin.php
+++ b/apps/dav/tests/unit/systemtag/systemtagplugin.php
@@ -34,7 +34,7 @@ class SystemTagPlugin extends \Test\TestCase {
 	private $tagManager;
 
 	/**
-	 * @var \OCA\DAV\Connector\Sabre\TagsPlugin
+	 * @var \OCA\DAV\SystemTag\SystemTagPlugin
 	 */
 	private $plugin;
 


### PR DESCRIPTION
The member is instantiated here with that other class https://github.com/owncloud/core/blob/master/apps/dav/tests/unit/systemtag/systemtagplugin.php#L51

@PVince81 @nickvergessen 
