### PR TITLE
Allow custom implementation of system tag managers

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -819,6 +819,13 @@ $CONFIG = array(
 'comments.managerFactory' => '\OC\Comments\ManagerFactory',
 
 /**
+ * Replaces the default System Tags Manager Factory. This can be utilized if an
+ * own or 3rdParty SystemTagsManager should be used that – for instance – uses the
+ * filesystem instead of the database to keep the comments.
+ */
+'systemtags.managerFactory' => '\OC\SystemTag\ManagerFactory',
+
+/**
  * Maintenance
  *
  * These options are for halting user activity when you are performing server

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -143,11 +143,18 @@ class Server extends ServerContainer implements IServerContainer {
 			$tagMapper = $c->query('TagMapper');
 			return new TagManager($tagMapper, $c->getUserSession());
 		});
+		$this->registerService('SystemTagManagerFactory', function (Server $c) {
+			$config = $c->getConfig();
+			$factoryClass = $config->getSystemValue('systemtags.managerFactory', '\OC\SystemTag\ManagerFactory');
+			/** @var \OC\SystemTag\ManagerFactory $factory */
+			$factory = new $factoryClass($this);
+			return $factory;
+		});
 		$this->registerService('SystemTagManager', function (Server $c) {
-			return new SystemTag\SystemTagManager($c->getDatabaseConnection());
+			return $c->query('SystemTagManagerFactory')->getManager();
 		});
 		$this->registerService('SystemTagObjectMapper', function (Server $c) {
-			return new SystemTag\SystemTagObjectMapper($c->getDatabaseConnection(), $c->getSystemTagManager());
+			return $c->query('SystemTagManagerFactory')->getObjectMapper();
 		});
 		$this->registerService('RootFolder', function (Server $c) {
 			// TODO: get user and user manager from container as well
@@ -533,7 +540,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$config = $c->getConfig();
 			$factoryClass = $config->getSystemValue('comments.managerFactory', '\OC\Comments\ManagerFactory');
 			/** @var \OCP\Comments\ICommentsManagerFactory $factory */
-			$factory = new $factoryClass();
+			$factory = new $factoryClass($this);
 			return $factory->getManager();
 		});
 		$this->registerService('EventDispatcher', function() {

--- a/lib/private/systemtag/managerfactory.php
+++ b/lib/private/systemtag/managerfactory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Arthur Schiwon <blizzz@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -18,13 +18,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Comments;
+namespace OC\SystemTag;
 
-use OCP\Comments\ICommentsManager;
-use OCP\Comments\ICommentsManagerFactory;
+use OCP\SystemTag\ISystemTagManagerFactory;
+use OCP\SystemTag\ISystemTagManager;
+use OC\SystemTag\SystemTagManager;
+use OC\SystemTag\SystemTagObjectMapper;
 use OCP\IServerContainer;
 
-class ManagerFactory implements ICommentsManagerFactory {
+/**
+ * Default factory class for system tag managers
+ *
+ * @package OCP\SystemTag
+ * @since 9.0.0
+ */
+class ManagerFactory implements ISystemTagManagerFactory {
 
 	/**
 	 * Server container
@@ -34,7 +42,7 @@ class ManagerFactory implements ICommentsManagerFactory {
 	private $serverContainer;
 
 	/**
-	 * Constructor for the comments manager factory
+	 * Constructor for the system tag manager factory
 	 *
 	 * @param IServerContainer $serverContainer server container
 	 */
@@ -43,15 +51,28 @@ class ManagerFactory implements ICommentsManagerFactory {
 	}
 
 	/**
-	 * creates and returns an instance of the ICommentsManager
+	 * Creates and returns an instance of the system tag manager
 	 *
-	 * @return ICommentsManager
+	 * @return ISystemTagManager
 	 * @since 9.0.0
 	 */
 	public function getManager() {
-		return new Manager(
+		return new SystemTagManager(
+			$this->serverContainer->getDatabaseConnection()
+		);
+	}
+
+	/**
+	 * Creates and returns an instance of the system tag object
+	 * mapper
+	 *
+	 * @return ISystemTagObjectMapper
+	 * @since 9.0.0
+	 */
+	public function getObjectMapper() {
+		return new SystemTagObjectMapper(
 			$this->serverContainer->getDatabaseConnection(),
-			$this->serverContainer->getLogger()
+			$this->getManager()
 		);
 	}
 }

--- a/lib/public/comments/icommentsmanagerfactory.php
+++ b/lib/public/comments/icommentsmanagerfactory.php
@@ -20,6 +20,8 @@
  */
 namespace OCP\Comments;
 
+use OCP\IServerContainer;
+
 /**
  * Interface ICommentsManagerFactory
  *
@@ -30,6 +32,14 @@ namespace OCP\Comments;
  * @since 9.0.0
  */
 interface ICommentsManagerFactory {
+
+	/**
+	 * Constructor for the comments manager factory
+	 *
+	 * @param IServerContainer $serverContainer server container
+	 * @since 9.0.0
+	 */
+	public function __construct(IServerContainer $serverContainer);
 
 	/**
 	 * creates and returns an instance of the ICommentsManager

--- a/lib/public/systemtag/isystemtagmanagerfactory.php
+++ b/lib/public/systemtag/isystemtagmanagerfactory.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Arthur Schiwon <blizzz@owncloud.com>
+ * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -18,40 +18,42 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Comments;
+namespace OCP\SystemTag;
 
-use OCP\Comments\ICommentsManager;
-use OCP\Comments\ICommentsManagerFactory;
 use OCP\IServerContainer;
 
-class ManagerFactory implements ICommentsManagerFactory {
+/**
+ * Interface ISystemTagManagerFactory
+ *
+ * Factory interface for system tag managers
+ *
+ * @package OCP\SystemTag
+ * @since 9.0.0
+ */
+interface ISystemTagManagerFactory {
 
 	/**
-	 * Server container
-	 *
-	 * @var IServerContainer
-	 */
-	private $serverContainer;
-
-	/**
-	 * Constructor for the comments manager factory
+	 * Constructor for the system tag manager factory
 	 *
 	 * @param IServerContainer $serverContainer server container
-	 */
-	public function __construct(IServerContainer $serverContainer) {
-		$this->serverContainer = $serverContainer;
-	}
-
-	/**
-	 * creates and returns an instance of the ICommentsManager
-	 *
-	 * @return ICommentsManager
 	 * @since 9.0.0
 	 */
-	public function getManager() {
-		return new Manager(
-			$this->serverContainer->getDatabaseConnection(),
-			$this->serverContainer->getLogger()
-		);
-	}
+	public function __construct(IServerContainer $serverContainer);
+
+	/**
+	 * creates and returns an instance of the system tag manager
+	 *
+	 * @return ISystemTagManager
+	 * @since 9.0.0
+	 */
+	public function getManager();
+
+	/**
+	 * creates and returns an instance of the system tag object
+	 * mapper
+	 *
+	 * @return ISystemTagObjectMapper
+	 * @since 9.0.0
+	 */
+	public function getObjectMapper();
 }

--- a/tests/lib/comments/fakefactory.php
+++ b/tests/lib/comments/fakefactory.php
@@ -2,10 +2,15 @@
 
 namespace Test\Comments;
 
+use OCP\IServerContainer;
+
 /**
  * Class FakeFactory
  */
 class FakeFactory implements \OCP\Comments\ICommentsManagerFactory {
+
+	public function __construct(IServerContainer $serverContainer) {
+	}
 
 	public function getManager() {
 		return new FakeManager();

--- a/tests/lib/comments/manager.php
+++ b/tests/lib/comments/manager.php
@@ -50,7 +50,7 @@ class Test_Comments_Manager extends TestCase
 	}
 
 	protected function getManager() {
-		$factory = new \OC\Comments\ManagerFactory();
+		$factory = new \OC\Comments\ManagerFactory(\OC::$server);
 		return $factory->getManager();
 	}
 

--- a/tests/lib/server.php
+++ b/tests/lib/server.php
@@ -155,6 +155,9 @@ class Server extends \Test\TestCase {
 			['TempManager', '\OC\TempManager'],
 			['TempManager', '\OCP\ITempManager'],
 			['TrustedDomainHelper', '\OC\Security\TrustedDomainHelper'],
+
+			['SystemTagManager', '\OCP\SystemTag\ISystemTagManager'],
+			['SystemTagObjectMapper', '\OCP\SystemTag\ISystemTagObjectMapper'],
 		];
 	}
 


### PR DESCRIPTION
Added config.php option to replace the default implementation of system
tag manager and system tag object mapper.

Ref: https://github.com/owncloud/core/issues/20258#issue-114788380
Similar to how it was done for comments.

Please review @blizzz @nickvergessen @icewind1991 @DeepDiver1975 @rullzer 
