### PR TITLE
[Share 2.0] Add share owner information to OCS Share API

### DIFF
--- a/apps/files_sharing/api/share20ocs.php
+++ b/apps/files_sharing/api/share20ocs.php
@@ -87,6 +87,8 @@ class Share20OCS {
 			'parent' => $share->getParent(),
 			'expiration' => null,
 			'token' => null,
+			'uid_file_owner' => $share->getShareOwner()->getUID(),
+			'displayname_file_owner' => $share->getShareOwner()->getDisplayName(),
 		];
 
 		$path = $share->getPath();

--- a/apps/files_sharing/tests/api/share20ocstest.php
+++ b/apps/files_sharing/tests/api/share20ocstest.php
@@ -171,6 +171,10 @@ class Share20OCSTest extends \Test\TestCase {
 	public function dataGetShare() {
 		$data = [];
 
+		$initiator = $this->getMock('OCP\IUser');
+		$initiator->method('getUID')->willReturn('initiatorId');
+		$initiator->method('getDisplayName')->willReturn('initiatorDisplay');
+
 		$owner = $this->getMock('OCP\IUser');
 		$owner->method('getUID')->willReturn('ownerId');
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
@@ -193,8 +197,6 @@ class Share20OCSTest extends \Test\TestCase {
 		$storage->method('getId')->willReturn('STORAGE');
 		$storage->method('getCache')->willReturn($cache);
 
-
-
 		$parentFolder = $this->getMock('OCP\Files\Folder');
 		$parentFolder->method('getId')->willReturn(3);
 
@@ -215,7 +217,7 @@ class Share20OCSTest extends \Test\TestCase {
 			100,
 			\OCP\Share::SHARE_TYPE_USER,
 			$user,
-			$owner,
+			$initiator,
 			$owner,
 			$file,
 			4,
@@ -230,8 +232,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'share_type' => \OCP\Share::SHARE_TYPE_USER,
 			'share_with' => 'userId',
 			'share_with_displayname' => 'userDisplay',
-			'uid_owner' => 'ownerId',
-			'displayname_owner' => 'ownerDisplay',
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
 			'item_type' => 'file',
 			'item_source' => 1,
 			'file_source' => 1,
@@ -246,6 +248,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'path' => 'file',
 			'storage' => 101,
 			'mail_send' => 0,
+			'uid_file_owner' => 'ownerId',
+			'displayname_file_owner' => 'ownerDisplay'
 		];
 		$data[] = [$share, $expected];
 
@@ -254,7 +258,7 @@ class Share20OCSTest extends \Test\TestCase {
 			101,
 			\OCP\Share::SHARE_TYPE_GROUP,
 			$group,
-			$owner,
+			$initiator,
 			$owner,
 			$folder,
 			4,
@@ -269,8 +273,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'share_type' => \OCP\Share::SHARE_TYPE_GROUP,
 			'share_with' => 'groupId',
 			'share_with_displayname' => 'groupId',
-			'uid_owner' => 'ownerId',
-			'displayname_owner' => 'ownerDisplay',
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
 			'item_type' => 'folder',
 			'item_source' => 2,
 			'file_source' => 2,
@@ -285,6 +289,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'path' => 'folder',
 			'storage' => 101,
 			'mail_send' => 0,
+			'uid_file_owner' => 'ownerId',
+			'displayname_file_owner' => 'ownerDisplay'
 		];
 		$data[] = [$share, $expected];
 
@@ -294,7 +300,7 @@ class Share20OCSTest extends \Test\TestCase {
 			101,
 			\OCP\Share::SHARE_TYPE_LINK,
 			null,
-			$owner,
+			$initiator,
 			$owner,
 			$folder,
 			4,
@@ -311,8 +317,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'share_type' => \OCP\Share::SHARE_TYPE_LINK,
 			'share_with' => 'password',
 			'share_with_displayname' => 'password',
-			'uid_owner' => 'ownerId',
-			'displayname_owner' => 'ownerDisplay',
+			'uid_owner' => 'initiatorId',
+			'displayname_owner' => 'initiatorDisplay',
 			'item_type' => 'folder',
 			'item_source' => 2,
 			'file_source' => 2,
@@ -328,6 +334,8 @@ class Share20OCSTest extends \Test\TestCase {
 			'storage' => 101,
 			'mail_send' => 0,
 			'url' => 'url',
+			'uid_file_owner' => 'ownerId',
+			'displayname_file_owner' => 'ownerDisplay'
 		];
 		$data[] = [$share, $expected];
 


### PR DESCRIPTION
@PVince81 as promised

For https://github.com/owncloud/core/issues/9058#issuecomment-171933015 and https://github.com/owncloud/core/issues/19331

Basically add a extra info to the OCS API output about the owner of the share (so the owner of the shared files). We will need this for proper displaying the new resharing behaviour in the clients (web + desktop + mobile).

Easy to review.

CC: @PVince81 @schiesbn @nickvergessen @DeepDiver1975 
