### PR TITLE
always allow autoloading encryption in unit test

### DIFF
--- a/tests/settings/controller/EncryptionControllerTest.php
+++ b/tests/settings/controller/EncryptionControllerTest.php
@@ -90,6 +90,9 @@ class EncryptionControllerTest extends TestCase {
 	}
 
 	public function testStartMigrationSuccessful() {
+		// we need to be able to autoload the class we're mocking
+		\OC::$loader->addValidRoot(\OC_App::getAppPath('encryption'));
+
 		$migration = $this->getMockBuilder('\\OCA\\Encryption\\Migration')
 			->disableOriginalConstructor()->getMock();
 		$this->encryptionController


### PR DESCRIPTION
Fixes failing tests if encryption isn't enabled

Superseeds https://github.com/owncloud/core/pull/21218

cc @DeepDiver1975 @schiesbn 
