### PR TITLE
Add X-Download-Options and X-Permitted-Cross-Domain-Policies

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -12,6 +12,8 @@
     Header set X-XSS-Protection "1; mode=block"
     Header set X-Robots-Tag "none"
     Header set X-Frame-Options "SAMEORIGIN"
+    Header set X-Download-Options "noopen"
+    Header set X-Permitted-Cross-Domain-Policies "none"
     SetEnv modHeadersAvailable true
   </IfModule>
 

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -202,7 +202,9 @@
 					'X-XSS-Protection': '1; mode=block',
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
-					'X-Frame-Options': 'SAMEORIGIN'
+					'X-Frame-Options': 'SAMEORIGIN',
+					'X-Download-Options': 'noopen',
+					'X-Permitted-Cross-Domain-Policies': 'none',
 				};
 
 				for (var header in securityHeaders) {

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -380,7 +380,14 @@ describe('OC.SetupChecks tests', function() {
 				}, {
 					msg: 'The "X-Frame-Options" HTTP header is not configured to equal to "SAMEORIGIN". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-				}]);
+				}, {
+					msg: 'The "X-Download-Options" HTTP header is not configured to equal to "noopen". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				}, {
+					msg: 'The "X-Permitted-Cross-Domain-Policies" HTTP header is not configured to equal to "none". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+				},
+				]);
 				done();
 			});
 		});
@@ -394,7 +401,9 @@ describe('OC.SetupChecks tests', function() {
 				{
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'Strict-Transport-Security': 'max-age=15768000;preload'
+					'Strict-Transport-Security': 'max-age=15768000;preload',
+					'X-Download-Options': 'noopen',
+					'X-Permitted-Cross-Domain-Policies': 'none',
 				}
 			);
 
@@ -421,7 +430,9 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'Strict-Transport-Security': 'max-age=15768000'
+					'Strict-Transport-Security': 'max-age=15768000',
+					'X-Download-Options': 'noopen',
+					'X-Permitted-Cross-Domain-Policies': 'none',
 				}
 			);
 
@@ -441,7 +452,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-XSS-Protection': '1; mode=block',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
-				'X-Frame-Options': 'SAMEORIGIN'
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
 			}
 		);
 
@@ -485,7 +498,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-XSS-Protection': '1; mode=block',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
-				'X-Frame-Options': 'SAMEORIGIN'
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
 			}
 		);
 
@@ -508,7 +523,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-XSS-Protection': '1; mode=block',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
-				'X-Frame-Options': 'SAMEORIGIN'
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
 			}
 		);
 
@@ -531,7 +548,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-XSS-Protection': '1; mode=block',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
-				'X-Frame-Options': 'SAMEORIGIN'
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
 			}
 		);
 
@@ -553,7 +572,9 @@ describe('OC.SetupChecks tests', function() {
 			'X-XSS-Protection': '1; mode=block',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN'
+			'X-Frame-Options': 'SAMEORIGIN',
+			'X-Download-Options': 'noopen',
+			'X-Permitted-Cross-Domain-Policies': 'none',
 		});
 
 		async.done(function( data, s, x ){
@@ -571,7 +592,9 @@ describe('OC.SetupChecks tests', function() {
 			'X-XSS-Protection': '1; mode=block',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN'
+			'X-Frame-Options': 'SAMEORIGIN',
+			'X-Download-Options': 'noopen',
+			'X-Permitted-Cross-Domain-Policies': 'none',
 		});
 
 		async.done(function( data, s, x ){
@@ -589,7 +612,9 @@ describe('OC.SetupChecks tests', function() {
 			'X-XSS-Protection': '1; mode=block',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN'
+			'X-Frame-Options': 'SAMEORIGIN',
+			'X-Download-Options': 'noopen',
+			'X-Permitted-Cross-Domain-Policies': 'none',
 		});
 
 		async.done(function( data, s, x ){
@@ -607,7 +632,9 @@ describe('OC.SetupChecks tests', function() {
 			'X-XSS-Protection': '1; mode=block',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN'
+			'X-Frame-Options': 'SAMEORIGIN',
+			'X-Download-Options': 'noopen',
+			'X-Permitted-Cross-Domain-Policies': 'none',
 		});
 
 		async.done(function( data, s, x ){

--- a/lib/private/response.php
+++ b/lib/private/response.php
@@ -260,6 +260,8 @@ class OC_Response {
 			header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
 			header('X-Frame-Options: Sameorigin'); // Disallow iFraming from other domains
 			header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
+			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
+			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
 		}
 	}
 


### PR DESCRIPTION
Two small security hardenings for our IE users and those with Adobe products. Aligns it more with https://github.com/twitter/secureheaders#secureheaders---

X-Download-Options: https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
X-Permitted-Cross-Domain-Policies: https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
