### PR TITLE
allow apps to register an \OCP\GroupInterface

### DIFF
--- a/lib/private/encryption/util.php
+++ b/lib/private/encryption/util.php
@@ -34,6 +34,7 @@ use OCP\Encryption\IEncryptionModule;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\IConfig;
+use OCP\IGroupManager;
 
 class Util {
 
@@ -72,20 +73,20 @@ class Util {
 	/** @var array paths excluded from encryption */
 	protected $excludedPaths;
 
-	/** @var \OC\Group\Manager $manager */
+	/** @var IGroupManager $manager */
 	protected $groupManager;
 
 	/**
 	 *
 	 * @param View $rootView
 	 * @param \OC\User\Manager $userManager
-	 * @param \OC\Group\Manager $groupManager
+	 * @param IGroupManager $groupManager
 	 * @param IConfig $config
 	 */
 	public function __construct(
 		View $rootView,
 		\OC\User\Manager $userManager,
-		\OC\Group\Manager $groupManager,
+		IGroupManager $groupManager,
 		IConfig $config) {
 
 		$this->ocHeaderKeys = [

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -727,7 +727,7 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OC\Group\Manager
+	 * @return \OCP\IGroupManager
 	 */
 	public function getGroupManager() {
 		return $this->query('GroupManager');

--- a/lib/public/igroupmanager.php
+++ b/lib/public/igroupmanager.php
@@ -135,4 +135,10 @@ interface IGroupManager {
 	 * @since 8.0.0
 	 */
 	public function isInGroup($userId, $group);
+
+	/**
+	 * FIXME: this leaks private core API, but it us used all over the place
+	 * @return \OC\SubAdmin
+	 */
+	public function getSubAdmin();
 }

--- a/settings/personal.php
+++ b/settings/personal.php
@@ -156,10 +156,9 @@ $tmpl->assign('showCertificates', $enableCertImport);
 $tmpl->assign('urlGenerator', $urlGenerator);
 
 // Get array of group ids for this user
-$groups = \OC::$server->getGroupManager()->getUserIdGroups(OC_User::getUser());
-$groups2 = array_map(function($group) { return $group->getGID(); }, $groups);
-sort($groups2);
-$tmpl->assign('groups', $groups2);
+$groups = \OC::$server->getGroupManager()->getUserGroupIds($user);
+sort($groups);
+$tmpl->assign('groups', $groups);
 
 // add hardcoded forms from the template
 $l = \OC::$server->getL10N('settings');


### PR DESCRIPTION
I am writing a user and group backend. Currently, the [server container API](https://github.com/owncloud/core/blob/master/lib/private/server.php#L730) forces me to use a `\OC\Group\Manager` from the private namespace to register a `\OC_Group_Backend` . I had hoped it was just a phpdoc issue, but in the end the current API effectively leaks getSubAdmin into the public API. This PR makes that explicit and adds a FIXME for it because the actual intention is to allow apps to register a `\OCP\GroupInterface` via `\OC::$server->getGroupManager()->addBackend(...)`

I did not add the proper phpdoc because I don't know if getSubAdmin really needs to be public.

Another option would be to make [base.php use the \OCP\IServerContainer](https://github.com/owncloud/core/blob/master/lib/base.php#L111)

hm ... what a mess ... I just want to be able to:

``` php
$myGroups = new MyGroups($config, $logger, $cache, $client);
\OC::$server->getGroupManager()->addBackend($myGroups);
```

But it does not seem to be possible with the public API. Neither is registering a user backend ... what a mess. I'll try to find a smaller PR.
