### PR TITLE
Solves #21835 (https://github.com/owncloud/core/issues/21835)

### DIFF
--- a/lib/private/group/manager.php
+++ b/lib/private/group/manager.php
@@ -126,10 +126,15 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	public function addBackend($backend) {
 		$this->backends[] = $backend;
+		$this->clearCaches();
 	}
 
 	public function clearBackends() {
 		$this->backends = array();
+		$this->clearCaches();
+	}
+	
+	protected function clearCaches() {
 		$this->cachedGroups = array();
 		$this->cachedUserGroups = array();
 	}


### PR DESCRIPTION
This pull request solves #21835 "Group Manager should clean cache, when new backends are added"
