### PR TITLE
Swapping an alert box for a yellow warning alert new user/group

### DIFF
--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -143,7 +143,7 @@ GroupList = {
 				}
 				GroupList.toggleAddGroup();
 			}).fail(function(result, textStatus, errorThrown) {
-				OC.dialogs.alert(result.responseJSON.message, t('settings', 'Error creating group'));
+				OC.Notification.showTemporary(result.responseJSON.message, t('settings', 'Error creating group'));
 			});
 	},
 

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -820,7 +820,7 @@ $(document).ready(function () {
 					$('#newusername').focus();
 					GroupList.incEveryoneCount();
 				}).fail(function(result, textStatus, errorThrown) {
-					OC.dialogs.alert(result.responseJSON.message, t('settings', 'Error creating user'));
+					OC.Notification.showTemporary(result.responseJSON.message, t('settings', 'Error creating user'));
 				}).success(function(){
 					$('#newuser').get(0).reset();
 				});


### PR DESCRIPTION
This is in response to https://github.com/owncloud/core/issues/20470

All errors on failure to create a user or a group will be displayed in a temporary yellow box rather than an alert.
