### PR TITLE
[Share 2.0] Add deleteFromSelf method

### DIFF
--- a/lib/private/share20/ishareprovider.php
+++ b/lib/private/share20/ishareprovider.php
@@ -58,6 +58,15 @@ interface IShareProvider {
 	public function delete(IShare $share);
 
 	/**
+	 * Unshare a file from self as recipient.
+	 * This may require special handling.
+	 *
+	 * @param IShare $share
+	 * @param IUser $recipient
+	 */
+	public function deleteFromSelf(IShare $share, IUser $recipient);
+
+	/**
 	 * Get all shares by the given user
 	 *
 	 * @param IUser $user

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -607,6 +607,22 @@ class Manager {
 
 
 	/**
+	 * Unshare a file as the recipient.
+	 * This can be different from a regular delete for example when one of
+	 * the users in a groups deletes that share. But the provider should
+	 * handle this.
+	 *
+	 * @param IShare $share
+	 * @param IUser $recipient
+	 */
+	public function deleteFromSelf(IShare $share, IUser $recipient) {
+		list($providerId, $id) = $this->splitFullId($share->getId());
+		$provider = $this->factory->getProvider($providerId);
+
+		$provider->deleteFromSelf($share, $recipient);
+	}
+
+	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
 	 * @param IUser $user


### PR DESCRIPTION
This allows recipient to delete a share. For user shares this is the
same as deleting (at least for now).
But for group shares this means creating a new share with type 2. With
permissions set to 0.

CC: @schiesbn @nickvergessen @DeepDiver1975 @PVince81 
