### PR TITLE
properly use standard

### DIFF
--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -102,7 +102,7 @@ describe('OC.Upload tests', function() {
 			expect(failStub.calledOnce).toEqual(true);
 			expect(failStub.getCall(0).args[1].textStatus).toEqual('sizeexceedlimit');
 			expect(failStub.getCall(0).args[1].errorThrown).toEqual(
-				'Total file size 5 kB exceeds upload limit 1000 B'
+				'Total file size 5 KB exceeds upload limit 1000 B'
 			);
 		});
 		it('does not add file if it exceeds free space', function() {
@@ -115,7 +115,7 @@ describe('OC.Upload tests', function() {
 			expect(failStub.calledOnce).toEqual(true);
 			expect(failStub.getCall(0).args[1].textStatus).toEqual('notenoughspace');
 			expect(failStub.getCall(0).args[1].errorThrown).toEqual(
-				'Not enough free space, you are uploading 5 kB but only 1000 B is left'
+				'Not enough free space, you are uploading 5 KB but only 1000 B is left'
 			);
 		});
 	});

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -213,7 +213,7 @@ describe('OCA.Files.FileList tests', function() {
 				.toEqual(OC.webroot + '/remote.php/webdav/subdir/testName.txt');
 			expect($tr.find('.nametext').text().trim()).toEqual('testName.txt');
 
-			expect($tr.find('.filesize').text()).toEqual('1 kB');
+			expect($tr.find('.filesize').text()).toEqual('1 KB');
 			expect($tr.find('.date').text()).not.toEqual('?');
 			expect(fileList.findFileEl('testName.txt')[0]).toEqual($tr[0]);
 		});
@@ -239,7 +239,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($tr.attr('data-mime')).toEqual('httpd/unix-directory');
 			expect($tr.attr('data-mtime')).toEqual('123456');
 
-			expect($tr.find('.filesize').text()).toEqual('1 kB');
+			expect($tr.find('.filesize').text()).toEqual('1 KB');
 			expect($tr.find('.date').text()).not.toEqual('?');
 
 			expect(fileList.findFileEl('testFolder')[0]).toEqual($tr[0]);
