### PR TITLE
No card ID when deleting is acceptable

### DIFF
--- a/apps/dav/lib/carddav/carddavbackend.php
+++ b/apps/dav/lib/carddav/carddavbackend.php
@@ -536,7 +536,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @return bool
 	 */
 	function deleteCard($addressBookId, $cardUri) {
-		$cardId = $this->getCardId($cardUri);
+		try {
+			$cardId = $this->getCardId($cardUri);
+		} catch (\InvalidArgumentException $e) {
+			$cardId = null;
+		}
 		$query = $this->db->getQueryBuilder();
 		$ret = $query->delete('cards')
 			->where($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId)))
@@ -546,7 +550,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$this->addChange($addressBookId, $cardUri, 3);
 
 		if ($ret === 1) {
-			$this->purgeProperties($addressBookId, $cardId);
+			if ($cardId !== null) {
+				$this->purgeProperties($addressBookId, $cardId);
+			}
 			return true;
 		}
 


### PR DESCRIPTION
Currently the tests of the activity app fail, because there is an exception when deleting a user:
https://travis-ci.org/owncloud/activity/jobs/103591541

```
InvalidArgumentException: Card does not exists: Database:activity-api-user1.vcf

/home/travis/build/owncloud/core/apps/dav/lib/carddav/carddavbackend.php:976
 /home/travis/build/owncloud/core/apps/dav/lib/carddav/carddavbackend.php:539
 /home/travis/build/owncloud/core/apps/dav/lib/carddav/syncservice.php:226
 /home/travis/build/owncloud/core/apps/dav/lib/hookmanager.php:70
 /home/travis/build/owncloud/core/lib/private/hook.php:104
 /home/travis/build/owncloud/core/lib/private/server.php:212
 /home/travis/build/owncloud/core/lib/private/hooks/emittertrait.php:98
 /home/travis/build/owncloud/core/lib/private/hooks/publicemitter.php:32
 /home/travis/build/owncloud/core/lib/private/user/user.php:198
 /home/travis/build/owncloud/core/apps/activity/tests/apitest.php:107
```

I don't know what the actual problem is, why the user creation doesn't create the card or whatever, but at least deleting should work, even through there is no card.
