### PR TITLE
Do not use duplicated tag

### DIFF
--- a/apps/systemtags/appinfo/info.xml
+++ b/apps/systemtags/appinfo/info.xml
@@ -8,8 +8,7 @@
 	<default_enable/>
 	<version>0.1</version>
 	<dependencies>
-		<owncloud min-version="9.0" />
-		<owncloud max-version="9.1" />
+		<owncloud min-version="9.0" max-version="9.0" />
 	</dependencies>
 	<documentation>
 		<user>user-systemtags</user>


### PR DESCRIPTION
Fixes "This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later.", the tag can only be there once. Also set to 9.0 as this will be the next major release.

cc @PVince81 @MorrisJobke @nickvergessen   
