### PR TITLE
Replace deprecated function calls to SecureRandom

### DIFF
--- a/apps/encryption/lib/crypto/encryptall.php
+++ b/apps/encryption/lib/crypto/encryptall.php
@@ -344,7 +344,7 @@ class EncryptAll {
 	 * @return string password
 	 */
 	protected function generateOneTimePassword($uid) {
-		$password = $this->secureRandom->getMediumStrengthGenerator()->generate(8);
+		$password = $this->secureRandom->generate(8);
 		$this->userPasswords[$uid] = $password;
 		return $password;
 	}

--- a/apps/federation/api/ocsauthapi.php
+++ b/apps/federation/api/ocsauthapi.php
@@ -139,7 +139,7 @@ class OCSAuthAPI {
 			return new \OC_OCS_Result(null, HTTP::STATUS_FORBIDDEN);
 		}
 
-		$sharedSecret = $this->secureRandom->getMediumStrengthGenerator()->generate(32);
+		$sharedSecret = $this->secureRandom->generate(32);
 
 		$this->trustedServers->addSharedSecret($url, $sharedSecret);
 		// reset token after the exchange of the shared secret was successful

--- a/apps/federation/lib/trustedservers.php
+++ b/apps/federation/lib/trustedservers.php
@@ -90,7 +90,7 @@ class TrustedServers {
 		$url = $this->updateProtocol($url);
 		$result = $this->dbHandler->addServer($url);
 		if ($result) {
-			$token = $this->secureRandom->getMediumStrengthGenerator()->generate(16);
+			$token = $this->secureRandom->generate(16);
 			$this->dbHandler->addToken($url, $token);
 			$this->jobList->add(
 				'OCA\Federation\BackgroundJob\RequestSharedSecret',

--- a/apps/federation/tests/api/ocsauthapitest.php
+++ b/apps/federation/tests/api/ocsauthapitest.php
@@ -155,8 +155,6 @@ class OCSAuthAPITest extends TestCase {
 			->method('isValidToken')->with($url, $token)->willReturn($isValidToken);
 
 		if($expected === Http::STATUS_OK) {
-			$this->secureRandom->expects($this->once())->method('getMediumStrengthGenerator')
-				->willReturn($this->secureRandom);
 			$this->secureRandom->expects($this->once())->method('generate')->with(32)
 				->willReturn('secret');
 			$this->trustedServers->expects($this->once())

--- a/apps/federation/tests/lib/trustedserverstest.php
+++ b/apps/federation/tests/lib/trustedserverstest.php
@@ -113,8 +113,6 @@ class TrustedServersTest extends TestCase {
 			->willReturn($success);
 
 		if ($success) {
-			$this->secureRandom->expects($this->once())->method('getMediumStrengthGenerator')
-				->willReturn($this->secureRandom);
 			$this->secureRandom->expects($this->once())->method('generate')
 				->willReturn('token');
 			$this->dbHandler->expects($this->once())->method('addToken')->with('https://url', 'token');

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -76,7 +76,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->oldUser = \OC_User::getUser();
 
 		// Create a dummy user
-		$this->user = \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(12, ISecureRandom::CHAR_LOWER);
+		$this->user = \OC::$server->getSecureRandom()->generate(12, ISecureRandom::CHAR_LOWER);
 
 		\OC::$server->getUserManager()->createUser($this->user, $this->user);
 		\OC_Util::tearDownFS();

--- a/core/lostpassword/controller/lostcontroller.php
+++ b/core/lostpassword/controller/lostcontroller.php
@@ -227,7 +227,7 @@ class LostController extends Controller {
 			);
 		}
 
-		$token = $this->secureRandom->getMediumStrengthGenerator()->generate(21,
+		$token = $this->secureRandom->generate(21,
 			ISecureRandom::CHAR_DIGITS.
 			ISecureRandom::CHAR_LOWER.
 			ISecureRandom::CHAR_UPPER);

--- a/lib/base.php
+++ b/lib/base.php
@@ -1076,7 +1076,7 @@ class OC {
 				if ($config->getSystemValue('debug', false)) {
 					self::$server->getLogger()->debug('Setting remember login to cookie', array('app' => 'core'));
 				}
-				$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(32);
+				$token = \OC::$server->getSecureRandom()->generate(32);
 				$config->setUserValue($userId, 'login_token', $token, time());
 				OC_User::setMagicInCookie($userId, $token);
 			} else {

--- a/lib/private/appframework/http/request.php
+++ b/lib/private/appframework/http/request.php
@@ -465,7 +465,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		if(empty($this->requestId)) {
-			$this->requestId = $this->secureRandom->getLowStrengthGenerator()->generate(20);
+			$this->requestId = $this->secureRandom->generate(20);
 		}
 
 		return $this->requestId;

--- a/lib/private/cache/file.php
+++ b/lib/private/cache/file.php
@@ -99,7 +99,7 @@ class File implements ICache {
 		$storage = $this->getStorage();
 		$result = false;
 		// unique id to avoid chunk collision, just in case
-		$uniqueId = \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(
+		$uniqueId = \OC::$server->getSecureRandom()->generate(
 			16,
 			ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER
 		);

--- a/lib/private/db/mdb2schemamanager.php
+++ b/lib/private/db/mdb2schemamanager.php
@@ -75,7 +75,7 @@ class MDB2SchemaManager {
 	 * @return \OC\DB\Migrator
 	 */
 	public function getMigrator() {
-		$random = \OC::$server->getSecureRandom()->getMediumStrengthGenerator();
+		$random = \OC::$server->getSecureRandom();
 		$platform = $this->conn->getDatabasePlatform();
 		$config = \OC::$server->getConfig();
 		if ($platform instanceof SqlitePlatform) {

--- a/lib/private/security/crypto.php
+++ b/lib/private/security/crypto.php
@@ -90,7 +90,7 @@ class Crypto implements ICrypto {
 		}
 		$this->cipher->setPassword($password);
 
-		$iv = $this->random->getLowStrengthGenerator()->generate($this->ivLength);
+		$iv = $this->random->generate($this->ivLength);
 		$this->cipher->setIV($iv);
 
 		$ciphertext = bin2hex($this->cipher->encrypt($plaintext));

--- a/lib/private/session/cryptowrapper.php
+++ b/lib/private/session/cryptowrapper.php
@@ -74,7 +74,7 @@ class CryptoWrapper {
 		if (!is_null($request->getCookie(self::COOKIE_NAME))) {
 			$this->passphrase = $request->getCookie(self::COOKIE_NAME);
 		} else {
-			$this->passphrase = $this->random->getMediumStrengthGenerator()->generate(128);
+			$this->passphrase = $this->random->generate(128);
 			$secureCookie = $request->getServerProtocol() === 'https';
 			// FIXME: Required for CI
 			if (!defined('PHPUNIT_RUN')) {

--- a/lib/private/setup.php
+++ b/lib/private/setup.php
@@ -310,9 +310,9 @@ class Setup {
 		}
 
 		//generate a random salt that is used to salt the local user passwords
-		$salt = $this->random->getLowStrengthGenerator()->generate(30);
+		$salt = $this->random->generate(30);
 		// generate a secret
-		$secret = $this->random->getMediumStrengthGenerator()->generate(48);
+		$secret = $this->random->generate(48);
 
 		//write the config file
 		$this->config->setSystemValues([

--- a/lib/private/setup/mysql.php
+++ b/lib/private/setup/mysql.php
@@ -143,7 +143,7 @@ class MySQL extends AbstractDatabase {
 							$this->dbUser = $adminUser;
 
 							//create a random password so we don't need to store the admin password in the config file
-							$this->dbPassword =  $this->random->getMediumStrengthGenerator()->generate(30);
+							$this->dbPassword =  $this->random->generate(30);
 
 							$this->createDBUser($connection);
 

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -819,7 +819,7 @@ class Share extends Constants {
 				if (isset($oldToken)) {
 					$token = $oldToken;
 				} else {
-					$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(self::TOKEN_LENGTH,
+					$token = \OC::$server->getSecureRandom()->generate(self::TOKEN_LENGTH,
 						\OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_UPPER.
 						\OCP\Security\ISecureRandom::CHAR_DIGITS
 					);
@@ -860,7 +860,7 @@ class Share extends Constants {
 				throw new \Exception($message_t);
 			}
 
-			$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(self::TOKEN_LENGTH, \OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
+			$token = \OC::$server->getSecureRandom()->generate(self::TOKEN_LENGTH, \OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
 				\OCP\Security\ISecureRandom::CHAR_DIGITS);
 
 			$shareWith = $user . '@' . $remote;

--- a/lib/private/user.php
+++ b/lib/private/user.php
@@ -393,7 +393,7 @@ class OC_User {
 	 * generates a password
 	 */
 	public static function generatePassword() {
-		return \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(30);
+		return \OC::$server->getSecureRandom()->generate(30);
 	}
 
 	/**

--- a/lib/private/user/session.php
+++ b/lib/private/user/session.php
@@ -260,7 +260,7 @@ class Session implements IUserSession, Emitter {
 		}
 		// replace successfully used token with a new one
 		\OC::$server->getConfig()->deleteUserValue($uid, 'login_token', $currentToken);
-		$newToken = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(32);
+		$newToken = \OC::$server->getSecureRandom()->generate(32);
 		\OC::$server->getConfig()->setUserValue($uid, 'login_token', $newToken, time());
 		$this->setMagicInCookie($user->getUID(), $newToken);
 

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1097,7 +1097,7 @@ class OC_Util {
 		$id = \OC::$server->getSystemConfig()->getValue('instanceid', null);
 		if (is_null($id)) {
 			// We need to guarantee at least one letter in instanceid so it can be used as the session_name
-			$id = 'oc' . \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(10, \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
+			$id = 'oc' . \OC::$server->getSecureRandom()->generate(10, \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
 			\OC::$server->getSystemConfig()->setValue('instanceid', $id);
 		}
 		return $id;

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -1125,7 +1125,7 @@ class OC_Util {
 		// Check if a token exists
 		if (!\OC::$server->getSession()->exists('requesttoken')) {
 			// No valid token found, generate a new one.
-			$requestToken = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate($tokenLength);
+			$requestToken = \OC::$server->getSecureRandom()->generate($tokenLength);
 			\OC::$server->getSession()->set('requesttoken', $requestToken);
 		} else {
 			// Valid token already exists, send it
@@ -1133,7 +1133,7 @@ class OC_Util {
 		}
 
 		// XOR the token to mitigate breach-like attacks
-		$sharedSecret = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate($tokenLength);
+		$sharedSecret = \OC::$server->getSecureRandom()->generate($tokenLength);
 		self::$obfuscatedToken =  base64_encode($requestToken ^ $sharedSecret) .':'.$sharedSecret;
 
 		return self::$obfuscatedToken;

--- a/tests/core/lostpassword/controller/lostcontrollertest.php
+++ b/tests/core/lostpassword/controller/lostcontrollertest.php
@@ -167,7 +167,6 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testEmailSuccessful() {
-		$randomToken = $this->secureRandom;
 		$this->secureRandom
 			->expects($this->once())
 			->method('generate')
@@ -187,10 +186,6 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			->expects($this->once())
 			->method('getTime')
 			->will($this->returnValue(12348));
-		$this->secureRandom
-			->expects($this->once())
-			->method('getMediumStrengthGenerator')
-			->will($this->returnValue($randomToken));
 		$this->config
 			->expects($this->once())
 			->method('setUserValue')
@@ -233,7 +228,6 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testEmailCantSendException() {
-		$randomToken = $this->secureRandom;
 		$this->secureRandom
 			->expects($this->once())
 			->method('generate')
@@ -249,10 +243,6 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 				->method('get')
 				->with('ExistingUser')
 				->willReturn($this->existingUser);
-		$this->secureRandom
-			->expects($this->once())
-			->method('getMediumStrengthGenerator')
-			->will($this->returnValue($randomToken));
 		$this->config
 			->expects($this->once())
 			->method('setUserValue')

--- a/tests/lib/appframework/http/RequestTest.php
+++ b/tests/lib/appframework/http/RequestTest.php
@@ -352,17 +352,10 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	public function testGetIdWithoutModUnique() {
-		$lowRandomSource = $this->getMockBuilder('\OCP\Security\ISecureRandom')
-			->disableOriginalConstructor()->getMock();
-		$lowRandomSource->expects($this->once())
+		$this->secureRandom->expects($this->once())
 			->method('generate')
 			->with('20')
 			->will($this->returnValue('GeneratedByOwnCloudItself'));
-
-		$this->secureRandom
-			->expects($this->once())
-			->method('getLowStrengthGenerator')
-			->will($this->returnValue($lowRandomSource));
 
 		$request = new Request(
 			[],

--- a/tests/lib/dbschema.php
+++ b/tests/lib/dbschema.php
@@ -26,7 +26,7 @@ class Test_DBSchema extends \Test\TestCase {
 		$dbfile = OC::$SERVERROOT.'/tests/data/db_structure.xml';
 		$dbfile2 = OC::$SERVERROOT.'/tests/data/db_structure2.xml';
 
-		$r = '_' . \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->
+		$r = '_' . \OC::$server->getSecureRandom()->
 			generate(4, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS) . '_';
 		$content = file_get_contents( $dbfile );
 		$content = str_replace( '*dbprefix*', '*dbprefix*'.$r, $content );

--- a/tests/lib/security/securerandom.php
+++ b/tests/lib/security/securerandom.php
@@ -51,7 +51,7 @@ class SecureRandomTest extends \Test\TestCase {
 	 * @dataProvider stringGenerationProvider
 	 */
 	function testMediumLowStrengthGeneratorLength($length, $expectedLength) {
-		$generator = $this->rng->getMediumStrengthGenerator();
+		$generator = $this->rng;
 
 		$this->assertEquals($expectedLength, strlen($generator->generate($length)));
 	}
@@ -67,7 +67,7 @@ class SecureRandomTest extends \Test\TestCase {
 	 * @dataProvider charCombinations
 	 */
 	public function testScheme($charName, $chars) {
-		$generator = $this->rng->getMediumStrengthGenerator();
+		$generator = $this->rng;
 		$scheme = constant('OCP\Security\ISecureRandom::' . $charName);
 		$randomString = $generator->generate(100, $scheme);
 		$matchesRegex = preg_match('/^'.$chars.'+$/', $randomString);

--- a/tests/lib/security/securerandom.php
+++ b/tests/lib/security/securerandom.php
@@ -42,7 +42,7 @@ class SecureRandomTest extends \Test\TestCase {
 	 * @dataProvider stringGenerationProvider
 	 */
 	function testGetLowStrengthGeneratorLength($length, $expectedLength) {
-		$generator = $this->rng->getLowStrengthGenerator();
+		$generator = $this->rng;
 
 		$this->assertEquals($expectedLength, strlen($generator->generate($length)));
 	}

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -150,7 +150,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 * @return string
 	 */
 	protected static function getUniqueID($prefix = '', $length = 13) {
-		return $prefix . \OC::$server->getSecureRandom()->getLowStrengthGenerator()->generate(
+		return $prefix . \OC::$server->getSecureRandom()->generate(
 			$length,
 			// Do not use dots and slashes as we use the value for file names
 			ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER


### PR DESCRIPTION
getLowStrengthGenerator and getMediumStrengthGenerator don't do anything anymore (other than returning this).

This removes the calls to those functions. Thus less deprecated calls in core.

CC: @MorrisJobke @LukasReschke @PVince81 
