### PR TITLE
Revert "Remove unneeded check if htaccess test file already exists"

### DIFF
--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1201,6 +1201,10 @@ class OC_Util {
 		// creating a test file
 		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
 
+		if (file_exists($testFile)) {// already running this test, possible recursive call
+			return false;
+		}
+
 		$fp = @fopen($testFile, 'w');
 		if (!$fp) {
 			throw new OC\HintException('Can\'t create test file to check for working .htaccess file.',


### PR DESCRIPTION
Reverts owncloud/core#21479

Potentially fixes https://github.com/owncloud/core/issues/21621
