### PR TITLE
Use legacy method when ownCloud is not yet installed

### DIFF
--- a/lib/private/http/client/client.php
+++ b/lib/private/http/client/client.php
@@ -62,7 +62,14 @@ class Client implements IClient {
 		if ($this->certificateManager->listCertificates() !== []) {
 			$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath());
 		} else {
-			$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath(null));
+			// If the instance is not yet setup we need to use the static path as
+			// $this->certificateManager->getAbsoluteBundlePath() tries to instantiiate
+			// a view
+			if($this->config->getSystemValue('installed', false)) {
+				$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath(null));
+			} else {
+				$this->client->setDefaultOption('verify', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
+			}
 		}
 
 		$this->client->setDefaultOption('headers/User-Agent', 'ownCloud Server Crawler');


### PR DESCRIPTION
The new `\OCP\ICertificateManager::getAbsoluteBundlePath` API instantiiates an ownCloud view which makes the installation fail as it queries the DB before it actually is setup. This change uses the old approach again for the case that the installation is not yet setup.

The client service is required for the `.htaccess` effectivity check in the setup. In the future we could move this to a JS based one (as we have for the other setupchecks) so we can get rid of such hacks.

Fixes https://github.com/owncloud/core/issues/21669 which was a regression in master caused by https://github.com/owncloud/core/issues/21336. This feels super hacky, if somebody has another idea that works: Permission to take over this branch granted :wink: 

@icewind1991 Please review.
