### PR TITLE
added .well-known/acme-challenge/.htaccess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,14 @@ nbproject
 .DS_Store
 
 # WebFinger
-.well-known
 /.buildpath
+
+# Only allow .htaccess in .well-known for Let's Encrypt SSL webroot validation with Force SSL enabled
+.well-known/*
+!.well-known/acme-challenge
+.well-known/acme-challenge/*
+!.well-known/acme-challenge/.htaccess
+
 
 # Tests
 /tests/phpunit.xml

--- a/.well-known/acme-challenge/.htaccess
+++ b/.well-known/acme-challenge/.htaccess
@@ -1,0 +1,8 @@
+# Purpose: Resolves issue 'urn:acme:error:unauthorized' with owncloud forced https activated
+# Method 1: Enables Lets Encrypt webroot validation to be performed on host successfully even with forced https
+# Method 2: Pre-created folder ensures that permissions unchanged the during validation.
+# Credits: https://github.com/plesk/letsencrypt-plesk/issues/13
+<IfModule mod_rewrite.c>
+  RewriteEngine off
+</IfModule>
+Satisfy any


### PR DESCRIPTION
1. Updated .gitignore rules to only allow .well-known/acme-challenge/.htaccess to be included in commits
2. Added .well-known/acme-challenge/.htaccess to enable letsencrypt to validate installation using webroot method even with force ssl enabled
3. Pre-created folders mitigate issue where root user will create .well-known folders and make it impossible for --webroot validation to be performed successfully due to improper permissions.
