### PR TITLE
Fix DAV backend to respect system tags permissions

### DIFF
--- a/apps/dav/lib/rootcollection.php
+++ b/apps/dav/lib/rootcollection.php
@@ -58,10 +58,13 @@ class RootCollection extends SimpleCollection {
 		$caldavBackend = new CalDavBackend($db);
 		$calendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
 		$calendarRoot->disableListing = $disableListing;
+		$isAdmin = \OC::$server->getGroupManager()->isAdmin(\OC::$server->getUserSession()->getUser()->getUID());
 		$systemTagCollection = new SystemTag\SystemTagsByIdCollection(
+			$isAdmin,
 			\OC::$server->getSystemTagManager()
 		);
 		$systemTagRelationsCollection = new SystemTag\SystemTagsRelationsCollection(
+			$isAdmin,
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper()
 		);

--- a/apps/dav/lib/rootcollection.php
+++ b/apps/dav/lib/rootcollection.php
@@ -58,15 +58,17 @@ class RootCollection extends SimpleCollection {
 		$caldavBackend = new CalDavBackend($db);
 		$calendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
 		$calendarRoot->disableListing = $disableListing;
-		$isAdmin = \OC::$server->getGroupManager()->isAdmin(\OC::$server->getUserSession()->getUser()->getUID());
+
 		$systemTagCollection = new SystemTag\SystemTagsByIdCollection(
-			$isAdmin,
-			\OC::$server->getSystemTagManager()
+			\OC::$server->getSystemTagManager(),
+			\OC::$server->getUserSession(),
+			\OC::$server->getGroupManager()
 		);
 		$systemTagRelationsCollection = new SystemTag\SystemTagsRelationsCollection(
-			$isAdmin,
 			\OC::$server->getSystemTagManager(),
-			\OC::$server->getSystemTagObjectMapper()
+			\OC::$server->getSystemTagObjectMapper(),
+			\OC::$server->getUserSession(),
+			\OC::$server->getGroupManager()
 		);
 
 		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend);

--- a/apps/dav/lib/systemtag/systemtagsobjectmappingcollection.php
+++ b/apps/dav/lib/systemtag/systemtagsobjectmappingcollection.php
@@ -58,22 +58,42 @@ class SystemTagsObjectMappingCollection implements ICollection {
 	private $tagMapper;
 
 	/**
+	 * Whether to return results only visible for admins
+	 *
+	 * @var bool
+	 */
+	private $isAdmin;
+
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $objectId object id
 	 * @param string $objectType object type
+	 * @param bool $isAdmin whether to return results visible only for admins
 	 * @param ISystemTagManager $tagManager
 	 * @param ISystemTagObjectMapper $tagMapper
 	 */
-	public function __construct($objectId, $objectType, $tagManager, $tagMapper) {
+	public function __construct($objectId, $objectType, $isAdmin, $tagManager, $tagMapper) {
 		$this->tagManager = $tagManager;
 		$this->tagMapper = $tagMapper;
 		$this->objectId = $objectId;
 		$this->objectType = $objectType;
+		$this->isAdmin = $isAdmin;
 	}
 
 	function createFile($tagId, $data = null) {
 		try {
+			if (!$this->isAdmin) {
+				$tag = $this->tagManager->getTagsByIds($tagId);
+				$tag = current($tag);
+				if (!$tag->isUserVisible()) {
+					throw new PreconditionFailed('Tag with id ' . $tagId . ' does not exist, cannot assign');
+				}
+				if (!$tag->isUserAssignable()) {
+					throw new Forbidden('No permission to assign tag ' . $tag->getId());
+				}
+			}
 			$this->tagMapper->assignTags($this->objectId, $this->objectType, $tagId);
 		} catch (TagNotFoundException $e) {
 			throw new PreconditionFailed('Tag with id ' . $tagId . ' does not exist, cannot assign');
@@ -88,7 +108,10 @@ class SystemTagsObjectMappingCollection implements ICollection {
 		try {
 			if ($this->tagMapper->haveTag([$this->objectId], $this->objectType, $tagId, true)) {
 				$tag = $this->tagManager->getTagsByIds([$tagId]);
-				return $this->makeNode(current($tag));
+				$tag = current($tag);
+				if ($this->isAdmin || $tag->isUserVisible()) {
+					return $this->makeNode($tag);
+				}
 			}
 			throw new NotFound('Tag with id ' . $tagId . ' not present for object ' . $this->objectId);
 		} catch (\InvalidArgumentException $e) {
@@ -104,6 +127,12 @@ class SystemTagsObjectMappingCollection implements ICollection {
 			return [];
 		}
 		$tags = $this->tagManager->getTagsByIds($tagIds);
+		if (!$this->isAdmin) {
+			// filter out non-visible tags
+			$tags = array_filter($tags, function($tag) {
+				return $tag->isUserVisible();
+			});
+		}
 		return array_values(array_map(function($tag) {
 			return $this->makeNode($tag);
 		}, $tags));
@@ -111,7 +140,18 @@ class SystemTagsObjectMappingCollection implements ICollection {
 
 	function childExists($tagId) {
 		try {
-			return ($this->tagMapper->haveTag([$this->objectId], $this->objectType, $tagId, true));
+			$result = ($this->tagMapper->haveTag([$this->objectId], $this->objectType, $tagId, true));
+			if ($this->isAdmin || !$result) {
+				return $result;
+			}
+
+			// verify if user is allowed to see this tag
+			$tag = $this->tagManager->getTagsByIds($tagId);
+			$tag = current($tag);
+			if (!$tag->isUserVisible()) {
+				return false;
+			}
+			return true;
 		} catch (\InvalidArgumentException $e) {
 			throw new BadRequest('Invalid tag id', 0, $e);
 		} catch (TagNotFoundException $e) {
@@ -153,6 +193,7 @@ class SystemTagsObjectMappingCollection implements ICollection {
 			$tag,
 			$this->objectId,
 			$this->objectType,
+			$this->isAdmin,
 			$this->tagManager,
 			$this->tagMapper
 		);

--- a/apps/dav/lib/systemtag/systemtagsobjecttypecollection.php
+++ b/apps/dav/lib/systemtag/systemtagsobjecttypecollection.php
@@ -51,16 +51,25 @@ class SystemTagsObjectTypeCollection implements ICollection {
 	private $tagMapper;
 
 	/**
+	 * Whether to return results only visible for admins
+	 *
+	 * @var bool
+	 */
+	private $isAdmin;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $objectType object type
+	 * @param bool $isAdmin whether to return results visible only for admins
 	 * @param ISystemTagManager $tagManager
 	 * @param ISystemTagObjectMapper $tagMapper
 	 */
-	public function __construct($objectType, $tagManager, $tagMapper) {
+	public function __construct($objectType, $isAdmin, $tagManager, $tagMapper) {
 		$this->tagManager = $tagManager;
 		$this->tagMapper = $tagMapper;
 		$this->objectType = $objectType;
+		$this->isAdmin = $isAdmin;
 	}
 
 	/**
@@ -86,6 +95,7 @@ class SystemTagsObjectTypeCollection implements ICollection {
 		return new SystemTagsObjectMappingCollection(
 			$objectId,
 			$this->objectType,
+			$this->isAdmin,
 			$this->tagManager,
 			$this->tagMapper
 		);

--- a/apps/dav/lib/systemtag/systemtagsrelationscollection.php
+++ b/apps/dav/lib/systemtag/systemtagsrelationscollection.php
@@ -32,12 +32,13 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 	/**
 	 * SystemTagsRelationsCollection constructor.
 	 *
+	 * @param bool $isAdmin whether to return results visible only for admins
 	 * @param ISystemTagManager $tagManager
 	 * @param ISystemTagObjectMapper $tagMapper
 	 */
-	public function __construct($tagManager, $tagMapper) {
+	public function __construct($isAdmin, $tagManager, $tagMapper) {
 		$children = [
-			new SystemTagsObjectTypeCollection('files', $tagManager, $tagMapper),
+			new SystemTagsObjectTypeCollection('files', $isAdmin, $tagManager, $tagMapper),
 		];
 
 		parent::__construct('root', $children);

--- a/apps/dav/lib/systemtag/systemtagsrelationscollection.php
+++ b/apps/dav/lib/systemtag/systemtagsrelationscollection.php
@@ -32,13 +32,25 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 	/**
 	 * SystemTagsRelationsCollection constructor.
 	 *
-	 * @param bool $isAdmin whether to return results visible only for admins
 	 * @param ISystemTagManager $tagManager
 	 * @param ISystemTagObjectMapper $tagMapper
+	 * @param IUserSession $userSession
+	 * @param IGroupManager $groupManager
 	 */
-	public function __construct($isAdmin, $tagManager, $tagMapper) {
+	public function __construct(
+		ISystemTagManager $tagManager,
+		ISystemTagObjectMapper $tagMapper,
+		IUserSession $userSession,
+		IGroupManager $groupManager
+	) {
 		$children = [
-			new SystemTagsObjectTypeCollection('files', $isAdmin, $tagManager, $tagMapper),
+			new SystemTagsObjectTypeCollection(
+				'files',
+				$tagManager,
+				$tagMapper,
+				$userSession,
+				$groupManager
+			),
 		];
 
 		parent::__construct('root', $children);

--- a/apps/dav/tests/unit/systemtag/systemtagnode.php
+++ b/apps/dav/tests/unit/systemtag/systemtagnode.php
@@ -32,46 +32,140 @@ use OCP\SystemTag\TagAlreadyExistsException;
 class SystemTagNode extends \Test\TestCase {
 
 	/**
-	 * @var \OCA\DAV\SystemTag\SystemTagNode
-	 */
-	private $node;
-
-	/**
 	 * @var \OCP\SystemTag\ISystemTagManager
 	 */
 	private $tagManager;
 
-	/**
-	 * @var \OCP\SystemTag\ISystemTag
-	 */
-	private $tag;
-
 	protected function setUp() {
 		parent::setUp();
 
-		$this->tag = new SystemTag(1, 'Test', true, false);
 		$this->tagManager = $this->getMock('\OCP\SystemTag\ISystemTagManager');
-
-		$this->node = new \OCA\DAV\SystemTag\SystemTagNode($this->tag, $this->tagManager);
 	}
 
-	public function testGetters() {
-		$this->assertEquals('1', $this->node->getName());
-		$this->assertEquals($this->tag, $this->node->getSystemTag());
+	protected function getTagNode($isAdmin = true, $tag = null) {
+		if ($tag === null) {
+			$tag = new SystemTag(1, 'Test', true, true);
+		}
+		return new \OCA\DAV\SystemTag\SystemTagNode(
+			$tag,
+			$isAdmin,
+			$this->tagManager
+		);
+	}
+
+	public function adminFlagProvider() {
+		return [[true], [false]];
+	}
+
+	/**
+	 * @dataProvider adminFlagProvider
+	 */
+	public function testGetters($isAdmin) {
+		$tag = new SystemTag('1', 'Test', true, true);
+		$node = $this->getTagNode($isAdmin, $tag);
+		$this->assertEquals('1', $node->getName());
+		$this->assertEquals($tag, $node->getSystemTag());
 	}
 
 	/**
 	 * @expectedException Sabre\DAV\Exception\MethodNotAllowed
 	 */
 	public function testSetName() {
-		$this->node->setName('2');
+		$this->getTagNode()->setName('2');
 	}
 
-	public function testUpdateTag() {
+	public function tagNodeProvider() {
+		return [
+			// admin
+			[
+				true,
+				new SystemTag(1, 'Original', true, true),
+				['Renamed', true, true]
+			],
+			[
+				true,
+				new SystemTag(1, 'Original', true, true),
+				['Original', false, false]
+			],
+			// non-admin
+			[
+				// renaming allowed
+				false,
+				new SystemTag(1, 'Original', true, true),
+				['Rename', true, true]
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider tagNodeProvider
+	 */
+	public function testUpdateTag($isAdmin, $originalTag, $changedArgs) {
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
-			->with(1, 'Renamed', false, true);
-		$this->node->update('Renamed', false, true);
+			->with(1, $changedArgs[0], $changedArgs[1], $changedArgs[2]);
+		$this->getTagNode($isAdmin, $originalTag)
+			->update($changedArgs[0], $changedArgs[1], $changedArgs[2]);
+	}
+
+	public function tagNodeProviderPermissionException() {
+		return [
+			[
+				// changing permissions not allowed
+				new SystemTag(1, 'Original', true, true),
+				['Original', false, true],
+				'Sabre\DAV\Exception\Forbidden',
+			],
+			[
+				// changing permissions not allowed
+				new SystemTag(1, 'Original', true, true),
+				['Original', true, false],
+				'Sabre\DAV\Exception\Forbidden',
+			],
+			[
+				// changing permissions not allowed
+				new SystemTag(1, 'Original', true, true),
+				['Original', false, false],
+				'Sabre\DAV\Exception\Forbidden',
+			],
+			[
+				// changing non-assignable not allowed
+				new SystemTag(1, 'Original', true, false),
+				['Rename', true, false],
+				'Sabre\DAV\Exception\Forbidden',
+			],
+			[
+				// changing non-assignable not allowed
+				new SystemTag(1, 'Original', true, false),
+				['Original', true, true],
+				'Sabre\DAV\Exception\Forbidden',
+			],
+			[
+				// invisible tag does not exist
+				new SystemTag(1, 'Original', false, false),
+				['Rename', false, false],
+				'Sabre\DAV\Exception\NotFound',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider tagNodeProviderPermissionException
+	 */
+	public function testUpdateTagPermissionException($originalTag, $changedArgs, $expectedException = null) {
+		$this->tagManager->expects($this->never())
+			->method('updateTag');
+
+		$thrown = null;
+
+		try {
+			$this->getTagNode(false, $originalTag)
+				->update($changedArgs[0], $changedArgs[1], $changedArgs[2]);
+		} catch (\Exception $e) {
+			$thrown = $e;
+		}
+
+		$this->assertInstanceOf($expectedException, $thrown);
 	}
 
 	/**
@@ -82,7 +176,7 @@ class SystemTagNode extends \Test\TestCase {
 			->method('updateTag')
 			->with(1, 'Renamed', false, true)
 			->will($this->throwException(new TagAlreadyExistsException()));
-		$this->node->update('Renamed', false, true);
+		$this->getTagNode()->update('Renamed', false, true);
 	}
 
 	/**
@@ -93,14 +187,48 @@ class SystemTagNode extends \Test\TestCase {
 			->method('updateTag')
 			->with(1, 'Renamed', false, true)
 			->will($this->throwException(new TagNotFoundException()));
-		$this->node->update('Renamed', false, true);
+		$this->getTagNode()->update('Renamed', false, true);
 	}
 
-	public function testDeleteTag() {
+	/**
+	 * @dataProvider adminFlagProvider
+	 */
+	public function testDeleteTag($isAdmin) {
 		$this->tagManager->expects($this->once())
 			->method('deleteTags')
 			->with('1');
-		$this->node->delete();
+		$this->getTagNode($isAdmin)->delete();
+	}
+
+	public function tagNodeDeleteProviderPermissionException() {
+		return [
+			[
+				// cannot delete invisible tag
+				new SystemTag(1, 'Original', false, true),
+				'Sabre\DAV\Exception\NotFound',
+			],
+			[
+				// cannot delete non-assignable tag
+				new SystemTag(1, 'Original', true, false),
+				'Sabre\DAV\Exception\Forbidden',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider tagNodeDeleteProviderPermissionException
+	 */
+	public function testDeleteTagPermissionException($tag, $expectedException) {
+		$this->tagManager->expects($this->never())
+			->method('deleteTags');
+
+		try {
+			$this->getTagNode(false, $tag)->delete();
+		} catch (\Exception $e) {
+			$thrown = $e;
+		}
+
+		$this->assertInstanceOf($expectedException, $thrown);
 	}
 
 	/**
@@ -111,6 +239,6 @@ class SystemTagNode extends \Test\TestCase {
 			->method('deleteTags')
 			->with('1')
 			->will($this->throwException(new TagNotFoundException()));
-		$this->node->delete();
+		$this->getTagNode()->delete();
 	}
 }

--- a/apps/dav/tests/unit/systemtag/systemtagsbyidcollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsbyidcollection.php
@@ -39,7 +39,24 @@ class SystemTagsByIdCollection extends \Test\TestCase {
 	}
 
 	public function getNode($isAdmin = true) {
-		return new \OCA\DAV\SystemTag\SystemTagsByIdCollection($isAdmin, $this->tagManager);
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('testuser'));
+		$userSession = $this->getMock('\OCP\IUserSession');
+		$userSession->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$groupManager = $this->getMock('\OCP\IGroupManager');
+		$groupManager->expects($this->any())
+			->method('isAdmin')
+			->with('testuser')
+			->will($this->returnValue($isAdmin));
+		return new \OCA\DAV\SystemTag\SystemTagsByIdCollection(
+			$this->tagManager,
+			$userSession,
+			$groupManager
+		);
 	}
 
 	public function adminFlagProvider() {

--- a/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
@@ -46,6 +46,7 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 
 		$this->node = new \OCA\DAV\SystemTag\SystemTagsObjectTypeCollection(
 			'files',
+			true,
 			$this->tagManager,
 			$this->tagMapper
 		);

--- a/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
+++ b/apps/dav/tests/unit/systemtag/systemtagsobjecttypecollection.php
@@ -44,11 +44,26 @@ class SystemTagsObjectTypeCollection extends \Test\TestCase {
 		$this->tagManager = $this->getMock('\OCP\SystemTag\ISystemTagManager');
 		$this->tagMapper = $this->getMock('\OCP\SystemTag\ISystemTagObjectMapper');
 
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('testuser'));
+		$userSession = $this->getMock('\OCP\IUserSession');
+		$userSession->expects($this->any())
+			->method('getUser')
+			->will($this->returnValue($user));
+		$groupManager = $this->getMock('\OCP\IGroupManager');
+		$groupManager->expects($this->any())
+			->method('isAdmin')
+			->with('testuser')
+			->will($this->returnValue(true));
+
 		$this->node = new \OCA\DAV\SystemTag\SystemTagsObjectTypeCollection(
 			'files',
-			true,
 			$this->tagManager,
-			$this->tagMapper
+			$this->tagMapper,
+			$userSession,
+			$groupManager
 		);
 	}
 


### PR DESCRIPTION
When queried as regular user, visible tags are not displayed in result
sets and queries for existence will return false.

Non-assignable or non-visible tags cannot be
renamed/assigned/unassigned.

User is not allowed to change tag permissions, only to change the name
if the tag is also assignable.

Please review @nickvergessen @rullzer @blizzz @DeepDiver1975 @icewind1991 

Note: the GUI is not on this branch but if you merge it with https://github.com/owncloud/core/pull/20847 to see the "userVisible" part in action. Note that in the GUI the "userAssignable" part isn't implemented yet.
