### PR TITLE
Updating system addressbook as soon as a user is added or removed

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -22,18 +22,16 @@
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
 
-\OC::$server->registerService('CardDAVSyncService', function() {
+$app = new \OCA\Dav\AppInfo\Application();
+$app->registerHooks();
 
-	$app = new \OCA\Dav\AppInfo\Application();
-	/** @var CardDavBackend */
-	$backend = $app->getContainer()->query('CardDavBackend');
+\OC::$server->registerService('CardDAVSyncService', function() use ($app) {
 
-	return new SyncService($backend);
+	return $app->getSyncService();
 });
 
 $cm = \OC::$server->getContactsManager();
-$cm->register(function() use ($cm) {
+$cm->register(function() use ($cm, $app) {
 	$userId = \OC::$server->getUserSession()->getUser()->getUID();
-	$app = new \OCA\Dav\AppInfo\Application();
 	$app->setupContactsProvider($cm, $userId);
 });

--- a/apps/dav/appinfo/application.php
+++ b/apps/dav/appinfo/application.php
@@ -20,7 +20,10 @@
  */
 namespace OCA\Dav\AppInfo;
 
+use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
+use OCA\DAV\CardDAV\SyncService;
+use OCA\DAV\HookManager;
 use \OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\Contacts\IManager;
@@ -40,6 +43,22 @@ class Application extends App {
 			/** @var IAppContainer $c */
 			return new ContactsManager(
 				$c->query('CardDavBackend')
+			);
+		});
+
+		$container->registerService('HookManager', function($c) {
+			/** @var IAppContainer $c */
+			return new HookManager(
+				$c->getServer()->getUserManager(),
+				$c->query('SyncService')
+			);
+		});
+
+		$container->registerService('SyncService', function($c) {
+			/** @var IAppContainer $c */
+			return new SyncService(
+				$c->query('CardDavBackend'),
+				$c->getServer()->getUserManager()
 			);
 		});
 
@@ -63,6 +82,16 @@ class Application extends App {
 		/** @var ContactsManager $cm */
 		$cm = $this->getContainer()->query('ContactsManager');
 		$cm->setupContactsProvider($contactsManager, $userID);
+	}
+
+	public function registerHooks() {
+		/** @var HookManager $hm */
+		$hm = $this->getContainer()->query('HookManager');
+		$hm->setup();
+	}
+
+	public function getSyncService() {
+		return $this->getContainer()->query('SyncService');
 	}
 
 }

--- a/apps/dav/appinfo/register_command.php
+++ b/apps/dav/appinfo/register_command.php
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+use OCA\Dav\AppInfo\Application;
 use OCA\DAV\Command\CreateAddressBook;
 use OCA\DAV\Command\CreateCalendar;
 use OCA\DAV\Command\SyncSystemAddressBook;
@@ -29,7 +30,9 @@ $userManager = OC::$server->getUserManager();
 $config = \OC::$server->getConfig();
 $logger = \OC::$server->getLogger();
 
+$app = new Application();
+
 /** @var Symfony\Component\Console\Application $application */
 $application->add(new CreateAddressBook($userManager, $dbConnection, $config, $logger));
 $application->add(new CreateCalendar($userManager, $dbConnection));
-$application->add(new SyncSystemAddressBook($userManager, $dbConnection, $config));
+$application->add(new SyncSystemAddressBook($app->getSyncService()));

--- a/apps/dav/lib/hookmanager.php
+++ b/apps/dav/lib/hookmanager.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV;
+
+use OCA\DAV\CardDAV\SyncService;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Util;
+
+class HookManager {
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var SyncService */
+	private $syncService;
+
+	/** @var IUser[] */
+	private $usersToDelete;
+
+	public function __construct(IUserManager $userManager, SyncService $syncService) {
+		$this->userManager = $userManager;
+		$this->syncService = $syncService;
+	}
+
+	public function setup() {
+		Util::connectHook('OC_User',
+			'post_createUser',
+			$this,
+			'postCreateUser');
+		Util::connectHook('OC_User',
+			'pre_deleteUser',
+			$this,
+			'preDeleteUser');
+		Util::connectHook('OC_User',
+			'post_deleteUser',
+			$this,
+			'postDeleteUser');
+	}
+
+	public function postCreateUser($params) {
+		$user = $this->userManager->get($params['uid']);
+		$this->syncService->updateUser($user);
+	}
+
+	public function preDeleteUser($params) {
+		$this->usersToDelete[$params['uid']] = $this->userManager->get($params['uid']);
+	}
+	public function postDeleteUser($params) {
+		$uid = $params['uid'];
+		if (isset($this->usersToDelete[$uid])){
+			$this->syncService->deleteUser($this->usersToDelete[$uid]);
+		}
+	}
+
+}

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -57,6 +57,17 @@ class SyncServiceTest extends TestCase {
 		$this->assertEquals('sync-token-1', $return);
 	}
 
+	public function testEnsureSystemAddressBookExists() {
+		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDAVBackend')->disableOriginalConstructor()->getMock();
+		$backend->expects($this->exactly(1))->method('createAddressBook');
+		$backend->expects($this->at(0))->method('getAddressBooksByUri')->willReturn(null);
+		$backend->expects($this->at(1))->method('getAddressBooksByUri')->willReturn([]);
+
+		$ss = new SyncService($backend);
+		$book = $ss->ensureSystemAddressBookExists('principals/users/adam', 'contacts', []);
+	}
+
 	/**
 	 * @param int $createCount
 	 * @param int $updateCount

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -77,8 +77,9 @@ class SyncServiceTest extends TestCase {
 	 * @return SyncService|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function getSyncServiceMock($backend, $response) {
+		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
 		/** @var SyncService | \PHPUnit_Framework_MockObject_MockObject $ss */
-		$ss = $this->getMock('OCA\DAV\CardDAV\SyncService', ['ensureSystemAddressBookExists', 'requestSyncReport', 'download'], [$backend]);
+		$ss = $this->getMock('OCA\DAV\CardDAV\SyncService', ['ensureSystemAddressBookExists', 'requestSyncReport', 'download'], [$backend, $userManager]);
 		$ss->method('requestSyncReport')->withAnyParameters()->willReturn(['response' => $response, 'token' => 'sync-token-1']);
 		$ss->method('ensureSystemAddressBookExists')->willReturn(['id' => 1]);
 		$ss->method('download')->willReturn([

--- a/apps/dav/tests/unit/carddav/syncservicetest.php
+++ b/apps/dav/tests/unit/carddav/syncservicetest.php
@@ -20,6 +20,8 @@
  */
 namespace OCA\DAV\CardDAV;
 
+use OCP\IUser;
+use OCP\IUserManager;
 use Test\TestCase;
 
 class SyncServiceTest extends TestCase {
@@ -64,8 +66,40 @@ class SyncServiceTest extends TestCase {
 		$backend->expects($this->at(0))->method('getAddressBooksByUri')->willReturn(null);
 		$backend->expects($this->at(1))->method('getAddressBooksByUri')->willReturn([]);
 
-		$ss = new SyncService($backend);
+		/** @var IUserManager $userManager */
+		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$ss = new SyncService($backend, $userManager);
 		$book = $ss->ensureSystemAddressBookExists('principals/users/adam', 'contacts', []);
+	}
+
+	public function testUpdateAndDeleteUser() {
+		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
+		$backend = $this->getMockBuilder('OCA\DAV\CardDAV\CardDAVBackend')->disableOriginalConstructor()->getMock();
+
+		$backend->expects($this->once())->method('createCard');
+		$backend->expects($this->once())->method('updateCard');
+		$backend->expects($this->once())->method('deleteCard');
+
+		$backend->method('getCard')->willReturnOnConsecutiveCalls(false, [
+			'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:test-user\r\nFN:test-user\r\nN:test-user;;;;\r\nEND:VCARD\r\n\r\n"
+		]);
+
+		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+
+		/** @var IUser | \PHPUnit_Framework_MockObject_MockObject $user */
+		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
+		$user->method('getBackendClassName')->willReturn('unittest');
+		$user->method('getUID')->willReturn('test-user');
+
+		$ss = new SyncService($backend, $userManager);
+		$ss->updateUser($user);
+
+		$user->method('getDisplayName')->willReturn('A test user for unit testing');
+
+		$ss->updateUser($user);
+
+		$ss->deleteUser($user);
 	}
 
 	/**


### PR DESCRIPTION
Various change events are handled in follow up PRs.

@LukasReschke @MorrisJobke @blizzz @icewind1991 please review - THX

Test plan:
1. start cadaver ${server}/remote.php/dav/addressbooks/system/system/system
2. that book might not yet be created 
3. add a new user via occ or the user management
4. see the user's vcard popping up in the system addressbook
