### PR TITLE
Correctly remove global applicable

### DIFF
--- a/apps/files_external/service/dbconfigservice.php
+++ b/apps/files_external/service/dbconfigservice.php
@@ -294,8 +294,14 @@ class DBConfigService {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->delete('external_applicable')
 			->where($builder->expr()->eq('mount_id', $builder->createNamedParameter($mountId, \PDO::PARAM_INT)))
-			->andWhere($builder->expr()->eq('type', $builder->createNamedParameter($type, \PDO::PARAM_INT)))
-			->andWhere($builder->expr()->eq('value', $builder->createNamedParameter($value, \PDO::PARAM_STR)));
+			->andWhere($builder->expr()->eq('type', $builder->createNamedParameter($type, \PDO::PARAM_INT)));
+
+		if (is_null($value)) {
+			$query = $query->andWhere($builder->expr()->isNull('value'));
+		} else {
+			$query = $query->andWhere($builder->expr()->eq('value', $builder->createNamedParameter($value, \PDO::PARAM_STR)));
+		}
+
 		$query->execute();
 	}
 

--- a/apps/files_external/tests/service/dbconfigservicetest.php
+++ b/apps/files_external/tests/service/dbconfigservicetest.php
@@ -124,6 +124,18 @@ class DBConfigServiceTest extends TestCase {
 		$this->assertEquals([], $mount['applicable']);
 	}
 
+	public function testRemoveApplicableGlobal() {
+		$id = $this->addMount('/test', 'foo', 'bar', 100, DBConfigService::MOUNT_TYPE_ADMIN);
+		$this->dbConfig->addApplicable($id, DBConfigService::APPLICABLE_TYPE_GLOBAL, null);
+		$this->dbConfig->removeApplicable($id, DBConfigService::APPLICABLE_TYPE_GLOBAL, null);
+		$this->dbConfig->addApplicable($id, DBConfigService::APPLICABLE_TYPE_USER, 'test');
+
+		$mount = $this->dbConfig->getMountById($id);
+		$this->assertEquals([
+			['type' => DBConfigService::APPLICABLE_TYPE_USER, 'value' => 'test', 'mount_id' => $id]
+		], $mount['applicable']);
+	}
+
 	public function testSetConfig() {
 		$id = $this->addMount('/test', 'foo', 'bar', 100, DBConfigService::MOUNT_TYPE_ADMIN);
 		$this->dbConfig->setConfig($id, 'foo', 'bar');


### PR DESCRIPTION
A slightly different syntax is needed when matching null values in a Doctrine WHERE clause.

Fixes #21749 

cc @PVince81 @icewind1991 
