### PR TITLE
add IUserMountCache->getMountsForFileId

### DIFF
--- a/lib/private/files/config/usermountcache.php
+++ b/lib/private/files/config/usermountcache.php
@@ -23,6 +23,7 @@ namespace OC\Files\Config;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Files\Filesystem;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Mount\IMountPoint;
@@ -137,7 +138,7 @@ class UserMountCache implements IUserMountCache {
 		$query = $builder->update('mounts')
 			->set('mount_point', $builder->createNamedParameter($mount->getMountPoint()))
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
-			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), \PDO::PARAM_INT)));
+			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)));
 
 		$query->execute();
 	}
@@ -147,7 +148,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
-			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), \PDO::PARAM_INT)));
+			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 
@@ -182,7 +183,7 @@ class UserMountCache implements IUserMountCache {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select('storage_id', 'root_id', 'user_id', 'mount_point')
 			->from('mounts')
-			->where($builder->expr()->eq('storage_id', $builder->createPositionalParameter($numericStorageId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('storage_id', $builder->createPositionalParameter($numericStorageId, IQueryBuilder::PARAM_INT)));
 
 		$rows = $query->execute()->fetchAll();
 
@@ -197,7 +198,7 @@ class UserMountCache implements IUserMountCache {
 		$builder = $this->connection->getQueryBuilder();
 		$query = $builder->select('storage_id', 'root_id', 'user_id', 'mount_point')
 			->from('mounts')
-			->where($builder->expr()->eq('root_id', $builder->createPositionalParameter($rootFileId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('root_id', $builder->createPositionalParameter($rootFileId, IQueryBuilder::PARAM_INT)));
 
 		$rows = $query->execute()->fetchAll();
 
@@ -214,7 +215,7 @@ class UserMountCache implements IUserMountCache {
 			$builder = $this->connection->getQueryBuilder();
 			$query = $builder->select('storage', 'path')
 				->from('filecache')
-				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, \PDO::PARAM_INT)));
+				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 
 			$row = $query->execute()->fetch();
 			if (is_array($row)) {
@@ -276,7 +277,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($userId)))
-			->andWhere($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, \PDO::PARAM_INT)));
+			->andWhere($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 
@@ -284,7 +285,7 @@ class UserMountCache implements IUserMountCache {
 		$builder = $this->connection->getQueryBuilder();
 
 		$query = $builder->delete('mounts')
-			->where($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, \PDO::PARAM_INT)));
+			->where($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 		$query->execute();
 	}
 }

--- a/lib/public/files/config/iusermountcache.php
+++ b/lib/public/files/config/iusermountcache.php
@@ -40,6 +40,8 @@ interface IUserMountCache {
 	public function registerMounts(IUser $user, array $mounts);
 
 	/**
+	 * Get all cached mounts for a user
+	 *
 	 * @param IUser $user
 	 * @return ICachedMountInfo[]
 	 * @since 9.0.0
@@ -47,6 +49,8 @@ interface IUserMountCache {
 	public function getMountsForUser(IUser $user);
 
 	/**
+	 * Get all cached mounts by storage
+	 *
 	 * @param int $numericStorageId
 	 * @return ICachedMountInfo[]
 	 * @since 9.0.0
@@ -54,11 +58,22 @@ interface IUserMountCache {
 	public function getMountsForStorageId($numericStorageId);
 
 	/**
+	 * Get all cached mounts by root
+	 *
 	 * @param int $rootFileId
 	 * @return ICachedMountInfo[]
 	 * @since 9.0.0
 	 */
 	public function getMountsForRootId($rootFileId);
+
+	/**
+	 * Get all cached mounts that contain a file
+	 *
+	 * @param int $fileId
+	 * @return ICachedMountInfo[]
+	 * @since 9.0.0
+	 */
+	public function getMountsForFileId($fileId);
 
 	/**
 	 * Remove all cached mounts for a user

--- a/tests/lib/files/config/usermountcache.php
+++ b/tests/lib/files/config/usermountcache.php
@@ -279,11 +279,11 @@ class UserMountCache extends TestCase {
 			'mimepart' => 0,
 			'size' => 0,
 			'storage_mtime' => 0,
-			'encrypted' => false,
+			'encrypted' => 0,
 			'unencrypted_size' => 0,
 			'etag' => '',
 			'permissions' => 31
-		]);
+		], ['storage', 'path_hash']);
 		$id = (int)$this->connection->lastInsertId('*PREFIX*filecache');
 		$this->fileIds[] = $id;
 		return $id;


### PR DESCRIPTION
Fixes #21846

Usage example:

```
$mountCache = \OC::$server->getMountProviderCollection()->getMountCache()
$mounts = $mountCache->getMountsForFileId($fileId);
$userWithAccessToFile = array_map(function(ICachedMountInfo $mount) {
    return $mount->getUser();
}, $mounts);
```

```
$mountCache = \OC::$server->getMountProviderCollection()->getMountCache()
$mounts = $mountCache->getMountsForFileId($fileId);
if (count($mounts) > 0) {
    $node = $mounts[0]->getMountPointNode();
    $owner = $node->getOwner();
}
```

cc @PVince81 @nickvergessen 
