### PR TITLE
Prevent invalid storages being displayed in the storages view

### DIFF
--- a/apps/files_external/controller/storagescontroller.php
+++ b/apps/files_external/controller/storagescontroller.php
@@ -268,7 +268,7 @@ abstract class StoragesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function index() {
-		$storages = $this->service->getAllStorages();
+		$storages = $this->service->getStorages();
 
 		return new DataResponse(
 			$storages,


### PR DESCRIPTION
This reintroduces 8.2 behaviour, where if an admin disables a storage backend for user mounting, any personal storages configured with that backend will just disappear from the list.

Fixes #21905 

cc @davitol @PVince81 @icewind1991 
