### PR TITLE
Add question about code signing status

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -22,6 +22,14 @@ Tell us what happens instead
 
 **Updated from an older ownCloud or fresh install:**
 
+**Signing status (ownCloud 9.0 and above):**
+
+```
+Login as admin user into your ownCloud and access 
+http://example.com/index.php/settings/integrity/failed 
+paste the results here.
+```
+
 **List of activated apps:**
 
 ```


### PR DESCRIPTION
Let's ask the users to paste the signing status of their ownCloud instance. I went this way instead of simply asking "Has your instance passed code signing?" as a lot of users would probably simply answer "Yes" here.

If they paste the results of http://example.org/index.php/settings/integrity/failed the expected output is "No errors have been found.". Everything else indicates they tampered with their installation and we would see what is wrong.

@karlitschek @jospoortvliet @jancborchardt As discussed.
