### PR TITLE
fix first run wizard button not wrapping

### DIFF
--- a/settings/templates/personal.php
+++ b/settings/templates/personal.php
@@ -194,7 +194,7 @@ if($_['passwordChangeSupported']) {
 	<?php endif; ?>
 
 	<?php if(OC_APP::isEnabled('firstrunwizard')) {?>
-	<a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a>
+	<p><a class="button" href="#" id="showWizard"><?php p($l->t('Show First Run Wizard again'));?></a></p>
 	<?php }?>
 </div>
 


### PR DESCRIPTION
Please review @SergioBertolinSG @davitol @owncloud/designers 

In case the text 

> If you want to support the project join development or spread the word! 

isn’t there, the first run wizard button would not wrap. This is fixed now.
