### PR TITLE
remove unneeded margin of app dependencies in app mgmt

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -362,7 +362,6 @@ span.version {
 }
 
 .app-dependencies {
-	margin-top: 10px;
 	color: #ce3702;
 }
 


### PR DESCRIPTION
Makes the dependency message + enable button be closer to the description and the rest of the app info as it should be.

Please review @owncloud/designers
