### PR TITLE
Fix occ app management for group apps

### DIFF
--- a/core/command/app/disable.php
+++ b/core/command/app/disable.php
@@ -23,12 +23,25 @@
 
 namespace OC\Core\Command\App;
 
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Command {
+
+	/** @var IAppManager */
+	protected $manager;
+
+	/**
+	 * @param IAppManager $manager
+	 */
+	public function __construct(IAppManager $manager) {
+		parent::__construct();
+		$this->manager = $manager;
+	}
+
 	protected function configure() {
 		$this
 			->setName('app:disable')
@@ -42,9 +55,9 @@ class Disable extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$appId = $input->getArgument('app-id');
-		if (\OC_App::isEnabled($appId)) {
+		if ($this->manager->isInstalled($appId)) {
 			try {
-				\OC_App::disable($appId);
+				$this->manager->disableApp($appId);
 				$output->writeln($appId . ' disabled');
 			} catch(\Exception $e) {
 				$output->writeln($e->getMessage());

--- a/core/command/app/enable.php
+++ b/core/command/app/enable.php
@@ -23,12 +23,26 @@
 
 namespace OC\Core\Command\App;
 
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Command {
+
+	/** @var IAppManager */
+	protected $manager;
+
+	/**
+	 * @param IAppManager $manager
+	 */
+	public function __construct(IAppManager $manager) {
+		parent::__construct();
+		$this->manager = $manager;
+	}
+
 	protected function configure() {
 		$this
 			->setName('app:enable')
@@ -37,19 +51,36 @@ class Enable extends Command {
 				'app-id',
 				InputArgument::REQUIRED,
 				'enable the specified app'
-			);
+			)
+			->addOption(
+				'groups',
+				'g',
+				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+				'enable the app only for a list of groups'
+			)
+		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$appId = $input->getArgument('app-id');
-		if (\OC_App::isEnabled($appId)) {
-			$output->writeln($appId . ' is already enabled');
-		} else if (!\OC_App::getAppPath($appId)) {
+
+		if (!\OC_App::getAppPath($appId)) {
 			$output->writeln($appId . ' not found');
 			return 1;
-		} else {
+		}
+
+		$groups = $input->getOption('groups');
+		if ($this->manager->isInstalled($appId) && empty($groups)) {
+			$output->writeln($appId . ' is already enabled');
+		}
+
+		if (empty($groups)) {
 			\OC_App::enable($appId);
 			$output->writeln($appId . ' enabled');
+		} else {
+			\OC_App::enable($appId, $groups);
+			$output->writeln($appId . ' enabled for groups: ' . implode(', ', $groups));
 		}
+		return 0;
 	}
 }

--- a/core/command/app/listapps.php
+++ b/core/command/app/listapps.php
@@ -25,11 +25,24 @@
 namespace OC\Core\Command\App;
 
 use OC\Core\Command\Base;
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListApps extends Base {
+
+	/** @var IAppManager */
+	protected $manager;
+
+	/**
+	 * @param IAppManager $manager
+	 */
+	public function __construct(IAppManager $manager) {
+		parent::__construct();
+		$this->manager = $manager;
+	}
+
 	protected function configure() {
 		parent::configure();
 
@@ -47,10 +60,9 @@ class ListApps extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		if ($input->getOption('shipped') === 'true' || $input->getOption('shipped') === 'false'){
-			$shouldFilterShipped = true;
 			$shippedFilter = $input->getOption('shipped') === 'true';
 		} else {
-			$shouldFilterShipped = false;
+			$shippedFilter = null;
 		}
 		
 		$apps = \OC_App::getAllApps();
@@ -59,10 +71,10 @@ class ListApps extends Base {
 
 		//sort enabled apps above disabled apps
 		foreach ($apps as $app) {
-			if ($shouldFilterShipped && \OC_App::isShipped($app) !== $shippedFilter){
+			if ($shippedFilter !== null && \OC_App::isShipped($app) !== $shippedFilter){
 				continue;
 			}
-			if (\OC_App::isEnabled($app)) {
+			if ($this->manager->isInstalled($app)) {
 				$enabledApps[] = $app;
 			} else {
 				$disabledApps[] = $app;

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -44,7 +44,7 @@ $application->add(new \OC\Core\Command\Integrity\SignCore(
 ));
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
-	$application->add(new OC\Core\Command\App\Disable());
+	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\Enable());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -47,7 +47,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable());
 	$application->add(new OC\Core\Command\App\Enable());
 	$application->add(new OC\Core\Command\App\GetPath());
-	$application->add(new OC\Core\Command\App\ListApps());
+	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
 
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -45,7 +45,7 @@ $application->add(new \OC\Core\Command\Integrity\SignCore(
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable());
+	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
 


### PR DESCRIPTION
### 1. App enabled for a group only, is not listed as "enabled"
1. Enable an app for a group only
2. Run `./occ app:list`
### 2. Can not disable app that is enabled for a specific group
1. Enable an app for a group only
2. Run `./occ app:disable testing`
### 3. Can not enable app for a specific group
1. Run `./occ app:enable help`

cc @MorrisJobke @LukasReschke @DeepDiver1975 

Fix #17737
