### PR TITLE
Fix errors after install

### DIFF
--- a/lib/private/config.php
+++ b/lib/private/config.php
@@ -184,7 +184,7 @@ class Config {
 
 		// Include file and merge config
 		foreach ($configFiles as $file) {
-			$filePointer = @fopen($file, 'r');
+			$filePointer = file_exists($file) ? fopen($file, 'r') : false;
 			if($file === $this->configFilePath &&
 				$filePointer === false &&
 				@!file_exists($this->configFilePath)) {

--- a/lib/private/log/owncloud.php
+++ b/lib/private/log/owncloud.php
@@ -43,17 +43,18 @@ class OC_Log_Owncloud {
 		$defaultLogFile = $systemConfig->getValue("datadirectory", OC::$SERVERROOT.'/data').'/owncloud.log';
 		self::$logFile = $systemConfig->getValue("logfile", $defaultLogFile);
 
-		/*
-		* Fall back to default log file if specified logfile does not exist
-		* and can not be created. Error suppression is required in order to
-		* not end up in the error handler which will try to log the error.
-		* A better solution (compared to error suppression) would be checking
-		* !is_writable(dirname(self::$logFile)) before touch(), but
-		* is_writable() on directories used to be pretty unreliable on Windows
-		* for at least some time.
-		*/
-		if (!file_exists(self::$logFile) && !@touch(self::$logFile)) {
-			self::$logFile = $defaultLogFile;
+		/**
+		 * Fall back to default log file if specified logfile does not exist
+		 * and can not be created.
+		 */
+		if (!file_exists(self::$logFile)) {
+			if(!is_writable(dirname(self::$logFile))) {
+				self::$logFile = $defaultLogFile;
+			} else {
+				if(!touch(self::$logFile)) {
+					self::$logFile = $defaultLogFile;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
When installing ownCloud the first time the first thing that an admin saw was an error message:

> touch(): Unable to create file /Users/lukasreschke/Documents/Programming/master/data/owncloud.log because No such file or directory at /Users/lukasreschke/Documents/Programming/master/lib/private/log/owncloud.php#55   

Or something related. This lead to a lot confusion as can be seen in our forum and in our issue tracker. This change should make the error messages disappear in most cases (e.g. where the file can actually be written). To test this:
1. On master install ownCloud and check owncloud.log => Error message
2. On this branch install ownCloud and check owncloud.log => No error message
3. Test the same with a custom config file `ee.config.php` in the config folder that contains:

``` php
<?php
$CONFIG = array (
    'logfile' => '/tmp/yolo.log',
);
```

adjust `index.php` to contain something like `\OC::$server->getLogger()->critical('yo');` so that an error get logged. Ensure that `/tmp/yolo.log` is used.

Fixes https://github.com/owncloud/core/issues/13736 and https://github.com/owncloud/core/issues/12893

<hr/>

@karlitschek Should make you happier as well. Heard you ranting about this some time ago :wink: 
@MorrisJobke @rullzer @DeepDiver1975  Mind testing?
