### PR TITLE
Remove unused deprecated function from l10n.php

### DIFF
--- a/lib/private/l10n.php
+++ b/lib/private/l10n.php
@@ -77,17 +77,6 @@ class OC_L10N implements \OCP\IL10N {
 	private $pluralFormFunction = null;
 
 	/**
-	 * get an L10N instance
-	 * @param string $app
-	 * @param string|null $lang
-	 * @return \OCP\IL10N
-	 * @deprecated Use \OC::$server->getL10NFactory()->get() instead
-	 */
-	public static function get($app, $lang=null) {
-		return \OC::$server->getL10NFactory()->get($app, $lang);
-	}
-
-	/**
 	 * The constructor
 	 * @param string $app app requesting l10n
 	 * @param string $lang default: null Language

--- a/tests/lib/l10n.php
+++ b/tests/lib/l10n.php
@@ -156,11 +156,6 @@ class Test_L10n extends \Test\TestCase {
 		);
 	}
 
-	public function testGetLanguageCode() {
-		$l = OC_L10N::get('lib', 'de');
-		$this->assertEquals('de', $l->getLanguageCode());
-	}
-
 	public function testFactoryGetLanguageCode() {
 		$factory = new \OC\L10N\Factory();
 		$l = $factory->get('lib', 'de');


### PR DESCRIPTION
Private function that is deprecated and no longer used => delete.

Easy to review.

CC: @PVince81 @MorrisJobke @nickvergessen @LukasReschke 
