### PR TITLE
Fix mock call to download

### DIFF
--- a/apps/dav/lib/carddav/syncservice.php
+++ b/apps/dav/lib/carddav/syncservice.php
@@ -124,7 +124,7 @@ class SyncService {
 	 * @param string $resourcePath
 	 * @return array
 	 */
-	private function download($url, $sharedSecret, $resourcePath) {
+	protected function download($url, $sharedSecret, $resourcePath) {
 		$settings = [
 			'baseUri' => $url,
 			'userName' => 'system',


### PR DESCRIPTION
We can only mock public and protected functions in phpunit.

This fixes my locally failing unit tests:

```
1) OCA\DAV\CardDAV\SyncServiceTest::testSyncWithNewElement
Sabre\HTTP\ClientException: Failed to connect to 0 port 80: Connection refused

/home/roeland/oc/core/3rdparty/sabre/http/lib/Client.php:356
/home/roeland/oc/core/3rdparty/sabre/http/lib/Client.php:103
/home/roeland/oc/core/3rdparty/sabre/dav/lib/DAV/Client.php:341
/home/roeland/oc/core/apps/dav/lib/carddav/syncservice.php:136
/home/roeland/oc/core/apps/dav/lib/carddav/syncservice.php:61
/home/roeland/oc/core/apps/dav/tests/unit/carddav/syncservicetest.php:39

2) OCA\DAV\CardDAV\SyncServiceTest::testSyncWithUpdatedElement
Sabre\HTTP\ClientException: Failed to connect to 0 port 80: Connection refused

/home/roeland/oc/core/3rdparty/sabre/http/lib/Client.php:356
/home/roeland/oc/core/3rdparty/sabre/http/lib/Client.php:103
/home/roeland/oc/core/3rdparty/sabre/dav/lib/DAV/Client.php:341
/home/roeland/oc/core/apps/dav/lib/carddav/syncservice.php:136
/home/roeland/oc/core/apps/dav/lib/carddav/syncservice.php:61
/home/roeland/oc/core/apps/dav/tests/unit/carddav/syncservicetest.php:48
```

CC: @DeepDiver1975 @PVince81 @nickvergessen @icewind1991 @LukasReschke 
