### PR TITLE
Handle no user set in sftp constructor

### DIFF
--- a/apps/files_external/lib/sftp.php
+++ b/apps/files_external/lib/sftp.php
@@ -85,6 +85,9 @@ class SFTP extends \OC\Files\Storage\Common {
 		$this->host = $parsedHost[0];
 		$this->port = $parsedHost[1];
 
+		if (!isset($params['user'])) {
+			throw new \UnexpectedValueException('no authentication parameters specified');
+		}
 		$this->user = $params['user'];
 
 		if (isset($params['public_key_auth'])) {


### PR DESCRIPTION
The user might not be available yet, for some auth mechanism

Prevents a warning being logged

cc @PVince81 @Xenopathic 
