### PR TITLE
Improve background job error message

### DIFF
--- a/lib/private/backgroundjob/job.php
+++ b/lib/private/backgroundjob/job.php
@@ -52,8 +52,10 @@ abstract class Job implements IJob {
 			$this->run($this->argument);
 		} catch (\Exception $e) {
 			if ($logger) {
-				$logger->error('Error while running background job (class: ' . get_class($this) . ', arguments: ' . print_r($this->argument, true) . ')');
-				$logger->logException($e);
+				$logger->logException($e, [
+					'app' => 'core',
+					'message' => 'Error while running background job (class: ' . get_class($this) . ', arguments: ' . print_r($this->argument, true) . ')'
+				]);
 			}
 		}
 	}

--- a/lib/private/backgroundjob/job.php
+++ b/lib/private/backgroundjob/job.php
@@ -52,7 +52,8 @@ abstract class Job implements IJob {
 			$this->run($this->argument);
 		} catch (\Exception $e) {
 			if ($logger) {
-				$logger->error('Error while running background job (class: ' . get_class($this) . ', arguments: ' . print_r($this->argument, true) . '): ' . $e->getMessage());
+				$logger->error('Error while running background job (class: ' . get_class($this) . ', arguments: ' . print_r($this->argument, true) . ')');
+				$logger->logException($e);
 			}
 		}
 	}

--- a/lib/private/backgroundjob/job.php
+++ b/lib/private/backgroundjob/job.php
@@ -52,7 +52,7 @@ abstract class Job implements IJob {
 			$this->run($this->argument);
 		} catch (\Exception $e) {
 			if ($logger) {
-				$logger->error('Error while running background job: ' . $e->getMessage());
+				$logger->error('Error while running background job (class: ' . get_class($this) . ', arguments: ' . print_r($this->argument, true) . '): ' . $e->getMessage());
 			}
 		}
 	}

--- a/lib/private/log.php
+++ b/lib/private/log.php
@@ -285,6 +285,8 @@ class Log implements ILogger {
 			'Line' => $exception->getLine(),
 		);
 		$exception['Trace'] = preg_replace('!(login|checkPassword)\(.*\)!', '$1(*** username and password replaced ***)', $exception['Trace']);
-		$this->error('Exception: ' . json_encode($exception), $context);
+		$msg = isset($context['message']) ? $context['message'] : 'Exception';
+		$msg .= ': ' . json_encode($exception);
+		$this->error($msg, $context);
 	}
 }

--- a/lib/public/ilogger.php
+++ b/lib/public/ilogger.php
@@ -125,6 +125,14 @@ interface ILogger {
 
 	/**
 	 * Logs an exception very detailed
+	 * An additional message can we written to the log by adding it to the
+	 * context.
+	 *
+	 * <code>
+	 * $logger->logException($ex, [
+	 *     'message' => 'Exception during cron job execution'
+	 * ]);
+	 * </code>
 	 *
 	 * @param \Exception $exception
 	 * @param array $context

--- a/tests/lib/backgroundjob/job.php
+++ b/tests/lib/backgroundjob/job.php
@@ -28,9 +28,6 @@ class Job extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$logger->expects($this->once())
-			->method('error')
-			->with('Error while running background job (class: Test\BackgroundJob\TestJob, arguments: )');
-		$logger->expects($this->once())
 			->method('logException')
 			->with($e);
 

--- a/tests/lib/backgroundjob/job.php
+++ b/tests/lib/backgroundjob/job.php
@@ -18,8 +18,9 @@ class Job extends \Test\TestCase {
 
 	public function testRemoveAfterException() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this, function () {
-			throw new \Exception();
+		$e = new \Exception();
+		$job = new TestJob($this, function () use ($e) {
+			throw $e;
 		});
 		$jobList->add($job);
 
@@ -28,7 +29,10 @@ class Job extends \Test\TestCase {
 			->getMock();
 		$logger->expects($this->once())
 			->method('error')
-			->with('Error while running background job (class: Test\BackgroundJob\TestJob, arguments: ): ');
+			->with('Error while running background job (class: Test\BackgroundJob\TestJob, arguments: )');
+		$logger->expects($this->once())
+			->method('logException')
+			->with($e);
 
 		$this->assertCount(1, $jobList->getAll());
 		$job->execute($jobList, $logger);

--- a/tests/lib/backgroundjob/job.php
+++ b/tests/lib/backgroundjob/job.php
@@ -28,7 +28,7 @@ class Job extends \Test\TestCase {
 			->getMock();
 		$logger->expects($this->once())
 			->method('error')
-			->with('Error while running background job: ');
+			->with('Error while running background job (class: Test\BackgroundJob\TestJob, arguments: ): ');
 
 		$this->assertCount(1, $jobList->getAll());
 		$job->execute($jobList, $logger);


### PR DESCRIPTION
@karlitschek I would like to backport this because it helps to make things like #19807 clear on the very first look and you don't have to guess which job and what could be possible wrong with it.
