### PR TITLE
Show email address in display name

### DIFF
--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -125,6 +125,14 @@ class User implements IUser {
 				$this->displayName = $this->uid;
 			}
 		}
+
+		if($this->config->getAppValue('core', 'showEmailInDisplayname', false)) {
+			$email = $this->getEMailAddress();
+			if(!is_null($email) && $email !== '' && strpos($this->displayName, $email) === false) {
+				$this->displayName .= ' (' . $email . ')';
+			}
+		}
+
 		return $this->displayName;
 	}
 


### PR DESCRIPTION
- hidden feature:
  - enable: ./occ config:app:set core showEmailInDisplayname --value 1
  - disable: ./occ config:app:set core showEmailInDisplayname --value 0
- drawback: user management & personal page shows the email also in the display name input field

cc @blizzz @DeepDiver1975 @karlitschek 

Could solve https://github.com/owncloud/enterprise/issues/690

I noticed some problems with the user object tests (I opened this anyway to start the discussion):
- [ ] requires #21832 to be sorted out first to be able to properly unit test this
