### PR TITLE
[Share 2.0] Resolve to correct usergroup share

### DIFF
--- a/tests/lib/share20/defaultshareprovidertest.php
+++ b/tests/lib/share20/defaultshareprovidertest.php
@@ -881,6 +881,27 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(1, $qb->execute());
 		$id = $qb->getLastInsertId();
 
+		/*
+		 * Wrong share. Should not be taken by code.
+		 */
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->insert('share')
+			->values([
+				'share_type' => $qb->expr()->literal(2),
+				'share_with' => $qb->expr()->literal('user2'),
+				'uid_owner' => $qb->expr()->literal('shareOwner'),
+				'uid_initiator' => $qb->expr()->literal('sharedBy'),
+				'item_type'   => $qb->expr()->literal('file'),
+				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('wrongTarget'),
+				'permissions' => $qb->expr()->literal(31),
+				'parent' => $qb->expr()->literal($id),
+			]);
+		$this->assertEquals(1, $qb->execute());
+
+		/*
+		 * Correct share. should be taken by code path.
+		 */
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
 			->values([


### PR DESCRIPTION
I found this bug when working on the moving shares code.

When we resolve a group share to a user specific group share (e.g. the user moved a group share or deleted it). We must resolve to the correct share.

Easy one.
- tests updated to tests this.

CC: @schiesbn @nickvergessen @PVince81 @DeepDiver1975 
