### PR TITLE
[Sharing 2.0] update share

### DIFF
--- a/apps/files_sharing/api/ocssharewrapper.php
+++ b/apps/files_sharing/api/ocssharewrapper.php
@@ -50,7 +50,8 @@ class OCSShareWrapper {
 	}
 
 	public function updateShare($params) {
-		return \OCA\Files_Sharing\API\Local::updateShare($params);
+		$id = $params['id'];
+		return $this->getShare20OCS()->updateShare($id);
 	}
 
 	public function deleteShare($params) {

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -241,11 +241,11 @@ class DefaultShareProvider implements IShareProvider {
 				->set('item_source', $qb->createNamedParameter($share->getPath()->getId()))
 				->set('file_source', $qb->createNamedParameter($share->getPath()->getId()))
 				->set('token', $qb->createNamedParameter($share->getToken()))
-				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), 'datetime'))
+				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 				->execute();
 		}
 
-		return $this->getShareById($share->getId());
+		return $share;
 	}
 
 	/**

--- a/lib/private/share20/defaultshareprovider.php
+++ b/lib/private/share20/defaultshareprovider.php
@@ -183,6 +183,69 @@ class DefaultShareProvider implements IShareProvider {
 	 * @return IShare The share object
 	 */
 	public function update(IShare $share) {
+		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_USER) {
+			/*
+			 * We allow updating the recipient on user shares.
+			 */
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
+				->set('share_with', $qb->createNamedParameter($share->getSharedWith()->getUID()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
+				->set('item_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->set('file_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->execute();
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_GROUP) {
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
+				->set('item_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->set('file_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->execute();
+
+			/*
+			 * Update all user defined group shares
+			 */
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('item_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->set('file_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->execute();
+
+			/*
+			 * Now update the permissions for all children that have not set it to 0
+			 */
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
+				->andWhere($qb->expr()->neq('permissions', $qb->createNamedParameter(0)))
+				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
+				->execute();
+
+		} else if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
+				->set('share_with', $qb->createNamedParameter($share->getPassword()))
+				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()->getUID()))
+				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()->getUID()))
+				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
+				->set('item_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->set('file_source', $qb->createNamedParameter($share->getPath()->getId()))
+				->set('token', $qb->createNamedParameter($share->getToken()))
+				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), 'datetime'))
+				->execute();
+		}
+
+		return $this->getShareById($share->getId());
 	}
 
 	/**

--- a/lib/private/share20/manager.php
+++ b/lib/private/share20/manager.php
@@ -217,19 +217,19 @@ class Manager {
 	/**
 	 * Validate if the expiration date fits the system settings
 	 *
-	 * @param \DateTime $expireDate The current expiration date (can be null)
+	 * @param \DateTime $expirationDate The current expiration date (can be null)
 	 * @return \DateTime|null The expiration date or null if $expireDate was null and it is not required
 	 * @throws \OC\HintException
 	 */
