### PR TITLE
[backport] [stable8] always use an LDAP URL when connecting to LDAP

### DIFF
--- a/apps/user_ldap/lib/connection.php
+++ b/apps/user_ldap/lib/connection.php
@@ -569,10 +569,6 @@ class Connection extends LDAPUtility {
 		if(empty($host)) {
 			return false;
 		}
-		if(strpos($host, '://') !== false) {
-			//ldap_connect ignores port parameter when URLs are passed
-			$host .= ':' . $port;
-		}
 		$this->ldapConnectionRes = $this->ldap->connect($host, $port);
 		if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			if($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_REFERRALS, 0)) {

--- a/apps/user_ldap/lib/ldap.php
+++ b/apps/user_ldap/lib/ldap.php
@@ -45,7 +45,14 @@ class LDAP implements ILDAPWrapper {
 	 * @return mixed
 	 */
 	public function connect($host, $port) {
-		return $this->invokeLDAPMethod('connect', $host, $port);
+		if(strpos($host, '://') === false) {
+			$host = 'ldap://' . $host;
+		}
+		if(strpos($host, ':', strpos($host, '://') + 1) === false) {
+			//ldap_connect ignores port parameter when URLs are passed
+			$host .= ':' . $port;
+		}
+		return $this->invokeLDAPMethod('connect', $host);
 	}
 
 	/**

--- a/apps/user_ldap/lib/wizard.php
+++ b/apps/user_ldap/lib/wizard.php
@@ -995,13 +995,6 @@ class Wizard extends LDAPUtility {
 		if(!$hostInfo) {
 			throw new \Exception($this->l->t('Invalid Host'));
 		}
-		if(isset($hostInfo['scheme'])) {
-			if(isset($hostInfo['port'])) {
-				//problem
-			} else {
-				$host .= ':' . $port;
-			}
-		}
 		\OCP\Util::writeLog('user_ldap', 'Wiz: Attempting to connect ', \OCP\Util::DEBUG);
 		$cr = $this->ldap->connect($host, $port);
 		if(!is_resource($cr)) {
@@ -1250,12 +1243,10 @@ class Wizard extends LDAPUtility {
 			return $this->cr;
 		}
 
-		$host = $this->configuration->ldapHost;
-		if(strpos($host, '://') !== false) {
-			//ldap_connect ignores port parameter when URLs are passed
-			$host .= ':' . $this->configuration->ldapPort;
-		}
-		$cr = $this->ldap->connect($host, $this->configuration->ldapPort);
+		$cr = $this->ldap->connect(
+			$this->configuration->ldapHost,
+			$this->configuration->ldapPort
+		);
 
 		$this->ldap->setOption($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
 		$this->ldap->setOption($cr, LDAP_OPT_REFERRALS, 0);


### PR DESCRIPTION
Backport of #17924, cf. #17924 (comment)

Please test and review @PVince81 @MorrisJobke @owncloud/ldap

Oh, and give doublecare – the integration test cannot be backported, because those were only introduced into 8.1.