@@ -296,7 +296,7 @@ describe('OCA.Files.FileList tests', function() {
 				size: '0'
 			};
 			var $tr = fileList.add(fileData);
-			expect($tr.find('.filesize').text()).toEqual('0 kB');
+			expect($tr.find('.filesize').text()).toEqual('0 KB');
 		});
 		it('generates file element with unknown date when mtime invalid', function() {
 			var fileData = {
@@ -424,7 +424,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($summary.find('.info').text()).toEqual('1 folder and 2 files');
 			expect($summary.find('.dirinfo').hasClass('hidden')).toEqual(false);
 			expect($summary.find('.fileinfo').hasClass('hidden')).toEqual(false);
-			expect($summary.find('.filesize').text()).toEqual('69 kB');
+			expect($summary.find('.filesize').text()).toEqual('69 KB');
 			expect(fileList.isEmpty).toEqual(false);
 		});
 		it('Shows empty content when removing last file', function() {
@@ -479,7 +479,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect($summary.find('.info').text()).toEqual('1 folder and 1 file');
 			expect($summary.find('.dirinfo').hasClass('hidden')).toEqual(false);
 			expect($summary.find('.fileinfo').hasClass('hidden')).toEqual(false);
-			expect($summary.find('.filesize').text()).toEqual('57 kB');
+			expect($summary.find('.filesize').text()).toEqual('57 KB');
 			expect(fileList.isEmpty).toEqual(false);
 			expect($('#filestable thead th').hasClass('hidden')).toEqual(false);
 			expect($('#emptycontent').hasClass('hidden')).toEqual(true);
@@ -777,7 +777,7 @@ describe('OCA.Files.FileList tests', function() {
 
 			// folder size has increased
 			expect(fileList.findFileEl('somedir').data('size')).toEqual(12311);
-			expect(fileList.findFileEl('somedir').find('.filesize').text()).toEqual('12 kB');
+			expect(fileList.findFileEl('somedir').find('.filesize').text()).toEqual('12 KB');
 
 			expect(notificationStub.notCalled).toEqual(true);
 		});
@@ -843,7 +843,7 @@ describe('OCA.Files.FileList tests', function() {
 			$summary = $('#filestable .summary');
 			expect($summary.hasClass('hidden')).toEqual(false);
 			expect($summary.find('.info').text()).toEqual('1 folder and 3 files');
-			expect($summary.find('.filesize').text()).toEqual('69 kB');
+			expect($summary.find('.filesize').text()).toEqual('69 KB');
 		});
 		it('shows headers, summary and hide empty content message after setting files', function(){
 			fileList.setFiles(testFiles);

--- a/apps/files/tests/js/filesummarySpec.js
+++ b/apps/files/tests/js/filesummarySpec.js
@@ -40,7 +40,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		});
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('5 folders and 2 files');
-		expect($container.find('.filesize').text()).toEqual('250 kB');
+		expect($container.find('.filesize').text()).toEqual('250 KB');
 	});
 	it('hides summary when no files or folders', function() {
 		var s = new FileSummary($container);
@@ -63,7 +63,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		s.update();
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('6 folders and 3 files');
-		expect($container.find('.filesize').text()).toEqual('500 kB');
+		expect($container.find('.filesize').text()).toEqual('500 KB');
 		expect(s.summary.totalDirs).toEqual(6);
 		expect(s.summary.totalFiles).toEqual(3);
 		expect(s.summary.totalSize).toEqual(512100);
@@ -80,7 +80,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		s.update();
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('4 folders and 1 file');
-		expect($container.find('.filesize').text()).toEqual('125 kB');
+		expect($container.find('.filesize').text()).toEqual('125 KB');
 		expect(s.summary.totalDirs).toEqual(4);
 		expect(s.summary.totalFiles).toEqual(1);
 		expect(s.summary.totalSize).toEqual(127900);
@@ -96,7 +96,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		});
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('5 folders and 2 files match \'foo\'');
-		expect($container.find('.filesize').text()).toEqual('250 kB');
+		expect($container.find('.filesize').text()).toEqual('250 KB');
 	});
 	it('hides filtered summary when no files or folders', function() {
 		var s = new FileSummary($container);
@@ -123,7 +123,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		s.update();
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('6 folders and 3 files match \'foo\'');
-		expect($container.find('.filesize').text()).toEqual('500 kB');
+		expect($container.find('.filesize').text()).toEqual('500 KB');
 		expect(s.summary.totalDirs).toEqual(6);
 		expect(s.summary.totalFiles).toEqual(3);
 		expect(s.summary.totalSize).toEqual(512103);
@@ -143,7 +143,7 @@ describe('OCA.Files.FileSummary tests', function() {
 		s.update();
 		expect($container.hasClass('hidden')).toEqual(false);
 		expect($container.find('.info').text()).toEqual('4 folders and 1 file match \'foo\'');
-		expect($container.find('.filesize').text()).toEqual('125 kB');
+		expect($container.find('.filesize').text()).toEqual('125 KB');
 		expect(s.summary.totalDirs).toEqual(4);
 		expect(s.summary.totalFiles).toEqual(1);
 		expect(s.summary.totalSize).toEqual(127903);

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1449,7 +1449,7 @@ $.fn.filterAttr = function(attr_name, attr_value) {
  * @return {string}
  */
 function humanFileSize(size, skipSmallSizes) {
-	var humanList = ['B', 'kB', 'MB', 'GB', 'TB'];
+	var humanList = ['B', 'KB', 'MB', 'GB', 'TB'];
 	// Calculate Log with base 1024: size = 1024 ** order
 	var order = size > 0 ? Math.floor(Math.log(size) / Math.log(1024)) : 0;
 	// Stay in range of the byte sizes that are defined
@@ -1458,9 +1458,9 @@ function humanFileSize(size, skipSmallSizes) {
 	var relativeSize = (size / Math.pow(1024, order)).toFixed(1);
 	if(skipSmallSizes === true && order === 0) {
 		if(relativeSize !== "0.0"){
-			return '< 1 kB';
+			return '< 1 KB';
 		} else {
-			return '0 kB';
+			return '0 KB';
 		}
 	}
 	if(order < 2){

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -524,7 +524,7 @@ describe('Core base tests', function() {
 					["0", '0 B'],
 					["A", 'NaN B'],
 					[125, '125 B'],
-					[128000, '125 kB'],
+					[128000, '125 KB'],
 					[128000000, '122.1 MB'],
 					[128000000000, '119.2 GB'],
 					[128000000000000, '116.4 TB']
@@ -535,9 +535,9 @@ describe('Core base tests', function() {
 			});
 			it('renders file sizes with the correct unit for small sizes', function() {
 				var data = [
-					[0, '0 kB'],
-					[125, '< 1 kB'],
-					[128000, '125 kB'],
+					[0, '0 KB'],
+					[125, '< 1 KB'],
+					[128000, '125 KB'],
 					[128000000, '122.1 MB'],
 					[128000000000, '119.2 GB'],
 					[128000000000000, '116.4 TB']

--- a/lib/private/helper.php
+++ b/lib/private/helper.php
@@ -112,7 +112,7 @@ class OC_Helper {
 		}
 		$bytes = round($bytes / 1024, 0);
 		if ($bytes < 1024) {
-			return "$bytes kB";
+			return "$bytes KB";
 		}
 		$bytes = round($bytes / 1024, 1);
 		if ($bytes < 1024) {

--- a/tests/lib/helper.php
+++ b/tests/lib/helper.php
@@ -21,7 +21,7 @@ class Test_Helper extends \Test\TestCase {
 	{
 		return array(
 			array('0 B', 0),
-			array('1 kB', 1024),
+			array('1 KB', 1024),
 			array('9.5 MB', 10000000),
 			array('1.3 GB', 1395864371),
 			array('465.7 GB', 500000000000),
@@ -63,7 +63,7 @@ class Test_Helper extends \Test\TestCase {
 	function providesComputerFileSize(){
 		return [
 			[0.0, "0 B"],
-			[1024.0, "1 kB"],
+			[1024.0, "1 KB"],
 			[1395864371.0, '1.3 GB'],
 			[9961472.0, "9.5 MB"],
 			[500041567437.0, "465.7 GB"],


### PR DESCRIPTION
- JEDEC standard - https://en.wikipedia.org/wiki/JEDEC_memory_standards#Unit_prefixes_for_semiconductor_storage_capacity
- ref https://github.com/owncloud/core/issues/13386#issuecomment-172791177

cc @nickvergessen @rullzer @LukasReschke @dragotin @guruz @jancborchardt 

@karlitschek Should we backport this to stop all the discussions (nitpicking) about file sizes and units?