-	protected function validateExpiredate($expireDate) {
+	protected function validateExpirationDate($expirationDate) {
 
-		if ($expireDate !== null) {
+		if ($expirationDate !== null) {
 			//Make sure the expiration date is a date
-			$expireDate->setTime(0, 0, 0);
+			$expirationDate->setTime(0, 0, 0);
 
 			$date = new \DateTime();
 			$date->setTime(0, 0, 0);
-			if ($date >= $expireDate) {
+			if ($date >= $expirationDate) {
 				$message = $this->l->t('Expiration date is in the past');
 				throw new \OC\HintException($message, $message, 404);
 			}
@@ -237,30 +237,30 @@ class Manager {
 
 		// If we enforce the expiration date check that is does not exceed
 		if ($this->shareApiLinkDefaultExpireDateEnforced()) {
-			if ($expireDate === null) {
+			if ($expirationDate === null) {
 				throw new \InvalidArgumentException('Expiration date is enforced');
 			}
 
 			$date = new \DateTime();
 			$date->setTime(0, 0, 0);
 			$date->add(new \DateInterval('P' . $this->shareApiLinkDefaultExpireDays() . 'D'));
-			if ($date < $expireDate) {
+			if ($date < $expirationDate) {
 				$message = $this->l->t('Cannot set expiration date more than %s days in the future', [$this->shareApiLinkDefaultExpireDays()]);
 				throw new \OC\HintException($message, $message, 404);
 			}
 
-			return $expireDate;
+			return $expirationDate;
 		}
 
 		// If expiredate is empty set a default one if there is a default
-		if ($expireDate === null && $this->shareApiLinkDefaultExpireDate()) {
+		if ($expirationDate === null && $this->shareApiLinkDefaultExpireDate()) {
 			$date = new \DateTime();
 			$date->setTime(0,0,0);
 			$date->add(new \DateInterval('P'.$this->shareApiLinkDefaultExpireDays().'D'));
 			return $date;
 		}
 
-		return $expireDate;
+		return $expirationDate;
 	}
 
 	/**
@@ -440,7 +440,7 @@ class Manager {
 			);
 
 			//Verify the expiration date
-			$share->setExpirationDate($this->validateExpiredate($share->getExpirationDate()));
+			$share->setExpirationDate($this->validateExpirationDate($share->getExpirationDate()));
 
 			//Verify the password
 			$this->verifyPassword($share->getPassword());
@@ -542,13 +542,13 @@ class Manager {
 
 		// We can't change the share type!
 		if ($share->getShareType() !== $originalShare->getShareType()) {
-			throw new \Exception('Can\'t change share type');
+			throw new \InvalidArgumentException('Can\'t change share type');
 		}
 
 		// We can only change the recipient on user shares
 		if ($share->getSharedWith() !== $originalShare->getSharedWith() &&
 		    $share->getShareType() !== \OCP\Share::SHARE_TYPE_USER) {
-			throw new \Exception('Can only update recipient on user shares');
+			throw new \InvalidArgumentException('Can only update recipient on user shares');
 		}
 
 		// Cannot share with the owner
@@ -578,7 +578,7 @@ class Manager {
 
 			if ($share->getExpirationDate() !== $originalShare->getExpirationDate()) {
 				//Verify the expiration date
-				$share->setExpirationDate($this->validateExpiredate($share->getExpirationDate()));
+				$share->setExpirationDate($this->validateExpirationDate($share->getExpirationDate()));
 				$expirationDateUpdated = true;
 			}
 		}

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -72,6 +72,43 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
+	 * @param int $shareType
+	 * @param string $sharedWith
+	 * @param string $sharedBy
+	 * @param string $shareOwner
+	 * @param string $itemType
+	 * @param int $fileSource
+	 * @param string $fileTarget
+	 * @param int $permissions
+	 * @param $token
+	 * @param $expiration
+	 * @return int
+	 */
+	private function addShareToDB($shareType, $sharedWith, $sharedBy, $shareOwner,
+			$itemType, $fileSource, $fileTarget, $permissions, $token, $expiration,
+			$parent = null) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share');
+
+		if ($shareType) $qb->setValue('share_type', $qb->expr()->literal($shareType));
+		if ($sharedWith) $qb->setValue('share_with', $qb->expr()->literal($sharedWith));
+		if ($sharedBy) $qb->setValue('uid_initiator', $qb->expr()->literal($sharedBy));
+		if ($shareOwner) $qb->setValue('uid_owner', $qb->expr()->literal($shareOwner));
+		if ($itemType) $qb->setValue('item_type', $qb->expr()->literal($itemType));
+		if ($fileSource) $qb->setValue('file_source', $qb->expr()->literal($fileSource));
+		if ($fileTarget) $qb->setValue('file_target', $qb->expr()->literal($fileTarget));
+		if ($permissions) $qb->setValue('permissions', $qb->expr()->literal($permissions));
+		if ($token) $qb->setValue('token', $qb->expr()->literal($token));
+		if ($expiration) $qb->setValue('expiration', $qb->createNamedParameter($expiration, 'datetime'));
+		if ($parent) $qb->setValue('parent', $qb->expr()->literal($parent));
+
+		$this->assertEquals(1, $qb->execute());
+		return$qb->getLastInsertId();
+	}
+
+
+
+	/**
 	 * @expectedException \OC\Share20\Exception\ShareNotFound
 	 */
 	public function testGetShareByIdNotExist() {
@@ -1393,14 +1430,14 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb = $this->dbConn->getQueryBuilder();
 		$stmt = $qb->insert('share')
 			->values([
-				'share_type'    => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
-				'uid_owner'     => $qb->expr()->literal('user1'),
+				'share_type' => $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK),
+				'uid_owner' => $qb->expr()->literal('user1'),
 				'uid_initiator' => $qb->expr()->literal('user1'),
-				'item_type'     => $qb->expr()->literal('file'),
-				'file_source'   => $qb->expr()->literal(1),
-				'file_target'   => $qb->expr()->literal('myTarget1'),
-				'permissions'   => $qb->expr()->literal(2),
-				'token'         => $qb->expr()->literal('token'),
+				'item_type' => $qb->expr()->literal('file'),
+				'file_source' => $qb->expr()->literal(1),
+				'file_target' => $qb->expr()->literal('myTarget1'),
+				'permissions' => $qb->expr()->literal(2),
+				'token' => $qb->expr()->literal('token'),
 			])->execute();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
@@ -1420,5 +1457,307 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$share = $this->provider->getShareById($id);
 
 		$this->provider->deleteFromSelf($share, $user1);
+	}
+
+	public function testUpdateUser() {
+		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_USER, 'user0', 'user1', 'user2',
+			'file', 42, 'target', 31, null, null);
+
+		$users = [];
+		for($i = 0; $i < 6; $i++) {
+			$user = $this->getMock('\OCP\IUser');
+			$user->method('getUID')->willReturn('user'.$i);
+			$users['user'.$i] = $user;
+		}
+
+		$this->userManager->method('get')->will(
+			$this->returnCallback(function($userId) use ($users) {
+				return $users[$userId];
+			})
+		);
+
+		$file1 = $this->getMock('\OCP\Files\File');
+		$file1->method('getId')->willReturn(42);
+		$file2 = $this->getMock('\OCP\Files\File');
+		$file2->method('getId')->willReturn(43);
+
+		$folder1 = $this->getMock('\OCP\Files\Folder');
+		$folder1->method('getById')->with(42)->willReturn([$file1]);
+		$folder2 = $this->getMock('\OCP\Files\Folder');
+		$folder2->method('getById')->with(43)->willReturn([$file2]);
+
+		$this->rootFolder->method('getUserFolder')->will($this->returnValueMap([
+			['user2', $folder1],
+			['user5', $folder2],
+		]));
+
+		$share = $this->provider->getShareById($id);
+
+		$share->setSharedWith($users['user3']);
+		$share->setSharedBy($users['user4']);
+		$share->setShareOwner($users['user5']);
+		$share->setPath($file2);
+		$share->setPermissions(1);
+
+		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertSame($users['user3'], $share2->getSharedWith());
+		$this->assertSame($users['user4'], $share2->getSharedBy());
+		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+	}
+
+	public function testUpdateLink() {
+		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_LINK, null, 'user1', 'user2',
+			'file', 42, 'target', 31, null, null);
+
+		$users = [];
+		for($i = 0; $i < 6; $i++) {
+			$user = $this->getMock('\OCP\IUser');
+			$user->method('getUID')->willReturn('user'.$i);
+			$users['user'.$i] = $user;
+		}
+
+		$this->userManager->method('get')->will(
+			$this->returnCallback(function($userId) use ($users) {
+				return $users[$userId];
+			})
+		);
+
+		$file1 = $this->getMock('\OCP\Files\File');
+		$file1->method('getId')->willReturn(42);
+		$file2 = $this->getMock('\OCP\Files\File');
+		$file2->method('getId')->willReturn(43);
+
+		$folder1 = $this->getMock('\OCP\Files\Folder');
+		$folder1->method('getById')->with(42)->willReturn([$file1]);
+		$folder2 = $this->getMock('\OCP\Files\Folder');
+		$folder2->method('getById')->with(43)->willReturn([$file2]);
+
+		$this->rootFolder->method('getUserFolder')->will($this->returnValueMap([
+			['user2', $folder1],
+			['user5', $folder2],
+		]));
+
+		$share = $this->provider->getShareById($id);
+
+		$share->setPassword('password');
+		$share->setSharedBy($users['user4']);
+		$share->setShareOwner($users['user5']);
+		$share->setPath($file2);
+		$share->setPermissions(1);
+
+		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertEquals('password', $share->getPassword());
+		$this->assertSame($users['user4'], $share2->getSharedBy());
+		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+	}
+
+	public function testUpdateLinkRemovePassword() {
+		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_LINK, 'foo', 'user1', 'user2',
+			'file', 42, 'target', 31, null, null);
+
+		$users = [];
+		for($i = 0; $i < 6; $i++) {
+			$user = $this->getMock('\OCP\IUser');
+			$user->method('getUID')->willReturn('user'.$i);
+			$users['user'.$i] = $user;
+		}
+
+		$this->userManager->method('get')->will(
+			$this->returnCallback(function($userId) use ($users) {
+				return $users[$userId];
+			})
+		);
+
+		$file1 = $this->getMock('\OCP\Files\File');
+		$file1->method('getId')->willReturn(42);
+		$file2 = $this->getMock('\OCP\Files\File');
+		$file2->method('getId')->willReturn(43);
+
+		$folder1 = $this->getMock('\OCP\Files\Folder');
+		$folder1->method('getById')->with(42)->willReturn([$file1]);
+		$folder2 = $this->getMock('\OCP\Files\Folder');
+		$folder2->method('getById')->with(43)->willReturn([$file2]);
+
+		$this->rootFolder->method('getUserFolder')->will($this->returnValueMap([
+			['user2', $folder1],
+			['user5', $folder2],
+		]));
+
+		$share = $this->provider->getShareById($id);
+
+		$share->setPassword(null);
+		$share->setSharedBy($users['user4']);
+		$share->setShareOwner($users['user5']);
+		$share->setPath($file2);
+		$share->setPermissions(1);
+
+		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		$this->assertEquals(null, $share->getPassword());
+		$this->assertSame($users['user4'], $share2->getSharedBy());
+		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+	}
+
+	public function testUpdateGroupNoSub() {
+		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_GROUP, 'group0', 'user1', 'user2',
+			'file', 42, 'target', 31, null, null);
+
+		$users = [];
+		for($i = 0; $i < 6; $i++) {
+			$user = $this->getMock('\OCP\IUser');
+			$user->method('getUID')->willReturn('user'.$i);
+			$users['user'.$i] = $user;
+		}
+
+		$this->userManager->method('get')->will(
+			$this->returnCallback(function($userId) use ($users) {
+				return $users[$userId];
+			})
+		);
+
+		$groups = [];
+		for($i = 0; $i < 2; $i++) {
+			$group = $this->getMock('\OCP\IGroup');
+			$group->method('getGID')->willReturn('group'.$i);
+			$groups['group'.$i] = $group;
+		}
+
+		$this->groupManager->method('get')->will(
+			$this->returnCallback(function($groupId) use ($groups) {
+				return $groups[$groupId];
+			})
+		);
+
+		$file1 = $this->getMock('\OCP\Files\File');
+		$file1->method('getId')->willReturn(42);
+		$file2 = $this->getMock('\OCP\Files\File');
+		$file2->method('getId')->willReturn(43);
+
+		$folder1 = $this->getMock('\OCP\Files\Folder');
+		$folder1->method('getById')->with(42)->willReturn([$file1]);
+		$folder2 = $this->getMock('\OCP\Files\Folder');
+		$folder2->method('getById')->with(43)->willReturn([$file2]);
+
+		$this->rootFolder->method('getUserFolder')->will($this->returnValueMap([
+			['user2', $folder1],
+			['user5', $folder2],
+		]));
+
+		$share = $this->provider->getShareById($id);
+
+		$share->setSharedWith($groups['group1']);
+		$share->setSharedBy($users['user4']);
+		$share->setShareOwner($users['user5']);
+		$share->setPath($file2);
+		$share->setPermissions(1);
+
+		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		// Group shares do not allow updating the recipient
+		$this->assertSame($groups['group0'], $share2->getSharedWith());
+		$this->assertSame($users['user4'], $share2->getSharedBy());
+		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+	}
+
+	public function testUpdateGroupSubShares() {
+		$id = $this->addShareToDB(\OCP\Share::SHARE_TYPE_GROUP, 'group0', 'user1', 'user2',
+			'file', 42, 'target', 31, null, null);
+
+		$id2 = $this->addShareToDB(2, 'user0', 'user1', 'user2',
+			'file', 42, 'mytarget', 31, null, null, $id);
+
+		$id3 = $this->addShareToDB(2, 'user3', 'user1', 'user2',
+			'file', 42, 'mytarget2', 0, null, null, $id);
+
+		$users = [];
+		for($i = 0; $i < 6; $i++) {
+			$user = $this->getMock('\OCP\IUser');
+			$user->method('getUID')->willReturn('user'.$i);
+			$users['user'.$i] = $user;
+		}
+
+		$this->userManager->method('get')->will(
+			$this->returnCallback(function($userId) use ($users) {
+				return $users[$userId];
+			})
+		);
+
+		$groups = [];
+		for($i = 0; $i < 2; $i++) {
+			$group = $this->getMock('\OCP\IGroup');
+			$group->method('getGID')->willReturn('group'.$i);
+			$groups['group'.$i] = $group;
+		}
+
+		$this->groupManager->method('get')->will(
+			$this->returnCallback(function($groupId) use ($groups) {
+				return $groups[$groupId];
+			})
+		);
+
+		$file1 = $this->getMock('\OCP\Files\File');
+		$file1->method('getId')->willReturn(42);
+		$file2 = $this->getMock('\OCP\Files\File');
+		$file2->method('getId')->willReturn(43);
+
+		$folder1 = $this->getMock('\OCP\Files\Folder');
+		$folder1->method('getById')->with(42)->willReturn([$file1]);
+		$folder2 = $this->getMock('\OCP\Files\Folder');
+		$folder2->method('getById')->with(43)->willReturn([$file2]);
+
+		$this->rootFolder->method('getUserFolder')->will($this->returnValueMap([
+			['user2', $folder1],
+			['user5', $folder2],
+		]));
+
+		$share = $this->provider->getShareById($id);
+
+		$share->setSharedWith($groups['group1']);
+		$share->setSharedBy($users['user4']);
+		$share->setShareOwner($users['user5']);
+		$share->setPath($file2);
+		$share->setPermissions(1);
+
+		$share2 = $this->provider->update($share);
+
+		$this->assertEquals($id, $share2->getId());
+		// Group shares do not allow updating the recipient
+		$this->assertSame($groups['group0'], $share2->getSharedWith());
+		$this->assertSame($users['user4'], $share2->getSharedBy());
+		$this->assertSame($users['user5'], $share2->getShareOwner());
+		$this->assertSame(1, $share2->getPermissions());
+
+		$qb = $this->dbConn->getQueryBuilder();
+		$stmt = $qb->select('*')
+			->from('share')
+			->where($qb->expr()->eq('parent', $qb->createNamedParameter($id)))
+			->orderBy('id')
+			->execute();
+
+		$shares = $stmt->fetchAll();
+
+		$this->assertSame('user0', $shares[0]['share_with']);
+		$this->assertSame('user4', $shares[0]['uid_initiator']);
+		$this->assertSame('user5', $shares[0]['uid_owner']);
+		$this->assertSame(1, (int)$shares[0]['permissions']);
+
+		$this->assertSame('user3', $shares[1]['share_with']);
+		$this->assertSame('user4', $shares[1]['uid_initiator']);
+		$this->assertSame('user5', $shares[1]['uid_owner']);
+		$this->assertSame(0, (int)$shares[1]['permissions']);
+
+
+		$stmt->closeCursor();
+
 	}
 }

--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -21,6 +21,7 @@
 namespace Test\Share20;
 
 use OC\Share20\Exception\ProviderException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\IGroupManager;
@@ -99,7 +100,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		if ($fileTarget) $qb->setValue('file_target', $qb->expr()->literal($fileTarget));
 		if ($permissions) $qb->setValue('permissions', $qb->expr()->literal($permissions));
 		if ($token) $qb->setValue('token', $qb->expr()->literal($token));
-		if ($expiration) $qb->setValue('expiration', $qb->createNamedParameter($expiration, 'datetime'));
+		if ($expiration) $qb->setValue('expiration', $qb->createNamedParameter($expiration, IQueryBuilder::PARAM_DATE));
 		if ($parent) $qb->setValue('parent', $qb->expr()->literal($parent));
 
 		$this->assertEquals(1, $qb->execute());
@@ -1653,7 +1654,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$share->setSharedWith($groups['group1']);
+		$share->setSharedWith($groups['group0']);
 		$share->setSharedBy($users['user4']);
 		$share->setShareOwner($users['user5']);
 		$share->setPath($file2);
@@ -1722,7 +1723,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 		$share = $this->provider->getShareById($id);
 
-		$share->setSharedWith($groups['group1']);
+		$share->setSharedWith($groups['group0']);
 		$share->setSharedBy($users['user4']);
 		$share->setShareOwner($users['user5']);
 		$share->setPath($file2);

--- a/tests/lib/share20/managertest.php
+++ b/tests/lib/share20/managertest.php
@@ -599,29 +599,29 @@ class ManagerTest extends \Test\TestCase {
 	 * @expectedException \OC\HintException
 	 * @expectedExceptionMessage Expiration date is in the past
 	 */
-	public function testValidateExpiredateInPast() {
+	public function testvalidateExpirationDateInPast() {
 
 		// Expire date in the past
 		$past = new \DateTime();
 		$past->sub(new \DateInterval('P1D'));
 
-		$this->invokePrivate($this->manager, 'validateExpiredate', [$past]);
+		$this->invokePrivate($this->manager, 'validateExpirationDate', [$past]);
 	}
 
 	/**
 	 * @expectedException InvalidArgumentException
 	 * @expectedExceptionMessage Expiration date is enforced
 	 */
-	public function testValidateExpiredateEnforceButNotSet() {
+	public function testvalidateExpirationDateEnforceButNotSet() {
 		$this->config->method('getAppValue')
 			->will($this->returnValueMap([
 				['core', 'shareapi_enforce_expire_date', 'no', 'yes'],
 			]));
 
-		$this->invokePrivate($this->manager, 'validateExpiredate', [null]);
+		$this->invokePrivate($this->manager, 'validateExpirationDate', [null]);
 	}
 
-	public function testValidateExpiredateEnforceToFarIntoFuture() {
+	public function testvalidateExpirationDateEnforceToFarIntoFuture() {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P7D'));
@@ -633,7 +633,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		try {
-			$this->invokePrivate($this->manager, 'validateExpiredate', [$future]);
+			$this->invokePrivate($this->manager, 'validateExpirationDate', [$future]);
 		} catch (\OC\HintException $e) {
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getMessage());
 			$this->assertEquals('Cannot set expiration date more than 3 days in the future', $e->getHint());
@@ -641,7 +641,7 @@ class ManagerTest extends \Test\TestCase {
 		}
 	}
 
-	public function testValidateExpiredateEnforceValid() {
+	public function testvalidateExpirationDateEnforceValid() {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
@@ -655,27 +655,27 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
 			]));
 
-		$future = $this->invokePrivate($this->manager, 'validateExpiredate', [$future]);
+		$future = $this->invokePrivate($this->manager, 'validateExpirationDate', [$future]);
 
 		$this->assertEquals($expected, $future->format(\DateTime::ISO8601));
 	}
 
-	public function testValidateExpiredateNoDateNoDefaultNull() {
+	public function testvalidateExpirationDateNoDateNoDefaultNull() {
 		$date = new \DateTime();
 		$date->add(new \DateInterval('P5D'));
 
-		$res = $this->invokePrivate($this->manager, 'validateExpiredate', [$date]);
+		$res = $this->invokePrivate($this->manager, 'validateExpirationDate', [$date]);
 
 		$this->assertEquals($date, $res);
 	}
 
-	public function testValidateExpiredateNoDateNoDefault() {
-		$date = $this->invokePrivate($this->manager, 'validateExpiredate', [null]);
+	public function testvalidateExpirationDateNoDateNoDefault() {
+		$date = $this->invokePrivate($this->manager, 'validateExpirationDate', [null]);
 
 		$this->assertNull($date);
 	}
 
-	public function testValidateExpiredateNoDateDefault() {
+	public function testvalidateExpirationDateNoDateDefault() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P3D'));
 		$future->setTime(0,0,0);
@@ -686,7 +686,7 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'shareapi_expire_after_n_days', '7', '3'],
 			]));
 
-		$date = $this->invokePrivate($this->manager, 'validateExpiredate', [null]);
+		$date = $this->invokePrivate($this->manager, 'validateExpirationDate', [null]);
 
 		$this->assertEquals($future->format(\DateTime::ISO8601), $date->format(\DateTime::ISO8601));
 	}
@@ -1314,7 +1314,7 @@ class ManagerTest extends \Test\TestCase {
 				'generalCreateChecks',
 				'linkCreateChecks',
 				'pathCreateChecks',
-				'validateExpiredate',
+				'validateExpirationDate',
 				'verifyPassword',
 			])
 			->getMock();
