### PR TITLE
Do not lower the sharee search

### DIFF
--- a/apps/files_sharing/api/sharees.php
+++ b/apps/files_sharing/api/sharees.php
@@ -353,7 +353,7 @@ class Sharees {
 		$this->limit = (int) $perPage;
 		$this->offset = $perPage * ($page - 1);
 
-		return $this->searchSharees(strtolower($search), $itemType, $shareTypes, $page, $perPage);
+		return $this->searchSharees($search, $itemType, $shareTypes, $page, $perPage);
 	}
 
 	/**

--- a/apps/files_sharing/tests/api/shareestest.php
+++ b/apps/files_sharing/tests/api/shareestest.php
@@ -1043,6 +1043,10 @@ class ShareesTest extends TestCase {
 			[[], 'no', 'yes',  true, '', null, $allTypes, 1, 200, false, true],
 			[[], 'no', 'no', true, '', null, $allTypes, 1, 200, false, false],
 
+			// Test keep case for search
+			[[
+				'search' => 'foo@example.com/ownCloud',
+			], '', 'yes', true, 'foo@example.com/ownCloud', null, $allTypes, 1, 200, false, true],
 		];
 	}
 


### PR DESCRIPTION
Fixes #21639

When lowering the remote search it break remotes that have uppercase
letters like foo@example.com/ownCloud/

Backends do the mathcing so they should also make sure that the search
string is converted to the format they require.

CC: @nickvergessen @PVince81  @owncloud/sharing 
