### PR TITLE
[Share 2.0] Default share provider should only query for supported types

### DIFF
--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -36,6 +36,9 @@ use OCP\Files\Node;
  */
 class DefaultShareProvider implements IShareProvider {
 
+	// Special share type for user modified group shares
+	const SHARE_TYPE_USERGROUP = 2;
+
 	/** @var IDBConnection */
 	private $dbConn;
 
@@ -186,6 +189,17 @@ class DefaultShareProvider implements IShareProvider {
 		$qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('parent', $qb->createNamedParameter($parent->getId())))
+			->andWhere(
+				$qb->expr()->in(
+					'share_type',
+					[
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_GROUP),
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
+						$qb->expr()->literal(self::SHARE_TYPE_USERGROUP),
+					]
+				)
+			)
 			->orderBy('id');
 
 		$cursor = $qb->execute();
@@ -242,7 +256,18 @@ class DefaultShareProvider implements IShareProvider {
 
 		$qb->select('*')
 			->from('share')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
+			->andWhere(
+				$qb->expr()->in(
+					'share_type',
+					[
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_USER),
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_GROUP),
+						$qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
+						$qb->expr()->literal(self::SHARE_TYPE_USERGROUP),
+					]
+				)
+			);
 		
 		$cursor = $qb->execute();
 		$data = $cursor->fetch();

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -185,8 +185,7 @@ class DefaultShareProvider implements IShareProvider {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('*')
 			->from('share')
-			->where($qb->expr()->eq('parent', $qb->createParameter('parent')))
-			->setParameter(':parent', $parent->getId())
+			->where($qb->expr()->eq('parent', $qb->createNamedParameter($parent->getId())))
 			->orderBy('id');
 
 		$cursor = $qb->execute();
@@ -210,8 +209,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('share')
-			->where($qb->expr()->eq('id', $qb->createParameter('id')))
-			->setParameter(':id', $share->getId());
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())));
 	
 		try {
 			$qb->execute();
@@ -244,8 +242,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		$qb->select('*')
 			->from('share')
-			->where($qb->expr()->eq('id', $qb->createParameter('id')))
-			->setParameter(':id', $id);
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 		
 		$cursor = $qb->execute();
 		$data = $cursor->fetch();

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -375,9 +375,6 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->method('where')
 			->will($this->returnSelf());
 		$qb->expects($this->once())
-			->method('setParameter')
-			->will($this->returnSelf());
-		$qb->expects($this->once())
 			->method('execute')
 			->will($this->throwException(new \Exception));
 


### PR DESCRIPTION
The default share provider currently handles User, Group and Link shares. So we should in queries make sure that we only select those.

I forsee possible future bugs where we would else query a share id which is actually a federated share (which at the moment use the same table). More of this is needed once modifing shares is handled. But this is a good small start.

Pretty easy to review.

CC: @schiesbn @DeepDiver1975 @nickvergessen 
