### PR TITLE
Show default placeholder if avatar image can't be fetched

### DIFF
--- a/core/js/jquery.avatar.js
+++ b/core/js/jquery.avatar.js
@@ -81,8 +81,10 @@
 
 		// If the displayname is not defined we use the old code path
 		if (typeof(displayname) === 'undefined') {
-			$.get(url, function(result) {
-				if (typeof(result) === 'object') {
+			$.get(url).always(function(result, status) {
+				// if there is an error or an object returned (contains user information):
+				// -> show the fallback placeholder
+				if (typeof(result) === 'object' || status === 'error') {
 					if (!hidedefault) {
 						if (result.data && result.data.displayname) {
 							$div.imageplaceholder(user, result.data.displayname);
@@ -94,6 +96,7 @@
 					} else {
 						$div.hide();
 					}
+				// else an image is transferred and should be shown
 				} else {
 					$div.show();
 					if (ie8fix === true) {


### PR DESCRIPTION
- fixes owncloud/documents#601
- ref #14564
- to test: open a documents app link in a private browser tab (before: no avatars, after: X avatars like below)

![bildschirmfoto 2016-01-20 um 15 31 18](https://cloud.githubusercontent.com/assets/245432/12451703/2087b5c0-bf8b-11e5-9a77-050122f10910.png)

cc @oparoz @rullzer @PVince81
