### PR TITLE
[Share 2.0] Fix pre_share and post_share hooks

### DIFF
--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -204,7 +204,7 @@ Feature: sharing
     When sending "GET" to "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And File "textfile0.txt" should be included in the response
+    And File "textfile0 (2).txt" should be included in the response
 
   Scenario: getting all shares of a user using another user
     Given user "user0" exists
@@ -264,7 +264,7 @@ Feature: sharing
       | share_type | 0 |
       | share_with | user1 |
       | file_source | A_NUMBER |
-      | file_target | /textfile0.txt |
+      | file_target | /textfile0 (2).txt |
       | path | /textfile0.txt |
       | permissions | 19 |
       | stime | A_NUMBER |

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -452,6 +452,16 @@ class Manager {
 		$target = \OC\Files\Filesystem::normalizePath($target);
 		$share->setTarget($target);
 
+		//Get sharewith for hooks
+		$sharedWith = null;
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+			$sharedWith = $share->getSharedWith()->getUID();
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$sharedWith = $share->getSharedWith()->getGID();
+		} else {
+			$sharedWith = $share->getSharedWith();
+		}
+
 		// Pre share hook
 		$run = true;
 		$error = '';
@@ -464,8 +474,10 @@ class Manager {
 			'fileSource' => $share->getPath()->getId(),
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
+			'itemTarget' => $share->getTarget(),
+			'shareWith' => $sharedWith,
 			'run' => &$run,
-			'error' => &$error
+			'error' => &$error,
 		];
 		\OC_Hook::emit('OCP\Share', 'pre_shared', $preHookData);
 
@@ -488,7 +500,11 @@ class Manager {
 			'expiration' => $share->getExpirationDate(),
 			'token' => $share->getToken(),
 			'id' => $share->getId(),
+			'shareWith' => $sharedWith,
+			'itemTarget' => $share->getTarget(),
+			'fileTarget' => $share->getTarget(),
 		];
+
 		\OC_Hook::emit('OCP\Share', 'post_shared', $postHookData);
 
 		return $share;

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -1364,6 +1364,8 @@ class ManagerTest extends \Test\TestCase {
 		$share->expects($this->once())
 			->method('setTarget')
 			->with('/target');
+		$share->method('getTarget')
+			->willReturn('/target');
 		$share->expects($this->once())
 			->method('setExpirationDate')
 			->with($date);
@@ -1388,6 +1390,8 @@ class ManagerTest extends \Test\TestCase {
 			'token' => 'token',
 			'run' => true,
 			'error' => '',
+			'itemTarget' => '/target',
+			'shareWith' => null,
 		];
 
 		$hookListnerExpectsPost = [
@@ -1400,6 +1404,9 @@ class ManagerTest extends \Test\TestCase {
 			'expiration' => $date,
 			'token' => 'token',
 			'id' => 42,
+			'itemTarget' => '/target',
+			'fileTarget' => '/target',
+			'shareWith' => null,
 		];
 
 		$share->method('getId')->willReturn(42);


### PR DESCRIPTION
Fixes errors like

```
{"reqId":"1rpQrTnaqAbR0hcibung","remoteAddr":"127.0.0.1","app":"PHP","message":"Undefined index: fileTarget at \/dev\/shm\/oc_test\/apps\/files_sharing\/lib\/updater.php#123","level":3,"time":"2016-01-13T20:49:39+00:00"}
```

I missed a few fields when moving over the pre_share and post_share hooks.

Easy one.

CC: @DeepDiver1975 @LukasReschke @nickvergessen @schiesbn @PVince81 @MorrisJobke 