@@ -1352,7 +1352,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('pathCreateChecks')
 			->with($path);
 		$manager->expects($this->once())
-			->method('validateExpiredate')
+			->method('validateExpirationDate')
 			->with($date)
 			->will($this->returnArgument(0));
 		$manager->expects($this->once())
@@ -1745,7 +1745,7 @@ class ManagerTest extends \Test\TestCase {
 				'linkCreateChecks',
 				'pathCreateChecks',
 				'verifyPassword',
-				'validateExpiredate',
+				'validateExpirationDate',
 			])
 			->getMock();
 
@@ -1761,7 +1761,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager->expects($this->once())->method('canShare')->willReturn(true);
 		$manager->expects($this->once())->method('getShareById')->with('foo:42')->willReturn($originalShare);
-		$manager->expects($this->once())->method('validateExpireDate')->with($tomorrow)->willReturn($tomorrow);
+		$manager->expects($this->once())->method('validateExpirationDate')->with($tomorrow)->willReturn($tomorrow);
 
 		$file = $this->getMock('OCP\Files\File', [], [], 'File');
 		$file->method('getId')->willReturn(100);


### PR DESCRIPTION
More for https://github.com/owncloud/core/issues/19331

Updating shares is now handled in the sharemanager.
Basically we run the same bunch of tests for updateShare as we do for createShare. And some more.
- Chaning shareTypes is not allowed
- Chaning recipient is only allowed for user shares

Please have a look: @DeepDiver1975 @schiesbn @nickvergessen @PVince81 
