### PR TITLE
Print output for integrity check during ./occ upgrade

### DIFF
--- a/core/command/upgrade.php
+++ b/core/command/upgrade.php
@@ -206,6 +206,12 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'resetLogLevel', function ($logLevel, $logLevelName) use($output) {
 				$output->writeln("<info>Reset log level</info>");
 			});
+			$updater->listen('\OC\Updater', 'startCheckCodeIntegrity', function () use($output) {
+				$output->writeln("<info>Starting code integrity check...</info>");
+			});
+			$updater->listen('\OC\Updater', 'finishedCheckCodeIntegrity', function () use($output) {
+				$output->writeln("<info>Finished code integrity check</info>");
+			});
 
 			if(OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				$updater->listen('\OC\Updater', 'repairInfo', function ($message) use($output) {


### PR DESCRIPTION
cc @LukasReschke @nickvergessen 

Otherwise it stalls for quite some time after `Updated database` without any output, which would confuse people and ask if the upgrade is broken.

This was only added to the web UI part - so I ported the messages from there. ;)
