### PR TITLE
Only check selection for delete permissions, not parent folder

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2305,7 +2305,6 @@
 		 */
 		updateSelectionSummary: function() {
 			var summary = this._selectionSummary.summary;
-			var canDelete;
 			var selection;
 
 			if (summary.totalFiles === 0 && summary.totalDirs === 0) {
@@ -2316,7 +2315,6 @@
 				this.$el.find('.selectedActions').addClass('hidden');
 			}
 			else {
-				canDelete = (this.getDirectoryPermissions() & OC.PERMISSION_DELETE) && this.isSelectedDeletable();
 				this.$el.find('.selectedActions').removeClass('hidden');
 				this.$el.find('#headerSize a>span:first').text(OC.Util.humanFileSize(summary.totalSize));
 
@@ -2338,7 +2336,7 @@
 				this.$el.find('#headerName a.name>span:first').text(selection);
 				this.$el.find('#modified a>span:first').text('');
 				this.$el.find('table').addClass('multiselect');
-				this.$el.find('.delete-selected').toggleClass('hidden', !canDelete);
+				this.$el.find('.delete-selected').toggleClass('hidden', !this.isSelectedDeletable());
 			}
 		},
 

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1705,16 +1705,6 @@ describe('OCA.Files.FileList tests', function() {
 			});
 		});
 		describe('Selection overlay', function() {
-			it('show delete action according to directory permissions', function() {
-				fileList.setFiles(testFiles);
-				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_DELETE);
-				$('.select-all').click();
-				expect(fileList.$el.find('.delete-selected').hasClass('hidden')).toEqual(false);
-				$('.select-all').click();
-				$('#permissions').val(OC.PERMISSION_READ);
-				$('.select-all').click();
-				expect(fileList.$el.find('.delete-selected').hasClass('hidden')).toEqual(true);
-			});
 			it('show doesnt show the delete action if one or more files are not deletable', function () {
 				fileList.setFiles(testFiles);
 				$('#permissions').val(OC.PERMISSION_READ | OC.PERMISSION_DELETE);


### PR DESCRIPTION
We should be able to delete a selection of files if they are deletable, the parent folder permissions have no effect on this (e.g. with admin external storage mounts, where the mount is not deletable but files inside are)

Fixes #16533

cc @PVince81 @davitol
