### PR TITLE
[Share 2.0] Additional checks for share object creation

### DIFF
--- a/lib/private/share20/exception/invalidshare.php
+++ b/lib/private/share20/exception/invalidshare.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Share20\Exception;
+
+class InvalidShare extends \Exception {
+
+}


### PR DESCRIPTION
- We can't assume that the file still exists
- We can't assume that the user/group still exists

Basically we do not always nicely cleanup shares.

CC: @schiesbn @nickvergessen @DeepDiver1975 @PVince81 
