### PR TITLE
Share2 link

### DIFF
--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -54,7 +54,8 @@ class Application extends App {
 				$server->getActivityManager(),
 				$c->query('ShareManager'),
 				$c->query('Session'),
-				$server->getPreviewManager()
+				$server->getPreviewManager(),
+				$c->query('RootFolder')
 			);
 		});
 		$container->registerService('ExternalSharesController', function (SimpleContainer $c) {
@@ -69,6 +70,9 @@ class Application extends App {
 		/**
 		 * Core class wrappers
 		 */
+		$container->registerService('RootFolder', function(SimpleContainer $c) use ($server) {
+			return $server->getRootFolder();
+		});
 		$container->registerService('Session', function(SimpleContainer $c) use ($server) {
 			return $server->getSession();
 		});

--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -48,14 +48,14 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$server->getConfig(),
-				$c->query('URLGenerator'),
-				$c->query('UserManager'),
+				$server->getURLGenerator(),
+				$server->getUserManager(),
 				$server->getLogger(),
 				$server->getActivityManager(),
-				$c->query('ShareManager'),
-				$c->query('Session'),
+				$server->getShareManager(),
+				$server->getSession(),
 				$server->getPreviewManager(),
-				$c->query('RootFolder')
+				$server->getRootFolder()
 			);
 		});
 		$container->registerService('ExternalSharesController', function (SimpleContainer $c) {
@@ -70,24 +70,6 @@ class Application extends App {
 		/**
 		 * Core class wrappers
 		 */
-		$container->registerService('RootFolder', function(SimpleContainer $c) use ($server) {
-			return $server->getRootFolder();
-		});
-		$container->registerService('Session', function(SimpleContainer $c) use ($server) {
-			return $server->getSession();
-		});
-		$container->registerService('ShareManager', function(SimpleContainer $c) use ($server) {
-			return $server->getShareManager();
-		});
-		$container->registerService('UserSession', function (SimpleContainer $c) use ($server) {
-			return $server->getUserSession();
-		});
-		$container->registerService('URLGenerator', function (SimpleContainer $c) use ($server) {
-			return $server->getUrlGenerator();
-		});
-		$container->registerService('UserManager', function (SimpleContainer $c) use ($server) {
-			return $server->getUserManager();
-		});
 		$container->registerService('HttpClientService', function (SimpleContainer $c) use ($server) {
 			return $server->getHTTPClientService();
 		});

--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -47,15 +47,13 @@ class Application extends App {
 			return new ShareController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('UserSession'),
-				$server->getAppConfig(),
 				$server->getConfig(),
 				$c->query('URLGenerator'),
 				$c->query('UserManager'),
 				$server->getLogger(),
 				$server->getActivityManager(),
-				$server->getShareManager(),
-				$server->getSession(),
+				$c->query('ShareManager'),
+				$c->query('Session'),
 				$server->getPreviewManager()
 			);
 		});
@@ -71,6 +69,12 @@ class Application extends App {
 		/**
 		 * Core class wrappers
 		 */
+		$container->registerService('Session', function(SimpleContainer $c) use ($server) {
+			return $server->getSession();
+		});
+		$container->registerService('ShareManager', function(SimpleContainer $c) use ($server) {
+			return $server->getShareManager();
+		});
 		$container->registerService('UserSession', function (SimpleContainer $c) use ($server) {
 			return $server->getUserSession();
 		});

--- a/apps/files_sharing/appinfo/application.php
+++ b/apps/files_sharing/appinfo/application.php
@@ -53,7 +53,10 @@ class Application extends App {
 				$c->query('URLGenerator'),
 				$c->query('UserManager'),
 				$server->getLogger(),
-				$server->getActivityManager()
+				$server->getActivityManager(),
+				$server->getShareManager(),
+				$server->getSession(),
+				$server->getPreviewManager()
 			);
 		});
 		$container->registerService('ExternalSharesController', function (SimpleContainer $c) {

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -91,6 +91,7 @@ class ShareController extends Controller {
 	 * @param \OC\Share20\Manager $shareManager
 	 * @param ISession $session
 	 * @param IPreview $previewManager
+	 * @param IRootFolder $rootFolder
 	 */
 	public function __construct($appName,
 								IRequest $request,

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -357,7 +357,7 @@ class ShareController extends Controller {
 				// Subset of files is downloaded
 				foreach ($files_list as $file) {
 					$subNode = $node->get($file);
-					$nodePath = $userFolder->getRelativePath($node->getPath());
+					$nodePath = $userFolder->getRelativePath($subNode->getPath());
 					if ($subNode instanceof \OCP\Files\File) {
 						$this->activityManager->publishActivity(
 							'files_sharing', Activity::SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED, [$nodePath], '', [],

--- a/apps/files_sharing/lib/controllers/sharecontroller.php
+++ b/apps/files_sharing/lib/controllers/sharecontroller.php
@@ -41,9 +41,12 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
-use OC\URLGenerator;
-use OC\AppConfig;
+use OCP\IURLGenerator;
+use OCP\IConfig;
 use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\ISession;
+use OCP\IPreview;
 use OCA\Files_Sharing\Helper;
 use OCP\Util;
 use OCA\Files_Sharing\Activity;
@@ -57,57 +60,47 @@ use \OC\Share20\IShare;
  */
 class ShareController extends Controller {
 
-	/** @var \OC\User\Session */
-	protected $userSession;
-	/** @var \OC\AppConfig */
-	protected $appConfig;
-	/** @var \OCP\IConfig */
+	/** @var IConfig */
 	protected $config;
-	/** @var \OC\URLGenerator */
+	/** @var IURLGenerator */
 	protected $urlGenerator;
-	/** @var \OC\User\Manager */
+	/** @var IUserManager */
 	protected $userManager;
-	/** @var \OCP\ILogger */
+	/** @var ILogger */
 	protected $logger;
 	/** @var OCP\Activity\IManager */
 	protected $activityManager;
 	/** @var OC\Share20\Manager */
 	protected $shareManager;
-	/** @var \OCP\ISession */
+	/** @var ISession */
 	protected $session;
-	/** @var \OCP\IPreview */
+	/** @var IPreview */
 	protected $previewManager;
 
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
-	 * @param OC\User\Session $userSession
-	 * @param AppConfig $appConfig
-	 * @param OCP\IConfig $config
-	 * @param URLGenerator $urlGenerator
-	 * @param OCP\IUserManager $userManager
+	 * @param IConfig $config
+	 * @param IURLGenerator $urlGenerator
+	 * @param IUserManager $userManager
 	 * @param ILogger $logger
 	 * @param OCP\Activity\IManager $activityManager
 	 * @param \OC\Share20\Manager $shareManager
-	 * @param \OCP\ISession $session
-	 * @param \OCP\IPreview $previewManager
+	 * @param ISession $session
+	 * @param IPreview $previewManager
 	 */
 	public function __construct($appName,
 								IRequest $request,
-								OC\User\Session $userSession,
-								AppConfig $appConfig,
-								OCP\IConfig $config,
-								URLGenerator $urlGenerator,
-								OCP\IUserManager $userManager,
+								IConfig $config,
+								IURLGenerator $urlGenerator,
+								IUserManager $userManager,
 								ILogger $logger,
-								OCP\Activity\IManager $activityManager,
+								\OCP\Activity\IManager $activityManager,
 								\OC\Share20\Manager $shareManager,
-								\OCP\ISession $session,
-								\OCP\IPreview $previewManager) {
+								ISession $session,
+								IPreview $previewManager) {
 		parent::__construct($appName, $request);
 
-		$this->userSession = $userSession;
-		$this->appConfig = $appConfig;
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -26,7 +26,7 @@ $thumbSize = 1024;
 ?>
 
 <?php if ($_['previewSupported']): /* This enables preview images for links (e.g. on Facebook, Google+, ...)*/?>
-	<link rel="image_src" href="<?php p(OCP\Util::linkToRoute( 'core_ajax_public_preview', array('x' => $thumbSize, 'y' => $thumbSize, 'file' => $_['directory_path'], 't' => $_['dirToken']))); ?>" />
+	<link rel="image_src" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute( 'core_ajax_public_preview', array('x' => $thumbSize, 'y' => $thumbSize, 'file' => $_['directory_path'], 't' => $_['dirToken']))); ?>" />
 <?php endif; ?>
 
 <div id="notification-container">

--- a/apps/files_sharing/tests/controller/sharecontroller.php
+++ b/apps/files_sharing/tests/controller/sharecontroller.php
@@ -317,27 +317,20 @@ class ShareControllerTest extends \Test\TestCase {
 	}
 
 	public function testDownloadShare() {
+		$share = $this->getMock('\OC\Share20\IShare');
+		$share->method('getPassword')->willReturn('password');
+
+		$this->shareManager
+			->expects($this->once())
+			->method('getShareByToken')
+			->with('validtoken')
+			->willReturn($share);
+
 		// Test with a password protected share and no authentication
-		$response = $this->shareController->downloadShare($this->token);
+		$response = $this->shareController->downloadShare('validtoken');
 		$expectedResponse = new RedirectResponse($this->urlGenerator->linkToRoute('files_sharing.sharecontroller.authenticate',
-			array('token' => $this->token)));
+			['token' => 'validtoken']));
 		$this->assertEquals($expectedResponse, $response);
-	}
-
-	/**
-	 * @expectedException \OCP\Files\NotFoundException
-	 */
-	public function testDownloadShareWithDeletedFile() {
-		$this->container['UserManager']->expects($this->once())
-			->method('userExists')
-			->with($this->user)
-			->will($this->returnValue(true));
-
-		$view = new View('/'. $this->user . '/files');
-		$view->unlink('file1.txt');
-		$linkItem = Share::getShareByToken($this->token, false);
-		\OC::$server->getSession()->set('public_link_authenticated', $linkItem['id']);
-		$this->shareController->downloadShare($this->token);
 	}
 
 }

--- a/lib/private/share20/ishareprovider.php
+++ b/lib/private/share20/ishareprovider.php
@@ -103,11 +103,11 @@ interface IShareProvider {
 	public function getSharedWithMe(IUser $user, $shareType = null);
 
 	/**
-	 * Get a share by token and if present verify the password
+	 * Get a share by token
 	 *
 	 * @param string $token
-	 * @param string $password
-	 * @param Share
+	 * @return IShare
+	 * @throws ShareNotFound
 	 */
-	public function getShareByToken($token, $password = null);
+	public function getShareByToken($token);
 }

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -665,13 +665,47 @@ class Manager {
 	 * Get the share by token possible with password
 	 *
 	 * @param string $token
-	 * @param string $password
-	 *
 	 * @return Share
 	 *
 	 * @throws ShareNotFound
 	 */
-	public function getShareByToken($token, $password=null) {
+	public function getShareByToken($token) {
+		$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_LINK);
+
+		$share = $provider->getShareByToken($token);
+
+		//TODO check if share expired
+
+		return $share;
+	}
+
+	/**
+	 * Verify the password of a public share
+	 *
+	 * @param IShare $share
+	 * @param string $password
+	 * @return bool
+	 */
+	public function checkPassword(IShare $share, $password) {
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_LINK) {
+			//TODO maybe exception?
+			return false;
+		}
+
+		if ($password === null || $share->getPassword() === null) {
+			return false;
+		}
+
+		$newHash = '';
+		if (!$this->hasher->verify($password, $share->getPassword(), $newHash)) {
+			return false;
+		}
+
+		if (!empty($newHash)) {
+			//TODO update hash!
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Requires https://github.com/owncloud/core/pull/21755

Move the sharecontroller that handles authentication/displaying/downloading of link shares over to the sharemanager instead of the old code paths.

It is actually pretty straight forward.

CC: @schiesbn @DeepDiver1975 @nickvergessen @PVince81 @LukasReschke 
